### PR TITLE
[ISSUE #9082]✨Migrate offset query headers to V3

### DIFF
--- a/rocketmq-protocol/src/protocol/header/get_earliest_msg_storetime_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/get_earliest_msg_storetime_request_header.rs
@@ -13,23 +13,28 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::protocol::header::message_operation_header::TopicRequestHeaderTrait;
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::get_earliest_msg_storetime_request_header::GetEarliestMsgStoretimeRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.GetEarliestMsgStoretimeRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct GetEarliestMsgStoretimeRequestHeader {
-    #[required]
+    #[header(required)]
     pub topic: CheetahString,
 
-    #[required]
+    #[header(required)]
     pub queue_id: i32,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/get_max_offset_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/get_max_offset_request_header.rs
@@ -13,25 +13,36 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::protocol::header::message_operation_header::TopicRequestHeaderTrait;
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
-#[derive(Debug, Clone, Serialize, Deserialize, RequestHeaderCodecV2)]
+const fn default_committed() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::get_max_offset_request_header::GetMaxOffsetRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.GetMaxOffsetRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct GetMaxOffsetRequestHeader {
-    #[required]
+    #[header(required)]
     pub topic: CheetahString,
 
-    #[required]
+    #[header(required)]
     pub queue_id: i32,
 
+    #[serde(default = "default_committed")]
+    #[header(default_with = "default_committed", default_semantic = "literal:true")]
     pub committed: bool,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/get_min_offset_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/get_min_offset_request_header.rs
@@ -13,23 +13,28 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::protocol::header::message_operation_header::TopicRequestHeaderTrait;
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::get_min_offset_request_header::GetMinOffsetRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.GetMinOffsetRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct GetMinOffsetRequestHeader {
-    #[required]
+    #[header(required)]
     pub topic: CheetahString,
 
-    #[required]
+    #[header(required)]
     pub queue_id: i32,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
@@ -33,8 +33,11 @@ use rocketmq_protocol::protocol::header::get_consumer_connection_list_request_he
 use rocketmq_protocol::protocol::header::get_consumer_listby_group_request_header::GetConsumerListByGroupRequestHeader;
 use rocketmq_protocol::protocol::header::get_consumer_running_info_request_header::GetConsumerRunningInfoRequestHeader;
 use rocketmq_protocol::protocol::header::get_consumer_status_request_header::GetConsumerStatusRequestHeader;
+use rocketmq_protocol::protocol::header::get_earliest_msg_storetime_request_header::GetEarliestMsgStoretimeRequestHeader;
 use rocketmq_protocol::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader;
 use rocketmq_protocol::protocol::header::get_lite_group_info_request_header::GetLiteGroupInfoRequestHeader;
+use rocketmq_protocol::protocol::header::get_max_offset_request_header::GetMaxOffsetRequestHeader;
+use rocketmq_protocol::protocol::header::get_min_offset_request_header::GetMinOffsetRequestHeader;
 use rocketmq_protocol::protocol::header::get_parent_topic_info_request_header::GetParentTopicInfoRequestHeader;
 use rocketmq_protocol::protocol::header::get_producer_connection_list_request_header::GetProducerConnectionListRequestHeader;
 use rocketmq_protocol::protocol::header::get_subscription_group_config_request_header::GetSubscriptionGroupConfigRequestHeader;
@@ -262,6 +265,11 @@ fn registry() -> Vec<RegisteredSchema> {
         }),
         register::<GetConsumerRunningInfoRequestHeader>(),
         register::<GetConsumerStatusRequestHeader>(),
+        register_value(&GetEarliestMsgStoretimeRequestHeader {
+            topic: CheetahString::from_static_str("registry"),
+            queue_id: 0,
+            topic_request_header: None,
+        }),
         register::<GetLiteClientInfoRequestHeader>(),
         register_value(&GetLiteGroupInfoRequestHeader {
             group: CheetahString::from_static_str("registry"),
@@ -272,6 +280,17 @@ fn registry() -> Vec<RegisteredSchema> {
         register_value(&GetParentTopicInfoRequestHeader {
             topic: CheetahString::from_static_str("registry"),
             rpc: None,
+        }),
+        register_value(&GetMaxOffsetRequestHeader {
+            topic: CheetahString::from_static_str("registry"),
+            queue_id: 0,
+            committed: true,
+            topic_request_header: None,
+        }),
+        register_value(&GetMinOffsetRequestHeader {
+            topic: CheetahString::from_static_str("registry"),
+            queue_id: 0,
+            topic_request_header: None,
         }),
         register::<GetProducerConnectionListRequestHeader>(),
         register::<GetSubscriptionGroupConfigRequestHeader>(),
@@ -635,6 +654,125 @@ fn assert_rpc_envelope_contract<T>(
     assert_eq!(empty_rpc.broker_name, None);
     assert_eq!(empty_rpc.oneway, None);
     assert_eq!(empty.encode_capability(), HeaderEncodeCapability::MapOnly);
+}
+
+fn assert_topic_queue_envelope_contract<T>(
+    local_fields: &[(&'static str, &'static str)],
+    required_keys: &[&'static str],
+    topic: fn(&T) -> &Option<TopicRequestHeader>,
+) where
+    T: CommandCustomHeader + FromMap<Target = T> + HeaderCodec,
+    <T as FromMap>::Error: std::fmt::Debug,
+{
+    let mut input = HeaderMap::from([
+        ("lo".into(), "true".into()),
+        ("ns".into(), "canonical-ns".into()),
+        ("namespace".into(), "legacy-ns".into()),
+        ("nsd".into(), "true".into()),
+        ("namespaced".into(), "false".into()),
+        ("bname".into(), "canonical-broker".into()),
+        ("brokerName".into(), "legacy-broker".into()),
+        ("oway".into(), "false".into()),
+        ("oneway".into(), "true".into()),
+    ]);
+    for &(key, value) in local_fields {
+        input.insert(key.into(), value.into());
+    }
+
+    let typed = <T as HeaderCodec>::decode_from_map(&input).expect("typed TopicQueue envelope decode");
+    let legacy = <T as FromMap>::from(&input).expect("legacy TopicQueue envelope adapter");
+    for decoded in [&typed, &legacy] {
+        let topic = topic(decoded)
+            .as_ref()
+            .expect("Java Topic parent is always present after decode");
+        assert_eq!(topic.lo, Some(true));
+        let rpc = topic
+            .rpc_request_header
+            .as_ref()
+            .expect("Java RPC parent is always present after decode");
+        assert_eq!(rpc.namespace.as_deref(), Some("canonical-ns"));
+        assert_eq!(rpc.namespaced, Some(true));
+        assert_eq!(rpc.broker_name.as_deref(), Some("canonical-broker"));
+        assert_eq!(rpc.oneway, Some(false));
+    }
+
+    for encoded in [typed.to_map().unwrap(), legacy.to_map().unwrap()] {
+        for &(key, value) in local_fields {
+            assert_eq!(encoded.get(key).map(CheetahString::as_str), Some(value));
+        }
+        assert_eq!(encoded.get("lo").map(CheetahString::as_str), Some("true"));
+        assert_eq!(encoded.get("ns").map(CheetahString::as_str), Some("canonical-ns"));
+        assert_eq!(encoded.get("nsd").map(CheetahString::as_str), Some("true"));
+        assert_eq!(
+            encoded.get("bname").map(CheetahString::as_str),
+            Some("canonical-broker")
+        );
+        assert_eq!(encoded.get("oway").map(CheetahString::as_str), Some("false"));
+        for alias in ["namespace", "namespaced", "brokerName", "oneway"] {
+            assert!(
+                !encoded.contains_key(alias),
+                "legacy alias {alias} must remain decode-only"
+            );
+        }
+    }
+
+    let parent_only = HeaderMap::from_iter(local_fields.iter().map(|&(key, value)| (key.into(), value.into())));
+    for &key in required_keys {
+        let mut missing = parent_only.clone();
+        missing.remove(key);
+        assert!(matches!(
+            <T as HeaderCodec>::decode_from_map(&missing),
+            Err(HeaderCodecError::Missing { key: actual, .. }) if actual == key
+        ));
+        assert!(<T as FromMap>::from(&missing).is_err());
+    }
+
+    let empty = <T as HeaderCodec>::decode_from_map(&parent_only).expect("TopicQueue header without parent fields");
+    let empty_topic = topic(&empty)
+        .as_ref()
+        .expect("Java Topic parent exists even when inherited fields are absent");
+    assert!(empty_topic.lo.is_none());
+    assert!(empty_topic.rpc_request_header.is_some());
+    assert_eq!(empty.encode_capability(), HeaderEncodeCapability::MapOnly);
+}
+
+#[test]
+fn topic_queue_headers_preserve_nested_java_inheritance_and_defaults() {
+    assert_topic_queue_envelope_contract::<GetMaxOffsetRequestHeader>(
+        &[
+            ("topic", "topic-max"),
+            ("queueId", "2147483647"),
+            ("committed", "false"),
+        ],
+        &["topic", "queueId"],
+        |header| &header.topic_request_header,
+    );
+    assert_topic_queue_envelope_contract::<GetMinOffsetRequestHeader>(
+        &[("topic", "topic-min"), ("queueId", "-2147483648")],
+        &["topic", "queueId"],
+        |header| &header.topic_request_header,
+    );
+    assert_topic_queue_envelope_contract::<GetEarliestMsgStoretimeRequestHeader>(
+        &[("topic", "topic-earliest"), ("queueId", "0")],
+        &["topic", "queueId"],
+        |header| &header.topic_request_header,
+    );
+
+    let max_without_committed = HeaderMap::from([("topic".into(), "topic-max".into()), ("queueId".into(), "0".into())]);
+    let typed = <GetMaxOffsetRequestHeader as HeaderCodec>::decode_from_map(&max_without_committed)
+        .expect("missing committed uses the Java true default");
+    let legacy = <GetMaxOffsetRequestHeader as FromMap>::from(&max_without_committed)
+        .expect("legacy adapter uses the Java true default");
+    assert!(typed.committed);
+    assert!(legacy.committed);
+
+    let mut malformed = max_without_committed;
+    malformed.insert("committed".into(), "not-a-bool".into());
+    assert!(matches!(
+        <GetMaxOffsetRequestHeader as HeaderCodec>::decode_from_map(&malformed),
+        Err(HeaderCodecError::InvalidValue { key: "committed", .. })
+    ));
+    assert!(<GetMaxOffsetRequestHeader as FromMap>::from(&malformed).is_err());
 }
 
 #[test]

--- a/scripts/request-header-codec/migration.json
+++ b/scripts/request-header-codec/migration.json
@@ -8,10 +8,10 @@
     "entryCount": 152,
     "mappedCount": 143,
     "rustOnlyExtensionCount": 9,
-    "v2Count": 112,
-    "v3Count": 40,
-    "pendingCount": 112,
-    "migratedCount": 40
+    "v2Count": 109,
+    "v3Count": 43,
+    "pendingCount": 109,
+    "migratedCount": 43
   },
   "baseline": {
     "v2TypeIds": [
@@ -187,8 +187,11 @@
       "rocketmq_protocol::protocol::header::get_consumer_listby_group_request_header::GetConsumerListByGroupRequestHeader",
       "rocketmq_protocol::protocol::header::get_consumer_running_info_request_header::GetConsumerRunningInfoRequestHeader",
       "rocketmq_protocol::protocol::header::get_consumer_status_request_header::GetConsumerStatusRequestHeader",
+      "rocketmq_protocol::protocol::header::get_earliest_msg_storetime_request_header::GetEarliestMsgStoretimeRequestHeader",
       "rocketmq_protocol::protocol::header::get_lite_client_info_request_header::GetLiteClientInfoRequestHeader",
       "rocketmq_protocol::protocol::header::get_lite_group_info_request_header::GetLiteGroupInfoRequestHeader",
+      "rocketmq_protocol::protocol::header::get_max_offset_request_header::GetMaxOffsetRequestHeader",
+      "rocketmq_protocol::protocol::header::get_min_offset_request_header::GetMinOffsetRequestHeader",
       "rocketmq_protocol::protocol::header::get_parent_topic_info_request_header::GetParentTopicInfoRequestHeader",
       "rocketmq_protocol::protocol::header::get_producer_connection_list_request_header::GetProducerConnectionListRequestHeader",
       "rocketmq_protocol::protocol::header::get_subscription_group_config_request_header::GetSubscriptionGroupConfigRequestHeader",
@@ -1521,16 +1524,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 2,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -1622,16 +1625,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 2,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -1683,16 +1686,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 2,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {

--- a/scripts/request-header-codec/tests/test_migrate.py
+++ b/scripts/request-header-codec/tests/test_migrate.py
@@ -55,7 +55,7 @@ class MigrationGuardTests(unittest.TestCase):
         )
         self.assertEqual(migrate.serialize(expected), migrate.serialize(self.manifest))
         self.assertEqual(len(self.headers), 152)
-        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 40)
+        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 43)
 
     def test_duplicate_simple_names_keep_distinct_stable_paths(self) -> None:
         graph, depths = migrate.flatten_graph(self.headers, self.repo_root)


### PR DESCRIPTION
## Summary

- migrate `GetMaxOffsetRequestHeader`, `GetMinOffsetRequestHeader`, and `GetEarliestMsgStoretimeRequestHeader` from V2 to V3
- preserve the nested Java TopicQueue, Topic, and RPC inheritance chain with always-present Rust parents
- fix missing `GetMaxOffsetRequestHeader.committed` to use the Java `true` default
- cover required keys, signed extrema, strict booleans, canonical alias precedence, empty parents, and typed/legacy parity
- refresh the governed inventory to 43 V3 / 109 V2
- infer Java-compatible value kinds from Rust fields without populating `java_type`

Closes #9082

## Compatibility

- `topic` and `queueId` remain required for all three headers
- `queueId` keeps the complete Java signed `Integer` range through Rust `i32`
- missing `committed` decodes to `true`, while malformed boolean text is rejected
- nested `lo` and `ns/nsd/bname/oway` fields preserve canonical-only encoding and decode-only legacy aliases
- empty Topic and RPC parents remain present after decoding
- all three headers remain `MapOnly`
- message body size remains governed outside Header Codec by Producer, Transport, and Broker/Store limits
- no `mod.rs` file is added

## Verification

- `python scripts/request-header-codec/migrate.py check`
- `python scripts/request-header-codec/compare_header_schema.py`
- `python -m unittest scripts.request-header-codec.tests.test_migrate`
- `cargo fmt -p rocketmq-protocol -- --check`
- focused tests for all three offset query headers
- `cargo test --locked -p rocketmq-protocol --test request_header_codec_v3_registry`
- `cargo test --locked -p rocketmq-protocol --all-features`
- `cargo clippy --locked -p rocketmq-protocol --all-targets --all-features --no-deps -- -A deprecated -D warnings`
- `git diff --check`

## Repository baselines

- `cargo fmt --all -- --check` stops on Windows with OS error 206 because the generated command line exceeds the platform path-length limit.
- strict workspace Clippy stops in `rocketmq-model` on six existing CheetahString deprecations and one useless conversion; the scoped protocol Clippy command above passes.