### PR TITLE
[ISSUE #9141]♻️Introduce generation-owned mappings and exactly-once physical detach

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4572,6 +4572,7 @@ dependencies = [
 name = "rocketmq-store-local"
 version = "1.0.0"
 dependencies = [
+ "arc-swap",
  "bytes",
  "cheetah-string",
  "criterion",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -3106,6 +3106,7 @@ dependencies = [
 name = "rocketmq-store-local"
 version = "1.0.0"
 dependencies = [
+ "arc-swap",
  "bytes",
  "cheetah-string",
  "dashmap",
@@ -3134,6 +3135,7 @@ name = "rocketmq-transport"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "bitvec",
  "bytemuck",
  "bytes",
@@ -3158,6 +3160,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_any_key",
+ "socket2",
  "thiserror",
  "tokio",
  "tokio-util",

--- a/rocketmq-doc/en/mapped-file-physical-owner-migration.md
+++ b/rocketmq-doc/en/mapped-file-physical-owner-migration.md
@@ -1,0 +1,68 @@
+# Mapped-file physical-owner API migration
+
+- Status: Accepted for issue [#9141](https://github.com/mxsm/rocketmq-rust/issues/9141)
+- Applies to: `rocketmq-store-local` and direct workspace consumers
+- Compatibility decision: source-breaking migration; persisted records, message bytes, offsets, and HA frames are unchanged
+
+## Why this migration is source-breaking
+
+The former APIs could detach lifecycle admission from a borrowed mapping or operating-system file
+handle. That made logical cleanup observable as complete while an mmap or cloned handle was still
+live. The replacement API makes every cross-call mapping or file capability own both an operation
+lease and the corresponding physical owner. Keeping the unsafe compatibility paths would preserve
+the race this change is intended to remove.
+
+## API mapping
+
+| Previous API | Replacement | Behavior change |
+|---|---|---|
+| `MappedFile::get_file() -> &File` | `DefaultMappedFile` selection/transfer APIs, or `MappedFileStorage::with_file` for standalone scoped storage work | No file reference can outlive the scoped owner capture. HA transfer uses an owner-bound `FileRangeLease`. |
+| `MappedFileStorage::file() -> &File` | `MappedFileStorage::with_file(...)` | The callback cannot return a value borrowing the file. Operations fail with `NotConnected` after owner detach. |
+| `NativeMappedMemory: Clone` and `clone_mmap()` | `MappedReadLease` for sealed reads | Writable mappings are not cloneable. Only a read-only generation can expose a safe cross-call slice. |
+| `MmapRegionSlice::try_new(Arc<MmapMut>, ...)` | `DefaultMappedFile::try_mapped_read_lease(...)` | Active writable files return `Ok(None)`; sealing must complete before a mapped read lease is available. Clone and split share one admission. |
+| Public `MappedFileMapping<M>` lazy value container | `DefaultMappedFile` and its internal generation slot | The old standalone `new_eager`, `new_lazy`, `get`, and `get_or_try_init` API has no direct compatibility facade because it could publish or borrow an owner outside lifecycle admission. General-purpose lazy values should use `OnceLock` or another application-owned cell. |
+| `MappedMemory::Region` and `MappedMemory::region(...)` | `MappedMemory::ReadOnly`, `MappedReadLease`, and internal owner-bound maintenance regions | Writable maintenance ranges expose no safe shared slice. Custom backends must provide a distinct read-only backend. |
+| Safe `MappedMemory::map_mut` / `ReadOnlyMappedMemory::map` implementations | `unsafe fn` implementations with the documented file-stability contract | Callers must prove the file remains sized and cannot be mutated incompatibly until the owner-bound generation drops. |
+| `SegmentLease::from_file_range(...)` | `SegmentLease::try_from_file_range(...)` | Range overflow and out-of-bounds input are typed errors instead of an unchecked or panicking construction. |
+| Manually paired mapping/file owner and lifecycle release | `MappedReadLease`, `FileRangeLease`, or `SegmentLease::from_selection(...)` | Final `Drop` releases the physical owner before the lifecycle operation; callers cannot release twice. |
+
+## Lifecycle semantics
+
+- `shutdown` rejects new operations and detaches the mapping and canonical file-owner slots after
+  admitted operations drain. It does not delete the segment path.
+- Detach is exactly once, but it is not forced reclamation. An existing owner-bound lease may keep
+  its generation or file handle alive until the lease's final `Drop`.
+- Namespace deletion is attempted only after detach completes. A failed deletion remains retryable
+  and does not authorize queue untracking.
+- A lazy mapping candidate is published only while holding the same close-control boundary as
+  `Closing`; a losing candidate is dropped and cannot remap later.
+- Sealing rejects new writers, waits for admitted writers, flushes the writable generation, and
+  publishes a distinct read-only generation before the sealing call succeeds.
+
+## Packed lifecycle counter compatibility
+
+The lifecycle now linearizes admission state, total leases, and writer leases in one packed
+`AtomicUsize`. Total and writer counts each have a maximum of 32,767 on 32-bit targets and
+2,147,483,647 on 64-bit targets. Exceeding either limit fails closed with the existing typed
+`MappedFileError::LeaseCountOverflow`; it never wraps a counter or admits an untracked operation.
+
+This architecture-dependent reduction from the former total-only packed counter is an accepted
+runtime compatibility change. It does not alter persisted bytes, offsets, HA frames, or error
+mapping, and it reuses the existing typed overflow surface. The new limits remain far above the
+number of simultaneously sustainable mapped-file operations in supported deployments.
+
+## Custom backend checklist
+
+- Implement the new `MappedMemory::ReadOnly` associated type.
+- Keep writable and read-only mapping addresses stable for their complete value lifetimes.
+- Call the unsafe mapping constructors only when file length and mutation exclusion are guaranteed.
+- Do not provide `Clone` or safe shared slices for writable mappings.
+- Use checked owner-bound ranges; never derive a slice from a temporary generation or file owner.
+
+## Rollback and deferred work
+
+This change has no disk-format migration. Code rollback requires a process restart so no generation
+or owner lease from the newer process remains live. Durable retirement tickets, incarnation-safe
+path reuse, tombstone rename, crash replay, and the deletion reaper are intentionally deferred to
+the M3 retirement protocol; a bare `NotFound` is not treated as proof that an old incarnation was
+successfully retired.

--- a/rocketmq-store-local/Cargo.toml
+++ b/rocketmq-store-local/Cargo.toml
@@ -35,6 +35,7 @@ observability = [
 ]
 
 [dependencies]
+arc-swap = "1.9"
 bytes.workspace = true
 cheetah-string.workspace = true
 dashmap.workspace = true

--- a/rocketmq-store-local/src/base/memory_lock_manager.rs
+++ b/rocketmq-store-local/src/base/memory_lock_manager.rs
@@ -21,7 +21,9 @@ use rocketmq_error::RocketMQResult;
 use tracing::warn;
 
 use crate::mapped_file::lifecycle::MappedFileLease;
+use crate::utils::ffi::lock_memory_address;
 use crate::utils::ffi::lock_memory_region;
+use crate::utils::ffi::unlock_memory_address;
 use crate::utils::ffi::unlock_memory_region;
 
 #[cfg(test)]
@@ -53,46 +55,88 @@ impl MemoryLockCategory {
 }
 
 trait LockedMemoryRegion: Send + Sync {
-    fn as_slice(&self) -> &[u8];
+    fn address(&self) -> *const u8;
+
+    fn len(&self) -> usize;
 }
 
-impl<T> LockedMemoryRegion for T
+struct SliceLockedMemoryRegion<T>(T);
+
+impl<T: AsRef<[u8]>> SliceLockedMemoryRegion<T> {
+    #[inline]
+    fn as_slice(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl<T> LockedMemoryRegion for SliceLockedMemoryRegion<T>
 where
     T: AsRef<[u8]> + Send + Sync,
 {
-    fn as_slice(&self) -> &[u8] {
-        self.as_ref()
+    fn address(&self) -> *const u8 {
+        self.0.as_ref().as_ptr()
+    }
+
+    fn len(&self) -> usize {
+        self.0.as_ref().len()
+    }
+}
+
+/// Owner-bearing raw range used by mapped writable generations.
+///
+/// Implementations expose only address and length. They must retain the backing allocation and
+/// must not manufacture a shared byte slice.
+pub(crate) trait OwnedMemoryRegion: Send + Sync + 'static {
+    fn address(&self) -> *const u8;
+
+    fn len(&self) -> usize;
+}
+
+struct RawLockedMemoryRegion<T>(T);
+
+impl<T: OwnedMemoryRegion> LockedMemoryRegion for RawLockedMemoryRegion<T> {
+    fn address(&self) -> *const u8 {
+        self.0.address()
+    }
+
+    fn len(&self) -> usize {
+        self.0.len()
     }
 }
 
 #[must_use = "an armed memory-lock handle must be unlocked or retained for a later retry"]
 pub struct MemoryLockHandle {
+    region: Option<Box<dyn LockedMemoryRegion>>,
     mapped_file_lease: Option<MappedFileLease>,
-    region: Box<dyn LockedMemoryRegion>,
+    region_len: usize,
+    slice_compatible: bool,
     category: MemoryLockCategory,
     locked: bool,
 }
 
 impl MemoryLockHandle {
-    fn new(region: Box<dyn LockedMemoryRegion>, category: MemoryLockCategory) -> Self {
+    fn new(region: Box<dyn LockedMemoryRegion>, category: MemoryLockCategory, slice_compatible: bool) -> Self {
+        let region_len = region.len();
         Self {
+            region: Some(region),
             mapped_file_lease: None,
-            region,
+            region_len,
+            slice_compatible,
             category,
             locked: true,
         }
     }
 
-    fn region(&self) -> &[u8] {
-        self.region.as_slice()
+    fn address(&self) -> Option<(*const u8, usize)> {
+        self.region.as_ref().map(|region| (region.address(), region.len()))
     }
 
     pub fn len(&self) -> usize {
-        self.region().len()
+        self.region_len
     }
 
     pub fn is_empty(&self) -> bool {
-        self.region().is_empty()
+        self.region_len == 0
     }
 
     pub fn category(&self) -> MemoryLockCategory {
@@ -104,8 +148,15 @@ impl MemoryLockHandle {
         self.mapped_file_lease = Some(lease);
     }
 
-    fn release_mapped_file_lease(&mut self) {
+    fn release_region_then_mapped_file_lease(&mut self) {
+        drop(self.region.take());
         drop(self.mapped_file_lease.take());
+    }
+}
+
+impl Drop for MemoryLockHandle {
+    fn drop(&mut self) {
+        self.release_region_then_mapped_file_lease();
     }
 }
 
@@ -307,8 +358,11 @@ impl MemoryLockManager {
         R: AsRef<[u8]> + Send + Sync + 'static,
         F: FnMut(&[u8]) -> RocketMQResult<()>,
     {
-        let region: Box<dyn LockedMemoryRegion> = Box::new(region);
-        let len = region.as_slice().len();
+        // Pin inline owners in their final heap allocation before the lock callback observes an
+        // address. Moving an array after mlock would make the later munlock target a different
+        // range.
+        let region = Box::new(SliceLockedMemoryRegion(region));
+        let len = region.len();
         self.lock_attempts.fetch_add(1, Ordering::Relaxed);
         emit_memory_lock_attempt_observability(self, category);
 
@@ -342,7 +396,96 @@ impl MemoryLockManager {
                     self.locked_bytes.fetch_add(len_bytes, Ordering::Relaxed);
                 }
                 emit_memory_lock_success_observability(self, category, self.locked_bytes.load(Ordering::Relaxed));
-                Ok(Some(MemoryLockHandle::new(region, category)))
+                Ok(Some(MemoryLockHandle::new(region, category, true)))
+            }
+            Err(error) => {
+                self.release_reserved_budget(len_bytes);
+                self.lock_failed_buffers.fetch_add(1, Ordering::Relaxed);
+                self.lock_failed_bytes.fetch_add(len_bytes, Ordering::Relaxed);
+                emit_memory_lock_failure_observability(self, category, self.locked_bytes.load(Ordering::Relaxed));
+                if self.warn_only {
+                    warn!(
+                        "Failed to lock {} memory region of {} bytes, continuing without mlock: {}",
+                        category.as_str(),
+                        len,
+                        error
+                    );
+                    Ok(None)
+                } else {
+                    Err(error)
+                }
+            }
+        }
+    }
+
+    /// Locks a mapped-generation range through its raw address capability.
+    ///
+    /// This path never creates `&[u8]`, so an active writable mapping cannot be aliased by a safe
+    /// shared slice. The returned handle owns `region` until successful unlock or final drop.
+    pub(crate) fn lock_owned_region<R>(
+        &self,
+        category: MemoryLockCategory,
+        region: R,
+    ) -> RocketMQResult<Option<MemoryLockHandle>>
+    where
+        R: OwnedMemoryRegion,
+    {
+        self.lock_owned_region_with(category, region, |address, len| {
+            // SAFETY: the boxed region owner remains live for this call and is moved into the
+            // returned handle only after the operating-system lock succeeds.
+            unsafe { lock_memory_address(address, len) }
+        })
+    }
+
+    pub(crate) fn lock_owned_region_with<R, F>(
+        &self,
+        category: MemoryLockCategory,
+        region: R,
+        mut locker: F,
+    ) -> RocketMQResult<Option<MemoryLockHandle>>
+    where
+        R: OwnedMemoryRegion,
+        F: FnMut(*const u8, usize) -> RocketMQResult<()>,
+    {
+        let len = region.len();
+        self.lock_attempts.fetch_add(1, Ordering::Relaxed);
+        emit_memory_lock_attempt_observability(self, category);
+
+        let len_bytes = len as u64;
+        if !self.reserve_lock_budget(len_bytes) {
+            self.lock_skipped_buffers.fetch_add(1, Ordering::Relaxed);
+            self.lock_skipped_bytes.fetch_add(len_bytes, Ordering::Relaxed);
+            emit_memory_lock_skip_observability(self, category, self.locked_bytes.load(Ordering::Relaxed));
+            if self.warn_only {
+                warn!(
+                    "Skipped {} memory lock of {} bytes because lock budget {} bytes is exhausted",
+                    category.as_str(),
+                    len_bytes,
+                    self.budget_bytes.load(Ordering::Relaxed)
+                );
+                return Ok(None);
+            }
+            return Err(rocketmq_error::RocketMQError::StorageLockFailed {
+                path: format!(
+                    "memory lock budget exhausted: requested={} budget={}",
+                    len_bytes,
+                    self.budget_bytes.load(Ordering::Relaxed)
+                ),
+            });
+        }
+
+        match locker(region.address(), len) {
+            Ok(()) => {
+                self.locked_buffers.fetch_add(1, Ordering::Relaxed);
+                if self.budget_bytes.load(Ordering::Relaxed) == 0 {
+                    self.locked_bytes.fetch_add(len_bytes, Ordering::Relaxed);
+                }
+                emit_memory_lock_success_observability(self, category, self.locked_bytes.load(Ordering::Relaxed));
+                Ok(Some(MemoryLockHandle::new(
+                    Box::new(RawLockedMemoryRegion(region)),
+                    category,
+                    false,
+                )))
             }
             Err(error) => {
                 self.release_reserved_budget(len_bytes);
@@ -365,7 +508,14 @@ impl MemoryLockManager {
     }
 
     pub fn unlock_region(&self, handle: &mut MemoryLockHandle) -> RocketMQResult<()> {
-        self.unlock_region_with(handle, unlock_memory_region)
+        if handle.slice_compatible {
+            self.unlock_region_with(handle, unlock_memory_region)
+        } else {
+            self.unlock_owned_region_with(handle, |address, len| {
+                // SAFETY: the handle retains the exact owner-backed range submitted to lock.
+                unsafe { unlock_memory_address(address, len) }
+            })
+        }
     }
 
     /// Runs the unlock operation through an injected compatibility callback.
@@ -388,8 +538,22 @@ impl MemoryLockManager {
         if !handle.locked {
             return Ok(());
         }
+        if !handle.slice_compatible {
+            return Err(rocketmq_error::RocketMQError::StorageLockFailed {
+                path: "mapped writable ranges require raw owner-backed unlock".to_string(),
+            });
+        }
 
-        match unlocker(handle.region()) {
+        let Some((address, len)) = handle.address() else {
+            return Err(rocketmq_error::RocketMQError::StorageLockFailed {
+                path: "memory-lock handle lost its region owner".to_string(),
+            });
+        };
+        // SAFETY: slice-compatible handles are constructed only from an owned `AsRef<[u8]>`
+        // value, retained in `handle` for this complete callback.
+        let memory = unsafe { std::slice::from_raw_parts(address, len) };
+
+        match unlocker(memory) {
             Ok(()) => {
                 handle.locked = false;
                 self.release_locked_bytes(handle.len() as u64);
@@ -398,7 +562,63 @@ impl MemoryLockManager {
                     handle.category(),
                     self.locked_bytes.load(Ordering::Relaxed),
                 );
-                handle.release_mapped_file_lease();
+                handle.release_region_then_mapped_file_lease();
+                Ok(())
+            }
+            Err(error) => {
+                emit_memory_unlock_failure_observability(
+                    self,
+                    handle.category(),
+                    self.locked_bytes.load(Ordering::Relaxed),
+                );
+                if self.warn_only {
+                    warn!(
+                        "Failed to unlock {} memory region of {} bytes; retaining handle for retry: {}",
+                        handle.category().as_str(),
+                        handle.len(),
+                        error
+                    );
+                }
+                Err(error)
+            }
+        }
+    }
+
+    /// Runs the unlock operation through an injected raw-address callback.
+    ///
+    /// This hidden seam is used by cross-crate storage lifecycle tests and adapters for mapped
+    /// generations that intentionally cannot expose a safe shared byte slice while writable.
+    /// The callback must not dereference the address after it returns; the handle retains the
+    /// owner for the complete call and remains armed on failure.
+    #[doc(hidden)]
+    pub fn unlock_owned_region_with<F>(&self, handle: &mut MemoryLockHandle, mut unlocker: F) -> RocketMQResult<()>
+    where
+        F: FnMut(*const u8, usize) -> RocketMQResult<()>,
+    {
+        if !handle.locked {
+            return Ok(());
+        }
+        if handle.slice_compatible {
+            return Err(rocketmq_error::RocketMQError::StorageLockFailed {
+                path: "slice-backed ranges require slice-compatible unlock".to_string(),
+            });
+        }
+        let Some((address, len)) = handle.address() else {
+            return Err(rocketmq_error::RocketMQError::StorageLockFailed {
+                path: "memory-lock handle lost its region owner".to_string(),
+            });
+        };
+
+        match unlocker(address, len) {
+            Ok(()) => {
+                handle.locked = false;
+                self.release_locked_bytes(handle.len() as u64);
+                emit_memory_lock_locked_bytes_observability(
+                    self,
+                    handle.category(),
+                    self.locked_bytes.load(Ordering::Relaxed),
+                );
+                handle.release_region_then_mapped_file_lease();
                 Ok(())
             }
             Err(error) => {
@@ -675,9 +895,62 @@ impl Default for MemoryLockManager {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
     use rocketmq_error::RocketMQError;
 
     use super::*;
+    use crate::mapped_file::lifecycle::MappedFileOperation;
+    use crate::mapped_file::lifecycle::PhysicalDetachHook;
+    use crate::mapped_file::lifecycle::SegmentLifecycle;
+
+    struct DropEventRegion {
+        memory: Box<[u8]>,
+        events: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    impl OwnedMemoryRegion for DropEventRegion {
+        fn address(&self) -> *const u8 {
+            self.memory.as_ptr()
+        }
+
+        fn len(&self) -> usize {
+            self.memory.len()
+        }
+    }
+
+    impl Drop for DropEventRegion {
+        fn drop(&mut self) {
+            self.events.lock().expect("event log").push("region");
+        }
+    }
+
+    struct OperationDropHook {
+        events: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    impl PhysicalDetachHook for OperationDropHook {
+        fn detach_owner_slots(&self) {
+            self.events.lock().expect("event log").push("operation");
+        }
+    }
+
+    fn closing_maintenance_lease(events: &Arc<Mutex<Vec<&'static str>>>) -> (Arc<SegmentLifecycle>, MappedFileLease) {
+        let lifecycle = SegmentLifecycle::shared();
+        let lease = lifecycle
+            .try_acquire(MappedFileOperation::Maintenance)
+            .expect("maintenance lease");
+        assert!(lifecycle.install_physical_detach_hook(Arc::new(OperationDropHook {
+            events: Arc::clone(events),
+        })));
+        lifecycle.begin_close(u64::MAX);
+        (lifecycle, lease)
+    }
+
+    fn drop_events(events: &Arc<Mutex<Vec<&'static str>>>) -> Vec<&'static str> {
+        events.lock().expect("event log").clone()
+    }
 
     #[test]
     fn warn_only_manager_records_failure_without_returning_error() {
@@ -846,13 +1119,103 @@ mod tests {
             })
             .expect("retry should unlock the retained region");
         assert_eq!(manager.locked_bytes(), 0);
-        assert_eq!(drops.load(Ordering::Relaxed), 0);
+        assert_eq!(drops.load(Ordering::Relaxed), 1);
 
         manager
             .unlock_region_with(&mut handle, |_| panic!("disarmed handle must be an idempotent no-op"))
             .expect("repeated unlock after success should be a no-op");
         drop(handle);
         assert_eq!(drops.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn successful_owned_unlock_drops_region_before_mapped_operation() {
+        let manager = MemoryLockManager::warn_only_with_budget(32);
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let (lifecycle, lease) = closing_maintenance_lease(&events);
+        let region = DropEventRegion {
+            memory: vec![0u8; 32].into_boxed_slice(),
+            events: Arc::clone(&events),
+        };
+        let address = region.address();
+        let mut handle = manager
+            .lock_owned_region_with(MemoryLockCategory::CommitLogActiveWindow, region, |locked, len| {
+                assert_eq!(locked, address);
+                assert_eq!(len, 32);
+                Ok(())
+            })
+            .expect("lock owned region")
+            .expect("successful lock handle");
+        handle.attach_mapped_file_lease(lease);
+
+        manager
+            .unlock_owned_region_with(&mut handle, |locked, len| {
+                assert_eq!(locked, address);
+                assert_eq!(len, 32);
+                Ok(())
+            })
+            .expect("unlock owned region");
+
+        assert_eq!(drop_events(&events), vec!["region", "operation"]);
+        assert_eq!(lifecycle.snapshot().active_leases, 0);
+        assert!(handle.region.is_none());
+        assert!(handle.mapped_file_lease.is_none());
+    }
+
+    #[test]
+    fn memory_lock_handle_drop_releases_region_before_mapped_operation() {
+        let manager = MemoryLockManager::warn_only();
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let (lifecycle, lease) = closing_maintenance_lease(&events);
+        let region = DropEventRegion {
+            memory: vec![0u8; 16].into_boxed_slice(),
+            events: Arc::clone(&events),
+        };
+        let mut handle = manager
+            .lock_owned_region_with(MemoryLockCategory::CommitLogActiveWindow, region, |_, _| Ok(()))
+            .expect("lock owned region")
+            .expect("successful lock handle");
+        handle.attach_mapped_file_lease(lease);
+
+        drop(handle);
+
+        assert_eq!(drop_events(&events), vec!["region", "operation"]);
+        assert_eq!(lifecycle.snapshot().active_leases, 0);
+    }
+
+    #[test]
+    fn failed_owned_unlock_retains_region_and_mapped_operation() {
+        let manager = MemoryLockManager::warn_only_with_budget(16);
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let (lifecycle, lease) = closing_maintenance_lease(&events);
+        let region = DropEventRegion {
+            memory: vec![0u8; 16].into_boxed_slice(),
+            events: Arc::clone(&events),
+        };
+        let mut handle = manager
+            .lock_owned_region_with(MemoryLockCategory::CommitLogActiveWindow, region, |_, _| Ok(()))
+            .expect("lock owned region")
+            .expect("successful lock handle");
+        handle.attach_mapped_file_lease(lease);
+
+        manager
+            .unlock_owned_region_with(&mut handle, |_, _| {
+                Err(RocketMQError::StorageLockFailed {
+                    path: "retryable owned unlock failure".to_string(),
+                })
+            })
+            .expect_err("failed unlock remains observable");
+
+        assert!(drop_events(&events).is_empty());
+        assert!(handle.region.is_some());
+        assert!(handle.mapped_file_lease.is_some());
+        assert!(handle.locked);
+        assert_eq!(manager.locked_bytes(), 16);
+        assert_eq!(lifecycle.snapshot().active_leases, 1);
+
+        drop(handle);
+        assert_eq!(drop_events(&events), vec!["region", "operation"]);
+        assert_eq!(lifecycle.snapshot().active_leases, 0);
     }
 
     #[test]

--- a/rocketmq-store-local/src/ha/transfer_engine/sendfile.rs
+++ b/rocketmq-store-local/src/ha/transfer_engine/sendfile.rs
@@ -156,7 +156,7 @@ where
         let out_fd = self.writer.sendfile_out_fd();
 
         for range in file_ranges {
-            let in_fd = range.file().as_raw_fd();
+            let in_fd = range.raw_fd();
             let mut position = range.position();
             let mut remaining = range.len();
             while remaining > 0 {

--- a/rocketmq-store-local/src/mapped_file.rs
+++ b/rocketmq-store-local/src/mapped_file.rs
@@ -21,6 +21,7 @@ mod default_mapped_file;
 mod direct_io;
 pub mod file;
 mod flush_strategy;
+mod generation;
 #[doc(hidden)]
 pub mod lifecycle;
 mod lifecycle_model;
@@ -63,19 +64,28 @@ pub use direct_io::DirectIoBuffer;
 pub use direct_io::DirectIoRequest;
 pub use direct_io::DirectIoValidationError;
 pub use flush_strategy::FlushStrategy;
+pub use generation::MappedReadLease;
+pub use generation::MappingGenerationId;
 pub use io_uring_impl::io_uring_backend_status;
 pub use io_uring_impl::IoUringBackendStatus;
 pub use lifecycle::MappedFileAdmissionState;
 pub use lifecycle::MappedFileLifecycleSnapshot;
 pub use lifecycle::MappedFileOperation;
 pub use lifecycle_outcome::MappedFileDestroyOutcome;
+pub use lifecycle_outcome::MappedFileDetachOutcome;
 pub use mapped_buffer::MappedBuffer;
 pub use mapped_file_error::MappedFileError;
 pub use mapped_file_error::MappedFileResult;
 pub use memory::MappedMemory;
 pub use memory::MmapRangeError;
-pub use memory::MmapRegionSlice;
 pub use memory::NativeMappedMemory;
+pub use memory::NativeReadOnlyMappedMemory;
+pub use memory::ReadOnlyMappedMemory;
+/// Legacy type name for the new owner-bound native read-only mapped lease.
+///
+/// Construction intentionally moved to [`DefaultMappedFile::try_mapped_read_lease`]; the former
+/// raw writable-mmap constructor is not retained.
+pub type MmapRegionSlice = MappedReadLease<NativeReadOnlyMappedMemory>;
 pub use metrics::MappedFileMetrics;
 pub use raw::MappedFileRawCore;
 pub use select_result::SelectMappedBufferCacheState;

--- a/rocketmq-store-local/src/mapped_file/contract.rs
+++ b/rocketmq-store-local/src/mapped_file/contract.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fs::File;
 use std::io;
 use std::time::Duration;
 use std::time::SystemTime;
@@ -534,19 +533,6 @@ pub trait MappedFile {
     /// # Returns
     /// An `i64` representing the number of accesses to the mapped byte buffer since the last swap.
     fn get_mapped_byte_buffer_access_count_since_last_swap(&self) -> i64;
-
-    /// Returns the underlying file through the legacy compatibility boundary.
-    ///
-    /// Repository callers use this handle only for metadata inspection and `try_clone`. A cloned
-    /// handle remains subject to the same compatibility contract.
-    ///
-    /// # Compatibility contract
-    ///
-    /// Callers must not invoke `set_len`, truncate the file, or perform any other size-changing
-    /// operation while a memory mapping or mapped-buffer lease backed by this file is alive. This
-    /// safe legacy accessor cannot enforce that invariant; violating it can invalidate the safety
-    /// requirements of the existing file-backed memory mappings.
-    fn get_file(&self) -> &File;
 
     /// Marks the mapped file for deletion.
     ///

--- a/rocketmq-store-local/src/mapped_file/default_mapped_file.rs
+++ b/rocketmq-store-local/src/mapped_file/default_mapped_file.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fs::File;
 use std::io;
 use std::path::Path;
 use std::ptr;
 use std::sync::atomic::AtomicI64;
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
 use std::time::Instant;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
@@ -35,6 +35,7 @@ use tracing::warn;
 use super::FlushStrategy;
 use super::MappedFile;
 use super::MappedFileDestroyOutcome;
+use super::MappedFileDetachOutcome;
 use super::MappedFileError;
 use super::MappedFileMetrics;
 use super::MappedFileRawCore;
@@ -47,10 +48,20 @@ use super::SelectMappedBufferResult;
 use crate::base::memory_lock_manager::MemoryLockCategory;
 use crate::base::memory_lock_manager::MemoryLockHandle;
 use crate::base::memory_lock_manager::MemoryLockManager;
+use crate::base::memory_lock_manager::OwnedMemoryRegion;
 use crate::base::transient_store_pool::TransientStorePool;
 use crate::config::FlushDiskType;
+use crate::mapped_file::file::FileOwner;
 use crate::mapped_file::file::FilePreallocateOutcome;
 use crate::mapped_file::file::MappedFileStorage;
+use crate::mapped_file::generation::GenerationRegion;
+use crate::mapped_file::generation::MappedFileMapping;
+use crate::mapped_file::generation::MappedReadLease;
+use crate::mapped_file::generation::MappingPublicationError;
+use crate::mapped_file::generation::ReadOnlyAccess;
+use crate::mapped_file::generation::ReadOnlyMappingGeneration;
+use crate::mapped_file::generation::WritableAccess;
+use crate::mapped_file::generation::WritableMappingGeneration;
 use crate::mapped_file::kernel::visit_mapped_file_warmup_schedule;
 use crate::mapped_file::kernel::MappedFileWarmupOperation;
 use crate::mapped_file::kernel::ReferenceResource;
@@ -60,8 +71,10 @@ pub use crate::mapped_file::kernel::OS_PAGE_SIZE;
 use crate::mapped_file::lifecycle::BorrowedMappedFileLease;
 use crate::mapped_file::lifecycle::MappedFileLease;
 use crate::mapped_file::lifecycle::MappedFileLeaseProof;
+use crate::mapped_file::lifecycle::PhysicalDetachClaimResult;
+use crate::mapped_file::lifecycle::PhysicalDetachHook;
 pub use crate::mapped_file::mapping::LazyMmapStats;
-use crate::mapped_file::mapping::MappedFileMapping;
+use crate::mapped_file::memory::ReadOnlyMappedMemory;
 use crate::mapped_file::MappedFileLifecycleSnapshot;
 use crate::mapped_file::MappedFileOperation;
 use crate::utils::ffi::advise_memory;
@@ -135,8 +148,7 @@ fn file_preallocate_degradation_event(outcome: FilePreallocateOutcome) -> Option
 
 pub struct DefaultMappedFile<M: MappedMemory = NativeMappedMemory> {
     reference_resource: ReferenceResourceCounter,
-    storage: MappedFileStorage,
-    mapping: MappedFileMapping<M>,
+    physical_owners: Arc<MappedFilePhysicalOwners<M>>,
     transient_store_pool: Option<TransientStorePool>,
     file_name: CheetahString,
     raw_core: MappedFileRawCore,
@@ -144,10 +156,82 @@ pub struct DefaultMappedFile<M: MappedMemory = NativeMappedMemory> {
     first_create_in_queue: bool,
     swap_state: Mutex<SwapLifecycleState>,
     mapped_byte_buffer_access_count_since_last_swap: AtomicI64,
-    metrics: Option<MappedFileMetrics>,
+    metrics: Option<Arc<MappedFileMetrics>>,
+    seal_lock: Mutex<()>,
     flush_strategy: FlushStrategy,
     #[cfg(feature = "observability")]
     store_metrics: rocketmq_observability::metrics::store::StoreMetricsRecorder,
+}
+
+struct MappedFilePhysicalOwners<M: MappedMemory> {
+    storage: Mutex<MappedFileStorage>,
+    mapping: MappedFileMapping<M, M::ReadOnly>,
+    metrics: Arc<MappedFileMetrics>,
+    detach_report: Mutex<Option<(Option<u64>, bool)>>,
+}
+
+impl<M: MappedMemory> MappedFilePhysicalOwners<M> {
+    fn detach_owner_slots(&self) -> (Option<u64>, bool) {
+        if let Some(report) = *self.detach_report.lock() {
+            return report;
+        }
+
+        let detached_generation = self.mapping.detach().into_generation();
+        let generation_id = detached_generation.as_ref().map(|generation| generation.id().get());
+        let detached_file_owner = self.storage.lock().take_owner();
+        let had_file_owner = detached_file_owner.is_some();
+        self.metrics.record_lifecycle_detach();
+
+        // Drop the mapping before the canonical file owner. A generation itself retains one
+        // FileOwner Arc, so this ordering guarantees unmap precedes last-close on Windows.
+        drop(detached_generation);
+        drop(detached_file_owner);
+
+        let report = (generation_id, had_file_owner);
+        *self.detach_report.lock() = Some(report);
+        report
+    }
+}
+
+impl<M: MappedMemory> PhysicalDetachHook for MappedFilePhysicalOwners<M> {
+    fn detach_owner_slots(&self) {
+        let _ = self.detach_owner_slots();
+    }
+}
+
+enum AdmittedReadGeneration<M: MappedMemory> {
+    Writable(Arc<WritableMappingGeneration<M>>),
+    ReadOnly(Arc<ReadOnlyMappingGeneration<M::ReadOnly>>),
+}
+
+enum MappedMemoryLockRegion<M: MappedMemory> {
+    Writable(GenerationRegion<M, WritableAccess>),
+    ReadOnly(GenerationRegion<M::ReadOnly, ReadOnlyAccess>),
+}
+
+impl<M: MappedMemory> OwnedMemoryRegion for MappedMemoryLockRegion<M> {
+    fn address(&self) -> *const u8 {
+        match self {
+            Self::Writable(region) => region.as_ptr(),
+            Self::ReadOnly(region) => region.as_ref().as_ptr(),
+        }
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            Self::Writable(region) => region.len(),
+            Self::ReadOnly(region) => region.len(),
+        }
+    }
+}
+
+impl<M: MappedMemory> AdmittedReadGeneration<M> {
+    fn with_slice<T>(&self, operation: impl FnOnce(&[u8]) -> T) -> T {
+        match self {
+            Self::Writable(generation) => generation.with_mapping(|mapping| operation(mapping.as_slice())),
+            Self::ReadOnly(generation) => generation.with_mapping(|mapping| operation(mapping.as_slice())),
+        }
+    }
 }
 
 #[derive(Default)]
@@ -279,15 +363,113 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
     }
 
     /// Seals the segment against new writes while keeping reads and maintenance available.
-    #[inline]
     pub fn seal_readable(&self) -> bool {
-        self.reference_resource.lifecycle().seal_readable()
+        match self.try_seal_readable() {
+            Ok(sealed) => sealed,
+            Err(error) => {
+                warn!(file_name = %self.file_name, error = %error, "failed to seal mapped file as read-only");
+                false
+            }
+        }
+    }
+
+    /// Rejects writers, drains already-admitted writes, performs the final flush, and publishes a
+    /// read-only mapping generation.
+    pub fn try_seal_readable(&self) -> MappedFileResult<bool> {
+        let _seal = self.seal_lock.lock();
+        let lifecycle = self.reference_resource.lifecycle();
+        let started = lifecycle
+            .seal_readable_and_wait_for_writers()
+            .map_err(|error| match error {
+                crate::mapped_file::lifecycle::LifecycleAcquireError::Unavailable { state, operation } => {
+                    MappedFileError::Unavailable { state, operation }
+                }
+                crate::mapped_file::lifecycle::LifecycleAcquireError::LeaseCountOverflow => {
+                    MappedFileError::LeaseCountOverflow
+                }
+            })?;
+        if self.physical_owners.mapping.load_read_only().is_some() {
+            return Ok(false);
+        }
+
+        let admission = self.acquire_borrowed(MappedFileOperation::Maintenance)?;
+        let _writer = self.write_state.lock();
+        let writable = self.try_get_writable_generation(&admission, MappedFileOperation::Maintenance)?;
+        writable
+            .with_mapping(MappedMemory::flush)
+            .map_err(MappedFileError::FlushFailed)?;
+        let file_owner = Arc::clone(writable.file_owner());
+        let expected = writable.id();
+        self.physical_owners
+            .mapping
+            .replace_with_read_only(
+                expected,
+                || {
+                    file_owner.with_file(|file| {
+                        // SAFETY: sealing has rejected and drained writers, `write_state` excludes
+                        // mutation, and the candidate immediately enters a generation retaining
+                        // this canonical FileOwner.
+                        unsafe { M::ReadOnly::map(file) }
+                    })
+                },
+                || {
+                    self.validate_lease(&admission, MappedFileOperation::Maintenance)
+                        .is_ok()
+                },
+                |publication| {
+                    lifecycle
+                        .try_publish_before_close(&admission, MappedFileOperation::Maintenance, || {
+                            publication.publish()
+                        })
+                        .ok()
+                },
+            )
+            .map_err(|error| self.map_publication_error(error, MappedFileOperation::Maintenance))?;
+        Ok(started || self.physical_owners.mapping.load_read_only().is_some())
     }
 
     /// Waits for currently admitted operations to drain.
     #[inline]
     pub fn wait_for_lifecycle_drain(&self, timeout: std::time::Duration) -> bool {
         self.reference_resource.lifecycle().wait_for_drain(timeout)
+    }
+
+    /// Acquires an immutable owner-bound mapped range from a sealed generation.
+    ///
+    /// The returned lease keeps both the read-only mapping generation and one read admission alive.
+    /// Clones and split ranges share that admission, and the final alias releases the generation
+    /// before it releases lifecycle admission. Active writable segments return `Ok(None)` because
+    /// safe cross-call byte slices are exposed only after [`Self::try_seal_readable`] publishes a
+    /// read-only generation.
+    ///
+    /// # Errors
+    ///
+    /// Returns a lifecycle error after close, or [`MappedFileError::OutOfBounds`] when the range
+    /// overflows or exceeds the configured segment mapping.
+    pub fn try_mapped_read_lease(
+        &self,
+        offset: usize,
+        len: usize,
+    ) -> MappedFileResult<Option<MappedReadLease<M::ReadOnly>>> {
+        let end = offset
+            .checked_add(len)
+            .ok_or_else(|| MappedFileError::out_of_bounds(offset, len, self.raw_core.file_size()))?;
+        let readable_position =
+            usize::try_from(self.get_read_position()).map_err(|_| MappedFileError::InvalidWritePosition {
+                position: self.get_read_position(),
+                capacity: self.raw_core.file_size(),
+            })?;
+        if end > readable_position {
+            return Ok(None);
+        }
+
+        let admission = self.acquire_owned(MappedFileOperation::Read)?;
+        let Some(generation) = self.physical_owners.mapping.load_read_only() else {
+            return Ok(None);
+        };
+        MappedReadLease::try_new(generation, admission, offset, len)
+            .map(Some)
+            .map_err(|_| MappedFileError::out_of_bounds(offset, len, self.raw_core.file_size()))
     }
 
     #[inline]
@@ -346,7 +528,9 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
             .ok_or_else(|| invalid_input_error(format!("file path is invalid: {file_name}")))?;
         std::fs::create_dir_all(dir)?;
 
-        let (storage, preallocate_outcome) = MappedFileStorage::open(path_buf, file_size)?;
+        let metrics = Arc::new(MappedFileMetrics::new());
+        let (storage, preallocate_outcome) =
+            MappedFileStorage::open_with_metrics(path_buf, file_size, Arc::clone(&metrics))?;
         if let Some(preallocate_outcome) = preallocate_outcome {
             match preallocate_outcome {
                 FilePreallocateOutcome::Allocated => {}
@@ -362,15 +546,40 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
         }
 
         let mapping = if lazy_mmap_enabled {
-            MappedFileMapping::new_lazy()
+            MappedFileMapping::new_lazy(Arc::clone(&metrics))
         } else {
-            MappedFileMapping::new_eager(M::map_mut(storage.file())?)
+            let file_owner = storage.owner().ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::NotConnected,
+                    "mapped-file owner detached during construction",
+                )
+            })?;
+            let mapping = file_owner.with_file(|file| {
+                // SAFETY: storage established the configured length and the mapping immediately
+                // enters a generation retaining the canonical FileOwner. All later mutation is
+                // serialized by mapped-file admission and `write_state`.
+                unsafe { M::map_mut(file) }
+            })?;
+            MappedFileMapping::new_eager(mapping, file_owner, Arc::clone(&metrics))
         };
 
-        Ok(Self {
-            reference_resource: ReferenceResourceCounter::new(),
-            storage,
+        let physical_owners = Arc::new(MappedFilePhysicalOwners {
+            storage: Mutex::new(storage),
             mapping,
+            metrics: Arc::clone(&metrics),
+            detach_report: Mutex::new(None),
+        });
+        let reference_resource = ReferenceResourceCounter::new();
+        let detach_hook: Arc<dyn PhysicalDetachHook> = physical_owners.clone();
+        if !reference_resource.lifecycle().install_physical_detach_hook(detach_hook) {
+            return Err(io::Error::other(
+                "mapped-file physical detach hook was already installed",
+            ));
+        }
+
+        Ok(Self {
+            reference_resource,
+            physical_owners,
             file_name,
             raw_core: MappedFileRawCore::new(file_size),
             write_state: Mutex::new(MappedWriteState::default()),
@@ -382,7 +591,8 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
             }),
             mapped_byte_buffer_access_count_since_last_swap: Default::default(),
             transient_store_pool,
-            metrics: Some(MappedFileMetrics::new()),
+            metrics: Some(metrics),
+            seal_lock: Mutex::new(()),
             flush_strategy: FlushStrategy::Async,
             #[cfg(feature = "observability")]
             store_metrics: rocketmq_observability::metrics::store::StoreMetricsRecorder::noop(),
@@ -443,6 +653,30 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
         })
     }
 
+    fn copy_to_writable_generation(
+        generation: &WritableMappingGeneration<M>,
+        start: usize,
+        end: usize,
+        data: &[u8],
+    ) -> MappedFileResult<()> {
+        generation.with_mapping(|mapped_memory| {
+            if end > mapped_memory.as_slice().len() {
+                return Err(MappedFileError::out_of_bounds(
+                    start,
+                    data.len(),
+                    mapped_memory.as_slice().len() as u64,
+                ));
+            }
+
+            // SAFETY: the caller holds `write_state`, which is the only mapped-file mutation
+            // sequencer. The staging allocation cannot overlap the mapped allocation.
+            unsafe {
+                mapped_memory.copy_from_slice(start, data)?;
+            }
+            Ok(())
+        })
+    }
+
     fn copy_to_mapping<L: MappedFileLeaseProof + ?Sized>(
         &self,
         lease: &L,
@@ -453,21 +687,21 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
             .checked_add(data.len())
             .filter(|end| *end <= self.raw_core.file_size() as usize)
             .ok_or_else(|| MappedFileError::out_of_bounds(start, data.len(), self.raw_core.file_size()))?;
-        let mapped_memory = self.try_get_mapped_file_ref(lease, MappedFileOperation::Write)?;
-        if end > mapped_memory.as_slice().len() {
-            return Err(MappedFileError::out_of_bounds(
-                start,
-                data.len(),
-                mapped_memory.as_slice().len() as u64,
-            ));
+        self.validate_lease(lease, MappedFileOperation::Write)?;
+
+        if let Some(result) = self
+            .physical_owners
+            .mapping
+            .with_writable_scoped(|generation| Self::copy_to_writable_generation(generation, start, end, data))
+        {
+            return result;
         }
 
-        // SAFETY: the caller holds `write_state`, which is the only mapped-file mutation
-        // sequencer. The staging allocation cannot overlap the mapped allocation.
-        unsafe {
-            mapped_memory.copy_from_slice(start, data)?;
-        }
-        Ok(())
+        // A missing writable generation is the lazy-initialization path. It intentionally keeps
+        // the owned publication flow so candidate construction remains serialized with close and
+        // terminal detach. Already-published generations never reach this branch.
+        let generation = self.try_get_writable_generation(lease, MappedFileOperation::Write)?;
+        Self::copy_to_writable_generation(&generation, start, end, data)
     }
 
     fn try_write_at(&self, start: usize, data: &[u8]) -> MappedFileResult<()> {
@@ -504,10 +738,8 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
         }
 
         let _writer = self.write_state.lock();
-        let mapped = self
-            .try_get_mapped_file_ref(admission, MappedFileOperation::Read)?
-            .as_slice();
-        Ok(mapped.get(pos..end).map(Bytes::copy_from_slice))
+        let generation = self.try_get_read_generation(admission, MappedFileOperation::Read)?;
+        Ok(generation.with_slice(|mapped| mapped.get(pos..end).map(Bytes::copy_from_slice)))
     }
 
     fn try_copy_range(
@@ -522,31 +754,53 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
 
     #[inline]
     pub fn is_lazy_mmap_enabled(&self) -> bool {
-        self.mapping.is_lazy_enabled()
+        self.physical_owners.mapping.is_lazy_enabled()
     }
 
     #[inline]
     pub fn is_mapped(&self) -> bool {
-        self.mapping.is_mapped()
+        self.physical_owners.mapping.is_mapped()
     }
 
     pub fn lazy_mmap_stats(&self) -> LazyMmapStats {
-        self.mapping.stats()
+        self.physical_owners.mapping.stats()
     }
 
-    /// Attempts logical shutdown followed by namespace removal.
+    /// Attempts the exactly-once transition that removes mapping and file owners from their slots.
     ///
-    /// A successful result only verifies path removal. Existing mmap and file owners remain alive
-    /// until their Rust owners are dropped.
+    /// Existing owner-bearing aliases, if any, keep their physical resources alive until their
+    /// own final `Arc` drops. The result therefore reports slot detach, not forced unmap/close.
+    pub fn try_detach_physical_owners(&self) -> MappedFileDetachOutcome {
+        match self.reference_resource.lifecycle().try_claim_physical_detach() {
+            PhysicalDetachClaimResult::Claimed(claim) => {
+                let (mapping_generation, had_file_owner) = self.physical_owners.detach_owner_slots();
+                claim.complete();
+                MappedFileDetachOutcome::Detached {
+                    mapping_generation,
+                    had_file_owner,
+                }
+            }
+            PhysicalDetachClaimResult::AlreadyDetached => MappedFileDetachOutcome::AlreadyDetached,
+            PhysicalDetachClaimResult::InProgress => MappedFileDetachOutcome::InProgress,
+            PhysicalDetachClaimResult::Pending { state, active_leases } => {
+                MappedFileDetachOutcome::Pending { state, active_leases }
+            }
+        }
+    }
+
+    /// Attempts shutdown, physical slot detach, and namespace removal.
+    ///
+    /// Namespace removal is attempted only after both physical owner slots are detached. Existing
+    /// external aliases, if any, still release their operating-system owners from final `Drop`.
     pub fn try_destroy(&self, interval_forcibly: u64) -> MappedFileDestroyOutcome {
         MappedFile::shutdown(self, interval_forcibly);
-        if !self.reference_resource.is_cleanup_over() {
+        if !ReferenceResource::is_cleanup_over(self) {
             return MappedFileDestroyOutcome::CleanupPending {
-                ref_count: self.reference_resource.get_ref_count(),
+                ref_count: ReferenceResource::get_ref_count(self),
             };
         }
 
-        match self.storage.delete() {
+        match self.physical_owners.storage.lock().delete() {
             Ok(()) => {
                 info!(file_name = %self.file_name, "mapped-file namespace removal succeeded");
                 MappedFileDestroyOutcome::NamespaceRemoved
@@ -567,19 +821,89 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
         }
     }
 
-    fn try_get_mapped_file_ref<'a, L: MappedFileLeaseProof + ?Sized>(
-        &'a self,
-        admission: &'a L,
+    fn try_get_writable_generation<L: MappedFileLeaseProof + ?Sized>(
+        &self,
+        admission: &L,
         required: MappedFileOperation,
-    ) -> MappedFileResult<&'a M> {
+    ) -> MappedFileResult<Arc<WritableMappingGeneration<M>>> {
         self.validate_lease(admission, required)?;
-        self.mapping
-            .get_or_try_init(|| M::map_mut(self.storage.file()).map_err(MappedFileError::MmapFailed))
+        if let Some(generation) = self.physical_owners.mapping.load_writable() {
+            return Ok(generation);
+        }
+        let lifecycle = self.reference_resource.lifecycle();
+        self.physical_owners
+            .mapping
+            .get_or_try_init(
+                || {
+                    let owner = self
+                        .physical_owners
+                        .storage
+                        .lock()
+                        .owner()
+                        .ok_or_else(|| io::Error::new(io::ErrorKind::NotConnected, "mapped-file owner detached"))?;
+                    let mapping = owner.with_file(|file| {
+                        // SAFETY: the owner retains the already-sized segment, this operation is
+                        // admitted and serialized against detach publication, and the candidate
+                        // immediately enters an owner-bound writable generation.
+                        unsafe { M::map_mut(file) }
+                    })?;
+                    Ok((mapping, owner))
+                },
+                || self.validate_lease(admission, required).is_ok(),
+                |publication| {
+                    lifecycle
+                        .try_publish_before_close(admission, required, || publication.publish())
+                        .ok()
+                },
+            )
+            .map_err(|error| self.map_publication_error(error, required))
     }
 
-    pub(crate) fn try_clone_file_admitted(&self, admission: &MappedFileLease) -> MappedFileResult<File> {
+    fn try_get_read_generation<L: MappedFileLeaseProof + ?Sized>(
+        &self,
+        admission: &L,
+        required: MappedFileOperation,
+    ) -> MappedFileResult<AdmittedReadGeneration<M>> {
         self.validate_lease(admission, MappedFileOperation::Read)?;
-        self.storage.file().try_clone().map_err(MappedFileError::Io)
+        if let Some(generation) = self.physical_owners.mapping.load_read_only() {
+            return Ok(AdmittedReadGeneration::ReadOnly(generation));
+        }
+        match self.try_get_writable_generation(admission, required) {
+            Ok(generation) => Ok(AdmittedReadGeneration::Writable(generation)),
+            Err(error) => self
+                .physical_owners
+                .mapping
+                .load_read_only()
+                .map(AdmittedReadGeneration::ReadOnly)
+                .ok_or(error),
+        }
+    }
+
+    fn map_publication_error(
+        &self,
+        error: MappingPublicationError<io::Error>,
+        operation: MappedFileOperation,
+    ) -> MappedFileError {
+        match error {
+            MappingPublicationError::Initialization(error) => MappedFileError::MmapFailed(error),
+            MappingPublicationError::PublicationRejected
+            | MappingPublicationError::Detached
+            | MappingPublicationError::AlreadyReadOnly => MappedFileError::Unavailable {
+                state: self.reference_resource.lifecycle().state(),
+                operation,
+            },
+            other => MappedFileError::Custom(other.to_string()),
+        }
+    }
+
+    pub(crate) fn file_owner_admitted(&self, admission: &MappedFileLease) -> MappedFileResult<Arc<FileOwner>> {
+        self.validate_lease(admission, MappedFileOperation::Read)?;
+        self.physical_owners.storage.lock().owner().ok_or_else(|| {
+            MappedFileError::Io(io::Error::new(
+                io::ErrorKind::NotConnected,
+                "mapped-file owner detached",
+            ))
+        })
     }
 
     pub(crate) fn mapped_snapshot_matches_admitted(
@@ -589,7 +913,14 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
         file_offset: u64,
         snapshot: &[u8],
     ) -> MappedFileResult<bool> {
-        if self.storage.file_from_offset().checked_add(file_offset) != Some(start_offset) {
+        if self
+            .physical_owners
+            .storage
+            .lock()
+            .file_from_offset()
+            .checked_add(file_offset)
+            != Some(start_offset)
+        {
             return Ok(false);
         }
         let Ok(start) = usize::try_from(file_offset) else {
@@ -606,10 +937,8 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
         }
 
         let _writer = self.write_state.lock();
-        let mapped = self
-            .try_get_mapped_file_ref(admission, MappedFileOperation::Read)?
-            .as_slice();
-        Ok(mapped.get(start..end) == Some(snapshot))
+        let generation = self.try_get_read_generation(admission, MappedFileOperation::Read)?;
+        Ok(generation.with_slice(|mapped| mapped.get(start..end) == Some(snapshot)))
     }
 
     /// Extracts the file offset from the given file name.
@@ -726,12 +1055,10 @@ impl<M: MappedMemory> MappedFile for DefaultMappedFile<M> {
             return false;
         };
         let new_file = Path::new(file_name);
-        match self.storage.rename(new_file) {
+        let mut storage = self.physical_owners.storage.lock();
+        match storage.rename(new_file) {
             Ok(_) => {
                 self.file_name = CheetahString::from(file_name);
-                if self.storage.reopen().is_err() {
-                    return false;
-                }
                 true
             }
             Err(_) => false,
@@ -839,7 +1166,7 @@ impl<M: MappedMemory> MappedFile for DefaultMappedFile<M> {
 
     #[inline]
     fn get_file_from_offset(&self) -> u64 {
-        self.storage.file_from_offset()
+        self.physical_owners.storage.lock().file_from_offset()
     }
 
     fn flush(&self, flush_least_pages: i32) -> i32 {
@@ -854,17 +1181,19 @@ impl<M: MappedMemory> MappedFile for DefaultMappedFile<M> {
 
     fn try_flush(&self, flush_least_pages: i32) -> MappedFileResult<i32> {
         self.try_flush_with(flush_least_pages, |mapped_file, admission, flushed_position, value| {
+            if mapped_file.physical_owners.mapping.load_read_only().is_some() {
+                return Ok(());
+            }
+            let generation = mapped_file.try_get_writable_generation(admission, MappedFileOperation::Maintenance)?;
             let flush_size = value - flushed_position;
             if flush_size > 0 && flush_size < (mapped_file.raw_core.file_size() as i32) / 2 {
-                mapped_file
-                    .try_get_mapped_file_ref(admission, MappedFileOperation::Maintenance)?
-                    .flush_range(flushed_position as usize, flush_size as usize)
-                    .map_err(MappedFileError::FlushFailed)
+                generation.with_mapping(|mapping| {
+                    mapping
+                        .flush_range(flushed_position as usize, flush_size as usize)
+                        .map_err(MappedFileError::FlushFailed)
+                })
             } else {
-                mapped_file
-                    .try_get_mapped_file_ref(admission, MappedFileOperation::Maintenance)?
-                    .flush()
-                    .map_err(MappedFileError::FlushFailed)
+                generation.with_mapping(|mapping| mapping.flush().map_err(MappedFileError::FlushFailed))
             }
         })
     }
@@ -897,7 +1226,7 @@ impl<M: MappedMemory> MappedFile for DefaultMappedFile<M> {
                 .copy_range_admitted(&admission, pos as usize, size as usize, None)?
                 .and_then(|bytes| {
                     SelectMappedBufferResult::from_bytes_with_metadata(
-                        self.storage.file_from_offset() + pos as u64,
+                        self.physical_owners.storage.lock().file_from_offset() + pos as u64,
                         pos as u64,
                         bytes,
                         is_in_cache,
@@ -909,7 +1238,7 @@ impl<M: MappedMemory> MappedFile for DefaultMappedFile<M> {
                 "selectMappedBuffer request pos invalid, request pos: {}, size:{}, fileFromOffset: {}",
                 pos,
                 size,
-                self.storage.file_from_offset()
+                self.physical_owners.storage.lock().file_from_offset()
             );
             Ok(None)
         }
@@ -966,7 +1295,10 @@ impl<M: MappedMemory> MappedFile for DefaultMappedFile<M> {
 
     #[inline]
     fn try_last_modified_time(&self) -> io::Result<SystemTime> {
-        self.storage.file().metadata()?.modified()
+        self.physical_owners
+            .storage
+            .lock()
+            .with_file(|file| file.metadata()?.modified())?
     }
 
     fn get_data(&self, pos: usize, size: usize) -> Option<bytes::Bytes> {
@@ -983,7 +1315,7 @@ impl<M: MappedMemory> MappedFile for DefaultMappedFile<M> {
                 "selectMappedBuffer request pos invalid, request pos: {}, size:{}, fileFromOffset: {}",
                 pos,
                 size,
-                self.storage.file_from_offset()
+                self.physical_owners.storage.lock().file_from_offset()
             );
             Ok(None)
         }
@@ -996,17 +1328,17 @@ impl<M: MappedMemory> MappedFile for DefaultMappedFile<M> {
 
     #[inline]
     fn shutdown(&self, interval_forcibly: u64) {
-        self.reference_resource.shutdown(interval_forcibly);
+        ReferenceResource::shutdown(self, interval_forcibly);
     }
 
     #[inline]
     fn release(&self) {
-        self.reference_resource.release();
+        ReferenceResource::release(self);
     }
 
     #[inline]
     fn hold(&self) -> bool {
-        self.reference_resource.hold()
+        ReferenceResource::hold(self)
     }
 
     #[inline]
@@ -1073,8 +1405,10 @@ impl<M: MappedMemory> MappedFile for DefaultMappedFile<M> {
 
     fn try_mlock(&self) -> MappedFileResult<()> {
         let admission = self.acquire_borrowed(MappedFileOperation::Maintenance)?;
-        let mapped = self.try_get_mapped_file_ref(&admission, MappedFileOperation::Maintenance)?;
-        lock_memory_region(mapped.as_slice()).map_err(|error| MappedFileError::Custom(error.to_string()))
+        let _writer = self.write_state.lock();
+        let generation = self.try_get_read_generation(&admission, MappedFileOperation::Maintenance)?;
+        generation
+            .with_slice(|mapped| lock_memory_region(mapped).map_err(|error| MappedFileError::Custom(error.to_string())))
     }
 
     #[inline]
@@ -1086,8 +1420,11 @@ impl<M: MappedMemory> MappedFile for DefaultMappedFile<M> {
 
     fn try_munlock(&self) -> MappedFileResult<()> {
         let admission = self.acquire_borrowed(MappedFileOperation::Maintenance)?;
-        let mapped = self.try_get_mapped_file_ref(&admission, MappedFileOperation::Maintenance)?;
-        unlock_memory_region(mapped.as_slice()).map_err(|error| MappedFileError::Custom(error.to_string()))
+        let _writer = self.write_state.lock();
+        let generation = self.try_get_read_generation(&admission, MappedFileOperation::Maintenance)?;
+        generation.with_slice(|mapped| {
+            unlock_memory_region(mapped).map_err(|error| MappedFileError::Custom(error.to_string()))
+        })
     }
 
     #[inline]
@@ -1098,7 +1435,9 @@ impl<M: MappedMemory> MappedFile for DefaultMappedFile<M> {
     }
 
     fn try_warm_mapped_file(&self, flush_disk_type: FlushDiskType, pages: usize) -> MappedFileResult<()> {
-        let admission = self.acquire_borrowed(MappedFileOperation::Maintenance)?;
+        // Page touching performs volatile writes, so it belongs to writable admission even though
+        // its business purpose is maintenance.
+        let admission = self.acquire_borrowed(MappedFileOperation::Write)?;
         self.warm_mapped_file_with_ops(
             &admission,
             flush_disk_type,
@@ -1139,11 +1478,6 @@ impl<M: MappedMemory> MappedFile for DefaultMappedFile<M> {
     fn get_mapped_byte_buffer_access_count_since_last_swap(&self) -> i64 {
         self.mapped_byte_buffer_access_count_since_last_swap
             .load(Ordering::Acquire)
-    }
-
-    #[inline]
-    fn get_file(&self) -> &File {
-        self.storage.file()
     }
 
     #[inline]
@@ -1339,29 +1673,32 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
         if !self.is_valid_cache_range(position, size) {
             return false;
         }
-        let Ok(mapped) = self.try_get_mapped_file_ref(admission, MappedFileOperation::Read) else {
+        let _writer = self.write_state.lock();
+        let Ok(generation) = self.try_get_read_generation(admission, MappedFileOperation::Read) else {
             return false;
         };
         let page_size = get_page_size();
-        let base_addr = mapped.as_slice().as_ptr() as usize;
-        let Some(plan) =
-            crate::mapped_file::kernel::plan_mapped_file_cache_residency(base_addr, position, size, page_size)
-        else {
-            return false;
-        };
-        let Some(offset) = plan.aligned_start.checked_sub(base_addr) else {
-            return false;
-        };
-        let Some(end) = offset.checked_add(plan.checked_len) else {
-            return false;
-        };
-        let Some(region) = mapped.as_slice().get(offset..end) else {
-            return false;
-        };
-        match memory_residency(region) {
-            Ok(residency) => residency.len() == plan.page_count && residency.iter().all(|page| page & 1 == 1),
-            Err(_) => false,
-        }
+        generation.with_slice(|mapped| {
+            let base_addr = mapped.as_ptr() as usize;
+            let Some(plan) =
+                crate::mapped_file::kernel::plan_mapped_file_cache_residency(base_addr, position, size, page_size)
+            else {
+                return false;
+            };
+            let Some(offset) = plan.aligned_start.checked_sub(base_addr) else {
+                return false;
+            };
+            let Some(end) = offset.checked_add(plan.checked_len) else {
+                return false;
+            };
+            let Some(region) = mapped.get(offset..end) else {
+                return false;
+            };
+            match memory_residency(region) {
+                Ok(residency) => residency.len() == plan.page_count && residency.iter().all(|page| page & 1 == 1),
+                Err(_) => false,
+            }
+        })
     }
 
     #[cfg(any(target_os = "windows", target_os = "macos"))]
@@ -1380,8 +1717,9 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
     /// backing mapping cannot be initialized.
     pub fn with_mapped_slice<R>(&self, callback: impl FnOnce(&[u8]) -> R) -> MappedFileResult<R> {
         let admission = self.acquire_borrowed(MappedFileOperation::Read)?;
-        let mapped_file = self.try_get_mapped_file_ref(&admission, MappedFileOperation::Read)?;
-        Ok(callback(mapped_file.as_slice()))
+        let _writer = self.write_state.lock();
+        let generation = self.try_get_read_generation(&admission, MappedFileOperation::Read)?;
+        Ok(generation.with_slice(callback))
     }
 
     fn touch_mapped_page(mapped_ptr: *mut u8, offset: usize) -> io::Result<()> {
@@ -1413,10 +1751,10 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
             .acquire_borrowed(MappedFileOperation::Maintenance)
             .map_err(|error| io::Error::new(io::ErrorKind::NotConnected, error))?;
         let _writer = self.write_state.lock();
-        let mapped = self
-            .try_get_mapped_file_ref(&admission, MappedFileOperation::Maintenance)
+        let generation = self
+            .try_get_read_generation(&admission, MappedFileOperation::Maintenance)
             .map_err(io::Error::other)?;
-        Self::advise_mapped_file(mapped.as_slice(), advice)
+        generation.with_slice(|mapped| Self::advise_mapped_file(mapped, advice))
     }
 
     fn warm_mapped_file_with_ops<L, T, F, A, R>(
@@ -1443,68 +1781,70 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
         }
 
         let warmup_started = Instant::now();
-        let mapped_file = self.try_get_mapped_file_ref(admission, MappedFileOperation::Maintenance)?;
-        let mapped_ptr = mapped_file.as_mut_ptr();
-        visit_mapped_file_warmup_schedule(
-            file_size,
-            get_page_size(),
-            pages,
-            flush_disk_type == FlushDiskType::SyncFlush,
-            |operation| match operation {
-                MappedFileWarmupOperation::Touch { offset } => {
-                    if let Err(error) = touch_page(mapped_ptr, offset) {
-                        record_degradation(LinuxStorageDegradationEvent::new(
-                            LINUX_STORAGE_OP_PAGE_TOUCH,
-                            LINUX_STORAGE_REASON_FAILED,
-                            errno_from_io_error(&error),
-                        ));
-                        warn!(
-                            "Failed to touch warmed mapped file page at offset {} for {}: {:?}",
-                            offset, self.file_name, error
-                        );
-                    }
-                }
-                MappedFileWarmupOperation::Flush {
-                    offset,
-                    len,
-                    final_flush,
-                } => {
-                    let end = offset + len;
-                    if let Err(error) = flush_range(mapped_file, offset, len) {
-                        record_degradation(LinuxStorageDegradationEvent::new(
-                            LINUX_STORAGE_OP_PAGE_TOUCH,
-                            LINUX_STORAGE_REASON_FLUSH_FAILED,
-                            errno_from_io_error(&error),
-                        ));
-                        if final_flush {
+        let generation = self.try_get_writable_generation(admission, MappedFileOperation::Write)?;
+        generation.with_mapping(|mapped_file| {
+            let mapped_ptr = mapped_file.as_mut_ptr();
+            visit_mapped_file_warmup_schedule(
+                file_size,
+                get_page_size(),
+                pages,
+                flush_disk_type == FlushDiskType::SyncFlush,
+                |operation| match operation {
+                    MappedFileWarmupOperation::Touch { offset } => {
+                        if let Err(error) = touch_page(mapped_ptr, offset) {
+                            record_degradation(LinuxStorageDegradationEvent::new(
+                                LINUX_STORAGE_OP_PAGE_TOUCH,
+                                LINUX_STORAGE_REASON_FAILED,
+                                errno_from_io_error(&error),
+                            ));
                             warn!(
-                                "Failed to flush final warmed mapped file range {}-{} for {}: {:?}",
-                                offset, end, self.file_name, error
-                            );
-                        } else {
-                            warn!(
-                                "Failed to flush warmed mapped file range {}-{} for {}: {:?}",
-                                offset, end, self.file_name, error
+                                "Failed to touch warmed mapped file page at offset {} for {}: {:?}",
+                                offset, self.file_name, error
                             );
                         }
-                    } else {
-                        self.raw_core.record_flush_time();
                     }
-                }
-            },
-        );
-
-        if let Err(error) = advise(mapped_file.as_slice(), MemoryAdvice::WillNeed) {
-            record_degradation(LinuxStorageDegradationEvent::new(
-                LINUX_STORAGE_OP_MADVISE,
-                LINUX_STORAGE_REASON_FAILED,
-                errno_from_io_error(&error),
-            ));
-            warn!(
-                "madvise(MADV_WILLNEED) failed while warming mapped file {}",
-                self.file_name
+                    MappedFileWarmupOperation::Flush {
+                        offset,
+                        len,
+                        final_flush,
+                    } => {
+                        let end = offset + len;
+                        if let Err(error) = flush_range(mapped_file, offset, len) {
+                            record_degradation(LinuxStorageDegradationEvent::new(
+                                LINUX_STORAGE_OP_PAGE_TOUCH,
+                                LINUX_STORAGE_REASON_FLUSH_FAILED,
+                                errno_from_io_error(&error),
+                            ));
+                            if final_flush {
+                                warn!(
+                                    "Failed to flush final warmed mapped file range {}-{} for {}: {:?}",
+                                    offset, end, self.file_name, error
+                                );
+                            } else {
+                                warn!(
+                                    "Failed to flush warmed mapped file range {}-{} for {}: {:?}",
+                                    offset, end, self.file_name, error
+                                );
+                            }
+                        } else {
+                            self.raw_core.record_flush_time();
+                        }
+                    }
+                },
             );
-        }
+
+            if let Err(error) = advise(mapped_file.as_slice(), MemoryAdvice::WillNeed) {
+                record_degradation(LinuxStorageDegradationEvent::new(
+                    LINUX_STORAGE_OP_MADVISE,
+                    LINUX_STORAGE_REASON_FAILED,
+                    errno_from_io_error(&error),
+                ));
+                warn!(
+                    "madvise(MADV_WILLNEED) failed while warming mapped file {}",
+                    self.file_name
+                );
+            }
+        });
         let warmup_duration = warmup_started.elapsed();
         let warmup_millis = u64::try_from(warmup_duration.as_millis()).unwrap_or(u64::MAX);
         #[cfg(feature = "observability")]
@@ -1527,7 +1867,8 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
         let Some((region, admission)) = self.lock_region_owner(offset, len) else {
             return Ok(None);
         };
-        let mut handle = memory_lock_manager.lock_region(category, region)?;
+        let _writer = self.write_state.lock();
+        let mut handle = memory_lock_manager.lock_owned_region(category, region)?;
         if let Some(handle) = handle.as_mut() {
             handle.attach_mapped_file_lease(admission);
         }
@@ -1540,7 +1881,7 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
         category: MemoryLockCategory,
         offset: u64,
         len: usize,
-        locker: F,
+        mut locker: F,
     ) -> RocketMQResult<Option<MemoryLockHandle>>
     where
         F: FnMut(&[u8]) -> RocketMQResult<()>,
@@ -1548,7 +1889,12 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
         let Some((region, admission)) = self.lock_region_owner(offset, len) else {
             return Ok(None);
         };
-        let mut handle = memory_lock_manager.lock_region_with(category, region, locker)?;
+        let _writer = self.write_state.lock();
+        let mut handle = memory_lock_manager.lock_owned_region_with(category, region, |address, len| {
+            // SAFETY: `region` owns the complete checked generation range, and `write_state`
+            // excludes pointer-based mutation for this compatibility callback.
+            locker(unsafe { std::slice::from_raw_parts(address, len) })
+        })?;
         if let Some(handle) = handle.as_mut() {
             handle.attach_mapped_file_lease(admission);
         }
@@ -1567,22 +1913,37 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
         &self,
         memory_lock_manager: &MemoryLockManager,
         handle: &mut MemoryLockHandle,
-        unlocker: F,
+        mut unlocker: F,
     ) -> RocketMQResult<()>
     where
         F: FnMut(&[u8]) -> RocketMQResult<()>,
     {
-        memory_lock_manager.unlock_region_with(handle, unlocker)
+        let _writer = self.write_state.lock();
+        memory_lock_manager.unlock_owned_region_with(handle, |address, len| {
+            // SAFETY: the armed handle retains the same checked generation range, and
+            // `write_state` excludes pointer-based mutation for this compatibility callback.
+            unlocker(unsafe { std::slice::from_raw_parts(address, len) })
+        })
     }
 
-    fn lock_region_owner(&self, offset: u64, requested_len: usize) -> Option<(M::Region, MappedFileLease)> {
+    fn lock_region_owner(
+        &self,
+        offset: u64,
+        requested_len: usize,
+    ) -> Option<(MappedMemoryLockRegion<M>, MappedFileLease)> {
         let (offset, len) = self.raw_core.lock_region_range(offset, requested_len)?;
         let admission = self.acquire_owned(MappedFileOperation::Maintenance).ok()?;
-        let region = self
-            .try_get_mapped_file_ref(&admission, MappedFileOperation::Maintenance)
+        let region = match self
+            .try_get_read_generation(&admission, MappedFileOperation::Maintenance)
             .ok()?
-            .region(offset, len)
-            .ok()?;
+        {
+            AdmittedReadGeneration::Writable(generation) => {
+                MappedMemoryLockRegion::Writable(generation.maintenance_region(offset, len).ok()?)
+            }
+            AdmittedReadGeneration::ReadOnly(generation) => {
+                MappedMemoryLockRegion::ReadOnly(generation.region(offset, len).ok()?)
+            }
+        };
         Some((region, admission))
     }
 
@@ -1636,24 +1997,39 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
     fn cleanup(&self, current_ref: i64) -> bool {
         if MappedFile::is_available(self) {
             error!(
-                "logical cleanup rejected for available file[REF:{}] {}",
+                "physical detach rejected for available file[REF:{}] {}",
                 current_ref, self.file_name
             );
             return false;
         }
 
-        if self.reference_resource.is_logical_cleanup_marked() {
-            error!(
-                "logical cleanup already marked for file[REF:{}] {}",
-                current_ref, self.file_name
-            );
-            return true;
+        match self.try_detach_physical_owners() {
+            MappedFileDetachOutcome::Detached {
+                mapping_generation,
+                had_file_owner,
+            } => {
+                info!(
+                    file_name = %self.file_name,
+                    current_ref,
+                    mapping_generation,
+                    had_file_owner,
+                    "mapped-file physical owner slots detached"
+                );
+                true
+            }
+            MappedFileDetachOutcome::AlreadyDetached => true,
+            MappedFileDetachOutcome::InProgress => false,
+            MappedFileDetachOutcome::Pending { state, active_leases } => {
+                error!(
+                    file_name = %self.file_name,
+                    current_ref,
+                    state = %state,
+                    active_leases,
+                    "mapped-file physical detach is still pending"
+                );
+                false
+            }
         }
-        info!(
-            "logical cleanup marked for file[REF:{}] {}; physical mapping release remains owner-driven",
-            current_ref, self.file_name
-        );
-        true
     }
 }
 
@@ -1686,7 +2062,7 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
     /// - Cache hit/miss rates
     #[inline]
     pub fn get_metrics(&self) -> Option<&MappedFileMetrics> {
-        self.metrics.as_ref()
+        self.metrics.as_deref()
     }
 
     /// Gets the current flush strategy.
@@ -1773,9 +2149,10 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
         let _writer = self.write_state.lock();
 
         let flush_start = Instant::now();
-        self.try_get_mapped_file_ref(&admission, MappedFileOperation::Maintenance)?
-            .flush_range(start, len)
-            .map_err(MappedFileError::FlushFailed)?;
+        if self.physical_owners.mapping.load_read_only().is_none() {
+            self.try_get_writable_generation(&admission, MappedFileOperation::Maintenance)?
+                .with_mapping(|mapping| mapping.flush_range(start, len).map_err(MappedFileError::FlushFailed))?;
+        }
 
         if self.transient_store_pool.is_some() {
             self.raw_core.record_transient_flush_range(end);
@@ -1812,9 +2189,9 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
 #[cfg(test)]
 mod tests {
     use std::fs::File;
-    use std::ops::Deref;
     use std::sync::Arc;
 
+    use memmap2::Mmap;
     use memmap2::MmapMut;
     use tempfile::TempDir;
 
@@ -1822,45 +2199,28 @@ mod tests {
     use crate::base::memory_lock_manager::MemoryLockCategory;
     use crate::base::memory_lock_manager::MemoryLockManager;
 
-    #[derive(Clone)]
     struct TestMappedMemory {
-        mmap: Arc<MmapMut>,
+        mmap: MmapMut,
     }
 
-    struct TestMappedRegion {
-        mmap: Arc<MmapMut>,
-        offset: usize,
-        len: usize,
+    struct TestReadOnlyMappedMemory {
+        mmap: Mmap,
     }
 
-    impl Deref for TestMappedRegion {
-        type Target = [u8];
-
-        fn deref(&self) -> &Self::Target {
-            &self.mmap[self.offset..self.offset + self.len]
-        }
-    }
-
-    impl AsRef<[u8]> for TestMappedRegion {
-        fn as_ref(&self) -> &[u8] {
-            self
-        }
-    }
-
-    // SAFETY: the backend owns the mapping through an `Arc`, keeps regions alive, and tests
-    // serialize mutable access through `DefaultMappedFile`.
+    // SAFETY: the backend owns one stable mapping and tests serialize mutable access through
+    // `DefaultMappedFile`.
     unsafe impl MappedMemory for TestMappedMemory {
-        type Region = TestMappedRegion;
+        type ReadOnly = TestReadOnlyMappedMemory;
 
-        fn map_mut(file: &File) -> io::Result<Self> {
+        unsafe fn map_mut(file: &File) -> io::Result<Self> {
             // SAFETY: `MappedFileStorage` sizes the file before invoking the backend and never
             // resizes it while this mapping is live.
             let mmap = unsafe { MmapMut::map_mut(file)? };
-            Ok(Self { mmap: Arc::new(mmap) })
+            Ok(Self { mmap })
         }
 
         fn as_slice(&self) -> &[u8] {
-            self.mmap.as_ref()
+            &self.mmap
         }
 
         fn as_mut_ptr(&self) -> *mut u8 {
@@ -1874,24 +2234,18 @@ mod tests {
         fn flush_range(&self, offset: usize, len: usize) -> io::Result<()> {
             self.mmap.flush_range(offset, len)
         }
+    }
 
-        fn region(&self, offset: usize, len: usize) -> Result<Self::Region, crate::mapped_file::MmapRangeError> {
-            let end = offset
-                .checked_add(len)
-                .ok_or(crate::mapped_file::MmapRangeError::Overflow { offset, len })?;
-            let mapping_len = self.mmap.len();
-            if end > mapping_len {
-                return Err(crate::mapped_file::MmapRangeError::OutOfBounds {
-                    offset,
-                    len,
-                    mapping_len,
-                });
-            }
-            Ok(TestMappedRegion {
-                mmap: self.mmap.clone(),
-                offset,
-                len,
-            })
+    // SAFETY: the mapping is immutable, stable, and owned for the complete value lifetime.
+    unsafe impl ReadOnlyMappedMemory for TestReadOnlyMappedMemory {
+        unsafe fn map(file: &File) -> io::Result<Self> {
+            // SAFETY: test storage keeps the file size stable while this mapping is live.
+            let mmap = unsafe { Mmap::map(file)? };
+            Ok(Self { mmap })
+        }
+
+        fn as_slice(&self) -> &[u8] {
+            &self.mmap
         }
     }
 
@@ -1995,6 +2349,21 @@ mod tests {
         assert_eq!(stats.mapped_files, 1);
         assert_eq!(stats.map_operations, 1);
         assert_eq!(stats.map_failures, 0);
+    }
+
+    #[test]
+    fn lazy_write_initializes_owned_generation_once_then_reuses_published_slot() {
+        let (_temp_dir, mapped_file) = create_lazy_test_file();
+
+        assert!(mapped_file.append_message_bytes(b"lazy"));
+        assert!(mapped_file.append_message_bytes(b"-mapped"));
+
+        assert_eq!(mapped_file.lazy_mmap_stats().map_operations, 1);
+        assert_eq!(mapped_file.get_wrote_position(), 11);
+        assert_eq!(
+            mapped_file.get_bytes_readable_checked(0, 11).as_deref(),
+            Some(&b"lazy-mapped"[..])
+        );
     }
 
     #[test]
@@ -2122,7 +2491,10 @@ mod tests {
         assert_eq!(mapped_file.get_file_name().as_str(), renamed.to_str().unwrap());
         assert!(!original.exists());
         assert!(renamed.exists());
-        assert_eq!(mapped_file.get_file().metadata().unwrap().len(), 4096);
+        assert_eq!(
+            std::fs::metadata(mapped_file.get_file_name().as_str()).unwrap().len(),
+            4096
+        );
         assert!(mapped_file.destroy(0));
         assert!(!renamed.exists());
     }
@@ -2136,7 +2508,10 @@ mod tests {
         assert!(!mapped_file.rename_to(missing_parent.to_str().expect("UTF-8 path")));
         assert_eq!(mapped_file.get_file_name().as_str(), original.to_str().unwrap());
         assert!(original.exists());
-        assert_eq!(mapped_file.get_file().metadata().unwrap().len(), 4096);
+        assert_eq!(
+            std::fs::metadata(mapped_file.get_file_name().as_str()).unwrap().len(),
+            4096
+        );
     }
 
     #[test]
@@ -2441,7 +2816,7 @@ mod tests {
         let mut events = Vec::new();
         let mut flush_calls = 0usize;
 
-        let admission = mapped_file.acquire_borrowed(MappedFileOperation::Maintenance).unwrap();
+        let admission = mapped_file.acquire_borrowed(MappedFileOperation::Write).unwrap();
         mapped_file
             .warm_mapped_file_with_ops(
                 &admission,

--- a/rocketmq-store-local/src/mapped_file/file.rs
+++ b/rocketmq-store-local/src/mapped_file/file.rs
@@ -17,12 +17,19 @@
 //! This module owns file lifecycle operations but does not own the configured segment size or
 //! memory mapping. Callers retain responsibility for mapping and observability policy.
 
+use std::fmt;
 use std::fs;
 use std::fs::File;
 use std::fs::OpenOptions;
 use std::io;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::MutexGuard;
+
+use super::metrics::FileOwnerGaugeGuard;
+use super::metrics::MappedFileMetrics;
 
 /// Legacy error number used when file preallocation is unavailable.
 pub const PREALLOCATE_UNSUPPORTED_ERRNO: i32 = 95;
@@ -148,16 +155,131 @@ pub fn try_parse_file_from_offset(file_name: &Path) -> io::Result<u64> {
         .ok_or_else(|| invalid_input_error(format!("file name parse to offset is invalid: {}", file_name.display())))
 }
 
-/// Owns the operating-system file and canonical identity of one mapped-file segment.
+/// Namespace identity for one mapped-file segment.
 ///
-/// The path is authoritative and changes only after a successful rename. The segment offset is
-/// parsed once when the storage is opened and remains stable across renames. Configured file size
-/// is intentionally owned by the mapped-file progress state and is not duplicated here.
-#[derive(Debug)]
-pub struct MappedFileStorage {
-    file: File,
+/// Identity deliberately excludes the operating-system handle. It remains available after the
+/// physical owner has been detached so namespace removal can still be retried.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileIdentity {
     path: PathBuf,
     file_from_offset: u64,
+}
+
+impl FileIdentity {
+    /// Returns the authoritative namespace path.
+    #[inline]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Returns the immutable base offset parsed when this identity was created.
+    #[inline]
+    pub fn file_from_offset(&self) -> u64 {
+        self.file_from_offset
+    }
+}
+
+enum FileHandle {
+    Owned(File),
+    // This exists only for the legacy standalone sendfile constructor. Mapped-file production
+    // paths publish `Owned` handles and never share a naked `Arc<File>`.
+    SharedCompatibility(Arc<File>),
+}
+
+impl FileHandle {
+    #[inline]
+    fn as_file(&self) -> &File {
+        match self {
+            Self::Owned(file) => file,
+            Self::SharedCompatibility(file) => file.as_ref(),
+        }
+    }
+}
+
+/// Canonical strong owner of an operating-system file handle.
+///
+/// Mapped-file mappings and transfer ranges retain this value through `Arc<FileOwner>`. The live
+/// gauge guard is declared after the handle so its `Drop` records physical release only after the
+/// owned handle has been dropped.
+pub struct FileOwner {
+    handle: FileHandle,
+    _gauge: FileOwnerGaugeGuard,
+}
+
+impl fmt::Debug for FileOwner {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("FileOwner")
+            .field("len", &self.len().ok())
+            .finish_non_exhaustive()
+    }
+}
+
+impl FileOwner {
+    /// Creates the canonical owner from an owner-bound metrics guard.
+    pub(crate) fn new(file: File, gauge: FileOwnerGaugeGuard) -> Self {
+        Self {
+            handle: FileHandle::Owned(file),
+            _gauge: gauge,
+        }
+    }
+
+    /// Creates a canonical owner and binds its lifetime to `metrics`.
+    pub(crate) fn new_tracked(file: File, metrics: Arc<MappedFileMetrics>) -> Self {
+        Self::new(file, metrics.track_file_owner())
+    }
+
+    /// Adapts a legacy standalone transfer handle without cloning the operating-system handle.
+    ///
+    /// Mapped-file production paths must use [`Self::new_tracked`] and capture the storage owner
+    /// instead.
+    pub(crate) fn from_shared_compatibility(file: Arc<File>, metrics: Arc<MappedFileMetrics>) -> Self {
+        let gauge = metrics.track_file_owner();
+        Self {
+            handle: FileHandle::SharedCompatibility(file),
+            _gauge: gauge,
+        }
+    }
+
+    /// Runs an operation while this owner keeps the file handle alive.
+    ///
+    /// The higher-ranked callback prevents the borrowed `File` from escaping the call.
+    #[inline]
+    pub(crate) fn with_file<R>(&self, operation: impl for<'file> FnOnce(&'file File) -> R) -> R {
+        operation(self.handle.as_file())
+    }
+
+    /// Returns the current file length without exposing the handle.
+    #[inline]
+    pub fn len(&self) -> io::Result<u64> {
+        self.with_file(|file| file.metadata().map(|metadata| metadata.len()))
+    }
+
+    /// Returns whether the underlying file is empty.
+    #[inline]
+    pub fn is_empty(&self) -> io::Result<bool> {
+        self.len().map(|len| len == 0)
+    }
+
+    /// Returns a descriptor whose validity is bounded by the borrowed owner capability.
+    #[cfg(unix)]
+    #[inline]
+    pub(crate) fn raw_fd(&self) -> std::os::fd::RawFd {
+        use std::os::fd::AsRawFd;
+
+        self.with_file(File::as_raw_fd)
+    }
+}
+
+/// Owns mutable namespace identity and an exactly-once takeable physical-owner slot.
+///
+/// Configured file size remains in mapped-file progress state. Taking the owner never removes the
+/// path identity, allowing namespace retirement to be retried independently of physical release.
+#[derive(Debug)]
+pub struct MappedFileStorage {
+    identity: FileIdentity,
+    owner: Mutex<Option<Arc<FileOwner>>>,
+    metrics: Arc<MappedFileMetrics>,
 }
 
 impl MappedFileStorage {
@@ -173,13 +295,35 @@ impl MappedFileStorage {
     /// Returns an error if the final path component is not a numeric offset, the file cannot be
     /// opened or created, or its length cannot be set.
     pub fn open(path: PathBuf, file_size: u64) -> io::Result<(Self, Option<FilePreallocateOutcome>)> {
-        Self::open_with_preallocator(path, file_size, preallocate_file)
+        Self::open_with_metrics(path, file_size, Arc::new(MappedFileMetrics::new()))
     }
 
+    /// Opens storage whose physical owners report into `metrics`.
+    pub(crate) fn open_with_metrics(
+        path: PathBuf,
+        file_size: u64,
+        metrics: Arc<MappedFileMetrics>,
+    ) -> io::Result<(Self, Option<FilePreallocateOutcome>)> {
+        Self::open_with_preallocator_and_metrics(path, file_size, preallocate_file, metrics)
+    }
+
+    #[cfg(test)]
     fn open_with_preallocator<P>(
         path: PathBuf,
         file_size: u64,
         preallocator: P,
+    ) -> io::Result<(Self, Option<FilePreallocateOutcome>)>
+    where
+        P: FnOnce(&File, u64) -> FilePreallocateOutcome,
+    {
+        Self::open_with_preallocator_and_metrics(path, file_size, preallocator, Arc::new(MappedFileMetrics::new()))
+    }
+
+    fn open_with_preallocator_and_metrics<P>(
+        path: PathBuf,
+        file_size: u64,
+        preallocator: P,
+        metrics: Arc<MappedFileMetrics>,
     ) -> io::Result<(Self, Option<FilePreallocateOutcome>)>
     where
         P: FnOnce(&File, u64) -> FilePreallocateOutcome,
@@ -194,33 +338,59 @@ impl MappedFileStorage {
             .open(&path)?;
         file.set_len(file_size)?;
         let preallocation = (existing_len < file_size).then(|| preallocator(&file, file_size));
+        let owner = Arc::new(FileOwner::new_tracked(file, Arc::clone(&metrics)));
 
         Ok((
             Self {
-                file,
-                path,
-                file_from_offset,
+                identity: FileIdentity { path, file_from_offset },
+                owner: Mutex::new(Some(owner)),
+                metrics,
             },
             preallocation,
         ))
     }
 
-    /// Returns the currently owned file handle.
+    fn owner_slot(&self) -> MutexGuard<'_, Option<Arc<FileOwner>>> {
+        self.owner.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Captures the currently published physical owner.
     ///
-    /// After a failed [`Self::reopen`], this remains the handle that was valid before the reopen
-    /// attempt.
+    /// A captured owner remains valid after a concurrent [`Self::take_owner`].
     #[inline]
-    pub fn file(&self) -> &File {
-        &self.file
+    pub(crate) fn owner(&self) -> Option<Arc<FileOwner>> {
+        self.owner_slot().clone()
+    }
+
+    /// Takes slot ownership exactly once without changing namespace identity.
+    #[inline]
+    pub(crate) fn take_owner(&self) -> Option<Arc<FileOwner>> {
+        self.owner_slot().take()
+    }
+
+    /// Returns namespace identity independently of physical-owner attachment.
+    #[inline]
+    pub fn identity(&self) -> &FileIdentity {
+        &self.identity
+    }
+
+    /// Runs a scoped operation against the currently published owner.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`io::ErrorKind::NotConnected`] after the owner slot has been detached.
+    pub fn with_file<R>(&self, operation: impl for<'file> FnOnce(&'file File) -> R) -> io::Result<R> {
+        self.owner()
+            .ok_or_else(owner_detached_error)
+            .map(|owner| owner.with_file(operation))
     }
 
     /// Returns the authoritative path for this segment.
     ///
-    /// A successful [`Self::rename`] updates this path before any later reopen attempt. A failed
-    /// rename leaves it unchanged.
+    /// A successful [`Self::rename`] updates this path. A failed rename leaves it unchanged.
     #[inline]
     pub fn path(&self) -> &Path {
-        &self.path
+        self.identity.path()
     }
 
     /// Returns the segment offset parsed when the storage was opened.
@@ -228,20 +398,20 @@ impl MappedFileStorage {
     /// Renaming the file does not change this value.
     #[inline]
     pub fn file_from_offset(&self) -> u64 {
-        self.file_from_offset
+        self.identity.file_from_offset()
     }
 
     /// Renames the segment and updates its authoritative path.
     ///
-    /// This operation does not reopen the file. Callers that require the legacy reopen sequence
-    /// must update their path projection after this method succeeds and then call [`Self::reopen`].
+    /// This operation does not reopen the file. Existing owner-bound mappings and ranges retain
+    /// the same operating-system handle across the namespace rename.
     ///
     /// # Errors
     ///
     /// Returns the filesystem rename error. On error, the path and file handle remain unchanged.
     pub fn rename(&mut self, path: &Path) -> io::Result<()> {
-        fs::rename(&self.path, path)?;
-        self.path = path.to_path_buf();
+        fs::rename(self.identity.path(), path)?;
+        self.identity.path = path.to_path_buf();
         Ok(())
     }
 
@@ -253,10 +423,21 @@ impl MappedFileStorage {
     ///
     /// # Errors
     ///
-    /// Returns an error if the authoritative path cannot be opened.
+    /// Returns an error if the authoritative path cannot be opened or if detach won before the
+    /// replacement could be published. In the latter case the candidate owner is dropped and the
+    /// slot remains empty.
     pub fn reopen(&mut self) -> io::Result<()> {
-        let file = File::open(&self.path)?;
-        self.file = file;
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(self.identity.path())?;
+        let candidate = Arc::new(FileOwner::new_tracked(file, Arc::clone(&self.metrics)));
+        let mut slot = self.owner_slot();
+        if slot.is_none() {
+            return Err(owner_detached_error());
+        }
+        *slot = Some(candidate);
         Ok(())
     }
 
@@ -267,18 +448,25 @@ impl MappedFileStorage {
     /// Returns the filesystem removal error, including when the path does not exist.
     #[inline]
     pub fn delete(&self) -> io::Result<()> {
-        fs::remove_file(&self.path)
+        fs::remove_file(self.identity.path())
     }
+}
+
+fn owner_detached_error() -> io::Error {
+    io::Error::new(io::ErrorKind::NotConnected, "mapped-file owner has been detached")
 }
 
 #[cfg(test)]
 mod tests {
     use std::cell::Cell;
+    use std::sync::Arc;
+    use std::sync::Barrier;
 
     use tempfile::tempdir;
 
     use super::FilePreallocateOutcome;
     use super::MappedFileStorage;
+    use crate::mapped_file::MappedFileMetrics;
 
     #[test]
     fn preallocator_runs_only_when_previous_length_is_smaller() {
@@ -302,5 +490,111 @@ mod tests {
         .expect("shrink storage");
         assert_eq!(calls.get(), 1);
         assert_eq!(outcome, None);
+    }
+
+    #[test]
+    fn identity_survives_exactly_once_owner_detach() {
+        let directory = tempdir().expect("create temporary directory");
+        let path = directory.path().join("16");
+        let metrics = Arc::new(MappedFileMetrics::new());
+        let (storage, _) =
+            MappedFileStorage::open_with_metrics(path.clone(), 8, Arc::clone(&metrics)).expect("open tracked storage");
+
+        assert_eq!(storage.path(), path);
+        assert_eq!(storage.file_from_offset(), 16);
+        assert_eq!(metrics.file_owners_live(), 1);
+
+        let external_owner = storage.owner().expect("published file owner");
+        let detached_owner = storage.take_owner().expect("detach file owner");
+        assert!(Arc::ptr_eq(&external_owner, &detached_owner));
+        assert!(storage.owner().is_none());
+        assert!(storage.take_owner().is_none());
+
+        assert_eq!(storage.path(), path);
+        assert_eq!(storage.file_from_offset(), 16);
+        assert_eq!(metrics.file_owners_live(), 1);
+        assert_eq!(metrics.physical_file_owner_drop_total(), 0);
+
+        drop(external_owner);
+        assert_eq!(metrics.file_owners_live(), 1);
+        drop(detached_owner);
+        assert_eq!(metrics.file_owners_live(), 0);
+        assert_eq!(metrics.physical_file_owner_drop_total(), 1);
+    }
+
+    #[test]
+    fn reopen_cannot_republish_after_owner_detach() {
+        let directory = tempdir().expect("create temporary directory");
+        let path = directory.path().join("32");
+        let metrics = Arc::new(MappedFileMetrics::new());
+        let (mut storage, _) =
+            MappedFileStorage::open_with_metrics(path, 8, Arc::clone(&metrics)).expect("open tracked storage");
+        let owner = storage.take_owner().expect("detach file owner");
+
+        let error = storage.reopen().expect_err("detached storage must stay detached");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::NotConnected);
+        assert!(storage.owner().is_none());
+        assert_eq!(metrics.file_owners_live(), 1);
+        drop(owner);
+        assert_eq!(metrics.file_owners_live(), 0);
+        assert_eq!(metrics.physical_file_owner_drop_total(), 2);
+    }
+
+    #[test]
+    fn reopen_preserves_length_and_publishes_a_writable_owner() {
+        let directory = tempdir().expect("create temporary directory");
+        let path = directory.path().join("40");
+        let metrics = Arc::new(MappedFileMetrics::new());
+        let (mut storage, _) =
+            MappedFileStorage::open_with_metrics(path, 8, Arc::clone(&metrics)).expect("open tracked storage");
+        storage
+            .with_file(|file| file.set_len(12))
+            .expect("attached owner")
+            .expect("extend initial owner");
+
+        storage.reopen().expect("reopen writable owner");
+
+        assert_eq!(storage.owner().expect("replacement owner").len().unwrap(), 12);
+        storage
+            .with_file(|file| file.set_len(16))
+            .expect("attached replacement")
+            .expect("replacement remains writable");
+        assert_eq!(storage.owner().expect("replacement owner").len().unwrap(), 16);
+        assert_eq!(metrics.file_owners_live(), 1);
+        assert_eq!(metrics.physical_file_owner_drop_total(), 1);
+    }
+
+    #[test]
+    fn concurrent_owner_detach_has_one_winner() {
+        let directory = tempdir().expect("create temporary directory");
+        let path = directory.path().join("48");
+        let metrics = Arc::new(MappedFileMetrics::new());
+        let (storage, _) =
+            MappedFileStorage::open_with_metrics(path, 8, Arc::clone(&metrics)).expect("open tracked storage");
+        let storage = Arc::new(storage);
+        let barrier = Arc::new(Barrier::new(3));
+        let mut workers = Vec::new();
+        for _ in 0..2 {
+            let storage = Arc::clone(&storage);
+            let barrier = Arc::clone(&barrier);
+            workers.push(std::thread::spawn(move || {
+                barrier.wait();
+                storage.take_owner()
+            }));
+        }
+
+        barrier.wait();
+        let detached = workers
+            .into_iter()
+            .filter_map(|worker| worker.join().expect("detach worker"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(detached.len(), 1);
+        assert!(storage.owner().is_none());
+        assert_eq!(metrics.file_owners_live(), 1);
+        drop(detached);
+        assert_eq!(metrics.file_owners_live(), 0);
+        assert_eq!(metrics.physical_file_owner_drop_total(), 1);
     }
 }

--- a/rocketmq-store-local/src/mapped_file/generation.rs
+++ b/rocketmq-store-local/src/mapped_file/generation.rs
@@ -1,0 +1,1310 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::marker::PhantomData;
+use std::num::NonZeroU64;
+use std::ops::Deref;
+use std::ops::Range;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Instant;
+
+use arc_swap::ArcSwapOption;
+use parking_lot::Mutex;
+
+use super::file::FileOwner;
+use super::lifecycle::MappedFileLease;
+use super::mapping::LazyMmapStats;
+use super::memory::checked_mmap_range;
+use super::memory::MappedMemory;
+use super::memory::MmapRangeError;
+use super::memory::ReadOnlyMappedMemory;
+use super::metrics::MappedFileMetrics;
+use super::metrics::MappingGenerationGaugeGuard;
+
+/// Stable, non-zero identity of one published or fully built mapping generation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct MappingGenerationId(NonZeroU64);
+
+impl MappingGenerationId {
+    /// First identity assigned by a fresh mapping slot.
+    pub const FIRST: Self = Self(NonZeroU64::MIN);
+
+    /// Returns the numeric generation identity.
+    #[inline]
+    pub const fn get(self) -> u64 {
+        self.0.get()
+    }
+}
+
+/// A mapping generation identity could not be assigned without reusing zero or an older value.
+#[derive(Clone, Copy, Debug, thiserror::Error, PartialEq, Eq)]
+#[error("mapping generation identity space is exhausted")]
+pub struct MappingGenerationIdExhausted;
+
+/// Monotonic identity source owned by one authoritative mapping slot.
+struct MappingGenerationIdSequence {
+    last_assigned: AtomicU64,
+}
+
+impl MappingGenerationIdSequence {
+    const fn new() -> Self {
+        Self::with_last_assigned(0)
+    }
+
+    const fn with_last_assigned(last_assigned: u64) -> Self {
+        Self {
+            last_assigned: AtomicU64::new(last_assigned),
+        }
+    }
+
+    fn next(&self) -> Result<MappingGenerationId, MappingGenerationIdExhausted> {
+        let previous = self
+            .last_assigned
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |last| last.checked_add(1))
+            .map_err(|_| MappingGenerationIdExhausted)?;
+        let next = previous.checked_add(1).ok_or(MappingGenerationIdExhausted)?;
+        NonZeroU64::new(next)
+            .map(MappingGenerationId)
+            .ok_or(MappingGenerationIdExhausted)
+    }
+}
+
+/// Type-state marker for a generation that may be mutated under the mapped-file writer fence.
+pub enum WritableAccess {}
+
+/// Type-state marker for a sealed generation that exposes immutable owner-bound regions.
+pub enum ReadOnlyAccess {}
+
+/// Physical owner of one mmap generation.
+///
+/// The generation owns the concrete mapping, the canonical file owner, and its live-gauge guard.
+/// It intentionally does not implement `Clone`; consumers clone the enclosing [`Arc`] instead.
+pub struct MappingGeneration<M, Access> {
+    id: MappingGenerationId,
+    mapping: M,
+    file_owner: Arc<FileOwner>,
+    mapped_bytes: usize,
+    _gauge: MappingGenerationGaugeGuard,
+    _access: PhantomData<Access>,
+}
+
+/// Writable mapping generation used while a segment accepts writers.
+pub type WritableMappingGeneration<W> = MappingGeneration<W, WritableAccess>;
+
+/// Read-only mapping generation used after a segment has been sealed.
+pub type ReadOnlyMappingGeneration<R> = MappingGeneration<R, ReadOnlyAccess>;
+
+impl<M, Access> MappingGeneration<M, Access> {
+    /// Returns this generation's stable identity.
+    #[inline]
+    pub const fn id(&self) -> MappingGenerationId {
+        self.id
+    }
+
+    /// Returns the number of bytes owned by this mapping generation.
+    #[inline]
+    pub const fn mapped_bytes(&self) -> usize {
+        self.mapped_bytes
+    }
+
+    #[inline]
+    pub(crate) fn file_owner(&self) -> &Arc<FileOwner> {
+        &self.file_owner
+    }
+}
+
+impl<W: MappedMemory> WritableMappingGeneration<W> {
+    pub(crate) fn new(
+        id: MappingGenerationId,
+        mapping: W,
+        file_owner: Arc<FileOwner>,
+        metrics: Arc<MappedFileMetrics>,
+    ) -> Self {
+        let mapped_bytes = mapping.as_slice().len();
+        let gauge = metrics.track_mapping_generation(mapped_bytes);
+        Self {
+            id,
+            mapping,
+            file_owner,
+            mapped_bytes,
+            _gauge: gauge,
+            _access: PhantomData,
+        }
+    }
+
+    /// Runs one synchronous operation against the writable mapping without allowing a borrowed
+    /// mapping reference to become the closure's return value.
+    #[inline]
+    pub(crate) fn with_mapping<T>(&self, operation: impl for<'a> FnOnce(&'a W) -> T) -> T {
+        operation(&self.mapping)
+    }
+
+    /// Creates an owner-bound range for internal maintenance such as memory locking.
+    ///
+    /// Unlike read-only regions, this range exposes no safe byte slice. Callers that need an
+    /// address must keep the mapped-file writer fence for the complete native operation.
+    pub(crate) fn maintenance_region(
+        self: &Arc<Self>,
+        offset: usize,
+        len: usize,
+    ) -> Result<GenerationRegion<W, WritableAccess>, MmapRangeError> {
+        GenerationRegion::try_new_writable(Arc::clone(self), offset, len)
+    }
+}
+
+impl<R: ReadOnlyMappedMemory> ReadOnlyMappingGeneration<R> {
+    pub(crate) fn new(
+        id: MappingGenerationId,
+        mapping: R,
+        file_owner: Arc<FileOwner>,
+        metrics: Arc<MappedFileMetrics>,
+    ) -> Self {
+        let mapped_bytes = mapping.as_slice().len();
+        let gauge = metrics.track_mapping_generation(mapped_bytes);
+        Self {
+            id,
+            mapping,
+            file_owner,
+            mapped_bytes,
+            _gauge: gauge,
+            _access: PhantomData,
+        }
+    }
+
+    /// Creates an immutable checked region that retains this generation owner.
+    pub fn region(
+        self: &Arc<Self>,
+        offset: usize,
+        len: usize,
+    ) -> Result<GenerationRegion<R, ReadOnlyAccess>, MmapRangeError> {
+        GenerationRegion::try_new_read_only(Arc::clone(self), offset, len)
+    }
+
+    /// Runs one synchronous operation against the immutable mapping without allowing the mapping
+    /// reference to escape the generation owner.
+    #[inline]
+    pub(crate) fn with_mapping<T>(&self, operation: impl for<'a> FnOnce(&'a R) -> T) -> T {
+        operation(&self.mapping)
+    }
+}
+
+/// Checked range bound to the mapping generation that owns its backing allocation.
+///
+/// The default access state is read-only. Writable maintenance ranges are constructed only by
+/// crate-internal code and do not implement `Deref` or `AsRef<[u8]>`.
+pub struct GenerationRegion<M, Access = ReadOnlyAccess> {
+    generation: Arc<MappingGeneration<M, Access>>,
+    range: Range<usize>,
+}
+
+impl<M, Access> GenerationRegion<M, Access> {
+    /// Returns the checked range length.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.range.len()
+    }
+}
+
+impl<R: ReadOnlyMappedMemory> GenerationRegion<R, ReadOnlyAccess> {
+    fn try_new_read_only(
+        generation: Arc<ReadOnlyMappingGeneration<R>>,
+        offset: usize,
+        len: usize,
+    ) -> Result<Self, MmapRangeError> {
+        let range = checked_mmap_range(generation.mapped_bytes, offset, len)?;
+        Ok(Self { generation, range })
+    }
+}
+
+impl<W: MappedMemory> GenerationRegion<W, WritableAccess> {
+    fn try_new_writable(
+        generation: Arc<WritableMappingGeneration<W>>,
+        offset: usize,
+        len: usize,
+    ) -> Result<Self, MmapRangeError> {
+        let range = checked_mmap_range(generation.mapped_bytes, offset, len)?;
+        Ok(Self { generation, range })
+    }
+
+    /// Returns the first byte address for an internal native maintenance operation.
+    ///
+    /// Dereferencing this pointer is unsafe. The caller must retain the writer fence and this range
+    /// owner for the complete operation.
+    pub(crate) fn as_ptr(&self) -> *const u8 {
+        // SAFETY: the checked range is within the live mapping retained by `generation`.
+        unsafe { self.generation.mapping.as_slice().as_ptr().add(self.range.start) }
+    }
+}
+
+impl<R: ReadOnlyMappedMemory> Deref for GenerationRegion<R, ReadOnlyAccess> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.generation.mapping.as_slice()[self.range.clone()]
+    }
+}
+
+impl<R: ReadOnlyMappedMemory> AsRef<[u8]> for GenerationRegion<R, ReadOnlyAccess> {
+    fn as_ref(&self) -> &[u8] {
+        self
+    }
+}
+
+/// Immutable mapped range that inseparably owns one admitted read operation.
+///
+/// Clones and split ranges share one inner owner and therefore one admission count. The final alias
+/// drops the read-only generation before releasing its operation lease, so physical unmap cannot
+/// race ahead of the last safe slice user.
+pub struct MappedReadLease<R: ReadOnlyMappedMemory> {
+    inner: Arc<MappedReadLeaseInner<R>>,
+    range: Range<usize>,
+}
+
+struct MappedReadLeaseInner<R: ReadOnlyMappedMemory> {
+    generation: Option<Arc<ReadOnlyMappingGeneration<R>>>,
+    operation: Option<MappedFileLease>,
+}
+
+impl<R: ReadOnlyMappedMemory> MappedReadLeaseInner<R> {
+    /// The fields are present for every observable inner value and are taken only by final `Drop`,
+    /// after the last `Arc` alias has gone away.
+    #[inline]
+    fn generation(&self) -> &Arc<ReadOnlyMappingGeneration<R>> {
+        self.generation
+            .as_ref()
+            .expect("mapped read generation exists until final inner drop")
+    }
+}
+
+impl<R: ReadOnlyMappedMemory> Drop for MappedReadLeaseInner<R> {
+    fn drop(&mut self) {
+        drop(self.generation.take());
+        drop(self.operation.take());
+    }
+}
+
+impl<R: ReadOnlyMappedMemory> MappedReadLease<R> {
+    /// Constructs an owner-bound read range from one already-admitted operation.
+    ///
+    /// This constructor is crate-private so external safe code cannot combine an unrelated
+    /// generation and operation lease. On range failure it preserves the same generation-before-
+    /// operation release order as the successfully constructed owner.
+    pub(crate) fn try_new(
+        generation: Arc<ReadOnlyMappingGeneration<R>>,
+        operation: MappedFileLease,
+        offset: usize,
+        len: usize,
+    ) -> Result<Self, MmapRangeError> {
+        let range = match checked_mmap_range(generation.mapped_bytes(), offset, len) {
+            Ok(range) => range,
+            Err(error) => {
+                drop(generation);
+                drop(operation);
+                return Err(error);
+            }
+        };
+        Ok(Self {
+            inner: Arc::new(MappedReadLeaseInner {
+                generation: Some(generation),
+                operation: Some(operation),
+            }),
+            range,
+        })
+    }
+
+    /// Returns the identity of the generation backing this range.
+    #[inline]
+    pub fn generation_id(&self) -> MappingGenerationId {
+        self.inner.generation().id()
+    }
+
+    /// Returns the mapped range length.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.range.len()
+    }
+
+    /// Returns whether this mapped range is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.range.is_empty()
+    }
+
+    /// Creates two aliases split at `mid` bytes relative to this range's start.
+    ///
+    /// The original remains valid. Both returned aliases share its single inner generation and
+    /// operation lease. Returns `None` when `mid` exceeds this range's length.
+    pub fn split_at(&self, mid: usize) -> Option<(Self, Self)> {
+        let split = self.range.start.checked_add(mid)?;
+        if split > self.range.end {
+            return None;
+        }
+        Some((
+            Self {
+                inner: Arc::clone(&self.inner),
+                range: self.range.start..split,
+            },
+            Self {
+                inner: Arc::clone(&self.inner),
+                range: split..self.range.end,
+            },
+        ))
+    }
+}
+
+impl<R: ReadOnlyMappedMemory> Clone for MappedReadLease<R> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            range: self.range.clone(),
+        }
+    }
+}
+
+impl<R: ReadOnlyMappedMemory> Deref for MappedReadLease<R> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner.generation().mapping.as_slice()[self.range.clone()]
+    }
+}
+
+impl<R: ReadOnlyMappedMemory> AsRef<[u8]> for MappedReadLease<R> {
+    fn as_ref(&self) -> &[u8] {
+        self
+    }
+}
+
+/// Currently published writable or read-only generation.
+pub enum PublishedGeneration<W, R> {
+    /// Active writable generation.
+    Writable(Arc<WritableMappingGeneration<W>>),
+    /// Sealed read-only generation.
+    ReadOnly(Arc<ReadOnlyMappingGeneration<R>>),
+}
+
+impl<W, R> PublishedGeneration<W, R> {
+    /// Returns the published generation identity.
+    pub fn id(&self) -> MappingGenerationId {
+        match self {
+            Self::Writable(generation) => generation.id(),
+            Self::ReadOnly(generation) => generation.id(),
+        }
+    }
+
+    #[inline]
+    fn file_owner(&self) -> &Arc<FileOwner> {
+        match self {
+            Self::Writable(generation) => generation.file_owner(),
+            Self::ReadOnly(generation) => generation.file_owner(),
+        }
+    }
+}
+
+/// Failure to initialize or atomically publish a mapping generation.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum MappingPublicationError<E> {
+    /// The concrete mapping initializer failed.
+    #[error("mapping initialization failed: {0}")]
+    Initialization(E),
+    /// Admission changed while the fully built candidate was awaiting publication.
+    #[error("mapping publication was rejected by lifecycle admission")]
+    PublicationRejected,
+    /// The mapping slot has been terminally detached.
+    #[error("mapping slot is detached")]
+    Detached,
+    /// No generation is available for replacement.
+    #[error("mapping slot has no published generation")]
+    NoPublishedGeneration,
+    /// A writable initializer observed an already sealed read-only generation.
+    #[error("mapping slot already contains a read-only generation")]
+    AlreadyReadOnly,
+    /// The expected generation is stale.
+    #[error("expected mapping generation {expected:?}, but current generation is {actual:?}")]
+    ExpectedGenerationMismatch {
+        /// Generation expected by the caller.
+        expected: MappingGenerationId,
+        /// Generation observed while publication was serialized.
+        actual: MappingGenerationId,
+    },
+    /// A fresh non-zero generation identity cannot be assigned.
+    #[error(transparent)]
+    GenerationExhausted(#[from] MappingGenerationIdExhausted),
+}
+
+/// Result of terminally detaching the authoritative mapping slot.
+pub(crate) enum MappingSlotDetach<W, R> {
+    /// This caller won detach; the slot may have been empty for a never-initialized lazy mapping.
+    Detached {
+        generation: Option<Arc<PublishedGeneration<W, R>>>,
+    },
+    /// A prior caller already detached the slot.
+    AlreadyDetached,
+}
+
+impl<W, R> MappingSlotDetach<W, R> {
+    pub(crate) fn into_generation(self) -> Option<Arc<PublishedGeneration<W, R>>> {
+        match self {
+            Self::Detached { generation } => generation,
+            Self::AlreadyDetached => None,
+        }
+    }
+
+    #[cfg(test)]
+    fn is_winner(&self) -> bool {
+        matches!(self, Self::Detached { .. })
+    }
+}
+
+/// Proof that one fully built generation was stored in the authoritative slot.
+pub(crate) struct PublishedGenerationToken<M, Access> {
+    generation: Arc<MappingGeneration<M, Access>>,
+}
+
+impl<M, Access> PublishedGenerationToken<M, Access> {
+    fn into_generation(self) -> Arc<MappingGeneration<M, Access>> {
+        self.generation
+    }
+}
+
+/// Consuming publication capability for one fully built writable candidate.
+///
+/// The lifecycle gate receives this value and may call [`Self::publish`] only while holding its
+/// close-control lock. Dropping it rejects and releases the unpublished candidate.
+pub(crate) struct WritableGenerationPublication<'a, W, R> {
+    owner: &'a MappedFileMapping<W, R>,
+    candidate: Arc<WritableMappingGeneration<W>>,
+}
+
+impl<W, R> WritableGenerationPublication<'_, W, R> {
+    pub(crate) fn publish(self) -> PublishedGenerationToken<W, WritableAccess> {
+        self.owner
+            .slot
+            .store(Some(Arc::new(PublishedGeneration::Writable(Arc::clone(
+                &self.candidate,
+            )))));
+        PublishedGenerationToken {
+            generation: self.candidate,
+        }
+    }
+}
+
+/// Consuming publication capability for one fully built read-only candidate.
+pub(crate) struct ReadOnlyGenerationPublication<'a, W, R> {
+    owner: &'a MappedFileMapping<W, R>,
+    candidate: Arc<ReadOnlyMappingGeneration<R>>,
+}
+
+impl<W, R> ReadOnlyGenerationPublication<'_, W, R> {
+    pub(crate) fn publish(self) -> PublishedGenerationToken<R, ReadOnlyAccess> {
+        self.owner
+            .slot
+            .store(Some(Arc::new(PublishedGeneration::ReadOnly(Arc::clone(
+                &self.candidate,
+            )))));
+        PublishedGenerationToken {
+            generation: self.candidate,
+        }
+    }
+}
+
+/// Atomic owner slot and serialized candidate-publication controller for one mapped file.
+pub struct MappedFileMapping<W, R> {
+    slot: ArcSwapOption<PublishedGeneration<W, R>>,
+    init_lock: Mutex<()>,
+    generation_ids: MappingGenerationIdSequence,
+    detached: AtomicBool,
+    lazy_enabled: bool,
+    metrics: Arc<MappedFileMetrics>,
+    map_operations: AtomicU64,
+    map_failures: AtomicU64,
+    total_millis: AtomicU64,
+    last_millis: AtomicU64,
+}
+
+impl<W: MappedMemory, R> MappedFileMapping<W, R> {
+    /// Creates an eagerly initialized writable generation.
+    pub(crate) fn new_eager(mapping: W, file_owner: Arc<FileOwner>, metrics: Arc<MappedFileMetrics>) -> Self {
+        let generation = Arc::new(WritableMappingGeneration::new(
+            MappingGenerationId::FIRST,
+            mapping,
+            file_owner,
+            Arc::clone(&metrics),
+        ));
+        Self {
+            slot: ArcSwapOption::from(Some(Arc::new(PublishedGeneration::Writable(generation)))),
+            init_lock: Mutex::new(()),
+            generation_ids: MappingGenerationIdSequence::with_last_assigned(MappingGenerationId::FIRST.get()),
+            detached: AtomicBool::new(false),
+            lazy_enabled: false,
+            metrics,
+            map_operations: AtomicU64::new(0),
+            map_failures: AtomicU64::new(0),
+            total_millis: AtomicU64::new(0),
+            last_millis: AtomicU64::new(0),
+        }
+    }
+}
+
+impl<W, R> MappedFileMapping<W, R> {
+    /// Creates an uninitialized mapping eligible for lazy initialization.
+    pub(crate) fn new_lazy(metrics: Arc<MappedFileMetrics>) -> Self {
+        Self {
+            slot: ArcSwapOption::empty(),
+            init_lock: Mutex::new(()),
+            generation_ids: MappingGenerationIdSequence::new(),
+            detached: AtomicBool::new(false),
+            lazy_enabled: true,
+            metrics,
+            map_operations: AtomicU64::new(0),
+            map_failures: AtomicU64::new(0),
+            total_millis: AtomicU64::new(0),
+            last_millis: AtomicU64::new(0),
+        }
+    }
+
+    /// Returns whether this slot was configured for lazy initialization.
+    #[inline]
+    pub fn is_lazy_enabled(&self) -> bool {
+        self.lazy_enabled
+    }
+
+    /// Returns whether a generation is currently published.
+    #[inline]
+    pub fn is_mapped(&self) -> bool {
+        self.slot.load().is_some()
+    }
+
+    /// Returns whether the owner slot has been terminally detached.
+    #[inline]
+    pub fn is_detached(&self) -> bool {
+        self.detached.load(Ordering::Acquire)
+    }
+
+    /// Returns lazy-initialization counters.
+    pub fn stats(&self) -> LazyMmapStats {
+        LazyMmapStats {
+            eligible_files: u64::from(self.lazy_enabled),
+            mapped_files: u64::from(self.lazy_enabled && self.is_mapped()),
+            map_operations: self.map_operations.load(Ordering::Acquire),
+            map_failures: self.map_failures.load(Ordering::Acquire),
+            total_millis: self.total_millis.load(Ordering::Acquire),
+            last_millis: self.last_millis.load(Ordering::Acquire),
+        }
+    }
+
+    pub(crate) fn load_writable(&self) -> Option<Arc<WritableMappingGeneration<W>>> {
+        let current = self.slot.load_full()?;
+        match current.as_ref() {
+            PublishedGeneration::Writable(generation) => Some(Arc::clone(generation)),
+            PublishedGeneration::ReadOnly(_) => None,
+        }
+    }
+
+    /// Runs one synchronous operation against the currently published writable generation.
+    ///
+    /// The ArcSwap guard retains the published owner for the complete closure call without the
+    /// eager outer clone performed by `load_full`; this method also does not clone the inner
+    /// generation `Arc`. The higher-ranked callback and independently chosen result type prevent
+    /// a generation borrow from escaping this scope. Callers that need an owner beyond the
+    /// callback must use [`Self::load_writable`] instead.
+    #[inline]
+    pub(crate) fn with_writable_scoped<T>(
+        &self,
+        operation: impl for<'generation> FnOnce(&'generation WritableMappingGeneration<W>) -> T,
+    ) -> Option<T> {
+        let current = self.slot.load();
+        let published = current.as_ref()?;
+        match published.as_ref() {
+            PublishedGeneration::Writable(generation) => Some(operation(generation.as_ref())),
+            PublishedGeneration::ReadOnly(_) => None,
+        }
+    }
+
+    pub(crate) fn load_read_only(&self) -> Option<Arc<ReadOnlyMappingGeneration<R>>> {
+        let current = self.slot.load_full()?;
+        match current.as_ref() {
+            PublishedGeneration::Writable(_) => None,
+            PublishedGeneration::ReadOnly(generation) => Some(Arc::clone(generation)),
+        }
+    }
+
+    /// Terminally detaches the authoritative slot exactly once.
+    pub(crate) fn detach(&self) -> MappingSlotDetach<W, R> {
+        let _guard = self.init_lock.lock();
+        if self.detached.swap(true, Ordering::AcqRel) {
+            return MappingSlotDetach::AlreadyDetached;
+        }
+        MappingSlotDetach::Detached {
+            generation: self.slot.swap(None),
+        }
+    }
+
+    fn record_map_failure(&self) {
+        if self.lazy_enabled {
+            self.map_failures.fetch_add(1, Ordering::AcqRel);
+        }
+    }
+}
+
+impl<W: MappedMemory, R> MappedFileMapping<W, R> {
+    /// Loads the current writable generation or lazily builds and publishes it.
+    ///
+    /// `can_build` checks the caller's admission before construction. The fully built candidate is
+    /// then passed to `publish_gate`; that closure must call the consuming publication capability
+    /// while holding the lifecycle close-control lock. Detach uses this method's serialization lock,
+    /// so the slot store has one ordering against both close and terminal detach.
+    pub(crate) fn get_or_try_init<E, F, V, P>(
+        &self,
+        initializer: F,
+        can_build: V,
+        publish_gate: P,
+    ) -> Result<Arc<WritableMappingGeneration<W>>, MappingPublicationError<E>>
+    where
+        F: FnOnce() -> Result<(W, Arc<FileOwner>), E>,
+        V: FnOnce() -> bool,
+        P: FnOnce(WritableGenerationPublication<'_, W, R>) -> Option<PublishedGenerationToken<W, WritableAccess>>,
+    {
+        if self.is_detached() {
+            return Err(MappingPublicationError::Detached);
+        }
+        if let Some(current) = self.slot.load_full() {
+            return match current.as_ref() {
+                PublishedGeneration::Writable(generation) => Ok(Arc::clone(generation)),
+                PublishedGeneration::ReadOnly(_) => Err(MappingPublicationError::AlreadyReadOnly),
+            };
+        }
+
+        let _guard = self.init_lock.lock();
+        if self.is_detached() {
+            return Err(MappingPublicationError::Detached);
+        }
+        if let Some(current) = self.slot.load_full() {
+            return match current.as_ref() {
+                PublishedGeneration::Writable(generation) => Ok(Arc::clone(generation)),
+                PublishedGeneration::ReadOnly(_) => Err(MappingPublicationError::AlreadyReadOnly),
+            };
+        }
+        if !can_build() {
+            self.record_map_failure();
+            return Err(MappingPublicationError::PublicationRejected);
+        }
+
+        let started = Instant::now();
+        let id = self.generation_ids.next().map_err(|error| {
+            self.record_map_failure();
+            MappingPublicationError::GenerationExhausted(error)
+        })?;
+        let (mapping, file_owner) = initializer().map_err(|error| {
+            self.record_map_failure();
+            MappingPublicationError::Initialization(error)
+        })?;
+        let candidate = Arc::new(WritableMappingGeneration::new(
+            id,
+            mapping,
+            file_owner,
+            Arc::clone(&self.metrics),
+        ));
+
+        let publication = WritableGenerationPublication { owner: self, candidate };
+        let candidate = publish_gate(publication)
+            .ok_or_else(|| {
+                self.record_map_failure();
+                MappingPublicationError::PublicationRejected
+            })?
+            .into_generation();
+        if self.lazy_enabled {
+            let elapsed_millis = started.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
+            self.map_operations.fetch_add(1, Ordering::AcqRel);
+            self.total_millis.fetch_add(elapsed_millis, Ordering::AcqRel);
+            self.last_millis.store(elapsed_millis, Ordering::Release);
+        }
+        Ok(candidate)
+    }
+}
+
+impl<W, R: ReadOnlyMappedMemory> MappedFileMapping<W, R> {
+    /// Builds and atomically publishes a read-only replacement for the expected generation.
+    ///
+    /// Existing owners retain the old generation through their `Arc`; only new loads observe the
+    /// replacement. The initializer runs while publication and detach are serialized. The complete
+    /// owner-bound candidate is published only if `publish_gate` invokes its consuming capability
+    /// while holding the lifecycle close-control lock.
+    pub(crate) fn replace_with_read_only<E, F, V, P>(
+        &self,
+        expected: MappingGenerationId,
+        initializer: F,
+        can_build: V,
+        publish_gate: P,
+    ) -> Result<Arc<ReadOnlyMappingGeneration<R>>, MappingPublicationError<E>>
+    where
+        F: FnOnce() -> Result<R, E>,
+        V: FnOnce() -> bool,
+        P: FnOnce(ReadOnlyGenerationPublication<'_, W, R>) -> Option<PublishedGenerationToken<R, ReadOnlyAccess>>,
+    {
+        let _guard = self.init_lock.lock();
+        if self.is_detached() {
+            return Err(MappingPublicationError::Detached);
+        }
+        let current = self
+            .slot
+            .load_full()
+            .ok_or(MappingPublicationError::NoPublishedGeneration)?;
+        if current.id() != expected {
+            return Err(MappingPublicationError::ExpectedGenerationMismatch {
+                expected,
+                actual: current.id(),
+            });
+        }
+        if !can_build() {
+            return Err(MappingPublicationError::PublicationRejected);
+        }
+
+        let id = self.generation_ids.next()?;
+        let mapping = initializer().map_err(MappingPublicationError::Initialization)?;
+        let candidate = Arc::new(ReadOnlyMappingGeneration::new(
+            id,
+            mapping,
+            Arc::clone(current.file_owner()),
+            Arc::clone(&self.metrics),
+        ));
+        publish_gate(ReadOnlyGenerationPublication { owner: self, candidate })
+            .ok_or(MappingPublicationError::PublicationRejected)
+            .map(PublishedGenerationToken::into_generation)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::io;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
+    use std::sync::Barrier;
+
+    use super::*;
+    use crate::mapped_file::file::FileOwner;
+    use crate::mapped_file::lifecycle::SegmentLifecycle;
+    use crate::mapped_file::memory::MappedMemory;
+    use crate::mapped_file::memory::ReadOnlyMappedMemory;
+    use crate::mapped_file::metrics::MappedFileMetrics;
+    use crate::mapped_file::MappedFileOperation;
+
+    struct TestWritableMemory(Vec<u8>);
+
+    struct TestReadOnlyMemory(Vec<u8>);
+
+    struct DropObservedReadOnlyMemory {
+        bytes: Vec<u8>,
+        lifecycle: Arc<SegmentLifecycle>,
+        drops: Arc<AtomicUsize>,
+        dropped_before_operation: Arc<AtomicBool>,
+    }
+
+    // SAFETY: tests serialize all mutation, ranges are checked by the generation owner, and the
+    // backing vector remains stable for the complete value lifetime.
+    unsafe impl MappedMemory for TestWritableMemory {
+        type ReadOnly = TestReadOnlyMemory;
+
+        unsafe fn map_mut(file: &File) -> io::Result<Self> {
+            Ok(Self(vec![0; file.metadata()?.len() as usize]))
+        }
+
+        fn as_slice(&self) -> &[u8] {
+            &self.0
+        }
+
+        fn as_mut_ptr(&self) -> *mut u8 {
+            self.0.as_ptr().cast_mut()
+        }
+
+        fn flush(&self) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn flush_range(&self, _offset: usize, _len: usize) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    // SAFETY: the backing vector is immutable and remains live for the complete value lifetime.
+    unsafe impl ReadOnlyMappedMemory for TestReadOnlyMemory {
+        unsafe fn map(file: &File) -> io::Result<Self> {
+            Ok(Self(vec![0; file.metadata()?.len() as usize]))
+        }
+
+        fn as_slice(&self) -> &[u8] {
+            &self.0
+        }
+    }
+
+    // SAFETY: the backing vector is immutable and remains live for the complete value lifetime.
+    unsafe impl ReadOnlyMappedMemory for DropObservedReadOnlyMemory {
+        unsafe fn map(_file: &File) -> io::Result<Self> {
+            Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "drop-observed test memory is constructed directly",
+            ))
+        }
+
+        fn as_slice(&self) -> &[u8] {
+            &self.bytes
+        }
+    }
+
+    impl Drop for DropObservedReadOnlyMemory {
+        fn drop(&mut self) {
+            self.dropped_before_operation
+                .store(self.lifecycle.snapshot().active_leases == 1, Ordering::Release);
+            self.drops.fetch_add(1, Ordering::AcqRel);
+        }
+    }
+
+    fn file_owner(metrics: &Arc<MappedFileMetrics>) -> Arc<FileOwner> {
+        Arc::new(FileOwner::new(
+            tempfile::tempfile().expect("temporary file opens"),
+            metrics.track_file_owner(),
+        ))
+    }
+
+    fn observed_read_lease(
+        bytes: Vec<u8>,
+        lifecycle: &Arc<SegmentLifecycle>,
+        metrics: &Arc<MappedFileMetrics>,
+        drops: Arc<AtomicUsize>,
+        dropped_before_operation: Arc<AtomicBool>,
+    ) -> MappedReadLease<DropObservedReadOnlyMemory> {
+        let operation = lifecycle
+            .try_acquire(MappedFileOperation::Read)
+            .expect("read admission succeeds");
+        let len = bytes.len();
+        let generation = Arc::new(ReadOnlyMappingGeneration::new(
+            MappingGenerationId::FIRST,
+            DropObservedReadOnlyMemory {
+                bytes,
+                lifecycle: Arc::clone(lifecycle),
+                drops,
+                dropped_before_operation,
+            },
+            file_owner(metrics),
+            Arc::clone(metrics),
+        ));
+        MappedReadLease::try_new(generation, operation, 0, len).expect("complete range is valid")
+    }
+
+    #[test]
+    fn generation_ids_are_non_zero_monotonic_and_exhaustion_fails_closed() {
+        let sequence = MappingGenerationIdSequence::new();
+        assert_eq!(sequence.next().expect("first id").get(), 1);
+        assert_eq!(sequence.next().expect("second id").get(), 2);
+
+        let almost_exhausted = MappingGenerationIdSequence::with_last_assigned(u64::MAX - 1);
+        assert_eq!(almost_exhausted.next().expect("last id").get(), u64::MAX);
+        assert_eq!(almost_exhausted.next(), Err(MappingGenerationIdExhausted));
+        assert_eq!(almost_exhausted.next(), Err(MappingGenerationIdExhausted));
+    }
+
+    #[test]
+    fn exhausted_slot_keeps_current_generation_and_does_not_build_candidate() {
+        let metrics = Arc::new(MappedFileMetrics::new());
+        let owner = file_owner(&metrics);
+        let mapping = MappedFileMapping::<TestWritableMemory, TestReadOnlyMemory>::new_eager(
+            TestWritableMemory(vec![1, 2, 3, 4]),
+            owner,
+            Arc::clone(&metrics),
+        );
+        mapping.generation_ids.last_assigned.store(u64::MAX, Ordering::Release);
+        let initializer_called = AtomicBool::new(false);
+
+        let result = mapping.replace_with_read_only(
+            MappingGenerationId::FIRST,
+            || {
+                initializer_called.store(true, Ordering::Release);
+                Ok::<_, &'static str>(TestReadOnlyMemory(vec![5, 6, 7, 8]))
+            },
+            || true,
+            |publication| Some(publication.publish()),
+        );
+
+        assert!(matches!(
+            result,
+            Err(MappingPublicationError::GenerationExhausted(
+                MappingGenerationIdExhausted
+            ))
+        ));
+        assert!(!initializer_called.load(Ordering::Acquire));
+        assert_eq!(
+            mapping.load_writable().expect("original remains").id(),
+            MappingGenerationId::FIRST
+        );
+        assert_eq!(metrics.mapped_generations_live(), 1);
+    }
+
+    #[test]
+    fn old_generation_survives_atomic_read_only_replacement() {
+        let metrics = Arc::new(MappedFileMetrics::new());
+        let owner = file_owner(&metrics);
+        let mapping = MappedFileMapping::<TestWritableMemory, TestReadOnlyMemory>::new_eager(
+            TestWritableMemory(vec![1, 2, 3, 4]),
+            Arc::clone(&owner),
+            Arc::clone(&metrics),
+        );
+        let old = mapping.load_writable().expect("eager writable generation");
+
+        let current = mapping
+            .replace_with_read_only(
+                old.id(),
+                || Ok::<_, &'static str>(TestReadOnlyMemory(vec![5, 6, 7, 8])),
+                || true,
+                |publication| Some(publication.publish()),
+            )
+            .expect("replacement publishes");
+
+        assert!(current.id().get() > old.id().get());
+        assert_eq!(mapping.load_read_only().expect("new generation").id(), current.id());
+        assert_eq!(metrics.mapped_generations_live(), 2);
+        assert_eq!(metrics.mapped_bytes_live(), 8);
+        assert_eq!(old.with_mapping(|memory| memory.as_slice().to_vec()), vec![1, 2, 3, 4]);
+
+        drop(old);
+        assert_eq!(metrics.mapped_generations_live(), 1);
+        assert_eq!(metrics.mapped_bytes_live(), 4);
+        assert_eq!(metrics.physical_mapping_drop_total(), 1);
+        assert_eq!(current.region(0, 4).expect("checked region").as_ref(), &[5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn scoped_writable_access_borrows_slot_without_arc_clones() {
+        let metrics = Arc::new(MappedFileMetrics::new());
+        let mapping = MappedFileMapping::<TestWritableMemory, TestReadOnlyMemory>::new_eager(
+            TestWritableMemory(vec![1, 2, 3, 4]),
+            file_owner(&metrics),
+            Arc::clone(&metrics),
+        );
+        let published = mapping.slot.load_full().expect("eager generation is published");
+        let PublishedGeneration::Writable(generation) = published.as_ref() else {
+            panic!("eager generation remains writable");
+        };
+        let published_owners = Arc::strong_count(&published);
+        let generation_owners = Arc::strong_count(generation);
+
+        let observed = mapping
+            .with_writable_scoped(|scoped| {
+                assert!(std::ptr::eq(scoped, generation.as_ref()));
+                assert_eq!(Arc::strong_count(&published), published_owners);
+                assert_eq!(Arc::strong_count(generation), generation_owners);
+                scoped.with_mapping(|memory| (scoped.id(), memory.as_slice().to_vec()))
+            })
+            .expect("writable generation is available");
+
+        assert_eq!(observed.0, MappingGenerationId::FIRST);
+        assert_eq!(observed.1, vec![1, 2, 3, 4]);
+        fn assert_owned_result<T: 'static>(_: &T) {}
+        assert_owned_result(&observed);
+        assert_eq!(Arc::strong_count(&published), published_owners);
+        assert_eq!(Arc::strong_count(generation), generation_owners);
+    }
+
+    #[test]
+    fn scoped_writable_access_survives_concurrent_replace_and_detach() {
+        let metrics = Arc::new(MappedFileMetrics::new());
+        let owner = file_owner(&metrics);
+        let mapping = Arc::new(MappedFileMapping::<TestWritableMemory, TestReadOnlyMemory>::new_eager(
+            TestWritableMemory(vec![1, 2, 3, 4]),
+            Arc::clone(&owner),
+            Arc::clone(&metrics),
+        ));
+        let entered = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+
+        let worker = {
+            let mapping = Arc::clone(&mapping);
+            let entered = Arc::clone(&entered);
+            let release = Arc::clone(&release);
+            std::thread::spawn(move || {
+                mapping
+                    .with_writable_scoped(|generation| {
+                        entered.wait();
+                        release.wait();
+                        generation.with_mapping(|memory| memory.as_slice().to_vec())
+                    })
+                    .expect("worker captures the writable generation")
+            })
+        };
+
+        entered.wait();
+        let writable_id = mapping
+            .load_writable()
+            .expect("writable generation remains published")
+            .id();
+        mapping
+            .replace_with_read_only(
+                writable_id,
+                || Ok::<_, &'static str>(TestReadOnlyMemory(vec![5, 6, 7, 8])),
+                || true,
+                |publication| Some(publication.publish()),
+            )
+            .expect("read-only replacement publishes");
+        assert!(mapping.with_writable_scoped(|_| ()).is_none());
+        let detached = mapping
+            .detach()
+            .into_generation()
+            .expect("read-only generation detaches");
+        assert!(mapping.is_detached());
+        assert!(mapping.with_writable_scoped(|_| ()).is_none());
+        assert_eq!(metrics.mapped_generations_live(), 2);
+        drop(detached);
+        assert_eq!(metrics.mapped_generations_live(), 1);
+
+        release.wait();
+        assert_eq!(worker.join().expect("scoped worker does not panic"), vec![1, 2, 3, 4]);
+        assert_eq!(metrics.mapped_generations_live(), 0);
+    }
+
+    #[test]
+    fn generation_region_rejects_overflow_and_out_of_bounds() {
+        let metrics = Arc::new(MappedFileMetrics::new());
+        let owner = file_owner(&metrics);
+        let generation = Arc::new(ReadOnlyMappingGeneration::new(
+            MappingGenerationId::FIRST,
+            TestReadOnlyMemory(vec![1, 2, 3, 4]),
+            owner,
+            Arc::clone(&metrics),
+        ));
+
+        assert_eq!(generation.region(1, 2).expect("valid region").as_ref(), &[2, 3]);
+        assert!(matches!(
+            generation.region(4, 1),
+            Err(MmapRangeError::OutOfBounds {
+                offset: 4,
+                len: 1,
+                mapping_len: 4,
+            })
+        ));
+        assert!(matches!(
+            generation.region(usize::MAX, 1),
+            Err(MmapRangeError::Overflow {
+                offset: usize::MAX,
+                len: 1,
+            })
+        ));
+
+        let region = generation.region(0, 4).expect("owner-bound region");
+        drop(generation);
+        assert_eq!(metrics.mapped_generations_live(), 1);
+        assert_eq!(region.as_ref(), &[1, 2, 3, 4]);
+        drop(region);
+        assert_eq!(metrics.mapped_generations_live(), 0);
+    }
+
+    #[test]
+    fn close_racing_lazy_init_never_publishes() {
+        let metrics = Arc::new(MappedFileMetrics::new());
+        let owner = file_owner(&metrics);
+        let mapping = Arc::new(MappedFileMapping::<TestWritableMemory, TestReadOnlyMemory>::new_lazy(
+            Arc::clone(&metrics),
+        ));
+        let publication_allowed = Arc::new(AtomicBool::new(true));
+        let initializer_started = Arc::new(Barrier::new(2));
+        let release_initializer = Arc::new(Barrier::new(2));
+
+        let worker = {
+            let mapping = Arc::clone(&mapping);
+            let owner = Arc::clone(&owner);
+            let publication_allowed = Arc::clone(&publication_allowed);
+            let initializer_started = Arc::clone(&initializer_started);
+            let release_initializer = Arc::clone(&release_initializer);
+            std::thread::spawn(move || {
+                mapping.get_or_try_init(
+                    || {
+                        initializer_started.wait();
+                        release_initializer.wait();
+                        Ok::<_, &'static str>((TestWritableMemory(vec![0; 8]), owner))
+                    },
+                    || true,
+                    |publication| {
+                        publication_allowed
+                            .load(Ordering::Acquire)
+                            .then(|| publication.publish())
+                    },
+                )
+            })
+        };
+
+        initializer_started.wait();
+        publication_allowed.store(false, Ordering::Release);
+        release_initializer.wait();
+
+        assert!(matches!(
+            worker.join().expect("initializer thread does not panic"),
+            Err(MappingPublicationError::PublicationRejected)
+        ));
+        assert!(!mapping.is_mapped());
+        assert_eq!(mapping.stats().map_failures, 1);
+        assert_eq!(metrics.mapped_generations_live(), 0);
+        assert_eq!(metrics.physical_mapping_drop_total(), 1);
+    }
+
+    #[test]
+    fn detach_is_exactly_once_and_terminal() {
+        let metrics = Arc::new(MappedFileMetrics::new());
+        let owner = file_owner(&metrics);
+        let mapping = MappedFileMapping::<TestWritableMemory, TestReadOnlyMemory>::new_eager(
+            TestWritableMemory(vec![0; 8]),
+            Arc::clone(&owner),
+            Arc::clone(&metrics),
+        );
+
+        let first = mapping.detach();
+        assert!(first.is_winner());
+        let detached = first.into_generation().expect("eager generation was detached");
+        assert!(!mapping.detach().is_winner());
+        assert!(mapping.is_detached());
+        assert!(!mapping.is_mapped());
+        assert!(matches!(
+            mapping.get_or_try_init(
+                || Ok::<_, &'static str>((TestWritableMemory(vec![0; 8]), owner)),
+                || true,
+                |publication| Some(publication.publish()),
+            ),
+            Err(MappingPublicationError::Detached)
+        ));
+
+        assert_eq!(metrics.mapped_generations_live(), 1);
+        drop(detached);
+        assert_eq!(metrics.mapped_generations_live(), 0);
+    }
+
+    #[test]
+    fn mapped_read_lease_drops_generation_before_operation_admission() {
+        let lifecycle = SegmentLifecycle::shared();
+        let metrics = Arc::new(MappedFileMetrics::new());
+        let drops = Arc::new(AtomicUsize::new(0));
+        let dropped_before_operation = Arc::new(AtomicBool::new(false));
+        let lease = observed_read_lease(
+            vec![1, 2, 3, 4],
+            &lifecycle,
+            &metrics,
+            Arc::clone(&drops),
+            Arc::clone(&dropped_before_operation),
+        );
+
+        assert_eq!(lifecycle.snapshot().active_leases, 1);
+        assert_eq!(lease.as_ref(), &[1, 2, 3, 4]);
+        drop(lease);
+
+        assert_eq!(drops.load(Ordering::Acquire), 1);
+        assert!(dropped_before_operation.load(Ordering::Acquire));
+        assert_eq!(lifecycle.snapshot().active_leases, 0);
+        assert_eq!(metrics.mapped_generations_live(), 0);
+    }
+
+    #[test]
+    fn mapped_read_lease_rejects_invalid_range_and_releases_both_owners() {
+        let lifecycle = SegmentLifecycle::shared();
+        let metrics = Arc::new(MappedFileMetrics::new());
+        let drops = Arc::new(AtomicUsize::new(0));
+        let dropped_before_operation = Arc::new(AtomicBool::new(false));
+        let operation = lifecycle
+            .try_acquire(MappedFileOperation::Read)
+            .expect("read admission succeeds");
+        let generation = Arc::new(ReadOnlyMappingGeneration::new(
+            MappingGenerationId::FIRST,
+            DropObservedReadOnlyMemory {
+                bytes: vec![1, 2, 3, 4],
+                lifecycle: Arc::clone(&lifecycle),
+                drops: Arc::clone(&drops),
+                dropped_before_operation: Arc::clone(&dropped_before_operation),
+            },
+            file_owner(&metrics),
+            Arc::clone(&metrics),
+        ));
+
+        assert!(matches!(
+            MappedReadLease::try_new(generation, operation, 4, 1),
+            Err(MmapRangeError::OutOfBounds {
+                offset: 4,
+                len: 1,
+                mapping_len: 4,
+            })
+        ));
+        assert_eq!(drops.load(Ordering::Acquire), 1);
+        assert!(dropped_before_operation.load(Ordering::Acquire));
+        assert_eq!(lifecycle.snapshot().active_leases, 0);
+
+        let operation = lifecycle
+            .try_acquire(MappedFileOperation::Read)
+            .expect("second read admission succeeds");
+        let generation = Arc::new(ReadOnlyMappingGeneration::new(
+            MappingGenerationId::FIRST,
+            DropObservedReadOnlyMemory {
+                bytes: vec![1, 2, 3, 4],
+                lifecycle: Arc::clone(&lifecycle),
+                drops: Arc::clone(&drops),
+                dropped_before_operation: Arc::clone(&dropped_before_operation),
+            },
+            file_owner(&metrics),
+            Arc::clone(&metrics),
+        ));
+        assert!(matches!(
+            MappedReadLease::try_new(generation, operation, usize::MAX, 1),
+            Err(MmapRangeError::Overflow {
+                offset: usize::MAX,
+                len: 1,
+            })
+        ));
+        assert_eq!(drops.load(Ordering::Acquire), 2);
+        assert_eq!(lifecycle.snapshot().active_leases, 0);
+    }
+
+    #[test]
+    fn mapped_read_lease_clone_and_split_share_one_inner_admission() {
+        let lifecycle = SegmentLifecycle::shared();
+        let metrics = Arc::new(MappedFileMetrics::new());
+        let drops = Arc::new(AtomicUsize::new(0));
+        let dropped_before_operation = Arc::new(AtomicBool::new(false));
+        let lease = observed_read_lease(
+            vec![1, 2, 3, 4],
+            &lifecycle,
+            &metrics,
+            Arc::clone(&drops),
+            Arc::clone(&dropped_before_operation),
+        );
+        let cloned = lease.clone();
+        let (left, right) = lease.split_at(2).expect("middle split is valid");
+
+        assert!(Arc::ptr_eq(&lease.inner, &cloned.inner));
+        assert!(Arc::ptr_eq(&lease.inner, &left.inner));
+        assert!(Arc::ptr_eq(&lease.inner, &right.inner));
+        assert_eq!(lifecycle.snapshot().active_leases, 1);
+        assert_eq!(left.as_ref(), &[1, 2]);
+        assert_eq!(right.as_ref(), &[3, 4]);
+
+        drop(lease);
+        drop(cloned);
+        drop(left);
+        assert_eq!(lifecycle.snapshot().active_leases, 1);
+        assert_eq!(drops.load(Ordering::Acquire), 0);
+        drop(right);
+
+        assert_eq!(lifecycle.snapshot().active_leases, 0);
+        assert_eq!(drops.load(Ordering::Acquire), 1);
+        assert!(dropped_before_operation.load(Ordering::Acquire));
+    }
+}

--- a/rocketmq-store-local/src/mapped_file/lifecycle.rs
+++ b/rocketmq-store-local/src/mapped_file/lifecycle.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -50,6 +53,83 @@ struct LifecycleControl {
     started_at: Option<Instant>,
     generation: u64,
     force_observed: bool,
+    physical_detach: PhysicalDetachState,
+}
+
+struct DrainWaiterPresence<'a> {
+    waiters: &'a AtomicUsize,
+}
+
+impl<'a> DrainWaiterPresence<'a> {
+    fn register(waiters: &'a AtomicUsize) -> Self {
+        waiters.fetch_add(1, Ordering::Release);
+        Self { waiters }
+    }
+}
+
+impl Drop for DrainWaiterPresence<'_> {
+    fn drop(&mut self) {
+        self.waiters.fetch_sub(1, Ordering::Release);
+    }
+}
+
+/// Owner-only callback invoked after Closing drains every admitted operation.
+///
+/// Implementations must not retain or call back into the lifecycle. Keeping this boundary
+/// acyclic lets a final lease drop detach physical slots without extending the mapped-file
+/// object's lifetime.
+pub(crate) trait PhysicalDetachHook: Send + Sync {
+    fn detach_owner_slots(&self);
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PhysicalDetachState {
+    Attached,
+    Detaching,
+    Detached,
+}
+
+/// Result of attempting to claim the one physical-owner detach transition.
+pub(crate) enum PhysicalDetachClaimResult<'a> {
+    /// This caller owns the detach transition until the claim is completed or dropped.
+    Claimed(PhysicalDetachClaim<'a>),
+    /// Another caller currently owns the detach transition.
+    InProgress,
+    /// The mapping and file-owner slots were already detached.
+    AlreadyDetached,
+    /// Closing has not drained every admitted operation yet.
+    Pending {
+        state: MappedFileAdmissionState,
+        active_leases: usize,
+    },
+}
+
+/// Unwind-safe exactly-once claim for detaching physical owner slots.
+pub(crate) struct PhysicalDetachClaim<'a> {
+    lifecycle: &'a SegmentLifecycle,
+    armed: bool,
+}
+
+impl PhysicalDetachClaim<'_> {
+    /// Commits the detach transition after both physical owner slots have been taken.
+    pub(crate) fn complete(mut self) {
+        let mut control = self.lifecycle.close_control.lock();
+        debug_assert_eq!(control.physical_detach, PhysicalDetachState::Detaching);
+        control.physical_detach = PhysicalDetachState::Detached;
+        self.armed = false;
+    }
+}
+
+impl Drop for PhysicalDetachClaim<'_> {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let mut control = self.lifecycle.close_control.lock();
+        if control.physical_detach == PhysicalDetachState::Detaching {
+            control.physical_detach = PhysicalDetachState::Attached;
+        }
+    }
 }
 
 impl LifecycleControl {
@@ -68,7 +148,12 @@ impl LifecycleControl {
 pub(crate) struct SegmentLifecycle {
     transitions: LifecycleTransitionState,
     close_control: Mutex<LifecycleControl>,
+    drain_waiters: AtomicUsize,
     drained: Condvar,
+    seal_wait_control: Mutex<()>,
+    seal_waiters: AtomicUsize,
+    writers_drained: Condvar,
+    physical_detach_hook: OnceLock<Arc<dyn PhysicalDetachHook>>,
 }
 
 impl SegmentLifecycle {
@@ -79,8 +164,14 @@ impl SegmentLifecycle {
                 started_at: None,
                 generation: 0,
                 force_observed: false,
+                physical_detach: PhysicalDetachState::Attached,
             }),
+            drain_waiters: AtomicUsize::new(0),
             drained: Condvar::new(),
+            seal_wait_control: Mutex::new(()),
+            seal_waiters: AtomicUsize::new(0),
+            writers_drained: Condvar::new(),
+            physical_detach_hook: OnceLock::new(),
         })
     }
 
@@ -155,12 +246,62 @@ impl SegmentLifecycle {
         if packed.active_leases == 0 {
             self.drained.notify_all();
         }
-        control.snapshot(packed)
+        let snapshot = control.snapshot(packed);
+        drop(control);
+        if packed.active_leases == 0 {
+            self.try_trigger_physical_detach();
+        }
+        snapshot
     }
 
-    #[inline]
-    pub(crate) fn seal_readable(&self) -> bool {
-        self.transitions.seal_readable()
+    /// Rejects new writers and waits until every writer admitted before the seal has completed.
+    ///
+    /// The seal CAS changes the state while preserving both packed counters. A writer CAS is
+    /// therefore ordered wholly before the seal and counted, or wholly after it and rejected.
+    pub(crate) fn seal_readable_and_wait_for_writers(&self) -> Result<bool, LifecycleAcquireError> {
+        // Publish waiter presence before the seal CAS. A final writer that observes the sealed
+        // packed word acquires this publication through that CAS, so it cannot miss the waiter.
+        self.seal_waiters.fetch_add(1, Ordering::Release);
+        let started = loop {
+            match self.transitions.state() {
+                MappedFileAdmissionState::ActiveWritable if self.transitions.seal_readable() => break true,
+                MappedFileAdmissionState::ActiveWritable => continue,
+                MappedFileAdmissionState::SealedReadable => break false,
+                MappedFileAdmissionState::Closing => {
+                    self.seal_waiters.fetch_sub(1, Ordering::Release);
+                    return Err(LifecycleAcquireError::Unavailable {
+                        state: MappedFileAdmissionState::Closing,
+                        operation: MappedFileOperation::Maintenance,
+                    });
+                }
+            }
+        };
+        if self.transitions.active_writers() == 0 {
+            self.seal_waiters.fetch_sub(1, Ordering::Release);
+            return Ok(started);
+        }
+
+        let mut control = self.seal_wait_control.lock();
+        if self.transitions.active_writers() == 0 {
+            self.seal_waiters.fetch_sub(1, Ordering::Release);
+            return Ok(started);
+        }
+        while self.transitions.active_writers() != 0 {
+            self.writers_drained.wait(&mut control);
+        }
+        self.seal_waiters.fetch_sub(1, Ordering::Release);
+        Ok(started)
+    }
+
+    /// Installs the acyclic physical-owner detach callback before the mapped file is published.
+    pub(crate) fn install_physical_detach_hook(&self, hook: Arc<dyn PhysicalDetachHook>) -> bool {
+        if self.physical_detach_hook.set(hook).is_err() {
+            return false;
+        }
+        if self.logical_cleanup_marked() {
+            self.try_trigger_physical_detach();
+        }
+        true
     }
 
     pub(crate) fn snapshot(&self) -> MappedFileLifecycleSnapshot {
@@ -179,6 +320,13 @@ impl SegmentLifecycle {
         let Some(deadline) = Instant::now().checked_add(timeout) else {
             return false;
         };
+        // Register before entering the packed-word modification order. If the identity RMW wins,
+        // the final release acquires this presence publication before deciding whether to notify;
+        // if the final release wins, the identity RMW observes zero and this caller never sleeps.
+        let _presence = DrainWaiterPresence::register(&self.drain_waiters);
+        if self.transitions.active_leases_after_drain_waiter_registration() == 0 {
+            return true;
+        }
         let mut control = self.close_control.lock();
         while self.transitions.active_leases() != 0 {
             let now = Instant::now();
@@ -191,6 +339,56 @@ impl SegmentLifecycle {
             }
         }
         true
+    }
+
+    /// Publishes one already-prepared owner candidate while holding the same cold lock as Closing.
+    ///
+    /// Candidate construction and filesystem I/O must happen before this call. The closure should
+    /// only publish a fully built owner into its slot, keeping the critical section short. A lease
+    /// admitted before close still protects any owner it captured before close; a lazy candidate
+    /// that was not yet published loses the race when Closing is already visible and is dropped.
+    pub(crate) fn try_publish_before_close<L, R>(
+        &self,
+        lease: &L,
+        operation: MappedFileOperation,
+        publish: impl FnOnce() -> R,
+    ) -> Result<R, LifecycleAcquireError>
+    where
+        L: MappedFileLeaseProof + ?Sized,
+    {
+        let _control = self.close_control.lock();
+        let state = self.transitions.state();
+        if !std::ptr::eq(lease.lifecycle(), self) || lease.operation() != operation || !state.allows(operation) {
+            return Err(LifecycleAcquireError::Unavailable { state, operation });
+        }
+        Ok(publish())
+    }
+
+    /// Claims the unique physical-owner detach transition after Closing has drained.
+    ///
+    /// Dropping a claim before [`PhysicalDetachClaim::complete`] restores the attached state so a
+    /// later attempt can finish any owner slot that was not taken before an unwind or early return.
+    pub(crate) fn try_claim_physical_detach(&self) -> PhysicalDetachClaimResult<'_> {
+        let mut control = self.close_control.lock();
+        let packed = self.transitions.snapshot();
+        if packed.state != MappedFileAdmissionState::Closing || packed.active_leases != 0 {
+            return PhysicalDetachClaimResult::Pending {
+                state: packed.state,
+                active_leases: packed.active_leases,
+            };
+        }
+
+        match control.physical_detach {
+            PhysicalDetachState::Attached => {
+                control.physical_detach = PhysicalDetachState::Detaching;
+                PhysicalDetachClaimResult::Claimed(PhysicalDetachClaim {
+                    lifecycle: self,
+                    armed: true,
+                })
+            }
+            PhysicalDetachState::Detaching => PhysicalDetachClaimResult::InProgress,
+            PhysicalDetachState::Detached => PhysicalDetachClaimResult::AlreadyDetached,
+        }
     }
 
     #[inline]
@@ -210,15 +408,46 @@ impl SegmentLifecycle {
     }
 
     #[inline]
-    fn release_one(&self) -> ReleaseTransition {
-        let transition = self.transitions.release();
-        if matches!(transition, ReleaseTransition::Drained | ReleaseTransition::Remaining(0)) {
+    fn release_one(&self, operation: MappedFileOperation) -> ReleaseTransition {
+        let outcome = self.transitions.release(operation);
+        if outcome.writers_drained_after_rejection() && self.seal_waiters.load(Ordering::Acquire) != 0 {
+            let _control = self.seal_wait_control.lock();
+            self.writers_drained.notify_all();
+        }
+        let transition = outcome.transition();
+        self.finish_release_transition(transition);
+        transition
+    }
+
+    fn finish_release_transition(&self, transition: ReleaseTransition) {
+        let final_total = matches!(transition, ReleaseTransition::Drained | ReleaseTransition::Remaining(0));
+        let notify_drain_waiters = final_total && self.drain_waiters.load(Ordering::Acquire) != 0;
+        if notify_drain_waiters {
             // Pair the final release with wait_for_drain's predicate check under the same mutex so
             // the condvar notification cannot be lost between checking and sleeping.
             let _control = self.close_control.lock();
             self.drained.notify_all();
         }
-        transition
+        if transition == ReleaseTransition::Drained {
+            self.try_trigger_physical_detach();
+        }
+    }
+
+    fn try_trigger_physical_detach(&self) {
+        let Some(hook) = self.physical_detach_hook.get().cloned() else {
+            return;
+        };
+        let PhysicalDetachClaimResult::Claimed(claim) = self.try_claim_physical_detach() else {
+            return;
+        };
+
+        let detached = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| hook.detach_owner_slots()));
+        match detached {
+            Ok(()) => claim.complete(),
+            Err(_) => {
+                tracing::error!("mapped-file physical detach hook panicked; detach remains retryable");
+            }
+        }
     }
 }
 
@@ -263,7 +492,7 @@ impl MappedFileLeaseProof for MappedFileLease {
 
 impl Drop for MappedFileLease {
     fn drop(&mut self) {
-        release_armed(&self.lifecycle, &mut self.armed);
+        release_armed(&self.lifecycle, self.operation, &mut self.armed);
     }
 }
 
@@ -294,23 +523,50 @@ impl MappedFileLeaseProof for BorrowedMappedFileLease<'_> {
 
 impl Drop for BorrowedMappedFileLease<'_> {
     fn drop(&mut self) {
-        release_armed(self.lifecycle, &mut self.armed);
+        release_armed(self.lifecycle, self.operation, &mut self.armed);
     }
 }
 
 #[inline]
-fn release_armed(lifecycle: &SegmentLifecycle, armed: &mut bool) {
+fn release_armed(lifecycle: &SegmentLifecycle, operation: MappedFileOperation, armed: &mut bool) {
     if !*armed {
         return;
     }
-    let transition = lifecycle.release_one();
+    let transition = lifecycle.release_one(operation);
     debug_assert!(!matches!(transition, ReleaseTransition::Underflow));
     *armed = false;
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
     use super::*;
+
+    struct CountingDetachHook {
+        calls: AtomicUsize,
+        panic_once: AtomicBool,
+    }
+
+    impl CountingDetachHook {
+        fn new(panic_once: bool) -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                panic_once: AtomicBool::new(panic_once),
+            }
+        }
+    }
+
+    impl PhysicalDetachHook for CountingDetachHook {
+        fn detach_owner_slots(&self) {
+            self.calls.fetch_add(1, Ordering::AcqRel);
+            if self.panic_once.swap(false, Ordering::AcqRel) {
+                panic!("injected detach failure");
+            }
+        }
+    }
 
     #[test]
     fn borrowed_and_owned_leases_share_one_active_counter() {
@@ -386,5 +642,195 @@ mod tests {
 
         assert!(result.is_err());
         assert_eq!(lifecycle.snapshot().active_leases, 0);
+    }
+
+    #[test]
+    fn seal_waits_for_packed_writer_and_rejects_late_writer() {
+        let lifecycle = SegmentLifecycle::shared();
+        let writer = lifecycle
+            .try_acquire(MappedFileOperation::Write)
+            .expect("registered writer");
+        let sealer = {
+            let lifecycle = Arc::clone(&lifecycle);
+            std::thread::spawn(move || lifecycle.seal_readable_and_wait_for_writers())
+        };
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while lifecycle.state() == MappedFileAdmissionState::ActiveWritable {
+            assert!(Instant::now() < deadline, "sealer must publish write rejection");
+            std::thread::yield_now();
+        }
+        assert!(matches!(
+            lifecycle.try_acquire(MappedFileOperation::Write),
+            Err(LifecycleAcquireError::Unavailable {
+                state: MappedFileAdmissionState::SealedReadable,
+                operation: MappedFileOperation::Write,
+            })
+        ));
+        drop(writer);
+
+        assert_eq!(sealer.join().expect("sealer does not panic"), Ok(true));
+        assert_eq!(lifecycle.snapshot().active_leases, 0);
+    }
+
+    #[test]
+    fn final_release_wakes_all_registered_non_closing_drain_waiters() {
+        for seal_before_wait in [false, true] {
+            let lifecycle = SegmentLifecycle::shared();
+            if seal_before_wait {
+                assert_eq!(lifecycle.seal_readable_and_wait_for_writers(), Ok(true));
+            }
+            let lease = lifecycle.try_acquire(MappedFileOperation::Read).expect("read lease");
+            let waiters = (0..2)
+                .map(|_| {
+                    let lifecycle = Arc::clone(&lifecycle);
+                    std::thread::spawn(move || lifecycle.wait_for_drain(Duration::from_secs(5)))
+                })
+                .collect::<Vec<_>>();
+
+            let deadline = Instant::now() + Duration::from_secs(1);
+            while lifecycle.drain_waiters.load(Ordering::Acquire) != 2 {
+                assert!(Instant::now() < deadline, "drain waiters must publish their presence");
+                std::thread::yield_now();
+            }
+            drop(lease);
+
+            for waiter in waiters {
+                assert!(waiter.join().expect("drain waiter does not panic"));
+            }
+            assert_eq!(lifecycle.drain_waiters.load(Ordering::Acquire), 0);
+        }
+    }
+
+    #[test]
+    fn timed_out_drain_wait_unregisters_presence() {
+        let lifecycle = SegmentLifecycle::shared();
+        let lease = lifecycle.try_acquire(MappedFileOperation::Read).expect("read lease");
+
+        assert!(!lifecycle.wait_for_drain(Duration::ZERO));
+        assert_eq!(lifecycle.drain_waiters.load(Ordering::Acquire), 0);
+        drop(lease);
+    }
+
+    #[test]
+    fn final_typed_lease_drop_triggers_physical_detach_once() {
+        let lifecycle = SegmentLifecycle::shared();
+        let hook = Arc::new(CountingDetachHook::new(false));
+        assert!(lifecycle.install_physical_detach_hook(hook.clone()));
+        let lease = lifecycle.try_acquire(MappedFileOperation::Read).expect("read lease");
+
+        lifecycle.begin_close(u64::MAX);
+        assert_eq!(hook.calls.load(Ordering::Acquire), 0);
+        drop(lease);
+
+        assert_eq!(hook.calls.load(Ordering::Acquire), 1);
+        assert!(matches!(
+            lifecycle.try_claim_physical_detach(),
+            PhysicalDetachClaimResult::AlreadyDetached
+        ));
+        lifecycle.begin_close(0);
+        assert_eq!(hook.calls.load(Ordering::Acquire), 1);
+    }
+
+    #[test]
+    fn panicking_physical_detach_hook_is_caught_and_retryable() {
+        let lifecycle = SegmentLifecycle::shared();
+        let hook = Arc::new(CountingDetachHook::new(true));
+        assert!(lifecycle.install_physical_detach_hook(hook.clone()));
+
+        lifecycle.begin_close(u64::MAX);
+        assert_eq!(hook.calls.load(Ordering::Acquire), 1);
+        assert!(matches!(
+            lifecycle.try_claim_physical_detach(),
+            PhysicalDetachClaimResult::Claimed(_)
+        ));
+
+        lifecycle.begin_close(0);
+        assert_eq!(hook.calls.load(Ordering::Acquire), 2);
+        assert!(matches!(
+            lifecycle.try_claim_physical_detach(),
+            PhysicalDetachClaimResult::AlreadyDetached
+        ));
+    }
+
+    #[test]
+    fn physical_detach_waits_for_closing_and_every_active_lease() {
+        let lifecycle = SegmentLifecycle::shared();
+        assert!(matches!(
+            lifecycle.try_claim_physical_detach(),
+            PhysicalDetachClaimResult::Pending {
+                state: MappedFileAdmissionState::ActiveWritable,
+                active_leases: 0,
+            }
+        ));
+
+        let lease = lifecycle.try_acquire(MappedFileOperation::Read).expect("read lease");
+        lifecycle.begin_close(u64::MAX);
+        assert!(matches!(
+            lifecycle.try_claim_physical_detach(),
+            PhysicalDetachClaimResult::Pending {
+                state: MappedFileAdmissionState::Closing,
+                active_leases: 1,
+            }
+        ));
+
+        drop(lease);
+        assert!(matches!(
+            lifecycle.try_claim_physical_detach(),
+            PhysicalDetachClaimResult::Claimed(_)
+        ));
+    }
+
+    #[test]
+    fn physical_detach_claim_is_retryable_on_drop_and_exactly_once_after_commit() {
+        let lifecycle = SegmentLifecycle::shared();
+        lifecycle.begin_close(u64::MAX);
+
+        let first = match lifecycle.try_claim_physical_detach() {
+            PhysicalDetachClaimResult::Claimed(claim) => claim,
+            _ => panic!("first drained close must claim detach"),
+        };
+        assert!(matches!(
+            lifecycle.try_claim_physical_detach(),
+            PhysicalDetachClaimResult::InProgress
+        ));
+        drop(first);
+
+        let retry = match lifecycle.try_claim_physical_detach() {
+            PhysicalDetachClaimResult::Claimed(claim) => claim,
+            _ => panic!("dropped detach claim must be retryable"),
+        };
+        retry.complete();
+        assert!(matches!(
+            lifecycle.try_claim_physical_detach(),
+            PhysicalDetachClaimResult::AlreadyDetached
+        ));
+    }
+
+    #[test]
+    fn publication_and_close_share_one_linearization_lock() {
+        let lifecycle = SegmentLifecycle::shared();
+        let first = lifecycle
+            .try_acquire_borrowed(MappedFileOperation::Read)
+            .expect("publication lease");
+        assert_eq!(
+            lifecycle
+                .try_publish_before_close(&first, MappedFileOperation::Read, || 7)
+                .expect("publication before close"),
+            7
+        );
+        drop(first);
+
+        let losing_candidate = lifecycle
+            .try_acquire_borrowed(MappedFileOperation::Read)
+            .expect("pre-close lazy candidate lease");
+        lifecycle.begin_close(u64::MAX);
+        assert!(matches!(
+            lifecycle.try_publish_before_close(&losing_candidate, MappedFileOperation::Read, || 9),
+            Err(LifecycleAcquireError::Unavailable {
+                state: MappedFileAdmissionState::Closing,
+                operation: MappedFileOperation::Read,
+            })
+        ));
     }
 }

--- a/rocketmq-store-local/src/mapped_file/lifecycle_model.rs
+++ b/rocketmq-store-local/src/mapped_file/lifecycle_model.rs
@@ -90,9 +90,32 @@ pub(crate) enum ReleaseTransition {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ReleaseOutcome {
+    transition: ReleaseTransition,
+    writers_drained_after_rejection: bool,
+}
+
+impl ReleaseOutcome {
+    #[inline]
+    pub(crate) const fn transition(self) -> ReleaseTransition {
+        self.transition
+    }
+
+    /// Returns whether this release removed the final writer after writes were rejected.
+    ///
+    /// `Closing` is included because close may overtake an already-published seal while its waiter
+    /// is still draining the writers admitted before that seal.
+    #[inline]
+    pub(crate) const fn writers_drained_after_rejection(self) -> bool {
+        self.writers_drained_after_rejection
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct LifecyclePackedSnapshot {
     pub(crate) state: MappedFileAdmissionState,
     pub(crate) active_leases: usize,
+    pub(crate) active_writers: usize,
 }
 
 /// Minimal atomic facade shared by the production implementation and Loom.
@@ -135,10 +158,15 @@ impl LifecycleAtomicUsize for AtomicUsize {
     }
 }
 
-const STATE_BITS: usize = 2;
-const STATE_SHIFT: u32 = usize::BITS - STATE_BITS as u32;
-const ACTIVE_LEASE_MASK: usize = usize::MAX >> STATE_BITS;
-const STATE_MASK: usize = !ACTIVE_LEASE_MASK;
+const STATE_BITS: u32 = 2;
+const COUNTER_BITS: u32 = (usize::BITS - STATE_BITS) / 2;
+const ACTIVE_LEASE_MASK: usize = (1usize << COUNTER_BITS) - 1;
+const ACTIVE_WRITER_SHIFT: u32 = COUNTER_BITS;
+const ACTIVE_WRITER_UNIT: usize = 1usize << ACTIVE_WRITER_SHIFT;
+const ACTIVE_WRITER_MASK: usize = ACTIVE_LEASE_MASK << ACTIVE_WRITER_SHIFT;
+const ACTIVE_COUNT_MASK: usize = ACTIVE_LEASE_MASK | ACTIVE_WRITER_MASK;
+const STATE_SHIFT: u32 = ACTIVE_WRITER_SHIFT + COUNTER_BITS;
+const STATE_MASK: usize = !ACTIVE_COUNT_MASK;
 
 #[inline]
 const fn encode_state(state: MappedFileAdmissionState) -> usize {
@@ -154,11 +182,19 @@ const fn decode_state(word: usize) -> MappedFileAdmissionState {
     }
 }
 
+#[inline]
+const fn decode_active_writers(word: usize) -> usize {
+    (word & ACTIVE_WRITER_MASK) >> ACTIVE_WRITER_SHIFT
+}
+
 /// Lock-free lifecycle transitions shared by production and Loom tests.
 ///
-/// The high two bits encode the admission state and the remaining bits encode the active lease
-/// count. Every admission-state transition and lease-count change is linearized by one CAS on the
-/// packed word, so a close cannot race with a successful post-close admission.
+/// The high two bits encode admission state; the remaining bits are split evenly between total
+/// leases and writer leases. Every state transition and count change is linearized by one CAS, so
+/// a write is either wholly counted before seal or wholly rejected after it.
+///
+/// Each counter is limited to 32,767 on 32-bit targets and 2,147,483,647 on 64-bit targets.
+/// Admission fails closed with `LeaseCountOverflow` instead of wrapping either packed field.
 #[derive(Debug)]
 pub(crate) struct LifecycleTransitionState<A: LifecycleAtomicUsize = AtomicUsize> {
     word: A,
@@ -178,6 +214,7 @@ impl<A: LifecycleAtomicUsize> LifecycleTransitionState<A> {
         LifecyclePackedSnapshot {
             state: decode_state(word),
             active_leases: word & ACTIVE_LEASE_MASK,
+            active_writers: decode_active_writers(word),
         }
     }
 
@@ -189,6 +226,30 @@ impl<A: LifecycleAtomicUsize> LifecycleTransitionState<A> {
     #[inline]
     pub(crate) fn active_leases(&self) -> usize {
         self.snapshot().active_leases
+    }
+
+    #[inline]
+    pub(crate) fn active_writers(&self) -> usize {
+        self.snapshot().active_writers
+    }
+
+    /// Publishes a drain-waiter registration into the packed-word modification order.
+    ///
+    /// The caller publishes presence before this identity RMW. If this RMW precedes the final
+    /// release, that release acquires the RMW's release sequence before checking presence. If a
+    /// final release precedes this RMW and no newer admission intervenes, the returned count is
+    /// zero and the caller must not sleep. A newer admission is included in the returned count and
+    /// its later final release acquires the same registration through the all-RMW modification
+    /// sequence.
+    #[inline]
+    pub(crate) fn active_leases_after_drain_waiter_registration(&self) -> usize {
+        let mut current = self.word.load_acquire();
+        loop {
+            match self.word.compare_exchange_weak_acq_rel(current, current) {
+                Ok(_) => return current & ACTIVE_LEASE_MASK,
+                Err(observed) => current = observed,
+            }
+        }
     }
 
     #[inline]
@@ -205,7 +266,12 @@ impl<A: LifecycleAtomicUsize> LifecycleTransitionState<A> {
                 return Err(AcquireTransitionError::LeaseCountOverflow);
             }
 
-            let next = current + 1;
+            let active_writers = decode_active_writers(current);
+            if operation == MappedFileOperation::Write && active_writers == ACTIVE_LEASE_MASK {
+                return Err(AcquireTransitionError::LeaseCountOverflow);
+            }
+
+            let next = current + 1 + usize::from(operation == MappedFileOperation::Write) * ACTIVE_WRITER_UNIT;
             match self.word.compare_exchange_weak_acquire(current, next) {
                 Ok(_) => return Ok(()),
                 Err(observed) => current = observed,
@@ -214,20 +280,33 @@ impl<A: LifecycleAtomicUsize> LifecycleTransitionState<A> {
     }
 
     #[inline]
-    pub(crate) fn release(&self) -> ReleaseTransition {
+    pub(crate) fn release(&self, operation: MappedFileOperation) -> ReleaseOutcome {
         let mut current = self.word.load_acquire();
         loop {
             let active_leases = current & ACTIVE_LEASE_MASK;
-            if active_leases == 0 {
-                return ReleaseTransition::Underflow;
+            let active_writers = decode_active_writers(current);
+            if active_leases == 0 || (operation == MappedFileOperation::Write && active_writers == 0) {
+                return ReleaseOutcome {
+                    transition: ReleaseTransition::Underflow,
+                    writers_drained_after_rejection: false,
+                };
             }
 
-            let next = current - 1;
+            let state = decode_state(current);
+            let next = current - 1 - usize::from(operation == MappedFileOperation::Write) * ACTIVE_WRITER_UNIT;
             match self.word.compare_exchange_weak_acq_rel_relaxed(current, next) {
-                Ok(_) if active_leases == 1 && decode_state(current) == MappedFileAdmissionState::Closing => {
-                    return ReleaseTransition::Drained;
+                Ok(_) => {
+                    return ReleaseOutcome {
+                        transition: if active_leases == 1 && state == MappedFileAdmissionState::Closing {
+                            ReleaseTransition::Drained
+                        } else {
+                            ReleaseTransition::Remaining(active_leases - 1)
+                        },
+                        writers_drained_after_rejection: operation == MappedFileOperation::Write
+                            && active_writers == 1
+                            && state != MappedFileAdmissionState::ActiveWritable,
+                    };
                 }
-                Ok(_) => return ReleaseTransition::Remaining(active_leases - 1),
                 Err(observed) => current = observed,
             }
         }
@@ -241,7 +320,7 @@ impl<A: LifecycleAtomicUsize> LifecycleTransitionState<A> {
                 return BeginCloseTransition::AlreadyClosing;
             }
 
-            let next = (current & ACTIVE_LEASE_MASK) | encode_state(MappedFileAdmissionState::Closing);
+            let next = (current & ACTIVE_COUNT_MASK) | encode_state(MappedFileAdmissionState::Closing);
             match self.word.compare_exchange_weak_acq_rel(current, next) {
                 Ok(_) => return BeginCloseTransition::Started,
                 Err(observed) => current = observed,
@@ -257,7 +336,7 @@ impl<A: LifecycleAtomicUsize> LifecycleTransitionState<A> {
                 return false;
             }
 
-            let next = (current & ACTIVE_LEASE_MASK) | encode_state(MappedFileAdmissionState::SealedReadable);
+            let next = (current & ACTIVE_COUNT_MASK) | encode_state(MappedFileAdmissionState::SealedReadable);
             match self.word.compare_exchange_weak_acq_rel(current, next) {
                 Ok(_) => return true,
                 Err(observed) => current = observed,

--- a/rocketmq-store-local/src/mapped_file/lifecycle_outcome.rs
+++ b/rocketmq-store-local/src/mapped_file/lifecycle_outcome.rs
@@ -14,6 +14,8 @@
 
 use std::io;
 
+use super::MappedFileAdmissionState;
+
 /// Result of one mapped-file namespace deletion attempt.
 ///
 /// This type deliberately separates a live-reference deferral from a filesystem failure. A
@@ -43,5 +45,41 @@ impl MappedFileDestroyOutcome {
     #[inline]
     pub fn is_namespace_removed(&self) -> bool {
         matches!(self, Self::NamespaceRemoved)
+    }
+}
+
+/// Result of one in-process physical-owner detach attempt.
+///
+/// Detaching removes the mapping and file owners from the mapped-file slots. It does not claim
+/// that an external owner has already been dropped, that the operating system has completed an
+/// unmap/last-close, or that the path was removed from the filesystem namespace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[must_use]
+pub enum MappedFileDetachOutcome {
+    /// This call detached both owner slots.
+    Detached {
+        /// Published mapping generation removed from the slot, when one existed.
+        mapping_generation: Option<u64>,
+        /// Whether the file-owner slot contained an owner.
+        had_file_owner: bool,
+    },
+    /// A previous call already detached both slots.
+    AlreadyDetached,
+    /// Another caller currently owns the detach transition.
+    InProgress,
+    /// Closing has not drained every admitted operation.
+    Pending {
+        /// Admission state observed while attempting detach.
+        state: MappedFileAdmissionState,
+        /// Number of admitted operations that must still complete.
+        active_leases: usize,
+    },
+}
+
+impl MappedFileDetachOutcome {
+    /// Returns whether both physical owner slots are detached after this result.
+    #[inline]
+    pub fn is_detached(self) -> bool {
+        matches!(self, Self::Detached { .. } | Self::AlreadyDetached)
     }
 }

--- a/rocketmq-store-local/src/mapped_file/mapped_file_error.rs
+++ b/rocketmq-store-local/src/mapped_file/mapped_file_error.rs
@@ -126,7 +126,10 @@ pub enum MappedFileError {
         operation: MappedFileOperation,
     },
 
-    /// The active lease counter cannot represent another admitted operation.
+    /// The packed lifecycle cannot represent another total or writer lease.
+    ///
+    /// Total and writer counters are each limited to 32,767 on 32-bit targets and 2,147,483,647 on
+    /// 64-bit targets. Admission fails closed with this typed error before either field wraps.
     #[error("Mapped-file active lease count overflow")]
     LeaseCountOverflow,
 

--- a/rocketmq-store-local/src/mapped_file/mapping.rs
+++ b/rocketmq-store-local/src/mapped_file/mapping.rs
@@ -12,13 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::atomic::AtomicU64;
-use std::sync::atomic::Ordering;
-use std::sync::OnceLock;
-use std::time::Instant;
-
-use parking_lot::Mutex;
-
 /// Aggregate statistics for lazy mapped-file initialization.
 ///
 /// Eager mappings report the default value because they are not eligible for lazy initialization.
@@ -48,125 +41,6 @@ impl LazyMmapStats {
         self.total_millis = self.total_millis.saturating_add(other.total_millis);
         if other.last_millis != 0 {
             self.last_millis = other.last_millis;
-        }
-    }
-}
-
-/// Owns the deterministic eager/lazy initialization lifecycle for one mapped-file value.
-///
-/// The mapped value remains generic so callers retain ownership of the concrete mmap and its
-/// compatibility wrapper. Lazy initialization is serialized, while already-initialized reads do
-/// not acquire the initialization lock.
-pub struct MappedFileMapping<M> {
-    value: OnceLock<M>,
-    init_lock: Mutex<()>,
-    lazy_enabled: bool,
-    map_operations: AtomicU64,
-    map_failures: AtomicU64,
-    total_millis: AtomicU64,
-    last_millis: AtomicU64,
-}
-
-impl<M> MappedFileMapping<M> {
-    /// Creates an eagerly initialized mapping.
-    ///
-    /// Eager mappings are not counted as lazy-eligible or lazily mapped files.
-    pub fn new_eager(value: M) -> Self {
-        Self {
-            value: OnceLock::from(value),
-            init_lock: Mutex::new(()),
-            lazy_enabled: false,
-            map_operations: AtomicU64::new(0),
-            map_failures: AtomicU64::new(0),
-            total_millis: AtomicU64::new(0),
-            last_millis: AtomicU64::new(0),
-        }
-    }
-
-    /// Creates an uninitialized mapping eligible for lazy initialization.
-    pub fn new_lazy() -> Self {
-        Self {
-            value: OnceLock::new(),
-            init_lock: Mutex::new(()),
-            lazy_enabled: true,
-            map_operations: AtomicU64::new(0),
-            map_failures: AtomicU64::new(0),
-            total_millis: AtomicU64::new(0),
-            last_millis: AtomicU64::new(0),
-        }
-    }
-
-    /// Returns whether this mapping was configured for lazy initialization.
-    #[inline]
-    pub fn is_lazy_enabled(&self) -> bool {
-        self.lazy_enabled
-    }
-
-    /// Returns whether the mapping value has been initialized.
-    #[inline]
-    pub fn is_mapped(&self) -> bool {
-        self.value.get().is_some()
-    }
-
-    /// Returns the initialized mapping value, if present.
-    #[inline]
-    pub fn get(&self) -> Option<&M> {
-        self.value.get()
-    }
-
-    /// Returns a snapshot of independently updated lazy initialization counters.
-    ///
-    /// Fields may reflect concurrent updates observed at different instants.
-    pub fn stats(&self) -> LazyMmapStats {
-        LazyMmapStats {
-            eligible_files: u64::from(self.lazy_enabled),
-            mapped_files: u64::from(self.lazy_enabled && self.is_mapped()),
-            map_operations: self.map_operations.load(Ordering::Acquire),
-            map_failures: self.map_failures.load(Ordering::Acquire),
-            total_millis: self.total_millis.load(Ordering::Acquire),
-            last_millis: self.last_millis.load(Ordering::Acquire),
-        }
-    }
-
-    /// Returns the existing value or initializes it with `initializer` exactly once.
-    ///
-    /// Concurrent callers double-check the cell while holding the initialization lock, so only
-    /// one successful initializer runs. A failed attempt increments the failure count, leaves the
-    /// cell uninitialized, and permits a later caller to retry.
-    ///
-    /// # Errors
-    ///
-    /// Returns the initializer error without storing a value when initialization fails.
-    pub fn get_or_try_init<E, F>(&self, initializer: F) -> Result<&M, E>
-    where
-        F: FnOnce() -> Result<M, E>,
-    {
-        if let Some(value) = self.value.get() {
-            return Ok(value);
-        }
-
-        let _guard = self.init_lock.lock();
-        if let Some(value) = self.value.get() {
-            return Ok(value);
-        }
-
-        let start = Instant::now();
-        match initializer() {
-            Ok(value) => {
-                let elapsed_millis = start.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
-                if self.lazy_enabled {
-                    self.map_operations.fetch_add(1, Ordering::AcqRel);
-                    self.total_millis.fetch_add(elapsed_millis, Ordering::AcqRel);
-                    self.last_millis.store(elapsed_millis, Ordering::Release);
-                }
-                Ok(self.value.get_or_init(|| value))
-            }
-            Err(error) => {
-                if self.lazy_enabled {
-                    self.map_failures.fetch_add(1, Ordering::AcqRel);
-                }
-                Err(error)
-            }
         }
     }
 }

--- a/rocketmq-store-local/src/mapped_file/memory.rs
+++ b/rocketmq-store-local/src/mapped_file/memory.rs
@@ -14,10 +14,9 @@
 
 use std::fs::File;
 use std::io;
-use std::ops::Deref;
 use std::ops::Range;
-use std::sync::Arc;
 
+use memmap2::Mmap;
 use memmap2::MmapMut;
 
 /// Failure to construct a safe view over a mapped range.
@@ -35,20 +34,25 @@ pub enum MmapRangeError {
     },
 }
 
-/// Memory-mapping backend used by the canonical local mapped-file owner.
+/// Writable memory-mapping backend used by an active mapped-file generation.
 ///
 /// # Safety
 ///
-/// Implementors must keep returned slices and regions backed by the same live mapping, serialize
-/// mutable access so it cannot race with reads or writes, reject overflowing or out-of-bounds
-/// regions before construction, and keep the mapping valid independently of compatible file-handle
-/// rename/reopen operations.
-pub unsafe trait MappedMemory: Clone + Send + Sync + 'static {
-    /// Owned immutable region suitable for zero-copy byte ownership.
-    type Region: AsRef<[u8]> + Send + Sync + 'static;
+/// Implementors must keep returned slices backed by the same live mapping, keep the mapped address
+/// stable for the complete value lifetime, serialize mutable access so it cannot race with safe
+/// reads, and keep the mapping valid independently of compatible file-handle rename operations.
+pub unsafe trait MappedMemory: Send + Sync + Sized + 'static {
+    /// Read-only mapping created when the writable generation is sealed.
+    type ReadOnly: ReadOnlyMappedMemory;
 
     /// Maps the complete file as writable memory.
-    fn map_mut(file: &File) -> io::Result<Self>;
+    ///
+    /// # Safety
+    ///
+    /// The caller must keep the file at least as large as the returned mapping and prevent
+    /// uncoordinated writes or truncation for the complete mapping lifetime. The returned value
+    /// must immediately enter an owner-bound generation before safe access is exposed.
+    unsafe fn map_mut(file: &File) -> io::Result<Self>;
 
     /// Returns the complete mapping as bytes.
     fn as_slice(&self) -> &[u8];
@@ -94,45 +98,49 @@ pub unsafe trait MappedMemory: Clone + Send + Sync + 'static {
 
     /// Flushes one mapped range.
     fn flush_range(&self, offset: usize, len: usize) -> io::Result<()>;
+}
 
-    /// Creates an owned immutable view over one mapped range.
+/// Read-only memory-mapping backend used by a sealed mapped-file generation.
+///
+/// # Safety
+///
+/// Implementors must keep the mapped address stable for the complete value lifetime and must not
+/// expose any mutation path for the mapped allocation. The file must not be resized or modified by
+/// another writable mapping while a value of this type is live.
+pub unsafe trait ReadOnlyMappedMemory: Send + Sync + Sized + 'static {
+    /// Maps the complete file as read-only memory.
     ///
-    /// # Errors
+    /// # Safety
     ///
-    /// Returns [`MmapRangeError::Overflow`] when `offset + len` cannot be
-    /// represented, or [`MmapRangeError::OutOfBounds`] when it exceeds the
-    /// mapping.
-    fn region(&self, offset: usize, len: usize) -> Result<Self::Region, MmapRangeError>;
+    /// The caller must keep the file at least as large as the returned mapping and prevent writes
+    /// through every writable mapping, direct file write, and truncation for the complete mapping
+    /// lifetime. The returned value must immediately enter an owner-bound read-only generation.
+    unsafe fn map(file: &File) -> io::Result<Self>;
+
+    /// Returns the complete immutable mapping as bytes.
+    fn as_slice(&self) -> &[u8];
 }
 
 /// Native writable mmap backend used by the default Local mapped-file owner.
-#[derive(Clone)]
 pub struct NativeMappedMemory {
-    mmap: Arc<MmapMut>,
+    mmap: MmapMut,
 }
 
-impl NativeMappedMemory {
-    /// Returns another owner for the live native mapping.
-    pub fn clone_mmap(&self) -> Arc<MmapMut> {
-        self.mmap.clone()
-    }
-}
-
-// SAFETY: construction maps an already-sized segment and `Arc` keeps that mapping alive across
-// cloned regions. Mutable access follows the mapped-file contract requiring callers to serialize
-// writes through the CommitLog/mapped-file ownership boundary.
+// SAFETY: construction maps an already-sized segment and the enclosing mapping generation keeps
+// this value alive. Mutable access follows the mapped-file contract requiring callers to serialize
+// writes through the CommitLog/mapped-file ownership boundary; this type is not cloneable.
 unsafe impl MappedMemory for NativeMappedMemory {
-    type Region = MmapRegionSlice;
+    type ReadOnly = NativeReadOnlyMappedMemory;
 
-    fn map_mut(file: &File) -> io::Result<Self> {
+    unsafe fn map_mut(file: &File) -> io::Result<Self> {
         // SAFETY: callers size the segment before mapping and do not resize it while the mapping is
         // live. NativeMappedMemory keeps the mapping alive independently of the file handle.
         let mmap = unsafe { MmapMut::map_mut(file)? };
-        Ok(Self { mmap: Arc::new(mmap) })
+        Ok(Self { mmap })
     }
 
     fn as_slice(&self) -> &[u8] {
-        self.mmap.as_ref()
+        &self.mmap
     }
 
     fn as_mut_ptr(&self) -> *mut u8 {
@@ -146,33 +154,32 @@ unsafe impl MappedMemory for NativeMappedMemory {
     fn flush_range(&self, offset: usize, len: usize) -> io::Result<()> {
         self.mmap.flush_range(offset, len)
     }
+}
 
-    fn region(&self, offset: usize, len: usize) -> Result<Self::Region, MmapRangeError> {
-        MmapRegionSlice::try_new(self.mmap.clone(), offset, len)
+/// Native read-only mmap backend used after a writable generation is sealed.
+pub struct NativeReadOnlyMappedMemory {
+    mmap: Mmap,
+}
+
+// SAFETY: construction creates a read-only mapping for an already-sized segment. The generation
+// owner keeps it alive, and this type exposes no mutation path.
+unsafe impl ReadOnlyMappedMemory for NativeReadOnlyMappedMemory {
+    unsafe fn map(file: &File) -> io::Result<Self> {
+        // SAFETY: callers keep the file sized and stable while the read-only generation is live.
+        let mmap = unsafe { Mmap::map(file)? };
+        Ok(Self { mmap })
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        &self.mmap
     }
 }
 
-/// Immutable owner for one region of a native mapping.
-pub struct MmapRegionSlice {
-    mmap: Arc<MmapMut>,
-    range: Range<usize>,
-}
-
-impl MmapRegionSlice {
-    /// Creates a checked region backed by a live native mapping.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`MmapRangeError::Overflow`] when `offset + len` cannot be
-    /// represented, or [`MmapRangeError::OutOfBounds`] when the resulting range
-    /// exceeds the mapping.
-    pub fn try_new(mmap: Arc<MmapMut>, offset: usize, len: usize) -> Result<Self, MmapRangeError> {
-        let range = checked_mmap_range(mmap.len(), offset, len)?;
-        Ok(Self { mmap, range })
-    }
-}
-
-fn checked_mmap_range(mapping_len: usize, offset: usize, len: usize) -> Result<Range<usize>, MmapRangeError> {
+pub(crate) fn checked_mmap_range(
+    mapping_len: usize,
+    offset: usize,
+    len: usize,
+) -> Result<Range<usize>, MmapRangeError> {
     let end = offset
         .checked_add(len)
         .ok_or(MmapRangeError::Overflow { offset, len })?;
@@ -184,20 +191,6 @@ fn checked_mmap_range(mapping_len: usize, offset: usize, len: usize) -> Result<R
         });
     }
     Ok(offset..end)
-}
-
-impl Deref for MmapRegionSlice {
-    type Target = [u8];
-
-    fn deref(&self) -> &Self::Target {
-        &self.mmap[self.range.clone()]
-    }
-}
-
-impl AsRef<[u8]> for MmapRegionSlice {
-    fn as_ref(&self) -> &[u8] {
-        self
-    }
 }
 
 #[cfg(test)]

--- a/rocketmq-store-local/src/mapped_file/metrics.rs
+++ b/rocketmq-store-local/src/mapped_file/metrics.rs
@@ -14,8 +14,44 @@
 
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
+
+/// Owner-bound gauge guard for one live mapping generation.
+///
+/// The guard is deliberately non-cloneable. Its constructor performs the only matching gauge
+/// increment and its [`Drop`] implementation performs the decrement and physical-drop count.
+pub(crate) struct MappingGenerationGaugeGuard {
+    metrics: Arc<MappedFileMetrics>,
+    mapped_bytes: u64,
+}
+
+impl Drop for MappingGenerationGaugeGuard {
+    fn drop(&mut self) {
+        self.metrics.mapped_generations_live.fetch_sub(1, Ordering::Relaxed);
+        self.metrics
+            .mapped_bytes_live
+            .fetch_sub(self.mapped_bytes, Ordering::Relaxed);
+        self.metrics.physical_mapping_drop_total.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Owner-bound gauge guard for one live operating-system file owner.
+///
+/// Moving the guard into `FileOwner` binds the live gauge to the final `Arc<FileOwner>` drop.
+pub(crate) struct FileOwnerGaugeGuard {
+    metrics: Arc<MappedFileMetrics>,
+}
+
+impl Drop for FileOwnerGaugeGuard {
+    fn drop(&mut self) {
+        self.metrics.file_owners_live.fetch_sub(1, Ordering::Relaxed);
+        self.metrics
+            .physical_file_owner_drop_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+}
 
 /// Performance metrics for mapped file operations.
 ///
@@ -92,6 +128,24 @@ pub struct MappedFileMetrics {
     /// Number of swapped-map cleanup decisions.
     clean_swap_operations: AtomicU64,
 
+    /// Number of mapping generations with a live physical owner.
+    mapped_generations_live: AtomicU64,
+
+    /// Number of bytes covered by live mapping generations.
+    mapped_bytes_live: AtomicU64,
+
+    /// Number of live canonical operating-system file owners.
+    file_owners_live: AtomicU64,
+
+    /// Number of mapping generations whose final owner has dropped.
+    physical_mapping_drop_total: AtomicU64,
+
+    /// Number of canonical file owners whose final owner has dropped.
+    physical_file_owner_drop_total: AtomicU64,
+
+    /// Number of mapping/file slot detach winners.
+    lifecycle_detach_total: AtomicU64,
+
     /// Timestamp when metrics collection started
     start_time: Instant,
 }
@@ -127,7 +181,35 @@ impl MappedFileMetrics {
             last_warm_time_ms: AtomicU64::new(0),
             swap_operations: AtomicU64::new(0),
             clean_swap_operations: AtomicU64::new(0),
+            mapped_generations_live: AtomicU64::new(0),
+            mapped_bytes_live: AtomicU64::new(0),
+            file_owners_live: AtomicU64::new(0),
+            physical_mapping_drop_total: AtomicU64::new(0),
+            physical_file_owner_drop_total: AtomicU64::new(0),
+            lifecycle_detach_total: AtomicU64::new(0),
             start_time: Instant::now(),
+        }
+    }
+
+    /// Starts tracking one mapping generation until the returned guard is dropped.
+    ///
+    /// The live byte sum cannot exceed the process address space, so its `u64` representation and
+    /// matching atomic add/subtract are exact on supported targets.
+    pub(crate) fn track_mapping_generation(self: &Arc<Self>, mapped_bytes: usize) -> MappingGenerationGaugeGuard {
+        let mapped_bytes = mapped_bytes as u64;
+        self.mapped_generations_live.fetch_add(1, Ordering::Relaxed);
+        self.mapped_bytes_live.fetch_add(mapped_bytes, Ordering::Relaxed);
+        MappingGenerationGaugeGuard {
+            metrics: Arc::clone(self),
+            mapped_bytes,
+        }
+    }
+
+    /// Starts tracking one canonical file owner until the returned guard is dropped.
+    pub(crate) fn track_file_owner(self: &Arc<Self>) -> FileOwnerGaugeGuard {
+        self.file_owners_live.fetch_add(1, Ordering::Relaxed);
+        FileOwnerGaugeGuard {
+            metrics: Arc::clone(self),
         }
     }
 
@@ -296,6 +378,48 @@ impl MappedFileMetrics {
         self.clean_swap_operations.load(Ordering::Relaxed)
     }
 
+    /// Returns the number of live mapping generation owners.
+    #[inline]
+    pub fn mapped_generations_live(&self) -> u64 {
+        self.mapped_generations_live.load(Ordering::Relaxed)
+    }
+
+    /// Returns the number of bytes covered by live mapping generation owners.
+    #[inline]
+    pub fn mapped_bytes_live(&self) -> u64 {
+        self.mapped_bytes_live.load(Ordering::Relaxed)
+    }
+
+    /// Returns the number of live canonical file owners.
+    #[inline]
+    pub fn file_owners_live(&self) -> u64 {
+        self.file_owners_live.load(Ordering::Relaxed)
+    }
+
+    /// Returns the number of mapping generations released by their final owner.
+    #[inline]
+    pub fn physical_mapping_drop_total(&self) -> u64 {
+        self.physical_mapping_drop_total.load(Ordering::Relaxed)
+    }
+
+    /// Returns the number of canonical file owners released by their final owner.
+    #[inline]
+    pub fn physical_file_owner_drop_total(&self) -> u64 {
+        self.physical_file_owner_drop_total.load(Ordering::Relaxed)
+    }
+
+    /// Records one mapping/file slot detach winner.
+    #[inline]
+    pub(crate) fn record_lifecycle_detach(&self) {
+        self.lifecycle_detach_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Returns the number of mapping/file slot detach winners.
+    #[inline]
+    pub fn lifecycle_detach_total(&self) -> u64 {
+        self.lifecycle_detach_total.load(Ordering::Relaxed)
+    }
+
     /// Calculates write operations per second.
     ///
     /// # Returns
@@ -394,9 +518,11 @@ impl MappedFileMetrics {
         }
     }
 
-    /// Resets all metrics to zero.
+    /// Resets operation metrics to zero.
     ///
-    /// Also resets the start time to the current instant.
+    /// Owner-bound live gauges and physical-drop totals are deliberately preserved: resetting them
+    /// while guards are live would make the matching `Drop` decrement asymmetric. The start time is
+    /// reset to the current instant.
     pub fn reset(&mut self) {
         self.total_writes.store(0, Ordering::Relaxed);
         self.total_bytes_written.store(0, Ordering::Relaxed);
@@ -425,7 +551,8 @@ impl MappedFileMetrics {
         format!(
             "MappedFile Metrics:\nWrites: {} ({:.2} writes/sec, {:.2} MB/s)\nReads: {} ({:.1}% zero-copy)\nFlushes: \
              {} (avg: {:?})\nCache Hit Rate: {:.1}%\nAvg Write Size: {:.1} bytes\nWarm: {} ops, {} bytes, total {} \
-             ms, last {} ms\nSwap: {} ops, clean: {} ops",
+             ms, last {} ms\nSwap: {} ops, clean: {} ops\nPhysical owners: {} mappings / {} bytes, {} files; drops: {} \
+             mappings, {} files; detach: {}",
             self.total_writes(),
             self.writes_per_sec(),
             self.write_throughput_mb_per_sec(),
@@ -440,7 +567,13 @@ impl MappedFileMetrics {
             self.total_warm_millis(),
             self.last_warm_millis(),
             self.swap_operations(),
-            self.clean_swap_operations()
+            self.clean_swap_operations(),
+            self.mapped_generations_live(),
+            self.mapped_bytes_live(),
+            self.file_owners_live(),
+            self.physical_mapping_drop_total(),
+            self.physical_file_owner_drop_total(),
+            self.lifecycle_detach_total()
         )
     }
 }
@@ -451,6 +584,8 @@ fn duration_to_millis(duration: Duration) -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
 
     #[test]
@@ -540,5 +675,33 @@ mod tests {
 
         assert_eq!(metrics.total_writes(), 0);
         assert_eq!(metrics.total_flushes(), 0);
+    }
+
+    #[test]
+    fn mapping_generation_gauge_tracks_owner_lifetime_symmetrically() {
+        let metrics = Arc::new(MappedFileMetrics::new());
+
+        let guard = metrics.track_mapping_generation(4096);
+        assert_eq!(metrics.mapped_generations_live(), 1);
+        assert_eq!(metrics.mapped_bytes_live(), 4096);
+        assert_eq!(metrics.physical_mapping_drop_total(), 0);
+
+        drop(guard);
+        assert_eq!(metrics.mapped_generations_live(), 0);
+        assert_eq!(metrics.mapped_bytes_live(), 0);
+        assert_eq!(metrics.physical_mapping_drop_total(), 1);
+    }
+
+    #[test]
+    fn file_owner_gauge_tracks_owner_lifetime_symmetrically() {
+        let metrics = Arc::new(MappedFileMetrics::new());
+
+        let guard = metrics.track_file_owner();
+        assert_eq!(metrics.file_owners_live(), 1);
+        assert_eq!(metrics.physical_file_owner_drop_total(), 0);
+
+        drop(guard);
+        assert_eq!(metrics.file_owners_live(), 0);
+        assert_eq!(metrics.physical_file_owner_drop_total(), 1);
     }
 }

--- a/rocketmq-store-local/src/transfer/segment.rs
+++ b/rocketmq-store-local/src/transfer/segment.rs
@@ -12,18 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
 use std::fs::File;
+use std::io;
+use std::ops::Range;
 use std::sync::Arc;
 
 use bytes::Bytes;
 
+use crate::mapped_file::file::FileOwner;
 use crate::mapped_file::lifecycle::MappedFileLease;
+#[cfg(test)]
 use crate::mapped_file::DefaultMappedFile;
 use crate::mapped_file::MappedFile;
+use crate::mapped_file::MappedFileMetrics;
 use crate::mapped_file::NativeMappedMemory;
 use crate::mapped_file::SelectMappedBufferCacheState;
 use crate::mapped_file::SelectMappedBufferResult;
 
+#[cfg(test)]
 type NativeDefaultMappedFile = DefaultMappedFile<NativeMappedMemory>;
 type NativeSelectMappedBufferResult = SelectMappedBufferResult<NativeMappedMemory>;
 
@@ -45,13 +52,7 @@ impl From<SelectMappedBufferCacheState> for TransferCacheState {
 }
 
 enum SegmentSource {
-    Mmap {
-        _mapped_file: Arc<NativeDefaultMappedFile>,
-    },
-    FileRange {
-        file: Arc<File>,
-        _mapped_file: Option<Arc<NativeDefaultMappedFile>>,
-    },
+    FileRange { lease: FileRangeLease },
     Bytes,
 }
 
@@ -64,23 +65,121 @@ pub struct CommitLogSegment {
     cache_state: TransferCacheState,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CheckedFileRange {
+    bounds: Range<u64>,
+}
+
+enum FileRangeOperationLease {
+    Mapped {
+        _lease: MappedFileLease,
+    },
+    Standalone,
+    #[cfg(test)]
+    Probe {
+        _probe: OperationDropProbe,
+    },
+}
+
+#[cfg(test)]
+struct OperationDropProbe {
+    metrics: Arc<MappedFileMetrics>,
+    observed_file_owners: Arc<std::sync::atomic::AtomicU64>,
+}
+
+#[cfg(test)]
+impl Drop for OperationDropProbe {
+    fn drop(&mut self) {
+        self.observed_file_owners
+            .store(self.metrics.file_owners_live(), std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+struct FileRangeAliasInner {
+    owner: Option<Arc<FileOwner>>,
+    operation: Option<FileRangeOperationLease>,
+}
+
+impl FileRangeAliasInner {
+    #[cfg(any(unix, test))]
+    #[inline]
+    fn owner(&self) -> &FileOwner {
+        self.owner
+            .as_deref()
+            .expect("file-range owner is present until alias Drop")
+    }
+}
+
+impl Drop for FileRangeAliasInner {
+    fn drop(&mut self) {
+        // The final operation release may run mapped-file cleanup synchronously. Drop the external
+        // file owner first so cleanup can detach the slot and remove the namespace on Windows.
+        drop(self.owner.take());
+        drop(self.operation.take());
+    }
+}
+
+/// Owner-bearing, admission-fenced capability for one checked file range.
+///
+/// Clones and splits share one owned M1 admission token and one canonical `FileOwner`. Admission
+/// is therefore released once after the final derived range drops, while the physical handle
+/// remains alive for every in-flight range.
 #[derive(Clone)]
-pub struct FileRange {
-    #[cfg_attr(
-        not(unix),
-        allow(dead_code, reason = "sendfile consumes the file handle only on Unix targets")
-    )]
-    file: Arc<File>,
-    position: u64,
-    len: usize,
-    _mapped_file_lease: Option<Arc<MappedFileLease>>,
+pub struct FileRangeLease {
+    aliases: Arc<FileRangeAliasInner>,
+    range: CheckedFileRange,
+}
+
+/// Legacy type name for the checked owner-bearing range capability.
+///
+/// Construction is intentionally fallible through [`SegmentLease::try_from_file_range`].
+pub type FileRange = FileRangeLease;
+
+/// Failure to construct or split a checked file-range capability.
+#[derive(Debug)]
+pub enum FileRangeError {
+    LengthOverflow { len: usize },
+    EndOverflow { position: u64, len: usize },
+    OutOfBounds { position: u64, len: usize, file_len: u64 },
+    InvalidSplit { at: usize, len: usize },
+    Metadata(io::Error),
+}
+
+impl fmt::Display for FileRangeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::LengthOverflow { len } => write!(formatter, "file range length does not fit u64: {len}"),
+            Self::EndOverflow { position, len } => {
+                write!(formatter, "file range end overflows: position={position}, len={len}")
+            }
+            Self::OutOfBounds {
+                position,
+                len,
+                file_len,
+            } => write!(
+                formatter,
+                "file range exceeds owner length: position={position}, len={len}, file_len={file_len}"
+            ),
+            Self::InvalidSplit { at, len } => {
+                write!(formatter, "file range split exceeds range: at={at}, len={len}")
+            }
+            Self::Metadata(error) => write!(formatter, "failed to inspect file owner: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for FileRangeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Metadata(error) => Some(error),
+            _ => None,
+        }
+    }
 }
 
 pub struct SegmentLease {
     segment: CommitLogSegment,
     bytes: Option<Bytes>,
-    // Drop source handles before releasing the admission that fences their use.
-    _mapped_file_lease: Option<Arc<MappedFileLease>>,
 }
 
 impl SegmentLease {
@@ -99,7 +198,6 @@ impl SegmentLease {
         let len = bytes.len();
         let file_offset = global_offset.saturating_sub(position_in_file as i64) as u64;
         Self {
-            _mapped_file_lease: None,
             segment: CommitLogSegment {
                 global_offset,
                 file_offset,
@@ -112,29 +210,63 @@ impl SegmentLease {
         }
     }
 
-    pub fn from_file_range(
+    /// Creates a checked standalone range for compatibility tests and benchmarks.
+    ///
+    /// Mapped-file production paths must use the internal `try_from_file_owner_range` constructor so the range
+    /// carries the mapped file's owned operation admission.
+    pub fn try_from_file_range(
         global_offset: i64,
         file_offset: u64,
         position_in_file: u64,
         len: usize,
         file: Arc<File>,
         cache_state: TransferCacheState,
-    ) -> Self {
-        Self {
-            _mapped_file_lease: None,
+    ) -> Result<Self, FileRangeError> {
+        let owner = Arc::new(FileOwner::from_shared_compatibility(
+            file,
+            Arc::new(MappedFileMetrics::new()),
+        ));
+        let lease = FileRangeLease::try_new(owner, position_in_file, len, FileRangeOperationLease::Standalone)?;
+        Ok(Self {
             segment: CommitLogSegment {
                 global_offset,
                 file_offset,
                 position_in_file,
                 len,
-                source: SegmentSource::FileRange {
-                    file,
-                    _mapped_file: None,
-                },
+                source: SegmentSource::FileRange { lease },
                 cache_state,
             },
             bytes: None,
-        }
+        })
+    }
+
+    /// Composes a canonical file owner with one owned mapped-file operation admission.
+    pub(crate) fn try_from_file_owner_range(
+        global_offset: i64,
+        file_offset: u64,
+        position_in_file: u64,
+        len: usize,
+        owner: Arc<FileOwner>,
+        operation: MappedFileLease,
+        cache_state: TransferCacheState,
+    ) -> Result<Self, FileRangeError> {
+        let lease = FileRangeLease::try_new(
+            owner,
+            position_in_file,
+            len,
+            FileRangeOperationLease::Mapped { _lease: operation },
+        )?;
+        Ok(Self {
+            segment: CommitLogSegment {
+                global_offset,
+                file_offset,
+                position_in_file,
+                len,
+                source: SegmentSource::FileRange { lease },
+                cache_state,
+            },
+            bytes: None,
+        })
     }
 
     /// Compatibility adapter for callers that already carry a separate global offset.
@@ -148,34 +280,43 @@ impl SegmentLease {
             .as_ref()
             .map(|(_lease, mapped_file)| mapped_file.get_file_from_offset())
             .unwrap_or_else(|| global_offset.saturating_sub(position_in_file as i64) as u64);
-        let (source, mapped_file_lease) = match mapped_source {
-            Some((lease, mapped_file)) => match mapped_file.try_clone_file_admitted(&lease) {
-                Ok(file) => (
-                    SegmentSource::FileRange {
-                        file: Arc::new(file),
-                        _mapped_file: Some(mapped_file),
-                    },
-                    Some(Arc::new(lease)),
-                ),
-                Err(_) => (
-                    SegmentSource::Mmap {
-                        _mapped_file: mapped_file,
-                    },
-                    Some(Arc::new(lease)),
-                ),
+        let cache_state = cache_state.into();
+        let source = match mapped_source {
+            Some((lease, mapped_file)) => match mapped_file.file_owner_admitted(&lease) {
+                Ok(owner) => match Self::try_from_file_owner_range(
+                    global_offset,
+                    file_offset,
+                    position_in_file,
+                    len,
+                    owner,
+                    lease,
+                    cache_state,
+                ) {
+                    Ok(mut segment) => {
+                        segment.bytes = bytes;
+                        return Some(segment);
+                    }
+                    Err(_) => SegmentSource::Bytes,
+                },
+                Err(_) => {
+                    // The byte snapshot is independent. Drop the mapped-file owner before the
+                    // admission in case final release runs cleanup synchronously.
+                    drop(mapped_file);
+                    drop(lease);
+                    SegmentSource::Bytes
+                }
             },
-            None => (SegmentSource::Bytes, None),
+            None => SegmentSource::Bytes,
         };
 
         Some(Self {
-            _mapped_file_lease: mapped_file_lease,
             segment: CommitLogSegment {
                 global_offset,
                 file_offset,
                 position_in_file,
                 len,
                 source,
-                cache_state: cache_state.into(),
+                cache_state,
             },
             bytes,
         })
@@ -191,12 +332,7 @@ impl SegmentLease {
 
     pub fn as_file_range(&self) -> Option<FileRange> {
         match &self.segment.source {
-            SegmentSource::FileRange { file, .. } => Some(FileRange {
-                file: file.clone(),
-                position: self.segment.position_in_file,
-                len: self.segment.len,
-                _mapped_file_lease: self._mapped_file_lease.clone(),
-            }),
+            SegmentSource::FileRange { lease } => Some(lease.clone()),
             _ => None,
         }
     }
@@ -242,32 +378,126 @@ impl CommitLogSegment {
     }
 }
 
-impl FileRange {
+impl CheckedFileRange {
+    fn try_new(position: u64, len: usize, file_len: u64) -> Result<Self, FileRangeError> {
+        let range_len = u64::try_from(len).map_err(|_| FileRangeError::LengthOverflow { len })?;
+        let end = position
+            .checked_add(range_len)
+            .ok_or(FileRangeError::EndOverflow { position, len })?;
+        if end > file_len {
+            return Err(FileRangeError::OutOfBounds {
+                position,
+                len,
+                file_len,
+            });
+        }
+        Ok(Self { bounds: position..end })
+    }
+
+    #[inline]
+    fn position(&self) -> u64 {
+        self.bounds.start
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        // Every bound is derived from an input `usize` and later operations only shorten it.
+        (self.bounds.end - self.bounds.start) as usize
+    }
+}
+
+impl FileRangeLease {
+    fn try_new(
+        owner: Arc<FileOwner>,
+        position: u64,
+        len: usize,
+        operation: FileRangeOperationLease,
+    ) -> Result<Self, FileRangeError> {
+        let file_len = match owner.len() {
+            Ok(file_len) => file_len,
+            Err(error) => {
+                drop(owner);
+                drop(operation);
+                return Err(FileRangeError::Metadata(error));
+            }
+        };
+        let range = match CheckedFileRange::try_new(position, len, file_len) {
+            Ok(range) => range,
+            Err(error) => {
+                drop(owner);
+                drop(operation);
+                return Err(error);
+            }
+        };
+        Ok(Self {
+            aliases: Arc::new(FileRangeAliasInner {
+                owner: Some(owner),
+                operation: Some(operation),
+            }),
+            range,
+        })
+    }
+
     #[inline]
     pub fn position(&self) -> u64 {
-        self.position
+        self.range.position()
     }
 
     #[inline]
     pub fn len(&self) -> usize {
-        self.len
+        self.range.len()
     }
 
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.len == 0
+        self.range.bounds.is_empty()
     }
 
-    #[cfg(any(unix, test))]
-    #[inline]
-    pub(crate) fn file(&self) -> &File {
-        self.file.as_ref()
+    /// Splits this capability at a relative byte offset.
+    ///
+    /// Both returned ranges share the same physical owner and admission. The operation admission
+    /// is released once after the final derived range drops.
+    pub fn split_at(mut self, at: usize) -> Result<(Self, Self), FileRangeError> {
+        let len = self.len();
+        if at > len {
+            return Err(FileRangeError::InvalidSplit { at, len });
+        }
+        let relative = u64::try_from(at).map_err(|_| FileRangeError::LengthOverflow { len: at })?;
+        let middle = self
+            .range
+            .bounds
+            .start
+            .checked_add(relative)
+            .ok_or(FileRangeError::EndOverflow {
+                position: self.range.bounds.start,
+                len: at,
+            })?;
+        let right = Self {
+            aliases: Arc::clone(&self.aliases),
+            range: CheckedFileRange {
+                bounds: middle..self.range.bounds.end,
+            },
+        };
+        self.range.bounds.end = middle;
+        Ok((self, right))
     }
 
     #[cfg(unix)]
     #[inline]
     pub(crate) fn truncate_to(&mut self, maximum_len: usize) {
-        self.len = self.len.min(maximum_len);
+        let retained = self.len().min(maximum_len);
+        self.range.bounds.end = self.range.bounds.start + retained as u64;
+    }
+
+    #[cfg(unix)]
+    #[inline]
+    pub(crate) fn raw_fd(&self) -> std::os::fd::RawFd {
+        self.aliases.owner().raw_fd()
+    }
+
+    #[cfg(test)]
+    fn with_file<R>(&self, operation: impl for<'file> FnOnce(&'file File) -> R) -> R {
+        self.aliases.owner().with_file(operation)
     }
 }
 
@@ -276,6 +506,7 @@ mod tests {
     use std::io::Read;
     use std::io::Seek;
     use std::io::SeekFrom;
+    use std::io::Write;
 
     use cheetah_string::CheetahString;
 
@@ -298,11 +529,13 @@ mod tests {
     }
 
     fn read_file_range(range: &FileRange) -> Vec<u8> {
-        let mut file = range.file().try_clone().expect("clone range file");
-        file.seek(SeekFrom::Start(range.position())).expect("seek range");
-        let mut bytes = vec![0; range.len()];
-        file.read_exact(&mut bytes).expect("read range");
-        bytes
+        range.with_file(|file| {
+            let mut file = file;
+            file.seek(SeekFrom::Start(range.position())).expect("seek range");
+            let mut bytes = vec![0; range.len()];
+            file.read_exact(&mut bytes).expect("read range");
+            bytes
+        })
     }
 
     #[test]
@@ -404,6 +637,72 @@ mod tests {
         assert_eq!(read_file_range(&range), b"range");
 
         drop(range);
+        assert_eq!(mapped_file.lifecycle_snapshot().active_leases, 0);
+        assert!(mapped_file.lifecycle_snapshot().logical_cleanup_marked);
+    }
+
+    #[test]
+    fn checked_file_range_rejects_overflow_and_out_of_bounds() {
+        let mut file = tempfile::tempfile().expect("temporary file");
+        file.write_all(b"four").expect("write file");
+        let file = Arc::new(file);
+
+        assert!(matches!(
+            SegmentLease::try_from_file_range(0, 0, 3, 2, Arc::clone(&file), TransferCacheState::Cold,),
+            Err(FileRangeError::OutOfBounds { .. })
+        ));
+        assert!(matches!(
+            SegmentLease::try_from_file_range(0, 0, u64::MAX, 2, file, TransferCacheState::Cold,),
+            Err(FileRangeError::EndOverflow { .. })
+        ));
+    }
+
+    #[test]
+    fn final_range_alias_drops_file_owner_before_operation() {
+        let metrics = Arc::new(MappedFileMetrics::new());
+        let owner = Arc::new(FileOwner::new_tracked(
+            tempfile::tempfile().expect("temporary file"),
+            Arc::clone(&metrics),
+        ));
+        let observed_file_owners = Arc::new(std::sync::atomic::AtomicU64::new(u64::MAX));
+        let range = FileRangeLease::try_new(
+            owner,
+            0,
+            0,
+            FileRangeOperationLease::Probe {
+                _probe: OperationDropProbe {
+                    metrics: Arc::clone(&metrics),
+                    observed_file_owners: Arc::clone(&observed_file_owners),
+                },
+            },
+        )
+        .expect("empty checked range");
+        assert_eq!(metrics.file_owners_live(), 1);
+
+        drop(range);
+
+        assert_eq!(observed_file_owners.load(std::sync::atomic::Ordering::Relaxed), 0);
+        assert_eq!(metrics.file_owners_live(), 0);
+        assert_eq!(metrics.physical_file_owner_drop_total(), 1);
+    }
+
+    #[test]
+    fn split_ranges_share_one_admission_until_the_last_piece_drops() {
+        let (_directory, mapped_file) = mapped_file();
+        assert!(mapped_file.append_message_bytes(b"split"));
+        let segment = selected_lease(&mapped_file, 5);
+        let range = segment.as_file_range().expect("file range");
+        let (left, right) = range.split_at(2).expect("checked split");
+
+        assert_eq!((left.position(), left.len()), (0, 2));
+        assert_eq!((right.position(), right.len()), (2, 3));
+        drop(segment);
+        MappedFile::shutdown(mapped_file.as_ref(), u64::MAX);
+        assert_eq!(mapped_file.lifecycle_snapshot().active_leases, 1);
+
+        drop(left);
+        assert_eq!(mapped_file.lifecycle_snapshot().active_leases, 1);
+        drop(right);
         assert_eq!(mapped_file.lifecycle_snapshot().active_leases, 0);
         assert!(mapped_file.lifecycle_snapshot().logical_cleanup_marked);
     }

--- a/rocketmq-store-local/src/utils/ffi.rs
+++ b/rocketmq-store-local/src/utils/ffi.rs
@@ -229,6 +229,20 @@ pub(crate) fn lock_memory_region(memory: &[u8]) -> RocketMQResult<()> {
     unsafe { sys_mlock(memory.as_ptr(), memory.len()) }
 }
 
+/// Locks an owner-backed raw address range without manufacturing a shared Rust slice.
+///
+/// # Safety
+///
+/// `addr..addr + len` must remain live and mapped for this call. The owner must prevent unmapping
+/// while the operating-system operation executes.
+pub(crate) unsafe fn lock_memory_address(addr: *const u8, len: usize) -> RocketMQResult<()> {
+    if len == 0 {
+        return Ok(());
+    }
+    // SAFETY: the caller upholds the live owner-backed range contract.
+    unsafe { sys_mlock(addr, len) }
+}
+
 pub(crate) fn unlock_memory_region(memory: &[u8]) -> RocketMQResult<()> {
     if memory.is_empty() {
         return Ok(());
@@ -236,6 +250,19 @@ pub(crate) fn unlock_memory_region(memory: &[u8]) -> RocketMQResult<()> {
     // SAFETY: the slice proves that the complete input range is live for this call. The OS does
     // not retain a Rust reference or access the range after the call returns.
     unsafe { sys_munlock(memory.as_ptr(), memory.len()) }
+}
+
+/// Unlocks an owner-backed raw address range without manufacturing a shared Rust slice.
+///
+/// # Safety
+///
+/// `addr..addr + len` must remain live and identify the same range submitted to the lock call.
+pub(crate) unsafe fn unlock_memory_address(addr: *const u8, len: usize) -> RocketMQResult<()> {
+    if len == 0 {
+        return Ok(());
+    }
+    // SAFETY: the caller upholds the live, previously locked owner-backed range contract.
+    unsafe { sys_munlock(addr, len) }
 }
 
 /// Invokes the platform memory-advice operation.

--- a/rocketmq-store-local/tests/ha_transfer_boundary.rs
+++ b/rocketmq-store-local/tests/ha_transfer_boundary.rs
@@ -157,7 +157,8 @@ async fn owning_file_range_and_bytes_fallback_emit_identical_frames() {
 async fn sendfile_and_owning_bytes_fallback_emit_identical_frames() {
     let mut input = tempfile::tempfile().expect("temporary input file");
     std::io::Write::write_all(&mut input, b"sendfile-parity").expect("write input");
-    let file_segment = SegmentLease::from_file_range(0, 0, 0, 15, Arc::new(input), TransferCacheState::Cold);
+    let file_segment = SegmentLease::try_from_file_range(0, 0, 0, 15, Arc::new(input), TransferCacheState::Cold)
+        .expect("checked file range");
     let mut file_batch = TransferBatch::data(0, vec![file_segment]);
     file_batch.frame_header = Bytes::from_static(b"frame:");
     let operation = RecordingSendfile::new(Bytes::from_static(b"sendfile-parity"), 3);

--- a/rocketmq-store-local/tests/mapped_file_admission.rs
+++ b/rocketmq-store-local/tests/mapped_file_admission.rs
@@ -124,7 +124,7 @@ fn closing_rejects_new_read_write_and_maintenance_operations() {
         mapped_file
             .try_warm_mapped_file(FlushDiskType::AsyncFlush, 1)
             .expect_err("warm-up must be rejected"),
-        MappedFileOperation::Maintenance,
+        MappedFileOperation::Write,
     );
     assert_unavailable(
         mapped_file.try_mlock().expect_err("mlock must be rejected"),

--- a/rocketmq-store-local/tests/mapped_file_mapping.rs
+++ b/rocketmq-store-local/tests/mapped_file_mapping.rs
@@ -12,33 +12,53 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fs::File;
+use std::io;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Barrier;
 
-use rocketmq_store_local::mapped_file::mapping::LazyMmapStats;
-use rocketmq_store_local::mapped_file::mapping::MappedFileMapping;
+use cheetah_string::CheetahString;
+use memmap2::Mmap;
+use memmap2::MmapMut;
+use rocketmq_store_local::mapped_file::DefaultMappedFile;
+use rocketmq_store_local::mapped_file::LazyMmapStats;
+use rocketmq_store_local::mapped_file::MappedMemory;
+use rocketmq_store_local::mapped_file::NativeMappedMemory;
+use rocketmq_store_local::mapped_file::ReadOnlyMappedMemory;
+
+fn mapped_path(directory: &tempfile::TempDir) -> CheetahString {
+    CheetahString::from(
+        directory
+            .path()
+            .join("00000000000000000000")
+            .to_string_lossy()
+            .into_owned(),
+    )
+}
 
 #[test]
 fn eager_mapping_starts_initialized_without_lazy_statistics() {
-    let mapping = MappedFileMapping::new_eager(String::from("eager"));
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let mapped_file =
+        DefaultMappedFile::<NativeMappedMemory>::try_new(mapped_path(&directory), 8).expect("eager mapped file");
 
-    assert!(!mapping.is_lazy_enabled());
-    assert!(mapping.is_mapped());
-    assert_eq!(mapping.get().map(String::as_str), Some("eager"));
-    assert_eq!(mapping.stats(), LazyMmapStats::default());
+    assert!(!mapped_file.is_lazy_mmap_enabled());
+    assert!(mapped_file.is_mapped());
+    assert_eq!(mapped_file.lazy_mmap_stats(), LazyMmapStats::default());
 }
 
 #[test]
 fn lazy_mapping_starts_eligible_and_uninitialized() {
-    let mapping = MappedFileMapping::<String>::new_lazy();
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let mapped_file = DefaultMappedFile::<NativeMappedMemory>::try_new_lazy_read_only(mapped_path(&directory), 8)
+        .expect("lazy mapped file");
 
-    assert!(mapping.is_lazy_enabled());
-    assert!(!mapping.is_mapped());
-    assert!(mapping.get().is_none());
+    assert!(mapped_file.is_lazy_mmap_enabled());
+    assert!(!mapped_file.is_mapped());
     assert_eq!(
-        mapping.stats(),
+        mapped_file.lazy_mmap_stats(),
         LazyMmapStats {
             eligible_files: 1,
             mapped_files: 0,
@@ -51,108 +71,100 @@ fn lazy_mapping_starts_eligible_and_uninitialized() {
 }
 
 #[test]
-fn successful_lazy_initialization_records_one_operation() {
-    let mapping = MappedFileMapping::new_lazy();
-
-    let value = mapping
-        .get_or_try_init(|| Ok::<_, &'static str>(String::from("mapped")))
-        .expect("initializer succeeds");
-
-    assert_eq!(value, "mapped");
-    assert!(mapping.is_mapped());
-    let stats = mapping.stats();
-    assert_eq!(stats.eligible_files, 1);
-    assert_eq!(stats.mapped_files, 1);
-    assert_eq!(stats.map_operations, 1);
-    assert_eq!(stats.map_failures, 0);
-    assert_eq!(stats.total_millis, stats.last_millis);
-}
-
-#[test]
-fn failed_lazy_initialization_is_retryable_and_records_each_failure() {
-    let mapping = MappedFileMapping::new_lazy();
-    let attempts = AtomicUsize::new(0);
-
-    let first = mapping.get_or_try_init(|| {
-        attempts.fetch_add(1, Ordering::SeqCst);
-        Err::<usize, _>("first attempt failed")
-    });
-    assert_eq!(first, Err("first attempt failed"));
-    assert!(!mapping.is_mapped());
-    assert_eq!(mapping.stats().map_failures, 1);
-
-    let value = mapping
-        .get_or_try_init(|| {
-            attempts.fetch_add(1, Ordering::SeqCst);
-            Ok::<_, &'static str>(42)
-        })
-        .expect("retry succeeds");
-    assert_eq!(*value, 42);
-    assert_eq!(attempts.load(Ordering::SeqCst), 2);
-    assert_eq!(mapping.stats().map_failures, 1);
-    assert_eq!(mapping.stats().map_operations, 1);
-}
-
-#[test]
-fn concurrent_lazy_callers_run_initializer_exactly_once() {
+fn concurrent_lazy_callers_publish_one_generation() {
     const CALLERS: usize = 8;
-    let mapping = Arc::new(MappedFileMapping::new_lazy());
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let mapped_file = Arc::new(
+        DefaultMappedFile::<NativeMappedMemory>::try_new_lazy_read_only(mapped_path(&directory), 8)
+            .expect("lazy mapped file"),
+    );
     let start = Arc::new(Barrier::new(CALLERS + 1));
-    let initializations = Arc::new(AtomicUsize::new(0));
 
     std::thread::scope(|scope| {
         let mut handles = Vec::with_capacity(CALLERS);
         for _ in 0..CALLERS {
-            let mapping = Arc::clone(&mapping);
+            let mapped_file = Arc::clone(&mapped_file);
             let start = Arc::clone(&start);
-            let initializations = Arc::clone(&initializations);
             handles.push(scope.spawn(move || {
                 start.wait();
-                mapping
-                    .get_or_try_init(|| {
-                        initializations.fetch_add(1, Ordering::SeqCst);
-                        Ok::<_, &'static str>(17usize)
-                    })
-                    .map(|value| value as *const usize as usize)
+                mapped_file.with_mapped_slice(<[u8]>::len)
             }));
         }
 
         start.wait();
-        let addresses = handles
-            .into_iter()
-            .map(|handle| handle.join().expect("caller does not panic").expect("init succeeds"))
-            .collect::<Vec<_>>();
-        assert!(addresses.windows(2).all(|pair| pair[0] == pair[1]));
+        for handle in handles {
+            assert_eq!(
+                handle.join().expect("caller does not panic").expect("mapping succeeds"),
+                8
+            );
+        }
     });
 
-    assert_eq!(initializations.load(Ordering::SeqCst), 1);
-    assert_eq!(mapping.stats().map_operations, 1);
+    assert!(mapped_file.is_mapped());
+    assert_eq!(mapped_file.lazy_mmap_stats().map_operations, 1);
+    assert_eq!(mapped_file.lazy_mmap_stats().map_failures, 0);
+}
+
+static RETRY_MAP_ATTEMPTS: AtomicUsize = AtomicUsize::new(0);
+
+struct RetryMappedMemory(MmapMut);
+struct RetryReadOnlyMappedMemory(Mmap);
+
+// SAFETY: the mapping remains stable for the value lifetime and DefaultMappedFile serializes all
+// mutation through its writer fence.
+unsafe impl MappedMemory for RetryMappedMemory {
+    type ReadOnly = RetryReadOnlyMappedMemory;
+
+    unsafe fn map_mut(file: &File) -> io::Result<Self> {
+        if RETRY_MAP_ATTEMPTS.fetch_add(1, Ordering::SeqCst) == 0 {
+            return Err(io::Error::other("injected first mapping failure"));
+        }
+        // SAFETY: DefaultMappedFile sizes and owns the file for the mapping lifetime.
+        unsafe { MmapMut::map_mut(file).map(Self) }
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+
+    fn as_mut_ptr(&self) -> *mut u8 {
+        self.0.as_ptr().cast_mut()
+    }
+
+    fn flush(&self) -> io::Result<()> {
+        self.0.flush()
+    }
+
+    fn flush_range(&self, offset: usize, len: usize) -> io::Result<()> {
+        self.0.flush_range(offset, len)
+    }
+}
+
+// SAFETY: this mapping is immutable, stable, and exposes no mutation path.
+unsafe impl ReadOnlyMappedMemory for RetryReadOnlyMappedMemory {
+    unsafe fn map(file: &File) -> io::Result<Self> {
+        // SAFETY: DefaultMappedFile keeps the segment size stable while this generation is live.
+        unsafe { Mmap::map(file).map(Self) }
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
 }
 
 #[test]
-fn initialized_value_identity_is_stable_across_reads() {
-    let mapping = MappedFileMapping::new_lazy();
-    let initialized = mapping
-        .get_or_try_init(|| Ok::<_, &'static str>(Box::new(23usize)))
-        .expect("init succeeds");
-    let read = mapping.get().expect("mapping remains initialized");
+fn failed_lazy_initialization_is_retryable_and_accounted() {
+    RETRY_MAP_ATTEMPTS.store(0, Ordering::SeqCst);
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let mapped_file = DefaultMappedFile::<RetryMappedMemory>::try_new_lazy_read_only(mapped_path(&directory), 8)
+        .expect("lazy mapped file");
 
-    assert!(std::ptr::eq(initialized, read));
-}
+    assert!(mapped_file.with_mapped_slice(<[u8]>::len).is_err());
+    assert!(!mapped_file.is_mapped());
+    assert_eq!(mapped_file.lazy_mmap_stats().map_failures, 1);
 
-#[test]
-fn statistics_are_monotonic_after_failures_and_success() {
-    let mapping = MappedFileMapping::new_lazy();
-    let initial = mapping.stats();
-    let _ = mapping.get_or_try_init(|| Err::<usize, _>("failed"));
-    let after_failure = mapping.stats();
-    let _ = mapping
-        .get_or_try_init(|| Ok::<_, &'static str>(1))
-        .expect("retry succeeds");
-    let after_success = mapping.stats();
-
-    assert!(after_failure.map_failures >= initial.map_failures);
-    assert!(after_success.map_failures >= after_failure.map_failures);
-    assert!(after_success.map_operations >= after_failure.map_operations);
-    assert!(after_success.total_millis >= after_failure.total_millis);
+    assert_eq!(mapped_file.with_mapped_slice(<[u8]>::len).expect("retry maps"), 8);
+    assert_eq!(RETRY_MAP_ATTEMPTS.load(Ordering::SeqCst), 2);
+    assert_eq!(mapped_file.lazy_mmap_stats().map_operations, 1);
+    assert_eq!(mapped_file.lazy_mmap_stats().map_failures, 1);
 }

--- a/rocketmq-store-local/tests/mapped_file_owner_miri.rs
+++ b/rocketmq-store-local/tests/mapped_file_owner_miri.rs
@@ -1,0 +1,163 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ops::Deref;
+use std::ops::Range;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RangeError {
+    Overflow,
+    OutOfBounds,
+}
+
+fn checked_range(mapping_len: usize, offset: usize, len: usize) -> Result<Range<usize>, RangeError> {
+    let end = offset.checked_add(len).ok_or(RangeError::Overflow)?;
+    if end > mapping_len {
+        return Err(RangeError::OutOfBounds);
+    }
+    Ok(offset..end)
+}
+
+struct GenerationOwner {
+    bytes: Box<[u8]>,
+    events: Arc<Mutex<Vec<&'static str>>>,
+}
+
+impl Drop for GenerationOwner {
+    fn drop(&mut self) {
+        self.events.lock().expect("event lock").push("generation");
+    }
+}
+
+struct OperationLease {
+    events: Arc<Mutex<Vec<&'static str>>>,
+}
+
+impl Drop for OperationLease {
+    fn drop(&mut self) {
+        self.events.lock().expect("event lock").push("operation");
+    }
+}
+
+struct AliasInner {
+    generation: Option<Arc<GenerationOwner>>,
+    operation: Option<OperationLease>,
+}
+
+impl Drop for AliasInner {
+    fn drop(&mut self) {
+        drop(self.generation.take());
+        drop(self.operation.take());
+    }
+}
+
+#[derive(Clone)]
+struct ReadAlias {
+    inner: Arc<AliasInner>,
+    range: Range<usize>,
+}
+
+impl ReadAlias {
+    fn try_new(
+        generation: Arc<GenerationOwner>,
+        operation: OperationLease,
+        offset: usize,
+        len: usize,
+    ) -> Result<Self, RangeError> {
+        let range = checked_range(generation.bytes.len(), offset, len)?;
+        Ok(Self {
+            inner: Arc::new(AliasInner {
+                generation: Some(generation),
+                operation: Some(operation),
+            }),
+            range,
+        })
+    }
+
+    fn split_at(&self, mid: usize) -> Result<(Self, Self), RangeError> {
+        let absolute_mid = self.range.start.checked_add(mid).ok_or(RangeError::Overflow)?;
+        if absolute_mid > self.range.end {
+            return Err(RangeError::OutOfBounds);
+        }
+        Ok((
+            Self {
+                inner: Arc::clone(&self.inner),
+                range: self.range.start..absolute_mid,
+            },
+            Self {
+                inner: Arc::clone(&self.inner),
+                range: absolute_mid..self.range.end,
+            },
+        ))
+    }
+}
+
+impl Deref for ReadAlias {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        let generation = self
+            .inner
+            .generation
+            .as_ref()
+            .expect("generation remains present until final alias drop");
+        &generation.bytes[self.range.clone()]
+    }
+}
+
+#[test]
+fn detached_slot_keeps_old_generation_readable_until_final_alias() {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let generation = Arc::new(GenerationOwner {
+        bytes: Box::from(&b"generation-owned"[..]),
+        events: Arc::clone(&events),
+    });
+    let mut slot = Some(Arc::clone(&generation));
+    let alias = ReadAlias::try_new(
+        Arc::clone(&generation),
+        OperationLease {
+            events: Arc::clone(&events),
+        },
+        0,
+        generation.bytes.len(),
+    )
+    .expect("complete checked range");
+    drop(generation);
+
+    let detached = slot.take().expect("one detach winner");
+    assert!(slot.take().is_none());
+    drop(detached);
+    assert_eq!(&*alias, b"generation-owned");
+    assert!(events.lock().expect("event lock").is_empty());
+
+    let clone = alias.clone();
+    let (left, right) = alias.split_at(10).expect("checked split");
+    drop(alias);
+    drop(clone);
+    drop(left);
+    assert_eq!(&*right, b"-owned");
+    assert!(events.lock().expect("event lock").is_empty());
+    drop(right);
+
+    assert_eq!(&*events.lock().expect("event lock"), &["generation", "operation"]);
+}
+
+#[test]
+fn checked_alias_ranges_reject_overflow_and_out_of_bounds() {
+    assert_eq!(checked_range(8, usize::MAX, 1), Err(RangeError::Overflow));
+    assert_eq!(checked_range(8, 8, 1), Err(RangeError::OutOfBounds));
+    assert_eq!(checked_range(8, 8, 0), Ok(8..8));
+}

--- a/rocketmq-store-local/tests/mapped_file_physical_owner.rs
+++ b/rocketmq-store-local/tests/mapped_file_physical_owner.rs
@@ -1,0 +1,304 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs::File;
+use std::io;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::mpsc;
+use std::sync::Arc;
+use std::sync::Barrier;
+use std::sync::OnceLock;
+
+use cheetah_string::CheetahString;
+use memmap2::Mmap;
+use memmap2::MmapMut;
+use rocketmq_store_local::mapped_file::kernel::ReferenceResource;
+use rocketmq_store_local::mapped_file::DefaultMappedFile;
+use rocketmq_store_local::mapped_file::MappedFile;
+use rocketmq_store_local::mapped_file::MappedFileAdmissionState;
+use rocketmq_store_local::mapped_file::MappedFileError;
+use rocketmq_store_local::mapped_file::MappedMemory;
+use rocketmq_store_local::mapped_file::MappedWriteLease;
+use rocketmq_store_local::mapped_file::NativeMappedMemory;
+use rocketmq_store_local::mapped_file::ReadOnlyMappedMemory;
+
+fn mapped_path(directory: &tempfile::TempDir) -> CheetahString {
+    CheetahString::from(
+        directory
+            .path()
+            .join("00000000000000000000")
+            .to_string_lossy()
+            .into_owned(),
+    )
+}
+
+fn eager_file(size: u64) -> (tempfile::TempDir, Arc<DefaultMappedFile>) {
+    let directory = tempfile::tempdir().expect("temporary mapped-file directory");
+    let mapped_file =
+        DefaultMappedFile::<NativeMappedMemory>::try_new(mapped_path(&directory), size).expect("eager mapped file");
+    (directory, Arc::new(mapped_file))
+}
+
+#[test]
+fn normal_shutdown_detaches_eager_mapping_and_file_owner_exactly_once() {
+    let (directory, mapped_file) = eager_file(16);
+    let path = directory.path().join("00000000000000000000");
+    let metrics = mapped_file.get_metrics().expect("mapped-file metrics");
+    assert_eq!(metrics.mapped_generations_live(), 1);
+    assert_eq!(metrics.mapped_bytes_live(), 16);
+    assert_eq!(metrics.file_owners_live(), 1);
+
+    MappedFile::shutdown(mapped_file.as_ref(), 0);
+
+    assert!(path.exists(), "normal shutdown must not remove the namespace");
+    assert!(!mapped_file.is_mapped());
+    assert_eq!(metrics.mapped_generations_live(), 0);
+    assert_eq!(metrics.mapped_bytes_live(), 0);
+    assert_eq!(metrics.file_owners_live(), 0);
+    assert_eq!(metrics.physical_mapping_drop_total(), 1);
+    assert_eq!(metrics.physical_file_owner_drop_total(), 1);
+    assert_eq!(metrics.lifecycle_detach_total(), 1);
+    assert!(ReferenceResource::is_cleanup_over(mapped_file.as_ref()));
+
+    MappedFile::shutdown(mapped_file.as_ref(), 0);
+    assert!(mapped_file.try_detach_physical_owners().is_detached());
+    assert_eq!(metrics.physical_mapping_drop_total(), 1);
+    assert_eq!(metrics.physical_file_owner_drop_total(), 1);
+    assert_eq!(metrics.lifecycle_detach_total(), 1);
+}
+
+#[test]
+fn normal_shutdown_of_never_mapped_lazy_file_closes_only_the_file_owner() {
+    let directory = tempfile::tempdir().expect("temporary mapped-file directory");
+    let path = directory.path().join("00000000000000000000");
+    let mapped_file = DefaultMappedFile::<NativeMappedMemory>::try_new_lazy_read_only(mapped_path(&directory), 16)
+        .expect("lazy mapped file");
+    let metrics = mapped_file.get_metrics().expect("mapped-file metrics");
+    assert!(!mapped_file.is_mapped());
+    assert_eq!(metrics.mapped_generations_live(), 0);
+    assert_eq!(metrics.file_owners_live(), 1);
+
+    MappedFile::shutdown(&mapped_file, 0);
+
+    assert!(path.exists(), "normal shutdown must preserve the namespace");
+    assert!(!mapped_file.is_mapped());
+    assert_eq!(metrics.mapped_generations_live(), 0);
+    assert_eq!(metrics.physical_mapping_drop_total(), 0);
+    assert_eq!(metrics.file_owners_live(), 0);
+    assert_eq!(metrics.physical_file_owner_drop_total(), 1);
+    assert_eq!(metrics.lifecycle_detach_total(), 1);
+}
+
+#[test]
+fn final_mapped_read_alias_drop_releases_physical_owners_and_unblocks_delete() {
+    let (directory, mapped_file) = eager_file(32);
+    let path = directory.path().join("00000000000000000000");
+    assert!(mapped_file.append_message_bytes(b"sealed-data"));
+    assert!(mapped_file.try_seal_readable().expect("seal mapped file"));
+    let metrics = mapped_file.get_metrics().expect("mapped-file metrics");
+    assert_eq!(metrics.mapped_generations_live(), 1);
+    assert_eq!(metrics.file_owners_live(), 1);
+
+    let lease = mapped_file
+        .try_mapped_read_lease(0, b"sealed-data".len())
+        .expect("read admission")
+        .expect("sealed generation");
+    let lease_clone = lease.clone();
+    assert_eq!(mapped_file.lifecycle_snapshot().active_leases, 1);
+
+    MappedFile::shutdown(mapped_file.as_ref(), 0);
+    assert!(path.exists());
+    assert!(mapped_file.is_mapped());
+    assert_eq!(metrics.mapped_generations_live(), 1);
+    assert_eq!(metrics.file_owners_live(), 1);
+    assert!(!mapped_file.try_destroy(0).is_namespace_removed());
+    assert_eq!(lease.as_ref(), b"sealed-data");
+
+    drop(lease);
+    assert_eq!(mapped_file.lifecycle_snapshot().active_leases, 1);
+    assert_eq!(lease_clone.as_ref(), b"sealed-data");
+    drop(lease_clone);
+
+    assert_eq!(mapped_file.lifecycle_snapshot().active_leases, 0);
+    assert!(!mapped_file.is_mapped());
+    assert_eq!(metrics.mapped_generations_live(), 0);
+    assert_eq!(metrics.file_owners_live(), 0);
+    assert_eq!(metrics.lifecycle_detach_total(), 1);
+    assert!(mapped_file.try_destroy(0).is_namespace_removed());
+    assert!(!path.exists());
+}
+
+#[test]
+fn active_writable_generation_never_exposes_a_cross_call_mapped_slice() {
+    let (_directory, mapped_file) = eager_file(16);
+    assert!(mapped_file.append_message_bytes(b"data"));
+
+    assert!(mapped_file
+        .try_mapped_read_lease(0, 4)
+        .expect("active reads remain admitted")
+        .is_none());
+    assert_eq!(mapped_file.lifecycle_snapshot().active_leases, 0);
+}
+
+#[test]
+fn seal_waits_for_admitted_writer_then_rejects_new_writes() {
+    let (_directory, mapped_file) = eager_file(16);
+    let mut write = mapped_file.reserve_write(4).expect("write admitted before seal");
+    write.buffer_mut().copy_from_slice(b"data");
+    let (sealed_tx, sealed_rx) = mpsc::sync_channel(1);
+
+    std::thread::scope(|scope| {
+        let seal_target = Arc::clone(&mapped_file);
+        scope.spawn(move || {
+            sealed_tx
+                .send(seal_target.try_seal_readable())
+                .expect("report seal result");
+        });
+
+        for _ in 0..10_000 {
+            if mapped_file.lifecycle_snapshot().state == MappedFileAdmissionState::SealedReadable {
+                break;
+            }
+            std::thread::yield_now();
+        }
+        assert_eq!(
+            mapped_file.lifecycle_snapshot().state,
+            MappedFileAdmissionState::SealedReadable
+        );
+        assert!(matches!(sealed_rx.try_recv(), Err(mpsc::TryRecvError::Empty)));
+        assert_eq!(write.commit(4, None).expect("admitted writer completes"), 4);
+        assert!(sealed_rx.recv().expect("seal worker completes").expect("seal succeeds"));
+    });
+
+    assert!(matches!(
+        mapped_file.reserve_write(1),
+        Err(MappedFileError::Unavailable {
+            state: MappedFileAdmissionState::SealedReadable,
+            ..
+        })
+    ));
+    let read = mapped_file
+        .try_mapped_read_lease(0, 4)
+        .expect("read admission")
+        .expect("read-only generation");
+    assert_eq!(read.as_ref(), b"data");
+}
+
+struct LazyRaceControl {
+    initializer_started: Barrier,
+    release_initializer: Barrier,
+    candidate_drops: AtomicUsize,
+}
+
+static LAZY_RACE_CONTROL: OnceLock<Arc<LazyRaceControl>> = OnceLock::new();
+
+struct BlockingMappedMemory(MmapMut);
+struct BlockingReadOnlyMappedMemory(Mmap);
+
+impl Drop for BlockingMappedMemory {
+    fn drop(&mut self) {
+        if let Some(control) = LAZY_RACE_CONTROL.get() {
+            control.candidate_drops.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+}
+
+// SAFETY: the mapping remains stable for the value lifetime and DefaultMappedFile serializes all
+// mutation. The barriers only delay construction before publication.
+unsafe impl MappedMemory for BlockingMappedMemory {
+    type ReadOnly = BlockingReadOnlyMappedMemory;
+
+    unsafe fn map_mut(file: &File) -> io::Result<Self> {
+        let control = LAZY_RACE_CONTROL.get().expect("lazy race control installed");
+        control.initializer_started.wait();
+        control.release_initializer.wait();
+        // SAFETY: DefaultMappedFile keeps the segment sized and owned for the candidate lifetime.
+        unsafe { MmapMut::map_mut(file).map(Self) }
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+
+    fn as_mut_ptr(&self) -> *mut u8 {
+        self.0.as_ptr().cast_mut()
+    }
+
+    fn flush(&self) -> io::Result<()> {
+        self.0.flush()
+    }
+
+    fn flush_range(&self, offset: usize, len: usize) -> io::Result<()> {
+        self.0.flush_range(offset, len)
+    }
+}
+
+// SAFETY: this mapping is immutable, stable, and exposes no mutation path.
+unsafe impl ReadOnlyMappedMemory for BlockingReadOnlyMappedMemory {
+    unsafe fn map(file: &File) -> io::Result<Self> {
+        // SAFETY: DefaultMappedFile keeps the segment stable while this generation is live.
+        unsafe { Mmap::map(file).map(Self) }
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+#[test]
+fn close_winning_lazy_publication_drops_candidate_and_never_late_publishes() {
+    let control = Arc::new(LazyRaceControl {
+        initializer_started: Barrier::new(2),
+        release_initializer: Barrier::new(2),
+        candidate_drops: AtomicUsize::new(0),
+    });
+    LAZY_RACE_CONTROL
+        .set(Arc::clone(&control))
+        .unwrap_or_else(|_| panic!("lazy race test control installed more than once"));
+    let directory = tempfile::tempdir().expect("temporary mapped-file directory");
+    let mapped_file = Arc::new(
+        DefaultMappedFile::<BlockingMappedMemory>::try_new_lazy_read_only(mapped_path(&directory), 16)
+            .expect("lazy mapped file"),
+    );
+
+    let worker = {
+        let mapped_file = Arc::clone(&mapped_file);
+        std::thread::spawn(move || mapped_file.with_mapped_slice(<[u8]>::len))
+    };
+    control.initializer_started.wait();
+    MappedFile::shutdown(mapped_file.as_ref(), 0);
+    assert_eq!(
+        mapped_file.lifecycle_snapshot().state,
+        MappedFileAdmissionState::Closing
+    );
+    assert_eq!(mapped_file.lifecycle_snapshot().active_leases, 1);
+    control.release_initializer.wait();
+
+    assert!(matches!(
+        worker.join().expect("lazy initializer thread"),
+        Err(MappedFileError::Unavailable {
+            state: MappedFileAdmissionState::Closing,
+            ..
+        })
+    ));
+    assert!(!mapped_file.is_mapped());
+    assert_eq!(control.candidate_drops.load(Ordering::SeqCst), 1);
+    let metrics = mapped_file.get_metrics().expect("mapped-file metrics");
+    assert_eq!(metrics.mapped_generations_live(), 0);
+    assert_eq!(metrics.file_owners_live(), 0);
+    assert_eq!(metrics.lifecycle_detach_total(), 1);
+    assert_eq!(mapped_file.lazy_mmap_stats().map_operations, 0);
+    assert_eq!(mapped_file.lazy_mmap_stats().map_failures, 1);
+}

--- a/rocketmq-store-local/tests/mapped_file_queue_lifecycle.rs
+++ b/rocketmq-store-local/tests/mapped_file_queue_lifecycle.rs
@@ -333,13 +333,21 @@ fn whole_destroy_preserves_unknown_directory_entries() {
 }
 
 #[test]
-fn logical_cleanup_marker_does_not_claim_physical_mapping_release() {
+fn drained_shutdown_marks_logical_cleanup_and_detaches_physical_mapping() {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let file = mapped_file(&temp_dir, 0, 16);
+    let path = temp_dir.path().join("00000000000000000000");
+    let metrics = file.get_metrics().expect("mapped-file metrics");
     assert!(file.is_mapped());
+    assert_eq!(metrics.mapped_generations_live(), 1);
+    assert_eq!(metrics.file_owners_live(), 1);
 
     file.shutdown(u64::MAX);
 
     assert!(rocketmq_store_local::mapped_file::kernel::ReferenceResource::is_logical_cleanup_marked(file.as_ref()));
-    assert!(file.is_mapped());
+    assert!(!file.is_mapped());
+    assert!(path.exists(), "normal shutdown must preserve the namespace");
+    assert_eq!(metrics.mapped_generations_live(), 0);
+    assert_eq!(metrics.file_owners_live(), 0);
+    assert_eq!(metrics.lifecycle_detach_total(), 1);
 }

--- a/rocketmq-store-local/tests/mapped_file_storage.rs
+++ b/rocketmq-store-local/tests/mapped_file_storage.rs
@@ -32,7 +32,12 @@ fn numeric_segment_name_opens_with_canonical_path_offset_and_size() {
 
     assert_eq!(storage.path(), path);
     assert_eq!(storage.file_from_offset(), 123);
-    assert_eq!(storage.file().metadata().expect("file metadata").len(), 32);
+    assert_eq!(
+        storage
+            .with_file(|file| file.metadata().expect("file metadata").len())
+            .expect("attached owner"),
+        32
+    );
     assert!(preallocation.is_some());
 }
 
@@ -58,15 +63,25 @@ fn reopen_resize_preserves_prefix_and_skips_preallocation_at_existing_size() {
 
     let (storage, grown) = MappedFileStorage::open(path, 12).expect("grow storage");
     assert!(grown.is_some());
-    storage.file().seek(SeekFrom::Start(0)).expect("seek file");
     let mut prefix = [0_u8; 6];
-    storage.file().read_exact(&mut prefix).expect("read prefix");
+    storage
+        .with_file(|file| {
+            let mut file = file;
+            file.seek(SeekFrom::Start(0)).expect("seek file");
+            file.read_exact(&mut prefix).expect("read prefix");
+        })
+        .expect("attached owner");
     assert_eq!(&prefix, b"prefix");
 
     let path = storage.path().to_path_buf();
     drop(storage);
     let (storage, unchanged) = MappedFileStorage::open(path, 12).expect("reopen storage");
-    assert_eq!(storage.file().metadata().expect("file metadata").len(), 12);
+    assert_eq!(
+        storage
+            .with_file(|file| file.metadata().expect("file metadata").len())
+            .expect("attached owner"),
+        12
+    );
     assert_eq!(unchanged, None);
 }
 
@@ -79,10 +94,20 @@ fn shrink_truncates_tail_without_preallocation() {
     let (storage, preallocation) = MappedFileStorage::open(path, 6).expect("shrink storage");
 
     assert_eq!(preallocation, None);
-    assert_eq!(storage.file().metadata().expect("file metadata").len(), 6);
-    storage.file().seek(SeekFrom::Start(0)).expect("seek file");
+    assert_eq!(
+        storage
+            .with_file(|file| file.metadata().expect("file metadata").len())
+            .expect("attached owner"),
+        6
+    );
     let mut bytes = Vec::new();
-    storage.file().read_to_end(&mut bytes).expect("read file");
+    storage
+        .with_file(|file| {
+            let mut file = file;
+            file.seek(SeekFrom::Start(0)).expect("seek file");
+            file.read_to_end(&mut bytes).expect("read file");
+        })
+        .expect("attached owner");
     assert_eq!(bytes, b"prefix");
 }
 
@@ -93,7 +118,12 @@ fn zero_length_file_skips_preallocation() {
 
     let (storage, preallocation) = MappedFileStorage::open(path, 0).expect("open zero-length storage");
 
-    assert_eq!(storage.file().metadata().expect("file metadata").len(), 0);
+    assert_eq!(
+        storage
+            .with_file(|file| file.metadata().expect("file metadata").len())
+            .expect("attached owner"),
+        0
+    );
     assert_eq!(preallocation, None);
 }
 
@@ -124,7 +154,10 @@ fn failed_rename_keeps_canonical_path_and_open_handle() {
 
     assert!(storage.rename(&missing_parent).is_err());
     assert_eq!(storage.path(), original);
-    assert!(storage.file().metadata().is_ok());
+    assert!(storage
+        .with_file(|file| file.metadata())
+        .expect("attached owner")
+        .is_ok());
 }
 
 #[test]
@@ -141,7 +174,13 @@ fn successful_rename_updates_path_before_reopen_failure() {
 
     assert!(storage.reopen().is_err());
     assert_eq!(storage.path(), renamed);
-    assert!(storage.file().metadata().is_ok(), "old handle must remain open");
+    assert!(
+        storage
+            .with_file(|file| file.metadata())
+            .expect("attached owner")
+            .is_ok(),
+        "old handle must remain open"
+    );
 }
 
 #[test]
@@ -161,9 +200,14 @@ fn file_handle_remains_usable_for_store_owned_mmap_and_io() {
     let path = directory.path().join("15");
     let (storage, _) = MappedFileStorage::open(path, 8).expect("open storage");
 
-    storage.file().write_all(b"bytes").expect("write through file handle");
-    storage.file().seek(SeekFrom::Start(0)).expect("seek file");
     let mut bytes = [0_u8; 5];
-    storage.file().read_exact(&mut bytes).expect("read through file handle");
+    storage
+        .with_file(|file| {
+            let mut file = file;
+            file.write_all(b"bytes").expect("write through file handle");
+            file.seek(SeekFrom::Start(0)).expect("seek file");
+            file.read_exact(&mut bytes).expect("read through file handle");
+        })
+        .expect("attached owner");
     assert_eq!(&bytes, b"bytes");
 }

--- a/rocketmq-store-local/tests/mapped_write_lease_loom.rs
+++ b/rocketmq-store-local/tests/mapped_write_lease_loom.rs
@@ -15,6 +15,7 @@
 use loom::sync::atomic::AtomicUsize;
 use loom::sync::atomic::Ordering;
 use loom::sync::Arc;
+use loom::sync::Condvar;
 use loom::sync::Mutex;
 use loom::thread;
 
@@ -131,6 +132,164 @@ fn concurrent_write_leases_publish_contiguous_non_overlapping_ranges() {
 struct ModelLease {
     lifecycle: Arc<LoomLifecycle>,
     drain_transitions: Arc<AtomicUsize>,
+    operation: MappedFileOperation,
+}
+
+struct ModelSealWait {
+    waiters: AtomicUsize,
+    control: Mutex<()>,
+    writers_drained: Condvar,
+    cold_notify_entries: AtomicUsize,
+}
+
+struct ModelDrainWait {
+    waiters: AtomicUsize,
+    control: Mutex<()>,
+    drained: Condvar,
+    cold_notify_entries: AtomicUsize,
+}
+
+impl ModelDrainWait {
+    fn new() -> Self {
+        Self {
+            waiters: AtomicUsize::new(0),
+            control: Mutex::new(()),
+            drained: Condvar::new(),
+            cold_notify_entries: AtomicUsize::new(0),
+        }
+    }
+
+    fn register(&self, lifecycle: &LoomLifecycle) -> bool {
+        self.waiters.fetch_add(1, Ordering::Release);
+        if lifecycle.active_leases_after_drain_waiter_registration() == 0 {
+            self.waiters.fetch_sub(1, Ordering::Release);
+            return false;
+        }
+        true
+    }
+
+    fn unregister(&self) {
+        self.waiters.fetch_sub(1, Ordering::Release);
+    }
+
+    fn wait_for_drain(&self, lifecycle: &LoomLifecycle) {
+        if !self.register(lifecycle) {
+            return;
+        }
+        let mut control = self.control.lock().expect("drain-wait control");
+        while lifecycle.active_leases() != 0 {
+            control = self.drained.wait(control).expect("drain-wait control after wait");
+        }
+        drop(control);
+        self.unregister();
+    }
+
+    fn cancel_after_registration(&self, lifecycle: &LoomLifecycle) {
+        if !self.register(lifecycle) {
+            return;
+        }
+        let control = self.control.lock().expect("cancelled drain-wait control");
+        let _ = lifecycle.active_leases();
+        drop(control);
+        self.unregister();
+    }
+
+    fn release(&self, lifecycle: &LoomLifecycle, operation: MappedFileOperation) -> ReleaseTransition {
+        let transition = lifecycle.release(operation).transition();
+        let final_total = matches!(transition, ReleaseTransition::Drained | ReleaseTransition::Remaining(0));
+        let notify = final_total && self.waiters.load(Ordering::Acquire) != 0;
+        if notify {
+            let _control = self.control.lock().expect("drain notification control");
+            self.cold_notify_entries.fetch_add(1, Ordering::SeqCst);
+            self.drained.notify_all();
+        }
+        transition
+    }
+}
+
+impl ModelSealWait {
+    fn new() -> Self {
+        Self {
+            waiters: AtomicUsize::new(0),
+            control: Mutex::new(()),
+            writers_drained: Condvar::new(),
+            cold_notify_entries: AtomicUsize::new(0),
+        }
+    }
+
+    fn try_acquire(
+        wait: &Arc<Self>,
+        lifecycle: Arc<LoomLifecycle>,
+        writer_live: Arc<AtomicUsize>,
+    ) -> Result<ModelWriterLease, AcquireTransitionError> {
+        lifecycle.try_acquire(MappedFileOperation::Write)?;
+        writer_live.store(1, Ordering::SeqCst);
+
+        Ok(ModelWriterLease {
+            lifecycle,
+            wait: Arc::clone(wait),
+            writer_live,
+        })
+    }
+
+    fn seal_and_wait(&self, lifecycle: &LoomLifecycle) -> Result<bool, AcquireTransitionError> {
+        self.waiters.fetch_add(1, Ordering::Release);
+        let started = loop {
+            match lifecycle.state() {
+                MappedFileAdmissionState::ActiveWritable if lifecycle.seal_readable() => break true,
+                MappedFileAdmissionState::ActiveWritable => continue,
+                MappedFileAdmissionState::SealedReadable => break false,
+                MappedFileAdmissionState::Closing => {
+                    self.waiters.fetch_sub(1, Ordering::Release);
+                    return Err(AcquireTransitionError::Unavailable(MappedFileAdmissionState::Closing));
+                }
+            }
+        };
+        if lifecycle.active_writers() == 0 {
+            self.waiters.fetch_sub(1, Ordering::Release);
+            return Ok(started);
+        }
+
+        let mut control = self.control.lock().expect("seal-wait control");
+        if lifecycle.active_writers() == 0 {
+            self.waiters.fetch_sub(1, Ordering::Release);
+            return Ok(started);
+        }
+        while lifecycle.active_writers() != 0 {
+            control = self
+                .writers_drained
+                .wait(control)
+                .expect("seal-wait control after wait");
+        }
+        self.waiters.fetch_sub(1, Ordering::Release);
+        Ok(started)
+    }
+
+    fn release(&self, lifecycle: &LoomLifecycle, operation: MappedFileOperation) -> ReleaseTransition {
+        let outcome = lifecycle.release(operation);
+        if outcome.writers_drained_after_rejection() && self.waiters.load(Ordering::Acquire) != 0 {
+            let _control = self.control.lock().expect("seal-wait notification control");
+            self.cold_notify_entries.fetch_add(1, Ordering::SeqCst);
+            self.writers_drained.notify_all();
+        }
+        outcome.transition()
+    }
+}
+
+struct ModelWriterLease {
+    lifecycle: Arc<LoomLifecycle>,
+    wait: Arc<ModelSealWait>,
+    writer_live: Arc<AtomicUsize>,
+}
+
+impl Drop for ModelWriterLease {
+    fn drop(&mut self) {
+        self.writer_live.store(0, Ordering::SeqCst);
+        assert_ne!(
+            self.wait.release(&self.lifecycle, MappedFileOperation::Write),
+            ReleaseTransition::Underflow
+        );
+    }
 }
 
 impl ModelLease {
@@ -143,13 +302,14 @@ impl ModelLease {
         Ok(Self {
             lifecycle,
             drain_transitions,
+            operation,
         })
     }
 }
 
 impl Drop for ModelLease {
     fn drop(&mut self) {
-        let transition = self.lifecycle.release();
+        let transition = self.lifecycle.release(self.operation).transition();
         assert_ne!(transition, ReleaseTransition::Underflow);
         if transition == ReleaseTransition::Drained {
             self.drain_transitions.fetch_add(1, Ordering::SeqCst);
@@ -187,10 +347,12 @@ fn acquire_and_close_have_one_serialized_outcome() {
         let expected_active = usize::from(lease.is_some());
         assert_eq!(lifecycle.state(), MappedFileAdmissionState::Closing);
         assert_eq!(lifecycle.active_leases(), expected_active);
+        assert_eq!(lifecycle.active_writers(), expected_active);
         assert_eq!(lifecycle.logical_cleanup_marked(), expected_active == 0);
 
         drop(lease);
         assert_eq!(lifecycle.active_leases(), 0);
+        assert_eq!(lifecycle.active_writers(), 0);
         assert!(lifecycle.logical_cleanup_marked());
         assert_eq!(drain_transitions.load(Ordering::SeqCst), expected_active);
     });
@@ -226,6 +388,7 @@ fn seal_and_write_admission_have_one_serialized_outcome() {
         let expected_write = usize::from(write_lease.is_some());
         assert_eq!(lifecycle.state(), MappedFileAdmissionState::SealedReadable);
         assert_eq!(lifecycle.active_leases(), expected_write);
+        assert_eq!(lifecycle.active_writers(), expected_write);
 
         let read_lease = ModelLease::try_acquire(
             Arc::clone(&lifecycle),
@@ -239,6 +402,8 @@ fn seal_and_write_admission_have_one_serialized_outcome() {
             Arc::clone(&drain_transitions),
         )
         .expect("sealed segments permit maintenance");
+        assert_eq!(lifecycle.active_leases(), expected_write + 2);
+        assert_eq!(lifecycle.active_writers(), expected_write);
         assert_eq!(
             lifecycle.try_acquire(MappedFileOperation::Write),
             Err(AcquireTransitionError::Unavailable(
@@ -250,7 +415,185 @@ fn seal_and_write_admission_have_one_serialized_outcome() {
         drop(maintenance_lease);
         drop(write_lease);
         assert_eq!(lifecycle.active_leases(), 0);
+        assert_eq!(lifecycle.active_writers(), 0);
         assert_eq!(drain_transitions.load(Ordering::SeqCst), 0);
+    });
+}
+
+#[test]
+fn packed_writer_and_seal_drain_are_linearized() {
+    loom::model(|| {
+        let lifecycle = Arc::new(LoomLifecycle::new());
+        let wait = Arc::new(ModelSealWait::new());
+        let writer_live = Arc::new(AtomicUsize::new(0));
+
+        let write_lifecycle = Arc::clone(&lifecycle);
+        let write_wait = Arc::clone(&wait);
+        let write_live = Arc::clone(&writer_live);
+        let writer =
+            thread::spawn(
+                move || match ModelSealWait::try_acquire(&write_wait, write_lifecycle, write_live) {
+                    Ok(lease) => {
+                        thread::yield_now();
+                        drop(lease);
+                    }
+                    Err(AcquireTransitionError::Unavailable(MappedFileAdmissionState::SealedReadable)) => {}
+                    Err(error) => panic!("unexpected writer admission error: {error:?}"),
+                },
+            );
+
+        let seal_lifecycle = Arc::clone(&lifecycle);
+        let seal_wait = Arc::clone(&wait);
+        let seal_live = Arc::clone(&writer_live);
+        let sealer = thread::spawn(move || {
+            assert!(seal_wait
+                .seal_and_wait(&seal_lifecycle)
+                .expect("seal remains available"));
+            assert_eq!(
+                seal_live.load(Ordering::SeqCst),
+                0,
+                "seal must not return while a registered writer is live"
+            );
+        });
+
+        writer.join().expect("writer");
+        sealer.join().expect("sealer");
+
+        assert_eq!(lifecycle.state(), MappedFileAdmissionState::SealedReadable);
+        assert_eq!(lifecycle.active_leases(), 0);
+        assert_eq!(lifecycle.active_writers(), 0);
+        assert_eq!(
+            lifecycle.try_acquire(MappedFileOperation::Write),
+            Err(AcquireTransitionError::Unavailable(
+                MappedFileAdmissionState::SealedReadable
+            ))
+        );
+    });
+}
+
+#[test]
+fn active_final_writer_does_not_enter_cold_seal_wait_control() {
+    loom::model(|| {
+        let lifecycle = LoomLifecycle::new();
+        let wait = ModelSealWait::new();
+
+        lifecycle
+            .try_acquire(MappedFileOperation::Write)
+            .expect("active writer");
+        let snapshot = lifecycle.snapshot();
+        assert_eq!(snapshot.active_leases, 1);
+        assert_eq!(snapshot.active_writers, 1);
+
+        assert_eq!(
+            wait.release(&lifecycle, MappedFileOperation::Write),
+            ReleaseTransition::Remaining(0)
+        );
+        assert_eq!(lifecycle.active_leases(), 0);
+        assert_eq!(lifecycle.active_writers(), 0);
+        assert_eq!(wait.cold_notify_entries.load(Ordering::SeqCst), 0);
+    });
+}
+
+#[test]
+fn non_closing_final_release_and_drain_waiter_cannot_miss_each_other() {
+    for seal_before_wait in [false, true] {
+        loom::model(move || {
+            let lifecycle = Arc::new(LoomLifecycle::new());
+            if seal_before_wait {
+                assert!(lifecycle.seal_readable());
+            }
+            lifecycle
+                .try_acquire(MappedFileOperation::Read)
+                .expect("read admission");
+            let wait = Arc::new(ModelDrainWait::new());
+
+            let waiter_lifecycle = Arc::clone(&lifecycle);
+            let waiter_wait = Arc::clone(&wait);
+            let waiter = thread::spawn(move || waiter_wait.wait_for_drain(&waiter_lifecycle));
+
+            let release_lifecycle = Arc::clone(&lifecycle);
+            let release_wait = Arc::clone(&wait);
+            let release = thread::spawn(move || {
+                assert_eq!(
+                    release_wait.release(&release_lifecycle, MappedFileOperation::Read),
+                    ReleaseTransition::Remaining(0)
+                );
+            });
+
+            waiter.join().expect("drain waiter");
+            release.join().expect("final release");
+            assert_eq!(lifecycle.active_leases(), 0);
+            assert!(wait.cold_notify_entries.load(Ordering::SeqCst) <= 1);
+        });
+    }
+}
+
+#[test]
+fn non_closing_final_release_without_waiter_skips_cold_drain_control() {
+    loom::model(|| {
+        let lifecycle = LoomLifecycle::new();
+        let wait = ModelDrainWait::new();
+        lifecycle
+            .try_acquire(MappedFileOperation::Read)
+            .expect("read admission");
+
+        assert_eq!(
+            wait.release(&lifecycle, MappedFileOperation::Read),
+            ReleaseTransition::Remaining(0)
+        );
+        assert_eq!(wait.cold_notify_entries.load(Ordering::SeqCst), 0);
+    });
+}
+
+#[test]
+fn multiple_registered_drain_waiters_share_one_notification() {
+    loom::model(|| {
+        let lifecycle = LoomLifecycle::new();
+        lifecycle
+            .try_acquire(MappedFileOperation::Read)
+            .expect("read admission");
+        let wait = ModelDrainWait::new();
+        assert!(wait.register(&lifecycle));
+        assert!(wait.register(&lifecycle));
+        assert_eq!(wait.waiters.load(Ordering::Acquire), 2);
+
+        assert_eq!(
+            wait.release(&lifecycle, MappedFileOperation::Read),
+            ReleaseTransition::Remaining(0)
+        );
+        assert_eq!(lifecycle.active_leases(), 0);
+        assert_eq!(wait.cold_notify_entries.load(Ordering::SeqCst), 1);
+        wait.unregister();
+        wait.unregister();
+        assert_eq!(wait.waiters.load(Ordering::Acquire), 0);
+    });
+}
+
+#[test]
+fn cancelled_drain_waiter_unregisters_during_final_release() {
+    loom::model(|| {
+        let lifecycle = Arc::new(LoomLifecycle::new());
+        lifecycle
+            .try_acquire(MappedFileOperation::Read)
+            .expect("read admission");
+        let wait = Arc::new(ModelDrainWait::new());
+
+        let cancel_lifecycle = Arc::clone(&lifecycle);
+        let cancel_wait = Arc::clone(&wait);
+        let cancel = thread::spawn(move || cancel_wait.cancel_after_registration(&cancel_lifecycle));
+        let release_lifecycle = Arc::clone(&lifecycle);
+        let release_wait = Arc::clone(&wait);
+        let release = thread::spawn(move || {
+            assert_eq!(
+                release_wait.release(&release_lifecycle, MappedFileOperation::Read),
+                ReleaseTransition::Remaining(0)
+            );
+        });
+
+        cancel.join().expect("cancelled drain waiter");
+        release.join().expect("final release");
+        assert_eq!(wait.waiters.load(Ordering::Acquire), 0);
+        assert_eq!(lifecycle.active_leases(), 0);
     });
 }
 

--- a/rocketmq-store-local/tests/mmap_region_bounds.rs
+++ b/rocketmq-store-local/tests/mmap_region_bounds.rs
@@ -12,67 +12,70 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use cheetah_string::CheetahString;
+use rocketmq_store_local::mapped_file::DefaultMappedFile;
+use rocketmq_store_local::mapped_file::MappedFile;
+use rocketmq_store_local::mapped_file::MappedFileError;
+use rocketmq_store_local::mapped_file::NativeMappedMemory;
 use std::panic::catch_unwind;
 use std::panic::AssertUnwindSafe;
-use std::sync::Arc;
-
-use memmap2::MmapMut;
-use rocketmq_store_local::mapped_file::MmapRangeError;
-use rocketmq_store_local::mapped_file::MmapRegionSlice;
 
 #[derive(Debug, Clone, Copy)]
 enum Expected {
     Valid(usize),
     Overflow,
-    OutOfBounds,
+    NotReadable,
 }
 
 #[test]
 fn safe_region_construction_never_panics_and_classifies_invalid_ranges() {
     let mapping_len = 8;
-    let mmap = Arc::new(MmapMut::map_anon(mapping_len).expect("create anonymous mapping"));
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let path = directory.path().join("00000000000000000000");
+    let mapped_file = DefaultMappedFile::<NativeMappedMemory>::try_new(
+        CheetahString::from(path.to_string_lossy().into_owned()),
+        mapping_len as u64,
+    )
+    .expect("mapped file");
+    mapped_file.set_wrote_position(mapping_len as i32);
+    assert!(mapped_file.try_seal_readable().expect("seal read-only generation"));
     let cases = [
         (0, 0, Expected::Valid(0)),
         (0, mapping_len, Expected::Valid(mapping_len)),
         (mapping_len, 0, Expected::Valid(0)),
-        (mapping_len, 1, Expected::OutOfBounds),
+        (mapping_len, 1, Expected::NotReadable),
         (usize::MAX, 1, Expected::Overflow),
         (1, usize::MAX, Expected::Overflow),
     ];
 
     for (offset, len, expected) in cases {
-        let outcome = catch_unwind(AssertUnwindSafe({
-            let mmap = Arc::clone(&mmap);
-            move || MmapRegionSlice::try_new(mmap, offset, len)
-        }));
+        let outcome = catch_unwind(AssertUnwindSafe(|| mapped_file.try_mapped_read_lease(offset, len)));
         let result = outcome.unwrap_or_else(|_| panic!("safe constructor panicked for offset={offset}, len={len}"));
 
         match expected {
             Expected::Valid(expected_len) => {
-                let region =
-                    result.unwrap_or_else(|error| panic!("valid range offset={offset}, len={len} returned {error}"));
+                let region = result
+                    .unwrap_or_else(|error| panic!("valid range offset={offset}, len={len} returned {error}"))
+                    .expect("sealed readable range");
                 assert_eq!(region.as_ref().len(), expected_len);
             }
             Expected::Overflow => {
                 assert!(
-                    matches!(result, Err(MmapRangeError::Overflow { offset: actual_offset, len: actual_len })
-                        if actual_offset == offset && actual_len == len),
+                    matches!(
+                        result,
+                        Err(MappedFileError::OutOfBounds {
+                            offset: actual_offset,
+                            size: actual_len,
+                            file_size: 8,
+                        }) if actual_offset == offset && actual_len == len
+                    ),
                     "expected overflow for offset={offset}, len={len}"
                 );
             }
-            Expected::OutOfBounds => {
+            Expected::NotReadable => {
                 assert!(
-                    matches!(
-                        result,
-                        Err(MmapRangeError::OutOfBounds {
-                            offset: actual_offset,
-                            len: actual_len,
-                            mapping_len: actual_mapping_len,
-                        }) if actual_offset == offset
-                            && actual_len == len
-                            && actual_mapping_len == mapping_len
-                    ),
-                    "expected out-of-bounds for offset={offset}, len={len}"
+                    matches!(result, Ok(None)),
+                    "expected unreadable range for offset={offset}, len={len}"
                 );
             }
         }

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -346,7 +346,7 @@ macro_rules! lock_active_mapped_file_parts {
             |manager, target| {
                 mapped_file.lock_region_with(manager, target.category, target.offset, target.len, $locker)
             },
-            |manager, handle| manager.unlock_region_with(handle, $unlocker),
+            |manager, handle| manager.unlock_owned_region_with(handle, $unlocker),
         )
     }};
 }
@@ -614,7 +614,7 @@ impl CommitLog {
     ) -> RocketMQResult<()>
     where
         F: FnMut(&[u8]) -> RocketMQResult<()>,
-        G: FnMut(&[u8]) -> RocketMQResult<()>,
+        G: FnMut(*const u8, usize) -> RocketMQResult<()>,
     {
         let target = self.active_memory_lock_target(mapped_file);
         let (active_memory_lock, active_memory_lock_present) = self.runtime_state.active_memory_lock_parts();
@@ -666,14 +666,14 @@ impl CommitLog {
 
     fn release_active_memory_lock_if_present<G>(&self, unlocker: G) -> RocketMQResult<()>
     where
-        G: FnMut(&[u8]) -> RocketMQResult<()>,
+        G: FnMut(*const u8, usize) -> RocketMQResult<()>,
     {
         let (active_memory_lock, active_memory_lock_present) = self.runtime_state.active_memory_lock_parts();
         let mut unlocker = unlocker;
         Self::release_active_memory_lock_if_present_parts(
             active_memory_lock,
             active_memory_lock_present,
-            |manager, handle| manager.unlock_region_with(handle, &mut unlocker),
+            |manager, handle| manager.unlock_owned_region_with(handle, &mut unlocker),
         )
     }
 
@@ -3107,8 +3107,8 @@ mod tests {
                     events.borrow_mut().push(("lock", memory.len()));
                     Ok(())
                 },
-                |memory| {
-                    events.borrow_mut().push(("unlock", memory.len()));
+                |_, len| {
+                    events.borrow_mut().push(("unlock", len));
                     Ok(())
                 },
             )
@@ -3121,8 +3121,8 @@ mod tests {
                     events.borrow_mut().push(("lock", memory.len()));
                     Ok(())
                 },
-                |memory| {
-                    events.borrow_mut().push(("unlock", memory.len()));
+                |_, len| {
+                    events.borrow_mut().push(("unlock", len));
                     Ok(())
                 },
             )
@@ -3165,8 +3165,8 @@ mod tests {
                     events.borrow_mut().push(("lock", memory.len()));
                     Ok(())
                 },
-                |memory| {
-                    events.borrow_mut().push(("unlock", memory.len()));
+                |_, len| {
+                    events.borrow_mut().push(("unlock", len));
                     Ok(())
                 },
             )
@@ -3180,8 +3180,8 @@ mod tests {
 
         store
             .get_commit_log()
-            .release_active_memory_lock_if_present(|memory| {
-                events.borrow_mut().push(("unlock", memory.len()));
+            .release_active_memory_lock_if_present(|_, len| {
+                events.borrow_mut().push(("unlock", len));
                 Ok(())
             })
             .expect("active file lock release should succeed");
@@ -3194,8 +3194,8 @@ mod tests {
 
         store
             .get_commit_log()
-            .release_active_memory_lock_if_present(|memory| {
-                events.borrow_mut().push(("unexpected_unlock", memory.len()));
+            .release_active_memory_lock_if_present(|_, len| {
+                events.borrow_mut().push(("unexpected_unlock", len));
                 Ok(())
             })
             .expect("inactive release should be a fast no-op");
@@ -3226,11 +3226,11 @@ mod tests {
         let mapped_file = new_test_mapped_file(&temp_root, 0, 4096);
         let commit_log = store.get_commit_log_mut();
         commit_log
-            .ensure_active_mapped_file_locked_with(&mapped_file, |_| Ok(()), |_| Ok(()))
+            .ensure_active_mapped_file_locked_with(&mapped_file, |_| Ok(()), |_, _| Ok(()))
             .expect("active file lock should succeed");
 
         let error = commit_log
-            .release_active_memory_lock_if_present(|_| {
+            .release_active_memory_lock_if_present(|_, _| {
                 Err(rocketmq_error::RocketMQError::StorageLockFailed {
                     path: "retryable active unlock".to_string(),
                 })
@@ -3246,8 +3246,8 @@ mod tests {
         assert_eq!(active_memory_lock.lock().manager().locked_bytes(), 4096);
 
         commit_log
-            .release_active_memory_lock_if_present(|memory| {
-                assert_eq!(memory.len(), 4096);
+            .release_active_memory_lock_if_present(|_, len| {
+                assert_eq!(len, 4096);
                 Ok(())
             })
             .expect("retry should release the retained handle");
@@ -3278,7 +3278,7 @@ mod tests {
         let mapped_file = new_test_mapped_file(&temp_root, 0, 4096);
         let commit_log = store.get_commit_log_mut();
         commit_log
-            .ensure_active_mapped_file_locked_with(&mapped_file, |_| Ok(()), |_| Ok(()))
+            .ensure_active_mapped_file_locked_with(&mapped_file, |_| Ok(()), |_, _| Ok(()))
             .expect("active file lock should succeed");
         let append_port = commit_log.append_runtime.port();
         let mut unlock_calls = 0;
@@ -3288,9 +3288,9 @@ mod tests {
                 append_port.snapshot().closed,
                 "append admission must close before unlock"
             );
-            manager.unlock_region_with(handle, |memory| {
+            manager.unlock_owned_region_with(handle, |_, len| {
                 unlock_calls += 1;
-                assert_eq!(memory.len(), 4096);
+                assert_eq!(len, 4096);
                 Ok(())
             })
         });
@@ -3326,11 +3326,11 @@ mod tests {
         let mapped_file = new_test_mapped_file(&temp_root, 0, 4096);
         let commit_log = store.get_commit_log_mut();
         commit_log
-            .ensure_active_mapped_file_locked_with(&mapped_file, |_| Ok(()), |_| Ok(()))
+            .ensure_active_mapped_file_locked_with(&mapped_file, |_| Ok(()), |_, _| Ok(()))
             .expect("active file lock should succeed");
 
         commit_log.release_active_memory_lock_for_drop_with(|manager, handle| {
-            manager.unlock_region_with(handle, |_| {
+            manager.unlock_owned_region_with(handle, |_, _| {
                 Err(rocketmq_error::RocketMQError::StorageLockFailed {
                     path: "drop retry".to_string(),
                 })
@@ -3342,8 +3342,9 @@ mod tests {
             .1
             .load(Ordering::Acquire));
 
-        commit_log
-            .release_active_memory_lock_for_drop_with(|manager, handle| manager.unlock_region_with(handle, |_| Ok(())));
+        commit_log.release_active_memory_lock_for_drop_with(|manager, handle| {
+            manager.unlock_owned_region_with(handle, |_, _| Ok(()))
+        });
         assert!(!commit_log
             .runtime_state
             .active_memory_lock_parts()
@@ -3383,8 +3384,8 @@ mod tests {
                     events.borrow_mut().push(("lock", memory.len()));
                     Ok(())
                 },
-                |memory| {
-                    events.borrow_mut().push(("unlock", memory.len()));
+                |_, len| {
+                    events.borrow_mut().push(("unlock", len));
                     Ok(())
                 },
             )
@@ -3398,8 +3399,8 @@ mod tests {
                     events.borrow_mut().push(("lock", memory.len()));
                     Ok(())
                 },
-                |memory| {
-                    events.borrow_mut().push(("unlock", memory.len()));
+                |_, len| {
+                    events.borrow_mut().push(("unlock", len));
                     Ok(())
                 },
             )
@@ -3439,7 +3440,7 @@ mod tests {
         let mapped_file = new_test_mapped_file(&temp_root, 4096, 4096);
         store
             .get_commit_log_mut()
-            .ensure_active_mapped_file_locked_with(&mapped_file, |_| Ok(()), |_| Ok(()))
+            .ensure_active_mapped_file_locked_with(&mapped_file, |_| Ok(()), |_, _| Ok(()))
             .expect("active file lock should succeed");
         let append_port = store.get_commit_log().append_runtime.port();
         let mut unlock_calls = 0;
@@ -3451,9 +3452,9 @@ mod tests {
                     append_port.snapshot().closed,
                     "append worker admission must close before unlock"
                 );
-                manager.unlock_region_with(handle, |memory| {
+                manager.unlock_owned_region_with(handle, |_, len| {
                     unlock_calls += 1;
-                    assert_eq!(memory.len(), 4096);
+                    assert_eq!(len, 4096);
                     Ok(())
                 })
             })

--- a/rocketmq-store/src/test_support.rs
+++ b/rocketmq-store/src/test_support.rs
@@ -504,14 +504,15 @@ fn ha_transfer_file_benchmark_batch(file: Arc<std::fs::File>, body_size: usize) 
     let start_offset = 16 * 1024;
     TransferBatch {
         frame_header: ha_transfer_benchmark_header(start_offset, body_size),
-        segments: vec![SegmentLease::from_file_range(
+        segments: vec![SegmentLease::try_from_file_range(
             start_offset,
             start_offset as u64,
             0,
             body_size,
             file,
             TransferCacheState::Hot,
-        )],
+        )
+        .expect("checked file range")],
         total_body_len: body_size,
         start_offset,
         next_offset: start_offset + body_size as i64,

--- a/rocketmq-store/tests/ha_sendfile_transfer_engine.rs
+++ b/rocketmq-store/tests/ha_sendfile_transfer_engine.rs
@@ -46,7 +46,8 @@ use tokio::io::AsyncWrite;
 #[test]
 fn segment_lease_from_file_range_exposes_only_position_and_len() {
     let file = Arc::new(temp_file_with_bytes(b"0123456789abcdef"));
-    let lease = SegmentLease::from_file_range(4096, 4096, 5, 7, file.clone(), TransferCacheState::Hot);
+    let lease = SegmentLease::try_from_file_range(4096, 4096, 5, 7, file.clone(), TransferCacheState::Hot)
+        .expect("checked file range");
 
     let range = lease.as_file_range().expect("file range");
 
@@ -68,14 +69,10 @@ async fn sendfile_transfer_engine_writes_header_then_sendfile_ranges() {
     let header = transfer_header(4096, 10);
     let batch = TransferBatch {
         frame_header: header.clone(),
-        segments: vec![SegmentLease::from_file_range(
-            4096,
-            4096,
-            3,
-            10,
-            file,
-            TransferCacheState::Hot,
-        )],
+        segments: vec![
+            SegmentLease::try_from_file_range(4096, 4096, 3, 10, file, TransferCacheState::Hot)
+                .expect("checked file range"),
+        ],
         total_body_len: 10,
         start_offset: 4096,
         next_offset: 4106,
@@ -158,14 +155,10 @@ async fn sendfile_transfer_engine_records_syscall_proxy_against_vectored_baselin
     let file = Arc::new(temp_file_with_bytes(&body));
     let sendfile_batch = TransferBatch {
         frame_header: header,
-        segments: vec![SegmentLease::from_file_range(
-            16384,
-            16384,
-            0,
-            body.len(),
-            file,
-            TransferCacheState::Hot,
-        )],
+        segments: vec![
+            SegmentLease::try_from_file_range(16384, 16384, 0, body.len(), file, TransferCacheState::Hot)
+                .expect("checked file range"),
+        ],
         total_body_len: body.len(),
         start_offset: 16384,
         next_offset: 16384 + body.len() as i64,
@@ -194,14 +187,10 @@ async fn sendfile_transfer_engine_retries_interrupted_and_would_block_without_ad
     let header = transfer_header(32768, 6);
     let batch = TransferBatch {
         frame_header: header.clone(),
-        segments: vec![SegmentLease::from_file_range(
-            32768,
-            32768,
-            0,
-            6,
-            file,
-            TransferCacheState::Hot,
-        )],
+        segments: vec![
+            SegmentLease::try_from_file_range(32768, 32768, 0, 6, file, TransferCacheState::Hot)
+                .expect("checked file range"),
+        ],
         total_body_len: 6,
         start_offset: 32768,
         next_offset: 32774,
@@ -243,14 +232,10 @@ async fn sendfile_transfer_engine_reports_write_zero_when_connection_closes() {
     let header = transfer_header(65536, 6);
     let batch = TransferBatch {
         frame_header: header,
-        segments: vec![SegmentLease::from_file_range(
-            65536,
-            65536,
-            0,
-            6,
-            file,
-            TransferCacheState::Hot,
-        )],
+        segments: vec![
+            SegmentLease::try_from_file_range(65536, 65536, 0, 6, file, TransferCacheState::Hot)
+                .expect("checked file range"),
+        ],
         total_body_len: 6,
         start_offset: 65536,
         next_offset: 65542,


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9141

### Brief Description

This change gives mapped files explicit, generation-owned physical resources and exactly-once owner-slot detach semantics:

- Replace the one-shot mapping cell with atomically published writable/read-only mapping generations that retain a canonical `FileOwner` and symmetric gauge guards.
- Add owner-bearing mapped-read, file-range, and memory-lock capabilities with checked ranges and explicit owner-before-operation Drop ordering.
- Linearize lazy publication, sealing, shutdown, and detach; closing drops a losing lazy candidate and the final admitted operation triggers exactly-once slot detach without forced unmap.
- Replace HA cloned file handles with checked `FileRangeLease` ownership and preserve Windows/Linux transfer parity.
- Pack lifecycle state, total leases, and writer leases into one CAS word, with Loom-proven seal/drain and non-closing waiter protocols.
- Document the intentional public API migration and architecture-dependent packed-counter limits in `rocketmq-doc/en/mapped-file-physical-owner-migration.md`.

Persisted CommitLog/ConsumeQueue bytes, RocketMQ wire contracts, HA frame layout, and directory layout are unchanged. Durable incarnation IDs, tombstones, deletion ledgers, and crash recovery remain scoped to the next lifecycle phase.

### How Did You Test This Change?

Passed validation:

- `cargo test -p rocketmq-store-local` — exit 0; 278 library tests and all integration targets passed.
- `python scripts/assert-rust-test-target.py --package rocketmq-store-local --target mapped_file_physical_owner` — 6/6 passed.
- The same target guard for `mmap_region_bounds`, `ha_transfer_boundary`, and `mapped_file_owner_miri` — 1/1, 3/3, and 2/2 passed on Windows.
- `cargo test -p rocketmq-store --features test-support --test ha_transfer_engine --test ha_sendfile_transfer_engine --test public_api_contract` — exit 0; 14 tests passed, with the sendfile target cfg-gated on Windows.
- Production-core Loom lifecycle suite — 13/13 passed on Windows and Linux.
- Pinned `nightly-2026-07-05` Miri with strict provenance and symbolic alignment checks — 2/2 passed.
- Ubuntu 24.04 WSL owner/lifecycle/HA matrix — 35/35 passed; the isolated target was cleaned afterward.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` — exit 0.
- `cargo doc -p rocketmq-store-local --no-deps` — exit 0 without warnings.
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` — exit 0; boundary baseline passed.
- From `fuzz/`, `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` — exit 0; `cargo audit --file Cargo.lock` also reported no vulnerabilities in 480 crates.
- Direct `rustfmt --check` over all 28 changed Rust files and `git diff --check` — exit 0.

`cargo fmt --all -- --check` did not reach formatting on Windows because it failed with OS error 206 (file name or extension too long); the direct changed-file `rustfmt --check` above passed.

The frozen short Criterion run completed all 10 mapped-write cases with a stable before/after source snapshot hash. The M2 ownership acceptance matrix has no performance hard gate; five historical-M0 comparisons above the 3% observation line are recorded explicitly as M4 performance debt. The owner-path optimization improved eight of ten cases versus the pre-optimization M2 snapshot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added lifecycle-safe mapped-file read leases and read-only sealing.
  - Added physical-owner detachment with deferred cleanup while active reads complete.
  - Added validated, owner-retaining file-range leases with splitting support.
  - Added metrics for live mappings, file owners, physical drops, and detach events.
  - Added raw-address memory locking for mapped regions.

- **Documentation**
  - Documented the mapped-file physical-owner API migration, lifecycle behavior, rollback, and compatibility details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->