### PR TITLE
[ISSUE #9125]🐛Provision protoc for architecture property suites

### DIFF
--- a/.github/workflows/architecture-documentation.yml
+++ b/.github/workflows/architecture-documentation.yml
@@ -95,7 +95,7 @@ jobs:
         run: >-
           sudo apt-get update &&
           sudo apt-get install -y
-          clang llvm libclang-dev cmake make ninja-build pkg-config
+          clang llvm libclang-dev cmake make ninja-build pkg-config protobuf-compiler
 
       - name: Validate architecture documentation
         run: python scripts/architecture_documentation_guard.py --check

--- a/scripts/tests/test_architecture_documentation_guard.py
+++ b/scripts/tests/test_architecture_documentation_guard.py
@@ -26,6 +26,7 @@ class ArchitectureDocumentationGuardTest(unittest.TestCase):
 
         self.assertIn("Install native build dependencies", workflow)
         self.assertIn("clang llvm libclang-dev", workflow)
+        self.assertIn("protobuf-compiler", workflow)
 
     def test_observability_cache_key_is_normalized_for_feature_lists(self) -> None:
         root = Path(__file__).resolve().parents[2]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9125

### Brief Description

Install `protobuf-compiler` in the `Architecture documentation` Ubuntu job so its registered proxy property suite can compile `rocketmq-proxy-core` and generate protobuf bindings. Extend the existing workflow dependency regression test to require the package and catch future configuration drift before the property suites run.

### How Did You Test This Change?

- `python -m unittest scripts.tests.test_architecture_documentation_guard.ArchitectureDocumentationGuardTest.test_documentation_workflow_provisions_property_suite_native_dependencies -v`: passed.
- `python -m unittest scripts.tests.test_architecture_documentation_guard -v`: passed, 8 tests.
- `python scripts/architecture_documentation_guard.py --check`: passed.
- `.\scripts\check-agents-routing.ps1`: passed.
- `git diff --check`: passed.
- The complete property and state suite was not run locally because `protoc` is not installed on the Windows host. The PR workflow provides the authoritative Ubuntu validation for the package installation and proxy suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated architecture documentation automation to support Protocol Buffers compilation.
* **Tests**
  * Enhanced validation to confirm the required Protocol Buffers compiler is installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->