### PR TITLE
[ISSUE #9084]✨Migrate topic metadata query headers to V3

### DIFF
--- a/rocketmq-protocol/src/protocol/header/get_topic_config_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/get_topic_config_request_header.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -21,13 +21,18 @@ use crate::protocol::header::message_operation_header::TopicRequestHeaderTrait;
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
-#[derive(Serialize, Deserialize, Debug, RequestHeaderCodecV2)]
+#[derive(Serialize, Deserialize, Debug, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::get_topic_config_request_header::GetTopicConfigRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.GetTopicConfigRequestHeader"
+)]
 pub struct GetTopicConfigRequestHeader {
-    #[required]
+    #[header(required)]
     #[serde(rename = "topic")]
     pub topic: CheetahString,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/get_topic_stats_info_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/get_topic_stats_info_request_header.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -21,13 +21,18 @@ use crate::protocol::header::message_operation_header::TopicRequestHeaderTrait;
 use crate::protocol::header::namesrv::topic_operation_header::TopicRequestHeader;
 use crate::rpc::rpc_request_header::RpcRequestHeader;
 
-#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::get_topic_stats_info_request_header::GetTopicStatsInfoRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.GetTopicStatsInfoRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct GetTopicStatsInfoRequestHeader {
-    #[required]
+    #[header(required)]
     pub topic: CheetahString,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/get_topic_stats_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/get_topic_stats_request_header.rs
@@ -13,19 +13,24 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
-#[derive(Serialize, Deserialize, Debug, RequestHeaderCodecV2)]
+#[derive(Serialize, Deserialize, Debug, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::get_topic_stats_request_header::GetTopicStatsRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.GetTopicStatsInfoRequestHeader"
+)]
 pub struct GetTopicStatsRequestHeader {
-    #[required]
+    #[header(required)]
     #[serde(rename = "topic")]
     pub topic: CheetahString,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
@@ -41,6 +41,9 @@ use rocketmq_protocol::protocol::header::get_min_offset_request_header::GetMinOf
 use rocketmq_protocol::protocol::header::get_parent_topic_info_request_header::GetParentTopicInfoRequestHeader;
 use rocketmq_protocol::protocol::header::get_producer_connection_list_request_header::GetProducerConnectionListRequestHeader;
 use rocketmq_protocol::protocol::header::get_subscription_group_config_request_header::GetSubscriptionGroupConfigRequestHeader;
+use rocketmq_protocol::protocol::header::get_topic_config_request_header::GetTopicConfigRequestHeader;
+use rocketmq_protocol::protocol::header::get_topic_stats_info_request_header::GetTopicStatsInfoRequestHeader;
+use rocketmq_protocol::protocol::header::get_topic_stats_request_header::GetTopicStatsRequestHeader;
 use rocketmq_protocol::protocol::header::heartbeat_request_header::HeartbeatRequestHeader;
 use rocketmq_protocol::protocol::header::lite_subscription_ctl_request_header::LiteSubscriptionCtlRequestHeader;
 use rocketmq_protocol::protocol::header::lock_batch_mq_request_header::LockBatchMqRequestHeader;
@@ -294,6 +297,18 @@ fn registry() -> Vec<RegisteredSchema> {
         }),
         register::<GetProducerConnectionListRequestHeader>(),
         register::<GetSubscriptionGroupConfigRequestHeader>(),
+        register_value(&GetTopicConfigRequestHeader {
+            topic: CheetahString::from_static_str("registry"),
+            topic_request_header: None,
+        }),
+        register_value(&GetTopicStatsInfoRequestHeader {
+            topic: CheetahString::from_static_str("registry"),
+            topic_request_header: None,
+        }),
+        register_value(&GetTopicStatsRequestHeader {
+            topic: CheetahString::from_static_str("registry"),
+            topic_request_header: None,
+        }),
         register::<HeartbeatRequestHeader>(),
         register::<LiteSubscriptionCtlRequestHeader>(),
         register::<LockBatchMqRequestHeader>(),
@@ -656,10 +671,15 @@ fn assert_rpc_envelope_contract<T>(
     assert_eq!(empty.encode_capability(), HeaderEncodeCapability::MapOnly);
 }
 
-fn assert_topic_queue_envelope_contract<T>(
+struct TopicEnvelopeRef<'a> {
+    lo: Option<bool>,
+    rpc: &'a Option<RpcRequestHeader>,
+}
+
+fn assert_topic_envelope_contract<T>(
     local_fields: &[(&'static str, &'static str)],
     required_keys: &[&'static str],
-    topic: fn(&T) -> &Option<TopicRequestHeader>,
+    topic: for<'a> fn(&'a T) -> Option<TopicEnvelopeRef<'a>>,
 ) where
     T: CommandCustomHeader + FromMap<Target = T> + HeaderCodec,
     <T as FromMap>::Error: std::fmt::Debug,
@@ -679,15 +699,13 @@ fn assert_topic_queue_envelope_contract<T>(
         input.insert(key.into(), value.into());
     }
 
-    let typed = <T as HeaderCodec>::decode_from_map(&input).expect("typed TopicQueue envelope decode");
-    let legacy = <T as FromMap>::from(&input).expect("legacy TopicQueue envelope adapter");
+    let typed = <T as HeaderCodec>::decode_from_map(&input).expect("typed Topic envelope decode");
+    let legacy = <T as FromMap>::from(&input).expect("legacy Topic envelope adapter");
     for decoded in [&typed, &legacy] {
-        let topic = topic(decoded)
-            .as_ref()
-            .expect("Java Topic parent is always present after decode");
+        let topic = topic(decoded).expect("Java Topic parent is always present after decode");
         assert_eq!(topic.lo, Some(true));
         let rpc = topic
-            .rpc_request_header
+            .rpc
             .as_ref()
             .expect("Java RPC parent is always present after decode");
         assert_eq!(rpc.namespace.as_deref(), Some("canonical-ns"));
@@ -727,36 +745,71 @@ fn assert_topic_queue_envelope_contract<T>(
         assert!(<T as FromMap>::from(&missing).is_err());
     }
 
-    let empty = <T as HeaderCodec>::decode_from_map(&parent_only).expect("TopicQueue header without parent fields");
-    let empty_topic = topic(&empty)
-        .as_ref()
-        .expect("Java Topic parent exists even when inherited fields are absent");
+    let empty = <T as HeaderCodec>::decode_from_map(&parent_only).expect("Topic header without parent fields");
+    let empty_topic = topic(&empty).expect("Java Topic parent exists even when inherited fields are absent");
     assert!(empty_topic.lo.is_none());
-    assert!(empty_topic.rpc_request_header.is_some());
+    assert!(empty_topic.rpc.is_some());
     assert_eq!(empty.encode_capability(), HeaderEncodeCapability::MapOnly);
 }
 
 #[test]
-fn topic_queue_headers_preserve_nested_java_inheritance_and_defaults() {
-    assert_topic_queue_envelope_contract::<GetMaxOffsetRequestHeader>(
+fn topic_headers_preserve_nested_java_inheritance_and_defaults() {
+    assert_topic_envelope_contract::<GetMaxOffsetRequestHeader>(
         &[
             ("topic", "topic-max"),
             ("queueId", "2147483647"),
             ("committed", "false"),
         ],
         &["topic", "queueId"],
-        |header| &header.topic_request_header,
+        |header| {
+            header.topic_request_header.as_ref().map(|topic| TopicEnvelopeRef {
+                lo: topic.lo,
+                rpc: &topic.rpc_request_header,
+            })
+        },
     );
-    assert_topic_queue_envelope_contract::<GetMinOffsetRequestHeader>(
+    assert_topic_envelope_contract::<GetMinOffsetRequestHeader>(
         &[("topic", "topic-min"), ("queueId", "-2147483648")],
         &["topic", "queueId"],
-        |header| &header.topic_request_header,
+        |header| {
+            header.topic_request_header.as_ref().map(|topic| TopicEnvelopeRef {
+                lo: topic.lo,
+                rpc: &topic.rpc_request_header,
+            })
+        },
     );
-    assert_topic_queue_envelope_contract::<GetEarliestMsgStoretimeRequestHeader>(
+    assert_topic_envelope_contract::<GetEarliestMsgStoretimeRequestHeader>(
         &[("topic", "topic-earliest"), ("queueId", "0")],
         &["topic", "queueId"],
-        |header| &header.topic_request_header,
+        |header| {
+            header.topic_request_header.as_ref().map(|topic| TopicEnvelopeRef {
+                lo: topic.lo,
+                rpc: &topic.rpc_request_header,
+            })
+        },
     );
+    assert_topic_envelope_contract::<GetTopicConfigRequestHeader>(&[("topic", "topic-config")], &["topic"], |header| {
+        header.topic_request_header.as_ref().map(|topic| TopicEnvelopeRef {
+            lo: topic.lo,
+            rpc: &topic.rpc_request_header,
+        })
+    });
+    assert_topic_envelope_contract::<GetTopicStatsInfoRequestHeader>(
+        &[("topic", "topic-stats-info")],
+        &["topic"],
+        |header| {
+            header.topic_request_header.as_ref().map(|topic| TopicEnvelopeRef {
+                lo: topic.lo,
+                rpc: &topic.rpc,
+            })
+        },
+    );
+    assert_topic_envelope_contract::<GetTopicStatsRequestHeader>(&[("topic", "topic-stats")], &["topic"], |header| {
+        header.topic_request_header.as_ref().map(|topic| TopicEnvelopeRef {
+            lo: topic.lo,
+            rpc: &topic.rpc_request_header,
+        })
+    });
 
     let max_without_committed = HeaderMap::from([("topic".into(), "topic-max".into()), ("queueId".into(), "0".into())]);
     let typed = <GetMaxOffsetRequestHeader as HeaderCodec>::decode_from_map(&max_without_committed)

--- a/scripts/request-header-codec/migration.json
+++ b/scripts/request-header-codec/migration.json
@@ -8,10 +8,10 @@
     "entryCount": 152,
     "mappedCount": 143,
     "rustOnlyExtensionCount": 9,
-    "v2Count": 109,
-    "v3Count": 43,
-    "pendingCount": 109,
-    "migratedCount": 43
+    "v2Count": 106,
+    "v3Count": 46,
+    "pendingCount": 106,
+    "migratedCount": 46
   },
   "baseline": {
     "v2TypeIds": [
@@ -195,6 +195,9 @@
       "rocketmq_protocol::protocol::header::get_parent_topic_info_request_header::GetParentTopicInfoRequestHeader",
       "rocketmq_protocol::protocol::header::get_producer_connection_list_request_header::GetProducerConnectionListRequestHeader",
       "rocketmq_protocol::protocol::header::get_subscription_group_config_request_header::GetSubscriptionGroupConfigRequestHeader",
+      "rocketmq_protocol::protocol::header::get_topic_config_request_header::GetTopicConfigRequestHeader",
+      "rocketmq_protocol::protocol::header::get_topic_stats_info_request_header::GetTopicStatsInfoRequestHeader",
+      "rocketmq_protocol::protocol::header::get_topic_stats_request_header::GetTopicStatsRequestHeader",
       "rocketmq_protocol::protocol::header::heartbeat_request_header::HeartbeatRequestHeader",
       "rocketmq_protocol::protocol::header::lite_subscription_ctl_request_header::LiteSubscriptionCtlRequestHeader",
       "rocketmq_protocol::protocol::header::lock_batch_mq_request_header::LockBatchMqRequestHeader",
@@ -1795,16 +1798,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 2,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -1818,16 +1821,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 2,
       "flattenTypeIds": [
         "rocketmq_protocol::protocol::header::namesrv::topic_operation_header::TopicRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -1841,16 +1844,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 2,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {

--- a/scripts/request-header-codec/tests/test_migrate.py
+++ b/scripts/request-header-codec/tests/test_migrate.py
@@ -55,7 +55,7 @@ class MigrationGuardTests(unittest.TestCase):
         )
         self.assertEqual(migrate.serialize(expected), migrate.serialize(self.manifest))
         self.assertEqual(len(self.headers), 152)
-        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 43)
+        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 46)
 
     def test_duplicate_simple_names_keep_distinct_stable_paths(self) -> None:
         graph, depths = migrate.flatten_graph(self.headers, self.repo_root)


### PR DESCRIPTION
## Summary

- migrate `GetTopicConfigRequestHeader`, `GetTopicStatsInfoRequestHeader`, and `GetTopicStatsRequestHeader` to `RequestHeaderCodecV3`
- preserve required `topic` fields and always-present Topic/RPC inheritance
- cover both Rust Topic parent representations, canonical RPC keys, alias precedence, empty parents, and typed/legacy parity
- refresh the governed inventory to 46 V3 / 106 frozen V2 without adding `mod.rs`, `java_type`, or direct-binary code

## Validation

- `python scripts/request-header-codec/migrate.py check`
- `python scripts/request-header-codec/compare_header_schema.py`
- `python -m unittest discover -s scripts/request-header-codec/tests -p 'test_migrate.py'`
- `cargo test --locked -p rocketmq-protocol --test request_header_codec_v3_registry`
- focused tests for all three migrated headers
- `cargo test --locked -p rocketmq-protocol --all-features`
- `cargo fmt -p rocketmq-protocol -- --check`
- `cargo clippy --locked -p rocketmq-protocol --all-targets --all-features --no-deps -- -A deprecated -D warnings`
- `git diff --check`

The standalone fuzz check is blocked before compilation because its checked-in lockfile requires an update; this change does not modify that lockfile. Map-only performance acceptance continues to use the formal RequestHeaderCodecV3 evidence in #9061.

Closes #9084

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Migrated three topic-related request headers to the latest protocol encoding format.
  * Improved consistency and reliability when encoding required topic data and nested request information.
  * Added support for type metadata to improve compatibility across Rust and Java implementations.

* **Tests**
  * Added coverage for inheritance, aliases, defaults, required fields, and request encoding.
  * Updated migration tracking and validation for the newly migrated headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->