### PR TITLE
[ISSUE #9094]✨Migrate POP message request headers to V3

### DIFF
--- a/rocketmq-macros/src/request_header_codec_v3/codegen_map.rs
+++ b/rocketmq-macros/src/request_header_codec_v3/codegen_map.rs
@@ -366,18 +366,40 @@ fn construct_field(
                 )?,
             }
         }
-        MissingPolicy::Default => quote! {
-            #ident: match #local {
-                Some(raw) => <#base_type as #value_trait>::decode(raw, Self::#context)?,
-                None => <#base_type as ::core::default::Default>::default(),
-            },
-        },
-        MissingPolicy::DefaultWith(path) => quote! {
-            #ident: match #local {
-                Some(raw) => <#base_type as #value_trait>::decode(raw, Self::#context)?,
-                None => #path(),
-            },
-        },
+        MissingPolicy::Default => {
+            if field.option_inner.is_some() {
+                quote! {
+                    #ident: match #local {
+                        Some(raw) => Some(<#base_type as #value_trait>::decode(raw, Self::#context)?),
+                        None => Some(<#base_type as ::core::default::Default>::default()),
+                    },
+                }
+            } else {
+                quote! {
+                    #ident: match #local {
+                        Some(raw) => <#base_type as #value_trait>::decode(raw, Self::#context)?,
+                        None => <#base_type as ::core::default::Default>::default(),
+                    },
+                }
+            }
+        }
+        MissingPolicy::DefaultWith(path) => {
+            if field.option_inner.is_some() {
+                quote! {
+                    #ident: match #local {
+                        Some(raw) => Some(<#base_type as #value_trait>::decode(raw, Self::#context)?),
+                        None => #path(),
+                    },
+                }
+            } else {
+                quote! {
+                    #ident: match #local {
+                        Some(raw) => <#base_type as #value_trait>::decode(raw, Self::#context)?,
+                        None => #path(),
+                    },
+                }
+            }
+        }
     }
 }
 

--- a/rocketmq-protocol/src/protocol/header/ack_message_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/ack_message_request_header.rs
@@ -13,44 +13,49 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
 /// Represents the request header for acknowledging a message.
-#[derive(Debug, Serialize, Deserialize, Clone, RequestHeaderCodecV2)]
+#[derive(Debug, Serialize, Deserialize, Clone, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::ack_message_request_header::AckMessageRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.AckMessageRequestHeader"
+)]
 pub struct AckMessageRequestHeader {
     /// Consumer group name (required)
     #[serde(rename = "consumerGroup")]
-    #[required]
+    #[header(required)]
     pub consumer_group: CheetahString,
 
     /// Topic name (required)
     #[serde(rename = "topic")]
-    #[required]
+    #[header(required)]
     pub topic: CheetahString,
 
     /// Queue ID (required)
     #[serde(rename = "queueId")]
-    #[required]
+    #[header(required)]
     pub queue_id: i32,
 
     /// Extra information (required)
     #[serde(rename = "extraInfo")]
-    #[required]
+    #[header(required)]
     pub extra_info: CheetahString,
 
     /// Offset (required)
     #[serde(rename = "offset")]
-    #[required]
+    #[header(required)]
     pub offset: i64,
 
     #[serde(rename = "liteTopic", skip_serializing_if = "Option::is_none")]
     pub lite_topic: Option<CheetahString>,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/change_invisible_time_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/change_invisible_time_request_header.rs
@@ -15,40 +15,47 @@
 use std::fmt::Display;
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
-#[derive(Serialize, Deserialize, Debug, Default, RequestHeaderCodecV2)]
+#[derive(Serialize, Deserialize, Debug, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::change_invisible_time_request_header::ChangeInvisibleTimeRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.ChangeInvisibleTimeRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct ChangeInvisibleTimeRequestHeader {
-    #[required]
+    #[header(required)]
     pub consumer_group: CheetahString,
 
-    #[required]
+    #[header(required)]
     pub topic: CheetahString,
 
-    #[required]
+    #[header(required)]
     pub queue_id: i32,
 
     //startOffset popTime invisibleTime queueId
-    #[required]
+    #[header(required)]
     pub extra_info: CheetahString,
 
-    #[required]
+    #[header(required)]
     pub offset: i64,
 
-    #[required]
+    #[header(required)]
     pub invisible_time: i64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lite_topic: Option<CheetahString>,
 
+    #[serde(default)]
+    #[header(default, default_semantic = "literal:false")]
     pub suspend: bool,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/pop_message_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/pop_message_request_header.rs
@@ -15,38 +15,49 @@
 use std::fmt::Display;
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::protocol::header::namesrv::topic_operation_header::TopicRequestHeader;
 
-#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::pop_message_request_header::PopMessageRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.PopMessageRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct PopMessageRequestHeader {
-    #[required]
+    #[header(required)]
     pub consumer_group: CheetahString,
-    #[required]
+    #[header(required)]
     pub topic: CheetahString,
-    #[required]
+    #[header(required)]
     pub queue_id: i32,
-    #[required]
+    #[header(required, range = "i32")]
     pub max_msg_nums: u32,
-    #[required]
+    #[header(required, range = "i64")]
     pub invisible_time: u64,
-    #[required]
+    #[header(required, range = "i64")]
     pub poll_time: u64,
-    #[required]
+    #[header(required, range = "i64")]
     pub born_time: u64,
-    #[required]
+    #[header(required)]
     pub init_mode: i32,
     pub exp_type: Option<CheetahString>,
     pub exp: Option<CheetahString>,
+    #[serde(default = "default_order")]
+    #[header(default_with = "default_order", default_semantic = "literal:false")]
     pub order: Option<bool>,
     pub attempt_id: Option<CheetahString>,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
+}
+
+fn default_order() -> Option<bool> {
+    Some(false)
 }
 
 impl PopMessageRequestHeader {

--- a/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
@@ -20,6 +20,7 @@ use cheetah_string::CheetahString;
 use rocketmq_macros::RequestHeaderCodecV3;
 use rocketmq_model::boundary_type::BoundaryType;
 use rocketmq_model::common::sys_flag::message_sys_flag::MessageSysFlag;
+use rocketmq_protocol::protocol::header::change_invisible_time_request_header::ChangeInvisibleTimeRequestHeader;
 use rocketmq_protocol::protocol::header::check_rocksdb_cq_write_progress_request_header::CheckRocksdbCqWriteProgressRequestHeader;
 use rocketmq_protocol::protocol::header::check_transaction_state_request_header::CheckTransactionStateRequestHeader;
 use rocketmq_protocol::protocol::header::clone_group_offset_request_header::CloneGroupOffsetRequestHeader;
@@ -76,6 +77,9 @@ use rocketmq_protocol::protocol::header::unlock_batch_mq_request_header::UnlockB
 use rocketmq_protocol::protocol::header::unregister_client_request_header::UnregisterClientRequestHeader;
 use rocketmq_protocol::protocol::header::update_consumer_offset_header::UpdateConsumerOffsetRequestHeader;
 use rocketmq_protocol::protocol::header::update_group_forbidden_request_header::UpdateGroupForbiddenRequestHeader;
+use rocketmq_protocol::protocol::header::{
+    ack_message_request_header::AckMessageRequestHeader, pop_message_request_header::PopMessageRequestHeader,
+};
 use rocketmq_protocol::protocol::header_codec::{
     AliasConflictPolicy, HeaderCodec, HeaderCodecError, HeaderFieldSpec, HeaderFlattenSpec, HeaderPresence,
     HeaderRange, HeaderValueKind,
@@ -230,6 +234,15 @@ fn registry() -> Vec<RegisteredSchema> {
         register::<RpcRequestHeader>(),
         register::<TopicRequestHeader>(),
         register::<NamesrvTopicRequestHeader>(),
+        register_value(&AckMessageRequestHeader {
+            consumer_group: CheetahString::from_static_str("registry"),
+            topic: CheetahString::from_static_str("registry"),
+            queue_id: 0,
+            extra_info: CheetahString::from_static_str("registry"),
+            offset: 0,
+            lite_topic: None,
+            topic_request_header: None,
+        }),
         register_value(&CheckTransactionStateRequestHeader {
             topic: None,
             tran_state_table_offset: 0,
@@ -244,6 +257,7 @@ fn registry() -> Vec<RegisteredSchema> {
             check_store_time: 0,
             rpc: None,
         }),
+        register::<ChangeInvisibleTimeRequestHeader>(),
         register::<CloneGroupOffsetRequestHeader>(),
         register::<ConsumeMessageDirectlyResultRequestHeader>(),
         register_value(&ConsumerSendMsgBackRequestHeader {
@@ -373,6 +387,21 @@ fn registry() -> Vec<RegisteredSchema> {
             consumer_group: CheetahString::from_static_str("registry"),
             topic: CheetahString::from_static_str("registry"),
             queue_id: 0,
+            topic_request_header: None,
+        }),
+        register_value(&PopMessageRequestHeader {
+            consumer_group: CheetahString::from_static_str("registry"),
+            topic: CheetahString::from_static_str("registry"),
+            queue_id: 0,
+            max_msg_nums: 0,
+            invisible_time: 0,
+            poll_time: 0,
+            born_time: 0,
+            init_mode: 0,
+            exp_type: None,
+            exp: None,
+            order: Some(false),
+            attempt_id: None,
             topic_request_header: None,
         }),
         register_value(&PopLiteMessageRequestHeader {
@@ -1033,6 +1062,179 @@ fn topic_headers_preserve_nested_java_inheritance_and_defaults() {
             })
         },
     );
+    assert_topic_envelope_contract::<AckMessageRequestHeader>(
+        &[
+            ("consumerGroup", "consumer-ack"),
+            ("topic", "topic-ack"),
+            ("queueId", "2147483647"),
+            ("extraInfo", "extra-ack"),
+            ("offset", "-9223372036854775808"),
+            ("liteTopic", "lite-ack"),
+        ],
+        &["consumerGroup", "topic", "queueId", "extraInfo", "offset"],
+        |header| {
+            header.topic_request_header.as_ref().map(|topic| TopicEnvelopeRef {
+                lo: topic.lo,
+                rpc: &topic.rpc_request_header,
+            })
+        },
+    );
+    assert_topic_envelope_contract::<ChangeInvisibleTimeRequestHeader>(
+        &[
+            ("consumerGroup", "consumer-change"),
+            ("topic", "topic-change"),
+            ("queueId", "-2147483648"),
+            ("extraInfo", "extra-change"),
+            ("offset", "9223372036854775807"),
+            ("invisibleTime", "-9223372036854775808"),
+            ("liteTopic", "lite-change"),
+            ("suspend", "true"),
+        ],
+        &[
+            "consumerGroup",
+            "topic",
+            "queueId",
+            "extraInfo",
+            "offset",
+            "invisibleTime",
+        ],
+        |header| {
+            header.topic_request_header.as_ref().map(|topic| TopicEnvelopeRef {
+                lo: topic.lo,
+                rpc: &topic.rpc_request_header,
+            })
+        },
+    );
+    assert_topic_envelope_contract::<PopMessageRequestHeader>(
+        &[
+            ("consumerGroup", "consumer-pop"),
+            ("topic", "topic-pop"),
+            ("queueId", "2147483647"),
+            ("maxMsgNums", "2147483647"),
+            ("invisibleTime", "9223372036854775807"),
+            ("pollTime", "9223372036854775807"),
+            ("bornTime", "9223372036854775807"),
+            ("initMode", "-2147483648"),
+            ("expType", "TAG"),
+            ("exp", "tag-a"),
+            ("order", "true"),
+            ("attemptId", "attempt-pop"),
+        ],
+        &[
+            "consumerGroup",
+            "topic",
+            "queueId",
+            "maxMsgNums",
+            "invisibleTime",
+            "pollTime",
+            "bornTime",
+            "initMode",
+        ],
+        |header| {
+            header.topic_request_header.as_ref().map(|topic| TopicEnvelopeRef {
+                lo: topic.lo,
+                rpc: &topic.rpc,
+            })
+        },
+    );
+
+    let pop_required_only = HeaderMap::from([
+        ("consumerGroup".into(), "consumer-pop".into()),
+        ("topic".into(), "topic-pop".into()),
+        ("queueId".into(), "0".into()),
+        ("maxMsgNums".into(), "32".into()),
+        ("invisibleTime".into(), "30000".into()),
+        ("pollTime".into(), "15000".into()),
+        ("bornTime".into(), "1720000000000".into()),
+        ("initMode".into(), "0".into()),
+    ]);
+    let typed = <PopMessageRequestHeader as HeaderCodec>::decode_from_map(&pop_required_only)
+        .expect("missing order uses the Java Boolean.FALSE initializer");
+    let legacy = <PopMessageRequestHeader as FromMap>::from(&pop_required_only)
+        .expect("legacy adapter uses the Java Boolean.FALSE initializer");
+    assert_eq!(typed.order, Some(false));
+    assert_eq!(legacy.order, Some(false));
+
+    let mut malformed_order = pop_required_only.clone();
+    malformed_order.insert("order".into(), "not-a-bool".into());
+    assert!(matches!(
+        <PopMessageRequestHeader as HeaderCodec>::decode_from_map(&malformed_order),
+        Err(HeaderCodecError::InvalidValue { key: "order", .. })
+    ));
+    assert!(<PopMessageRequestHeader as FromMap>::from(&malformed_order).is_err());
+
+    let mut malformed_suspend = HeaderMap::from([
+        ("consumerGroup".into(), "consumer-change".into()),
+        ("topic".into(), "topic-change".into()),
+        ("queueId".into(), "0".into()),
+        ("extraInfo".into(), "extra-change".into()),
+        ("offset".into(), "0".into()),
+        ("invisibleTime".into(), "1".into()),
+    ]);
+    let typed = <ChangeInvisibleTimeRequestHeader as HeaderCodec>::decode_from_map(&malformed_suspend)
+        .expect("missing suspend uses the Java false initializer");
+    let legacy = <ChangeInvisibleTimeRequestHeader as FromMap>::from(&malformed_suspend)
+        .expect("legacy adapter uses the Java false initializer");
+    assert!(!typed.suspend);
+    assert!(!legacy.suspend);
+    malformed_suspend.insert("suspend".into(), "not-a-bool".into());
+    assert!(matches!(
+        <ChangeInvisibleTimeRequestHeader as HeaderCodec>::decode_from_map(&malformed_suspend),
+        Err(HeaderCodecError::InvalidValue { key: "suspend", .. })
+    ));
+    assert!(<ChangeInvisibleTimeRequestHeader as FromMap>::from(&malformed_suspend).is_err());
+
+    let ack_signed_maximum = HeaderMap::from([
+        ("consumerGroup".into(), "consumer-ack".into()),
+        ("topic".into(), "topic-ack".into()),
+        ("queueId".into(), "-2147483648".into()),
+        ("extraInfo".into(), "extra-ack".into()),
+        ("offset".into(), "9223372036854775807".into()),
+    ]);
+    let typed = <AckMessageRequestHeader as HeaderCodec>::decode_from_map(&ack_signed_maximum)
+        .expect("signed Java extrema remain valid");
+    let legacy = <AckMessageRequestHeader as FromMap>::from(&ack_signed_maximum)
+        .expect("legacy adapter accepts signed Java extrema");
+    assert_eq!(typed.queue_id, i32::MIN);
+    assert_eq!(legacy.queue_id, i32::MIN);
+    assert_eq!(typed.offset, i64::MAX);
+    assert_eq!(legacy.offset, i64::MAX);
+
+    let valid_pop = PopMessageRequestHeader {
+        consumer_group: "consumer-pop".into(),
+        topic: "topic-pop".into(),
+        queue_id: 0,
+        max_msg_nums: 32,
+        invisible_time: 30_000,
+        poll_time: 15_000,
+        born_time: 1_720_000_000_000,
+        init_mode: 0,
+        exp_type: None,
+        exp: None,
+        order: Some(false),
+        attempt_id: None,
+        topic_request_header: None,
+    };
+    let mut overflow_cases = Vec::new();
+    let mut max_msg_nums = valid_pop.clone();
+    max_msg_nums.max_msg_nums = i32::MAX as u32 + 1;
+    overflow_cases.push(("maxMsgNums", max_msg_nums));
+    let mut invisible_time = valid_pop.clone();
+    invisible_time.invisible_time = i64::MAX as u64 + 1;
+    overflow_cases.push(("invisibleTime", invisible_time));
+    let mut poll_time = valid_pop.clone();
+    poll_time.poll_time = i64::MAX as u64 + 1;
+    overflow_cases.push(("pollTime", poll_time));
+    let mut born_time = valid_pop;
+    born_time.born_time = i64::MAX as u64 + 1;
+    overflow_cases.push(("bornTime", born_time));
+    for (key, header) in overflow_cases {
+        let mut map = HeaderMap::new();
+        assert!(matches!(
+            header.try_encode_into_map(&mut map),
+            Err(HeaderCodecError::JavaRange { key: actual, .. }) if actual == key
+        ));
+    }
 
     let update_signed_minimum = HeaderMap::from([
         ("consumerGroup".into(), "consumer-update".into()),

--- a/scripts/request-header-codec/migration.json
+++ b/scripts/request-header-codec/migration.json
@@ -8,10 +8,10 @@
     "entryCount": 152,
     "mappedCount": 143,
     "rustOnlyExtensionCount": 9,
-    "v2Count": 94,
-    "v3Count": 58,
-    "pendingCount": 94,
-    "migratedCount": 58
+    "v2Count": 91,
+    "v3Count": 61,
+    "pendingCount": 91,
+    "migratedCount": 61
   },
   "baseline": {
     "v2TypeIds": [
@@ -174,6 +174,8 @@
       }
     },
     "acceptedV3TypeIds": [
+      "rocketmq_protocol::protocol::header::ack_message_request_header::AckMessageRequestHeader",
+      "rocketmq_protocol::protocol::header::change_invisible_time_request_header::ChangeInvisibleTimeRequestHeader",
       "rocketmq_protocol::protocol::header::check_rocksdb_cq_write_progress_request_header::CheckRocksdbCqWriteProgressRequestHeader",
       "rocketmq_protocol::protocol::header::check_transaction_state_request_header::CheckTransactionStateRequestHeader",
       "rocketmq_protocol::protocol::header::clone_group_offset_request_header::CloneGroupOffsetRequestHeader",
@@ -215,6 +217,7 @@
       "rocketmq_protocol::protocol::header::peek_message_request_header::PeekMessageRequestHeader",
       "rocketmq_protocol::protocol::header::polling_info_request_header::PollingInfoRequestHeader",
       "rocketmq_protocol::protocol::header::pop_lite_message_request_header::PopLiteMessageRequestHeader",
+      "rocketmq_protocol::protocol::header::pop_message_request_header::PopMessageRequestHeader",
       "rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader",
       "rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader",
       "rocketmq_protocol::protocol::header::query_consume_queue_request_header::QueryConsumeQueueRequestHeader",
@@ -450,16 +453,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 2,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -515,16 +518,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 2,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -2778,16 +2781,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 2,
       "flattenTypeIds": [
         "rocketmq_protocol::protocol::header::namesrv::topic_operation_header::TopicRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {

--- a/scripts/request-header-codec/tests/test_migrate.py
+++ b/scripts/request-header-codec/tests/test_migrate.py
@@ -55,7 +55,7 @@ class MigrationGuardTests(unittest.TestCase):
         )
         self.assertEqual(migrate.serialize(expected), migrate.serialize(self.manifest))
         self.assertEqual(len(self.headers), 152)
-        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 58)
+        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 61)
 
     def test_duplicate_simple_names_keep_distinct_stable_paths(self) -> None:
         graph, depths = migrate.flatten_graph(self.headers, self.repo_root)


### PR DESCRIPTION
## Summary
- migrate Ack, ChangeInvisibleTime, and Pop message request headers to `RequestHeaderCodecV3`
- preserve Java required fields, optional values, nested Topic/RPC inheritance, canonical aliases, and primitive/default semantics
- make V3 decode `default/default_with` correctly support `Option<T>`, preserving `PopMessageRequestHeader.order = Boolean.FALSE`
- infer Java kinds from Rust; retain only `range = i32/i64` for unsigned Pop fields
- refresh the governed inventory to 61 V3 and 91 frozen V2 headers

## Validation
- `cargo fmt -p rocketmq-macros -p rocketmq-protocol -- --check`
- `python scripts/request-header-codec/migrate.py check`
- `python scripts/request-header-codec/compare_header_schema.py`
- Python migration unit tests
- `cargo test --locked -p rocketmq-macros --lib`
- renamed-consumer `cargo check --locked --offline`
- `cargo test --locked -p rocketmq-protocol --all-features`
- `cargo clippy --locked -p rocketmq-macros -p rocketmq-protocol --all-targets --all-features --no-deps -- -A deprecated -D warnings`
- `git diff --check`

The standalone fuzz check remains blocked before compilation by its pre-existing stale lockfile. The migrated headers stay `MapOnly`; formal performance evidence #9061/#9062 remains authoritative.

Closes #9094

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Migrated acknowledgment, visibility-change, and message-pop request headers to the latest protocol format.
  * Added explicit validation, required-field handling, defaults, and numeric range support for these requests.
  * Improved handling of nested topic header information.

* **Bug Fixes**
  * Corrected default behavior for optional fields and boolean request values.

* **Tests**
  * Expanded coverage for defaults, malformed values, boundary conditions, and encoding validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->