### PR TITLE
[ISSUE #9225]✨Make POP polling non-blocking and lossless

### DIFF
--- a/rocketmq-client/src/consumer/consumer_impl/pull_api_wrapper.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/pull_api_wrapper.rs
@@ -49,6 +49,12 @@ use crate::hook::filter_message_hook::FilterMessageHook;
 use crate::implementation::communication_mode::CommunicationMode;
 use crate::implementation::mq_client_api_impl::MQClientAPIImpl;
 
+const POP_REQUEST_TIMEOUT_MARGIN_MILLIS: u64 = 500;
+
+fn pop_request_timeout_millis(poll_timeout_millis: u64) -> u64 {
+    poll_timeout_millis.saturating_add(POP_REQUEST_TIMEOUT_MARGIN_MILLIS)
+}
+
 fn is_inner_batch_message(message: &MessageExt) -> bool {
     MessageSysFlag::check(message.sys_flag, MessageSysFlag::INNER_BATCH_FLAG)
         && MessageSysFlag::check(message.sys_flag, MessageSysFlag::NEED_UNWRAP_FLAG)
@@ -475,7 +481,7 @@ impl PullAPIWrapper {
                     mq.broker_name(),
                     &find_broker_result.broker_addr,
                     request_header,
-                    timeout,
+                    pop_request_timeout_millis(timeout),
                     pop_callback,
                 )
                 .await
@@ -591,6 +597,12 @@ mod tests {
     use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
 
     use super::*;
+
+    #[test]
+    fn pop_rpc_timeout_keeps_a_safety_margin_after_long_poll() {
+        assert_eq!(pop_request_timeout_millis(15_000), 15_500);
+        assert_eq!(pop_request_timeout_millis(u64::MAX), u64::MAX);
+    }
     use crate::base::client_config::ClientConfig;
     use crate::consumer::pull_result::PullResult;
 

--- a/rocketmq-client/src/consumer/consumer_impl/pull_message_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/pull_message_service.rs
@@ -69,6 +69,9 @@ const DEFAULT_MAX_PULL_SHARDS: usize = 8;
 /// Default shutdown timeout in milliseconds
 const DEFAULT_SHUTDOWN_TIMEOUT_MS: u64 = 1000;
 
+/// Bounded delay before retrying a POP scheduler admission rejected by the immediate queue.
+const POP_REQUEUE_DELAY_MS: u64 = 10;
+
 type BoxedMessageRequest = Box<dyn MessageRequest + Send + 'static>;
 type MessageRequestQueue = BudgetedQueue<BoxedMessageRequest>;
 
@@ -333,9 +336,9 @@ impl DelayedSchedulePayload {
         }
     }
 
-    async fn execute(self, stopped: &AtomicBool) {
+    async fn execute(self, stopped: &AtomicBool) -> Option<Self> {
         if stopped.load(Ordering::Acquire) {
-            return;
+            return None;
         }
 
         match self {
@@ -345,16 +348,35 @@ impl DelayedSchedulePayload {
                 } else {
                     warn!("PullMessageService not started");
                 }
+                None
             }
             Self::Pop { request, tx } => {
                 if let Some(tx) = tx {
                     let retained_bytes = request.retained_bytes();
-                    if let Err(error) = tx.try_push_data(Box::new(request), retained_bytes) {
-                        warn!("Failed to send pop request: {:?}", error);
+                    match tx.try_push_data(Box::new(request), retained_bytes) {
+                        Ok(_) => None,
+                        Err(error) => {
+                            warn!("POP request queue rejected a delayed request; retrying: {:?}", error);
+                            match error.into_item().into_any().downcast::<PopRequest>() {
+                                Ok(request) => Some(Self::Pop {
+                                    request: *request,
+                                    tx: Some(tx),
+                                }),
+                                Err(_) => {
+                                    error!("POP request queue returned an unexpected request type");
+                                    None
+                                }
+                            }
+                        }
                     }
+                } else {
+                    None
                 }
             }
-            Self::Task(task) => task(),
+            Self::Task(task) => {
+                task();
+                None
+            }
         }
     }
 }
@@ -489,8 +511,22 @@ async fn drain_expired_delayed_requests(
     let now = TokioInstant::now();
     while delayed_queue.peek().is_some_and(|entry| entry.deadline <= now) {
         let entry = delayed_queue.pop().expect("entry should exist after peek");
-        metrics.record_expired();
-        entry.payload.execute(stopped).await;
+        let DelayedQueueEntry {
+            sequence,
+            payload,
+            _permit,
+            ..
+        } = entry;
+        if let Some(payload) = payload.execute(stopped).await {
+            delayed_queue.push(DelayedQueueEntry {
+                deadline: TokioInstant::now() + Duration::from_millis(POP_REQUEUE_DELAY_MS),
+                sequence,
+                payload,
+                _permit,
+            });
+        } else {
+            metrics.record_expired();
+        }
     }
 }
 
@@ -1010,11 +1046,15 @@ impl PullMessageService {
         let tx = self.tx.read().unwrap_or_else(|poisoned| poisoned.into_inner()).clone();
         if let Some(tx) = tx {
             let retained_bytes = pop_request.retained_bytes();
-            if let Err(e) = tx.try_push_data(Box::new(pop_request), retained_bytes) {
-                error!(
-                    "executePopPullRequestImmediately messageRequestQueue.put error: {:?}",
-                    e
+            if let Err(error) = tx.try_push_data(Box::new(pop_request), retained_bytes) {
+                warn!(
+                    "executePopPullRequestImmediately queue admission failed; retrying with delay: {:?}",
+                    error
                 );
+                match error.into_item().into_any().downcast::<PopRequest>() {
+                    Ok(pop_request) => self.execute_pop_pull_request_later(*pop_request, POP_REQUEUE_DELAY_MS),
+                    Err(_) => error!("POP request queue returned an unexpected request type"),
+                }
             }
         } else {
             warn!("PullMessageService not started");
@@ -1267,6 +1307,42 @@ fn pull_message_service_shutdown_signal_failed() -> RocketMQError {
 mod tests {
     use super::*;
     use rocketmq_error::ErrorKind;
+
+    fn test_pop_request(queue_id: i32) -> PopRequest {
+        PopRequest::new(
+            CheetahString::from_static_str("topic"),
+            CheetahString::from_static_str("group"),
+            rocketmq_model::common::message::message_queue::MessageQueue::from_parts("topic", "broker-a", queue_id),
+            crate::consumer::consumer_impl::pop_process_queue::PopProcessQueue::new(),
+            0,
+        )
+    }
+
+    #[tokio::test]
+    async fn rejected_delayed_pop_payload_returns_the_original_request_for_retry() {
+        let service = PullMessageService::with_capacity_and_shards(1, 1);
+        let queue = service
+            .build_request_queue::<BoxedMessageRequest>("pop-retry-overload", FullPolicy::Reject)
+            .expect("POP retry queue");
+        let first = test_pop_request(0);
+        queue
+            .try_push_data(Box::new(first), std::mem::size_of::<PopRequest>())
+            .expect("first POP request should fill the queue");
+
+        let retry = DelayedSchedulePayload::Pop {
+            request: test_pop_request(1),
+            tx: Some(queue.clone()),
+        }
+        .execute(&AtomicBool::new(false))
+        .await;
+
+        let Some(DelayedSchedulePayload::Pop { request, tx }) = retry else {
+            panic!("rejected POP request should be returned");
+        };
+        assert_eq!(request.get_message_queue().queue_id(), 1);
+        assert!(tx.is_some());
+        assert_eq!(queue.snapshot().depth, 1);
+    }
 
     #[test]
     fn overload_rejects_excess_pull_worker_requests() {

--- a/rocketmq-client/src/implementation/mq_client_api_impl/consumer.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl/consumer.rs
@@ -19,6 +19,13 @@ use super::request_builder::notification_request;
 use super::response_decoder::notify_result_from_response;
 use super::*;
 
+fn pop_background_task_cancelled(actual: impl Into<String>) -> RocketMQError {
+    RocketMQError::ClientInvalidState {
+        expected: "active client POP request",
+        actual: actual.into(),
+    }
+}
+
 pub struct ConsumerClient<'a> {
     api: &'a MQClientAPIImpl,
 }
@@ -37,6 +44,66 @@ impl ConsumerClient<'_> {
 }
 
 impl MQClientAPIImpl {
+    pub(super) fn spawn_pop_callback_task<PC, F>(
+        service_context: &ChildServiceContext,
+        tracker: &TaskTracker,
+        shutdown_token: &CancellationToken,
+        request: F,
+        pop_callback: PC,
+    ) where
+        PC: PopCallback + 'static,
+        F: Future<Output = rocketmq_error::RocketMQResult<PopResult>> + Send + 'static,
+    {
+        let callback = Arc::new(std::sync::Mutex::new(Some(pop_callback)));
+        if shutdown_token.is_cancelled() {
+            if let Some(mut callback) = callback
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .take()
+            {
+                callback.on_error(pop_background_task_cancelled("client API is shutting down"));
+            }
+            return;
+        }
+
+        let task_callback = callback.clone();
+        let shutdown_token = shutdown_token.clone();
+        let tracked_task = tracker.track_future(async move {
+            let outcome = tokio::select! {
+                biased;
+                _ = shutdown_token.cancelled() => {
+                    Err(pop_background_task_cancelled("client API shutdown cancelled the POP request"))
+                }
+                outcome = request => outcome,
+            };
+            let callback = task_callback
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .take();
+            let Some(mut callback) = callback else {
+                return;
+            };
+            match outcome {
+                Ok(pop_result) => callback.on_success(pop_result).await,
+                Err(error) => callback.on_error(error),
+            }
+        });
+
+        if let Err(error) =
+            spawn_client_task_with_context(service_context, "rocketmq-client-pop-message-async", tracked_task)
+        {
+            if let Some(mut callback) = callback
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .take()
+            {
+                callback.on_error(pop_background_task_cancelled(format!(
+                    "failed to spawn client POP task: {error}"
+                )));
+            }
+        }
+    }
+
     #[must_use]
     pub fn consumer_client(&self) -> ConsumerClient<'_> {
         ConsumerClient { api: self }
@@ -1105,75 +1172,61 @@ impl MQClientAPIImpl {
     }
 
     pub async fn pop_message_async<PC>(
-        &self,
+        self: Arc<Self>,
         broker_name: &CheetahString,
         addr: &CheetahString,
         request_header: PopMessageRequestHeader,
         timeout_millis: u64,
-        mut pop_callback: PC,
+        pop_callback: PC,
     ) -> rocketmq_error::RocketMQResult<()>
     where
         PC: PopCallback + 'static,
     {
+        let service_context = self.service_context.clone();
+        let tracker = self.background_tasks.clone();
+        let shutdown_token = self.background_shutdown.clone();
+        let broker_name = broker_name.clone();
+        let addr = addr.clone();
         let topic = request_header.topic.clone();
         let order = request_header.order.unwrap_or_default();
         let request = RemotingCommand::create_request_command(RequestCode::PopMessage, request_header);
-        match self
-            .remoting_client
-            .invoke_request(Some(addr), request, timeout_millis)
-            .await
-        {
-            Ok(response) => {
-                let result = self.process_pop_response(broker_name, response, &topic, order);
-                match result {
-                    Ok(pop_result) => {
-                        pop_callback.on_success(pop_result).await;
-                    }
-                    Err(e) => {
-                        pop_callback.on_error(e);
-                    }
-                }
-            }
-            Err(e) => {
-                pop_callback.on_error(e);
-            }
-        }
+        let request_task = async move {
+            let response = self
+                .remoting_client
+                .invoke_request(Some(&addr), request, timeout_millis)
+                .await?;
+            self.process_pop_response(&broker_name, response, &topic, order)
+        };
+        Self::spawn_pop_callback_task(&service_context, &tracker, &shutdown_token, request_task, pop_callback);
         Ok(())
     }
 
     pub async fn pop_lite_message_async<PC>(
-        &self,
+        self: Arc<Self>,
         broker_name: &CheetahString,
         addr: &CheetahString,
         request_header: PopLiteMessageRequestHeader,
         timeout_millis: u64,
-        mut pop_callback: PC,
+        pop_callback: PC,
     ) -> rocketmq_error::RocketMQResult<()>
     where
         PC: PopCallback + 'static,
     {
+        let service_context = self.service_context.clone();
+        let tracker = self.background_tasks.clone();
+        let shutdown_token = self.background_shutdown.clone();
+        let broker_name = broker_name.clone();
+        let addr = addr.clone();
         let bind_topic = request_header.topic.clone();
         let request = RemotingCommand::create_request_command(RequestCode::PopLiteMessage, request_header);
-        match self
-            .remoting_client
-            .invoke_request(Some(addr), request, timeout_millis)
-            .await
-        {
-            Ok(response) => {
-                let result = self.process_pop_lite_response(broker_name, response, &bind_topic);
-                match result {
-                    Ok(pop_result) => {
-                        pop_callback.on_success(pop_result).await;
-                    }
-                    Err(e) => {
-                        pop_callback.on_error(e);
-                    }
-                }
-            }
-            Err(e) => {
-                pop_callback.on_error(e);
-            }
-        }
+        let request_task = async move {
+            let response = self
+                .remoting_client
+                .invoke_request(Some(&addr), request, timeout_millis)
+                .await?;
+            self.process_pop_lite_response(&broker_name, response, &bind_topic)
+        };
+        Self::spawn_pop_callback_task(&service_context, &tracker, &shutdown_token, request_task, pop_callback);
         Ok(())
     }
 

--- a/rocketmq-client/tests/implementation/mq_client_api_impl/unit.rs
+++ b/rocketmq-client/tests/implementation/mq_client_api_impl/unit.rs
@@ -93,6 +93,29 @@ impl Drop for DropFlag {
     }
 }
 
+struct RecordingPopCallback {
+    calls: Arc<AtomicUsize>,
+    errors: Arc<AtomicUsize>,
+    completed: Option<tokio::sync::oneshot::Sender<()>>,
+}
+
+impl PopCallback for RecordingPopCallback {
+    async fn on_success(&mut self, _pop_result: PopResult) {
+        self.calls.fetch_add(1, AtomicOrdering::AcqRel);
+        if let Some(completed) = self.completed.take() {
+            let _ = completed.send(());
+        }
+    }
+
+    fn on_error(&mut self, _error: RocketMQError) {
+        self.calls.fetch_add(1, AtomicOrdering::AcqRel);
+        self.errors.fetch_add(1, AtomicOrdering::AcqRel);
+        if let Some(completed) = self.completed.take() {
+            let _ = completed.send(());
+        }
+    }
+}
+
 struct CountingAfterSendHook {
     calls: Arc<AtomicUsize>,
 }
@@ -733,6 +756,75 @@ async fn api_background_task_shutdown_token_cancels_pending_task() {
         .expect("shutdown token should release pending API background task");
 
     assert!(dropped.load(AtomicOrdering::Acquire));
+}
+
+#[tokio::test]
+async fn pop_callback_task_does_not_wait_for_the_remoting_future() {
+    let tracker = TaskTracker::new();
+    let token = CancellationToken::new();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let errors = Arc::new(AtomicUsize::new(0));
+    let (release, released) = tokio::sync::oneshot::channel();
+    let (completed, completion) = tokio::sync::oneshot::channel();
+
+    MQClientAPIImpl::spawn_pop_callback_task(
+        &crate::runtime::test_service_context("client-pop-background-test").component("api-background"),
+        &tracker,
+        &token,
+        async move {
+            released.await.expect("test should release blocked POP request");
+            Ok(PopResult::default())
+        },
+        RecordingPopCallback {
+            calls: calls.clone(),
+            errors: errors.clone(),
+            completed: Some(completed),
+        },
+    );
+
+    assert_eq!(calls.load(AtomicOrdering::Acquire), 0);
+    release.send(()).expect("blocked POP request should still be alive");
+    tokio::time::timeout(Duration::from_secs(1), completion)
+        .await
+        .expect("POP callback should complete")
+        .expect("POP callback completion sender should remain alive");
+    tracker.close();
+    tracker.wait().await;
+
+    assert_eq!(calls.load(AtomicOrdering::Acquire), 1);
+    assert_eq!(errors.load(AtomicOrdering::Acquire), 0);
+}
+
+#[tokio::test]
+async fn pop_callback_task_completes_once_when_shutdown_cancels_the_request() {
+    let tracker = TaskTracker::new();
+    let token = CancellationToken::new();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let errors = Arc::new(AtomicUsize::new(0));
+    let (completed, completion) = tokio::sync::oneshot::channel();
+
+    MQClientAPIImpl::spawn_pop_callback_task(
+        &crate::runtime::test_service_context("client-pop-cancel-test").component("api-background"),
+        &tracker,
+        &token,
+        pending::<rocketmq_error::RocketMQResult<PopResult>>(),
+        RecordingPopCallback {
+            calls: calls.clone(),
+            errors: errors.clone(),
+            completed: Some(completed),
+        },
+    );
+    token.cancel();
+
+    tokio::time::timeout(Duration::from_secs(1), completion)
+        .await
+        .expect("cancelled POP callback should complete")
+        .expect("cancelled POP callback sender should remain alive");
+    tracker.close();
+    tracker.wait().await;
+
+    assert_eq!(calls.load(AtomicOrdering::Acquire), 1);
+    assert_eq!(errors.load(AtomicOrdering::Acquire), 1);
 }
 
 #[cfg(feature = "admin-mutation")]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9225

### Brief Description

- Move POP and POP-lite remoting long polls into lifecycle-owned client background tasks so the single POP dispatcher is not held for the broker suspend interval.
- Complete POP callbacks exactly once on success, request failure, shutdown cancellation, and task-spawn failure.
- Keep a 500 ms RPC deadline margin beyond the broker long-poll duration.
- Recover rejected POP scheduler requests and retry them through the existing bounded delayed scheduler instead of dropping the queue token.
- Add deterministic callback, cancellation, timeout-margin, and rejected-request recovery tests.

### How Did You Test This Change?

- `cargo test -p rocketmq-client-rust --lib --quiet -- --test-threads=1` (1,042 passed)
- Focused POP callback, timeout-margin, scheduler retry, and PullMessageService tests
- `cargo clippy -p rocketmq-client-rust --no-deps --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `cargo fmt --all -- --check` (root and standalone example, run through WSL)
- `cargo clippy --all-targets -- -D warnings` from the standalone `rocketmq-example` project
- `.\scripts\check-error-hygiene.ps1` (all Client callback/error guards passed; the command remains blocked by the pre-existing Dashboard `AppConfig` sensitive `Debug` finding)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message POP request reliability with automatic retries for temporary queueing and execution failures.
  * Added safer timeout handling to prevent excessive delays or overflow.
  * POP callbacks now report request, cancellation, and task-start failures consistently.
  * Requests interrupted during client shutdown are handled cleanly without duplicate callbacks.

* **Tests**
  * Added coverage for timeout limits, delayed retries, callback completion, and shutdown cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->