### PR TITLE
[ISSUE #9070]✨Migrate single-key RPC request headers to V3

### DIFF
--- a/rocketmq-protocol/src/protocol/header/get_consumer_connection_list_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/get_consumer_connection_list_request_header.rs
@@ -13,19 +13,24 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Serialize, Deserialize, Debug, RequestHeaderCodecV2)]
+#[derive(Serialize, Deserialize, Debug, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::get_consumer_connection_list_request_header::GetConsumerConnectionListRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.GetConsumerConnectionListRequestHeader"
+)]
 pub struct GetConsumerConnectionListRequestHeader {
-    #[required]
+    #[header(required)]
     #[serde(rename = "consumerGroup")]
     pub consumer_group: CheetahString,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub rpc_request_header: Option<RpcRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/get_producer_connection_list_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/get_producer_connection_list_request_header.rs
@@ -13,19 +13,24 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Serialize, Deserialize, Debug, RequestHeaderCodecV2, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, RequestHeaderCodecV3, Clone, Default)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::get_producer_connection_list_request_header::GetProducerConnectionListRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.GetProducerConnectionListRequestHeader"
+)]
 pub struct GetProducerConnectionListRequestHeader {
-    #[required]
+    #[header(required)]
     #[serde(rename = "producerGroup")]
     pub producer_group: CheetahString,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub rpc_request_header: Option<RpcRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/get_subscription_group_config_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/get_subscription_group_config_request_header.rs
@@ -13,18 +13,23 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::get_subscription_group_config_request_header::GetSubscriptionGroupConfigRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.GetSubscriptionGroupConfigRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct GetSubscriptionGroupConfigRequestHeader {
-    #[required]
+    #[header(required)]
     pub group: CheetahString,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub rpc_request_header: Option<RpcRequestHeader>,
 }

--- a/rocketmq-protocol/src/protocol/header/notify_consumer_ids_changed_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/notify_consumer_ids_changed_request_header.rs
@@ -13,19 +13,24 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Serialize, Deserialize, Debug, RequestHeaderCodecV2)]
+#[derive(Serialize, Deserialize, Debug, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::notify_consumer_ids_changed_request_header::NotifyConsumerIdsChangedRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.NotifyConsumerIdsChangedRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct NotifyConsumerIdsChangedRequestHeader {
-    #[required]
+    #[header(required)]
     pub consumer_group: CheetahString,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub rpc_request_header: Option<RpcRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/query_topics_by_consumer_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/query_topics_by_consumer_request_header.rs
@@ -13,19 +13,24 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Serialize, Deserialize, Debug, RequestHeaderCodecV2, Default)]
+#[derive(Serialize, Deserialize, Debug, RequestHeaderCodecV3, Default)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::query_topics_by_consumer_request_header::QueryTopicsByConsumerRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.QueryTopicsByConsumerRequestHeader"
+)]
 pub struct QueryTopicsByConsumerRequestHeader {
-    #[required]
+    #[header(required)]
     #[serde(rename = "group")]
     pub group: CheetahString,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub rpc_request_header: Option<RpcRequestHeader>,
 }
 

--- a/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
@@ -22,8 +22,11 @@ use rocketmq_model::boundary_type::BoundaryType;
 use rocketmq_protocol::protocol::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader;
 use rocketmq_protocol::protocol::header::controller::clean_broker_data_request_header::CleanBrokerDataRequestHeader;
 use rocketmq_protocol::protocol::header::create_topic_list_request_header::CreateTopicListRequestHeader;
+use rocketmq_protocol::protocol::header::get_consumer_connection_list_request_header::GetConsumerConnectionListRequestHeader;
 use rocketmq_protocol::protocol::header::get_consumer_status_request_header::GetConsumerStatusRequestHeader;
 use rocketmq_protocol::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader;
+use rocketmq_protocol::protocol::header::get_producer_connection_list_request_header::GetProducerConnectionListRequestHeader;
+use rocketmq_protocol::protocol::header::get_subscription_group_config_request_header::GetSubscriptionGroupConfigRequestHeader;
 use rocketmq_protocol::protocol::header::heartbeat_request_header::HeartbeatRequestHeader;
 use rocketmq_protocol::protocol::header::lite_subscription_ctl_request_header::LiteSubscriptionCtlRequestHeader;
 use rocketmq_protocol::protocol::header::lock_batch_mq_request_header::LockBatchMqRequestHeader;
@@ -33,9 +36,11 @@ use rocketmq_protocol::protocol::header::message_operation_header::send_message_
 use rocketmq_protocol::protocol::header::namesrv::topic_operation_header::DeleteTopicFromNamesrvRequestHeader;
 use rocketmq_protocol::protocol::header::namesrv::topic_operation_header::TopicRequestHeader as NamesrvTopicRequestHeader;
 use rocketmq_protocol::protocol::header::notification_request_header::NotificationRequestHeader;
+use rocketmq_protocol::protocol::header::notify_consumer_ids_changed_request_header::NotifyConsumerIdsChangedRequestHeader;
 use rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader;
 use rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader;
 use rocketmq_protocol::protocol::header::query_consume_queue_request_header::QueryConsumeQueueRequestHeader;
+use rocketmq_protocol::protocol::header::query_topics_by_consumer_request_header::QueryTopicsByConsumerRequestHeader;
 use rocketmq_protocol::protocol::header::search_offset_request_header::SearchOffsetRequestHeader;
 use rocketmq_protocol::protocol::header::search_offset_response_header::SearchOffsetResponseHeader;
 use rocketmq_protocol::protocol::header::unlock_batch_mq_request_header::UnlockBatchMqRequestHeader;
@@ -144,15 +149,15 @@ impl SingleValidationHeader {
     }
 }
 
-fn register<T: HeaderCodec + CommandCustomHeader + Default>() -> RegisteredSchema {
+fn register_value<T: HeaderCodec + CommandCustomHeader>(header: &T) -> RegisteredSchema {
     assert_eq!(
-        T::default().encode_capability() == HeaderEncodeCapability::DirectBinary,
+        header.encode_capability() == HeaderEncodeCapability::DirectBinary,
         T::FAST_ENABLED,
         "{} encode capability must follow its fast schema flag",
         T::TYPE_ID
     );
     assert_eq!(
-        T::default().supports_direct_json_fields(),
+        header.supports_direct_json_fields(),
         T::FAST_ENABLED,
         "{} direct JSON capability must follow its fast schema flag",
         T::TYPE_ID
@@ -171,6 +176,10 @@ fn register<T: HeaderCodec + CommandCustomHeader + Default>() -> RegisteredSchem
     }
 }
 
+fn register<T: HeaderCodec + CommandCustomHeader + Default>() -> RegisteredSchema {
+    register_value(&T::default())
+}
+
 fn registry() -> Vec<RegisteredSchema> {
     vec![
         register::<RpcRequestHeader>(),
@@ -179,8 +188,14 @@ fn registry() -> Vec<RegisteredSchema> {
         register::<ConsumeMessageDirectlyResultRequestHeader>(),
         register::<CleanBrokerDataRequestHeader>(),
         register::<CreateTopicListRequestHeader>(),
+        register_value(&GetConsumerConnectionListRequestHeader {
+            consumer_group: CheetahString::from_static_str("registry"),
+            rpc_request_header: None,
+        }),
         register::<GetConsumerStatusRequestHeader>(),
         register::<GetLiteClientInfoRequestHeader>(),
+        register::<GetProducerConnectionListRequestHeader>(),
+        register::<GetSubscriptionGroupConfigRequestHeader>(),
         register::<HeartbeatRequestHeader>(),
         register::<LiteSubscriptionCtlRequestHeader>(),
         register::<LockBatchMqRequestHeader>(),
@@ -194,6 +209,11 @@ fn registry() -> Vec<RegisteredSchema> {
         register::<SendMessageRequestHeaderV2>(),
         register::<SendMessageResponseHeader>(),
         register::<NotificationRequestHeader>(),
+        register_value(&NotifyConsumerIdsChangedRequestHeader {
+            consumer_group: CheetahString::from_static_str("registry"),
+            rpc_request_header: None,
+        }),
+        register::<QueryTopicsByConsumerRequestHeader>(),
         register::<UnlockBatchMqRequestHeader>(),
     ]
 }
@@ -408,12 +428,14 @@ fn registered_typed_schemas_match_the_pinned_java_contract() {
     }
 }
 
-fn assert_rpc_envelope_contract<T>(rpc: fn(&T) -> &Option<RpcRequestHeader>)
-where
+fn assert_rpc_envelope_contract<T>(
+    local_field: Option<(&'static str, &'static str)>,
+    rpc: fn(&T) -> &Option<RpcRequestHeader>,
+) where
     T: CommandCustomHeader + FromMap<Target = T> + HeaderCodec,
     <T as FromMap>::Error: std::fmt::Debug,
 {
-    let input = HeaderMap::from([
+    let mut input = HeaderMap::from([
         ("ns".into(), "canonical-ns".into()),
         ("namespace".into(), "legacy-ns".into()),
         ("nsd".into(), "true".into()),
@@ -423,6 +445,9 @@ where
         ("oway".into(), "false".into()),
         ("oneway".into(), "true".into()),
     ]);
+    if let Some((key, value)) = local_field {
+        input.insert(key.into(), value.into());
+    }
     let typed = <T as HeaderCodec>::decode_from_map(&input).expect("typed RPC envelope decode");
     let legacy = <T as FromMap>::from(&input).expect("legacy RPC envelope adapter");
     for decoded in [rpc(&typed), rpc(&legacy)] {
@@ -436,6 +461,11 @@ where
     }
 
     let encoded = typed.to_map().expect("typed RPC envelope encode");
+    let legacy_encoded = legacy.to_map().expect("legacy RPC envelope encode");
+    if let Some((key, value)) = local_field {
+        assert_eq!(encoded.get(key).map(CheetahString::as_str), Some(value));
+        assert_eq!(legacy_encoded.get(key).map(CheetahString::as_str), Some(value));
+    }
     assert_eq!(encoded.get("ns").map(CheetahString::as_str), Some("canonical-ns"));
     assert_eq!(encoded.get("nsd").map(CheetahString::as_str), Some("true"));
     assert_eq!(
@@ -450,7 +480,20 @@ where
         );
     }
 
-    let empty = <T as HeaderCodec>::decode_from_map(&HeaderMap::new()).expect("empty inherited header");
+    let mut parent_only = HeaderMap::new();
+    if let Some((key, value)) = local_field {
+        parent_only.insert(key.into(), value.into());
+        let typed_missing = <T as HeaderCodec>::decode_from_map(&HeaderMap::new());
+        assert!(
+            matches!(typed_missing, Err(HeaderCodecError::Missing { key: actual, .. }) if actual == key),
+            "typed decode must reject missing required field {key}"
+        );
+        assert!(
+            <T as FromMap>::from(&HeaderMap::new()).is_err(),
+            "legacy adapter must reject missing required field {key}"
+        );
+    }
+    let empty = <T as HeaderCodec>::decode_from_map(&parent_only).expect("inherited header without RPC fields");
     let empty_rpc = rpc(&empty)
         .as_ref()
         .expect("Java parent exists even when all fields are absent");
@@ -463,11 +506,26 @@ where
 
 #[test]
 fn rpc_envelope_headers_preserve_java_inheritance_and_legacy_aliases() {
-    assert_rpc_envelope_contract::<CreateTopicListRequestHeader>(|header| &header.rpc_request_header);
-    assert_rpc_envelope_contract::<HeartbeatRequestHeader>(|header| &header.rpc_request);
-    assert_rpc_envelope_contract::<LiteSubscriptionCtlRequestHeader>(|header| &header.rpc_request_header);
-    assert_rpc_envelope_contract::<LockBatchMqRequestHeader>(|header| &header.rpc_request_header);
-    assert_rpc_envelope_contract::<UnlockBatchMqRequestHeader>(|header| &header.rpc_request_header);
+    assert_rpc_envelope_contract::<CreateTopicListRequestHeader>(None, |header| &header.rpc_request_header);
+    assert_rpc_envelope_contract::<GetConsumerConnectionListRequestHeader>(Some(("consumerGroup", "cg")), |header| {
+        &header.rpc_request_header
+    });
+    assert_rpc_envelope_contract::<GetProducerConnectionListRequestHeader>(Some(("producerGroup", "pg")), |header| {
+        &header.rpc_request_header
+    });
+    assert_rpc_envelope_contract::<GetSubscriptionGroupConfigRequestHeader>(Some(("group", "sg")), |header| {
+        &header.rpc_request_header
+    });
+    assert_rpc_envelope_contract::<HeartbeatRequestHeader>(None, |header| &header.rpc_request);
+    assert_rpc_envelope_contract::<LiteSubscriptionCtlRequestHeader>(None, |header| &header.rpc_request_header);
+    assert_rpc_envelope_contract::<LockBatchMqRequestHeader>(None, |header| &header.rpc_request_header);
+    assert_rpc_envelope_contract::<NotifyConsumerIdsChangedRequestHeader>(Some(("consumerGroup", "ng")), |header| {
+        &header.rpc_request_header
+    });
+    assert_rpc_envelope_contract::<QueryTopicsByConsumerRequestHeader>(Some(("group", "qg")), |header| {
+        &header.rpc_request_header
+    });
+    assert_rpc_envelope_contract::<UnlockBatchMqRequestHeader>(None, |header| &header.rpc_request_header);
 }
 
 #[test]

--- a/scripts/request-header-codec/migration.json
+++ b/scripts/request-header-codec/migration.json
@@ -8,10 +8,10 @@
     "entryCount": 152,
     "mappedCount": 143,
     "rustOnlyExtensionCount": 9,
-    "v2Count": 130,
-    "v3Count": 22,
-    "pendingCount": 130,
-    "migratedCount": 22
+    "v2Count": 125,
+    "v3Count": 27,
+    "pendingCount": 125,
+    "migratedCount": 27
   },
   "baseline": {
     "v2TypeIds": [
@@ -177,8 +177,11 @@
       "rocketmq_protocol::protocol::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader",
       "rocketmq_protocol::protocol::header::controller::clean_broker_data_request_header::CleanBrokerDataRequestHeader",
       "rocketmq_protocol::protocol::header::create_topic_list_request_header::CreateTopicListRequestHeader",
+      "rocketmq_protocol::protocol::header::get_consumer_connection_list_request_header::GetConsumerConnectionListRequestHeader",
       "rocketmq_protocol::protocol::header::get_consumer_status_request_header::GetConsumerStatusRequestHeader",
       "rocketmq_protocol::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader",
+      "rocketmq_protocol::protocol::header::get_producer_connection_list_request_header::GetProducerConnectionListRequestHeader",
+      "rocketmq_protocol::protocol::header::get_subscription_group_config_request_header::GetSubscriptionGroupConfigRequestHeader",
       "rocketmq_protocol::protocol::header::heartbeat_request_header::HeartbeatRequestHeader",
       "rocketmq_protocol::protocol::header::lite_subscription_ctl_request_header::LiteSubscriptionCtlRequestHeader",
       "rocketmq_protocol::protocol::header::lock_batch_mq_request_header::LockBatchMqRequestHeader",
@@ -188,9 +191,11 @@
       "rocketmq_protocol::protocol::header::namesrv::topic_operation_header::DeleteTopicFromNamesrvRequestHeader",
       "rocketmq_protocol::protocol::header::namesrv::topic_operation_header::TopicRequestHeader",
       "rocketmq_protocol::protocol::header::notification_request_header::NotificationRequestHeader",
+      "rocketmq_protocol::protocol::header::notify_consumer_ids_changed_request_header::NotifyConsumerIdsChangedRequestHeader",
       "rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader",
       "rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader",
       "rocketmq_protocol::protocol::header::query_consume_queue_request_header::QueryConsumeQueueRequestHeader",
+      "rocketmq_protocol::protocol::header::query_topics_by_consumer_request_header::QueryTopicsByConsumerRequestHeader",
       "rocketmq_protocol::protocol::header::search_offset_request_header::SearchOffsetRequestHeader",
       "rocketmq_protocol::protocol::header::search_offset_response_header::SearchOffsetResponseHeader",
       "rocketmq_protocol::protocol::header::unlock_batch_mq_request_header::UnlockBatchMqRequestHeader",
@@ -1392,16 +1397,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 1,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -1728,16 +1733,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 1,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -1751,16 +1756,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 1,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -2591,16 +2596,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 1,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -3025,16 +3030,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 1,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {

--- a/scripts/request-header-codec/tests/test_migrate.py
+++ b/scripts/request-header-codec/tests/test_migrate.py
@@ -55,7 +55,7 @@ class MigrationGuardTests(unittest.TestCase):
         )
         self.assertEqual(migrate.serialize(expected), migrate.serialize(self.manifest))
         self.assertEqual(len(self.headers), 152)
-        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 22)
+        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 27)
 
     def test_duplicate_simple_names_keep_distinct_stable_paths(self) -> None:
         graph, depths = migrate.flatten_graph(self.headers, self.repo_root)


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9070

### Brief Description

Migrate five single-key RPC request headers from `RequestHeaderCodecV2` to `RequestHeaderCodecV3`:

- `GetConsumerConnectionListRequestHeader`
- `GetProducerConnectionListRequestHeader`
- `GetSubscriptionGroupConfigRequestHeader`
- `QueryTopicsByConsumerRequestHeader`
- `NotifyConsumerIdsChangedRequestHeader`

Replace legacy required markers with V3 `#[header(required)]`, preserve the pinned Java local keys and always-present `RpcRequestHeader` inheritance, and keep every migrated header map-only. Extend the typed registry to accept valid instances for required types without adding invalid production `Default` implementations, and advance the migration baseline from 22 to 27 accepted V3 headers.

### How Did You Test This Change?

- `python scripts/request-header-codec/migrate.py check` (passed: 152 registered, 27 V3, 125 frozen V2)
- `python -m unittest discover -s scripts/request-header-codec/tests -p 'test_*.py'` (passed: 3 tests)
- `python scripts/request-header-codec/compare_header_schema.py` (passed: 143 Java mappings, 0 differences)
- `cargo fmt -p rocketmq-protocol -- --check` (passed)
- `cargo test --locked -p rocketmq-protocol --test request_header_codec_v3_registry` (passed: 11 tests, including post-rebase rerun)
- `cargo test --locked -p rocketmq-protocol --all-features` (passed: library, integration, UI, and documentation tests)
- `cargo clippy --locked -p rocketmq-protocol --no-deps --test request_header_codec_v3_registry --all-features -- -D warnings -A deprecated` (passed, including post-rebase rerun)
- `git diff --check` (passed)

Repository-wide `cargo fmt --all -- --check` remains blocked on Windows by OS error 206. Repository-wide strict Clippy remains blocked by pre-existing `rocketmq-model` deprecation and useless-conversion findings; the affected package and focused Clippy checks above pass.
