### PR TITLE
[ISSUE #9181]✨Preserve typed error sources in timer timeline adapters

### DIFF
--- a/rocketmq-store/src/timer/timeline/rocksdb_index.rs
+++ b/rocketmq-store/src/timer/timeline/rocksdb_index.rs
@@ -113,7 +113,7 @@ impl TimerIndex for RocksDbTimerIndex {
                 Ok(entries.len())
             })
             .await
-            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error.to_string())))?
+            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error)))?
     }
 
     async fn scan_due(
@@ -176,7 +176,7 @@ impl TimerIndex for RocksDbTimerIndex {
                 })
             })
             .await
-            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error.to_string())))?
+            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error)))?
     }
 
     async fn set_state(
@@ -197,7 +197,7 @@ impl TimerIndex for RocksDbTimerIndex {
                 state_index.put(timer_id, generation, &current).map_err(storage_error)
             })
             .await
-            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error.to_string())))?
+            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error)))?
     }
 
     async fn checkpoint(&self, checkpoint: TimerIndexCheckpoint) -> Result<(), TimerEngineError> {
@@ -223,7 +223,7 @@ impl TimerIndex for RocksDbTimerIndex {
                     .map_err(storage_error)
             })
             .await
-            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error.to_string())))?
+            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error)))?
     }
 
     async fn load_checkpoint(&self) -> Result<Option<TimerIndexCheckpoint>, TimerEngineError> {
@@ -241,7 +241,7 @@ impl TimerIndex for RocksDbTimerIndex {
                     .map_err(storage_error)
             })
             .await
-            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error.to_string())))?
+            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error)))?
     }
 
     async fn pin_snapshot(&self, gc_fence: TimerTimelineCursor) -> Result<TimerSnapshotPin, TimerEngineError> {
@@ -259,7 +259,7 @@ impl TimerIndex for RocksDbTimerIndex {
                     .map_err(storage_error)
             })
             .await
-            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error.to_string())))??;
+            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error)))??;
         self.pins.lock().insert(pin.generation, pin);
         Ok(TimerSnapshotPin {
             generation: pin.generation,
@@ -279,7 +279,7 @@ impl TimerIndex for RocksDbTimerIndex {
                 index.release_snapshot(native).map_err(storage_error)
             })
             .await
-            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error.to_string())))?
+            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error)))?
     }
 
     async fn gc(&self, fence: TimerTimelineCursor, budget: WorkBudget) -> Result<usize, TimerEngineError> {
@@ -319,7 +319,7 @@ impl TimerIndex for RocksDbTimerIndex {
                 Ok(removed)
             })
             .await
-            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error.to_string())))?
+            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error)))?
     }
 }
 
@@ -402,5 +402,24 @@ const fn map_state(state: TimerRecordState) -> TimelineState {
 }
 
 fn storage_error(error: rocketmq_error::RocketMQError) -> TimerEngineError {
-    TimerEngineError::Storage(std::io::Error::other(error.to_string()))
+    TimerEngineError::Storage(std::io::Error::other(error))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn storage_error_preserves_rocketmq_error_as_source() {
+        let error = storage_error(rocketmq_error::RocketMQError::InvalidProperty(
+            "invalid timer property".to_owned(),
+        ));
+
+        let TimerEngineError::Storage(error) = error else {
+            panic!("expected timer storage error");
+        };
+        assert!(error
+            .get_ref()
+            .is_some_and(|source| source.is::<rocketmq_error::RocketMQError>()));
+    }
 }

--- a/rocketmq-store/src/timer/timeline/segmented_index.rs
+++ b/rocketmq-store/src/timer/timeline/segmented_index.rs
@@ -312,7 +312,7 @@ impl TimerIndex for SegmentedTimelineIndex {
                 Ok(entries.len())
             })
             .await
-            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error.to_string())))?
+            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error)))?
     }
 
     async fn scan_due(
@@ -374,7 +374,7 @@ impl TimerIndex for SegmentedTimelineIndex {
                 Ok(TimerIndexPage { records, continuation })
             })
             .await
-            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error.to_string())))?
+            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error)))?
     }
 
     async fn set_state(
@@ -395,7 +395,7 @@ impl TimerIndex for SegmentedTimelineIndex {
                 state_index.put(timer_id, generation, &current).map_err(storage_error)
             })
             .await
-            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error.to_string())))?
+            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error)))?
     }
 
     async fn checkpoint(&self, checkpoint: TimerIndexCheckpoint) -> Result<(), TimerEngineError> {
@@ -421,7 +421,7 @@ impl TimerIndex for SegmentedTimelineIndex {
                     .map_err(storage_error)
             })
             .await
-            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error.to_string())))?
+            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error)))?
     }
 
     async fn load_checkpoint(&self) -> Result<Option<TimerIndexCheckpoint>, TimerEngineError> {
@@ -439,7 +439,7 @@ impl TimerIndex for SegmentedTimelineIndex {
                     .map_err(storage_error)
             })
             .await
-            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error.to_string())))?
+            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error)))?
     }
 
     async fn pin_snapshot(&self, gc_fence: TimerTimelineCursor) -> Result<TimerSnapshotPin, TimerEngineError> {
@@ -499,7 +499,7 @@ impl TimerIndex for SegmentedTimelineIndex {
                     .count())
             })
             .await
-            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error.to_string())))?
+            .map_err(|error| TimerEngineError::Storage(std::io::Error::other(error)))?
     }
 }
 
@@ -650,15 +650,15 @@ const fn map_state(state: TimerRecordState) -> TimelineState {
 }
 
 fn storage_error(error: rocketmq_error::RocketMQError) -> TimerEngineError {
-    TimerEngineError::Storage(std::io::Error::other(error.to_string()))
+    TimerEngineError::Storage(std::io::Error::other(error))
 }
 
-fn local_error(error: impl std::fmt::Display) -> TimerEngineError {
-    TimerEngineError::Storage(std::io::Error::other(error.to_string()))
+fn local_error(error: rocketmq_store_local::timer::segmented_timeline::SegmentedTimelineError) -> TimerEngineError {
+    TimerEngineError::Storage(std::io::Error::other(error))
 }
 
 fn commit_error(error: SegmentedCommitError) -> TimerEngineError {
-    TimerEngineError::Storage(std::io::Error::other(error.to_string()))
+    TimerEngineError::Storage(std::io::Error::other(error))
 }
 
 /// Native/overlay commit or recovery failure.
@@ -674,4 +674,31 @@ pub(crate) enum SegmentedCommitError {
     EmptyBatch,
     #[error("injected segmented commit crash at {0:?}")]
     InjectedCrash(SegmentedCommitCrashPoint),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_storage_source<T>(error: TimerEngineError)
+    where
+        T: std::error::Error + Send + Sync + 'static,
+    {
+        let TimerEngineError::Storage(error) = error else {
+            panic!("expected timer storage error");
+        };
+        assert!(error.get_ref().is_some_and(|source| source.is::<T>()));
+    }
+
+    #[test]
+    fn local_error_preserves_segmented_timeline_error_as_source() {
+        assert_storage_source::<rocketmq_store_local::timer::segmented_timeline::SegmentedTimelineError>(local_error(
+            rocketmq_store_local::timer::segmented_timeline::SegmentedTimelineError::EmptyBatch,
+        ));
+    }
+
+    #[test]
+    fn commit_error_preserves_segmented_commit_error_as_source() {
+        assert_storage_source::<SegmentedCommitError>(commit_error(SegmentedCommitError::EmptyBatch));
+    }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9181

### Brief Description

- Preserve typed `RuntimeError`, `RocketMQError`, `SegmentedTimelineError`, and `SegmentedCommitError` sources when timer timeline adapters map storage failures.
- Narrow the segmented timeline local-error adapter to its concrete source type.
- Add regression tests that verify storage errors retain downcastable source values.
- Keep the source-stringification allowlist unchanged.

### How Did You Test This Change?

- `cargo test -p rocketmq-store --lib --features extended_timeline error_preserves -- --nocapture` (3 passed)
- `python scripts/error_architecture_guard.py` (passed)
- `./scripts/check-error-hygiene.ps1` (passed)
- `cargo fmt --all -- --check` (passed on WSL)
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` (passed)
- `git diff --check` (passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for timer index and timeline operations by preserving the original underlying error details.
  * Added coverage to verify that storage and commit errors retain their source information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->