### PR TITLE
[ISSUE #9221]✨Bound mapped-file reads to requested ranges

### DIFF
--- a/rocketmq-store-local/src/commit_log/record_parser.rs
+++ b/rocketmq-store-local/src/commit_log/record_parser.rs
@@ -316,6 +316,13 @@ pub fn decode_commit_log_record<C: CommitLogRecordChecksum>(
         });
     }
     let declared_len = declared_size as usize;
+    let magic_code = top_level_i32(input, 4, CommitLogRecordField::MagicCode).map_err(|mut error| {
+        error.declared_size = Some(declared_size);
+        error
+    })?;
+    if magic_code == BLANK_MAGIC_CODE {
+        return Ok(CommitLogRecordOutcome::Blank { declared_size });
+    }
     if input.len() < declared_len {
         return Err(CommitLogRecordError {
             declared_size: Some(declared_size),
@@ -325,13 +332,6 @@ pub fn decode_commit_log_record<C: CommitLogRecordChecksum>(
                 remaining: input.len(),
             },
         });
-    }
-    let magic_code = top_level_i32(input, 4, CommitLogRecordField::MagicCode).map_err(|mut error| {
-        error.declared_size = Some(declared_size);
-        error
-    })?;
-    if magic_code == BLANK_MAGIC_CODE {
-        return Ok(CommitLogRecordOutcome::Blank { declared_size });
     }
     let version = match magic_code {
         MESSAGE_MAGIC_CODE => CommitLogRecordVersion::V1,
@@ -457,6 +457,7 @@ mod tests {
     use super::CommitLogRecordChecksum;
     use super::CommitLogRecordOutcome;
     use super::CommitLogRecordVersion;
+    use super::BLANK_MAGIC_CODE;
     use super::MESSAGE_MAGIC_CODE;
     use super::MESSAGE_MAGIC_CODE_V2;
 
@@ -576,6 +577,25 @@ mod tests {
 
         assert!(result.is_err());
         assert_eq!(checksum.calls.get(), 1);
+    }
+
+    #[test]
+    fn blank_marker_decodes_from_header_without_materializing_file_tail() {
+        let mut input = BytesMut::with_capacity(8);
+        input.put_i32(16 * 1024 * 1024);
+        input.put_i32(BLANK_MAGIC_CODE);
+        let checksum = SpyChecksum { calls: Cell::new(0) };
+
+        let outcome = decode_commit_log_record(&input.freeze(), CommitLogRecordBodyMode::Skip, &checksum)
+            .expect("blank marker header should decode");
+
+        assert!(matches!(
+            outcome,
+            CommitLogRecordOutcome::Blank {
+                declared_size: 16_777_216
+            }
+        ));
+        assert_eq!(checksum.calls.get(), 0);
     }
 
     #[test]

--- a/rocketmq-store-local/src/mapped_file/default_mapped_file.rs
+++ b/rocketmq-store-local/src/mapped_file/default_mapped_file.rs
@@ -1016,7 +1016,13 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
 
         let _writer = self.write_state.lock();
         let generation = self.try_get_read_generation(admission, MappedFileOperation::Read)?;
-        Ok(generation.with_slice(|mapped| mapped.get(pos..end).map(Bytes::copy_from_slice)))
+        let copied = generation.with_slice(|mapped| mapped.get(pos..end).map(Bytes::copy_from_slice));
+        if copied.is_some() {
+            if let Some(metrics) = self.metrics.as_ref() {
+                metrics.record_selection_copy(size);
+            }
+        }
+        Ok(copied)
     }
 
     fn try_copy_range(
@@ -1213,7 +1219,11 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
 
         let _writer = self.write_state.lock();
         let generation = self.try_get_read_generation(admission, MappedFileOperation::Read)?;
-        Ok(generation.with_slice(|mapped| mapped.get(start..end) == Some(snapshot)))
+        let matches = generation.with_slice(|mapped| mapped.get(start..end) == Some(snapshot));
+        if let Some(metrics) = self.metrics.as_ref() {
+            metrics.record_selection_compare(snapshot.len());
+        }
+        Ok(matches)
     }
 
     /// Extracts the file offset from the given file name.

--- a/rocketmq-store-local/src/mapped_file/metrics.rs
+++ b/rocketmq-store-local/src/mapped_file/metrics.rs
@@ -110,6 +110,12 @@ pub struct MappedFileMetrics {
     /// Number of times data was not in page cache (disk I/O required)
     cache_misses: AtomicU64,
 
+    /// Bytes copied while materializing mapped-file read selections.
+    selection_copy_bytes_total: AtomicU64,
+
+    /// Bytes compared while attaching copied selections to mapped-file owners.
+    selection_compare_bytes_total: AtomicU64,
+
     /// Number of mapped file warm-up operations.
     warm_operations: AtomicU64,
 
@@ -175,6 +181,8 @@ impl MappedFileMetrics {
             zero_copy_reads: AtomicU64::new(0),
             cache_hits: AtomicU64::new(0),
             cache_misses: AtomicU64::new(0),
+            selection_copy_bytes_total: AtomicU64::new(0),
+            selection_compare_bytes_total: AtomicU64::new(0),
             warm_operations: AtomicU64::new(0),
             warm_bytes: AtomicU64::new(0),
             total_warm_time_ms: AtomicU64::new(0),
@@ -268,6 +276,20 @@ impl MappedFileMetrics {
         self.cache_misses.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Records bytes copied into an owned mapped-file read selection.
+    #[inline]
+    pub(crate) fn record_selection_copy(&self, bytes: usize) {
+        self.selection_copy_bytes_total
+            .fetch_add(bytes as u64, Ordering::Relaxed);
+    }
+
+    /// Records bytes compared while validating a mapped-file selection attachment.
+    #[inline]
+    pub(crate) fn record_selection_compare(&self, bytes: usize) {
+        self.selection_compare_bytes_total
+            .fetch_add(bytes as u64, Ordering::Relaxed);
+    }
+
     /// Records a mapped file warm-up operation.
     #[inline]
     pub fn record_warm(&self, bytes: usize) {
@@ -340,6 +362,18 @@ impl MappedFileMetrics {
     #[inline]
     pub fn cache_misses(&self) -> u64 {
         self.cache_misses.load(Ordering::Relaxed)
+    }
+
+    /// Returns bytes copied into owned mapped-file read selections.
+    #[inline]
+    pub fn selection_copy_bytes_total(&self) -> u64 {
+        self.selection_copy_bytes_total.load(Ordering::Relaxed)
+    }
+
+    /// Returns bytes compared while attaching selections to mapped-file owners.
+    #[inline]
+    pub fn selection_compare_bytes_total(&self) -> u64 {
+        self.selection_compare_bytes_total.load(Ordering::Relaxed)
     }
 
     /// Returns total warm-up operations.
@@ -533,6 +567,8 @@ impl MappedFileMetrics {
         self.zero_copy_reads.store(0, Ordering::Relaxed);
         self.cache_hits.store(0, Ordering::Relaxed);
         self.cache_misses.store(0, Ordering::Relaxed);
+        self.selection_copy_bytes_total.store(0, Ordering::Relaxed);
+        self.selection_compare_bytes_total.store(0, Ordering::Relaxed);
         self.warm_operations.store(0, Ordering::Relaxed);
         self.warm_bytes.store(0, Ordering::Relaxed);
         self.total_warm_time_ms.store(0, Ordering::Relaxed);
@@ -549,7 +585,8 @@ impl MappedFileMetrics {
     /// A multi-line string with human-readable metrics
     pub fn summary(&self) -> String {
         format!(
-            "MappedFile Metrics:\nWrites: {} ({:.2} writes/sec, {:.2} MB/s)\nReads: {} ({:.1}% zero-copy)\nFlushes: \
+            "MappedFile Metrics:\nWrites: {} ({:.2} writes/sec, {:.2} MB/s)\nReads: {} ({:.1}% zero-copy), \
+             selection copy/compare: {}/{} bytes\nFlushes: \
              {} (avg: {:?})\nCache Hit Rate: {:.1}%\nAvg Write Size: {:.1} bytes\nWarm: {} ops, {} bytes, total {} \
              ms, last {} ms\nSwap: {} ops, clean: {} ops\nPhysical owners: {} mappings / {} bytes, {} files; drops: {} \
              mappings, {} files; detach: {}",
@@ -558,6 +595,8 @@ impl MappedFileMetrics {
             self.write_throughput_mb_per_sec(),
             self.total_reads(),
             self.zero_copy_read_percentage(),
+            self.selection_copy_bytes_total(),
+            self.selection_compare_bytes_total(),
             self.total_flushes(),
             self.avg_flush_duration(),
             self.cache_hit_rate(),
@@ -620,6 +659,20 @@ mod tests {
         // Use approximate comparison for floating point
         let percentage = metrics.zero_copy_read_percentage();
         assert!((percentage - 66.666).abs() < 0.01);
+    }
+
+    #[test]
+    fn selection_copy_and_compare_bytes_are_counted_and_reset() {
+        let mut metrics = MappedFileMetrics::new();
+        metrics.record_selection_copy(256);
+        metrics.record_selection_compare(128);
+
+        assert_eq!(metrics.selection_copy_bytes_total(), 256);
+        assert_eq!(metrics.selection_compare_bytes_total(), 128);
+
+        metrics.reset();
+        assert_eq!(metrics.selection_copy_bytes_total(), 0);
+        assert_eq!(metrics.selection_compare_bytes_total(), 0);
     }
 
     #[test]

--- a/rocketmq-store-local/src/mapped_file/queue_metrics.rs
+++ b/rocketmq-store-local/src/mapped_file/queue_metrics.rs
@@ -44,6 +44,15 @@ pub struct MappedFileIoStats {
     pub bytes_read: u64,
 }
 
+/// Aggregate materialization costs from one mapped-file queue generation.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct MappedFileSelectionStats {
+    /// Bytes copied into owned read selections.
+    pub copied_bytes: u64,
+    /// Bytes compared while attaching selections to mapped-file owners.
+    pub compared_bytes: u64,
+}
+
 /// Aggregates I/O metrics from the current mapped-file snapshot.
 #[doc(hidden)]
 pub fn mapped_file_queue_io_stats(files: &[Arc<DefaultMappedFile>]) -> MappedFileIoStats {
@@ -57,6 +66,22 @@ pub fn mapped_file_queue_io_stats(files: &[Arc<DefaultMappedFile>]) -> MappedFil
         stats.flush_operations = stats.flush_operations.saturating_add(metrics.total_flushes());
         stats.read_operations = stats.read_operations.saturating_add(metrics.total_reads());
         stats.bytes_read = stats.bytes_read.saturating_add(metrics.total_bytes_read());
+    }
+    stats
+}
+
+/// Aggregates read-selection materialization metrics from the current mapped-file snapshot.
+#[doc(hidden)]
+pub fn mapped_file_queue_selection_stats(files: &[Arc<DefaultMappedFile>]) -> MappedFileSelectionStats {
+    let mut stats = MappedFileSelectionStats::default();
+    for mapped_file in files {
+        let Some(metrics) = mapped_file.get_metrics() else {
+            continue;
+        };
+        stats.copied_bytes = stats.copied_bytes.saturating_add(metrics.selection_copy_bytes_total());
+        stats.compared_bytes = stats
+            .compared_bytes
+            .saturating_add(metrics.selection_compare_bytes_total());
     }
     stats
 }

--- a/rocketmq-store/benches/commit_log_performance.rs
+++ b/rocketmq-store/benches/commit_log_performance.rs
@@ -171,6 +171,13 @@ fn benchmark_service_context() -> ChildServiceContext {
 }
 
 fn new_bench_store(flush_disk_type: FlushDiskType) -> BenchStore {
+    new_bench_store_with_mapped_file_size(flush_disk_type, 1024 * 1024 * 256)
+}
+
+fn new_bench_store_with_mapped_file_size(
+    flush_disk_type: FlushDiskType,
+    mapped_file_size_commit_log: usize,
+) -> BenchStore {
     let temp_dir = TempDir::new().expect("create temp dir for benchmark");
     let mut message_store_config = MessageStoreConfig {
         store_path_root_dir: temp_dir.path().to_string_lossy().to_string().into(),
@@ -178,7 +185,7 @@ fn new_bench_store(flush_disk_type: FlushDiskType) -> BenchStore {
         ha_listen_port: 0,
         ..MessageStoreConfig::default()
     };
-    message_store_config.mapped_file_size_commit_log = 1024 * 1024 * 256;
+    message_store_config.mapped_file_size_commit_log = mapped_file_size_commit_log;
 
     let mut store = LocalFileMessageStore::new(
         Arc::new(message_store_config),
@@ -196,6 +203,49 @@ fn new_bench_store(flush_disk_type: FlushDiskType) -> BenchStore {
         store,
         _temp_dir: temp_dir,
     }
+}
+
+fn bench_bounded_bulk_read(c: &mut Criterion) {
+    const MAPPED_FILE_SIZE: usize = 64 * 1024 * 1024;
+    const TRANSFER_SIZE: usize = 256 * 1024;
+
+    let mut group = c.benchmark_group("mapped_file/bounded_bulk_read");
+    group.sample_size(10);
+    group.throughput(Throughput::Bytes(TRANSFER_SIZE as u64));
+    group.bench_function("64MiB_active_file_256KiB_transfer", |b| {
+        let runtime = Runtime::new().expect("create runtime");
+        let mut bench_store = new_bench_store_with_mapped_file_size(FlushDiskType::AsyncFlush, MAPPED_FILE_SIZE);
+        runtime.block_on(async {
+            bench_store.store.init().await.expect("init bulk read benchmark store");
+            let payload = vec![0x5a; MAPPED_FILE_SIZE];
+            assert!(bench_store
+                .store
+                .get_commit_log_mut()
+                .append_data(0, &payload, 0, payload.len() as i32)
+                .await
+                .expect("append bulk read benchmark payload"));
+        });
+
+        b.iter_custom(|iters| {
+            let before = bench_store.store.get_commit_log().selection_stats();
+            let started = Instant::now();
+            for _ in 0..iters {
+                let selections = bench_store
+                    .store
+                    .get_commit_log()
+                    .get_bulk_data(0, TRANSFER_SIZE as i32)
+                    .expect("select bounded bulk data");
+                black_box(selections);
+            }
+            let elapsed = started.elapsed();
+            let after = bench_store.store.get_commit_log().selection_stats();
+            let expected_bytes = iters.saturating_mul(TRANSFER_SIZE as u64);
+            assert_eq!(after.copied_bytes - before.copied_bytes, expected_bytes);
+            assert_eq!(after.compared_bytes - before.compared_bytes, expected_bytes);
+            elapsed
+        });
+    });
+    group.finish();
 }
 
 fn create_test_message(topic: &str, queue_id: i32, body_size: usize, key_seed: u64) -> MessageExtBrokerInner {
@@ -329,6 +379,11 @@ fn write_commit_log_lock_profile_artifact() {
     .expect("CommitLog lock profile report should be written");
 }
 
+fn ensure_commit_log_lock_profile_artifact() {
+    static ARTIFACT: OnceLock<()> = OnceLock::new();
+    ARTIFACT.get_or_init(write_commit_log_lock_profile_artifact);
+}
+
 fn bench_async_flush_single_message(c: &mut Criterion) {
     let mut group = c.benchmark_group("phase5/async_flush_single_message");
     group.sample_size(20);
@@ -400,8 +455,6 @@ fn bench_async_flush_multi_queue(c: &mut Criterion) {
 }
 
 fn bench_commit_log_lock_profile_contention(c: &mut Criterion) {
-    write_commit_log_lock_profile_artifact();
-
     let mut group = c.benchmark_group("phase5/commit_log_lock_profile_contention");
     group.sample_size(10);
 
@@ -410,6 +463,7 @@ fn bench_commit_log_lock_profile_contention(c: &mut Criterion) {
             scenario.queue_count as u64 * scenario.messages_per_queue,
         ));
         group.bench_with_input(BenchmarkId::from_parameter(scenario.name), &scenario, |b, &scenario| {
+            ensure_commit_log_lock_profile_artifact();
             let runtime = Runtime::new().expect("create runtime");
             let mut bench_store = new_bench_store(scenario.flush_disk_type);
             runtime.block_on(start_store_if_needed(&mut bench_store, scenario.flush_disk_type));
@@ -513,5 +567,6 @@ criterion_group!(
     bench_commit_log_lock_profile_contention,
     bench_reput_once_after_batch,
     bench_sync_flush_tail_latency_baseline,
+    bench_bounded_bulk_read,
 );
 criterion_main!(benches);

--- a/rocketmq-store/src/consume_queue/mapped_file_queue.rs
+++ b/rocketmq-store/src/consume_queue/mapped_file_queue.rs
@@ -61,10 +61,12 @@ use rocketmq_store_local::mapped_file::queue_metrics::mapped_file_queue_lazy_mma
 use rocketmq_store_local::mapped_file::queue_metrics::mapped_file_queue_max_offset;
 use rocketmq_store_local::mapped_file::queue_metrics::mapped_file_queue_max_wrote_position;
 use rocketmq_store_local::mapped_file::queue_metrics::mapped_file_queue_min_offset;
+use rocketmq_store_local::mapped_file::queue_metrics::mapped_file_queue_selection_stats;
 use rocketmq_store_local::mapped_file::queue_metrics::mapped_file_queue_should_roll;
 use rocketmq_store_local::mapped_file::queue_metrics::mapped_file_queue_total_size;
 use rocketmq_store_local::mapped_file::queue_metrics::mapped_file_queue_warmup_stats;
 pub use rocketmq_store_local::mapped_file::queue_metrics::MappedFileIoStats;
+pub use rocketmq_store_local::mapped_file::queue_metrics::MappedFileSelectionStats;
 pub use rocketmq_store_local::mapped_file::queue_metrics::MappedFileWarmupStats;
 use rocketmq_store_local::mapped_file::queue_state::MappedFileQueueRuntimeState;
 use rocketmq_store_local::mapped_file::queue_storage::MappedFileQueueStorage;
@@ -316,6 +318,24 @@ impl MappedFileQueueReadHandle {
         result
     }
 
+    pub(crate) fn get_data_bounded(&self, offset: i64, max_bytes: usize) -> Option<SelectMappedBufferResult> {
+        if max_bytes == 0 {
+            return None;
+        }
+        let mapped_file = self.find_mapped_file_by_offset(offset, offset == 0)?;
+        let position = (offset % self.mapped_file_size as i64) as i32;
+        let readable = mapped_file.get_read_position().checked_sub(position)?;
+        if readable <= 0 {
+            return None;
+        }
+        let size = usize::try_from(readable).ok()?.min(max_bytes).min(i32::MAX as usize) as i32;
+        let mut result = mapped_file.select_mapped_buffer(position, size);
+        if let Some(result) = result.as_mut() {
+            result.try_attach_mapped_file(mapped_file);
+        }
+        result
+    }
+
     pub(crate) fn get_message(&self, offset: i64, size: i32) -> Option<SelectMappedBufferResult> {
         let mapped_file = self.find_mapped_file_by_offset(offset, offset == 0)?;
         let position = (offset % self.mapped_file_size as i64) as i32;
@@ -339,18 +359,13 @@ impl MappedFileQueueReadHandle {
         while remaining > 0 {
             let mapped_file = self.find_mapped_file_by_offset(current_offset, current_offset == offset)?;
             let pos = (current_offset % mapped_file_size) as i32;
-            let mut result = mapped_file.select_mapped_buffer_with_position(pos)?;
+            let readable = mapped_file.get_read_position().checked_sub(pos)?;
+            if readable <= 0 {
+                return None;
+            }
+            let take = usize::try_from(readable).ok()?.min(remaining);
+            let mut result = mapped_file.select_mapped_buffer(pos, take as i32)?;
             result.try_attach_mapped_file(mapped_file);
-
-            let readable = result.size().max(0) as usize;
-            if readable == 0 {
-                return None;
-            }
-
-            let take = readable.min(remaining);
-            if take < readable && !result.try_truncate(take) {
-                return None;
-            }
 
             results.push(result);
             current_offset += take as i64;
@@ -1023,6 +1038,11 @@ impl MappedFileQueue {
     pub fn io_stats(&self) -> MappedFileIoStats {
         let mapped_files = self.storage.mapped_files().snapshot();
         mapped_file_queue_io_stats(mapped_files.as_ref())
+    }
+
+    pub fn selection_stats(&self) -> MappedFileSelectionStats {
+        let mapped_files = self.storage.mapped_files().snapshot();
+        mapped_file_queue_selection_stats(mapped_files.as_ref())
     }
 
     pub fn lazy_mmap_stats(&self) -> LazyMmapStats {

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -2375,6 +2375,11 @@ impl CommitLog {
         self.read_handle().get_bulk_data(offset, size)
     }
 
+    /// Returns cumulative heap-copy and attachment-comparison bytes for mapped-file selections.
+    pub fn selection_stats(&self) -> crate::consume_queue::mapped_file_queue::MappedFileSelectionStats {
+        self.mapped_file_queue.selection_stats()
+    }
+
     pub fn select_segments(
         &self,
         offset: i64,
@@ -3913,6 +3918,10 @@ mod tests {
             })
             .collect();
         assert_eq!(combined, b"CDEFghij");
+
+        let selection_stats = store.get_commit_log().selection_stats();
+        assert_eq!(selection_stats.copied_bytes, 8);
+        assert_eq!(selection_stats.compared_bytes, 8);
 
         let _ = fs::remove_dir_all(temp_root);
     }

--- a/rocketmq-store/src/log_file/commit_log/handles.rs
+++ b/rocketmq-store/src/log_file/commit_log/handles.rs
@@ -105,6 +105,10 @@ impl CommitLogReadHandle {
         self.mapped_file_queue.get_data(offset)
     }
 
+    pub(crate) fn get_data_bounded(&self, offset: i64, max_bytes: usize) -> Option<SelectMappedBufferResult> {
+        self.mapped_file_queue.get_data_bounded(offset, max_bytes)
+    }
+
     pub(crate) fn get_max_offset(&self) -> i64 {
         self.mapped_file_queue.get_max_offset()
     }

--- a/rocketmq-store/src/message_store/local_file_message_store/dispatch.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/dispatch.rs
@@ -799,6 +799,45 @@ pub(super) struct ReputMessageServiceInner {
     pub(super) runtime_context: ReputRuntimeContext,
 }
 
+const MIN_REPUT_READ_BYTES: usize = 1024 * 1024;
+const COMMIT_LOG_RECORD_OVERHEAD_BUDGET: i32 = 64 * 1024;
+
+fn reput_read_max_bytes(config: &MessageStoreConfig) -> usize {
+    let max_message_size = config.max_message_size.max(0);
+    let max_record_size = if i32::MAX - max_message_size >= COMMIT_LOG_RECORD_OVERHEAD_BUDGET {
+        max_message_size + COMMIT_LOG_RECORD_OVERHEAD_BUDGET
+    } else {
+        i32::MAX
+    };
+    usize::try_from(max_record_size)
+        .unwrap_or(MIN_REPUT_READ_BYTES)
+        .max(MIN_REPUT_READ_BYTES)
+}
+
+fn reput_record_is_complete(bytes: &Bytes) -> bool {
+    let Some(total_size) = bytes
+        .get(..4)
+        .and_then(|value| <[u8; 4]>::try_from(value).ok())
+        .map(i32::from_be_bytes)
+    else {
+        return false;
+    };
+    if total_size < 8 {
+        return true;
+    }
+    let Some(magic_code) = bytes
+        .get(4..8)
+        .and_then(|value| <[u8; 4]>::try_from(value).ok())
+        .map(i32::from_be_bytes)
+    else {
+        return false;
+    };
+    if magic_code == commit_log::BLANK_MAGIC_CODE {
+        return true;
+    }
+    usize::try_from(total_size).map_or(true, |total_size| total_size <= bytes.len())
+}
+
 async fn dispatch_reput_batch(
     dispatcher: &CommitLogDispatchHandle,
     runtime_context: &ReputRuntimeContext,
@@ -836,7 +875,10 @@ impl ReputMessageServiceInner {
         let mut dispatch_batch: Vec<DispatchRequest> = Vec::with_capacity(64);
 
         while do_next && self.is_commit_log_available() {
-            let Some(mut result) = self.commit_log.get_data(self.reput_from_offset.load(Ordering::Acquire)) else {
+            let Some(mut result) = self.commit_log.get_data_bounded(
+                self.reput_from_offset.load(Ordering::Acquire),
+                reput_read_max_bytes(self.runtime_context.message_store_config.as_ref()),
+            ) else {
                 break;
             };
             self.reput_from_offset
@@ -850,6 +892,9 @@ impl ReputMessageServiceInner {
                     warn!("commitlog data is missing bytes during reput dispatch");
                     break;
                 };
+                if !reput_record_is_complete(bytes) {
+                    break;
+                }
                 let dispatch_request = commit_log::check_message_and_return_size(
                     bytes,
                     false,
@@ -1008,9 +1053,10 @@ impl ReputMessageServiceInner {
 
         let mut dispatch_batch: Vec<DispatchRequest> = Vec::with_capacity(64);
 
-        let mut result = self
-            .commit_log
-            .get_data(self.reput_from_offset.load(Ordering::Acquire))?;
+        let mut result = self.commit_log.get_data_bounded(
+            self.reput_from_offset.load(Ordering::Acquire),
+            reput_read_max_bytes(self.runtime_context.message_store_config.as_ref()),
+        )?;
         self.reput_from_offset
             .store(result.start_offset() as i64, Ordering::Release);
         let mut read_size = 0i32;
@@ -1023,6 +1069,9 @@ impl ReputMessageServiceInner {
                 warn!("commitlog data is missing bytes during batch reput dispatch");
                 break;
             };
+            if !reput_record_is_complete(bytes) {
+                break;
+            }
             let dispatch_request = commit_log::check_message_and_return_size(
                 bytes,
                 false,
@@ -1104,5 +1153,42 @@ impl ReputMessageServiceInner {
         } else {
             Some(dispatch_batch)
         }
+    }
+}
+
+#[cfg(test)]
+mod bounded_reput_read_tests {
+    use super::*;
+
+    #[test]
+    fn read_budget_covers_one_maximum_encoded_message() {
+        let config = MessageStoreConfig {
+            max_message_size: 4 * 1024 * 1024,
+            ..MessageStoreConfig::default()
+        };
+
+        assert_eq!(
+            reput_read_max_bytes(&config),
+            config.max_message_size as usize + COMMIT_LOG_RECORD_OVERHEAD_BUDGET as usize
+        );
+    }
+
+    #[test]
+    fn partial_message_waits_for_the_next_bounded_read() {
+        let mut frame = Vec::new();
+        frame.extend_from_slice(&16i32.to_be_bytes());
+        frame.extend_from_slice(&commit_log::MESSAGE_MAGIC_CODE.to_be_bytes());
+        frame.extend_from_slice(&[0; 4]);
+
+        assert!(!reput_record_is_complete(&Bytes::from(frame)));
+    }
+
+    #[test]
+    fn blank_marker_only_requires_its_header() {
+        let mut frame = Vec::new();
+        frame.extend_from_slice(&(16 * 1024 * 1024i32).to_be_bytes());
+        frame.extend_from_slice(&commit_log::BLANK_MAGIC_CODE.to_be_bytes());
+
+        assert!(reput_record_is_complete(&Bytes::from(frame)));
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9221

### Brief Description

Bound mapped-file reads before materializing heap snapshots so HA bulk transfer and Reput no longer copy and compare the readable file tail before truncation.

- Calculate the exact per-file `take` before selecting bulk CommitLog data.
- Add a bounded CommitLog read capability for Reput with a read budget large enough for one configured maximum encoded message.
- Preserve partial-frame retry and blank-marker rollover without materializing the complete blank file tail.
- Record copied and compared selection bytes and expose an aggregate snapshot for benchmarks and diagnostics.
- Add regression tests that preserve cross-file bytes and offsets while enforcing copy and compare bytes equal to the requested payload.
- Add a 64 MiB active-file / 256 KiB transfer benchmark with per-iteration materialization assertions.

This change keeps the existing byte snapshot, mapped-file lease, wire format, storage format, and dispatch ordering. Owner-backed zero-copy ranges remain separate follow-up work.

### How Did You Test This Change?

- `cargo test -p rocketmq-store --lib --quiet -- --test-threads=1`: passed, 670 tests.
- `cargo test -p rocketmq-store-local --quiet`: passed all unit, integration, UI, and compile-boundary tests.
- Focused cross-file bulk read, mapped-file boundary, Reput, blank-marker, and selection-counter tests: passed.
- `cargo bench -p rocketmq-store --bench commit_log_performance -- bounded_bulk_read --noplot`: passed; 14.338 to 17.138 microseconds and 14.245 to 17.028 GiB/s for a 256 KiB transfer, with copy and compare each asserted at 1.0 times payload.
- `cargo clippy -p rocketmq-store-local -p rocketmq-store --no-deps --all-targets --all-features -- -D warnings`: passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- `cargo check --manifest-path fuzz/Cargo.toml --all-targets`: passed.
- `cargo fmt --all -- --check` under WSL: passed.
- `git diff --check`: passed.
- `python scripts/public_api_intent_guard.py` still reports the pre-existing repository manifest drift (253 findings); this change does not modify any scanned `lib.rs` or `public_api.rs` export declaration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bounded commit-log reads to limit data processed per operation.
  * Added selection statistics showing bytes copied and compared across mapped files.
* **Bug Fixes**
  * Improved handling of incomplete records by pausing processing until complete data is available.
  * Blank markers are now recognized correctly even when their declared data is truncated.
* **Performance**
  * Optimized bulk reads to retrieve only the requested data range.
  * Added performance coverage for large, cross-file reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->