### PR TITLE
[ISSUE #9128]✨Restore architecture guard inventories

### DIFF
--- a/rocketmq-doc/en/module-maintainability-board.md
+++ b/rocketmq-doc/en/module-maintainability-board.md
@@ -20,8 +20,8 @@ A high rank is a review priority, not evidence that line count alone is a defect
 | 10 | `rocketmq-store/src/config/message_store_config.rs` | 354.040 | 1982 | 32 | 2 | 1 | 126 | 0 | 0 | 5 |
 | 11 | `rocketmq-broker/src/config/broker_config.rs` | 353.333 | 1794 | 5 | 1 | 1 | 181 | 0 | 0 | 4 |
 | 12 | `rocketmq-client/src/implementation/mq_client_api_impl.rs` | 346.275 | 401 | 104 | 10 | 0 | 6 | 3 | 1 | 13 |
-| 13 | `rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs` | 320.825 | 2143 | 54 | 2 | 1 | 41 | 19 | 0 | 12 |
-| 14 | `rocketmq-broker/src/out_api/broker_outer_api.rs` | 313.457 | 1492 | 62 | 6 | 2 | 45 | 0 | 0 | 7 |
+| 13 | `rocketmq-broker/src/out_api/broker_outer_api.rs` | 321.582 | 1537 | 63 | 6 | 2 | 48 | 0 | 0 | 7 |
+| 14 | `rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs` | 320.825 | 2143 | 54 | 2 | 1 | 41 | 19 | 0 | 12 |
 | 15 | `rocketmq-client/src/consumer/default_lite_pull_consumer.rs` | 302.462 | 1252 | 18 | 1 | 0 | 125 | 4 | 0 | 9 |
 | 16 | `rocketmq-broker/src/processor/send_message_processor.rs` | 290.968 | 1710 | 65 | 6 | 3 | 8 | 0 | 0 | 13 |
 | 17 | `rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs` | 290.850 | 334 | 81 | 5 | 1 | 1 | 10 | 3 | 13 |
@@ -127,20 +127,20 @@ A high rank is a review priority, not evidence that line count alone is a defect
 - Tests: Run focused `rocketmq-client` behavior tests, strict Clippy, stable-surface checks, and affected standalone consumers.
 - Exit: Remove from the ranked board after production LOC is at most 800, public surface does not grow, and independent child fixtures cover each extracted use case.
 
-### `rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs`
-
-- Owner: rocketmq-client maintainers.
-- Use-case boundaries: `lifecycle`, `assignment and routing`, `message flow`, `offset and shutdown`.
-- State ownership: `default_mq_push_consumer_impl` remains the single composition owner; child use-case modules may receive narrow references but must not expose lock guards.
-- Tests: Run focused `rocketmq-client` behavior tests, strict Clippy, stable-surface checks, and affected standalone consumers.
-- Exit: Remove from the ranked board after production LOC is at most 800, public surface does not grow, and independent child fixtures cover each extracted use case.
-
 ### `rocketmq-broker/src/out_api/broker_outer_api.rs`
 
 - Owner: rocketmq-broker maintainers.
 - Use-case boundaries: `broker outer api`, `lifecycle`, `request execution`, `result projection`.
 - State ownership: `broker_outer_api` remains the single composition owner; child use-case modules may receive narrow references but must not expose lock guards.
 - Tests: Run focused `rocketmq-broker` behavior tests, strict Clippy, stable-surface checks, and affected standalone consumers.
+- Exit: Remove from the ranked board after production LOC is at most 800, public surface does not grow, and independent child fixtures cover each extracted use case.
+
+### `rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs`
+
+- Owner: rocketmq-client maintainers.
+- Use-case boundaries: `lifecycle`, `assignment and routing`, `message flow`, `offset and shutdown`.
+- State ownership: `default_mq_push_consumer_impl` remains the single composition owner; child use-case modules may receive narrow references but must not expose lock guards.
+- Tests: Run focused `rocketmq-client` behavior tests, strict Clippy, stable-surface checks, and affected standalone consumers.
 - Exit: Remove from the ranked board after production LOC is at most 800, public surface does not grow, and independent child fixtures cover each extracted use case.
 
 ### `rocketmq-client/src/consumer/default_lite_pull_consumer.rs`

--- a/rocketmq-transport/src/codec/remoting_command_codec.rs
+++ b/rocketmq-transport/src/codec/remoting_command_codec.rs
@@ -249,11 +249,17 @@ impl SessionCommandDecoder {
     }
 
     fn reserve_announced_frame(&mut self, src: &BytesMut) -> Result<(), rocketmq_error::RocketMQError> {
-        if self.partial_frame_permit.is_some() || src.len() < 4 {
+        if self.partial_frame_permit.is_some() {
             return Ok(());
         }
+        let Some(length_prefix) = src.get(..4) else {
+            return Ok(());
+        };
         self.inner.validate_announced_frame(src)?;
-        let total = i32::from_be_bytes(src[..4].try_into().expect("four bytes checked"));
+        let Ok(length_prefix) = <[u8; 4]>::try_from(length_prefix) else {
+            return Ok(());
+        };
+        let total = i32::from_be_bytes(length_prefix);
         if total <= 0 {
             return Ok(());
         }

--- a/rocketmq-transport/src/server.rs
+++ b/rocketmq-transport/src/server.rs
@@ -753,7 +753,6 @@ pub async fn run_connected_session<H>(
 }
 
 /// Runs an already-connected stream with explicit bounded I/O policy.
-#[allow(clippy::too_many_arguments)]
 pub async fn run_connected_session_with_io_policy<H>(
     connection: Connection,
     local_addr: SocketAddr,

--- a/scripts/module-maintainability-baseline.json
+++ b/scripts/module-maintainability-baseline.json
@@ -17,7 +17,7 @@
       "reexports": 172
     },
     "rocketmq-broker": {
-      "public_items": 1395,
+      "public_items": 1398,
       "reexports": 20
     },
     "rocketmq-client": {
@@ -97,7 +97,7 @@
       "reexports": 5
     },
     "rocketmq-runtime": {
-      "public_items": 676,
+      "public_items": 680,
       "reexports": 162
     },
     "rocketmq-security-api": {
@@ -133,8 +133,8 @@
       "reexports": 85
     },
     "rocketmq-transport": {
-      "public_items": 595,
-      "reexports": 170
+      "public_items": 598,
+      "reexports": 173
     }
   },
   "files": {
@@ -654,7 +654,7 @@
       "reexports": 0
     },
     "rocketmq-broker/src/broker/broker_control_plane/bootstrap.rs": {
-      "production_lines": 663,
+      "production_lines": 674,
       "public_items": 0,
       "reexports": 0
     },
@@ -1199,8 +1199,8 @@
       "reexports": 0
     },
     "rocketmq-broker/src/out_api/broker_outer_api.rs": {
-      "production_lines": 1492,
-      "public_items": 45,
+      "production_lines": 1537,
+      "public_items": 48,
       "reexports": 0
     },
     "rocketmq-broker/src/out_api/pull.rs": {
@@ -2414,7 +2414,7 @@
       "reexports": 5
     },
     "rocketmq-client/src/implementation/mq_client_api_impl/admin.rs": {
-      "production_lines": 3320,
+      "production_lines": 3319,
       "public_items": 29,
       "reexports": 0
     },
@@ -2424,12 +2424,12 @@
       "reexports": 0
     },
     "rocketmq-client/src/implementation/mq_client_api_impl/consumer.rs": {
-      "production_lines": 1524,
+      "production_lines": 1522,
       "public_items": 39,
       "reexports": 0
     },
     "rocketmq-client/src/implementation/mq_client_api_impl/producer.rs": {
-      "production_lines": 792,
+      "production_lines": 791,
       "public_items": 14,
       "reexports": 0
     },
@@ -2449,12 +2449,12 @@
       "reexports": 0
     },
     "rocketmq-client/src/implementation/mq_client_api_impl/transaction.rs": {
-      "production_lines": 39,
+      "production_lines": 38,
       "public_items": 4,
       "reexports": 0
     },
     "rocketmq-client/src/implementation/mq_client_api_impl/transport.rs": {
-      "production_lines": 131,
+      "production_lines": 130,
       "public_items": 10,
       "reexports": 0
     },
@@ -4809,7 +4809,7 @@
       "reexports": 2
     },
     "rocketmq-namesrv/src/route/route_info_manager.rs": {
-      "production_lines": 1202,
+      "production_lines": 1213,
       "public_items": 25,
       "reexports": 0
     },
@@ -7334,8 +7334,8 @@
       "reexports": 23
     },
     "rocketmq-runtime/src/resource_budget/budget.rs": {
-      "production_lines": 597,
-      "public_items": 27,
+      "production_lines": 620,
+      "public_items": 28,
       "reexports": 0
     },
     "rocketmq-runtime/src/resource_budget/clock.rs": {
@@ -7399,8 +7399,8 @@
       "reexports": 0
     },
     "rocketmq-runtime/src/service_context.rs": {
-      "production_lines": 265,
-      "public_items": 29,
+      "production_lines": 291,
+      "public_items": 30,
       "reexports": 0
     },
     "rocketmq-runtime/src/service_lifecycle.rs": {
@@ -7439,8 +7439,8 @@
       "reexports": 0
     },
     "rocketmq-runtime/src/task_group.rs": {
-      "production_lines": 807,
-      "public_items": 32,
+      "production_lines": 827,
+      "public_items": 34,
       "reexports": 0
     },
     "rocketmq-runtime/src/task_group/registry.rs": {
@@ -12974,7 +12974,7 @@
       "reexports": 0
     },
     "rocketmq-transport/src/admission.rs": {
-      "production_lines": 665,
+      "production_lines": 753,
       "public_items": 26,
       "reexports": 1
     },
@@ -13019,7 +13019,7 @@
       "reexports": 0
     },
     "rocketmq-transport/src/clients.rs": {
-      "production_lines": 50,
+      "production_lines": 61,
       "public_items": 4,
       "reexports": 1
     },
@@ -13044,7 +13044,7 @@
       "reexports": 0
     },
     "rocketmq-transport/src/clients/rocketmq_tokio_client.rs": {
-      "production_lines": 895,
+      "production_lines": 908,
       "public_items": 19,
       "reexports": 0
     },
@@ -13054,7 +13054,7 @@
       "reexports": 0
     },
     "rocketmq-transport/src/codec/remoting_command_codec.rs": {
-      "production_lines": 134,
+      "production_lines": 196,
       "public_items": 5,
       "reexports": 0
     },
@@ -13099,7 +13099,7 @@
       "reexports": 0
     },
     "rocketmq-transport/src/connection.rs": {
-      "production_lines": 764,
+      "production_lines": 768,
       "public_items": 37,
       "reexports": 0
     },
@@ -13144,7 +13144,7 @@
       "reexports": 10
     },
     "rocketmq-transport/src/dispatch/authorized_dispatcher.rs": {
-      "production_lines": 282,
+      "production_lines": 296,
       "public_items": 9,
       "reexports": 0
     },
@@ -13169,9 +13169,9 @@
       "reexports": 0
     },
     "rocketmq-transport/src/lib.rs": {
-      "production_lines": 161,
+      "production_lines": 164,
       "public_items": 2,
-      "reexports": 125
+      "reexports": 128
     },
     "rocketmq-transport/src/local.rs": {
       "production_lines": 61,
@@ -13309,12 +13309,12 @@
       "reexports": 0
     },
     "rocketmq-transport/src/server.rs": {
-      "production_lines": 907,
-      "public_items": 30,
+      "production_lines": 1025,
+      "public_items": 33,
       "reexports": 0
     },
     "rocketmq-transport/src/session_executor.rs": {
-      "production_lines": 154,
+      "production_lines": 184,
       "public_items": 0,
       "reexports": 0
     },
@@ -13673,6 +13673,34 @@
     },
     {
       "metrics": {
+        "churn_commits": 63,
+        "contributors": 6,
+        "crate": "rocketmq-broker",
+        "defect_commits": 2,
+        "fan_out": 7,
+        "lock_sites": 0,
+        "path": "rocketmq-broker/src/out_api/broker_outer_api.rs",
+        "production_lines": 1537,
+        "public_items": 48,
+        "reexports": 0,
+        "score": 321.582,
+        "state_owners": 0,
+        "test_functions": 8
+      },
+      "owner": "rocketmq-broker maintainers",
+      "path": "rocketmq-broker/src/out_api/broker_outer_api.rs",
+      "removal_condition": "Remove from the ranked board after production LOC is at most 800, public surface does not grow, and independent child fixtures cover each extracted use case.",
+      "state_owner": "`broker_outer_api` remains the single composition owner; child use-case modules may receive narrow references but must not expose lock guards.",
+      "test_strategy": "Run focused `rocketmq-broker` behavior tests, strict Clippy, stable-surface checks, and affected standalone consumers.",
+      "use_cases": [
+        "broker outer api",
+        "lifecycle",
+        "request execution",
+        "result projection"
+      ]
+    },
+    {
+      "metrics": {
         "churn_commits": 54,
         "contributors": 2,
         "crate": "rocketmq-client",
@@ -13697,34 +13725,6 @@
         "assignment and routing",
         "message flow",
         "offset and shutdown"
-      ]
-    },
-    {
-      "metrics": {
-        "churn_commits": 62,
-        "contributors": 6,
-        "crate": "rocketmq-broker",
-        "defect_commits": 2,
-        "fan_out": 7,
-        "lock_sites": 0,
-        "path": "rocketmq-broker/src/out_api/broker_outer_api.rs",
-        "production_lines": 1492,
-        "public_items": 45,
-        "reexports": 0,
-        "score": 313.457,
-        "state_owners": 0,
-        "test_functions": 8
-      },
-      "owner": "rocketmq-broker maintainers",
-      "path": "rocketmq-broker/src/out_api/broker_outer_api.rs",
-      "removal_condition": "Remove from the ranked board after production LOC is at most 800, public surface does not grow, and independent child fixtures cover each extracted use case.",
-      "state_owner": "`broker_outer_api` remains the single composition owner; child use-case modules may receive narrow references but must not expose lock guards.",
-      "test_strategy": "Run focused `rocketmq-broker` behavior tests, strict Clippy, stable-surface checks, and affected standalone consumers.",
-      "use_cases": [
-        "broker outer api",
-        "lifecycle",
-        "request execution",
-        "result projection"
       ]
     },
     {

--- a/scripts/public-api-intent.json
+++ b/scripts/public-api-intent.json
@@ -5718,6 +5718,15 @@
         },
         {
           "category": "stable",
+          "declaration": "pub use admission::ResourceSnapshot",
+          "identity": "rocketmq-transport/src/lib.rs:pub use admission::ResourceSnapshot",
+          "owner": "transport",
+          "path": "rocketmq-transport/src/lib.rs",
+          "rationale": "deliberate root entry point",
+          "removal_condition": "retain while the stable entry point remains supported"
+        },
+        {
+          "category": "stable",
           "declaration": "pub use base::channel_event_listener::ChannelEventListener",
           "identity": "rocketmq-transport/src/lib.rs:pub use base::channel_event_listener::ChannelEventListener",
           "owner": "transport",
@@ -6690,6 +6699,15 @@
         },
         {
           "category": "stable",
+          "declaration": "pub use server::SessionIoPolicy",
+          "identity": "rocketmq-transport/src/lib.rs:pub use server::SessionIoPolicy",
+          "owner": "transport",
+          "path": "rocketmq-transport/src/lib.rs",
+          "rationale": "deliberate root entry point",
+          "removal_condition": "retain while the stable entry point remains supported"
+        },
+        {
+          "category": "stable",
           "declaration": "pub use server::TransportListener",
           "identity": "rocketmq-transport/src/lib.rs:pub use server::TransportListener",
           "owner": "transport",
@@ -6710,6 +6728,15 @@
           "category": "stable",
           "declaration": "pub use server::run_connected_session",
           "identity": "rocketmq-transport/src/lib.rs:pub use server::run_connected_session",
+          "owner": "transport",
+          "path": "rocketmq-transport/src/lib.rs",
+          "rationale": "deliberate root entry point",
+          "removal_condition": "retain while the stable entry point remains supported"
+        },
+        {
+          "category": "stable",
+          "declaration": "pub use server::run_connected_session_with_io_policy",
+          "identity": "rocketmq-transport/src/lib.rs:pub use server::run_connected_session_with_io_policy",
           "owner": "transport",
           "path": "rocketmq-transport/src/lib.rs",
           "rationale": "deliberate root entry point",
@@ -6959,7 +6986,7 @@
           "removal_condition": "retain while the stable entry point remains supported"
         }
       ],
-      "maximum_exports": 149
+      "maximum_exports": 152
     }
   },
   "policy": "Every deliberate export is classified; additions and count growth fail closed.",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9128

### Brief Description

Restore the architecture guard contracts after the transport session hardening changes. This refreshes the generated module-maintainability baseline and ownership board, classifies the three new transport root exports, removes an unnecessary `too_many_arguments` exception, and replaces the partial-frame length-prefix `expect` with a non-panicking conversion path.

The lint-debt registry does not grow, and the generated maintainability artifacts remain governed by the existing decision ledger.

### How Did You Test This Change?

- `python scripts/run_architecture_tests.py --tier pr_static`: passed all 24 modules.
- All remaining Architecture Guards workflow commands: passed.
- `cargo test -p rocketmq-transport --all-features --lib --test partial_frame_admission --test writer_stall`: passed 161 unit tests and both focused integration test targets.
- `cargo fmt -p rocketmq-transport -- --check`: passed.
- `cargo clippy -p rocketmq-transport --no-deps --all-targets --all-features -- -D warnings`: passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- `git diff --check`: passed.

The workspace-wide `cargo fmt --all -- --check` invocation could not run on Windows because the generated rustfmt command exceeded the operating-system command-line length limit; the affected package format check passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stable transport APIs for resource monitoring, session I/O policies, and connected-session execution.
  - Expanded the transport library’s public API surface.

- **Bug Fixes**
  - Improved handling of incomplete or invalid message length prefixes to prevent decoding errors and ensure malformed frames are rejected safely.

- **Maintenance**
  - Updated maintainability rankings and quality metrics to reflect current project structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->