### PR TITLE
[ISSUE #9112]✨Align Controller authentication with the strict architecture target

### DIFF
--- a/scripts/architecture-dependency-policy.json
+++ b/scripts/architecture-dependency-policy.json
@@ -380,6 +380,7 @@
       "rocketmq-protocol",
       "rocketmq-transport",
       "rocketmq-security-api",
+      "rocketmq-auth",
       "rocketmq-store-api",
       "rocketmq-runtime",
       "rocketmq-error",

--- a/scripts/tests/test_architecture_dependency_guard.py
+++ b/scripts/tests/test_architecture_dependency_guard.py
@@ -701,11 +701,11 @@ use rocketmq_client_rust::producer::Producer;
         policy["target_debt"]["entries"] = [
             {
                 "caller": "rocketmq-controller",
-                "target": "rocketmq-auth",
+                "target": "rocketmq-broker",
                 "kind": "normal",
                 "path": "rocketmq-controller/Cargo.toml",
-                "alias": "rocketmq_auth",
-                "owner": "controller-security",
+                "alias": "rocketmq_broker",
+                "owner": "controller-fixture",
                 "reason": "fixture debt",
                 "remove_phase": "P2.1",
                 "remove_by": "2099-12-31",
@@ -715,10 +715,10 @@ use rocketmq_client_rust::producer::Producer;
             [
                 package(
                     "rocketmq-controller",
-                    [dependency("rocketmq-auth")],
+                    [dependency("rocketmq-broker")],
                     manifest_path="rocketmq-controller/Cargo.toml",
                 ),
-                package("rocketmq-auth"),
+                package("rocketmq-broker"),
             ]
         )
 
@@ -737,18 +737,18 @@ use rocketmq_client_rust::producer::Producer;
         policy = json.loads(POLICY.read_text(encoding="utf-8"))
         entry = {
             "caller": "rocketmq-controller",
-            "target": "rocketmq-auth",
+            "target": "rocketmq-broker",
             "kind": "normal",
             "path": "rocketmq-controller/Cargo.toml",
-            "alias": "rocketmq_auth",
-            "owner": "controller-security",
+            "alias": "rocketmq_broker",
+            "owner": "controller-fixture",
             "reason": "fixture debt",
             "remove_phase": "P2.1",
             "remove_by": "2099-12-31",
         }
         policy["target_debt"]["entries"] = [entry]
         stale = self.run_guard(
-            metadata([package("rocketmq-controller"), package("rocketmq-auth")]),
+            metadata([package("rocketmq-controller"), package("rocketmq-broker")]),
             mode="transition",
             policy_override=policy,
         )
@@ -761,10 +761,10 @@ use rocketmq_client_rust::producer::Producer;
                 [
                     package(
                         "rocketmq-controller",
-                        [dependency("rocketmq-auth")],
+                        [dependency("rocketmq-broker")],
                         manifest_path="rocketmq-controller/Cargo.toml",
                     ),
-                    package("rocketmq-auth"),
+                    package("rocketmq-broker"),
                 ]
             ),
             mode="transition",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9112

### Brief Description

- Register `rocketmq-auth` as an allowed production dependency of `rocketmq-controller` in the strict target DAG because the Controller binary composes the production authentication runtime.
- Keep the target debt ledger empty; this edge is an intentional permanent boundary, not a temporary exception.
- Move the dependency-guard debt fixture to the forbidden `rocketmq-controller` to `rocketmq-broker` edge so strict and transition enforcement remain covered.

### How Did You Test This Change?

- `python scripts/architecture_dependency_guard.py --mode target --output target/architecture-dependency-target.json`
- `python -m unittest scripts.tests.test_architecture_dependency_guard -v`
- `python -m unittest scripts.tests.test_m09_target_dag_closeout -v`
- `python scripts/architecture_release_guard.py`
- `python scripts/run_architecture_tests.py --tier milestone_contract --tier phase_contract --tier dynamic_fixture`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependency governance to reflect current component relationships.

* **Tests**
  * Revised architecture validation scenarios and dependency-debt fixtures for more accurate coverage.
  * Improved handling of transition, expiration, stale, and expired dependency checks.

* **Impact**
  * No changes to user-facing functionality or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->