### PR TITLE
[ISSUE #9173]♻️Complete mapped-file lifecycle finalization

### DIFF
--- a/rocketmq-store-local/src/mapped_file/retirement/activation.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/activation.rs
@@ -220,7 +220,7 @@ impl PreparedManagedLifecycleActivation {
             None => self.store_root = Some(store_root.to_path_buf()),
         }
 
-        let segments = match self
+        let mut segments = match self
             .session
             .take_active_segments_in_directory(directory, configured_file_size)
         {
@@ -233,6 +233,29 @@ impl PreparedManagedLifecycleActivation {
                 ));
             }
         };
+        let namespace_root = VerifiedNamespaceRoot::from_reconciled_session(&self.session).map_err(|source| {
+            self.staging_failed = true;
+            ManagedLifecycleActivationError::new(
+                ManagedLifecycleActivationErrorKind::Namespace,
+                ManagedLifecycleActivationSource::Namespace(source),
+            )
+        })?;
+        for segment in &mut segments {
+            let writable = namespace_root
+                .open_active_segment(
+                    segment.canonical_path(),
+                    segment.physical_key(),
+                    segment.expected_length(),
+                )
+                .map_err(|source| {
+                    self.staging_failed = true;
+                    ManagedLifecycleActivationError::new(
+                        ManagedLifecycleActivationErrorKind::Namespace,
+                        ManagedLifecycleActivationSource::Namespace(source),
+                    )
+                })?;
+            segment.replace_retained_file(writable);
+        }
         let generation = match load_reconciled_mapped_file_queue(store_root, segments) {
             Ok(generation) => generation,
             Err(source) => {

--- a/rocketmq-store-local/src/mapped_file/retirement/fixture_corpus/build/edges.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/fixture_corpus/build/edges.rs
@@ -1,0 +1,322 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::samples::*;
+use super::Fixture;
+use super::FixtureValidation;
+use crate::mapped_file::retirement::codec::crc32;
+use crate::mapped_file::retirement::codec::encode_acknowledgement_slot;
+use crate::mapped_file::retirement::codec::encode_commit_seal;
+use crate::mapped_file::retirement::codec::encode_ledger_frame;
+use crate::mapped_file::retirement::codec::AcknowledgementSlot;
+use crate::mapped_file::retirement::codec::CommitSeal;
+use crate::mapped_file::retirement::codec::LedgerRecord;
+use crate::mapped_file::retirement::codec::MAX_PAYLOAD_LENGTH;
+use crate::mapped_file::retirement::sidecar::encode_enabled_marker_file;
+use crate::mapped_file::retirement::sidecar::encode_snapshot;
+use crate::mapped_file::retirement::sidecar::EnabledMarkerFile;
+use crate::mapped_file::retirement::sidecar::SnapshotMode;
+use crate::mapped_file::retirement::sidecar::MAX_SNAPSHOT_BODY_LENGTH;
+use crate::mapped_file::retirement::sidecar::MAX_SNAPSHOT_ENTRY_COUNT;
+
+pub(super) fn add_edge_cases(fixtures: &mut Vec<Fixture>) {
+    let frame = completed_frame(100, 3);
+    let slot0 = acknowledgement_slot(0, 77, 100, 3, &frame);
+    let encoded_slot0 = encode_acknowledgement_slot(&slot0).expect("slot zero encodes");
+    let seal = CommitSeal::from_acknowledgement_slot(&slot0, &encoded_slot0).expect("seal derives from slot zero");
+    let encoded_seal = encode_commit_seal(&seal).expect("commit seal encodes");
+
+    add_acknowledgement_edges(fixtures, &frame, &slot0, &encoded_slot0, &encoded_seal);
+    add_stream_edges(fixtures, &frame, &encoded_seal);
+    add_bounded_decode_edges(fixtures, &frame);
+    add_marker_edges(fixtures);
+}
+
+fn add_acknowledgement_edges(
+    fixtures: &mut Vec<Fixture>,
+    frame: &[u8],
+    slot0: &AcknowledgementSlot,
+    encoded_slot0: &[u8; 104],
+    encoded_seal: &[u8; 72],
+) {
+    let initial_slot0 = encode_acknowledgement_slot(&AcknowledgementSlot {
+        acknowledgement_epoch: 1,
+        ..slot0.clone()
+    })
+    .expect("initial slot zero encodes");
+    let initial_slot1 = encode_acknowledgement_slot(&AcknowledgementSlot {
+        slot_index: 1,
+        acknowledgement_epoch: 2,
+        frame_sequence: 101,
+        ..slot0.clone()
+    })
+    .expect("initial slot one encodes");
+    let mut slot1_file = initial_slot0.to_vec();
+    slot1_file.extend_from_slice(&initial_slot1);
+    fixtures.push(Fixture::new(
+        "acknowledgement.slot1.bin",
+        slot1_file,
+        FixtureValidation::AcknowledgementFile,
+    ));
+    fixtures.push(Fixture::new(
+        "acknowledgement.all-zero.bin",
+        vec![0_u8; 208],
+        FixtureValidation::AcknowledgementFileWithoutAuthoritative,
+    ));
+
+    let nonconsecutive_slot1 = AcknowledgementSlot {
+        acknowledgement_epoch: 80,
+        frame_sequence: 103,
+        ..slot0.clone()
+    };
+    let mut nonconsecutive = encoded_slot0.to_vec();
+    nonconsecutive.extend_from_slice(
+        &encode_acknowledgement_slot(&AcknowledgementSlot {
+            slot_index: 1,
+            ..nonconsecutive_slot1
+        })
+        .expect("individually valid nonconsecutive slot encodes"),
+    );
+    fixtures.push(Fixture::new(
+        "invalid.acknowledgement-nonconsecutive.bin",
+        nonconsecutive,
+        FixtureValidation::InvalidAcknowledgementFile,
+    ));
+
+    let mut torn_slot = *encoded_slot0;
+    torn_slot[103] ^= 1;
+    let mut reconstruction = bundle_prefix(frame);
+    reconstruction.extend_from_slice(&torn_slot);
+    reconstruction.extend_from_slice(encoded_slot0);
+    reconstruction.extend_from_slice(encoded_seal);
+    fixtures.push(Fixture::new(
+        "recovery.ack-seal-reconstruction.bundle.bin",
+        reconstruction,
+        FixtureValidation::AcknowledgementReconstructionBundle {
+            sequence: 100,
+            generation: 3,
+        },
+    ));
+
+    let mut mismatched_seal = *encoded_seal;
+    let wrong_slot_crc = u32::from_le_bytes(mismatched_seal[60..64].try_into().expect("slot CRC field")) ^ 1;
+    mismatched_seal[60..64].copy_from_slice(&wrong_slot_crc.to_le_bytes());
+    let seal_crc = crc32(&mismatched_seal[..68]);
+    mismatched_seal[68..72].copy_from_slice(&seal_crc.to_le_bytes());
+    let mut mismatch_bundle = bundle_prefix(frame);
+    mismatch_bundle.extend_from_slice(encoded_slot0);
+    mismatch_bundle.extend_from_slice(&mismatched_seal);
+    fixtures.push(Fixture::new(
+        "invalid.seal-slot-crc-mismatch.bundle.bin",
+        mismatch_bundle,
+        FixtureValidation::InvalidAcknowledgedUnitBinding {
+            sequence: 100,
+            generation: 3,
+        },
+    ));
+}
+
+fn add_stream_edges(fixtures: &mut Vec<Fixture>, frame: &[u8], encoded_seal: &[u8; 72]) {
+    let mut unit = frame.to_vec();
+    unit.extend_from_slice(encoded_seal);
+    let mut truncations = Vec::new();
+    for length in 0..=unit.len() {
+        truncations.extend_from_slice(&(length as u16).to_le_bytes());
+        truncations.extend_from_slice(&unit[..length]);
+    }
+    fixtures.push(Fixture::new(
+        "recovery.acknowledged-unit-all-truncations.bin",
+        truncations,
+        FixtureValidation::TruncatedSealedUnit {
+            sequence: 100,
+            generation: 3,
+            frame_length: frame.len(),
+        },
+    ));
+    fixtures.push(Fixture::new(
+        "recovery.valid-ack-missing-seal.log.bin",
+        frame,
+        FixtureValidation::LedgerFrame {
+            sequence: 100,
+            generation: 3,
+        },
+    ));
+    let mut partial_seal = frame.to_vec();
+    partial_seal.extend_from_slice(&encoded_seal[..36]);
+    fixtures.push(Fixture::new(
+        "recovery.valid-ack-partial-seal.log.bin",
+        partial_seal,
+        FixtureValidation::LedgerFrameThenPartialSeal {
+            sequence: 100,
+            generation: 3,
+        },
+    ));
+
+    let frame101 = completed_frame(101, 3);
+    let frame102 = completed_frame(102, 3);
+    let mut gap = frame.to_vec();
+    gap.extend_from_slice(&frame102);
+    fixtures.push(Fixture::new(
+        "invalid.sequence-gap.log.bin",
+        gap,
+        FixtureValidation::InvalidLedgerFrameStream {
+            first_sequence: 100,
+            generation: 3,
+        },
+    ));
+    let mut duplicate = frame.to_vec();
+    duplicate.extend_from_slice(frame);
+    fixtures.push(Fixture::new(
+        "invalid.sequence-duplicate.log.bin",
+        duplicate,
+        FixtureValidation::InvalidLedgerFrameStream {
+            first_sequence: 100,
+            generation: 3,
+        },
+    ));
+    let mut damaged = frame.to_vec();
+    let mut bad_second = frame101;
+    let final_byte = bad_second.len() - 1;
+    bad_second[final_byte] ^= 1;
+    damaged.extend_from_slice(&bad_second);
+    damaged.extend_from_slice(&frame102);
+    fixtures.push(Fixture::new(
+        "invalid.mid-log-damage.log.bin",
+        damaged,
+        FixtureValidation::InvalidLedgerFrameStream {
+            first_sequence: 100,
+            generation: 3,
+        },
+    ));
+
+    let mut overflow = completed_frame(u64::MAX, 3);
+    overflow.extend_from_slice(frame);
+    fixtures.push(Fixture::new(
+        "invalid.sequence-overflow.log.bin",
+        overflow,
+        FixtureValidation::SequenceOverflowStream { generation: 3 },
+    ));
+}
+
+fn add_bounded_decode_edges(fixtures: &mut Vec<Fixture>, frame: &[u8]) {
+    let mut oversized_header = frame[..16].to_vec();
+    oversized_header[14..16].copy_from_slice(&41_u16.to_le_bytes());
+    fixtures.push(Fixture::new(
+        "invalid.oversized-header.bin",
+        oversized_header,
+        FixtureValidation::InvalidLedgerFrame {
+            sequence: 100,
+            generation: 3,
+        },
+    ));
+    let mut oversized_payload = frame[..20].to_vec();
+    oversized_payload[16..20].copy_from_slice(&((MAX_PAYLOAD_LENGTH + 1) as u32).to_le_bytes());
+    fixtures.push(Fixture::new(
+        "invalid.oversized-payload.bin",
+        oversized_payload,
+        FixtureValidation::InvalidLedgerFrame {
+            sequence: 100,
+            generation: 3,
+        },
+    ));
+
+    let empty_snapshot = encode_snapshot(&snapshot(SnapshotMode::OrdinaryCompaction, Vec::new()))
+        .expect("empty compacted snapshot encodes");
+    let mut oversized_body = empty_snapshot.clone();
+    oversized_body[12..20].copy_from_slice(&(MAX_SNAPSHOT_BODY_LENGTH as u64 + 109).to_le_bytes());
+    oversized_body[88..96].copy_from_slice(&(MAX_SNAPSHOT_BODY_LENGTH as u64 + 1).to_le_bytes());
+    refresh_snapshot_header_crc(&mut oversized_body);
+    fixtures.push(Fixture::new(
+        "invalid.snapshot-oversized-body.bin",
+        oversized_body,
+        FixtureValidation::InvalidSnapshot,
+    ));
+    let mut too_many_entries = empty_snapshot.clone();
+    too_many_entries[84..88].copy_from_slice(&(MAX_SNAPSHOT_ENTRY_COUNT + 1).to_le_bytes());
+    refresh_snapshot_header_crc(&mut too_many_entries);
+    fixtures.push(Fixture::new(
+        "invalid.snapshot-too-many-entries.bin",
+        too_many_entries,
+        FixtureValidation::InvalidSnapshot,
+    ));
+    let mut reserved = empty_snapshot;
+    reserved[96..100].copy_from_slice(&1_u32.to_le_bytes());
+    refresh_snapshot_header_crc(&mut reserved);
+    fixtures.push(Fixture::new(
+        "invalid.snapshot-reserved.bin",
+        reserved,
+        FixtureValidation::InvalidSnapshot,
+    ));
+}
+
+fn add_marker_edges(fixtures: &mut Vec<Fixture>) {
+    let marker = EnabledMarkerFile {
+        slots: [
+            Some(marker_slot(0, 1, 0, 2, 108, 0x1111_1111, 0x2222_2222)),
+            Some(marker_slot(1, 2, 1, 200, 108, 0x3333_3333, 0x4444_4444)),
+        ],
+    };
+    fixtures.push(Fixture::new(
+        "enabled.newer-slot-missing-pair.bin",
+        encode_enabled_marker_file(&marker).expect("newer marker slot encodes"),
+        FixtureValidation::MarkerFile,
+    ));
+}
+
+fn completed_frame(sequence: u64, generation: u64) -> Vec<u8> {
+    encode_ledger_frame(
+        &LedgerRecord::Completed {
+            ticket_id: ticket(),
+            incarnation: incarnation(),
+            completion_time_ns: 66,
+            namespace_absent_sequence: 99,
+        },
+        sequence,
+        generation,
+    )
+    .expect("completed edge frame encodes")
+}
+
+fn acknowledgement_slot(
+    slot_index: u8,
+    acknowledgement_epoch: u64,
+    frame_sequence: u64,
+    log_generation: u64,
+    frame: &[u8],
+) -> AcknowledgementSlot {
+    AcknowledgementSlot {
+        slot_index,
+        activated: true,
+        store_uuid: sample_store_uuid(),
+        bootstrap_id: bootstrap_id(),
+        acknowledgement_epoch,
+        marker_epoch: 5,
+        log_generation,
+        frame_sequence,
+        frame_end_offset: frame.len() as u64,
+        frame_crc32: crc32(frame),
+    }
+}
+
+fn bundle_prefix(frame: &[u8]) -> Vec<u8> {
+    let mut bundle = Vec::with_capacity(4 + frame.len() + 208);
+    bundle.extend_from_slice(&(frame.len() as u32).to_le_bytes());
+    bundle.extend_from_slice(frame);
+    bundle
+}
+
+fn refresh_snapshot_header_crc(snapshot: &mut [u8]) {
+    let checksum = crc32(&snapshot[..100]);
+    snapshot[100..104].copy_from_slice(&checksum.to_le_bytes());
+}

--- a/rocketmq-store-local/src/mapped_file/retirement/fixture_corpus/build/frontiers.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/fixture_corpus/build/frontiers.rs
@@ -1,0 +1,541 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::refresh_payload_crc;
+use super::samples::*;
+use super::Fixture;
+use super::FixtureValidation;
+use crate::mapped_file::retirement::codec::crc32;
+use crate::mapped_file::retirement::codec::encode_acknowledgement_file;
+use crate::mapped_file::retirement::codec::encode_acknowledgement_slot;
+use crate::mapped_file::retirement::codec::encode_commit_seal;
+use crate::mapped_file::retirement::codec::encode_ledger_frame;
+use crate::mapped_file::retirement::codec::AcknowledgementSlot;
+use crate::mapped_file::retirement::codec::AcknowledgementSlotState;
+use crate::mapped_file::retirement::codec::CommitSeal;
+use crate::mapped_file::retirement::codec::LedgerRecord;
+use crate::mapped_file::retirement::codec::OpenReason;
+use crate::mapped_file::retirement::codec::MAX_SEALED_RECORD_UNIT_LENGTH;
+use crate::mapped_file::retirement::sidecar::encode_enabled_marker_file;
+use crate::mapped_file::retirement::sidecar::encode_enabled_marker_slot;
+use crate::mapped_file::retirement::sidecar::encode_snapshot;
+use crate::mapped_file::retirement::sidecar::EnabledMarkerFile;
+use crate::mapped_file::retirement::sidecar::LifecycleSnapshot;
+use crate::mapped_file::retirement::sidecar::SnapshotMode;
+
+pub(super) fn add_frontier_cases(fixtures: &mut Vec<Fixture>) {
+    add_compaction_frontiers(fixtures);
+    add_tail_repair_frontiers(fixtures);
+    add_orphan_generation_pair(fixtures);
+    add_acknowledged_suffix_loss(fixtures);
+    add_overlong_tail_repair(fixtures);
+}
+
+fn add_compaction_frontiers(fixtures: &mut Vec<Fixture>) {
+    const SOURCE_GENERATION: u64 = 2;
+    const TARGET_GENERATION: u64 = 3;
+    const BASE_SEQUENCE: u64 = 20;
+    const PREPARED_ACK_EPOCH: u64 = 9;
+    const TARGET_MARKER_EPOCH: u64 = 4;
+
+    let prepared = LedgerRecord::GenerationPrepared {
+        store_uuid: sample_store_uuid(),
+        source_generation: SOURCE_GENERATION,
+        target_generation: TARGET_GENERATION,
+        target_snapshot_generation: TARGET_GENERATION,
+        open_reason: OpenReason::Compaction,
+    };
+    let prepared_unit = acknowledged_unit(
+        &prepared,
+        BASE_SEQUENCE,
+        SOURCE_GENERATION,
+        PREPARED_ACK_EPOCH,
+        TARGET_MARKER_EPOCH - 1,
+        0,
+    );
+    fixtures.push(Fixture::new(
+        "compaction.source-prepared.acknowledged-unit.bundle.bin",
+        acknowledged_log_bundle(&[], &prepared_unit),
+        FixtureValidation::AcknowledgedLogBundle {
+            first_sequence: BASE_SEQUENCE,
+            final_sequence: BASE_SEQUENCE,
+            generation: SOURCE_GENERATION,
+        },
+    ));
+
+    let snapshot = generation_snapshot(
+        SnapshotMode::OrdinaryCompaction,
+        TARGET_GENERATION,
+        SOURCE_GENERATION,
+        BASE_SEQUENCE,
+    );
+    let snapshot_bytes = encode_snapshot(&snapshot).expect("compaction target snapshot encodes");
+    fixtures.push(Fixture::new(
+        "compaction.target-snapshot.bin",
+        snapshot_bytes.clone(),
+        FixtureValidation::Snapshot,
+    ));
+    let opened = log_opened_record(
+        &snapshot_bytes,
+        TARGET_GENERATION,
+        SOURCE_GENERATION,
+        BASE_SEQUENCE,
+        PREPARED_ACK_EPOCH,
+        OpenReason::Compaction,
+        &[],
+    );
+    let opened_unit = acknowledged_unit(
+        &opened,
+        BASE_SEQUENCE + 1,
+        TARGET_GENERATION,
+        PREPARED_ACK_EPOCH + 1,
+        TARGET_MARKER_EPOCH,
+        0,
+    );
+    fixtures.push(Fixture::new(
+        "compaction.target-log-opened.unsealed.bin",
+        opened_unit.frame.clone(),
+        FixtureValidation::LedgerFrame {
+            sequence: BASE_SEQUENCE + 1,
+            generation: TARGET_GENERATION,
+        },
+    ));
+    fixtures.push(Fixture::new(
+        "compaction.target-log-opened.acknowledged-unit.bundle.bin",
+        acknowledged_log_bundle(&[], &opened_unit),
+        FixtureValidation::AcknowledgedLogBundle {
+            first_sequence: BASE_SEQUENCE + 1,
+            final_sequence: BASE_SEQUENCE + 1,
+            generation: TARGET_GENERATION,
+        },
+    ));
+
+    let marker = switched_marker(
+        &snapshot_bytes,
+        &opened_unit.frame,
+        SOURCE_GENERATION,
+        TARGET_GENERATION,
+        BASE_SEQUENCE,
+        TARGET_MARKER_EPOCH,
+    );
+    fixtures.push(Fixture::new(
+        "compaction.marker-switched.bin",
+        encode_enabled_marker_file(&marker).expect("compaction marker encodes"),
+        FixtureValidation::MarkerFile,
+    ));
+    add_marker_committed_frontiers(
+        fixtures,
+        "compaction",
+        &marker,
+        &opened_unit,
+        TARGET_GENERATION,
+        BASE_SEQUENCE,
+        PREPARED_ACK_EPOCH + 2,
+        TARGET_MARKER_EPOCH,
+    );
+}
+
+fn add_tail_repair_frontiers(fixtures: &mut Vec<Fixture>) {
+    const SOURCE_GENERATION: u64 = 1;
+    const TARGET_GENERATION: u64 = 2;
+    const BASE_SEQUENCE: u64 = 20;
+    const PREDECESSOR_ACK_EPOCH: u64 = 20;
+    const TARGET_MARKER_EPOCH: u64 = 3;
+    const SUFFIX: &[u8] = b"unacknowledged-frame-suffix";
+
+    let snapshot = generation_snapshot(
+        SnapshotMode::TailRepair,
+        TARGET_GENERATION,
+        SOURCE_GENERATION,
+        BASE_SEQUENCE,
+    );
+    let snapshot_bytes = encode_snapshot(&snapshot).expect("tail-repair snapshot encodes");
+    fixtures.push(Fixture::new(
+        "tail-repair.target-snapshot.bin",
+        snapshot_bytes.clone(),
+        FixtureValidation::Snapshot,
+    ));
+    fixtures.push(Fixture::new(
+        "tail-repair.quarantine-suffix.bin",
+        SUFFIX,
+        FixtureValidation::TailEvidence {
+            length: SUFFIX.len(),
+            crc32: crc32(SUFFIX),
+        },
+    ));
+    let opened = log_opened_record(
+        &snapshot_bytes,
+        TARGET_GENERATION,
+        SOURCE_GENERATION,
+        BASE_SEQUENCE,
+        PREDECESSOR_ACK_EPOCH,
+        OpenReason::TailRepair,
+        SUFFIX,
+    );
+    let opened_unit = acknowledged_unit(
+        &opened,
+        BASE_SEQUENCE + 1,
+        TARGET_GENERATION,
+        PREDECESSOR_ACK_EPOCH + 1,
+        TARGET_MARKER_EPOCH,
+        0,
+    );
+    fixtures.push(Fixture::new(
+        "tail-repair.target-log-opened.unsealed.bin",
+        opened_unit.frame.clone(),
+        FixtureValidation::LedgerFrame {
+            sequence: BASE_SEQUENCE + 1,
+            generation: TARGET_GENERATION,
+        },
+    ));
+    fixtures.push(Fixture::new(
+        "tail-repair.target-log-opened.acknowledged-unit.bundle.bin",
+        acknowledged_log_bundle(&[], &opened_unit),
+        FixtureValidation::AcknowledgedLogBundle {
+            first_sequence: BASE_SEQUENCE + 1,
+            final_sequence: BASE_SEQUENCE + 1,
+            generation: TARGET_GENERATION,
+        },
+    ));
+
+    let marker = switched_marker(
+        &snapshot_bytes,
+        &opened_unit.frame,
+        SOURCE_GENERATION,
+        TARGET_GENERATION,
+        BASE_SEQUENCE,
+        TARGET_MARKER_EPOCH,
+    );
+    fixtures.push(Fixture::new(
+        "tail-repair.marker-switched.bin",
+        encode_enabled_marker_file(&marker).expect("tail-repair marker encodes"),
+        FixtureValidation::MarkerFile,
+    ));
+    add_marker_committed_frontiers(
+        fixtures,
+        "tail-repair",
+        &marker,
+        &opened_unit,
+        TARGET_GENERATION,
+        BASE_SEQUENCE,
+        PREDECESSOR_ACK_EPOCH + 2,
+        TARGET_MARKER_EPOCH,
+    );
+}
+
+fn add_marker_committed_frontiers(
+    fixtures: &mut Vec<Fixture>,
+    prefix: &str,
+    marker: &EnabledMarkerFile,
+    opened_unit: &AcknowledgedUnit,
+    generation: u64,
+    base_sequence: u64,
+    acknowledgement_epoch: u64,
+    marker_epoch: u64,
+) {
+    let selected = marker.selected_slot().expect("switched marker selects its target");
+    let encoded_marker_slot = encode_enabled_marker_slot(selected).expect("selected marker slot encodes");
+    let marker_committed = LedgerRecord::MarkerCommitted {
+        store_uuid: sample_store_uuid(),
+        marker_epoch,
+        snapshot_generation: generation,
+        log_generation: generation,
+        anchor_sequence: base_sequence + 1,
+        slot_index: selected.slot_index,
+        slot_crc32: u32::from_le_bytes(encoded_marker_slot[100..104].try_into().expect("marker slot CRC")),
+    };
+    let opened_prefix = opened_unit.log_bytes();
+    let committed_unit = acknowledged_unit(
+        &marker_committed,
+        base_sequence + 2,
+        generation,
+        acknowledgement_epoch,
+        marker_epoch,
+        opened_prefix.len() as u64,
+    );
+
+    let mut unsealed = opened_prefix.clone();
+    unsealed.extend_from_slice(&committed_unit.frame);
+    fixtures.push(Fixture::new(
+        format!("{prefix}.marker-committed.unsealed.bin"),
+        unsealed,
+        FixtureValidation::SealedUnitsWithUnsealedFinal {
+            first_sequence: base_sequence + 1,
+            generation,
+            sealed_units: 1,
+        },
+    ));
+    fixtures.push(Fixture::new(
+        format!("{prefix}.marker-committed.acknowledged-unit.bundle.bin"),
+        acknowledged_log_bundle(&opened_prefix, &committed_unit),
+        FixtureValidation::AcknowledgedLogBundle {
+            first_sequence: base_sequence + 1,
+            final_sequence: base_sequence + 2,
+            generation,
+        },
+    ));
+}
+
+fn add_orphan_generation_pair(fixtures: &mut Vec<Fixture>) {
+    const SOURCE_GENERATION: u64 = 3;
+    const TARGET_GENERATION: u64 = 4;
+    const BASE_SEQUENCE: u64 = 30;
+
+    let snapshot = generation_snapshot(
+        SnapshotMode::OrdinaryCompaction,
+        TARGET_GENERATION,
+        SOURCE_GENERATION,
+        BASE_SEQUENCE,
+    );
+    let snapshot_bytes = encode_snapshot(&snapshot).expect("orphan snapshot encodes");
+    let opened = log_opened_record(
+        &snapshot_bytes,
+        TARGET_GENERATION,
+        SOURCE_GENERATION,
+        BASE_SEQUENCE,
+        30,
+        OpenReason::Compaction,
+        &[],
+    );
+    let log =
+        encode_ledger_frame(&opened, BASE_SEQUENCE + 1, TARGET_GENERATION).expect("orphan unsealed LogOpened encodes");
+    fixtures.push(Fixture::new(
+        "generation.orphan-higher.snapshot.bin",
+        snapshot_bytes,
+        FixtureValidation::Snapshot,
+    ));
+    fixtures.push(Fixture::new(
+        "generation.orphan-higher.log.bin",
+        log,
+        FixtureValidation::LedgerFrame {
+            sequence: BASE_SEQUENCE + 1,
+            generation: TARGET_GENERATION,
+        },
+    ));
+}
+
+fn add_acknowledged_suffix_loss(fixtures: &mut Vec<Fixture>) {
+    const GENERATION: u64 = 3;
+    const FIRST_SEQUENCE: u64 = 100;
+
+    let first_record = completed_record(99, 66);
+    let first = acknowledged_unit(&first_record, FIRST_SEQUENCE, GENERATION, 41, 4, 0);
+    let retained_log = first.log_bytes();
+    let missing_frame = encode_ledger_frame(&completed_record(99, 67), FIRST_SEQUENCE + 1, GENERATION)
+        .expect("missing acknowledged frame encodes");
+    let missing_slot = AcknowledgementSlot {
+        slot_index: 1,
+        activated: true,
+        store_uuid: sample_store_uuid(),
+        bootstrap_id: bootstrap_id(),
+        acknowledgement_epoch: 42,
+        marker_epoch: 4,
+        log_generation: GENERATION,
+        frame_sequence: FIRST_SEQUENCE + 1,
+        frame_end_offset: retained_log.len() as u64 + missing_frame.len() as u64,
+        frame_crc32: crc32(&missing_frame),
+    };
+    let history = encode_acknowledgement_file(&[
+        AcknowledgementSlotState::Populated(first.slot.clone()),
+        AcknowledgementSlotState::Populated(missing_slot),
+    ])
+    .expect("suffix-loss acknowledgement history encodes");
+    let mut bundle = Vec::with_capacity(4 + retained_log.len() + history.len());
+    bundle.extend_from_slice(&(retained_log.len() as u32).to_le_bytes());
+    bundle.extend_from_slice(&retained_log);
+    bundle.extend_from_slice(&history);
+    fixtures.push(Fixture::new(
+        "invalid.acknowledged-complete-suffix-loss.bundle.bin",
+        bundle,
+        FixtureValidation::AcknowledgedSuffixLossBundle {
+            first_sequence: FIRST_SEQUENCE,
+            generation: GENERATION,
+        },
+    ));
+}
+
+fn add_overlong_tail_repair(fixtures: &mut Vec<Fixture>) {
+    let snapshot = generation_snapshot(SnapshotMode::TailRepair, 2, 1, 20);
+    let snapshot_bytes = encode_snapshot(&snapshot).expect("tail-repair snapshot encodes");
+    let record = log_opened_record(&snapshot_bytes, 2, 1, 20, 20, OpenReason::TailRepair, b"tail");
+    let mut frame = encode_ledger_frame(&record, 21, 2).expect("valid tail-repair frame encodes");
+    let suffix_length_offset = 40 + 80;
+    frame[suffix_length_offset..suffix_length_offset + 4]
+        .copy_from_slice(&(MAX_SEALED_RECORD_UNIT_LENGTH as u32).to_le_bytes());
+    refresh_payload_crc(&mut frame);
+    fixtures.push(Fixture::new(
+        "invalid.log-opened-overlong-suffix.bin",
+        frame,
+        FixtureValidation::InvalidTypedLedgerFrame {
+            sequence: 21,
+            generation: 2,
+        },
+    ));
+}
+
+fn generation_snapshot(
+    mode: SnapshotMode,
+    generation: u64,
+    predecessor_log_generation: u64,
+    base_sequence: u64,
+) -> LifecycleSnapshot {
+    LifecycleSnapshot {
+        mode,
+        store_uuid: sample_store_uuid(),
+        generation,
+        log_generation: generation,
+        predecessor_log_generation,
+        base_sequence,
+        create_high_water: 7,
+        ticket_high_water: 42,
+        entries: Vec::new(),
+    }
+}
+
+fn log_opened_record(
+    snapshot_bytes: &[u8],
+    generation: u64,
+    predecessor_generation: u64,
+    base_sequence: u64,
+    predecessor_acknowledgement_epoch: u64,
+    open_reason: OpenReason,
+    unacknowledged_suffix: &[u8],
+) -> LedgerRecord {
+    LedgerRecord::LogOpened {
+        store_uuid: sample_store_uuid(),
+        generation,
+        snapshot_generation: generation,
+        predecessor_log_generation: predecessor_generation,
+        predecessor_terminal_acknowledged_sequence: base_sequence,
+        snapshot_base_sequence: base_sequence,
+        snapshot_file_length: snapshot_bytes.len() as u64,
+        snapshot_file_crc32: crc32(snapshot_bytes),
+        predecessor_prefix_crc32: crc32(b"acknowledged-predecessor-prefix"),
+        validated_prefix_length: 1_024,
+        unacknowledged_suffix_length: unacknowledged_suffix.len() as u32,
+        unacknowledged_suffix_crc32: crc32(unacknowledged_suffix),
+        open_reason,
+        predecessor_acknowledgement_epoch,
+    }
+}
+
+fn switched_marker(
+    snapshot_bytes: &[u8],
+    opened_frame: &[u8],
+    source_generation: u64,
+    target_generation: u64,
+    base_sequence: u64,
+    marker_epoch: u64,
+) -> EnabledMarkerFile {
+    let target_index = ((marker_epoch - 1) & 1) as u8;
+    let source_index = 1 - target_index;
+    let source = marker_slot(
+        source_index,
+        marker_epoch - 1,
+        source_generation,
+        base_sequence,
+        108,
+        0x1111_1111,
+        0x2222_2222,
+    );
+    let target = marker_slot(
+        target_index,
+        marker_epoch,
+        target_generation,
+        base_sequence + 1,
+        snapshot_bytes.len() as u64,
+        crc32(snapshot_bytes),
+        crc32(opened_frame),
+    );
+    if target_index == 0 {
+        EnabledMarkerFile {
+            slots: [Some(target), Some(source)],
+        }
+    } else {
+        EnabledMarkerFile {
+            slots: [Some(source), Some(target)],
+        }
+    }
+}
+
+fn completed_record(namespace_absent_sequence: u64, completion_time_ns: u64) -> LedgerRecord {
+    LedgerRecord::Completed {
+        ticket_id: ticket(),
+        incarnation: incarnation(),
+        completion_time_ns,
+        namespace_absent_sequence,
+    }
+}
+
+struct AcknowledgedUnit {
+    frame: Vec<u8>,
+    slot: AcknowledgementSlot,
+    encoded_slot: [u8; 104],
+    encoded_seal: [u8; 72],
+}
+
+impl AcknowledgedUnit {
+    fn log_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(self.frame.len() + self.encoded_seal.len());
+        bytes.extend_from_slice(&self.frame);
+        bytes.extend_from_slice(&self.encoded_seal);
+        bytes
+    }
+}
+
+fn acknowledged_unit(
+    record: &LedgerRecord,
+    sequence: u64,
+    generation: u64,
+    acknowledgement_epoch: u64,
+    marker_epoch: u64,
+    frame_offset: u64,
+) -> AcknowledgedUnit {
+    let frame = encode_ledger_frame(record, sequence, generation).expect("frontier frame encodes");
+    let slot = AcknowledgementSlot {
+        slot_index: ((acknowledgement_epoch - 1) & 1) as u8,
+        activated: true,
+        store_uuid: sample_store_uuid(),
+        bootstrap_id: bootstrap_id(),
+        acknowledgement_epoch,
+        marker_epoch,
+        log_generation: generation,
+        frame_sequence: sequence,
+        frame_end_offset: frame_offset + frame.len() as u64,
+        frame_crc32: crc32(&frame),
+    };
+    let encoded_slot = encode_acknowledgement_slot(&slot).expect("frontier acknowledgement slot encodes");
+    let seal =
+        CommitSeal::from_acknowledgement_slot(&slot, &encoded_slot).expect("frontier seal derives from the exact slot");
+    let encoded_seal = encode_commit_seal(&seal).expect("frontier seal encodes");
+    AcknowledgedUnit {
+        frame,
+        slot,
+        encoded_slot,
+        encoded_seal,
+    }
+}
+
+fn acknowledged_log_bundle(prefix: &[u8], final_unit: &AcknowledgedUnit) -> Vec<u8> {
+    let mut bundle = Vec::with_capacity(
+        8 + prefix.len() + final_unit.frame.len() + final_unit.encoded_seal.len() + final_unit.encoded_slot.len(),
+    );
+    bundle.extend_from_slice(&(prefix.len() as u32).to_le_bytes());
+    bundle.extend_from_slice(&(final_unit.frame.len() as u32).to_le_bytes());
+    bundle.extend_from_slice(prefix);
+    bundle.extend_from_slice(&final_unit.frame);
+    bundle.extend_from_slice(&final_unit.encoded_seal);
+    bundle.extend_from_slice(&final_unit.encoded_slot);
+    bundle
+}

--- a/rocketmq-store-local/src/mapped_file/retirement/fixture_corpus/build/samples.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/fixture_corpus/build/samples.rs
@@ -1,0 +1,395 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::mapped_file::retirement::codec::ContentFingerprint;
+use crate::mapped_file::retirement::codec::GenerationAbortReason;
+use crate::mapped_file::retirement::codec::LedgerRecord;
+use crate::mapped_file::retirement::codec::OpenReason;
+use crate::mapped_file::retirement::codec::QuarantineEntityKind;
+use crate::mapped_file::retirement::codec::QuarantineReason;
+use crate::mapped_file::retirement::codec::RetirementReason;
+use crate::mapped_file::retirement::identity::FileIncarnationId;
+use crate::mapped_file::retirement::identity::PhysicalFileKey;
+use crate::mapped_file::retirement::identity::StoreRelativePath;
+use crate::mapped_file::retirement::identity::StoreUuid;
+use crate::mapped_file::retirement::identity::TicketId;
+use crate::mapped_file::retirement::sidecar::EnabledMarkerSlot;
+use crate::mapped_file::retirement::sidecar::IncarnationPhase;
+use crate::mapped_file::retirement::sidecar::IncarnationSnapshotEntry;
+use crate::mapped_file::retirement::sidecar::LifecycleSnapshot;
+use crate::mapped_file::retirement::sidecar::QuarantineSnapshotEntry;
+use crate::mapped_file::retirement::sidecar::RetirementStage;
+use crate::mapped_file::retirement::sidecar::RetirementTicketSnapshotEntry;
+use crate::mapped_file::retirement::sidecar::SnapshotEntry;
+use crate::mapped_file::retirement::sidecar::SnapshotMode;
+use crate::mapped_file::retirement::sidecar::StoreMeta;
+
+pub(super) fn sample_records() -> Vec<(&'static str, LedgerRecord, u64, u64)> {
+    record_map()
+        .into_iter()
+        .enumerate()
+        .map(|(index, (name, record))| match name {
+            "store-initialized" => (name, record, 1, 0),
+            "bootstrap-installed" => (name, record, 2, 0),
+            "log-opened" => (name, record, 21, 3),
+            "generation-prepared" => (name, record, 10, 2),
+            "generation-aborted" => (name, record, 11, 2),
+            "marker-committed" => (name, record, 3, 0),
+            _ => (name, record, 100 + index as u64, 3),
+        })
+        .collect()
+}
+
+pub(super) fn record_map() -> Vec<(&'static str, LedgerRecord)> {
+    let canonical_path = canonical_path();
+    let create_file_path = create_path();
+    let tombstone_path = tombstone_path();
+    let unix_key = unix_key();
+    let windows_key = windows_key();
+    vec![
+        (
+            "store-initialized",
+            LedgerRecord::StoreInitialized {
+                store_uuid: sample_store_uuid(),
+                bootstrap_id: bootstrap_id(),
+                creation_time_ns: 11,
+            },
+        ),
+        (
+            "bootstrap-installed",
+            LedgerRecord::BootstrapInstalled {
+                store_uuid: sample_store_uuid(),
+                bootstrap_id: bootstrap_id(),
+                snapshot_generation: 0,
+                snapshot_base_sequence: 1,
+                snapshot_file_length: 108,
+                snapshot_file_crc32: 0x1234_5678,
+                inventory_count: 3,
+                create_high_water: 7,
+                ticket_high_water: 42,
+            },
+        ),
+        (
+            "log-opened",
+            LedgerRecord::LogOpened {
+                store_uuid: sample_store_uuid(),
+                generation: 3,
+                snapshot_generation: 3,
+                predecessor_log_generation: 2,
+                predecessor_terminal_acknowledged_sequence: 20,
+                snapshot_base_sequence: 20,
+                snapshot_file_length: 108,
+                snapshot_file_crc32: 0x1111_1111,
+                predecessor_prefix_crc32: 0x2222_2222,
+                validated_prefix_length: 1_000,
+                unacknowledged_suffix_length: 0,
+                unacknowledged_suffix_crc32: 0,
+                open_reason: OpenReason::Compaction,
+                predecessor_acknowledgement_epoch: 9,
+            },
+        ),
+        (
+            "generation-prepared",
+            LedgerRecord::GenerationPrepared {
+                store_uuid: sample_store_uuid(),
+                source_generation: 2,
+                target_generation: 3,
+                target_snapshot_generation: 3,
+                open_reason: OpenReason::Compaction,
+            },
+        ),
+        (
+            "generation-aborted",
+            LedgerRecord::GenerationAborted {
+                store_uuid: sample_store_uuid(),
+                source_generation: 2,
+                target_generation: 3,
+                prepared_sequence: 10,
+                abort_reason: GenerationAbortReason::Io,
+            },
+        ),
+        (
+            "marker-committed",
+            LedgerRecord::MarkerCommitted {
+                store_uuid: sample_store_uuid(),
+                marker_epoch: 1,
+                snapshot_generation: 0,
+                log_generation: 0,
+                anchor_sequence: 2,
+                slot_index: 0,
+                slot_crc32: 0x3344_5566,
+            },
+        ),
+        (
+            "allocate-incarnation",
+            LedgerRecord::AllocateIncarnation {
+                incarnation: incarnation(),
+                segment_offset: 0,
+                expected_length: 1_024,
+                create_nonce: [0x20; 16],
+                canonical_path: canonical_path.clone(),
+                create_file_path: create_file_path.clone(),
+            },
+        ),
+        (
+            "bind-incarnation-unix",
+            LedgerRecord::BindIncarnation {
+                incarnation: incarnation(),
+                expected_length: 1_024,
+                physical_key: unix_key,
+                canonical_path: canonical_path.clone(),
+                create_file_path: create_file_path.clone(),
+            },
+        ),
+        (
+            "publish-incarnation-windows",
+            LedgerRecord::PublishIncarnation {
+                incarnation: incarnation(),
+                expected_length: 1_024,
+                physical_key: windows_key,
+                canonical_path: canonical_path.clone(),
+                create_file_path,
+            },
+        ),
+        (
+            "retirement-intent",
+            LedgerRecord::RetirementIntent {
+                ticket_id: ticket(),
+                incarnation: incarnation(),
+                reason: RetirementReason::TtlExpired,
+                mapping_generation: 3,
+                segment_offset: 0,
+                expected_length: 1_024,
+                retirement_nonce: [0x40; 16],
+                target_key: unix_key,
+                canonical_path: canonical_path.clone(),
+            },
+        ),
+        (
+            "logical-removed",
+            LedgerRecord::LogicalRemoved {
+                ticket_id: ticket(),
+                incarnation: incarnation(),
+                target_key: unix_key,
+                canonical_path: canonical_path.clone(),
+            },
+        ),
+        (
+            "tombstoned",
+            LedgerRecord::Tombstoned {
+                ticket_id: ticket(),
+                incarnation: incarnation(),
+                target_key: unix_key,
+                retirement_nonce: [0x40; 16],
+                canonical_path: canonical_path.clone(),
+                tombstone_path: tombstone_path.clone(),
+            },
+        ),
+        (
+            "namespace-absent",
+            LedgerRecord::NamespaceAbsent {
+                ticket_id: ticket(),
+                incarnation: incarnation(),
+                replacement_observed: true,
+                observation_time_ns: 55,
+                target_key: unix_key,
+                canonical_path: canonical_path.clone(),
+                tombstone_path: Some(tombstone_path.clone()),
+            },
+        ),
+        (
+            "completed",
+            LedgerRecord::Completed {
+                ticket_id: ticket(),
+                incarnation: incarnation(),
+                completion_time_ns: 66,
+                namespace_absent_sequence: 99,
+            },
+        ),
+        (
+            "superseded-path",
+            LedgerRecord::SupersededPath {
+                ticket_id: ticket(),
+                incarnation: incarnation(),
+                expected_target_key: unix_key,
+                observed_replacement_key: windows_key,
+                canonical_path,
+            },
+        ),
+        (
+            "quarantined",
+            LedgerRecord::Quarantined {
+                entity_kind: QuarantineEntityKind::Tombstone,
+                reason: QuarantineReason::KeyMismatch,
+                sequence_at_observation: 77,
+                physical_key: Some(windows_key),
+                content_fingerprint: Some(ContentFingerprint {
+                    length: 1_024,
+                    crc32: 0x1234_5678,
+                }),
+                source_path: tombstone_path,
+                destination_path: Some(path(".rocketmq-lifecycle/quarantine/tombstone.bin")),
+            },
+        ),
+    ]
+}
+
+pub(super) fn sample_store_meta() -> StoreMeta {
+    StoreMeta {
+        store_uuid: sample_store_uuid(),
+        creation_time_ns: 0x0102_0304_0506_0708,
+        bootstrap_id: bootstrap_id(),
+    }
+}
+
+pub(super) fn marker_slot(
+    slot_index: u8,
+    marker_epoch: u64,
+    generation: u64,
+    anchor_sequence: u64,
+    snapshot_file_length: u64,
+    snapshot_file_crc32: u32,
+    anchor_frame_crc32: u32,
+) -> EnabledMarkerSlot {
+    EnabledMarkerSlot {
+        slot_index,
+        store_uuid: sample_store_uuid(),
+        bootstrap_id: bootstrap_id(),
+        marker_epoch,
+        snapshot_generation: generation,
+        log_generation: generation,
+        anchor_sequence,
+        snapshot_file_length,
+        snapshot_file_crc32,
+        anchor_frame_crc32,
+    }
+}
+
+pub(super) fn snapshot(mode: SnapshotMode, entries: Vec<SnapshotEntry>) -> LifecycleSnapshot {
+    let (generation, predecessor_log_generation, base_sequence) = match mode {
+        SnapshotMode::BootstrapInventory => (0, u64::MAX, 1),
+        SnapshotMode::OrdinaryCompaction => (1, 0, 100),
+        SnapshotMode::TailRepair => (2, 1, 100),
+    };
+    LifecycleSnapshot {
+        mode,
+        store_uuid: sample_store_uuid(),
+        generation,
+        log_generation: generation,
+        predecessor_log_generation,
+        base_sequence,
+        create_high_water: 7,
+        ticket_high_water: 42,
+        entries,
+    }
+}
+
+pub(super) fn sample_incarnation_entry() -> IncarnationSnapshotEntry {
+    IncarnationSnapshotEntry {
+        incarnation: incarnation(),
+        phase: IncarnationPhase::Published,
+        segment_offset: 0,
+        expected_file_length: 1_024,
+        create_nonce: [0x20; 16],
+        physical_key: Some(unix_key()),
+        canonical_path: canonical_path(),
+        create_file_path: create_path(),
+    }
+}
+
+pub(super) fn sample_retirement_entry(stage: RetirementStage) -> RetirementTicketSnapshotEntry {
+    RetirementTicketSnapshotEntry {
+        ticket_id: ticket(),
+        incarnation: incarnation(),
+        stage,
+        superseded_path_observed: true,
+        quarantined: false,
+        reason: RetirementReason::TtlExpired,
+        stage_sequence: 99,
+        mapping_generation: 3,
+        segment_offset: 0,
+        expected_file_length: 1_024,
+        retirement_nonce: [0x40; 16],
+        target_key: unix_key(),
+        canonical_path: canonical_path(),
+        tombstone_path: match stage {
+            RetirementStage::Tombstoned | RetirementStage::NamespaceAbsent | RetirementStage::CompletedRetained => {
+                Some(tombstone_path())
+            }
+            RetirementStage::IntentDurable | RetirementStage::LogicalRemoved => None,
+        },
+    }
+}
+
+pub(super) fn sample_quarantine_entry() -> QuarantineSnapshotEntry {
+    QuarantineSnapshotEntry {
+        entity_kind: QuarantineEntityKind::Sidecar,
+        reason: QuarantineReason::UnknownOwner,
+        sequence_at_observation: 88,
+        physical_key: Some(windows_key()),
+        content_fingerprint: Some(ContentFingerprint {
+            length: 1_234,
+            crc32: 0xaabb_ccdd,
+        }),
+        source_path: path(".rocketmq-lifecycle/orphan.tmp"),
+        destination_path: Some(path(".rocketmq-lifecycle/quarantine/orphan.bin")),
+    }
+}
+
+pub(super) fn sample_store_uuid() -> StoreUuid {
+    StoreUuid::new(std::array::from_fn(|index| index as u8)).expect("sample UUID is nonzero")
+}
+
+pub(super) fn bootstrap_id() -> [u8; 16] {
+    std::array::from_fn(|index| 0x10 + index as u8)
+}
+
+pub(super) fn incarnation() -> FileIncarnationId {
+    FileIncarnationId::new(sample_store_uuid(), 7).expect("sample incarnation is nonzero")
+}
+
+pub(super) fn ticket() -> TicketId {
+    TicketId::new(42).expect("sample ticket is nonzero")
+}
+
+pub(super) fn unix_key() -> PhysicalFileKey {
+    PhysicalFileKey::unix(0x0102_0304_0506_0708, 0x1112_1314_1516_1718)
+}
+
+pub(super) fn windows_key() -> PhysicalFileKey {
+    PhysicalFileKey::windows(0x2122_2324_2526_2728, std::array::from_fn(|index| 0x30 + index as u8))
+}
+
+pub(super) fn path(value: &str) -> StoreRelativePath {
+    StoreRelativePath::new(value).expect("fixture path is canonical")
+}
+
+pub(super) fn canonical_path() -> StoreRelativePath {
+    path("commitlog/00000000000000000000")
+}
+
+pub(super) fn create_path() -> StoreRelativePath {
+    path("commitlog/.create.i0000000000000007.s00000000000000000000.n20202020202020202020202020202020")
+}
+
+pub(super) fn tombstone_path() -> StoreRelativePath {
+    path(
+        "commitlog/.delete.t000000000000002a.i0000000000000007.s00000000000000000000.m0000000000000003.n40404040404040404040404040404040",
+    )
+}
+
+pub(super) fn maximum_path() -> StoreRelativePath {
+    let raw = std::iter::repeat_n("a".repeat(240), 17).collect::<Vec<_>>().join("/");
+    StoreRelativePath::new(&raw).expect("4096-byte path is valid")
+}

--- a/rocketmq-store-local/src/mapped_file/retirement/platform.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/platform.rs
@@ -15,6 +15,8 @@
 use std::fs::File;
 use std::io;
 
+use super::identity::StoreRelativePath;
+
 mod creation;
 #[allow(dead_code, reason = "M3 stages the namespace engine before Wave-B reaper wiring")]
 mod engine;
@@ -261,6 +263,19 @@ impl VerifiedNamespaceRoot {
             store_uuid: session.writer_frontier().store_uuid(),
             native,
         })
+    }
+
+    /// Opens one replay-authorized active segment for writable mapping from the retained root.
+    ///
+    /// The native backend performs strict handle-relative, no-follow resolution and revalidates
+    /// the exact physical key and durable length before returning the handle.
+    pub(in crate::mapped_file::retirement) fn open_active_segment(
+        &self,
+        path: &StoreRelativePath,
+        physical_key: PhysicalFileKey,
+        expected_length: u64,
+    ) -> Result<File, NamespaceVerificationError> {
+        self.native.open_active_segment(path, physical_key, expected_length)
     }
 
     pub(crate) fn reserve(

--- a/rocketmq-store-local/src/mapped_file/retirement/platform/linux.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/platform/linux.rs
@@ -33,6 +33,7 @@ use super::types::NamespaceRetirementRequest;
 use super::types::NamespaceTransition;
 use super::types::NamespaceVerificationError;
 use crate::mapped_file::retirement::identity::PhysicalFileKey;
+use crate::mapped_file::retirement::identity::StoreRelativePath;
 use crate::mapped_file::retirement::writer::AllocatedIncarnationReceipt;
 use crate::mapped_file::retirement::writer::BoundIncarnationReceipt;
 
@@ -107,6 +108,60 @@ impl NamespaceRoot {
             canonical: None,
             tombstone: None,
         })
+    }
+
+    pub(super) fn open_active_segment(
+        &self,
+        path: &StoreRelativePath,
+        expected_key: PhysicalFileKey,
+        expected_length: u64,
+    ) -> Result<File, NamespaceVerificationError> {
+        if !matches!(expected_key, PhysicalFileKey::Unix(_)) {
+            return Err(NamespaceVerificationError::Rejected(
+                NamespacePolicyViolation::PhysicalKeyPlatformMismatch,
+            ));
+        }
+        let (parent_path, file_name) = split_parent(path.as_str());
+        let parent = open_parent_strict(&self.file, parent_path)?;
+        let parent_metadata = parent
+            .metadata()
+            .map_err(|error| classify_io(NamespaceOperation::OpenParent, error).into_verification_error())?;
+        if !parent_metadata.is_dir() || parent_metadata.dev() != self.device {
+            return Err(NamespaceVerificationError::Rejected(
+                NamespacePolicyViolation::ParentEscapedRoot,
+            ));
+        }
+        let file_name = CString::new(file_name)
+            .map_err(|_| NamespaceVerificationError::Rejected(NamespacePolicyViolation::ParentEscapedRoot))?;
+        let file = openat2(&parent, &file_name, libc::O_RDWR | libc::O_CLOEXEC | libc::O_NOFOLLOW)
+            .map_err(|error| classify_io(NamespaceOperation::VerifyCanonical, error).into_verification_error())?;
+        let metadata = file
+            .metadata()
+            .map_err(|error| classify_io(NamespaceOperation::VerifyCanonical, error).into_verification_error())?;
+        if !metadata.is_file() || metadata.dev() != self.device {
+            return Err(NamespaceVerificationError::Rejected(
+                NamespacePolicyViolation::UnexpectedEntryType {
+                    entry: NamespaceEntry::Canonical,
+                },
+            ));
+        }
+        if metadata.len() != expected_length {
+            return Err(NamespaceVerificationError::Rejected(
+                NamespacePolicyViolation::ExpectedLengthMismatch {
+                    entry: NamespaceEntry::Canonical,
+                    expected: expected_length,
+                    actual: metadata.len(),
+                },
+            ));
+        }
+        let actual_key = physical_key::capture(&file)
+            .map_err(|error| classify_io(NamespaceOperation::VerifyCanonical, error).into_verification_error())?;
+        if actual_key != expected_key {
+            return Err(NamespaceVerificationError::Rejected(
+                NamespacePolicyViolation::NamespaceChangedDuringVerification,
+            ));
+        }
+        Ok(file)
     }
 
     pub(super) fn create_incarnation_temp(

--- a/rocketmq-store-local/src/mapped_file/retirement/platform/windows.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/platform/windows.rs
@@ -94,6 +94,7 @@ use super::types::NamespaceRetirementRequest;
 use super::types::NamespaceTransition;
 use super::types::NamespaceVerificationError;
 use crate::mapped_file::retirement::identity::PhysicalFileKey;
+use crate::mapped_file::retirement::identity::StoreRelativePath;
 use crate::mapped_file::retirement::writer::AllocatedIncarnationReceipt;
 use crate::mapped_file::retirement::writer::BoundIncarnationReceipt;
 
@@ -163,6 +164,58 @@ impl NamespaceRoot {
             canonical: None,
             tombstone: None,
         })
+    }
+
+    pub(super) fn open_active_segment(
+        &self,
+        path: &StoreRelativePath,
+        expected_key: PhysicalFileKey,
+        expected_length: u64,
+    ) -> Result<File, NamespaceVerificationError> {
+        if !self.writer_qualified {
+            return Err(NamespaceVerificationError::Unsupported {
+                platform: "windows",
+                reason: UNQUALIFIED_WRITER_REASON,
+            });
+        }
+        if !matches!(expected_key, PhysicalFileKey::Windows(_)) {
+            return Err(NamespaceVerificationError::Rejected(
+                NamespacePolicyViolation::PhysicalKeyPlatformMismatch,
+            ));
+        }
+        let (parent_path, file_name) = split_parent(path.as_str());
+        let parent = open_parent(&self.file, parent_path)?;
+        let file = open_writable_relative(&parent, file_name, FILE_OPEN, false)
+            .map_err(|error| classify_io(NamespaceOperation::VerifyCanonical, error).into_verification_error())?;
+        let attributes = query_attributes(&file, NamespaceOperation::VerifyCanonical)
+            .map_err(BackendFailure::into_verification_error)?;
+        if attributes.FileAttributes & (FILE_ATTRIBUTE_DIRECTORY.0 | FILE_ATTRIBUTE_REPARSE_POINT.0) != 0 {
+            return Err(NamespaceVerificationError::Rejected(
+                NamespacePolicyViolation::UnexpectedEntryType {
+                    entry: NamespaceEntry::Canonical,
+                },
+            ));
+        }
+        let metadata = file
+            .metadata()
+            .map_err(|error| classify_io(NamespaceOperation::VerifyCanonical, error).into_verification_error())?;
+        if metadata.len() != expected_length {
+            return Err(NamespaceVerificationError::Rejected(
+                NamespacePolicyViolation::ExpectedLengthMismatch {
+                    entry: NamespaceEntry::Canonical,
+                    expected: expected_length,
+                    actual: metadata.len(),
+                },
+            ));
+        }
+        let actual_key = physical_key::capture(&file)
+            .map_err(|error| classify_io(NamespaceOperation::VerifyCanonical, error).into_verification_error())?;
+        if actual_key != expected_key {
+            return Err(NamespaceVerificationError::Rejected(
+                NamespacePolicyViolation::NamespaceChangedDuringVerification,
+            ));
+        }
+        Ok(file)
     }
 
     pub(super) fn create_incarnation_temp(
@@ -640,6 +693,15 @@ fn open_created_relative(
     name: &str,
     disposition: windows::Wdk::Storage::FileSystem::NTCREATEFILE_CREATE_DISPOSITION,
 ) -> io::Result<File> {
+    open_writable_relative(parent, name, disposition, true)
+}
+
+fn open_writable_relative(
+    parent: &File,
+    name: &str,
+    disposition: windows::Wdk::Storage::FileSystem::NTCREATEFILE_CREATE_DISPOSITION,
+    request_delete_access: bool,
+) -> io::Result<File> {
     let mut wide = name.encode_utf16().collect::<Vec<_>>();
     let byte_length = wide
         .len()
@@ -659,8 +721,11 @@ fn open_created_relative(
         SecurityDescriptor: ptr::null(),
         SecurityQualityOfService: ptr::null(),
     };
-    let desired =
-        FILE_ACCESS_RIGHTS(DELETE.0 | FILE_READ_DATA.0 | FILE_WRITE_DATA.0 | FILE_READ_ATTRIBUTES.0 | SYNCHRONIZE.0);
+    let mut desired = FILE_READ_DATA.0 | FILE_WRITE_DATA.0 | FILE_READ_ATTRIBUTES.0 | SYNCHRONIZE.0;
+    if request_delete_access {
+        desired |= DELETE.0;
+    }
+    let desired = FILE_ACCESS_RIGHTS(desired);
     let share = FILE_SHARE_MODE(FILE_SHARE_READ.0 | FILE_SHARE_WRITE.0 | FILE_SHARE_DELETE.0);
     let options = FILE_OPEN_REPARSE_POINT.0 | FILE_SYNCHRONOUS_IO_NONALERT.0 | FILE_NON_DIRECTORY_FILE.0;
     let mut handle = HANDLE(ptr::null_mut());

--- a/rocketmq-store-local/src/mapped_file/retirement/registry/queue_slot.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/registry/queue_slot.rs
@@ -351,6 +351,10 @@ impl<T> ManagedMappedFileQueueGeneration<T> {
         self.slot.snapshot()
     }
 
+    pub(in crate::mapped_file::retirement) fn same_queue_as(&self, other: &Self) -> bool {
+        self.slot.identity.same_as(&other.slot.identity)
+    }
+
     pub(in crate::mapped_file::retirement) fn queue_identity(&self) -> QueueIdentity {
         self.slot.identity.clone()
     }

--- a/rocketmq-store-local/src/mapped_file/retirement/service.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/service.rs
@@ -252,7 +252,28 @@ struct ManagedLifecycleRuntimeInner {
     // Retains the exclusive Store-root lease and replay proof for the writer's lifetime.
     _session: super::state::reconciliation::ReconciledLifecycleSession,
     core: ManagedRetirementCore<FileLedgerIo, VerifiedNamespaceRoot, DefaultMappedFile>,
-    accepting: bool,
+    admission: RuntimeAdmission,
+    queue_generations: Vec<ManagedMappedFileQueueGeneration<DefaultMappedFile>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RuntimeAdmission {
+    Running,
+    Shutdown,
+    StoreDestroy,
+}
+
+impl RuntimeAdmission {
+    fn enter_store_destroy(&mut self) -> bool {
+        match self {
+            Self::Running => false,
+            Self::Shutdown => {
+                *self = Self::StoreDestroy;
+                true
+            }
+            Self::StoreDestroy => true,
+        }
+    }
 }
 
 impl std::fmt::Debug for ManagedLifecycleRuntime {
@@ -262,7 +283,7 @@ impl std::fmt::Debug for ManagedLifecycleRuntime {
             .debug_struct("ManagedLifecycleRuntime")
             .field("pending_tickets", &inner.core.registry.retained_identity_count())
             .field("recovery_required", &inner.core.recovery_required)
-            .field("accepting", &inner.accepting)
+            .field("admission", &inner.admission)
             .finish_non_exhaustive()
     }
 }
@@ -285,7 +306,8 @@ impl ManagedLifecycleRuntime {
             inner: Arc::new(Mutex::new(ManagedLifecycleRuntimeInner {
                 _session: session,
                 core,
-                accepting: true,
+                admission: RuntimeAdmission::Running,
+                queue_generations: Vec::new(),
             })),
         }
     }
@@ -296,7 +318,26 @@ impl ManagedLifecycleRuntime {
     /// receipt. Admission remains controlled by the runtime when allocation is attempted.
     #[must_use]
     pub fn empty_queue_generation(&self) -> ManagedMappedFileQueueGeneration<DefaultMappedFile> {
-        ManagedMappedFileQueueGeneration::new_write_disabled()
+        let generation = ManagedMappedFileQueueGeneration::new_write_disabled();
+        self.track_queue_generation(&generation);
+        generation
+    }
+
+    /// Registers a reconciled queue generation with this runtime's Store-wide lifecycle owner.
+    ///
+    /// Registration is process-local and idempotent. Durable publication and replay validation
+    /// remain prerequisites performed by activation before this method is called.
+    #[doc(hidden)]
+    pub fn track_queue_generation(&self, generation: &ManagedMappedFileQueueGeneration<DefaultMappedFile>) {
+        let mut inner = self.inner.lock();
+        if inner
+            .queue_generations
+            .iter()
+            .any(|tracked| tracked.same_queue_as(generation))
+        {
+            return;
+        }
+        inner.queue_generations.push(generation.clone());
     }
 
     /// Executes at most `max_actions` durable or namespace transitions synchronously.
@@ -318,7 +359,42 @@ impl ManagedLifecycleRuntime {
 
     /// Stops admission of new durable intents while preserving replayable backlog authority.
     pub fn begin_shutdown(&self) {
-        self.inner.lock().accepting = false;
+        self.inner.lock().admission = RuntimeAdmission::Shutdown;
+    }
+
+    /// Durably submits every currently active member of every tracked managed queue.
+    ///
+    /// The simple lifecycle gate permits only `Shutdown -> StoreDestroy`; retries remain in
+    /// `StoreDestroy`. This function performs blocking ledger I/O and must run inside one Store
+    /// storage-IO operation.
+    pub fn submit_store_destroy_retirements(&self) -> Result<usize, ManagedRetirementSubmissionError> {
+        let mut inner = self.inner.lock();
+        if !inner.admission.enter_store_destroy() {
+            return Err(ManagedRetirementSubmissionError::admission_closed());
+        }
+        let generations = inner.queue_generations.clone();
+        inner
+            .core
+            .submit_store_destroy_at(&generations, store_destroy_nonce, Instant::now())
+    }
+
+    /// Returns whether every tracked queue member completed namespace retirement.
+    #[must_use]
+    pub fn store_destroy_complete(&self) -> bool {
+        let inner = self.inner.lock();
+        !inner.core.recovery_required
+            && inner.core.backlog.is_empty()
+            && inner
+                .queue_generations
+                .iter()
+                .all(|generation| generation.snapshot().is_empty())
+    }
+
+    /// Returns whether a prior retirement submission still owns unfinished durable work.
+    #[must_use]
+    pub fn has_retirement_backlog(&self) -> bool {
+        let inner = self.inner.lock();
+        inner.core.recovery_required || !inner.core.backlog.is_empty()
     }
 
     /// Executes one bounded drain batch without waiting for retry backoff.
@@ -342,7 +418,7 @@ impl ManagedLifecycleRuntime {
         retirement_nonce: [u8; 16],
     ) -> Result<ManagedRetirementSubmission, ManagedRetirementSubmissionError> {
         let mut inner = self.inner.lock();
-        if !inner.accepting {
+        if inner.admission != RuntimeAdmission::Running {
             return Err(ManagedRetirementSubmissionError::admission_closed());
         }
         inner
@@ -363,6 +439,19 @@ fn unix_time_ns() -> u64 {
         .unwrap_or_default()
         .as_nanos();
     u64::try_from(nanos).unwrap_or(u64::MAX)
+}
+
+fn store_destroy_nonce() -> [u8; 16] {
+    static NEXT_NONCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+    let sequence = NEXT_NONCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut nonce = [0u8; 16];
+    nonce[..8].copy_from_slice(&sequence.to_le_bytes());
+    nonce[8..].copy_from_slice(&unix_time_ns().to_le_bytes());
+    if nonce == [0; 16] {
+        nonce[0] = 1;
+    }
+    nonce
 }
 
 pub(super) trait NamespaceDriver<I: LedgerIo, O> {
@@ -582,6 +671,26 @@ impl<I: LedgerIo, D: NamespaceDriver<I, O>, O> ManagedRetirementCore<I, D, O> {
                 }
             },
         }
+    }
+
+    fn submit_store_destroy_at<F>(
+        &mut self,
+        generations: &[ManagedMappedFileQueueGeneration<O>],
+        mut next_nonce: F,
+        now: Instant,
+    ) -> Result<usize, ManagedRetirementSubmissionError>
+    where
+        F: FnMut() -> [u8; 16],
+    {
+        let mut submitted = 0usize;
+        for generation in generations {
+            let owners = generation.snapshot();
+            for owner in owners.iter() {
+                self.submit_at(generation, owner, RetirementReason::StoreDestroy, next_nonce(), now)?;
+                submitted = submitted.saturating_add(1);
+            }
+        }
+        Ok(submitted)
     }
 
     fn push_work(&mut self, work: PendingRetirement<O>, now: Instant) {

--- a/rocketmq-store-local/src/mapped_file/retirement/service/creation.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/service/creation.rs
@@ -214,7 +214,7 @@ impl ManagedLifecycleRuntime {
         request: ManagedIncarnationCreateRequest,
     ) -> Result<ManagedIncarnationCreation, ManagedIncarnationCreationError> {
         let mut inner = self.inner.lock();
-        if !inner.accepting {
+        if inner.admission != super::RuntimeAdmission::Running {
             return Err(ManagedIncarnationCreationError::new(
                 ManagedIncarnationCreationErrorKind::AdmissionClosed,
                 ManagedIncarnationCreationErrorSource::AdmissionClosed,

--- a/rocketmq-store-local/src/mapped_file/retirement/service/tests.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/service/tests.rs
@@ -212,6 +212,65 @@ fn new_retirement_is_durable_before_the_single_queue_handoff() {
     assert!(!report.recovery_required());
 }
 
+#[test]
+fn store_destroy_submits_every_active_member_through_the_existing_retirement_pipeline() {
+    let registry = RetirementRegistry::new_for_test(store_uuid(), 0);
+    let first_owner = Arc::new(TestOwner);
+    let second_owner = Arc::new(TestOwner);
+    let second_incarnation = FileIncarnationId::new(store_uuid(), 2).expect("second incarnation is nonzero");
+    let second_path = StoreRelativePath::new("commitlog/00000000000000001024").expect("second path is canonical");
+    let queue = ManagedMappedFileQueueGeneration::from_reconciled_members(vec![
+        ManagedQueueMember::new(
+            Arc::clone(&first_owner),
+            incarnation(),
+            physical_key(),
+            canonical_path(),
+            0,
+            FILE_LENGTH,
+            1,
+        )
+        .expect("first managed member is valid"),
+        ManagedQueueMember::new(
+            Arc::clone(&second_owner),
+            second_incarnation,
+            PhysicalFileKey::unix(7, 12),
+            second_path,
+            FILE_LENGTH,
+            FILE_LENGTH,
+            2,
+        )
+        .expect("second managed member is valid"),
+    ])
+    .expect("managed queue generation is valid");
+    queue
+        .register_reconciled_members(&registry)
+        .expect("published identities are registered");
+    let writer = ManagedLedgerWriter::for_test(ModelLedgerIo::empty(), store_uuid(), BOOTSTRAP_ID, 4, 1, 1, 0, true, 1)
+        .expect("managed writer cursor is valid");
+    let started = Instant::now();
+    let mut core = ManagedRetirementCore::new(registry, writer, ImmediateAbsence, Vec::new(), started);
+    let mut nonce = 0x90u8;
+
+    let submitted = core
+        .submit_store_destroy_at(
+            std::slice::from_ref(&queue),
+            || {
+                let current = [nonce; 16];
+                nonce = nonce.wrapping_add(1);
+                current
+            },
+            started,
+        )
+        .expect("Store destroy submits every active member");
+
+    assert_eq!(submitted, 2);
+    assert!(queue.snapshot().is_empty());
+    let report = core.drive_batch_at(4, started, 323);
+    assert_eq!(report.completed(), 2);
+    assert_eq!(report.pending_tickets(), 0);
+    assert!(!report.recovery_required());
+}
+
 struct RetryableNamespace;
 
 impl NamespaceDriver<ModelLedgerIo, TestOwner> for RetryableNamespace {
@@ -256,4 +315,19 @@ fn retryable_namespace_work_is_owned_and_backed_off() {
     assert_eq!(before_backoff.attempted(), 0);
     assert_eq!(before_backoff.pending_tickets(), 1);
     assert!(!core.registry().needs_recovery());
+}
+
+#[test]
+fn store_destroy_admission_requires_completed_shutdown() {
+    let mut running = RuntimeAdmission::Running;
+    assert!(!running.enter_store_destroy());
+    assert_eq!(running, RuntimeAdmission::Running);
+
+    let mut shutdown = RuntimeAdmission::Shutdown;
+    assert!(shutdown.enter_store_destroy());
+    assert_eq!(shutdown, RuntimeAdmission::StoreDestroy);
+    assert!(
+        shutdown.enter_store_destroy(),
+        "Store-destroy retries remain idempotent"
+    );
 }

--- a/rocketmq-store-local/src/mapped_file/retirement/state/reconciliation.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/state/reconciliation.rs
@@ -450,6 +450,10 @@ impl ReconciledSegmentFile {
         self.binding.incarnation
     }
 
+    pub(in crate::mapped_file::retirement) fn replace_retained_file(&mut self, file: std::fs::File) {
+        self.file = file;
+    }
+
     pub(in crate::mapped_file) fn into_parts(self) -> (StoreRelativePath, PublishedIncarnationBinding, std::fs::File) {
         (self.relative_path, self.binding, self.file)
     }

--- a/rocketmq-store/src/base/backend_ops.rs
+++ b/rocketmq-store/src/base/backend_ops.rs
@@ -282,8 +282,21 @@ pub trait BackendOps: Send + Sync + 'static {
     /// Shut down this message store through the legacy unit-returning compatibility adapter.
     async fn shutdown(&mut self);
 
-    /// Destroy this message store.
-    /// Generally, all persistent files should be removed after invocation.
+    /// Durably destroys every managed mapped-file segment after shutdown.
+    ///
+    /// Returns `true` only after all tracked segment retirements reach `Completed`. Implementations
+    /// that have not activated the managed lifecycle return `false` without namespace mutation.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed storage error when durable submission, replay state, or namespace retirement
+    /// requires recovery before the operation can continue.
+    async fn destroy_gracefully(&mut self) -> Result<bool, StoreError>;
+
+    /// Requests destruction through the legacy synchronous compatibility adapter.
+    ///
+    /// This adapter cannot await durable ledger and namespace work. Managed callers should use
+    /// [`Self::destroy_gracefully`].
     fn destroy(&mut self);
     /*
     /// Store a message into the store in async manner.

--- a/rocketmq-store/src/consume_queue/mapped_file_queue.rs
+++ b/rocketmq-store/src/consume_queue/mapped_file_queue.rs
@@ -220,10 +220,14 @@ impl MappedFileGeneration {
         };
         let next = Arc::new(MappedFileGenerationState::Managed {
             generation: generation.clone(),
-            runtime: Some(runtime),
+            runtime: Some(runtime.clone()),
         });
         let previous = self.state.compare_and_swap(&current, next);
-        Arc::ptr_eq(&previous, &current)
+        let installed = Arc::ptr_eq(&previous, &current);
+        if installed {
+            runtime.track_queue_generation(generation);
+        }
+        installed
     }
 }
 

--- a/rocketmq-store/src/message_store.rs
+++ b/rocketmq-store/src/message_store.rs
@@ -175,6 +175,10 @@ macro_rules! message_store_methods {
         }
     }
 
+    async fn destroy_gracefully(&mut self) -> Result<bool, StoreError> {
+        delegate_store_async!(self, destroy_gracefully())
+    }
+
     fn destroy(&mut self) {
         delegate_store!(self, destroy());
     }

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -801,6 +801,10 @@ impl BackendOps for LocalFileMessageStore {
         self.shutdown_store().await;
     }
 
+    async fn destroy_gracefully(&mut self) -> Result<bool, StoreError> {
+        self.destroy_store_gracefully().await
+    }
+
     fn destroy(&mut self) {
         self.destroy_store();
     }

--- a/rocketmq-store/src/message_store/local_file_message_store/lifecycle.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/lifecycle.rs
@@ -892,6 +892,52 @@ impl LocalFileMessageStore {
         }
     }
 
+    /// Durably retires every managed mapped-file segment after ordinary Store shutdown.
+    ///
+    /// Lifecycle sidecars remain as the replayable audit trail. Legacy configurations continue to
+    /// fail closed through [`Self::destroy_store_with_outcome`].
+    pub(super) async fn destroy_store_gracefully(&mut self) -> Result<bool, StoreError> {
+        if self.store_root_lease_state == StoreRootLeaseState::Destroyed {
+            return Ok(true);
+        }
+        if self.lifecycle_state() != LocalStoreState::Shutdown {
+            return Err(StoreError::invalid_state(
+                StoreOperation::Admin,
+                "managed Store destroy requires ordinary shutdown to complete first",
+            ));
+        }
+        if !self.message_store_config.enable_mapped_file_lifecycle_wave_b {
+            self.store_root_lease_state = StoreRootLeaseState::DestroyRetryPending;
+            return Ok(false);
+        }
+        if let Err(error) = self.validate_current_root_mode(StoreOperation::Admin) {
+            self.store_root_lease_state = StoreRootLeaseState::DestroyRetryPending;
+            return Err(error);
+        }
+        let Some(runtime) = self.managed_lifecycle_runtime.clone() else {
+            self.store_root_lease_state = StoreRootLeaseState::DestroyRetryPending;
+            return Err(StoreError::invalid_state(
+                StoreOperation::Admin,
+                "managed lifecycle runtime is unavailable after shutdown",
+            ));
+        };
+        let Some(service) = self.mapped_file_retirement_service.as_mut() else {
+            self.store_root_lease_state = StoreRootLeaseState::DestroyRetryPending;
+            return Err(StoreError::invalid_state(
+                StoreOperation::Admin,
+                "managed mapped-file retirement service is unavailable after shutdown",
+            ));
+        };
+
+        self.store_root_lease_state = StoreRootLeaseState::DestroyRetryPending;
+        let report = service.destroy_all_and_await().await?;
+        let complete = report.pending_tickets == 0 && !report.recovery_required && runtime.store_destroy_complete();
+        if complete {
+            self.store_root_lease_state = StoreRootLeaseState::Destroyed;
+        }
+        Ok(complete)
+    }
+
     /// Attempts an explicit Store-level destroy without bypassing mapped-file retirement.
     ///
     /// Wave-B enables durable per-segment retirement, but whole-Store destruction remains disabled

--- a/rocketmq-store/src/message_store/local_file_message_store/mapped_file_retirement_service.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/mapped_file_retirement_service.rs
@@ -133,6 +133,39 @@ impl MappedFileRetirementService<ManagedLifecycleRuntime> {
             RetirementServiceConfig::default(),
         )
     }
+
+    pub(super) async fn destroy_all_and_await(&mut self) -> Result<RetirementServiceBatch, StoreError> {
+        self.accepting.store(false, Ordering::Release);
+        if self.driver.has_retirement_backlog() {
+            let existing = self
+                .drain_pending(None, "mapped-file-store-destroy-retry-drain", StoreOperation::Admin)
+                .await?;
+            if self.driver.has_retirement_backlog() {
+                return Ok(existing);
+            }
+        }
+        let driver = self.driver.clone();
+        self.runtime_scope
+            .spawn_io("mapped-file-store-destroy-submit", move || {
+                driver.submit_store_destroy_retirements()
+            })
+            .await
+            .map_err(|source| {
+                StoreError::new(StoreErrorKind::Storage, StoreOperation::Admin)
+                    .in_component(StoreComponent::MappedFile)
+                    .with_detail("failed to execute managed Store-destroy retirement submission")
+                    .with_source(source)
+            })?
+            .map_err(|source| {
+                StoreError::new(StoreErrorKind::Storage, StoreOperation::Admin)
+                    .in_component(StoreComponent::MappedFile)
+                    .with_detail("managed Store-destroy retirement submission failed closed")
+                    .with_source(source)
+            })?;
+
+        self.drain_pending(None, "mapped-file-store-destroy-drain", StoreOperation::Admin)
+            .await
+    }
 }
 
 impl<D: RetirementBatchDriver> MappedFileRetirementService<D> {
@@ -237,6 +270,16 @@ impl<D: RetirementBatchDriver> MappedFileRetirementService<D> {
             }
         }
 
+        self.drain_pending(first_error, "mapped-file-retirement-drain", StoreOperation::Shutdown)
+            .await
+    }
+
+    async fn drain_pending(
+        &mut self,
+        mut first_error: Option<StoreError>,
+        task_name: &'static str,
+        operation: StoreOperation,
+    ) -> Result<RetirementServiceBatch, StoreError> {
         let deadline = ShutdownDeadline::after(self.config.drain_timeout);
         let batch_size = self.config.batch_size;
         let mut latest = self.driver.snapshot();
@@ -244,9 +287,7 @@ impl<D: RetirementBatchDriver> MappedFileRetirementService<D> {
             let driver = self.driver.clone();
             match self
                 .runtime_scope
-                .spawn_io_until("mapped-file-retirement-drain", deadline, move || {
-                    driver.drive_drain_batch(batch_size)
-                })
+                .spawn_io_until(task_name, deadline, move || driver.drive_drain_batch(batch_size))
                 .await
             {
                 Ok(report) => {
@@ -259,7 +300,7 @@ impl<D: RetirementBatchDriver> MappedFileRetirementService<D> {
                 Err(error) => {
                     if first_error.is_none() {
                         first_error = Some(
-                            StoreError::new(StoreErrorKind::Timeout, StoreOperation::Shutdown)
+                            StoreError::new(StoreErrorKind::Timeout, operation)
                                 .in_component(StoreComponent::MappedFile)
                                 .with_detail("managed mapped-file retirement drain failed")
                                 .with_source(error),

--- a/rocketmq-store/src/message_store/rocksdb_message_store.rs
+++ b/rocketmq-store/src/message_store/rocksdb_message_store.rs
@@ -577,6 +577,12 @@ impl BackendOps for RocksDBMessageStore {
         }
     }
 
+    async fn destroy_gracefully(&mut self) -> Result<bool, StoreError> {
+        let destroyed = self.local_file_store.destroy_gracefully().await?;
+        self.close_rocksdb();
+        Ok(destroyed)
+    }
+
     fn destroy(&mut self) {
         self.local_file_store.destroy();
         self.close_rocksdb();

--- a/rocketmq-store/tests/mapped_file_retirement_service.rs
+++ b/rocketmq-store/tests/mapped_file_retirement_service.rs
@@ -50,7 +50,8 @@ fn service_source_owns_scheduling_blocking_drain_and_await_boundaries() {
     assert!(service.contains("ScheduledTaskGroup::new"));
     assert!(service.contains("schedule_fixed_delay"));
     assert!(service.contains("spawn_io(\"mapped-file-retirement-batch\""));
-    assert!(service.contains("spawn_io_until(\"mapped-file-retirement-drain\""));
+    assert!(service.contains("drain_pending(first_error, \"mapped-file-retirement-drain\""));
+    assert!(service.contains("spawn_io_until(task_name, deadline"));
     assert!(service.contains("task_group.shutdown"));
     assert!(service.contains("driver.begin_shutdown()"));
     assert!(!service.contains("tokio::spawn"));

--- a/rocketmq-store/tests/message_store/local_file_message_store/unit.rs
+++ b/rocketmq-store/tests/message_store/local_file_message_store/unit.rs
@@ -322,6 +322,125 @@ async fn wave_b_managed_store_bootstraps_starts_and_creates_first_queue_segments
 
 #[cfg(any(target_os = "linux", windows))]
 #[tokio::test]
+async fn wave_b_normal_shutdown_preserves_segments_until_explicit_durable_destroy() {
+    let temp_dir = tempdir().expect("temporary managed Store root");
+    let mut store = new_configured_test_store(
+        &temp_dir,
+        MessageStoreConfig {
+            enable_mapped_file_lifecycle_wave_b: true,
+            message_index_enable: false,
+            timer_wheel_enable: false,
+            enable_consume_queue_ext: false,
+            duplication_enable: true,
+            flush_disk_type: FlushDiskType::AsyncFlush,
+            mapped_file_size_commit_log: 16 * 1024,
+            mapped_file_size_consume_queue: 20 * 100,
+            ..MessageStoreConfig::default()
+        },
+    );
+    let topic = CheetahString::from_static_str("wave-b-explicit-store-destroy");
+    let commitlog = temp_dir.path().join("commitlog/00000000000000000000");
+    let consume_queue = temp_dir
+        .path()
+        .join("consumequeue/wave-b-explicit-store-destroy/0/00000000000000000000");
+
+    store.init().await.expect("initialize managed Store");
+    assert!(store.load().await, "reconcile and activate managed Store");
+    store.start().await.expect("start fully activated managed Store");
+    let result = store
+        .put_message(build_test_message(&topic, Bytes::from_static(b"managed-destroy")))
+        .await;
+    assert_eq!(result.put_message_status(), PutMessageStatus::PutOk);
+    for _ in 0..100 {
+        if store.get_max_offset_in_queue(&topic, 0) == 1 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    let error = BackendOps::destroy_gracefully(&mut store)
+        .await
+        .expect_err("explicit destroy must wait for ordinary shutdown");
+    assert_eq!(error.kind(), StoreErrorKind::Internal);
+    assert!(commitlog.is_file());
+    assert!(consume_queue.is_file());
+
+    store.shutdown().await;
+    assert!(commitlog.is_file(), "ordinary shutdown must preserve CommitLog data");
+    assert!(
+        consume_queue.is_file(),
+        "ordinary shutdown must preserve consume-queue data"
+    );
+
+    assert!(BackendOps::destroy_gracefully(&mut store)
+        .await
+        .expect("explicit managed Store destroy completes"));
+    assert_eq!(store.store_root_lease_state, StoreRootLeaseState::Destroyed);
+    assert!(!commitlog.exists());
+    assert!(!consume_queue.exists());
+    assert!(
+        temp_dir.path().join(".rocketmq-lifecycle").is_dir(),
+        "durable lifecycle evidence remains as the audit trail"
+    );
+    assert!(BackendOps::destroy_gracefully(&mut store)
+        .await
+        .expect("completed managed Store destroy is idempotent"));
+}
+
+#[cfg(any(target_os = "linux", windows))]
+#[tokio::test]
+async fn wave_b_normal_shutdown_replays_the_same_segments_on_restart() {
+    let temp_dir = tempdir().expect("temporary managed Store root");
+    let config = || MessageStoreConfig {
+        enable_mapped_file_lifecycle_wave_b: true,
+        message_index_enable: false,
+        timer_wheel_enable: false,
+        enable_consume_queue_ext: false,
+        duplication_enable: true,
+        flush_disk_type: FlushDiskType::AsyncFlush,
+        mapped_file_size_commit_log: 16 * 1024,
+        mapped_file_size_consume_queue: 20 * 100,
+        ..MessageStoreConfig::default()
+    };
+    let topic = CheetahString::from_static_str("wave-b-restart-preserves-data");
+    let commitlog = temp_dir.path().join("commitlog/00000000000000000000");
+    let consume_queue = temp_dir
+        .path()
+        .join("consumequeue/wave-b-restart-preserves-data/0/00000000000000000000");
+
+    let mut first = new_configured_test_store(&temp_dir, config());
+    first.init().await.expect("initialize first managed Store");
+    assert!(first.load().await, "activate first managed Store");
+    first.start().await.expect("start first managed Store");
+    let result = first
+        .put_message(build_test_message(&topic, Bytes::from_static(b"managed-restart")))
+        .await;
+    assert_eq!(result.put_message_status(), PutMessageStatus::PutOk);
+    for _ in 0..100 {
+        if first.get_max_offset_in_queue(&topic, 0) == 1 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    first.shutdown().await;
+    drop(first);
+
+    let mut reopened = new_configured_test_store(&temp_dir, config());
+    reopened.init().await.expect("initialize reopened managed Store");
+    assert!(reopened.load().await, "replay and load reopened managed Store");
+    assert_eq!(reopened.get_max_offset_in_queue(&topic, 0), 1);
+    assert!(commitlog.is_file());
+    assert!(consume_queue.is_file());
+
+    reopened.start().await.expect("start reopened managed Store");
+    reopened.shutdown().await;
+    assert!(BackendOps::destroy_gracefully(&mut reopened)
+        .await
+        .expect("durably destroy reopened managed Store"));
+}
+
+#[cfg(any(target_os = "linux", windows))]
+#[tokio::test]
 async fn wave_b_managed_truncation_durably_retires_the_tail_segment() {
     let temp_dir = tempdir().expect("temporary managed Store root");
     let mut store = new_configured_test_store(
@@ -545,6 +664,23 @@ async fn destroy_store_is_write_disabled_and_retries_without_namespace_mutation(
 
     drop(store);
     drop(new_configured_test_store(&temp_dir, MessageStoreConfig::default()));
+}
+
+#[tokio::test]
+async fn graceful_destroy_keeps_legacy_store_namespace_write_disabled() {
+    let temp_dir = tempdir().unwrap();
+    let mut store = new_configured_test_store(&temp_dir, MessageStoreConfig::default());
+    let root = temp_dir.path();
+    let commitlog = root.join("commitlog/00000000000000000000");
+    fs::create_dir_all(commitlog.parent().expect("commitlog parent")).expect("commitlog directory");
+    fs::write(&commitlog, b"legacy-segment-must-remain").expect("legacy segment");
+    store.set_lifecycle_state(LocalStoreState::Shutdown);
+
+    assert!(!BackendOps::destroy_gracefully(&mut store)
+        .await
+        .expect("legacy graceful destroy remains write-disabled"));
+    assert_eq!(store.store_root_lease_state, StoreRootLeaseState::DestroyRetryPending);
+    assert_eq!(fs::read(&commitlog).unwrap(), b"legacy-segment-must-remain");
 }
 
 #[test]

--- a/rocketmq-tools/rocketmq-store-inspect/src/content_show.rs
+++ b/rocketmq-tools/rocketmq-store-inspect/src/content_show.rs
@@ -13,10 +13,11 @@
 // limitations under the License.
 
 use std::borrow::Cow;
-use std::fs;
+use std::fs::File;
+use std::io::BufReader;
+use std::io::Read;
 use std::path::PathBuf;
 
-use bytes::Buf;
 use bytes::Bytes;
 use cheetah_string::CheetahString;
 use rocketmq_error::RocketMQError;
@@ -26,8 +27,6 @@ use rocketmq_store::CommitLogRecord;
 use rocketmq_store::CommitLogRecordBodyMode;
 use rocketmq_store::CommitLogRecordChecksum;
 use rocketmq_store::CommitLogRecordOutcome;
-use rocketmq_store::DefaultMappedFile;
-use rocketmq_store::MappedFile;
 use tabled::Table;
 use tabled::Tabled;
 
@@ -44,10 +43,13 @@ pub fn print_content(from: Option<u32>, to: Option<u32>, path: Option<PathBuf>) 
     }
 
     let path_display = path.to_string_lossy().to_string();
-    let file_metadata = fs::metadata(&path)
+    let file = File::open(&path)
+        .map_err(|error| RocketMQError::storage_read_failed(path_display.clone(), error.to_string()))?;
+    let file_metadata = file
+        .metadata()
         .map_err(|error| RocketMQError::storage_read_failed(path_display.clone(), error.to_string()))?;
     println!("file size: {}B", file_metadata.len());
-    let mapped_file = DefaultMappedFile::new(CheetahString::from(path_display), file_metadata.len());
+    let mut reader = BufReader::new(file);
     // read message number
     let mut counter = 0;
     let mut current_pos = 0usize;
@@ -56,22 +58,30 @@ pub fn print_content(from: Option<u32>, to: Option<u32>, path: Option<PathBuf>) 
         if counter >= to {
             break;
         }
-        let Some(mut size_bytes) = mapped_file.get_bytes(current_pos, 4) else {
+        let mut size_bytes = [0_u8; 4];
+        if reader.read_exact(&mut size_bytes).is_err() {
             break;
-        };
-        let size = size_bytes.get_i32();
+        }
+        let size = i32::from_be_bytes(size_bytes);
         if size <= 0 {
+            break;
+        }
+        let size = size as usize;
+        if size < size_bytes.len() || size as u64 > file_metadata.len().saturating_sub(current_pos as u64) {
+            break;
+        }
+        let mut message = vec![0_u8; size];
+        message[..size_bytes.len()].copy_from_slice(&size_bytes);
+        if reader.read_exact(&mut message[size_bytes.len()..]).is_err() {
             break;
         }
         counter += 1;
         if counter < from {
-            current_pos += size as usize;
+            current_pos += size;
             continue;
         }
-        let Some(msg_bytes) = mapped_file.get_bytes(current_pos, size as usize) else {
-            break;
-        };
-        current_pos += size as usize;
+        current_pos += size;
+        let msg_bytes = Bytes::from(message);
         if let Ok(CommitLogRecordOutcome::Message(record)) =
             decode_commit_log_record(&msg_bytes, CommitLogRecordBodyMode::Skip, &InspectionChecksum)
         {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9173

### Brief Description

- Complete the remaining mapped-file lifecycle consumer convergence and enable explicit Store destruction only after ordinary shutdown.
- Keep the activation boundary simple and fail-closed: explicit default-off configuration, retained exclusive Store-root lease, complete replay/reconciliation, and qualified platform support. No signatures, private keys, activation tokens, timestamps, force flags, or bypass path are introduced.
- Route Store-destroy retirement through the durable intent, registry, single-CAS queue handoff, namespace, and completion pipeline while preserving normal-shutdown segments for restart.
- Reopen reconciled segments through retained-root, handle-relative, no-follow platform APIs with exact physical-key and length validation.
- Migrate the store inspection reader away from direct mapped-file ownership and restore the checked-in lifecycle fixture corpus required by the frozen format tests.

### How Did You Test This Change?

- `cargo fmt --all -- --check` on WSL2 Ubuntu 24.04: passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- `cargo test -p rocketmq-store-local --lib mapped_file::retirement -- --test-threads=1`: 303 passed.
- `cargo test -p rocketmq-store --lib wave_b_ -- --test-threads=1`: 8 passed.
- Linux focused Store-destroy admission and shutdown-to-explicit-destroy tests: 2 passed in an isolated target.
- Full affected-package Windows and Linux test/Clippy matrices, strict-provenance Miri, runtime ownership audit, and the `store_recovery_record` fuzz target passed.
- `mapped_write_lease` benchmark completed 10/10 cases with a stable source snapshot; 4/10 cases were within the M0 3% observation line and 7/10 within the pre-optimization line. Remaining deviations are recorded as performance debt rather than treated as a hard safety gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added graceful store destruction that safely retires stored data and reports completion status.
  * Store shutdown now drains pending retirement work before final destruction.
  * Durable message data is preserved across ordinary shutdown and can be replayed after restart.
* **Bug Fixes**
  * Improved validation when opening stored segments, detecting invalid, altered, truncated, or mismatched files.
  * Hardened content inspection against malformed or incomplete records.
* **Lifecycle**
  * Destruction is now state-aware, retryable, and idempotent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->