### PR TITLE
[ISSUE #9098]✨Migrate remaining nested request headers to V3

### DIFF
--- a/rocketmq-protocol/src/protocol/header/client_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/client_request_header.rs
@@ -13,21 +13,26 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
-#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::client_request_header::GetRouteInfoRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.namesrv.GetRouteInfoRequestHeader"
+)]
 pub struct GetRouteInfoRequestHeader {
-    #[required]
+    #[header(required)]
     pub topic: CheetahString,
 
     #[serde(rename = "acceptStandardJsonOnly")]
     pub accept_standard_json_only: Option<bool>,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/create_topic_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/create_topic_request_header.rs
@@ -13,43 +13,47 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
-#[derive(Serialize, Deserialize, Debug, RequestHeaderCodecV2)]
-#[request_header(validate = "validate")]
+#[derive(Serialize, Deserialize, Debug, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::create_topic_request_header::CreateTopicRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.CreateTopicRequestHeader",
+    validate = "Self::validate"
+)]
 pub struct CreateTopicRequestHeader {
-    #[required]
+    #[header(required)]
     #[serde(rename = "topic")]
     pub topic: CheetahString,
 
-    #[required]
+    #[header(required)]
     #[serde(rename = "defaultTopic")]
     pub default_topic: CheetahString,
 
-    #[required]
+    #[header(required)]
     #[serde(rename = "readQueueNums")]
     pub read_queue_nums: i32,
 
-    #[required]
+    #[header(required)]
     #[serde(rename = "writeQueueNums")]
     pub write_queue_nums: i32,
 
-    #[required]
+    #[header(required)]
     #[serde(rename = "perm")]
     pub perm: i32,
 
-    #[required]
+    #[header(required)]
     #[serde(rename = "topicFilterType")]
     pub topic_filter_type: CheetahString,
 
     #[serde(rename = "topicSysFlag")]
     pub topic_sys_flag: Option<i32>,
 
-    #[required]
+    #[header(required)]
     #[serde(rename = "order")]
     pub order: bool,
 
@@ -57,21 +61,43 @@ pub struct CreateTopicRequestHeader {
     pub attributes: Option<CheetahString>,
 
     #[serde(rename = "force")]
+    #[serde(default = "default_force")]
+    #[header(default_with = "default_force", default_semantic = "literal:false")]
     pub force: Option<bool>,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 
+fn default_force() -> Option<bool> {
+    Some(false)
+}
+
 impl CreateTopicRequestHeader {
-    fn validate(&self) -> rocketmq_error::RocketMQResult<()> {
+    fn validate(&self) -> Result<(), crate::protocol::header_codec::HeaderCodecError> {
         match self.topic_filter_type.as_str() {
             "SINGLE_TAG" | "MULTI_TAG" => Ok(()),
-            _ => Err(rocketmq_error::RocketMQError::request_header_error(
-                "CreateTopicRequestHeader.topicFilterType: unsupported value",
-            )),
+            _ => Err(crate::protocol::header_codec::HeaderCodecError::Validation {
+                header: "rocketmq_protocol::protocol::header::create_topic_request_header::CreateTopicRequestHeader",
+                rule: "supported_topic_filter_type",
+            }),
         }
     }
+}
+
+#[cfg(test)]
+impl CreateTopicRequestHeader {
+    const TOPIC: &'static str = "topic";
+    const DEFAULT_TOPIC: &'static str = "defaultTopic";
+    const READ_QUEUE_NUMS: &'static str = "readQueueNums";
+    const WRITE_QUEUE_NUMS: &'static str = "writeQueueNums";
+    const PERM: &'static str = "perm";
+    const TOPIC_FILTER_TYPE: &'static str = "topicFilterType";
+    const TOPIC_SYS_FLAG: &'static str = "topicSysFlag";
+    const ORDER: &'static str = "order";
+    const ATTRIBUTES: &'static str = "attributes";
+    const FORCE: &'static str = "force";
 }
 
 #[cfg(test)]
@@ -258,7 +284,7 @@ mod tests {
         assert_eq!(header.topic_sys_flag, None);
         assert!(header.order);
         assert_eq!(header.attributes, None);
-        assert_eq!(header.force, None);
+        assert_eq!(header.force, Some(false));
     }
 
     #[test]

--- a/rocketmq-protocol/src/protocol/header/query_message_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/query_message_request_header.rs
@@ -13,28 +13,32 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
-#[derive(Debug, Clone, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[derive(Debug, Clone, Serialize, Deserialize, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::query_message_request_header::QueryMessageRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.QueryMessageRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryMessageRequestHeader {
-    #[required]
+    #[header(required)]
     pub topic: CheetahString,
 
-    #[required]
+    #[header(required)]
     pub key: CheetahString,
 
-    #[required]
+    #[header(required)]
     pub max_num: i32,
 
-    #[required]
+    #[header(required)]
     pub begin_timestamp: i64,
 
-    #[required]
+    #[header(required)]
     pub end_timestamp: i64,
 
     pub index_type: Option<CheetahString>,
@@ -42,6 +46,7 @@ pub struct QueryMessageRequestHeader {
     pub last_key: Option<CheetahString>,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/recall_message_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/recall_message_request_header.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -24,7 +24,11 @@ use crate::rpc::topic_request_header::TopicRequestHeader;
 /// This header is used with `RequestCode::RECALL_MESSAGE` to recall a previously
 /// sent message from the broker. The recall operation requires the producer group,
 /// topic, and a recall handle that identifies the message to be recalled.
-#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::recall_message_request_header::RecallMessageRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.RecallMessageRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct RecallMessageRequestHeader {
     /// Producer group name (optional).
@@ -37,14 +41,14 @@ pub struct RecallMessageRequestHeader {
     /// Topic name (required).
     ///
     /// The topic to which the message was originally sent.
-    #[required]
+    #[header(required)]
     pub topic: CheetahString,
 
     /// Recall handle (required).
     ///
     /// A unique identifier or handle that specifies which message to recall.
     /// The format and semantics of this handle are implementation-specific.
-    #[required]
+    #[header(required)]
     pub recall_handle: CheetahString,
 
     /// Topic request header containing common request metadata.
@@ -52,6 +56,7 @@ pub struct RecallMessageRequestHeader {
     /// This field is flattened during serialization/deserialization to merge
     /// its fields with the top-level structure.
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
 }
 

--- a/rocketmq-protocol/src/protocol/header/reply_message_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/reply_message_request_header.rs
@@ -13,46 +13,50 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::protocol::header::namesrv::topic_operation_header::TopicRequestHeader;
 
 /// Represents the header of a reply message request.
-#[derive(Serialize, Deserialize, Debug, Default, RequestHeaderCodecV2)]
+#[derive(Serialize, Deserialize, Debug, Default, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::reply_message_request_header::ReplyMessageRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.ReplyMessageRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct ReplyMessageRequestHeader {
     /// Producer group associated with the message.
-    #[required]
+    #[header(required)]
     pub producer_group: CheetahString,
 
     /// The topic of the message.
-    #[required]
+    #[header(required)]
     pub topic: CheetahString,
 
     /// Default topic used when the specified topic is not found.
-    #[required]
+    #[header(required)]
     pub default_topic: CheetahString,
 
     /// Number of queues in the default topic.
-    #[required]
+    #[header(required)]
     pub default_topic_queue_nums: i32,
 
     /// Queue ID of the message.
-    #[required]
+    #[header(required)]
     pub queue_id: i32,
 
     /// System flags associated with the message.
-    #[required]
+    #[header(required)]
     pub sys_flag: i32,
 
     /// Timestamp of when the message was born.
-    #[required]
+    #[header(required)]
     pub born_timestamp: i64,
 
     /// Flags associated with the message.
-    #[required]
+    #[header(required)]
     pub flag: i32,
 
     /// Properties of the message (nullable).
@@ -62,22 +66,29 @@ pub struct ReplyMessageRequestHeader {
     pub reconsume_times: Option<i32>,
 
     /// Whether the message processing is in unit mode (nullable).
+    #[serde(default = "default_unit_mode")]
+    #[header(default_with = "default_unit_mode", default_semantic = "literal:false")]
     pub unit_mode: Option<bool>,
 
     /// Host where the message was born.
-    #[required]
+    #[header(required)]
     pub born_host: CheetahString,
 
     /// Host where the message is stored.
-    #[required]
+    #[header(required)]
     pub store_host: CheetahString,
 
     /// Timestamp of when the message was stored.
-    #[required]
+    #[header(required)]
     pub store_timestamp: i64,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request: Option<TopicRequestHeader>,
+}
+
+fn default_unit_mode() -> Option<bool> {
+    Some(false)
 }
 
 #[cfg(test)]

--- a/rocketmq-protocol/src/protocol/header/reset_offset_request_header.rs
+++ b/rocketmq-protocol/src/protocol/header/reset_offset_request_header.rs
@@ -13,28 +13,39 @@
 // limitations under the License.
 
 use cheetah_string::CheetahString;
-use rocketmq_macros::RequestHeaderCodecV2;
+use rocketmq_macros::RequestHeaderCodecV3;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::rpc::topic_request_header::TopicRequestHeader;
 
-#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV2)]
+#[derive(Clone, Debug, Serialize, Deserialize, RequestHeaderCodecV3)]
+#[header(
+    type_id = "rocketmq_protocol::protocol::header::reset_offset_request_header::ResetOffsetRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.ResetOffsetRequestHeader"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct ResetOffsetRequestHeader {
-    #[required]
+    #[header(required)]
     pub topic: CheetahString,
-    #[required]
+    #[header(required)]
     pub group: CheetahString,
+    #[serde(default = "default_queue_id")]
+    #[header(default_with = "default_queue_id", default_semantic = "literal:-1")]
     pub queue_id: i32,
     pub offset: Option<i64>,
-    #[required]
+    #[header(required)]
     pub timestamp: i64,
-    #[required]
+    #[header(required)]
     pub is_force: bool,
 
     #[serde(flatten)]
+    #[header(flatten, presence = "always")]
     pub topic_request_header: Option<TopicRequestHeader>,
+}
+
+fn default_queue_id() -> i32 {
+    -1
 }
 
 impl Default for ResetOffsetRequestHeader {
@@ -42,7 +53,7 @@ impl Default for ResetOffsetRequestHeader {
         ResetOffsetRequestHeader {
             topic: CheetahString::empty(),
             group: CheetahString::empty(),
-            queue_id: -1,
+            queue_id: default_queue_id(),
             offset: None,
             timestamp: 0,
             is_force: false,

--- a/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v3_registry.rs
@@ -23,11 +23,13 @@ use rocketmq_model::common::sys_flag::message_sys_flag::MessageSysFlag;
 use rocketmq_protocol::protocol::header::change_invisible_time_request_header::ChangeInvisibleTimeRequestHeader;
 use rocketmq_protocol::protocol::header::check_rocksdb_cq_write_progress_request_header::CheckRocksdbCqWriteProgressRequestHeader;
 use rocketmq_protocol::protocol::header::check_transaction_state_request_header::CheckTransactionStateRequestHeader;
+use rocketmq_protocol::protocol::header::client_request_header::GetRouteInfoRequestHeader;
 use rocketmq_protocol::protocol::header::clone_group_offset_request_header::CloneGroupOffsetRequestHeader;
 use rocketmq_protocol::protocol::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader;
 use rocketmq_protocol::protocol::header::consumer_send_msg_back_request_header::ConsumerSendMsgBackRequestHeader;
 use rocketmq_protocol::protocol::header::controller::clean_broker_data_request_header::CleanBrokerDataRequestHeader;
 use rocketmq_protocol::protocol::header::create_topic_list_request_header::CreateTopicListRequestHeader;
+use rocketmq_protocol::protocol::header::create_topic_request_header::CreateTopicRequestHeader;
 use rocketmq_protocol::protocol::header::delete_subscription_group_request_header::DeleteSubscriptionGroupRequestHeader;
 use rocketmq_protocol::protocol::header::delete_topic_request_header::DeleteTopicRequestHeader;
 use rocketmq_protocol::protocol::header::end_transaction_request_header::EndTransactionRequestHeader;
@@ -68,9 +70,13 @@ use rocketmq_protocol::protocol::header::query_consume_queue_request_header::Que
 use rocketmq_protocol::protocol::header::query_consume_time_span_request_header::QueryConsumeTimeSpanRequestHeader;
 use rocketmq_protocol::protocol::header::query_consumer_offset_request_header::QueryConsumerOffsetRequestHeader;
 use rocketmq_protocol::protocol::header::query_correction_offset_header::QueryCorrectionOffsetHeader;
+use rocketmq_protocol::protocol::header::query_message_request_header::QueryMessageRequestHeader;
 use rocketmq_protocol::protocol::header::query_subscription_by_consumer_request_header::QuerySubscriptionByConsumerRequestHeader;
 use rocketmq_protocol::protocol::header::query_topic_consume_by_who_request_header::QueryTopicConsumeByWhoRequestHeader;
 use rocketmq_protocol::protocol::header::query_topics_by_consumer_request_header::QueryTopicsByConsumerRequestHeader;
+use rocketmq_protocol::protocol::header::recall_message_request_header::RecallMessageRequestHeader;
+use rocketmq_protocol::protocol::header::reply_message_request_header::ReplyMessageRequestHeader;
+use rocketmq_protocol::protocol::header::reset_offset_request_header::ResetOffsetRequestHeader;
 use rocketmq_protocol::protocol::header::search_offset_request_header::SearchOffsetRequestHeader;
 use rocketmq_protocol::protocol::header::search_offset_response_header::SearchOffsetResponseHeader;
 use rocketmq_protocol::protocol::header::unlock_batch_mq_request_header::UnlockBatchMqRequestHeader;
@@ -272,6 +278,19 @@ fn registry() -> Vec<RegisteredSchema> {
         }),
         register::<CleanBrokerDataRequestHeader>(),
         register::<CreateTopicListRequestHeader>(),
+        register_value(&CreateTopicRequestHeader {
+            topic: CheetahString::from_static_str("registry"),
+            default_topic: CheetahString::from_static_str("registry"),
+            read_queue_nums: 0,
+            write_queue_nums: 0,
+            perm: 0,
+            topic_filter_type: CheetahString::from_static_str("SINGLE_TAG"),
+            topic_sys_flag: None,
+            order: false,
+            attributes: None,
+            force: Some(false),
+            topic_request_header: None,
+        }),
         register::<DeleteSubscriptionGroupRequestHeader>(),
         register_value(&DeleteTopicRequestHeader {
             topic: CheetahString::from_static_str("registry"),
@@ -331,6 +350,11 @@ fn registry() -> Vec<RegisteredSchema> {
             queue_id: 0,
             topic_request_header: None,
         }),
+        register_value(&GetRouteInfoRequestHeader {
+            topic: CheetahString::from_static_str("registry"),
+            accept_standard_json_only: None,
+            topic_request_header: None,
+        }),
         register::<GetProducerConnectionListRequestHeader>(),
         register::<GetSubscriptionGroupConfigRequestHeader>(),
         register_value(&GetTopicConfigRequestHeader {
@@ -363,6 +387,16 @@ fn registry() -> Vec<RegisteredSchema> {
             topic: CheetahString::from_static_str("registry"),
             topic_request_header: None,
         }),
+        register_value(&QueryMessageRequestHeader {
+            topic: CheetahString::from_static_str("registry"),
+            key: CheetahString::from_static_str("registry"),
+            max_num: 0,
+            begin_timestamp: 0,
+            end_timestamp: 0,
+            index_type: None,
+            last_key: None,
+            topic_request_header: None,
+        }),
         register_value(&QuerySubscriptionByConsumerRequestHeader {
             group: CheetahString::from_static_str("registry"),
             topic: CheetahString::new(),
@@ -372,6 +406,30 @@ fn registry() -> Vec<RegisteredSchema> {
             topic: CheetahString::from_static_str("registry"),
             topic_request_header: None,
         }),
+        register_value(&RecallMessageRequestHeader {
+            producer_group: None,
+            topic: CheetahString::from_static_str("registry"),
+            recall_handle: CheetahString::from_static_str("registry"),
+            topic_request_header: None,
+        }),
+        register_value(&ReplyMessageRequestHeader {
+            producer_group: CheetahString::from_static_str("registry"),
+            topic: CheetahString::from_static_str("registry"),
+            default_topic: CheetahString::from_static_str("registry"),
+            default_topic_queue_nums: 0,
+            queue_id: 0,
+            sys_flag: 0,
+            born_timestamp: 0,
+            flag: 0,
+            properties: None,
+            reconsume_times: None,
+            unit_mode: Some(false),
+            born_host: CheetahString::from_static_str("registry"),
+            store_host: CheetahString::from_static_str("registry"),
+            store_timestamp: 0,
+            topic_request: None,
+        }),
+        register::<ResetOffsetRequestHeader>(),
         register::<SearchOffsetRequestHeader>(),
         register::<SearchOffsetResponseHeader>(),
         register::<PullMessageRequestHeader>(),
@@ -1137,6 +1195,131 @@ fn topic_headers_preserve_nested_java_inheritance_and_defaults() {
             })
         },
     );
+    assert_topic_envelope_contract::<GetRouteInfoRequestHeader>(
+        &[("topic", "topic-route"), ("acceptStandardJsonOnly", "true")],
+        &["topic"],
+        |header| {
+            header.topic_request_header.as_ref().map(|topic| TopicEnvelopeRef {
+                lo: topic.lo,
+                rpc: &topic.rpc_request_header,
+            })
+        },
+    );
+    assert_topic_envelope_contract::<CreateTopicRequestHeader>(
+        &[
+            ("topic", "topic-create"),
+            ("defaultTopic", "TBW102"),
+            ("readQueueNums", "-2147483648"),
+            ("writeQueueNums", "2147483647"),
+            ("perm", "-2147483648"),
+            ("topicFilterType", "MULTI_TAG"),
+            ("topicSysFlag", "2147483647"),
+            ("order", "true"),
+            ("attributes", "+message.type=NORMAL"),
+            ("force", "true"),
+        ],
+        &[
+            "topic",
+            "defaultTopic",
+            "readQueueNums",
+            "writeQueueNums",
+            "perm",
+            "topicFilterType",
+            "order",
+        ],
+        |header| {
+            header.topic_request_header.as_ref().map(|topic| TopicEnvelopeRef {
+                lo: topic.lo,
+                rpc: &topic.rpc_request_header,
+            })
+        },
+    );
+    assert_topic_envelope_contract::<QueryMessageRequestHeader>(
+        &[
+            ("topic", "topic-query-message"),
+            ("key", "key-a"),
+            ("maxNum", "2147483647"),
+            ("beginTimestamp", "-9223372036854775808"),
+            ("endTimestamp", "9223372036854775807"),
+            ("indexType", "U"),
+            ("lastKey", "last-a"),
+        ],
+        &["topic", "key", "maxNum", "beginTimestamp", "endTimestamp"],
+        |header| {
+            header.topic_request_header.as_ref().map(|topic| TopicEnvelopeRef {
+                lo: topic.lo,
+                rpc: &topic.rpc_request_header,
+            })
+        },
+    );
+    assert_topic_envelope_contract::<RecallMessageRequestHeader>(
+        &[
+            ("producerGroup", "producer-recall"),
+            ("topic", "topic-recall"),
+            ("recallHandle", "handle-a"),
+        ],
+        &["topic", "recallHandle"],
+        |header| {
+            header.topic_request_header.as_ref().map(|topic| TopicEnvelopeRef {
+                lo: topic.lo,
+                rpc: &topic.rpc_request_header,
+            })
+        },
+    );
+    assert_topic_envelope_contract::<ReplyMessageRequestHeader>(
+        &[
+            ("producerGroup", "producer-reply"),
+            ("topic", "topic-reply"),
+            ("defaultTopic", "TBW102"),
+            ("defaultTopicQueueNums", "-2147483648"),
+            ("queueId", "2147483647"),
+            ("sysFlag", "-2147483648"),
+            ("bornTimestamp", "-9223372036854775808"),
+            ("flag", "2147483647"),
+            ("properties", "KEYS=key-a"),
+            ("reconsumeTimes", "-2147483648"),
+            ("unitMode", "true"),
+            ("bornHost", "127.0.0.1:1000"),
+            ("storeHost", "127.0.0.1:2000"),
+            ("storeTimestamp", "9223372036854775807"),
+        ],
+        &[
+            "producerGroup",
+            "topic",
+            "defaultTopic",
+            "defaultTopicQueueNums",
+            "queueId",
+            "sysFlag",
+            "bornTimestamp",
+            "flag",
+            "bornHost",
+            "storeHost",
+            "storeTimestamp",
+        ],
+        |header| {
+            header.topic_request.as_ref().map(|topic| TopicEnvelopeRef {
+                lo: topic.lo,
+                rpc: &topic.rpc,
+            })
+        },
+    );
+    assert_topic_envelope_contract::<ResetOffsetRequestHeader>(
+        &[
+            ("topic", "topic-reset"),
+            ("group", "group-reset"),
+            ("queueId", "2147483647"),
+            ("offset", "-9223372036854775808"),
+            ("timestamp", "9223372036854775807"),
+            ("isForce", "true"),
+        ],
+        &["topic", "group", "timestamp", "isForce"],
+        |header| {
+            header.topic_request_header.as_ref().map(|topic| TopicEnvelopeRef {
+                lo: topic.lo,
+                rpc: &topic.rpc_request_header,
+            })
+        },
+    );
 
     let pop_required_only = HeaderMap::from([
         ("consumerGroup".into(), "consumer-pop".into()),
@@ -1235,6 +1418,105 @@ fn topic_headers_preserve_nested_java_inheritance_and_defaults() {
             Err(HeaderCodecError::JavaRange { key: actual, .. }) if actual == key
         ));
     }
+
+    let create_required_only = HeaderMap::from([
+        ("topic".into(), "topic-create".into()),
+        ("defaultTopic".into(), "TBW102".into()),
+        ("readQueueNums".into(), "4".into()),
+        ("writeQueueNums".into(), "4".into()),
+        ("perm".into(), "6".into()),
+        ("topicFilterType".into(), "SINGLE_TAG".into()),
+        ("order".into(), "false".into()),
+    ]);
+    let typed = <CreateTopicRequestHeader as HeaderCodec>::decode_from_map(&create_required_only)
+        .expect("missing force uses the Java Boolean.FALSE initializer");
+    let legacy = <CreateTopicRequestHeader as FromMap>::from(&create_required_only)
+        .expect("legacy adapter uses the Java Boolean.FALSE initializer");
+    assert_eq!(typed.force, Some(false));
+    assert_eq!(legacy.force, Some(false));
+
+    let reply_required_only = HeaderMap::from([
+        ("producerGroup".into(), "producer-reply".into()),
+        ("topic".into(), "topic-reply".into()),
+        ("defaultTopic".into(), "TBW102".into()),
+        ("defaultTopicQueueNums".into(), "4".into()),
+        ("queueId".into(), "0".into()),
+        ("sysFlag".into(), "0".into()),
+        ("bornTimestamp".into(), "1".into()),
+        ("flag".into(), "0".into()),
+        ("bornHost".into(), "127.0.0.1:1000".into()),
+        ("storeHost".into(), "127.0.0.1:2000".into()),
+        ("storeTimestamp".into(), "2".into()),
+    ]);
+    let typed = <ReplyMessageRequestHeader as HeaderCodec>::decode_from_map(&reply_required_only)
+        .expect("missing unitMode uses the Java false initializer");
+    let legacy = <ReplyMessageRequestHeader as FromMap>::from(&reply_required_only)
+        .expect("legacy adapter uses the Java false initializer");
+    assert_eq!(typed.unit_mode, Some(false));
+    assert_eq!(legacy.unit_mode, Some(false));
+
+    let reset_without_queue = HeaderMap::from([
+        ("topic".into(), "topic-reset".into()),
+        ("group".into(), "group-reset".into()),
+        ("timestamp".into(), "0".into()),
+        ("isForce".into(), "false".into()),
+    ]);
+    let typed = <ResetOffsetRequestHeader as HeaderCodec>::decode_from_map(&reset_without_queue)
+        .expect("missing queueId uses the Java -1 initializer");
+    let legacy = <ResetOffsetRequestHeader as FromMap>::from(&reset_without_queue)
+        .expect("legacy adapter uses the Java -1 initializer");
+    assert_eq!(typed.queue_id, -1);
+    assert_eq!(legacy.queue_id, -1);
+
+    let mut invalid_filter_type = create_required_only.clone();
+    invalid_filter_type.insert("topicFilterType".into(), "SQL92".into());
+    assert!(matches!(
+        <CreateTopicRequestHeader as HeaderCodec>::decode_from_map(&invalid_filter_type),
+        Err(HeaderCodecError::Validation {
+            rule: "supported_topic_filter_type",
+            ..
+        })
+    ));
+    assert!(<CreateTopicRequestHeader as FromMap>::from(&invalid_filter_type).is_err());
+
+    for (key, mut fields) in [
+        ("force", create_required_only.clone()),
+        ("order", create_required_only.clone()),
+        ("unitMode", reply_required_only.clone()),
+        ("isForce", reset_without_queue.clone()),
+    ] {
+        fields.insert(key.into(), "not-a-bool".into());
+        let (typed_is_error, legacy_is_error) = match key {
+            "force" | "order" => (
+                <CreateTopicRequestHeader as HeaderCodec>::decode_from_map(&fields).is_err(),
+                <CreateTopicRequestHeader as FromMap>::from(&fields).is_err(),
+            ),
+            "unitMode" => (
+                <ReplyMessageRequestHeader as HeaderCodec>::decode_from_map(&fields).is_err(),
+                <ReplyMessageRequestHeader as FromMap>::from(&fields).is_err(),
+            ),
+            "isForce" => (
+                <ResetOffsetRequestHeader as HeaderCodec>::decode_from_map(&fields).is_err(),
+                <ResetOffsetRequestHeader as FromMap>::from(&fields).is_err(),
+            ),
+            _ => unreachable!(),
+        };
+        assert!(typed_is_error, "typed decode must reject malformed {key}");
+        assert!(legacy_is_error, "legacy decode must reject malformed {key}");
+    }
+
+    let malformed_accept = HeaderMap::from([
+        ("topic".into(), "topic-route".into()),
+        ("acceptStandardJsonOnly".into(), "not-a-bool".into()),
+    ]);
+    assert!(matches!(
+        <GetRouteInfoRequestHeader as HeaderCodec>::decode_from_map(&malformed_accept),
+        Err(HeaderCodecError::InvalidValue {
+            key: "acceptStandardJsonOnly",
+            ..
+        })
+    ));
+    assert!(<GetRouteInfoRequestHeader as FromMap>::from(&malformed_accept).is_err());
 
     let update_signed_minimum = HeaderMap::from([
         ("consumerGroup".into(), "consumer-update".into()),

--- a/scripts/request-header-codec/migration.json
+++ b/scripts/request-header-codec/migration.json
@@ -8,10 +8,10 @@
     "entryCount": 152,
     "mappedCount": 143,
     "rustOnlyExtensionCount": 9,
-    "v2Count": 91,
-    "v3Count": 61,
-    "pendingCount": 91,
-    "migratedCount": 61
+    "v2Count": 85,
+    "v3Count": 67,
+    "pendingCount": 85,
+    "migratedCount": 67
   },
   "baseline": {
     "v2TypeIds": [
@@ -178,11 +178,13 @@
       "rocketmq_protocol::protocol::header::change_invisible_time_request_header::ChangeInvisibleTimeRequestHeader",
       "rocketmq_protocol::protocol::header::check_rocksdb_cq_write_progress_request_header::CheckRocksdbCqWriteProgressRequestHeader",
       "rocketmq_protocol::protocol::header::check_transaction_state_request_header::CheckTransactionStateRequestHeader",
+      "rocketmq_protocol::protocol::header::client_request_header::GetRouteInfoRequestHeader",
       "rocketmq_protocol::protocol::header::clone_group_offset_request_header::CloneGroupOffsetRequestHeader",
       "rocketmq_protocol::protocol::header::consume_message_directly_result_request_header::ConsumeMessageDirectlyResultRequestHeader",
       "rocketmq_protocol::protocol::header::consumer_send_msg_back_request_header::ConsumerSendMsgBackRequestHeader",
       "rocketmq_protocol::protocol::header::controller::clean_broker_data_request_header::CleanBrokerDataRequestHeader",
       "rocketmq_protocol::protocol::header::create_topic_list_request_header::CreateTopicListRequestHeader",
+      "rocketmq_protocol::protocol::header::create_topic_request_header::CreateTopicRequestHeader",
       "rocketmq_protocol::protocol::header::delete_subscription_group_request_header::DeleteSubscriptionGroupRequestHeader",
       "rocketmq_protocol::protocol::header::delete_topic_request_header::DeleteTopicRequestHeader",
       "rocketmq_protocol::protocol::header::end_transaction_request_header::EndTransactionRequestHeader",
@@ -224,9 +226,13 @@
       "rocketmq_protocol::protocol::header::query_consume_time_span_request_header::QueryConsumeTimeSpanRequestHeader",
       "rocketmq_protocol::protocol::header::query_consumer_offset_request_header::QueryConsumerOffsetRequestHeader",
       "rocketmq_protocol::protocol::header::query_correction_offset_header::QueryCorrectionOffsetHeader",
+      "rocketmq_protocol::protocol::header::query_message_request_header::QueryMessageRequestHeader",
       "rocketmq_protocol::protocol::header::query_subscription_by_consumer_request_header::QuerySubscriptionByConsumerRequestHeader",
       "rocketmq_protocol::protocol::header::query_topic_consume_by_who_request_header::QueryTopicConsumeByWhoRequestHeader",
       "rocketmq_protocol::protocol::header::query_topics_by_consumer_request_header::QueryTopicsByConsumerRequestHeader",
+      "rocketmq_protocol::protocol::header::recall_message_request_header::RecallMessageRequestHeader",
+      "rocketmq_protocol::protocol::header::reply_message_request_header::ReplyMessageRequestHeader",
+      "rocketmq_protocol::protocol::header::reset_offset_request_header::ResetOffsetRequestHeader",
       "rocketmq_protocol::protocol::header::search_offset_request_header::SearchOffsetRequestHeader",
       "rocketmq_protocol::protocol::header::search_offset_response_header::SearchOffsetResponseHeader",
       "rocketmq_protocol::protocol::header::unlock_batch_mq_request_header::UnlockBatchMqRequestHeader",
@@ -629,16 +635,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 2,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -1007,16 +1013,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 2,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -2976,16 +2982,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 2,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -3087,16 +3093,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 2,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -3150,16 +3156,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 2,
       "flattenTypeIds": [
         "rocketmq_protocol::protocol::header::namesrv::topic_operation_header::TopicRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {
@@ -3194,16 +3200,16 @@
       "baselineCodec": "v2",
       "v2AtBaseline": true,
       "legacyV2Exception": null,
-      "currentCodec": "v2",
+      "currentCodec": "v3",
       "flattenDepth": 2,
       "flattenTypeIds": [
         "rocketmq_protocol::rpc::topic_request_header::TopicRequestHeader"
       ],
       "fastCodec": false,
       "risk": "tier2",
-      "wave": "B",
+      "wave": "A",
       "owner": "remoting",
-      "status": "pending",
+      "status": "migrated",
       "extensionDecision": null
     },
     {

--- a/scripts/request-header-codec/tests/test_migrate.py
+++ b/scripts/request-header-codec/tests/test_migrate.py
@@ -55,7 +55,7 @@ class MigrationGuardTests(unittest.TestCase):
         )
         self.assertEqual(migrate.serialize(expected), migrate.serialize(self.manifest))
         self.assertEqual(len(self.headers), 152)
-        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 61)
+        self.assertEqual(sum(header.codec == "v3" for header in self.headers.values()), 67)
 
     def test_duplicate_simple_names_keep_distinct_stable_paths(self) -> None:
         graph, depths = migrate.flatten_graph(self.headers, self.repo_root)


### PR DESCRIPTION
## Summary
- migrate GetRouteInfo, CreateTopic, QueryMessage, RecallMessage, ReplyMessage, and ResetOffset request headers to RequestHeaderCodecV3
- preserve Java-compatible defaults for force, unitMode, and queueId without explicit java_type metadata
- add required-field, alias, flatten, default, validation, typed/legacy parity, and signed-boundary coverage
- retain MapOnly strategy; DirectBinary promotion remains governed by #9061 and #9062

## Validation
- `cargo fmt -p rocketmq-protocol -- --check`
- `cargo test --locked -p rocketmq-protocol --all-features`
- `cargo clippy --locked -p rocketmq-protocol --all-targets --all-features --no-deps -- -A deprecated -D warnings`
- `cargo check --locked --offline --manifest-path rocketmq-macros/tests/fixtures/renamed-consumer/Cargo.toml`
- request-header migration guard, Java schema comparison, and Python unit tests

`cargo check --locked --manifest-path fuzz/Cargo.toml` remains blocked by the pre-existing stale checked-in fuzz lockfile; this change does not modify it.

Closes #9098

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Migrated six RocketMQ request headers to the latest header encoding and validation format.
  - Improved handling of required fields, nested topic information, default values, and queue identifiers.
  - Added clearer validation for unsupported topic filter types and malformed request values.

- **Tests**
  - Expanded coverage for header registration, decoding, validation, defaults, inherited fields, and boundary values.
  - Updated migration tracking and regression expectations for the expanded set of supported headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->