### PR TITLE
[ISSUE #9078]✨Migrate consumer send-back request header to V3

### DIFF
--- a/rocketmq-protocol/src/protocol/header/consumer_send_msg_back_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/consumer_send_msg_back_request_header.rs
@@ -13,26 +13,33 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::consumer_send_msg_back_request_header::ConsumerSendMsgBackRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.ConsumerSendMsgBackRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct ConsumerSendMsgBackRequestHeader {
-    #[required]
+    #[header(required)]
     pub offset: i64,
-    #[required]
+    #[header(required)]
     pub group: CheetahString, //consumer group
-    #[required]
+    #[header(required)]
     pub delay_level: i32,
     pub origin_msg_id: Option<CheetahString>,
     pub origin_topic: Option<CheetahString>,
+    #[serde(default)]
+    #[header(default, default_semantic = "literal:false")]
     pub unit_mode: bool,
     pub max_reconsume_times: Option<i32>,
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub rpc_request_header: Option<RpcRequestHeader>,
 }
 

--- a/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
@@ -23,6 +23,7 @@ use rocketmq_model::common::sys_flag::message_sys_flag::MessageSysFlag;
 use rocketmq_protocol::protocol::header::check_transaction_state_request_header::CheckTransactionStateRequestHeader;
 use rocketmq_protocol::protocol::header::clone_group_offset_request_header::CloneGroupOffsetRequestHeader;
 use rocketmq_protocol::protocol::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader;
+use rocketmq_protocol::protocol::header::consumer_send_msg_back_request_header::ConsumerSendMsgBackRequestHeader;
 use rocketmq_protocol::protocol::header::controller::clean_broker_data_request_header::CleanBrokerDataRequestHeader;
 use rocketmq_protocol::protocol::header::create_topic_list_request_header::CreateTopicListRequestHeader;
 use rocketmq_protocol::protocol::header::delete_subscription_group_request_header::DeleteSubscriptionGroupRequestHeader;
@@ -205,6 +206,16 @@ fn registry() -> Vec<RegisteredSchema> {
         }),
         register::<CloneGroupOffsetRequestHeader>(),
         register::<ConsumeMessageDirectlyResultRequestHeader>(),
+        register_value(&ConsumerSendMsgBackRequestHeader {
+            offset: 0,
+            group: CheetahString::from_static_str("registry"),
+            delay_level: 0,
+            origin_msg_id: None,
+            origin_topic: None,
+            unit_mode: false,
+            max_reconsume_times: None,
+            rpc_request_header: None,
+        }),
         register::<CleanBrokerDataRequestHeader>(),
         register::<CreateTopicListRequestHeader>(),
         register::<DeleteSubscriptionGroupRequestHeader>(),
@@ -564,6 +575,18 @@ fn rpc_envelope_headers_preserve_java_inheritance_and_legacy_aliases() {
         &["srcGroup", "destGroup"],
         |header| &header.rpc_request_header,
     );
+    assert_rpc_envelope_contract::<ConsumerSendMsgBackRequestHeader>(
+        &[
+            ("offset", "9223372036854775807"),
+            ("group", "cg"),
+            ("delayLevel", "2147483647"),
+            ("originMsgId", "msg-a"),
+            ("originTopic", "topic-a"),
+            ("maxReconsumeTimes", "2147483647"),
+        ],
+        &["offset", "group", "delayLevel"],
+        |header| &header.rpc_request_header,
+    );
     assert_rpc_envelope_contract::<CreateTopicListRequestHeader>(&[], &[], |header| &header.rpc_request_header);
     assert_rpc_envelope_contract::<DeleteSubscriptionGroupRequestHeader>(
         &[("groupName", "dg")],
@@ -730,6 +753,30 @@ fn rpc_envelope_headers_preserve_java_inheritance_and_legacy_aliases() {
     assert!(checked.transaction_id.is_none());
     assert!(checked.offset_msg_id.is_none());
     assert!(checked.rpc_request_header.is_some());
+
+    let send_back = <ConsumerSendMsgBackRequestHeader as HeaderCodec>::decode_from_map(&HeaderMap::from([
+        ("offset".into(), i64::MIN.to_string().into()),
+        ("group".into(), "cg".into()),
+        ("delayLevel".into(), i32::MIN.to_string().into()),
+        ("maxReconsumeTimes".into(), i32::MIN.to_string().into()),
+    ]))
+    .expect("Java signed minima and missing unitMode remain valid");
+    assert_eq!(send_back.offset, i64::MIN);
+    assert_eq!(send_back.delay_level, i32::MIN);
+    assert_eq!(send_back.max_reconsume_times, Some(i32::MIN));
+    assert!(send_back.origin_msg_id.is_none());
+    assert!(send_back.origin_topic.is_none());
+    assert!(!send_back.unit_mode);
+    assert!(send_back.rpc_request_header.is_some());
+
+    let invalid_unit_mode = HeaderMap::from([
+        ("offset".into(), "0".into()),
+        ("group".into(), "cg".into()),
+        ("delayLevel".into(), "0".into()),
+        ("unitMode".into(), "invalid".into()),
+    ]);
+    assert!(<ConsumerSendMsgBackRequestHeader as HeaderCodec>::decode_from_map(&invalid_unit_mode).is_err());
+    assert!(<ConsumerSendMsgBackRequestHeader as FromMap>::from(&invalid_unit_mode).is_err());
 
     let unregister_input = HeaderMap::from([
         ("clientID".into(), "canonical-client".into()),

--- a/scripts/request-header-codec/migration.json
+++ b/scripts/request-header-codec/migration.json
@@ -8,10 +8,10 @@
     "entryCount": 152,
     "mappedCount": 143,
     "rustOnlyExtensionCount": 9,
-    "v2Count": 117,
-    "v3Count": 35,
-    "pendingCount": 117,
-    "migratedCount": 35
+    "v2Count": 116,
+    "v3Count": 36,
+    "pendingCount": 116,
+    "migratedCount": 36
   },
   "baseline": {
     "v2TypeIds": [
@@ -177,6 +177,7 @@
       "rocketmq_protocol::protocol::header::check_transaction_state_request_header::CheckTransactionStateRequestHeader",
       "rocketmq_protocol::protocol::header::clone_group_offset_request_header::CloneGroupOffsetRequestHeader",
       "rocketmq_protocol::protocol::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader",
+      "rocketmq_protocol::protocol::header::consumer_send_msg_back_request_header::ConsumerSendMsgBackRequestHeader",
       "rocketmq_protocol::protocol::header::controller::clean_broker_data_request_header::CleanBrokerDataRequestHeader",
       "rocketmq_protocol::protocol::header::create_topic_list_request_header::CreateTopicListRequestHeader",
       "rocketmq_protocol::protocol::header::delete_subscription_group_request_header::DeleteSubscriptionGroupRequestHeader",
@@ -672,16 +673,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 1,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier1",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {

--- a/scripts/request-header-codec/schema-overrides.json
+++ b/scripts/request-header-codec/schema-overrides.json
@@ -315,7 +315,7 @@
         "CONSUMER_SEND_MSG_BACK"
       ],
       "owner": "rocketmq-rust protocol maintainers",
-      "reason": "Preserve the public optional Rust API while V3 enforces Java strict presence",
+      "reason": "Preserve the public non-optional Rust boolean while accepting the Java primitive false default",
       "referenceSource": {
         "rust": "rocketmq-protocol/src/protocol/header/consumer_send_msg_back_request_header.rs",
         "java": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/ConsumerSendMsgBackRequestHeader.java"

--- a/scripts/request-header-codec/tests/test_migrate.py
+++ b/scripts/request-header-codec/tests/test_migrate.py
@@ -55,7 +55,7 @@ class MigrationGuardTests(unittest.TestCase):
         )
         self.assertEqual(migrate.serialize(expected), migrate.serialize(self.manifest))
         self.assertEqual(len(self.headers), 152)
-        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 35)
+        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 36)
 
     def test_duplicate_simple_names_keep_distinct_stable_paths(self) -> None:
         graph, depths = migrate.flatten_graph(self.headers, self.repo_root)


### PR DESCRIPTION
## Summary

- migrate `ConsumerSendMsgBackRequestHeader` from V2 to V3
- preserve Java required, optional, primitive-default, signed numeric, and `RpcRequestHeader` inheritance semantics
- cover Java signed maxima and minima, malformed booleans, canonical RPC encoding, and typed/legacy parity
- refresh the governed inventory to 36 V3 / 116 V2
- infer Java-compatible value kinds from Rust fields without populating `java_type`

Closes #9078

## Compatibility

- `offset` keeps the complete Java `Long` range through Rust `i64`
- `delayLevel` and `maxReconsumeTimes` keep the complete Java `Integer` range through Rust `i32`
- a missing `unitMode` decodes to `false`
- the RPC parent remains always present after decoding, while legacy aliases remain decode-only
- the header remains `MapOnly`
- message body size remains governed by Producer and Store configuration
- no `mod.rs` file is added

## Verification

- `python scripts/request-header-codec/migrate.py check`
- `python scripts/request-header-codec/compare_header_schema.py`
- `python -m unittest discover -s scripts/request-header-codec/tests -p 'test_*.py'`
- `cargo fmt -p rocketmq-protocol -- --check`
- `cargo test --locked -p rocketmq-protocol --test request_header_codec_v3_registry`
- `cargo test --locked -p rocketmq-protocol consumer_send_msg_back_request_header`
- `cargo test --locked -p rocketmq-protocol --all-features`
- `cargo clippy --locked -p rocketmq-protocol --all-targets --all-features --no-deps -- -A deprecated -D warnings`
- `git diff --check`

## Repository baselines

- `cargo fmt --all -- --check` stops on Windows with OS error 206 because the generated command line exceeds the platform path-length limit.
- strict workspace Clippy stops in `rocketmq-model` on existing CheetahString deprecations and one useless conversion; the scoped protocol Clippy command above passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when sending messages back, including required fields and numeric boundary values.
  * Applied consistent default handling for the unit mode setting.
  * Improved decoding of invalid unit mode values across supported request formats.

* **Compatibility**
  * Migrated this request header to the newer protocol handling, improving RPC envelope consistency and interoperability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->