### PR TITLE
[ISSUE #9229]✨Isolate long polling from consumer control traffic

### DIFF
--- a/rocketmq-proxy-cluster/src/cluster.rs
+++ b/rocketmq-proxy-cluster/src/cluster.rs
@@ -2795,6 +2795,7 @@ mod tests {
     use super::ClusterWorkerState;
     use super::RocketmqClusterClient;
     use super::TelemetryHandle;
+    use crate::cluster::cluster_admission::ClusterCommandClass;
     use crate::config::ClusterConfig;
     use rocketmq_model::common::message::message_queue::MessageQueue;
     use rocketmq_proxy_core::ProxyError;
@@ -2957,6 +2958,7 @@ mod tests {
             max_queue_age: Duration::from_secs(1),
             io_max_inflight: 2,
             control_reserve: 1,
+            long_poll_max_inflight: 2,
             lane_idle_timeout: Duration::from_secs(1),
         })
         .expect("count budget");
@@ -3000,6 +3002,7 @@ mod tests {
             max_queue_age: Duration::from_secs(1),
             io_max_inflight: 2,
             control_reserve: 1,
+            long_poll_max_inflight: 2,
             lane_idle_timeout: Duration::from_secs(1),
         })
         .expect("byte budget");
@@ -3031,6 +3034,82 @@ mod tests {
             }
         ));
         assert_eq!(byte_lanes.root_budget.snapshot().current_bytes, 0);
+
+        let long_poll_lanes = ClusterExecutionLanes::new(ClusterExecutionPolicy {
+            capacity_count: 2,
+            capacity_bytes: 4 * 1024,
+            max_queue_age: Duration::from_secs(1),
+            io_max_inflight: 2,
+            control_reserve: 1,
+            long_poll_max_inflight: 2,
+            lane_idle_timeout: Duration::from_secs(1),
+        })
+        .expect("long-poll budget");
+        for _ in 0..2 {
+            let (reply, _receiver) = oneshot::channel();
+            long_poll_lanes
+                .enqueue(
+                    ClusterCommand::PullMessage {
+                        request: PullMessageRequest {
+                            group: ResourceIdentity::new("", "GroupA"),
+                            target: MessageQueueTarget {
+                                topic: ResourceIdentity::new("", "TopicA"),
+                                queue_id: 0,
+                                broker_name: Some("broker-a".to_owned()),
+                                broker_addr: Some("127.0.0.1:10911".to_owned()),
+                            },
+                            offset: 0,
+                            batch_size: 1,
+                            filter_expression: rocketmq_proxy_core::ConsumerFilterExpression {
+                                expression_type: "TAG".to_owned(),
+                                expression: "*".to_owned(),
+                            },
+                            long_polling_timeout: Duration::from_secs(1),
+                        },
+                        deadline: Some(Duration::from_secs(2)),
+                        reply,
+                    },
+                    CancellationToken::new(),
+                    &config,
+                )
+                .expect("long poll is admitted");
+        }
+        let (reply, _receiver) = oneshot::channel();
+        let long_poll_error = long_poll_lanes
+            .enqueue(
+                ClusterCommand::PullMessage {
+                    request: PullMessageRequest {
+                        group: ResourceIdentity::new("", "GroupA"),
+                        target: MessageQueueTarget {
+                            topic: ResourceIdentity::new("", "TopicA"),
+                            queue_id: 0,
+                            broker_name: Some("broker-a".to_owned()),
+                            broker_addr: Some("127.0.0.1:10911".to_owned()),
+                        },
+                        offset: 0,
+                        batch_size: 1,
+                        filter_expression: rocketmq_proxy_core::ConsumerFilterExpression {
+                            expression_type: "TAG".to_owned(),
+                            expression: "*".to_owned(),
+                        },
+                        long_polling_timeout: Duration::from_secs(1),
+                    },
+                    deadline: Some(Duration::from_secs(2)),
+                    reply,
+                },
+                CancellationToken::new(),
+                &config,
+            )
+            .expect_err("third long poll exceeds the independent count budget");
+        assert!(matches!(
+            long_poll_error,
+            ProxyError::TooManyRequests {
+                resource: "proxy-cluster-command-queue"
+            }
+        ));
+        assert_eq!(long_poll_lanes.root_budget.snapshot().current_count, 0);
+        assert_eq!(long_poll_lanes.long_poll_budget.snapshot().current_count, 2);
+        assert_eq!(long_poll_lanes.snapshot().long_poll_queued_and_active, 2);
     }
 
     #[test]
@@ -3048,6 +3127,10 @@ mod tests {
             },
             ClusterConfig {
                 control_reserve: 0,
+                ..Default::default()
+            },
+            ClusterConfig {
+                long_poll_max_inflight: 0,
                 ..Default::default()
             },
             ClusterConfig {
@@ -3069,7 +3152,7 @@ mod tests {
     }
 
     #[test]
-    fn related_consumer_commands_share_a_fifo_lane() {
+    fn consumer_poll_control_and_offset_commands_use_separate_lanes() {
         let group = ResourceIdentity::new("tenant-a", "GroupA");
         let topic = ResourceIdentity::new("tenant-a", "TopicA");
         let target = MessageQueueTarget {
@@ -3116,8 +3199,12 @@ mod tests {
         };
 
         let config = ClusterConfig::default();
-        assert_eq!(pull.ordering_key(&config), ack.ordering_key(&config));
-        assert_eq!(pull.ordering_key(&config), update_offset.ordering_key(&config));
+        assert_eq!(pull.class(), ClusterCommandClass::LongPoll);
+        assert_eq!(ack.class(), ClusterCommandClass::Control);
+        assert_eq!(update_offset.class(), ClusterCommandClass::Control);
+        assert_ne!(pull.ordering_key(&config), ack.ordering_key(&config));
+        assert_ne!(pull.ordering_key(&config), update_offset.ordering_key(&config));
+        assert_ne!(ack.ordering_key(&config), update_offset.ordering_key(&config));
     }
 
     #[tokio::test]
@@ -3131,6 +3218,7 @@ mod tests {
                 max_queue_age: Duration::from_millis(1),
                 io_max_inflight: 2,
                 control_reserve: 1,
+                long_poll_max_inflight: 2,
                 lane_idle_timeout: Duration::from_secs(1),
             })
             .expect("expiry lanes"),

--- a/rocketmq-proxy-cluster/src/cluster_admission.rs
+++ b/rocketmq-proxy-cluster/src/cluster_admission.rs
@@ -28,6 +28,7 @@ use rocketmq_model::common::message::message_queue::MessageQueue;
 use rocketmq_proxy_core::MessageQueueTarget;
 use rocketmq_proxy_core::ProxyError;
 use rocketmq_proxy_core::ProxyResult;
+use rocketmq_proxy_core::ReceiveTarget;
 use rocketmq_proxy_core::ResourceIdentity;
 use rocketmq_runtime::BudgetCapacity;
 use rocketmq_runtime::BudgetLimit;
@@ -50,7 +51,8 @@ use crate::config::ClusterExecutionDiagnostics;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum ClusterCommandClass {
     Control,
-    Data,
+    ShortData,
+    LongPoll,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -99,11 +101,13 @@ struct ClusterExecutionCounters {
 pub(super) struct ClusterExecutionLanes {
     registry: Mutex<HashMap<ClusterOrderingKey, RegisteredLane>>,
     pub(super) root_budget: ResourceBudget,
+    pub(super) long_poll_budget: ResourceBudget,
     policy: ClusterExecutionPolicy,
     next_generation: AtomicU64,
     closed: AtomicBool,
     total_inflight: Arc<Semaphore>,
     data_inflight: Arc<Semaphore>,
+    long_poll_inflight: Arc<Semaphore>,
     counters: Arc<ClusterExecutionCounters>,
     active_lane_tasks: AtomicUsize,
     lane_tasks_idle: Notify,
@@ -118,15 +122,24 @@ impl ClusterExecutionLanes {
         let tree = ResourceBudgetTree::new("proxy-cluster-commands", limit).map_err(|error| ProxyError::Transport {
             message: format!("invalid proxy cluster command budget: {error}"),
         })?;
+        let long_poll_tree = ResourceBudgetTree::new(
+            "proxy-cluster-long-polls",
+            BudgetLimit::new(policy.capacity_count, policy.capacity_bytes, FullPolicy::Reject),
+        )
+        .map_err(|error| ProxyError::Transport {
+            message: format!("invalid proxy cluster long-poll budget: {error}"),
+        })?;
         let root_budget = tree.root();
         Ok(Self {
             registry: Mutex::new(HashMap::new()),
             root_budget,
+            long_poll_budget: long_poll_tree.root(),
             policy,
             next_generation: AtomicU64::new(1),
             closed: AtomicBool::new(false),
             total_inflight: Arc::new(Semaphore::new(policy.io_max_inflight)),
             data_inflight: Arc::new(Semaphore::new(policy.io_max_inflight - policy.control_reserve)),
+            long_poll_inflight: Arc::new(Semaphore::new(policy.long_poll_max_inflight)),
             counters: Arc::new(ClusterExecutionCounters::default()),
             active_lane_tasks: AtomicUsize::new(0),
             lane_tasks_idle: Notify::new(),
@@ -166,20 +179,28 @@ impl ClusterExecutionLanes {
             Some(registered) => (registered.clone(), false),
             None => {
                 let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
-                let queue = self
-                    .root_budget
-                    .child(
-                        format!("key-{generation}"),
-                        BudgetLimit::new(
-                            self.policy.capacity_count,
-                            self.policy.capacity_bytes,
-                            FullPolicy::Reject,
-                        )
-                        .with_control_reserve(BudgetCapacity::new(
-                            self.policy.control_reserve,
-                            self.policy.control_reserve_bytes(),
-                        )),
+                let parent_budget = match class {
+                    ClusterCommandClass::LongPoll => &self.long_poll_budget,
+                    ClusterCommandClass::Control | ClusterCommandClass::ShortData => &self.root_budget,
+                };
+                let lane_limit = match class {
+                    ClusterCommandClass::LongPoll => BudgetLimit::new(
+                        self.policy.capacity_count,
+                        self.policy.capacity_bytes,
+                        FullPolicy::Reject,
+                    ),
+                    ClusterCommandClass::Control | ClusterCommandClass::ShortData => BudgetLimit::new(
+                        self.policy.capacity_count,
+                        self.policy.capacity_bytes,
+                        FullPolicy::Reject,
                     )
+                    .with_control_reserve(BudgetCapacity::new(
+                        self.policy.control_reserve,
+                        self.policy.control_reserve_bytes(),
+                    )),
+                };
+                let queue = parent_budget
+                    .child(format!("key-{generation}"), lane_limit)
                     .map(BudgetedQueue::new)
                     .map_err(|error| ProxyError::Transport {
                         message: format!("invalid proxy cluster keyed lane budget: {error}"),
@@ -192,7 +213,9 @@ impl ClusterExecutionLanes {
 
         let push_result = match class {
             ClusterCommandClass::Control => registered.queue.try_push_control(queued, retained_bytes),
-            ClusterCommandClass::Data => registered.queue.try_push_data(queued, retained_bytes),
+            ClusterCommandClass::ShortData | ClusterCommandClass::LongPoll => {
+                registered.queue.try_push_data(queued, retained_bytes)
+            }
         };
         match push_result {
             Ok(_) => {
@@ -215,7 +238,10 @@ impl ClusterExecutionLanes {
                 }
                 self.counters.rejected.fetch_add(1, Ordering::Relaxed);
                 let snapshot = registered.queue.snapshot();
-                let root_snapshot = self.root_budget.snapshot();
+                let root_snapshot = match class {
+                    ClusterCommandClass::LongPoll => self.long_poll_budget.snapshot(),
+                    ClusterCommandClass::Control | ClusterCommandClass::ShortData => self.root_budget.snapshot(),
+                };
                 tracing::warn!(
                     depth = snapshot.depth,
                     retained_bytes = snapshot.retained_bytes,
@@ -279,6 +305,7 @@ impl ClusterExecutionLanes {
 
     pub(super) fn snapshot(&self) -> ClusterExecutionDiagnostics {
         let budget = self.root_budget.snapshot();
+        let long_poll_budget = self.long_poll_budget.snapshot();
         let registry = self.registry.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         let active_keys = registry.len();
         let oldest_queued_age_ms = registry
@@ -289,11 +316,18 @@ impl ClusterExecutionLanes {
         ClusterExecutionDiagnostics {
             active_keys,
             active_lane_tasks: self.active_lane_tasks.load(Ordering::Acquire),
-            queued_and_active: budget.current_count,
-            retained_bytes: budget.current_bytes,
+            queued_and_active: budget.current_count.saturating_add(long_poll_budget.current_count),
+            retained_bytes: budget.current_bytes.saturating_add(long_poll_budget.current_bytes),
+            long_poll_queued_and_active: long_poll_budget.current_count,
+            long_poll_retained_bytes: long_poll_budget.current_bytes,
             oldest_queued_age_ms,
             current_inflight: self.counters.current_inflight.load(Ordering::Relaxed),
             max_inflight: self.counters.max_inflight.load(Ordering::Relaxed),
+            current_long_poll_inflight: self
+                .policy
+                .long_poll_max_inflight
+                .saturating_sub(self.long_poll_inflight.available_permits()),
+            long_poll_max_inflight: self.policy.long_poll_max_inflight,
             admitted: self.counters.admitted.load(Ordering::Relaxed),
             rejected: self.counters.rejected.load(Ordering::Relaxed),
             timed_out: self.counters.timed_out.load(Ordering::Relaxed),
@@ -304,16 +338,29 @@ impl ClusterExecutionLanes {
     }
 
     pub(super) async fn acquire_inflight(&self, class: ClusterCommandClass) -> Option<ClusterInflightPermit> {
-        let data = match class {
-            ClusterCommandClass::Control => None,
-            ClusterCommandClass::Data => Some(self.data_inflight.clone().acquire_owned().await.ok()?),
+        let (data, total, long_poll) = match class {
+            ClusterCommandClass::Control => (
+                None,
+                Some(self.total_inflight.clone().acquire_owned().await.ok()?),
+                None,
+            ),
+            ClusterCommandClass::ShortData => (
+                Some(self.data_inflight.clone().acquire_owned().await.ok()?),
+                Some(self.total_inflight.clone().acquire_owned().await.ok()?),
+                None,
+            ),
+            ClusterCommandClass::LongPoll => (
+                None,
+                None,
+                Some(self.long_poll_inflight.clone().acquire_owned().await.ok()?),
+            ),
         };
-        let total = self.total_inflight.clone().acquire_owned().await.ok()?;
         let current = self.counters.current_inflight.fetch_add(1, Ordering::AcqRel) + 1;
         self.counters.max_inflight.fetch_max(current, Ordering::Relaxed);
         Some(ClusterInflightPermit {
             _data: data,
             _total: total,
+            _long_poll: long_poll,
             counters: self.counters.clone(),
         })
     }
@@ -365,7 +412,8 @@ impl Drop for ClusterExecutionLanes {
 
 pub(super) struct ClusterInflightPermit {
     _data: Option<OwnedSemaphorePermit>,
-    _total: OwnedSemaphorePermit,
+    _total: Option<OwnedSemaphorePermit>,
+    _long_poll: Option<OwnedSemaphorePermit>,
     counters: Arc<ClusterExecutionCounters>,
 }
 
@@ -382,6 +430,7 @@ pub(super) struct ClusterExecutionPolicy {
     pub(super) max_queue_age: Duration,
     pub(super) io_max_inflight: usize,
     pub(super) control_reserve: usize,
+    pub(super) long_poll_max_inflight: usize,
     pub(super) lane_idle_timeout: Duration,
 }
 
@@ -399,6 +448,7 @@ impl ClusterExecutionPolicy {
             max_queue_age: config.command_queue_max_age(),
             io_max_inflight: config.io_max_inflight,
             control_reserve: config.control_reserve,
+            long_poll_max_inflight: config.long_poll_max_inflight,
             lane_idle_timeout: config.execution_lane_idle_timeout(),
         }
     }
@@ -416,6 +466,11 @@ impl ClusterExecutionPolicy {
         }
         if self.control_reserve == 0 {
             return Err(invalid_execution_policy("control_reserve must be greater than zero"));
+        }
+        if self.long_poll_max_inflight == 0 {
+            return Err(invalid_execution_policy(
+                "long_poll_max_inflight must be greater than zero",
+            ));
         }
         if self.max_queue_age.is_zero() {
             return Err(invalid_execution_policy(
@@ -457,8 +512,15 @@ pub(super) struct QueuedClusterCommand {
 impl ClusterCommand {
     pub(super) fn class(&self) -> ClusterCommandClass {
         match self {
-            Self::ReadinessCheck { .. } => ClusterCommandClass::Control,
-            _ => ClusterCommandClass::Data,
+            Self::ReadinessCheck { .. }
+            | Self::AckMessage { .. }
+            | Self::ForwardMessageToDeadLetterQueue { .. }
+            | Self::ChangeInvisibleDuration { .. }
+            | Self::UpdateOffset { .. }
+            | Self::GetOffset { .. }
+            | Self::QueryOffset { .. } => ClusterCommandClass::Control,
+            Self::ReceiveMessage { .. } | Self::PullMessage { .. } => ClusterCommandClass::LongPoll,
+            _ => ClusterCommandClass::ShortData,
         }
     }
 
@@ -506,25 +568,27 @@ impl ClusterCommand {
                     .unwrap_or_else(|| build_proxy_producer_group(config, client_id.as_deref(), request_id.as_str()))],
             ),
             Self::ReceiveMessage { request, .. } => {
-                resource_ordering_key("consumer", [&request.group, &request.target.topic])
+                receive_target_ordering_key("consumer-poll", &request.group, &request.target)
             }
             Self::PullMessage { request, .. } => {
-                resource_ordering_key("consumer", [&request.group, &request.target.topic])
+                target_ordering_key("consumer-poll", Some(&request.group), &request.target)
             }
-            Self::AckMessage { request, .. } => resource_ordering_key("consumer", [&request.group, &request.topic]),
+            Self::AckMessage { request, .. } => {
+                resource_ordering_key("consumer-control", [&request.group, &request.topic])
+            }
             Self::ForwardMessageToDeadLetterQueue { request, .. } => {
-                resource_ordering_key("consumer", [&request.group, &request.topic])
+                resource_ordering_key("consumer-control", [&request.group, &request.topic])
             }
             Self::ChangeInvisibleDuration { request, .. } => {
-                resource_ordering_key("consumer", [&request.group, &request.topic])
+                resource_ordering_key("consumer-control", [&request.group, &request.topic])
             }
             Self::UpdateOffset { request, .. } => {
-                resource_ordering_key("consumer", [&request.group, &request.target.topic])
+                target_ordering_key("consumer-offset", Some(&request.group), &request.target)
             }
             Self::GetOffset { request, .. } => {
-                resource_ordering_key("consumer", [&request.group, &request.target.topic])
+                target_ordering_key("consumer-offset", Some(&request.group), &request.target)
             }
-            Self::QueryOffset { request, .. } => target_ordering_key("queue-offset", None, &request.target),
+            Self::QueryOffset { request, .. } => target_ordering_key("consumer-offset", None, &request.target),
             Self::LockBatchMq { request, .. } => ClusterOrderingKey::new(
                 "consumer-lock",
                 [
@@ -822,6 +886,22 @@ fn target_ordering_key(
         components.push(group.namespace().to_owned());
         components.push(group.name().to_owned());
     }
+    components.push(target.topic.namespace().to_owned());
+    components.push(target.topic.name().to_owned());
+    components.push(target.queue_id.to_string());
+    components.push(target.broker_name.clone().unwrap_or_default());
+    components.push(target.broker_addr.clone().unwrap_or_default());
+    ClusterOrderingKey::new(domain, components)
+}
+
+fn receive_target_ordering_key(
+    domain: &'static str,
+    group: &ResourceIdentity,
+    target: &ReceiveTarget,
+) -> ClusterOrderingKey {
+    let mut components = Vec::with_capacity(8);
+    components.push(group.namespace().to_owned());
+    components.push(group.name().to_owned());
     components.push(target.topic.namespace().to_owned());
     components.push(target.topic.name().to_owned());
     components.push(target.queue_id.to_string());

--- a/rocketmq-proxy-cluster/src/cluster_behavior_tests.rs
+++ b/rocketmq-proxy-cluster/src/cluster_behavior_tests.rs
@@ -666,6 +666,18 @@ fn pull_request(group: &str) -> PullMessageRequest {
     }
 }
 
+fn ack_request(group: &str) -> AckMessageRequest {
+    AckMessageRequest {
+        group: ResourceIdentity::new("", group),
+        topic: ResourceIdentity::new("", "TopicA"),
+        entries: vec![AckMessageEntry {
+            message_id: "message-id".to_owned(),
+            receipt_handle: ExtraInfoUtil::build_extra_info_with_offset(0, 1, 30_000, 0, "TopicA", "broker-a", 0, 7),
+            lite_topic: None,
+        }],
+    }
+}
+
 async fn wait_until(mut condition: impl FnMut() -> bool) {
     tokio::time::timeout(Duration::from_millis(250), async {
         while !condition() {
@@ -846,7 +858,7 @@ async fn distinct_consumer_keys_reach_remote_io_concurrently() {
 }
 
 #[tokio::test]
-async fn data_saturation_preserves_readiness_capacity_and_releases_all_permits() {
+async fn long_poll_saturation_preserves_short_data_and_control_capacity() {
     let events = Arc::new(Mutex::new(Vec::new()));
     let (client, first_pull_entered) = ScriptedClientIo::blocking_pull(events.clone());
     client.push_pull(PullOutcome::new(
@@ -856,6 +868,15 @@ async fn data_saturation_preserves_readiness_capacity_and_releases_all_permits()
         21,
         None::<Vec<MessageExt>>,
     ));
+    client.push_pull(PullOutcome::new(
+        PullStatus::NoNewMsg,
+        22,
+        1,
+        32,
+        None::<Vec<MessageExt>>,
+    ));
+    client.push_route(TopicRouteData::default());
+    client.push_ack(AckResult::default());
     let client = Arc::new(client);
     let factory = Arc::new(ScriptedProducerFactory {
         events,
@@ -869,6 +890,7 @@ async fn data_saturation_preserves_readiness_capacity_and_releases_all_permits()
         max_queue_age: Duration::from_secs(2),
         io_max_inflight: 2,
         control_reserve: 1,
+        long_poll_max_inflight: 1,
         lane_idle_timeout: Duration::from_secs(1),
     };
 
@@ -884,24 +906,21 @@ async fn data_saturation_preserves_readiness_capacity_and_releases_all_permits()
                 let checks = async {
                     wait_until(|| {
                         let snapshot = executor.lanes.snapshot();
-                        snapshot.queued_and_active == 2 && snapshot.current_inflight == 1
+                        snapshot.long_poll_queued_and_active == 2 && snapshot.current_long_poll_inflight == 1
                     })
                     .await;
-                    let data_error = executor
+                    executor
                         .query_route(ResourceIdentity::new("", "DataOverflow"))
                         .await
-                        .expect_err("data capacity is saturated");
-                    assert!(matches!(data_error, ProxyError::TooManyRequests { .. }));
-
-                    let readiness_error = executor
-                        .readiness_check()
+                        .expect("short-data request must not wait behind long polling");
+                    let ack = executor
+                        .ack_message(ack_request("GroupA"), Some(Duration::from_secs(1)))
                         .await
-                        .expect_err("scripted readiness returns a remote error");
-                    assert!(
-                        !matches!(readiness_error, ProxyError::TooManyRequests { .. }),
-                        "control reserve must admit readiness"
-                    );
-                    assert_eq!(client.readiness_calls.load(Ordering::Acquire), 1);
+                        .expect("control request must not wait behind long polling");
+                    assert_eq!(ack.len(), 1);
+                    assert!(ack[0].status.is_ok());
+                    assert_eq!(client.route_calls.load(Ordering::Acquire), 1);
+                    assert_eq!(client.ack_calls.load(Ordering::Acquire), 1);
                     cancellation.cancel();
                 };
                 let (second, ()) = tokio::join!(second, checks);
@@ -912,7 +931,10 @@ async fn data_saturation_preserves_readiness_capacity_and_releases_all_permits()
             assert!(second.is_err(), "shutdown cancels the queued data command");
             wait_until(|| {
                 let snapshot = executor.lanes.snapshot();
-                snapshot.current_inflight == 0 && snapshot.queued_and_active == 0 && snapshot.active_keys == 0
+                snapshot.current_inflight == 0
+                    && snapshot.current_long_poll_inflight == 0
+                    && snapshot.queued_and_active == 0
+                    && snapshot.active_keys == 0
             })
             .await;
             assert_eq!(executor.lanes.snapshot().oldest_queued_age_ms, None);
@@ -939,6 +961,7 @@ async fn idle_key_lane_is_reclaimed_without_leaking_budget_or_tasks() {
         max_queue_age: Duration::from_secs(1),
         io_max_inflight: 2,
         control_reserve: 1,
+        long_poll_max_inflight: 2,
         lane_idle_timeout: Duration::from_millis(10),
     };
 
@@ -976,7 +999,7 @@ async fn idle_key_lane_is_reclaimed_without_leaking_budget_or_tasks() {
 }
 
 #[tokio::test]
-async fn active_command_holds_its_global_admission_permit() {
+async fn active_long_poll_uses_only_the_long_poll_budget() {
     let events = Arc::new(Mutex::new(Vec::new()));
     let (client, pull_entered) = ScriptedClientIo::blocking_pull(events.clone());
     client.push_pull(PullOutcome::new(
@@ -986,6 +1009,7 @@ async fn active_command_holds_its_global_admission_permit() {
         11,
         None::<Vec<MessageExt>>,
     ));
+    client.push_route(TopicRouteData::default());
     let client = Arc::new(client);
     let factory = Arc::new(ScriptedProducerFactory {
         events,
@@ -999,6 +1023,7 @@ async fn active_command_holds_its_global_admission_permit() {
         max_queue_age: Duration::from_secs(1),
         io_max_inflight: 2,
         control_reserve: 1,
+        long_poll_max_inflight: 1,
         lane_idle_timeout: Duration::from_secs(1),
     };
 
@@ -1021,30 +1046,26 @@ async fn active_command_holds_its_global_admission_permit() {
             let probe = async {
                 let pull_started = pull_entered.await;
                 assert!(pull_started.is_ok(), "pull operation was entered");
-                let route_result = executor
+                let snapshot = executor.lanes.snapshot();
+                assert_eq!(snapshot.long_poll_queued_and_active, 1);
+                assert_eq!(snapshot.current_long_poll_inflight, 1);
+                assert_eq!(executor.lanes.root_budget.snapshot().current_count, 0);
+                executor
                     .query_route(ResourceIdentity::new("", "IndependentTopic"))
-                    .await;
-                assert!(
-                    route_result.is_err(),
-                    "the one-command global budget remains reserved while pull is active"
-                );
-                let Some(error) = route_result.err() else {
-                    std::process::abort();
-                };
+                    .await
+                    .expect("short-data admission remains available during long polling");
                 if let Some(block) = &client.pull_block {
                     block.notify_one();
                 }
-                error
             };
-            let (pull_result, admission_error) = tokio::join!(pull, probe);
+            let (pull_result, ()) = tokio::join!(pull, probe);
             assert!(pull_result.is_ok(), "blocked pull result");
             cancellation.cancel();
-            assert!(matches!(
-                admission_error,
-                ProxyError::TooManyRequests {
-                    resource: "proxy-cluster-command-queue"
-                }
-            ));
+            wait_until(|| {
+                let snapshot = executor.lanes.snapshot();
+                snapshot.current_long_poll_inflight == 0 && snapshot.long_poll_queued_and_active == 0
+            })
+            .await;
         },
     )
     .await;

--- a/rocketmq-proxy-cluster/src/cluster_bench_support.rs
+++ b/rocketmq-proxy-cluster/src/cluster_bench_support.rs
@@ -67,6 +67,7 @@ pub fn run_cluster_admission_microprobe(
         max_queue_age: Duration::from_secs(30),
         io_max_inflight: 16,
         control_reserve,
+        long_poll_max_inflight: 256,
         lane_idle_timeout: Duration::from_secs(30),
     };
     let lanes = ClusterExecutionLanes::new(policy)?;
@@ -166,6 +167,7 @@ pub fn run_cluster_mixed_execution_probe(
         max_queue_age: Duration::from_secs(30),
         io_max_inflight: unrelated_key_count.saturating_add(control_reserve).max(3),
         control_reserve,
+        long_poll_max_inflight: 256,
         lane_idle_timeout: Duration::from_secs(30),
     };
     let lanes = ClusterExecutionLanes::new(policy)?;

--- a/rocketmq-proxy-cluster/src/config.rs
+++ b/rocketmq-proxy-cluster/src/config.rs
@@ -25,9 +25,13 @@ pub struct ClusterExecutionDiagnostics {
     pub active_lane_tasks: usize,
     pub queued_and_active: usize,
     pub retained_bytes: usize,
+    pub long_poll_queued_and_active: usize,
+    pub long_poll_retained_bytes: usize,
     pub oldest_queued_age_ms: Option<u64>,
     pub current_inflight: usize,
     pub max_inflight: usize,
+    pub current_long_poll_inflight: usize,
+    pub long_poll_max_inflight: usize,
     pub admitted: u64,
     pub rejected: u64,
     pub timed_out: u64,
@@ -55,6 +59,7 @@ pub struct ClusterConfig {
     pub command_queue_max_age_ms: u64,
     pub io_max_inflight: usize,
     pub control_reserve: usize,
+    pub long_poll_max_inflight: usize,
     pub execution_lane_idle_timeout_ms: u64,
 }
 
@@ -76,6 +81,7 @@ impl Default for ClusterConfig {
             command_queue_max_age_ms: 30_000,
             io_max_inflight: 16,
             control_reserve: 2,
+            long_poll_max_inflight: 256,
             execution_lane_idle_timeout_ms: 30_000,
         }
     }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9229

### Brief Description

- isolates Receive and Pull long polling behind an independent bounded queue and inflight limit
- reserves the existing short-data and control capacity for route, ACK, visibility, and offset operations
- narrows consumer ordering keys so polls remain FIFO per queue without blocking control traffic
- exposes long-poll queue, retained-byte, and inflight diagnostics

### How Did You Test This Change?

- `cargo test -p rocketmq-proxy-cluster`
- `cargo clippy -p rocketmq-proxy-cluster --no-deps --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check` (WSL)
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated capacity controls for long-polling operations, separate from short-data and control requests.
  * Added configurable long-poll concurrency limits, with a default capacity of 256.
  * Added long-poll monitoring metrics, including queued/active requests, retained bytes, and current capacity usage.

* **Bug Fixes**
  * Improved request admission and ordering to prevent long-poll traffic from consuming unrelated capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->