### PR TITLE
[ISSUE #9178]🐛Fix macOS mapped-file retirement build

### DIFF
--- a/rocketmq-store-local/src/mapped_file/retirement/platform.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/platform.rs
@@ -39,6 +39,13 @@ mod native;
 #[allow(dead_code, reason = "M3 retains a typed unsupported backend for other targets")]
 #[path = "platform/unsupported.rs"]
 mod native;
+#[cfg(all(test, any(target_os = "linux", windows)))]
+#[allow(
+    dead_code,
+    reason = "supported-target tests compile the unsupported backend contract"
+)]
+#[path = "platform/unsupported.rs"]
+mod unsupported_contract;
 
 #[allow(unused_imports, reason = "M3 proof types are staged for the future reaper boundary")]
 pub(crate) use types::NamespaceAbsenceProof;
@@ -76,6 +83,14 @@ use super::identity::PhysicalFileKey;
 use super::identity::StoreUuid;
 use super::registry::LogicalRemovedCapability;
 use super::registry::TombstonedCapability;
+
+#[cfg(all(test, any(target_os = "linux", windows)))]
+const _: fn(
+    &unsupported_contract::NamespaceRoot,
+    &StoreRelativePath,
+    PhysicalFileKey,
+    u64,
+) -> Result<File, NamespaceVerificationError> = unsupported_contract::NamespaceRoot::open_active_segment;
 
 /// Exact namespace mutation authority derived from one durable `LogicalRemoved` stage.
 ///

--- a/rocketmq-store-local/src/mapped_file/retirement/platform/unsupported.rs
+++ b/rocketmq-store-local/src/mapped_file/retirement/platform/unsupported.rs
@@ -24,6 +24,7 @@ use super::types::NamespaceRetirementRequest;
 use super::types::NamespaceTransition;
 use super::types::NamespaceVerificationError;
 use crate::mapped_file::retirement::identity::PhysicalFileKey;
+use crate::mapped_file::retirement::identity::StoreRelativePath;
 use crate::mapped_file::retirement::writer::AllocatedIncarnationReceipt;
 use crate::mapped_file::retirement::writer::BoundIncarnationReceipt;
 
@@ -36,6 +37,18 @@ pub(super) struct NamespaceRoot;
 
 impl NamespaceRoot {
     pub(super) fn open(_file: File) -> Result<Self, NamespaceVerificationError> {
+        Err(NamespaceVerificationError::Unsupported {
+            platform: "unsupported target",
+            reason: REASON,
+        })
+    }
+
+    pub(super) fn open_active_segment(
+        &self,
+        _path: &StoreRelativePath,
+        _expected_key: PhysicalFileKey,
+        _expected_length: u64,
+    ) -> Result<File, NamespaceVerificationError> {
         Err(NamespaceVerificationError::Unsupported {
             platform: "unsupported target",
             reason: REASON,


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9178

### Brief Description

Add the missing `NamespaceRoot::open_active_segment` implementation to the unsupported mapped-file retirement backend used on macOS and other non-Linux/non-Windows targets. The method preserves the existing safe behavior by returning `NamespaceVerificationError::Unsupported`.

Add a supported-host compile-time function-signature contract for the unsupported backend so regular test and Clippy builds detect future backend interface drift.

### How Did You Test This Change?

- `cargo fmt --all -- --check`: passed.
- `cargo check -p rocketmq-store-local --tests --all-features`: passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`: passed.
- `git diff --check`: passed.
- A local `x86_64-apple-darwin` cross-check was attempted from Linux but could not compile native C dependencies because a macOS C cross-compiler was unavailable; the pull request CI provides the native macOS build verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved behavior on unsupported platforms by returning a clear verification error when attempting to open active storage segments.
  * Prevented unsupported storage operations from being treated as successful.

* **Tests**
  * Added validation to ensure unsupported-platform behavior remains consistent and follows the expected operation contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->