### PR TITLE
[ISSUE #9174]🐛Restore mapped-file retirement fixture modules for CI

### DIFF
--- a/rocketmq-store-local/src/mapped_file/retirement/fixture_corpus/build.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/fixture_corpus/build.rs
@@ -34,8 +34,11 @@ use crate::mapped_file::retirement::sidecar::RetirementStage;
 use crate::mapped_file::retirement::sidecar::SnapshotEntry;
 use crate::mapped_file::retirement::sidecar::SnapshotMode;
 
+#[path = "test_cases/edges.rs"]
 mod edges;
+#[path = "test_cases/frontiers.rs"]
 mod frontiers;
+#[path = "test_cases/samples.rs"]
 mod samples;
 
 use edges::add_edge_cases;

--- a/rocketmq-store-local/src/mapped_file/retirement/fixture_corpus/test_cases/edges.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/fixture_corpus/test_cases/edges.rs
@@ -1,0 +1,322 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::samples::*;
+use super::Fixture;
+use super::FixtureValidation;
+use crate::mapped_file::retirement::codec::crc32;
+use crate::mapped_file::retirement::codec::encode_acknowledgement_slot;
+use crate::mapped_file::retirement::codec::encode_commit_seal;
+use crate::mapped_file::retirement::codec::encode_ledger_frame;
+use crate::mapped_file::retirement::codec::AcknowledgementSlot;
+use crate::mapped_file::retirement::codec::CommitSeal;
+use crate::mapped_file::retirement::codec::LedgerRecord;
+use crate::mapped_file::retirement::codec::MAX_PAYLOAD_LENGTH;
+use crate::mapped_file::retirement::sidecar::encode_enabled_marker_file;
+use crate::mapped_file::retirement::sidecar::encode_snapshot;
+use crate::mapped_file::retirement::sidecar::EnabledMarkerFile;
+use crate::mapped_file::retirement::sidecar::SnapshotMode;
+use crate::mapped_file::retirement::sidecar::MAX_SNAPSHOT_BODY_LENGTH;
+use crate::mapped_file::retirement::sidecar::MAX_SNAPSHOT_ENTRY_COUNT;
+
+pub(super) fn add_edge_cases(fixtures: &mut Vec<Fixture>) {
+    let frame = completed_frame(100, 3);
+    let slot0 = acknowledgement_slot(0, 77, 100, 3, &frame);
+    let encoded_slot0 = encode_acknowledgement_slot(&slot0).expect("slot zero encodes");
+    let seal = CommitSeal::from_acknowledgement_slot(&slot0, &encoded_slot0).expect("seal derives from slot zero");
+    let encoded_seal = encode_commit_seal(&seal).expect("commit seal encodes");
+
+    add_acknowledgement_edges(fixtures, &frame, &slot0, &encoded_slot0, &encoded_seal);
+    add_stream_edges(fixtures, &frame, &encoded_seal);
+    add_bounded_decode_edges(fixtures, &frame);
+    add_marker_edges(fixtures);
+}
+
+fn add_acknowledgement_edges(
+    fixtures: &mut Vec<Fixture>,
+    frame: &[u8],
+    slot0: &AcknowledgementSlot,
+    encoded_slot0: &[u8; 104],
+    encoded_seal: &[u8; 72],
+) {
+    let initial_slot0 = encode_acknowledgement_slot(&AcknowledgementSlot {
+        acknowledgement_epoch: 1,
+        ..slot0.clone()
+    })
+    .expect("initial slot zero encodes");
+    let initial_slot1 = encode_acknowledgement_slot(&AcknowledgementSlot {
+        slot_index: 1,
+        acknowledgement_epoch: 2,
+        frame_sequence: 101,
+        ..slot0.clone()
+    })
+    .expect("initial slot one encodes");
+    let mut slot1_file = initial_slot0.to_vec();
+    slot1_file.extend_from_slice(&initial_slot1);
+    fixtures.push(Fixture::new(
+        "acknowledgement.slot1.bin",
+        slot1_file,
+        FixtureValidation::AcknowledgementFile,
+    ));
+    fixtures.push(Fixture::new(
+        "acknowledgement.all-zero.bin",
+        vec![0_u8; 208],
+        FixtureValidation::AcknowledgementFileWithoutAuthoritative,
+    ));
+
+    let nonconsecutive_slot1 = AcknowledgementSlot {
+        acknowledgement_epoch: 80,
+        frame_sequence: 103,
+        ..slot0.clone()
+    };
+    let mut nonconsecutive = encoded_slot0.to_vec();
+    nonconsecutive.extend_from_slice(
+        &encode_acknowledgement_slot(&AcknowledgementSlot {
+            slot_index: 1,
+            ..nonconsecutive_slot1
+        })
+        .expect("individually valid nonconsecutive slot encodes"),
+    );
+    fixtures.push(Fixture::new(
+        "invalid.acknowledgement-nonconsecutive.bin",
+        nonconsecutive,
+        FixtureValidation::InvalidAcknowledgementFile,
+    ));
+
+    let mut torn_slot = *encoded_slot0;
+    torn_slot[103] ^= 1;
+    let mut reconstruction = bundle_prefix(frame);
+    reconstruction.extend_from_slice(&torn_slot);
+    reconstruction.extend_from_slice(encoded_slot0);
+    reconstruction.extend_from_slice(encoded_seal);
+    fixtures.push(Fixture::new(
+        "recovery.ack-seal-reconstruction.bundle.bin",
+        reconstruction,
+        FixtureValidation::AcknowledgementReconstructionBundle {
+            sequence: 100,
+            generation: 3,
+        },
+    ));
+
+    let mut mismatched_seal = *encoded_seal;
+    let wrong_slot_crc = u32::from_le_bytes(mismatched_seal[60..64].try_into().expect("slot CRC field")) ^ 1;
+    mismatched_seal[60..64].copy_from_slice(&wrong_slot_crc.to_le_bytes());
+    let seal_crc = crc32(&mismatched_seal[..68]);
+    mismatched_seal[68..72].copy_from_slice(&seal_crc.to_le_bytes());
+    let mut mismatch_bundle = bundle_prefix(frame);
+    mismatch_bundle.extend_from_slice(encoded_slot0);
+    mismatch_bundle.extend_from_slice(&mismatched_seal);
+    fixtures.push(Fixture::new(
+        "invalid.seal-slot-crc-mismatch.bundle.bin",
+        mismatch_bundle,
+        FixtureValidation::InvalidAcknowledgedUnitBinding {
+            sequence: 100,
+            generation: 3,
+        },
+    ));
+}
+
+fn add_stream_edges(fixtures: &mut Vec<Fixture>, frame: &[u8], encoded_seal: &[u8; 72]) {
+    let mut unit = frame.to_vec();
+    unit.extend_from_slice(encoded_seal);
+    let mut truncations = Vec::new();
+    for length in 0..=unit.len() {
+        truncations.extend_from_slice(&(length as u16).to_le_bytes());
+        truncations.extend_from_slice(&unit[..length]);
+    }
+    fixtures.push(Fixture::new(
+        "recovery.acknowledged-unit-all-truncations.bin",
+        truncations,
+        FixtureValidation::TruncatedSealedUnit {
+            sequence: 100,
+            generation: 3,
+            frame_length: frame.len(),
+        },
+    ));
+    fixtures.push(Fixture::new(
+        "recovery.valid-ack-missing-seal.log.bin",
+        frame,
+        FixtureValidation::LedgerFrame {
+            sequence: 100,
+            generation: 3,
+        },
+    ));
+    let mut partial_seal = frame.to_vec();
+    partial_seal.extend_from_slice(&encoded_seal[..36]);
+    fixtures.push(Fixture::new(
+        "recovery.valid-ack-partial-seal.log.bin",
+        partial_seal,
+        FixtureValidation::LedgerFrameThenPartialSeal {
+            sequence: 100,
+            generation: 3,
+        },
+    ));
+
+    let frame101 = completed_frame(101, 3);
+    let frame102 = completed_frame(102, 3);
+    let mut gap = frame.to_vec();
+    gap.extend_from_slice(&frame102);
+    fixtures.push(Fixture::new(
+        "invalid.sequence-gap.log.bin",
+        gap,
+        FixtureValidation::InvalidLedgerFrameStream {
+            first_sequence: 100,
+            generation: 3,
+        },
+    ));
+    let mut duplicate = frame.to_vec();
+    duplicate.extend_from_slice(frame);
+    fixtures.push(Fixture::new(
+        "invalid.sequence-duplicate.log.bin",
+        duplicate,
+        FixtureValidation::InvalidLedgerFrameStream {
+            first_sequence: 100,
+            generation: 3,
+        },
+    ));
+    let mut damaged = frame.to_vec();
+    let mut bad_second = frame101;
+    let final_byte = bad_second.len() - 1;
+    bad_second[final_byte] ^= 1;
+    damaged.extend_from_slice(&bad_second);
+    damaged.extend_from_slice(&frame102);
+    fixtures.push(Fixture::new(
+        "invalid.mid-log-damage.log.bin",
+        damaged,
+        FixtureValidation::InvalidLedgerFrameStream {
+            first_sequence: 100,
+            generation: 3,
+        },
+    ));
+
+    let mut overflow = completed_frame(u64::MAX, 3);
+    overflow.extend_from_slice(frame);
+    fixtures.push(Fixture::new(
+        "invalid.sequence-overflow.log.bin",
+        overflow,
+        FixtureValidation::SequenceOverflowStream { generation: 3 },
+    ));
+}
+
+fn add_bounded_decode_edges(fixtures: &mut Vec<Fixture>, frame: &[u8]) {
+    let mut oversized_header = frame[..16].to_vec();
+    oversized_header[14..16].copy_from_slice(&41_u16.to_le_bytes());
+    fixtures.push(Fixture::new(
+        "invalid.oversized-header.bin",
+        oversized_header,
+        FixtureValidation::InvalidLedgerFrame {
+            sequence: 100,
+            generation: 3,
+        },
+    ));
+    let mut oversized_payload = frame[..20].to_vec();
+    oversized_payload[16..20].copy_from_slice(&((MAX_PAYLOAD_LENGTH + 1) as u32).to_le_bytes());
+    fixtures.push(Fixture::new(
+        "invalid.oversized-payload.bin",
+        oversized_payload,
+        FixtureValidation::InvalidLedgerFrame {
+            sequence: 100,
+            generation: 3,
+        },
+    ));
+
+    let empty_snapshot = encode_snapshot(&snapshot(SnapshotMode::OrdinaryCompaction, Vec::new()))
+        .expect("empty compacted snapshot encodes");
+    let mut oversized_body = empty_snapshot.clone();
+    oversized_body[12..20].copy_from_slice(&(MAX_SNAPSHOT_BODY_LENGTH as u64 + 109).to_le_bytes());
+    oversized_body[88..96].copy_from_slice(&(MAX_SNAPSHOT_BODY_LENGTH as u64 + 1).to_le_bytes());
+    refresh_snapshot_header_crc(&mut oversized_body);
+    fixtures.push(Fixture::new(
+        "invalid.snapshot-oversized-body.bin",
+        oversized_body,
+        FixtureValidation::InvalidSnapshot,
+    ));
+    let mut too_many_entries = empty_snapshot.clone();
+    too_many_entries[84..88].copy_from_slice(&(MAX_SNAPSHOT_ENTRY_COUNT + 1).to_le_bytes());
+    refresh_snapshot_header_crc(&mut too_many_entries);
+    fixtures.push(Fixture::new(
+        "invalid.snapshot-too-many-entries.bin",
+        too_many_entries,
+        FixtureValidation::InvalidSnapshot,
+    ));
+    let mut reserved = empty_snapshot;
+    reserved[96..100].copy_from_slice(&1_u32.to_le_bytes());
+    refresh_snapshot_header_crc(&mut reserved);
+    fixtures.push(Fixture::new(
+        "invalid.snapshot-reserved.bin",
+        reserved,
+        FixtureValidation::InvalidSnapshot,
+    ));
+}
+
+fn add_marker_edges(fixtures: &mut Vec<Fixture>) {
+    let marker = EnabledMarkerFile {
+        slots: [
+            Some(marker_slot(0, 1, 0, 2, 108, 0x1111_1111, 0x2222_2222)),
+            Some(marker_slot(1, 2, 1, 200, 108, 0x3333_3333, 0x4444_4444)),
+        ],
+    };
+    fixtures.push(Fixture::new(
+        "enabled.newer-slot-missing-pair.bin",
+        encode_enabled_marker_file(&marker).expect("newer marker slot encodes"),
+        FixtureValidation::MarkerFile,
+    ));
+}
+
+fn completed_frame(sequence: u64, generation: u64) -> Vec<u8> {
+    encode_ledger_frame(
+        &LedgerRecord::Completed {
+            ticket_id: ticket(),
+            incarnation: incarnation(),
+            completion_time_ns: 66,
+            namespace_absent_sequence: 99,
+        },
+        sequence,
+        generation,
+    )
+    .expect("completed edge frame encodes")
+}
+
+fn acknowledgement_slot(
+    slot_index: u8,
+    acknowledgement_epoch: u64,
+    frame_sequence: u64,
+    log_generation: u64,
+    frame: &[u8],
+) -> AcknowledgementSlot {
+    AcknowledgementSlot {
+        slot_index,
+        activated: true,
+        store_uuid: sample_store_uuid(),
+        bootstrap_id: bootstrap_id(),
+        acknowledgement_epoch,
+        marker_epoch: 5,
+        log_generation,
+        frame_sequence,
+        frame_end_offset: frame.len() as u64,
+        frame_crc32: crc32(frame),
+    }
+}
+
+fn bundle_prefix(frame: &[u8]) -> Vec<u8> {
+    let mut bundle = Vec::with_capacity(4 + frame.len() + 208);
+    bundle.extend_from_slice(&(frame.len() as u32).to_le_bytes());
+    bundle.extend_from_slice(frame);
+    bundle
+}
+
+fn refresh_snapshot_header_crc(snapshot: &mut [u8]) {
+    let checksum = crc32(&snapshot[..100]);
+    snapshot[100..104].copy_from_slice(&checksum.to_le_bytes());
+}

--- a/rocketmq-store-local/src/mapped_file/retirement/fixture_corpus/test_cases/frontiers.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/fixture_corpus/test_cases/frontiers.rs
@@ -1,0 +1,541 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::refresh_payload_crc;
+use super::samples::*;
+use super::Fixture;
+use super::FixtureValidation;
+use crate::mapped_file::retirement::codec::crc32;
+use crate::mapped_file::retirement::codec::encode_acknowledgement_file;
+use crate::mapped_file::retirement::codec::encode_acknowledgement_slot;
+use crate::mapped_file::retirement::codec::encode_commit_seal;
+use crate::mapped_file::retirement::codec::encode_ledger_frame;
+use crate::mapped_file::retirement::codec::AcknowledgementSlot;
+use crate::mapped_file::retirement::codec::AcknowledgementSlotState;
+use crate::mapped_file::retirement::codec::CommitSeal;
+use crate::mapped_file::retirement::codec::LedgerRecord;
+use crate::mapped_file::retirement::codec::OpenReason;
+use crate::mapped_file::retirement::codec::MAX_SEALED_RECORD_UNIT_LENGTH;
+use crate::mapped_file::retirement::sidecar::encode_enabled_marker_file;
+use crate::mapped_file::retirement::sidecar::encode_enabled_marker_slot;
+use crate::mapped_file::retirement::sidecar::encode_snapshot;
+use crate::mapped_file::retirement::sidecar::EnabledMarkerFile;
+use crate::mapped_file::retirement::sidecar::LifecycleSnapshot;
+use crate::mapped_file::retirement::sidecar::SnapshotMode;
+
+pub(super) fn add_frontier_cases(fixtures: &mut Vec<Fixture>) {
+    add_compaction_frontiers(fixtures);
+    add_tail_repair_frontiers(fixtures);
+    add_orphan_generation_pair(fixtures);
+    add_acknowledged_suffix_loss(fixtures);
+    add_overlong_tail_repair(fixtures);
+}
+
+fn add_compaction_frontiers(fixtures: &mut Vec<Fixture>) {
+    const SOURCE_GENERATION: u64 = 2;
+    const TARGET_GENERATION: u64 = 3;
+    const BASE_SEQUENCE: u64 = 20;
+    const PREPARED_ACK_EPOCH: u64 = 9;
+    const TARGET_MARKER_EPOCH: u64 = 4;
+
+    let prepared = LedgerRecord::GenerationPrepared {
+        store_uuid: sample_store_uuid(),
+        source_generation: SOURCE_GENERATION,
+        target_generation: TARGET_GENERATION,
+        target_snapshot_generation: TARGET_GENERATION,
+        open_reason: OpenReason::Compaction,
+    };
+    let prepared_unit = acknowledged_unit(
+        &prepared,
+        BASE_SEQUENCE,
+        SOURCE_GENERATION,
+        PREPARED_ACK_EPOCH,
+        TARGET_MARKER_EPOCH - 1,
+        0,
+    );
+    fixtures.push(Fixture::new(
+        "compaction.source-prepared.acknowledged-unit.bundle.bin",
+        acknowledged_log_bundle(&[], &prepared_unit),
+        FixtureValidation::AcknowledgedLogBundle {
+            first_sequence: BASE_SEQUENCE,
+            final_sequence: BASE_SEQUENCE,
+            generation: SOURCE_GENERATION,
+        },
+    ));
+
+    let snapshot = generation_snapshot(
+        SnapshotMode::OrdinaryCompaction,
+        TARGET_GENERATION,
+        SOURCE_GENERATION,
+        BASE_SEQUENCE,
+    );
+    let snapshot_bytes = encode_snapshot(&snapshot).expect("compaction target snapshot encodes");
+    fixtures.push(Fixture::new(
+        "compaction.target-snapshot.bin",
+        snapshot_bytes.clone(),
+        FixtureValidation::Snapshot,
+    ));
+    let opened = log_opened_record(
+        &snapshot_bytes,
+        TARGET_GENERATION,
+        SOURCE_GENERATION,
+        BASE_SEQUENCE,
+        PREPARED_ACK_EPOCH,
+        OpenReason::Compaction,
+        &[],
+    );
+    let opened_unit = acknowledged_unit(
+        &opened,
+        BASE_SEQUENCE + 1,
+        TARGET_GENERATION,
+        PREPARED_ACK_EPOCH + 1,
+        TARGET_MARKER_EPOCH,
+        0,
+    );
+    fixtures.push(Fixture::new(
+        "compaction.target-log-opened.unsealed.bin",
+        opened_unit.frame.clone(),
+        FixtureValidation::LedgerFrame {
+            sequence: BASE_SEQUENCE + 1,
+            generation: TARGET_GENERATION,
+        },
+    ));
+    fixtures.push(Fixture::new(
+        "compaction.target-log-opened.acknowledged-unit.bundle.bin",
+        acknowledged_log_bundle(&[], &opened_unit),
+        FixtureValidation::AcknowledgedLogBundle {
+            first_sequence: BASE_SEQUENCE + 1,
+            final_sequence: BASE_SEQUENCE + 1,
+            generation: TARGET_GENERATION,
+        },
+    ));
+
+    let marker = switched_marker(
+        &snapshot_bytes,
+        &opened_unit.frame,
+        SOURCE_GENERATION,
+        TARGET_GENERATION,
+        BASE_SEQUENCE,
+        TARGET_MARKER_EPOCH,
+    );
+    fixtures.push(Fixture::new(
+        "compaction.marker-switched.bin",
+        encode_enabled_marker_file(&marker).expect("compaction marker encodes"),
+        FixtureValidation::MarkerFile,
+    ));
+    add_marker_committed_frontiers(
+        fixtures,
+        "compaction",
+        &marker,
+        &opened_unit,
+        TARGET_GENERATION,
+        BASE_SEQUENCE,
+        PREPARED_ACK_EPOCH + 2,
+        TARGET_MARKER_EPOCH,
+    );
+}
+
+fn add_tail_repair_frontiers(fixtures: &mut Vec<Fixture>) {
+    const SOURCE_GENERATION: u64 = 1;
+    const TARGET_GENERATION: u64 = 2;
+    const BASE_SEQUENCE: u64 = 20;
+    const PREDECESSOR_ACK_EPOCH: u64 = 20;
+    const TARGET_MARKER_EPOCH: u64 = 3;
+    const SUFFIX: &[u8] = b"unacknowledged-frame-suffix";
+
+    let snapshot = generation_snapshot(
+        SnapshotMode::TailRepair,
+        TARGET_GENERATION,
+        SOURCE_GENERATION,
+        BASE_SEQUENCE,
+    );
+    let snapshot_bytes = encode_snapshot(&snapshot).expect("tail-repair snapshot encodes");
+    fixtures.push(Fixture::new(
+        "tail-repair.target-snapshot.bin",
+        snapshot_bytes.clone(),
+        FixtureValidation::Snapshot,
+    ));
+    fixtures.push(Fixture::new(
+        "tail-repair.quarantine-suffix.bin",
+        SUFFIX,
+        FixtureValidation::TailEvidence {
+            length: SUFFIX.len(),
+            crc32: crc32(SUFFIX),
+        },
+    ));
+    let opened = log_opened_record(
+        &snapshot_bytes,
+        TARGET_GENERATION,
+        SOURCE_GENERATION,
+        BASE_SEQUENCE,
+        PREDECESSOR_ACK_EPOCH,
+        OpenReason::TailRepair,
+        SUFFIX,
+    );
+    let opened_unit = acknowledged_unit(
+        &opened,
+        BASE_SEQUENCE + 1,
+        TARGET_GENERATION,
+        PREDECESSOR_ACK_EPOCH + 1,
+        TARGET_MARKER_EPOCH,
+        0,
+    );
+    fixtures.push(Fixture::new(
+        "tail-repair.target-log-opened.unsealed.bin",
+        opened_unit.frame.clone(),
+        FixtureValidation::LedgerFrame {
+            sequence: BASE_SEQUENCE + 1,
+            generation: TARGET_GENERATION,
+        },
+    ));
+    fixtures.push(Fixture::new(
+        "tail-repair.target-log-opened.acknowledged-unit.bundle.bin",
+        acknowledged_log_bundle(&[], &opened_unit),
+        FixtureValidation::AcknowledgedLogBundle {
+            first_sequence: BASE_SEQUENCE + 1,
+            final_sequence: BASE_SEQUENCE + 1,
+            generation: TARGET_GENERATION,
+        },
+    ));
+
+    let marker = switched_marker(
+        &snapshot_bytes,
+        &opened_unit.frame,
+        SOURCE_GENERATION,
+        TARGET_GENERATION,
+        BASE_SEQUENCE,
+        TARGET_MARKER_EPOCH,
+    );
+    fixtures.push(Fixture::new(
+        "tail-repair.marker-switched.bin",
+        encode_enabled_marker_file(&marker).expect("tail-repair marker encodes"),
+        FixtureValidation::MarkerFile,
+    ));
+    add_marker_committed_frontiers(
+        fixtures,
+        "tail-repair",
+        &marker,
+        &opened_unit,
+        TARGET_GENERATION,
+        BASE_SEQUENCE,
+        PREDECESSOR_ACK_EPOCH + 2,
+        TARGET_MARKER_EPOCH,
+    );
+}
+
+fn add_marker_committed_frontiers(
+    fixtures: &mut Vec<Fixture>,
+    prefix: &str,
+    marker: &EnabledMarkerFile,
+    opened_unit: &AcknowledgedUnit,
+    generation: u64,
+    base_sequence: u64,
+    acknowledgement_epoch: u64,
+    marker_epoch: u64,
+) {
+    let selected = marker.selected_slot().expect("switched marker selects its target");
+    let encoded_marker_slot = encode_enabled_marker_slot(selected).expect("selected marker slot encodes");
+    let marker_committed = LedgerRecord::MarkerCommitted {
+        store_uuid: sample_store_uuid(),
+        marker_epoch,
+        snapshot_generation: generation,
+        log_generation: generation,
+        anchor_sequence: base_sequence + 1,
+        slot_index: selected.slot_index,
+        slot_crc32: u32::from_le_bytes(encoded_marker_slot[100..104].try_into().expect("marker slot CRC")),
+    };
+    let opened_prefix = opened_unit.log_bytes();
+    let committed_unit = acknowledged_unit(
+        &marker_committed,
+        base_sequence + 2,
+        generation,
+        acknowledgement_epoch,
+        marker_epoch,
+        opened_prefix.len() as u64,
+    );
+
+    let mut unsealed = opened_prefix.clone();
+    unsealed.extend_from_slice(&committed_unit.frame);
+    fixtures.push(Fixture::new(
+        format!("{prefix}.marker-committed.unsealed.bin"),
+        unsealed,
+        FixtureValidation::SealedUnitsWithUnsealedFinal {
+            first_sequence: base_sequence + 1,
+            generation,
+            sealed_units: 1,
+        },
+    ));
+    fixtures.push(Fixture::new(
+        format!("{prefix}.marker-committed.acknowledged-unit.bundle.bin"),
+        acknowledged_log_bundle(&opened_prefix, &committed_unit),
+        FixtureValidation::AcknowledgedLogBundle {
+            first_sequence: base_sequence + 1,
+            final_sequence: base_sequence + 2,
+            generation,
+        },
+    ));
+}
+
+fn add_orphan_generation_pair(fixtures: &mut Vec<Fixture>) {
+    const SOURCE_GENERATION: u64 = 3;
+    const TARGET_GENERATION: u64 = 4;
+    const BASE_SEQUENCE: u64 = 30;
+
+    let snapshot = generation_snapshot(
+        SnapshotMode::OrdinaryCompaction,
+        TARGET_GENERATION,
+        SOURCE_GENERATION,
+        BASE_SEQUENCE,
+    );
+    let snapshot_bytes = encode_snapshot(&snapshot).expect("orphan snapshot encodes");
+    let opened = log_opened_record(
+        &snapshot_bytes,
+        TARGET_GENERATION,
+        SOURCE_GENERATION,
+        BASE_SEQUENCE,
+        30,
+        OpenReason::Compaction,
+        &[],
+    );
+    let log =
+        encode_ledger_frame(&opened, BASE_SEQUENCE + 1, TARGET_GENERATION).expect("orphan unsealed LogOpened encodes");
+    fixtures.push(Fixture::new(
+        "generation.orphan-higher.snapshot.bin",
+        snapshot_bytes,
+        FixtureValidation::Snapshot,
+    ));
+    fixtures.push(Fixture::new(
+        "generation.orphan-higher.log.bin",
+        log,
+        FixtureValidation::LedgerFrame {
+            sequence: BASE_SEQUENCE + 1,
+            generation: TARGET_GENERATION,
+        },
+    ));
+}
+
+fn add_acknowledged_suffix_loss(fixtures: &mut Vec<Fixture>) {
+    const GENERATION: u64 = 3;
+    const FIRST_SEQUENCE: u64 = 100;
+
+    let first_record = completed_record(99, 66);
+    let first = acknowledged_unit(&first_record, FIRST_SEQUENCE, GENERATION, 41, 4, 0);
+    let retained_log = first.log_bytes();
+    let missing_frame = encode_ledger_frame(&completed_record(99, 67), FIRST_SEQUENCE + 1, GENERATION)
+        .expect("missing acknowledged frame encodes");
+    let missing_slot = AcknowledgementSlot {
+        slot_index: 1,
+        activated: true,
+        store_uuid: sample_store_uuid(),
+        bootstrap_id: bootstrap_id(),
+        acknowledgement_epoch: 42,
+        marker_epoch: 4,
+        log_generation: GENERATION,
+        frame_sequence: FIRST_SEQUENCE + 1,
+        frame_end_offset: retained_log.len() as u64 + missing_frame.len() as u64,
+        frame_crc32: crc32(&missing_frame),
+    };
+    let history = encode_acknowledgement_file(&[
+        AcknowledgementSlotState::Populated(first.slot.clone()),
+        AcknowledgementSlotState::Populated(missing_slot),
+    ])
+    .expect("suffix-loss acknowledgement history encodes");
+    let mut bundle = Vec::with_capacity(4 + retained_log.len() + history.len());
+    bundle.extend_from_slice(&(retained_log.len() as u32).to_le_bytes());
+    bundle.extend_from_slice(&retained_log);
+    bundle.extend_from_slice(&history);
+    fixtures.push(Fixture::new(
+        "invalid.acknowledged-complete-suffix-loss.bundle.bin",
+        bundle,
+        FixtureValidation::AcknowledgedSuffixLossBundle {
+            first_sequence: FIRST_SEQUENCE,
+            generation: GENERATION,
+        },
+    ));
+}
+
+fn add_overlong_tail_repair(fixtures: &mut Vec<Fixture>) {
+    let snapshot = generation_snapshot(SnapshotMode::TailRepair, 2, 1, 20);
+    let snapshot_bytes = encode_snapshot(&snapshot).expect("tail-repair snapshot encodes");
+    let record = log_opened_record(&snapshot_bytes, 2, 1, 20, 20, OpenReason::TailRepair, b"tail");
+    let mut frame = encode_ledger_frame(&record, 21, 2).expect("valid tail-repair frame encodes");
+    let suffix_length_offset = 40 + 80;
+    frame[suffix_length_offset..suffix_length_offset + 4]
+        .copy_from_slice(&(MAX_SEALED_RECORD_UNIT_LENGTH as u32).to_le_bytes());
+    refresh_payload_crc(&mut frame);
+    fixtures.push(Fixture::new(
+        "invalid.log-opened-overlong-suffix.bin",
+        frame,
+        FixtureValidation::InvalidTypedLedgerFrame {
+            sequence: 21,
+            generation: 2,
+        },
+    ));
+}
+
+fn generation_snapshot(
+    mode: SnapshotMode,
+    generation: u64,
+    predecessor_log_generation: u64,
+    base_sequence: u64,
+) -> LifecycleSnapshot {
+    LifecycleSnapshot {
+        mode,
+        store_uuid: sample_store_uuid(),
+        generation,
+        log_generation: generation,
+        predecessor_log_generation,
+        base_sequence,
+        create_high_water: 7,
+        ticket_high_water: 42,
+        entries: Vec::new(),
+    }
+}
+
+fn log_opened_record(
+    snapshot_bytes: &[u8],
+    generation: u64,
+    predecessor_generation: u64,
+    base_sequence: u64,
+    predecessor_acknowledgement_epoch: u64,
+    open_reason: OpenReason,
+    unacknowledged_suffix: &[u8],
+) -> LedgerRecord {
+    LedgerRecord::LogOpened {
+        store_uuid: sample_store_uuid(),
+        generation,
+        snapshot_generation: generation,
+        predecessor_log_generation: predecessor_generation,
+        predecessor_terminal_acknowledged_sequence: base_sequence,
+        snapshot_base_sequence: base_sequence,
+        snapshot_file_length: snapshot_bytes.len() as u64,
+        snapshot_file_crc32: crc32(snapshot_bytes),
+        predecessor_prefix_crc32: crc32(b"acknowledged-predecessor-prefix"),
+        validated_prefix_length: 1_024,
+        unacknowledged_suffix_length: unacknowledged_suffix.len() as u32,
+        unacknowledged_suffix_crc32: crc32(unacknowledged_suffix),
+        open_reason,
+        predecessor_acknowledgement_epoch,
+    }
+}
+
+fn switched_marker(
+    snapshot_bytes: &[u8],
+    opened_frame: &[u8],
+    source_generation: u64,
+    target_generation: u64,
+    base_sequence: u64,
+    marker_epoch: u64,
+) -> EnabledMarkerFile {
+    let target_index = ((marker_epoch - 1) & 1) as u8;
+    let source_index = 1 - target_index;
+    let source = marker_slot(
+        source_index,
+        marker_epoch - 1,
+        source_generation,
+        base_sequence,
+        108,
+        0x1111_1111,
+        0x2222_2222,
+    );
+    let target = marker_slot(
+        target_index,
+        marker_epoch,
+        target_generation,
+        base_sequence + 1,
+        snapshot_bytes.len() as u64,
+        crc32(snapshot_bytes),
+        crc32(opened_frame),
+    );
+    if target_index == 0 {
+        EnabledMarkerFile {
+            slots: [Some(target), Some(source)],
+        }
+    } else {
+        EnabledMarkerFile {
+            slots: [Some(source), Some(target)],
+        }
+    }
+}
+
+fn completed_record(namespace_absent_sequence: u64, completion_time_ns: u64) -> LedgerRecord {
+    LedgerRecord::Completed {
+        ticket_id: ticket(),
+        incarnation: incarnation(),
+        completion_time_ns,
+        namespace_absent_sequence,
+    }
+}
+
+struct AcknowledgedUnit {
+    frame: Vec<u8>,
+    slot: AcknowledgementSlot,
+    encoded_slot: [u8; 104],
+    encoded_seal: [u8; 72],
+}
+
+impl AcknowledgedUnit {
+    fn log_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(self.frame.len() + self.encoded_seal.len());
+        bytes.extend_from_slice(&self.frame);
+        bytes.extend_from_slice(&self.encoded_seal);
+        bytes
+    }
+}
+
+fn acknowledged_unit(
+    record: &LedgerRecord,
+    sequence: u64,
+    generation: u64,
+    acknowledgement_epoch: u64,
+    marker_epoch: u64,
+    frame_offset: u64,
+) -> AcknowledgedUnit {
+    let frame = encode_ledger_frame(record, sequence, generation).expect("frontier frame encodes");
+    let slot = AcknowledgementSlot {
+        slot_index: ((acknowledgement_epoch - 1) & 1) as u8,
+        activated: true,
+        store_uuid: sample_store_uuid(),
+        bootstrap_id: bootstrap_id(),
+        acknowledgement_epoch,
+        marker_epoch,
+        log_generation: generation,
+        frame_sequence: sequence,
+        frame_end_offset: frame_offset + frame.len() as u64,
+        frame_crc32: crc32(&frame),
+    };
+    let encoded_slot = encode_acknowledgement_slot(&slot).expect("frontier acknowledgement slot encodes");
+    let seal =
+        CommitSeal::from_acknowledgement_slot(&slot, &encoded_slot).expect("frontier seal derives from the exact slot");
+    let encoded_seal = encode_commit_seal(&seal).expect("frontier seal encodes");
+    AcknowledgedUnit {
+        frame,
+        slot,
+        encoded_slot,
+        encoded_seal,
+    }
+}
+
+fn acknowledged_log_bundle(prefix: &[u8], final_unit: &AcknowledgedUnit) -> Vec<u8> {
+    let mut bundle = Vec::with_capacity(
+        8 + prefix.len() + final_unit.frame.len() + final_unit.encoded_seal.len() + final_unit.encoded_slot.len(),
+    );
+    bundle.extend_from_slice(&(prefix.len() as u32).to_le_bytes());
+    bundle.extend_from_slice(&(final_unit.frame.len() as u32).to_le_bytes());
+    bundle.extend_from_slice(prefix);
+    bundle.extend_from_slice(&final_unit.frame);
+    bundle.extend_from_slice(&final_unit.encoded_seal);
+    bundle.extend_from_slice(&final_unit.encoded_slot);
+    bundle
+}

--- a/rocketmq-store-local/src/mapped_file/retirement/fixture_corpus/test_cases/samples.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/fixture_corpus/test_cases/samples.rs
@@ -1,0 +1,395 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::mapped_file::retirement::codec::ContentFingerprint;
+use crate::mapped_file::retirement::codec::GenerationAbortReason;
+use crate::mapped_file::retirement::codec::LedgerRecord;
+use crate::mapped_file::retirement::codec::OpenReason;
+use crate::mapped_file::retirement::codec::QuarantineEntityKind;
+use crate::mapped_file::retirement::codec::QuarantineReason;
+use crate::mapped_file::retirement::codec::RetirementReason;
+use crate::mapped_file::retirement::identity::FileIncarnationId;
+use crate::mapped_file::retirement::identity::PhysicalFileKey;
+use crate::mapped_file::retirement::identity::StoreRelativePath;
+use crate::mapped_file::retirement::identity::StoreUuid;
+use crate::mapped_file::retirement::identity::TicketId;
+use crate::mapped_file::retirement::sidecar::EnabledMarkerSlot;
+use crate::mapped_file::retirement::sidecar::IncarnationPhase;
+use crate::mapped_file::retirement::sidecar::IncarnationSnapshotEntry;
+use crate::mapped_file::retirement::sidecar::LifecycleSnapshot;
+use crate::mapped_file::retirement::sidecar::QuarantineSnapshotEntry;
+use crate::mapped_file::retirement::sidecar::RetirementStage;
+use crate::mapped_file::retirement::sidecar::RetirementTicketSnapshotEntry;
+use crate::mapped_file::retirement::sidecar::SnapshotEntry;
+use crate::mapped_file::retirement::sidecar::SnapshotMode;
+use crate::mapped_file::retirement::sidecar::StoreMeta;
+
+pub(super) fn sample_records() -> Vec<(&'static str, LedgerRecord, u64, u64)> {
+    record_map()
+        .into_iter()
+        .enumerate()
+        .map(|(index, (name, record))| match name {
+            "store-initialized" => (name, record, 1, 0),
+            "bootstrap-installed" => (name, record, 2, 0),
+            "log-opened" => (name, record, 21, 3),
+            "generation-prepared" => (name, record, 10, 2),
+            "generation-aborted" => (name, record, 11, 2),
+            "marker-committed" => (name, record, 3, 0),
+            _ => (name, record, 100 + index as u64, 3),
+        })
+        .collect()
+}
+
+pub(super) fn record_map() -> Vec<(&'static str, LedgerRecord)> {
+    let canonical_path = canonical_path();
+    let create_file_path = create_path();
+    let tombstone_path = tombstone_path();
+    let unix_key = unix_key();
+    let windows_key = windows_key();
+    vec![
+        (
+            "store-initialized",
+            LedgerRecord::StoreInitialized {
+                store_uuid: sample_store_uuid(),
+                bootstrap_id: bootstrap_id(),
+                creation_time_ns: 11,
+            },
+        ),
+        (
+            "bootstrap-installed",
+            LedgerRecord::BootstrapInstalled {
+                store_uuid: sample_store_uuid(),
+                bootstrap_id: bootstrap_id(),
+                snapshot_generation: 0,
+                snapshot_base_sequence: 1,
+                snapshot_file_length: 108,
+                snapshot_file_crc32: 0x1234_5678,
+                inventory_count: 3,
+                create_high_water: 7,
+                ticket_high_water: 42,
+            },
+        ),
+        (
+            "log-opened",
+            LedgerRecord::LogOpened {
+                store_uuid: sample_store_uuid(),
+                generation: 3,
+                snapshot_generation: 3,
+                predecessor_log_generation: 2,
+                predecessor_terminal_acknowledged_sequence: 20,
+                snapshot_base_sequence: 20,
+                snapshot_file_length: 108,
+                snapshot_file_crc32: 0x1111_1111,
+                predecessor_prefix_crc32: 0x2222_2222,
+                validated_prefix_length: 1_000,
+                unacknowledged_suffix_length: 0,
+                unacknowledged_suffix_crc32: 0,
+                open_reason: OpenReason::Compaction,
+                predecessor_acknowledgement_epoch: 9,
+            },
+        ),
+        (
+            "generation-prepared",
+            LedgerRecord::GenerationPrepared {
+                store_uuid: sample_store_uuid(),
+                source_generation: 2,
+                target_generation: 3,
+                target_snapshot_generation: 3,
+                open_reason: OpenReason::Compaction,
+            },
+        ),
+        (
+            "generation-aborted",
+            LedgerRecord::GenerationAborted {
+                store_uuid: sample_store_uuid(),
+                source_generation: 2,
+                target_generation: 3,
+                prepared_sequence: 10,
+                abort_reason: GenerationAbortReason::Io,
+            },
+        ),
+        (
+            "marker-committed",
+            LedgerRecord::MarkerCommitted {
+                store_uuid: sample_store_uuid(),
+                marker_epoch: 1,
+                snapshot_generation: 0,
+                log_generation: 0,
+                anchor_sequence: 2,
+                slot_index: 0,
+                slot_crc32: 0x3344_5566,
+            },
+        ),
+        (
+            "allocate-incarnation",
+            LedgerRecord::AllocateIncarnation {
+                incarnation: incarnation(),
+                segment_offset: 0,
+                expected_length: 1_024,
+                create_nonce: [0x20; 16],
+                canonical_path: canonical_path.clone(),
+                create_file_path: create_file_path.clone(),
+            },
+        ),
+        (
+            "bind-incarnation-unix",
+            LedgerRecord::BindIncarnation {
+                incarnation: incarnation(),
+                expected_length: 1_024,
+                physical_key: unix_key,
+                canonical_path: canonical_path.clone(),
+                create_file_path: create_file_path.clone(),
+            },
+        ),
+        (
+            "publish-incarnation-windows",
+            LedgerRecord::PublishIncarnation {
+                incarnation: incarnation(),
+                expected_length: 1_024,
+                physical_key: windows_key,
+                canonical_path: canonical_path.clone(),
+                create_file_path,
+            },
+        ),
+        (
+            "retirement-intent",
+            LedgerRecord::RetirementIntent {
+                ticket_id: ticket(),
+                incarnation: incarnation(),
+                reason: RetirementReason::TtlExpired,
+                mapping_generation: 3,
+                segment_offset: 0,
+                expected_length: 1_024,
+                retirement_nonce: [0x40; 16],
+                target_key: unix_key,
+                canonical_path: canonical_path.clone(),
+            },
+        ),
+        (
+            "logical-removed",
+            LedgerRecord::LogicalRemoved {
+                ticket_id: ticket(),
+                incarnation: incarnation(),
+                target_key: unix_key,
+                canonical_path: canonical_path.clone(),
+            },
+        ),
+        (
+            "tombstoned",
+            LedgerRecord::Tombstoned {
+                ticket_id: ticket(),
+                incarnation: incarnation(),
+                target_key: unix_key,
+                retirement_nonce: [0x40; 16],
+                canonical_path: canonical_path.clone(),
+                tombstone_path: tombstone_path.clone(),
+            },
+        ),
+        (
+            "namespace-absent",
+            LedgerRecord::NamespaceAbsent {
+                ticket_id: ticket(),
+                incarnation: incarnation(),
+                replacement_observed: true,
+                observation_time_ns: 55,
+                target_key: unix_key,
+                canonical_path: canonical_path.clone(),
+                tombstone_path: Some(tombstone_path.clone()),
+            },
+        ),
+        (
+            "completed",
+            LedgerRecord::Completed {
+                ticket_id: ticket(),
+                incarnation: incarnation(),
+                completion_time_ns: 66,
+                namespace_absent_sequence: 99,
+            },
+        ),
+        (
+            "superseded-path",
+            LedgerRecord::SupersededPath {
+                ticket_id: ticket(),
+                incarnation: incarnation(),
+                expected_target_key: unix_key,
+                observed_replacement_key: windows_key,
+                canonical_path,
+            },
+        ),
+        (
+            "quarantined",
+            LedgerRecord::Quarantined {
+                entity_kind: QuarantineEntityKind::Tombstone,
+                reason: QuarantineReason::KeyMismatch,
+                sequence_at_observation: 77,
+                physical_key: Some(windows_key),
+                content_fingerprint: Some(ContentFingerprint {
+                    length: 1_024,
+                    crc32: 0x1234_5678,
+                }),
+                source_path: tombstone_path,
+                destination_path: Some(path(".rocketmq-lifecycle/quarantine/tombstone.bin")),
+            },
+        ),
+    ]
+}
+
+pub(super) fn sample_store_meta() -> StoreMeta {
+    StoreMeta {
+        store_uuid: sample_store_uuid(),
+        creation_time_ns: 0x0102_0304_0506_0708,
+        bootstrap_id: bootstrap_id(),
+    }
+}
+
+pub(super) fn marker_slot(
+    slot_index: u8,
+    marker_epoch: u64,
+    generation: u64,
+    anchor_sequence: u64,
+    snapshot_file_length: u64,
+    snapshot_file_crc32: u32,
+    anchor_frame_crc32: u32,
+) -> EnabledMarkerSlot {
+    EnabledMarkerSlot {
+        slot_index,
+        store_uuid: sample_store_uuid(),
+        bootstrap_id: bootstrap_id(),
+        marker_epoch,
+        snapshot_generation: generation,
+        log_generation: generation,
+        anchor_sequence,
+        snapshot_file_length,
+        snapshot_file_crc32,
+        anchor_frame_crc32,
+    }
+}
+
+pub(super) fn snapshot(mode: SnapshotMode, entries: Vec<SnapshotEntry>) -> LifecycleSnapshot {
+    let (generation, predecessor_log_generation, base_sequence) = match mode {
+        SnapshotMode::BootstrapInventory => (0, u64::MAX, 1),
+        SnapshotMode::OrdinaryCompaction => (1, 0, 100),
+        SnapshotMode::TailRepair => (2, 1, 100),
+    };
+    LifecycleSnapshot {
+        mode,
+        store_uuid: sample_store_uuid(),
+        generation,
+        log_generation: generation,
+        predecessor_log_generation,
+        base_sequence,
+        create_high_water: 7,
+        ticket_high_water: 42,
+        entries,
+    }
+}
+
+pub(super) fn sample_incarnation_entry() -> IncarnationSnapshotEntry {
+    IncarnationSnapshotEntry {
+        incarnation: incarnation(),
+        phase: IncarnationPhase::Published,
+        segment_offset: 0,
+        expected_file_length: 1_024,
+        create_nonce: [0x20; 16],
+        physical_key: Some(unix_key()),
+        canonical_path: canonical_path(),
+        create_file_path: create_path(),
+    }
+}
+
+pub(super) fn sample_retirement_entry(stage: RetirementStage) -> RetirementTicketSnapshotEntry {
+    RetirementTicketSnapshotEntry {
+        ticket_id: ticket(),
+        incarnation: incarnation(),
+        stage,
+        superseded_path_observed: true,
+        quarantined: false,
+        reason: RetirementReason::TtlExpired,
+        stage_sequence: 99,
+        mapping_generation: 3,
+        segment_offset: 0,
+        expected_file_length: 1_024,
+        retirement_nonce: [0x40; 16],
+        target_key: unix_key(),
+        canonical_path: canonical_path(),
+        tombstone_path: match stage {
+            RetirementStage::Tombstoned | RetirementStage::NamespaceAbsent | RetirementStage::CompletedRetained => {
+                Some(tombstone_path())
+            }
+            RetirementStage::IntentDurable | RetirementStage::LogicalRemoved => None,
+        },
+    }
+}
+
+pub(super) fn sample_quarantine_entry() -> QuarantineSnapshotEntry {
+    QuarantineSnapshotEntry {
+        entity_kind: QuarantineEntityKind::Sidecar,
+        reason: QuarantineReason::UnknownOwner,
+        sequence_at_observation: 88,
+        physical_key: Some(windows_key()),
+        content_fingerprint: Some(ContentFingerprint {
+            length: 1_234,
+            crc32: 0xaabb_ccdd,
+        }),
+        source_path: path(".rocketmq-lifecycle/orphan.tmp"),
+        destination_path: Some(path(".rocketmq-lifecycle/quarantine/orphan.bin")),
+    }
+}
+
+pub(super) fn sample_store_uuid() -> StoreUuid {
+    StoreUuid::new(std::array::from_fn(|index| index as u8)).expect("sample UUID is nonzero")
+}
+
+pub(super) fn bootstrap_id() -> [u8; 16] {
+    std::array::from_fn(|index| 0x10 + index as u8)
+}
+
+pub(super) fn incarnation() -> FileIncarnationId {
+    FileIncarnationId::new(sample_store_uuid(), 7).expect("sample incarnation is nonzero")
+}
+
+pub(super) fn ticket() -> TicketId {
+    TicketId::new(42).expect("sample ticket is nonzero")
+}
+
+pub(super) fn unix_key() -> PhysicalFileKey {
+    PhysicalFileKey::unix(0x0102_0304_0506_0708, 0x1112_1314_1516_1718)
+}
+
+pub(super) fn windows_key() -> PhysicalFileKey {
+    PhysicalFileKey::windows(0x2122_2324_2526_2728, std::array::from_fn(|index| 0x30 + index as u8))
+}
+
+pub(super) fn path(value: &str) -> StoreRelativePath {
+    StoreRelativePath::new(value).expect("fixture path is canonical")
+}
+
+pub(super) fn canonical_path() -> StoreRelativePath {
+    path("commitlog/00000000000000000000")
+}
+
+pub(super) fn create_path() -> StoreRelativePath {
+    path("commitlog/.create.i0000000000000007.s00000000000000000000.n20202020202020202020202020202020")
+}
+
+pub(super) fn tombstone_path() -> StoreRelativePath {
+    path(
+        "commitlog/.delete.t000000000000002a.i0000000000000007.s00000000000000000000.m0000000000000003.n40404040404040404040404040404040",
+    )
+}
+
+pub(super) fn maximum_path() -> StoreRelativePath {
+    let raw = std::iter::repeat_n("a".repeat(240), 17).collect::<Vec<_>>().join("/");
+    StoreRelativePath::new(&raw).expect("4096-byte path is valid")
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9174

### Brief Description

Move the mapped-file retirement fixture source modules from the ignored `fixture_corpus/build/` directory to `fixture_corpus/test_cases/`.

Reference `edges.rs`, `frontiers.rs`, and `samples.rs` through explicit `#[path = "test_cases/..."]` attributes in `fixture_corpus/build.rs`. This ensures clean Git checkouts contain every declared test module without adding an exception to the repository-wide build-output ignore rule. The generated fixture bytes and SHA-256 manifest remain unchanged.

### How Did You Test This Change?

- `cargo fmt --all -- --check` - passed
- `cargo test -p rocketmq-store-local --lib mapped_file::retirement::fixture_corpus::tests::checked_in_lifecycle_corpus_is_byte_exact_decodable_and_hash_complete -- --exact` - passed (`1 passed`)
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` - passed
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/` - passed
- `git diff --cached --check` - passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive deterministic test fixtures for mapped-file retirement workflows.
  * Added coverage for compaction, recovery, corruption, truncation, sequence limits, marker handling, quarantine, and path replacement scenarios.
  * Added sample records and metadata covering initialization, bootstrap, generation transitions, retirement stages, and lifecycle snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->