### PR TITLE
[ISSUE #9076]✨Migrate transaction RPC headers to V3

### DIFF
--- a/rocketmq-protocol/src/protocol/header/check_transaction_state_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/check_transaction_state_request_header.rs
@@ -13,24 +13,29 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Serialize, Deserialize, Debug, Default, RequestHeaderCodecV2)]
+#[derive(Serialize, Deserialize, Debug, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::check_transaction_state_request_header::CheckTransactionStateRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.CheckTransactionStateRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct CheckTransactionStateRequestHeader {
     pub topic: Option<CheetahString>,
-    #[required]
+    #[header(required)]
     pub tran_state_table_offset: i64,
-    #[required]
+    #[header(required)]
     pub commit_log_offset: i64,
     pub msg_id: Option<CheetahString>,
     pub transaction_id: Option<CheetahString>,
     pub offset_msg_id: Option<CheetahString>,
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub rpc_request_header: Option<RpcRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/end_transaction_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/end_transaction_request_header.rs
@@ -13,58 +13,81 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
-#[request_header(validate = "validate")]
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::end_transaction_request_header::EndTransactionRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.EndTransactionRequestHeader",
+    validate = "Self::validate"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct EndTransactionRequestHeader {
+    #[serde(default)]
+    #[header(default, default_semantic = "literal:")]
     pub topic: CheetahString,
 
-    #[required]
+    #[header(required)]
     pub producer_group: CheetahString,
 
     //ConsumeQueue Offset
-    #[required]
+    #[header(required)]
     pub tran_state_table_offset: i64,
 
     // Offset of the message in the CommitLog
-    #[required]
+    #[header(required)]
     pub commit_log_offset: i64,
 
     //TRANSACTION_COMMIT_TYPE,TRANSACTION_ROLLBACK_TYPE,TRANSACTION_NOT_TYPE
-    #[required]
+    #[header(required)]
     pub commit_or_rollback: i32,
 
     //Whether the check-back is initiated by the Broker
+    #[serde(default)]
+    #[header(default, default_semantic = "literal:false")]
     pub from_transaction_check: bool,
 
-    #[required]
+    #[header(required)]
     pub msg_id: CheetahString,
 
     pub transaction_id: Option<CheetahString>,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub rpc_request_header: RpcRequestHeader,
 }
 
 impl EndTransactionRequestHeader {
-    fn validate(&self) -> rocketmq_error::RocketMQResult<()> {
+    fn validate(&self) -> Result<(), crate::protocol::header_codec::HeaderCodecError> {
         use rocketmq_model::common::sys_flag::message_sys_flag::MessageSysFlag;
 
         match self.commit_or_rollback {
             MessageSysFlag::TRANSACTION_NOT_TYPE
             | MessageSysFlag::TRANSACTION_COMMIT_TYPE
             | MessageSysFlag::TRANSACTION_ROLLBACK_TYPE => Ok(()),
-            _ => Err(rocketmq_error::RocketMQError::request_header_error(
-                "EndTransactionRequestHeader.commitOrRollback: unsupported transaction state",
-            )),
+            _ => Err(crate::protocol::header_codec::HeaderCodecError::Validation {
+                header:
+                    "rocketmq_protocol::protocol::header::end_transaction_request_header::EndTransactionRequestHeader",
+                rule: "supported_transaction_state",
+            }),
         }
     }
+}
+
+#[cfg(test)]
+impl EndTransactionRequestHeader {
+    const TOPIC: &'static str = "topic";
+    const PRODUCER_GROUP: &'static str = "producerGroup";
+    const TRAN_STATE_TABLE_OFFSET: &'static str = "tranStateTableOffset";
+    const COMMIT_LOG_OFFSET: &'static str = "commitLogOffset";
+    const COMMIT_OR_ROLLBACK: &'static str = "commitOrRollback";
+    const FROM_TRANSACTION_CHECK: &'static str = "fromTransactionCheck";
+    const MSG_ID: &'static str = "msgId";
+    const TRANSACTION_ID: &'static str = "transactionId";
 }
 
 #[cfg(test)]

--- a/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
@@ -19,11 +19,14 @@ use bytes::BytesMut;
 use cheetah_string::CheetahString;
 use rocketmq_macros::RequestHeaderCodecV3;
 use rocketmq_model::boundary_type::BoundaryType;
+use rocketmq_model::common::sys_flag::message_sys_flag::MessageSysFlag;
+use rocketmq_protocol::protocol::header::check_transaction_state_request_header::CheckTransactionStateRequestHeader;
 use rocketmq_protocol::protocol::header::clone_group_offset_request_header::CloneGroupOffsetRequestHeader;
 use rocketmq_protocol::protocol::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader;
 use rocketmq_protocol::protocol::header::controller::clean_broker_data_request_header::CleanBrokerDataRequestHeader;
 use rocketmq_protocol::protocol::header::create_topic_list_request_header::CreateTopicListRequestHeader;
 use rocketmq_protocol::protocol::header::delete_subscription_group_request_header::DeleteSubscriptionGroupRequestHeader;
+use rocketmq_protocol::protocol::header::end_transaction_request_header::EndTransactionRequestHeader;
 use rocketmq_protocol::protocol::header::get_consumer_connection_list_request_header::GetConsumerConnectionListRequestHeader;
 use rocketmq_protocol::protocol::header::get_consumer_listby_group_request_header::GetConsumerListByGroupRequestHeader;
 use rocketmq_protocol::protocol::header::get_consumer_running_info_request_header::GetConsumerRunningInfoRequestHeader;
@@ -191,11 +194,31 @@ fn registry() -> Vec<RegisteredSchema> {
         register::<RpcRequestHeader>(),
         register::<TopicRequestHeader>(),
         register::<NamesrvTopicRequestHeader>(),
+        register_value(&CheckTransactionStateRequestHeader {
+            topic: None,
+            tran_state_table_offset: 0,
+            commit_log_offset: 0,
+            msg_id: None,
+            transaction_id: None,
+            offset_msg_id: None,
+            rpc_request_header: None,
+        }),
         register::<CloneGroupOffsetRequestHeader>(),
         register::<ConsumeMessageDirectlyResultRequestHeader>(),
         register::<CleanBrokerDataRequestHeader>(),
         register::<CreateTopicListRequestHeader>(),
         register::<DeleteSubscriptionGroupRequestHeader>(),
+        register_value(&EndTransactionRequestHeader {
+            topic: CheetahString::new(),
+            producer_group: CheetahString::from_static_str("registry"),
+            tran_state_table_offset: 0,
+            commit_log_offset: 0,
+            commit_or_rollback: MessageSysFlag::TRANSACTION_NOT_TYPE,
+            from_transaction_check: false,
+            msg_id: CheetahString::from_static_str("registry"),
+            transaction_id: None,
+            rpc_request_header: RpcRequestHeader::default(),
+        }),
         register_value(&GetConsumerConnectionListRequestHeader {
             consumer_group: CheetahString::from_static_str("registry"),
             rpc_request_header: None,
@@ -531,6 +554,11 @@ fn assert_rpc_envelope_contract<T>(
 
 #[test]
 fn rpc_envelope_headers_preserve_java_inheritance_and_legacy_aliases() {
+    assert_rpc_envelope_contract::<CheckTransactionStateRequestHeader>(
+        &[("tranStateTableOffset", "-1"), ("commitLogOffset", "-2")],
+        &["tranStateTableOffset", "commitLogOffset"],
+        |header| &header.rpc_request_header,
+    );
     assert_rpc_envelope_contract::<CloneGroupOffsetRequestHeader>(
         &[("srcGroup", "src"), ("destGroup", "dest"), ("topic", "topic-a")],
         &["srcGroup", "destGroup"],
@@ -592,6 +620,81 @@ fn rpc_envelope_headers_preserve_java_inheritance_and_legacy_aliases() {
         |header| &header.rpc_request_header,
     );
 
+    let end_input = HeaderMap::from([
+        ("producerGroup".into(), "pg".into()),
+        ("tranStateTableOffset".into(), "-1".into()),
+        ("commitLogOffset".into(), "-2".into()),
+        (
+            "commitOrRollback".into(),
+            MessageSysFlag::TRANSACTION_COMMIT_TYPE.to_string().into(),
+        ),
+        ("msgId".into(), "msg-a".into()),
+        ("ns".into(), "canonical-ns".into()),
+        ("namespace".into(), "legacy-ns".into()),
+        ("nsd".into(), "true".into()),
+        ("namespaced".into(), "false".into()),
+        ("bname".into(), "canonical-broker".into()),
+        ("brokerName".into(), "legacy-broker".into()),
+        ("oway".into(), "false".into()),
+        ("oneway".into(), "true".into()),
+    ]);
+    let end_typed = <EndTransactionRequestHeader as HeaderCodec>::decode_from_map(&end_input)
+        .expect("typed end transaction decode");
+    let end_legacy =
+        <EndTransactionRequestHeader as FromMap>::from(&end_input).expect("legacy end transaction adapter");
+    for decoded in [&end_typed, &end_legacy] {
+        assert_eq!(decoded.topic, "");
+        assert_eq!(decoded.producer_group, "pg");
+        assert_eq!(decoded.tran_state_table_offset, -1);
+        assert_eq!(decoded.commit_log_offset, -2);
+        assert!(!decoded.from_transaction_check);
+        assert!(decoded.transaction_id.is_none());
+        assert_eq!(decoded.rpc_request_header.namespace.as_deref(), Some("canonical-ns"));
+        assert_eq!(decoded.rpc_request_header.namespaced, Some(true));
+        assert_eq!(
+            decoded.rpc_request_header.broker_name.as_deref(),
+            Some("canonical-broker")
+        );
+        assert_eq!(decoded.rpc_request_header.oneway, Some(false));
+    }
+    let end_encoded = end_typed.to_map().expect("end transaction encode");
+    assert_eq!(end_encoded.get("topic").map(CheetahString::as_str), Some(""));
+    assert_eq!(
+        end_encoded.get("fromTransactionCheck").map(CheetahString::as_str),
+        Some("false")
+    );
+    for alias in ["namespace", "namespaced", "brokerName", "oneway"] {
+        assert!(!end_encoded.contains_key(alias));
+    }
+    assert_eq!(end_typed.encode_capability(), HeaderEncodeCapability::MapOnly);
+
+    for required in [
+        "producerGroup",
+        "tranStateTableOffset",
+        "commitLogOffset",
+        "commitOrRollback",
+        "msgId",
+    ] {
+        let mut missing = end_input.clone();
+        missing.remove(required);
+        assert!(matches!(
+            <EndTransactionRequestHeader as HeaderCodec>::decode_from_map(&missing),
+            Err(HeaderCodecError::Missing { key, .. }) if key == required
+        ));
+        assert!(<EndTransactionRequestHeader as FromMap>::from(&missing).is_err());
+    }
+
+    let mut unsupported_state = end_input;
+    unsupported_state.insert("commitOrRollback".into(), "999".into());
+    assert!(matches!(
+        <EndTransactionRequestHeader as HeaderCodec>::decode_from_map(&unsupported_state),
+        Err(HeaderCodecError::Validation {
+            rule: "supported_transaction_state",
+            ..
+        })
+    ));
+    assert!(<EndTransactionRequestHeader as FromMap>::from(&unsupported_state).is_err());
+
     let running = <GetConsumerRunningInfoRequestHeader as HeaderCodec>::decode_from_map(&HeaderMap::from([
         ("consumerGroup".into(), "cg".into()),
         ("clientId".into(), "ci".into()),
@@ -614,6 +717,19 @@ fn rpc_envelope_headers_preserve_java_inheritance_and_legacy_aliases() {
     assert!(cloned.topic.is_none());
     assert!(!cloned.offline);
     assert!(cloned.rpc_request_header.is_some());
+
+    let checked = <CheckTransactionStateRequestHeader as HeaderCodec>::decode_from_map(&HeaderMap::from([
+        ("tranStateTableOffset".into(), i64::MIN.to_string().into()),
+        ("commitLogOffset".into(), i64::MAX.to_string().into()),
+    ]))
+    .expect("Java signed long extrema remain valid");
+    assert_eq!(checked.tran_state_table_offset, i64::MIN);
+    assert_eq!(checked.commit_log_offset, i64::MAX);
+    assert!(checked.topic.is_none());
+    assert!(checked.msg_id.is_none());
+    assert!(checked.transaction_id.is_none());
+    assert!(checked.offset_msg_id.is_none());
+    assert!(checked.rpc_request_header.is_some());
 
     let unregister_input = HeaderMap::from([
         ("clientID".into(), "canonical-client".into()),

--- a/scripts/request-header-codec/migration.json
+++ b/scripts/request-header-codec/migration.json
@@ -8,10 +8,10 @@
     "entryCount": 152,
     "mappedCount": 143,
     "rustOnlyExtensionCount": 9,
-    "v2Count": 119,
-    "v3Count": 33,
-    "pendingCount": 119,
-    "migratedCount": 33
+    "v2Count": 117,
+    "v3Count": 35,
+    "pendingCount": 117,
+    "migratedCount": 35
   },
   "baseline": {
     "v2TypeIds": [
@@ -174,11 +174,13 @@
       }
     },
     "acceptedV3TypeIds": [
+      "rocketmq_protocol::protocol::header::check_transaction_state_request_header::CheckTransactionStateRequestHeader",
       "rocketmq_protocol::protocol::header::clone_group_offset_request_header::CloneGroupOffsetRequestHeader",
       "rocketmq_protocol::protocol::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader",
       "rocketmq_protocol::protocol::header::controller::clean_broker_data_request_header::CleanBrokerDataRequestHeader",
       "rocketmq_protocol::protocol::header::create_topic_list_request_header::CreateTopicListRequestHeader",
       "rocketmq_protocol::protocol::header::delete_subscription_group_request_header::DeleteSubscriptionGroupRequestHeader",
+      "rocketmq_protocol::protocol::header::end_transaction_request_header::EndTransactionRequestHeader",
       "rocketmq_protocol::protocol::header::get_consumer_connection_list_request_header::GetConsumerConnectionListRequestHeader",
       "rocketmq_protocol::protocol::header::get_consumer_listby_group_request_header::GetConsumerListByGroupRequestHeader",
       "rocketmq_protocol::protocol::header::get_consumer_running_info_request_header::GetConsumerRunningInfoRequestHeader",
@@ -555,16 +557,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 1,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -1130,16 +1132,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 1,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {

--- a/scripts/request-header-codec/schema-overrides.json
+++ b/scripts/request-header-codec/schema-overrides.json
@@ -77,6 +77,17 @@
         "rust": "rocketmq-protocol/src/protocol/header/query_consume_queue_request_header.rs",
         "java": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/QueryConsumeQueueRequestHeader.java"
       }
+    },
+    {
+      "rustType": "EndTransactionRequestHeader",
+      "field": "topic",
+      "semantic": "literal:",
+      "owner": "rocketmq-rust protocol maintainers",
+      "reason": "Preserves the public non-optional Rust field while accepting a Java frame that omits the nullable topic",
+      "referenceSource": {
+        "rust": "rocketmq-protocol/src/protocol/header/end_transaction_request_header.rs",
+        "java": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/EndTransactionRequestHeader.java"
+      }
     }
   ],
   "nameMappings": [

--- a/scripts/request-header-codec/tests/test_migrate.py
+++ b/scripts/request-header-codec/tests/test_migrate.py
@@ -55,7 +55,7 @@ class MigrationGuardTests(unittest.TestCase):
         )
         self.assertEqual(migrate.serialize(expected), migrate.serialize(self.manifest))
         self.assertEqual(len(self.headers), 152)
-        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 33)
+        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 35)
 
     def test_duplicate_simple_names_keep_distinct_stable_paths(self) -> None:
         graph, depths = migrate.flatten_graph(self.headers, self.repo_root)


### PR DESCRIPTION
## Summary

- migrate `CheckTransactionStateRequestHeader` and `EndTransactionRequestHeader` from V2 to V3
- preserve Java required fields, nullable/default behavior, signed `Long` bounds, transaction-state validation, and `RpcRequestHeader` inheritance
- extend the typed registry and refresh the governed inventory to 35 V3 / 117 V2
- infer Java-compatible value kinds from Rust fields without populating `java_type`

Closes #9076

## Compatibility

- both headers remain `MapOnly`
- signed transaction offsets accept the full Rust `i64` range matching Java `Long`
- a missing end-transaction topic decodes to the existing Rust empty-string representation
- a missing `fromTransactionCheck` decodes to `false`
- RPC legacy aliases remain decode-only and canonical keys win conflicts
- no `mod.rs` file is added

## Verification

- `python scripts/request-header-codec/migrate.py check`
- `python scripts/request-header-codec/compare_header_schema.py`
- `python -m unittest discover -s scripts/request-header-codec/tests -p 'test_*.py'`
- `cargo fmt -p rocketmq-protocol -- --check`
- `cargo test --locked -p rocketmq-protocol --test request_header_codec_v3_registry`
- `cargo test --locked -p rocketmq-protocol end_transaction_request_header`
- `cargo test --locked -p rocketmq-protocol check_transaction_state_request_header`
- `cargo test --locked -p rocketmq-protocol --all-features`
- `cargo clippy --locked -p rocketmq-protocol --all-targets --all-features --no-deps -- -A deprecated -D warnings`
- `git diff --check`

## Repository baselines

- `cargo fmt --all -- --check` stops on Windows with OS error 206 because the generated command line exceeds the platform path-length limit.
- strict workspace Clippy stops in `rocketmq-model` on existing CheetahString deprecations and one useless conversion; the scoped protocol Clippy command above passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction request header encoding and decoding compatibility.
  * Added required-field validation for transaction offsets and supported transaction states.
  * Preserved default behavior for missing transaction topics.

* **Tests**
  * Added coverage for typed and legacy transaction header formats.
  * Added RPC envelope tests and signed 64-bit offset boundary checks.

* **Refactor**
  * Migrated transaction request headers to the latest header codec format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->