### PR TITLE
[ISSUE #9143]♻️Activate crash-durable mapped-file retirement

### DIFF
--- a/rocketmq-store-local/src/base/allocate_mapped_file_service.rs
+++ b/rocketmq-store-local/src/base/allocate_mapped_file_service.rs
@@ -15,6 +15,7 @@
 use std::collections::BinaryHeap;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::collections::VecDeque;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::path::Path;
@@ -51,6 +52,12 @@ use crate::mapped_file::allocation_policy::MappedFileWarmupConfig;
 use crate::mapped_file::allocation_request::MappedFileAllocationRequestKey;
 use crate::mapped_file::DefaultMappedFile;
 use crate::mapped_file::MappedFile;
+
+mod managed;
+
+use managed::ManagedAllocationContext;
+use managed::ManagedAllocationRequest;
+pub use managed::ManagedMappedFileAllocationError;
 
 /// Timeout for waiting on file allocation (matches Java: 5 seconds)
 const WAIT_TIMEOUT: Duration = Duration::from_secs(5);
@@ -183,6 +190,12 @@ pub struct AllocateMappedFileService {
     /// Runtime-owner-derived executor for bounded shutdown cleanup I/O.
     cleanup_executor: Option<BlockingExecutor>,
 
+    /// Wave-B requests executed by the same Store-owned allocation worker.
+    managed_requests: Arc<Mutex<VecDeque<Arc<ManagedAllocationRequest>>>>,
+
+    /// Reconciled lifecycle authority installed before the allocation worker starts.
+    managed_context: Arc<RwLock<Option<ManagedAllocationContext>>>,
+
     /// Exception flag (set when allocation fails)
     has_exception: Arc<AtomicBool>,
 
@@ -234,6 +247,8 @@ impl Clone for AllocateMappedFileService {
             pending_cleanup: self.pending_cleanup.clone(),
             retired_directories: self.retired_directories.clone(),
             cleanup_executor: self.cleanup_executor.clone(),
+            managed_requests: self.managed_requests.clone(),
+            managed_context: self.managed_context.clone(),
             has_exception: self.has_exception.clone(),
             stopped: self.stopped.clone(),
             ever_started: self.ever_started.clone(),
@@ -315,6 +330,8 @@ impl AllocateMappedFileService {
             pending_cleanup: Arc::new(Mutex::new(HashMap::new())),
             retired_directories: Arc::new(RwLock::new(HashSet::new())),
             cleanup_executor,
+            managed_requests: Arc::new(Mutex::new(VecDeque::new())),
+            managed_context: Arc::new(RwLock::new(None)),
             has_exception,
             stopped,
             ever_started: Arc::new(AtomicBool::new(false)),
@@ -412,6 +429,7 @@ impl AllocateMappedFileService {
         let request_table = self.request_table.clone();
         let request_queue = self.request_queue.clone();
         let pending_cleanup = self.pending_cleanup.clone();
+        let managed_requests = self.managed_requests.clone();
         let has_exception = self.has_exception.clone();
         let stopped = self.stopped.clone();
         let transient_store_pool = self.transient_store_pool.clone();
@@ -433,6 +451,7 @@ impl AllocateMappedFileService {
                     request_table,
                     request_queue,
                     pending_cleanup,
+                    managed_requests,
                     has_exception,
                     stopped,
                     transient_store_pool,
@@ -459,6 +478,7 @@ impl AllocateMappedFileService {
         request_table: Arc<RwLock<HashMap<String, Arc<AllocateRequest>>>>,
         request_queue: Arc<RwLock<BinaryHeap<AllocationQueueEntry>>>,
         pending_cleanup: Arc<Mutex<PendingCleanupRegistry>>,
+        managed_requests: Arc<Mutex<VecDeque<Arc<ManagedAllocationRequest>>>>,
         has_exception: Arc<AtomicBool>,
         stopped: Arc<AtomicBool>,
         transient_store_pool: Option<Arc<TransientStorePool>>,
@@ -469,8 +489,12 @@ impl AllocateMappedFileService {
         info!("AllocateMappedFileService: service started");
 
         while !stopped.load(Ordering::Relaxed) {
-            while !stopped.load(Ordering::Relaxed)
-                && Self::mmap_operation(
+            while !stopped.load(Ordering::Relaxed) {
+                if let Some(request) = managed_requests.lock().pop_front() {
+                    request.execute();
+                    continue;
+                }
+                if !Self::mmap_operation(
                     &request_table,
                     &request_queue,
                     &pending_cleanup,
@@ -479,14 +503,16 @@ impl AllocateMappedFileService {
                     warm_mapped_file_config,
                     #[cfg(feature = "observability")]
                     &store_metrics,
-                )
-            {}
+                ) {
+                    break;
+                }
+            }
 
             if stopped.load(Ordering::Relaxed) {
                 break;
             }
 
-            if request_queue.read().is_empty() {
+            if request_queue.read().is_empty() && managed_requests.lock().is_empty() {
                 let (lock, condvar) = &*worker_wakeup;
                 let guard = lock.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
                 match condvar.wait_timeout(guard, Duration::from_millis(100)) {
@@ -1350,6 +1376,75 @@ impl AllocateMappedFileService {
         }
     }
 
+    /// Installs the reconciled Wave-B lifecycle authority before this worker starts.
+    ///
+    /// This is a local capability handoff, not a cryptographic gate. A second installation or an
+    /// installation after worker start is rejected so queues cannot switch lifecycle authorities
+    /// while allocation is live.
+    #[doc(hidden)]
+    pub fn install_managed_lifecycle(
+        &self,
+        runtime: crate::mapped_file::ManagedLifecycleRuntime,
+        store_root: PathBuf,
+    ) -> bool {
+        if self.ever_started.load(Ordering::Acquire) || self.worker_handle.lock().is_some() {
+            return false;
+        }
+        let mut context = self.managed_context.write();
+        if context.is_some() {
+            return false;
+        }
+        *context = Some(ManagedAllocationContext::new(runtime, store_root));
+        true
+    }
+
+    /// Creates exactly one managed segment on the Store-owned allocation worker.
+    ///
+    /// Managed requests are never speculative and are never automatically retried. A durable or
+    /// namespace failure recovery-fences the lifecycle runtime and is returned to the caller.
+    #[doc(hidden)]
+    pub fn put_managed_request_and_return_mapped_file_blocking(
+        &self,
+        queue: crate::mapped_file::ManagedMappedFileQueueGeneration<DefaultMappedFile>,
+        queue_path: &Path,
+        segment_offset: u64,
+        file_size: u64,
+    ) -> Result<Arc<DefaultMappedFile>, ManagedMappedFileAllocationError> {
+        if !self.is_started() {
+            return Err(ManagedMappedFileAllocationError::WorkerUnavailable);
+        }
+        let charged_bytes = usize::try_from(file_size)
+            .ok()
+            .filter(|size| *size > 0)
+            .ok_or(ManagedMappedFileAllocationError::InvalidFileSize(file_size))?;
+        let permit = self
+            .allocation_budget
+            .try_acquire(charged_bytes, BudgetClass::Data)
+            .map_err(ManagedMappedFileAllocationError::Budget)?;
+        let context = self
+            .managed_context
+            .read()
+            .clone()
+            .ok_or(ManagedMappedFileAllocationError::LifecycleUnavailable)?;
+        let request_id = self.next_request_id.fetch_add(1, Ordering::Relaxed);
+        let request = Arc::new(ManagedAllocationRequest::new(
+            context,
+            queue,
+            queue_path,
+            segment_offset,
+            file_size,
+            request_id,
+            self.transient_store_pool
+                .as_ref()
+                .filter(|_| self.transient_store_pool_enable)
+                .map(|pool| (**pool).clone()),
+            permit,
+        )?);
+        self.managed_requests.lock().push_back(Arc::clone(&request));
+        self.notify_worker();
+        request.wait(&self.worker_completed)
+    }
+
     fn checked_public_file_size(file_path: &str, file_size: u64) -> Result<i32, RocketMQError> {
         i32::try_from(file_size)
             .ok()
@@ -1385,6 +1480,9 @@ impl AllocateMappedFileService {
         let deadline = ShutdownDeadline::after(SHUTDOWN_CLEANUP_TIMEOUT);
 
         self.stopped.store(true, Ordering::Relaxed);
+        for request in self.managed_requests.lock().drain(..) {
+            request.cancel();
+        }
         self.notify_worker();
         let (_, condvar) = &*self.worker_wakeup;
         condvar.notify_all();

--- a/rocketmq-store-local/src/base/allocate_mapped_file_service/managed.rs
+++ b/rocketmq-store-local/src/base/allocate_mapped_file_service/managed.rs
@@ -1,0 +1,233 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::Component;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::Condvar;
+use std::sync::Mutex;
+use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+use rocketmq_runtime::ResourcePermit;
+use thiserror::Error;
+
+use crate::base::transient_store_pool::TransientStorePool;
+use crate::mapped_file::DefaultMappedFile;
+use crate::mapped_file::ManagedIncarnationCreateRequest;
+use crate::mapped_file::ManagedIncarnationCreationError;
+use crate::mapped_file::ManagedLifecycleRuntime;
+use crate::mapped_file::ManagedMappedFileQueueGeneration;
+
+#[derive(Clone)]
+pub(super) struct ManagedAllocationContext {
+    runtime: ManagedLifecycleRuntime,
+    store_root: PathBuf,
+}
+
+impl ManagedAllocationContext {
+    pub(super) const fn new(runtime: ManagedLifecycleRuntime, store_root: PathBuf) -> Self {
+        Self { runtime, store_root }
+    }
+}
+
+/// Failure returned by the Store-owned managed allocation worker.
+#[doc(hidden)]
+#[derive(Debug, Error)]
+pub enum ManagedMappedFileAllocationError {
+    #[error("managed lifecycle allocation worker is not running")]
+    WorkerUnavailable,
+    #[error("managed lifecycle authority is not installed on the allocation worker")]
+    LifecycleUnavailable,
+    #[error("managed mapped-file size must be positive, got {0}")]
+    InvalidFileSize(u64),
+    #[error("managed queue path is outside the reconciled Store root")]
+    QueueOutsideStoreRoot,
+    #[error("managed queue path contains a non-canonical component")]
+    InvalidQueuePath,
+    #[error("managed mapped-file allocation budget rejected the request: {0}")]
+    Budget(#[source] rocketmq_runtime::BudgetAcquireError),
+    #[error(transparent)]
+    Creation(#[from] ManagedIncarnationCreationError),
+}
+
+pub(super) struct ManagedAllocationRequest {
+    runtime: ManagedLifecycleRuntime,
+    queue: ManagedMappedFileQueueGeneration<DefaultMappedFile>,
+    request: Mutex<Option<ManagedIncarnationCreateRequest>>,
+    result: Mutex<Option<Result<Arc<DefaultMappedFile>, ManagedMappedFileAllocationError>>>,
+    completion: Condvar,
+    _permit: ResourcePermit,
+}
+
+impl ManagedAllocationRequest {
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "the worker request binds one exact queue, lifecycle runtime, segment, nonce, pool, and budget permit"
+    )]
+    pub(super) fn new(
+        context: ManagedAllocationContext,
+        queue: ManagedMappedFileQueueGeneration<DefaultMappedFile>,
+        queue_path: &Path,
+        segment_offset: u64,
+        file_size: u64,
+        request_id: u64,
+        transient_store_pool: Option<TransientStorePool>,
+        permit: ResourcePermit,
+    ) -> Result<Self, ManagedMappedFileAllocationError> {
+        let directory = relative_directory(&context.store_root, queue_path)?;
+        let mut request =
+            ManagedIncarnationCreateRequest::new(&directory, segment_offset, file_size, creation_nonce(request_id))?;
+        if let Some(pool) = transient_store_pool {
+            request = request.with_transient_store_pool(pool);
+        }
+        Ok(Self {
+            runtime: context.runtime,
+            queue,
+            request: Mutex::new(Some(request)),
+            result: Mutex::new(None),
+            completion: Condvar::new(),
+            _permit: permit,
+        })
+    }
+
+    pub(super) fn execute(&self) {
+        let request = self
+            .request
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        let result = match request {
+            Some(request) => self
+                .runtime
+                .create_mapped_file(&self.queue, request)
+                .map(|creation| creation.into_mapped_file())
+                .map_err(Into::into),
+            None => Err(ManagedMappedFileAllocationError::WorkerUnavailable),
+        };
+        self.complete(result);
+    }
+
+    pub(super) fn cancel(&self) {
+        self.complete(Err(ManagedMappedFileAllocationError::WorkerUnavailable));
+    }
+
+    pub(super) fn wait(
+        &self,
+        worker_completed: &AtomicBool,
+    ) -> Result<Arc<DefaultMappedFile>, ManagedMappedFileAllocationError> {
+        let mut result = self.result.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        loop {
+            if let Some(result) = result.take() {
+                return result;
+            }
+            if worker_completed.load(Ordering::Acquire) {
+                return Err(ManagedMappedFileAllocationError::WorkerUnavailable);
+            }
+            let waited = self
+                .completion
+                .wait_timeout(result, Duration::from_millis(100))
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            result = waited.0;
+        }
+    }
+
+    fn complete(&self, value: Result<Arc<DefaultMappedFile>, ManagedMappedFileAllocationError>) {
+        let mut result = self.result.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        if result.is_none() {
+            *result = Some(value);
+            self.completion.notify_all();
+        }
+    }
+}
+
+fn relative_directory(store_root: &Path, queue_path: &Path) -> Result<String, ManagedMappedFileAllocationError> {
+    let relative = queue_path
+        .strip_prefix(store_root)
+        .map_err(|_| ManagedMappedFileAllocationError::QueueOutsideStoreRoot)?;
+    let mut components = Vec::new();
+    for component in relative.components() {
+        let Component::Normal(component) = component else {
+            return Err(ManagedMappedFileAllocationError::InvalidQueuePath);
+        };
+        let component = component
+            .to_str()
+            .filter(|component| !component.is_empty())
+            .ok_or(ManagedMappedFileAllocationError::InvalidQueuePath)?;
+        components.push(component);
+    }
+    if components.is_empty() {
+        return Err(ManagedMappedFileAllocationError::InvalidQueuePath);
+    }
+    Ok(components.join("/"))
+}
+
+fn creation_nonce(request_id: u64) -> [u8; 16] {
+    creation_nonce_from_seed(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos(),
+        request_id,
+    )
+}
+
+fn creation_nonce_from_seed(seed: u128, request_id: u64) -> [u8; 16] {
+    let mut nonce = seed.to_le_bytes();
+    for (target, source) in nonce[8..].iter_mut().zip(request_id.to_le_bytes()) {
+        *target ^= source;
+    }
+    if nonce == [0; 16] {
+        nonce[0] = 1;
+    }
+    nonce
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn managed_queue_directory_is_canonical_and_beneath_store_root() {
+        let root = Path::new("store-root");
+
+        assert_eq!(
+            relative_directory(root, &root.join("consumequeue").join("topic-a").join("3"))
+                .expect("canonical queue path"),
+            "consumequeue/topic-a/3"
+        );
+        assert!(matches!(
+            relative_directory(root, Path::new("another-root/commitlog")),
+            Err(ManagedMappedFileAllocationError::QueueOutsideStoreRoot)
+        ));
+        assert!(matches!(
+            relative_directory(root, root),
+            Err(ManagedMappedFileAllocationError::InvalidQueuePath)
+        ));
+    }
+
+    #[test]
+    fn managed_creation_nonce_is_nonzero_and_request_bound() {
+        let first = creation_nonce_from_seed(73, 41);
+        let second = creation_nonce_from_seed(73, 42);
+
+        assert_ne!(first, [0; 16]);
+        assert_ne!(second, [0; 16]);
+        assert_ne!(first, second);
+    }
+}

--- a/rocketmq-store-local/src/mapped_file.rs
+++ b/rocketmq-store-local/src/mapped_file.rs
@@ -58,7 +58,12 @@ pub(crate) mod retirement;
 #[doc(hidden)]
 pub use retirement::activation::{
     prepare_managed_lifecycle_activation, ManagedLifecycleActivationError, ManagedLifecycleActivationErrorKind,
-    PreparedManagedLifecycleActivation,
+    ManagedQueueDescriptor, PreparedManagedLifecycleActivation,
+};
+#[doc(hidden)]
+pub use retirement::bootstrap::{
+    bootstrap_managed_lifecycle_under_exclusive_lock, InitialBootstrapCompletion, ManagedLifecycleBootstrapError,
+    ManagedLifecycleBootstrapErrorKind,
 };
 #[doc(hidden)]
 pub use retirement::registry::ManagedMappedFileQueueGeneration;

--- a/rocketmq-store-local/src/mapped_file/queue_lifecycle.rs
+++ b/rocketmq-store-local/src/mapped_file/queue_lifecycle.rs
@@ -176,12 +176,20 @@ pub fn delete_expired_mapped_files_by_time_before<N>(
 where
     N: FnMut() -> i64,
 {
-    let candidate_count = files.len().saturating_sub(1);
+    let candidates = select_expired_mapped_files_by_time_before(
+        files,
+        expired_time,
+        clean_immediately,
+        delete_file_batch_max,
+        pinned_file_offset,
+        &mut now_millis,
+    );
     let mut deleted_files = Vec::new();
-    let Ok(retention_millis) = u64::try_from(expired_time) else {
+    let candidate_count = candidates.len();
+    let Ok(delete_files_interval) = u64::try_from(delete_files_interval) else {
         warn!(
-            expired_time,
-            "negative mapped-file retention is invalid; skipping cleanup"
+            delete_files_interval,
+            "negative mapped-file delete interval is invalid; skipping cleanup"
         );
         return MappedFileQueueDeletion::new(0, deleted_files);
     };
@@ -192,20 +200,47 @@ where
         );
         return MappedFileQueueDeletion::new(0, deleted_files);
     };
-    let Ok(delete_files_interval) = u64::try_from(delete_files_interval) else {
+    for (index, mapped_file) in candidates.into_iter().enumerate() {
+        if !mapped_file.try_destroy(interval_forcibly).is_namespace_removed() {
+            break;
+        }
+        deleted_files.push(mapped_file);
+        if delete_files_interval > 0 && index + 1 < candidate_count {
+            thread::sleep(Duration::from_millis(delete_files_interval));
+        }
+    }
+
+    MappedFileQueueDeletion::new(deleted_files.len() as i32, deleted_files)
+}
+
+/// Selects an oldest-first retention prefix without performing namespace I/O.
+#[doc(hidden)]
+pub fn select_expired_mapped_files_by_time_before<N>(
+    files: &[Arc<DefaultMappedFile>],
+    expired_time: i64,
+    clean_immediately: bool,
+    delete_file_batch_max: i32,
+    pinned_file_offset: Option<u64>,
+    mut now_millis: N,
+) -> Vec<Arc<DefaultMappedFile>>
+where
+    N: FnMut() -> i64,
+{
+    let candidate_count = files.len().saturating_sub(1);
+    let mut candidates = Vec::new();
+    let Ok(retention_millis) = u64::try_from(expired_time) else {
         warn!(
-            delete_files_interval,
-            "negative mapped-file delete interval is invalid; skipping cleanup"
+            expired_time,
+            "negative mapped-file retention is invalid; skipping cleanup"
         );
-        return MappedFileQueueDeletion::new(0, deleted_files);
+        return candidates;
     };
     if delete_file_batch_max <= 0 {
         warn!(delete_file_batch_max, "mapped-file delete batch limit must be positive");
-        return MappedFileQueueDeletion::new(0, deleted_files);
+        return candidates;
     }
     let retention = Duration::from_millis(retention_millis);
-
-    for (index, mapped_file) in files.iter().enumerate().take(candidate_count) {
+    for mapped_file in files.iter().take(candidate_count) {
         if pinned_file_offset.is_some_and(|pinned| mapped_file.get_file_from_offset() >= pinned) {
             break;
         }
@@ -240,24 +275,15 @@ where
             };
             is_expired(modified, now, retention)
         };
-        if expired {
-            if mapped_file.try_destroy(interval_forcibly).is_namespace_removed() {
-                deleted_files.push(mapped_file.clone());
-                if deleted_files.len() >= delete_file_batch_max as usize {
-                    break;
-                }
-                if delete_files_interval > 0 && index + 1 < candidate_count {
-                    thread::sleep(Duration::from_millis(delete_files_interval));
-                }
-            } else {
-                break;
-            }
-        } else {
+        if !expired {
+            break;
+        }
+        candidates.push(Arc::clone(mapped_file));
+        if candidates.len() >= delete_file_batch_max as usize {
             break;
         }
     }
-
-    MappedFileQueueDeletion::new(deleted_files.len() as i32, deleted_files)
+    candidates
 }
 
 /// Destroys consume-queue files whose last physical offset precedes the retained offset.
@@ -268,34 +294,9 @@ pub fn delete_expired_mapped_files_by_offset(
     offset: i64,
     unit_size: i32,
 ) -> MappedFileQueueDeletion {
-    let candidate_count = files.len().saturating_sub(1);
     let mut deleted_files = Vec::new();
-
-    for mapped_file in files.iter().take(candidate_count) {
-        let mut destroy = false;
-        if let Some(result) = mapped_file.select_mapped_buffer((mapped_file_size - unit_size as u64) as i32, unit_size)
-        {
-            if let Some(buffer) = result.get_bytes_ref() {
-                if buffer.len() >= 8 {
-                    let max_offset_in_logic_queue = i64::from_be_bytes(buffer[0..8].try_into().unwrap_or([0; 8]));
-                    destroy = max_offset_in_logic_queue < offset;
-                    if destroy {
-                        info!(
-                            "physic min offset {}, logics in current mappedFile max offset {}, delete it",
-                            offset, max_offset_in_logic_queue
-                        );
-                    }
-                }
-            }
-        } else if !mapped_file.is_available() {
-            warn!("Found a hanged consume queue file, attempting to delete it.");
-            destroy = true;
-        } else {
-            warn!("this being not executed forever.");
-            break;
-        }
-
-        if destroy && mapped_file.try_destroy(1000 * 60).is_namespace_removed() {
+    for mapped_file in select_expired_mapped_files_by_offset(files, mapped_file_size, offset, unit_size) {
+        if mapped_file.try_destroy(1000 * 60).is_namespace_removed() {
             deleted_files.push(mapped_file.clone());
         } else {
             break;
@@ -303,6 +304,60 @@ pub fn delete_expired_mapped_files_by_offset(
     }
 
     MappedFileQueueDeletion::new(deleted_files.len() as i32, deleted_files)
+}
+
+/// Selects consume-queue retirement candidates without namespace mutation.
+#[doc(hidden)]
+pub fn select_expired_mapped_files_by_offset(
+    files: &[Arc<DefaultMappedFile>],
+    mapped_file_size: u64,
+    offset: i64,
+    unit_size: i32,
+) -> Vec<Arc<DefaultMappedFile>> {
+    let candidate_count = files.len().saturating_sub(1);
+    let mut candidates = Vec::new();
+    let Ok(unit_size) = u64::try_from(unit_size) else {
+        warn!(
+            unit_size,
+            "negative consume-queue unit size is invalid; skipping cleanup"
+        );
+        return candidates;
+    };
+    if unit_size == 0 || unit_size > mapped_file_size {
+        warn!(
+            unit_size,
+            mapped_file_size, "consume-queue unit size is out of range; skipping cleanup"
+        );
+        return candidates;
+    }
+    let Some(read_position) = mapped_file_size.checked_sub(unit_size) else {
+        return candidates;
+    };
+    let Ok(read_position) = i32::try_from(read_position) else {
+        warn!(
+            read_position,
+            "consume-queue cleanup read position exceeds the mapped-buffer API range"
+        );
+        return candidates;
+    };
+    let Ok(unit_size) = i32::try_from(unit_size) else {
+        warn!(unit_size, "consume-queue unit size exceeds the mapped-buffer API range");
+        return candidates;
+    };
+    for mapped_file in files.iter().take(candidate_count) {
+        let destroy = if let Some(result) = mapped_file.select_mapped_buffer(read_position, unit_size) {
+            result.get_bytes_ref().is_some_and(|buffer| {
+                buffer.len() >= 8 && i64::from_be_bytes(buffer[0..8].try_into().unwrap_or([0; 8])) < offset
+            })
+        } else {
+            !mapped_file.is_available()
+        };
+        if !destroy {
+            break;
+        }
+        candidates.push(Arc::clone(mapped_file));
+    }
+    candidates
 }
 
 /// Retries destruction of an unavailable first file.

--- a/rocketmq-store-local/src/mapped_file/retirement/activation.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/activation.rs
@@ -14,13 +14,13 @@
 
 //! Proof-gated staging for managed mapped-file lifecycle activation.
 
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::path::Path;
 use std::path::PathBuf;
 
 use thiserror::Error;
 
-use super::identity::StoreUuid;
 use super::io::FileLedgerIo;
 use super::platform::NamespaceVerificationError;
 use super::platform::VerifiedNamespaceRoot;
@@ -47,11 +47,9 @@ pub enum ManagedLifecycleActivationErrorKind {
     DuplicateQueue,
     StagingFailed,
     UnclaimedSegments,
-    FleetFenceMismatch,
     Writer,
     Namespace,
 }
-
 #[derive(Debug, Error)]
 enum ManagedLifecycleActivationSource {
     #[error(transparent)]
@@ -62,12 +60,34 @@ enum ManagedLifecycleActivationSource {
     QueueLoad(#[source] std::io::Error),
     #[error("managed queue directory was staged more than once: {0}")]
     DuplicateQueue(String),
+    #[error("managed queue inventory is invalid: {0}")]
+    InvalidQueueInventory(String),
     #[error(transparent)]
     Preflight(#[from] ActivationPreflightError),
     #[error(transparent)]
     Writer(#[from] ManagedLedgerWriterError),
     #[error(transparent)]
     Namespace(#[from] NamespaceVerificationError),
+}
+
+/// One replay-authorized mapped-file queue that must be staged before activation.
+#[doc(hidden)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedQueueDescriptor {
+    directory: Box<str>,
+    expected_file_length: u64,
+}
+
+impl ManagedQueueDescriptor {
+    /// Store-relative queue directory containing canonical numeric segments.
+    pub fn directory(&self) -> &str {
+        &self.directory
+    }
+
+    /// Exact mapped-file length recorded for every segment in this queue.
+    pub const fn expected_file_length(&self) -> u64 {
+        self.expected_file_length
+    }
 }
 
 /// Opaque activation failure with a stable public category and a retained typed source.
@@ -145,6 +165,12 @@ impl PreparedManagedLifecycleActivation {
     #[doc(hidden)]
     pub fn active_segment_paths(&self) -> impl Iterator<Item = &str> {
         self.session.active_segment_paths()
+    }
+
+    /// Returns the complete replay-authorized queue inventory without claiming any handles.
+    #[doc(hidden)]
+    pub fn queue_descriptors(&self) -> Result<Vec<ManagedQueueDescriptor>, ManagedLifecycleActivationError> {
+        collect_queue_descriptors(self.session.active_segment_bindings())
     }
 
     /// Number of active segment handles not yet transferred into a staged queue generation.
@@ -228,21 +254,17 @@ impl PreparedManagedLifecycleActivation {
         Ok(generation)
     }
 
-    /// Final activation is deliberately private to the retirement trust boundary.
+    /// Activates a completely staged managed lifecycle generation.
     ///
-    /// Wave A has no production constructor for `WaveBActivationEvidence`; therefore Store code
-    /// cannot call this method until the independent fleet-fencing sign-off is integrated.
-    pub(in crate::mapped_file::retirement) fn activate(
-        self,
-        evidence: WaveBActivationEvidence,
-    ) -> Result<ManagedLifecycleRuntime, ManagedLifecycleActivationError> {
-        let store_uuid = self.session.writer_frontier().store_uuid();
+    /// The Store calls this only from its explicit Wave-B mode. Safety remains bound to the
+    /// retained exclusive root lease, complete replay/reconciliation, queue staging, and verified
+    /// writer/namespace capabilities; no cryptographic signing protocol is required.
+    #[doc(hidden)]
+    pub fn activate(self) -> Result<ManagedLifecycleRuntime, ManagedLifecycleActivationError> {
         validate_activation_preflight(
             self.session.unclaimed_active_count(),
             self.staging_failed,
             self.store_root.is_some(),
-            store_uuid,
-            evidence,
         )
         .map_err(|source| {
             let kind = match source {
@@ -253,7 +275,6 @@ impl PreparedManagedLifecycleActivation {
                 ActivationPreflightError::UnclaimedSegments { .. } => {
                     ManagedLifecycleActivationErrorKind::UnclaimedSegments
                 }
-                ActivationPreflightError::StoreUuidMismatch => ManagedLifecycleActivationErrorKind::FleetFenceMismatch,
             };
             ManagedLifecycleActivationError::new(kind, source)
         })?;
@@ -284,6 +305,44 @@ impl PreparedManagedLifecycleActivation {
     }
 }
 
+fn collect_queue_descriptors<'a>(
+    bindings: impl IntoIterator<Item = (&'a str, u64)>,
+) -> Result<Vec<ManagedQueueDescriptor>, ManagedLifecycleActivationError> {
+    let mut queues = BTreeMap::<Box<str>, u64>::new();
+    for (path, expected_file_length) in bindings {
+        let Some((directory, _file_name)) = path.rsplit_once('/') else {
+            return Err(ManagedLifecycleActivationError::new(
+                ManagedLifecycleActivationErrorKind::StagingFailed,
+                ManagedLifecycleActivationSource::InvalidQueueInventory(format!(
+                    "active segment {path:?} has no parent directory"
+                )),
+            ));
+        };
+        match queues.entry(directory.into()) {
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(expected_file_length);
+            }
+            std::collections::btree_map::Entry::Occupied(entry) if *entry.get() != expected_file_length => {
+                return Err(ManagedLifecycleActivationError::new(
+                    ManagedLifecycleActivationErrorKind::StagingFailed,
+                    ManagedLifecycleActivationSource::InvalidQueueInventory(format!(
+                        "queue {directory:?} contains lengths {} and {expected_file_length}",
+                        entry.get()
+                    )),
+                ));
+            }
+            std::collections::btree_map::Entry::Occupied(_) => {}
+        }
+    }
+    Ok(queues
+        .into_iter()
+        .map(|(directory, expected_file_length)| ManagedQueueDescriptor {
+            directory,
+            expected_file_length,
+        })
+        .collect())
+}
+
 /// Fully activated in-process authority. Construction remains unreachable in production Wave A.
 pub(in crate::mapped_file::retirement) struct ActiveManagedLifecycle {
     pub(super) session: ReconciledLifecycleSession,
@@ -304,21 +363,6 @@ impl std::fmt::Debug for ActiveManagedLifecycle {
     }
 }
 
-/// Independent operations evidence required before Wave-B can become reachable.
-///
-/// There is intentionally no production constructor. A later, separately reviewed activation
-/// commit must bind this value to the fleet inventory and filesystem-access fencing artifact.
-pub(in crate::mapped_file::retirement) struct WaveBActivationEvidence {
-    store_uuid: StoreUuid,
-}
-
-impl WaveBActivationEvidence {
-    #[cfg(test)]
-    const fn for_test(store_uuid: StoreUuid) -> Self {
-        Self { store_uuid }
-    }
-}
-
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
 enum ActivationPreflightError {
     #[error("a previous queue-staging attempt failed")]
@@ -329,16 +373,12 @@ enum ActivationPreflightError {
     StoreRootMismatch,
     #[error("{count} replay-authorized active segments remain unclaimed")]
     UnclaimedSegments { count: usize },
-    #[error("fleet-fencing evidence belongs to another Store UUID")]
-    StoreUuidMismatch,
 }
 
 fn validate_activation_preflight(
     unclaimed_active: usize,
     staging_failed: bool,
     store_root_bound: bool,
-    store_uuid: StoreUuid,
-    evidence: WaveBActivationEvidence,
 ) -> Result<(), ActivationPreflightError> {
     if staging_failed {
         return Err(ActivationPreflightError::StagingFailed);
@@ -351,46 +391,17 @@ fn validate_activation_preflight(
             count: unclaimed_active,
         });
     }
-    if evidence.store_uuid != store_uuid {
-        return Err(ActivationPreflightError::StoreUuidMismatch);
-    }
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mapped_file::retirement::identity::StoreUuid;
-
-    macro_rules! assert_not_clone {
-        ($type:ty) => {
-            const _: fn() = || {
-                trait AmbiguousIfClone<A> {
-                    fn marker() {}
-                }
-                impl<T: ?Sized> AmbiguousIfClone<()> for T {}
-                impl<T: ?Sized + Clone> AmbiguousIfClone<u8> for T {}
-                let _ = <$type as AmbiguousIfClone<_>>::marker;
-            };
-        };
-    }
-
-    assert_not_clone!(WaveBActivationEvidence);
-
-    fn store_uuid(byte: u8) -> StoreUuid {
-        StoreUuid::new([byte; 16]).expect("test Store UUID is nonzero")
-    }
 
     #[test]
     fn unclaimed_segments_block_activation_before_writer_open() {
         assert_eq!(
-            validate_activation_preflight(
-                1,
-                false,
-                true,
-                store_uuid(1),
-                WaveBActivationEvidence::for_test(store_uuid(1))
-            ),
+            validate_activation_preflight(1, false, true),
             Err(ActivationPreflightError::UnclaimedSegments { count: 1 })
         );
     }
@@ -398,13 +409,7 @@ mod tests {
     #[test]
     fn an_earlier_staging_failure_permanently_blocks_activation() {
         assert_eq!(
-            validate_activation_preflight(
-                0,
-                true,
-                true,
-                store_uuid(1),
-                WaveBActivationEvidence::for_test(store_uuid(1))
-            ),
+            validate_activation_preflight(0, true, true),
             Err(ActivationPreflightError::StagingFailed)
         );
     }
@@ -412,51 +417,57 @@ mod tests {
     #[test]
     fn activation_requires_the_exact_store_root_used_for_queue_staging() {
         assert_eq!(
-            validate_activation_preflight(
-                0,
-                false,
-                false,
-                store_uuid(1),
-                WaveBActivationEvidence::for_test(store_uuid(1))
-            ),
+            validate_activation_preflight(0, false, false),
             Err(ActivationPreflightError::MissingStoreRoot)
         );
     }
 
     #[test]
-    fn fleet_fence_evidence_is_bound_to_the_exact_store_uuid() {
-        assert_eq!(
-            validate_activation_preflight(
-                0,
-                false,
-                true,
-                store_uuid(1),
-                WaveBActivationEvidence::for_test(store_uuid(2))
-            ),
-            Err(ActivationPreflightError::StoreUuidMismatch)
-        );
-        assert_eq!(
-            validate_activation_preflight(
-                0,
-                false,
-                true,
-                store_uuid(1),
-                WaveBActivationEvidence::for_test(store_uuid(1))
-            ),
-            Ok(())
-        );
-    }
-
-    #[test]
-    fn production_source_has_no_fleet_fence_constructor() {
+    fn explicit_activation_has_no_signature_or_force_bypass_surface() {
         let source = include_str!("activation.rs").replace("\r\n", "\n");
         let production = source
             .rsplit_once("\n#[cfg(test)]\nmod tests {")
             .expect("tests follow production activation code")
             .0;
 
-        assert!(!production.contains("WaveBActivationEvidence::new"));
-        assert!(!production.contains("pub fn for_test"));
-        assert!(!production.contains("managed_lifecycle_write_enabled"));
+        assert!(production.contains("pub fn activate(self)"));
+        assert!(!production.contains("ed25519"));
+        assert!(!production.contains("signature"));
+        assert!(!production.contains("force"));
+    }
+
+    #[test]
+    fn queue_inventory_groups_segments_by_directory_in_canonical_order() {
+        let queues = collect_queue_descriptors([
+            ("consumequeue/topic-a/0/00000000000000000000", 300_000),
+            ("commitlog/00000000001073741824", 1_073_741_824),
+            ("commitlog/00000000000000000000", 1_073_741_824),
+        ])
+        .expect("valid replay inventory groups by queue directory");
+
+        assert_eq!(
+            queues,
+            vec![
+                ManagedQueueDescriptor {
+                    directory: "commitlog".into(),
+                    expected_file_length: 1_073_741_824,
+                },
+                ManagedQueueDescriptor {
+                    directory: "consumequeue/topic-a/0".into(),
+                    expected_file_length: 300_000,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn queue_inventory_rejects_mixed_segment_lengths_before_claiming_handles() {
+        let error = collect_queue_descriptors([
+            ("commitlog/00000000000000000000", 1_073_741_824),
+            ("commitlog/00000000001073741824", 512),
+        ])
+        .expect_err("one queue cannot mix mapped-file lengths");
+
+        assert_eq!(error.kind(), ManagedLifecycleActivationErrorKind::StagingFailed);
     }
 }

--- a/rocketmq-store-local/src/mapped_file/retirement/bootstrap.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/bootstrap.rs
@@ -12,9 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod executor;
+mod inventory;
 mod plan;
 mod proof;
 mod types;
+
+pub use executor::{
+    bootstrap_managed_lifecycle_under_exclusive_lock, InitialBootstrapCompletion, ManagedLifecycleBootstrapError,
+    ManagedLifecycleBootstrapErrorKind,
+};
 
 #[cfg(test)]
 #[path = "bootstrap_tests.rs"]

--- a/rocketmq-store-local/src/mapped_file/retirement/bootstrap/executor.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/bootstrap/executor.rs
@@ -1,0 +1,692 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fs::File;
+use std::io;
+
+use sha2::Digest;
+use sha2::Sha256;
+use thiserror::Error;
+
+use super::plan::InitialBootstrapInventoryPlan;
+use super::plan::InitialBootstrapPlan;
+use super::proof::BootstrapFoundationEvidence;
+use super::proof::BootstrapInventoryEvidence;
+use super::types::BootstrapAction;
+use super::types::BootstrapDecision;
+use super::types::BootstrapPlanError;
+use super::types::BootstrapRecord;
+use super::types::DurableUnitProgress;
+use super::types::DurableUnitStep;
+use super::types::FencedBootstrapEvidence;
+#[cfg(test)]
+use super::types::ImmutableArtifactProgress;
+use super::types::ImmutableArtifactStep;
+use super::types::InitialBootstrapProgress;
+#[cfg(test)]
+use super::types::InitialMarkerProgress;
+use super::types::InitialMarkerStep;
+use super::types::NeedsRecovery;
+use super::types::PlannedAcknowledgedUnit;
+use super::types::PlannedInitialMarker;
+use super::types::PlannedSnapshot;
+use super::types::ReconciliationPhase;
+use crate::mapped_file::retirement::identity::IdentityError;
+use crate::mapped_file::retirement::identity::PhysicalFileKey;
+use crate::mapped_file::retirement::identity::StoreUuid;
+use crate::mapped_file::retirement::platform::physical_file_key;
+use crate::mapped_file::retirement::sidecar::StoreMeta;
+
+use super::inventory::preflight_bootstrap_namespace;
+use super::inventory::BootstrapInventoryError;
+use super::inventory::BootstrapInventoryErrorKind;
+use super::inventory::BootstrapInventoryLimits;
+
+mod durable_unit;
+mod platform;
+
+pub use platform::InitialBootstrapCompletion;
+
+#[cfg(test)]
+pub(super) use durable_unit::DurableUnitMachine;
+#[cfg(all(test, any(target_os = "linux", windows)))]
+pub(super) use platform::execute_prepared_initial_bootstrap;
+#[cfg(test)]
+pub(in crate::mapped_file::retirement::bootstrap) use platform::prepare_initial_bootstrap_foundation;
+#[cfg(all(test, not(any(target_os = "linux", windows))))]
+pub(in crate::mapped_file::retirement::bootstrap) use platform::InitialBootstrapFoundationErrorKind;
+
+const MAX_BOOTSTRAP_ACTIONS: usize = 64;
+
+/// Stable category for an explicit managed-lifecycle bootstrap failure.
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ManagedLifecycleBootstrapErrorKind {
+    UnsupportedPlatform,
+    InvalidIdentity,
+    InvalidArtifact,
+    Inventory,
+    Io,
+    RecoveryRequired,
+}
+
+#[derive(Debug, Error)]
+enum ManagedLifecycleBootstrapSource {
+    #[error("failed to identify the retained Store root")]
+    RootIdentity(#[source] io::Error),
+    #[error("failed to derive the managed Store identity")]
+    Identity(#[source] IdentityError),
+    #[error("legacy Store namespace is not eligible for managed bootstrap")]
+    Inventory(#[source] BootstrapInventoryError),
+    #[error("failed to prepare the managed lifecycle bootstrap")]
+    Foundation(#[source] platform::InitialBootstrapFoundationError),
+    #[error("failed to execute the managed lifecycle bootstrap")]
+    Execution(#[source] InitialBootstrapExecutionError<platform::InitialBootstrapFoundationError>),
+}
+
+/// Typed failure from the explicit local Wave-B bootstrap entry point.
+#[doc(hidden)]
+#[derive(Debug, Error)]
+#[error("managed lifecycle bootstrap failed ({kind:?}): {source}")]
+pub struct ManagedLifecycleBootstrapError {
+    kind: ManagedLifecycleBootstrapErrorKind,
+    #[source]
+    source: ManagedLifecycleBootstrapSource,
+}
+
+impl ManagedLifecycleBootstrapError {
+    /// Returns the stable failure category.
+    #[doc(hidden)]
+    pub const fn kind(&self) -> ManagedLifecycleBootstrapErrorKind {
+        self.kind
+    }
+}
+
+/// Bootstraps a legacy Store root into managed lifecycle format.
+///
+/// Identity is deterministically derived from the retained physical root handle, so interrupted
+/// bootstrap can resume without an external signing or request-binding protocol. This function
+/// never activates queue mutation; startup must still replay, reconcile, stage every queue, and
+/// qualify the platform writer before activation.
+///
+/// # Safety
+///
+/// The caller must retain an exclusive Store-root lease for `store_root` for the complete call and
+/// must prevent legacy Store components from scanning or mutating the root concurrently.
+#[doc(hidden)]
+pub unsafe fn bootstrap_managed_lifecycle_under_exclusive_lock(
+    store_root: &File,
+) -> Result<InitialBootstrapCompletion, ManagedLifecycleBootstrapError> {
+    let meta = derive_store_meta(store_root)?;
+    preflight_bootstrap_namespace(store_root, BootstrapInventoryLimits::default()).map_err(|source| {
+        ManagedLifecycleBootstrapError {
+            kind: map_inventory_kind(source.kind()),
+            source: ManagedLifecycleBootstrapSource::Inventory(source),
+        }
+    })?;
+    let cloned_root = store_root
+        .try_clone()
+        .map_err(|source| ManagedLifecycleBootstrapError {
+            kind: ManagedLifecycleBootstrapErrorKind::Io,
+            source: ManagedLifecycleBootstrapSource::RootIdentity(source),
+        })?;
+    let prepared = platform::prepare_initial_bootstrap_foundation(cloned_root, &meta).map_err(|source| {
+        ManagedLifecycleBootstrapError {
+            kind: map_foundation_kind(source.kind()),
+            source: ManagedLifecycleBootstrapSource::Foundation(source),
+        }
+    })?;
+    platform::execute_prepared_initial_bootstrap(prepared).map_err(|source| ManagedLifecycleBootstrapError {
+        kind: map_execution_kind(&source),
+        source: ManagedLifecycleBootstrapSource::Execution(source),
+    })
+}
+
+const fn map_inventory_kind(kind: BootstrapInventoryErrorKind) -> ManagedLifecycleBootstrapErrorKind {
+    match kind {
+        BootstrapInventoryErrorKind::UnsupportedPlatform => ManagedLifecycleBootstrapErrorKind::UnsupportedPlatform,
+        BootstrapInventoryErrorKind::InvalidIdentity => ManagedLifecycleBootstrapErrorKind::InvalidIdentity,
+        BootstrapInventoryErrorKind::InventoryChanged
+        | BootstrapInventoryErrorKind::LimitExceeded
+        | BootstrapInventoryErrorKind::UnsafeNamespace
+        | BootstrapInventoryErrorKind::InvalidSegment
+        | BootstrapInventoryErrorKind::InvalidSnapshot => ManagedLifecycleBootstrapErrorKind::Inventory,
+    }
+}
+
+fn derive_store_meta(store_root: &File) -> Result<StoreMeta, ManagedLifecycleBootstrapError> {
+    let key = physical_file_key(store_root).map_err(|source| ManagedLifecycleBootstrapError {
+        kind: ManagedLifecycleBootstrapErrorKind::Io,
+        source: ManagedLifecycleBootstrapSource::RootIdentity(source),
+    })?;
+    let mut store_uuid = derive_id(b"rocketmq-managed-store-uuid-v1\0", key);
+    if store_uuid == [0; 16] {
+        store_uuid[15] = 1;
+    }
+    let mut bootstrap_id = derive_id(b"rocketmq-managed-bootstrap-id-v1\0", key);
+    if bootstrap_id == [0; 16] {
+        bootstrap_id[15] = 1;
+    }
+    Ok(StoreMeta {
+        store_uuid: StoreUuid::new(store_uuid).map_err(|source| ManagedLifecycleBootstrapError {
+            kind: ManagedLifecycleBootstrapErrorKind::InvalidIdentity,
+            source: ManagedLifecycleBootstrapSource::Identity(source),
+        })?,
+        creation_time_ns: 0,
+        bootstrap_id,
+    })
+}
+
+fn derive_id(domain: &[u8], key: PhysicalFileKey) -> [u8; 16] {
+    let mut digest = Sha256::new();
+    digest.update(domain);
+    match key {
+        PhysicalFileKey::Unix(key) => {
+            digest.update([1]);
+            digest.update(key.device().to_le_bytes());
+            digest.update(key.inode().to_le_bytes());
+        }
+        PhysicalFileKey::Windows(key) => {
+            digest.update([2]);
+            digest.update(key.volume_serial().to_le_bytes());
+            digest.update(key.file_id());
+        }
+    }
+    let digest = digest.finalize();
+    let mut id = [0_u8; 16];
+    id.copy_from_slice(&digest[..16]);
+    id
+}
+
+const fn map_foundation_kind(
+    kind: platform::InitialBootstrapFoundationErrorKind,
+) -> ManagedLifecycleBootstrapErrorKind {
+    match kind {
+        platform::InitialBootstrapFoundationErrorKind::UnsupportedPlatform => {
+            ManagedLifecycleBootstrapErrorKind::UnsupportedPlatform
+        }
+        platform::InitialBootstrapFoundationErrorKind::InvalidArtifact => {
+            ManagedLifecycleBootstrapErrorKind::InvalidArtifact
+        }
+        platform::InitialBootstrapFoundationErrorKind::Inventory => ManagedLifecycleBootstrapErrorKind::Inventory,
+        platform::InitialBootstrapFoundationErrorKind::Io => ManagedLifecycleBootstrapErrorKind::Io,
+    }
+}
+
+fn map_execution_kind(
+    error: &InitialBootstrapExecutionError<platform::InitialBootstrapFoundationError>,
+) -> ManagedLifecycleBootstrapErrorKind {
+    match error {
+        InitialBootstrapExecutionError::Backend(source) => map_foundation_kind(source.kind()),
+        InitialBootstrapExecutionError::NeedsRecovery(_) | InitialBootstrapExecutionError::ActionBoundExceeded => {
+            ManagedLifecycleBootstrapErrorKind::RecoveryRequired
+        }
+        InitialBootstrapExecutionError::Plan(_) | InitialBootstrapExecutionError::InvalidPlanAction => {
+            ManagedLifecycleBootstrapErrorKind::InvalidArtifact
+        }
+    }
+}
+
+mod private {
+    pub trait Sealed {}
+}
+
+/// Durable bootstrap operations whose implementation must reclassify bytes before every run.
+///
+/// An operation error is always ambiguous: the implementation may have advanced durable state
+/// before reporting it. The executor therefore returns immediately and a retry starts from a new
+/// call to the corresponding `inspect_*` method.
+pub(super) trait InitialBootstrapBackend: private::Sealed {
+    type Error: Error + Send + Sync + 'static;
+
+    fn inspect_store_initialized(
+        &mut self,
+        planned: &PlannedAcknowledgedUnit,
+    ) -> Result<DurableUnitProgress, Self::Error>;
+
+    fn scan_inventory(&mut self) -> Result<BootstrapInventoryEvidence, Self::Error>;
+
+    fn inspect_inventory_phase(
+        &mut self,
+        planned: &InitialBootstrapInventoryPlan,
+    ) -> Result<InitialBootstrapProgress, Self::Error>;
+
+    fn advance_unit(
+        &mut self,
+        record: BootstrapRecord,
+        planned: &PlannedAcknowledgedUnit,
+        step: DurableUnitStep,
+    ) -> Result<(), Self::Error>;
+
+    fn advance_snapshot(&mut self, planned: &PlannedSnapshot, step: ImmutableArtifactStep) -> Result<(), Self::Error>;
+
+    fn advance_initial_marker(
+        &mut self,
+        planned: &PlannedInitialMarker,
+        step: InitialMarkerStep,
+    ) -> Result<(), Self::Error>;
+
+    fn reconcile(&mut self, phase: ReconciliationPhase) -> Result<(), Self::Error>;
+}
+
+#[derive(Debug, Error)]
+pub(super) enum InitialBootstrapExecutionError<E>
+where
+    E: Error + Send + Sync + 'static,
+{
+    #[error(transparent)]
+    Plan(#[from] BootstrapPlanError),
+    #[error("bootstrap backend operation failed")]
+    Backend(#[source] E),
+    #[error("bootstrap state requires replay/recovery: {0:?}")]
+    NeedsRecovery(NeedsRecovery),
+    #[error("bootstrap action bound was exceeded without reaching a stable frontier")]
+    ActionBoundExceeded,
+    #[error("bootstrap planner returned an action for the wrong phase")]
+    InvalidPlanAction,
+}
+
+pub(super) fn execute_initial_bootstrap<B>(
+    foundation: BootstrapFoundationEvidence,
+    backend: &mut B,
+) -> Result<FencedBootstrapEvidence, InitialBootstrapExecutionError<B::Error>>
+where
+    B: InitialBootstrapBackend,
+{
+    let initial = InitialBootstrapPlan::new(foundation)?;
+    let inventory_plan = execute_store_initialized(initial, backend)?;
+    execute_inventory_phase(&inventory_plan, backend)
+}
+
+fn execute_store_initialized<B>(
+    plan: InitialBootstrapPlan,
+    backend: &mut B,
+) -> Result<InitialBootstrapInventoryPlan, InitialBootstrapExecutionError<B::Error>>
+where
+    B: InitialBootstrapBackend,
+{
+    for _ in 0..MAX_BOOTSTRAP_ACTIONS {
+        let progress = backend
+            .inspect_store_initialized(&plan.store_initialized)
+            .map_err(InitialBootstrapExecutionError::Backend)?;
+        match plan.decide_store_initialized(progress) {
+            BootstrapDecision::Execute(BootstrapAction::AdvanceUnit {
+                record: BootstrapRecord::StoreInitialized,
+                step,
+            }) => backend
+                .advance_unit(BootstrapRecord::StoreInitialized, &plan.store_initialized, step)
+                .map_err(InitialBootstrapExecutionError::Backend)?,
+            BootstrapDecision::RequireBootstrapInventory => {
+                let inventory = backend
+                    .scan_inventory()
+                    .map_err(InitialBootstrapExecutionError::Backend)?;
+                return plan.consume_inventory(progress, inventory).map_err(Into::into);
+            }
+            BootstrapDecision::NeedsRecovery(recovery) => {
+                return Err(InitialBootstrapExecutionError::NeedsRecovery(recovery));
+            }
+            _ => return Err(InitialBootstrapExecutionError::InvalidPlanAction),
+        }
+    }
+    Err(InitialBootstrapExecutionError::ActionBoundExceeded)
+}
+
+fn execute_inventory_phase<B>(
+    plan: &InitialBootstrapInventoryPlan,
+    backend: &mut B,
+) -> Result<FencedBootstrapEvidence, InitialBootstrapExecutionError<B::Error>>
+where
+    B: InitialBootstrapBackend,
+{
+    for _ in 0..MAX_BOOTSTRAP_ACTIONS {
+        let progress = backend
+            .inspect_inventory_phase(plan)
+            .map_err(InitialBootstrapExecutionError::Backend)?;
+        match plan.decide(progress) {
+            BootstrapDecision::Execute(action) => execute_inventory_action(plan, backend, action)?,
+            BootstrapDecision::NeedsRecovery(recovery) => {
+                return Err(InitialBootstrapExecutionError::NeedsRecovery(recovery));
+            }
+            BootstrapDecision::FencedComplete(evidence) => return Ok(evidence),
+            BootstrapDecision::RequireBootstrapInventory => {
+                return Err(InitialBootstrapExecutionError::InvalidPlanAction);
+            }
+        }
+    }
+    Err(InitialBootstrapExecutionError::ActionBoundExceeded)
+}
+
+fn execute_inventory_action<B>(
+    plan: &InitialBootstrapInventoryPlan,
+    backend: &mut B,
+    action: BootstrapAction,
+) -> Result<(), InitialBootstrapExecutionError<B::Error>>
+where
+    B: InitialBootstrapBackend,
+{
+    match action {
+        BootstrapAction::AdvanceSnapshot { step } => backend
+            .advance_snapshot(&plan.snapshot, step)
+            .map_err(InitialBootstrapExecutionError::Backend),
+        BootstrapAction::AdvanceInitialMarker { step } => backend
+            .advance_initial_marker(&plan.initial_marker, step)
+            .map_err(InitialBootstrapExecutionError::Backend),
+        BootstrapAction::AdvanceUnit { record, step } => {
+            let planned = match record {
+                BootstrapRecord::BootstrapInstalled => &plan.bootstrap_installed,
+                BootstrapRecord::MarkerCommitted => &plan.marker_committed,
+                _ => return Err(InitialBootstrapExecutionError::InvalidPlanAction),
+            };
+            backend
+                .advance_unit(record, planned, step)
+                .map_err(InitialBootstrapExecutionError::Backend)
+        }
+        BootstrapAction::Reconcile { phase } => backend
+            .reconcile(phase)
+            .map_err(InitialBootstrapExecutionError::Backend),
+        BootstrapAction::AdvanceMarker { .. } => Err(InitialBootstrapExecutionError::InvalidPlanAction),
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, Error)]
+#[error("injected bootstrap failure after action {action:?}")]
+pub(super) struct ModelBootstrapError {
+    action: BootstrapAction,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ModelMarkerProgress {
+    Missing,
+    TemporaryWritten,
+    TemporarySynced,
+    Published,
+    DirectorySynced,
+    Verified,
+}
+
+#[cfg(test)]
+pub(super) struct ModelInitialBootstrapBackend {
+    inventory_snapshot: super::super::sidecar::LifecycleSnapshot,
+    store_initialized: DurableUnitProgress,
+    snapshot: ImmutableArtifactProgress,
+    bootstrap_installed: DurableUnitProgress,
+    pre_marker_reconciled: bool,
+    marker: ModelMarkerProgress,
+    marker_committed: DurableUnitProgress,
+    post_witness_reconciled: bool,
+    actions: Vec<BootstrapAction>,
+    fail_after: Option<usize>,
+}
+
+#[cfg(test)]
+impl private::Sealed for ModelInitialBootstrapBackend {}
+
+#[cfg(test)]
+impl ModelInitialBootstrapBackend {
+    pub(super) fn new(inventory: BootstrapInventoryEvidence) -> Self {
+        Self {
+            inventory_snapshot: inventory.snapshot,
+            store_initialized: DurableUnitProgress::Missing,
+            snapshot: ImmutableArtifactProgress::Missing,
+            bootstrap_installed: DurableUnitProgress::Missing,
+            pre_marker_reconciled: false,
+            marker: ModelMarkerProgress::Missing,
+            marker_committed: DurableUnitProgress::Missing,
+            post_witness_reconciled: false,
+            actions: Vec::new(),
+            fail_after: None,
+        }
+    }
+
+    pub(super) const fn expected_action_count() -> usize {
+        41
+    }
+
+    pub(super) fn executed_action_count(&self) -> usize {
+        self.actions.len()
+    }
+
+    pub(super) fn fail_after_action(&mut self, index: usize) {
+        self.fail_after = Some(index);
+    }
+
+    pub(super) fn clear_failure(&mut self) {
+        self.fail_after = None;
+    }
+
+    pub(super) fn assert_frozen_order(&self) {
+        assert_eq!(self.actions.len(), Self::expected_action_count());
+        assert_eq!(
+            self.actions.first(),
+            Some(&BootstrapAction::AdvanceUnit {
+                record: BootstrapRecord::StoreInitialized,
+                step: DurableUnitStep::AppendFrame,
+            })
+        );
+        assert_eq!(
+            self.actions.last(),
+            Some(&BootstrapAction::Reconcile {
+                phase: ReconciliationPhase::AfterMarkerWitness,
+            })
+        );
+        let marker_publish = self
+            .actions
+            .iter()
+            .position(|action| {
+                *action
+                    == BootstrapAction::AdvanceInitialMarker {
+                        step: InitialMarkerStep::PublishFinalNoReplace,
+                    }
+            })
+            .expect("initial marker publication is present");
+        let witness = self
+            .actions
+            .iter()
+            .position(|action| {
+                matches!(
+                    action,
+                    BootstrapAction::AdvanceUnit {
+                        record: BootstrapRecord::MarkerCommitted,
+                        step: DurableUnitStep::AppendFrame
+                    }
+                )
+            })
+            .expect("marker witness append is present");
+        assert!(marker_publish < witness);
+    }
+
+    pub(super) fn assert_each_action_at_most_once(&self) {
+        for (index, action) in self.actions.iter().enumerate() {
+            assert!(
+                !self.actions[index + 1..].contains(action),
+                "action repeated: {action:?}"
+            );
+        }
+    }
+
+    fn record_action(&mut self, action: BootstrapAction) -> Result<(), ModelBootstrapError> {
+        let index = self.actions.len();
+        self.actions.push(action);
+        if self.fail_after == Some(index) {
+            return Err(ModelBootstrapError { action });
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+impl InitialBootstrapBackend for ModelInitialBootstrapBackend {
+    type Error = ModelBootstrapError;
+
+    fn inspect_store_initialized(
+        &mut self,
+        _planned: &PlannedAcknowledgedUnit,
+    ) -> Result<DurableUnitProgress, Self::Error> {
+        Ok(self.store_initialized)
+    }
+
+    fn scan_inventory(&mut self) -> Result<BootstrapInventoryEvidence, Self::Error> {
+        Ok(BootstrapInventoryEvidence::verified_for_test(&self.inventory_snapshot)
+            .expect("model inventory remains canonical"))
+    }
+
+    fn inspect_inventory_phase(
+        &mut self,
+        planned: &InitialBootstrapInventoryPlan,
+    ) -> Result<InitialBootstrapProgress, Self::Error> {
+        if self.snapshot != ImmutableArtifactProgress::Verified {
+            return Ok(InitialBootstrapProgress::BootstrapSnapshot(self.snapshot));
+        }
+        if self.bootstrap_installed != DurableUnitProgress::Committed {
+            return Ok(InitialBootstrapProgress::BootstrapInstalled(self.bootstrap_installed));
+        }
+        if !self.pre_marker_reconciled {
+            return Ok(InitialBootstrapProgress::BootstrapInstalled(
+                DurableUnitProgress::Committed,
+            ));
+        }
+        if self.marker != ModelMarkerProgress::Verified {
+            return Ok(match self.marker {
+                ModelMarkerProgress::Missing => InitialBootstrapProgress::PreMarkerReconciled,
+                ModelMarkerProgress::TemporaryWritten => {
+                    InitialBootstrapProgress::InitialMarker(InitialMarkerProgress::TemporaryWritten)
+                }
+                ModelMarkerProgress::TemporarySynced => {
+                    InitialBootstrapProgress::InitialMarker(InitialMarkerProgress::TemporarySynced)
+                }
+                ModelMarkerProgress::Published => {
+                    InitialBootstrapProgress::InitialMarker(InitialMarkerProgress::Published)
+                }
+                ModelMarkerProgress::DirectorySynced => {
+                    InitialBootstrapProgress::InitialMarker(InitialMarkerProgress::DirectorySynced)
+                }
+                ModelMarkerProgress::Verified => unreachable!("handled above"),
+            });
+        }
+        if self.marker_committed == DurableUnitProgress::Missing {
+            let evidence = super::types::InitialMarkerVerificationEvidence::from_reopened_bytes(
+                planned.initial_marker.encoded_file,
+                &planned.initial_marker,
+            )
+            .expect("model reopens the exact marker");
+            return Ok(InitialBootstrapProgress::InitialMarker(
+                InitialMarkerProgress::Verified(Box::new(evidence)),
+            ));
+        }
+        if self.marker_committed != DurableUnitProgress::Committed {
+            return Ok(InitialBootstrapProgress::MarkerCommitted(self.marker_committed));
+        }
+        if !self.post_witness_reconciled {
+            return Ok(InitialBootstrapProgress::MarkerCommitted(
+                DurableUnitProgress::Committed,
+            ));
+        }
+        Ok(InitialBootstrapProgress::PostWitnessReconciled)
+    }
+
+    fn advance_unit(
+        &mut self,
+        record: BootstrapRecord,
+        _planned: &PlannedAcknowledgedUnit,
+        step: DurableUnitStep,
+    ) -> Result<(), Self::Error> {
+        let progress = match record {
+            BootstrapRecord::StoreInitialized => &mut self.store_initialized,
+            BootstrapRecord::BootstrapInstalled => &mut self.bootstrap_installed,
+            BootstrapRecord::MarkerCommitted => &mut self.marker_committed,
+            BootstrapRecord::LogOpened => unreachable!("not part of initial bootstrap"),
+        };
+        *progress = advance_unit_progress(*progress, step);
+        self.record_action(BootstrapAction::AdvanceUnit { record, step })
+    }
+
+    fn advance_snapshot(&mut self, _planned: &PlannedSnapshot, step: ImmutableArtifactStep) -> Result<(), Self::Error> {
+        self.snapshot = match (self.snapshot, step) {
+            (ImmutableArtifactProgress::Missing, ImmutableArtifactStep::WriteTemporary) => {
+                ImmutableArtifactProgress::TemporaryWritten
+            }
+            (ImmutableArtifactProgress::TemporaryWritten, ImmutableArtifactStep::SyncTemporary) => {
+                ImmutableArtifactProgress::TemporarySynced
+            }
+            (ImmutableArtifactProgress::TemporarySynced, ImmutableArtifactStep::PublishFinalNoReplace) => {
+                ImmutableArtifactProgress::Published
+            }
+            (ImmutableArtifactProgress::Published, ImmutableArtifactStep::ReopenAndVerify) => {
+                ImmutableArtifactProgress::Verified
+            }
+            _ => unreachable!("planner must advance snapshot monotonically"),
+        };
+        self.record_action(BootstrapAction::AdvanceSnapshot { step })
+    }
+
+    fn advance_initial_marker(
+        &mut self,
+        _planned: &PlannedInitialMarker,
+        step: InitialMarkerStep,
+    ) -> Result<(), Self::Error> {
+        self.marker = match (self.marker, step) {
+            (ModelMarkerProgress::Missing, InitialMarkerStep::WriteTemporary) => ModelMarkerProgress::TemporaryWritten,
+            (ModelMarkerProgress::TemporaryWritten, InitialMarkerStep::SyncTemporary) => {
+                ModelMarkerProgress::TemporarySynced
+            }
+            (ModelMarkerProgress::TemporarySynced, InitialMarkerStep::PublishFinalNoReplace) => {
+                ModelMarkerProgress::Published
+            }
+            (ModelMarkerProgress::Published, InitialMarkerStep::SyncLifecycleDirectory) => {
+                ModelMarkerProgress::DirectorySynced
+            }
+            (ModelMarkerProgress::DirectorySynced, InitialMarkerStep::ReopenAndVerifyEntireFile) => {
+                ModelMarkerProgress::Verified
+            }
+            _ => unreachable!("planner must advance initial marker monotonically"),
+        };
+        self.record_action(BootstrapAction::AdvanceInitialMarker { step })
+    }
+
+    fn reconcile(&mut self, phase: ReconciliationPhase) -> Result<(), Self::Error> {
+        match phase {
+            ReconciliationPhase::BeforeMarker => self.pre_marker_reconciled = true,
+            ReconciliationPhase::AfterMarkerWitness => self.post_witness_reconciled = true,
+        }
+        self.record_action(BootstrapAction::Reconcile { phase })
+    }
+}
+
+#[cfg(test)]
+fn advance_unit_progress(current: DurableUnitProgress, step: DurableUnitStep) -> DurableUnitProgress {
+    match (current, step) {
+        (DurableUnitProgress::Missing, DurableUnitStep::AppendFrame) => DurableUnitProgress::ExactFramePrefix,
+        (DurableUnitProgress::ExactFramePrefix, DurableUnitStep::CompleteFrame) => DurableUnitProgress::FrameWritten,
+        (DurableUnitProgress::FrameWritten, DurableUnitStep::SyncFrame) => DurableUnitProgress::FrameSynced,
+        (DurableUnitProgress::FrameSynced, DurableUnitStep::WriteAcknowledgementSlot) => {
+            DurableUnitProgress::AcknowledgementWritten
+        }
+        (DurableUnitProgress::AcknowledgementWritten, DurableUnitStep::SyncAcknowledgementSlot) => {
+            DurableUnitProgress::AcknowledgementSynced
+        }
+        (DurableUnitProgress::AcknowledgementSynced, DurableUnitStep::VerifyAcknowledgementSlot) => {
+            DurableUnitProgress::AcknowledgementVerified
+        }
+        (DurableUnitProgress::AcknowledgementVerified, DurableUnitStep::AppendSeal) => {
+            DurableUnitProgress::ExactSealPrefix
+        }
+        (DurableUnitProgress::ExactSealPrefix, DurableUnitStep::CompleteSeal) => DurableUnitProgress::SealWritten,
+        (DurableUnitProgress::SealWritten, DurableUnitStep::SyncSeal) => DurableUnitProgress::SealSynced,
+        (DurableUnitProgress::SealSynced, DurableUnitStep::VerifySealAndEof) => DurableUnitProgress::Committed,
+        _ => unreachable!("planner must advance durable unit monotonically"),
+    }
+}

--- a/rocketmq-store-local/src/mapped_file/retirement/bootstrap/executor/durable_unit.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/bootstrap/executor/durable_unit.rs
@@ -1,0 +1,247 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use thiserror::Error;
+
+use super::super::types::BootstrapRecord;
+use super::super::types::DurableUnitProgress;
+use super::super::types::DurableUnitStep;
+use super::super::types::PlannedAcknowledgedUnit;
+use crate::mapped_file::retirement::io::LedgerIo;
+use crate::mapped_file::retirement::io::LedgerIoError;
+
+#[derive(Debug, Error)]
+pub(in crate::mapped_file::retirement::bootstrap) enum DurableUnitError {
+    #[error(transparent)]
+    Io(#[from] LedgerIoError),
+    #[error("bootstrap durable unit is not an exact prefix of its canonical bytes: {0}")]
+    NonCanonical(&'static str),
+    #[error("bootstrap durable-unit offset arithmetic overflowed")]
+    OffsetOverflow,
+    #[error("bootstrap durable-unit action does not match the inspected frontier")]
+    InvalidStep,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct UnitIdentity {
+    record: BootstrapRecord,
+    sequence: u64,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct EphemeralDurability {
+    frame_synced: bool,
+    acknowledgement_synced: bool,
+    acknowledgement_verified: bool,
+    seal_synced: bool,
+    seal_verified: bool,
+}
+
+/// Exact frame/ACK/seal executor over an already verified handle-relative ledger backend.
+///
+/// Sync and reread facts are deliberately process-local. A newly constructed machine starts with
+/// every fact false and safely repeats sync/reread operations before advancing durable bytes.
+pub(in crate::mapped_file::retirement::bootstrap) struct DurableUnitMachine<I> {
+    io: I,
+    durability: BTreeMap<UnitIdentity, EphemeralDurability>,
+}
+
+impl<I> DurableUnitMachine<I>
+where
+    I: LedgerIo,
+{
+    pub(in crate::mapped_file::retirement::bootstrap) fn new(io: I) -> Self {
+        Self {
+            io,
+            durability: BTreeMap::new(),
+        }
+    }
+
+    pub(in crate::mapped_file::retirement::bootstrap) fn inspect(
+        &mut self,
+        record: BootstrapRecord,
+        planned: &PlannedAcknowledgedUnit,
+    ) -> Result<DurableUnitProgress, DurableUnitError> {
+        let durability = self.durability(record, planned.sequence);
+        let log_length = self.io.log_len()?;
+        if log_length < planned.frame_start_offset {
+            return Err(DurableUnitError::NonCanonical("log ends before planned frame start"));
+        }
+        if log_length < planned.frame_end_offset {
+            let prefix_length = usize::try_from(log_length - planned.frame_start_offset)
+                .map_err(|_| DurableUnitError::OffsetOverflow)?;
+            self.require_log_bytes(planned.frame_start_offset, &planned.frame[..prefix_length])?;
+            return Ok(if prefix_length == 0 {
+                DurableUnitProgress::Missing
+            } else {
+                DurableUnitProgress::ExactFramePrefix
+            });
+        }
+        self.require_log_bytes(planned.frame_start_offset, &planned.frame)?;
+
+        let sealed_end = planned.sealed_log_length;
+        if log_length > sealed_end {
+            self.require_log_bytes(planned.frame_end_offset, &planned.seal)?;
+            return Ok(DurableUnitProgress::Committed);
+        }
+
+        let acknowledgement = self.io.read_acknowledgement_slot(slot_index(planned)?)?;
+        if log_length == planned.frame_end_offset {
+            if !durability.frame_synced {
+                return Ok(DurableUnitProgress::FrameWritten);
+            }
+            if acknowledgement != planned.acknowledgement_slot {
+                return Ok(DurableUnitProgress::FrameSynced);
+            }
+            if !durability.acknowledgement_synced {
+                return Ok(DurableUnitProgress::AcknowledgementWritten);
+            }
+            if !durability.acknowledgement_verified {
+                return Ok(DurableUnitProgress::AcknowledgementSynced);
+            }
+            return Ok(DurableUnitProgress::AcknowledgementVerified);
+        }
+
+        if acknowledgement != planned.acknowledgement_slot {
+            return Err(DurableUnitError::NonCanonical(
+                "seal bytes exist without the exact acknowledgement slot",
+            ));
+        }
+        if log_length < sealed_end {
+            let prefix_length =
+                usize::try_from(log_length - planned.frame_end_offset).map_err(|_| DurableUnitError::OffsetOverflow)?;
+            self.require_log_bytes(planned.frame_end_offset, &planned.seal[..prefix_length])?;
+            return Ok(if prefix_length == 0 {
+                DurableUnitProgress::AcknowledgementVerified
+            } else {
+                DurableUnitProgress::ExactSealPrefix
+            });
+        }
+        self.require_log_bytes(planned.frame_end_offset, &planned.seal)?;
+        if durability.seal_verified {
+            Ok(DurableUnitProgress::Committed)
+        } else if !durability.seal_synced {
+            Ok(DurableUnitProgress::SealWritten)
+        } else {
+            Ok(DurableUnitProgress::SealSynced)
+        }
+    }
+
+    pub(in crate::mapped_file::retirement::bootstrap) fn advance(
+        &mut self,
+        record: BootstrapRecord,
+        planned: &PlannedAcknowledgedUnit,
+        step: DurableUnitStep,
+    ) -> Result<(), DurableUnitError> {
+        let identity = UnitIdentity {
+            record,
+            sequence: planned.sequence,
+        };
+        self.durability.entry(identity).or_default();
+        match step {
+            DurableUnitStep::AppendFrame | DurableUnitStep::CompleteFrame => {
+                self.append_remaining(planned.frame_start_offset, &planned.frame)?;
+            }
+            DurableUnitStep::SyncFrame => {
+                self.io.sync_log()?;
+                self.durability.entry(identity).or_default().frame_synced = true;
+            }
+            DurableUnitStep::WriteAcknowledgementSlot => {
+                self.io
+                    .write_acknowledgement_slot(slot_index(planned)?, &planned.acknowledgement_slot)?;
+            }
+            DurableUnitStep::SyncAcknowledgementSlot => {
+                self.io.sync_acknowledgement_file()?;
+                self.durability.entry(identity).or_default().acknowledgement_synced = true;
+            }
+            DurableUnitStep::VerifyAcknowledgementSlot => {
+                let actual = self.io.read_acknowledgement_slot(slot_index(planned)?)?;
+                if actual != planned.acknowledgement_slot {
+                    return Err(DurableUnitError::NonCanonical("acknowledgement reread mismatch"));
+                }
+                self.durability.entry(identity).or_default().acknowledgement_verified = true;
+            }
+            DurableUnitStep::AppendSeal | DurableUnitStep::CompleteSeal => {
+                self.append_remaining(planned.frame_end_offset, &planned.seal)?;
+            }
+            DurableUnitStep::SyncSeal => {
+                self.io.sync_log()?;
+                self.durability.entry(identity).or_default().seal_synced = true;
+            }
+            DurableUnitStep::VerifySealAndEof => {
+                self.require_log_bytes(planned.frame_end_offset, &planned.seal)?;
+                if self.io.log_len()? != planned.sealed_log_length {
+                    return Err(DurableUnitError::NonCanonical("sealed log EOF mismatch"));
+                }
+                self.durability.entry(identity).or_default().seal_verified = true;
+            }
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(in crate::mapped_file::retirement::bootstrap) const fn io_for_test(&self) -> &I {
+        &self.io
+    }
+
+    fn durability(&mut self, record: BootstrapRecord, sequence: u64) -> EphemeralDurability {
+        let identity = UnitIdentity { record, sequence };
+        *self.durability.entry(identity).or_default()
+    }
+
+    fn append_remaining(&mut self, start: u64, expected: &[u8]) -> Result<(), DurableUnitError> {
+        let actual = self.io.log_len()?;
+        let end = start
+            .checked_add(u64::try_from(expected.len()).map_err(|_| DurableUnitError::OffsetOverflow)?)
+            .ok_or(DurableUnitError::OffsetOverflow)?;
+        if actual < start || actual > end {
+            return Err(DurableUnitError::NonCanonical(
+                "append frontier is outside planned bytes",
+            ));
+        }
+        let consumed = usize::try_from(actual - start).map_err(|_| DurableUnitError::OffsetOverflow)?;
+        self.require_log_bytes(start, &expected[..consumed])?;
+        self.io.append_log(actual, &expected[consumed..])?;
+        Ok(())
+    }
+
+    fn require_log_bytes(&mut self, offset: u64, expected: &[u8]) -> Result<(), DurableUnitError> {
+        if expected.is_empty() {
+            return Ok(());
+        }
+        let mut actual = Vec::new();
+        actual
+            .try_reserve_exact(expected.len())
+            .map_err(|_| DurableUnitError::OffsetOverflow)?;
+        actual.resize(expected.len(), 0);
+        self.io.read_log_exact(offset, &mut actual)?;
+        if actual != expected {
+            return Err(DurableUnitError::NonCanonical("log byte mismatch"));
+        }
+        Ok(())
+    }
+}
+
+fn slot_index(planned: &PlannedAcknowledgedUnit) -> Result<u8, DurableUnitError> {
+    u8::try_from(
+        planned
+            .acknowledgement_epoch
+            .checked_sub(1)
+            .ok_or(DurableUnitError::OffsetOverflow)?
+            & 1,
+    )
+    .map_err(|_| DurableUnitError::OffsetOverflow)
+}

--- a/rocketmq-store-local/src/mapped_file/retirement/bootstrap/executor/platform.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/bootstrap/executor/platform.rs
@@ -1,0 +1,377 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io;
+
+use thiserror::Error;
+
+use super::super::inventory::scan_bootstrap_inventory;
+use super::super::inventory::BootstrapInventoryError;
+use super::super::inventory::BootstrapInventoryLimits;
+use super::super::plan::InitialBootstrapInventoryPlan;
+use super::super::proof::BootstrapFoundationEvidence;
+use super::super::proof::BootstrapInventoryEvidence;
+use super::super::types::BootstrapRecord;
+use super::super::types::DurableUnitProgress;
+use super::super::types::DurableUnitStep;
+use super::super::types::FencedBootstrapEvidence;
+use super::super::types::ImmutableArtifactStep;
+use super::super::types::InitialBootstrapProgress;
+use super::super::types::InitialMarkerProgress;
+use super::super::types::InitialMarkerStep;
+use super::super::types::PlannedAcknowledgedUnit;
+use super::super::types::PlannedInitialMarker;
+use super::super::types::PlannedSnapshot;
+use super::super::types::ReconciliationPhase;
+use super::durable_unit::DurableUnitError;
+use super::durable_unit::DurableUnitMachine;
+use super::private;
+use super::InitialBootstrapBackend;
+use crate::mapped_file::retirement::identity::StoreRelativePath;
+use crate::mapped_file::retirement::io::FileLedgerIo;
+use crate::mapped_file::retirement::io::LedgerIoError;
+use crate::mapped_file::retirement::sidecar::LifecycleSnapshot;
+use crate::mapped_file::retirement::sidecar::SidecarError;
+use crate::mapped_file::retirement::sidecar::StoreMeta;
+
+#[cfg(target_os = "linux")]
+#[path = "platform/linux.rs"]
+mod native;
+#[cfg(windows)]
+#[path = "platform/windows.rs"]
+mod native;
+#[cfg(not(any(target_os = "linux", windows)))]
+#[path = "platform/unsupported.rs"]
+mod native;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::mapped_file::retirement::bootstrap) enum InitialBootstrapFoundationErrorKind {
+    UnsupportedPlatform,
+    InvalidArtifact,
+    Inventory,
+    Io,
+}
+
+#[derive(Debug, Error)]
+enum InitialBootstrapFoundationSource {
+    #[error("managed lifecycle bootstrap is unsupported on this platform: {0}")]
+    UnsupportedPlatform(&'static str),
+    #[error("bootstrap artifact is not the exact resumable prefix: {0}")]
+    InvalidArtifact(&'static str),
+    #[error("bootstrap sidecar validation failed")]
+    Sidecar(#[source] SidecarError),
+    #[error("bootstrap ledger handle validation failed")]
+    Ledger(#[source] LedgerIoError),
+    #[error("bootstrap frame/acknowledgement/seal transition failed")]
+    DurableUnit(#[source] DurableUnitError),
+    #[error("bootstrap numeric-segment inventory failed")]
+    Inventory(#[source] BootstrapInventoryError),
+    #[error("bootstrap filesystem operation failed")]
+    Io(#[source] io::Error),
+}
+
+#[derive(Debug, Error)]
+#[error("initial bootstrap foundation failed ({kind:?}): {source}")]
+pub(in crate::mapped_file::retirement::bootstrap) struct InitialBootstrapFoundationError {
+    kind: InitialBootstrapFoundationErrorKind,
+    #[source]
+    source: InitialBootstrapFoundationSource,
+}
+
+impl InitialBootstrapFoundationError {
+    pub(in crate::mapped_file::retirement::bootstrap) const fn kind(&self) -> InitialBootstrapFoundationErrorKind {
+        self.kind
+    }
+
+    fn unsupported(reason: &'static str) -> Self {
+        Self {
+            kind: InitialBootstrapFoundationErrorKind::UnsupportedPlatform,
+            source: InitialBootstrapFoundationSource::UnsupportedPlatform(reason),
+        }
+    }
+
+    fn invalid(detail: &'static str) -> Self {
+        Self {
+            kind: InitialBootstrapFoundationErrorKind::InvalidArtifact,
+            source: InitialBootstrapFoundationSource::InvalidArtifact(detail),
+        }
+    }
+
+    fn sidecar(source: SidecarError) -> Self {
+        Self {
+            kind: InitialBootstrapFoundationErrorKind::InvalidArtifact,
+            source: InitialBootstrapFoundationSource::Sidecar(source),
+        }
+    }
+
+    fn ledger(source: LedgerIoError) -> Self {
+        Self {
+            kind: InitialBootstrapFoundationErrorKind::InvalidArtifact,
+            source: InitialBootstrapFoundationSource::Ledger(source),
+        }
+    }
+
+    fn durable_unit(source: DurableUnitError) -> Self {
+        Self {
+            kind: InitialBootstrapFoundationErrorKind::InvalidArtifact,
+            source: InitialBootstrapFoundationSource::DurableUnit(source),
+        }
+    }
+
+    fn inventory(source: BootstrapInventoryError) -> Self {
+        Self {
+            kind: InitialBootstrapFoundationErrorKind::Inventory,
+            source: InitialBootstrapFoundationSource::Inventory(source),
+        }
+    }
+
+    fn io(source: io::Error) -> Self {
+        Self {
+            kind: InitialBootstrapFoundationErrorKind::Io,
+            source: InitialBootstrapFoundationSource::Io(source),
+        }
+    }
+}
+
+pub(in crate::mapped_file::retirement::bootstrap) struct PreparedInitialBootstrapFoundation {
+    foundation: Option<BootstrapFoundationEvidence>,
+    ledger: DurableUnitMachine<FileLedgerIo>,
+    store_root: File,
+    artifacts: native::InitialArtifactStore,
+    expected_meta: StoreMeta,
+    expected_inventory: Option<LifecycleSnapshot>,
+    retained_files: BTreeMap<StoreRelativePath, File>,
+    pre_marker_reconciled: bool,
+    post_witness_reconciled: bool,
+}
+
+/// Complete initial bootstrap that remains fenced until startup replay and reconciliation succeed.
+#[doc(hidden)]
+pub struct InitialBootstrapCompletion {
+    evidence: FencedBootstrapEvidence,
+}
+
+impl std::fmt::Debug for InitialBootstrapCompletion {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("InitialBootstrapCompletion")
+            .field("store_uuid", &self.evidence.store_uuid)
+            .field("witness_sequence", &self.evidence.witness_sequence)
+            .field("acknowledgement_epoch", &self.evidence.acknowledgement_epoch)
+            .field("marker_epoch", &self.evidence.marker_epoch)
+            .finish_non_exhaustive()
+    }
+}
+
+impl InitialBootstrapCompletion {
+    #[doc(hidden)]
+    pub fn store_uuid(&self) -> [u8; 16] {
+        *self.evidence.store_uuid.as_bytes()
+    }
+
+    #[doc(hidden)]
+    pub const fn witness_sequence(&self) -> u64 {
+        self.evidence.witness_sequence
+    }
+
+    #[doc(hidden)]
+    pub const fn acknowledgement_epoch(&self) -> u64 {
+        self.evidence.acknowledgement_epoch
+    }
+
+    #[doc(hidden)]
+    pub const fn marker_epoch(&self) -> u64 {
+        self.evidence.marker_epoch
+    }
+}
+
+impl std::fmt::Debug for PreparedInitialBootstrapFoundation {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PreparedInitialBootstrapFoundation")
+            .field(
+                "store_uuid",
+                &self
+                    .foundation
+                    .as_ref()
+                    .map(|foundation| foundation.store_meta.meta.store_uuid),
+            )
+            .finish_non_exhaustive()
+    }
+}
+
+impl PreparedInitialBootstrapFoundation {
+    fn new(
+        foundation: BootstrapFoundationEvidence,
+        ledger: FileLedgerIo,
+        store_root: File,
+        artifacts: native::InitialArtifactStore,
+        expected_meta: StoreMeta,
+    ) -> Self {
+        Self {
+            foundation: Some(foundation),
+            ledger: DurableUnitMachine::new(ledger),
+            store_root,
+            artifacts,
+            expected_meta,
+            expected_inventory: None,
+            retained_files: BTreeMap::new(),
+            pre_marker_reconciled: false,
+            post_witness_reconciled: false,
+        }
+    }
+
+    #[cfg(test)]
+    pub(in crate::mapped_file::retirement::bootstrap) fn store_uuid_for_test(
+        &self,
+    ) -> crate::mapped_file::retirement::identity::StoreUuid {
+        self.foundation
+            .as_ref()
+            .expect("test observes foundation before execution")
+            .store_meta
+            .meta
+            .store_uuid
+    }
+}
+
+pub(in crate::mapped_file::retirement::bootstrap) fn execute_prepared_initial_bootstrap(
+    mut prepared: PreparedInitialBootstrapFoundation,
+) -> Result<InitialBootstrapCompletion, super::InitialBootstrapExecutionError<InitialBootstrapFoundationError>> {
+    let foundation = prepared.foundation.take().ok_or_else(|| {
+        super::InitialBootstrapExecutionError::Backend(InitialBootstrapFoundationError::invalid(
+            "bootstrap foundation was already consumed",
+        ))
+    })?;
+    let evidence = super::execute_initial_bootstrap(foundation, &mut prepared)?;
+    Ok(InitialBootstrapCompletion { evidence })
+}
+
+impl private::Sealed for PreparedInitialBootstrapFoundation {}
+
+impl InitialBootstrapBackend for PreparedInitialBootstrapFoundation {
+    type Error = InitialBootstrapFoundationError;
+
+    fn inspect_store_initialized(
+        &mut self,
+        planned: &PlannedAcknowledgedUnit,
+    ) -> Result<DurableUnitProgress, Self::Error> {
+        self.ledger
+            .inspect(BootstrapRecord::StoreInitialized, planned)
+            .map_err(InitialBootstrapFoundationError::durable_unit)
+    }
+
+    fn scan_inventory(&mut self) -> Result<BootstrapInventoryEvidence, Self::Error> {
+        let stable = scan_bootstrap_inventory(
+            &self.store_root,
+            &self.expected_meta,
+            BootstrapInventoryLimits::default(),
+        )
+        .map_err(InitialBootstrapFoundationError::inventory)?;
+        self.expected_inventory = Some(stable.snapshot().clone());
+        let (evidence, retained_files) = stable.into_parts();
+        self.retained_files = retained_files;
+        Ok(evidence)
+    }
+
+    fn inspect_inventory_phase(
+        &mut self,
+        planned: &InitialBootstrapInventoryPlan,
+    ) -> Result<InitialBootstrapProgress, Self::Error> {
+        let snapshot = self.artifacts.inspect_snapshot(&planned.snapshot)?;
+        if snapshot != super::super::types::ImmutableArtifactProgress::Verified {
+            return Ok(InitialBootstrapProgress::BootstrapSnapshot(snapshot));
+        }
+        let bootstrap_installed = self
+            .ledger
+            .inspect(BootstrapRecord::BootstrapInstalled, &planned.bootstrap_installed)
+            .map_err(InitialBootstrapFoundationError::durable_unit)?;
+        if bootstrap_installed != DurableUnitProgress::Committed || !self.pre_marker_reconciled {
+            return Ok(InitialBootstrapProgress::BootstrapInstalled(bootstrap_installed));
+        }
+        let marker = self.artifacts.inspect_initial_marker(&planned.initial_marker)?;
+        if !matches!(&marker, InitialMarkerProgress::Verified(_)) {
+            return Ok(if matches!(&marker, InitialMarkerProgress::Missing) {
+                InitialBootstrapProgress::PreMarkerReconciled
+            } else {
+                InitialBootstrapProgress::InitialMarker(marker)
+            });
+        }
+        let marker_committed = self
+            .ledger
+            .inspect(BootstrapRecord::MarkerCommitted, &planned.marker_committed)
+            .map_err(InitialBootstrapFoundationError::durable_unit)?;
+        if marker_committed == DurableUnitProgress::Missing {
+            return Ok(InitialBootstrapProgress::InitialMarker(marker));
+        }
+        if marker_committed != DurableUnitProgress::Committed || !self.post_witness_reconciled {
+            return Ok(InitialBootstrapProgress::MarkerCommitted(marker_committed));
+        }
+        Ok(InitialBootstrapProgress::PostWitnessReconciled)
+    }
+
+    fn advance_unit(
+        &mut self,
+        record: BootstrapRecord,
+        planned: &PlannedAcknowledgedUnit,
+        step: DurableUnitStep,
+    ) -> Result<(), Self::Error> {
+        self.ledger
+            .advance(record, planned, step)
+            .map_err(InitialBootstrapFoundationError::durable_unit)
+    }
+
+    fn advance_snapshot(&mut self, planned: &PlannedSnapshot, step: ImmutableArtifactStep) -> Result<(), Self::Error> {
+        self.artifacts.advance_snapshot(planned, step)
+    }
+
+    fn advance_initial_marker(
+        &mut self,
+        planned: &PlannedInitialMarker,
+        step: InitialMarkerStep,
+    ) -> Result<(), Self::Error> {
+        self.artifacts.advance_initial_marker(planned, step)
+    }
+
+    fn reconcile(&mut self, phase: ReconciliationPhase) -> Result<(), Self::Error> {
+        let expected = self.expected_inventory.as_ref().ok_or_else(|| {
+            InitialBootstrapFoundationError::invalid("inventory was not retained before reconciliation")
+        })?;
+        let stable = scan_bootstrap_inventory(
+            &self.store_root,
+            &self.expected_meta,
+            BootstrapInventoryLimits::default(),
+        )
+        .map_err(InitialBootstrapFoundationError::inventory)?;
+        if stable.snapshot() != expected || stable.retained_file_count_for_reconciliation() != self.retained_files.len()
+        {
+            return Err(InitialBootstrapFoundationError::invalid(
+                "numeric segment inventory changed before bootstrap reconciliation",
+            ));
+        }
+        match phase {
+            ReconciliationPhase::BeforeMarker => self.pre_marker_reconciled = true,
+            ReconciliationPhase::AfterMarkerWitness => self.post_witness_reconciled = true,
+        }
+        Ok(())
+    }
+}
+
+pub(in crate::mapped_file::retirement::bootstrap) fn prepare_initial_bootstrap_foundation(
+    store_root: File,
+    expected_meta: &StoreMeta,
+) -> Result<PreparedInitialBootstrapFoundation, InitialBootstrapFoundationError> {
+    native::prepare(store_root, expected_meta)
+}

--- a/rocketmq-store-local/src/mapped_file/retirement/bootstrap/executor/platform/linux.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/bootstrap/executor/platform/linux.rs
@@ -1,0 +1,644 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ffi::CStr;
+use std::fs::File;
+use std::io;
+use std::os::fd::AsRawFd;
+use std::os::fd::FromRawFd;
+use std::os::unix::fs::FileExt;
+use std::os::unix::fs::MetadataExt;
+
+use super::InitialBootstrapFoundationError;
+use super::PreparedInitialBootstrapFoundation;
+use crate::mapped_file::retirement::bootstrap::proof::BootstrapFoundationEvidence;
+use crate::mapped_file::retirement::bootstrap::proof::CanonicalStoreMetaEvidence;
+use crate::mapped_file::retirement::bootstrap::types::ImmutableArtifactProgress;
+use crate::mapped_file::retirement::bootstrap::types::ImmutableArtifactStep;
+use crate::mapped_file::retirement::bootstrap::types::InitialMarkerProgress;
+use crate::mapped_file::retirement::bootstrap::types::InitialMarkerStep;
+use crate::mapped_file::retirement::bootstrap::types::InitialMarkerVerificationEvidence;
+use crate::mapped_file::retirement::bootstrap::types::PlannedInitialMarker;
+use crate::mapped_file::retirement::bootstrap::types::PlannedSnapshot;
+use crate::mapped_file::retirement::io::FileLedgerIo;
+use crate::mapped_file::retirement::sidecar::decode_store_meta;
+use crate::mapped_file::retirement::sidecar::encode_store_meta;
+use crate::mapped_file::retirement::sidecar::StoreMeta;
+use crate::mapped_file::retirement::sidecar::STORE_META_LENGTH;
+
+const LIFECYCLE_DIRECTORY: &CStr = c".rocketmq-lifecycle";
+const STORE_META_FILE: &CStr = c"store.meta";
+const STORE_META_TEMP_FILE: &CStr = c"store.meta.bootstrap.tmp";
+const ACKNOWLEDGEMENT_FILE: &CStr = c"ACKNOWLEDGED.v1";
+const GENERATION_ZERO_LOG: &CStr = c"retirement.log.g00000000000000000000";
+const GENERATION_ZERO_SNAPSHOT: &CStr = c"manifest.snapshot.g00000000000000000000";
+const GENERATION_ZERO_SNAPSHOT_TEMP: &CStr = c"manifest.snapshot.g00000000000000000000.bootstrap.tmp";
+const ENABLED_MARKER: &CStr = c"ENABLED.v1";
+const ENABLED_MARKER_TEMP: &CStr = c"ENABLED.v1.bootstrap.tmp";
+const ACKNOWLEDGEMENT_FILE_LENGTH: usize = 208;
+const MAX_INTERRUPTED_RETRIES: usize = 16;
+const STRICT_RESOLVE: u64 =
+    libc::RESOLVE_BENEATH | libc::RESOLVE_NO_MAGICLINKS | libc::RESOLVE_NO_SYMLINKS | libc::RESOLVE_NO_XDEV;
+
+pub(super) fn prepare(
+    store_root: File,
+    expected_meta: &StoreMeta,
+) -> Result<PreparedInitialBootstrapFoundation, InitialBootstrapFoundationError> {
+    let root_metadata = store_root.metadata().map_err(InitialBootstrapFoundationError::io)?;
+    if !root_metadata.is_dir() {
+        return Err(InitialBootstrapFoundationError::invalid(
+            "Store root is not a directory",
+        ));
+    }
+    let lifecycle = open_or_create_lifecycle_directory(&store_root, root_metadata.dev())?;
+    let canonical_meta = encode_store_meta(expected_meta).map_err(InitialBootstrapFoundationError::sidecar)?;
+    publish_store_meta(&lifecycle, &canonical_meta)?;
+    let acknowledgement = ensure_acknowledgement(&lifecycle)?;
+    ensure_generation_zero_log(&lifecycle, &acknowledgement)?;
+
+    let decoded_meta = decode_store_meta(&canonical_meta).map_err(InitialBootstrapFoundationError::sidecar)?;
+    let foundation = BootstrapFoundationEvidence {
+        store_meta: CanonicalStoreMetaEvidence {
+            meta: decoded_meta,
+            canonical_bytes: canonical_meta,
+            stored_crc32: u32::from_le_bytes(
+                canonical_meta[60..64]
+                    .try_into()
+                    .map_err(|_| InitialBootstrapFoundationError::invalid("store.meta CRC field is unavailable"))?,
+            ),
+        },
+    };
+    let ledger = FileLedgerIo::open_from_store_root(&store_root, 0).map_err(InitialBootstrapFoundationError::ledger)?;
+    let artifacts = InitialArtifactStore::new(
+        store_root.try_clone().map_err(InitialBootstrapFoundationError::io)?,
+        lifecycle.try_clone().map_err(InitialBootstrapFoundationError::io)?,
+    )?;
+    Ok(PreparedInitialBootstrapFoundation::new(
+        foundation,
+        ledger,
+        store_root,
+        artifacts,
+        expected_meta.clone(),
+    ))
+}
+
+pub(super) struct InitialArtifactStore {
+    store_root: File,
+    lifecycle: File,
+    device: u64,
+    inode: u64,
+    snapshot_temporary_synced: bool,
+    snapshot_verified: bool,
+    marker_temporary_synced: bool,
+    marker_directory_synced: bool,
+    marker_verified: bool,
+}
+
+impl InitialArtifactStore {
+    fn new(store_root: File, lifecycle: File) -> Result<Self, InitialBootstrapFoundationError> {
+        let metadata = lifecycle.metadata().map_err(InitialBootstrapFoundationError::io)?;
+        if !metadata.is_dir() {
+            return Err(InitialBootstrapFoundationError::invalid(
+                "retained lifecycle handle is not a directory",
+            ));
+        }
+        Ok(Self {
+            store_root,
+            lifecycle,
+            device: metadata.dev(),
+            inode: metadata.ino(),
+            snapshot_temporary_synced: false,
+            snapshot_verified: false,
+            marker_temporary_synced: false,
+            marker_directory_synced: false,
+            marker_verified: false,
+        })
+    }
+
+    pub(super) fn inspect_snapshot(
+        &self,
+        planned: &PlannedSnapshot,
+    ) -> Result<ImmutableArtifactProgress, InitialBootstrapFoundationError> {
+        self.verify_lifecycle()?;
+        let final_file = open_optional(
+            &self.lifecycle,
+            GENERATION_ZERO_SNAPSHOT,
+            libc::O_RDONLY | libc::O_NONBLOCK,
+        )?;
+        let temporary = open_optional(
+            &self.lifecycle,
+            GENERATION_ZERO_SNAPSHOT_TEMP,
+            libc::O_RDWR | libc::O_NONBLOCK,
+        )?;
+        match (final_file, temporary) {
+            (Some(final_file), None) => {
+                require_exact_file(&final_file, &planned.encoded, "bootstrap snapshot")?;
+                Ok(if self.snapshot_verified {
+                    ImmutableArtifactProgress::Verified
+                } else {
+                    ImmutableArtifactProgress::Published
+                })
+            }
+            (Some(_), Some(_)) => Err(InitialBootstrapFoundationError::invalid(
+                "bootstrap snapshot final and temporary both exist",
+            )),
+            (None, Some(temporary)) => {
+                let complete = require_exact_prefix(&temporary, &planned.encoded, "bootstrap snapshot temporary")?;
+                Ok(if !complete {
+                    ImmutableArtifactProgress::Missing
+                } else if self.snapshot_temporary_synced {
+                    ImmutableArtifactProgress::TemporarySynced
+                } else {
+                    ImmutableArtifactProgress::TemporaryWritten
+                })
+            }
+            (None, None) => Ok(ImmutableArtifactProgress::Missing),
+        }
+    }
+
+    pub(super) fn advance_snapshot(
+        &mut self,
+        planned: &PlannedSnapshot,
+        step: ImmutableArtifactStep,
+    ) -> Result<(), InitialBootstrapFoundationError> {
+        self.verify_lifecycle()?;
+        match step {
+            ImmutableArtifactStep::WriteTemporary => {
+                let temporary = match open_optional(
+                    &self.lifecycle,
+                    GENERATION_ZERO_SNAPSHOT_TEMP,
+                    libc::O_RDWR | libc::O_NONBLOCK,
+                )? {
+                    Some(file) => file,
+                    None => create_exclusive(&self.lifecycle, GENERATION_ZERO_SNAPSHOT_TEMP)?,
+                };
+                complete_exact_prefix(&temporary, &planned.encoded, "bootstrap snapshot temporary")
+            }
+            ImmutableArtifactStep::SyncTemporary => {
+                let temporary = open_required(
+                    &self.lifecycle,
+                    GENERATION_ZERO_SNAPSHOT_TEMP,
+                    libc::O_RDWR | libc::O_NONBLOCK,
+                )?;
+                require_exact_file(&temporary, &planned.encoded, "bootstrap snapshot temporary")?;
+                temporary.sync_all().map_err(InitialBootstrapFoundationError::io)?;
+                self.snapshot_temporary_synced = true;
+                Ok(())
+            }
+            ImmutableArtifactStep::PublishFinalNoReplace => {
+                if !self.snapshot_temporary_synced {
+                    return Err(InitialBootstrapFoundationError::invalid(
+                        "bootstrap snapshot temporary was not synced in this process",
+                    ));
+                }
+                rename_no_replace(&self.lifecycle, GENERATION_ZERO_SNAPSHOT_TEMP, GENERATION_ZERO_SNAPSHOT)
+            }
+            ImmutableArtifactStep::ReopenAndVerify => {
+                self.lifecycle.sync_all().map_err(InitialBootstrapFoundationError::io)?;
+                let final_file = open_required(
+                    &self.lifecycle,
+                    GENERATION_ZERO_SNAPSHOT,
+                    libc::O_RDONLY | libc::O_NONBLOCK,
+                )?;
+                require_exact_file(&final_file, &planned.encoded, "bootstrap snapshot")?;
+                self.snapshot_verified = true;
+                Ok(())
+            }
+        }
+    }
+
+    pub(super) fn inspect_initial_marker(
+        &self,
+        planned: &PlannedInitialMarker,
+    ) -> Result<InitialMarkerProgress, InitialBootstrapFoundationError> {
+        self.verify_lifecycle()?;
+        let final_file = open_optional(&self.lifecycle, ENABLED_MARKER, libc::O_RDONLY | libc::O_NONBLOCK)?;
+        let temporary = open_optional(&self.lifecycle, ENABLED_MARKER_TEMP, libc::O_RDWR | libc::O_NONBLOCK)?;
+        match (final_file, temporary) {
+            (Some(final_file), None) => {
+                require_exact_file(&final_file, &planned.encoded_file, "ENABLED.v1")?;
+                if self.marker_verified {
+                    let evidence =
+                        InitialMarkerVerificationEvidence::from_reopened_bytes(planned.encoded_file, planned)
+                            .ok_or_else(|| InitialBootstrapFoundationError::invalid("marker verification mismatch"))?;
+                    Ok(InitialMarkerProgress::Verified(Box::new(evidence)))
+                } else if self.marker_directory_synced {
+                    Ok(InitialMarkerProgress::DirectorySynced)
+                } else {
+                    Ok(InitialMarkerProgress::Published)
+                }
+            }
+            (Some(_), Some(_)) => Err(InitialBootstrapFoundationError::invalid(
+                "ENABLED.v1 final and temporary both exist",
+            )),
+            (None, Some(temporary)) => {
+                let complete = require_exact_prefix(&temporary, &planned.encoded_file, "ENABLED.v1 temporary")?;
+                Ok(if !complete {
+                    InitialMarkerProgress::Missing
+                } else if self.marker_temporary_synced {
+                    InitialMarkerProgress::TemporarySynced
+                } else {
+                    InitialMarkerProgress::TemporaryWritten
+                })
+            }
+            (None, None) => Ok(InitialMarkerProgress::Missing),
+        }
+    }
+
+    pub(super) fn advance_initial_marker(
+        &mut self,
+        planned: &PlannedInitialMarker,
+        step: InitialMarkerStep,
+    ) -> Result<(), InitialBootstrapFoundationError> {
+        self.verify_lifecycle()?;
+        match step {
+            InitialMarkerStep::WriteTemporary => {
+                let temporary =
+                    match open_optional(&self.lifecycle, ENABLED_MARKER_TEMP, libc::O_RDWR | libc::O_NONBLOCK)? {
+                        Some(file) => file,
+                        None => create_exclusive(&self.lifecycle, ENABLED_MARKER_TEMP)?,
+                    };
+                complete_exact_prefix(&temporary, &planned.encoded_file, "ENABLED.v1 temporary")
+            }
+            InitialMarkerStep::SyncTemporary => {
+                let temporary = open_required(&self.lifecycle, ENABLED_MARKER_TEMP, libc::O_RDWR | libc::O_NONBLOCK)?;
+                require_exact_file(&temporary, &planned.encoded_file, "ENABLED.v1 temporary")?;
+                temporary.sync_all().map_err(InitialBootstrapFoundationError::io)?;
+                self.marker_temporary_synced = true;
+                Ok(())
+            }
+            InitialMarkerStep::PublishFinalNoReplace => {
+                if !self.marker_temporary_synced {
+                    return Err(InitialBootstrapFoundationError::invalid(
+                        "ENABLED.v1 temporary was not synced in this process",
+                    ));
+                }
+                rename_no_replace(&self.lifecycle, ENABLED_MARKER_TEMP, ENABLED_MARKER)
+            }
+            InitialMarkerStep::SyncLifecycleDirectory => {
+                self.lifecycle.sync_all().map_err(InitialBootstrapFoundationError::io)?;
+                self.marker_directory_synced = true;
+                Ok(())
+            }
+            InitialMarkerStep::ReopenAndVerifyEntireFile => {
+                if !self.marker_directory_synced {
+                    return Err(InitialBootstrapFoundationError::invalid(
+                        "ENABLED.v1 directory entry was not synced in this process",
+                    ));
+                }
+                let final_file = open_required(&self.lifecycle, ENABLED_MARKER, libc::O_RDONLY | libc::O_NONBLOCK)?;
+                require_exact_file(&final_file, &planned.encoded_file, "ENABLED.v1")?;
+                self.marker_verified = true;
+                Ok(())
+            }
+        }
+    }
+
+    fn verify_lifecycle(&self) -> Result<(), InitialBootstrapFoundationError> {
+        let metadata = self.lifecycle.metadata().map_err(InitialBootstrapFoundationError::io)?;
+        let reopened = open_required(
+            &self.store_root,
+            LIFECYCLE_DIRECTORY,
+            libc::O_RDONLY | libc::O_DIRECTORY,
+        )?;
+        let reopened_metadata = reopened.metadata().map_err(InitialBootstrapFoundationError::io)?;
+        if metadata.is_dir()
+            && metadata.dev() == self.device
+            && metadata.ino() == self.inode
+            && reopened_metadata.is_dir()
+            && reopened_metadata.dev() == self.device
+            && reopened_metadata.ino() == self.inode
+        {
+            Ok(())
+        } else {
+            Err(InitialBootstrapFoundationError::invalid(
+                "retained lifecycle directory is no longer bound beneath the retained Store root",
+            ))
+        }
+    }
+}
+
+fn open_or_create_lifecycle_directory(
+    store_root: &File,
+    root_device: u64,
+) -> Result<File, InitialBootstrapFoundationError> {
+    let lifecycle = match open_optional(store_root, LIFECYCLE_DIRECTORY, libc::O_RDONLY | libc::O_DIRECTORY)? {
+        Some(directory) => directory,
+        None => {
+            // SAFETY: the retained root descriptor is live, the name is a single NUL-terminated
+            // component, and no pointer escapes this call.
+            let result = unsafe { libc::mkdirat(store_root.as_raw_fd(), LIFECYCLE_DIRECTORY.as_ptr(), 0o700) };
+            if result != 0 {
+                return Err(InitialBootstrapFoundationError::io(io::Error::last_os_error()));
+            }
+            store_root.sync_all().map_err(InitialBootstrapFoundationError::io)?;
+            open_required(store_root, LIFECYCLE_DIRECTORY, libc::O_RDONLY | libc::O_DIRECTORY)?
+        }
+    };
+    let metadata = lifecycle.metadata().map_err(InitialBootstrapFoundationError::io)?;
+    if !metadata.is_dir() || metadata.dev() != root_device {
+        return Err(InitialBootstrapFoundationError::invalid(
+            "lifecycle directory is not a contained same-device directory",
+        ));
+    }
+    Ok(lifecycle)
+}
+
+fn publish_store_meta(
+    lifecycle: &File,
+    expected: &[u8; STORE_META_LENGTH],
+) -> Result<(), InitialBootstrapFoundationError> {
+    let final_file = open_optional(lifecycle, STORE_META_FILE, libc::O_RDONLY | libc::O_NONBLOCK)?;
+    let temporary = open_optional(lifecycle, STORE_META_TEMP_FILE, libc::O_RDWR | libc::O_NONBLOCK)?;
+    match (final_file, temporary) {
+        (Some(final_file), None) => {
+            require_exact_file(&final_file, expected, "store.meta")?;
+            lifecycle.sync_all().map_err(InitialBootstrapFoundationError::io)
+        }
+        (Some(_), Some(_)) => Err(InitialBootstrapFoundationError::invalid(
+            "store.meta final and bootstrap temporary both exist",
+        )),
+        (None, temporary) => {
+            let temporary = match temporary {
+                Some(file) => file,
+                None => create_exclusive(lifecycle, STORE_META_TEMP_FILE)?,
+            };
+            complete_exact_prefix(&temporary, expected, "store.meta bootstrap temporary")?;
+            temporary.sync_all().map_err(InitialBootstrapFoundationError::io)?;
+            require_exact_file(&temporary, expected, "store.meta bootstrap temporary")?;
+            rename_no_replace(lifecycle, STORE_META_TEMP_FILE, STORE_META_FILE)?;
+            lifecycle.sync_all().map_err(InitialBootstrapFoundationError::io)?;
+            let final_file = open_required(lifecycle, STORE_META_FILE, libc::O_RDONLY | libc::O_NONBLOCK)?;
+            require_same_file(&temporary, &final_file, "store.meta publication changed identity")?;
+            require_exact_file(&final_file, expected, "store.meta")
+        }
+    }
+}
+
+fn ensure_acknowledgement(
+    lifecycle: &File,
+) -> Result<[u8; ACKNOWLEDGEMENT_FILE_LENGTH], InitialBootstrapFoundationError> {
+    let file = match open_optional(lifecycle, ACKNOWLEDGEMENT_FILE, libc::O_RDWR | libc::O_NONBLOCK)? {
+        Some(file) => file,
+        None => create_exclusive(lifecycle, ACKNOWLEDGEMENT_FILE)?,
+    };
+    validate_regular(&file, "ACKNOWLEDGED.v1")?;
+    let length = usize::try_from(file.metadata().map_err(InitialBootstrapFoundationError::io)?.len())
+        .map_err(|_| InitialBootstrapFoundationError::invalid("ACKNOWLEDGED.v1 length is not representable"))?;
+    if length > ACKNOWLEDGEMENT_FILE_LENGTH {
+        return Err(InitialBootstrapFoundationError::invalid("ACKNOWLEDGED.v1 is oversized"));
+    }
+    let mut bytes = [0_u8; ACKNOWLEDGEMENT_FILE_LENGTH];
+    if length != 0 {
+        read_exact_at(&file, &mut bytes[..length], 0)?;
+    }
+    if length < ACKNOWLEDGEMENT_FILE_LENGTH {
+        if bytes[..length].iter().any(|byte| *byte != 0) {
+            return Err(InitialBootstrapFoundationError::invalid(
+                "partial ACKNOWLEDGED.v1 contains nonzero bytes",
+            ));
+        }
+        write_all_at(&file, &bytes[length..], length as u64)?;
+    }
+    file.sync_all().map_err(InitialBootstrapFoundationError::io)?;
+    require_exact_file(&file, &bytes, "ACKNOWLEDGED.v1")?;
+    lifecycle.sync_all().map_err(InitialBootstrapFoundationError::io)?;
+    Ok(bytes)
+}
+
+fn ensure_generation_zero_log(
+    lifecycle: &File,
+    acknowledgement: &[u8; ACKNOWLEDGEMENT_FILE_LENGTH],
+) -> Result<(), InitialBootstrapFoundationError> {
+    if let Some(file) = open_optional(lifecycle, GENERATION_ZERO_LOG, libc::O_RDWR | libc::O_NONBLOCK)? {
+        validate_regular(&file, "generation-0 log")?;
+        return Ok(());
+    }
+    if acknowledgement.iter().any(|byte| *byte != 0) {
+        return Err(InitialBootstrapFoundationError::invalid(
+            "acknowledgement bytes exist without generation-0 log",
+        ));
+    }
+    let file = create_exclusive(lifecycle, GENERATION_ZERO_LOG)?;
+    file.sync_all().map_err(InitialBootstrapFoundationError::io)?;
+    lifecycle.sync_all().map_err(InitialBootstrapFoundationError::io)
+}
+
+fn open_optional(parent: &File, name: &CStr, flags: i32) -> Result<Option<File>, InitialBootstrapFoundationError> {
+    match openat2(parent, name, flags, 0) {
+        Ok(file) => Ok(Some(file)),
+        Err(error) if error.raw_os_error() == Some(libc::ENOENT) => Ok(None),
+        Err(error) => Err(InitialBootstrapFoundationError::io(error)),
+    }
+}
+
+fn open_required(parent: &File, name: &CStr, flags: i32) -> Result<File, InitialBootstrapFoundationError> {
+    openat2(parent, name, flags, 0).map_err(InitialBootstrapFoundationError::io)
+}
+
+fn create_exclusive(parent: &File, name: &CStr) -> Result<File, InitialBootstrapFoundationError> {
+    openat2(
+        parent,
+        name,
+        libc::O_RDWR | libc::O_NONBLOCK | libc::O_CREAT | libc::O_EXCL,
+        0o600,
+    )
+    .map_err(InitialBootstrapFoundationError::io)
+}
+
+fn openat2(parent: &File, name: &CStr, flags: i32, mode: u32) -> io::Result<File> {
+    // SAFETY: all-zero is a valid version-zero `open_how` value.
+    let mut how: libc::open_how = unsafe { std::mem::zeroed() };
+    how.flags = u64::try_from(flags | libc::O_CLOEXEC | libc::O_NOFOLLOW)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid open flags"))?;
+    how.mode = u64::from(mode);
+    how.resolve = STRICT_RESOLVE;
+    // SAFETY: `parent` owns a live directory descriptor, `name` is a live single component, and
+    // `how` is a version-zero structure whose mode is present only for create calls.
+    let result = unsafe {
+        libc::syscall(
+            libc::SYS_openat2,
+            parent.as_raw_fd(),
+            name.as_ptr(),
+            &how,
+            std::mem::size_of::<libc::open_how>(),
+        )
+    };
+    if result < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let descriptor =
+        i32::try_from(result).map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "openat2 descriptor overflow"))?;
+    // SAFETY: successful openat2 returned this descriptor uniquely and `File` takes sole ownership.
+    Ok(unsafe { File::from_raw_fd(descriptor) })
+}
+
+fn rename_no_replace(parent: &File, source: &CStr, destination: &CStr) -> Result<(), InitialBootstrapFoundationError> {
+    // SAFETY: both names are live NUL-terminated components beneath the same retained directory;
+    // `RENAME_NOREPLACE` forbids overwriting an existing final artifact.
+    let result = unsafe {
+        libc::syscall(
+            libc::SYS_renameat2,
+            parent.as_raw_fd(),
+            source.as_ptr(),
+            parent.as_raw_fd(),
+            destination.as_ptr(),
+            libc::RENAME_NOREPLACE,
+        )
+    };
+    if result < 0 {
+        Err(InitialBootstrapFoundationError::io(io::Error::last_os_error()))
+    } else {
+        Ok(())
+    }
+}
+
+fn complete_exact_prefix(
+    file: &File,
+    expected: &[u8],
+    object: &'static str,
+) -> Result<(), InitialBootstrapFoundationError> {
+    let complete = require_exact_prefix(file, expected, object)?;
+    if complete {
+        return Ok(());
+    }
+    let length = file.metadata().map_err(InitialBootstrapFoundationError::io)?.len();
+    let consumed = usize::try_from(length)
+        .map_err(|_| InitialBootstrapFoundationError::invalid("artifact length is not representable"))?;
+    write_all_at(file, &expected[consumed..], length)
+}
+
+fn require_exact_prefix(
+    file: &File,
+    expected: &[u8],
+    object: &'static str,
+) -> Result<bool, InitialBootstrapFoundationError> {
+    validate_regular(file, object)?;
+    let length = usize::try_from(file.metadata().map_err(InitialBootstrapFoundationError::io)?.len())
+        .map_err(|_| InitialBootstrapFoundationError::invalid("artifact length is not representable"))?;
+    if length > expected.len() {
+        return Err(InitialBootstrapFoundationError::invalid(
+            "artifact is longer than canonical bytes",
+        ));
+    }
+    if length != 0 {
+        let mut prefix = vec![0_u8; length];
+        read_exact_at(file, &mut prefix, 0)?;
+        if prefix != expected[..length] {
+            return Err(InitialBootstrapFoundationError::invalid(
+                "artifact prefix differs from canonical bytes",
+            ));
+        }
+    }
+    Ok(length == expected.len())
+}
+
+fn require_exact_file(
+    file: &File,
+    expected: &[u8],
+    object: &'static str,
+) -> Result<(), InitialBootstrapFoundationError> {
+    validate_regular(file, object)?;
+    let actual_length = file.metadata().map_err(InitialBootstrapFoundationError::io)?.len();
+    if actual_length != expected.len() as u64 {
+        return Err(InitialBootstrapFoundationError::invalid(
+            "artifact length differs from canonical bytes",
+        ));
+    }
+    let mut actual = vec![0_u8; expected.len()];
+    read_exact_at(file, &mut actual, 0)?;
+    if actual != expected {
+        return Err(InitialBootstrapFoundationError::invalid(
+            "artifact bytes differ from canonical bytes",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_regular(file: &File, object: &'static str) -> Result<(), InitialBootstrapFoundationError> {
+    let metadata = file.metadata().map_err(InitialBootstrapFoundationError::io)?;
+    if !metadata.is_file() || metadata.nlink() != 1 {
+        return Err(InitialBootstrapFoundationError::invalid(match object {
+            "store.meta" => "store.meta is not a single-link regular file",
+            "store.meta bootstrap temporary" => "store.meta temporary is not a single-link regular file",
+            "ACKNOWLEDGED.v1" => "ACKNOWLEDGED.v1 is not a single-link regular file",
+            "generation-0 log" => "generation-0 log is not a single-link regular file",
+            _ => "bootstrap artifact is not a single-link regular file",
+        }));
+    }
+    Ok(())
+}
+
+fn require_same_file(left: &File, right: &File, detail: &'static str) -> Result<(), InitialBootstrapFoundationError> {
+    let left = left.metadata().map_err(InitialBootstrapFoundationError::io)?;
+    let right = right.metadata().map_err(InitialBootstrapFoundationError::io)?;
+    if left.dev() == right.dev() && left.ino() == right.ino() {
+        Ok(())
+    } else {
+        Err(InitialBootstrapFoundationError::invalid(detail))
+    }
+}
+
+fn write_all_at(file: &File, mut bytes: &[u8], mut offset: u64) -> Result<(), InitialBootstrapFoundationError> {
+    let mut interrupted = 0;
+    while !bytes.is_empty() {
+        match file.write_at(bytes, offset) {
+            Ok(0) => {
+                return Err(InitialBootstrapFoundationError::io(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "bootstrap positional write returned zero",
+                )));
+            }
+            Ok(written) => {
+                interrupted = 0;
+                bytes = &bytes[written..];
+                offset = offset
+                    .checked_add(written as u64)
+                    .ok_or_else(|| InitialBootstrapFoundationError::invalid("write offset overflow"))?;
+            }
+            Err(error) if error.kind() == io::ErrorKind::Interrupted && interrupted < MAX_INTERRUPTED_RETRIES => {
+                interrupted += 1;
+            }
+            Err(error) => return Err(InitialBootstrapFoundationError::io(error)),
+        }
+    }
+    Ok(())
+}
+
+fn read_exact_at(file: &File, mut bytes: &mut [u8], mut offset: u64) -> Result<(), InitialBootstrapFoundationError> {
+    let mut interrupted = 0;
+    while !bytes.is_empty() {
+        match file.read_at(bytes, offset) {
+            Ok(0) => {
+                return Err(InitialBootstrapFoundationError::io(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "bootstrap positional read reached EOF",
+                )));
+            }
+            Ok(read) => {
+                interrupted = 0;
+                let (_, remaining) = bytes.split_at_mut(read);
+                bytes = remaining;
+                offset = offset
+                    .checked_add(read as u64)
+                    .ok_or_else(|| InitialBootstrapFoundationError::invalid("read offset overflow"))?;
+            }
+            Err(error) if error.kind() == io::ErrorKind::Interrupted && interrupted < MAX_INTERRUPTED_RETRIES => {
+                interrupted += 1;
+            }
+            Err(error) => return Err(InitialBootstrapFoundationError::io(error)),
+        }
+    }
+    Ok(())
+}

--- a/rocketmq-store-local/src/mapped_file/retirement/bootstrap/executor/platform/unsupported.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/bootstrap/executor/platform/unsupported.rs
@@ -1,0 +1,72 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs::File;
+
+use super::InitialBootstrapFoundationError;
+use super::PreparedInitialBootstrapFoundation;
+use crate::mapped_file::retirement::bootstrap::types::ImmutableArtifactProgress;
+use crate::mapped_file::retirement::bootstrap::types::ImmutableArtifactStep;
+use crate::mapped_file::retirement::bootstrap::types::InitialMarkerProgress;
+use crate::mapped_file::retirement::bootstrap::types::InitialMarkerStep;
+use crate::mapped_file::retirement::bootstrap::types::PlannedInitialMarker;
+use crate::mapped_file::retirement::bootstrap::types::PlannedSnapshot;
+use crate::mapped_file::retirement::sidecar::StoreMeta;
+
+pub(super) struct InitialArtifactStore;
+
+impl InitialArtifactStore {
+    pub(super) fn inspect_snapshot(
+        &self,
+        _planned: &PlannedSnapshot,
+    ) -> Result<ImmutableArtifactProgress, InitialBootstrapFoundationError> {
+        Err(unsupported())
+    }
+
+    pub(super) fn advance_snapshot(
+        &mut self,
+        _planned: &PlannedSnapshot,
+        _step: ImmutableArtifactStep,
+    ) -> Result<(), InitialBootstrapFoundationError> {
+        Err(unsupported())
+    }
+
+    pub(super) fn inspect_initial_marker(
+        &self,
+        _planned: &PlannedInitialMarker,
+    ) -> Result<InitialMarkerProgress, InitialBootstrapFoundationError> {
+        Err(unsupported())
+    }
+
+    pub(super) fn advance_initial_marker(
+        &mut self,
+        _planned: &PlannedInitialMarker,
+        _step: InitialMarkerStep,
+    ) -> Result<(), InitialBootstrapFoundationError> {
+        Err(unsupported())
+    }
+}
+
+pub(super) fn prepare(
+    _store_root: File,
+    _expected_meta: &StoreMeta,
+) -> Result<PreparedInitialBootstrapFoundation, InitialBootstrapFoundationError> {
+    Err(unsupported())
+}
+
+fn unsupported() -> InitialBootstrapFoundationError {
+    InitialBootstrapFoundationError::unsupported(
+        "this target lacks a qualified handle-relative initial-bootstrap writer",
+    )
+}

--- a/rocketmq-store-local/src/mapped_file/retirement/bootstrap/executor/platform/windows.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/bootstrap/executor/platform/windows.rs
@@ -1,0 +1,900 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ffi::c_void;
+use std::fs::File;
+use std::io;
+use std::mem::size_of;
+use std::mem::MaybeUninit;
+use std::os::windows::fs::FileExt;
+use std::os::windows::io::AsRawHandle;
+use std::os::windows::io::FromRawHandle;
+use std::ptr;
+
+use windows::core::PWSTR;
+use windows::Wdk::Foundation::OBJECT_ATTRIBUTES;
+use windows::Wdk::Storage::FileSystem::FileRenameInformation;
+use windows::Wdk::Storage::FileSystem::FileRenameInformationEx;
+use windows::Wdk::Storage::FileSystem::NtCreateFile;
+use windows::Wdk::Storage::FileSystem::NtSetInformationFile;
+use windows::Wdk::Storage::FileSystem::FILE_CREATE;
+use windows::Wdk::Storage::FileSystem::FILE_DIRECTORY_FILE;
+use windows::Wdk::Storage::FileSystem::FILE_NON_DIRECTORY_FILE;
+use windows::Wdk::Storage::FileSystem::FILE_OPEN;
+use windows::Wdk::Storage::FileSystem::FILE_OPEN_IF;
+use windows::Wdk::Storage::FileSystem::FILE_OPEN_REPARSE_POINT;
+use windows::Wdk::Storage::FileSystem::FILE_RENAME_INFORMATION;
+use windows::Wdk::Storage::FileSystem::FILE_SYNCHRONOUS_IO_NONALERT;
+use windows::Wdk::Storage::FileSystem::NTCREATEFILE_CREATE_DISPOSITION;
+use windows::Wdk::Storage::FileSystem::NTCREATEFILE_CREATE_OPTIONS;
+use windows::Win32::Foundation::RtlNtStatusToDosError;
+use windows::Win32::Foundation::ERROR_INVALID_PARAMETER;
+use windows::Win32::Foundation::ERROR_NOT_SUPPORTED;
+use windows::Win32::Foundation::HANDLE;
+use windows::Win32::Foundation::NTSTATUS;
+use windows::Win32::Foundation::OBJ_DONT_REPARSE;
+use windows::Win32::Foundation::STATUS_OBJECT_NAME_NOT_FOUND;
+use windows::Win32::Foundation::UNICODE_STRING;
+use windows::Win32::Storage::FileSystem::FileAttributeTagInfo;
+use windows::Win32::Storage::FileSystem::FileStandardInfo;
+use windows::Win32::Storage::FileSystem::GetFileInformationByHandleEx;
+use windows::Win32::Storage::FileSystem::GetVolumeInformationByHandleW;
+use windows::Win32::Storage::FileSystem::DELETE;
+use windows::Win32::Storage::FileSystem::FILE_ACCESS_RIGHTS;
+use windows::Win32::Storage::FileSystem::FILE_APPEND_DATA;
+use windows::Win32::Storage::FileSystem::FILE_ATTRIBUTE_DIRECTORY;
+use windows::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT;
+use windows::Win32::Storage::FileSystem::FILE_ATTRIBUTE_TAG_INFO;
+use windows::Win32::Storage::FileSystem::FILE_FLAGS_AND_ATTRIBUTES;
+use windows::Win32::Storage::FileSystem::FILE_LIST_DIRECTORY;
+use windows::Win32::Storage::FileSystem::FILE_READ_ATTRIBUTES;
+use windows::Win32::Storage::FileSystem::FILE_READ_DATA;
+use windows::Win32::Storage::FileSystem::FILE_SHARE_DELETE;
+use windows::Win32::Storage::FileSystem::FILE_SHARE_MODE;
+use windows::Win32::Storage::FileSystem::FILE_SHARE_READ;
+use windows::Win32::Storage::FileSystem::FILE_SHARE_WRITE;
+use windows::Win32::Storage::FileSystem::FILE_STANDARD_INFO;
+use windows::Win32::Storage::FileSystem::FILE_TRAVERSE;
+use windows::Win32::Storage::FileSystem::FILE_WRITE_DATA;
+use windows::Win32::Storage::FileSystem::SYNCHRONIZE;
+use windows::Win32::System::IO::IO_STATUS_BLOCK;
+
+use super::InitialBootstrapFoundationError;
+use super::PreparedInitialBootstrapFoundation;
+use crate::mapped_file::retirement::bootstrap::proof::BootstrapFoundationEvidence;
+use crate::mapped_file::retirement::bootstrap::proof::CanonicalStoreMetaEvidence;
+use crate::mapped_file::retirement::bootstrap::types::ImmutableArtifactProgress;
+use crate::mapped_file::retirement::bootstrap::types::ImmutableArtifactStep;
+use crate::mapped_file::retirement::bootstrap::types::InitialMarkerProgress;
+use crate::mapped_file::retirement::bootstrap::types::InitialMarkerStep;
+use crate::mapped_file::retirement::bootstrap::types::InitialMarkerVerificationEvidence;
+use crate::mapped_file::retirement::bootstrap::types::PlannedInitialMarker;
+use crate::mapped_file::retirement::bootstrap::types::PlannedSnapshot;
+use crate::mapped_file::retirement::identity::PhysicalFileKey;
+use crate::mapped_file::retirement::io::FileLedgerIo;
+use crate::mapped_file::retirement::platform::physical_file_key;
+use crate::mapped_file::retirement::sidecar::decode_store_meta;
+use crate::mapped_file::retirement::sidecar::encode_store_meta;
+use crate::mapped_file::retirement::sidecar::StoreMeta;
+use crate::mapped_file::retirement::sidecar::STORE_META_LENGTH;
+
+const LIFECYCLE_DIRECTORY: &str = ".rocketmq-lifecycle";
+const STORE_META_FILE: &str = "store.meta";
+const STORE_META_TEMP_FILE: &str = "store.meta.bootstrap.tmp";
+const ACKNOWLEDGEMENT_FILE: &str = "ACKNOWLEDGED.v1";
+const GENERATION_ZERO_LOG: &str = "retirement.log.g00000000000000000000";
+const GENERATION_ZERO_SNAPSHOT: &str = "manifest.snapshot.g00000000000000000000";
+const GENERATION_ZERO_SNAPSHOT_TEMP: &str = "manifest.snapshot.g00000000000000000000.bootstrap.tmp";
+const ENABLED_MARKER: &str = "ENABLED.v1";
+const ENABLED_MARKER_TEMP: &str = "ENABLED.v1.bootstrap.tmp";
+const ACKNOWLEDGEMENT_FILE_LENGTH: usize = 208;
+const MAX_INTERRUPTED_RETRIES: usize = 16;
+const NON_NTFS_REASON: &str = "managed lifecycle bootstrap is qualified only for an NTFS Store root";
+
+pub(super) fn prepare(
+    store_root: File,
+    expected_meta: &StoreMeta,
+) -> Result<PreparedInitialBootstrapFoundation, InitialBootstrapFoundationError> {
+    validate_directory(&store_root, "Store root")?;
+    if !is_ntfs_volume(&store_root)? {
+        return Err(InitialBootstrapFoundationError::unsupported(NON_NTFS_REASON));
+    }
+    let lifecycle = open_or_create_lifecycle_directory(&store_root)?;
+    let canonical_meta = encode_store_meta(expected_meta).map_err(InitialBootstrapFoundationError::sidecar)?;
+    publish_store_meta(&lifecycle, &canonical_meta)?;
+    let acknowledgement = ensure_acknowledgement(&lifecycle)?;
+    ensure_generation_zero_log(&lifecycle, &acknowledgement)?;
+
+    let decoded_meta = decode_store_meta(&canonical_meta).map_err(InitialBootstrapFoundationError::sidecar)?;
+    let foundation = BootstrapFoundationEvidence {
+        store_meta: CanonicalStoreMetaEvidence {
+            meta: decoded_meta,
+            canonical_bytes: canonical_meta,
+            stored_crc32: u32::from_le_bytes(
+                canonical_meta[60..64]
+                    .try_into()
+                    .map_err(|_| InitialBootstrapFoundationError::invalid("store.meta CRC field is unavailable"))?,
+            ),
+        },
+    };
+    let ledger = FileLedgerIo::open_from_store_root(&store_root, 0).map_err(InitialBootstrapFoundationError::ledger)?;
+    let artifacts = InitialArtifactStore::new(
+        store_root.try_clone().map_err(InitialBootstrapFoundationError::io)?,
+        lifecycle.try_clone().map_err(InitialBootstrapFoundationError::io)?,
+    )?;
+    Ok(PreparedInitialBootstrapFoundation::new(
+        foundation,
+        ledger,
+        store_root,
+        artifacts,
+        expected_meta.clone(),
+    ))
+}
+
+pub(super) struct InitialArtifactStore {
+    store_root: File,
+    lifecycle: File,
+    lifecycle_identity: PhysicalFileKey,
+    snapshot_temporary_synced: bool,
+    snapshot_verified: bool,
+    marker_temporary_synced: bool,
+    marker_directory_synced: bool,
+    marker_verified: bool,
+}
+
+impl InitialArtifactStore {
+    fn new(store_root: File, lifecycle: File) -> Result<Self, InitialBootstrapFoundationError> {
+        validate_directory(&lifecycle, "retained lifecycle directory")?;
+        let lifecycle_identity = physical_identity(&lifecycle)?;
+        Ok(Self {
+            store_root,
+            lifecycle,
+            lifecycle_identity,
+            snapshot_temporary_synced: false,
+            snapshot_verified: false,
+            marker_temporary_synced: false,
+            marker_directory_synced: false,
+            marker_verified: false,
+        })
+    }
+
+    pub(super) fn inspect_snapshot(
+        &self,
+        planned: &PlannedSnapshot,
+    ) -> Result<ImmutableArtifactProgress, InitialBootstrapFoundationError> {
+        self.verify_lifecycle()?;
+        let final_file = open_optional_file(&self.lifecycle, GENERATION_ZERO_SNAPSHOT, false)?;
+        let temporary = open_optional_file(&self.lifecycle, GENERATION_ZERO_SNAPSHOT_TEMP, true)?;
+        match (final_file, temporary) {
+            (Some(final_file), None) => {
+                require_exact_file(&final_file, &planned.encoded, "bootstrap snapshot")?;
+                Ok(if self.snapshot_verified {
+                    ImmutableArtifactProgress::Verified
+                } else {
+                    ImmutableArtifactProgress::Published
+                })
+            }
+            (Some(_), Some(_)) => Err(InitialBootstrapFoundationError::invalid(
+                "bootstrap snapshot final and temporary both exist",
+            )),
+            (None, Some(temporary)) => {
+                let complete = require_exact_prefix(&temporary, &planned.encoded, "bootstrap snapshot temporary")?;
+                Ok(if !complete {
+                    ImmutableArtifactProgress::Missing
+                } else if self.snapshot_temporary_synced {
+                    ImmutableArtifactProgress::TemporarySynced
+                } else {
+                    ImmutableArtifactProgress::TemporaryWritten
+                })
+            }
+            (None, None) => Ok(ImmutableArtifactProgress::Missing),
+        }
+    }
+
+    pub(super) fn advance_snapshot(
+        &mut self,
+        planned: &PlannedSnapshot,
+        step: ImmutableArtifactStep,
+    ) -> Result<(), InitialBootstrapFoundationError> {
+        self.verify_lifecycle()?;
+        match step {
+            ImmutableArtifactStep::WriteTemporary => {
+                let temporary = match open_optional_file(&self.lifecycle, GENERATION_ZERO_SNAPSHOT_TEMP, true)? {
+                    Some(file) => file,
+                    None => create_exclusive_file(&self.lifecycle, GENERATION_ZERO_SNAPSHOT_TEMP)?,
+                };
+                complete_exact_prefix(&temporary, &planned.encoded, "bootstrap snapshot temporary")
+            }
+            ImmutableArtifactStep::SyncTemporary => {
+                let temporary = open_required_file(&self.lifecycle, GENERATION_ZERO_SNAPSHOT_TEMP, true)?;
+                require_exact_file(&temporary, &planned.encoded, "bootstrap snapshot temporary")?;
+                temporary.sync_all().map_err(InitialBootstrapFoundationError::io)?;
+                self.snapshot_temporary_synced = true;
+                Ok(())
+            }
+            ImmutableArtifactStep::PublishFinalNoReplace => {
+                if !self.snapshot_temporary_synced {
+                    return Err(InitialBootstrapFoundationError::invalid(
+                        "bootstrap snapshot temporary was not synced in this process",
+                    ));
+                }
+                let temporary = open_required_file(&self.lifecycle, GENERATION_ZERO_SNAPSHOT_TEMP, true)?;
+                rename_handle_no_replace(&temporary, &self.lifecycle, GENERATION_ZERO_SNAPSHOT)
+            }
+            ImmutableArtifactStep::ReopenAndVerify => {
+                self.verify_lifecycle()?;
+                let final_file = open_required_file(&self.lifecycle, GENERATION_ZERO_SNAPSHOT, false)?;
+                require_exact_file(&final_file, &planned.encoded, "bootstrap snapshot")?;
+                self.snapshot_verified = true;
+                Ok(())
+            }
+        }
+    }
+
+    pub(super) fn inspect_initial_marker(
+        &self,
+        planned: &PlannedInitialMarker,
+    ) -> Result<InitialMarkerProgress, InitialBootstrapFoundationError> {
+        self.verify_lifecycle()?;
+        let final_file = open_optional_file(&self.lifecycle, ENABLED_MARKER, false)?;
+        let temporary = open_optional_file(&self.lifecycle, ENABLED_MARKER_TEMP, true)?;
+        match (final_file, temporary) {
+            (Some(final_file), None) => {
+                require_exact_file(&final_file, &planned.encoded_file, "ENABLED.v1")?;
+                if self.marker_verified {
+                    let evidence =
+                        InitialMarkerVerificationEvidence::from_reopened_bytes(planned.encoded_file, planned)
+                            .ok_or_else(|| InitialBootstrapFoundationError::invalid("marker verification mismatch"))?;
+                    Ok(InitialMarkerProgress::Verified(Box::new(evidence)))
+                } else if self.marker_directory_synced {
+                    Ok(InitialMarkerProgress::DirectorySynced)
+                } else {
+                    Ok(InitialMarkerProgress::Published)
+                }
+            }
+            (Some(_), Some(_)) => Err(InitialBootstrapFoundationError::invalid(
+                "ENABLED.v1 final and temporary both exist",
+            )),
+            (None, Some(temporary)) => {
+                let complete = require_exact_prefix(&temporary, &planned.encoded_file, "ENABLED.v1 temporary")?;
+                Ok(if !complete {
+                    InitialMarkerProgress::Missing
+                } else if self.marker_temporary_synced {
+                    InitialMarkerProgress::TemporarySynced
+                } else {
+                    InitialMarkerProgress::TemporaryWritten
+                })
+            }
+            (None, None) => Ok(InitialMarkerProgress::Missing),
+        }
+    }
+
+    pub(super) fn advance_initial_marker(
+        &mut self,
+        planned: &PlannedInitialMarker,
+        step: InitialMarkerStep,
+    ) -> Result<(), InitialBootstrapFoundationError> {
+        self.verify_lifecycle()?;
+        match step {
+            InitialMarkerStep::WriteTemporary => {
+                let temporary = match open_optional_file(&self.lifecycle, ENABLED_MARKER_TEMP, true)? {
+                    Some(file) => file,
+                    None => create_exclusive_file(&self.lifecycle, ENABLED_MARKER_TEMP)?,
+                };
+                complete_exact_prefix(&temporary, &planned.encoded_file, "ENABLED.v1 temporary")
+            }
+            InitialMarkerStep::SyncTemporary => {
+                let temporary = open_required_file(&self.lifecycle, ENABLED_MARKER_TEMP, true)?;
+                require_exact_file(&temporary, &planned.encoded_file, "ENABLED.v1 temporary")?;
+                temporary.sync_all().map_err(InitialBootstrapFoundationError::io)?;
+                self.marker_temporary_synced = true;
+                Ok(())
+            }
+            InitialMarkerStep::PublishFinalNoReplace => {
+                if !self.marker_temporary_synced {
+                    return Err(InitialBootstrapFoundationError::invalid(
+                        "ENABLED.v1 temporary was not synced in this process",
+                    ));
+                }
+                let temporary = open_required_file(&self.lifecycle, ENABLED_MARKER_TEMP, true)?;
+                rename_handle_no_replace(&temporary, &self.lifecycle, ENABLED_MARKER)
+            }
+            InitialMarkerStep::SyncLifecycleDirectory => {
+                self.verify_lifecycle()?;
+                self.marker_directory_synced = true;
+                Ok(())
+            }
+            InitialMarkerStep::ReopenAndVerifyEntireFile => {
+                if !self.marker_directory_synced {
+                    return Err(InitialBootstrapFoundationError::invalid(
+                        "ENABLED.v1 directory entry was not verified in this process",
+                    ));
+                }
+                let final_file = open_required_file(&self.lifecycle, ENABLED_MARKER, false)?;
+                require_exact_file(&final_file, &planned.encoded_file, "ENABLED.v1")?;
+                self.marker_verified = true;
+                Ok(())
+            }
+        }
+    }
+
+    fn verify_lifecycle(&self) -> Result<(), InitialBootstrapFoundationError> {
+        validate_directory(&self.lifecycle, "retained lifecycle directory")?;
+        require_identity(
+            physical_identity(&self.lifecycle)?,
+            self.lifecycle_identity,
+            "retained lifecycle directory identity changed",
+        )?;
+        let reopened = open_required_directory(&self.store_root, LIFECYCLE_DIRECTORY)?;
+        require_identity(
+            physical_identity(&reopened)?,
+            self.lifecycle_identity,
+            "lifecycle directory is no longer bound beneath the retained Store root",
+        )
+    }
+}
+
+fn open_or_create_lifecycle_directory(store_root: &File) -> Result<File, InitialBootstrapFoundationError> {
+    let lifecycle = open_relative(store_root, LIFECYCLE_DIRECTORY, true, FILE_OPEN_IF, true)?;
+    validate_directory(&lifecycle, "lifecycle directory")?;
+    let reopened = open_required_directory(store_root, LIFECYCLE_DIRECTORY)?;
+    require_identity(
+        physical_identity(&lifecycle)?,
+        physical_identity(&reopened)?,
+        "lifecycle directory publication changed identity",
+    )?;
+    Ok(lifecycle)
+}
+
+fn publish_store_meta(
+    lifecycle: &File,
+    expected: &[u8; STORE_META_LENGTH],
+) -> Result<(), InitialBootstrapFoundationError> {
+    let final_file = open_optional_file(lifecycle, STORE_META_FILE, false)?;
+    let temporary = open_optional_file(lifecycle, STORE_META_TEMP_FILE, true)?;
+    match (final_file, temporary) {
+        (Some(final_file), None) => require_exact_file(&final_file, expected, "store.meta"),
+        (Some(_), Some(_)) => Err(InitialBootstrapFoundationError::invalid(
+            "store.meta final and bootstrap temporary both exist",
+        )),
+        (None, temporary) => {
+            let temporary = match temporary {
+                Some(file) => file,
+                None => create_exclusive_file(lifecycle, STORE_META_TEMP_FILE)?,
+            };
+            complete_exact_prefix(&temporary, expected, "store.meta bootstrap temporary")?;
+            temporary.sync_all().map_err(InitialBootstrapFoundationError::io)?;
+            require_exact_file(&temporary, expected, "store.meta bootstrap temporary")?;
+            rename_handle_no_replace(&temporary, lifecycle, STORE_META_FILE)?;
+            let final_file = open_required_file(lifecycle, STORE_META_FILE, false)?;
+            require_same_file(&temporary, &final_file, "store.meta publication changed identity")?;
+            require_exact_file(&final_file, expected, "store.meta")
+        }
+    }
+}
+
+fn ensure_acknowledgement(
+    lifecycle: &File,
+) -> Result<[u8; ACKNOWLEDGEMENT_FILE_LENGTH], InitialBootstrapFoundationError> {
+    let file = match open_optional_file(lifecycle, ACKNOWLEDGEMENT_FILE, true)? {
+        Some(file) => file,
+        None => create_exclusive_file(lifecycle, ACKNOWLEDGEMENT_FILE)?,
+    };
+    validate_regular(&file, "ACKNOWLEDGED.v1")?;
+    let length = usize::try_from(file.metadata().map_err(InitialBootstrapFoundationError::io)?.len())
+        .map_err(|_| InitialBootstrapFoundationError::invalid("ACKNOWLEDGED.v1 length is not representable"))?;
+    if length > ACKNOWLEDGEMENT_FILE_LENGTH {
+        return Err(InitialBootstrapFoundationError::invalid("ACKNOWLEDGED.v1 is oversized"));
+    }
+    let mut bytes = [0_u8; ACKNOWLEDGEMENT_FILE_LENGTH];
+    if length != 0 {
+        read_exact_at(&file, &mut bytes[..length], 0)?;
+    }
+    if length < ACKNOWLEDGEMENT_FILE_LENGTH {
+        if bytes[..length].iter().any(|byte| *byte != 0) {
+            return Err(InitialBootstrapFoundationError::invalid(
+                "partial ACKNOWLEDGED.v1 contains nonzero bytes",
+            ));
+        }
+        write_all_at(&file, &bytes[length..], length as u64)?;
+    }
+    file.sync_all().map_err(InitialBootstrapFoundationError::io)?;
+    require_exact_file(&file, &bytes, "ACKNOWLEDGED.v1")?;
+    Ok(bytes)
+}
+
+fn ensure_generation_zero_log(
+    lifecycle: &File,
+    acknowledgement: &[u8; ACKNOWLEDGEMENT_FILE_LENGTH],
+) -> Result<(), InitialBootstrapFoundationError> {
+    if let Some(file) = open_optional_file(lifecycle, GENERATION_ZERO_LOG, true)? {
+        validate_regular(&file, "generation-0 log")?;
+        return Ok(());
+    }
+    if acknowledgement.iter().any(|byte| *byte != 0) {
+        return Err(InitialBootstrapFoundationError::invalid(
+            "acknowledgement bytes exist without generation-0 log",
+        ));
+    }
+    let file = create_exclusive_file(lifecycle, GENERATION_ZERO_LOG)?;
+    file.sync_all().map_err(InitialBootstrapFoundationError::io)
+}
+
+fn open_required_directory(parent: &File, name: &str) -> Result<File, InitialBootstrapFoundationError> {
+    let file = open_relative(parent, name, true, FILE_OPEN, false)?;
+    validate_directory(&file, "lifecycle directory")?;
+    Ok(file)
+}
+
+fn open_optional_file(
+    parent: &File,
+    name: &str,
+    writable: bool,
+) -> Result<Option<File>, InitialBootstrapFoundationError> {
+    match open_relative_optional(parent, name, false, FILE_OPEN, writable)? {
+        Some(file) => {
+            validate_regular(&file, "bootstrap sidecar")?;
+            Ok(Some(file))
+        }
+        None => Ok(None),
+    }
+}
+
+fn open_required_file(parent: &File, name: &str, writable: bool) -> Result<File, InitialBootstrapFoundationError> {
+    let file = open_relative(parent, name, false, FILE_OPEN, writable)?;
+    validate_regular(&file, "bootstrap sidecar")?;
+    Ok(file)
+}
+
+fn create_exclusive_file(parent: &File, name: &str) -> Result<File, InitialBootstrapFoundationError> {
+    let file = open_relative(parent, name, false, FILE_CREATE, true)?;
+    validate_regular(&file, "bootstrap sidecar")?;
+    Ok(file)
+}
+
+fn open_relative_optional(
+    parent: &File,
+    name: &str,
+    directory: bool,
+    disposition: NTCREATEFILE_CREATE_DISPOSITION,
+    writable: bool,
+) -> Result<Option<File>, InitialBootstrapFoundationError> {
+    match open_relative_raw(parent, name, directory, disposition, writable) {
+        Ok(file) => Ok(Some(file)),
+        Err(OpenRelativeError::Missing) => Ok(None),
+        Err(OpenRelativeError::Io(source)) => Err(InitialBootstrapFoundationError::io(source)),
+    }
+}
+
+fn open_relative(
+    parent: &File,
+    name: &str,
+    directory: bool,
+    disposition: NTCREATEFILE_CREATE_DISPOSITION,
+    writable: bool,
+) -> Result<File, InitialBootstrapFoundationError> {
+    open_relative_raw(parent, name, directory, disposition, writable).map_err(|error| match error {
+        OpenRelativeError::Missing => InitialBootstrapFoundationError::io(io::Error::new(
+            io::ErrorKind::NotFound,
+            "required bootstrap artifact is absent",
+        )),
+        OpenRelativeError::Io(source) => InitialBootstrapFoundationError::io(source),
+    })
+}
+
+enum OpenRelativeError {
+    Missing,
+    Io(io::Error),
+}
+
+fn open_relative_raw(
+    parent: &File,
+    name: &str,
+    directory: bool,
+    disposition: NTCREATEFILE_CREATE_DISPOSITION,
+    writable: bool,
+) -> Result<File, OpenRelativeError> {
+    let mut wide = name.encode_utf16().collect::<Vec<_>>();
+    let byte_length = wide
+        .len()
+        .checked_mul(size_of::<u16>())
+        .and_then(|value| u16::try_from(value).ok())
+        .ok_or_else(|| OpenRelativeError::Io(io::Error::new(io::ErrorKind::InvalidInput, "relative name too long")))?;
+    let unicode = UNICODE_STRING {
+        Length: byte_length,
+        MaximumLength: byte_length,
+        Buffer: PWSTR(wide.as_mut_ptr()),
+    };
+    let attributes = OBJECT_ATTRIBUTES {
+        Length: size_of::<OBJECT_ATTRIBUTES>() as u32,
+        RootDirectory: HANDLE(parent.as_raw_handle()),
+        ObjectName: &unicode,
+        Attributes: OBJ_DONT_REPARSE,
+        SecurityDescriptor: ptr::null(),
+        SecurityQualityOfService: ptr::null(),
+    };
+    let desired = if directory {
+        FILE_ACCESS_RIGHTS(FILE_LIST_DIRECTORY.0 | FILE_TRAVERSE.0 | FILE_READ_ATTRIBUTES.0 | SYNCHRONIZE.0)
+    } else {
+        let write = if writable {
+            FILE_WRITE_DATA.0 | FILE_APPEND_DATA.0 | DELETE.0
+        } else {
+            0
+        };
+        FILE_ACCESS_RIGHTS(FILE_READ_DATA.0 | FILE_READ_ATTRIBUTES.0 | SYNCHRONIZE.0 | write)
+    };
+    let share = FILE_SHARE_MODE(FILE_SHARE_READ.0 | FILE_SHARE_WRITE.0 | FILE_SHARE_DELETE.0);
+    let type_option = if directory {
+        FILE_DIRECTORY_FILE.0
+    } else {
+        FILE_NON_DIRECTORY_FILE.0
+    };
+    let options = NTCREATEFILE_CREATE_OPTIONS(FILE_OPEN_REPARSE_POINT.0 | FILE_SYNCHRONOUS_IO_NONALERT.0 | type_option);
+    let mut handle = HANDLE(ptr::null_mut());
+    let mut io_status = IO_STATUS_BLOCK::default();
+    // SAFETY: all pointers refer to live storage for this synchronous call. `parent` is a retained
+    // verified directory handle and `name` is one component resolved without reparses.
+    let status = unsafe {
+        NtCreateFile(
+            &mut handle,
+            desired,
+            &attributes,
+            &mut io_status,
+            None,
+            FILE_FLAGS_AND_ATTRIBUTES(0),
+            share,
+            disposition,
+            options,
+            None,
+            0,
+        )
+    };
+    if status == STATUS_OBJECT_NAME_NOT_FOUND {
+        return Err(OpenRelativeError::Missing);
+    }
+    if status.0 < 0 {
+        return Err(OpenRelativeError::Io(status_error(status)));
+    }
+    if handle.is_invalid() {
+        return Err(OpenRelativeError::Io(io::Error::other(
+            "NtCreateFile returned an invalid handle",
+        )));
+    }
+    // SAFETY: successful NtCreateFile returned unique ownership of a valid kernel handle.
+    Ok(unsafe { File::from_raw_handle(handle.0) })
+}
+
+fn rename_handle_no_replace(
+    source: &File,
+    parent: &File,
+    destination: &str,
+) -> Result<(), InitialBootstrapFoundationError> {
+    let mut buffer = rename_buffer(parent, destination, true)?;
+    let length = rename_buffer_length(destination)?;
+    let mut io_status = IO_STATUS_BLOCK::default();
+    // SAFETY: the aligned buffer contains a complete FILE_RENAME_INFORMATION and the verified
+    // source and parent handles remain live throughout this synchronous call.
+    let status = unsafe {
+        NtSetInformationFile(
+            HANDLE(source.as_raw_handle()),
+            &mut io_status,
+            buffer.as_mut_ptr().cast::<c_void>(),
+            length,
+            FileRenameInformationEx,
+        )
+    };
+    if status.0 >= 0 {
+        return Ok(());
+    }
+    if is_information_class_unsupported(status) {
+        let mut fallback = rename_buffer(parent, destination, false)?;
+        let mut fallback_status = IO_STATUS_BLOCK::default();
+        // SAFETY: the legacy information class consumes the same complete aligned buffer and
+        // preserves the no-replace request for the same verified handles.
+        let status = unsafe {
+            NtSetInformationFile(
+                HANDLE(source.as_raw_handle()),
+                &mut fallback_status,
+                fallback.as_mut_ptr().cast::<c_void>(),
+                length,
+                FileRenameInformation,
+            )
+        };
+        return status_result(status);
+    }
+    status_result(status)
+}
+
+fn rename_buffer(parent: &File, name: &str, extended: bool) -> Result<Vec<usize>, InitialBootstrapFoundationError> {
+    let wide = name.encode_utf16().collect::<Vec<_>>();
+    let byte_length = wide
+        .len()
+        .checked_mul(size_of::<u16>())
+        .ok_or_else(|| InitialBootstrapFoundationError::invalid("rename name length overflow"))?;
+    let total = size_of::<FILE_RENAME_INFORMATION>()
+        .checked_add(byte_length)
+        .ok_or_else(|| InitialBootstrapFoundationError::invalid("rename buffer length overflow"))?;
+    let mut storage = vec![0_usize; total.div_ceil(size_of::<usize>())];
+    let info = storage.as_mut_ptr().cast::<FILE_RENAME_INFORMATION>();
+    // SAFETY: Vec<usize> supplies sufficient alignment and capacity for the fixed header and name.
+    unsafe {
+        if extended {
+            (*info).Anonymous.Flags = 0;
+        } else {
+            (*info).Anonymous.ReplaceIfExists = false;
+        }
+        (*info).RootDirectory = HANDLE(parent.as_raw_handle());
+        (*info).FileNameLength = u32::try_from(byte_length)
+            .map_err(|_| InitialBootstrapFoundationError::invalid("rename name length is not representable"))?;
+        ptr::copy_nonoverlapping(wide.as_ptr(), (*info).FileName.as_mut_ptr(), wide.len());
+    }
+    Ok(storage)
+}
+
+fn rename_buffer_length(name: &str) -> Result<u32, InitialBootstrapFoundationError> {
+    let bytes = name
+        .encode_utf16()
+        .count()
+        .checked_mul(size_of::<u16>())
+        .ok_or_else(|| InitialBootstrapFoundationError::invalid("rename name length overflow"))?;
+    let total = size_of::<FILE_RENAME_INFORMATION>()
+        .checked_add(bytes)
+        .ok_or_else(|| InitialBootstrapFoundationError::invalid("rename buffer length overflow"))?;
+    u32::try_from(total)
+        .map_err(|_| InitialBootstrapFoundationError::invalid("rename buffer length is not representable"))
+}
+
+fn status_result(status: NTSTATUS) -> Result<(), InitialBootstrapFoundationError> {
+    if status.0 >= 0 {
+        Ok(())
+    } else {
+        Err(InitialBootstrapFoundationError::io(status_error(status)))
+    }
+}
+
+fn is_information_class_unsupported(status: NTSTATUS) -> bool {
+    // SAFETY: RtlNtStatusToDosError accepts every NTSTATUS and has no pointer arguments.
+    let code = unsafe { RtlNtStatusToDosError(status) };
+    code == ERROR_INVALID_PARAMETER.0 || code == ERROR_NOT_SUPPORTED.0
+}
+
+fn complete_exact_prefix(
+    file: &File,
+    expected: &[u8],
+    object: &'static str,
+) -> Result<(), InitialBootstrapFoundationError> {
+    if require_exact_prefix(file, expected, object)? {
+        return Ok(());
+    }
+    let length = file.metadata().map_err(InitialBootstrapFoundationError::io)?.len();
+    let consumed = usize::try_from(length)
+        .map_err(|_| InitialBootstrapFoundationError::invalid("artifact length is not representable"))?;
+    write_all_at(file, &expected[consumed..], length)
+}
+
+fn require_exact_prefix(
+    file: &File,
+    expected: &[u8],
+    object: &'static str,
+) -> Result<bool, InitialBootstrapFoundationError> {
+    validate_regular(file, object)?;
+    let length = usize::try_from(file.metadata().map_err(InitialBootstrapFoundationError::io)?.len())
+        .map_err(|_| InitialBootstrapFoundationError::invalid("artifact length is not representable"))?;
+    if length > expected.len() {
+        return Err(InitialBootstrapFoundationError::invalid(
+            "artifact is longer than canonical bytes",
+        ));
+    }
+    if length != 0 {
+        let mut prefix = vec![0_u8; length];
+        read_exact_at(file, &mut prefix, 0)?;
+        if prefix != expected[..length] {
+            return Err(InitialBootstrapFoundationError::invalid(
+                "artifact prefix differs from canonical bytes",
+            ));
+        }
+    }
+    Ok(length == expected.len())
+}
+
+fn require_exact_file(
+    file: &File,
+    expected: &[u8],
+    object: &'static str,
+) -> Result<(), InitialBootstrapFoundationError> {
+    validate_regular(file, object)?;
+    let actual_length = file.metadata().map_err(InitialBootstrapFoundationError::io)?.len();
+    if actual_length != expected.len() as u64 {
+        return Err(InitialBootstrapFoundationError::invalid(
+            "artifact length differs from canonical bytes",
+        ));
+    }
+    let mut actual = vec![0_u8; expected.len()];
+    read_exact_at(file, &mut actual, 0)?;
+    if actual != expected {
+        return Err(InitialBootstrapFoundationError::invalid(
+            "artifact bytes differ from canonical bytes",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_directory(file: &File, object: &'static str) -> Result<(), InitialBootstrapFoundationError> {
+    let (attributes, standard) = handle_information(file)?;
+    if attributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT.0 != 0 {
+        return Err(InitialBootstrapFoundationError::invalid(match object {
+            "Store root" => "Store root is a reparse point",
+            _ => "lifecycle directory is a reparse point",
+        }));
+    }
+    if !standard.Directory || attributes.FileAttributes & FILE_ATTRIBUTE_DIRECTORY.0 == 0 {
+        return Err(InitialBootstrapFoundationError::invalid(match object {
+            "Store root" => "Store root is not a directory",
+            _ => "lifecycle handle is not a directory",
+        }));
+    }
+    Ok(())
+}
+
+fn validate_regular(file: &File, object: &'static str) -> Result<(), InitialBootstrapFoundationError> {
+    let (attributes, standard) = handle_information(file)?;
+    if attributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT.0 != 0
+        || standard.Directory
+        || attributes.FileAttributes & FILE_ATTRIBUTE_DIRECTORY.0 != 0
+        || standard.NumberOfLinks != 1
+    {
+        return Err(InitialBootstrapFoundationError::invalid(match object {
+            "store.meta" => "store.meta is not a single-link regular file",
+            "store.meta bootstrap temporary" => "store.meta temporary is not a single-link regular file",
+            "ACKNOWLEDGED.v1" => "ACKNOWLEDGED.v1 is not a single-link regular file",
+            "generation-0 log" => "generation-0 log is not a single-link regular file",
+            _ => "bootstrap artifact is not a single-link regular file",
+        }));
+    }
+    Ok(())
+}
+
+fn handle_information(
+    file: &File,
+) -> Result<(FILE_ATTRIBUTE_TAG_INFO, FILE_STANDARD_INFO), InitialBootstrapFoundationError> {
+    Ok((
+        query_information::<FILE_ATTRIBUTE_TAG_INFO>(file, FileAttributeTagInfo)?,
+        query_information::<FILE_STANDARD_INFO>(file, FileStandardInfo)?,
+    ))
+}
+
+fn query_information<T: Copy>(
+    file: &File,
+    class: windows::Win32::Storage::FileSystem::FILE_INFO_BY_HANDLE_CLASS,
+) -> Result<T, InitialBootstrapFoundationError> {
+    let mut output = MaybeUninit::<T>::uninit();
+    // SAFETY: the retained handle remains borrowed and output is aligned writable storage of the
+    // exact information-class size; Windows initializes it completely on success.
+    unsafe {
+        GetFileInformationByHandleEx(
+            HANDLE(file.as_raw_handle()),
+            class,
+            output.as_mut_ptr().cast(),
+            size_of::<T>() as u32,
+        )
+        .map_err(|error| InitialBootstrapFoundationError::io(windows_error_to_io(error)))?;
+        Ok(output.assume_init())
+    }
+}
+
+fn physical_identity(file: &File) -> Result<PhysicalFileKey, InitialBootstrapFoundationError> {
+    physical_file_key(file).map_err(InitialBootstrapFoundationError::io)
+}
+
+fn require_identity(
+    actual: PhysicalFileKey,
+    expected: PhysicalFileKey,
+    detail: &'static str,
+) -> Result<(), InitialBootstrapFoundationError> {
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(InitialBootstrapFoundationError::invalid(detail))
+    }
+}
+
+fn require_same_file(left: &File, right: &File, detail: &'static str) -> Result<(), InitialBootstrapFoundationError> {
+    require_identity(physical_identity(left)?, physical_identity(right)?, detail)
+}
+
+fn write_all_at(file: &File, mut bytes: &[u8], mut offset: u64) -> Result<(), InitialBootstrapFoundationError> {
+    let mut interrupted = 0;
+    while !bytes.is_empty() {
+        match file.seek_write(bytes, offset) {
+            Ok(0) => {
+                return Err(InitialBootstrapFoundationError::io(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "bootstrap positional write returned zero",
+                )));
+            }
+            Ok(written) => {
+                interrupted = 0;
+                bytes = &bytes[written..];
+                offset = offset
+                    .checked_add(written as u64)
+                    .ok_or_else(|| InitialBootstrapFoundationError::invalid("write offset overflow"))?;
+            }
+            Err(error) if error.kind() == io::ErrorKind::Interrupted && interrupted < MAX_INTERRUPTED_RETRIES => {
+                interrupted += 1;
+            }
+            Err(error) => return Err(InitialBootstrapFoundationError::io(error)),
+        }
+    }
+    Ok(())
+}
+
+fn read_exact_at(file: &File, mut bytes: &mut [u8], mut offset: u64) -> Result<(), InitialBootstrapFoundationError> {
+    let mut interrupted = 0;
+    while !bytes.is_empty() {
+        match file.seek_read(bytes, offset) {
+            Ok(0) => {
+                return Err(InitialBootstrapFoundationError::io(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "bootstrap positional read reached EOF",
+                )));
+            }
+            Ok(read) => {
+                interrupted = 0;
+                let (_, remaining) = bytes.split_at_mut(read);
+                bytes = remaining;
+                offset = offset
+                    .checked_add(read as u64)
+                    .ok_or_else(|| InitialBootstrapFoundationError::invalid("read offset overflow"))?;
+            }
+            Err(error) if error.kind() == io::ErrorKind::Interrupted && interrupted < MAX_INTERRUPTED_RETRIES => {
+                interrupted += 1;
+            }
+            Err(error) => return Err(InitialBootstrapFoundationError::io(error)),
+        }
+    }
+    Ok(())
+}
+
+fn is_ntfs_volume(file: &File) -> Result<bool, InitialBootstrapFoundationError> {
+    let mut filesystem_name = [0_u16; 32];
+    // SAFETY: the retained root handle remains borrowed and the fixed UTF-16 output buffer is live.
+    unsafe {
+        GetVolumeInformationByHandleW(
+            HANDLE(file.as_raw_handle()),
+            None,
+            None,
+            None,
+            None,
+            Some(&mut filesystem_name),
+        )
+        .map_err(|error| InitialBootstrapFoundationError::io(windows_error_to_io(error)))?;
+    }
+    let length = filesystem_name
+        .iter()
+        .position(|unit| *unit == 0)
+        .unwrap_or(filesystem_name.len());
+    Ok(String::from_utf16_lossy(&filesystem_name[..length]).eq_ignore_ascii_case("NTFS"))
+}
+
+fn windows_error_to_io(error: windows::core::Error) -> io::Error {
+    windows::Win32::Foundation::WIN32_ERROR::from_error(&error)
+        .map(|code| io::Error::from_raw_os_error(code.0 as i32))
+        .unwrap_or_else(|| io::Error::other(error))
+}
+
+fn status_error(status: NTSTATUS) -> io::Error {
+    // SAFETY: RtlNtStatusToDosError accepts every NTSTATUS value and has no pointer arguments.
+    let code = unsafe { RtlNtStatusToDosError(status) };
+    io::Error::from_raw_os_error(code as i32)
+}

--- a/rocketmq-store-local/src/mapped_file/retirement/bootstrap/inventory.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/bootstrap/inventory.rs
@@ -1,0 +1,685 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+use std::fs::File;
+
+use thiserror::Error;
+
+use super::super::identity::IdentityError;
+use super::super::sidecar::SidecarError;
+use super::super::sidecar::StoreMeta;
+use super::proof::BootstrapInventoryEvidence;
+
+#[cfg(any(target_os = "linux", windows))]
+use sha2::Digest;
+#[cfg(any(target_os = "linux", windows))]
+use sha2::Sha256;
+#[cfg(any(target_os = "linux", windows))]
+use std::collections::BTreeSet;
+
+#[cfg(any(target_os = "linux", windows))]
+use super::super::codec::crc32;
+#[cfg(any(target_os = "linux", windows))]
+use super::super::identity::FileIncarnationId;
+#[cfg(any(target_os = "linux", windows))]
+use super::super::identity::PhysicalFileKey;
+#[cfg(any(target_os = "linux", windows))]
+use super::super::identity::StoreRelativePath;
+#[cfg(any(target_os = "linux", windows))]
+use super::super::replay::discovery::platform::EntryKind;
+#[cfg(any(target_os = "linux", windows))]
+use super::super::replay::discovery::platform::FileStamp;
+#[cfg(any(target_os = "linux", windows))]
+use super::super::replay::discovery::platform::InventoryEntry;
+#[cfg(any(target_os = "linux", windows))]
+use super::super::replay::discovery::platform::LifecycleDirectory;
+#[cfg(any(target_os = "linux", windows))]
+use super::super::replay::discovery::platform::OpenedEntry;
+use super::super::replay::discovery::platform::PlatformError;
+#[cfg(any(target_os = "linux", windows))]
+use super::super::sidecar::decode_snapshot;
+#[cfg(any(target_os = "linux", windows))]
+use super::super::sidecar::encode_snapshot;
+#[cfg(any(target_os = "linux", windows))]
+use super::super::sidecar::IncarnationPhase;
+#[cfg(any(target_os = "linux", windows))]
+use super::super::sidecar::IncarnationSnapshotEntry;
+#[cfg(any(target_os = "linux", windows))]
+use super::super::sidecar::LifecycleSnapshot;
+#[cfg(any(target_os = "linux", windows))]
+use super::super::sidecar::SnapshotEntry;
+#[cfg(any(target_os = "linux", windows))]
+use super::super::sidecar::SnapshotMode;
+
+const LIFECYCLE_DIRECTORY: &str = ".rocketmq-lifecycle";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct BootstrapInventoryLimits {
+    max_directories: usize,
+    max_entries: usize,
+    max_depth: usize,
+}
+
+impl Default for BootstrapInventoryLimits {
+    fn default() -> Self {
+        Self {
+            max_directories: 16_384,
+            max_entries: 1_048_576,
+            max_depth: 64,
+        }
+    }
+}
+
+impl BootstrapInventoryLimits {
+    fn validate(self) -> Result<Self, BootstrapInventoryError> {
+        if self.max_directories == 0 || self.max_entries == 0 || self.max_depth == 0 {
+            return Err(BootstrapInventoryError::invalid_limits());
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum BootstrapInventoryErrorKind {
+    UnsupportedPlatform,
+    LimitExceeded,
+    UnsafeNamespace,
+    InventoryChanged,
+    InvalidSegment,
+    InvalidIdentity,
+    InvalidSnapshot,
+}
+
+#[derive(Debug, Error)]
+enum BootstrapInventorySource {
+    #[error("this platform has no qualified managed lifecycle writer")]
+    UnsupportedPlatform,
+    #[error("bootstrap inventory limits are invalid")]
+    InvalidLimits,
+    #[error("bootstrap inventory limit exceeded: {0}")]
+    Limit(&'static str),
+    #[error("unsafe bootstrap namespace: {0}")]
+    UnsafeNamespace(&'static str),
+    #[error("bootstrap inventory changed between complete scans")]
+    InventoryChanged,
+    #[error("invalid numeric segment: {0}")]
+    InvalidSegment(&'static str),
+    #[error("bootstrap inventory path or incarnation is invalid")]
+    Identity(#[source] IdentityError),
+    #[error("bootstrap inventory snapshot is invalid")]
+    Sidecar(#[source] SidecarError),
+    #[error("handle-relative bootstrap inventory failed")]
+    Platform(#[source] PlatformError),
+}
+
+#[derive(Debug, Error)]
+#[error("bootstrap inventory failed ({kind:?}): {source}")]
+pub(super) struct BootstrapInventoryError {
+    kind: BootstrapInventoryErrorKind,
+    #[source]
+    source: BootstrapInventorySource,
+}
+
+impl BootstrapInventoryError {
+    pub(super) const fn kind(&self) -> BootstrapInventoryErrorKind {
+        self.kind
+    }
+
+    fn unsupported() -> Self {
+        Self {
+            kind: BootstrapInventoryErrorKind::UnsupportedPlatform,
+            source: BootstrapInventorySource::UnsupportedPlatform,
+        }
+    }
+
+    fn invalid_limits() -> Self {
+        Self {
+            kind: BootstrapInventoryErrorKind::LimitExceeded,
+            source: BootstrapInventorySource::InvalidLimits,
+        }
+    }
+
+    fn limit(detail: &'static str) -> Self {
+        Self {
+            kind: BootstrapInventoryErrorKind::LimitExceeded,
+            source: BootstrapInventorySource::Limit(detail),
+        }
+    }
+
+    fn unsafe_namespace(detail: &'static str) -> Self {
+        Self {
+            kind: BootstrapInventoryErrorKind::UnsafeNamespace,
+            source: BootstrapInventorySource::UnsafeNamespace(detail),
+        }
+    }
+
+    fn changed() -> Self {
+        Self {
+            kind: BootstrapInventoryErrorKind::InventoryChanged,
+            source: BootstrapInventorySource::InventoryChanged,
+        }
+    }
+
+    fn invalid_segment(detail: &'static str) -> Self {
+        Self {
+            kind: BootstrapInventoryErrorKind::InvalidSegment,
+            source: BootstrapInventorySource::InvalidSegment(detail),
+        }
+    }
+
+    fn identity(source: IdentityError) -> Self {
+        Self {
+            kind: BootstrapInventoryErrorKind::InvalidIdentity,
+            source: BootstrapInventorySource::Identity(source),
+        }
+    }
+
+    fn sidecar(source: SidecarError) -> Self {
+        Self {
+            kind: BootstrapInventoryErrorKind::InvalidSnapshot,
+            source: BootstrapInventorySource::Sidecar(source),
+        }
+    }
+
+    fn platform(source: PlatformError) -> Self {
+        let kind = match source.kind() {
+            super::super::replay::discovery::platform::PlatformErrorKind::Changed => {
+                BootstrapInventoryErrorKind::InventoryChanged
+            }
+            super::super::replay::discovery::platform::PlatformErrorKind::Limit => {
+                BootstrapInventoryErrorKind::LimitExceeded
+            }
+            super::super::replay::discovery::platform::PlatformErrorKind::Unsupported => {
+                BootstrapInventoryErrorKind::UnsupportedPlatform
+            }
+            super::super::replay::discovery::platform::PlatformErrorKind::Io
+            | super::super::replay::discovery::platform::PlatformErrorKind::UnsafeNamespace => {
+                BootstrapInventoryErrorKind::UnsafeNamespace
+            }
+        };
+        Self {
+            kind,
+            source: BootstrapInventorySource::Platform(source),
+        }
+    }
+}
+
+pub(super) struct StableBootstrapInventory {
+    evidence: BootstrapInventoryEvidence,
+    retained_files: BTreeMap<super::super::identity::StoreRelativePath, File>,
+}
+
+impl std::fmt::Debug for StableBootstrapInventory {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("StableBootstrapInventory")
+            .field("entries", &self.evidence.inventory_count)
+            .field("retained_files", &self.retained_files.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl StableBootstrapInventory {
+    pub(super) const fn snapshot(&self) -> &super::super::sidecar::LifecycleSnapshot {
+        &self.evidence.snapshot
+    }
+
+    pub(super) fn into_parts(
+        self,
+    ) -> (
+        BootstrapInventoryEvidence,
+        BTreeMap<super::super::identity::StoreRelativePath, File>,
+    ) {
+        (self.evidence, self.retained_files)
+    }
+
+    pub(super) fn retained_file_count_for_reconciliation(&self) -> usize {
+        self.retained_files.len()
+    }
+
+    #[cfg(test)]
+    pub(super) const fn snapshot_for_test(&self) -> &super::super::sidecar::LifecycleSnapshot {
+        self.snapshot()
+    }
+
+    #[cfg(test)]
+    pub(super) fn retained_file_count_for_test(&self) -> usize {
+        self.retained_files.len()
+    }
+}
+
+pub(super) fn scan_bootstrap_inventory(
+    root: &File,
+    meta: &StoreMeta,
+    limits: BootstrapInventoryLimits,
+) -> Result<StableBootstrapInventory, BootstrapInventoryError> {
+    let limits = limits.validate()?;
+    #[cfg(any(target_os = "linux", windows))]
+    {
+        scan_native(root, meta, limits)
+    }
+    #[cfg(not(any(target_os = "linux", windows)))]
+    {
+        let _ = (root, meta, limits);
+        Err(BootstrapInventoryError::unsupported())
+    }
+}
+
+pub(super) fn preflight_bootstrap_namespace(
+    root: &File,
+    limits: BootstrapInventoryLimits,
+) -> Result<(), BootstrapInventoryError> {
+    let limits = limits.validate()?;
+    #[cfg(any(target_os = "linux", windows))]
+    {
+        scan_tree(root, limits, false).map(|_| ())
+    }
+    #[cfg(not(any(target_os = "linux", windows)))]
+    {
+        let _ = (root, limits);
+        Err(BootstrapInventoryError::unsupported())
+    }
+}
+
+#[cfg(any(target_os = "linux", windows))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TreeSnapshot {
+    directories: Vec<(String, FileStamp)>,
+    entries: Vec<(String, InventoryEntry)>,
+}
+
+#[cfg(any(target_os = "linux", windows))]
+struct NumericSegment {
+    path: StoreRelativePath,
+    offset: u64,
+    expected_length: u64,
+    physical_key: PhysicalFileKey,
+    expected_entry: InventoryEntry,
+    opened: OpenedEntry,
+}
+
+#[cfg(any(target_os = "linux", windows))]
+struct TreeScan {
+    snapshot: TreeSnapshot,
+    numeric_segments: Vec<NumericSegment>,
+    queue_lengths: BTreeMap<String, u64>,
+}
+
+#[cfg(any(target_os = "linux", windows))]
+fn scan_native(
+    root: &File,
+    meta: &StoreMeta,
+    limits: BootstrapInventoryLimits,
+) -> Result<StableBootstrapInventory, BootstrapInventoryError> {
+    let first = scan_tree(root, limits, true)?;
+    let second = scan_tree(root, limits, false)?;
+    if first.snapshot != second.snapshot {
+        return Err(BootstrapInventoryError::changed());
+    }
+    verify_numeric_handles(&first.numeric_segments)?;
+    let third = scan_tree(root, limits, false)?;
+    if first.snapshot != third.snapshot {
+        return Err(BootstrapInventoryError::changed());
+    }
+    verify_numeric_handles(&first.numeric_segments)?;
+    materialize_inventory(meta, first.numeric_segments)
+}
+
+#[cfg(any(target_os = "linux", windows))]
+fn scan_tree(
+    root: &File,
+    limits: BootstrapInventoryLimits,
+    retain_numeric: bool,
+) -> Result<TreeScan, BootstrapInventoryError> {
+    let directory = LifecycleDirectory::open(root, "")
+        .map_err(BootstrapInventoryError::platform)?
+        .ok_or_else(|| BootstrapInventoryError::unsafe_namespace("retained Store root disappeared"))?;
+    let inventory = directory
+        .enumerate(limits.max_entries)
+        .map_err(BootstrapInventoryError::platform)?;
+    let mut output = TreeScan {
+        snapshot: TreeSnapshot {
+            directories: vec![(String::new(), inventory.directory_stamp.clone())],
+            entries: Vec::new(),
+        },
+        numeric_segments: Vec::new(),
+        queue_lengths: BTreeMap::new(),
+    };
+    walk_root_directory(
+        &directory,
+        "",
+        inventory.entries,
+        0,
+        limits,
+        retain_numeric,
+        &mut output,
+    )?;
+    output.snapshot.directories.sort();
+    output.snapshot.entries.sort();
+    output
+        .numeric_segments
+        .sort_by(|left, right| left.path.cmp(&right.path));
+    Ok(output)
+}
+
+#[cfg(any(target_os = "linux", windows))]
+fn walk_root_directory(
+    directory: &LifecycleDirectory,
+    parent: &str,
+    entries: Vec<InventoryEntry>,
+    depth: usize,
+    limits: BootstrapInventoryLimits,
+    retain_numeric: bool,
+    output: &mut TreeScan,
+) -> Result<(), BootstrapInventoryError> {
+    for entry in entries {
+        let path = join_path(parent, &entry.name);
+        record_entry(&path, &entry, limits, output)?;
+        if parent.is_empty() && entry.name.eq_ignore_ascii_case(LIFECYCLE_DIRECTORY) {
+            if entry.name != LIFECYCLE_DIRECTORY || entry.kind != EntryKind::Directory {
+                return Err(BootstrapInventoryError::unsafe_namespace(
+                    "lifecycle directory has a case-fold collision or wrong type",
+                ));
+            }
+            continue;
+        }
+        let opened = directory
+            .open_entry(&entry)
+            .map_err(BootstrapInventoryError::platform)?;
+        walk_opened_entry(path, entry, opened, depth, limits, retain_numeric, output)?;
+    }
+    Ok(())
+}
+
+#[cfg(any(target_os = "linux", windows))]
+fn walk_opened_entry(
+    path: String,
+    entry: InventoryEntry,
+    opened: OpenedEntry,
+    depth: usize,
+    limits: BootstrapInventoryLimits,
+    retain_numeric: bool,
+    output: &mut TreeScan,
+) -> Result<(), BootstrapInventoryError> {
+    match entry.kind {
+        EntryKind::Directory => {
+            let next_depth = depth
+                .checked_add(1)
+                .ok_or_else(|| BootstrapInventoryError::limit("depth"))?;
+            if next_depth > limits.max_depth {
+                return Err(BootstrapInventoryError::limit("directory depth"));
+            }
+            if output.snapshot.directories.len() >= limits.max_directories {
+                return Err(BootstrapInventoryError::limit("directory count"));
+            }
+            let remaining = limits
+                .max_entries
+                .checked_sub(output.snapshot.entries.len())
+                .ok_or_else(|| BootstrapInventoryError::limit("entry count"))?;
+            let children = opened.enumerate(remaining).map_err(BootstrapInventoryError::platform)?;
+            output
+                .snapshot
+                .directories
+                .push((path.clone(), children.directory_stamp));
+            for child in children.entries {
+                let child_path = join_path(&path, &child.name);
+                record_entry(&child_path, &child, limits, output)?;
+                let child_opened = opened.open_entry(&child).map_err(BootstrapInventoryError::platform)?;
+                walk_opened_entry(
+                    child_path,
+                    child,
+                    child_opened,
+                    next_depth,
+                    limits,
+                    retain_numeric,
+                    output,
+                )?;
+            }
+        }
+        EntryKind::File => {
+            if is_numeric_segment_name(&entry.name) {
+                let queue_directory = validate_supported_segment_path(&path)?;
+                match output.queue_lengths.entry(queue_directory.to_owned()) {
+                    std::collections::btree_map::Entry::Vacant(length) => {
+                        length.insert(entry.stamp.length);
+                    }
+                    std::collections::btree_map::Entry::Occupied(length) if *length.get() != entry.stamp.length => {
+                        return Err(BootstrapInventoryError::invalid_segment(
+                            "one mapped-file queue contains mixed segment lengths",
+                        ));
+                    }
+                    std::collections::btree_map::Entry::Occupied(_) => {}
+                }
+                if entry.stamp.link_count != 1 {
+                    return Err(BootstrapInventoryError::unsafe_namespace(
+                        "numeric segment has an external hardlink alias",
+                    ));
+                }
+                if entry.stamp.length == 0 {
+                    return Err(BootstrapInventoryError::invalid_segment(
+                        "numeric segment has zero length",
+                    ));
+                }
+                if retain_numeric {
+                    let offset = entry
+                        .name
+                        .parse::<u64>()
+                        .map_err(|_| BootstrapInventoryError::invalid_segment("numeric offset overflow"))?;
+                    let canonical_path = StoreRelativePath::new(&path).map_err(BootstrapInventoryError::identity)?;
+                    canonical_path
+                        .validate_segment_binding(offset)
+                        .map_err(BootstrapInventoryError::identity)?;
+                    let physical_key = entry
+                        .stamp
+                        .physical_key()
+                        .ok_or_else(|| BootstrapInventoryError::invalid_segment("physical key is unavailable"))?;
+                    output.numeric_segments.push(NumericSegment {
+                        path: canonical_path,
+                        offset,
+                        expected_length: entry.stamp.length,
+                        physical_key,
+                        expected_entry: entry,
+                        opened,
+                    });
+                }
+            }
+        }
+        EntryKind::Reparse | EntryKind::Other => {
+            return Err(BootstrapInventoryError::unsafe_namespace(
+                "Store tree contains a symbolic link, reparse point, or special file",
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(any(target_os = "linux", windows))]
+fn record_entry(
+    path: &str,
+    entry: &InventoryEntry,
+    limits: BootstrapInventoryLimits,
+    output: &mut TreeScan,
+) -> Result<(), BootstrapInventoryError> {
+    if output.snapshot.entries.len() >= limits.max_entries {
+        return Err(BootstrapInventoryError::limit("entry count"));
+    }
+    output.snapshot.entries.push((path.to_owned(), entry.clone()));
+    Ok(())
+}
+
+#[cfg(any(target_os = "linux", windows))]
+fn verify_numeric_handles(segments: &[NumericSegment]) -> Result<(), BootstrapInventoryError> {
+    for segment in segments {
+        segment
+            .opened
+            .verify(&segment.expected_entry)
+            .map_err(BootstrapInventoryError::platform)?;
+    }
+    Ok(())
+}
+
+#[cfg(any(target_os = "linux", windows))]
+fn materialize_inventory(
+    meta: &StoreMeta,
+    segments: Vec<NumericSegment>,
+) -> Result<StableBootstrapInventory, BootstrapInventoryError> {
+    let mut physical_keys = BTreeSet::new();
+    let mut entries = Vec::new();
+    let mut retained_files = BTreeMap::new();
+    entries
+        .try_reserve_exact(segments.len())
+        .map_err(|_| BootstrapInventoryError::limit("snapshot allocation"))?;
+    for (index, segment) in segments.into_iter().enumerate() {
+        if !physical_keys.insert(segment.physical_key) {
+            return Err(BootstrapInventoryError::unsafe_namespace(
+                "two numeric paths resolve to one physical file",
+            ));
+        }
+        let create_sequence = u64::try_from(index)
+            .ok()
+            .and_then(|value| value.checked_add(1))
+            .ok_or_else(|| BootstrapInventoryError::limit("create sequence"))?;
+        let incarnation =
+            FileIncarnationId::new(meta.store_uuid, create_sequence).map_err(BootstrapInventoryError::identity)?;
+        let create_nonce = derive_create_nonce(meta, &segment, create_sequence);
+        let create_file_path = segment
+            .path
+            .create_file_path(incarnation, segment.offset, &create_nonce)
+            .map_err(BootstrapInventoryError::identity)?;
+        let path = segment.path.clone();
+        entries.push(SnapshotEntry::Incarnation(IncarnationSnapshotEntry {
+            incarnation,
+            phase: IncarnationPhase::Published,
+            segment_offset: segment.offset,
+            expected_file_length: segment.expected_length,
+            create_nonce,
+            physical_key: Some(segment.physical_key),
+            canonical_path: segment.path,
+            create_file_path,
+        }));
+        if retained_files.insert(path, segment.opened.into_file()).is_some() {
+            return Err(BootstrapInventoryError::unsafe_namespace(
+                "duplicate canonical numeric segment path",
+            ));
+        }
+    }
+    let create_high_water =
+        u64::try_from(entries.len()).map_err(|_| BootstrapInventoryError::limit("create high-water"))?;
+    let snapshot = LifecycleSnapshot {
+        mode: SnapshotMode::BootstrapInventory,
+        store_uuid: meta.store_uuid,
+        generation: 0,
+        log_generation: 0,
+        predecessor_log_generation: u64::MAX,
+        base_sequence: 1,
+        create_high_water,
+        ticket_high_water: 0,
+        entries,
+    };
+    let canonical_snapshot = encode_snapshot(&snapshot).map_err(BootstrapInventoryError::sidecar)?;
+    let decoded = decode_snapshot(&canonical_snapshot).map_err(BootstrapInventoryError::sidecar)?;
+    if decoded != snapshot {
+        return Err(BootstrapInventoryError::invalid_segment(
+            "snapshot canonical round trip changed inventory",
+        ));
+    }
+    let inventory_count =
+        u64::try_from(decoded.entries.len()).map_err(|_| BootstrapInventoryError::limit("inventory count"))?;
+    Ok(StableBootstrapInventory {
+        evidence: BootstrapInventoryEvidence {
+            store_uuid: decoded.store_uuid,
+            snapshot_crc32: crc32(&canonical_snapshot),
+            canonical_snapshot,
+            inventory_count,
+            create_high_water: decoded.create_high_water,
+            ticket_high_water: decoded.ticket_high_water,
+            snapshot: decoded,
+        },
+        retained_files,
+    })
+}
+
+#[cfg(any(target_os = "linux", windows))]
+fn derive_create_nonce(meta: &StoreMeta, segment: &NumericSegment, create_sequence: u64) -> [u8; 16] {
+    let mut digest = Sha256::new();
+    digest.update(b"rocketmq-bootstrap-incarnation-v1\0");
+    digest.update(meta.store_uuid.as_bytes());
+    digest.update(meta.bootstrap_id);
+    digest.update(create_sequence.to_le_bytes());
+    digest.update(segment.offset.to_le_bytes());
+    digest.update(segment.expected_length.to_le_bytes());
+    digest.update(segment.path.as_bytes());
+    match segment.physical_key {
+        PhysicalFileKey::Unix(key) => {
+            digest.update([1]);
+            digest.update(key.device().to_le_bytes());
+            digest.update(key.inode().to_le_bytes());
+        }
+        PhysicalFileKey::Windows(key) => {
+            digest.update([2]);
+            digest.update(key.volume_serial().to_le_bytes());
+            digest.update(key.file_id());
+        }
+    }
+    let digest = digest.finalize();
+    let mut nonce = [0_u8; 16];
+    nonce.copy_from_slice(&digest[..16]);
+    if nonce == [0; 16] {
+        nonce[15] = 1;
+    }
+    nonce
+}
+
+#[cfg(any(target_os = "linux", windows))]
+fn is_numeric_segment_name(name: &str) -> bool {
+    name.len() == 20 && name.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+#[cfg(any(target_os = "linux", windows))]
+fn validate_supported_segment_path(path: &str) -> Result<&str, BootstrapInventoryError> {
+    StoreRelativePath::new(path).map_err(BootstrapInventoryError::identity)?;
+    let components = path.split('/').collect::<Vec<_>>();
+    let queue_id = match components.as_slice() {
+        ["commitlog", _file_name] => return Ok("commitlog"),
+        ["consumequeue" | "consumequeue_ext" | "batchconsumequeue", topic, queue_id, _file_name]
+            if !topic.is_empty() =>
+        {
+            *queue_id
+        }
+        _ => {
+            return Err(BootstrapInventoryError::invalid_segment(
+                "numeric file is outside a supported mapped-file queue",
+            ));
+        }
+    };
+    let parsed = queue_id
+        .parse::<i32>()
+        .map_err(|_| BootstrapInventoryError::invalid_segment("queue id is not a non-negative integer"))?;
+    if parsed < 0 || parsed.to_string() != queue_id {
+        return Err(BootstrapInventoryError::invalid_segment("queue id is not canonical"));
+    }
+    path.rsplit_once('/')
+        .map(|(directory, _)| directory)
+        .ok_or_else(|| BootstrapInventoryError::invalid_segment("mapped-file segment has no queue directory"))
+}
+
+#[cfg(any(target_os = "linux", windows))]
+fn join_path(parent: &str, name: &str) -> String {
+    if parent.is_empty() {
+        name.to_owned()
+    } else {
+        format!("{parent}/{name}")
+    }
+}

--- a/rocketmq-store-local/src/mapped_file/retirement/bootstrap/types.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/bootstrap/types.rs
@@ -50,7 +50,7 @@ pub(super) enum BootstrapPlanError {
     ArithmeticOverflow { field: &'static str },
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub(super) enum BootstrapRecord {
     StoreInitialized,
     BootstrapInstalled,
@@ -303,6 +303,20 @@ impl InitialMarkerVerificationEvidence {
         self.encoded_file == planned.encoded_file
             && self.file_crc32 == planned.file_crc32
             && self.slot0_stored_crc32 == planned.slot0_stored_crc32
+    }
+
+    pub(super) fn from_reopened_bytes(
+        encoded_file: [u8; ENABLED_MARKER_FILE_LENGTH],
+        planned: &PlannedInitialMarker,
+    ) -> Option<Self> {
+        if encoded_file != planned.encoded_file {
+            return None;
+        }
+        Some(Self {
+            encoded_file,
+            file_crc32: planned.file_crc32,
+            slot0_stored_crc32: planned.slot0_stored_crc32,
+        })
     }
 
     #[cfg(test)]

--- a/rocketmq-store-local/src/mapped_file/retirement/bootstrap_tests.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/bootstrap_tests.rs
@@ -12,12 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::executor::*;
 use super::plan::*;
 use super::proof::*;
 use super::types::*;
 
+#[path = "bootstrap_tests/executor.rs"]
+mod executor_flow;
+#[path = "bootstrap_tests/foundation.rs"]
+mod foundation;
 #[path = "bootstrap_tests/initial.rs"]
 mod initial;
+#[path = "bootstrap_tests/inventory.rs"]
+mod inventory_scan;
 #[path = "bootstrap_tests/support.rs"]
 mod support;
 #[path = "bootstrap_tests/switch.rs"]

--- a/rocketmq-store-local/src/mapped_file/retirement/bootstrap_tests/executor.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/bootstrap_tests/executor.rs
@@ -1,0 +1,79 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::support::*;
+use super::*;
+use crate::mapped_file::retirement::writer::model_io::ModelLedgerIo;
+
+#[test]
+fn initial_executor_runs_every_durability_boundary_in_frozen_order() {
+    let mut backend = ModelInitialBootstrapBackend::new(inventory(&bootstrap_snapshot()));
+    let completed = execute_initial_bootstrap(foundation(&store_meta()), &mut backend)
+        .expect("canonical initial bootstrap completes");
+
+    assert_eq!(completed.store_uuid, store_uuid());
+    assert_eq!(completed.witness_sequence, 3);
+    assert_eq!(backend.executed_action_count(), 41);
+    backend.assert_frozen_order();
+}
+
+#[test]
+fn every_executor_boundary_failure_requires_reinspection_and_resumes_exactly_once() {
+    let action_count = ModelInitialBootstrapBackend::expected_action_count();
+    for failure_index in 0..action_count {
+        let mut backend = ModelInitialBootstrapBackend::new(inventory(&bootstrap_snapshot()));
+        backend.fail_after_action(failure_index);
+
+        execute_initial_bootstrap(foundation(&store_meta()), &mut backend)
+            .expect_err("injected boundary must stop the current executor run");
+        let actions_after_failure = backend.executed_action_count();
+        backend.clear_failure();
+        let completed = execute_initial_bootstrap(foundation(&store_meta()), &mut backend)
+            .expect("reinspection resumes the exact durable frontier");
+
+        assert_eq!(completed.witness_sequence, 3);
+        assert!(backend.executed_action_count() >= actions_after_failure);
+        backend.assert_each_action_at_most_once();
+    }
+}
+
+#[test]
+fn durable_unit_machine_writes_and_reclassifies_the_exact_frame_ack_seal_protocol() {
+    let plan = initial_store_plan();
+    let mut machine = DurableUnitMachine::new(ModelLedgerIo::empty());
+
+    loop {
+        let progress = machine
+            .inspect(BootstrapRecord::StoreInitialized, &plan.store_initialized)
+            .expect("model ledger remains canonical");
+        if progress == DurableUnitProgress::Committed {
+            break;
+        }
+        let BootstrapDecision::Execute(BootstrapAction::AdvanceUnit { record, step }) =
+            plan.decide_store_initialized(progress)
+        else {
+            panic!("unit must advance until committed");
+        };
+        machine
+            .advance(record, &plan.store_initialized, step)
+            .expect("planned unit operation succeeds");
+    }
+
+    assert_eq!(
+        machine.io_for_test().log().len() as u64,
+        plan.store_initialized.sealed_log_length
+    );
+    let slot = &machine.io_for_test().acknowledgement()[..104];
+    assert_eq!(slot, plan.store_initialized.acknowledgement_slot);
+}

--- a/rocketmq-store-local/src/mapped_file/retirement/bootstrap_tests/foundation.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/bootstrap_tests/foundation.rs
@@ -1,0 +1,167 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(any(target_os = "linux", windows))]
+use std::fs;
+use std::fs::File;
+#[cfg(windows)]
+use std::fs::OpenOptions;
+#[cfg(windows)]
+use std::os::windows::fs::OpenOptionsExt;
+
+#[cfg(any(target_os = "linux", windows))]
+use crate::mapped_file::retirement::sidecar::encode_store_meta;
+use crate::mapped_file::retirement::sidecar::StoreMeta;
+
+#[cfg(any(target_os = "linux", windows))]
+use super::execute_prepared_initial_bootstrap;
+use super::prepare_initial_bootstrap_foundation;
+use super::support::store_uuid;
+
+fn store_meta() -> StoreMeta {
+    StoreMeta {
+        store_uuid: store_uuid(),
+        creation_time_ns: 17,
+        bootstrap_id: [0x51; 16],
+    }
+}
+
+#[cfg(not(windows))]
+fn open_root(path: &std::path::Path) -> File {
+    File::open(path).expect("open Store root")
+}
+
+#[cfg(windows)]
+fn open_root(path: &std::path::Path) -> File {
+    use windows::Win32::Storage::FileSystem::FILE_FLAG_BACKUP_SEMANTICS;
+
+    OpenOptions::new()
+        .read(true)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS.0)
+        .open(path)
+        .expect("open Store root")
+}
+
+#[cfg(any(target_os = "linux", windows))]
+#[test]
+fn native_foundation_is_handle_relative_and_reopens_exact_initial_artifacts() {
+    let root = tempfile::tempdir().expect("temporary Store root");
+    let root_file = open_root(root.path());
+    let meta = store_meta();
+
+    let prepared = prepare_initial_bootstrap_foundation(root_file, &meta)
+        .expect("platform creates the exact bootstrap foundation");
+
+    let lifecycle = root.path().join(".rocketmq-lifecycle");
+    assert_eq!(
+        fs::read(lifecycle.join("store.meta")).expect("read store.meta"),
+        encode_store_meta(&meta).expect("encode store.meta")
+    );
+    assert_eq!(
+        fs::read(lifecycle.join("ACKNOWLEDGED.v1")).expect("read acknowledgement"),
+        [0_u8; 208]
+    );
+    assert_eq!(
+        fs::read(lifecycle.join("retirement.log.g00000000000000000000")).expect("read generation-0 log"),
+        Vec::<u8>::new()
+    );
+    assert_eq!(prepared.store_uuid_for_test(), meta.store_uuid);
+}
+
+#[cfg(any(target_os = "linux", windows))]
+#[test]
+fn native_executor_idempotently_replays_the_complete_initial_bootstrap() {
+    let root = tempfile::tempdir().expect("temporary Store root");
+    fs::create_dir(root.path().join("commitlog")).expect("commitlog directory");
+    fs::write(root.path().join("commitlog/00000000000000000000"), [7_u8; 32]).expect("legacy segment");
+    let meta = store_meta();
+
+    let execute = || {
+        let root_file = open_root(root.path());
+        let prepared = prepare_initial_bootstrap_foundation(root_file, &meta).expect("prepare exact foundation");
+        execute_prepared_initial_bootstrap(prepared).expect("complete fenced bootstrap")
+    };
+
+    let first = execute();
+    let second = execute();
+
+    assert_eq!(first.store_uuid(), second.store_uuid());
+    assert_eq!(first.witness_sequence(), second.witness_sequence());
+    assert_eq!(first.acknowledgement_epoch(), second.acknowledgement_epoch());
+    assert_eq!(first.marker_epoch(), second.marker_epoch());
+    assert_eq!(first.witness_sequence(), 3);
+    assert_eq!(first.acknowledgement_epoch(), 3);
+    assert_eq!(first.marker_epoch(), 1);
+    let lifecycle = root.path().join(".rocketmq-lifecycle");
+    for expected in [
+        "store.meta",
+        "ACKNOWLEDGED.v1",
+        "retirement.log.g00000000000000000000",
+        "manifest.snapshot.g00000000000000000000",
+        "ENABLED.v1",
+    ] {
+        assert!(lifecycle.join(expected).is_file(), "missing {expected}");
+    }
+    assert!(!lifecycle.join("store.meta.bootstrap.tmp").exists());
+    assert!(!lifecycle
+        .join("manifest.snapshot.g00000000000000000000.bootstrap.tmp")
+        .exists());
+    assert!(!lifecycle.join("ENABLED.v1.bootstrap.tmp").exists());
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn linux_fences_bootstrap_when_the_lifecycle_directory_binding_changes() {
+    let root = tempfile::tempdir().expect("temporary Store root");
+    fs::create_dir(root.path().join("commitlog")).expect("commitlog directory");
+    fs::write(root.path().join("commitlog/00000000000000000000"), [7_u8; 32]).expect("legacy segment");
+    let meta = store_meta();
+    let root_file = open_root(root.path());
+    let prepared = prepare_initial_bootstrap_foundation(root_file, &meta).expect("prepare exact foundation");
+
+    let lifecycle = root.path().join(".rocketmq-lifecycle");
+    let displaced = root.path().join(".rocketmq-lifecycle.displaced");
+    fs::rename(&lifecycle, &displaced).expect("displace lifecycle directory");
+    fs::create_dir(&lifecycle).expect("install replacement lifecycle directory");
+    fs::write(lifecycle.join("replacement.sentinel"), b"replacement").expect("replacement sentinel");
+
+    execute_prepared_initial_bootstrap(prepared)
+        .expect_err("a replacement lifecycle directory must fence bootstrap before mutation");
+
+    assert_eq!(
+        fs::read(lifecycle.join("replacement.sentinel")).expect("replacement sentinel remains"),
+        b"replacement"
+    );
+    assert_eq!(
+        fs::read_dir(&lifecycle).expect("replacement directory").count(),
+        1,
+        "bootstrap must not publish artifacts into the replacement directory"
+    );
+}
+
+#[cfg(not(any(target_os = "linux", windows)))]
+#[test]
+fn unsupported_platform_is_rejected_before_any_artifact_is_created() {
+    let root = tempfile::tempdir().expect("temporary Store root");
+    let root_file = open_root(root.path());
+
+    let error = prepare_initial_bootstrap_foundation(root_file, &store_meta())
+        .expect_err("this platform is not Wave-B writer-qualified");
+
+    assert_eq!(
+        error.kind(),
+        super::InitialBootstrapFoundationErrorKind::UnsupportedPlatform
+    );
+    assert!(!root.path().join(".rocketmq-lifecycle").exists());
+}

--- a/rocketmq-store-local/src/mapped_file/retirement/bootstrap_tests/inventory.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/bootstrap_tests/inventory.rs
@@ -1,0 +1,199 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(target_os = "linux")]
+use std::fs;
+#[cfg(not(windows))]
+use std::fs::File;
+
+#[cfg(target_os = "linux")]
+use crate::mapped_file::retirement::bootstrap::inventory::preflight_bootstrap_namespace;
+#[cfg(not(windows))]
+use crate::mapped_file::retirement::bootstrap::inventory::scan_bootstrap_inventory;
+#[cfg(not(windows))]
+use crate::mapped_file::retirement::bootstrap::inventory::BootstrapInventoryErrorKind;
+#[cfg(not(windows))]
+use crate::mapped_file::retirement::bootstrap::inventory::BootstrapInventoryLimits;
+#[cfg(target_os = "linux")]
+use crate::mapped_file::retirement::sidecar::IncarnationPhase;
+#[cfg(target_os = "linux")]
+use crate::mapped_file::retirement::sidecar::SnapshotEntry;
+use crate::mapped_file::retirement::sidecar::StoreMeta;
+
+#[cfg(target_os = "linux")]
+use super::bootstrap_managed_lifecycle_under_exclusive_lock;
+use super::support::store_uuid;
+#[cfg(target_os = "linux")]
+use super::ManagedLifecycleBootstrapErrorKind;
+
+fn meta() -> StoreMeta {
+    StoreMeta {
+        store_uuid: store_uuid(),
+        creation_time_ns: 17,
+        bootstrap_id: [0x61; 16],
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn recursive_inventory_is_complete_canonical_and_retains_numeric_segments() {
+    let root = tempfile::tempdir().expect("temporary Store root");
+    fs::create_dir(root.path().join("commitlog")).expect("commitlog directory");
+    fs::create_dir_all(root.path().join("consumequeue/topic/0")).expect("consume queue directory");
+    fs::create_dir(root.path().join(".rocketmq-lifecycle")).expect("lifecycle directory");
+    fs::write(root.path().join("commitlog/00000000000000000000"), [1_u8; 16]).expect("first segment");
+    fs::write(root.path().join("commitlog/00000000000000000016"), [2_u8; 16]).expect("second segment");
+    fs::write(root.path().join("consumequeue/topic/0/00000000000000000000"), [3_u8; 8]).expect("consume queue segment");
+    fs::write(root.path().join("checkpoint"), b"ignored non-segment").expect("ordinary Store file");
+    fs::write(
+        root.path()
+            .join(".rocketmq-lifecycle/retirement.log.g00000000000000000000"),
+        b"not a legacy segment",
+    )
+    .expect("lifecycle log");
+
+    let root_file = File::open(root.path()).expect("open root");
+    let inventory = scan_bootstrap_inventory(&root_file, &meta(), BootstrapInventoryLimits::default())
+        .expect("stable complete inventory");
+    let snapshot = inventory.snapshot_for_test();
+
+    assert_eq!(snapshot.entries.len(), 3);
+    assert_eq!(snapshot.create_high_water, 3);
+    assert_eq!(snapshot.ticket_high_water, 0);
+    assert_eq!(inventory.retained_file_count_for_test(), 3);
+    let paths = snapshot
+        .entries
+        .iter()
+        .map(|entry| match entry {
+            SnapshotEntry::Incarnation(entry) => {
+                assert_eq!(entry.phase, IncarnationPhase::Published);
+                assert!(entry.physical_key.is_some());
+                assert_ne!(entry.create_nonce, [0; 16]);
+                entry.canonical_path.as_bytes().to_owned()
+            }
+            _ => panic!("bootstrap inventory contains only incarnations"),
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        paths,
+        [
+            b"commitlog/00000000000000000000".to_vec(),
+            b"commitlog/00000000000000000016".to_vec(),
+            b"consumequeue/topic/0/00000000000000000000".to_vec(),
+        ]
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn inventory_rejects_hardlinks_and_zero_length_segments() {
+    use std::os::unix::fs::symlink;
+
+    let hardlink = tempfile::tempdir().expect("hardlink root");
+    fs::create_dir(hardlink.path().join("commitlog")).expect("commitlog directory");
+    let segment = hardlink.path().join("commitlog/00000000000000000000");
+    fs::write(&segment, [1_u8; 16]).expect("segment");
+    fs::hard_link(&segment, hardlink.path().join("alias")).expect("hard link");
+    let error = scan_bootstrap_inventory(
+        &File::open(hardlink.path()).expect("open hardlink root"),
+        &meta(),
+        BootstrapInventoryLimits::default(),
+    )
+    .expect_err("external hardlink aliases are unsafe");
+    assert_eq!(error.kind(), BootstrapInventoryErrorKind::UnsafeNamespace);
+
+    let empty = tempfile::tempdir().expect("empty root");
+    fs::create_dir(empty.path().join("commitlog")).expect("commitlog directory");
+    fs::write(empty.path().join("commitlog/00000000000000000000"), []).expect("empty segment");
+    let error = scan_bootstrap_inventory(
+        &File::open(empty.path()).expect("open empty root"),
+        &meta(),
+        BootstrapInventoryLimits::default(),
+    )
+    .expect_err("zero-length segments are not active incarnations");
+    assert_eq!(error.kind(), BootstrapInventoryErrorKind::InvalidSegment);
+
+    let linked = tempfile::tempdir().expect("symlink root");
+    fs::create_dir(linked.path().join("commitlog")).expect("commitlog directory");
+    symlink("commitlog", linked.path().join("hidden")).expect("directory symlink");
+    let error = scan_bootstrap_inventory(
+        &File::open(linked.path()).expect("open symlink root"),
+        &meta(),
+        BootstrapInventoryLimits::default(),
+    )
+    .expect_err("a symlink can hide additional numeric segments");
+    assert_eq!(error.kind(), BootstrapInventoryErrorKind::UnsafeNamespace);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn unsupported_numeric_store_files_are_rejected_before_bootstrap_artifacts_exist() {
+    let root = tempfile::tempdir().expect("temporary Store root");
+    fs::create_dir(root.path().join("timerlog")).expect("timer log directory");
+    fs::write(root.path().join("timerlog/00000000000000000000"), [1_u8; 16]).expect("timer segment");
+    fs::write(root.path().join("checkpoint"), b"ordinary Store file").expect("checkpoint");
+
+    let error = preflight_bootstrap_namespace(
+        &File::open(root.path()).expect("open Store root"),
+        BootstrapInventoryLimits::default(),
+    )
+    .expect_err("numeric files outside mapped-file queues are not lifecycle incarnations");
+
+    assert_eq!(error.kind(), BootstrapInventoryErrorKind::InvalidSegment);
+    assert!(!root.path().join(".rocketmq-lifecycle").exists());
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn public_bootstrap_entry_runs_namespace_preflight_before_any_write() {
+    let root = tempfile::tempdir().expect("temporary Store root");
+    fs::create_dir(root.path().join("timerlog")).expect("timer log directory");
+    fs::write(root.path().join("timerlog/00000000000000000000"), [1_u8; 16]).expect("timer segment");
+    let root_file = File::open(root.path()).expect("open Store root");
+
+    // SAFETY: the temporary root is private to this test and no Store component is running.
+    let error = unsafe { bootstrap_managed_lifecycle_under_exclusive_lock(&root_file) }
+        .expect_err("unsupported numeric files must block bootstrap before mutation");
+
+    assert_eq!(error.kind(), ManagedLifecycleBootstrapErrorKind::Inventory);
+    assert!(!root.path().join(".rocketmq-lifecycle").exists());
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn mixed_queue_lengths_are_rejected_before_bootstrap_artifacts_exist() {
+    let root = tempfile::tempdir().expect("temporary Store root");
+    fs::create_dir(root.path().join("commitlog")).expect("commit log directory");
+    fs::write(root.path().join("commitlog/00000000000000000000"), [1_u8; 16]).expect("first segment");
+    fs::write(root.path().join("commitlog/00000000000000000016"), [2_u8; 8]).expect("second segment");
+    let root_file = File::open(root.path()).expect("open Store root");
+
+    // SAFETY: the temporary root is private to this test and no Store component is running.
+    let error = unsafe { bootstrap_managed_lifecycle_under_exclusive_lock(&root_file) }
+        .expect_err("mixed queue lengths must block bootstrap before mutation");
+
+    assert_eq!(error.kind(), ManagedLifecycleBootstrapErrorKind::Inventory);
+    assert!(!root.path().join(".rocketmq-lifecycle").exists());
+}
+
+#[cfg(not(any(target_os = "linux", windows)))]
+#[test]
+fn bootstrap_inventory_is_unsupported_without_a_qualified_writer_platform() {
+    let root = tempfile::tempdir().expect("temporary Store root");
+    let root_file = File::open(root.path()).expect("open Store root");
+
+    let error = scan_bootstrap_inventory(&root_file, &meta(), BootstrapInventoryLimits::default())
+        .expect_err("unsupported platforms cannot mint bootstrap inventory evidence");
+    assert_eq!(error.kind(), BootstrapInventoryErrorKind::UnsupportedPlatform);
+}

--- a/rocketmq-store-local/src/mapped_file/retirement/platform/linux.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/platform/linux.rs
@@ -121,7 +121,7 @@ impl NamespaceRoot {
                 "canonical and create-file paths have different parents",
             ));
         }
-        let parent = open_parent_strict(&self.file, parent_path)
+        let parent = open_or_create_parent_strict(&self.file, parent_path)
             .map_err(|error| IncarnationCreationError::namespace(IncarnationCreationStage::OpenParent, error))?;
         let metadata = parent
             .metadata()
@@ -425,6 +425,82 @@ fn open_parent_strict(root: &File, parent_path: &str) -> Result<File, NamespaceV
         ),
         Err(error) => Err(classify_io(NamespaceOperation::OpenParent, error).into_verification_error()),
     }
+}
+
+fn open_or_create_parent_strict(root: &File, parent_path: &str) -> Result<File, NamespaceVerificationError> {
+    let root_device = root
+        .metadata()
+        .map_err(|error| classify_io(NamespaceOperation::VerifyRoot, error).into_verification_error())?
+        .dev();
+    if parent_path.is_empty() {
+        return root
+            .try_clone()
+            .map_err(|error| classify_io(NamespaceOperation::OpenParent, error).into_verification_error());
+    }
+
+    let mut parent = root
+        .try_clone()
+        .map_err(|error| classify_io(NamespaceOperation::OpenParent, error).into_verification_error())?;
+    for component in parent_path.split('/') {
+        if component.is_empty() || component == "." || component == ".." {
+            return Err(NamespaceVerificationError::Rejected(
+                NamespacePolicyViolation::ParentEscapedRoot,
+            ));
+        }
+        let component = CString::new(component)
+            .map_err(|_| NamespaceVerificationError::Rejected(NamespacePolicyViolation::ParentEscapedRoot))?;
+        let next = match openat2(
+            &parent,
+            &component,
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+        ) {
+            Ok(next) => next,
+            Err(error) if error.raw_os_error() == Some(libc::ENOENT) => {
+                // SAFETY: `component` is one validated relative name and `parent` is a retained,
+                // verified directory handle beneath the Store root. mkdirat cannot traverse it.
+                let result = unsafe { libc::mkdirat(parent.as_raw_fd(), component.as_ptr(), 0o700) };
+                if result != 0 {
+                    let error = io::Error::last_os_error();
+                    if error.raw_os_error() != Some(libc::EEXIST) {
+                        return Err(classify_io(NamespaceOperation::OpenParent, error).into_verification_error());
+                    }
+                }
+                parent.sync_all().map_err(|error| {
+                    classify_io(NamespaceOperation::SyncParentOrHandle, error).into_verification_error()
+                })?;
+                openat2(
+                    &parent,
+                    &component,
+                    libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+                )
+                .map_err(|error| classify_io(NamespaceOperation::OpenParent, error).into_verification_error())?
+            }
+            Err(error) if error.raw_os_error() == Some(libc::ENOSYS) => {
+                return Err(NamespaceVerificationError::Unsupported {
+                    platform: "linux",
+                    reason: OPENAT2_UNAVAILABLE,
+                });
+            }
+            Err(error) if error.raw_os_error() == Some(libc::EXDEV) || error.raw_os_error() == Some(libc::ELOOP) => {
+                return Err(NamespaceVerificationError::Rejected(
+                    NamespacePolicyViolation::ParentEscapedRoot,
+                ));
+            }
+            Err(error) => {
+                return Err(classify_io(NamespaceOperation::OpenParent, error).into_verification_error());
+            }
+        };
+        let metadata = next
+            .metadata()
+            .map_err(|error| classify_io(NamespaceOperation::OpenParent, error).into_verification_error())?;
+        if !metadata.is_dir() || metadata.dev() != root_device {
+            return Err(NamespaceVerificationError::Rejected(
+                NamespacePolicyViolation::ParentEscapedRoot,
+            ));
+        }
+        parent = next;
+    }
+    Ok(parent)
 }
 
 fn openat2(parent: &File, path: &CString, flags: i32) -> io::Result<File> {

--- a/rocketmq-store-local/src/mapped_file/retirement/platform/windows.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/platform/windows.rs
@@ -28,8 +28,10 @@ use windows::Wdk::Storage::FileSystem::FileRenameInformationEx;
 use windows::Wdk::Storage::FileSystem::NtCreateFile;
 use windows::Wdk::Storage::FileSystem::NtSetInformationFile;
 use windows::Wdk::Storage::FileSystem::FILE_CREATE;
+use windows::Wdk::Storage::FileSystem::FILE_DIRECTORY_FILE;
 use windows::Wdk::Storage::FileSystem::FILE_NON_DIRECTORY_FILE;
 use windows::Wdk::Storage::FileSystem::FILE_OPEN;
+use windows::Wdk::Storage::FileSystem::FILE_OPEN_IF;
 use windows::Wdk::Storage::FileSystem::FILE_OPEN_REPARSE_POINT;
 use windows::Wdk::Storage::FileSystem::FILE_RENAME_INFORMATION;
 use windows::Wdk::Storage::FileSystem::FILE_SYNCHRONOUS_IO_NONALERT;
@@ -182,7 +184,7 @@ impl NamespaceRoot {
                 "canonical and create-file paths have different parents",
             ));
         }
-        let parent = open_parent(&self.file, parent_path)
+        let parent = open_or_create_parent(&self.file, parent_path)
             .map_err(|error| IncarnationCreationError::namespace(IncarnationCreationStage::OpenParent, error))?;
         require_missing(&parent, canonical_name, IncarnationCreationStage::VerifyNames)?;
         require_missing(&parent, create_name, IncarnationCreationStage::VerifyNames)?;
@@ -453,6 +455,111 @@ fn open_parent(root: &File, parent_path: &str) -> Result<File, NamespaceVerifica
         }
     }
     Ok(parent)
+}
+
+fn open_or_create_parent(root: &File, parent_path: &str) -> Result<File, NamespaceVerificationError> {
+    let mut parent = root
+        .try_clone()
+        .map_err(|error| classify_io(NamespaceOperation::OpenParent, error).into_verification_error())?;
+    if parent_path.is_empty() {
+        return Ok(parent);
+    }
+    for component in parent_path.split('/') {
+        if component.is_empty() || component == "." || component == ".." {
+            return Err(NamespaceVerificationError::Rejected(
+                NamespacePolicyViolation::ParentEscapedRoot,
+            ));
+        }
+        let next = open_or_create_directory_component(&parent, component)?;
+        let attributes =
+            query_attributes(&next, NamespaceOperation::OpenParent).map_err(BackendFailure::into_verification_error)?;
+        if attributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT.0 != 0
+            || attributes.FileAttributes & FILE_ATTRIBUTE_DIRECTORY.0 == 0
+        {
+            return Err(NamespaceVerificationError::Rejected(
+                NamespacePolicyViolation::ParentEscapedRoot,
+            ));
+        }
+        let reopened = open_relative(&parent, component, true, NamespaceOperation::OpenParent)
+            .map_err(BackendFailure::into_verification_error)?
+            .ok_or_else(|| {
+                BackendFailure::retryable(
+                    NamespaceOperation::OpenParent,
+                    NamespaceFailureClass::NotFoundNeedsReconciliation,
+                    Some(ERROR_PATH_NOT_FOUND.0 as i32),
+                )
+                .into_verification_error()
+            })?;
+        let created_key = physical_key::capture(&next)
+            .map_err(|error| classify_io(NamespaceOperation::OpenParent, error).into_verification_error())?;
+        let reopened_key = physical_key::capture(&reopened)
+            .map_err(|error| classify_io(NamespaceOperation::OpenParent, error).into_verification_error())?;
+        if created_key != reopened_key {
+            return Err(NamespaceVerificationError::Rejected(
+                NamespacePolicyViolation::ParentEscapedRoot,
+            ));
+        }
+        parent = reopened;
+    }
+    Ok(parent)
+}
+
+fn open_or_create_directory_component(parent: &File, name: &str) -> Result<File, NamespaceVerificationError> {
+    let mut wide = name.encode_utf16().collect::<Vec<_>>();
+    let byte_length = wide
+        .len()
+        .checked_mul(size_of::<u16>())
+        .and_then(|value| u16::try_from(value).ok())
+        .ok_or(NamespaceVerificationError::Rejected(
+            NamespacePolicyViolation::ParentEscapedRoot,
+        ))?;
+    let unicode = UNICODE_STRING {
+        Length: byte_length,
+        MaximumLength: byte_length,
+        Buffer: PWSTR(wide.as_mut_ptr()),
+    };
+    let attributes = OBJECT_ATTRIBUTES {
+        Length: size_of::<OBJECT_ATTRIBUTES>() as u32,
+        RootDirectory: HANDLE(parent.as_raw_handle()),
+        ObjectName: &unicode,
+        Attributes: OBJ_DONT_REPARSE,
+        SecurityDescriptor: ptr::null(),
+        SecurityQualityOfService: ptr::null(),
+    };
+    let desired = FILE_ACCESS_RIGHTS(FILE_LIST_DIRECTORY.0 | FILE_TRAVERSE.0 | FILE_READ_ATTRIBUTES.0 | SYNCHRONIZE.0);
+    let share = FILE_SHARE_MODE(FILE_SHARE_READ.0 | FILE_SHARE_WRITE.0 | FILE_SHARE_DELETE.0);
+    let options =
+        NTCREATEFILE_CREATE_OPTIONS(FILE_OPEN_REPARSE_POINT.0 | FILE_SYNCHRONOUS_IO_NONALERT.0 | FILE_DIRECTORY_FILE.0);
+    let mut handle = HANDLE(ptr::null_mut());
+    let mut io_status = IO_STATUS_BLOCK::default();
+    // SAFETY: the retained parent handle and one-component UTF-16 name remain live for this
+    // synchronous call. The directory/open-reparse options prevent traversal through the child.
+    let status = unsafe {
+        NtCreateFile(
+            &mut handle,
+            desired,
+            &attributes,
+            &mut io_status,
+            None,
+            FILE_FLAGS_AND_ATTRIBUTES(0),
+            share,
+            FILE_OPEN_IF,
+            options,
+            None,
+            0,
+        )
+    };
+    if status.0 < 0 {
+        return Err(classify_io(NamespaceOperation::OpenParent, status_error(status)).into_verification_error());
+    }
+    if handle.is_invalid() {
+        return Err(
+            BackendFailure::failed(NamespaceOperation::OpenParent, NamespaceFailureClass::OtherIo, None)
+                .into_verification_error(),
+        );
+    }
+    // SAFETY: successful NtCreateFile returned unique ownership of a valid kernel handle.
+    Ok(unsafe { File::from_raw_handle(handle.0) })
 }
 
 fn open_relative(
@@ -736,6 +843,7 @@ fn is_information_class_unsupported(error: &windows::core::Error) -> bool {
 }
 
 fn is_status_information_class_unsupported(status: NTSTATUS) -> bool {
+    // SAFETY: `RtlNtStatusToDosError` accepts any NTSTATUS value and does not retain pointers.
     let code = unsafe { RtlNtStatusToDosError(status) };
     code == ERROR_INVALID_PARAMETER.0 || code == ERROR_NOT_SUPPORTED.0
 }

--- a/rocketmq-store-local/src/mapped_file/retirement/registry/queue_slot.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/registry/queue_slot.rs
@@ -340,7 +340,7 @@ impl<T> ManagedMappedFileQueueGeneration<T> {
         })
     }
 
-    pub(in crate::mapped_file::retirement::registry) fn new_write_disabled() -> Self {
+    pub(in crate::mapped_file::retirement) fn new_write_disabled() -> Self {
         Self {
             slot: Arc::new(QueueSlot::new(Vec::new())),
         }

--- a/rocketmq-store-local/src/mapped_file/retirement/replay/discovery/platform.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/replay/discovery/platform.rs
@@ -221,7 +221,7 @@ impl PlatformError {
         Self::Unsupported
     }
 
-    pub(super) const fn kind(&self) -> PlatformErrorKind {
+    pub(in crate::mapped_file::retirement) const fn kind(&self) -> PlatformErrorKind {
         match self {
             Self::Io { .. } => PlatformErrorKind::Io,
             #[cfg(windows)]

--- a/rocketmq-store-local/src/mapped_file/retirement/service.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/service.rs
@@ -290,6 +290,15 @@ impl ManagedLifecycleRuntime {
         }
     }
 
+    /// Creates an empty queue generation bound to this managed runtime's trust boundary.
+    ///
+    /// The generation contains no owner and cannot publish one without a durable creation
+    /// receipt. Admission remains controlled by the runtime when allocation is attempted.
+    #[must_use]
+    pub fn empty_queue_generation(&self) -> ManagedMappedFileQueueGeneration<DefaultMappedFile> {
+        ManagedMappedFileQueueGeneration::new_write_disabled()
+    }
+
     /// Executes at most `max_actions` durable or namespace transitions synchronously.
     ///
     /// This function performs blocking file operations and must not run directly on an async

--- a/rocketmq-store-local/src/mapped_file/retirement/service/creation.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/service/creation.rs
@@ -405,6 +405,24 @@ mod tests {
         assert!(!core.report(std::time::Instant::now(), 0, 0).recovery_required());
     }
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn durable_creation_builds_a_new_queue_directory_under_the_retained_root() {
+        let mut fixture = Fixture::new_without_queue_directory();
+        let (mut core, queue) = fixture.core(0);
+        let request = ManagedIncarnationCreateRequest::new("consumequeue/topic-a/3", 0, 4096, [0x54; 16])
+            .expect("creation request is valid");
+
+        core.create_mapped_file(&queue, request)
+            .expect("managed creation builds missing queue directories safely");
+
+        assert!(fixture
+            .root
+            .path()
+            .join("consumequeue/topic-a/3/00000000000000000000")
+            .is_file());
+    }
+
     #[test]
     fn failure_after_allocate_advances_high_water_and_recovery_fences_creation() {
         let mut fixture = Fixture::new();
@@ -440,6 +458,14 @@ mod tests {
         fn new() -> Self {
             let root = tempfile::tempdir().expect("create temporary Store root");
             std::fs::create_dir(root.path().join("commitlog")).expect("create commitlog directory");
+            Self::from_root(root)
+        }
+
+        fn new_without_queue_directory() -> Self {
+            Self::from_root(tempfile::tempdir().expect("create temporary Store root"))
+        }
+
+        fn from_root(root: TempDir) -> Self {
             let handle = open_root_handle(root.path()).expect("open Store root handle");
             let namespace = VerifiedNamespaceRoot::open(handle, store_uuid()).expect("verify Store root");
             Self {

--- a/rocketmq-store-local/src/mapped_file/retirement/state/reconciliation.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/state/reconciliation.rs
@@ -356,6 +356,13 @@ impl ReconciledLifecycleSession {
     pub fn active_segment_paths(&self) -> impl Iterator<Item = &str> {
         self.state.active.keys().map(StoreRelativePath::as_str)
     }
+
+    pub(crate) fn active_segment_bindings(&self) -> impl Iterator<Item = (&str, u64)> {
+        self.state
+            .active
+            .iter()
+            .map(|(path, binding)| (path.as_str(), binding.expected_length))
+    }
 }
 
 /// Recovery plan paired with the exact root/session proof from which it was derived.

--- a/rocketmq-store-local/tests/mapped_file_queue_lifecycle.rs
+++ b/rocketmq-store-local/tests/mapped_file_queue_lifecycle.rs
@@ -27,6 +27,8 @@ use rocketmq_store_local::mapped_file::queue_lifecycle::destroy_mapped_file_queu
 use rocketmq_store_local::mapped_file::queue_lifecycle::is_expired;
 use rocketmq_store_local::mapped_file::queue_lifecycle::mapped_files_after_removal;
 use rocketmq_store_local::mapped_file::queue_lifecycle::retry_delete_first_mapped_file;
+use rocketmq_store_local::mapped_file::queue_lifecycle::select_expired_mapped_files_by_offset;
+use rocketmq_store_local::mapped_file::queue_lifecycle::select_expired_mapped_files_by_time_before;
 use rocketmq_store_local::mapped_file::queue_lifecycle::shutdown_mapped_file_queue;
 use rocketmq_store_local::mapped_file::queue_lifecycle::swap_mapped_file_queue;
 use rocketmq_store_local::mapped_file::DefaultMappedFile;
@@ -211,6 +213,29 @@ fn offset_deletion_releases_selection_before_destroy() {
     assert!(!files[0].is_available());
     assert!(files[1].is_available());
     assert!(files[2].is_available());
+}
+
+#[test]
+fn managed_cleanup_selection_is_non_mutating_and_rejects_invalid_unit_sizes() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let files = vec![mapped_file(&temp_dir, 0, 20), mapped_file(&temp_dir, 20, 20)];
+    let mut unit = vec![0; 20];
+    unit[0..8].copy_from_slice(&5_i64.to_be_bytes());
+    assert!(files[0].append_message_bytes(&unit));
+
+    let selected = select_expired_mapped_files_by_offset(&files, 20, 10, 20);
+    assert_eq!(selected.len(), 1);
+    assert!(Arc::ptr_eq(&selected[0], &files[0]));
+    assert!(files.iter().all(|file| file.is_available()));
+
+    for unit_size in [-1, 0, 21] {
+        assert!(select_expired_mapped_files_by_offset(&files, 20, 10, unit_size).is_empty());
+    }
+
+    let selected = select_expired_mapped_files_by_time_before(&files, 0, true, 1, None, || 0);
+    assert_eq!(selected.len(), 1);
+    assert!(Arc::ptr_eq(&selected[0], &files[0]));
+    assert!(files.iter().all(|file| file.is_available()));
 }
 
 #[test]

--- a/rocketmq-store/src/config/message_store_config.rs
+++ b/rocketmq-store/src/config/message_store_config.rs
@@ -1165,6 +1165,13 @@ pub struct MessageStoreConfig {
     #[serde(default)]
     pub mapped_file_swap_enable: bool,
 
+    /// Enables the crash-durable mapped-file lifecycle writer after Wave-A readers are deployed.
+    ///
+    /// This remains disabled by default. Enabling it does not bypass replay, reconciliation,
+    /// retained-root validation, or platform writer qualification.
+    #[serde(default)]
+    pub enable_mapped_file_lifecycle_wave_b: bool,
+
     #[serde(default)]
     pub commit_log_force_swap_map_interval: usize,
 
@@ -1550,6 +1557,7 @@ impl Default for MessageStoreConfig {
             correct_logic_min_offset_sleep_interval: 0,
             correct_logic_min_offset_force_interval: 0,
             mapped_file_swap_enable: false,
+            enable_mapped_file_lifecycle_wave_b: false,
             commit_log_force_swap_map_interval: 0,
             commit_log_swap_map_interval: 0,
             commit_log_swap_map_reserve_file_num: 0,
@@ -2316,6 +2324,10 @@ impl MessageStoreConfig {
             self.mapped_file_swap_enable.to_string(),
         );
         properties.insert(
+            "enableMappedFileLifecycleWaveB".to_string(),
+            self.enable_mapped_file_lifecycle_wave_b.to_string(),
+        );
+        properties.insert(
             "commitLogForceSwapMapInterval".to_string(),
             self.commit_log_force_swap_map_interval.to_string(),
         );
@@ -2566,7 +2578,22 @@ mod tests {
 
     #[test]
     fn default_max_checksum_range_matches_java_default() {
-        assert_eq!(MessageStoreConfig::default().max_checksum_range, 1024 * 1024 * 1024);
+        let config = MessageStoreConfig::default();
+
+        assert_eq!(config.max_checksum_range, 1024 * 1024 * 1024);
+        assert!(!config.enable_mapped_file_lifecycle_wave_b);
+        assert_eq!(config.get_properties()["enableMappedFileLifecycleWaveB"], "false");
+    }
+
+    #[test]
+    fn serde_requires_an_explicit_wave_b_opt_in() -> Result<(), serde_json::Error> {
+        let legacy: MessageStoreConfig = serde_json::from_str("{}")?;
+        let enabled: MessageStoreConfig = serde_json::from_str(r#"{"enableMappedFileLifecycleWaveB":true}"#)?;
+
+        assert!(!legacy.enable_mapped_file_lifecycle_wave_b);
+        assert!(enabled.enable_mapped_file_lifecycle_wave_b);
+        assert_eq!(enabled.get_properties()["enableMappedFileLifecycleWaveB"], "true");
+        Ok(())
     }
 
     #[test]

--- a/rocketmq-store/src/consume_queue/mapped_file_queue.rs
+++ b/rocketmq-store/src/consume_queue/mapped_file_queue.rs
@@ -45,6 +45,8 @@ use rocketmq_store_local::mapped_file::queue_lifecycle::destroy_last_mapped_file
 use rocketmq_store_local::mapped_file::queue_lifecycle::destroy_mapped_file_queue;
 use rocketmq_store_local::mapped_file::queue_lifecycle::destroy_mapped_files_in_order;
 use rocketmq_store_local::mapped_file::queue_lifecycle::retry_delete_first_mapped_file;
+use rocketmq_store_local::mapped_file::queue_lifecycle::select_expired_mapped_files_by_offset;
+use rocketmq_store_local::mapped_file::queue_lifecycle::select_expired_mapped_files_by_time_before;
 use rocketmq_store_local::mapped_file::queue_lifecycle::shutdown_mapped_file_queue;
 use rocketmq_store_local::mapped_file::queue_lifecycle::swap_mapped_file_queue;
 use rocketmq_store_local::mapped_file::queue_lifecycle::MappedFileQueueDeletion;
@@ -66,10 +68,13 @@ pub use rocketmq_store_local::mapped_file::queue_metrics::MappedFileIoStats;
 pub use rocketmq_store_local::mapped_file::queue_metrics::MappedFileWarmupStats;
 use rocketmq_store_local::mapped_file::queue_state::MappedFileQueueRuntimeState;
 use rocketmq_store_local::mapped_file::queue_storage::MappedFileQueueStorage;
+use rocketmq_store_local::mapped_file::ManagedLifecycleRuntime;
 use rocketmq_store_local::mapped_file::ManagedMappedFileQueueGeneration;
+use rocketmq_store_local::mapped_file::ManagedRetirementReason;
 use rocketmq_store_local::mapped_file::MappedFileQueueGeneration;
 use rocketmq_store_local::mapped_file::MappedFileQueueSnapshot;
 use tracing::error;
+use tracing::warn;
 
 use crate::base::allocate_mapped_file_service::AllocateMappedFileService;
 use crate::base::select_result::SelectMappedBufferResult;
@@ -82,7 +87,10 @@ use crate::queue::single_consume_queue::CQ_STORE_UNIT_SIZE;
 
 enum MappedFileGenerationState {
     Legacy(MappedFileQueueGeneration<DefaultMappedFile>),
-    Managed(ManagedMappedFileQueueGeneration<DefaultMappedFile>),
+    Managed {
+        generation: ManagedMappedFileQueueGeneration<DefaultMappedFile>,
+        runtime: Option<ManagedLifecycleRuntime>,
+    },
 }
 
 #[derive(Clone)]
@@ -99,6 +107,16 @@ impl MappedFileGeneration {
         }
     }
 
+    fn managed(runtime: ManagedLifecycleRuntime) -> Self {
+        let generation = runtime.empty_queue_generation();
+        Self {
+            state: Arc::new(ArcSwap::from_pointee(MappedFileGenerationState::Managed {
+                generation,
+                runtime: Some(runtime),
+            })),
+        }
+    }
+
     #[cfg(test)]
     fn from_legacy_recovery_files(files: Vec<Arc<DefaultMappedFile>>) -> Self {
         Self {
@@ -111,12 +129,35 @@ impl MappedFileGeneration {
     fn snapshot(&self) -> MappedFileQueueSnapshot<DefaultMappedFile> {
         match self.state.load().as_ref() {
             MappedFileGenerationState::Legacy(generation) => generation.snapshot(),
-            MappedFileGenerationState::Managed(generation) => generation.snapshot(),
+            MappedFileGenerationState::Managed { generation, .. } => generation.snapshot(),
         }
     }
 
     fn allows_legacy_namespace_mutation(&self) -> bool {
         matches!(self.state.load().as_ref(), MappedFileGenerationState::Legacy(_))
+    }
+
+    fn managed_generation(&self) -> Option<ManagedMappedFileQueueGeneration<DefaultMappedFile>> {
+        match self.state.load().as_ref() {
+            MappedFileGenerationState::Legacy(_) => None,
+            MappedFileGenerationState::Managed { generation, .. } => Some(generation.clone()),
+        }
+    }
+
+    fn managed_runtime_generation(
+        &self,
+    ) -> Option<(
+        ManagedLifecycleRuntime,
+        ManagedMappedFileQueueGeneration<DefaultMappedFile>,
+    )> {
+        match self.state.load().as_ref() {
+            MappedFileGenerationState::Legacy(_) => None,
+            MappedFileGenerationState::Managed {
+                generation,
+                runtime: Some(runtime),
+            } => Some((runtime.clone(), generation.clone())),
+            MappedFileGenerationState::Managed { runtime: None, .. } => None,
+        }
     }
 
     fn publish_legacy_created_file(&self, mapped_file: Arc<DefaultMappedFile>) -> bool {
@@ -131,7 +172,7 @@ impl MappedFileGeneration {
     fn apply_legacy_namespace_removal(&self, deletion: MappedFileQueueDeletion) -> i32 {
         match self.state.load().as_ref() {
             MappedFileGenerationState::Legacy(generation) => generation.apply_legacy_namespace_removal(deletion),
-            MappedFileGenerationState::Managed(_) => 0,
+            MappedFileGenerationState::Managed { .. } => 0,
         }
     }
 
@@ -158,9 +199,30 @@ impl MappedFileGeneration {
         if !matches!(current.as_ref(), MappedFileGenerationState::Legacy(_)) {
             return false;
         }
-        let previous = self
-            .state
-            .compare_and_swap(&current, Arc::new(MappedFileGenerationState::Managed(generation)));
+        let previous = self.state.compare_and_swap(
+            &current,
+            Arc::new(MappedFileGenerationState::Managed {
+                generation,
+                runtime: None,
+            }),
+        );
+        Arc::ptr_eq(&previous, &current)
+    }
+
+    fn bind_managed_runtime(&self, runtime: ManagedLifecycleRuntime) -> bool {
+        let current = self.state.load_full();
+        let MappedFileGenerationState::Managed {
+            generation,
+            runtime: None,
+        } = current.as_ref()
+        else {
+            return false;
+        };
+        let next = Arc::new(MappedFileGenerationState::Managed {
+            generation: generation.clone(),
+            runtime: Some(runtime),
+        });
+        let previous = self.state.compare_and_swap(&current, next);
         Arc::ptr_eq(&previous, &current)
     }
 }
@@ -344,7 +406,7 @@ fn get_last_mapped_file_for_append(
     start_offset: u64,
     need_create: bool,
 ) -> Option<Arc<DefaultMappedFile>> {
-    if runtime_state.is_closing() || !mapped_files.allows_legacy_namespace_mutation() {
+    if runtime_state.is_closing() {
         return None;
     }
     let mapped_file_last = mapped_files.snapshot().last().cloned();
@@ -438,12 +500,9 @@ fn create_and_publish_mapped_file_with_before_lock<F>(
 where
     F: FnOnce(),
 {
-    if !mapped_files.allows_legacy_namespace_mutation() {
-        return None;
-    }
     before_lock();
     let _maintenance_guard = runtime_state.commit_lock().lock();
-    if runtime_state.is_closing() || !mapped_files.allows_legacy_namespace_mutation() {
+    if runtime_state.is_closing() {
         return None;
     }
     let current_files = mapped_files.snapshot();
@@ -453,6 +512,27 @@ where
     {
         return Some(Arc::clone(existing));
     }
+    if let Some(generation) = mapped_files.managed_generation() {
+        let service = allocate_mapped_file_service?;
+        return match service.put_managed_request_and_return_mapped_file_blocking(
+            generation,
+            Path::new(store_path),
+            create_offset,
+            mapped_file_size,
+        ) {
+            Ok(mapped_file) => Some(mapped_file),
+            Err(error) => {
+                error!(
+                    queue = store_path,
+                    create_offset,
+                    %error,
+                    "managed mapped-file allocation failed closed"
+                );
+                None
+            }
+        };
+    }
+
     let is_first = current_files.is_empty();
     let next_file_path = PathBuf::from(store_path).join(offset_to_file_name(create_offset));
     let next_next_file_path = PathBuf::from(store_path).join(offset_to_file_name(create_offset + mapped_file_size));
@@ -522,11 +602,19 @@ impl MappedFileQueueCleanupHandle {
         pinned_file_offset: Option<u64>,
     ) -> i32 {
         let _maintenance_guard = self.runtime_state.commit_lock().lock();
-        if !self.mapped_files.allows_legacy_namespace_mutation() {
-            return 0;
-        }
         let files = self.mapped_files.snapshot();
         self.check_self();
+        if let Some((runtime, generation)) = self.mapped_files.managed_runtime_generation() {
+            let candidates = select_expired_mapped_files_by_time_before(
+                files.as_ref(),
+                expired_time,
+                clean_immediately,
+                delete_file_batch_max,
+                pinned_file_offset,
+                || i64::try_from(current_millis()).unwrap_or(i64::MAX),
+            );
+            return submit_managed_retirements(&runtime, &generation, candidates, ManagedRetirementReason::TtlExpired);
+        }
         let deletion = delete_expired_mapped_files_by_time_before(
             files.as_ref(),
             expired_time,
@@ -542,7 +630,9 @@ impl MappedFileQueueCleanupHandle {
 
     pub(crate) fn retry_delete_first_file(&self, interval_forcibly: i64) -> bool {
         let _maintenance_guard = self.runtime_state.commit_lock().lock();
-        if !self.mapped_files.allows_legacy_namespace_mutation() {
+        if self.mapped_files.managed_generation().is_some() {
+            // Managed retirement retries are owned by the durable reaper. The legacy helper has
+            // no eligibility proof and therefore must never retire an arbitrary queue head.
             return false;
         }
         let first = self.mapped_files.snapshot().first().cloned();
@@ -551,6 +641,35 @@ impl MappedFileQueueCleanupHandle {
         self.mapped_files.apply_legacy_namespace_removal(deletion);
         deleted
     }
+}
+
+fn submit_managed_retirements(
+    runtime: &ManagedLifecycleRuntime,
+    generation: &ManagedMappedFileQueueGeneration<DefaultMappedFile>,
+    candidates: Vec<Arc<DefaultMappedFile>>,
+    reason: ManagedRetirementReason,
+) -> i32 {
+    let mut submitted = 0i32;
+    for owner in candidates {
+        if let Err(error) = runtime.submit_retirement(generation, &owner, reason, managed_retirement_nonce()) {
+            error!(%error, "managed mapped-file retirement submission failed closed");
+            break;
+        }
+        submitted = submitted.saturating_add(1);
+    }
+    submitted
+}
+
+fn managed_retirement_nonce() -> [u8; 16] {
+    static NEXT_NONCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+    let value = NEXT_NONCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut nonce = [0u8; 16];
+    nonce[..8].copy_from_slice(&value.to_le_bytes());
+    nonce[8..].copy_from_slice(&current_millis().to_le_bytes());
+    if nonce == [0; 16] {
+        nonce[0] = 1;
+    }
+    nonce
 }
 
 /// Narrow, cloneable capability used by commit-log flush workers.
@@ -683,6 +802,21 @@ impl MappedFileQueue {
             runtime_state: MappedFileQueueRuntimeState::default(),
         }
     }
+
+    /// Creates an empty managed queue whose first owner must be published through the durable
+    /// allocation worker.
+    pub(crate) fn new_managed(
+        store_path: String,
+        mapped_file_size: u64,
+        allocate_mapped_file_service: AllocateMappedFileService,
+        runtime: ManagedLifecycleRuntime,
+    ) -> Self {
+        Self {
+            storage: MappedFileQueueStorage::new(store_path, mapped_file_size, MappedFileGeneration::managed(runtime)),
+            allocate_mapped_file_service: Some(allocate_mapped_file_service),
+            runtime_state: MappedFileQueueRuntimeState::default(),
+        }
+    }
 }
 
 impl MappedFileQueue {
@@ -811,8 +945,20 @@ impl MappedFileQueue {
         self.storage.mapped_files().install_reconciled_generation(generation)
     }
 
+    pub(crate) fn bind_managed_runtime(&self, runtime: ManagedLifecycleRuntime) -> bool {
+        let _maintenance_guard = self.runtime_state.commit_lock().lock();
+        if self.runtime_state.is_closing() {
+            return false;
+        }
+        self.storage.mapped_files().bind_managed_runtime(runtime)
+    }
+
     pub(crate) fn allows_legacy_namespace_mutation(&self) -> bool {
         self.storage.mapped_files().allows_legacy_namespace_mutation()
+    }
+
+    pub(crate) fn is_managed(&self) -> bool {
+        !self.storage.mapped_files().allows_legacy_namespace_mutation()
     }
 
     /// Returns an immutable owner snapshot without exposing the publication primitive.
@@ -899,7 +1045,11 @@ impl MappedFileQueue {
         let _ = self.try_truncate_dirty_files(offset);
     }
 
-    /// Truncates dirty data and reports whether every tail namespace was removed.
+    /// Truncates dirty data after every tail segment is safely retired.
+    ///
+    /// Legacy queues return success after namespace removal. Managed queues return success after
+    /// every tail segment has a durable intent, has left the exact queue generation, and has a
+    /// durable `LogicalRemoved` record; the owned reaper completes namespace removal.
     #[must_use]
     pub fn try_truncate_dirty_files(&self, offset: i64) -> bool {
         self.try_truncate_dirty_files_with_before_lock(offset, || {})
@@ -909,15 +1059,14 @@ impl MappedFileQueue {
     where
         F: FnOnce(),
     {
-        if !self.allows_legacy_namespace_mutation() {
-            return false;
-        }
+        let began_in_legacy_mode = self.allows_legacy_namespace_mutation();
         before_lock();
         let _maintenance_guard = self.runtime_state.commit_lock().lock();
-        if !self.allows_legacy_namespace_mutation() {
+        if began_in_legacy_mode && self.is_managed() {
             return false;
         }
         let mut removal_candidates = Vec::new();
+        let mut position_updates = Vec::new();
 
         let current_files = self.storage.mapped_files().snapshot();
         for mapped_file in current_files.iter() {
@@ -928,14 +1077,54 @@ impl MappedFileQueue {
             ) {
                 MappedFileQueueTruncateAction::Retain => {}
                 MappedFileQueueTruncateAction::Truncate(position) => {
-                    mapped_file.set_wrote_position(position);
-                    mapped_file.set_committed_position(position);
-                    mapped_file.set_flushed_position(position);
+                    position_updates.push((Arc::clone(mapped_file), position));
                 }
                 MappedFileQueueTruncateAction::Remove => {
                     removal_candidates.push(mapped_file.clone());
                 }
             }
+        }
+
+        if self.is_managed() && removal_candidates.is_empty() {
+            for (mapped_file, position) in position_updates {
+                mapped_file.set_wrote_position(position);
+                mapped_file.set_committed_position(position);
+                mapped_file.set_flushed_position(position);
+            }
+            return true;
+        }
+        if let Some((runtime, generation)) = self.storage.mapped_files().managed_runtime_generation() {
+            let ordered_candidates: Vec<_> = removal_candidates.into_iter().rev().collect();
+            let expected = ordered_candidates.len();
+            let submitted = submit_managed_retirements(
+                &runtime,
+                &generation,
+                ordered_candidates,
+                ManagedRetirementReason::OffsetTruncate,
+            );
+            if usize::try_from(submitted).ok() != Some(expected) {
+                warn!(
+                    offset,
+                    expected,
+                    submitted,
+                    "managed tail retirement remains pending; retained positions were not truncated"
+                );
+                return false;
+            }
+            for (mapped_file, position) in position_updates {
+                mapped_file.set_wrote_position(position);
+                mapped_file.set_committed_position(position);
+                mapped_file.set_flushed_position(position);
+            }
+            return true;
+        }
+        if self.is_managed() {
+            return false;
+        }
+        for (mapped_file, position) in position_updates {
+            mapped_file.set_wrote_position(position);
+            mapped_file.set_committed_position(position);
+            mapped_file.set_flushed_position(position);
         }
 
         // Tail deletion runs newest-to-oldest. If one attempt is deferred, any already removed
@@ -961,13 +1150,21 @@ impl MappedFileQueue {
     #[must_use]
     pub fn try_delete_last_mapped_file(&mut self) -> bool {
         let _maintenance_guard = self.runtime_state.commit_lock().lock();
+        let files = self.storage.mapped_files().snapshot();
+        let Some(last_mapped_file) = files.last().cloned() else {
+            return true;
+        };
+        if let Some((runtime, generation)) = self.storage.mapped_files().managed_runtime_generation() {
+            return submit_managed_retirements(
+                &runtime,
+                &generation,
+                vec![last_mapped_file],
+                ManagedRetirementReason::DeleteLast,
+            ) == 1;
+        }
         if !self.allows_legacy_namespace_mutation() {
             return false;
         }
-        let files = self.storage.mapped_files().snapshot();
-        let Some(_last_mapped_file) = files.last() else {
-            return true;
-        };
         let deletion = destroy_last_mapped_file_for_queue(files.as_ref());
         let removed = deletion.deleted_count() > 0;
         self.apply_namespace_removal_under_maintenance_lock(deletion);
@@ -1070,10 +1267,21 @@ impl MappedFileQueue {
     /// Number of files deleted
     pub fn delete_expired_file_by_offset(&self, offset: i64, unit_size: i32) -> i32 {
         let _maintenance_guard = self.runtime_state.commit_lock().lock();
-        if !self.allows_legacy_namespace_mutation() {
-            return 0;
-        }
         let files = self.storage.mapped_files().snapshot();
+        if let Some((runtime, generation)) = self.storage.mapped_files().managed_runtime_generation() {
+            let candidates = select_expired_mapped_files_by_offset(
+                files.as_ref(),
+                self.storage.mapped_file_size(),
+                offset,
+                unit_size,
+            );
+            return submit_managed_retirements(
+                &runtime,
+                &generation,
+                candidates,
+                ManagedRetirementReason::DerivedFileRetirement,
+            );
+        }
         let deletion =
             delete_expired_mapped_files_by_offset(files.as_ref(), self.storage.mapped_file_size(), offset, unit_size);
         self.apply_namespace_removal_under_maintenance_lock(deletion)
@@ -1090,9 +1298,6 @@ impl MappedFileQueue {
     /// true if reset succeeded, false if offset is too far back
     pub fn reset_offset(&self, offset: i64) -> bool {
         let _maintenance_guard = self.runtime_state.commit_lock().lock();
-        if !self.allows_legacy_namespace_mutation() {
-            return false;
-        }
         let last_file = self.get_last_mapped_file().map(|mapped_file| {
             MappedFileQueueResetLastFile::new(mapped_file.get_file_from_offset(), mapped_file.get_wrote_position())
         });
@@ -1114,6 +1319,28 @@ impl MappedFileQueue {
             .iter()
             .map(|&index| Arc::clone(&current_files[index]))
             .collect();
+        if let Some((runtime, generation)) = self.storage.mapped_files().managed_runtime_generation() {
+            let expected = removal_candidates.len();
+            let submitted = submit_managed_retirements(
+                &runtime,
+                &generation,
+                removal_candidates,
+                ManagedRetirementReason::Reset,
+            );
+            if usize::try_from(submitted).ok() != Some(expected) {
+                return false;
+            }
+            if let Some((index, position)) = plan.target() {
+                let mapped_file = &current_files[index];
+                mapped_file.set_flushed_position(position);
+                mapped_file.set_wrote_position(position);
+                mapped_file.set_committed_position(position);
+            }
+            return true;
+        }
+        if !self.allows_legacy_namespace_mutation() {
+            return false;
+        }
         let (deletion, complete) = destroy_mapped_files_in_order(&removal_candidates, 1000);
         self.apply_namespace_removal_under_maintenance_lock(deletion);
         if !complete {
@@ -2248,6 +2475,20 @@ mod tests {
         assert!(!truncation.join().expect("truncation completes"));
         assert!(first_path.exists());
         assert!(tail_path.exists());
+        assert!(queue.get_mapped_files().is_empty());
+    }
+
+    #[test]
+    fn empty_managed_queue_accepts_non_destructive_recovery_position_reset() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let queue = MappedFileQueue::new(temp_dir.path().to_string_lossy().into_owned(), 1024, None);
+        let managed =
+            rocketmq_store_local::mapped_file::queue_io::load_reconciled_mapped_file_queue(temp_dir.path(), Vec::new())
+                .expect("construct an empty reconciled generation");
+        assert!(queue.install_reconciled_generation(managed));
+
+        assert!(queue.try_truncate_dirty_files(0));
+        assert!(queue.is_managed());
         assert!(queue.get_mapped_files().is_empty());
     }
 

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -92,6 +92,8 @@ use crate::consume_queue::mapped_file_queue::MappedFileWarmupStats;
 use crate::ha::general_ha_service::GeneralHAService;
 use crate::ha::ha_service::HAService;
 use crate::log_file::cold_data_check_service::ColdDataCheckService;
+use rocketmq_store_local::mapped_file::ManagedLifecycleRuntime;
+use rocketmq_store_local::mapped_file::ManagedMappedFileQueueGeneration;
 // Import the optimized loader module
 use crate::base::flush_manager::SyncFlushRuntimeInfo;
 use crate::log_file::commit_log_loader::CommitLogLoader;
@@ -206,7 +208,18 @@ macro_rules! apply_recovery_completion {
     ($commit_log:ident, $completion:expr, $max_consume_queue_offset:expr $(,)?) => {{
         match $completion {
             CommitLogRecoveryCompletion::Empty => {
-                if $commit_log.consume_queue_store.destroy_with_outcome() {
+                if $commit_log.mapped_file_queue.is_managed() {
+                    if $commit_log.consume_queue_store.get_total_size() == 0 {
+                        $commit_log.mapped_file_queue.set_flushed_where(0);
+                        $commit_log.mapped_file_queue.set_committed_where(0);
+                        true
+                    } else {
+                        warn!(
+                            "managed empty CommitLog recovery found consume-queue data that requires durable retirement"
+                        );
+                        false
+                    }
+                } else if $commit_log.consume_queue_store.destroy_with_outcome() {
                     if $commit_log.consume_queue_store.load_after_destroy() {
                         $commit_log.mapped_file_queue.set_flushed_where(0);
                         $commit_log.mapped_file_queue.set_committed_where(0);
@@ -396,6 +409,16 @@ impl DerefMut for CommitLog {
 }
 
 impl CommitLog {
+    /// Installs the reconciled managed CommitLog generation before Store workers start.
+    pub(crate) fn install_reconciled_generation(
+        &self,
+        generation: ManagedMappedFileQueueGeneration<DefaultMappedFile>,
+        runtime: ManagedLifecycleRuntime,
+    ) -> bool {
+        self.mapped_file_queue.install_reconciled_generation(generation)
+            && self.mapped_file_queue.bind_managed_runtime(runtime)
+    }
+
     pub(crate) fn try_new(
         runtime_scope: crate::runtime::StoreRuntimeScope,
         message_store_config: Arc<MessageStoreConfig>,
@@ -2223,6 +2246,11 @@ impl CommitLog {
     #[cfg(test)]
     pub(crate) fn last_mapped_file_for_testing(&self) -> Option<Arc<DefaultMappedFile>> {
         self.mapped_file_queue.get_last_mapped_file()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn try_delete_last_mapped_file_for_testing(&mut self) -> bool {
+        self.mapped_file_queue.try_delete_last_mapped_file()
     }
 
     #[inline]

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -252,11 +252,15 @@ use health::CommitLogWalPin;
 use health::CorrectLogicOffsetService;
 use lifecycle::FlushConsumeQueueService;
 use managed_recovery::inspect_and_reconcile_managed_root;
+use managed_recovery::require_wave_b_ready;
+use managed_recovery::validate_wave_b_configuration;
 use managed_recovery::wave_b_activation_fence;
 use mapped_file_retirement_service::MappedFileRetirementService;
 use read_path::estimate_in_mem_by_commit_offset;
 use read_path::is_the_batch_full;
 use recovery::BackgroundIndexRebuildService;
+use rocketmq_store_local::mapped_file::ManagedLifecycleRuntime;
+use rocketmq_store_local::mapped_file::PreparedManagedLifecycleActivation;
 use root_lock::StoreRootLease;
 use root_lock::StoreRootMode;
 use write_path::murmur3_x64_128_bytes;
@@ -613,6 +617,8 @@ pub struct LocalFileMessageStore {
     scheduled_task_group: Option<rocketmq_runtime::TaskGroup>,
     scheduled_tasks: Option<ScheduledTaskGroup>,
     mapped_file_retirement_service: Option<MappedFileRetirementService>,
+    managed_lifecycle_activation: Option<PreparedManagedLifecycleActivation>,
+    managed_lifecycle_runtime: Option<ManagedLifecycleRuntime>,
     ha_update_master_group: Arc<StdMutex<Option<rocketmq_runtime::TaskGroup>>>,
     delay_level_table: Arc<BTreeMap<i32 /* level */, i64 /* delay timeMillis */>>,
     max_delay_level: i32,

--- a/rocketmq-store/src/message_store/local_file_message_store/composition.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/composition.rs
@@ -74,11 +74,31 @@ impl LocalFileMessageStore {
         // publish even a partial in-memory view of the root.
         let store_root = Path::new(message_store_config.store_path_root_dir.as_str());
         let store_root_lease = StoreRootLease::acquire_unclassified(store_root, StoreOperation::Load)?;
-        let store_root_mode = store_root_lease.classify(StoreOperation::Load)?;
-        if store_root_mode == StoreRootMode::Managed {
-            let disposition = inspect_and_reconcile_managed_root(&store_root_lease)?;
-            return Err(wave_b_activation_fence(disposition));
+        let initial_outcome = store_root_lease.lifecycle_outcome(StoreOperation::Load)?;
+        if message_store_config.enable_mapped_file_lifecycle_wave_b {
+            validate_wave_b_configuration(&message_store_config)?;
         }
+        if message_store_config.enable_mapped_file_lifecycle_wave_b
+            && matches!(
+                initial_outcome,
+                rocketmq_store_local::mapped_file::ManagedLifecycleReadOutcome::LegacyAbsent
+                    | rocketmq_store_local::mapped_file::ManagedLifecycleReadOutcome::RecoveryWriteRequired(
+                        rocketmq_store_local::mapped_file::ManagedLifecycleRecoveryReason::BootstrapResume
+                    )
+            )
+        {
+            store_root_lease.bootstrap_managed_lifecycle(StoreOperation::Load)?;
+        }
+        let store_root_mode = store_root_lease.classify(StoreOperation::Load)?;
+        let managed_lifecycle_activation = if store_root_mode == StoreRootMode::Managed {
+            let disposition = inspect_and_reconcile_managed_root(&store_root_lease)?;
+            if !message_store_config.enable_mapped_file_lifecycle_wave_b {
+                return Err(wave_b_activation_fence(disposition));
+            }
+            Some(require_wave_b_ready(disposition)?)
+        } else {
+            None
+        };
         let runtime_scope = StoreRuntimeScope::new(service_context.clone());
         let local_backend_config = message_store_config.normalized_local_backend_config();
         let cleanup_policy = LocalCleanupPolicy::new(local_backend_config.cleanup);
@@ -367,6 +387,8 @@ impl LocalFileMessageStore {
             scheduled_task_group: None,
             scheduled_tasks: None,
             mapped_file_retirement_service: None,
+            managed_lifecycle_activation,
+            managed_lifecycle_runtime: None,
             ha_update_master_group: Arc::new(StdMutex::new(None)),
             delay_level_table,
             max_delay_level,
@@ -466,6 +488,7 @@ impl LocalFileMessageStore {
             self.store_checkpoint
                 .clone()
                 .expect("store checkpoint is initialized with LocalFileMessageStore"),
+            self.allocate_mapped_file_service.as_ref().clone(),
         )
     }
 
@@ -786,7 +809,9 @@ impl LocalFileMessageStore {
             self.message_store_config
                 .timer_store_config
                 .validate()
-                .map_err(|error| StoreError::config(StoreOperation::Load, error.to_string()))?;
+                .map_err(|error| {
+                    StoreError::config(StoreOperation::Load, "invalid Timer Store configuration").with_source(error)
+                })?;
         }
 
         let enabled_rocksdb_options = Self::enabled_rocksdb_specific_options(self.message_store_config.as_ref());
@@ -930,13 +955,19 @@ impl LocalFileMessageStore {
         let completion = self.extended_timeline_completion_reconciler.as_ref().ok_or_else(|| {
             StoreError::invalid_state(StoreOperation::Admin, "Extended completion replay is not wired")
         })?;
-        let (source_cq_cursor, source_physical_cursor, format_fingerprint) = materializer
-            .snapshot_source_cursors()
-            .map_err(|error| StoreError::storage(StoreOperation::Read, error.to_string()))?;
+        let (source_cq_cursor, source_physical_cursor, format_fingerprint) =
+            materializer.snapshot_source_cursors().map_err(|error| {
+                StoreError::storage(StoreOperation::Read, "failed to read Extended Timeline source cursors")
+                    .with_source(error)
+            })?;
         let metrics = materializer.metrics();
-        let completion_cursor = completion
-            .completion_physical_cursor()
-            .map_err(|error| StoreError::storage(StoreOperation::Read, error.to_string()))?;
+        let completion_cursor = completion.completion_physical_cursor().map_err(|error| {
+            StoreError::storage(
+                StoreOperation::Read,
+                "failed to read Extended Timeline completion cursor",
+            )
+            .with_source(error)
+        })?;
         let replicated_final_end = self
             .commit_log
             .get_flushed_where()
@@ -974,14 +1005,17 @@ impl LocalFileMessageStore {
         let snapshot = self.extended_timeline_snapshot.as_ref().ok_or_else(|| {
             StoreError::unsupported(StoreOperation::Admin, "Extended Timeline snapshot is not enabled")
         })?;
-        let manifest = snapshot
-            .create()
-            .map_err(|error| StoreError::storage(StoreOperation::Admin, error.to_string()))?;
+        let manifest = snapshot.create().map_err(|error| {
+            StoreError::storage(StoreOperation::Admin, "failed to create Extended Timeline snapshot").with_source(error)
+        })?;
         self.extended_timeline_promotion_gate
             .as_ref()
             .ok_or_else(|| StoreError::invalid_state(StoreOperation::Admin, "Extended promotion gate is not wired"))?
             .mark_snapshot_installed(manifest.clone())
-            .map_err(|error| StoreError::invalid_state(StoreOperation::Admin, error.to_string()))?;
+            .map_err(|error| {
+                StoreError::invalid_state(StoreOperation::Admin, "failed to publish Extended Timeline snapshot")
+                    .with_source(error)
+            })?;
         Ok(manifest)
     }
 
@@ -995,7 +1029,10 @@ impl LocalFileMessageStore {
             .as_ref()
             .ok_or_else(|| StoreError::unsupported(StoreOperation::Admin, "Extended Timeline snapshot is not enabled"))?
             .release(manifest)
-            .map_err(|error| StoreError::storage(StoreOperation::Admin, error.to_string()))
+            .map_err(|error| {
+                StoreError::storage(StoreOperation::Admin, "failed to release Extended Timeline snapshot")
+                    .with_source(error)
+            })
     }
 
     pub(super) fn refresh_controller_confirm_offset_after_role_change(&self) {

--- a/rocketmq-store/src/message_store/local_file_message_store/dispatch.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/dispatch.rs
@@ -250,27 +250,6 @@ impl LocalFileMessageStore {
         self.consume_queue_store.replace_topic_queue_table(topic_queue_table);
     }
 
-    pub(super) fn delete_file(&mut self, file_name: String) {
-        let _ = self.delete_file_with_outcome(file_name);
-    }
-
-    pub(super) fn delete_file_with_outcome(&mut self, file_name: String) -> bool {
-        match fs::remove_file(PathBuf::from(file_name.as_str())) {
-            Ok(_) => {
-                info!("delete OK, file:{}", file_name);
-                true
-            }
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                info!("delete skipped because file is already absent: {}", file_name);
-                true
-            }
-            Err(err) => {
-                error!("delete error, file:{}, {:?}", file_name, err);
-                false
-            }
-        }
-    }
-
     pub fn set_message_arriving_listener(
         &mut self,
         message_arriving_listener: Option<Arc<Box<dyn MessageArrivingListener + Sync + Send + 'static>>>,

--- a/rocketmq-store/src/message_store/local_file_message_store/lifecycle.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/lifecycle.rs
@@ -400,7 +400,7 @@ impl LocalFileMessageStore {
             );
             return false;
         }
-        debug_assert_eq!(self.store_root_mode, StoreRootMode::Legacy);
+        let managed = self.store_root_mode == StoreRootMode::Managed;
         let last_exit_ok = match self.is_temp_file_exist() {
             Ok(present) => !present,
             Err(error) => {
@@ -413,13 +413,23 @@ impl LocalFileMessageStore {
             if last_exit_ok { "normally" } else { "abnormally" },
             self.message_store_config.store_path_root_dir
         );
-        //load Commit log-- init commit mapped file queue
-        let mut result = self.commit_log.load();
-        if !result {
-            return result;
-        }
-        // load Consume Queue-- init Consume log mapped file queue
-        result &= self.consume_queue_store.load();
+        let mut result = if managed {
+            match self.activate_managed_queue_runtime() {
+                Ok(()) => true,
+                Err(error) => {
+                    error!(error = %error, "managed queue activation failed before recovery");
+                    return false;
+                }
+            }
+        } else {
+            //load Commit log-- init commit mapped file queue
+            let loaded_commit_log = self.commit_log.load();
+            if !loaded_commit_log {
+                return false;
+            }
+            // load Consume Queue-- init Consume log mapped file queue
+            loaded_commit_log && self.consume_queue_store.load()
+        };
 
         if self.message_store_config.enable_compaction {
             let required_wal_position = self.commit_log.get_max_offset();
@@ -495,12 +505,13 @@ impl LocalFileMessageStore {
     pub(super) async fn start_store(&mut self) -> Result<(), StoreError> {
         self.validate_supported_configuration()?;
         self.ensure_operational_root_lease(StoreOperation::Start)?;
-        if self.store_root_mode == StoreRootMode::Managed {
-            return Err(StoreError::new(StoreErrorKind::Unsupported, StoreOperation::Start)
-                .in_component(StoreComponent::MappedFile)
-                .with_detail(
-                    "managed mapped-file lifecycle is read-only until Wave-B queue, registry, and reaper activation is complete",
-                ));
+        if self.store_root_mode == StoreRootMode::Managed
+            && (self.managed_lifecycle_runtime.is_none() || self.mapped_file_retirement_service.is_none())
+        {
+            return Err(StoreError::invalid_state(
+                StoreOperation::Start,
+                "managed mapped-file lifecycle has not completed queue/runtime/reaper activation",
+            ));
         }
         match self.lifecycle_state() {
             LocalStoreState::Initialized => {}
@@ -600,6 +611,15 @@ impl LocalFileMessageStore {
                 Ok(())
             }
             Err(error) => {
+                if self.store_root_mode == StoreRootMode::Managed {
+                    if let Some(runtime) = self.managed_lifecycle_runtime.as_ref() {
+                        runtime.begin_shutdown();
+                    }
+                    if let Some(service) = self.mapped_file_retirement_service.as_mut() {
+                        let _ = service.cancel_drain_and_await().await;
+                    }
+                    self.allocate_mapped_file_service.shutdown().await;
+                }
                 if self.background_index_rebuild_service.has_task_group() {
                     self.background_index_rebuild_service.shutdown().await;
                 }
@@ -634,11 +654,6 @@ impl LocalFileMessageStore {
                     "message store cannot be initialized while recovering".to_string(),
                 ));
             }
-        }
-
-        if self.store_root_mode == StoreRootMode::Managed {
-            self.set_lifecycle_state(LocalStoreState::Initialized);
-            return Ok(());
         }
 
         if !Self::is_dledger_commit_log_enabled_config(self.message_store_config.as_ref())
@@ -879,9 +894,10 @@ impl LocalFileMessageStore {
 
     /// Attempts an explicit Store-level destroy without bypassing mapped-file retirement.
     ///
-    /// Wave A keeps lifecycle writes disabled. Until the durable retirement handoff and deletion
-    /// reaper are wired, an eligible request is fenced as retry-pending and performs no consume
-    /// queue, commitlog, index, or metadata namespace mutation.
+    /// Wave-B enables durable per-segment retirement, but whole-Store destruction remains disabled
+    /// until every Store-owned namespace and metadata artifact participates in the same durable
+    /// handoff. An eligible request is fenced as retry-pending and performs no consume queue,
+    /// commitlog, index, or metadata namespace mutation.
     #[must_use]
     pub(super) fn destroy_store_with_outcome(&mut self) -> bool {
         if self.store_root_lease_state == StoreRootLeaseState::Destroyed {
@@ -901,9 +917,7 @@ impl LocalFileMessageStore {
             return false;
         }
         self.store_root_lease_state = StoreRootLeaseState::DestroyRetryPending;
-        warn!(
-            "message store explicit destroy is write-disabled until durable retirement handoff and reaping are active"
-        );
+        warn!("message store explicit destroy is write-disabled until all Store namespaces support durable retirement");
         false
     }
 }

--- a/rocketmq-store/src/message_store/local_file_message_store/managed_recovery.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/managed_recovery.rs
@@ -12,10 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use rocketmq_model::common::attribute::cq_type::CQType;
 use rocketmq_store_local::mapped_file::prepare_managed_lifecycle_activation;
+use rocketmq_store_local::mapped_file::DefaultMappedFile;
 use rocketmq_store_local::mapped_file::LockedManagedLifecycleInspection;
 use rocketmq_store_local::mapped_file::ManagedLifecycleActivationError;
 use rocketmq_store_local::mapped_file::ManagedLifecycleActivationErrorKind;
+use rocketmq_store_local::mapped_file::ManagedLifecycleRuntime;
+use rocketmq_store_local::mapped_file::ManagedMappedFileQueueGeneration;
+use rocketmq_store_local::mapped_file::ManagedQueueDescriptor;
 use rocketmq_store_local::mapped_file::ManagedReconciliationDisposition;
 use rocketmq_store_local::mapped_file::ManagedReconciliationError;
 use rocketmq_store_local::mapped_file::ManagedReconciliationErrorKind;
@@ -24,6 +35,9 @@ use rocketmq_store_local::mapped_file::ManagedRecoverySession;
 use rocketmq_store_local::mapped_file::PreparedManagedLifecycleActivation;
 
 use super::root_lock::StoreRootLease;
+use super::LocalFileMessageStore;
+use super::MappedFileRetirementService;
+use crate::config::message_store_config::MessageStoreConfig;
 use crate::store_error::StoreComponent;
 use crate::store_error::StoreError;
 use crate::store_error::StoreErrorKind;
@@ -34,6 +48,402 @@ use crate::store_error::StoreOperation;
 pub(super) enum ManagedReadOnlyDisposition {
     Ready(PreparedManagedLifecycleActivation),
     RecoveryRequired(ManagedRecoverySession),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ManagedQueueKind {
+    CommitLog,
+    SimpleConsumeQueue,
+    ConsumeQueueExtension,
+    BatchConsumeQueue,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ManagedQueueRoute {
+    pub directory: Box<str>,
+    pub kind: ManagedQueueKind,
+    pub topic: Option<Box<str>>,
+    pub queue_id: Option<i32>,
+    pub expected_file_length: u64,
+}
+
+pub(super) struct StagedManagedQueue {
+    pub route: ManagedQueueRoute,
+    pub generation: ManagedMappedFileQueueGeneration<DefaultMappedFile>,
+}
+
+pub(super) struct ActivatedManagedQueues {
+    pub runtime: ManagedLifecycleRuntime,
+    pub queues: Vec<StagedManagedQueue>,
+}
+
+pub(super) fn validate_wave_b_configuration(config: &MessageStoreConfig) -> Result<(), StoreError> {
+    if !cfg!(any(target_os = "linux", windows)) {
+        return Err(StoreError::new(StoreErrorKind::Unsupported, StoreOperation::Load)
+            .in_component(StoreComponent::MappedFile)
+            .with_detail("managed mapped-file lifecycle Wave-B writes require a qualified Linux or Windows backend"));
+    }
+    let expected_commit_log = PathBuf::from(config.store_path_root_dir.as_str()).join("commitlog");
+    if Path::new(&config.get_store_path_commit_log()) != expected_commit_log {
+        return Err(StoreError::new(StoreErrorKind::Unsupported, StoreOperation::Load)
+            .in_component(StoreComponent::MappedFile)
+            .with_detail("managed mapped-file lifecycle requires CommitLog under <storeRoot>/commitlog"));
+    }
+    if config.is_enable_rocksdb_store() {
+        return Err(StoreError::new(StoreErrorKind::Unsupported, StoreOperation::Load)
+            .in_component(StoreComponent::MappedFile)
+            .with_detail("managed mapped-file lifecycle does not yet cover RocksDB consume-queue storage"));
+    }
+    if config.enable_compaction {
+        return Err(StoreError::new(StoreErrorKind::Unsupported, StoreOperation::Load)
+            .in_component(StoreComponent::MappedFile)
+            .with_detail("managed mapped-file lifecycle does not yet cover compaction queues"));
+    }
+    if config.is_timer_wheel_enable() {
+        return Err(StoreError::new(StoreErrorKind::Unsupported, StoreOperation::Load)
+            .in_component(StoreComponent::MappedFile)
+            .with_detail("managed mapped-file lifecycle does not yet cover timer-wheel mapped files"));
+    }
+    if config.message_index_enable {
+        return Err(StoreError::new(StoreErrorKind::Unsupported, StoreOperation::Load)
+            .in_component(StoreComponent::MappedFile)
+            .with_detail("managed mapped-file lifecycle does not yet cover index-file retirement"));
+    }
+    Ok(())
+}
+
+/// Validates the complete replay-authorized queue inventory before any retained handle is claimed.
+pub(super) fn plan_managed_queue_routes(
+    descriptors: &[ManagedQueueDescriptor],
+    config: &MessageStoreConfig,
+) -> Result<Vec<ManagedQueueRoute>, StoreError> {
+    plan_queue_routes(
+        descriptors
+            .iter()
+            .map(|descriptor| (descriptor.directory(), descriptor.expected_file_length())),
+        config.mapped_file_size_commit_log as u64,
+        config.get_mapped_file_size_consume_queue() as u64,
+        config.mapped_file_size_consume_queue_ext as u64,
+        config.mapper_file_size_batch_consume_queue as u64,
+        config.enable_consume_queue_ext,
+    )
+    .map_err(|detail| {
+        StoreError::new(StoreErrorKind::Corruption, StoreOperation::Load)
+            .in_component(StoreComponent::MappedFile)
+            .with_detail(detail)
+    })
+}
+
+/// Claims every preflighted queue generation, then opens managed write capabilities exactly once.
+pub(super) fn stage_and_activate_managed_queues(
+    mut activation: PreparedManagedLifecycleActivation,
+    store_root: &Path,
+    routes: Vec<ManagedQueueRoute>,
+) -> Result<ActivatedManagedQueues, StoreError> {
+    let mut queues = Vec::new();
+    queues.try_reserve_exact(routes.len()).map_err(|_| {
+        StoreError::new(StoreErrorKind::Unavailable, StoreOperation::Load)
+            .in_component(StoreComponent::MappedFile)
+            .with_detail("failed to reserve managed queue staging inventory")
+    })?;
+    for route in routes {
+        let generation = activation
+            .stage_queue(store_root, &route.directory, route.expected_file_length)
+            .map_err(managed_activation_error)?;
+        queues.push(StagedManagedQueue { route, generation });
+    }
+    let runtime = activation.activate().map_err(managed_activation_error)?;
+    Ok(ActivatedManagedQueues { runtime, queues })
+}
+
+fn plan_queue_routes<'a>(
+    descriptors: impl IntoIterator<Item = (&'a str, u64)>,
+    commit_log_file_size: u64,
+    consume_queue_file_size: u64,
+    consume_queue_ext_file_size: u64,
+    batch_consume_queue_file_size: u64,
+    consume_queue_ext_enabled: bool,
+) -> Result<Vec<ManagedQueueRoute>, String> {
+    let mut routes = Vec::new();
+    let mut logical_queues = BTreeMap::<(Box<str>, i32), ManagedQueueKind>::new();
+    let mut extensions = BTreeSet::<(Box<str>, i32)>::new();
+    let mut has_commit_log = false;
+
+    for (directory, expected_file_length) in descriptors {
+        let components = directory.split('/').collect::<Vec<_>>();
+        let (kind, topic, queue_id, configured_file_length) = match components.as_slice() {
+            ["commitlog"] => {
+                has_commit_log = true;
+                (ManagedQueueKind::CommitLog, None, None, commit_log_file_size)
+            }
+            ["consumequeue", topic, queue_id] => (
+                ManagedQueueKind::SimpleConsumeQueue,
+                Some(*topic),
+                Some(parse_queue_id(directory, queue_id)?),
+                consume_queue_file_size,
+            ),
+            ["consumequeue_ext", topic, queue_id] => {
+                if !consume_queue_ext_enabled {
+                    return Err(format!(
+                        "managed consume-queue extension {directory:?} exists while consume-queue extensions are disabled"
+                    ));
+                }
+                (
+                    ManagedQueueKind::ConsumeQueueExtension,
+                    Some(*topic),
+                    Some(parse_queue_id(directory, queue_id)?),
+                    consume_queue_ext_file_size,
+                )
+            }
+            ["batchconsumequeue", topic, queue_id] => (
+                ManagedQueueKind::BatchConsumeQueue,
+                Some(*topic),
+                Some(parse_queue_id(directory, queue_id)?),
+                batch_consume_queue_file_size,
+            ),
+            _ => {
+                return Err(format!(
+                    "replay-authorized mapped-file directory {directory:?} is not a supported queue layout"
+                ));
+            }
+        };
+        if topic.is_some_and(str::is_empty) {
+            return Err(format!("managed queue directory {directory:?} has an empty topic"));
+        }
+        if expected_file_length != configured_file_length {
+            return Err(format!(
+                "managed queue {directory:?} has replay length {expected_file_length}, but configuration requires {configured_file_length}"
+            ));
+        }
+
+        let topic = topic.map(Box::<str>::from);
+        if let (Some(topic), Some(queue_id)) = (topic.as_ref(), queue_id) {
+            let identity = (topic.clone(), queue_id);
+            match kind {
+                ManagedQueueKind::SimpleConsumeQueue | ManagedQueueKind::BatchConsumeQueue => {
+                    if let Some(previous) = logical_queues.insert(identity, kind) {
+                        return Err(format!(
+                            "managed queue {topic}/{queue_id} is present as both {previous:?} and {kind:?}"
+                        ));
+                    }
+                }
+                ManagedQueueKind::ConsumeQueueExtension => {
+                    extensions.insert(identity);
+                }
+                ManagedQueueKind::CommitLog => {}
+            }
+        }
+        routes.push(ManagedQueueRoute {
+            directory: directory.into(),
+            kind,
+            topic,
+            queue_id,
+            expected_file_length,
+        });
+    }
+
+    if !has_commit_log {
+        routes.insert(
+            0,
+            ManagedQueueRoute {
+                directory: "commitlog".into(),
+                kind: ManagedQueueKind::CommitLog,
+                topic: None,
+                queue_id: None,
+                expected_file_length: commit_log_file_size,
+            },
+        );
+    }
+
+    for identity in &extensions {
+        if logical_queues.get(identity) != Some(&ManagedQueueKind::SimpleConsumeQueue) {
+            return Err(format!(
+                "managed consume-queue extension {}/{} has no matching simple consume queue",
+                identity.0, identity.1
+            ));
+        }
+    }
+    if consume_queue_ext_enabled {
+        for ((topic, queue_id), kind) in &logical_queues {
+            if *kind == ManagedQueueKind::SimpleConsumeQueue && !extensions.contains(&(topic.clone(), *queue_id)) {
+                routes.push(ManagedQueueRoute {
+                    directory: format!("consumequeue_ext/{topic}/{queue_id}").into(),
+                    kind: ManagedQueueKind::ConsumeQueueExtension,
+                    topic: Some(topic.clone()),
+                    queue_id: Some(*queue_id),
+                    expected_file_length: consume_queue_ext_file_size,
+                });
+            }
+        }
+    }
+    Ok(routes)
+}
+
+fn parse_queue_id(directory: &str, value: &str) -> Result<i32, String> {
+    let queue_id = value
+        .parse::<i32>()
+        .map_err(|_| format!("managed queue directory {directory:?} has an invalid queue id"))?;
+    if queue_id < 0 || queue_id.to_string() != value {
+        return Err(format!(
+            "managed queue directory {directory:?} does not use the canonical non-negative queue id"
+        ));
+    }
+    Ok(queue_id)
+}
+
+impl LocalFileMessageStore {
+    pub(super) fn activate_managed_queue_runtime(&mut self) -> Result<(), StoreError> {
+        let Some(activation) = self.managed_lifecycle_activation.as_ref() else {
+            return Err(managed_queue_install_error(
+                "managed Store has no reconciled lifecycle activation candidate",
+            ));
+        };
+        let descriptors = activation.queue_descriptors().map_err(managed_activation_error)?;
+        let routes = plan_managed_queue_routes(&descriptors, &self.message_store_config)?;
+
+        for route in &routes {
+            let Some(topic) = route.topic.as_deref() else {
+                continue;
+            };
+            let expected_type = match route.kind {
+                ManagedQueueKind::SimpleConsumeQueue | ManagedQueueKind::ConsumeQueueExtension => CQType::SimpleCQ,
+                ManagedQueueKind::BatchConsumeQueue => CQType::BatchCQ,
+                ManagedQueueKind::CommitLog => continue,
+            };
+            if !self
+                .consume_queue_store
+                .accepts_reconciled_queue_type(topic, expected_type)
+            {
+                return Err(managed_queue_install_error(format!(
+                    "managed queue {} does not match the configured topic queue type",
+                    route.directory
+                )));
+            }
+        }
+
+        let activation = self
+            .managed_lifecycle_activation
+            .take()
+            .ok_or_else(|| managed_queue_install_error("managed lifecycle activation candidate disappeared"))?;
+        let store_root = Path::new(self.message_store_config.store_path_root_dir.as_str());
+        let activated = stage_and_activate_managed_queues(activation, store_root, routes)?;
+
+        let mut commit_log = None;
+        let mut logical_queues = Vec::new();
+        let mut extensions = BTreeMap::new();
+        for staged in activated.queues {
+            let topic = staged.route.topic.clone();
+            let queue_id = staged.route.queue_id;
+            match staged.route.kind {
+                ManagedQueueKind::CommitLog => commit_log = Some(staged.generation),
+                ManagedQueueKind::SimpleConsumeQueue | ManagedQueueKind::BatchConsumeQueue => {
+                    logical_queues.push((staged.route, staged.generation));
+                }
+                ManagedQueueKind::ConsumeQueueExtension => {
+                    let (Some(topic), Some(queue_id)) = (topic, queue_id) else {
+                        return Err(managed_queue_install_error(
+                            "managed consume-queue extension lost its queue identity",
+                        ));
+                    };
+                    if extensions.insert((topic, queue_id), staged.generation).is_some() {
+                        return Err(managed_queue_install_error(
+                            "managed consume-queue extension was staged more than once",
+                        ));
+                    }
+                }
+            }
+        }
+
+        let Some(commit_log) = commit_log else {
+            return Err(managed_queue_install_error(
+                "managed activation did not stage the required CommitLog generation",
+            ));
+        };
+        let runtime = activated.runtime;
+        if !self
+            .commit_log
+            .install_reconciled_generation(commit_log, runtime.clone())
+        {
+            return Err(managed_runtime_install_error(
+                &runtime,
+                "failed to publish the reconciled CommitLog generation before worker start",
+            ));
+        }
+
+        for (route, generation) in logical_queues {
+            let (Some(topic), Some(queue_id)) = (route.topic, route.queue_id) else {
+                return Err(managed_runtime_install_error(
+                    &runtime,
+                    "managed consume queue lost its queue identity",
+                ));
+            };
+            let installed = match route.kind {
+                ManagedQueueKind::SimpleConsumeQueue => {
+                    let extension = extensions.remove(&(topic.clone(), queue_id));
+                    self.consume_queue_store.install_reconciled_simple_queue(
+                        &topic,
+                        queue_id,
+                        generation,
+                        extension,
+                        runtime.clone(),
+                    )
+                }
+                ManagedQueueKind::BatchConsumeQueue => self.consume_queue_store.install_reconciled_batch_queue(
+                    &topic,
+                    queue_id,
+                    generation,
+                    runtime.clone(),
+                ),
+                ManagedQueueKind::CommitLog | ManagedQueueKind::ConsumeQueueExtension => false,
+            };
+            if !installed {
+                return Err(managed_runtime_install_error(
+                    &runtime,
+                    format!("failed to publish reconciled managed queue {}", route.directory),
+                ));
+            }
+        }
+        if !extensions.is_empty() {
+            return Err(managed_runtime_install_error(
+                &runtime,
+                "one or more managed consume-queue extensions were not attached to their queue",
+            ));
+        }
+
+        if !self.allocate_mapped_file_service.install_managed_lifecycle(
+            runtime.clone(),
+            PathBuf::from(self.message_store_config.store_path_root_dir.as_str()),
+        ) {
+            return Err(managed_runtime_install_error(
+                &runtime,
+                "failed to bind the reconciled lifecycle runtime to the allocation worker before start",
+            ));
+        }
+        if !self.consume_queue_store.bind_managed_lifecycle_runtime(runtime.clone()) {
+            return Err(managed_runtime_install_error(
+                &runtime,
+                "failed to bind the reconciled lifecycle runtime to dynamic consume-queue creation",
+            ));
+        }
+        self.mapped_file_retirement_service = Some(MappedFileRetirementService::new(
+            runtime.clone(),
+            self.runtime_scope.clone(),
+            Arc::clone(&self.running_flags),
+        ));
+        self.managed_lifecycle_runtime = Some(runtime);
+        Ok(())
+    }
+}
+
+fn managed_queue_install_error(detail: impl Into<String>) -> StoreError {
+    StoreError::new(StoreErrorKind::Corruption, StoreOperation::Load)
+        .in_component(StoreComponent::MappedFile)
+        .with_detail(detail)
+}
+
+fn managed_runtime_install_error(runtime: &ManagedLifecycleRuntime, detail: impl Into<String>) -> StoreError {
+    runtime.begin_shutdown();
+    managed_queue_install_error(detail)
 }
 
 /// Replays and reconciles managed lifecycle evidence before any persistent Store component exists.
@@ -82,6 +492,23 @@ pub(super) fn wave_b_activation_fence(disposition: ManagedReadOnlyDisposition) -
         .with_detail(detail)
 }
 
+/// Accepts only a completely reconciled root for the explicit local Wave-B mode.
+pub(super) fn require_wave_b_ready(
+    disposition: ManagedReadOnlyDisposition,
+) -> Result<PreparedManagedLifecycleActivation, StoreError> {
+    match disposition {
+        ManagedReadOnlyDisposition::Ready(prepared) => Ok(prepared),
+        ManagedReadOnlyDisposition::RecoveryRequired(recovery) => {
+            Err(StoreError::new(StoreErrorKind::Unavailable, StoreOperation::Load)
+                .in_component(StoreComponent::MappedFile)
+                .with_detail(format!(
+                    "managed lifecycle requires {} durable recovery actions before Wave-B activation",
+                    recovery.required_action_count(),
+                )))
+        }
+    }
+}
+
 fn managed_activation_error(error: ManagedLifecycleActivationError) -> StoreError {
     let kind = match error.kind() {
         ManagedLifecycleActivationErrorKind::QueueLoad | ManagedLifecycleActivationErrorKind::SegmentClaim => {
@@ -90,8 +517,7 @@ fn managed_activation_error(error: ManagedLifecycleActivationError) -> StoreErro
         ManagedLifecycleActivationErrorKind::Registry
         | ManagedLifecycleActivationErrorKind::DuplicateQueue
         | ManagedLifecycleActivationErrorKind::StagingFailed
-        | ManagedLifecycleActivationErrorKind::UnclaimedSegments
-        | ManagedLifecycleActivationErrorKind::FleetFenceMismatch => StoreErrorKind::Corruption,
+        | ManagedLifecycleActivationErrorKind::UnclaimedSegments => StoreErrorKind::Corruption,
         ManagedLifecycleActivationErrorKind::Writer | ManagedLifecycleActivationErrorKind::Namespace => {
             StoreErrorKind::Storage
         }
@@ -113,4 +539,127 @@ fn managed_reconciliation_error(error: ManagedReconciliationError) -> StoreError
         .in_component(StoreComponent::MappedFile)
         .with_detail("managed replay and namespace reconciliation failed before Store construction")
         .with_source(error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const COMMIT_LOG_SIZE: u64 = 1_073_741_824;
+    const CONSUME_QUEUE_SIZE: u64 = 6_000_000;
+    const EXT_SIZE: u64 = 50_000_000;
+    const BATCH_SIZE: u64 = 13_800_000;
+
+    fn plan<const N: usize>(bindings: [(&str, u64); N]) -> Result<Vec<ManagedQueueRoute>, String> {
+        plan_queue_routes(
+            bindings,
+            COMMIT_LOG_SIZE,
+            CONSUME_QUEUE_SIZE,
+            EXT_SIZE,
+            BATCH_SIZE,
+            true,
+        )
+    }
+
+    #[test]
+    fn managed_queue_routes_accept_only_complete_supported_layouts() {
+        let routes = plan([
+            ("commitlog", COMMIT_LOG_SIZE),
+            ("consumequeue/topic-a/0", CONSUME_QUEUE_SIZE),
+            ("consumequeue_ext/topic-a/0", EXT_SIZE),
+            ("batchconsumequeue/topic-b/7", BATCH_SIZE),
+        ])
+        .expect("supported queue inventory");
+
+        assert_eq!(routes.len(), 4);
+        assert_eq!(routes[0].kind, ManagedQueueKind::CommitLog);
+        assert_eq!(routes[1].topic.as_deref(), Some("topic-a"));
+        assert_eq!(routes[1].queue_id, Some(0));
+        assert_eq!(routes[3].kind, ManagedQueueKind::BatchConsumeQueue);
+    }
+
+    #[test]
+    fn managed_queue_routes_reject_unknown_or_noncanonical_directories() {
+        for directory in [
+            "timerlog",
+            "consumequeue/topic-a",
+            "consumequeue//0",
+            "consumequeue/topic-a/-1",
+            "consumequeue/topic-a/01",
+        ] {
+            assert!(
+                plan([(directory, CONSUME_QUEUE_SIZE)]).is_err(),
+                "{directory} must fail before handle claiming"
+            );
+        }
+    }
+
+    #[test]
+    fn managed_queue_routes_reject_size_and_queue_type_mismatches() {
+        assert!(plan([("commitlog", 512)]).is_err());
+        assert!(plan([
+            ("consumequeue/topic-a/0", CONSUME_QUEUE_SIZE),
+            ("batchconsumequeue/topic-a/0", BATCH_SIZE),
+        ])
+        .is_err());
+        assert!(plan([("consumequeue_ext/topic-a/0", EXT_SIZE)]).is_err());
+    }
+
+    #[test]
+    fn empty_managed_inventory_stages_an_empty_commit_log_queue() {
+        let routes = plan([]).expect("an empty Store still needs a managed CommitLog queue");
+
+        assert_eq!(
+            routes,
+            vec![ManagedQueueRoute {
+                directory: "commitlog".into(),
+                kind: ManagedQueueKind::CommitLog,
+                topic: None,
+                queue_id: None,
+                expected_file_length: COMMIT_LOG_SIZE,
+            }]
+        );
+    }
+
+    #[test]
+    fn enabled_extensions_stage_an_empty_managed_generation_for_each_simple_queue() {
+        let routes = plan([("consumequeue/topic-a/0", CONSUME_QUEUE_SIZE)])
+            .expect("simple queue gets an empty managed extension generation");
+
+        assert!(routes.iter().any(|route| {
+            route.directory.as_ref() == "consumequeue_ext/topic-a/0"
+                && route.kind == ManagedQueueKind::ConsumeQueueExtension
+        }));
+    }
+
+    #[test]
+    fn wave_b_configuration_rejects_external_commitlog_and_unmigrated_queue_backends() {
+        let root = tempfile::tempdir().expect("temporary Store root");
+        let mut config = MessageStoreConfig {
+            store_path_root_dir: root.path().to_string_lossy().into_owned().into(),
+            timer_wheel_enable: false,
+            message_index_enable: false,
+            ..MessageStoreConfig::default()
+        };
+        if !cfg!(any(target_os = "linux", windows)) {
+            assert!(validate_wave_b_configuration(&config).is_err());
+            return;
+        }
+        assert!(validate_wave_b_configuration(&config).is_ok());
+
+        config.store_path_commit_log = Some(root.path().join("external").to_string_lossy().into_owned().into());
+        assert!(validate_wave_b_configuration(&config).is_err());
+
+        config.store_path_commit_log = None;
+        config.enable_compaction = true;
+        assert!(validate_wave_b_configuration(&config).is_err());
+
+        config.enable_compaction = false;
+        config.timer_wheel_enable = true;
+        assert!(validate_wave_b_configuration(&config).is_err());
+
+        config.timer_wheel_enable = false;
+        config.message_index_enable = true;
+        assert!(validate_wave_b_configuration(&config).is_err());
+    }
 }

--- a/rocketmq-store/src/message_store/local_file_message_store/root_lock.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/root_lock.rs
@@ -21,6 +21,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use fs2::FileExt;
+use rocketmq_store_local::mapped_file::bootstrap_managed_lifecycle_under_exclusive_lock;
 use rocketmq_store_local::mapped_file::inspect_managed_lifecycle_read_only;
 use rocketmq_store_local::mapped_file::inspect_managed_lifecycle_under_exclusive_lock;
 use rocketmq_store_local::mapped_file::LockedManagedLifecycleInspection;
@@ -99,11 +100,48 @@ impl StoreRootLease {
     }
 
     pub(super) fn classify(&self, operation: StoreOperation) -> Result<StoreRootMode, StoreError> {
-        self.validate_root_binding(operation)?;
-        let outcome = inspect_managed_lifecycle_read_only(&self.root)
-            .map_err(|error| managed_lifecycle_read_error(operation, &self.configured_root, error))?;
+        let outcome = self.lifecycle_outcome(operation)?;
         StoreRootMode::from_read_outcome(outcome)
             .map_err(|reason| managed_lifecycle_fence(operation, recovery_requirement(reason)))
+    }
+
+    pub(super) fn lifecycle_outcome(
+        &self,
+        operation: StoreOperation,
+    ) -> Result<ManagedLifecycleReadOutcome, StoreError> {
+        self.validate_root_binding(operation)?;
+        inspect_managed_lifecycle_read_only(&self.root)
+            .map_err(|error| managed_lifecycle_read_error(operation, &self.configured_root, error))
+    }
+
+    pub(super) fn bootstrap_managed_lifecycle(&self, operation: StoreOperation) -> Result<(), StoreError> {
+        self.validate_root_binding(operation)?;
+        // SAFETY: this lease retains the exact no-follow Store-root and lock handles, owns the
+        // exclusive lock, and revalidated both configured-path bindings immediately above. Store
+        // construction has not published or started any legacy component.
+        unsafe { bootstrap_managed_lifecycle_under_exclusive_lock(&self.root) }.map_err(|error| {
+            let kind = match error.kind() {
+                rocketmq_store_local::mapped_file::ManagedLifecycleBootstrapErrorKind::UnsupportedPlatform => {
+                    StoreErrorKind::Unsupported
+                }
+                rocketmq_store_local::mapped_file::ManagedLifecycleBootstrapErrorKind::Io
+                | rocketmq_store_local::mapped_file::ManagedLifecycleBootstrapErrorKind::Inventory => {
+                    StoreErrorKind::Storage
+                }
+                rocketmq_store_local::mapped_file::ManagedLifecycleBootstrapErrorKind::InvalidIdentity
+                | rocketmq_store_local::mapped_file::ManagedLifecycleBootstrapErrorKind::InvalidArtifact => {
+                    StoreErrorKind::Corruption
+                }
+                rocketmq_store_local::mapped_file::ManagedLifecycleBootstrapErrorKind::RecoveryRequired => {
+                    StoreErrorKind::Unavailable
+                }
+            };
+            StoreError::new(kind, operation)
+                .in_component(StoreComponent::MappedFile)
+                .with_detail("explicit Wave-B bootstrap failed before Store component construction")
+                .with_source(error)
+        })?;
+        self.validate_root_binding(operation)
     }
 
     pub(super) fn acquire_unclassified(configured_root: &Path, operation: StoreOperation) -> Result<Self, StoreError> {

--- a/rocketmq-store/src/queue/batch_consume_queue.rs
+++ b/rocketmq-store/src/queue/batch_consume_queue.rs
@@ -39,9 +39,12 @@ use rocketmq_store_local::consume_queue::root::ConsumeQueueDispatchMetadata;
 use rocketmq_store_local::consume_queue::root::ConsumeQueueDispatchMode;
 use rocketmq_store_local::consume_queue::root::ConsumeQueueDispatchOutcome;
 use rocketmq_store_local::consume_queue::single::ConsumeQueueTimeBoundary;
+use rocketmq_store_local::mapped_file::ManagedLifecycleRuntime;
+use rocketmq_store_local::mapped_file::ManagedMappedFileQueueGeneration;
 use tracing::info;
 use tracing::warn;
 
+use crate::base::allocate_mapped_file_service::AllocateMappedFileService;
 use crate::base::dispatch_request::DispatchRequest;
 use crate::base::swappable::Swappable;
 use crate::config::message_store_config::MessageStoreConfig;
@@ -72,6 +75,15 @@ pub struct BatchConsumeQueue {
 }
 
 impl BatchConsumeQueue {
+    pub(crate) fn install_reconciled_generation(
+        &self,
+        generation: ManagedMappedFileQueueGeneration<DefaultMappedFile>,
+        runtime: ManagedLifecycleRuntime,
+    ) -> bool {
+        self.mapped_file_queue.install_reconciled_generation(generation)
+            && self.mapped_file_queue.bind_managed_runtime(runtime)
+    }
+
     #[inline]
     pub fn new(
         topic: CheetahString,
@@ -81,19 +93,67 @@ impl BatchConsumeQueue {
         subfolder: Option<CheetahString>,
         message_store_config: Arc<MessageStoreConfig>,
     ) -> Self {
+        Self::new_inner(
+            topic,
+            queue_id,
+            store_path,
+            mapped_file_size,
+            subfolder,
+            message_store_config,
+            None,
+        )
+    }
+
+    pub(crate) fn new_managed(
+        topic: CheetahString,
+        queue_id: i32,
+        store_path: CheetahString,
+        mapped_file_size: usize,
+        subfolder: Option<CheetahString>,
+        message_store_config: Arc<MessageStoreConfig>,
+        allocate_mapped_file_service: AllocateMappedFileService,
+        runtime: ManagedLifecycleRuntime,
+    ) -> Self {
+        Self::new_inner(
+            topic,
+            queue_id,
+            store_path,
+            mapped_file_size,
+            subfolder,
+            message_store_config,
+            Some((allocate_mapped_file_service, runtime)),
+        )
+    }
+
+    fn new_inner(
+        topic: CheetahString,
+        queue_id: i32,
+        store_path: CheetahString,
+        mapped_file_size: usize,
+        subfolder: Option<CheetahString>,
+        message_store_config: Arc<MessageStoreConfig>,
+        managed: Option<(AllocateMappedFileService, ManagedLifecycleRuntime)>,
+    ) -> Self {
         let commit_log_size = message_store_config.mapped_file_size_commit_log;
 
-        let mapped_file_queue = if let Some(subfolder) = subfolder {
-            let queue_dir = PathBuf::from(store_path.as_str())
+        let queue_dir = if let Some(subfolder) = subfolder {
+            PathBuf::from(store_path.as_str())
                 .join(topic.as_str())
                 .join(queue_id.to_string())
-                .join(subfolder.as_str());
-            MappedFileQueue::new(queue_dir.to_string_lossy().to_string(), mapped_file_size as u64, None)
+                .join(subfolder.as_str())
         } else {
-            let queue_dir = PathBuf::from(store_path.as_str())
+            PathBuf::from(store_path.as_str())
                 .join(topic.as_str())
-                .join(queue_id.to_string());
-            MappedFileQueue::new(queue_dir.to_string_lossy().to_string(), mapped_file_size as u64, None)
+                .join(queue_id.to_string())
+        };
+        let mapped_file_queue = match managed {
+            Some((allocator, runtime)) => MappedFileQueue::new_managed(
+                queue_dir.to_string_lossy().to_string(),
+                mapped_file_size as u64,
+                allocator,
+                runtime,
+            ),
+            None => MappedFileQueue::new(queue_dir.to_string_lossy().to_string(), mapped_file_size as u64, None),
         };
 
         BatchConsumeQueue {

--- a/rocketmq-store/src/queue/consume_queue_ext.rs
+++ b/rocketmq-store/src/queue/consume_queue_ext.rs
@@ -25,10 +25,13 @@ use rocketmq_store_local::consume_queue::extension::plan_cq_ext_append;
 use rocketmq_store_local::consume_queue::extension::scan_cq_ext_recovery;
 use rocketmq_store_local::consume_queue::extension::undecorate_cq_ext_address;
 use rocketmq_store_local::consume_queue::extension::CqExtAppendPlan;
+use rocketmq_store_local::mapped_file::ManagedLifecycleRuntime;
+use rocketmq_store_local::mapped_file::ManagedMappedFileQueueGeneration;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
 
+use crate::base::allocate_mapped_file_service::AllocateMappedFileService;
 use crate::consume_queue::cq_ext_unit::CqExtUnit;
 use crate::consume_queue::cq_ext_unit::MAX_EXT_UNIT_SIZE;
 use crate::consume_queue::mapped_file_queue::MappedFileQueue;
@@ -45,6 +48,15 @@ pub struct ConsumeQueueExt {
 }
 
 impl ConsumeQueueExt {
+    pub(crate) fn install_reconciled_generation(
+        &self,
+        generation: ManagedMappedFileQueueGeneration<DefaultMappedFile>,
+        runtime: ManagedLifecycleRuntime,
+    ) -> bool {
+        let queue = self.mapped_file_queue.lock();
+        queue.install_reconciled_generation(generation) && queue.bind_managed_runtime(runtime)
+    }
+
     pub fn new(
         topic: CheetahString,
         queue_id: i32,
@@ -59,6 +71,34 @@ impl ConsumeQueueExt {
             queue_dir.to_string_lossy().to_string(),
             mapped_file_size as u64,
             None,
+        )));
+        let _ = bit_map_length;
+        Self {
+            mapped_file_queue,
+            topic,
+            queue_id,
+            store_path,
+            mapped_file_size,
+        }
+    }
+
+    pub(crate) fn new_managed(
+        topic: CheetahString,
+        queue_id: i32,
+        store_path: CheetahString,
+        mapped_file_size: i32,
+        bit_map_length: i32,
+        allocate_mapped_file_service: AllocateMappedFileService,
+        runtime: ManagedLifecycleRuntime,
+    ) -> Self {
+        let queue_dir = PathBuf::from(store_path.as_str())
+            .join(topic.as_str())
+            .join(queue_id.to_string());
+        let mapped_file_queue = Arc::new(Mutex::new(MappedFileQueue::new_managed(
+            queue_dir.to_string_lossy().to_string(),
+            mapped_file_size as u64,
+            allocate_mapped_file_service,
+            runtime,
         )));
         let _ = bit_map_length;
         Self {

--- a/rocketmq-store/src/queue/local_file_consume_queue_store.rs
+++ b/rocketmq-store/src/queue/local_file_consume_queue_store.rs
@@ -40,14 +40,18 @@ use rocketmq_model::utils::queue_type_utils::QueueTypeUtils;
 use rocketmq_store_local::consume_queue::root::clamp_consume_queue_offset;
 use rocketmq_store_local::consume_queue::root::find_or_create_consume_queue as drive_find_or_create_consume_queue;
 use rocketmq_store_local::consume_queue::root::ConsumeQueueStoreRoot;
+use rocketmq_store_local::mapped_file::ManagedLifecycleRuntime;
+use rocketmq_store_local::mapped_file::ManagedMappedFileQueueGeneration;
 use tokio::sync::Semaphore;
 use tracing::error;
 use tracing::info;
 
+use crate::base::allocate_mapped_file_service::AllocateMappedFileService;
 use crate::base::dispatch_request::DispatchRequest;
 use crate::base::store_checkpoint::StoreCheckpoint;
 use crate::config::message_store_config::MessageStoreConfig;
 use crate::log_file::commit_log::CommitLogReadHandle;
+use crate::log_file::mapped_file::default_mapped_file_impl::DefaultMappedFile;
 use crate::queue::batch_consume_queue::BatchConsumeQueue;
 use crate::queue::consume_queue::ConsumeQueueTrait;
 use crate::queue::consume_queue_store::ConsumeQueueStoreTrait;
@@ -159,6 +163,7 @@ struct Inner {
     pub(crate) broker_config: Arc<StoreRuntimeConfig>,
     pub(crate) queue_offset_operator: QueueOffsetOperator,
     pub(crate) consume_queue_table: Arc<ConsumeQueueTable>,
+    managed_lifecycle_runtime: RwLock<Option<ManagedLifecycleRuntime>>,
     /// Serializes queue admission with destructive work for the same topic.
     topic_lifecycle_locks: parking_lot::Mutex<HashMap<CheetahString, Arc<RwLock<()>>>>,
 }
@@ -170,6 +175,7 @@ pub(crate) struct ConsumeQueueStoreContext {
     commit_log: CommitLogReadHandle,
     running_flags: Arc<RunningFlags>,
     store_checkpoint: Arc<StoreCheckpoint>,
+    allocate_mapped_file_service: AllocateMappedFileService,
 }
 
 impl ConsumeQueueStoreContext {
@@ -179,6 +185,7 @@ impl ConsumeQueueStoreContext {
         commit_log: CommitLogReadHandle,
         running_flags: Arc<RunningFlags>,
         store_checkpoint: Arc<StoreCheckpoint>,
+        allocate_mapped_file_service: AllocateMappedFileService,
     ) -> Self {
         Self {
             message_store_config,
@@ -186,6 +193,7 @@ impl ConsumeQueueStoreContext {
             commit_log,
             running_flags,
             store_checkpoint,
+            allocate_mapped_file_service,
         }
     }
 
@@ -207,6 +215,10 @@ impl ConsumeQueueStoreContext {
 
     pub(crate) fn store_checkpoint(&self) -> &StoreCheckpoint {
         self.store_checkpoint.as_ref()
+    }
+
+    pub(crate) fn allocate_mapped_file_service(&self) -> AllocateMappedFileService {
+        self.allocate_mapped_file_service.clone()
     }
 }
 
@@ -245,6 +257,89 @@ impl Inner {
 }
 
 impl ConsumeQueueStore {
+    pub(crate) fn bind_managed_lifecycle_runtime(&self, runtime: ManagedLifecycleRuntime) -> bool {
+        let mut installed = self.inner.managed_lifecycle_runtime.write();
+        if installed.is_some() {
+            return false;
+        }
+        *installed = Some(runtime);
+        true
+    }
+
+    pub(crate) fn accepts_reconciled_queue_type(&self, topic: &str, cq_type: CQType) -> bool {
+        self.queue_type_should_be(&CheetahString::from_string(topic.to_owned()), cq_type)
+    }
+
+    pub(crate) fn install_reconciled_simple_queue(
+        &self,
+        topic: &str,
+        queue_id: i32,
+        queue: ManagedMappedFileQueueGeneration<DefaultMappedFile>,
+        extension: Option<ManagedMappedFileQueueGeneration<DefaultMappedFile>>,
+        runtime: ManagedLifecycleRuntime,
+    ) -> bool {
+        let topic = CheetahString::from_string(topic.to_owned());
+        if !self.queue_type_should_be(&topic, CQType::SimpleCQ)
+            || self
+                .inner
+                .consume_queue_table
+                .lock()
+                .get(&topic)
+                .is_some_and(|queues| queues.contains_key(&queue_id))
+        {
+            return false;
+        }
+        let Some(context) = self.inner.context.read().clone() else {
+            return false;
+        };
+        let consume_queue = ConsumeQueue::new(
+            topic.clone(),
+            queue_id,
+            get_store_path_consume_queue(self.inner.message_store_config.store_path_root_dir.as_str()).into(),
+            self.inner.message_store_config.get_mapped_file_size_consume_queue(),
+            context,
+            self.lookup_handle(),
+        );
+        if !consume_queue.install_reconciled_generations(queue, extension, runtime) {
+            return false;
+        }
+        self.put_consume_queue(topic, queue_id, ArcConsumeQueue::new(Box::new(consume_queue)));
+        true
+    }
+
+    pub(crate) fn install_reconciled_batch_queue(
+        &self,
+        topic: &str,
+        queue_id: i32,
+        generation: ManagedMappedFileQueueGeneration<DefaultMappedFile>,
+        runtime: ManagedLifecycleRuntime,
+    ) -> bool {
+        let topic = CheetahString::from_string(topic.to_owned());
+        if !self.queue_type_should_be(&topic, CQType::BatchCQ)
+            || self
+                .inner
+                .consume_queue_table
+                .lock()
+                .get(&topic)
+                .is_some_and(|queues| queues.contains_key(&queue_id))
+        {
+            return false;
+        }
+        let consume_queue = BatchConsumeQueue::new(
+            topic.clone(),
+            queue_id,
+            get_store_path_batch_consume_queue(self.inner.message_store_config.store_path_root_dir.as_str()).into(),
+            self.inner.message_store_config.mapper_file_size_batch_consume_queue,
+            None,
+            Arc::clone(&self.inner.message_store_config),
+        );
+        if !consume_queue.install_reconciled_generation(generation, runtime) {
+            return false;
+        }
+        self.put_consume_queue(topic, queue_id, ArcConsumeQueue::new(Box::new(consume_queue)));
+        true
+    }
+
     fn topic_lifecycle_lock(&self, topic: &CheetahString) -> Arc<RwLock<()>> {
         self.inner
             .topic_lifecycle_locks
@@ -255,6 +350,7 @@ impl ConsumeQueueStore {
     }
 
     fn find_or_create_consume_queue_unfenced(&self, topic: &CheetahString, queue_id: i32) -> ArcConsumeQueue {
+        let managed_runtime = self.inner.managed_lifecycle_runtime.read().clone();
         drive_find_or_create_consume_queue(
             || {
                 self.inner
@@ -274,29 +370,54 @@ impl ConsumeQueueStore {
                 let cq_type = QueueTypeUtils::get_cq_type_arc_mut(topic_config.as_ref());
                 match cq_type {
                     CQType::SimpleCQ | CQType::RocksDBCQ => {
-                        let consume_queue = ConsumeQueue::new(
-                            topic.clone(),
-                            queue_id,
-                            CheetahString::from_string(get_store_path_consume_queue(
-                                self.inner.message_store_config.store_path_root_dir.as_str(),
-                            )),
-                            self.inner.message_store_config.get_mapped_file_size_consume_queue(),
-                            context,
-                            self.lookup_handle(),
-                        );
+                        let store_path = CheetahString::from_string(get_store_path_consume_queue(
+                            self.inner.message_store_config.store_path_root_dir.as_str(),
+                        ));
+                        let consume_queue = match managed_runtime.as_ref() {
+                            Some(runtime) => ConsumeQueue::new_managed(
+                                topic.clone(),
+                                queue_id,
+                                store_path,
+                                self.inner.message_store_config.get_mapped_file_size_consume_queue(),
+                                context,
+                                self.lookup_handle(),
+                                runtime.clone(),
+                            ),
+                            None => ConsumeQueue::new(
+                                topic.clone(),
+                                queue_id,
+                                store_path,
+                                self.inner.message_store_config.get_mapped_file_size_consume_queue(),
+                                context,
+                                self.lookup_handle(),
+                            ),
+                        };
                         ArcConsumeQueue::new(Box::new(consume_queue))
                     }
                     CQType::BatchCQ => {
-                        let consume_queue = BatchConsumeQueue::new(
-                            topic.clone(),
-                            queue_id,
-                            CheetahString::from_string(get_store_path_batch_consume_queue(
-                                self.inner.message_store_config.store_path_root_dir.as_str(),
-                            )),
-                            self.inner.message_store_config.mapper_file_size_batch_consume_queue,
-                            None,
-                            self.inner.message_store_config.clone(),
-                        );
+                        let store_path = CheetahString::from_string(get_store_path_batch_consume_queue(
+                            self.inner.message_store_config.store_path_root_dir.as_str(),
+                        ));
+                        let consume_queue = match managed_runtime.as_ref() {
+                            Some(runtime) => BatchConsumeQueue::new_managed(
+                                topic.clone(),
+                                queue_id,
+                                store_path,
+                                self.inner.message_store_config.mapper_file_size_batch_consume_queue,
+                                None,
+                                self.inner.message_store_config.clone(),
+                                context.allocate_mapped_file_service(),
+                                runtime.clone(),
+                            ),
+                            None => BatchConsumeQueue::new(
+                                topic.clone(),
+                                queue_id,
+                                store_path,
+                                self.inner.message_store_config.mapper_file_size_batch_consume_queue,
+                                None,
+                                self.inner.message_store_config.clone(),
+                            ),
+                        };
                         ArcConsumeQueue::new(Box::new(consume_queue))
                     }
                 }
@@ -783,6 +904,7 @@ impl ConsumeQueueStore {
                 broker_config,
                 queue_offset_operator: Default::default(),
                 consume_queue_table: Arc::new(Default::default()),
+                managed_lifecycle_runtime: RwLock::new(None),
                 topic_lifecycle_locks: parking_lot::Mutex::new(HashMap::new()),
             })),
         }

--- a/rocketmq-store/src/queue/single_consume_queue.rs
+++ b/rocketmq-store/src/queue/single_consume_queue.rs
@@ -39,6 +39,8 @@ use rocketmq_store_local::consume_queue::single::scan_recovery_records;
 use rocketmq_store_local::consume_queue::single::search_queue_offset_by_time;
 use rocketmq_store_local::consume_queue::single::ConsumeQueueTimeBoundary;
 use rocketmq_store_local::consume_queue::single::ConsumeQueueTruncatePlan;
+use rocketmq_store_local::mapped_file::ManagedLifecycleRuntime;
+use rocketmq_store_local::mapped_file::ManagedMappedFileQueueGeneration;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
@@ -87,6 +89,26 @@ pub struct ConsumeQueue {
 }
 
 impl ConsumeQueue {
+    pub(crate) fn install_reconciled_generations(
+        &self,
+        queue: ManagedMappedFileQueueGeneration<DefaultMappedFile>,
+        extension: Option<ManagedMappedFileQueueGeneration<DefaultMappedFile>>,
+        runtime: ManagedLifecycleRuntime,
+    ) -> bool {
+        if !self.mapped_file_queue.install_reconciled_generation(queue)
+            || !self.mapped_file_queue.bind_managed_runtime(runtime.clone())
+        {
+            return false;
+        }
+        match (self.consume_queue_ext.as_ref(), extension) {
+            (Some(extension_queue), Some(generation)) => {
+                extension_queue.install_reconciled_generation(generation, runtime)
+            }
+            (None, None) => true,
+            _ => false,
+        }
+    }
+
     #[inline]
     pub(crate) fn new(
         topic: CheetahString,
@@ -96,22 +118,81 @@ impl ConsumeQueue {
         context: ConsumeQueueStoreContext,
         queue_lookup: ConsumeQueueLookupHandle,
     ) -> Self {
+        Self::new_inner(
+            topic,
+            queue_id,
+            store_path,
+            mapped_file_size,
+            context,
+            queue_lookup,
+            None,
+        )
+    }
+
+    pub(crate) fn new_managed(
+        topic: CheetahString,
+        queue_id: i32,
+        store_path: CheetahString,
+        mapped_file_size: i32,
+        context: ConsumeQueueStoreContext,
+        queue_lookup: ConsumeQueueLookupHandle,
+        runtime: ManagedLifecycleRuntime,
+    ) -> Self {
+        Self::new_inner(
+            topic,
+            queue_id,
+            store_path,
+            mapped_file_size,
+            context,
+            queue_lookup,
+            Some(runtime),
+        )
+    }
+
+    fn new_inner(
+        topic: CheetahString,
+        queue_id: i32,
+        store_path: CheetahString,
+        mapped_file_size: i32,
+        context: ConsumeQueueStoreContext,
+        queue_lookup: ConsumeQueueLookupHandle,
+        managed_runtime: Option<ManagedLifecycleRuntime>,
+    ) -> Self {
         let message_store_config = context.message_store_config();
         let queue_dir = PathBuf::from(store_path.as_str())
             .join(topic.as_str())
             .join(queue_id.to_string());
-        let mapped_file_queue =
-            MappedFileQueue::new(queue_dir.to_string_lossy().to_string(), mapped_file_size as u64, None);
+        let mapped_file_queue = match managed_runtime.as_ref() {
+            Some(runtime) => MappedFileQueue::new_managed(
+                queue_dir.to_string_lossy().to_string(),
+                mapped_file_size as u64,
+                context.allocate_mapped_file_service(),
+                runtime.clone(),
+            ),
+            None => MappedFileQueue::new(queue_dir.to_string_lossy().to_string(), mapped_file_size as u64, None),
+        };
         let consume_queue_ext = if message_store_config.enable_consume_queue_ext {
-            Some(ConsumeQueueExt::new(
-                topic.clone(),
-                queue_id,
-                CheetahString::from_string(get_store_path_consume_queue_ext(
-                    message_store_config.store_path_root_dir.as_str(),
-                )),
-                message_store_config.mapped_file_size_consume_queue_ext as i32,
-                message_store_config.bit_map_length_consume_queue_ext as i32,
-            ))
+            let extension_path = CheetahString::from_string(get_store_path_consume_queue_ext(
+                message_store_config.store_path_root_dir.as_str(),
+            ));
+            Some(match managed_runtime.as_ref() {
+                Some(runtime) => ConsumeQueueExt::new_managed(
+                    topic.clone(),
+                    queue_id,
+                    extension_path,
+                    message_store_config.mapped_file_size_consume_queue_ext as i32,
+                    message_store_config.bit_map_length_consume_queue_ext as i32,
+                    context.allocate_mapped_file_service(),
+                    runtime.clone(),
+                ),
+                None => ConsumeQueueExt::new(
+                    topic.clone(),
+                    queue_id,
+                    extension_path,
+                    message_store_config.mapped_file_size_consume_queue_ext as i32,
+                    message_store_config.bit_map_length_consume_queue_ext as i32,
+                ),
+            })
         } else {
             None
         };

--- a/rocketmq-store/tests/message_store/local_file_message_store/unit.rs
+++ b/rocketmq-store/tests/message_store/local_file_message_store/unit.rs
@@ -272,6 +272,216 @@ fn new_controller_test_store(
     )
 }
 
+#[cfg(any(target_os = "linux", windows))]
+#[tokio::test]
+async fn wave_b_managed_store_bootstraps_starts_and_creates_first_queue_segments() {
+    let temp_dir = tempdir().expect("temporary managed Store root");
+    let mut store = new_configured_test_store(
+        &temp_dir,
+        MessageStoreConfig {
+            enable_mapped_file_lifecycle_wave_b: true,
+            message_index_enable: false,
+            timer_wheel_enable: false,
+            enable_consume_queue_ext: false,
+            duplication_enable: true,
+            flush_disk_type: FlushDiskType::AsyncFlush,
+            mapped_file_size_commit_log: 16 * 1024,
+            mapped_file_size_consume_queue: 20 * 100,
+            ..MessageStoreConfig::default()
+        },
+    );
+    let topic = CheetahString::from_static_str("wave-b-first-managed-queue");
+
+    store.init().await.expect("initialize managed Store");
+    assert!(store.load().await, "reconcile and activate managed Store");
+    store.start().await.expect("start fully activated managed Store");
+
+    let result = store
+        .put_message(build_test_message(&topic, Bytes::from_static(b"managed-wave-b")))
+        .await;
+    assert_eq!(result.put_message_status(), PutMessageStatus::PutOk);
+
+    let mut queue_offset = 0;
+    for _ in 0..100 {
+        queue_offset = store.get_max_offset_in_queue(&topic, 0);
+        if queue_offset == 1 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    store.shutdown().await;
+
+    assert_eq!(queue_offset, 1);
+    assert!(temp_dir.path().join("commitlog/00000000000000000000").is_file());
+    assert!(temp_dir
+        .path()
+        .join("consumequeue/wave-b-first-managed-queue/0/00000000000000000000")
+        .is_file());
+}
+
+#[cfg(any(target_os = "linux", windows))]
+#[tokio::test]
+async fn wave_b_managed_truncation_durably_retires_the_tail_segment() {
+    let temp_dir = tempdir().expect("temporary managed Store root");
+    let mut store = new_configured_test_store(
+        &temp_dir,
+        MessageStoreConfig {
+            enable_mapped_file_lifecycle_wave_b: true,
+            message_index_enable: false,
+            timer_wheel_enable: false,
+            enable_consume_queue_ext: false,
+            duplication_enable: true,
+            flush_disk_type: FlushDiskType::AsyncFlush,
+            mapped_file_size_commit_log: 512,
+            mapped_file_size_consume_queue: 20 * 100,
+            ..MessageStoreConfig::default()
+        },
+    );
+    let topic = CheetahString::from_static_str("wave-b-managed-truncation");
+
+    store.init().await.expect("initialize managed Store");
+    assert!(store.load().await, "reconcile and activate managed Store");
+    store.start().await.expect("start fully activated managed Store");
+
+    let first = store
+        .put_message(build_test_message(&topic, Bytes::from(vec![1_u8; 245])))
+        .await;
+    assert_eq!(first.put_message_status(), PutMessageStatus::PutOk);
+    let first_append = first.append_message_result().expect("first append result");
+    let truncate_offset = first_append.wrote_offset + i64::from(first_append.wrote_bytes);
+    let second = store
+        .put_message(build_test_message(&topic, Bytes::from(vec![2_u8; 75])))
+        .await;
+    assert_eq!(second.put_message_status(), PutMessageStatus::PutOk);
+    assert_eq!(
+        second
+            .append_message_result()
+            .expect("second append result")
+            .wrote_offset,
+        512
+    );
+    assert!(
+        store.get_max_phy_offset() > truncate_offset,
+        "the second managed segment must be published before truncation"
+    );
+    let retired_tail = temp_dir.path().join("commitlog/00000000000000000512");
+    assert!(retired_tail.is_file());
+
+    assert!(store.truncate_files(truncate_offset).expect("truncate outcome"));
+    assert_eq!(store.get_max_phy_offset(), truncate_offset);
+
+    store.shutdown().await;
+
+    assert!(
+        !retired_tail.exists(),
+        "shutdown drain must complete the durable tail retirement"
+    );
+}
+
+#[cfg(any(target_os = "linux", windows))]
+#[tokio::test]
+async fn wave_b_managed_reset_durably_retires_the_tail_segment() {
+    let temp_dir = tempdir().expect("temporary managed Store root");
+    let mut store = new_configured_test_store(
+        &temp_dir,
+        MessageStoreConfig {
+            enable_mapped_file_lifecycle_wave_b: true,
+            message_index_enable: false,
+            timer_wheel_enable: false,
+            enable_consume_queue_ext: false,
+            duplication_enable: true,
+            flush_disk_type: FlushDiskType::AsyncFlush,
+            mapped_file_size_commit_log: 512,
+            mapped_file_size_consume_queue: 20 * 100,
+            ..MessageStoreConfig::default()
+        },
+    );
+    let topic = CheetahString::from_static_str("wave-b-managed-reset");
+
+    store.init().await.expect("initialize managed Store");
+    assert!(store.load().await, "reconcile and activate managed Store");
+    store.start().await.expect("start fully activated managed Store");
+
+    let first = store
+        .put_message(build_test_message(&topic, Bytes::from(vec![1_u8; 245])))
+        .await;
+    let first_append = first.append_message_result().expect("first append result");
+    let reset_offset = first_append.wrote_offset + i64::from(first_append.wrote_bytes);
+    let second = store
+        .put_message(build_test_message(&topic, Bytes::from(vec![2_u8; 75])))
+        .await;
+    assert_eq!(
+        second
+            .append_message_result()
+            .expect("second append result")
+            .wrote_offset,
+        512
+    );
+    let retired_tail = temp_dir.path().join("commitlog/00000000000000000512");
+
+    assert!(store.reset_write_offset(reset_offset));
+    assert_eq!(store.get_max_phy_offset(), reset_offset);
+
+    store.shutdown().await;
+
+    assert!(
+        !retired_tail.exists(),
+        "shutdown drain must complete the reset retirement"
+    );
+}
+
+#[cfg(any(target_os = "linux", windows))]
+#[tokio::test]
+async fn wave_b_managed_delete_last_durably_retires_the_exact_tail_segment() {
+    let temp_dir = tempdir().expect("temporary managed Store root");
+    let mut store = new_configured_test_store(
+        &temp_dir,
+        MessageStoreConfig {
+            enable_mapped_file_lifecycle_wave_b: true,
+            message_index_enable: false,
+            timer_wheel_enable: false,
+            enable_consume_queue_ext: false,
+            duplication_enable: true,
+            flush_disk_type: FlushDiskType::AsyncFlush,
+            mapped_file_size_commit_log: 512,
+            mapped_file_size_consume_queue: 20 * 100,
+            ..MessageStoreConfig::default()
+        },
+    );
+    let topic = CheetahString::from_static_str("wave-b-managed-delete-last");
+
+    store.init().await.expect("initialize managed Store");
+    assert!(store.load().await, "reconcile and activate managed Store");
+    store.start().await.expect("start fully activated managed Store");
+
+    let first = store
+        .put_message(build_test_message(&topic, Bytes::from(vec![1_u8; 245])))
+        .await;
+    let _first_append = first.append_message_result().expect("first append result");
+    let second = store
+        .put_message(build_test_message(&topic, Bytes::from(vec![2_u8; 75])))
+        .await;
+    assert_eq!(
+        second
+            .append_message_result()
+            .expect("second append result")
+            .wrote_offset,
+        512
+    );
+    let retired_tail = temp_dir.path().join("commitlog/00000000000000000512");
+
+    assert!(store.commit_log.try_delete_last_mapped_file_for_testing());
+    assert_eq!(store.get_max_phy_offset(), 512);
+
+    store.shutdown().await;
+
+    assert!(
+        !retired_tail.exists(),
+        "shutdown drain must complete the delete-last retirement"
+    );
+}
+
 #[tokio::test]
 async fn destroy_store_is_write_disabled_and_retries_without_namespace_mutation() {
     let temp_dir = tempdir().unwrap();


### PR DESCRIPTION
## Summary

- activate the crash-durable mapped-file lifecycle behind an explicit, default-off Store configuration
- bootstrap and reconcile lifecycle state under the retained exclusive Store-root lease before numeric segment publication
- route allocation, TTL, truncate, reset, delete-last, and derived-file retirement through durable incarnation, registry, queue-CAS, namespace, and reaper capabilities
- qualify native NTFS and Linux handle-relative/no-follow namespace operations without recursive or raw path deletion
- keep the activation gate simple: explicit opt-in, exclusive root lease, complete replay/reconciliation, and platform qualification; no signature, token, or force-bypass scheme

## Safety properties

- a queue cannot forget an active identity before durable intent or exact verified-absence authority exists
- stale tickets cannot delete a same-path replacement with a different physical key or length
- startup fails closed on corrupt, unsupported, ambiguous, hard-linked, symlinked, or changing lifecycle inventory
- Store-owned retirement work is bounded, cancellable, drainable, and replayable after restart
- managed whole-Store destroy remains fail-closed for the M4 consumer-convergence milestone

## Validation

- `cargo test -p rocketmq-store-local --all-features -- --test-threads=1` (618 lib tests plus integration/doc targets)
- `cargo test -p rocketmq-store --lib --all-features -- --test-threads=1` (684/684)
- focused deletion recovery, incarnation reuse, capability compile-fail, Windows namespace, retirement service, and Wave-B Store tests
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo doc -p rocketmq-store-local --no-deps --all-features`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`
- Windows and WSL Ubuntu 24.04 native lifecycle tests; WSL retirement 311/311 and Store Wave-B scenarios passed in a fresh isolated target
- `./scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `./scripts/check-agents-routing.ps1`
- 40 changed Rust files passed individual `rustfmt --check`; package-level Store/Store-local format check passed. Root `cargo fmt --all -- --check` remains blocked by Windows OS error 206.
- error architecture guard has no findings in this PR's changed source; its remaining 18 findings are unchanged default-branch Timer index source-stringification debt

Closes #9143

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in managed mapped-file lifecycle support for local stores.
  * Added automatic startup bootstrap, queue recovery, durable segment allocation, and retirement handling.
  * Added support for managed CommitLog, consume queue, extension, and batch queue segments.
  * Added platform-specific lifecycle initialization for Linux and Windows.

* **Bug Fixes**
  * Improved cleanup and truncation safety by removing files only after successful validation and retirement.
  * Added stronger protection against invalid, inconsistent, or unsafe store layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->