### PR TITLE
[ISSUE #9086]✨Migrate topic-only request headers to V3

### DIFF
--- a/rocketmq-protocol/src/protocol/header/delete_topic_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/delete_topic_request_header.rs
@@ -13,20 +13,30 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
-#[derive(Serialize, Deserialize, Debug, RequestHeaderCodecV2)]
+#[derive(Serialize, Deserialize, Debug, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::delete_topic_request_header::DeleteTopicRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.DeleteTopicRequestHeader"
+)]
 pub struct DeleteTopicRequestHeader {
-    #[required]
+    #[header(required)]
     #[serde(rename = "topic")]
     pub topic: CheetahString,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
+}
+
+#[cfg(test)]
+impl DeleteTopicRequestHeader {
+    const TOPIC: &'static str = "topic";
 }
 
 #[cfg(test)]

--- a/rocketmq-protocol/src/protocol/header/namesrv/topic_operation_header.rs
+++ b/rocketmq-protocol/src/protocol/header/namesrv/topic_operation_header.rs
@@ -46,12 +46,17 @@ impl DeleteTopicFromNamesrvRequestHeader {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, Default, RequestHeaderCodecV2)]
+#[derive(Debug, Clone, Deserialize, Serialize, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::namesrv::topic_operation_header::RegisterTopicRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.namesrv.RegisterTopicRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct RegisterTopicRequestHeader {
-    #[required]
+    #[header(required)]
     pub topic: CheetahString,
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/query_topic_consume_by_who_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/query_topic_consume_by_who_request_header.rs
@@ -13,19 +13,24 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
-#[derive(Serialize, Deserialize, Debug, RequestHeaderCodecV2)]
+#[derive(Serialize, Deserialize, Debug, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::query_topic_consume_by_who_request_header::QueryTopicConsumeByWhoRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.QueryTopicConsumeByWhoRequestHeader"
+)]
 pub struct QueryTopicConsumeByWhoRequestHeader {
-    #[required]
+    #[header(required)]
     #[serde(rename = "topic")]
     pub topic: CheetahString,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
@@ -28,6 +28,7 @@ use rocketmq_protocol::protocol::header::consumer_send_msg_back_request_header::
 use rocketmq_protocol::protocol::header::controller::clean_broker_data_request_header::CleanBrokerDataRequestHeader;
 use rocketmq_protocol::protocol::header::create_topic_list_request_header::CreateTopicListRequestHeader;
 use rocketmq_protocol::protocol::header::delete_subscription_group_request_header::DeleteSubscriptionGroupRequestHeader;
+use rocketmq_protocol::protocol::header::delete_topic_request_header::DeleteTopicRequestHeader;
 use rocketmq_protocol::protocol::header::end_transaction_request_header::EndTransactionRequestHeader;
 use rocketmq_protocol::protocol::header::get_consumer_connection_list_request_header::GetConsumerConnectionListRequestHeader;
 use rocketmq_protocol::protocol::header::get_consumer_listby_group_request_header::GetConsumerListByGroupRequestHeader;
@@ -51,6 +52,7 @@ use rocketmq_protocol::protocol::header::message_operation_header::send_message_
 use rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header_v2::SendMessageRequestHeaderV2;
 use rocketmq_protocol::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader;
 use rocketmq_protocol::protocol::header::namesrv::topic_operation_header::DeleteTopicFromNamesrvRequestHeader;
+use rocketmq_protocol::protocol::header::namesrv::topic_operation_header::RegisterTopicRequestHeader;
 use rocketmq_protocol::protocol::header::namesrv::topic_operation_header::TopicRequestHeader as NamesrvTopicRequestHeader;
 use rocketmq_protocol::protocol::header::notification_request_header::NotificationRequestHeader;
 use rocketmq_protocol::protocol::header::notify_consumer_ids_changed_request_header::NotifyConsumerIdsChangedRequestHeader;
@@ -59,6 +61,7 @@ use rocketmq_protocol::protocol::header::pop_lite_message_request_header::PopLit
 use rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader;
 use rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader;
 use rocketmq_protocol::protocol::header::query_consume_queue_request_header::QueryConsumeQueueRequestHeader;
+use rocketmq_protocol::protocol::header::query_topic_consume_by_who_request_header::QueryTopicConsumeByWhoRequestHeader;
 use rocketmq_protocol::protocol::header::query_topics_by_consumer_request_header::QueryTopicsByConsumerRequestHeader;
 use rocketmq_protocol::protocol::header::search_offset_request_header::SearchOffsetRequestHeader;
 use rocketmq_protocol::protocol::header::search_offset_response_header::SearchOffsetResponseHeader;
@@ -247,6 +250,10 @@ fn registry() -> Vec<RegisteredSchema> {
         register::<CleanBrokerDataRequestHeader>(),
         register::<CreateTopicListRequestHeader>(),
         register::<DeleteSubscriptionGroupRequestHeader>(),
+        register_value(&DeleteTopicRequestHeader {
+            topic: CheetahString::from_static_str("registry"),
+            topic_request_header: None,
+        }),
         register_value(&EndTransactionRequestHeader {
             topic: CheetahString::new(),
             producer_group: CheetahString::from_static_str("registry"),
@@ -314,7 +321,12 @@ fn registry() -> Vec<RegisteredSchema> {
         register::<LockBatchMqRequestHeader>(),
         register::<SendMessageRequestHeader>(),
         register::<DeleteTopicFromNamesrvRequestHeader>(),
+        register::<RegisterTopicRequestHeader>(),
         register::<QueryConsumeQueueRequestHeader>(),
+        register_value(&QueryTopicConsumeByWhoRequestHeader {
+            topic: CheetahString::from_static_str("registry"),
+            topic_request_header: None,
+        }),
         register::<SearchOffsetRequestHeader>(),
         register::<SearchOffsetResponseHeader>(),
         register::<PullMessageRequestHeader>(),
@@ -810,6 +822,32 @@ fn topic_headers_preserve_nested_java_inheritance_and_defaults() {
             rpc: &topic.rpc_request_header,
         })
     });
+    assert_topic_envelope_contract::<DeleteTopicRequestHeader>(&[("topic", "topic-delete")], &["topic"], |header| {
+        header.topic_request_header.as_ref().map(|topic| TopicEnvelopeRef {
+            lo: topic.lo,
+            rpc: &topic.rpc_request_header,
+        })
+    });
+    assert_topic_envelope_contract::<RegisterTopicRequestHeader>(
+        &[("topic", "topic-register")],
+        &["topic"],
+        |header| {
+            header.topic_request.as_ref().map(|topic| TopicEnvelopeRef {
+                lo: topic.lo,
+                rpc: &topic.rpc,
+            })
+        },
+    );
+    assert_topic_envelope_contract::<QueryTopicConsumeByWhoRequestHeader>(
+        &[("topic", "topic-consumers")],
+        &["topic"],
+        |header| {
+            header.topic_request_header.as_ref().map(|topic| TopicEnvelopeRef {
+                lo: topic.lo,
+                rpc: &topic.rpc_request_header,
+            })
+        },
+    );
 
     let max_without_committed = HeaderMap::from([("topic".into(), "topic-max".into()), ("queueId".into(), "0".into())]);
     let typed = <GetMaxOffsetRequestHeader as HeaderCodec>::decode_from_map(&max_without_committed)

--- a/scripts/request-header-codec/migration.json
+++ b/scripts/request-header-codec/migration.json
@@ -8,10 +8,10 @@
     "entryCount": 152,
     "mappedCount": 143,
     "rustOnlyExtensionCount": 9,
-    "v2Count": 106,
-    "v3Count": 46,
-    "pendingCount": 106,
-    "migratedCount": 46
+    "v2Count": 103,
+    "v3Count": 49,
+    "pendingCount": 103,
+    "migratedCount": 49
   },
   "baseline": {
     "v2TypeIds": [
@@ -182,6 +182,7 @@
       "rocketmq_protocol::protocol::header::controller::clean_broker_data_request_header::CleanBrokerDataRequestHeader",
       "rocketmq_protocol::protocol::header::create_topic_list_request_header::CreateTopicListRequestHeader",
       "rocketmq_protocol::protocol::header::delete_subscription_group_request_header::DeleteSubscriptionGroupRequestHeader",
+      "rocketmq_protocol::protocol::header::delete_topic_request_header::DeleteTopicRequestHeader",
       "rocketmq_protocol::protocol::header::end_transaction_request_header::EndTransactionRequestHeader",
       "rocketmq_protocol::protocol::header::get_consumer_connection_list_request_header::GetConsumerConnectionListRequestHeader",
       "rocketmq_protocol::protocol::header::get_consumer_listby_group_request_header::GetConsumerListByGroupRequestHeader",
@@ -205,6 +206,7 @@
       "rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header_v2::SendMessageRequestHeaderV2",
       "rocketmq_protocol::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader",
       "rocketmq_protocol::protocol::header::namesrv::topic_operation_header::DeleteTopicFromNamesrvRequestHeader",
+      "rocketmq_protocol::protocol::header::namesrv::topic_operation_header::RegisterTopicRequestHeader",
       "rocketmq_protocol::protocol::header::namesrv::topic_operation_header::TopicRequestHeader",
       "rocketmq_protocol::protocol::header::notification_request_header::NotificationRequestHeader",
       "rocketmq_protocol::protocol::header::notify_consumer_ids_changed_request_header::NotifyConsumerIdsChangedRequestHeader",
@@ -213,6 +215,7 @@
       "rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader",
       "rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader",
       "rocketmq_protocol::protocol::header::query_consume_queue_request_header::QueryConsumeQueueRequestHeader",
+      "rocketmq_protocol::protocol::header::query_topic_consume_by_who_request_header::QueryTopicConsumeByWhoRequestHeader",
       "rocketmq_protocol::protocol::header::query_topics_by_consumer_request_header::QueryTopicsByConsumerRequestHeader",
       "rocketmq_protocol::protocol::header::search_offset_request_header::SearchOffsetRequestHeader",
       "rocketmq_protocol::protocol::header::search_offset_response_header::SearchOffsetResponseHeader",
@@ -1080,16 +1083,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 2,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -2508,16 +2511,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 2,
       "flattenTypeIds": [
         "rocketmq_protocol::protocol::header::namesrv::topic_operation_header::TopicRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -3026,16 +3029,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 2,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {

--- a/scripts/request-header-codec/tests/test_migrate.py
+++ b/scripts/request-header-codec/tests/test_migrate.py
@@ -55,7 +55,7 @@ class MigrationGuardTests(unittest.TestCase):
         )
         self.assertEqual(migrate.serialize(expected), migrate.serialize(self.manifest))
         self.assertEqual(len(self.headers), 152)
-        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 46)
+        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 49)
 
     def test_duplicate_simple_names_keep_distinct_stable_paths(self) -> None:
         graph, depths = migrate.flatten_graph(self.headers, self.repo_root)


### PR DESCRIPTION
## Summary

- migrate `DeleteTopicRequestHeader`, `RegisterTopicRequestHeader`, and `QueryTopicConsumeByWhoRequestHeader` to `RequestHeaderCodecV3`
- preserve required `topic` fields and always-present Topic/RPC inheritance across both Rust parent representations
- reuse the shared Topic envelope contract for canonical RPC keys, alias precedence, empty parents, and typed/legacy parity
- refresh the governed inventory to 49 V3 / 103 frozen V2 without adding `mod.rs`, `java_type`, ranges, or direct-binary code

## Validation

- `python scripts/request-header-codec/migrate.py check`
- `python scripts/request-header-codec/compare_header_schema.py`
- `python -m unittest discover -s scripts/request-header-codec/tests -p 'test_migrate.py'`
- `cargo test --locked -p rocketmq-protocol --test request_header_codec_v3_registry`
- `cargo test --locked -p rocketmq-protocol --all-features`
- `cargo fmt -p rocketmq-protocol -- --check`
- `cargo clippy --locked -p rocketmq-protocol --all-targets --all-features --no-deps -- -A deprecated -D warnings`
- `git diff --check`

These low-frequency headers remain `MapOnly`; performance acceptance continues to use the formal RequestHeaderCodecV3 evidence in #9061.

Closes #9086