### PR TITLE
[ISSUE #9177]♻️Replace direct once_cell usage in RocketMQ MCP with standard library

### DIFF
--- a/rocketmq-tools/rocketmq-mcp/Cargo.lock
+++ b/rocketmq-tools/rocketmq-mcp/Cargo.lock
@@ -3488,7 +3488,6 @@ dependencies = [
  "jsonschema",
  "jsonwebtoken",
  "mockall",
- "once_cell",
  "percent-encoding",
  "pretty_assertions",
  "rcgen",

--- a/rocketmq-tools/rocketmq-mcp/Cargo.toml
+++ b/rocketmq-tools/rocketmq-mcp/Cargo.toml
@@ -70,7 +70,6 @@ clap               = { version = "4.6.1", features = ["derive", "env"] }
 config             = "0.15.23"
 jsonschema         = { version = "0.49", default-features = false }
 jsonwebtoken       = { version = "11.0", default-features = false, features = ["rust_crypto", "use_pem"] }
-once_cell          = "1.21"
 percent-encoding   = "2.3"
 regex              = "1.12.4"
 reqwest            = { version = "0.13", default-features = false, features = ["rustls"], optional = true }

--- a/rocketmq-tools/rocketmq-mcp/src/guard/sanitizer.rs
+++ b/rocketmq-tools/rocketmq-mcp/src/guard/sanitizer.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
+
 use regex::Regex;
 use rmcp::model::CallToolResult;
 use rmcp::model::ContentBlock;
@@ -26,14 +27,14 @@ use crate::tools::output_policy;
 
 const REDACTED: &str = "[REDACTED]";
 
-static SENSITIVE_ASSIGNMENT: Lazy<Regex> = Lazy::new(|| {
+static SENSITIVE_ASSIGNMENT: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
             r#"(?i)(access[_-]?key|secret[_-]?key|client[_-]?secret|token|password|private[_-]?key|message[_-]?body)(["'\s:=]+)([^,\s"'}]+)"#,
         )
         .expect("sensitive assignment regex is a compile-time invariant")
 });
 
-static NETWORK_ADDRESS: Lazy<Regex> = Lazy::new(|| {
+static NETWORK_ADDRESS: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r"(?ix)
         \b(?:\d{1,3}\.){3}\d{1,3}(?::\d{1,5})?\b


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #9177

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal initialization handling without changing user-visible behavior.
  * Preserved existing sensitive-data and network-address detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->