### PR TITLE
[ISSUE #9183]🐛Synchronize observability metric catalog counts

### DIFF
--- a/rocketmq-observability/src/metrics/catalog.rs
+++ b/rocketmq-observability/src/metrics/catalog.rs
@@ -1414,8 +1414,8 @@ mod tests {
             .collect::<HashSet<_>>();
 
         assert_eq!(JAVA_METRICS.len(), 94);
-        assert_eq!(RUST_METRICS.len(), 61);
-        assert_eq!(combined.len(), 155, "duplicate metric names across catalogs");
+        assert_eq!(RUST_METRICS.len(), 64);
+        assert_eq!(combined.len(), 158, "duplicate metric names across catalogs");
     }
 
     #[test]

--- a/scripts/telemetry-semantic-guard-violations.json
+++ b/scripts/telemetry-semantic-guard-violations.json
@@ -42,7 +42,7 @@
       "operation": "delete",
       "path": [
         "signals",
-        170,
+        173,
         "sampling",
         "max_per_second"
       ],
@@ -53,7 +53,7 @@
       "operation": "set",
       "path": [
         "signals",
-        170,
+        173,
         "deprecation"
       ],
       "value": {

--- a/scripts/telemetry-semantic-registry.json
+++ b/scripts/telemetry-semantic-registry.json
@@ -3434,8 +3434,77 @@
       }
     },
     {
-      "id": "rocketmq_transport_network_bytes",
-      "source_symbol": "TRANSPORT_NETWORK_BYTES",
+      "id": "rocketmq_transport_outbound_attempted_plaintext_bytes",
+      "source_symbol": "TRANSPORT_OUTBOUND_ATTEMPTED_PLAINTEXT_BYTES",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "By",
+      "owner": "remoting",
+      "catalog": "rust",
+      "family": "connection-bytes",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_transport_outbound_accepted_plaintext_bytes",
+      "source_symbol": "TRANSPORT_OUTBOUND_ACCEPTED_PLAINTEXT_BYTES",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "By",
+      "owner": "remoting",
+      "catalog": "rust",
+      "family": "connection-bytes",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_transport_outbound_written_plaintext_bytes",
+      "source_symbol": "TRANSPORT_OUTBOUND_WRITTEN_PLAINTEXT_BYTES",
+      "signal_type": "metric",
+      "kind": "counter",
+      "unit": "By",
+      "owner": "remoting",
+      "catalog": "rust",
+      "family": "connection-bytes",
+      "stability": "stable",
+      "attributes": [],
+      "cardinality_budget": 1,
+      "privacy": "operational",
+      "sampling": {
+        "strategy": "aggregate"
+      },
+      "deprecation": {
+        "status": "active",
+        "since": "1.0.0",
+        "replacement": null,
+        "remove_after": null
+      }
+    },
+    {
+      "id": "rocketmq_transport_inbound_decoded_plaintext_bytes",
+      "source_symbol": "TRANSPORT_INBOUND_DECODED_PLAINTEXT_BYTES",
       "signal_type": "metric",
       "kind": "counter",
       "unit": "By",

--- a/scripts/tests/test_telemetry_semantic_guard.py
+++ b/scripts/tests/test_telemetry_semantic_guard.py
@@ -40,10 +40,10 @@ class TelemetrySemanticGuardTest(unittest.TestCase):
 
     def test_live_registry_matches_every_rust_signal(self) -> None:
         self.assertEqual([], guard.validate_registry(self.registry, self.inventory))
-        self.assertEqual(155, len(self.inventory["metrics"]))
+        self.assertEqual(158, len(self.inventory["metrics"]))
         self.assertEqual(15, len(self.inventory["spans"]))
         self.assertEqual(11, len(self.inventory["events"]))
-        self.assertEqual(181, len(self.registry["signals"]))
+        self.assertEqual(184, len(self.registry["signals"]))
 
     def test_log_filter_metrics_have_stable_registry_contracts(self) -> None:
         symbols = {
@@ -84,7 +84,7 @@ class TelemetrySemanticGuardTest(unittest.TestCase):
             check=False,
         )
         self.assertEqual(0, result.returncode, result.stdout + result.stderr)
-        self.assertIn("metrics=155 spans=15 logs=11 attributes=75", result.stdout)
+        self.assertIn("metrics=158 spans=15 logs=11 attributes=75", result.stdout)
 
     def test_committed_violation_fixtures_are_rejected(self) -> None:
         fixture_ids = {fixture["id"] for fixture in self.fixtures}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9183

### Brief Description

- Update the Rust and combined metric catalog assertions after the transport byte metric was split into four plaintext byte counters.
- Regenerate the telemetry semantic registry so it removes the retired aggregate metric and includes all four replacement metrics.
- Synchronize semantic guard fixtures and regression-test counts with the 158-metric, 184-signal registry.

### How Did You Test This Change?

- `cargo test -p rocketmq-observability metrics::catalog::tests::combined_catalog_contains_every_semantic_metric_once -- --exact --nocapture`: passed.
- `cargo test -p rocketmq-observability --lib --all-features`: 286 tests passed.
- The seven CI observability feature combinations each passed `cargo check`, `cargo test`, and Clippy for `rocketmq-observability`.
- `python scripts/telemetry_semantic_guard.py`: passed with 158 metrics, 15 spans, 11 logs, and 75 attributes.
- `python -m unittest scripts.tests.test_telemetry_semantic_guard -v`: 8 tests passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- `cargo fmt --all -- --check`: passed on Linux.
- `git diff --check`: passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate transport telemetry for outbound attempted, accepted, and written plaintext bytes, plus inbound decoded plaintext bytes.
  * These metrics provide more precise visibility into transport byte activity and use byte-based measurements.

* **Bug Fixes**
  * Updated telemetry validation and inventory checks to reflect the expanded metric and signal catalog.
  * Corrected semantic guard references for updated telemetry definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->