### PR TITLE
[ISSUE #9106]🐛Align message body and remoting frame limits

### DIFF
--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -1726,7 +1726,7 @@ where
         &self,
         channel: &Channel,
         _ctx: &ConnectionHandlerContext,
-        _request: &RemotingCommand,
+        request: &RemotingCommand,
         request_header: &SendMessageRequestHeader,
         response: &mut RemotingCommand,
     ) where
@@ -1759,6 +1759,12 @@ where
                 "Sending message to topic[{}] is forbidden.",
                 request_header.topic.as_str()
             ));
+            return;
+        }
+
+        if let Some(remark) = message_body_limit_violation(request, policy.max_message_size) {
+            response.with_code(ResponseCode::MessageIllegal);
+            response.with_remark(remark);
             return;
         }
         let mut topic_config = self.context.topics.select_topic_config(&request_header.topic);
@@ -1862,6 +1868,13 @@ fn rewrite_response_for_static_topic(
     None
 }
 
+fn message_body_limit_violation(request: &RemotingCommand, configured_max_message_size: i32) -> Option<String> {
+    let body_size = request.body().map_or(0, |body| body.len());
+    let max_message_size = usize::try_from(configured_max_message_size).unwrap_or_default();
+    (body_size > max_message_size)
+        .then(|| format!("message body size {body_size} exceeds the configured maximum {max_message_size} bytes"))
+}
+
 fn message_store_not_initialized() -> RocketMQError {
     RocketMQError::not_initialized("message_store")
 }
@@ -1871,6 +1884,7 @@ mod tests {
     use std::future::Future;
 
     use crate::config::broker_config::BrokerConfig;
+    use rocketmq_protocol::code::request_code::RequestCode;
     use rocketmq_protocol::code::response_code::RemotingSysResponseCode;
     use rocketmq_protocol::code::response_code::ResponseCode;
     use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
@@ -1891,6 +1905,7 @@ mod tests {
     use super::has_registered_send_message_hooks;
     use super::map_put_status_to_response;
     use super::map_store_api_error;
+    use super::message_body_limit_violation;
     use super::message_store_not_initialized;
     use super::store_health_reject_remark;
     use super::store_health_reject_remark_from;
@@ -1976,6 +1991,22 @@ mod tests {
         let error = message_store_not_initialized();
 
         assert_eq!(error.kind(), rocketmq_error::ErrorKind::NotInitialized);
+    }
+
+    #[test]
+    fn single_and_batch_requests_share_the_configured_message_body_limit() {
+        let max_message_size = 1024;
+
+        for request_code in [RequestCode::SendMessage, RequestCode::SendBatchMessage] {
+            let exact =
+                RemotingCommand::create_remoting_command(request_code).set_body(vec![0_u8; max_message_size as usize]);
+            let oversized =
+                RemotingCommand::create_remoting_command(request_code)
+                    .set_body(vec![0_u8; max_message_size as usize + 1]);
+
+            assert!(message_body_limit_violation(&exact, max_message_size).is_none());
+            assert!(message_body_limit_violation(&oversized, max_message_size).is_some());
+        }
     }
 
     #[test]

--- a/rocketmq-client/src/base/validators.rs
+++ b/rocketmq-client/src/base/validators.rs
@@ -182,7 +182,9 @@ impl Validators {
 mod tests {
     use std::collections::HashMap;
 
+    use bytes::Bytes;
     use rocketmq_model::common::config::TopicConfig;
+    use rocketmq_model::common::message::message_single::Message;
 
     use super::*;
 
@@ -190,6 +192,23 @@ mod tests {
     fn check_group_blank_group() {
         let result = Validators::check_group("");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn check_message_accepts_exact_body_limit_and_rejects_one_byte_over() {
+        let producer_config = ProducerConfig::default();
+        let max_message_size = producer_config.max_message_size() as usize;
+        let exact = Message::builder()
+            .topic("TopicTest")
+            .body(Bytes::from(vec![0_u8; max_message_size]))
+            .build_unchecked();
+        let oversized = Message::builder()
+            .topic("TopicTest")
+            .body(Bytes::from(vec![0_u8; max_message_size + 1]))
+            .build_unchecked();
+
+        assert!(Validators::check_message(Some(&exact), &producer_config).is_ok());
+        assert!(Validators::check_message(Some(&oversized), &producer_config).is_err());
     }
 
     #[test]

--- a/rocketmq-store/src/message_encoder/message_ext_encoder.rs
+++ b/rocketmq-store/src/message_encoder/message_ext_encoder.rs
@@ -509,7 +509,23 @@ impl MessageExtEncoder {
 mod tests {
     use std::sync::Arc;
 
+    use bytes::Bytes;
+    use cheetah_string::CheetahString;
+
     use super::*;
+
+    fn message_with_body_size(body_size: usize) -> MessageExtBrokerInner {
+        let mut message = MessageExtBrokerInner::default();
+        message
+            .message_ext_inner
+            .message
+            .set_topic(CheetahString::from_static_str("TopicTest"));
+        message
+            .message_ext_inner
+            .message
+            .set_body(Some(Bytes::from(vec![0_u8; body_size])));
+        message
+    }
 
     #[test]
     fn message_ext_encoder_new_creates_encoder_with_correct_config() {
@@ -565,6 +581,31 @@ mod tests {
         let result = encoder.encode(&msg_inner);
 
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn encode_accepts_exact_configured_body_limit() {
+        let config = MessageStoreConfig {
+            max_message_size: 1024,
+            ..MessageStoreConfig::default()
+        };
+        let mut encoder = MessageExtEncoder::new(Arc::new(config));
+        let message = message_with_body_size(1024);
+
+        assert!(encoder.encode(&message).is_none());
+    }
+
+    #[test]
+    fn encode_rejects_body_one_byte_over_configured_limit() {
+        let config = MessageStoreConfig {
+            max_message_size: 1024,
+            ..MessageStoreConfig::default()
+        };
+        let mut encoder = MessageExtEncoder::new(Arc::new(config));
+        let message = message_with_body_size(1025);
+
+        let result = encoder.encode(&message).expect("oversized body must be rejected");
+        assert_eq!(result.put_message_status(), PutMessageStatus::MessageIllegal);
     }
 
     #[test]

--- a/rocketmq-transport/src/codec/remoting_command_codec.rs
+++ b/rocketmq-transport/src/codec/remoting_command_codec.rs
@@ -65,7 +65,9 @@ pub struct FrameLimits {
 impl Default for FrameLimits {
     fn default() -> Self {
         Self {
-            max_frame_bytes: 4 * 1024 * 1024,
+            // Match RocketMQ Java's default frame envelope. The body remains capped at 4 MiB,
+            // while this headroom allows an exact-limit body to carry its remoting header.
+            max_frame_bytes: 16 * 1024 * 1024,
             max_header_bytes: 1024 * 1024,
             max_body_bytes: 4 * 1024 * 1024,
             initial_read_bytes: 8 * 1024,

--- a/rocketmq-transport/tests/codec_bounds.rs
+++ b/rocketmq-transport/tests/codec_bounds.rs
@@ -53,11 +53,41 @@ fn oversized_frame_is_rejected_before_body_allocation() {
 }
 
 #[test]
-fn legacy_large_frame_acceptance_requires_an_explicit_owner_profile() {
+fn legacy_large_body_acceptance_requires_an_explicit_owner_profile() {
     let canonical = FrameLimits::default();
     let legacy = FrameLimits::legacy_compatibility();
 
-    assert!(canonical.max_frame_bytes < 16 * 1024 * 1024);
+    assert_eq!(canonical.max_frame_bytes, 16 * 1024 * 1024);
+    assert_eq!(canonical.max_header_bytes, 1024 * 1024);
+    assert_eq!(canonical.max_body_bytes, 4 * 1024 * 1024);
     assert_eq!(legacy.max_frame_bytes, 16 * 1024 * 1024);
+    assert_eq!(legacy.max_body_bytes, 16 * 1024 * 1024);
     assert_eq!(canonical.initial_read_bytes, 8 * 1024);
+}
+
+#[test]
+fn canonical_limits_accept_exact_body_limit_with_non_empty_header() {
+    let limits = FrameLimits::default();
+    let mut codec = RemotingCommandCodec::with_limits(limits);
+    let command = RemotingCommand::create_remoting_command(105).set_body(vec![0_u8; limits.max_body_bytes]);
+    let mut encoded = BytesMut::new();
+
+    codec.encode(command, &mut encoded).unwrap();
+    assert!(encoded.len() > limits.max_body_bytes);
+
+    let decoded = codec.decode(&mut encoded).unwrap().unwrap();
+    assert_eq!(decoded.body().unwrap().len(), limits.max_body_bytes);
+}
+
+#[test]
+fn canonical_limits_reject_announced_body_over_limit_before_allocation() {
+    let limits = FrameLimits::default();
+    let announced_total = 4 + limits.max_body_bytes + 1;
+    let mut announced = BytesMut::with_capacity(8);
+    announced.extend_from_slice(&(announced_total as i32).to_be_bytes());
+    announced.extend_from_slice(&0_u32.to_be_bytes());
+    let mut codec = RemotingCommandCodec::with_limits(limits);
+
+    assert!(codec.decode(&mut announced).is_err());
+    assert!(announced.capacity() < 1024);
 }


### PR DESCRIPTION
## Summary

- keep the canonical message body limit at 4 MiB while expanding the default remoting frame envelope to the Java-compatible 16 MiB
- reject oversized announced bodies before body allocation
- reject oversized single and batch send requests in the broker before topic creation and message construction
- cover exact-limit acceptance and one-byte-over rejection in Producer, Transport, Broker, and Store

## Validation

- focused Producer, Transport, Broker, and Store boundary tests
- affected-package formatting checks
- strict Clippy across affected packages and all targets/features
- fuzz lock check attempted; the checked-in fuzz lock requires an update and cannot pass with `--locked`

Closes #9106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the default maximum transport frame size to 16 MiB.
  * Frames can now support larger payloads while retaining separate header and message-body limits.

* **Bug Fixes**
  * Message requests exceeding the configured body-size limit are now rejected consistently for single and batch submissions.
  * Boundary-sized messages are accepted correctly, while oversized messages are rejected before significant processing or memory allocation.
  * Improved error reporting identifies message-size violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->