### PR TITLE
[ISSUE #9088]✨Migrate consumer metadata headers to V3

### DIFF
--- a/rocketmq-protocol/src/protocol/header/get_consume_stats_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/get_consume_stats_request_header.rs
@@ -13,22 +13,29 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
-#[derive(Debug, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[derive(Debug, Serialize, Deserialize, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::get_consume_stats_request_header::GetConsumeStatsRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.GetConsumeStatsRequestHeader"
+)]
 pub struct GetConsumeStatsRequestHeader {
     #[serde(rename = "consumerGroup")]
-    #[required]
+    #[header(required)]
     pub consumer_group: CheetahString,
+    #[serde(default)]
     #[serde(rename = "topic")]
+    #[header(default, default_semantic = "literal:")]
     pub topic: CheetahString,
     #[serde(rename = "topicList")]
     pub topic_list: Option<CheetahString>,
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/query_consume_time_span_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/query_consume_time_span_request_header.rs
@@ -13,22 +13,27 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::protocol::header::namesrv::topic_operation_header::TopicRequestHeader;
 
-#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::query_consume_time_span_request_header::QueryConsumeTimeSpanRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.QueryConsumeTimeSpanRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryConsumeTimeSpanRequestHeader {
-    #[required]
+    #[header(required)]
     pub topic: CheetahString,
 
-    #[required]
+    #[header(required)]
     pub group: CheetahString,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/query_correction_offset_header.rs
+++ b/rocketmq-protocol/src/protocol/header/query_correction_offset_header.rs
@@ -13,21 +13,26 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::query_correction_offset_header::QueryCorrectionOffsetHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.QueryCorrectionOffsetHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryCorrectionOffsetHeader {
     pub filter_groups: Option<CheetahString>,
-    #[required]
+    #[header(required)]
     pub compare_group: CheetahString,
-    #[required]
+    #[header(required)]
     pub topic: CheetahString,
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/query_subscription_by_consumer_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/query_subscription_by_consumer_request_header.rs
@@ -13,21 +13,28 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
-#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::query_subscription_by_consumer_request_header::QuerySubscriptionByConsumerRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.QuerySubscriptionByConsumerRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct QuerySubscriptionByConsumerRequestHeader {
-    #[required]
+    #[header(required)]
     pub group: CheetahString,
 
+    #[serde(default)]
+    #[header(default, default_semantic = "literal:")]
     pub topic: CheetahString,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/update_group_forbidden_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/update_group_forbidden_request_header.rs
@@ -13,24 +13,29 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
-#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::update_group_forbidden_request_header::UpdateGroupForbiddenRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.UpdateGroupForbiddenRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateGroupForbiddenRequestHeader {
-    #[required]
+    #[header(required)]
     pub group: CheetahString,
 
-    #[required]
+    #[header(required)]
     pub topic: CheetahString,
 
     pub readable: Option<bool>,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
@@ -30,6 +30,7 @@ use rocketmq_protocol::protocol::header::create_topic_list_request_header::Creat
 use rocketmq_protocol::protocol::header::delete_subscription_group_request_header::DeleteSubscriptionGroupRequestHeader;
 use rocketmq_protocol::protocol::header::delete_topic_request_header::DeleteTopicRequestHeader;
 use rocketmq_protocol::protocol::header::end_transaction_request_header::EndTransactionRequestHeader;
+use rocketmq_protocol::protocol::header::get_consume_stats_request_header::GetConsumeStatsRequestHeader;
 use rocketmq_protocol::protocol::header::get_consumer_connection_list_request_header::GetConsumerConnectionListRequestHeader;
 use rocketmq_protocol::protocol::header::get_consumer_listby_group_request_header::GetConsumerListByGroupRequestHeader;
 use rocketmq_protocol::protocol::header::get_consumer_running_info_request_header::GetConsumerRunningInfoRequestHeader;
@@ -61,12 +62,16 @@ use rocketmq_protocol::protocol::header::pop_lite_message_request_header::PopLit
 use rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader;
 use rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader;
 use rocketmq_protocol::protocol::header::query_consume_queue_request_header::QueryConsumeQueueRequestHeader;
+use rocketmq_protocol::protocol::header::query_consume_time_span_request_header::QueryConsumeTimeSpanRequestHeader;
+use rocketmq_protocol::protocol::header::query_correction_offset_header::QueryCorrectionOffsetHeader;
+use rocketmq_protocol::protocol::header::query_subscription_by_consumer_request_header::QuerySubscriptionByConsumerRequestHeader;
 use rocketmq_protocol::protocol::header::query_topic_consume_by_who_request_header::QueryTopicConsumeByWhoRequestHeader;
 use rocketmq_protocol::protocol::header::query_topics_by_consumer_request_header::QueryTopicsByConsumerRequestHeader;
 use rocketmq_protocol::protocol::header::search_offset_request_header::SearchOffsetRequestHeader;
 use rocketmq_protocol::protocol::header::search_offset_response_header::SearchOffsetResponseHeader;
 use rocketmq_protocol::protocol::header::unlock_batch_mq_request_header::UnlockBatchMqRequestHeader;
 use rocketmq_protocol::protocol::header::unregister_client_request_header::UnregisterClientRequestHeader;
+use rocketmq_protocol::protocol::header::update_group_forbidden_request_header::UpdateGroupForbiddenRequestHeader;
 use rocketmq_protocol::protocol::header_codec::{
     AliasConflictPolicy, HeaderCodec, HeaderCodecError, HeaderFieldSpec, HeaderFlattenSpec, HeaderPresence,
     HeaderRange, HeaderValueKind,
@@ -275,6 +280,12 @@ fn registry() -> Vec<RegisteredSchema> {
         }),
         register::<GetConsumerRunningInfoRequestHeader>(),
         register::<GetConsumerStatusRequestHeader>(),
+        register_value(&GetConsumeStatsRequestHeader {
+            consumer_group: CheetahString::from_static_str("registry"),
+            topic: CheetahString::new(),
+            topic_list: None,
+            topic_request_header: None,
+        }),
         register_value(&GetEarliestMsgStoretimeRequestHeader {
             topic: CheetahString::from_static_str("registry"),
             queue_id: 0,
@@ -323,6 +334,22 @@ fn registry() -> Vec<RegisteredSchema> {
         register::<DeleteTopicFromNamesrvRequestHeader>(),
         register::<RegisterTopicRequestHeader>(),
         register::<QueryConsumeQueueRequestHeader>(),
+        register_value(&QueryConsumeTimeSpanRequestHeader {
+            topic: CheetahString::from_static_str("registry"),
+            group: CheetahString::from_static_str("registry"),
+            topic_request_header: None,
+        }),
+        register_value(&QueryCorrectionOffsetHeader {
+            filter_groups: None,
+            compare_group: CheetahString::from_static_str("registry"),
+            topic: CheetahString::from_static_str("registry"),
+            topic_request_header: None,
+        }),
+        register_value(&QuerySubscriptionByConsumerRequestHeader {
+            group: CheetahString::from_static_str("registry"),
+            topic: CheetahString::new(),
+            topic_request_header: None,
+        }),
         register_value(&QueryTopicConsumeByWhoRequestHeader {
             topic: CheetahString::from_static_str("registry"),
             topic_request_header: None,
@@ -358,6 +385,12 @@ fn registry() -> Vec<RegisteredSchema> {
         register::<QueryTopicsByConsumerRequestHeader>(),
         register::<UnlockBatchMqRequestHeader>(),
         register::<UnregisterClientRequestHeader>(),
+        register_value(&UpdateGroupForbiddenRequestHeader {
+            group: CheetahString::from_static_str("registry"),
+            topic: CheetahString::from_static_str("registry"),
+            readable: None,
+            topic_request_header: None,
+        }),
     ]
 }
 
@@ -848,6 +881,97 @@ fn topic_headers_preserve_nested_java_inheritance_and_defaults() {
             })
         },
     );
+    assert_topic_envelope_contract::<GetConsumeStatsRequestHeader>(
+        &[
+            ("consumerGroup", "consumer-a"),
+            ("topic", "topic-stats"),
+            ("topicList", "topic-a;topic-b"),
+        ],
+        &["consumerGroup"],
+        |header| {
+            header.topic_request_header.as_ref().map(|topic| TopicEnvelopeRef {
+                lo: topic.lo,
+                rpc: &topic.rpc_request_header,
+            })
+        },
+    );
+    assert_topic_envelope_contract::<QueryConsumeTimeSpanRequestHeader>(
+        &[("topic", "topic-span"), ("group", "group-span")],
+        &["topic", "group"],
+        |header| {
+            header.topic_request_header.as_ref().map(|topic| TopicEnvelopeRef {
+                lo: topic.lo,
+                rpc: &topic.rpc,
+            })
+        },
+    );
+    assert_topic_envelope_contract::<QueryCorrectionOffsetHeader>(
+        &[
+            ("filterGroups", "group-a,group-b"),
+            ("compareGroup", "group-c"),
+            ("topic", "topic-correction"),
+        ],
+        &["compareGroup", "topic"],
+        |header| {
+            header.topic_request_header.as_ref().map(|topic| TopicEnvelopeRef {
+                lo: topic.lo,
+                rpc: &topic.rpc_request_header,
+            })
+        },
+    );
+    assert_topic_envelope_contract::<QuerySubscriptionByConsumerRequestHeader>(
+        &[("group", "group-subscription"), ("topic", "topic-subscription")],
+        &["group"],
+        |header| {
+            header.topic_request_header.as_ref().map(|topic| TopicEnvelopeRef {
+                lo: topic.lo,
+                rpc: &topic.rpc_request_header,
+            })
+        },
+    );
+    assert_topic_envelope_contract::<UpdateGroupForbiddenRequestHeader>(
+        &[
+            ("group", "group-forbidden"),
+            ("topic", "topic-forbidden"),
+            ("readable", "false"),
+        ],
+        &["group", "topic"],
+        |header| {
+            header.topic_request_header.as_ref().map(|topic| TopicEnvelopeRef {
+                lo: topic.lo,
+                rpc: &topic.rpc_request_header,
+            })
+        },
+    );
+
+    let consume_stats_minimum = HeaderMap::from([("consumerGroup".into(), "consumer-min".into())]);
+    let typed = <GetConsumeStatsRequestHeader as HeaderCodec>::decode_from_map(&consume_stats_minimum)
+        .expect("nullable Java topic decodes to the reviewed Rust empty-string default");
+    let legacy = <GetConsumeStatsRequestHeader as FromMap>::from(&consume_stats_minimum)
+        .expect("legacy adapter preserves the reviewed Rust empty-string default");
+    assert!(typed.topic.is_empty());
+    assert!(legacy.topic.is_empty());
+    assert!(typed.topic_list.is_none());
+    assert!(legacy.topic_list.is_none());
+
+    let subscription_minimum = HeaderMap::from([("group".into(), "group-min".into())]);
+    let typed = <QuerySubscriptionByConsumerRequestHeader as HeaderCodec>::decode_from_map(&subscription_minimum)
+        .expect("nullable Java topic decodes to the reviewed Rust empty-string default");
+    let legacy = <QuerySubscriptionByConsumerRequestHeader as FromMap>::from(&subscription_minimum)
+        .expect("legacy adapter preserves the reviewed Rust empty-string default");
+    assert!(typed.topic.is_empty());
+    assert!(legacy.topic.is_empty());
+
+    let malformed_readable = HeaderMap::from([
+        ("group".into(), "group-forbidden".into()),
+        ("topic".into(), "topic-forbidden".into()),
+        ("readable".into(), "not-a-bool".into()),
+    ]);
+    assert!(matches!(
+        <UpdateGroupForbiddenRequestHeader as HeaderCodec>::decode_from_map(&malformed_readable),
+        Err(HeaderCodecError::InvalidValue { key: "readable", .. })
+    ));
+    assert!(<UpdateGroupForbiddenRequestHeader as FromMap>::from(&malformed_readable).is_err());
 
     let max_without_committed = HeaderMap::from([("topic".into(), "topic-max".into()), ("queueId".into(), "0".into())]);
     let typed = <GetMaxOffsetRequestHeader as HeaderCodec>::decode_from_map(&max_without_committed)

--- a/scripts/request-header-codec/migration.json
+++ b/scripts/request-header-codec/migration.json
@@ -8,10 +8,10 @@
     "entryCount": 152,
     "mappedCount": 143,
     "rustOnlyExtensionCount": 9,
-    "v2Count": 103,
-    "v3Count": 49,
-    "pendingCount": 103,
-    "migratedCount": 49
+    "v2Count": 98,
+    "v3Count": 54,
+    "pendingCount": 98,
+    "migratedCount": 54
   },
   "baseline": {
     "v2TypeIds": [
@@ -184,6 +184,7 @@
       "rocketmq_protocol::protocol::header::delete_subscription_group_request_header::DeleteSubscriptionGroupRequestHeader",
       "rocketmq_protocol::protocol::header::delete_topic_request_header::DeleteTopicRequestHeader",
       "rocketmq_protocol::protocol::header::end_transaction_request_header::EndTransactionRequestHeader",
+      "rocketmq_protocol::protocol::header::get_consume_stats_request_header::GetConsumeStatsRequestHeader",
       "rocketmq_protocol::protocol::header::get_consumer_connection_list_request_header::GetConsumerConnectionListRequestHeader",
       "rocketmq_protocol::protocol::header::get_consumer_listby_group_request_header::GetConsumerListByGroupRequestHeader",
       "rocketmq_protocol::protocol::header::get_consumer_running_info_request_header::GetConsumerRunningInfoRequestHeader",
@@ -215,12 +216,16 @@
       "rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader",
       "rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader",
       "rocketmq_protocol::protocol::header::query_consume_queue_request_header::QueryConsumeQueueRequestHeader",
+      "rocketmq_protocol::protocol::header::query_consume_time_span_request_header::QueryConsumeTimeSpanRequestHeader",
+      "rocketmq_protocol::protocol::header::query_correction_offset_header::QueryCorrectionOffsetHeader",
+      "rocketmq_protocol::protocol::header::query_subscription_by_consumer_request_header::QuerySubscriptionByConsumerRequestHeader",
       "rocketmq_protocol::protocol::header::query_topic_consume_by_who_request_header::QueryTopicConsumeByWhoRequestHeader",
       "rocketmq_protocol::protocol::header::query_topics_by_consumer_request_header::QueryTopicsByConsumerRequestHeader",
       "rocketmq_protocol::protocol::header::search_offset_request_header::SearchOffsetRequestHeader",
       "rocketmq_protocol::protocol::header::search_offset_response_header::SearchOffsetResponseHeader",
       "rocketmq_protocol::protocol::header::unlock_batch_mq_request_header::UnlockBatchMqRequestHeader",
       "rocketmq_protocol::protocol::header::unregister_client_request_header::UnregisterClientRequestHeader",
+      "rocketmq_protocol::protocol::header::update_group_forbidden_request_header::UpdateGroupForbiddenRequestHeader",
       "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader",
       "rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader"
     ],
@@ -1396,16 +1401,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 2,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -2876,16 +2881,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 2,
       "flattenTypeIds": [
         "rocketmq_protocol::protocol::header::namesrv::topic_operation_header::TopicRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -2941,16 +2946,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 2,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -3006,16 +3011,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 2,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -3474,16 +3479,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 2,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {

--- a/scripts/request-header-codec/schema-overrides.json
+++ b/scripts/request-header-codec/schema-overrides.json
@@ -99,6 +99,28 @@
         "rust": "rocketmq-protocol/src/protocol/header/get_lite_group_info_request_header.rs",
         "java": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetLiteGroupInfoRequestHeader.java"
       }
+    },
+    {
+      "rustType": "GetConsumeStatsRequestHeader",
+      "field": "topic",
+      "semantic": "literal:",
+      "owner": "rocketmq-rust protocol maintainers",
+      "reason": "Preserves the public non-optional Rust field while accepting a Java frame that omits the nullable topic",
+      "referenceSource": {
+        "rust": "rocketmq-protocol/src/protocol/header/get_consume_stats_request_header.rs",
+        "java": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetConsumeStatsRequestHeader.java"
+      }
+    },
+    {
+      "rustType": "QuerySubscriptionByConsumerRequestHeader",
+      "field": "topic",
+      "semantic": "literal:",
+      "owner": "rocketmq-rust protocol maintainers",
+      "reason": "Preserves the public non-optional Rust field while accepting a Java frame that omits the nullable topic",
+      "referenceSource": {
+        "rust": "rocketmq-protocol/src/protocol/header/query_subscription_by_consumer_request_header.rs",
+        "java": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/QuerySubscriptionByConsumerRequestHeader.java"
+      }
     }
   ],
   "nameMappings": [

--- a/scripts/request-header-codec/tests/test_migrate.py
+++ b/scripts/request-header-codec/tests/test_migrate.py
@@ -55,7 +55,7 @@ class MigrationGuardTests(unittest.TestCase):
         )
         self.assertEqual(migrate.serialize(expected), migrate.serialize(self.manifest))
         self.assertEqual(len(self.headers), 152)
-        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 49)
+        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 54)
 
     def test_duplicate_simple_names_keep_distinct_stable_paths(self) -> None:
         graph, depths = migrate.flatten_graph(self.headers, self.repo_root)


### PR DESCRIPTION
## Summary

- migrate five related consumer and topic metadata request headers to `RequestHeaderCodecV3`
- preserve Java required and nullable fields across both Rust Topic parent representations
- record reviewed empty-string defaults for the two nullable Java `topic` fields that remain non-optional in Rust
- cover canonical RPC keys, alias precedence, empty parents, malformed Boolean input, and typed/legacy parity
- refresh the governed inventory to 54 V3 / 98 frozen V2 without adding `mod.rs`, `java_type`, ranges, or direct-binary code

## Validation

- `python scripts/request-header-codec/migrate.py check`
- `python scripts/request-header-codec/compare_header_schema.py`
- `python -m unittest discover -s scripts/request-header-codec/tests -p 'test_migrate.py'`
- `cargo test --locked -p rocketmq-protocol --test request_header_codec_v3_registry`
- `cargo test --locked -p rocketmq-protocol --all-features`
- `cargo fmt -p rocketmq-protocol -- --check`
- `cargo clippy --locked -p rocketmq-protocol --all-targets --all-features --no-deps -- -A deprecated -D warnings`
- `git diff --check`

These low-frequency headers remain `MapOnly`; performance acceptance continues to use the formal RequestHeaderCodecV3 evidence in #9061.

Closes #9088

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added V3 protocol support for five consumer and topic-related request headers.
  - Improved handling of required fields, default topic values, and topic header data.

- **Bug Fixes**
  - Added validation for missing required fields and malformed boolean values.
  - Preserved compatibility when optional topics are omitted.

- **Tests**
  - Expanded coverage for the newly migrated request headers and their default behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->