### PR TITLE
[ISSUE #9110]✨Restore strict Clippy after cheetah-string 3 migration

### DIFF
--- a/rocketmq-broker/src/config/sections.rs
+++ b/rocketmq-broker/src/config/sections.rs
@@ -430,7 +430,7 @@ fn validate_network(broker: &BrokerConfig) -> Result<NetworkConfig, BrokerConfig
     let mut name_server_addresses = Vec::new();
     if let Some(addresses) = broker.namesrv_addr.as_ref() {
         for address in addresses
-            .split(';')
+            .split_char(';')
             .map(str::trim)
             .filter(|address| !address.is_empty())
         {
@@ -481,7 +481,7 @@ fn validate_high_availability(
         }
         for address in broker
             .controller_addr
-            .split(';')
+            .split_char(';')
             .map(str::trim)
             .filter(|address| !address.is_empty())
         {

--- a/rocketmq-broker/src/controller/replicas_manager.rs
+++ b/rocketmq-broker/src/controller/replicas_manager.rs
@@ -796,7 +796,7 @@ fn parse_controller_addresses(controller_addr: &CheetahString) -> Vec<CheetahStr
     }
 
     controller_addr
-        .split(';')
+        .split_char(';')
         .map(str::trim)
         .filter(|item| !item.is_empty())
         .map(CheetahString::from)

--- a/rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service.rs
@@ -282,7 +282,7 @@ impl<RP: PopLongPollingRequestProcessor + Sync + 'static> PopLongPollingService<
                     continue;
                 }
 
-                let key_array: Vec<&str> = key.split(PopAckConstants::SPLIT).collect();
+                let key_array: Vec<&str> = key.split_str(PopAckConstants::SPLIT).collect();
                 if key_array.len() != 3 {
                     continue;
                 }

--- a/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
+++ b/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
@@ -60,7 +60,7 @@ fn build_topic_group_key(topic: &CheetahString, group: &CheetahString) -> Cheeta
     builder.push_str(topic);
     builder.push_str(TOPIC_GROUP_SEPARATOR);
     builder.push_str(group);
-    builder.finish_string()
+    builder.finish()
 }
 
 fn build_topic_group_lookup_key(topic: &str, group: &str) -> String {
@@ -456,7 +456,7 @@ where
             .filter(|value| !value.is_empty())
             .map(|value| {
                 value
-                    .split(',')
+                    .split_char(',')
                     .map(str::trim)
                     .filter(|group| !group.is_empty())
                     .collect::<HashSet<_>>()

--- a/rocketmq-broker/src/offset/manager/consumer_order_info_manager.rs
+++ b/rocketmq-broker/src/offset/manager/consumer_order_info_manager.rs
@@ -115,7 +115,7 @@ impl ConsumerOrderInfoManager {
         let mut keys_to_remove = Vec::new(); // Temporary storage for keys to remove
 
         for (topic_at_group, qs) in table.iter_mut() {
-            let arrays: Vec<&str> = topic_at_group.split('@').collect();
+            let arrays: Vec<&str> = topic_at_group.split_char('@').collect();
             if arrays.len() != 2 {
                 continue;
             }

--- a/rocketmq-broker/src/out_api/broker_outer_api.rs
+++ b/rocketmq-broker/src/out_api/broker_outer_api.rs
@@ -197,7 +197,7 @@ impl BrokerOuterAPI {
 
     pub async fn update_name_server_address_list(&self, addrs: CheetahString) {
         let addr_vec = addrs
-            .split(";")
+            .split_str(";")
             .map(CheetahString::from_slice)
             .collect::<Vec<CheetahString>>();
         self.remoting_client.update_name_server_address_list(addr_vec).await

--- a/rocketmq-broker/src/processor/pop_inflight_message_counter.rs
+++ b/rocketmq-broker/src/processor/pop_inflight_message_counter.rs
@@ -314,7 +314,7 @@ impl PopInflightMessageCounter {
     /// * `Some((topic, group))` if key is valid
     /// * `None` if key format is invalid
     fn split_key(key: &CheetahString) -> Option<(CheetahString, CheetahString)> {
-        let parts: Vec<&str> = key.split(Self::TOPIC_GROUP_SEPARATOR).collect();
+        let parts: Vec<&str> = key.split_str(Self::TOPIC_GROUP_SEPARATOR).collect();
         if parts.len() == 2 {
             Some((parts[0].into(), parts[1].into()))
         } else {

--- a/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
+++ b/rocketmq-broker/src/processor/processor_service/pop_buffer_merge_service.rs
@@ -589,7 +589,7 @@ impl<MS: BrokerReadWriteStore> PopBufferMergeService<MS> {
         let timeout_threshold = self.minute5;
 
         self.commit_offsets.retain(|key, value| {
-            let key_array: Vec<&str> = key.split(PopAckConstants::SPLIT).collect();
+            let key_array: Vec<&str> = key.split_str(PopAckConstants::SPLIT).collect();
             if key_array.len() != 3 {
                 warn!("[PopBuffer]invalid lock key format: {}, removing", key);
                 return false;

--- a/rocketmq-broker/src/topic/route.rs
+++ b/rocketmq-broker/src/topic/route.rs
@@ -52,7 +52,7 @@ impl BrokerPublishRoute {
     pub(crate) fn from_topic_route_data(topic: &str, route: &mut TopicRouteData) -> Self {
         let mut message_queues = Vec::new();
         if let Some(order_topic_conf) = route.order_topic_conf.as_ref().filter(|conf| !conf.is_empty()) {
-            for broker in order_topic_conf.split(';') {
+            for broker in order_topic_conf.split_char(';') {
                 let Some((broker_name, queue_count)) = broker.split_once(':') else {
                     continue;
                 };

--- a/rocketmq-client/benches/message_util_bench.rs
+++ b/rocketmq-client/benches/message_util_bench.rs
@@ -105,7 +105,7 @@ fn legacy_message_properties_to_string(properties: &HashMap<CheetahString, Cheet
         builder.push_str(value.as_str());
         builder.push(PROPERTY_SEPARATOR);
     }
-    builder.finish_string()
+    builder.finish()
 }
 
 // ============================================================================

--- a/rocketmq-client/src/factory/mq_client_instance/route_conversion.rs
+++ b/rocketmq-client/src/factory/mq_client_instance/route_conversion.rs
@@ -38,7 +38,7 @@ pub fn topic_route_data2topic_publish_info(topic: &str, route: &mut TopicRouteDa
         ..Default::default()
     };
     if let Some(order_topic_conf) = route.order_topic_conf.as_ref().filter(|conf| !conf.is_empty()) {
-        for broker in order_topic_conf.split(';') {
+        for broker in order_topic_conf.split_char(';') {
             let item = broker.split(':').collect::<Vec<&str>>();
             if item.len() != 2 {
                 continue;

--- a/rocketmq-client/src/implementation/mq_admin_impl.rs
+++ b/rocketmq-client/src/implementation/mq_admin_impl.rs
@@ -101,7 +101,7 @@ impl MQAdminImpl {
         let Some(keys) = MessageTrait::get_keys(msg) else {
             return false;
         };
-        keys.split(MessageConst::KEY_SEPARATOR)
+        keys.split_str(MessageConst::KEY_SEPARATOR)
             .any(|candidate| candidate == key.as_str())
     }
 

--- a/rocketmq-client/src/implementation/mq_client_api_impl/admin.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl/admin.rs
@@ -2862,13 +2862,13 @@ impl MQClientAPIImpl {
                 .unwrap_or_default();
             if mix_all::is_lmq(Some(topic)) && message_ext.reconsume_times() == 0 && !dispatch.is_empty() {
                 // process LMQ
-                let queues: Vec<&str> = dispatch.split(mix_all::MULTI_DISPATCH_QUEUE_SPLITTER).collect();
+                let queues: Vec<&str> = dispatch.split_str(mix_all::MULTI_DISPATCH_QUEUE_SPLITTER).collect();
                 let data = message_ext
                     .property(&CheetahString::from_static_str(
                         MessageConst::PROPERTY_INNER_MULTI_QUEUE_OFFSET,
                     ))
                     .unwrap_or_default();
-                let queue_offsets: Vec<&str> = data.split(mix_all::MULTI_DISPATCH_QUEUE_SPLITTER).collect();
+                let queue_offsets: Vec<&str> = data.split_str(mix_all::MULTI_DISPATCH_QUEUE_SPLITTER).collect();
                 // LMQ topic has only 1 queue, which queue id is 0
                 key = ExtraInfoUtil::get_start_offset_info_map_key(topic, mix_all::LMQ_QUEUE_ID as i64);
                 let Some(position) = queues.iter().position(|&q| q == topic) else {
@@ -3209,7 +3209,7 @@ pub(super) fn admin_message_matches_query(
         return false;
     };
 
-    keys.split(MessageConst::KEY_SEPARATOR)
+    keys.split_str(MessageConst::KEY_SEPARATOR)
         .any(|candidate| candidate == key.as_str())
 }
 

--- a/rocketmq-client/src/implementation/mq_client_api_impl/consumer.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl/consumer.rs
@@ -1284,13 +1284,13 @@ impl MQClientAPIImpl {
                     let (queue_offset_key, queue_id_key) = if mix_all::is_lmq(Some(topic.as_str()))
                         && !dispatch.is_empty()
                     {
-                        let queues: Vec<&str> = dispatch.split(mix_all::MULTI_DISPATCH_QUEUE_SPLITTER).collect();
+                        let queues: Vec<&str> = dispatch.split_str(mix_all::MULTI_DISPATCH_QUEUE_SPLITTER).collect();
                         let data = message
                             .property(&CheetahString::from_static_str(
                                 MessageConst::PROPERTY_INNER_MULTI_QUEUE_OFFSET,
                             ))
                             .unwrap_or_default();
-                        let queue_offsets: Vec<&str> = data.split(mix_all::MULTI_DISPATCH_QUEUE_SPLITTER).collect();
+                        let queue_offsets: Vec<&str> = data.split_str(mix_all::MULTI_DISPATCH_QUEUE_SPLITTER).collect();
                         let Some(position) = queues.iter().position(|&q| q == topic.as_str()) else {
                             warn!(
                                 "LMQ dispatch queue does not contain topic={}, dispatch={}",

--- a/rocketmq-client/src/trace/trace_data_encoder.rs
+++ b/rocketmq-client/src/trace/trace_data_encoder.rs
@@ -140,7 +140,7 @@ impl TraceDataEncoder {
             transfer_bean.add_key(bean.msg_id.clone());
 
             if !bean.keys.is_empty() {
-                let keys: Vec<&str> = bean.keys.split(MessageConst::KEY_SEPARATOR).collect();
+                let keys: Vec<&str> = bean.keys.split_str(MessageConst::KEY_SEPARATOR).collect();
                 for key in keys {
                     if !key.is_empty() {
                         transfer_bean.add_key(CheetahString::from_slice(key));

--- a/rocketmq-controller/src/controller/open_raft_controller.rs
+++ b/rocketmq-controller/src/controller/open_raft_controller.rs
@@ -1129,7 +1129,7 @@ impl Controller for OpenRaftController {
             broker_name: request.broker_name.to_string(),
             broker_address: request
                 .register_check_code
-                .split(';')
+                .split_char(';')
                 .next()
                 .unwrap_or_default()
                 .to_string(),

--- a/rocketmq-macros/src/request_header_codec_v2/codegen.rs
+++ b/rocketmq-macros/src/request_header_codec_v2/codegen.rs
@@ -191,17 +191,15 @@ fn gen_encode(field: &FieldModel, command_trait: &TokenStream, string_type: &Tok
         }
         (TypeCategory::CheetahString, false) => insert(quote!(self.#field_ident.clone())),
         (TypeCategory::String, true) => {
-            let insert = insert(quote!(#string_type::from_string_owned(value.clone())));
+            let insert = insert(quote!(#string_type::from_string(value.clone())));
             quote!(if let Some(value) = &self.#field_ident { #insert })
         }
-        (TypeCategory::String, false) => insert(quote!(#string_type::from_string_owned(self.#field_ident.clone()))),
+        (TypeCategory::String, false) => insert(quote!(#string_type::from_string(self.#field_ident.clone()))),
         (TypeCategory::Primitive, true) => {
-            let insert = insert(quote!(#string_type::from_string_owned(value.to_string())));
+            let insert = insert(quote!(#string_type::from_string(value.to_string())));
             quote!(if let Some(value) = &self.#field_ident { #insert })
         }
-        (TypeCategory::Primitive, false) => {
-            insert(quote!(#string_type::from_string_owned(self.#field_ident.to_string())))
-        }
+        (TypeCategory::Primitive, false) => insert(quote!(#string_type::from_string(self.#field_ident.to_string()))),
         (TypeCategory::Flattened, _) => unreachable!("flattened fields are handled above"),
     }
 }

--- a/rocketmq-macros/src/request_header_custom.rs
+++ b/rocketmq-macros/src/request_header_custom.rs
@@ -90,7 +90,7 @@ pub(super) fn request_header_codec_inner(input: proc_macro::TokenStream) -> proc
                                    if let Some(ref value) = self.#field_name {
                                       map.insert (
                                            cheetah_string::CheetahString::from_static_str(Self::#static_name),
-                                           cheetah_string::CheetahString::from_string_owned(value.clone())
+                                           cheetah_string::CheetahString::from_string(value.clone())
                                       );
                                     }
                                }
@@ -107,7 +107,7 @@ pub(super) fn request_header_codec_inner(input: proc_macro::TokenStream) -> proc
                                    if let Some(ref value) = self.#field_name {
                                       map.insert (
                                           cheetah_string::CheetahString::from_static_str(Self::#static_name),
-                                          cheetah_string::CheetahString::from_string_owned(value.to_string())
+                                          cheetah_string::CheetahString::from_string(value.to_string())
                                       );
                                     }
                                }
@@ -123,7 +123,7 @@ pub(super) fn request_header_codec_inner(input: proc_macro::TokenStream) -> proc
                         quote! {
                              map.insert (
                                  cheetah_string::CheetahString::from_static_str(Self::#static_name),
-                                 cheetah_string::CheetahString::from_string_owned(self.#field_name.clone())
+                                 cheetah_string::CheetahString::from_string(self.#field_name.clone())
                              );
                          }
                     } else if is_struct_type && has_serde_flatten_attribute {
@@ -138,7 +138,7 @@ pub(super) fn request_header_codec_inner(input: proc_macro::TokenStream) -> proc
                         quote! {
                              map.insert (
                                  cheetah_string::CheetahString::from_static_str(Self::#static_name),
-                                 cheetah_string::CheetahString::from_string_owned(self.#field_name.to_string())
+                                 cheetah_string::CheetahString::from_string(self.#field_name.to_string())
                              );
                          }
                     },

--- a/rocketmq-model/src/codec.rs
+++ b/rocketmq-model/src/codec.rs
@@ -67,7 +67,7 @@ pub fn message_properties_to_string(properties: &HashMap<CheetahString, CheetahS
         value.push_str(property);
         value.push(PROPERTY_SEPARATOR);
     }
-    CheetahString::from_string_owned(value)
+    CheetahString::from_string(value)
 }
 
 pub fn string_to_message_properties(properties: Option<&CheetahString>) -> HashMap<CheetahString, CheetahString> {
@@ -75,7 +75,7 @@ pub fn string_to_message_properties(properties: Option<&CheetahString>) -> HashM
         return HashMap::new();
     };
     properties
-        .split(PROPERTY_SEPARATOR)
+        .split_char(PROPERTY_SEPARATOR)
         .filter_map(|entry| {
             let (name, value) = entry.split_once(NAME_VALUE_SEPARATOR)?;
             (!name.is_empty()).then(|| (CheetahString::from_slice(name), CheetahString::from_slice(value)))

--- a/rocketmq-model/src/common/message/storage_metadata.rs
+++ b/rocketmq-model/src/common/message/storage_metadata.rs
@@ -17,7 +17,6 @@ use std::net::SocketAddr;
 use bytes::BufMut;
 use bytes::Bytes;
 use bytes::BytesMut;
-use cheetah_string::CheetahStr;
 use cheetah_string::CheetahString;
 
 /// Message storage metadata
@@ -25,7 +24,7 @@ use cheetah_string::CheetahString;
 /// Contains indexing and location information for messages in the Broker storage engine.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StorageMetadata {
-    broker_name: CheetahStr,
+    broker_name: CheetahString,
     queue_id: i32,
     queue_offset: i64,
     commit_log_offset: i64,
@@ -47,7 +46,7 @@ impl StorageMetadata {
         store_size: i32,
     ) -> Self {
         Self {
-            broker_name: broker_name.into(),
+            broker_name,
             queue_id,
             queue_offset,
             commit_log_offset,
@@ -125,7 +124,7 @@ impl StorageMetadata {
 impl Default for StorageMetadata {
     fn default() -> Self {
         Self {
-            broker_name: CheetahStr::new(),
+            broker_name: CheetahString::new(),
             queue_id: 0,
             queue_offset: 0,
             commit_log_offset: 0,

--- a/rocketmq-model/tests/cheetah_string_contract.rs
+++ b/rocketmq-model/tests/cheetah_string_contract.rs
@@ -19,12 +19,11 @@ use std::collections::HashSet;
 
 use cheetah_string::CheetahBuilder;
 use cheetah_string::CheetahBytes;
-use cheetah_string::CheetahStr;
 use cheetah_string::CheetahString;
 
 #[test]
-fn cheetah_str_can_be_used_for_clone_cheap_keys() {
-    let topic = CheetahStr::from_static_str("topic-a");
+fn cheetah_string_can_be_used_for_clone_cheap_keys() {
+    let topic = CheetahString::from_static_str("topic-a");
     let cloned = topic.clone();
 
     assert_eq!(topic, cloned);
@@ -40,22 +39,22 @@ fn cheetah_string_lookup_by_str_still_works_for_hash_maps() {
 }
 
 #[test]
-fn cheetah_builder_finishes_into_string_for_append_heavy_paths() {
+fn cheetah_builder_finishes_into_clone_cheap_string() {
     let mut builder = CheetahBuilder::with_capacity("topic".len() + 1 + "group".len());
     builder.push_str("topic");
     builder.push('@');
     builder.push_str("group");
 
-    assert_eq!(builder.finish_string(), "topic@group");
+    assert_eq!(builder.finish(), "topic@group");
 }
 
 #[test]
-fn cheetah_builder_finish_string_preserves_owned_capacity_for_later_push() {
+fn cheetah_builder_into_string_preserves_owned_capacity_for_later_push() {
     let mut builder = CheetahBuilder::with_capacity(128);
     builder.push_str("topic");
     let before = builder.as_str().as_bytes().as_ptr();
 
-    let mut value = builder.finish_string();
+    let mut value = builder.into_string();
     value.push_str("@group");
 
     assert_eq!(value, "topic@group");
@@ -78,9 +77,9 @@ fn cheetah_bytes_keeps_byte_semantics_and_validates_before_string_conversion() {
 }
 
 #[test]
-fn cheetah_str_hash_set_keeps_str_semantics() {
-    let mut set = HashSet::<CheetahStr>::new();
-    set.insert(CheetahStr::from_static_str("group-a"));
+fn cheetah_string_hash_set_keeps_str_semantics() {
+    let mut set = HashSet::<CheetahString>::new();
+    set.insert(CheetahString::from_static_str("group-a"));
 
     assert!(set.contains("group-a"));
 }
@@ -88,7 +87,7 @@ fn cheetah_str_hash_set_keeps_str_semantics() {
 #[test]
 fn char_split_supports_reverse_iteration_for_single_char_separators() {
     let value = CheetahString::from_static_str("a@b@c");
-    let parts: Vec<&str> = value.split('@').rev().collect();
+    let parts: Vec<&str> = value.split_char('@').rev().collect();
 
     assert_eq!(parts, vec!["c", "b", "a"]);
 }

--- a/rocketmq-namesrv/src/route/types.rs
+++ b/rocketmq-namesrv/src/route/types.rs
@@ -16,13 +16,12 @@
 //!
 //! This module contains optimized type definitions using:
 //! - `CheetahString` instead of `String` for public route names
-//! - `CheetahStr` for immutable internal route table keys
+//! - `CheetahString` for immutable internal route table keys
 //! - `Arc<T>` for immutable shared data
 //! - Strong typing for better API safety
 
 use std::sync::Arc;
 
-use cheetah_string::CheetahStr;
 use cheetah_string::CheetahString;
 use rocketmq_protocol::protocol::route::route_data_view::BrokerData;
 use rocketmq_protocol::protocol::route::route_data_view::QueueData;
@@ -41,32 +40,32 @@ pub type BrokerName = CheetahString;
 pub type ClusterName = CheetahString;
 
 /// Internal route topic key type.
-pub(crate) type RouteTopicName = CheetahStr;
+pub(crate) type RouteTopicName = CheetahString;
 
 /// Internal route broker key type.
-pub(crate) type RouteBrokerName = CheetahStr;
+pub(crate) type RouteBrokerName = CheetahString;
 
 /// Internal route cluster key type.
-pub(crate) type RouteClusterName = CheetahStr;
+pub(crate) type RouteClusterName = CheetahString;
 
 #[inline]
 pub(crate) fn route_topic_name(topic: TopicName) -> RouteTopicName {
-    CheetahStr::from(topic)
+    topic
 }
 
 #[inline]
 pub(crate) fn route_broker_name(broker_name: BrokerName) -> RouteBrokerName {
-    CheetahStr::from(broker_name)
+    broker_name
 }
 
 #[inline]
 pub(crate) fn route_cluster_name(cluster_name: ClusterName) -> RouteClusterName {
-    CheetahStr::from(cluster_name)
+    cluster_name
 }
 
 #[inline]
-pub(crate) fn public_name_from_route(route_name: &CheetahStr) -> CheetahString {
-    CheetahString::from_slice(route_name.as_str())
+pub(crate) fn public_name_from_route(route_name: &CheetahString) -> CheetahString {
+    route_name.clone()
 }
 
 /// Broker address string

--- a/rocketmq-protocol/src/common/message/message_decoder.rs
+++ b/rocketmq-protocol/src/common/message/message_decoder.rs
@@ -155,7 +155,7 @@ pub fn message_properties_to_string(properties: &HashMap<CheetahString, CheetahS
         builder.push_str(value.as_str());
         builder.push(PROPERTY_SEPARATOR);
     }
-    builder.finish_string()
+    builder.finish()
 }
 
 /// Converts UTF-8 message protocol bytes into a [`CheetahString`], preserving
@@ -163,7 +163,7 @@ pub fn message_properties_to_string(properties: &HashMap<CheetahString, CheetahS
 pub fn cheetah_from_utf8_lossy(bytes: &[u8]) -> CheetahString {
     match String::from_utf8_lossy(bytes) {
         Cow::Borrowed(value) => CheetahString::from_slice(value),
-        Cow::Owned(value) => CheetahString::from_string_owned(value),
+        Cow::Owned(value) => CheetahString::from_string(value),
     }
 }
 

--- a/rocketmq-protocol/src/protocol/filter/filter_api.rs
+++ b/rocketmq-protocol/src/protocol/filter/filter_api.rs
@@ -36,7 +36,7 @@ impl FilterAPI {
             return Ok(subscription_data);
         }
 
-        let tags: Vec<&str> = sub_string.split("||").collect();
+        let tags: Vec<&str> = sub_string.split_str("||").collect();
         if tags.is_empty() {
             return Err("subString split error".to_string());
         }

--- a/rocketmq-protocol/src/protocol/rocketmq_serializable.rs
+++ b/rocketmq-protocol/src/protocol/rocketmq_serializable.rs
@@ -119,7 +119,8 @@ impl RocketMQSerializable {
 
         // Checked UTF-8 decode with CheetahString storage optimization
         let bytes = buf.split_to(len).freeze();
-        Ok(Some(CheetahString::try_from_bytes_buf(bytes)?))
+        let value = CheetahString::try_copy_from_bytes(bytes).map_err(|error| error.into_parts().1)?;
+        Ok(Some(value))
     }
 
     /// Optimized ROCKETMQ protocol encoding with reduced allocations

--- a/rocketmq-proxy-local/src/local.rs
+++ b/rocketmq-proxy-local/src/local.rs
@@ -1906,13 +1906,13 @@ fn attach_pop_receipt_handles(
                 ))
                 .unwrap_or_default();
             let (queue_offset_key, queue_id_key) = if mix_all::is_lmq(Some(topic)) && !dispatch.is_empty() {
-                let queues: Vec<&str> = dispatch.split(mix_all::MULTI_DISPATCH_QUEUE_SPLITTER).collect();
+                let queues: Vec<&str> = dispatch.split_str(mix_all::MULTI_DISPATCH_QUEUE_SPLITTER).collect();
                 let data = message
                     .property(&CheetahString::from_static_str(
                         MessageConst::PROPERTY_INNER_MULTI_QUEUE_OFFSET,
                     ))
                     .unwrap_or_default();
-                let queue_offsets: Vec<&str> = data.split(mix_all::MULTI_DISPATCH_QUEUE_SPLITTER).collect();
+                let queue_offsets: Vec<&str> = data.split_str(mix_all::MULTI_DISPATCH_QUEUE_SPLITTER).collect();
                 let offset = queue_offsets[queues.iter().position(|&queue| queue == topic).unwrap()]
                     .parse::<i64>()
                     .unwrap_or_default();
@@ -2006,13 +2006,13 @@ fn build_queue_offset_sorted_map(topic: &str, messages: &[MessageExt]) -> ProxyR
             ))
             .unwrap_or_default();
         if mix_all::is_lmq(Some(topic)) && message.reconsume_times() == 0 && !dispatch.is_empty() {
-            let queues: Vec<&str> = dispatch.split(mix_all::MULTI_DISPATCH_QUEUE_SPLITTER).collect();
+            let queues: Vec<&str> = dispatch.split_str(mix_all::MULTI_DISPATCH_QUEUE_SPLITTER).collect();
             let data = message
                 .property(&CheetahString::from_static_str(
                     MessageConst::PROPERTY_INNER_MULTI_QUEUE_OFFSET,
                 ))
                 .unwrap_or_default();
-            let queue_offsets: Vec<&str> = data.split(mix_all::MULTI_DISPATCH_QUEUE_SPLITTER).collect();
+            let queue_offsets: Vec<&str> = data.split_str(mix_all::MULTI_DISPATCH_QUEUE_SPLITTER).collect();
             let key = ExtraInfoUtil::get_start_offset_info_map_key(topic, mix_all::LMQ_QUEUE_ID as i64);
             sort_map.entry(key).or_insert_with(|| Vec::with_capacity(4)).push(
                 queue_offsets[queues.iter().position(|&queue| queue == topic).unwrap()]

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -2480,7 +2480,7 @@ pub fn check_message_and_return_size(
         if check_dup_info {
             let dup_info = properties_map.get(MessageConst::DUP_INFO).cloned();
             if let Some(content) = dup_info {
-                let vec = content.split('_').collect::<Vec<&str>>();
+                let vec = content.split_char('_').collect::<Vec<&str>>();
                 if vec.len() != 2 {
                     warn!("DupInfo in properties check failed. dupInfo={}", content);
                     return DispatchRequest {

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -451,7 +451,7 @@ impl TimerMessageWriteHandle {
         let mut queue_keys = Vec::new();
         let mut saw_queue = false;
         let mut is_all_lmq_dispatch = true;
-        for queue_name in multi_dispatch_queue.split(MULTI_DISPATCH_QUEUE_SPLITTER) {
+        for queue_name in multi_dispatch_queue.split_str(MULTI_DISPATCH_QUEUE_SPLITTER) {
             if queue_name.is_empty() {
                 is_all_lmq_dispatch = false;
                 continue;
@@ -582,8 +582,8 @@ fn notify_message_arrive_for_multi_dispatch(
         return;
     }
 
-    let mut queue_iter = multi_dispatch_queue.split(MULTI_DISPATCH_QUEUE_SPLITTER);
-    let mut offset_iter = multi_queue_offset.split(MULTI_DISPATCH_QUEUE_SPLITTER);
+    let mut queue_iter = multi_dispatch_queue.split_str(MULTI_DISPATCH_QUEUE_SPLITTER);
+    let mut offset_iter = multi_queue_offset.split_str(MULTI_DISPATCH_QUEUE_SPLITTER);
     loop {
         match (queue_iter.next(), offset_iter.next()) {
             (None, None) => break,
@@ -597,8 +597,8 @@ fn notify_message_arrive_for_multi_dispatch(
     }
 
     for (queue_name, queue_offset) in multi_dispatch_queue
-        .split(MULTI_DISPATCH_QUEUE_SPLITTER)
-        .zip(multi_queue_offset.split(MULTI_DISPATCH_QUEUE_SPLITTER))
+        .split_str(MULTI_DISPATCH_QUEUE_SPLITTER)
+        .zip(multi_queue_offset.split_str(MULTI_DISPATCH_QUEUE_SPLITTER))
     {
         let Ok(queue_offset) = queue_offset.parse::<i64>() else {
             return;

--- a/rocketmq-store/src/queue/single_consume_queue.rs
+++ b/rocketmq-store/src/queue/single_consume_queue.rs
@@ -313,8 +313,8 @@ impl ConsumeQueue {
             return;
         };
 
-        let queues: Vec<&str> = multi_dispatch_queue.split(MULTI_DISPATCH_QUEUE_SPLITTER).collect();
-        let queue_offsets: Vec<&str> = multi_queue_offset.split(MULTI_DISPATCH_QUEUE_SPLITTER).collect();
+        let queues: Vec<&str> = multi_dispatch_queue.split_str(MULTI_DISPATCH_QUEUE_SPLITTER).collect();
+        let queue_offsets: Vec<&str> = multi_queue_offset.split_str(MULTI_DISPATCH_QUEUE_SPLITTER).collect();
         if queues.len() != queue_offsets.len() {
             error!(
                 "[BUG] queues length mismatches queueOffsets length for topic {}",

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/controller/get_controller_metadata_sub_command.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/commands/controller/get_controller_metadata_sub_command.rs
@@ -97,7 +97,7 @@ impl GetControllerMetadataSubCommand {
         println!("AppliedLogIndex\t{}", applied_log_index);
 
         if let Some(peers) = &meta_data.peers {
-            peers.split(";").for_each(|peer| println!("#Peer:\t{}", peer));
+            peers.split_str(";").for_each(|peer| println!("#Peer:\t{}", peer));
         } else {
             println!("No peers found");
         }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/consumer/query.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/consumer/query.rs
@@ -355,7 +355,7 @@ pub(super) async fn message_queue_allocation(
         else {
             continue;
         };
-        let client_ip = client_id.split('@').next().unwrap_or_default().to_string();
+        let client_ip = client_id.split_char('@').next().unwrap_or_default().to_string();
         for queue in running_info.mq_table.keys() {
             allocation.insert(queue.clone(), client_ip.clone());
         }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/consumer.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/consumer.rs
@@ -1294,7 +1294,7 @@ async fn get_message_queue_allocation_result_with_admin(
                 .await
             {
                 for mq in consumer_running_info.mq_table.keys() {
-                    results.insert(mq.clone(), client_id.split('@').next().unwrap_or("").to_string());
+                    results.insert(mq.clone(), client_id.split_char('@').next().unwrap_or("").to_string());
                 }
             }
         }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/topic/operations.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/topic/operations.rs
@@ -690,7 +690,7 @@ impl TopicService {
         let ip_list = ip_list.into();
 
         let requested_ips = ip_list
-            .split(',')
+            .split_char(',')
             .map(str::trim)
             .filter(|ip| !ip.is_empty())
             .map(CheetahString::from)

--- a/rocketmq-tools/rocketmq-store-inspect/src/content_show.rs
+++ b/rocketmq-tools/rocketmq-store-inspect/src/content_show.rs
@@ -122,7 +122,7 @@ fn property_value<'a>(properties: &'a [u8], name: &[u8]) -> Option<&'a [u8]> {
 fn cheetah_from_utf8_lossy(bytes: &[u8]) -> CheetahString {
     match String::from_utf8_lossy(bytes) {
         Cow::Borrowed(value) => CheetahString::from_slice(value),
-        Cow::Owned(value) => CheetahString::from_string_owned(value),
+        Cow::Owned(value) => CheetahString::from_string(value),
     }
 }
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9110

### Brief Description

- Replace deprecated `cheetah-string` aliases, builders, constructors, UTF-8 conversion, and generic split calls with supported version 3 APIs across the workspace.
- Keep request-header macro expansion on supported constructors so generated V2 and custom codec code remains warning-free.
- Preserve existing wire, parsing, clone, and allocation behavior while restoring the strict workspace Clippy gate.

### How Did You Test This Change?

- `cargo test --locked -p rocketmq-model --all-features`
- `cargo test --locked -p rocketmq-protocol --all-features`
- `cargo test --locked -p rocketmq-macros`
- Targeted `cargo fmt -- --check` for every changed package.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized string parsing and construction across broker, client, controller, protocol, storage, and administration workflows.
  * Improved consistency when processing addresses, message properties, subscription tags, queue metadata, and dispatch information.
  * Updated message and route metadata handling to use owned string values where appropriate.
  * Updated serialization, deserialization, and builder usage for current string APIs.

* **Tests**
  * Refreshed string contract coverage for splitting, builders, ownership, and hashing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->