### PR TITLE
[ISSUE #9108]✨Promote RequestHeaderCodecV3 and deprecate legacy derives

### DIFF
--- a/rocketmq-macros/README-zh_cn.md
+++ b/rocketmq-macros/README-zh_cn.md
@@ -2,178 +2,140 @@
 
 [English](README.md) | [简体中文](README-zh_cn.md)
 
-RocketMQ-Rust protocol 类型、请求头和 remoting 序列化辅助能力使用的 procedural macros。
+RocketMQ-Rust 协议类型和 Remoting Header 使用的过程宏。
 
-`rocketmq-macros` 是 RocketMQ-Rust workspace 内部使用的小型 proc-macro crate，用于消除 request/response header
-定义中的重复 protocol glue。它的核心职责是为 RocketMQ remoting header 生成 `CommandCustomHeader` 和 `FromMap`
-实现，在保持 Java 兼容 wire key 的同时，让 Rust 结构体保持类型化和可维护。
+`rocketmq-macros` 是编译期基础设施。多数应用代码应使用上层 client、broker 或 remoting crate，不应直接依赖这些宏。
 
-该 crate 是基础设施，不是运行时组件。大多数应用代码应使用更高层的 `rocketmq-remoting`、`rocketmq-client-rust`、
-`rocketmq-broker` 或服务 crate，而不是直接依赖这些宏。
+## Request Header Derive
 
-## 能力边界
+| 宏 | 状态 | 用途 |
+| --- | --- | --- |
+| `RequestHeaderCodecV3` | 推荐 | 生成类型化 map/source codec、wire schema、校验、键解析、兼容适配器，以及经过审查的可选直接编码。 |
+| `RequestHeaderCodecV2` | 已废弃 | 在兼容窗口内保留加固后的 V2 wire 契约；生产 Header 禁止新增使用。 |
+| `RequestHeaderCodec` | 已废弃 | 仅为下游源码兼容保留最早版本的 Request Header derive。 |
+| `RemotingSerializable` | 工具 | 为类型生成 Remoting 序列化辅助实现。 |
 
-| 宏 | 状态 | 生成能力 |
-|----|------|----------|
-| `RequestHeaderCodecV2` | 主用 | 为具名 Rust struct 生成 `CommandCustomHeader::to_map`、低分配 `encode_into_map` 和借用式 `FromMap::from`，支持确定性 alias、required、泛型和 flattened nested header。 |
-| `RequestHeaderCodec` | 兼容 | 早期 request-header codec derive，支持 Java 风格 camelCase key、`#[required]`、可选字段、primitive parse 和 flattened nested header。 |
-| `RemotingSerializable` | 工具 | 为类型实现 `crate::protocol::RemotingSerializable`。当前多数 remoting 路径优先使用 serde-backed blanket impl。 |
+仓库中登记的全部生产请求头和响应头都已使用 V3。旧 derive 至少保留一个发布窗口，只会在未来的破坏性版本中删除。
 
-## 工作方式
+## 快速开始
 
-```text
-typed protocol header struct
-        |
-        | #[derive(RequestHeaderCodecV2)]
-        v
-generated constants + CommandCustomHeader::encode_into_map()
-        |
-        v
-RocketMQ remoting ext fields: HashMap<CheetahString, CheetahString>
-        |
-        v
-generated FromMap::from() with required-field validation and parsing
-```
-
-生成代码面向 `rocketmq-protocol` 的公共 contract：
-
-- `rocketmq_protocol::protocol::command_custom_header::CommandCustomHeader`
-- `rocketmq_protocol::protocol::command_custom_header::FromMap`
-- `rocketmq_protocol::HeaderMap`
-
-derive 能自动解析 `Cargo.toml` 中重命名后的 `rocketmq-protocol` 依赖。生成代码或 re-export 场景也可以显式指定路径：
+V3 只把专用 `#[header(...)]` 元数据作为 RocketMQ wire 契约。Serde 属性继续独立服务 JSON/DTO，不能用于推断 Header 的 key、default、alias 或 flatten。
 
 ```rust
-#[derive(RequestHeaderCodecV2)]
-#[request_header_codec_v2(crate = "path::to::protocol_api")]
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodecV3;
+
+#[derive(Debug, RequestHeaderCodecV3)]
+#[header(
+    type_id = "example::SendMessageRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.SendMessageRequestHeader"
+)]
+struct SendMessageRequestHeader {
+    #[header(required)]
+    producer_group: CheetahString,
+    #[header(required)]
+    topic: CheetahString,
+    #[header(default, default_semantic = "literal:0")]
+    sys_flag: i32,
+    batch: Option<bool>,
+}
+```
+
+生成结果包括：
+
+- 带稳定类型 ID 和字段/flatten schema 的 `HeaderCodec`；
+- `CommandCustomHeader` 与 `FromMap` 兼容适配器；
+- canonical key 与 decode alias 的确定性解析和冲突处理；
+- 显式 required/default/validation/range 语义；
+- 输入支持时的借用式、零拷贝 field-source 解码；
+- 默认 `MapOnly` 编码，以及仅对显式审查过的 `fast` Header 生成直接编码。
+
+## 元数据规则
+
+容器属性：
+
+| 属性 | 含义 |
+| --- | --- |
+| `type_id = "..."` | 必填的稳定 Rust schema 标识。 |
+| `java_class = "..."` | 存在 Java 对应类型时填写 Java FQCN；Rust-only Header 不填写。 |
+| `crate = "path"` | 可选的 protocol crate 路径覆盖，支持依赖重命名。 |
+| `fast` | 只有完成正确性和性能审查后才启用生成式直接编码。 |
+| `validate = "path"` | 编码首次写入前和解码完成后执行类型化校验。 |
+| `legacy_shim = "manual"` | 已有审计过的手工兼容实现时避免生成重复实现。 |
+
+字段属性：
+
+| 属性 | 含义 |
+| --- | --- |
+| `required` | 输入缺失时报错。 |
+| `default` / `default_with = "path"` | 显式定义字段缺失行为，并同时声明 `default_semantic`。 |
+| `key = "..."` | canonical wire key；省略时使用 Rust 字段名。 |
+| `alias = "..."` | 仅用于解码的历史 key；V3 不会输出 alias。 |
+| `flatten, presence = "always|any"` | 嵌套 Header 的继承/存在性契约。 |
+| `range = "i32|i64"` | 把无符号 Rust 字段限制到对应 Java 有符号域。 |
+
+生产字段不填写 `java_type`。V3 会根据 Rust 类型推断普通 wire kind。只有当无符号 Rust 字段受 Java 有符号 `int` 或 `long` 约束时才填写 `range`；有符号 Rust 字段和 Rust-only 无符号字段都不需要填写。
+
+## 运行路径与回退
+
+所有登记 Header 都实现了类型化 codec 和对象安全兼容适配器，因此 V3 已是生产默认路径。普通 Header 返回 `MapOnly`，Remoting 编码器会物化 canonical extension fields，不依赖可变 `Arc` 访问。经过审查的热 Header 可以对 ROCKETMQ frame 使用 `DirectBinary`，并可提供直接 JSON fields。如果命令已经包含物化字段或动态字段，同一份类型化 schema 会负责冲突解析，map 路径仍是权威回退。
+
+回退按 Header 和命令生效，不改变 wire 契约，也不会在每条消息上增加全局开关或环境变量查询。
+
+## 从 V2 迁移
+
+V2 元数据不会被静默解释成 V3。必须对照固定 Java schema 审核后显式转换：
+
+| V2 来源 | V3 决策 |
+| --- | --- |
+| `#[required]` | `#[header(required)]` |
+| `serde(rename = "...")` | 确认是 wire key 后改为 `#[header(key = "...")]` |
+| `serde(alias = "...")` | 改为 `#[header(alias = "...")]`，必要时明确冲突策略 |
+| `serde(default)` | 改为带 `default_semantic` 的 `header(default)` 或已审查的 `default_with` |
+| `serde(flatten)` | 改为 `#[header(flatten, presence = "always|any")]` |
+| 对应 Java `int`/`long` 的无符号字段 | `range = "i32"` / `range = "i64"` |
+
+V2 只应用于尚未完成迁移的既有下游模型。RocketMQ-Rust 新增生产 Header 必须使用 V3，并进入 checked-in schema inventory，否则 migration guard 会拒绝。
+
+## 重命名 Protocol 依赖
+
+derive 会通过 Cargo 元数据解析 `rocketmq-protocol`。生成代码或 re-export 场景可显式覆盖：
+
+```rust
+#[derive(RequestHeaderCodecV3)]
+#[header(type_id = "example::Header", crate = "protocol_api")]
 struct Header {
+    #[header(required)]
     queue_id: i32,
 }
 ```
 
-## 快速开始
-
-在表示 RocketMQ remoting header 的具名 struct 上使用 `RequestHeaderCodecV2`：
-
-```rust
-use rocketmq_macros::RequestHeaderCodecV2;
-use serde::{Deserialize, Serialize};
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
-#[serde(rename_all = "camelCase")]
-pub struct SendMessageRequestHeader {
-    #[required]
-    pub producer_group: cheetah_string::CheetahString,
-    #[required]
-    pub topic: cheetah_string::CheetahString,
-    pub queue_id: Option<i32>,
-    pub sys_flag: i32,
-    pub born_timestamp: i64,
-    pub batch: Option<bool>,
-}
-```
-
-该 derive 会生成：
-
-- wire key 对应的 associated string constants；
-- `CommandCustomHeader::to_map`，并省略 `None` 值；
-- `CommandCustomHeader::encode_into_map`，将 flattened 字段直接写入同一个目标 map；
-- `FromMap::from`，将 `CheetahString` map value 转回类型化字段；
-- `#[required]` 字段的缺失校验；
-- 非 required、非 `Option` 字段缺失时使用默认值。
-
-## 字段映射
-
-| Rust 字段形态 | 序列化行为 | 反序列化行为 |
-|---------------|------------|--------------|
-| `CheetahString` | 直接写入 ext-field map。 | 直接读取，非 required 缺失时使用默认值。 |
-| `String` | 转换为 `CheetahString`。 | 转回 `String`。 |
-| Primitive 类型 | 使用 `to_string()` 转换。 | 使用 `FromStr` 解析；required 字段解析失败时返回 header 错误。 |
-| `Option<T>` | 仅在 `Some` 时写入。 | 缺失时为 `None`；存在的 primitive value 会被解析。 |
-| `#[serde(flatten)]` nested header | 合并 nested header map。 | 通过 nested type 的 `FromMap::from` 重建。 |
-
-`RequestHeaderCodecV2` 默认将 snake_case 字段名转换为 camelCase wire key；如果存在 `serde(rename = "...")`，则使用
-rename 指定的 wire key。`serde(alias = "...")` 按声明顺序在 canonical key 之后查找，因此结果不受
-`HashMap` 迭代顺序影响。
-
-tuple/unit struct、enum、union、空或冲突 wire key、`#[required] Option<T>`、required 与
-`serde(default)` 组合、scalar 与 `serde(flatten)` 组合都会在编译期报错。跨 flattened child 的 key
-冲突由仓库 schema comparator 检查，因为 derive macro 无法检查另一类型的字段。
-
-## Required 字段
-
-`#[required]` 表示 `FromMap::from` 时必须存在该 header 字段：
-
-```rust
-#[derive(RequestHeaderCodecV2)]
-pub struct QueryMessageRequestHeader {
-    #[required]
-    pub topic: cheetah_string::CheetahString,
-    pub key: Option<cheetah_string::CheetahString>,
-}
-```
-
-这对应 Java RocketMQ 中 `@CFNotNull` 的意图。缺失 required 字段会返回
-`RocketMQError::DeserializeHeaderError`，错误信息使用生成后的 wire-key name。
+独立项目 `tests/fixtures/renamed-consumer` 同时验证 V3 路径和保留的 V2 兼容能力。
 
 ## Crate 结构
 
-| 路径 | 职责 |
-|------|------|
-| [`src/lib.rs`](src/lib.rs) | 公共 proc-macro 入口和共享类型辅助函数。 |
-| [`src/request_header_custom.rs`](src/request_header_custom.rs) | 旧版 `RequestHeaderCodec` 展开逻辑。 |
-| [`src/request_header_codec_v2/`](src/request_header_codec_v2/) | V2 属性解析、语义模型、校验和代码生成。 |
-| [`src/remoting_serializable.rs`](src/remoting_serializable.rs) | `RemotingSerializable` derive 展开逻辑。 |
-| [`Cargo.toml`](Cargo.toml) | Proc-macro crate 配置和宏解析依赖。 |
+| 路径 | 用途 |
+| --- | --- |
+| [`src/lib.rs`](src/lib.rs) | 公开 derive 入口和共享解析辅助函数。 |
+| [`src/request_header_codec_v3/`](src/request_header_codec_v3/) | V3 元数据、语义模型、校验和代码生成。 |
+| [`src/request_header_codec_v2/`](src/request_header_codec_v2/) | 兼容窗口内保留的 V2 实现。 |
+| [`src/request_header_custom.rs`](src/request_header_custom.rs) | 已废弃的最早版本 derive 实现。 |
+| [`src/remoting_serializable.rs`](src/remoting_serializable.rs) | Remoting 序列化 derive。 |
 
-## 环境要求
-
-- Stable Rust `1.95.0`，使用仓库固定的工具链。
-- 使用仓库中的 [`../rust-toolchain.toml`](../rust-toolchain.toml) 工具链。
-- 直接或重命名的 `rocketmq-protocol` 依赖，或显式 `request_header_codec_v2(crate = "...")` 路径。
-
-## 安装
-
-在当前 workspace 内使用：
-
-```toml
-[dependencies]
-rocketmq-macros = { path = "../rocketmq-macros" }
-```
-
-外部项目使用：
-
-```toml
-[dependencies]
-rocketmq-macros = "1.0.0"
-```
-
-依赖重命名无需修改源代码。`tests/fixtures/renamed-consumer` 会通过离线 Cargo check 验证该契约。
+Cargo 构建不会访问 Java checkout。Java schema、golden frame、迁移状态和性能证据由仓库中的 `scripts/request-header-codec` 资产治理。
 
 ## 验证
 
-该 crate 的聚焦检查：
-
-```bash
+```powershell
+python scripts/request-header-codec/migrate.py check
+python scripts/request-header-codec/compare_header_schema.py
 cargo test -p rocketmq-macros --lib
-cargo test -p rocketmq-protocol --test request_header_codec_v2_wire_snapshot
+cargo test -p rocketmq-protocol --test request_header_codec_v3_ui
 cargo test -p rocketmq-protocol --test request_header_codec_v2_ui
-cargo check --offline --manifest-path rocketmq-macros/tests/fixtures/renamed-consumer/Cargo.toml
-```
-
-由于该宏被大多数 protocol header 使用，修改展开逻辑后还应验证 protocol crate：
-
-```bash
-cargo test -p rocketmq-protocol --lib
-```
-
-如果修改 Rust 代码，需要在仓库根目录执行 workspace 级验证：
-
-```bash
-cargo fmt --all
-cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
+cargo test -p rocketmq-protocol --test request_header_codec_v2_wire_snapshot
+cargo check --locked --offline --manifest-path rocketmq-macros/tests/fixtures/renamed-consumer/Cargo.toml
 ```
 
 ## License
 
-RocketMQ-Rust 使用 Apache License 2.0。详见 [../LICENSE-APACHE](../LICENSE-APACHE)。
+RocketMQ-Rust 使用 Apache License 2.0，详见 [../LICENSE-APACHE](../LICENSE-APACHE)。

--- a/rocketmq-macros/README.md
+++ b/rocketmq-macros/README.md
@@ -2,181 +2,150 @@
 
 [English](README.md) | [简体中文](README-zh_cn.md)
 
-Procedural macros for RocketMQ-Rust protocol types, request headers, and remoting serialization helpers.
+Procedural macros for RocketMQ-Rust protocol types and remoting headers.
 
-`rocketmq-macros` is a small proc-macro crate used by the RocketMQ-Rust workspace to remove repetitive protocol glue
-from request and response header definitions. Its primary job is to generate `CommandCustomHeader` and `FromMap`
-implementations for RocketMQ remoting headers, preserving Java-compatible wire keys while keeping the Rust structs
-typed and maintainable.
+`rocketmq-macros` is build-time infrastructure. Most application code should use the higher-level client, broker,
+or remoting crates instead of depending on it directly.
 
-This crate is infrastructure, not a runtime component. Most application code should use the higher-level
-`rocketmq-remoting`, `rocketmq-client-rust`, `rocketmq-broker`, or service crates instead of depending on these macros
-directly.
+## Request-header derives
 
-## Capabilities
+| Macro | Status | Purpose |
+| --- | --- | --- |
+| `RequestHeaderCodecV3` | Recommended | Generates typed map/source codecs, wire schema, validation, key resolution, compatibility adapters, and optional reviewed direct encoding. |
+| `RequestHeaderCodecV2` | Deprecated | Preserves the hardened V2 wire contract during the compatibility window. No production header may newly adopt it. |
+| `RequestHeaderCodec` | Deprecated | Preserves the original request-header derive for downstream source compatibility. |
+| `RemotingSerializable` | Utility | Implements the remoting serialization helper for a type. |
 
-| Macro | Status | What it generates |
-|-------|--------|-------------------|
-| `RequestHeaderCodecV2` | Primary | `CommandCustomHeader::to_map`, allocation-aware `encode_into_map`, and borrowed `FromMap::from` generation for named Rust structs, with deterministic aliases, required-field checks, generics, and flattened nested headers. |
-| `RequestHeaderCodec` | Compatibility | Earlier request-header codec derive with Java-style camelCase keys, `#[required]`, optional fields, primitive parsing, and flattened nested headers. |
-| `RemotingSerializable` | Utility | Implements `crate::protocol::RemotingSerializable` for a type. In most current remoting paths, serde-backed blanket implementations are preferred. |
+All registered production request and response headers use V3. Legacy derives remain callable for at least one
+release window and will only be removed in a future breaking release.
 
-## How It Fits
+## Quick start
 
-```text
-typed protocol header struct
-        |
-        | #[derive(RequestHeaderCodecV2)]
-        v
-generated constants + CommandCustomHeader::encode_into_map()
-        |
-        v
-RocketMQ remoting ext fields: HashMap<CheetahString, CheetahString>
-        |
-        v
-generated FromMap::from() with required-field validation and parsing
-```
-
-The generated code targets the public protocol contracts from `rocketmq-protocol`:
-
-- `rocketmq_protocol::protocol::command_custom_header::CommandCustomHeader`
-- `rocketmq_protocol::protocol::command_custom_header::FromMap`
-- `rocketmq_protocol::HeaderMap`
-
-The derive resolves `rocketmq-protocol` even when the dependency is renamed in `Cargo.toml`. An explicit path can be
-provided for generated or re-exported protocol APIs:
+V3 uses dedicated `#[header(...)]` metadata as the only RocketMQ wire contract. Serde attributes remain independent
+and must not be used to infer header keys, defaults, aliases, or flattening.
 
 ```rust
-#[derive(RequestHeaderCodecV2)]
-#[request_header_codec_v2(crate = "path::to::protocol_api")]
+use cheetah_string::CheetahString;
+use rocketmq_macros::RequestHeaderCodecV3;
+
+#[derive(Debug, RequestHeaderCodecV3)]
+#[header(
+    type_id = "example::SendMessageRequestHeader",
+    java_class = "org.apache.rocketmq.remoting.protocol.header.SendMessageRequestHeader"
+)]
+struct SendMessageRequestHeader {
+    #[header(required)]
+    producer_group: CheetahString,
+    #[header(required)]
+    topic: CheetahString,
+    #[header(default, default_semantic = "literal:0")]
+    sys_flag: i32,
+    batch: Option<bool>,
+}
+```
+
+The generated implementation provides:
+
+- `HeaderCodec` with a stable type ID and typed field/flatten schema;
+- `CommandCustomHeader` and `FromMap` compatibility adapters;
+- canonical-key and decode-alias resolution with deterministic conflict handling;
+- explicit required/default/validation/range behavior;
+- zero-copy borrowed field-source decoding where the input supports it;
+- `MapOnly` encoding by default and generated direct encoding only for explicitly reviewed `fast` headers.
+
+## Metadata rules
+
+Container metadata:
+
+| Attribute | Meaning |
+| --- | --- |
+| `type_id = "..."` | Required stable Rust schema identity. |
+| `java_class = "..."` | Java oracle FQCN when the Rust type has a Java peer. Omit it for Rust-only headers. |
+| `crate = "path"` | Optional protocol-crate override, including renamed dependencies. |
+| `fast` | Enables generated direct encoding only after correctness and performance review. |
+| `validate = "path"` | Runs a typed validation hook before the first encode mutation and after decode. |
+| `legacy_shim = "manual"` | Avoids duplicate compatibility impls when an audited manual adapter exists. |
+
+Field metadata:
+
+| Attribute | Meaning |
+| --- | --- |
+| `required` | Missing input is an error. |
+| `default` / `default_with = "path"` | Explicit missing-field behavior; pair it with `default_semantic`. |
+| `key = "..."` | Canonical wire key. The Rust field name is used when omitted. |
+| `alias = "..."` | Decode-only legacy key. V3 never emits aliases. |
+| `flatten, presence = "always|any"` | Nested header inheritance/presence contract. |
+| `range = "i32|i64"` | Restricts an unsigned Rust field to the corresponding Java signed domain. |
+
+Do not write `java_type` on production fields. V3 infers the ordinary wire kind from the Rust type. Use `range`
+only for unsigned Rust fields that are constrained by a Java signed `int` or `long`; signed Rust fields and
+Rust-only unsigned fields do not need it.
+
+## Runtime paths and fallback
+
+V3 is the production default because every registered header implements its typed codec and object-safe
+compatibility adapter. A normal header reports `MapOnly`; the remoting encoder materializes canonical extension
+fields without relying on mutable `Arc` access. A reviewed hot header may report `DirectBinary` for ROCKETMQ frames
+and may provide direct JSON fields. If a command already contains materialized or dynamic fields, the same typed
+schema resolves collisions and the map path remains authoritative.
+
+This fallback is per header and per command. It does not change the wire contract, and it avoids adding a global
+branch or environment lookup to every message.
+
+## Migrating from V2
+
+V2 metadata is not silently reinterpreted. Review it against the fixed Java schema and convert it explicitly:
+
+| V2 source | V3 decision |
+| --- | --- |
+| `#[required]` | `#[header(required)]` |
+| `serde(rename = "...")` | `#[header(key = "...")]` when it is a wire key |
+| `serde(alias = "...")` | `#[header(alias = "...")]` with an explicit conflict policy when required |
+| `serde(default)` | `#[header(default, default_semantic = "literal:...")]` or reviewed `default_with` |
+| `serde(flatten)` | `#[header(flatten, presence = "always|any")]` |
+| unsigned field matching Java `int`/`long` | `range = "i32"` / `range = "i64"` |
+
+Keep V2 only while migrating an existing downstream model. New RocketMQ-Rust production headers are rejected by
+the migration guard unless they use V3 and are registered in the checked-in schema inventory.
+
+## Renamed protocol dependency
+
+The derive resolves `rocketmq-protocol` through Cargo metadata. Generated/re-exported environments can override it:
+
+```rust
+#[derive(RequestHeaderCodecV3)]
+#[header(type_id = "example::Header", crate = "protocol_api")]
 struct Header {
+    #[header(required)]
     queue_id: i32,
 }
 ```
 
-## Quick Start
+The standalone `tests/fixtures/renamed-consumer` project verifies both the V3 path and retained V2 compatibility.
 
-Use `RequestHeaderCodecV2` on a named struct that represents a RocketMQ remoting header:
-
-```rust
-use rocketmq_macros::RequestHeaderCodecV2;
-use serde::{Deserialize, Serialize};
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default, RequestHeaderCodecV2)]
-#[serde(rename_all = "camelCase")]
-pub struct SendMessageRequestHeader {
-    #[required]
-    pub producer_group: cheetah_string::CheetahString,
-    #[required]
-    pub topic: cheetah_string::CheetahString,
-    pub queue_id: Option<i32>,
-    pub sys_flag: i32,
-    pub born_timestamp: i64,
-    pub batch: Option<bool>,
-}
-```
-
-The derive generates:
-
-- associated string constants for the wire keys;
-- `CommandCustomHeader::to_map`, omitting `None` values;
-- `CommandCustomHeader::encode_into_map`, writing flattened fields into one destination map;
-- `FromMap::from`, converting `CheetahString` map values back into typed fields;
-- required-field errors for fields annotated with `#[required]`;
-- default values for missing non-required, non-`Option` fields.
-
-## Field Mapping
-
-| Rust field shape | Serialization behavior | Deserialization behavior |
-|------------------|------------------------|--------------------------|
-| `CheetahString` | Insert directly into the ext-field map. | Read directly, or default when not required. |
-| `String` | Convert to `CheetahString`. | Convert back to `String`. |
-| Primitive types | Convert with `to_string()`. | Parse with `FromStr`; required fields return a typed header error on parse failure. |
-| `Option<T>` | Insert only when `Some`. | Missing values become `None`; present primitive values are parsed. |
-| `#[serde(flatten)]` nested header | Merge the nested header map. | Reconstruct by calling the nested type's `FromMap::from`. |
-
-`RequestHeaderCodecV2` uses the field name converted from snake_case to camelCase unless a `serde(rename = "...")`
-attribute is present. `serde(alias = "...")` values are checked in declaration order during decoding, after the
-canonical key. Canonical values therefore win independently of `HashMap` iteration order.
-
-Invalid combinations are rejected at compile time, including tuple/unit structs, enums, unions, empty or colliding
-wire keys, `#[required] Option<T>`, required fields with `serde(default)`, and scalar fields with `serde(flatten)`.
-Key collisions inside flattened child headers are checked by the repository schema comparator because a derive macro
-cannot inspect another type's fields.
-
-## Required Fields
-
-`#[required]` marks a header field that must be present during `FromMap::from`:
-
-```rust
-#[derive(RequestHeaderCodecV2)]
-pub struct QueryMessageRequestHeader {
-    #[required]
-    pub topic: cheetah_string::CheetahString,
-    pub key: Option<cheetah_string::CheetahString>,
-}
-```
-
-This mirrors the intent of Java RocketMQ's `@CFNotNull` annotation. Missing required fields return
-`RocketMQError::DeserializeHeaderError` with the generated wire-key name.
-
-## Crate Layout
+## Crate layout
 
 | Path | Purpose |
-|------|---------|
-| [`src/lib.rs`](src/lib.rs) | Public proc-macro entry points and shared type helpers. |
-| [`src/request_header_custom.rs`](src/request_header_custom.rs) | Legacy `RequestHeaderCodec` expansion logic. |
-| [`src/request_header_codec_v2/`](src/request_header_codec_v2/) | V2 attribute parsing, semantic model, validation, and code generation. |
-| [`src/remoting_serializable.rs`](src/remoting_serializable.rs) | `RemotingSerializable` derive expansion. |
-| [`Cargo.toml`](Cargo.toml) | Proc-macro crate configuration and macro parsing dependencies. |
+| --- | --- |
+| [`src/lib.rs`](src/lib.rs) | Public derive entry points and shared parsing helpers. |
+| [`src/request_header_codec_v3/`](src/request_header_codec_v3/) | V3 metadata, semantic model, validation, and code generation. |
+| [`src/request_header_codec_v2/`](src/request_header_codec_v2/) | Deprecated V2 implementation retained during the compatibility window. |
+| [`src/request_header_custom.rs`](src/request_header_custom.rs) | Deprecated original derive implementation. |
+| [`src/remoting_serializable.rs`](src/remoting_serializable.rs) | Remoting serialization derive. |
 
-## Requirements
-
-- Stable Rust `1.95.0`, using the pinned repository toolchain.
-- The repository toolchain from [`../rust-toolchain.toml`](../rust-toolchain.toml).
-- A direct or renamed `rocketmq-protocol` dependency, or an explicit `request_header_codec_v2(crate = "...")` path.
-
-## Installation
-
-Inside this workspace:
-
-```toml
-[dependencies]
-rocketmq-macros = { path = "../rocketmq-macros" }
-```
-
-For external consumers:
-
-```toml
-[dependencies]
-rocketmq-macros = "1.0.0"
-```
-
-Renamed dependencies are supported without source changes. The standalone fixture under
-`tests/fixtures/renamed-consumer` verifies this contract with an offline Cargo check.
+No Java checkout is accessed during Cargo builds. Java schemas, golden frames, migration state, and performance
+evidence are governed by the repository's `scripts/request-header-codec` assets.
 
 ## Validation
 
-Focused checks for this crate:
-
-```bash
+```powershell
+python scripts/request-header-codec/migrate.py check
+python scripts/request-header-codec/compare_header_schema.py
 cargo test -p rocketmq-macros --lib
-cargo test -p rocketmq-protocol --test request_header_codec_v2_wire_snapshot
+cargo test -p rocketmq-protocol --test request_header_codec_v3_ui
 cargo test -p rocketmq-protocol --test request_header_codec_v2_ui
-cargo check --offline --manifest-path rocketmq-macros/tests/fixtures/renamed-consumer/Cargo.toml
-```
-
-Because the macro is consumed by most protocol headers, validate the protocol crate after changing generation logic:
-
-```bash
-cargo test -p rocketmq-protocol --lib
-```
-
-Workspace-level Rust validation is run from the repository root when Rust code changes:
-
-```bash
-cargo fmt --all
-cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
+cargo test -p rocketmq-protocol --test request_header_codec_v2_wire_snapshot
+cargo check --locked --offline --manifest-path rocketmq-macros/tests/fixtures/renamed-consumer/Cargo.toml
 ```
 
 ## License

--- a/rocketmq-macros/src/lib.rs
+++ b/rocketmq-macros/src/lib.rs
@@ -28,18 +28,28 @@ mod request_header_codec_v2;
 mod request_header_codec_v3;
 mod request_header_custom;
 
+/// Legacy request-header derive retained for downstream compatibility.
+#[deprecated(
+    since = "1.0.0",
+    note = "use RequestHeaderCodecV3 with dedicated #[header(...)] wire metadata"
+)]
 #[proc_macro_derive(RequestHeaderCodec, attributes(required))]
 pub fn request_header_codec(input: TokenStream) -> TokenStream {
     request_header_codec_inner(input)
 }
 
+/// Hardened V2 request-header derive retained for one compatibility window.
+#[deprecated(
+    since = "1.0.0",
+    note = "use RequestHeaderCodecV3; RequestHeaderCodecV2 will be removed in a future breaking release"
+)]
 #[proc_macro_derive(RequestHeaderCodecV2, attributes(required, request_header, request_header_codec_v2))]
 pub fn request_header_codec_v2(input: TokenStream) -> TokenStream {
     request_header_codec_inner_v2(input)
 }
 
-/// Generates typed map codecs, schema metadata, and compatibility adapters for
-/// an explicit request-header wire model.
+/// Recommended request-header derive. Generates typed map codecs, schema
+/// metadata, and compatibility adapters for an explicit wire model.
 #[proc_macro_derive(RequestHeaderCodecV3, attributes(header, required))]
 pub fn request_header_codec_v3(input: TokenStream) -> TokenStream {
     request_header_codec_inner_v3(input)

--- a/rocketmq-macros/tests/fixtures/renamed-consumer/src/main.rs
+++ b/rocketmq-macros/tests/fixtures/renamed-consumer/src/main.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(deprecated)]
+
 use protocol_api::{CommandCustomHeader, HeaderCodec};
 use rocketmq_macros::{RequestHeaderCodecV2, RequestHeaderCodecV3};
 

--- a/rocketmq-protocol/tests/request_header_codec_v2_wire_snapshot.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v2_wire_snapshot.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(deprecated)]
+
 use std::collections::BTreeMap;
 
 use cheetah_string::CheetahString;

--- a/rocketmq-protocol/tests/request_header_codec_v3_typed_map.rs
+++ b/rocketmq-protocol/tests/request_header_codec_v3_typed_map.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(deprecated)]
+
 use cheetah_string::CheetahString;
 use rocketmq_macros::{RequestHeaderCodecV2, RequestHeaderCodecV3};
 use rocketmq_protocol::protocol::header_codec::{

--- a/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/combined_errors.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/combined_errors.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use rocketmq_macros::RequestHeaderCodecV2;
 
 #[derive(serde::Serialize, RequestHeaderCodecV2)]

--- a/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/combined_errors.stderr
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/combined_errors.stderr
@@ -1,11 +1,11 @@
 error: required cannot be used on Option<T>
- --> tests/ui/request_header_codec_v2/fail/combined_errors.rs:6:5
+ --> tests/ui/request_header_codec_v2/fail/combined_errors.rs:8:5
   |
-6 |     #[required]
+8 |     #[required]
   |     ^
 
 error: required and serde(default) are mutually exclusive
- --> tests/ui/request_header_codec_v2/fail/combined_errors.rs:6:5
+ --> tests/ui/request_header_codec_v2/fail/combined_errors.rs:8:5
   |
-6 |     #[required]
+8 |     #[required]
   |     ^

--- a/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/deprecated.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/deprecated.rs
@@ -1,0 +1,10 @@
+#![deny(deprecated)]
+
+use rocketmq_macros::RequestHeaderCodecV2;
+
+#[derive(RequestHeaderCodecV2)]
+struct DeprecatedHeader {
+    value: Option<i32>,
+}
+
+fn main() {}

--- a/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/deprecated.stderr
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/deprecated.stderr
@@ -1,0 +1,11 @@
+error: use of deprecated macro `RequestHeaderCodecV2`: use RequestHeaderCodecV3; RequestHeaderCodecV2 will be removed in a future breaking release
+ --> tests/ui/request_header_codec_v2/fail/deprecated.rs:5:10
+  |
+5 | #[derive(RequestHeaderCodecV2)]
+  |          ^^^^^^^^^^^^^^^^^^^^
+  |
+note: the lint level is defined here
+ --> tests/ui/request_header_codec_v2/fail/deprecated.rs:1:9
+  |
+1 | #![deny(deprecated)]
+  |         ^^^^^^^^^^

--- a/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/duplicate_key.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/duplicate_key.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use rocketmq_macros::RequestHeaderCodecV2;
 
 #[derive(serde::Serialize, RequestHeaderCodecV2)]

--- a/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/duplicate_key.stderr
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/duplicate_key.stderr
@@ -1,5 +1,5 @@
 error: wire key `same` is already used by field `first`
- --> tests/ui/request_header_codec_v2/fail/duplicate_key.rs:8:5
-  |
-8 |     #[serde(alias = "same")]
-  |     ^
+  --> tests/ui/request_header_codec_v2/fail/duplicate_key.rs:10:5
+   |
+10 |     #[serde(alias = "same")]
+   |     ^

--- a/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/flatten_scalar.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/flatten_scalar.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use rocketmq_macros::RequestHeaderCodecV2;
 
 #[derive(serde::Serialize, RequestHeaderCodecV2)]

--- a/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/flatten_scalar.stderr
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/flatten_scalar.stderr
@@ -1,5 +1,5 @@
 error: serde(flatten) requires a nested header type
- --> tests/ui/request_header_codec_v2/fail/flatten_scalar.rs:6:5
+ --> tests/ui/request_header_codec_v2/fail/flatten_scalar.rs:8:5
   |
-6 |     #[serde(flatten)]
+8 |     #[serde(flatten)]
   |     ^

--- a/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/invalid_shapes.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/invalid_shapes.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use rocketmq_macros::RequestHeaderCodecV2;
 
 #[derive(RequestHeaderCodecV2)]

--- a/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/invalid_shapes.stderr
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/invalid_shapes.stderr
@@ -1,17 +1,17 @@
 error: RequestHeaderCodecV2 does not support unit structs
- --> tests/ui/request_header_codec_v2/fail/invalid_shapes.rs:5:8
+ --> tests/ui/request_header_codec_v2/fail/invalid_shapes.rs:7:8
   |
-5 | struct UnitHeader;
+7 | struct UnitHeader;
   |        ^^^^^^^^^^
 
 error: RequestHeaderCodecV2 does not support enums
- --> tests/ui/request_header_codec_v2/fail/invalid_shapes.rs:9:1
-  |
-9 | enum EnumHeader {
-  | ^^^^
+  --> tests/ui/request_header_codec_v2/fail/invalid_shapes.rs:11:1
+   |
+11 | enum EnumHeader {
+   | ^^^^
 
 error: RequestHeaderCodecV2 does not support unions
-  --> tests/ui/request_header_codec_v2/fail/invalid_shapes.rs:15:1
+  --> tests/ui/request_header_codec_v2/fail/invalid_shapes.rs:17:1
    |
-15 | union UnionHeader {
+17 | union UnionHeader {
    | ^^^^^

--- a/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/malformed_alias_default.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/malformed_alias_default.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use rocketmq_macros::RequestHeaderCodecV2;
 
 #[derive(serde::Serialize, RequestHeaderCodecV2)]

--- a/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/malformed_alias_default.stderr
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/malformed_alias_default.stderr
@@ -1,23 +1,23 @@
 error: expected serde alias attribute to be a string: `alias = "..."`
- --> tests/ui/request_header_codec_v2/fail/malformed_alias_default.rs:6:21
+ --> tests/ui/request_header_codec_v2/fail/malformed_alias_default.rs:8:21
   |
-6 |     #[serde(alias = 7)]
+8 |     #[serde(alias = 7)]
   |                     ^
 
 error: expected string literal
- --> tests/ui/request_header_codec_v2/fail/malformed_alias_default.rs:6:21
+ --> tests/ui/request_header_codec_v2/fail/malformed_alias_default.rs:8:21
   |
-6 |     #[serde(alias = 7)]
+8 |     #[serde(alias = 7)]
   |                     ^
 
 error: failed to parse path: "not a valid::path"
-  --> tests/ui/request_header_codec_v2/fail/malformed_alias_default.rs:13:23
+  --> tests/ui/request_header_codec_v2/fail/malformed_alias_default.rs:15:23
    |
-13 |     #[serde(default = "not a valid::path")]
+15 |     #[serde(default = "not a valid::path")]
    |                       ^^^^^^^^^^^^^^^^^^^
 
 error: invalid serde default path: unexpected token
-  --> tests/ui/request_header_codec_v2/fail/malformed_alias_default.rs:13:23
+  --> tests/ui/request_header_codec_v2/fail/malformed_alias_default.rs:15:23
    |
-13 |     #[serde(default = "not a valid::path")]
+15 |     #[serde(default = "not a valid::path")]
    |                       ^^^^^^^^^^^^^^^^^^^

--- a/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/malformed_rename.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/malformed_rename.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use rocketmq_macros::RequestHeaderCodecV2;
 
 #[derive(serde::Serialize, RequestHeaderCodecV2)]

--- a/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/malformed_rename.stderr
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/malformed_rename.stderr
@@ -1,11 +1,11 @@
 error: expected serde rename attribute to be a string: `rename = "..."`
- --> tests/ui/request_header_codec_v2/fail/malformed_rename.rs:6:22
+ --> tests/ui/request_header_codec_v2/fail/malformed_rename.rs:8:22
   |
-6 |     #[serde(rename = 7)]
+8 |     #[serde(rename = 7)]
   |                      ^
 
 error: expected string literal
- --> tests/ui/request_header_codec_v2/fail/malformed_rename.rs:6:22
+ --> tests/ui/request_header_codec_v2/fail/malformed_rename.rs:8:22
   |
-6 |     #[serde(rename = 7)]
+8 |     #[serde(rename = 7)]
   |                      ^

--- a/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/required_default.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/required_default.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use rocketmq_macros::RequestHeaderCodecV2;
 
 #[derive(serde::Serialize, RequestHeaderCodecV2)]

--- a/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/required_default.stderr
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/required_default.stderr
@@ -1,5 +1,5 @@
 error: required and serde(default) are mutually exclusive
- --> tests/ui/request_header_codec_v2/fail/required_default.rs:6:5
+ --> tests/ui/request_header_codec_v2/fail/required_default.rs:8:5
   |
-6 |     #[required]
+8 |     #[required]
   |     ^

--- a/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/required_option.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/required_option.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use rocketmq_macros::RequestHeaderCodecV2;
 
 #[derive(RequestHeaderCodecV2)]

--- a/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/required_option.stderr
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/required_option.stderr
@@ -1,5 +1,5 @@
 error: required cannot be used on Option<T>
- --> tests/ui/request_header_codec_v2/fail/required_option.rs:6:5
+ --> tests/ui/request_header_codec_v2/fail/required_option.rs:8:5
   |
-6 |     #[required]
+8 |     #[required]
   |     ^

--- a/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/tuple_struct.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/tuple_struct.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use rocketmq_macros::RequestHeaderCodecV2;
 
 #[derive(RequestHeaderCodecV2)]

--- a/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/tuple_struct.stderr
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v2/fail/tuple_struct.stderr
@@ -1,5 +1,5 @@
 error: RequestHeaderCodecV2 requires a named struct
- --> tests/ui/request_header_codec_v2/fail/tuple_struct.rs:5:19
+ --> tests/ui/request_header_codec_v2/fail/tuple_struct.rs:7:19
   |
-5 | struct TupleHeader(String);
+7 | struct TupleHeader(String);
   |                   ^^^^^^^^

--- a/rocketmq-protocol/tests/ui/request_header_codec_v2/pass/generic_and_explicit_crate.rs
+++ b/rocketmq-protocol/tests/ui/request_header_codec_v2/pass/generic_and_explicit_crate.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use rocketmq_macros::RequestHeaderCodecV2;
 
 #[derive(RequestHeaderCodecV2)]


### PR DESCRIPTION
## Summary

- establish `RequestHeaderCodecV3` as the recommended derive; all 152 registered production headers already use it
- deprecate the legacy V1 and V2 derives without removing compatibility surfaces
- refresh the English and Chinese macro documentation with V3-first guidance and repair the Chinese file encoding
- add a compile-time deprecation diagnostic while retaining explicit legacy compatibility coverage

## Compatibility

- no production wire metadata changes
- migration audit reports 152 V3 headers, zero V2 headers, and zero unreviewed differences
- Java schema comparison reports 143 mappings and zero differences
- legacy derives remain available for one supported release cycle

## Performance

This change does not add a branch or environment lookup to the message hot path. The formal benchmark evidence in #9062 remains authoritative: V3 exceeds both V2 and Java with all confidence-interval gates passing.

## Validation

- `python scripts/request-header-codec/migrate.py check`
- `python scripts/request-header-codec/compare_header_schema.py`
- `pytest` governance checks
- `cargo test --locked -p rocketmq-macros`
- `cargo test --locked -p rocketmq-protocol --all-features`
- renamed dependency fixture check, formatting check, scoped strict Clippy, and `git diff --check`

Closes #9108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated English and Chinese documentation to recommend the V3 request-header codec.
  * Added V3 usage examples, metadata guidance, validation behavior, runtime fallback details, migration instructions, and renamed-dependency configuration.

* **Deprecations**
  * Marked legacy and V2 request-header codec derives as deprecated while preserving their existing behavior.
  * Added migration guidance directing users toward V3.

* **Tests**
  * Updated compatibility tests and compiler diagnostics to reflect deprecation notices and revised source locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->