### PR TITLE
[ISSUE #9170]♻️Adopt native async traits in RocketMQ MCP

### DIFF
--- a/rocketmq-tools/rocketmq-mcp/AGENTS.md
+++ b/rocketmq-tools/rocketmq-mcp/AGENTS.md
@@ -12,6 +12,7 @@ This file applies to `rocketmq-tools/rocketmq-mcp/`.
 - Do not enable `client-adapter`, `mutation-client-adapter`, `admin-full`, or `admin-mutation`.
 - Streamable HTTP is authenticated by default. Stdio is local-development only and writes protocol frames only to stdout.
 - Tool and Resource output must use the shared authorization, audit, correlation, sanitization, row, and byte policy.
+- Prefer native async fn methods in traits. #[allow(async_fn_in_trait)] is permitted when required by the lint for an intentional public async trait API; do not add #[async_trait].
 
 ## Mandatory validation
 

--- a/rocketmq-tools/rocketmq-mcp/Cargo.lock
+++ b/rocketmq-tools/rocketmq-mcp/Cargo.lock
@@ -3479,7 +3479,6 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "arc-swap",
- "async-trait",
  "axum",
  "base64 0.23.1",
  "chrono",

--- a/rocketmq-tools/rocketmq-mcp/Cargo.toml
+++ b/rocketmq-tools/rocketmq-mcp/Cargo.toml
@@ -64,7 +64,6 @@ rocketmq-transport    = { version = "1.0.0", path = "../../rocketmq-transport", 
 
 anyhow             = "1.0.102"
 arc-swap           = { version = "1.9", optional = true }
-async-trait         = "0.1"
 axum               = { version = "0.8", optional = true }
 chrono             = { version = "0.4", default-features = false, features = ["clock", "std"] }
 clap               = { version = "4.6.1", features = ["derive", "env"] }

--- a/rocketmq-tools/rocketmq-mcp/scripts/check_read_only_boundary.py
+++ b/rocketmq-tools/rocketmq-mcp/scripts/check_read_only_boundary.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import pathlib
+import re
 import subprocess
 import sys
 
@@ -28,6 +29,14 @@ FORBIDDEN_IMPORTS = (
     "RouteAdmin",
     "TopicAdmin",
 )
+FORBIDDEN_DIRECT_DEPENDENCIES = {"async-trait"}
+FORBIDDEN_SOURCE_PATTERNS = (
+    (
+        "async-trait source token",
+        re.compile(r"\basync_trait\b"),
+    ),
+)
+SOURCE_ROOTS = (ROOT / "src", ROOT / "tests")
 
 
 def main() -> int:
@@ -43,6 +52,16 @@ def main() -> int:
     metadata = json.loads(subprocess.check_output(command, cwd=ROOT, text=True))
     packages = {package["id"]: package["name"] for package in metadata["packages"]}
     violations: list[str] = []
+    root_manifest = (ROOT / "Cargo.toml").resolve()
+    root_package = next(
+        package
+        for package in metadata["packages"]
+        if pathlib.Path(package["manifest_path"]).resolve() == root_manifest
+    )
+    for dependency in root_package["dependencies"]:
+        if dependency["name"] in FORBIDDEN_DIRECT_DEPENDENCIES:
+            violations.append(f"rocketmq-mcp directly depends on forbidden `{dependency['name']}`")
+
     for node in metadata["resolve"]["nodes"]:
         package = packages.get(node["id"])
         forbidden = FORBIDDEN.get(package)
@@ -53,11 +72,15 @@ def main() -> int:
         if overlap:
             violations.append(f"{package}: forbidden features enabled: {', '.join(overlap)}")
 
-    for path in sorted((ROOT / "src").rglob("*.rs")):
-        text = path.read_text(encoding="utf-8")
-        for forbidden in FORBIDDEN_IMPORTS:
-            if forbidden in text:
-                violations.append(f"{path.relative_to(ROOT)} imports forbidden capability `{forbidden}`")
+    for source_root in SOURCE_ROOTS:
+        for path in sorted(source_root.rglob("*.rs")):
+            text = path.read_text(encoding="utf-8")
+            for forbidden in FORBIDDEN_IMPORTS:
+                if forbidden in text:
+                    violations.append(f"{path.relative_to(ROOT)} imports forbidden capability `{forbidden}`")
+            for label, pattern in FORBIDDEN_SOURCE_PATTERNS:
+                if pattern.search(text):
+                    violations.append(f"{path.relative_to(ROOT)} uses forbidden {label}")
 
     if violations:
         print("MCP read-only boundary violations:", file=sys.stderr)

--- a/rocketmq-tools/rocketmq-mcp/src/adapter/admin_session.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/adapter/admin_session.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::BTreeMap;
+use std::future::Future;
 use std::sync::Arc;
 
 use rocketmq_admin_core::core::broker::BrokerQueryAdmin;
@@ -60,32 +61,35 @@ pub(crate) struct SessionConsumerLag {
     pub inflight_total: i64,
 }
 
-#[async_trait::async_trait]
 pub(crate) trait AdminSession: Send {
-    async fn broker_rows(&mut self) -> Result<Vec<BrokerSummary>, ToolExecutionError>;
+    fn broker_rows(&mut self) -> impl Future<Output = Result<Vec<BrokerSummary>, ToolExecutionError>> + Send;
 
-    async fn topic_entries(&mut self) -> Result<Vec<TopicListEntry>, ToolExecutionError>;
+    fn topic_entries(&mut self) -> impl Future<Output = Result<Vec<TopicListEntry>, ToolExecutionError>> + Send;
 
-    async fn topic_route(&mut self, topic: &str) -> Result<SessionTopicRoute, ToolExecutionError>;
+    fn topic_route(
+        &mut self,
+        topic: &str,
+    ) -> impl Future<Output = Result<SessionTopicRoute, ToolExecutionError>> + Send;
 
-    async fn consumer_groups(&mut self) -> Result<Vec<ConsumerGroupSummary>, ToolExecutionError>;
+    fn consumer_groups(&mut self)
+        -> impl Future<Output = Result<Vec<ConsumerGroupSummary>, ToolExecutionError>> + Send;
 
-    async fn consumer_lag(
+    fn consumer_lag(
         &mut self,
         topic: &str,
         consumer_group: &str,
-    ) -> Result<SessionConsumerLag, ToolExecutionError>;
+    ) -> impl Future<Output = Result<SessionConsumerLag, ToolExecutionError>> + Send;
 
-    async fn probe_broker_runtime(&mut self) -> Result<(), ToolExecutionError>;
+    fn probe_broker_runtime(&mut self) -> impl Future<Output = Result<(), ToolExecutionError>> + Send;
 
-    async fn shutdown(self) -> Result<(), ToolExecutionError>;
+    fn shutdown(self) -> impl Future<Output = Result<(), ToolExecutionError>> + Send;
 }
 
-#[async_trait::async_trait]
 pub(crate) trait AdminSessionFactory: Clone + Send + Sync + 'static {
     type Session: AdminSession;
 
-    async fn start(&self, cluster: ResolvedCluster) -> Result<Self::Session, ToolExecutionError>;
+    fn start(&self, cluster: ResolvedCluster)
+        -> impl Future<Output = Result<Self::Session, ToolExecutionError>> + Send;
 }
 
 #[derive(Clone)]
@@ -108,7 +112,6 @@ impl AdminCoreSessionFactory {
     }
 }
 
-#[async_trait::async_trait]
 impl AdminSessionFactory for AdminCoreSessionFactory {
     type Session = AdminCoreSession;
 
@@ -138,7 +141,6 @@ impl AdminCoreSession {
     }
 }
 
-#[async_trait::async_trait]
 impl AdminSession for AdminCoreSession {
     async fn broker_rows(&mut self) -> Result<Vec<BrokerSummary>, ToolExecutionError> {
         let request = ListBrokersRequest::try_new(self.cluster.rocketmq_cluster_name.clone())

--- a/rocketmq-tools/rocketmq-mcp/src/adapter/query_facade.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/adapter/query_facade.rs
@@ -74,44 +74,46 @@ impl Default for WorkflowControl {
 
 type WorkflowFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, ToolExecutionError>> + Send + 'a>>;
 
-#[async_trait::async_trait]
 pub(crate) trait ReadOnlyQuery: Clone + Send + Sync + 'static {
-    async fn cluster_overview(
+    fn cluster_overview(
         &self,
         args: ClusterOverviewArgs,
-    ) -> Result<QueryResult<ClusterOverviewOutput>, ToolExecutionError>;
+    ) -> impl Future<Output = Result<QueryResult<ClusterOverviewOutput>, ToolExecutionError>> + Send;
 
-    async fn list_topics(&self, args: ListTopicsArgs) -> Result<QueryResult<ListTopicsOutput>, ToolExecutionError>;
+    fn list_topics(
+        &self,
+        args: ListTopicsArgs,
+    ) -> impl Future<Output = Result<QueryResult<ListTopicsOutput>, ToolExecutionError>> + Send;
 
-    async fn describe_topic(
+    fn describe_topic(
         &self,
         args: DescribeTopicArgs,
-    ) -> Result<QueryResult<DescribeTopicOutput>, ToolExecutionError>;
+    ) -> impl Future<Output = Result<QueryResult<DescribeTopicOutput>, ToolExecutionError>> + Send;
 
-    async fn query_topic_route(
+    fn query_topic_route(
         &self,
         args: QueryTopicRouteArgs,
-    ) -> Result<QueryResult<QueryTopicRouteOutput>, ToolExecutionError>;
+    ) -> impl Future<Output = Result<QueryResult<QueryTopicRouteOutput>, ToolExecutionError>> + Send;
 
-    async fn list_consumer_groups(
+    fn list_consumer_groups(
         &self,
         args: ListConsumerGroupsArgs,
-    ) -> Result<QueryResult<ListConsumerGroupsOutput>, ToolExecutionError>;
+    ) -> impl Future<Output = Result<QueryResult<ListConsumerGroupsOutput>, ToolExecutionError>> + Send;
 
-    async fn query_consumer_lag(
+    fn query_consumer_lag(
         &self,
         args: QueryConsumerLagArgs,
-    ) -> Result<QueryResult<QueryConsumerLagOutput>, ToolExecutionError>;
+    ) -> impl Future<Output = Result<QueryResult<QueryConsumerLagOutput>, ToolExecutionError>> + Send;
 
-    async fn describe_broker(
+    fn describe_broker(
         &self,
         args: DescribeBrokerArgs,
-    ) -> Result<QueryResult<DescribeBrokerOutput>, ToolExecutionError>;
+    ) -> impl Future<Output = Result<QueryResult<DescribeBrokerOutput>, ToolExecutionError>> + Send;
 
-    async fn diagnose_consumer_lag(
+    fn diagnose_consumer_lag(
         &self,
         args: DiagnoseConsumerLagArgs,
-    ) -> Result<QueryResult<DiagnosisReport>, ToolExecutionError>;
+    ) -> impl Future<Output = Result<QueryResult<DiagnosisReport>, ToolExecutionError>> + Send;
 }
 
 #[derive(Clone)]
@@ -578,7 +580,6 @@ impl QueryFacade<AdminCoreSessionFactory> {
     }
 }
 
-#[async_trait::async_trait]
 impl<F> ReadOnlyQuery for QueryFacade<F>
 where
     F: AdminSessionFactory,
@@ -822,7 +823,6 @@ mod tests {
         fail_topic_query: bool,
     }
 
-    #[async_trait::async_trait]
     impl AdminSessionFactory for FakeSessionFactory {
         type Session = FakeSession;
 
@@ -850,7 +850,6 @@ mod tests {
         fail_topic_query: bool,
     }
 
-    #[async_trait::async_trait]
     impl AdminSession for FakeSession {
         async fn broker_rows(&mut self) -> Result<Vec<BrokerSummary>, ToolExecutionError> {
             self.counters.broker_queries.fetch_add(1, Ordering::SeqCst);
@@ -915,6 +914,68 @@ mod tests {
             self.counters.shutdowns.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
+    }
+
+    #[test]
+    fn read_only_query_futures_preserve_the_send_contract() {
+        fn assert_send<T: Send>(_: T) {}
+
+        fn assert_query_futures_are_send<Q: ReadOnlyQuery>(
+            query: &Q,
+            cluster_overview: ClusterOverviewArgs,
+            list_topics: ListTopicsArgs,
+            describe_topic: DescribeTopicArgs,
+            topic_route: QueryTopicRouteArgs,
+            consumer_groups: ListConsumerGroupsArgs,
+            consumer_lag: QueryConsumerLagArgs,
+            broker: DescribeBrokerArgs,
+            diagnosis: DiagnoseConsumerLagArgs,
+        ) {
+            assert_send(query.cluster_overview(cluster_overview));
+            assert_send(query.list_topics(list_topics));
+            assert_send(query.describe_topic(describe_topic));
+            assert_send(query.query_topic_route(topic_route));
+            assert_send(query.list_consumer_groups(consumer_groups));
+            assert_send(query.query_consumer_lag(consumer_lag));
+            assert_send(query.describe_broker(broker));
+            assert_send(query.diagnose_consumer_lag(diagnosis));
+        }
+
+        let facade = QueryFacade::with_factory(example_config(), FakeSessionFactory::default());
+        let page = PageRequest::default();
+        assert_query_futures_are_send(
+            &facade,
+            ClusterOverviewArgs {
+                cluster: "local-dev".to_string(),
+            },
+            ListTopicsArgs::default(),
+            DescribeTopicArgs {
+                cluster: "local-dev".to_string(),
+                topic: "orders".to_string(),
+                page: page.clone(),
+            },
+            QueryTopicRouteArgs {
+                cluster: "local-dev".to_string(),
+                topic: "orders".to_string(),
+                page: page.clone(),
+            },
+            ListConsumerGroupsArgs::default(),
+            QueryConsumerLagArgs {
+                cluster: "local-dev".to_string(),
+                topic: "orders".to_string(),
+                consumer_group: "order-service".to_string(),
+                page,
+            },
+            DescribeBrokerArgs {
+                cluster: "local-dev".to_string(),
+                broker_name: "broker-a".to_string(),
+            },
+            DiagnoseConsumerLagArgs {
+                cluster: "local-dev".to_string(),
+                topic: "orders".to_string(),
+                consumer_group: "order-service".to_string(),
+            },
+        );
     }
 
     #[tokio::test]

--- a/rocketmq-tools/rocketmq-mcp/src/guard/audit.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/guard/audit.rs
@@ -14,6 +14,7 @@
 
 use std::collections::VecDeque;
 use std::fs::OpenOptions;
+use std::future::Future;
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
@@ -26,7 +27,6 @@ use std::time::Instant;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
-use async_trait::async_trait;
 use serde::Serialize;
 use tokio::sync::mpsc;
 use tokio::sync::Notify;
@@ -259,13 +259,13 @@ impl AuditLog {
         config: &AuditConfig,
         service_context: &rocketmq_runtime::ChildServiceContext,
     ) -> Result<(), GuardError> {
-        let sink: Box<dyn AuditSink> = match config.sink.as_str() {
-            "file" => Box::new(FileAuditSink {
+        let sink = match config.sink.as_str() {
+            "file" => ConfiguredAuditSink::File(FileAuditSink {
                 path: PathBuf::from(&config.path),
                 blocking: service_context.storage_io().clone(),
             }),
-            "tracing" => Box::new(TracingAuditSink),
-            "memory" => Box::new(MemoryAuditSink),
+            "tracing" => ConfiguredAuditSink::Tracing(TracingAuditSink),
+            "memory" => ConfiguredAuditSink::Memory(MemoryAuditSink),
             _ => {
                 return Err(GuardError::InvalidArgument("unsupported audit sink".to_string()));
             }
@@ -426,12 +426,15 @@ impl AuditLog {
         self.drain_report(status, started_at.elapsed())
     }
 
-    fn start_with_sink(
+    fn start_with_sink<S>(
         &self,
         config: &AuditConfig,
         service_context: &rocketmq_runtime::ChildServiceContext,
-        sink: Box<dyn AuditSink>,
-    ) -> Result<(), GuardError> {
+        sink: S,
+    ) -> Result<(), GuardError>
+    where
+        S: AuditSink,
+    {
         validate_queue_config(config)?;
         let mut lifecycle = self
             .lifecycle
@@ -551,10 +554,33 @@ struct AuditEnvelope {
     pending: PendingAuditRecord,
 }
 
-#[async_trait]
-trait AuditSink: Send {
-    async fn write(&mut self, record: &AuditRecord, encoded: &[u8]) -> Result<(), ()>;
-    async fn flush(&mut self) -> Result<(), ()>;
+trait AuditSink: Send + 'static {
+    fn write(&mut self, record: &AuditRecord, encoded: &[u8]) -> impl Future<Output = Result<(), ()>> + Send;
+    fn flush(&mut self) -> impl Future<Output = Result<(), ()>> + Send;
+}
+
+enum ConfiguredAuditSink {
+    File(FileAuditSink),
+    Tracing(TracingAuditSink),
+    Memory(MemoryAuditSink),
+}
+
+impl AuditSink for ConfiguredAuditSink {
+    async fn write(&mut self, record: &AuditRecord, encoded: &[u8]) -> Result<(), ()> {
+        match self {
+            Self::File(sink) => sink.write(record, encoded).await,
+            Self::Tracing(sink) => sink.write(record, encoded).await,
+            Self::Memory(sink) => sink.write(record, encoded).await,
+        }
+    }
+
+    async fn flush(&mut self) -> Result<(), ()> {
+        match self {
+            Self::File(sink) => sink.flush().await,
+            Self::Tracing(sink) => sink.flush().await,
+            Self::Memory(sink) => sink.flush().await,
+        }
+    }
 }
 
 struct FileAuditSink {
@@ -562,7 +588,6 @@ struct FileAuditSink {
     blocking: rocketmq_runtime::BlockingExecutor,
 }
 
-#[async_trait]
 impl AuditSink for FileAuditSink {
     async fn write(&mut self, _record: &AuditRecord, encoded: &[u8]) -> Result<(), ()> {
         let path = self.path.clone();
@@ -586,7 +611,6 @@ impl AuditSink for FileAuditSink {
 
 struct TracingAuditSink;
 
-#[async_trait]
 impl AuditSink for TracingAuditSink {
     async fn write(&mut self, record: &AuditRecord, _encoded: &[u8]) -> Result<(), ()> {
         tracing::info!(
@@ -611,7 +635,6 @@ impl AuditSink for TracingAuditSink {
 
 struct MemoryAuditSink;
 
-#[async_trait]
 impl AuditSink for MemoryAuditSink {
     async fn write(&mut self, _record: &AuditRecord, _encoded: &[u8]) -> Result<(), ()> {
         Ok(())
@@ -622,13 +645,15 @@ impl AuditSink for MemoryAuditSink {
     }
 }
 
-async fn run_audit_writer(
+async fn run_audit_writer<S>(
     mut receiver: mpsc::Receiver<AuditEnvelope>,
-    mut sink: Box<dyn AuditSink>,
+    mut sink: S,
     counters: Arc<AuditCounters>,
     records: Arc<Mutex<VecDeque<AuditRecord>>>,
     completion: Arc<WriterCompletion>,
-) {
+) where
+    S: AuditSink,
+{
     let completion = CompletionGuard(completion);
     while let Some(envelope) = receiver.recv().await {
         if sink.write(&envelope.record, &envelope.encoded).await.is_ok() {

--- a/rocketmq-tools/rocketmq-mcp/src/guard/audit/tests.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/guard/audit/tests.rs
@@ -43,7 +43,6 @@ struct TestAuditSink {
     state: Arc<TestSinkState>,
 }
 
-#[async_trait]
 impl AuditSink for TestAuditSink {
     async fn write(&mut self, record: &AuditRecord, _encoded: &[u8]) -> Result<(), ()> {
         self.state
@@ -127,7 +126,7 @@ async fn count_capacity_is_non_blocking_and_preserves_fifo_for_accepted_records(
     config.queue_capacity = 1;
     let state = Arc::new(TestSinkState::default());
     state.stall_first.store(true, Ordering::Release);
-    log.start_with_sink(&config, &service, Box::new(TestAuditSink { state: state.clone() }))
+    log.start_with_sink(&config, &service, TestAuditSink { state: state.clone() })
         .unwrap();
 
     log.record(&config, sample_record("request-1", None));
@@ -171,7 +170,7 @@ async fn byte_capacity_is_non_blocking_independent_of_record_capacity() {
     config.queue_capacity = 8;
     let state = Arc::new(TestSinkState::default());
     state.stall_first.store(true, Ordering::Release);
-    log.start_with_sink(&config, &service, Box::new(TestAuditSink { state: state.clone() }))
+    log.start_with_sink(&config, &service, TestAuditSink { state: state.clone() })
         .unwrap();
 
     log.record(&config, sample_record("request-1", None));
@@ -203,7 +202,7 @@ async fn sink_failure_does_not_stop_fifo_writer_and_flush_failure_is_reported() 
     let state = Arc::new(TestSinkState::default());
     state.failures_remaining.store(1, Ordering::Release);
     state.fail_flush.store(true, Ordering::Release);
-    log.start_with_sink(&config, &service, Box::new(TestAuditSink { state: state.clone() }))
+    log.start_with_sink(&config, &service, TestAuditSink { state: state.clone() })
         .unwrap();
 
     for request_id in ["request-1", "request-2", "request-3"] {
@@ -239,7 +238,7 @@ async fn one_absolute_deadline_reports_stall_then_allows_a_later_drain() {
     let config = test_config("tracing");
     let state = Arc::new(TestSinkState::default());
     state.stall_first.store(true, Ordering::Release);
-    log.start_with_sink(&config, &service, Box::new(TestAuditSink { state: state.clone() }))
+    log.start_with_sink(&config, &service, TestAuditSink { state: state.clone() })
         .unwrap();
     log.record(&config, sample_record("request-1", None));
     tokio::time::timeout(Duration::from_secs(1), state.started.notified())
@@ -273,7 +272,7 @@ async fn runtime_cancellation_releases_pending_capacity_without_claiming_a_drain
     let config = test_config("tracing");
     let state = Arc::new(TestSinkState::default());
     state.stall_first.store(true, Ordering::Release);
-    log.start_with_sink(&config, &service, Box::new(TestAuditSink { state: state.clone() }))
+    log.start_with_sink(&config, &service, TestAuditSink { state: state.clone() })
         .unwrap();
     log.record(&config, sample_record("request-cancelled", None));
     tokio::time::timeout(Duration::from_secs(1), state.started.notified())

--- a/rocketmq-tools/rocketmq-mcp/src/guard/http_auth.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/guard/http_auth.rs
@@ -36,27 +36,56 @@ use crate::config::HttpConfig;
 use crate::guard::context::Principal;
 use crate::guard::context::RequestContext;
 use crate::guard::jwks::HttpJwksSource;
+use crate::guard::jwks::JwksSource;
 use crate::guard::jwks::JwksVerifier;
 use crate::guard::Guard;
 
-#[derive(Clone)]
-pub struct HttpAuthState {
-    authenticator: HttpAuthenticator,
+pub struct HttpAuthState<S = HttpJwksSource> {
+    authenticator: HttpAuthenticator<S>,
     guard: Guard,
     resource_metadata: Option<Arc<str>>,
 }
 
-#[derive(Clone)]
-enum HttpAuthenticator {
+enum HttpAuthenticator<S = HttpJwksSource> {
     DevelopmentToken {
         token: Arc<str>,
         tenant: Option<String>,
     },
     OAuthJwt {
-        verifier: JwksVerifier,
+        verifier: JwksVerifier<S>,
         validation: Arc<Validation>,
         required_scopes: BTreeSet<String>,
     },
+}
+
+impl<S> Clone for HttpAuthState<S> {
+    fn clone(&self) -> Self {
+        Self {
+            authenticator: self.authenticator.clone(),
+            guard: self.guard.clone(),
+            resource_metadata: self.resource_metadata.clone(),
+        }
+    }
+}
+
+impl<S> Clone for HttpAuthenticator<S> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::DevelopmentToken { token, tenant } => Self::DevelopmentToken {
+                token: token.clone(),
+                tenant: tenant.clone(),
+            },
+            Self::OAuthJwt {
+                verifier,
+                validation,
+                required_scopes,
+            } => Self::OAuthJwt {
+                verifier: verifier.clone(),
+                validation: validation.clone(),
+                required_scopes: required_scopes.clone(),
+            },
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -76,7 +105,7 @@ struct JwtClaims {
     rocketmq_clusters: Option<Vec<String>>,
 }
 
-impl HttpAuthState {
+impl HttpAuthState<HttpJwksSource> {
     pub fn from_config(config: &HttpAuthConfig, guard: Guard) -> Result<Self, HttpAuthError> {
         Self::from_parts(config, guard, None)
     }
@@ -133,7 +162,12 @@ impl HttpAuthState {
             resource_metadata,
         })
     }
+}
 
+impl<S> HttpAuthState<S>
+where
+    S: JwksSource,
+{
     pub async fn warm_up(&self) -> Result<(), HttpAuthError> {
         if let HttpAuthenticator::OAuthJwt { verifier, .. } = &self.authenticator {
             verifier.warm_up().await.map_err(|_| HttpAuthError::InvalidJwksConfig)?;
@@ -320,7 +354,6 @@ pub async fn http_auth_middleware(State(state): State<HttpAuthState>, mut reques
 
 #[cfg(test)]
 mod tests {
-    use async_trait::async_trait;
     use jsonwebtoken::encode;
     use jsonwebtoken::EncodingKey;
     use jsonwebtoken::Header;
@@ -350,6 +383,7 @@ mod tests {
     #[tokio::test]
     async fn oauth_jwt_attributes_the_verified_principal() {
         let state = oauth_state(["rocketmq:read"]).await;
+        let _cloned = state.clone();
         let token = signed_token("rocketmq:read rocketmq:diagnose", "test-key");
         let context = state.authenticate(&bearer_headers(&token)).await.unwrap();
 
@@ -429,7 +463,7 @@ mod tests {
         }
     }
 
-    async fn oauth_state(required_scopes: impl IntoIterator<Item = &'static str>) -> HttpAuthState {
+    async fn oauth_state(required_scopes: impl IntoIterator<Item = &'static str>) -> HttpAuthState<StaticSource> {
         let verifier = JwksVerifier::new(
             Arc::new(StaticSource),
             Duration::from_secs(300),
@@ -514,7 +548,6 @@ mod tests {
 
     struct StaticSource;
 
-    #[async_trait]
     impl JwksSource for StaticSource {
         async fn fetch(&self) -> Result<Vec<u8>, JwksError> {
             Ok(serde_json::to_vec(&serde_json::json!({"keys": [{

--- a/rocketmq-tools/rocketmq-mcp/src/guard/jwks.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/guard/jwks.rs
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 use std::collections::BTreeMap;
+use std::future::Future;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 
 use arc_swap::ArcSwap;
-use async_trait::async_trait;
 use jsonwebtoken::Algorithm;
 use jsonwebtoken::DecodingKey;
 use serde::Deserialize;
@@ -29,9 +29,8 @@ const MAX_JWKS_BYTES: usize = 256 * 1024;
 const MAX_JWKS_KEYS: usize = 64;
 const JWKS_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
 
-#[async_trait]
 pub trait JwksSource: Send + Sync {
-    async fn fetch(&self) -> Result<Vec<u8>, JwksError>;
+    fn fetch(&self) -> impl Future<Output = Result<Vec<u8>, JwksError>> + Send;
 }
 
 #[derive(Clone)]
@@ -64,7 +63,6 @@ impl HttpJwksSource {
     }
 }
 
-#[async_trait]
 impl JwksSource for HttpJwksSource {
     async fn fetch(&self) -> Result<Vec<u8>, JwksError> {
         let mut response = self
@@ -93,16 +91,27 @@ impl JwksSource for HttpJwksSource {
     }
 }
 
-#[derive(Clone)]
-pub struct JwksVerifier {
-    source: Arc<dyn JwksSource>,
+pub struct JwksVerifier<S = HttpJwksSource> {
+    source: Arc<S>,
     active: Arc<ArcSwap<JwksSnapshot>>,
     refresh_writer: Arc<Mutex<()>>,
     refresh_after: Duration,
     max_stale: Duration,
 }
 
-impl std::fmt::Debug for JwksVerifier {
+impl<S> Clone for JwksVerifier<S> {
+    fn clone(&self) -> Self {
+        Self {
+            source: self.source.clone(),
+            active: self.active.clone(),
+            refresh_writer: self.refresh_writer.clone(),
+            refresh_after: self.refresh_after,
+            max_stale: self.max_stale,
+        }
+    }
+}
+
+impl<S> std::fmt::Debug for JwksVerifier<S> {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
             .debug_struct("JwksVerifier")
@@ -113,8 +122,11 @@ impl std::fmt::Debug for JwksVerifier {
     }
 }
 
-impl JwksVerifier {
-    pub fn new(source: Arc<dyn JwksSource>, refresh_after: Duration, max_stale: Duration) -> Self {
+impl<S> JwksVerifier<S>
+where
+    S: JwksSource,
+{
+    pub fn new(source: Arc<S>, refresh_after: Duration, max_stale: Duration) -> Self {
         Self {
             source,
             active: Arc::new(ArcSwap::from_pointee(JwksSnapshot::empty())),
@@ -337,6 +349,19 @@ mod tests {
         assert!(verifier.decoding_key("eyJhbGciOiJSUzI1NiJ9.e30.invalid").await.is_err());
     }
 
+    #[test]
+    fn source_future_is_send_and_verifier_clone_does_not_require_source_clone() {
+        fn assert_send<T: Send>(_: T) {}
+        fn assert_source_future_is_send<S: JwksSource>(source: &S) {
+            assert_send(source.fetch());
+        }
+
+        let source = Arc::new(QueueSource::new([Ok(jwks_document(&["one"]))]));
+        assert_source_future_is_send(source.as_ref());
+        let verifier = JwksVerifier::new(source, Duration::from_secs(60), Duration::from_secs(60));
+        let _cloned = verifier.clone();
+    }
+
     fn jwks_document(kids: &[&str]) -> Vec<u8> {
         serde_json::to_vec(&serde_json::json!({
             "keys": kids.iter().map(|kid| serde_json::json!({
@@ -371,7 +396,6 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl JwksSource for QueueSource {
         async fn fetch(&self) -> Result<Vec<u8>, JwksError> {
             self.responses

--- a/rocketmq-tools/rocketmq-mcp/src/resources/reader.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/resources/reader.rs
@@ -328,7 +328,6 @@ mod tests {
     #[derive(Clone)]
     struct FakeQuery;
 
-    #[async_trait::async_trait]
     impl ReadOnlyQuery for FakeQuery {
         async fn cluster_overview(
             &self,

--- a/rocketmq-tools/rocketmq-mcp/src/service/diagnosis_service.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/service/diagnosis_service.rs
@@ -510,7 +510,6 @@ mod tests {
         missing_lag: bool,
     }
 
-    #[async_trait::async_trait]
     impl ReadOnlyQuery for FakeDiagnosisAdapter {
         async fn cluster_overview(
             &self,

--- a/rocketmq-tools/rocketmq-mcp/src/tools/executor.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/tools/executor.rs
@@ -902,7 +902,6 @@ mod tests {
         fail: bool,
     }
 
-    #[async_trait::async_trait]
     impl ReadOnlyQuery for FakeAdapter {
         async fn cluster_overview(
             &self,


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9170

### Brief Description

This PR removes RocketMQ MCP's direct dependency on `async-trait` and migrates production and test implementations to native Rust async traits.

- Preserve `Send` future contracts through return-position `impl Future + Send` for admin sessions, read-only queries, JWKS sources, and audit sinks.
- Replace JWKS trait-object ownership with generic static dispatch and replace configured audit trait objects with closed enum dispatch.
- Preserve authentication and JWKS cloneability without requiring source implementations to implement `Clone`.
- Add compile-time regression coverage for future and clone contracts.
- Extend the MCP boundary check to reject direct `async-trait` dependencies and source-token usage across `src/` and `tests/`.
- Document the native async trait rule in the MCP-specific agent guidance.

Third-party crates such as `config` and `rmcp` may continue to bring `async-trait` transitively; the MCP crate no longer declares or uses it directly.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-mcp -- --check` - passed. The all-package formatter route hit Windows OS error 206 because of the expanded path-dependency command length; no out-of-scope files were changed.
- `cargo check --locked` - passed.
- `python scripts/check_read_only_boundary.py` - passed.
- `cargo test --locked` - 107 passed, 0 failed, 1 environment-dependent test ignored.
- `cargo test --locked --all-features` - 131 passed, 0 failed, 1 environment-dependent test ignored.
- `cargo clippy --locked --all-targets --features streamable-http -- -D warnings` - passed.
- `cargo doc --locked --no-deps` - passed.
- `powershell -File scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` - passed.
- `powershell -File scripts/check-agents-routing.ps1` - passed.
- `git diff --check` - passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Reworked asynchronous operations to use native Rust async support.
  - Preserved existing audit, authentication, JWKS, and read-only query behavior.
  - Improved flexibility for authentication and verification components through configurable implementations.

- **Tests**
  - Added coverage confirming asynchronous operations remain safe for concurrent use.
  - Expanded verification for cloning authentication components and related test implementations.

- **Chores**
  - Strengthened automated checks to detect prohibited asynchronous patterns and dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->