### PR TITLE
[ISSUE #9223]✨Add explicit Java 5.5 and strict store profiles

### DIFF
--- a/distribution/config/broker/1m-1s-async-one-machine/broker-master.toml
+++ b/distribution/config/broker/1m-1s-async-one-machine/broker-master.toml
@@ -23,6 +23,7 @@ brokerClusterName = "DefaultCluster-mxsm"
 brokerId = 0
 
 [store]
+compatibilityProfile = "JAVA_5_5"
 brokerRole = "ASYNC_MASTER"
 flushDiskType = "ASYNC_FLUSH"
 deleteWhen = 4

--- a/distribution/config/broker/1m-1s-async-one-machine/broker-slave.toml
+++ b/distribution/config/broker/1m-1s-async-one-machine/broker-slave.toml
@@ -26,6 +26,7 @@ brokerId = 1
 bindAddress = "127.0.0.1"
 
 [store]
+compatibilityProfile = "JAVA_5_5"
 brokerRole = "SLAVE"
 flushDiskType = "ASYNC_FLUSH"
 deleteWhen = 4

--- a/distribution/config/broker/2m-2s-async/broker-a-master.toml
+++ b/distribution/config/broker/2m-2s-async/broker-a-master.toml
@@ -23,6 +23,7 @@ brokerClusterName = "DefaultCluster-mxsm"
 brokerId = 0
 
 [store]
+compatibilityProfile = "JAVA_5_5"
 brokerRole = "ASYNC_MASTER"
 flushDiskType = "ASYNC_FLUSH"
 deleteWhen = 4

--- a/distribution/config/broker/2m-2s-async/broker-a-slave.toml
+++ b/distribution/config/broker/2m-2s-async/broker-a-slave.toml
@@ -23,6 +23,7 @@ brokerClusterName = "DefaultCluster-mxsm"
 brokerId = 1
 
 [store]
+compatibilityProfile = "JAVA_5_5"
 brokerRole = "SLAVE"
 flushDiskType = "ASYNC_FLUSH"
 deleteWhen = 4

--- a/distribution/config/broker/2m-2s-async/broker-b-master.toml
+++ b/distribution/config/broker/2m-2s-async/broker-b-master.toml
@@ -23,6 +23,7 @@ brokerClusterName = "DefaultCluster-mxsm"
 brokerId = 0
 
 [store]
+compatibilityProfile = "JAVA_5_5"
 brokerRole = "ASYNC_MASTER"
 flushDiskType = "ASYNC_FLUSH"
 deleteWhen = 4

--- a/distribution/config/broker/2m-2s-async/broker-b-slave.toml
+++ b/distribution/config/broker/2m-2s-async/broker-b-slave.toml
@@ -23,6 +23,7 @@ brokerClusterName = "DefaultCluster-mxsm"
 brokerId = 1
 
 [store]
+compatibilityProfile = "JAVA_5_5"
 brokerRole = "SLAVE"
 flushDiskType = "ASYNC_FLUSH"
 deleteWhen = 4

--- a/distribution/config/broker/broker-simple-master.toml
+++ b/distribution/config/broker/broker-simple-master.toml
@@ -23,6 +23,7 @@ brokerClusterName = "DefaultCluster-mxsm"
 brokerId = 0
 
 [store]
+compatibilityProfile = "JAVA_5_5"
 brokerRole = "ASYNC_MASTER"
 flushDiskType = "ASYNC_FLUSH"
 deleteWhen = 4

--- a/distribution/config/broker/broker-simple-slave.toml
+++ b/distribution/config/broker/broker-simple-slave.toml
@@ -26,6 +26,7 @@ brokerId = 1
 bindAddress = "127.0.0.1"
 
 [store]
+compatibilityProfile = "JAVA_5_5"
 brokerRole = "SLAVE"
 flushDiskType = "ASYNC_FLUSH"
 deleteWhen = 4

--- a/distribution/config/broker/broker.toml
+++ b/distribution/config/broker/broker.toml
@@ -46,6 +46,7 @@ defaultTopicQueueNums = 8
 timerWheelEnable = false
 
 [store]
+compatibilityProfile = "JAVA_5_5"
 storePathRootDir = "/opt/data/rocketmq/store"
 brokerRole = "ASYNC_MASTER"
 flushDiskType = "ASYNC_FLUSH"

--- a/distribution/helm/rocketmq-rust/templates/configmaps.yaml
+++ b/distribution/helm/rocketmq-rust/templates/configmaps.yaml
@@ -60,6 +60,7 @@ data:
 
 {{- end }}
     [store]
+    compatibilityProfile = "JAVA_5_5"
     haListenAddress = "0.0.0.0"
     haListenPort = 10912
     storePathRootDir = "/var/lib/rocketmq/store"

--- a/distribution/kubernetes/base/manifest.yaml
+++ b/distribution/kubernetes/base/manifest.yaml
@@ -509,6 +509,7 @@ data:
     brokerClusterName = "RocketmqRust"
     brokerId = 0
     [store]
+    compatibilityProfile = "JAVA_5_5"
     haListenAddress = "0.0.0.0"
     haListenPort = 10912
     storePathRootDir = "/var/lib/rocketmq/store"
@@ -540,6 +541,7 @@ data:
     brokerClusterName = "RocketmqRust"
     brokerId = 0
     [store]
+    compatibilityProfile = "JAVA_5_5"
     haListenAddress = "0.0.0.0"
     haListenPort = 10912
     storePathRootDir = "/var/lib/rocketmq/store"
@@ -571,6 +573,7 @@ data:
     brokerClusterName = "RocketmqRust"
     brokerId = 0
     [store]
+    compatibilityProfile = "JAVA_5_5"
     haListenAddress = "0.0.0.0"
     haListenPort = 10912
     storePathRootDir = "/var/lib/rocketmq/store"

--- a/docker/smoke-config/broker.toml
+++ b/docker/smoke-config/broker.toml
@@ -17,6 +17,7 @@ brokerId = 0
 bindAddress = "127.0.0.1"
 
 [store]
+compatibilityProfile = "JAVA_5_5"
 storePathRootDir = "/var/lib/rocketmq/broker"
 haListenAddress = "127.0.0.1"
 haListenPort = 10912

--- a/rocketmq-broker/src/bin/broker_bootstrap_server.rs
+++ b/rocketmq-broker/src/bin/broker_bootstrap_server.rs
@@ -414,10 +414,18 @@ fn print_important_broker_config(config: &BrokerConfig) {
 /// Print important message store configuration items
 fn print_important_message_store_config(config: &MessageStoreConfig) {
     println!("  MessageStoreConfig:");
+    println!("    compatibilityProfile: {}", config.compatibility_profile);
     println!("    storePathRootDir: {}", config.store_path_root_dir);
     println!("    storePathCommitLog: {:?}", config.store_path_commit_log);
     println!("    deleteWhen: {}", config.delete_when);
     println!("    flushDiskType: {:?}", config.flush_disk_type);
+    println!("    flushCommitLogLeastPages: {}", config.flush_commit_log_least_pages);
+    println!(
+        "    flushConsumeQueueLeastPages: {}",
+        config.flush_consume_queue_least_pages
+    );
+    println!("    slaveTimeout: {}", config.slave_timeout);
+    println!("    minInSyncReplicas: {}", config.min_in_sync_replicas);
     #[cfg(feature = "tieredstore")]
     print_important_tieredstore_config(config);
 }
@@ -450,13 +458,11 @@ fn print_all_broker_config(config: &BrokerConfig) {
 /// Print all message store configuration items
 fn print_all_message_store_config(config: &MessageStoreConfig) {
     println!("  MessageStoreConfig:");
-    // Message store config doesn't implement get_properties yet
-    // Print key fields manually
-    println!("    storePathRootDir: {}", config.store_path_root_dir);
-    println!("    storePathCommitLog: {:?}", config.store_path_commit_log);
-    println!("    deleteWhen: {}", config.delete_when);
-    println!("    flushDiskType: {:?}", config.flush_disk_type);
-    println!("    commitLogFileSize: {}", config.mapped_file_size_commit_log);
+    let mut properties = config.get_properties().into_iter().collect::<Vec<_>>();
+    properties.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+    for (key, value) in properties {
+        println!("    {}: {}", key, value);
+    }
     #[cfg(feature = "tieredstore")]
     print_all_tieredstore_config(config);
 }

--- a/rocketmq-broker/src/config/raw.rs
+++ b/rocketmq-broker/src/config/raw.rs
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 use std::path::Path;
+use std::sync::Once;
 
 use cheetah_string::CheetahString;
 use config::Config;
@@ -19,7 +20,9 @@ use config::File;
 use rocketmq_observability::LoggingOverrides;
 use rocketmq_observability::ReloadConfig;
 use rocketmq_store::MessageStoreConfig;
+use rocketmq_store::StoreCompatibilityProfile;
 use serde::Deserialize;
+use tracing::warn;
 
 use super::broker_config::BrokerConfig;
 use super::error::BrokerConfigError;
@@ -36,6 +39,10 @@ pub struct RawBrokerConfig {
     store: MessageStoreConfig,
     logging: RawLoggingConfig,
     log_filter: Option<String>,
+    #[serde(skip)]
+    store_markers: StoreOwnershipMarkers,
+    #[serde(skip)]
+    warn_implicit_store_profile: bool,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -51,34 +58,46 @@ struct RawReloadConfig {
     enabled: bool,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 struct CanonicalOwnershipMarkers {
     broker: BrokerOwnershipMarkers,
     store: StoreOwnershipMarkers,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 struct BrokerOwnershipMarkers {
     broker_server_config: ServerOwnershipMarkers,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 struct ServerOwnershipMarkers {
     listen_port: Option<u32>,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 struct StoreOwnershipMarkers {
     enable_controller_mode: Option<bool>,
     duplication_enable: Option<bool>,
+    compatibility_profile: Option<StoreCompatibilityProfile>,
+    max_recovery_commit_log_files: Option<usize>,
+    flush_commit_log_least_pages: Option<i32>,
+    commit_commit_log_least_pages: Option<i32>,
+    flush_consume_queue_least_pages: Option<usize>,
+    flush_consume_queue_thorough_interval: Option<usize>,
+    flush_disk_type: Option<rocketmq_store::FlushDiskType>,
+    slave_timeout: Option<usize>,
+    transient_store_pool_size: Option<usize>,
+    min_in_sync_replicas: Option<usize>,
+    ha_max_time_slave_not_catchup: Option<usize>,
+    all_ack_in_sync_state_set: Option<bool>,
 }
 
 impl CanonicalOwnershipMarkers {
-    fn validate(self) -> Result<(), BrokerConfigError> {
+    fn validate(&self) -> Result<(), BrokerConfigError> {
         if self.broker.broker_server_config.listen_port.is_some() {
             return Err(BrokerConfigError::invalid(
                 super::error::ConfigSection::Network,
@@ -104,6 +123,62 @@ impl CanonicalOwnershipMarkers {
     }
 }
 
+impl StoreOwnershipMarkers {
+    fn all_explicit(store: &MessageStoreConfig) -> Self {
+        Self {
+            enable_controller_mode: Some(store.enable_controller_mode),
+            duplication_enable: Some(store.duplication_enable),
+            compatibility_profile: Some(store.compatibility_profile),
+            max_recovery_commit_log_files: Some(store.max_recovery_commit_log_files),
+            flush_commit_log_least_pages: Some(store.flush_commit_log_least_pages),
+            commit_commit_log_least_pages: Some(store.commit_commit_log_least_pages),
+            flush_consume_queue_least_pages: Some(store.flush_consume_queue_least_pages),
+            flush_consume_queue_thorough_interval: Some(store.flush_consume_queue_thorough_interval),
+            flush_disk_type: Some(store.flush_disk_type),
+            slave_timeout: Some(store.slave_timeout),
+            transient_store_pool_size: Some(store.transient_store_pool_size),
+            min_in_sync_replicas: Some(store.min_in_sync_replicas),
+            ha_max_time_slave_not_catchup: Some(store.ha_max_time_slave_not_catchup),
+            all_ack_in_sync_state_set: Some(store.all_ack_in_sync_state_set),
+        }
+    }
+}
+
+fn apply_store_profile_defaults(store: &mut MessageStoreConfig, markers: &StoreOwnershipMarkers) {
+    if store.compatibility_profile.is_legacy() {
+        return;
+    }
+    let preset = MessageStoreConfig::for_compatibility_profile(store.compatibility_profile);
+    macro_rules! apply_when_omitted {
+        ($field:ident) => {
+            if markers.$field.is_none() {
+                store.$field = preset.$field;
+            }
+        };
+    }
+    apply_when_omitted!(max_recovery_commit_log_files);
+    apply_when_omitted!(flush_commit_log_least_pages);
+    apply_when_omitted!(commit_commit_log_least_pages);
+    apply_when_omitted!(flush_consume_queue_least_pages);
+    apply_when_omitted!(flush_consume_queue_thorough_interval);
+    apply_when_omitted!(flush_disk_type);
+    apply_when_omitted!(slave_timeout);
+    apply_when_omitted!(transient_store_pool_size);
+    apply_when_omitted!(min_in_sync_replicas);
+    apply_when_omitted!(ha_max_time_slave_not_catchup);
+    apply_when_omitted!(all_ack_in_sync_state_set);
+}
+
+fn warn_implicit_legacy_profile_once() {
+    static WARNING: Once = Once::new();
+    WARNING.call_once(|| {
+        warn!(
+            "store.compatibilityProfile is omitted; preserving LEGACY_RUST defaults for this release. Set \
+             JAVA_5_5 or DURABILITY_STRICT explicitly after reviewing durability and RPO behavior"
+        );
+    });
+}
+
 impl RawBrokerConfig {
     pub fn load(path: impl AsRef<Path>) -> Result<Self, BrokerConfigError> {
         let path = path.as_ref();
@@ -114,7 +189,7 @@ impl RawBrokerConfig {
                 path: path.to_path_buf(),
                 source,
             })?;
-        let raw = loaded
+        let mut raw: Self = loaded
             .clone()
             .try_deserialize()
             .map_err(|source| BrokerConfigError::Load {
@@ -127,14 +202,18 @@ impl RawBrokerConfig {
                 source,
             })?;
         ownership.validate()?;
+        raw.warn_implicit_store_profile = ownership.store.compatibility_profile.is_none();
+        raw.store_markers = ownership.store;
         Ok(raw)
     }
 
     #[must_use]
     pub fn from_parts(broker: BrokerConfig, store: MessageStoreConfig) -> Self {
+        let store_markers = StoreOwnershipMarkers::all_explicit(&store);
         Self {
             broker,
             store,
+            store_markers,
             ..Self::default()
         }
     }
@@ -167,6 +246,10 @@ impl RawBrokerConfig {
     }
 
     pub(crate) fn into_normalized_parts(mut self) -> (BrokerConfig, MessageStoreConfig, LoggingOverrides) {
+        if self.warn_implicit_store_profile {
+            warn_implicit_legacy_profile_once();
+        }
+        apply_store_profile_defaults(&mut self.store, &self.store_markers);
         normalize_config_parts(&mut self.broker, &mut self.store);
         let logging = self.logging_overrides();
         (self.broker, self.store, logging)

--- a/rocketmq-broker/src/config/sections.rs
+++ b/rocketmq-broker/src/config/sections.rs
@@ -27,6 +27,7 @@ use rocketmq_runtime::FullPolicy;
 use rocketmq_runtime::MemoryLimitSource;
 use rocketmq_runtime::ProcessMemoryLimit;
 use rocketmq_runtime::ResourceBudgetTree;
+use rocketmq_store::FlushDiskType;
 use rocketmq_store::MessageStoreConfig;
 use rocketmq_store::StoreType;
 
@@ -454,6 +455,48 @@ fn validate_high_availability(
     network: &NetworkConfig,
     identity: &IdentityConfig,
 ) -> Result<HighAvailabilityConfig, BrokerConfigError> {
+    if !store.compatibility_profile.is_legacy() {
+        if store.min_in_sync_replicas == 0 {
+            return Err(BrokerConfigError::invalid(
+                ConfigSection::HighAvailability,
+                "store.minInSyncReplicas",
+                "must be at least 1 for JAVA_5_5 and DURABILITY_STRICT profiles",
+            ));
+        }
+        let in_sync_replicas = usize::try_from(store.in_sync_replicas).map_err(|_| {
+            BrokerConfigError::invalid(
+                ConfigSection::HighAvailability,
+                "store.inSyncReplicas",
+                "must be positive",
+            )
+        })?;
+        if store.min_in_sync_replicas > in_sync_replicas || in_sync_replicas > store.total_replicas {
+            return Err(BrokerConfigError::invalid(
+                ConfigSection::HighAvailability,
+                "store.minInSyncReplicas",
+                "must satisfy minInSyncReplicas <= inSyncReplicas <= totalReplicas",
+            ));
+        }
+        let replica_ack_required = store.broker_role == BrokerRole::SyncMaster
+            || store.all_ack_in_sync_state_set
+            || store.min_in_sync_replicas > 1;
+        if replica_ack_required && store.slave_timeout == 0 {
+            return Err(BrokerConfigError::invalid(
+                ConfigSection::HighAvailability,
+                "store.slaveTimeout",
+                "must be greater than zero when replica acknowledgement is required",
+            ));
+        }
+        if (broker.enable_controller_mode || store.enable_auto_in_sync_replicas)
+            && store.ha_max_time_slave_not_catchup == 0
+        {
+            return Err(BrokerConfigError::invalid(
+                ConfigSection::HighAvailability,
+                "store.haMaxTimeSlaveNotCatchup",
+                "must be greater than zero when Controller or automatic in-sync replicas are enabled",
+            ));
+        }
+    }
     let listen_port = u32::try_from(store.ha_listen_port)
         .ok()
         .and_then(|port| validated_port(ConfigSection::HighAvailability, "store.haListenPort", port).ok())
@@ -505,6 +548,39 @@ fn validate_high_availability(
 }
 
 fn validate_storage(broker: &BrokerConfig, store: &MessageStoreConfig) -> Result<StorageConfig, BrokerConfigError> {
+    if store.enable_dledger_commit_log
+        || store.enable_dleger_commit_log
+        || store.store_path_dledger_commit_log.is_some()
+        || store.dledger_group.is_some()
+        || store.dledger_peers.is_some()
+        || store.dledger_self_id.is_some()
+        || store.preferred_leader_id.is_some()
+    {
+        return Err(BrokerConfigError::invalid(
+            ConfigSection::Storage,
+            "store.enableDledgerCommitLog",
+            "DLedger is intentionally unsupported; use the independent Controller HA mode instead",
+        ));
+    }
+    if store.transient_store_pool_enable && store.transient_store_pool_size == 0 {
+        return Err(BrokerConfigError::invalid(
+            ConfigSection::Storage,
+            "store.transientStorePoolSize",
+            "must be greater than zero when transientStorePoolEnable is true",
+        ));
+    }
+    if !store.compatibility_profile.is_legacy()
+        && store.flush_disk_type == FlushDiskType::AsyncFlush
+        && (store.flush_commit_log_least_pages == 0
+            || store.flush_consume_queue_least_pages == 0
+            || store.flush_consume_queue_thorough_interval == 0)
+    {
+        return Err(BrokerConfigError::invalid(
+            ConfigSection::Storage,
+            "store.flushDiskType",
+            "ASYNC_FLUSH requires non-zero CommitLog and ConsumeQueue flush thresholds in this profile",
+        ));
+    }
     if broker.store_path_root_dir.trim().is_empty() {
         return Err(BrokerConfigError::invalid(
             ConfigSection::Storage,

--- a/rocketmq-broker/tests/config_contract.rs
+++ b/rocketmq-broker/tests/config_contract.rs
@@ -25,7 +25,9 @@ use rocketmq_broker::config::transaction::ConfigUpdateTransaction;
 use rocketmq_broker::config::validated::ConfigGeneration;
 use rocketmq_broker::config::validated::ValidatedBrokerConfig;
 use rocketmq_runtime::MemoryLimitSource;
+use rocketmq_store::FlushDiskType;
 use rocketmq_store::MessageStoreConfig;
+use rocketmq_store::StoreCompatibilityProfile;
 use rocketmq_store_api::TimerStoreMode;
 
 fn fixture(name: &str) -> PathBuf {
@@ -97,6 +99,111 @@ fn canonical_fixture_crosses_the_raw_and_validated_boundary() {
     assert!(!sections.telemetry().trace_exporter().is_enable());
     assert_eq!(validated.logging().logging.filter.as_deref(), Some("info"));
     assert!(validated.logging().logging.reload.enabled);
+    assert_eq!(
+        validated.store().compatibility_profile,
+        StoreCompatibilityProfile::Java55
+    );
+    assert_eq!(validated.store().max_recovery_commit_log_files, 30);
+    assert_eq!(validated.store().flush_consume_queue_least_pages, 2);
+}
+
+#[test]
+fn omitted_profile_preserves_legacy_rust_defaults() {
+    let raw = load_inline_config("[store]\n").expect("legacy config should deserialize");
+    let validated = ValidatedBrokerConfig::try_from(raw).expect("legacy config should validate");
+    let legacy = MessageStoreConfig::default();
+
+    assert_eq!(
+        validated.store().compatibility_profile,
+        StoreCompatibilityProfile::LegacyRust
+    );
+    assert_eq!(validated.store().flush_disk_type, legacy.flush_disk_type);
+    assert_eq!(
+        validated.store().max_recovery_commit_log_files,
+        legacy.max_recovery_commit_log_files
+    );
+    assert_eq!(
+        validated.store().flush_commit_log_least_pages,
+        legacy.flush_commit_log_least_pages
+    );
+    assert_eq!(validated.store().min_in_sync_replicas, legacy.min_in_sync_replicas);
+}
+
+#[test]
+fn java55_profile_applies_only_to_omitted_fields() {
+    let raw = load_inline_config("[store]\ncompatibilityProfile = \"JAVA_5_5\"\nflushDiskType = \"SYNC_FLUSH\"\n")
+        .expect("Java profile should deserialize");
+    let validated = ValidatedBrokerConfig::try_from(raw).expect("Java profile should validate");
+    let store = validated.store();
+
+    assert_eq!(store.compatibility_profile, StoreCompatibilityProfile::Java55);
+    assert_eq!(store.flush_disk_type, FlushDiskType::SyncFlush);
+    assert_eq!(store.max_recovery_commit_log_files, 30);
+    assert_eq!(store.flush_commit_log_least_pages, 4);
+    assert_eq!(store.commit_commit_log_least_pages, 4);
+    assert_eq!(store.flush_consume_queue_least_pages, 2);
+    assert_eq!(store.flush_consume_queue_thorough_interval, 60_000);
+    assert_eq!(store.slave_timeout, 3_000);
+    assert_eq!(store.transient_store_pool_size, 5);
+    assert_eq!(store.min_in_sync_replicas, 1);
+    assert_eq!(store.ha_max_time_slave_not_catchup, 15_000);
+}
+
+#[test]
+fn explicit_zero_is_not_overwritten_by_a_profile() {
+    let raw = load_inline_config("[store]\ncompatibilityProfile = \"JAVA_5_5\"\nflushCommitLogLeastPages = 0\n")
+        .expect("explicit zero should deserialize");
+
+    assert_invalid_section(ValidatedBrokerConfig::try_from(raw), ConfigSection::Storage);
+}
+
+#[test]
+fn strict_profile_enables_sync_flush_and_all_ack() {
+    let raw = load_inline_config("[store]\ncompatibilityProfile = \"DURABILITY_STRICT\"\n")
+        .expect("strict profile should deserialize");
+    let validated = ValidatedBrokerConfig::try_from(raw).expect("strict profile should validate");
+
+    assert_eq!(
+        validated.store().compatibility_profile,
+        StoreCompatibilityProfile::DurabilityStrict
+    );
+    assert_eq!(validated.store().flush_disk_type, FlushDiskType::SyncFlush);
+    assert!(validated.store().all_ack_in_sync_state_set);
+}
+
+#[test]
+fn unknown_store_profile_is_rejected_during_deserialization() {
+    let error = load_inline_config("[store]\ncompatibilityProfile = \"JAVA_6\"\n")
+        .expect_err("unknown profile must fail before validation");
+
+    assert!(error.to_string().contains("JAVA_6"));
+}
+
+#[test]
+fn dledger_configuration_is_rejected_at_the_validated_boundary() {
+    let store = MessageStoreConfig {
+        enable_dledger_commit_log: true,
+        ..MessageStoreConfig::default()
+    };
+
+    assert_invalid_section(
+        ValidatedBrokerConfig::try_from_parts(BrokerConfig::default(), store),
+        ConfigSection::Storage,
+    );
+}
+
+#[test]
+fn enabled_transient_pool_requires_at_least_one_buffer() {
+    let store = MessageStoreConfig {
+        transient_store_pool_enable: true,
+        transient_store_pool_size: 0,
+        ..MessageStoreConfig::default()
+    };
+
+    assert_invalid_section(
+        ValidatedBrokerConfig::try_from_parts(BrokerConfig::default(), store),
+        ConfigSection::Storage,
+    );
 }
 
 #[test]
@@ -316,6 +423,7 @@ fn rendered_deployment_sources_use_the_canonical_section_layout() {
         assert!(source.contains("    [broker]"));
         assert!(source.contains("    [broker.brokerIdentity]"));
         assert!(source.contains("    [store]"));
+        assert!(source.contains("    compatibilityProfile = \"JAVA_5_5\""));
     }
 }
 

--- a/rocketmq-broker/tests/fixtures/config/valid.toml
+++ b/rocketmq-broker/tests/fixtures/config/valid.toml
@@ -16,6 +16,7 @@ brokerClusterName = "ConfigContract"
 brokerId = 0
 
 [store]
+compatibilityProfile = "JAVA_5_5"
 haListenAddress = "127.0.0.1"
 haListenPort = 10912
 storePathRootDir = "./target/config-contract/store"

--- a/rocketmq-store/src/config.rs
+++ b/rocketmq-store/src/config.rs
@@ -14,6 +14,7 @@
 
 pub mod flush_disk_type;
 pub mod message_store_config;
+pub mod store_compatibility_profile;
 pub(crate) mod store_path_config_helper;
 pub mod store_runtime_config;
 pub mod timer_store_config;

--- a/rocketmq-store/src/config/message_store_config.rs
+++ b/rocketmq-store/src/config/message_store_config.rs
@@ -33,6 +33,7 @@ use super::timer_store_config::TimerStoreConfig;
 
 use crate::base::store_enum::StoreType;
 use crate::config::flush_disk_type::FlushDiskType;
+use crate::config::store_compatibility_profile::StoreCompatibilityProfile;
 use crate::queue::single_consume_queue::CQ_STORE_UNIT_SIZE;
 
 static USER_HOME: LazyLock<PathBuf> = LazyLock::new(|| dirs::home_dir().unwrap());
@@ -642,6 +643,9 @@ pub fn bounded_local_file_consume_queue_recovery_parallelism(
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct MessageStoreConfig {
+    #[serde(default)]
+    pub compatibility_profile: StoreCompatibilityProfile,
+
     #[serde(default = "defaults::store_path_root_dir")]
     pub store_path_root_dir: CheetahString,
 
@@ -1383,6 +1387,7 @@ impl Default for MessageStoreConfig {
     fn default() -> Self {
         let store_path_root_dir = USER_HOME.clone().join("store").to_string_lossy().to_string();
         Self {
+            compatibility_profile: StoreCompatibilityProfile::LegacyRust,
             store_path_root_dir: store_path_root_dir.into(),
             store_path_commit_log: None,
             store_path_dledger_commit_log: None,
@@ -1631,6 +1636,35 @@ impl Default for MessageStoreConfig {
 }
 
 impl MessageStoreConfig {
+    /// Builds Store defaults for an explicit compatibility profile.
+    #[must_use]
+    pub fn for_compatibility_profile(profile: StoreCompatibilityProfile) -> Self {
+        let mut config = Self {
+            compatibility_profile: profile,
+            ..Self::default()
+        };
+        match profile {
+            StoreCompatibilityProfile::LegacyRust => {}
+            StoreCompatibilityProfile::Java55 | StoreCompatibilityProfile::DurabilityStrict => {
+                config.max_recovery_commit_log_files = 30;
+                config.flush_commit_log_least_pages = 4;
+                config.commit_commit_log_least_pages = 4;
+                config.flush_consume_queue_least_pages = 2;
+                config.flush_consume_queue_thorough_interval = 60_000;
+                config.flush_disk_type = FlushDiskType::AsyncFlush;
+                config.slave_timeout = 3_000;
+                config.transient_store_pool_size = 5;
+                config.min_in_sync_replicas = 1;
+                config.ha_max_time_slave_not_catchup = 15_000;
+            }
+        }
+        if profile == StoreCompatibilityProfile::DurabilityStrict {
+            config.flush_disk_type = FlushDiskType::SyncFlush;
+            config.all_ack_in_sync_state_set = true;
+        }
+        config
+    }
+
     /// Returns the validated Java-compatible timer admission policy.
     ///
     /// # Errors
@@ -1821,6 +1855,10 @@ impl MessageStoreConfig {
 
     pub fn get_properties(&self) -> HashMap<CheetahString, CheetahString> {
         let mut properties: HashMap<String, String> = HashMap::new();
+        properties.insert(
+            "compatibilityProfile".to_string(),
+            self.compatibility_profile.to_string(),
+        );
         properties.insert(
             "storePathRootDir".to_string(),
             self.store_path_root_dir.clone().to_string(),
@@ -2567,6 +2605,7 @@ impl MessageStoreConfig {
 #[cfg(test)]
 mod tests {
     use super::bounded_local_file_consume_queue_recovery_parallelism;
+    use super::FlushDiskType;
     use super::LinuxMappedFileWarmMode;
     use super::LinuxMemoryLockMode;
     use super::LinuxRecoveryFadviseMode;
@@ -2574,6 +2613,7 @@ mod tests {
     use super::LinuxTransferEngine;
     use super::MessageStoreConfig;
     use super::RecoveryMode;
+    use super::StoreCompatibilityProfile;
     use super::LOCAL_FILE_CONSUME_QUEUE_RECOVERY_PARALLELISM_SAFETY_CAP;
 
     #[test]
@@ -2583,6 +2623,41 @@ mod tests {
         assert_eq!(config.max_checksum_range, 1024 * 1024 * 1024);
         assert!(!config.enable_mapped_file_lifecycle_wave_b);
         assert_eq!(config.get_properties()["enableMappedFileLifecycleWaveB"], "false");
+    }
+
+    #[test]
+    fn legacy_profile_preserves_historical_defaults() {
+        let config = MessageStoreConfig::for_compatibility_profile(StoreCompatibilityProfile::LegacyRust);
+
+        assert_eq!(config, MessageStoreConfig::default());
+        assert_eq!(config.get_properties()["compatibilityProfile"], "LEGACY_RUST");
+    }
+
+    #[test]
+    fn java55_profile_matches_store_defaults_contract() {
+        let config = MessageStoreConfig::for_compatibility_profile(StoreCompatibilityProfile::Java55);
+
+        assert_eq!(config.max_recovery_commit_log_files, 30);
+        assert_eq!(config.flush_commit_log_least_pages, 4);
+        assert_eq!(config.commit_commit_log_least_pages, 4);
+        assert_eq!(config.flush_consume_queue_least_pages, 2);
+        assert_eq!(config.flush_consume_queue_thorough_interval, 60_000);
+        assert_eq!(config.flush_disk_type, FlushDiskType::AsyncFlush);
+        assert_eq!(config.slave_timeout, 3_000);
+        assert_eq!(config.transient_store_pool_size, 5);
+        assert_eq!(config.min_in_sync_replicas, 1);
+        assert_eq!(config.ha_max_time_slave_not_catchup, 15_000);
+        assert!(!config.all_ack_in_sync_state_set);
+    }
+
+    #[test]
+    fn strict_profile_adds_sync_flush_and_all_ack() {
+        let config = MessageStoreConfig::for_compatibility_profile(StoreCompatibilityProfile::DurabilityStrict);
+
+        assert_eq!(config.flush_disk_type, FlushDiskType::SyncFlush);
+        assert!(config.all_ack_in_sync_state_set);
+        assert_eq!(config.slave_timeout, 3_000);
+        assert_eq!(config.min_in_sync_replicas, 1);
     }
 
     #[test]

--- a/rocketmq-store/src/config/store_compatibility_profile.rs
+++ b/rocketmq-store/src/config/store_compatibility_profile.rs
@@ -1,0 +1,80 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+/// Selects the default Store semantics applied to fields omitted from configuration files.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub enum StoreCompatibilityProfile {
+    /// Preserves the historical rocketmq-rust defaults for existing deployments.
+    #[default]
+    #[serde(rename = "LEGACY_RUST")]
+    LegacyRust,
+    /// Applies the Apache RocketMQ Java 5.5 Store defaults.
+    #[serde(rename = "JAVA_5_5")]
+    Java55,
+    /// Applies Java 5.5 defaults with synchronous flush and fail-closed replica ACKs.
+    #[serde(rename = "DURABILITY_STRICT")]
+    DurabilityStrict,
+}
+
+impl StoreCompatibilityProfile {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::LegacyRust => "LEGACY_RUST",
+            Self::Java55 => "JAVA_5_5",
+            Self::DurabilityStrict => "DURABILITY_STRICT",
+        }
+    }
+
+    #[must_use]
+    pub const fn is_legacy(self) -> bool {
+        matches!(self, Self::LegacyRust)
+    }
+}
+
+impl fmt::Display for StoreCompatibilityProfile {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_profile_names_round_trip() {
+        for (profile, encoded) in [
+            (StoreCompatibilityProfile::LegacyRust, "\"LEGACY_RUST\""),
+            (StoreCompatibilityProfile::Java55, "\"JAVA_5_5\""),
+            (StoreCompatibilityProfile::DurabilityStrict, "\"DURABILITY_STRICT\""),
+        ] {
+            assert_eq!(serde_json::to_string(&profile).expect("serialize profile"), encoded);
+            assert_eq!(
+                serde_json::from_str::<StoreCompatibilityProfile>(encoded).expect("deserialize profile"),
+                profile
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_profile_is_rejected() {
+        assert!(serde_json::from_str::<StoreCompatibilityProfile>("\"DLedger\"").is_err());
+    }
+}

--- a/rocketmq-store/src/public_api.rs
+++ b/rocketmq-store/src/public_api.rs
@@ -70,6 +70,7 @@ pub use crate::capability::StoreHealthSnapshot;
 pub use crate::config::flush_disk_type::FlushDiskType;
 pub use crate::config::message_store_config::bounded_local_file_consume_queue_recovery_parallelism;
 pub use crate::config::message_store_config::MessageStoreConfig;
+pub use crate::config::store_compatibility_profile::StoreCompatibilityProfile;
 pub use crate::config::store_runtime_config::StoreRuntimeConfig;
 pub use crate::config::timer_store_config::TimerStoreConfig;
 pub use crate::config::timer_store_config::TimerStoreConfigError;

--- a/scripts/public-api-intent.json
+++ b/scripts/public-api-intent.json
@@ -3885,6 +3885,15 @@
         },
         {
           "category": "stable",
+          "declaration": "pub use crate::config::store_compatibility_profile::StoreCompatibilityProfile",
+          "identity": "rocketmq-store/src/public_api.rs:pub use crate::config::store_compatibility_profile::StoreCompatibilityProfile",
+          "owner": "store",
+          "path": "rocketmq-store/src/public_api.rs",
+          "rationale": "explicit compatibility contract for store defaults and durability",
+          "removal_condition": "retain while compatibility profiles are part of broker configuration"
+        },
+        {
+          "category": "stable",
           "declaration": "pub use crate::config::message_store_config::bounded_local_file_consume_queue_recovery_parallelism",
           "identity": "rocketmq-store/src/public_api.rs:pub use crate::config::message_store_config::bounded_local_file_consume_queue_recovery_parallelism",
           "owner": "store",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9223

### Brief Description

- Add explicit `LEGACY_RUST`, `JAVA_5_5`, and `DURABILITY_STRICT` Store compatibility profiles.
- Preserve historical defaults when existing configuration omits the profile, while applying Java-aligned defaults only to omitted fields for explicit profiles.
- Reject unsafe zero-valued durability combinations and reject all DLedger configuration because DLedger is permanently outside the Rust product scope.
- Expose effective profile values in Broker configuration diagnostics and opt new deployment templates into `JAVA_5_5`.
- Register the profile as an intentional public configuration API and add focused profile/configuration contract tests.

### How Did You Test This Change?

- `cargo test -p rocketmq-broker --test config_contract -- --nocapture` (19 passed)
- `cargo test -p rocketmq-store --lib --quiet -- --test-threads=1` (675 passed)
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo check --manifest-path fuzz/Cargo.toml --all-targets`
- `cargo fmt --all -- --check` (run from the worktree root through WSL)
- `.\scripts\check-agents-routing.ps1`
- `python scripts/public_api_intent_guard.py` (253 pre-existing findings; the new Store profile export is classified and adds no finding)
- `.\scripts\check-error-hygiene.ps1` (all relevant guards passed; the command remains blocked by the pre-existing Dashboard `AppConfig` sensitive `Debug` finding)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable storage compatibility profiles, including Legacy Rust, Java 5.5, and durability-focused options.
  - Profile-specific defaults now support recovery, flushing, replication, timeouts, and transient storage behavior.
  - Compatibility profile information is included in broker configuration output.

- **Bug Fixes**
  - Improved configuration validation for replica settings, durability options, storage thresholds, and unsupported combinations.
  - Added warnings when compatibility settings are omitted and clearer rejection of unknown profiles.

- **Deployment**
  - Updated packaged, Kubernetes, Helm, and Docker broker configurations to use the Java 5.5 compatibility profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->