### PR TITLE
[ISSUE #9215]🐛Release Broker store lease after healthy shutdown

### DIFF
--- a/rocketmq-broker/src/broker_runtime/lifecycle.rs
+++ b/rocketmq-broker/src/broker_runtime/lifecycle.rs
@@ -299,12 +299,19 @@ impl BrokerRuntime {
         } else {
             MessageStoreShutdownOutcome::TimedOut
         };
+        let message_store_shutdown_completed =
+            matches!(&message_store_outcome, MessageStoreShutdownOutcome::Completed(_));
         record_message_store_shutdown_outcome(
             &mut shutdown_report,
             &progress,
             message_store_outcome,
             started.elapsed(),
         );
+        if message_store_shutdown_completed {
+            // A completed shutdown is the ownership boundary for the Store root lease. Retain the
+            // owner after failures or timeouts so a later shutdown attempt can finish durably.
+            self.composition.state.message_store.take();
+        }
 
         if let Some(hook) = self.lifecycle.shutdown_hook.clone() {
             let hook_result = if let Some(service_context) = self.composition.state.service_context.as_ref() {

--- a/rocketmq-broker/tests/broker_runtime/unit.rs
+++ b/rocketmq-broker/tests/broker_runtime/unit.rs
@@ -1118,6 +1118,10 @@ async fn broker_shutdown_cancels_scheduled_store_lease_before_store_lock_release
         report.message_store.present && report.message_store.healthy,
         "{report:?}"
     );
+    assert!(
+        runtime.composition.state.message_store().is_none(),
+        "a healthy shutdown should release the runtime's final message-store owner"
+    );
     let mut restarted = BrokerRuntime::new(
         Arc::new(BrokerConfig {
             store_path_root_dir: temp_root.to_string_lossy().into_owned().into(),
@@ -2548,6 +2552,20 @@ async fn initialize_controller_mode_broker(runtime: &mut BrokerRuntime, broker_l
     assert!(
         runtime.initial_rpc_hooks(),
         "{broker_label} rpc hooks should initialize"
+    );
+}
+
+async fn shutdown_controller_mode_broker_for_rejoin(runtime: &mut BrokerRuntime, broker_label: &str) {
+    let report = runtime
+        .shutdown_basic_service_until(ShutdownDeadline::after(Duration::from_secs(120)))
+        .await;
+    assert!(
+        report.message_store.present && report.message_store.healthy,
+        "{broker_label} message store should shut down before same-path rejoin: {report:?}"
+    );
+    assert!(
+        runtime.composition.state.message_store().is_none(),
+        "{broker_label} should release its message-store owner before same-path rejoin"
     );
 }
 
@@ -5811,7 +5829,7 @@ async fn three_controller_two_broker_controller_mode_failover_and_rejoin() {
     };
 
     if broker_a_is_master {
-        broker_a.shutdown().await;
+        shutdown_controller_mode_broker_for_rejoin(&mut broker_a, "broker A").await;
         broker_b
             .composition
             .state
@@ -5819,7 +5837,7 @@ async fn three_controller_two_broker_controller_mode_failover_and_rejoin() {
             .send_heartbeat()
             .await;
     } else {
-        broker_b.shutdown().await;
+        shutdown_controller_mode_broker_for_rejoin(&mut broker_b, "broker B").await;
         broker_a
             .composition
             .state
@@ -6149,7 +6167,7 @@ async fn three_controller_two_broker_controller_mode_failover_reregisters_namesr
     };
 
     if broker_a_is_master {
-        broker_a.shutdown().await;
+        shutdown_controller_mode_broker_for_rejoin(&mut broker_a, "broker A").await;
         broker_b
             .composition
             .state
@@ -6157,7 +6175,7 @@ async fn three_controller_two_broker_controller_mode_failover_reregisters_namesr
             .send_heartbeat()
             .await;
     } else {
-        broker_b.shutdown().await;
+        shutdown_controller_mode_broker_for_rejoin(&mut broker_b, "broker B").await;
         broker_a
             .composition
             .state


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9215

### Brief Description

Release the Broker runtime's final message-store owner after a completed durable shutdown so `StoreRootLeaseInner` drops before an immediate same-path restart. Failed and timed-out shutdowns retain the owner for a safe retry instead of releasing a potentially active store.

The restart regressions now assert the ownership boundary directly. Controller failover/rejoin tests use an explicit test-only shutdown deadline and require a healthy message-store report before reusing the old store root, which keeps the check deterministic on loaded CI runners without changing the production deadline.

### How Did You Test This Change?

- `cargo test -p rocketmq-broker --lib --all-features` (`790 passed`, `0 failed`, `2 ignored`)
- `cargo test -p rocketmq-broker --lib broker_shutdown_cancels_scheduled_store_lease_before_store_lock_release -- --nocapture`
- `cargo test -p rocketmq-broker --lib three_controller_two_broker_controller_mode_failover -- --nocapture`
- `cargo fmt -p rocketmq-broker -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful broker shutdown handling to preserve message-store ownership when shutdown fails, times out, or does not complete.
  * Successfully completed shutdowns now release message-store ownership, supporting reliable broker rejoin and failover scenarios.

* **Tests**
  * Added coverage for healthy shutdown, ownership release, and broker rejoin behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->