### PR TITLE
[ISSUE #9150]🐛Set recursion limits for all client examples

### DIFF
--- a/rocketmq-client/examples/batch/callback_batch_producer.rs
+++ b/rocketmq-client/examples/batch/callback_batch_producer.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 #[path = "../support/mod.rs"]
 mod support;
 

--- a/rocketmq-client/examples/batch/simple_batch_producer.rs
+++ b/rocketmq-client/examples/batch/simple_batch_producer.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 #[path = "../support/mod.rs"]
 mod support;
 

--- a/rocketmq-client/examples/benchmark/client_production_benchmark.rs
+++ b/rocketmq-client/examples/benchmark/client_production_benchmark.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 #[path = "../support/mod.rs"]
 mod support;
 

--- a/rocketmq-client/examples/ordermessage/hash_selector_producer.rs
+++ b/rocketmq-client/examples/ordermessage/hash_selector_producer.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 //! Example demonstrating the use of SelectMessageQueueByHash for ordered message delivery.
 //!
 //! This example shows how to use hash-based queue selection to ensure that messages

--- a/rocketmq-client/examples/ordermessage/ordermessage_producer.rs
+++ b/rocketmq-client/examples/ordermessage/ordermessage_producer.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 #[path = "../support/mod.rs"]
 mod support;
 

--- a/rocketmq-client/examples/ordermessage/random_selector_producer.rs
+++ b/rocketmq-client/examples/ordermessage/random_selector_producer.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 //! Example demonstrating the use of SelectMessageQueueByRandom for load-balanced message delivery.
 //!
 //! This example shows how to use random queue selection to distribute messages

--- a/rocketmq-client/examples/producer/simple_producer.rs
+++ b/rocketmq-client/examples/producer/simple_producer.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 #[path = "../support/mod.rs"]
 mod support;
 

--- a/rocketmq-client/examples/quickstart/producer.rs
+++ b/rocketmq-client/examples/quickstart/producer.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 #[path = "../support/mod.rs"]
 mod support;
 

--- a/rocketmq-client/examples/rpc/request_callback_producer.rs
+++ b/rocketmq-client/examples/rpc/request_callback_producer.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 #[path = "../support/mod.rs"]
 mod support;
 

--- a/rocketmq-client/examples/rpc/request_producer.rs
+++ b/rocketmq-client/examples/rpc/request_producer.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 #[path = "../support/mod.rs"]
 mod support;
 

--- a/rocketmq-client/examples/support/mod.rs
+++ b/rocketmq-client/examples/support/mod.rs
@@ -54,22 +54,16 @@ impl ExampleClientRuntime {
     }
 
     pub async fn shutdown(self) {
-        // Every example compiles this module into its own crate. Keep the deep client shutdown
-        // future behind a pointer so its layout does not exhaust rustc's query-depth limit in
-        // each calling example's async state machine.
-        Box::pin(async move {
-            let client_report = self.client_runtime.shutdown().await;
-            assert!(client_report.is_healthy(), "{}", client_report.to_json());
+        let client_report = self.client_runtime.shutdown().await;
+        assert!(client_report.is_healthy(), "{}", client_report.to_json());
 
-            let owner_report = self.owner.shutdown_tasks().await;
-            assert!(owner_report.is_healthy(), "{}", owner_report.to_json());
+        let owner_report = self.owner.shutdown_tasks().await;
+        assert!(owner_report.is_healthy(), "{}", owner_report.to_json());
 
-            let background_report = self.owner.shutdown_background();
-            assert!(background_report.is_healthy(), "{}", background_report.to_json());
+        let background_report = self.owner.shutdown_background();
+        assert!(background_report.is_healthy(), "{}", background_report.to_json());
 
-            let telemetry_report = self.telemetry_guard.shutdown();
-            assert!(telemetry_report.is_healthy(), "{}", telemetry_report.to_json());
-        })
-        .await;
+        let telemetry_report = self.telemetry_guard.shutdown();
+        assert!(telemetry_report.is_healthy(), "{}", telemetry_report.to_json());
     }
 }

--- a/rocketmq-client/examples/transaction/transaction_producer.rs
+++ b/rocketmq-client/examples/transaction/transaction_producer.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 #[path = "../support/mod.rs"]
 mod support;
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9150

### Brief Description

Set `recursion_limit = "256"` on all 11 explicitly declared RocketMQ client example crates that did not already define a higher limit. Preserve the existing 512 limit on the four complex consumer examples, so all 15 Cargo example targets have an explicit compiler query-depth budget.

Revert the boxed shutdown async block introduced by #9149. Ubuntu still overflowed while computing that block's layout, and the allocation changed shutdown behavior without solving the compiler failure. The replacement is compile-time only and has no runtime allocation, message hot-path cost, or public API impact.

### How Did You Test This Change?

- `cargo clippy -p rocketmq-client-rust --example ordermessage-producer --example random-selector-producer --example hash-selector-producer --all-features -- -D warnings`: passed with the failing job's CI profile environment.
- `cargo clippy -p rocketmq-client-rust --examples --all-features -- -D warnings`: passed for all 15 examples.
- `cargo clippy -p rocketmq-client-rust --no-deps --all-targets --all-features -- -D warnings`: passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed with the failing job's CI profile environment.
- `cargo fmt -p rocketmq-client-rust -- --check`: passed.
- `git diff --check`: passed.

The workspace-wide `cargo fmt --all -- --check` invocation could not run on Windows because the generated rustfmt command exceeded the operating-system command-line length limit; the affected package format check passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when running producer, batch, order-message, RPC, benchmark, quickstart, and transaction examples by increasing their supported recursion depth.
  * Simplified example shutdown handling while preserving existing health checks and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->