### PR TITLE
[ISSUE #9216]✨Align producer retry and send validation semantics

### DIFF
--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -572,22 +572,14 @@ where
         message_ext.message_ext_inner.message.set_properties(ori_props);
         let cleanup_policy = cleanup_policy_utils::get_delete_policy(Some(&topic_config));
 
-        if cleanup_policy == CleanupPolicy::COMPACTION {
-            if let Some(value) = message_ext
-                .message_ext_inner
-                .message
-                .properties()
-                .as_map()
-                .get(MessageConst::PROPERTY_KEYS)
-            {
-                if value.trim().is_empty() {
-                    return Ok(Some(
-                        response
-                            .set_code(ResponseCode::MessageIllegal)
-                            .set_remark("Required message key is missing"),
-                    ));
-                }
-            }
+        if cleanup_policy == CleanupPolicy::COMPACTION
+            && !has_valid_compaction_key(message_ext.message_ext_inner.message.properties().as_map())
+        {
+            return Ok(Some(
+                response
+                    .set_code(ResponseCode::MessageIllegal)
+                    .set_remark("Required message key is missing"),
+            ));
         }
         message_ext.tags_code = MessageExtBrokerInner::tags_string2tags_code(
             &topic_config.topic_filter_type,
@@ -1739,9 +1731,7 @@ where
     {
         //check broker permission
         let policy = self.context.policy.snapshot();
-        if !PermName::is_writeable(policy.broker_permission)
-            && self.context.topics.is_order_topic(request_header.topic.as_str())
-        {
+        if broker_send_permission_denied(policy.broker_permission) {
             response.with_code(ResponseCode::NoPermission);
             response.with_remark(format!(
                 "the broker[{}] sending message is forbidden",
@@ -1880,15 +1870,29 @@ fn message_body_limit_violation(request: &RemotingCommand, configured_max_messag
         .then(|| format!("message body size {body_size} exceeds the configured maximum {max_message_size} bytes"))
 }
 
+fn broker_send_permission_denied(broker_permission: u32) -> bool {
+    !PermName::is_writeable(broker_permission)
+}
+
+fn has_valid_compaction_key(properties: &HashMap<CheetahString, CheetahString>) -> bool {
+    properties
+        .get(MessageConst::PROPERTY_KEYS)
+        .is_some_and(|value| !value.trim().is_empty())
+}
+
 fn message_store_not_initialized() -> RocketMQError {
     RocketMQError::not_initialized("message_store")
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::future::Future;
 
     use crate::config::broker_config::BrokerConfig;
+    use cheetah_string::CheetahString;
+    use rocketmq_model::common::constant::PermName;
+    use rocketmq_model::common::message::MessageConst;
     use rocketmq_protocol::code::request_code::RequestCode;
     use rocketmq_protocol::code::response_code::RemotingSysResponseCode;
     use rocketmq_protocol::code::response_code::ResponseCode;
@@ -1907,7 +1911,9 @@ mod tests {
     use crate::send_message_constants::error_messages;
 
     use super::append_message_with_store;
+    use super::broker_send_permission_denied;
     use super::has_registered_send_message_hooks;
+    use super::has_valid_compaction_key;
     use super::map_put_status_to_response;
     use super::map_store_api_error;
     use super::message_body_limit_violation;
@@ -2012,6 +2018,41 @@ mod tests {
             assert!(message_body_limit_violation(&exact, max_message_size).is_none());
             assert!(message_body_limit_violation(&oversized, max_message_size).is_some());
         }
+    }
+
+    #[test]
+    fn broker_write_permission_rejects_every_send_request_shape() {
+        for request_code in [
+            RequestCode::SendMessage,
+            RequestCode::SendMessageV2,
+            RequestCode::SendBatchMessage,
+        ] {
+            assert!(
+                broker_send_permission_denied(PermName::PERM_READ),
+                "{request_code:?} must be rejected by the shared pre-send check"
+            );
+            assert!(
+                !broker_send_permission_denied(PermName::PERM_READ | PermName::PERM_WRITE),
+                "{request_code:?} must be accepted when write permission is present"
+            );
+        }
+    }
+
+    #[test]
+    fn compaction_message_requires_non_blank_key() {
+        let key = CheetahString::from_static_str(MessageConst::PROPERTY_KEYS);
+
+        assert!(!has_valid_compaction_key(&HashMap::new()));
+        for invalid in ["", " ", "\t\r\n"] {
+            assert!(!has_valid_compaction_key(&HashMap::from([(
+                key.clone(),
+                CheetahString::from_string(invalid.to_string()),
+            )])));
+        }
+        assert!(has_valid_compaction_key(&HashMap::from([(
+            key,
+            CheetahString::from_static_str("business-key"),
+        )])));
     }
 
     #[test]

--- a/rocketmq-client/src/implementation/mq_client_api_impl/producer.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl/producer.rs
@@ -268,6 +268,7 @@ impl MQClientAPIImpl {
         let topic_publish_info_cloned = topic_publish_info.cloned();
         let instance_cloned = instance.clone();
         let mq_fault_strategy = producer.fault_strategy_snapshot();
+        let retry_response_codes = producer.producer_config_snapshot().retry_response_codes().clone();
         // Snapshot only the immutable hook capability and context data needed by the callback.
         let context_data = context.as_ref().map(|c| AsyncSendHookContext {
             producer_group: c.producer_group.as_ref().cloned(),
@@ -298,6 +299,7 @@ impl MQClientAPIImpl {
             topic_publish_info_cloned,
             instance_cloned,
             retry_times_when_send_failed,
+            retry_response_codes,
             context_data,
         )
         .await;
@@ -324,6 +326,7 @@ impl MQClientAPIImpl {
         topic_publish_info: Option<TopicPublishInfo>,
         instance: Option<Arc<MQClientInstance>>,
         retry_times_when_send_failed: u32,
+        retry_response_codes: HashSet<i32>,
         context_data: Option<AsyncSendHookContext>,
     ) {
         let begin_start_time_all = Instant::now();
@@ -361,7 +364,6 @@ impl MQClientAPIImpl {
                         ResponseCode::SlaveNotAvailable => SendStatus::SlaveNotAvailable,
                         ResponseCode::Success => SendStatus::SendOk,
                         _ => {
-                            // Non-success response: update fault and call callback with an error
                             mq_fault_strategy
                                 .update_fault_item(current_broker_name.clone(), cost, true, true)
                                 .await;
@@ -369,6 +371,33 @@ impl MQClientAPIImpl {
                                 response.code(),
                                 response.remark().map_or("".to_string(), |s| s.to_string())
                             );
+
+                            let retry_elapsed = (Instant::now() - begin_start_time_all).as_millis() as u64;
+                            let has_retry_budget = retry_count < retry_times_when_send_failed
+                                && retry_elapsed < timeout_millis
+                                && Self::should_retry_async_producer_send_error(&err_obj, &retry_response_codes);
+                            if has_retry_budget {
+                                retry_count += 1;
+                                if let Some((retry_addr, retry_broker_name)) = Self::select_async_retry_target(
+                                    &mq_fault_strategy,
+                                    topic_publish_info.as_ref(),
+                                    instance.as_ref(),
+                                    &current_broker_name,
+                                    &current_addr,
+                                )
+                                .await
+                                {
+                                    warn!(
+                                        "async send msg by retry {} times after broker response. topic={}, brokerAddr={}, brokerName={}",
+                                        retry_count, msg_topic, retry_addr, retry_broker_name
+                                    );
+                                    current_addr = retry_addr;
+                                    current_broker_name = retry_broker_name;
+                                    retry_request.set_retry_opaque(RemotingCommand::create_new_request_id());
+                                    continue;
+                                }
+                            }
+
                             Self::execute_async_send_hook_after(
                                 &context_data,
                                 None,
@@ -464,7 +493,7 @@ impl MQClientAPIImpl {
                     let retry_elapsed = (Instant::now() - begin_start_time_all).as_millis() as u64;
                     let has_retry_budget = retry_count < retry_times_when_send_failed
                         && retry_elapsed < timeout_millis
-                        && Self::should_retry_async_send_error(&e);
+                        && Self::should_retry_async_producer_send_error(&e, &retry_response_codes);
                     if has_retry_budget {
                         retry_count += 1;
                         if let Some((retry_addr, retry_broker_name)) = Self::select_async_retry_target(
@@ -505,8 +534,11 @@ impl MQClientAPIImpl {
         })
     }
 
-    pub(super) fn should_retry_async_send_error(error: &rocketmq_error::RocketMQError) -> bool {
-        crate::common::retry_decision::should_retry_async_send_error(error)
+    pub(super) fn should_retry_async_producer_send_error(
+        error: &rocketmq_error::RocketMQError,
+        retry_response_codes: &HashSet<i32>,
+    ) -> bool {
+        crate::common::retry_decision::producer_send_retry_decision(error, retry_response_codes).should_retry()
     }
 
     pub(super) async fn select_async_retry_target(

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -284,6 +284,7 @@ struct RetryState {
     times_total: u32,
     brokers_sent: Vec<String>,
     last_error: Option<rocketmq_error::RocketMQError>,
+    last_send_result: Option<SendResult>,
 }
 
 impl RetryState {
@@ -292,6 +293,7 @@ impl RetryState {
             times_total,
             brokers_sent: vec![String::new(); times_total as usize],
             last_error: None,
+            last_send_result: None,
         }
     }
 
@@ -303,6 +305,14 @@ impl RetryState {
 
     fn set_error(&mut self, error: rocketmq_error::RocketMQError) {
         self.last_error = Some(error);
+    }
+
+    fn record_send_result(&mut self, result: SendResult) {
+        self.last_send_result = Some(result);
+    }
+
+    fn take_last_send_result(&mut self) -> Option<SendResult> {
+        self.last_send_result.take()
     }
 
     fn build_failure_error(&self, topic: &CheetahString, elapsed_ms: u128) -> rocketmq_error::RocketMQError {

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl/retry.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl/retry.rs
@@ -32,7 +32,6 @@ impl DefaultMQProducerImpl {
         let retry_times = Self::get_retry_times(runtime, ctx.communication_mode);
         let mut retry_state = RetryState::new(retry_times);
         let mut last_broker_name: Option<CheetahString> = None;
-        let send_result: Option<SendResult> = None;
 
         for attempt in 0..retry_times {
             let reset_index = attempt > 0;
@@ -79,6 +78,9 @@ impl DefaultMQProducerImpl {
 
                     // Check if need to retry based on send status
                     if Self::should_retry_on_result(runtime, &result, ctx.communication_mode) {
+                        if let Some(result) = result {
+                            retry_state.record_send_result(result);
+                        }
                         retry_state.set_error(mq_client_err!("Send status not OK"));
                         continue;
                     }
@@ -101,8 +103,8 @@ impl DefaultMQProducerImpl {
         }
 
         // All retries exhausted
-        if send_result.is_some() {
-            return Ok(send_result);
+        if let Some(send_result) = retry_state.take_last_send_result() {
+            return Ok(Some(send_result));
         }
 
         Err(retry_state.build_failure_error(topic, ctx.elapsed() as u128))

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl/transaction.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl/transaction.rs
@@ -61,22 +61,28 @@ impl DefaultMQProducerImpl {
             .await
             .map_err(|e| mq_client_err!(format!("send message in transaction error, {}", e)))?
             .ok_or_else(|| mq_client_err!("send result is none"))?;
+
+        if send_result.send_status == SendStatus::SendOk {
+            if let Some(ref transaction_id) = send_result.transaction_id {
+                msg.put_user_property(
+                    CheetahString::from_static_str(MessageConst::PROPERTY_TRANSACTION_ID),
+                    CheetahString::from_string(transaction_id.to_owned()),
+                )
+                .map_err(|e| mq_client_err!(e.to_string()))?;
+            }
+            let transaction_id = msg.property(&CheetahString::from_static_str(
+                MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX,
+            ));
+            if let Some(transaction_id) = transaction_id {
+                msg.set_transaction_id(transaction_id);
+            }
+        }
+
+        let msg = Arc::new(msg);
         let (local_transaction_state, local_exception) = match send_result.send_status {
             SendStatus::SendOk => {
-                if let Some(ref transaction_id) = send_result.transaction_id {
-                    msg.put_user_property(
-                        CheetahString::from_static_str(MessageConst::PROPERTY_TRANSACTION_ID),
-                        CheetahString::from_string(transaction_id.to_owned()),
-                    )
-                    .map_err(|e| mq_client_err!(e.to_string()))?;
-                }
-                let transaction_id = msg.property(&CheetahString::from_static_str(
-                    MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX,
-                ));
-                if let Some(transaction_id) = transaction_id {
-                    msg.set_transaction_id(transaction_id);
-                }
-                Self::execute_local_transaction_branch(&transaction_listener, &msg, arg.as_deref())
+                self.execute_local_transaction_listener(transaction_listener, Arc::clone(&msg), arg)
+                    .await
             }
             SendStatus::FlushDiskTimeout | SendStatus::FlushSlaveTimeout | SendStatus::SlaveNotAvailable => {
                 (LocalTransactionState::RollbackMessage, None)
@@ -105,6 +111,31 @@ impl DefaultMQProducerImpl {
             send_result: Some(send_result),
         };
         Ok(transaction_send_result)
+    }
+
+    pub(super) async fn execute_local_transaction_listener<M>(
+        &self,
+        transaction_listener: ArcTransactionListener,
+        msg: Arc<M>,
+        arg: Option<Box<dyn Any + Send + Sync>>,
+    ) -> (LocalTransactionState, Option<CheetahString>)
+    where
+        M: MessageTrait + Send + Sync + 'static,
+    {
+        let task = move || Self::execute_local_transaction_branch(&transaction_listener, msg.as_ref(), arg.as_deref());
+
+        match spawn_client_blocking_io_with_context(&self.service_context, "client.transaction.execute", task).await {
+            Ok(result) => result,
+            Err(error) => {
+                tracing::error!(%error, "executeLocalTransactionBranch blocking task failed");
+                (
+                    LocalTransactionState::Unknown,
+                    Some(CheetahString::from_string(format!(
+                        "executeLocalTransactionBranch blocking task failed: {error}"
+                    ))),
+                )
+            }
+        }
     }
 
     pub(super) fn execute_local_transaction_branch(

--- a/rocketmq-client/tests/implementation/mq_client_api_impl/unit.rs
+++ b/rocketmq-client/tests/implementation/mq_client_api_impl/unit.rs
@@ -1002,8 +1002,31 @@ fn async_send_retries_transient_network_failures_only() {
         "write failed",
     ));
 
-    assert!(MQClientAPIImpl::should_retry_async_send_error(&connection_failed));
-    assert!(MQClientAPIImpl::should_retry_async_send_error(&send_failed));
+    let retry_response_codes = HashSet::new();
+    assert!(MQClientAPIImpl::should_retry_async_producer_send_error(
+        &connection_failed,
+        &retry_response_codes,
+    ));
+    assert!(MQClientAPIImpl::should_retry_async_producer_send_error(
+        &send_failed,
+        &retry_response_codes,
+    ));
+}
+
+#[test]
+fn async_producer_send_uses_configured_response_code_allowlist() {
+    let retryable =
+        rocketmq_error::RocketMQError::broker_operation_failed("SEND_MESSAGE", ResponseCode::SystemBusy as i32, "busy");
+    let configured = HashSet::from([ResponseCode::SystemBusy as i32]);
+
+    assert!(MQClientAPIImpl::should_retry_async_producer_send_error(
+        &retryable,
+        &configured,
+    ));
+    assert!(!MQClientAPIImpl::should_retry_async_producer_send_error(
+        &retryable,
+        &HashSet::new(),
+    ));
 }
 
 #[test]
@@ -1021,11 +1044,22 @@ fn async_send_does_not_retry_timeout_backpressure_or_stopped_client() {
         limit: 1,
     });
 
-    assert!(!MQClientAPIImpl::should_retry_async_send_error(&timeout));
-    assert!(!MQClientAPIImpl::should_retry_async_send_error(&request_timeout));
-    assert!(!MQClientAPIImpl::should_retry_async_send_error(&too_many_requests));
-    assert!(!MQClientAPIImpl::should_retry_async_send_error(
+    let retry_response_codes = HashSet::new();
+    assert!(!MQClientAPIImpl::should_retry_async_producer_send_error(
+        &timeout,
+        &retry_response_codes,
+    ));
+    assert!(!MQClientAPIImpl::should_retry_async_producer_send_error(
+        &request_timeout,
+        &retry_response_codes,
+    ));
+    assert!(!MQClientAPIImpl::should_retry_async_producer_send_error(
+        &too_many_requests,
+        &retry_response_codes,
+    ));
+    assert!(!MQClientAPIImpl::should_retry_async_producer_send_error(
         &rocketmq_error::RocketMQError::ClientShuttingDown,
+        &retry_response_codes,
     ));
 }
 

--- a/rocketmq-client/tests/producer/default_mq_producer_impl/unit.rs
+++ b/rocketmq-client/tests/producer/default_mq_producer_impl/unit.rs
@@ -387,6 +387,25 @@ impl TransactionListener for NoopTransactionListener {
     }
 }
 
+struct ThreadRecordingTransactionListener {
+    thread_id: Arc<std::sync::Mutex<Option<std::thread::ThreadId>>>,
+}
+
+impl TransactionListener for ThreadRecordingTransactionListener {
+    fn execute_local_transaction(
+        &self,
+        _msg: &dyn MessageTrait,
+        _arg: Option<&(dyn Any + Send + Sync)>,
+    ) -> LocalTransactionState {
+        *self.thread_id.lock().expect("thread id lock should not be poisoned") = Some(std::thread::current().id());
+        LocalTransactionState::CommitMessage
+    }
+
+    fn check_local_transaction(&self, _msg: &MessageExt) -> LocalTransactionState {
+        LocalTransactionState::Unknown
+    }
+}
+
 struct CapturingSendHook {
     exception_message: Arc<std::sync::Mutex<Option<String>>>,
 }
@@ -638,6 +657,30 @@ fn send_timeout_for_attempt_caps_only_retryable_attempts_like_java() {
         DefaultMQProducerImpl::send_timeout_for_attempt(&runtime, 3_000, 0, 3),
         3_000
     );
+}
+
+#[test]
+fn last_retryable_send_result_is_preserved() {
+    let first = SendResult::new(
+        SendStatus::FlushDiskTimeout,
+        Some(CheetahString::from_static_str("first-id")),
+        Some("first-offset-id".to_string()),
+        Some(MessageQueue::from_parts("TopicTest", "broker-a", 0)),
+        11,
+    );
+    let last = SendResult::new(
+        SendStatus::FlushSlaveTimeout,
+        Some(CheetahString::from_static_str("last-id")),
+        Some("last-offset-id".to_string()),
+        Some(MessageQueue::from_parts("TopicTest", "broker-b", 1)),
+        22,
+    );
+    let mut retry_state = RetryState::new(2);
+
+    retry_state.record_send_result(first);
+    retry_state.record_send_result(last.clone());
+
+    assert_eq!(retry_state.take_last_send_result(), Some(last));
 }
 
 #[test]
@@ -1156,6 +1199,34 @@ fn local_transaction_listener_panic_becomes_unknown_like_java() {
     assert!(remark
         .as_ref()
         .is_some_and(|remark| remark.as_str().contains("local transaction boom")));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn initial_transaction_listener_uses_owned_blocking_lane() {
+    let producer = running_producer_without_client();
+    let caller_thread = std::thread::current().id();
+    let listener_thread = Arc::new(std::sync::Mutex::new(None));
+    let listener: ArcTransactionListener = Arc::new(ThreadRecordingTransactionListener {
+        thread_id: Arc::clone(&listener_thread),
+    });
+    let msg = Arc::new(
+        Message::builder()
+            .topic("TopicTest")
+            .body_slice(b"transaction")
+            .build_unchecked(),
+    );
+
+    let (state, remark) = producer.execute_local_transaction_listener(listener, msg, None).await;
+
+    assert_eq!(state, LocalTransactionState::CommitMessage);
+    assert!(remark.is_none());
+    assert_ne!(
+        listener_thread
+            .lock()
+            .expect("thread id lock should not be poisoned")
+            .expect("listener should record its thread"),
+        caller_thread
+    );
 }
 
 #[test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9216

### Brief Description

Align producer retry behavior and Broker send validation with the intended Java-compatible semantics.

- Preserve the last retryable non-OK `SendResult` after synchronous retries are exhausted.
- Apply the producer response-code allowlist consistently to asynchronous retries while retaining a single overall timeout and exactly-once terminal callback/hook behavior.
- Run the initial transaction listener on the owned client blocking lane so user code does not block Tokio workers.
- Reject every send request shape when the Broker is not writable and reject missing or blank compaction keys before append.
- Add focused regression coverage for synchronous/asynchronous retries, transaction listener isolation, write permission, and compaction-key validation.

### How Did You Test This Change?

- `cargo test -p rocketmq-client-rust --lib --quiet`: passed, 1,038 tests.
- Focused Broker tests for write permission, compaction keys, and message body limits: passed.
- `cargo clippy -p rocketmq-client-rust -p rocketmq-broker --no-deps --all-targets --all-features -- -D warnings`: passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- `cargo check --manifest-path fuzz/Cargo.toml --all-targets`: passed.
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`: passed.
- `cargo fmt --all -- --check` under WSL: passed; the native Windows invocation hit OS error 206 due to path length.
- The full Broker library suite reached 763 passed and 4 pre-existing failures unrelated to this diff: the tracked store-lease shutdown test, two controller failover tests, and the extended-timer policy-generation test.
- `.\scripts\check-error-hygiene.ps1` passed the client retry checks but reported the pre-existing dashboard backend `derive(Debug)` sensitive-field finding in `rocketmq-dashboard/rocketmq-dashboard-web/backend/src/config/app_config.rs`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved asynchronous producer retries using configured broker response codes and transport-error handling.
  - Transactional message callbacks now execute asynchronously while preserving broker transaction details.
  - Retry results now retain the latest send outcome for clearer final responses.

- **Bug Fixes**
  - Message sends are rejected consistently by non-writable brokers.
  - Compaction-topic messages must include a non-blank key.

- **Tests**
  - Added coverage for retry decisions, transaction callback execution, broker permissions, and compaction-key validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->