### PR TITLE
[ISSUE #9074]✨Migrate offset and consumer lookup RPC headers to V3

### DIFF
--- a/rocketmq-protocol/src/protocol/header/clone_group_offset_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/clone_group_offset_request_header.rs
@@ -13,26 +13,33 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::clone_group_offset_request_header::CloneGroupOffsetRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.CloneGroupOffsetRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct CloneGroupOffsetRequestHeader {
-    #[required]
+    #[header(required)]
     pub src_group: CheetahString,
 
-    #[required]
+    #[header(required)]
     pub dest_group: CheetahString,
 
     pub topic: Option<CheetahString>,
 
+    #[serde(default)]
+    #[header(default, default_semantic = "literal:false")]
     pub offline: bool,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub rpc_request_header: Option<RpcRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/get_consumer_listby_group_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/get_consumer_listby_group_request_header.rs
@@ -13,19 +13,24 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::get_consumer_listby_group_request_header::GetConsumerListByGroupRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.GetConsumerListByGroupRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct GetConsumerListByGroupRequestHeader {
-    #[required]
+    #[header(required)]
     pub consumer_group: CheetahString,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub rpc: Option<RpcRequestHeader>,
 }
 
@@ -45,19 +50,13 @@ mod tests {
         };
 
         let map: HashMap<CheetahString, CheetahString> = header.to_map().unwrap();
-        assert_eq!(
-            map.get(GetConsumerListByGroupRequestHeader::CONSUMER_GROUP),
-            Some(&"test_group".into())
-        );
+        assert_eq!(map.get("consumerGroup"), Some(&"test_group".into()));
     }
 
     #[test]
     fn get_consumer_list_by_group_request_header_from_map() {
         let mut map = HashMap::new();
-        map.insert(
-            GetConsumerListByGroupRequestHeader::CONSUMER_GROUP.into(),
-            "test_group".into(),
-        );
+        map.insert("consumerGroup".into(), "test_group".into());
 
         let header = <GetConsumerListByGroupRequestHeader as FromMap>::from(&map).unwrap();
         assert_eq!(header.consumer_group, "test_group");

--- a/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
@@ -19,11 +19,13 @@ use bytes::BytesMut;
 use cheetah_string::CheetahString;
 use rocketmq_macros::RequestHeaderCodecV3;
 use rocketmq_model::boundary_type::BoundaryType;
+use rocketmq_protocol::protocol::header::clone_group_offset_request_header::CloneGroupOffsetRequestHeader;
 use rocketmq_protocol::protocol::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader;
 use rocketmq_protocol::protocol::header::controller::clean_broker_data_request_header::CleanBrokerDataRequestHeader;
 use rocketmq_protocol::protocol::header::create_topic_list_request_header::CreateTopicListRequestHeader;
 use rocketmq_protocol::protocol::header::delete_subscription_group_request_header::DeleteSubscriptionGroupRequestHeader;
 use rocketmq_protocol::protocol::header::get_consumer_connection_list_request_header::GetConsumerConnectionListRequestHeader;
+use rocketmq_protocol::protocol::header::get_consumer_listby_group_request_header::GetConsumerListByGroupRequestHeader;
 use rocketmq_protocol::protocol::header::get_consumer_running_info_request_header::GetConsumerRunningInfoRequestHeader;
 use rocketmq_protocol::protocol::header::get_consumer_status_request_header::GetConsumerStatusRequestHeader;
 use rocketmq_protocol::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader;
@@ -189,6 +191,7 @@ fn registry() -> Vec<RegisteredSchema> {
         register::<RpcRequestHeader>(),
         register::<TopicRequestHeader>(),
         register::<NamesrvTopicRequestHeader>(),
+        register::<CloneGroupOffsetRequestHeader>(),
         register::<ConsumeMessageDirectlyResultRequestHeader>(),
         register::<CleanBrokerDataRequestHeader>(),
         register::<CreateTopicListRequestHeader>(),
@@ -196,6 +199,10 @@ fn registry() -> Vec<RegisteredSchema> {
         register_value(&GetConsumerConnectionListRequestHeader {
             consumer_group: CheetahString::from_static_str("registry"),
             rpc_request_header: None,
+        }),
+        register_value(&GetConsumerListByGroupRequestHeader {
+            consumer_group: CheetahString::from_static_str("registry"),
+            rpc: None,
         }),
         register::<GetConsumerRunningInfoRequestHeader>(),
         register::<GetConsumerStatusRequestHeader>(),
@@ -524,6 +531,11 @@ fn assert_rpc_envelope_contract<T>(
 
 #[test]
 fn rpc_envelope_headers_preserve_java_inheritance_and_legacy_aliases() {
+    assert_rpc_envelope_contract::<CloneGroupOffsetRequestHeader>(
+        &[("srcGroup", "src"), ("destGroup", "dest"), ("topic", "topic-a")],
+        &["srcGroup", "destGroup"],
+        |header| &header.rpc_request_header,
+    );
     assert_rpc_envelope_contract::<CreateTopicListRequestHeader>(&[], &[], |header| &header.rpc_request_header);
     assert_rpc_envelope_contract::<DeleteSubscriptionGroupRequestHeader>(
         &[("groupName", "dg")],
@@ -534,6 +546,11 @@ fn rpc_envelope_headers_preserve_java_inheritance_and_legacy_aliases() {
         &[("consumerGroup", "cg")],
         &["consumerGroup"],
         |header| &header.rpc_request_header,
+    );
+    assert_rpc_envelope_contract::<GetConsumerListByGroupRequestHeader>(
+        &[("consumerGroup", "cg")],
+        &["consumerGroup"],
+        |header| &header.rpc,
     );
     assert_rpc_envelope_contract::<GetConsumerRunningInfoRequestHeader>(
         &[("consumerGroup", "cg"), ("clientId", "ci")],
@@ -588,6 +605,15 @@ fn rpc_envelope_headers_preserve_java_inheritance_and_legacy_aliases() {
     )]))
     .expect("missing Java primitive boolean uses false");
     assert!(!deleted.clean_offset);
+
+    let cloned = <CloneGroupOffsetRequestHeader as HeaderCodec>::decode_from_map(&HeaderMap::from([
+        ("srcGroup".into(), "src".into()),
+        ("destGroup".into(), "dest".into()),
+    ]))
+    .expect("optional topic and primitive offline may be absent");
+    assert!(cloned.topic.is_none());
+    assert!(!cloned.offline);
+    assert!(cloned.rpc_request_header.is_some());
 
     let unregister_input = HeaderMap::from([
         ("clientID".into(), "canonical-client".into()),

--- a/scripts/request-header-codec/migration.json
+++ b/scripts/request-header-codec/migration.json
@@ -8,10 +8,10 @@
     "entryCount": 152,
     "mappedCount": 143,
     "rustOnlyExtensionCount": 9,
-    "v2Count": 121,
-    "v3Count": 31,
-    "pendingCount": 121,
-    "migratedCount": 31
+    "v2Count": 119,
+    "v3Count": 33,
+    "pendingCount": 119,
+    "migratedCount": 33
   },
   "baseline": {
     "v2TypeIds": [
@@ -174,11 +174,13 @@
       }
     },
     "acceptedV3TypeIds": [
+      "rocketmq_protocol::protocol::header::clone_group_offset_request_header::CloneGroupOffsetRequestHeader",
       "rocketmq_protocol::protocol::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader",
       "rocketmq_protocol::protocol::header::controller::clean_broker_data_request_header::CleanBrokerDataRequestHeader",
       "rocketmq_protocol::protocol::header::create_topic_list_request_header::CreateTopicListRequestHeader",
       "rocketmq_protocol::protocol::header::delete_subscription_group_request_header::DeleteSubscriptionGroupRequestHeader",
       "rocketmq_protocol::protocol::header::get_consumer_connection_list_request_header::GetConsumerConnectionListRequestHeader",
+      "rocketmq_protocol::protocol::header::get_consumer_listby_group_request_header::GetConsumerListByGroupRequestHeader",
       "rocketmq_protocol::protocol::header::get_consumer_running_info_request_header::GetConsumerRunningInfoRequestHeader",
       "rocketmq_protocol::protocol::header::get_consumer_status_request_header::GetConsumerStatusRequestHeader",
       "rocketmq_protocol::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader",
@@ -622,16 +624,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 1,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -1424,16 +1426,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 1,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {

--- a/scripts/request-header-codec/tests/test_migrate.py
+++ b/scripts/request-header-codec/tests/test_migrate.py
@@ -55,7 +55,7 @@ class MigrationGuardTests(unittest.TestCase):
         )
         self.assertEqual(migrate.serialize(expected), migrate.serialize(self.manifest))
         self.assertEqual(len(self.headers), 152)
-        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 31)
+        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 33)
 
     def test_duplicate_simple_names_keep_distinct_stable_paths(self) -> None:
         graph, depths = migrate.flatten_graph(self.headers, self.repo_root)


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9074

### Brief Description

- migrate `CloneGroupOffsetRequestHeader` and `GetConsumerListByGroupRequestHeader` to `RequestHeaderCodecV3`
- enforce Java-required `srcGroup`, `destGroup`, and `consumerGroup` fields
- preserve optional `topic`, missing `offline=false`, always-present RPC inheritance, and MapOnly dispatch
- extend the shared registry contract and refresh the governed inventory to 33 V3 / 119 V2
- keep Rust field types as the Java semantic source without `java_type` metadata or new `mod.rs` files

### How Did You Test This Change?

- `python -m unittest discover -s scripts/request-header-codec/tests -p 'test_*.py'`
- `python scripts/request-header-codec/migrate.py check`
- `python scripts/request-header-codec/compare_header_schema.py`
- `cargo fmt -p rocketmq-protocol -- --check`
- `cargo test --locked -p rocketmq-protocol --test request_header_codec_v3_registry`
- `cargo test --locked -p rocketmq-protocol --all-features`
- `cargo clippy --locked -p rocketmq-protocol --no-deps --all-targets --all-features -- -D warnings -A deprecated`
- `git diff --check`

The repository-wide formatter remains blocked on Windows by OS error 206. Strict workspace Clippy reaches the existing `rocketmq-model` CheetahString deprecations and useless conversion; the scoped no-dependency Clippy check above passes.
