### PR TITLE
[ISSUE #9148]🐛Bound example shutdown future layout

### DIFF
--- a/rocketmq-client/examples/ordermessage/ordermessage_producer.rs
+++ b/rocketmq-client/examples/ordermessage/ordermessage_producer.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![recursion_limit = "256"]
-
 #[path = "../support/mod.rs"]
 mod support;
 

--- a/rocketmq-client/examples/ordermessage/random_selector_producer.rs
+++ b/rocketmq-client/examples/ordermessage/random_selector_producer.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![recursion_limit = "256"]
-
 //! Example demonstrating the use of SelectMessageQueueByRandom for load-balanced message delivery.
 //!
 //! This example shows how to use random queue selection to distribute messages

--- a/rocketmq-client/examples/support/mod.rs
+++ b/rocketmq-client/examples/support/mod.rs
@@ -54,16 +54,22 @@ impl ExampleClientRuntime {
     }
 
     pub async fn shutdown(self) {
-        let client_report = self.client_runtime.shutdown().await;
-        assert!(client_report.is_healthy(), "{}", client_report.to_json());
+        // Every example compiles this module into its own crate. Keep the deep client shutdown
+        // future behind a pointer so its layout does not exhaust rustc's query-depth limit in
+        // each calling example's async state machine.
+        Box::pin(async move {
+            let client_report = self.client_runtime.shutdown().await;
+            assert!(client_report.is_healthy(), "{}", client_report.to_json());
 
-        let owner_report = self.owner.shutdown_tasks().await;
-        assert!(owner_report.is_healthy(), "{}", owner_report.to_json());
+            let owner_report = self.owner.shutdown_tasks().await;
+            assert!(owner_report.is_healthy(), "{}", owner_report.to_json());
 
-        let background_report = self.owner.shutdown_background();
-        assert!(background_report.is_healthy(), "{}", background_report.to_json());
+            let background_report = self.owner.shutdown_background();
+            assert!(background_report.is_healthy(), "{}", background_report.to_json());
 
-        let telemetry_report = self.telemetry_guard.shutdown();
-        assert!(telemetry_report.is_healthy(), "{}", telemetry_report.to_json());
+            let telemetry_report = self.telemetry_guard.shutdown();
+            assert!(telemetry_report.is_healthy(), "{}", telemetry_report.to_json());
+        })
+        .await;
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9148

### Brief Description

Keep the shared `ExampleClientRuntime::shutdown()` state machine behind a pinned box so the deep `ClientRuntime::shutdown()` future does not become part of every calling example's inline layout. This fixes the query-depth overflow for `hash-selector-producer` and prevents the same failure from moving to another example target.

Remove the `recursion_limit = "256"` workarounds from `ordermessage-producer` and `random-selector-producer`. All RocketMQ client examples now compile under rustc's default recursion limit. The single allocation occurs only during example shutdown and does not affect the message-processing hot path or public APIs.

### How Did You Test This Change?

- `cargo clippy -p rocketmq-client-rust --example hash-selector-producer --all-features -- -D warnings`: passed with the CI development profile environment.
- `cargo clippy -p rocketmq-client-rust --examples --all-features -- -D warnings`: passed for all 15 examples.
- `cargo clippy -p rocketmq-client-rust --no-deps --all-targets --all-features -- -D warnings`: passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- `cargo fmt -p rocketmq-client-rust -- --check`: passed.
- `git diff --check`: passed.

The workspace-wide `cargo fmt --all -- --check` invocation could not run on Windows because the generated rustfmt command exceeded the operating-system command-line length limit; the affected package format check passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown handling in example applications for more reliable completion.
* **Examples**
  * Simplified producer examples without changing their message-sending behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->