### PR TITLE
[ISSUE #9095]🐛Refresh standalone routing lockfiles

### DIFF
--- a/rocketmq-macros/tests/fixtures/renamed-consumer/Cargo.lock
+++ b/rocketmq-macros/tests/fixtures/renamed-consumer/Cargo.lock
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "cheetah-string"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34617d68520087a27a373f84fa30b683ef46c83603143e861a22fdcd65daab55"
+checksum = "352256e2fe5dedcda13ebaefb12a6a7d7012ce0706f874bc469bd131c0b0f2ef"
 dependencies = [
  "bytes",
  "memchr",
@@ -517,9 +517,9 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lz4_flex"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
 
 [[package]]
 name = "md-5"
@@ -715,7 +715,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/rocketmq-tools/rocketmq-mcp/Cargo.lock
+++ b/rocketmq-tools/rocketmq-mcp/Cargo.lock
@@ -298,9 +298,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bit-set"
@@ -2993,7 +2993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad26b216c966e987e80e86daf784a455c039c43d98575ceed57b8faa259e5695"
 dependencies = [
  "async-trait",
- "base64 0.23.0",
+ "base64 0.23.1",
  "bytes",
  "chrono",
  "futures",
@@ -3058,7 +3058,7 @@ version = "1.0.0"
 dependencies = [
  "aes-gcm",
  "arc-swap",
- "base64 0.23.0",
+ "base64 0.23.1",
  "cheetah-string",
  "chrono",
  "hex",
@@ -3129,7 +3129,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3140,7 +3140,7 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "axum",
- "base64 0.23.0",
+ "base64 0.23.1",
  "chrono",
  "clap",
  "config",
@@ -3181,7 +3181,7 @@ dependencies = [
 name = "rocketmq-model"
 version = "1.0.0"
 dependencies = [
- "base64 0.23.0",
+ "base64 0.23.1",
  "byteorder",
  "bytes",
  "cheetah-string",


### PR DESCRIPTION
## Summary
- refresh the renamed codec fixture lockfile to the current path-dependency graph
- refresh the RocketMQ MCP lockfile required by locked metadata routing checks
- keep manifests, source code, and the MCP deny-by-default boundary unchanged

## Validation
- `cargo check --locked --offline --manifest-path rocketmq-macros/tests/fixtures/renamed-consumer/Cargo.toml`
- `./scripts/check-agents-routing.ps1`
- MCP `cargo fmt -- --check`
- MCP `cargo check --locked`
- MCP `python scripts/check_read_only_boundary.py`
- MCP `cargo test --locked` (98 tests plus integration/doc tests)
- MCP `cargo clippy --locked --all-targets --features streamable-http -- -D warnings`
- MCP `cargo doc --locked --no-deps`
- `git diff --check`

## Existing platform baselines
- MCP `cargo fmt --all -- --check` stops with Windows OS error 206 before formatting; the project-only format check passes.
- MCP `cargo test --locked --all-features` passes 118/121 tests; three existing OAuth JWT tests panic because the current all-features graph enables both jsonwebtoken CryptoProviders. The two lockfile refreshes do not change the JWT/provider graph.

Closes #9095