### PR TITLE
[ISSUE #9152]🐛Enforce recursion limits for all client targets

### DIFF
--- a/rocketmq-client/benches/client_consume_pipeline_benchmark.rs
+++ b/rocketmq-client/benches/client_consume_pipeline_benchmark.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 //! Broker-free consumer cache pipeline baselines.
 //!
 //! These benchmarks exercise ProcessQueue hot operations through hidden probe

--- a/rocketmq-client/benches/client_hot_path_benchmark.rs
+++ b/rocketmq-client/benches/client_hot_path_benchmark.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 //! Client hot-path benchmarks for Java parity and production readiness.
 //!
 //! These benches are intentionally broker-free. They cover paths whose latency

--- a/rocketmq-client/benches/client_pull_scheduler_benchmark.rs
+++ b/rocketmq-client/benches/client_pull_scheduler_benchmark.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 #[path = "support/mod.rs"]
 mod support;
 

--- a/rocketmq-client/benches/client_runtime_spawn_benchmark.rs
+++ b/rocketmq-client/benches/client_runtime_spawn_benchmark.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 #[path = "support/mod.rs"]
 mod support;
 

--- a/rocketmq-client/benches/client_send_pipeline_benchmark.rs
+++ b/rocketmq-client/benches/client_send_pipeline_benchmark.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 //! Broker-free producer send pipeline baselines.
 //!
 //! These benchmarks measure local work performed before a request reaches the

--- a/rocketmq-client/benches/concurrent_clean_expire_lifecycle_bench.rs
+++ b/rocketmq-client/benches/concurrent_clean_expire_lifecycle_bench.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 #[path = "support/mod.rs"]
 mod support;
 

--- a/rocketmq-client/benches/connection_event_listener_lifecycle_bench.rs
+++ b/rocketmq-client/benches/connection_event_listener_lifecycle_bench.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 #[path = "support/mod.rs"]
 mod support;
 

--- a/rocketmq-client/benches/consumer_stats_manager_lifecycle_bench.rs
+++ b/rocketmq-client/benches/consumer_stats_manager_lifecycle_bench.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 #[path = "support/mod.rs"]
 mod support;
 

--- a/rocketmq-client/benches/latency_fault_detector_lifecycle_bench.rs
+++ b/rocketmq-client/benches/latency_fault_detector_lifecycle_bench.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 #[path = "support/mod.rs"]
 mod support;
 

--- a/rocketmq-client/benches/lite_pull_task_lifecycle_bench.rs
+++ b/rocketmq-client/benches/lite_pull_task_lifecycle_bench.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 #[path = "support/mod.rs"]
 mod support;
 

--- a/rocketmq-client/benches/local_file_offset_store_lifecycle_bench.rs
+++ b/rocketmq-client/benches/local_file_offset_store_lifecycle_bench.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 #[path = "support/mod.rs"]
 mod support;
 

--- a/rocketmq-client/benches/message_util_bench.rs
+++ b/rocketmq-client/benches/message_util_bench.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 use std::collections::HashMap;
 use std::hint::black_box;
 

--- a/rocketmq-client/benches/namesrv_refresh_lifecycle_bench.rs
+++ b/rocketmq-client/benches/namesrv_refresh_lifecycle_bench.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 #[path = "support/mod.rs"]
 mod support;
 

--- a/rocketmq-client/benches/oneway_benchmark.rs
+++ b/rocketmq-client/benches/oneway_benchmark.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 //! Performance benchmarks for send_oneway optimization (P0 + P1)
 //!
 //! Run with:

--- a/rocketmq-client/benches/orderly_lock_periodic_lifecycle_bench.rs
+++ b/rocketmq-client/benches/orderly_lock_periodic_lifecycle_bench.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 #[path = "support/mod.rs"]
 mod support;
 

--- a/rocketmq-client/benches/pop_orderly_lock_refresh_lifecycle_bench.rs
+++ b/rocketmq-client/benches/pop_orderly_lock_refresh_lifecycle_bench.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 #[path = "support/mod.rs"]
 mod support;
 

--- a/rocketmq-client/benches/produce_accumulator_benchmark.rs
+++ b/rocketmq-client/benches/produce_accumulator_benchmark.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 //! ProduceAccumulator Performance Benchmark
 //!
 //!

--- a/rocketmq-client/benches/produce_accumulator_guard_lifecycle_bench.rs
+++ b/rocketmq-client/benches/produce_accumulator_guard_lifecycle_bench.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 #[path = "support/mod.rs"]
 mod support;
 

--- a/rocketmq-client/benches/producer_oneway_egress.rs
+++ b/rocketmq-client/benches/producer_oneway_egress.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::Criterion;

--- a/rocketmq-client/benches/pull_message_service_lifecycle_bench.rs
+++ b/rocketmq-client/benches/pull_message_service_lifecycle_bench.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 #[path = "support/mod.rs"]
 mod support;
 

--- a/rocketmq-client/benches/rebalance_service_lifecycle_bench.rs
+++ b/rocketmq-client/benches/rebalance_service_lifecycle_bench.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 #[path = "support/mod.rs"]
 mod support;
 

--- a/rocketmq-client/benches/request_future_holder_lifecycle_bench.rs
+++ b/rocketmq-client/benches/request_future_holder_lifecycle_bench.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 #[path = "support/mod.rs"]
 mod support;
 

--- a/rocketmq-client/benches/select_queue_benchmark.rs
+++ b/rocketmq-client/benches/select_queue_benchmark.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::Criterion;

--- a/rocketmq-client/benches/thread_local_index_bench.rs
+++ b/rocketmq-client/benches/thread_local_index_bench.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 use std::cell::RefCell;
 use std::hint::black_box;
 

--- a/rocketmq-client/benches/trace_worker_lifecycle_bench.rs
+++ b/rocketmq-client/benches/trace_worker_lifecycle_bench.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 #[path = "support/mod.rs"]
 mod support;
 

--- a/rocketmq-client/tests/admin_capability_compile_tests.rs
+++ b/rocketmq-client/tests/admin_capability_compile_tests.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 mod support;
 
 use rocketmq_client_rust::AuthAdmin;

--- a/rocketmq-client/tests/broker_backed_smoke.rs
+++ b/rocketmq-client/tests/broker_backed_smoke.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 //! Broker-backed client smoke tests.
 //!
 //! These tests are skipped unless `ROCKETMQ_NAMESRV_ADDR` is set. They are

--- a/rocketmq-client/tests/client_capability_boundaries.rs
+++ b/rocketmq-client/tests/client_capability_boundaries.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 const CLIENT_FACADE: &str = include_str!("../src/implementation/mq_client_api_impl.rs");
 const CLIENT_ADMIN: &str = include_str!("../src/implementation/mq_client_api_impl/admin.rs");
 const CLIENT_VERSIONED_CONFIG: &str =

--- a/rocketmq-client/tests/client_lifecycle_probes_test.rs
+++ b/rocketmq-client/tests/client_lifecycle_probes_test.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 use rocketmq_client_rust::test_support::run_concurrent_clean_expire_lifecycle_probe;
 use rocketmq_client_rust::test_support::run_connection_event_listener_lifecycle_probe;
 use rocketmq_client_rust::test_support::run_consumer_stats_manager_lifecycle_probe;

--- a/rocketmq-client/tests/client_runtime_ownership.rs
+++ b/rocketmq-client/tests/client_runtime_ownership.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/rocketmq-client/tests/client_runtime_scope_compile_fail.rs
+++ b/rocketmq-client/tests/client_runtime_scope_compile_fail.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 #[test]
 fn client_runtime_and_builder_ownership_boundaries_are_compile_time_enforced() {
     let tests = trybuild::TestCases::new();

--- a/rocketmq-client/tests/lite_pull_assignment_registry_tests.rs
+++ b/rocketmq-client/tests/lite_pull_assignment_registry_tests.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 use rocketmq_client_rust::test_support::run_lite_pull_assignment_registry_probe;
 
 #[tokio::test]

--- a/rocketmq-client/tests/lite_pull_capability_tests.rs
+++ b/rocketmq-client/tests/lite_pull_capability_tests.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 mod support;
 
 use rocketmq_client_rust::AssignmentControl;

--- a/rocketmq-client/tests/model_type_identity.rs
+++ b/rocketmq-client/tests/model_type_identity.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 use rocketmq_client_rust::AllocateMessageQueueAveragely as LegacyAverage;
 use rocketmq_client_rust::AllocateMessageQueueStrategy as LegacyAllocationStrategy;
 use rocketmq_client_rust::PullOutcome;

--- a/rocketmq-client/tests/producer_capability_tests.rs
+++ b/rocketmq-client/tests/producer_capability_tests.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 mod support;
 
 use rocketmq_client_rust::DefaultMQProducer;

--- a/rocketmq-client/tests/producer_oneway_egress.rs
+++ b/rocketmq-client/tests/producer_oneway_egress.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 use rocketmq_runtime::BudgetClass;
 use rocketmq_runtime::BudgetLimit;
 use rocketmq_runtime::FullPolicy;

--- a/rocketmq-client/tests/public_api_contract.rs
+++ b/rocketmq-client/tests/public_api_contract.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 use rocketmq_client_rust::ClientConfig;
 use rocketmq_client_rust::ClientRuntimeConfig;
 use rocketmq_client_rust::DefaultMQProducer;

--- a/rocketmq-client/tests/pull_message_service_test.rs
+++ b/rocketmq-client/tests/pull_message_service_test.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 //! Integration tests for PullMessageService
 //!
 //! Tests cover:

--- a/rocketmq-client/tests/rebalance_concurrent_safety_test.rs
+++ b/rocketmq-client/tests/rebalance_concurrent_safety_test.rs
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+#![recursion_limit = "256"]
+
 //! Concurrent Safety Tests for RebalanceImpl
 //!
 //! These tests verify that the bug fixes for race conditions and deadlocks

--- a/rocketmq-client/tests/send_oneway_tests.rs
+++ b/rocketmq-client/tests/send_oneway_tests.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 //! Simple compilation tests for send_oneway optimization (P0 + P1)
 //!
 //! These tests verify that the new APIs compile correctly

--- a/rocketmq-client/tests/target_recursion_limit_contract.rs
+++ b/rocketmq-client/tests/target_recursion_limit_contract.rs
@@ -1,0 +1,77 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![recursion_limit = "256"]
+
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+
+const RECURSION_LIMIT_ATTRIBUTE: &str = "#![recursion_limit = \"";
+
+fn top_level_rust_files(directory: &Path) -> Vec<PathBuf> {
+    fs::read_dir(directory)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", directory.display()))
+        .map(|entry| {
+            entry
+                .unwrap_or_else(|error| panic!("failed to read an entry in {}: {error}", directory.display()))
+                .path()
+        })
+        .filter(|path| path.extension().is_some_and(|extension| extension == "rs"))
+        .collect()
+}
+
+fn explicit_example_roots(manifest_dir: &Path) -> Vec<PathBuf> {
+    let manifest_path = manifest_dir.join("Cargo.toml");
+    let manifest = fs::read_to_string(&manifest_path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", manifest_path.display()));
+
+    manifest
+        .lines()
+        .filter_map(|line| {
+            line.trim()
+                .strip_prefix("path = \"")
+                .and_then(|path| path.strip_suffix('"'))
+                .filter(|path| path.starts_with("examples/") && path.ends_with(".rs"))
+                .map(|path| manifest_dir.join(path))
+        })
+        .collect()
+}
+
+#[test]
+fn every_client_cargo_target_declares_a_recursion_limit() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut target_roots = vec![manifest_dir.join("src/lib.rs")];
+    target_roots.extend(top_level_rust_files(&manifest_dir.join("tests")));
+    target_roots.extend(top_level_rust_files(&manifest_dir.join("benches")));
+    target_roots.extend(explicit_example_roots(&manifest_dir));
+    target_roots.sort();
+    target_roots.dedup();
+
+    let missing = target_roots
+        .iter()
+        .filter(|path| {
+            !fs::read_to_string(path)
+                .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+                .contains(RECURSION_LIMIT_ATTRIBUTE)
+        })
+        .map(|path| path.strip_prefix(&manifest_dir).unwrap_or(path).display().to_string())
+        .collect::<Vec<_>>();
+
+    assert!(
+        missing.is_empty(),
+        "Cargo target crates must declare a recursion limit; missing:\n{}",
+        missing.join("\n")
+    );
+}

--- a/rocketmq-client/tests/thread_local_index_test.rs
+++ b/rocketmq-client/tests/thread_local_index_test.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use rand::RngExt;
 use rocketmq_client_rust::ThreadLocalIndex;
 use std::cell::RefCell;

--- a/rocketmq-client/tests/transaction_producer_test.rs
+++ b/rocketmq-client/tests/transaction_producer_test.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 use std::any::Any;
 use std::sync::Arc;
 

--- a/rocketmq-client/tests/typed_error_client_flow_tests.rs
+++ b/rocketmq-client/tests/typed_error_client_flow_tests.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 #[test]
 fn client_callback_files_do_not_use_legacy_error_enum() {
     let files = [


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9152

### Brief Description

Set `recursion_limit = "256"` on the 18 RocketMQ client integration-test crate roots and 25 benchmark crate roots that did not already declare a compiler query-depth budget. Integration tests and benchmarks are independent Cargo crates, so they do not inherit the limit from `rocketmq-client/src/lib.rs`.

Add `target_recursion_limit_contract.rs`, which dynamically scans the client library root, every top-level integration test, every top-level benchmark, and every explicitly declared example path. Future Cargo targets now fail with a focused missing-file list instead of surfacing sequential query-depth failures in the workspace Clippy job. The change is compile-time and test-only, with no runtime or public API impact.

### How Did You Test This Change?

- `cargo clippy --workspace --test client_runtime_ownership --all-features -- -D warnings`: passed on Ubuntu 24.04 WSL after reproducing the base-branch failure with the same command.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed on Ubuntu 24.04 WSL with the CI profile environment.
- `cargo test -p rocketmq-client-rust --test target_recursion_limit_contract --all-features`: passed.
- `cargo fmt --all -- --check`: passed on Ubuntu 24.04 WSL.
- `cargo fmt -p rocketmq-client-rust -- --check`: passed on Windows.
- `git diff --check`: passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage to verify consistent recursion-limit configuration across client libraries, tests, benchmarks, and examples.
  - Improved diagnostics when required configuration is missing or targets cannot be inspected.

- **Chores**
  - Updated client test and benchmark targets to support deeper compile-time type expansion.
  - Improved reliability and consistency when building and validating the client project, with no changes to runtime behavior or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->