### PR TITLE
[ISSUE #9146]🐛Raise random selector example recursion limit

### DIFF
--- a/rocketmq-client/examples/ordermessage/random_selector_producer.rs
+++ b/rocketmq-client/examples/ordermessage/random_selector_producer.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 //! Example demonstrating the use of SelectMessageQueueByRandom for load-balanced message delivery.
 //!
 //! This example shows how to use random queue selection to distribute messages


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9146

### Brief Description

Set the `random-selector-producer` example crate recursion limit to 256, as recommended by rustc. The Ubuntu workspace all-targets Clippy gate otherwise exceeds the default query depth while computing the shared example runtime shutdown future layout.

The change is scoped to this example crate and does not affect runtime behavior, public APIs, or other workspace packages.

### How Did You Test This Change?

- `cargo clippy -p rocketmq-client-rust --example random-selector-producer --all-features -- -D warnings`: passed.
- `cargo clippy -p rocketmq-client-rust --no-deps --all-targets --all-features -- -D warnings`: passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- `cargo fmt -p rocketmq-client-rust -- --check`: passed.
- `git diff --check`: passed.

The workspace-wide `cargo fmt --all -- --check` invocation could not run on Windows because the generated rustfmt command exceeded the operating-system command-line length limit; the affected package format check passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the recursion limit for the random selector producer example to support successful compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->