### PR TITLE
[ISSUE #9117]🐛Restore reproducible fuzz workspace lockfile

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -3109,7 +3109,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9117

### Brief Description

- Synchronize the standalone fuzz workspace lockfile with the current `rocketmq-macros` manifest.
- Record the existing `syn 3.0.3` dependency edge instead of the stale `syn 2.0.119` edge.
- Preserve the fixed-nightly `--locked` workflow contract without upgrading unrelated registry dependencies.

### How Did You Test This Change?

- `cargo +nightly-2026-07-05 check --locked --manifest-path fuzz/Cargo.toml --all-targets --all-features` passed.
- `python scripts/architecture_evidence_governance_guard.py` passed with all four owned fuzz targets.
- `git diff --check` passed.
- `cargo audit --file Cargo.lock` reported the pre-existing `RUSTSEC-2026-0235` advisory for `rkyv 0.7.46`; the unchanged `main` lockfile reports the same advisory, and this PR does not change `rkyv`.
