### PR TITLE
[ISSUE #9090]✨Migrate consumer queue headers to V3

### DIFF
--- a/rocketmq-protocol/src/protocol/header/peek_message_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/peek_message_request_header.rs
@@ -13,30 +13,35 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::protocol::header::message_operation_header::TopicRequestHeaderTrait;
 use crate::protocol::header::namesrv::topic_operation_header::TopicRequestHeader;
 
-#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::peek_message_request_header::PeekMessageRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.PeekMessageRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct PeekMessageRequestHeader {
-    #[required]
+    #[header(required)]
     pub consumer_group: CheetahString,
 
-    #[required]
+    #[header(required)]
     pub topic: CheetahString,
 
     /// If negative, peek from all queues
-    #[required]
+    #[header(required)]
     pub queue_id: i32,
 
-    #[required]
+    #[header(required)]
     pub max_msg_nums: i32,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/polling_info_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/polling_info_request_header.rs
@@ -13,26 +13,31 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::protocol::header::message_operation_header::TopicRequestHeaderTrait;
 use crate::protocol::header::namesrv::topic_operation_header::TopicRequestHeader;
 
-#[derive(Debug, Clone, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[derive(Debug, Clone, Serialize, Deserialize, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::polling_info_request_header::PollingInfoRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.PollingInfoRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct PollingInfoRequestHeader {
-    #[required]
+    #[header(required)]
     pub consumer_group: CheetahString,
 
-    #[required]
+    #[header(required)]
     pub topic: CheetahString,
 
-    #[required]
+    #[header(required)]
     pub queue_id: i32,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/query_consumer_offset_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/query_consumer_offset_request_header.rs
@@ -13,28 +13,33 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::protocol::header::message_operation_header::TopicRequestHeaderTrait;
 use crate::protocol::header::namesrv::topic_operation_header::TopicRequestHeader;
 
-#[derive(Debug, Clone, Serialize, Deserialize, RequestHeaderCodecV2, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, RequestHeaderCodecV3, Default)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::query_consumer_offset_request_header::QueryConsumerOffsetRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.QueryConsumerOffsetRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryConsumerOffsetRequestHeader {
-    #[required]
+    #[header(required)]
     pub consumer_group: CheetahString,
 
-    #[required]
+    #[header(required)]
     pub topic: CheetahString,
 
-    #[required]
+    #[header(required)]
     pub queue_id: i32,
 
     pub set_zero_if_not_found: Option<bool>,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/update_consumer_offset_header.rs
+++ b/rocketmq-protocol/src/protocol/header/update_consumer_offset_header.rs
@@ -14,6 +14,7 @@
 
 use cheetah_string::CheetahString;
 use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -23,18 +24,23 @@ use crate::protocol::header::namesrv::topic_operation_header::TopicRequestHeader
 #[derive(Debug, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
 pub struct UpdateConsumerOffsetResponseHeader {}
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::update_consumer_offset_header::UpdateConsumerOffsetRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.UpdateConsumerOffsetRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateConsumerOffsetRequestHeader {
-    #[required]
+    #[header(required)]
     pub consumer_group: CheetahString,
-    #[required]
+    #[header(required)]
     pub topic: CheetahString,
-    #[required]
+    #[header(required)]
     pub queue_id: i32,
-    #[required]
+    #[header(required)]
     pub commit_offset: i64,
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
@@ -58,11 +58,14 @@ use rocketmq_protocol::protocol::header::namesrv::topic_operation_header::TopicR
 use rocketmq_protocol::protocol::header::notification_request_header::NotificationRequestHeader;
 use rocketmq_protocol::protocol::header::notify_consumer_ids_changed_request_header::NotifyConsumerIdsChangedRequestHeader;
 use rocketmq_protocol::protocol::header::notify_unsubscribe_lite_request_header::NotifyUnsubscribeLiteRequestHeader;
+use rocketmq_protocol::protocol::header::peek_message_request_header::PeekMessageRequestHeader;
+use rocketmq_protocol::protocol::header::polling_info_request_header::PollingInfoRequestHeader;
 use rocketmq_protocol::protocol::header::pop_lite_message_request_header::PopLiteMessageRequestHeader;
 use rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader;
 use rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader;
 use rocketmq_protocol::protocol::header::query_consume_queue_request_header::QueryConsumeQueueRequestHeader;
 use rocketmq_protocol::protocol::header::query_consume_time_span_request_header::QueryConsumeTimeSpanRequestHeader;
+use rocketmq_protocol::protocol::header::query_consumer_offset_request_header::QueryConsumerOffsetRequestHeader;
 use rocketmq_protocol::protocol::header::query_correction_offset_header::QueryCorrectionOffsetHeader;
 use rocketmq_protocol::protocol::header::query_subscription_by_consumer_request_header::QuerySubscriptionByConsumerRequestHeader;
 use rocketmq_protocol::protocol::header::query_topic_consume_by_who_request_header::QueryTopicConsumeByWhoRequestHeader;
@@ -71,6 +74,7 @@ use rocketmq_protocol::protocol::header::search_offset_request_header::SearchOff
 use rocketmq_protocol::protocol::header::search_offset_response_header::SearchOffsetResponseHeader;
 use rocketmq_protocol::protocol::header::unlock_batch_mq_request_header::UnlockBatchMqRequestHeader;
 use rocketmq_protocol::protocol::header::unregister_client_request_header::UnregisterClientRequestHeader;
+use rocketmq_protocol::protocol::header::update_consumer_offset_header::UpdateConsumerOffsetRequestHeader;
 use rocketmq_protocol::protocol::header::update_group_forbidden_request_header::UpdateGroupForbiddenRequestHeader;
 use rocketmq_protocol::protocol::header_codec::{
     AliasConflictPolicy, HeaderCodec, HeaderCodecError, HeaderFieldSpec, HeaderFlattenSpec, HeaderPresence,
@@ -358,6 +362,19 @@ fn registry() -> Vec<RegisteredSchema> {
         register::<SearchOffsetResponseHeader>(),
         register::<PullMessageRequestHeader>(),
         register::<PullMessageResponseHeader>(),
+        register_value(&PeekMessageRequestHeader {
+            consumer_group: CheetahString::from_static_str("registry"),
+            topic: CheetahString::from_static_str("registry"),
+            queue_id: 0,
+            max_msg_nums: 0,
+            topic_request_header: None,
+        }),
+        register_value(&PollingInfoRequestHeader {
+            consumer_group: CheetahString::from_static_str("registry"),
+            topic: CheetahString::from_static_str("registry"),
+            queue_id: 0,
+            topic_request_header: None,
+        }),
         register_value(&PopLiteMessageRequestHeader {
             client_id: CheetahString::from_static_str("registry"),
             consumer_group: CheetahString::from_static_str("registry"),
@@ -383,8 +400,22 @@ fn registry() -> Vec<RegisteredSchema> {
             rpc_request_header: None,
         }),
         register::<QueryTopicsByConsumerRequestHeader>(),
+        register_value(&QueryConsumerOffsetRequestHeader {
+            consumer_group: CheetahString::from_static_str("registry"),
+            topic: CheetahString::from_static_str("registry"),
+            queue_id: 0,
+            set_zero_if_not_found: None,
+            topic_request_header: None,
+        }),
         register::<UnlockBatchMqRequestHeader>(),
         register::<UnregisterClientRequestHeader>(),
+        register_value(&UpdateConsumerOffsetRequestHeader {
+            consumer_group: CheetahString::from_static_str("registry"),
+            topic: CheetahString::from_static_str("registry"),
+            queue_id: 0,
+            commit_offset: 0,
+            topic_request_header: None,
+        }),
         register_value(&UpdateGroupForbiddenRequestHeader {
             group: CheetahString::from_static_str("registry"),
             topic: CheetahString::from_static_str("registry"),
@@ -943,6 +974,110 @@ fn topic_headers_preserve_nested_java_inheritance_and_defaults() {
             })
         },
     );
+    assert_topic_envelope_contract::<QueryConsumerOffsetRequestHeader>(
+        &[
+            ("consumerGroup", "consumer-query"),
+            ("topic", "topic-query"),
+            ("queueId", "2147483647"),
+            ("setZeroIfNotFound", "true"),
+        ],
+        &["consumerGroup", "topic", "queueId"],
+        |header| {
+            header.topic_request_header.as_ref().map(|topic| TopicEnvelopeRef {
+                lo: topic.lo,
+                rpc: &topic.rpc,
+            })
+        },
+    );
+    assert_topic_envelope_contract::<UpdateConsumerOffsetRequestHeader>(
+        &[
+            ("consumerGroup", "consumer-update"),
+            ("topic", "topic-update"),
+            ("queueId", "-2147483648"),
+            ("commitOffset", "9223372036854775807"),
+        ],
+        &["consumerGroup", "topic", "queueId", "commitOffset"],
+        |header| {
+            header.topic_request_header.as_ref().map(|topic| TopicEnvelopeRef {
+                lo: topic.lo,
+                rpc: &topic.rpc,
+            })
+        },
+    );
+    assert_topic_envelope_contract::<PollingInfoRequestHeader>(
+        &[
+            ("consumerGroup", "consumer-polling"),
+            ("topic", "topic-polling"),
+            ("queueId", "0"),
+        ],
+        &["consumerGroup", "topic", "queueId"],
+        |header| {
+            header.topic_request_header.as_ref().map(|topic| TopicEnvelopeRef {
+                lo: topic.lo,
+                rpc: &topic.rpc,
+            })
+        },
+    );
+    assert_topic_envelope_contract::<PeekMessageRequestHeader>(
+        &[
+            ("consumerGroup", "consumer-peek"),
+            ("topic", "topic-peek"),
+            ("queueId", "-1"),
+            ("maxMsgNums", "2147483647"),
+        ],
+        &["consumerGroup", "topic", "queueId", "maxMsgNums"],
+        |header| {
+            header.topic_request_header.as_ref().map(|topic| TopicEnvelopeRef {
+                lo: topic.lo,
+                rpc: &topic.rpc,
+            })
+        },
+    );
+
+    let update_signed_minimum = HeaderMap::from([
+        ("consumerGroup".into(), "consumer-update".into()),
+        ("topic".into(), "topic-update".into()),
+        ("queueId".into(), "2147483647".into()),
+        ("commitOffset".into(), "-9223372036854775808".into()),
+    ]);
+    let typed = <UpdateConsumerOffsetRequestHeader as HeaderCodec>::decode_from_map(&update_signed_minimum)
+        .expect("signed Java Long and Integer minima remain valid");
+    let legacy = <UpdateConsumerOffsetRequestHeader as FromMap>::from(&update_signed_minimum)
+        .expect("legacy adapter accepts signed Java extrema");
+    assert_eq!(typed.queue_id, i32::MAX);
+    assert_eq!(legacy.queue_id, i32::MAX);
+    assert_eq!(typed.commit_offset, i64::MIN);
+    assert_eq!(legacy.commit_offset, i64::MIN);
+
+    let peek_signed_minimum = HeaderMap::from([
+        ("consumerGroup".into(), "consumer-peek".into()),
+        ("topic".into(), "topic-peek".into()),
+        ("queueId".into(), "-2147483648".into()),
+        ("maxMsgNums".into(), "-2147483648".into()),
+    ]);
+    let typed = <PeekMessageRequestHeader as HeaderCodec>::decode_from_map(&peek_signed_minimum)
+        .expect("signed Java Integer minima remain valid");
+    let legacy = <PeekMessageRequestHeader as FromMap>::from(&peek_signed_minimum)
+        .expect("legacy adapter accepts signed Java Integer minima");
+    assert_eq!(typed.queue_id, i32::MIN);
+    assert_eq!(legacy.queue_id, i32::MIN);
+    assert_eq!(typed.max_msg_nums, i32::MIN);
+    assert_eq!(legacy.max_msg_nums, i32::MIN);
+
+    let malformed_set_zero = HeaderMap::from([
+        ("consumerGroup".into(), "consumer-query".into()),
+        ("topic".into(), "topic-query".into()),
+        ("queueId".into(), "0".into()),
+        ("setZeroIfNotFound".into(), "not-a-bool".into()),
+    ]);
+    assert!(matches!(
+        <QueryConsumerOffsetRequestHeader as HeaderCodec>::decode_from_map(&malformed_set_zero),
+        Err(HeaderCodecError::InvalidValue {
+            key: "setZeroIfNotFound",
+            ..
+        })
+    ));
+    assert!(<QueryConsumerOffsetRequestHeader as FromMap>::from(&malformed_set_zero).is_err());
 
     let consume_stats_minimum = HeaderMap::from([("consumerGroup".into(), "consumer-min".into())]);
     let typed = <GetConsumeStatsRequestHeader as HeaderCodec>::decode_from_map(&consume_stats_minimum)

--- a/scripts/request-header-codec/migration.json
+++ b/scripts/request-header-codec/migration.json
@@ -8,10 +8,10 @@
     "entryCount": 152,
     "mappedCount": 143,
     "rustOnlyExtensionCount": 9,
-    "v2Count": 98,
-    "v3Count": 54,
-    "pendingCount": 98,
-    "migratedCount": 54
+    "v2Count": 94,
+    "v3Count": 58,
+    "pendingCount": 94,
+    "migratedCount": 58
   },
   "baseline": {
     "v2TypeIds": [
@@ -212,11 +212,14 @@
       "rocketmq_protocol::protocol::header::notification_request_header::NotificationRequestHeader",
       "rocketmq_protocol::protocol::header::notify_consumer_ids_changed_request_header::NotifyConsumerIdsChangedRequestHeader",
       "rocketmq_protocol::protocol::header::notify_unsubscribe_lite_request_header::NotifyUnsubscribeLiteRequestHeader",
+      "rocketmq_protocol::protocol::header::peek_message_request_header::PeekMessageRequestHeader",
+      "rocketmq_protocol::protocol::header::polling_info_request_header::PollingInfoRequestHeader",
       "rocketmq_protocol::protocol::header::pop_lite_message_request_header::PopLiteMessageRequestHeader",
       "rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader",
       "rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader",
       "rocketmq_protocol::protocol::header::query_consume_queue_request_header::QueryConsumeQueueRequestHeader",
       "rocketmq_protocol::protocol::header::query_consume_time_span_request_header::QueryConsumeTimeSpanRequestHeader",
+      "rocketmq_protocol::protocol::header::query_consumer_offset_request_header::QueryConsumerOffsetRequestHeader",
       "rocketmq_protocol::protocol::header::query_correction_offset_header::QueryCorrectionOffsetHeader",
       "rocketmq_protocol::protocol::header::query_subscription_by_consumer_request_header::QuerySubscriptionByConsumerRequestHeader",
       "rocketmq_protocol::protocol::header::query_topic_consume_by_who_request_header::QueryTopicConsumeByWhoRequestHeader",
@@ -225,6 +228,7 @@
       "rocketmq_protocol::protocol::header::search_offset_response_header::SearchOffsetResponseHeader",
       "rocketmq_protocol::protocol::header::unlock_batch_mq_request_header::UnlockBatchMqRequestHeader",
       "rocketmq_protocol::protocol::header::unregister_client_request_header::UnregisterClientRequestHeader",
+      "rocketmq_protocol::protocol::header::update_consumer_offset_header::UpdateConsumerOffsetRequestHeader",
       "rocketmq_protocol::protocol::header::update_group_forbidden_request_header::UpdateGroupForbiddenRequestHeader",
       "rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader",
       "rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader"
@@ -2669,16 +2673,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 2,
       "flattenTypeIds": [
         "rocketmq_protocol::protocol::header::namesrv::topic_operation_header::TopicRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -2692,16 +2696,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 2,
       "flattenTypeIds": [
         "rocketmq_protocol::protocol::header::namesrv::topic_operation_header::TopicRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -2904,16 +2908,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 2,
       "flattenTypeIds": [
         "rocketmq_protocol::protocol::header::namesrv::topic_operation_header::TopicRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -3411,16 +3415,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 2,
       "flattenTypeIds": [
         "rocketmq_protocol::protocol::header::namesrv::topic_operation_header::TopicRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {

--- a/scripts/request-header-codec/tests/test_migrate.py
+++ b/scripts/request-header-codec/tests/test_migrate.py
@@ -55,7 +55,7 @@ class MigrationGuardTests(unittest.TestCase):
         )
         self.assertEqual(migrate.serialize(expected), migrate.serialize(self.manifest))
         self.assertEqual(len(self.headers), 152)
-        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 54)
+        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 58)
 
     def test_duplicate_simple_names_keep_distinct_stable_paths(self) -> None:
         graph, depths = migrate.flatten_graph(self.headers, self.repo_root)


### PR DESCRIPTION
## Summary
- migrate consumer queue request headers to `RequestHeaderCodecV3`
- preserve Java wire compatibility for required fields, signed integer domains, aliases, and nested topic inheritance
- add typed/legacy parity, malformed-value, required-field, and signed-boundary coverage
- refresh the migration inventory to 58 V3 and 94 frozen V2 headers

## Validation
- `cargo fmt -p rocketmq-protocol -- --check`
- `python scripts/request-header-codec/migrate.py check`
- `python scripts/request-header-codec/compare_header_schema.py`
- `python -m pytest scripts/request-header-codec/tests/test_migrate.py`
- `cargo test --locked -p rocketmq-protocol --all-features`
- `cargo clippy --locked -p rocketmq-protocol --all-targets --all-features --no-deps -- -A deprecated -D warnings`
- `git diff --check`

The migrated headers remain `MapOnly`; direct-binary promotion is controlled by the formal performance gates tracked in #9061 and #9062.

Closes #9090

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated message peeking, polling, consumer offset querying, and offset updating to use the latest request-header encoding format.
  * Strengthened request validation for required fields and nested topic information.
  * Improved compatibility for numeric boundaries and malformed boolean values.

* **Tests**
  * Added comprehensive coverage for the updated request headers and validation behavior.
  * Updated migration tracking to reflect four additional headers using the latest format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->