### PR TITLE
[ISSUE #9187]🐛Align standalone CI with Rust 1.95

### DIFF
--- a/.github/workflows/rocketmq-mcp-ci.yaml
+++ b/.github/workflows/rocketmq-mcp-ci.yaml
@@ -49,7 +49,7 @@ jobs:
         working-directory: rocketmq-tools/rocketmq-mcp
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@1.100.0
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
@@ -70,5 +70,5 @@ jobs:
         working-directory: rocketmq-tools/rocketmq-mcp
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@1.100.0
+      - uses: dtolnay/rust-toolchain@1.95.0
       - run: cargo check --locked

--- a/.github/workflows/rocketmq-sre-ci.yml
+++ b/.github/workflows/rocketmq-sre-ci.yml
@@ -94,7 +94,7 @@ jobs:
         run: ./rocketmq-sre/scripts/phase01-kind-smoke.ps1 -ValidateOnly
 
       - name: Set up Rust 1.95
-        uses: dtolnay/rust-toolchain@1.100.0
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt, clippy
 
@@ -178,7 +178,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Rust 1.95
-        uses: dtolnay/rust-toolchain@1.100.0
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Check workspace
         run: cargo check --manifest-path rocketmq-sre/Cargo.toml --locked --workspace


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9187

### Brief Description

- Replace four nonexistent `dtolnay/rust-toolchain@1.100.0` references with the repository Rust `1.95.0` toolchain.
- Keep the SRE and MCP validation and MSRV jobs aligned with `rust-toolchain.toml` and both workspace manifests.
- Preserve the existing rustfmt and Clippy component setup without changing dependencies or source behavior.

### How Did You Test This Change?

- Confirmed `rustc 1.95.0` is installed and the `dtolnay/rust-toolchain` repository exposes its `1.95.0` action branch.
- `cargo +1.95.0 check --manifest-path rocketmq-sre/Cargo.toml --locked --workspace`: passed.
- SRE source-layout, execution-dependency, and Phase 01 static guards: passed.
- MCP formatting, locked check, read-only boundary, default tests, all-feature tests, Clippy, and documentation build: passed.
- `scripts/check-agents-routing.ps1`: passed.
- `cargo fmt --all -- --check`: passed for both standalone workspaces on Linux.
- `git diff --check`: passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Rust toolchain used by continuous integration checks to version 1.95.0.
  * Applied the toolchain update consistently across standard and minimum-supported-version validation jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->