### PR TITLE
[ISSUE #9072]✨Migrate consumer lifecycle RPC headers to V3

### DIFF
--- a/rocketmq-protocol/src/protocol/header/delete_subscription_group_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/delete_subscription_group_request_header.rs
@@ -13,21 +13,28 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::delete_subscription_group_request_header::DeleteSubscriptionGroupRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.DeleteSubscriptionGroupRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct DeleteSubscriptionGroupRequestHeader {
-    #[required]
+    #[header(required)]
     pub group_name: CheetahString,
 
+    #[serde(default)]
+    #[header(default, default_semantic = "literal:false")]
     pub clean_offset: bool,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub rpc_request_header: Option<RpcRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/get_consumer_running_info_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/get_consumer_running_info_request_header.rs
@@ -13,24 +13,31 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::get_consumer_running_info_request_header::GetConsumerRunningInfoRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.GetConsumerRunningInfoRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct GetConsumerRunningInfoRequestHeader {
-    #[required]
+    #[header(required)]
     pub consumer_group: CheetahString,
 
-    #[required]
+    #[header(required)]
     pub client_id: CheetahString,
 
+    #[serde(default)]
+    #[header(default, default_semantic = "literal:false")]
     pub jstack_enable: bool,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub rpc_request_header: Option<RpcRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/notify_unsubscribe_lite_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/notify_unsubscribe_lite_request_header.rs
@@ -13,25 +13,30 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::notify_unsubscribe_lite_request_header::NotifyUnsubscribeLiteRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.NotifyUnsubscribeLiteRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct NotifyUnsubscribeLiteRequestHeader {
-    #[required]
+    #[header(required)]
     pub lite_topic: CheetahString,
 
-    #[required]
+    #[header(required)]
     pub consumer_group: CheetahString,
 
-    #[required]
+    #[header(required)]
     pub client_id: CheetahString,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub rpc_request_header: Option<RpcRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/unregister_client_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/unregister_client_request_header.rs
@@ -13,20 +13,25 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Debug, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[derive(Debug, Serialize, Deserialize, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::unregister_client_request_header::UnregisterClientRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.UnregisterClientRequestHeader"
+)]
 pub struct UnregisterClientRequestHeader {
-    #[required]
     #[serde(rename = "clientID", alias = "clientId")]
+    #[header(key = "clientID", alias = "clientId", alias_conflict = "prefer_canonical", required)]
     pub client_id: CheetahString,
     pub producer_group: Option<CheetahString>,
     pub consumer_group: Option<CheetahString>,
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub rpc_request_header: Option<RpcRequestHeader>,
 }
 

--- a/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
@@ -22,7 +22,9 @@ use rocketmq_model::boundary_type::BoundaryType;
 use rocketmq_protocol::protocol::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader;
 use rocketmq_protocol::protocol::header::controller::clean_broker_data_request_header::CleanBrokerDataRequestHeader;
 use rocketmq_protocol::protocol::header::create_topic_list_request_header::CreateTopicListRequestHeader;
+use rocketmq_protocol::protocol::header::delete_subscription_group_request_header::DeleteSubscriptionGroupRequestHeader;
 use rocketmq_protocol::protocol::header::get_consumer_connection_list_request_header::GetConsumerConnectionListRequestHeader;
+use rocketmq_protocol::protocol::header::get_consumer_running_info_request_header::GetConsumerRunningInfoRequestHeader;
 use rocketmq_protocol::protocol::header::get_consumer_status_request_header::GetConsumerStatusRequestHeader;
 use rocketmq_protocol::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader;
 use rocketmq_protocol::protocol::header::get_producer_connection_list_request_header::GetProducerConnectionListRequestHeader;
@@ -37,6 +39,7 @@ use rocketmq_protocol::protocol::header::namesrv::topic_operation_header::Delete
 use rocketmq_protocol::protocol::header::namesrv::topic_operation_header::TopicRequestHeader as NamesrvTopicRequestHeader;
 use rocketmq_protocol::protocol::header::notification_request_header::NotificationRequestHeader;
 use rocketmq_protocol::protocol::header::notify_consumer_ids_changed_request_header::NotifyConsumerIdsChangedRequestHeader;
+use rocketmq_protocol::protocol::header::notify_unsubscribe_lite_request_header::NotifyUnsubscribeLiteRequestHeader;
 use rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader;
 use rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader;
 use rocketmq_protocol::protocol::header::query_consume_queue_request_header::QueryConsumeQueueRequestHeader;
@@ -44,6 +47,7 @@ use rocketmq_protocol::protocol::header::query_topics_by_consumer_request_header
 use rocketmq_protocol::protocol::header::search_offset_request_header::SearchOffsetRequestHeader;
 use rocketmq_protocol::protocol::header::search_offset_response_header::SearchOffsetResponseHeader;
 use rocketmq_protocol::protocol::header::unlock_batch_mq_request_header::UnlockBatchMqRequestHeader;
+use rocketmq_protocol::protocol::header::unregister_client_request_header::UnregisterClientRequestHeader;
 use rocketmq_protocol::protocol::header_codec::{
     AliasConflictPolicy, HeaderCodec, HeaderCodecError, HeaderFieldSpec, HeaderFlattenSpec, HeaderPresence,
     HeaderRange, HeaderValueKind,
@@ -188,10 +192,12 @@ fn registry() -> Vec<RegisteredSchema> {
         register::<ConsumeMessageDirectlyResultRequestHeader>(),
         register::<CleanBrokerDataRequestHeader>(),
         register::<CreateTopicListRequestHeader>(),
+        register::<DeleteSubscriptionGroupRequestHeader>(),
         register_value(&GetConsumerConnectionListRequestHeader {
             consumer_group: CheetahString::from_static_str("registry"),
             rpc_request_header: None,
         }),
+        register::<GetConsumerRunningInfoRequestHeader>(),
         register::<GetConsumerStatusRequestHeader>(),
         register::<GetLiteClientInfoRequestHeader>(),
         register::<GetProducerConnectionListRequestHeader>(),
@@ -213,8 +219,15 @@ fn registry() -> Vec<RegisteredSchema> {
             consumer_group: CheetahString::from_static_str("registry"),
             rpc_request_header: None,
         }),
+        register_value(&NotifyUnsubscribeLiteRequestHeader {
+            lite_topic: CheetahString::from_static_str("registry"),
+            consumer_group: CheetahString::from_static_str("registry"),
+            client_id: CheetahString::from_static_str("registry"),
+            rpc_request_header: None,
+        }),
         register::<QueryTopicsByConsumerRequestHeader>(),
         register::<UnlockBatchMqRequestHeader>(),
+        register::<UnregisterClientRequestHeader>(),
     ]
 }
 
@@ -429,7 +442,8 @@ fn registered_typed_schemas_match_the_pinned_java_contract() {
 }
 
 fn assert_rpc_envelope_contract<T>(
-    local_field: Option<(&'static str, &'static str)>,
+    local_fields: &[(&'static str, &'static str)],
+    required_keys: &[&'static str],
     rpc: fn(&T) -> &Option<RpcRequestHeader>,
 ) where
     T: CommandCustomHeader + FromMap<Target = T> + HeaderCodec,
@@ -445,7 +459,7 @@ fn assert_rpc_envelope_contract<T>(
         ("oway".into(), "false".into()),
         ("oneway".into(), "true".into()),
     ]);
-    if let Some((key, value)) = local_field {
+    for &(key, value) in local_fields {
         input.insert(key.into(), value.into());
     }
     let typed = <T as HeaderCodec>::decode_from_map(&input).expect("typed RPC envelope decode");
@@ -462,7 +476,7 @@ fn assert_rpc_envelope_contract<T>(
 
     let encoded = typed.to_map().expect("typed RPC envelope encode");
     let legacy_encoded = legacy.to_map().expect("legacy RPC envelope encode");
-    if let Some((key, value)) = local_field {
+    for &(key, value) in local_fields {
         assert_eq!(encoded.get(key).map(CheetahString::as_str), Some(value));
         assert_eq!(legacy_encoded.get(key).map(CheetahString::as_str), Some(value));
     }
@@ -481,15 +495,19 @@ fn assert_rpc_envelope_contract<T>(
     }
 
     let mut parent_only = HeaderMap::new();
-    if let Some((key, value)) = local_field {
+    for &(key, value) in local_fields {
         parent_only.insert(key.into(), value.into());
-        let typed_missing = <T as HeaderCodec>::decode_from_map(&HeaderMap::new());
+    }
+    for &key in required_keys {
+        let mut missing = parent_only.clone();
+        missing.remove(key);
+        let typed_missing = <T as HeaderCodec>::decode_from_map(&missing);
         assert!(
             matches!(typed_missing, Err(HeaderCodecError::Missing { key: actual, .. }) if actual == key),
             "typed decode must reject missing required field {key}"
         );
         assert!(
-            <T as FromMap>::from(&HeaderMap::new()).is_err(),
+            <T as FromMap>::from(&missing).is_err(),
             "legacy adapter must reject missing required field {key}"
         );
     }
@@ -506,26 +524,89 @@ fn assert_rpc_envelope_contract<T>(
 
 #[test]
 fn rpc_envelope_headers_preserve_java_inheritance_and_legacy_aliases() {
-    assert_rpc_envelope_contract::<CreateTopicListRequestHeader>(None, |header| &header.rpc_request_header);
-    assert_rpc_envelope_contract::<GetConsumerConnectionListRequestHeader>(Some(("consumerGroup", "cg")), |header| {
+    assert_rpc_envelope_contract::<CreateTopicListRequestHeader>(&[], &[], |header| &header.rpc_request_header);
+    assert_rpc_envelope_contract::<DeleteSubscriptionGroupRequestHeader>(
+        &[("groupName", "dg")],
+        &["groupName"],
+        |header| &header.rpc_request_header,
+    );
+    assert_rpc_envelope_contract::<GetConsumerConnectionListRequestHeader>(
+        &[("consumerGroup", "cg")],
+        &["consumerGroup"],
+        |header| &header.rpc_request_header,
+    );
+    assert_rpc_envelope_contract::<GetConsumerRunningInfoRequestHeader>(
+        &[("consumerGroup", "cg"), ("clientId", "ci")],
+        &["consumerGroup", "clientId"],
+        |header| &header.rpc_request_header,
+    );
+    assert_rpc_envelope_contract::<GetProducerConnectionListRequestHeader>(
+        &[("producerGroup", "pg")],
+        &["producerGroup"],
+        |header| &header.rpc_request_header,
+    );
+    assert_rpc_envelope_contract::<GetSubscriptionGroupConfigRequestHeader>(&[("group", "sg")], &["group"], |header| {
         &header.rpc_request_header
     });
-    assert_rpc_envelope_contract::<GetProducerConnectionListRequestHeader>(Some(("producerGroup", "pg")), |header| {
+    assert_rpc_envelope_contract::<HeartbeatRequestHeader>(&[], &[], |header| &header.rpc_request);
+    assert_rpc_envelope_contract::<LiteSubscriptionCtlRequestHeader>(&[], &[], |header| &header.rpc_request_header);
+    assert_rpc_envelope_contract::<LockBatchMqRequestHeader>(&[], &[], |header| &header.rpc_request_header);
+    assert_rpc_envelope_contract::<NotifyConsumerIdsChangedRequestHeader>(
+        &[("consumerGroup", "ng")],
+        &["consumerGroup"],
+        |header| &header.rpc_request_header,
+    );
+    assert_rpc_envelope_contract::<NotifyUnsubscribeLiteRequestHeader>(
+        &[("liteTopic", "lt"), ("consumerGroup", "ng"), ("clientId", "ci")],
+        &["liteTopic", "consumerGroup", "clientId"],
+        |header| &header.rpc_request_header,
+    );
+    assert_rpc_envelope_contract::<QueryTopicsByConsumerRequestHeader>(&[("group", "qg")], &["group"], |header| {
         &header.rpc_request_header
     });
-    assert_rpc_envelope_contract::<GetSubscriptionGroupConfigRequestHeader>(Some(("group", "sg")), |header| {
-        &header.rpc_request_header
-    });
-    assert_rpc_envelope_contract::<HeartbeatRequestHeader>(None, |header| &header.rpc_request);
-    assert_rpc_envelope_contract::<LiteSubscriptionCtlRequestHeader>(None, |header| &header.rpc_request_header);
-    assert_rpc_envelope_contract::<LockBatchMqRequestHeader>(None, |header| &header.rpc_request_header);
-    assert_rpc_envelope_contract::<NotifyConsumerIdsChangedRequestHeader>(Some(("consumerGroup", "ng")), |header| {
-        &header.rpc_request_header
-    });
-    assert_rpc_envelope_contract::<QueryTopicsByConsumerRequestHeader>(Some(("group", "qg")), |header| {
-        &header.rpc_request_header
-    });
-    assert_rpc_envelope_contract::<UnlockBatchMqRequestHeader>(None, |header| &header.rpc_request_header);
+    assert_rpc_envelope_contract::<UnlockBatchMqRequestHeader>(&[], &[], |header| &header.rpc_request_header);
+    assert_rpc_envelope_contract::<UnregisterClientRequestHeader>(
+        &[
+            ("clientID", "canonical-client"),
+            ("producerGroup", "pg"),
+            ("consumerGroup", "cg"),
+        ],
+        &["clientID"],
+        |header| &header.rpc_request_header,
+    );
+
+    let running = <GetConsumerRunningInfoRequestHeader as HeaderCodec>::decode_from_map(&HeaderMap::from([
+        ("consumerGroup".into(), "cg".into()),
+        ("clientId".into(), "ci".into()),
+    ]))
+    .expect("missing Java primitive boolean uses false");
+    assert!(!running.jstack_enable);
+
+    let deleted = <DeleteSubscriptionGroupRequestHeader as HeaderCodec>::decode_from_map(&HeaderMap::from([(
+        "groupName".into(),
+        "dg".into(),
+    )]))
+    .expect("missing Java primitive boolean uses false");
+    assert!(!deleted.clean_offset);
+
+    let unregister_input = HeaderMap::from([
+        ("clientID".into(), "canonical-client".into()),
+        ("clientId".into(), "legacy-client".into()),
+    ]);
+    let unregister = <UnregisterClientRequestHeader as HeaderCodec>::decode_from_map(&unregister_input)
+        .expect("reviewed alias conflict uses canonical input");
+    let legacy_unregister = <UnregisterClientRequestHeader as FromMap>::from(&unregister_input)
+        .expect("legacy adapter uses the same reviewed alias policy");
+    assert_eq!(unregister.client_id, "canonical-client");
+    assert_eq!(legacy_unregister.client_id, "canonical-client");
+    assert!(unregister.producer_group.is_none());
+    assert!(unregister.consumer_group.is_none());
+    let encoded = unregister.to_map().expect("unregister header encodes");
+    assert_eq!(
+        encoded.get("clientID").map(CheetahString::as_str),
+        Some("canonical-client")
+    );
+    assert!(!encoded.contains_key("clientId"));
 }
 
 #[test]

--- a/scripts/request-header-codec/legacy-alias-window.json
+++ b/scripts/request-header-codec/legacy-alias-window.json
@@ -72,6 +72,18 @@
       "owner": "rocketmq-rust protocol maintainers",
       "rationale": "Preserve decode compatibility for the legacy Rust RPC long key",
       "evidence": "scripts/request-header-codec/schema-overrides.json"
+    },
+    {
+      "rustTypeId": "rocketmq_protocol::protocol::header::unregister_client_request_header::UnregisterClientRequestHeader",
+      "canonical": "clientID",
+      "alias": "clientId",
+      "firstSupportedVersion": "1.0.0",
+      "lastEncodeVersion": "0.9.0",
+      "lastDecodeVersion": null,
+      "reviewBy": "2027-08-01",
+      "owner": "rocketmq-rust protocol maintainers",
+      "rationale": "Preserve decode compatibility for the legacy Rust clientId spelling while Java clientID remains canonical",
+      "evidence": "scripts/request-header-codec/schema-overrides.json"
     }
   ]
 }

--- a/scripts/request-header-codec/migration.json
+++ b/scripts/request-header-codec/migration.json
@@ -8,10 +8,10 @@
     "entryCount": 152,
     "mappedCount": 143,
     "rustOnlyExtensionCount": 9,
-    "v2Count": 125,
-    "v3Count": 27,
-    "pendingCount": 125,
-    "migratedCount": 27
+    "v2Count": 121,
+    "v3Count": 31,
+    "pendingCount": 121,
+    "migratedCount": 31
   },
   "baseline": {
     "v2TypeIds": [
@@ -177,7 +177,9 @@
       "rocketmq_protocol::protocol::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader",
       "rocketmq_protocol::protocol::header::controller::clean_broker_data_request_header::CleanBrokerDataRequestHeader",
       "rocketmq_protocol::protocol::header::create_topic_list_request_header::CreateTopicListRequestHeader",
+      "rocketmq_protocol::protocol::header::delete_subscription_group_request_header::DeleteSubscriptionGroupRequestHeader",
       "rocketmq_protocol::protocol::header::get_consumer_connection_list_request_header::GetConsumerConnectionListRequestHeader",
+      "rocketmq_protocol::protocol::header::get_consumer_running_info_request_header::GetConsumerRunningInfoRequestHeader",
       "rocketmq_protocol::protocol::header::get_consumer_status_request_header::GetConsumerStatusRequestHeader",
       "rocketmq_protocol::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader",
       "rocketmq_protocol::protocol::header::get_producer_connection_list_request_header::GetProducerConnectionListRequestHeader",
@@ -192,6 +194,7 @@
       "rocketmq_protocol::protocol::header::namesrv::topic_operation_header::TopicRequestHeader",
       "rocketmq_protocol::protocol::header::notification_request_header::NotificationRequestHeader",
       "rocketmq_protocol::protocol::header::notify_consumer_ids_changed_request_header::NotifyConsumerIdsChangedRequestHeader",
+      "rocketmq_protocol::protocol::header::notify_unsubscribe_lite_request_header::NotifyUnsubscribeLiteRequestHeader",
       "rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader",
       "rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader",
       "rocketmq_protocol::protocol::header::query_consume_queue_request_header::QueryConsumeQueueRequestHeader",
@@ -199,6 +202,7 @@
       "rocketmq_protocol::protocol::header::search_offset_request_header::SearchOffsetRequestHeader",
       "rocketmq_protocol::protocol::header::search_offset_response_header::SearchOffsetResponseHeader",
       "rocketmq_protocol::protocol::header::unlock_batch_mq_request_header::UnlockBatchMqRequestHeader",
+      "rocketmq_protocol::protocol::header::unregister_client_request_header::UnregisterClientRequestHeader",
       "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader",
       "rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader"
     ],
@@ -1038,16 +1042,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 1,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -1462,16 +1466,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 1,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -2619,16 +2623,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 1,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -3288,16 +3292,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 1,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {

--- a/scripts/request-header-codec/schema-overrides.json
+++ b/scripts/request-header-codec/schema-overrides.json
@@ -176,6 +176,20 @@
         "rust": "rocketmq-protocol/src/protocol/header/controller/clean_broker_data_request_header.rs",
         "java": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/controller/admin/CleanControllerBrokerDataRequestHeader.java"
       }
+    },
+    {
+      "rustType": "UnregisterClientRequestHeader",
+      "canonical": "clientID",
+      "aliases": [
+        "clientId"
+      ],
+      "policy": "prefer_canonical",
+      "owner": "rocketmq-rust maintainers",
+      "reason": "Preserve the legacy Rust clientId spelling as decode-only input while Java clientID remains canonical",
+      "referenceSource": {
+        "rust": "rocketmq-protocol/src/protocol/header/unregister_client_request_header.rs",
+        "java": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/UnregisterClientRequestHeader.java"
+      }
     }
   ],
   "requiredDrift": [

--- a/scripts/request-header-codec/tests/test_migrate.py
+++ b/scripts/request-header-codec/tests/test_migrate.py
@@ -55,7 +55,7 @@ class MigrationGuardTests(unittest.TestCase):
         )
         self.assertEqual(migrate.serialize(expected), migrate.serialize(self.manifest))
         self.assertEqual(len(self.headers), 152)
-        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 27)
+        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 31)
 
     def test_duplicate_simple_names_keep_distinct_stable_paths(self) -> None:
         graph, depths = migrate.flatten_graph(self.headers, self.repo_root)


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9072

### Brief Description

- migrate four consumer lifecycle RPC request headers from `RequestHeaderCodecV2` to `RequestHeaderCodecV3`
- encode Java-required fields and primitive boolean defaults in the generated V3 schemas
- preserve `clientId` as reviewed decode-only input while always encoding Java's canonical `clientID`
- retain always-present `RpcRequestHeader` inheritance and MapOnly dispatch
- refresh the governed inventory to 31 V3 and 121 V2 headers

Compatibility details:

- `GetConsumerRunningInfoRequestHeader` defaults a missing `jstackEnable` to `false`
- `DeleteSubscriptionGroupRequestHeader` defaults a missing `cleanOffset` to `false`
- `UnregisterClientRequestHeader` prefers `clientID` when canonical and legacy keys are both present
- no `mod.rs` file or manual `java_type` metadata is introduced

### How Did You Test This Change?

- `python -m unittest discover -s scripts/request-header-codec/tests -p 'test_*.py'`
- `python scripts/request-header-codec/migrate.py check`
- `python scripts/request-header-codec/compare_header_schema.py`
- `cargo fmt -p rocketmq-protocol -- --check`
- `cargo test --locked -p rocketmq-protocol --test request_header_codec_v3_registry`
- `cargo test --locked -p rocketmq-protocol --all-features`
- `cargo clippy --locked -p rocketmq-protocol --no-deps --all-targets --all-features -- -D warnings -A deprecated`
- `git diff --check`

The repository-wide formatter remains blocked on Windows by OS error 206. Strict workspace Clippy reaches the existing `rocketmq-model` CheetahString deprecations and useless conversion; the scoped no-dependency Clippy check above passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved request-header compatibility and validation across several RocketMQ operations.
  * Added support for required fields, default values, canonical header names, and legacy aliases.
  * Improved RPC header handling and interoperability with Java-based clients.

* **Bug Fixes**
  * Preserved compatibility with the legacy `clientId` header while prioritizing the canonical `clientID` format.

* **Tests**
  * Expanded coverage for defaults, required fields, aliases, encoding, and missing-header scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->