### PR TITLE
[ISSUE #9080]✨Migrate remaining direct RPC header models to V3

### DIFF
--- a/rocketmq-protocol/src/protocol/header/check_rocksdb_cq_write_progress_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/check_rocksdb_cq_write_progress_request_header.rs
@@ -13,20 +13,27 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::check_rocksdb_cq_write_progress_request_header::CheckRocksdbCqWriteProgressRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.CheckRocksdbCqWriteProgressRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct CheckRocksdbCqWriteProgressRequestHeader {
-    #[required]
+    #[header(required)]
     pub topic: CheetahString,
 
+    #[serde(default)]
+    #[header(default, default_semantic = "literal:0")]
     pub check_store_time: i64,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub rpc: Option<RpcRequestHeader>,
 }

--- a/rocketmq-protocol/src/protocol/header/get_lite_group_info_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/get_lite_group_info_request_header.rs
@@ -13,23 +13,32 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::get_lite_group_info_request_header::GetLiteGroupInfoRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.GetLiteGroupInfoRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct GetLiteGroupInfoRequestHeader {
-    #[required]
+    #[header(required)]
     pub group: CheetahString,
 
+    #[serde(default)]
+    #[header(default, default_semantic = "literal:")]
     pub lite_topic: CheetahString,
 
+    #[serde(default)]
+    #[header(default, default_semantic = "literal:0")]
     pub top_k: i32,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub rpc: Option<RpcRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/get_parent_topic_info_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/get_parent_topic_info_request_header.rs
@@ -13,18 +13,23 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::get_parent_topic_info_request_header::GetParentTopicInfoRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.GetParentTopicInfoRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct GetParentTopicInfoRequestHeader {
-    #[required]
+    #[header(required)]
     pub topic: CheetahString,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub rpc: Option<RpcRequestHeader>,
 }

--- a/rocketmq-protocol/src/protocol/header/pop_lite_message_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/pop_lite_message_request_header.rs
@@ -15,32 +15,37 @@
 use std::fmt::Display;
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::pop_lite_message_request_header::PopLiteMessageRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.PopLiteMessageRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct PopLiteMessageRequestHeader {
-    #[required]
+    #[header(required)]
     pub client_id: CheetahString,
-    #[required]
+    #[header(required)]
     pub consumer_group: CheetahString,
-    #[required]
+    #[header(required)]
     pub topic: CheetahString,
-    #[required]
+    #[header(required)]
     pub max_msg_num: i32,
-    #[required]
+    #[header(required)]
     pub invisible_time: i64,
-    #[required]
+    #[header(required)]
     pub poll_time: i64,
-    #[required]
+    #[header(required)]
     pub born_time: i64,
     pub attempt_id: Option<CheetahString>,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub rpc: Option<RpcRequestHeader>,
 }
 

--- a/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
@@ -20,6 +20,7 @@ use cheetah_string::CheetahString;
 use rocketmq_macros::RequestHeaderCodecV3;
 use rocketmq_model::boundary_type::BoundaryType;
 use rocketmq_model::common::sys_flag::message_sys_flag::MessageSysFlag;
+use rocketmq_protocol::protocol::header::check_rocksdb_cq_write_progress_request_header::CheckRocksdbCqWriteProgressRequestHeader;
 use rocketmq_protocol::protocol::header::check_transaction_state_request_header::CheckTransactionStateRequestHeader;
 use rocketmq_protocol::protocol::header::clone_group_offset_request_header::CloneGroupOffsetRequestHeader;
 use rocketmq_protocol::protocol::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader;
@@ -33,6 +34,8 @@ use rocketmq_protocol::protocol::header::get_consumer_listby_group_request_heade
 use rocketmq_protocol::protocol::header::get_consumer_running_info_request_header::GetConsumerRunningInfoRequestHeader;
 use rocketmq_protocol::protocol::header::get_consumer_status_request_header::GetConsumerStatusRequestHeader;
 use rocketmq_protocol::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader;
+use rocketmq_protocol::protocol::header::get_lite_group_info_request_header::GetLiteGroupInfoRequestHeader;
+use rocketmq_protocol::protocol::header::get_parent_topic_info_request_header::GetParentTopicInfoRequestHeader;
 use rocketmq_protocol::protocol::header::get_producer_connection_list_request_header::GetProducerConnectionListRequestHeader;
 use rocketmq_protocol::protocol::header::get_subscription_group_config_request_header::GetSubscriptionGroupConfigRequestHeader;
 use rocketmq_protocol::protocol::header::heartbeat_request_header::HeartbeatRequestHeader;
@@ -46,6 +49,7 @@ use rocketmq_protocol::protocol::header::namesrv::topic_operation_header::TopicR
 use rocketmq_protocol::protocol::header::notification_request_header::NotificationRequestHeader;
 use rocketmq_protocol::protocol::header::notify_consumer_ids_changed_request_header::NotifyConsumerIdsChangedRequestHeader;
 use rocketmq_protocol::protocol::header::notify_unsubscribe_lite_request_header::NotifyUnsubscribeLiteRequestHeader;
+use rocketmq_protocol::protocol::header::pop_lite_message_request_header::PopLiteMessageRequestHeader;
 use rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader;
 use rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader;
 use rocketmq_protocol::protocol::header::query_consume_queue_request_header::QueryConsumeQueueRequestHeader;
@@ -97,6 +101,19 @@ struct JavaField {
 struct SchemaOverrides {
     defaults: Vec<DefaultOverride>,
     alias_conflict_policies: Vec<AliasOverride>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ExtensionAllowlist {
+    extensions: Vec<ExtensionOverride>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ExtensionOverride {
+    rust_type_id: String,
+    fields: Vec<String>,
 }
 
 #[derive(Deserialize)]
@@ -204,6 +221,11 @@ fn registry() -> Vec<RegisteredSchema> {
             offset_msg_id: None,
             rpc_request_header: None,
         }),
+        register_value(&CheckRocksdbCqWriteProgressRequestHeader {
+            topic: CheetahString::from_static_str("registry"),
+            check_store_time: 0,
+            rpc: None,
+        }),
         register::<CloneGroupOffsetRequestHeader>(),
         register::<ConsumeMessageDirectlyResultRequestHeader>(),
         register_value(&ConsumerSendMsgBackRequestHeader {
@@ -241,6 +263,16 @@ fn registry() -> Vec<RegisteredSchema> {
         register::<GetConsumerRunningInfoRequestHeader>(),
         register::<GetConsumerStatusRequestHeader>(),
         register::<GetLiteClientInfoRequestHeader>(),
+        register_value(&GetLiteGroupInfoRequestHeader {
+            group: CheetahString::from_static_str("registry"),
+            lite_topic: CheetahString::new(),
+            top_k: 0,
+            rpc: None,
+        }),
+        register_value(&GetParentTopicInfoRequestHeader {
+            topic: CheetahString::from_static_str("registry"),
+            rpc: None,
+        }),
         register::<GetProducerConnectionListRequestHeader>(),
         register::<GetSubscriptionGroupConfigRequestHeader>(),
         register::<HeartbeatRequestHeader>(),
@@ -253,6 +285,17 @@ fn registry() -> Vec<RegisteredSchema> {
         register::<SearchOffsetResponseHeader>(),
         register::<PullMessageRequestHeader>(),
         register::<PullMessageResponseHeader>(),
+        register_value(&PopLiteMessageRequestHeader {
+            client_id: CheetahString::from_static_str("registry"),
+            consumer_group: CheetahString::from_static_str("registry"),
+            topic: CheetahString::from_static_str("registry"),
+            max_msg_num: 0,
+            invisible_time: 0,
+            poll_time: 0,
+            born_time: 0,
+            attempt_id: None,
+            rpc: None,
+        }),
         register::<SendMessageRequestHeaderV2>(),
         register::<SendMessageResponseHeader>(),
         register::<NotificationRequestHeader>(),
@@ -374,6 +417,10 @@ fn registered_typed_schemas_match_the_pinned_java_contract() {
     let overrides: SchemaOverrides =
         serde_json::from_str(include_str!("../../scripts/request-header-codec/schema-overrides.json"))
             .expect("schema overrides");
+    let extensions: ExtensionAllowlist = serde_json::from_str(include_str!(
+        "../../scripts/request-header-codec/extension-allowlist.json"
+    ))
+    .expect("extension allowlist");
     let registered = registry();
 
     let mut type_ids = HashSet::new();
@@ -403,19 +450,44 @@ fn registered_typed_schemas_match_the_pinned_java_contract() {
             "{} must preserve Java fast encoding through generated direct binary",
             schema.type_id
         );
+        let allowed_extension_fields = extensions
+            .extensions
+            .iter()
+            .find(|entry| entry.rust_type_id == schema.type_id)
+            .map(|entry| entry.fields.iter().map(String::as_str).collect::<HashSet<_>>())
+            .unwrap_or_default();
         assert_eq!(
             schema.fields.len(),
-            java_header.fields.len(),
+            java_header.fields.len() + allowed_extension_fields.len(),
             "{} field count",
             schema.type_id
         );
 
+        let mut seen_extension_fields = HashSet::new();
         for field in &schema.fields {
-            let java_field = java_header
-                .fields
-                .iter()
-                .find(|candidate| candidate.key == field.key)
-                .unwrap_or_else(|| panic!("missing Java field {}.{}", schema.type_id, field.key));
+            let owner = by_type_id
+                .get(field.declared_in)
+                .unwrap_or_else(|| panic!("unregistered field owner {}", field.declared_in));
+            let Some(java_field) = java_header.fields.iter().find(|candidate| candidate.key == field.key) else {
+                assert!(
+                    allowed_extension_fields.contains(field.key),
+                    "unreviewed Rust extension field {}.{}",
+                    schema.type_id,
+                    field.key
+                );
+                assert!(
+                    seen_extension_fields.insert(field.key),
+                    "duplicate Rust extension field {}.{}",
+                    schema.type_id,
+                    field.key
+                );
+                assert_ne!(
+                    owner.type_id, schema.type_id,
+                    "extension field {}.{} must come from a registered flattened owner",
+                    schema.type_id, field.key
+                );
+                continue;
+            };
             assert_eq!(rust_kind(field.kind), java_kind(&java_field.java_type));
             match field.kind {
                 HeaderValueKind::U32 => assert_eq!(field.java_range, Some(HeaderRange::I32)),
@@ -423,9 +495,6 @@ fn registered_typed_schemas_match_the_pinned_java_contract() {
                 _ => assert_eq!(field.java_range, None),
             }
 
-            let owner = by_type_id
-                .get(field.declared_in)
-                .unwrap_or_else(|| panic!("unregistered field owner {}", field.declared_in));
             assert_eq!(owner.java_class, java_field.declared_in);
 
             match field.presence {
@@ -448,6 +517,11 @@ fn registered_typed_schemas_match_the_pinned_java_contract() {
                 }
             }
         }
+        assert_eq!(
+            seen_extension_fields, allowed_extension_fields,
+            "{} reviewed extension fields must be present exactly once",
+            schema.type_id
+        );
 
         for flatten in &schema.flattens {
             assert!(
@@ -565,6 +639,11 @@ fn assert_rpc_envelope_contract<T>(
 
 #[test]
 fn rpc_envelope_headers_preserve_java_inheritance_and_legacy_aliases() {
+    assert_rpc_envelope_contract::<CheckRocksdbCqWriteProgressRequestHeader>(
+        &[("topic", "topic-a"), ("checkStoreTime", "9223372036854775807")],
+        &["topic"],
+        |header| &header.rpc,
+    );
     assert_rpc_envelope_contract::<CheckTransactionStateRequestHeader>(
         &[("tranStateTableOffset", "-1"), ("commitLogOffset", "-2")],
         &["tranStateTableOffset", "commitLogOffset"],
@@ -608,6 +687,14 @@ fn rpc_envelope_headers_preserve_java_inheritance_and_legacy_aliases() {
         &["consumerGroup", "clientId"],
         |header| &header.rpc_request_header,
     );
+    assert_rpc_envelope_contract::<GetLiteGroupInfoRequestHeader>(
+        &[("group", "lg"), ("liteTopic", "lite-a"), ("topK", "2147483647")],
+        &["group"],
+        |header| &header.rpc,
+    );
+    assert_rpc_envelope_contract::<GetParentTopicInfoRequestHeader>(&[("topic", "parent-a")], &["topic"], |header| {
+        &header.rpc
+    });
     assert_rpc_envelope_contract::<GetProducerConnectionListRequestHeader>(
         &[("producerGroup", "pg")],
         &["producerGroup"],
@@ -628,6 +715,28 @@ fn rpc_envelope_headers_preserve_java_inheritance_and_legacy_aliases() {
         &[("liteTopic", "lt"), ("consumerGroup", "ng"), ("clientId", "ci")],
         &["liteTopic", "consumerGroup", "clientId"],
         |header| &header.rpc_request_header,
+    );
+    assert_rpc_envelope_contract::<PopLiteMessageRequestHeader>(
+        &[
+            ("clientId", "client-a"),
+            ("consumerGroup", "cg"),
+            ("topic", "topic-a"),
+            ("maxMsgNum", "2147483647"),
+            ("invisibleTime", "9223372036854775807"),
+            ("pollTime", "9223372036854775807"),
+            ("bornTime", "9223372036854775807"),
+            ("attemptId", "attempt-a"),
+        ],
+        &[
+            "clientId",
+            "consumerGroup",
+            "topic",
+            "maxMsgNum",
+            "invisibleTime",
+            "pollTime",
+            "bornTime",
+        ],
+        |header| &header.rpc,
     );
     assert_rpc_envelope_contract::<QueryTopicsByConsumerRequestHeader>(&[("group", "qg")], &["group"], |header| {
         &header.rpc_request_header
@@ -753,6 +862,40 @@ fn rpc_envelope_headers_preserve_java_inheritance_and_legacy_aliases() {
     assert!(checked.transaction_id.is_none());
     assert!(checked.offset_msg_id.is_none());
     assert!(checked.rpc_request_header.is_some());
+
+    let rocksdb = <CheckRocksdbCqWriteProgressRequestHeader as HeaderCodec>::decode_from_map(&HeaderMap::from([(
+        "topic".into(),
+        "topic-a".into(),
+    )]))
+    .expect("missing Java primitive checkStoreTime uses zero");
+    assert_eq!(rocksdb.check_store_time, 0);
+    assert!(rocksdb.rpc.is_some());
+
+    let lite_group = <GetLiteGroupInfoRequestHeader as HeaderCodec>::decode_from_map(&HeaderMap::from([(
+        "group".into(),
+        "lg".into(),
+    )]))
+    .expect("missing nullable liteTopic and primitive topK use reviewed defaults");
+    assert_eq!(lite_group.lite_topic, "");
+    assert_eq!(lite_group.top_k, 0);
+    assert!(lite_group.rpc.is_some());
+
+    let pop_lite = <PopLiteMessageRequestHeader as HeaderCodec>::decode_from_map(&HeaderMap::from([
+        ("clientId".into(), "client-a".into()),
+        ("consumerGroup".into(), "cg".into()),
+        ("topic".into(), "topic-a".into()),
+        ("maxMsgNum".into(), i32::MIN.to_string().into()),
+        ("invisibleTime".into(), i64::MIN.to_string().into()),
+        ("pollTime".into(), i64::MIN.to_string().into()),
+        ("bornTime".into(), i64::MIN.to_string().into()),
+    ]))
+    .expect("Java signed minima and optional attemptId remain valid");
+    assert_eq!(pop_lite.max_msg_num, i32::MIN);
+    assert_eq!(pop_lite.invisible_time, i64::MIN);
+    assert_eq!(pop_lite.poll_time, i64::MIN);
+    assert_eq!(pop_lite.born_time, i64::MIN);
+    assert!(pop_lite.attempt_id.is_none());
+    assert!(pop_lite.rpc.is_some());
 
     let send_back = <ConsumerSendMsgBackRequestHeader as HeaderCodec>::decode_from_map(&HeaderMap::from([
         ("offset".into(), i64::MIN.to_string().into()),

--- a/scripts/request-header-codec/migration.json
+++ b/scripts/request-header-codec/migration.json
@@ -8,10 +8,10 @@
     "entryCount": 152,
     "mappedCount": 143,
     "rustOnlyExtensionCount": 9,
-    "v2Count": 116,
-    "v3Count": 36,
-    "pendingCount": 116,
-    "migratedCount": 36
+    "v2Count": 112,
+    "v3Count": 40,
+    "pendingCount": 112,
+    "migratedCount": 40
   },
   "baseline": {
     "v2TypeIds": [
@@ -174,6 +174,7 @@
       }
     },
     "acceptedV3TypeIds": [
+      "rocketmq_protocol::protocol::header::check_rocksdb_cq_write_progress_request_header::CheckRocksdbCqWriteProgressRequestHeader",
       "rocketmq_protocol::protocol::header::check_transaction_state_request_header::CheckTransactionStateRequestHeader",
       "rocketmq_protocol::protocol::header::clone_group_offset_request_header::CloneGroupOffsetRequestHeader",
       "rocketmq_protocol::protocol::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader",
@@ -187,6 +188,8 @@
       "rocketmq_protocol::protocol::header::get_consumer_running_info_request_header::GetConsumerRunningInfoRequestHeader",
       "rocketmq_protocol::protocol::header::get_consumer_status_request_header::GetConsumerStatusRequestHeader",
       "rocketmq_protocol::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader",
+      "rocketmq_protocol::protocol::header::get_lite_group_info_request_header::GetLiteGroupInfoRequestHeader",
+      "rocketmq_protocol::protocol::header::get_parent_topic_info_request_header::GetParentTopicInfoRequestHeader",
       "rocketmq_protocol::protocol::header::get_producer_connection_list_request_header::GetProducerConnectionListRequestHeader",
       "rocketmq_protocol::protocol::header::get_subscription_group_config_request_header::GetSubscriptionGroupConfigRequestHeader",
       "rocketmq_protocol::protocol::header::heartbeat_request_header::HeartbeatRequestHeader",
@@ -200,6 +203,7 @@
       "rocketmq_protocol::protocol::header::notification_request_header::NotificationRequestHeader",
       "rocketmq_protocol::protocol::header::notify_consumer_ids_changed_request_header::NotifyConsumerIdsChangedRequestHeader",
       "rocketmq_protocol::protocol::header::notify_unsubscribe_lite_request_header::NotifyUnsubscribeLiteRequestHeader",
+      "rocketmq_protocol::protocol::header::pop_lite_message_request_header::PopLiteMessageRequestHeader",
       "rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader",
       "rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader",
       "rocketmq_protocol::protocol::header::query_consume_queue_request_header::QueryConsumeQueueRequestHeader",
@@ -535,16 +539,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 1,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -1576,16 +1580,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 1,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -1719,16 +1723,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 1,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -2714,16 +2718,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 1,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {

--- a/scripts/request-header-codec/schema-overrides.json
+++ b/scripts/request-header-codec/schema-overrides.json
@@ -88,6 +88,17 @@
         "rust": "rocketmq-protocol/src/protocol/header/end_transaction_request_header.rs",
         "java": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/EndTransactionRequestHeader.java"
       }
+    },
+    {
+      "rustType": "GetLiteGroupInfoRequestHeader",
+      "field": "liteTopic",
+      "semantic": "literal:",
+      "owner": "rocketmq-rust protocol maintainers",
+      "reason": "Preserves the public non-optional Rust field while accepting a Java frame that omits the nullable lite topic",
+      "referenceSource": {
+        "rust": "rocketmq-protocol/src/protocol/header/get_lite_group_info_request_header.rs",
+        "java": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetLiteGroupInfoRequestHeader.java"
+      }
     }
   ],
   "nameMappings": [

--- a/scripts/request-header-codec/tests/test_migrate.py
+++ b/scripts/request-header-codec/tests/test_migrate.py
@@ -55,7 +55,7 @@ class MigrationGuardTests(unittest.TestCase):
         )
         self.assertEqual(migrate.serialize(expected), migrate.serialize(self.manifest))
         self.assertEqual(len(self.headers), 152)
-        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 36)
+        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 40)
 
     def test_duplicate_simple_names_keep_distinct_stable_paths(self) -> None:
         graph, depths = migrate.flatten_graph(self.headers, self.repo_root)


### PR DESCRIPTION
## Summary

- migrate the four remaining Rust models that directly flatten `RpcRequestHeader` from V2 to V3
- distinguish the actual Java RPC inheritance on Pop Lite from the three governed Rust RPC extensions
- preserve Java required, nullable, primitive-default, optional, and signed numeric behavior
- make the typed registry consume `extension-allowlist.json` and reject missing, duplicate, stale, or non-flattened extension fields
- refresh the governed inventory to 40 V3 / 112 V2
- infer Java-compatible value kinds from Rust fields without populating `java_type`

Closes #9080

## Compatibility

- `checkStoreTime` and `topK` use Java primitive zero defaults
- missing nullable `liteTopic` maps to the reviewed empty-string Rust compatibility default
- Pop Lite keeps the complete Java signed `Integer` and `Long` ranges through Rust `i32` and `i64`
- all four Rust RPC parents remain always present after decoding, while legacy aliases remain decode-only
- the three reviewed extension sets stay governed by their existing allowlist entries
- all four headers remain `MapOnly`
- no `mod.rs` file is added

## Verification

- `python scripts/request-header-codec/migrate.py check`
- `python scripts/request-header-codec/compare_header_schema.py`
- `python -m unittest scripts.request-header-codec.tests.test_migrate`
- `cargo fmt -p rocketmq-protocol -- --check`
- focused Get Lite Group and Pop Lite tests
- `cargo test --locked -p rocketmq-protocol --test request_header_codec_v3_registry`
- `cargo test --locked -p rocketmq-protocol --all-features`
- `cargo clippy --locked -p rocketmq-protocol --all-targets --all-features --no-deps -- -A deprecated -D warnings`
- `git diff --check`

## Repository baselines

- `cargo fmt --all -- --check` stops on Windows with OS error 206 because the generated command line exceeds the platform path-length limit.
- strict workspace Clippy stops in `rocketmq-model` on six existing CheetahString deprecations and one useless conversion; the scoped protocol Clippy command above passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Compatibility**
  - Migrated four RocketMQ request headers to the V3 protocol format.
  - Added explicit header metadata, required-field validation, default values, and consistent RPC data handling.
  - Preserved compatibility when optional fields are omitted, including lite group information requests.

- **Tests**
  - Added validation for header registration, inheritance, defaults, optional fields, and protocol boundary values.
  - Expanded migration tracking and verification for the updated V3 headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->