### PR TITLE
[ISSUE #9231]✨Run local proxy requests with bounded deadline-aware concurrency

### DIFF
--- a/rocketmq-broker/src/proxy_facade.rs
+++ b/rocketmq-broker/src/proxy_facade.rs
@@ -144,7 +144,16 @@ impl ProxyBrokerFacade {
 
     pub async fn process_request(
         &self,
+        request: rocketmq_protocol::protocol::remoting_command::RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<rocketmq_protocol::protocol::remoting_command::RemotingCommand> {
+        self.process_request_with_timeout(request, LOCAL_PROXY_RESPONSE_TIMEOUT)
+            .await
+    }
+
+    pub async fn process_request_with_timeout(
+        &self,
         mut request: rocketmq_protocol::protocol::remoting_command::RemotingCommand,
+        timeout: Duration,
     ) -> rocketmq_error::RocketMQResult<rocketmq_protocol::protocol::remoting_command::RemotingCommand> {
         request.make_custom_header_to_net();
         let dispatcher = self
@@ -153,7 +162,7 @@ impl ProxyBrokerFacade {
             .ok_or_else(embedded_broker_request_processor_not_ready)?;
 
         let opaque = request.opaque();
-        let deadline = RequestDeadline::after(LOCAL_PROXY_RESPONSE_TIMEOUT);
+        let deadline = RequestDeadline::after(timeout);
         let context =
             RequestContext::try_embedded(Some(Principal::new("embedded-proxy")), Some(deadline)).map_err(|error| {
                 rocketmq_error::RocketMQError::response_process_failed(
@@ -164,7 +173,7 @@ impl ProxyBrokerFacade {
         let response = dispatcher
             .dispatch_embedded(&self.local_request_tasks, context, request)
             .await
-            .map_err(embedded_dispatch_error)?
+            .map_err(|error| embedded_dispatch_error(error, timeout))?
             .set_opaque(opaque)
             .mark_response_type();
         Ok(response)
@@ -175,7 +184,10 @@ fn embedded_broker_request_processor_not_ready() -> rocketmq_error::RocketMQErro
     rocketmq_error::RocketMQError::not_initialized("embedded_broker_request_processor")
 }
 
-fn embedded_dispatch_error(error: rocketmq_transport::api::v1::DispatchError) -> rocketmq_error::RocketMQError {
+fn embedded_dispatch_error(
+    error: rocketmq_transport::api::v1::DispatchError,
+    timeout: Duration,
+) -> rocketmq_error::RocketMQError {
     if matches!(
         &error,
         rocketmq_transport::api::v1::DispatchError::Response(
@@ -184,7 +196,7 @@ fn embedded_dispatch_error(error: rocketmq_transport::api::v1::DispatchError) ->
     ) {
         return rocketmq_error::RocketMQError::Timeout {
             operation: "embedded_broker_response",
-            timeout_ms: LOCAL_PROXY_RESPONSE_TIMEOUT.as_millis() as u64,
+            timeout_ms: timeout.as_millis().min(u128::from(u64::MAX)) as u64,
         };
     }
     rocketmq_error::RocketMQError::response_process_failed("embedded_broker_dispatch", error.to_string())
@@ -225,5 +237,23 @@ mod tests {
         let error = embedded_broker_request_processor_not_ready();
 
         assert_eq!(error.kind(), ErrorKind::NotInitialized);
+    }
+
+    #[test]
+    fn embedded_dispatch_timeout_reports_the_explicit_budget() {
+        let error = embedded_dispatch_error(
+            rocketmq_transport::api::v1::DispatchError::Response(
+                rocketmq_transport::api::v1::ResponseSinkError::DeadlineExceeded,
+            ),
+            Duration::from_millis(15_500),
+        );
+
+        assert!(matches!(
+            error,
+            rocketmq_error::RocketMQError::Timeout {
+                operation: "embedded_broker_response",
+                timeout_ms: 15_500
+            }
+        ));
     }
 }

--- a/rocketmq-proxy-core/src/context.rs
+++ b/rocketmq-proxy-core/src/context.rs
@@ -75,7 +75,7 @@ pub struct ProxyContextWithPrincipal<P> {
     client_version: Option<String>,
     namespace: Option<String>,
     connection_id: Option<String>,
-    deadline: Option<Duration>,
+    deadline_at: Option<Instant>,
     received_at: Instant,
     authenticated_principal: Option<P>,
 }
@@ -96,7 +96,7 @@ impl<P> ProxyContextWithPrincipal<P> {
             client_version: self.client_version.clone(),
             namespace: self.namespace.clone(),
             connection_id: self.connection_id.clone(),
-            deadline: self.deadline,
+            deadline_at: self.deadline_at,
             received_at: self.received_at,
             authenticated_principal: None,
         }
@@ -105,6 +105,8 @@ impl<P> ProxyContextWithPrincipal<P> {
     pub fn from_grpc_request<T>(rpc_name: &'static str, request: &Request<T>) -> ProxyResult<Self> {
         let metadata = request.metadata();
         let deadline = parse_grpc_timeout_metadata(metadata)?;
+        let received_at = Instant::now();
+        let deadline_at = deadline.map(|timeout| received_at.checked_add(timeout).unwrap_or(received_at));
 
         Ok(Self {
             request_id: Uuid::new_v4().to_string(),
@@ -120,8 +122,8 @@ impl<P> ProxyContextWithPrincipal<P> {
             client_version: metadata_string(metadata, "x-mq-client-version"),
             namespace: metadata_string(metadata, "x-mq-namespace"),
             connection_id: metadata_string(metadata, "x-mq-channel-id"),
-            deadline,
-            received_at: Instant::now(),
+            deadline_at,
+            received_at,
             authenticated_principal: None,
         })
     }
@@ -149,7 +151,7 @@ impl<P> ProxyContextWithPrincipal<P> {
             client_version: Some(request.version().to_string()),
             namespace: remoting_ext_field(request, "namespace"),
             connection_id: Some(channel.connection_id().to_owned()),
-            deadline: None,
+            deadline_at: None,
             received_at: Instant::now(),
             authenticated_principal: None,
         }
@@ -166,7 +168,7 @@ impl<P> ProxyContextWithPrincipal<P> {
             client_version: None,
             namespace: None,
             connection_id: None,
-            deadline: None,
+            deadline_at: None,
             received_at: Instant::now(),
             authenticated_principal: None,
         }
@@ -213,7 +215,13 @@ impl<P> ProxyContextWithPrincipal<P> {
     }
 
     pub fn deadline(&self) -> Option<Duration> {
-        self.deadline
+        self.deadline_at
+            .map(|deadline| deadline.saturating_duration_since(Instant::now()))
+    }
+
+    /// Returns the immutable request deadline captured at ingress.
+    pub fn deadline_at(&self) -> Option<Instant> {
+        self.deadline_at
     }
 
     pub fn received_at(&self) -> Instant {
@@ -281,6 +289,7 @@ mod tests {
     use std::collections::HashMap;
     use std::net::SocketAddr;
     use std::time::Duration;
+    use std::time::Instant;
 
     use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
     use rocketmq_transport::api::v1::ConnectionContext;
@@ -351,6 +360,26 @@ mod tests {
         let error = ProxyContext::from_grpc_request("QueryRoute", &request).expect_err("context should reject timeout");
         assert!(matches!(error, ProxyError::InvalidMetadata { .. }));
         assert!(error.to_string().contains("grpc-timeout"));
+    }
+
+    #[test]
+    fn proxy_context_freezes_grpc_timeout_as_an_absolute_deadline() {
+        let mut request = Request::new(());
+        request
+            .metadata_mut()
+            .insert("grpc-timeout", "1S".parse().expect("timeout metadata"));
+        let before = Instant::now();
+
+        let context =
+            ProxyContext::from_grpc_request("ReceiveMessage", &request).expect("context should freeze the timeout");
+        let after = Instant::now();
+        let deadline_at = context.deadline_at().expect("absolute deadline");
+
+        assert!(deadline_at >= before + Duration::from_secs(1));
+        assert!(deadline_at <= after + Duration::from_secs(1));
+        assert!(context
+            .deadline()
+            .is_some_and(|remaining| { !remaining.is_zero() && remaining <= Duration::from_secs(1) }));
     }
 
     #[test]

--- a/rocketmq-proxy-local/src/config.rs
+++ b/rocketmq-proxy-local/src/config.rs
@@ -21,6 +21,10 @@ const LOCAL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 const DEFAULT_LOCAL_COMMAND_QUEUE_CAPACITY: usize = 1_024;
 const DEFAULT_LOCAL_COMMAND_QUEUE_MAX_BYTES: usize = 16 * 1024 * 1024;
 const DEFAULT_LOCAL_COMMAND_QUEUE_MAX_AGE_MILLIS: u64 = 1_000;
+const DEFAULT_LOCAL_IO_MAX_INFLIGHT: usize = 16;
+const DEFAULT_LOCAL_CONTROL_RESERVE: usize = 2;
+const DEFAULT_LOCAL_LONG_POLL_MAX_INFLIGHT: usize = 256;
+const DEFAULT_LOCAL_EXECUTION_LANE_IDLE_TIMEOUT_MILLIS: u64 = 30_000;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default, rename_all = "camelCase")]
@@ -34,6 +38,10 @@ pub struct LocalConfig {
     pub command_queue_capacity: usize,
     pub command_queue_max_bytes: usize,
     pub command_queue_max_age_millis: u64,
+    pub io_max_inflight: usize,
+    pub control_reserve: usize,
+    pub long_poll_max_inflight: usize,
+    pub execution_lane_idle_timeout_millis: u64,
 }
 
 impl LocalConfig {
@@ -43,6 +51,10 @@ impl LocalConfig {
 
     pub fn command_queue_max_age(&self) -> Duration {
         Duration::from_millis(self.command_queue_max_age_millis)
+    }
+
+    pub fn execution_lane_idle_timeout(&self) -> Duration {
+        Duration::from_millis(self.execution_lane_idle_timeout_millis)
     }
 }
 
@@ -58,6 +70,10 @@ impl Default for LocalConfig {
             command_queue_capacity: DEFAULT_LOCAL_COMMAND_QUEUE_CAPACITY,
             command_queue_max_bytes: DEFAULT_LOCAL_COMMAND_QUEUE_MAX_BYTES,
             command_queue_max_age_millis: DEFAULT_LOCAL_COMMAND_QUEUE_MAX_AGE_MILLIS,
+            io_max_inflight: DEFAULT_LOCAL_IO_MAX_INFLIGHT,
+            control_reserve: DEFAULT_LOCAL_CONTROL_RESERVE,
+            long_poll_max_inflight: DEFAULT_LOCAL_LONG_POLL_MAX_INFLIGHT,
+            execution_lane_idle_timeout_millis: DEFAULT_LOCAL_EXECUTION_LANE_IDLE_TIMEOUT_MILLIS,
         }
     }
 }

--- a/rocketmq-proxy-local/src/execution.rs
+++ b/rocketmq-proxy-local/src/execution.rs
@@ -1,0 +1,824 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::hash::Hash;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
+
+use rocketmq_protocol::code::request_code::RequestCode;
+use rocketmq_protocol::protocol::header::ack_message_request_header::AckMessageRequestHeader;
+use rocketmq_protocol::protocol::header::change_invisible_time_request_header::ChangeInvisibleTimeRequestHeader;
+use rocketmq_protocol::protocol::header::pop_message_request_header::PopMessageRequestHeader;
+use rocketmq_protocol::protocol::header::pull_message_request_header::PullMessageRequestHeader;
+use rocketmq_protocol::protocol::header::query_consumer_offset_request_header::QueryConsumerOffsetRequestHeader;
+use rocketmq_protocol::protocol::header::update_consumer_offset_header::UpdateConsumerOffsetRequestHeader;
+use rocketmq_proxy_core::ResourceIdentity;
+use rocketmq_runtime::ChildServiceContext;
+use rocketmq_runtime::ShutdownDeadline;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+use tokio::sync::Notify;
+use tokio::sync::OwnedSemaphorePermit;
+use tokio::sync::Semaphore;
+use tokio_util::sync::CancellationToken;
+
+use crate::config::LocalConfig;
+use crate::local::LocalBrokerCommand;
+use crate::local::QueuedLocalBrokerCommand;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum LocalExecutionClass {
+    Control,
+    ShortData,
+    LongPoll,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct LocalOrderingKey {
+    domain: &'static str,
+    components: Vec<String>,
+}
+
+impl LocalOrderingKey {
+    fn new(domain: &'static str, components: impl IntoIterator<Item = String>) -> Self {
+        Self {
+            domain,
+            components: components.into_iter().collect(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct LocalExecutionPolicy {
+    capacity_count: usize,
+    max_queue_age: Duration,
+    io_max_inflight: usize,
+    control_reserve: usize,
+    long_poll_max_inflight: usize,
+    lane_idle_timeout: Duration,
+}
+
+impl LocalExecutionPolicy {
+    pub(crate) fn from_config(config: &LocalConfig) -> Self {
+        Self {
+            capacity_count: config.command_queue_capacity,
+            max_queue_age: config.command_queue_max_age(),
+            io_max_inflight: config.io_max_inflight,
+            control_reserve: config.control_reserve,
+            long_poll_max_inflight: config.long_poll_max_inflight,
+            lane_idle_timeout: config.execution_lane_idle_timeout(),
+        }
+    }
+}
+
+pub(crate) trait LocalCommandHandler: Send + Sync + 'static {
+    fn handle(&self, command: LocalBrokerCommand) -> impl Future<Output = ()> + Send;
+}
+
+struct LocalExecutionLimits {
+    total_inflight: Arc<Semaphore>,
+    short_data_inflight: Arc<Semaphore>,
+    long_poll_inflight: Arc<Semaphore>,
+}
+
+impl LocalExecutionLimits {
+    fn new(policy: LocalExecutionPolicy) -> Self {
+        Self {
+            total_inflight: Arc::new(Semaphore::new(policy.io_max_inflight)),
+            short_data_inflight: Arc::new(Semaphore::new(policy.io_max_inflight - policy.control_reserve)),
+            long_poll_inflight: Arc::new(Semaphore::new(policy.long_poll_max_inflight)),
+        }
+    }
+
+    async fn acquire(&self, class: LocalExecutionClass) -> Option<LocalInflightPermit> {
+        let (short_data, total, long_poll) = match class {
+            LocalExecutionClass::Control => (
+                None,
+                Some(self.total_inflight.clone().acquire_owned().await.ok()?),
+                None,
+            ),
+            LocalExecutionClass::ShortData => (
+                Some(self.short_data_inflight.clone().acquire_owned().await.ok()?),
+                Some(self.total_inflight.clone().acquire_owned().await.ok()?),
+                None,
+            ),
+            LocalExecutionClass::LongPoll => (
+                None,
+                None,
+                Some(self.long_poll_inflight.clone().acquire_owned().await.ok()?),
+            ),
+        };
+        Some(LocalInflightPermit {
+            _short_data: short_data,
+            _total: total,
+            _long_poll: long_poll,
+        })
+    }
+}
+
+struct LocalInflightPermit {
+    _short_data: Option<OwnedSemaphorePermit>,
+    _total: Option<OwnedSemaphorePermit>,
+    _long_poll: Option<OwnedSemaphorePermit>,
+}
+
+#[derive(Clone)]
+struct RegisteredLane {
+    generation: u64,
+    sender: mpsc::Sender<QueuedLocalBrokerCommand>,
+}
+
+struct LaneRetirement {
+    key: LocalOrderingKey,
+    generation: u64,
+    decision: oneshot::Sender<bool>,
+}
+
+struct ActiveLanes {
+    count: AtomicUsize,
+    idle: Notify,
+}
+
+impl ActiveLanes {
+    fn new() -> Self {
+        Self {
+            count: AtomicUsize::new(0),
+            idle: Notify::new(),
+        }
+    }
+
+    fn start(self: &Arc<Self>) -> ActiveLaneGuard {
+        self.count.fetch_add(1, Ordering::AcqRel);
+        ActiveLaneGuard { lanes: self.clone() }
+    }
+
+    async fn wait_until_idle(&self, deadline: ShutdownDeadline) -> bool {
+        loop {
+            let idle = self.idle.notified();
+            if self.count.load(Ordering::Acquire) == 0 {
+                return true;
+            }
+            if tokio::time::timeout(deadline.remaining(), idle).await.is_err() {
+                return self.count.load(Ordering::Acquire) == 0;
+            }
+        }
+    }
+}
+
+struct ActiveLaneGuard {
+    lanes: Arc<ActiveLanes>,
+}
+
+impl Drop for ActiveLaneGuard {
+    fn drop(&mut self) {
+        if self.lanes.count.fetch_sub(1, Ordering::AcqRel) == 1 {
+            self.lanes.idle.notify_waiters();
+        }
+    }
+}
+
+pub(crate) async fn run_local_execution<H>(
+    policy: LocalExecutionPolicy,
+    mut receiver: mpsc::Receiver<QueuedLocalBrokerCommand>,
+    cancellation: CancellationToken,
+    shutdown_context: ChildServiceContext,
+    lane_context: ChildServiceContext,
+    handler: Arc<H>,
+    shutdown_timeout: Duration,
+) where
+    H: LocalCommandHandler,
+{
+    let limits = Arc::new(LocalExecutionLimits::new(policy));
+    let active_lanes = Arc::new(ActiveLanes::new());
+    let next_generation = AtomicU64::new(1);
+    let (retirement_tx, mut retirement_rx) = mpsc::channel(policy.capacity_count);
+    let mut registry = HashMap::<LocalOrderingKey, RegisteredLane>::new();
+    let mut cancelled = false;
+
+    loop {
+        tokio::select! {
+            biased;
+            () = cancellation.cancelled() => {
+                cancelled = true;
+                receiver.close();
+                while let Ok(queued) = receiver.try_recv() {
+                    queued.command.reject_unavailable();
+                }
+                break;
+            }
+            retirement = retirement_rx.recv() => {
+                if let Some(retirement) = retirement {
+                    decide_lane_retirement(&mut registry, retirement);
+                }
+            }
+            queued = receiver.recv() => match queued {
+                Some(queued) => dispatch_to_lane(
+                    queued,
+                    policy,
+                    &mut registry,
+                    &next_generation,
+                    &retirement_tx,
+                    &lane_context,
+                    &active_lanes,
+                    &limits,
+                    &handler,
+                ),
+                None => break,
+            },
+        }
+    }
+
+    registry.clear();
+    drop(retirement_tx);
+    let deadline = shutdown_context
+        .task_group()
+        .shutdown_deadline()
+        .unwrap_or_else(|| ShutdownDeadline::after(shutdown_timeout));
+    if cancelled {
+        lane_context.task_group().cancel();
+    }
+    if !active_lanes.wait_until_idle(deadline).await {
+        lane_context.task_group().cancel();
+    }
+    let report = lane_context.task_group().shutdown_until(deadline).await;
+    if !report.is_healthy() {
+        tracing::warn!(report = %report.to_json(), "proxy local command lanes did not shut down cleanly");
+    }
+}
+
+#[allow(
+    clippy::too_many_arguments,
+    reason = "lane construction keeps all lifecycle and budget owners explicit"
+)]
+fn dispatch_to_lane<H>(
+    mut queued: QueuedLocalBrokerCommand,
+    policy: LocalExecutionPolicy,
+    registry: &mut HashMap<LocalOrderingKey, RegisteredLane>,
+    next_generation: &AtomicU64,
+    retirement_tx: &mpsc::Sender<LaneRetirement>,
+    lane_context: &ChildServiceContext,
+    active_lanes: &Arc<ActiveLanes>,
+    limits: &Arc<LocalExecutionLimits>,
+    handler: &Arc<H>,
+) where
+    H: LocalCommandHandler,
+{
+    let now = Instant::now();
+    if queued.is_expired(now, policy.max_queue_age) {
+        queued.command.reject_overload();
+        return;
+    }
+    if queued.deadline_expired(now) {
+        queued.command.reject_timeout(queued.timeout_budget.unwrap_or_default());
+        return;
+    }
+    let key = queued.command.ordering_key();
+    loop {
+        if let Some(registered) = registry.get(&key) {
+            match registered.sender.try_send(queued) {
+                Ok(()) => return,
+                Err(mpsc::error::TrySendError::Full(rejected)) => {
+                    rejected.command.reject_overload();
+                    return;
+                }
+                Err(mpsc::error::TrySendError::Closed(rejected)) => {
+                    registry.remove(&key);
+                    queued = rejected;
+                    continue;
+                }
+            }
+        }
+
+        let generation = next_generation.fetch_add(1, Ordering::Relaxed);
+        let (sender, receiver) = mpsc::channel(policy.capacity_count);
+        let lane_cancellation = lane_context.task_group().cancellation_token();
+        let lane_retirement = retirement_tx.clone();
+        let lane_key = key.clone();
+        let lane_limits = limits.clone();
+        let lane_handler = handler.clone();
+        let active_guard = active_lanes.start();
+        let spawn = lane_context.spawn_service(format!("proxy.local.lane.{generation}"), async move {
+            let _active_guard = active_guard;
+            run_local_lane(
+                lane_key,
+                generation,
+                receiver,
+                lane_retirement,
+                lane_cancellation,
+                policy,
+                lane_limits,
+                lane_handler,
+            )
+            .await;
+        });
+        if let Err(error) = spawn {
+            queued
+                .command
+                .reject_with_transport(format!("failed to spawn proxy local command lane: {error}"));
+            return;
+        }
+        registry.insert(
+            key.clone(),
+            RegisteredLane {
+                generation,
+                sender: sender.clone(),
+            },
+        );
+        match sender.try_send(queued) {
+            Ok(()) => return,
+            Err(mpsc::error::TrySendError::Full(rejected)) | Err(mpsc::error::TrySendError::Closed(rejected)) => {
+                registry.remove(&key);
+                rejected.command.reject_overload();
+                return;
+            }
+        }
+    }
+}
+
+fn decide_lane_retirement(registry: &mut HashMap<LocalOrderingKey, RegisteredLane>, retirement: LaneRetirement) {
+    let retire = registry.get(&retirement.key).is_some_and(|registered| {
+        registered.generation == retirement.generation
+            && registered.sender.capacity() == registered.sender.max_capacity()
+    });
+    if retire {
+        registry.remove(&retirement.key);
+    }
+    let _ = retirement.decision.send(retire);
+}
+
+#[allow(
+    clippy::too_many_arguments,
+    reason = "lane execution keeps ownership and limits explicit"
+)]
+async fn run_local_lane<H>(
+    key: LocalOrderingKey,
+    generation: u64,
+    mut receiver: mpsc::Receiver<QueuedLocalBrokerCommand>,
+    retirement_tx: mpsc::Sender<LaneRetirement>,
+    cancellation: CancellationToken,
+    policy: LocalExecutionPolicy,
+    limits: Arc<LocalExecutionLimits>,
+    handler: Arc<H>,
+) where
+    H: LocalCommandHandler,
+{
+    loop {
+        let queued = tokio::select! {
+            biased;
+            () = cancellation.cancelled() => {
+                reject_lane(&mut receiver);
+                return;
+            }
+            queued = tokio::time::timeout(policy.lane_idle_timeout, receiver.recv()) => match queued {
+                Ok(Some(queued)) => queued,
+                Ok(None) => return,
+                Err(_) => {
+                    let (decision, response) = oneshot::channel();
+                    if retirement_tx
+                        .send(LaneRetirement {
+                            key: key.clone(),
+                            generation,
+                            decision,
+                        })
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
+                    match response.await {
+                        Ok(true) => return,
+                        Ok(false) => continue,
+                        Err(_) => return,
+                    }
+                }
+            },
+        };
+        execute_queued_command(queued, policy.max_queue_age, &limits, handler.as_ref(), &cancellation).await;
+    }
+}
+
+async fn execute_queued_command<H>(
+    mut queued: QueuedLocalBrokerCommand,
+    max_queue_age: Duration,
+    limits: &LocalExecutionLimits,
+    handler: &H,
+    cancellation: &CancellationToken,
+) where
+    H: LocalCommandHandler,
+{
+    let now = Instant::now();
+    if queued.is_expired(now, max_queue_age) {
+        queued.command.reject_overload();
+        return;
+    }
+    if queued.deadline_expired(now) {
+        queued.command.reject_timeout(queued.timeout_budget.unwrap_or_default());
+        return;
+    }
+    let class = queued.command.execution_class();
+    let permit = tokio::select! {
+        biased;
+        () = cancellation.cancelled() => {
+            queued.command.reject_unavailable();
+            return;
+        }
+        permit = limits.acquire(class) => permit,
+    };
+    let Some(_permit) = permit else {
+        queued.command.reject_unavailable();
+        return;
+    };
+    let now = Instant::now();
+    if queued.deadline_expired(now) {
+        queued.command.reject_timeout(queued.timeout_budget.unwrap_or_default());
+        return;
+    }
+    queued.apply_remaining_deadline(now);
+    tokio::select! {
+        biased;
+        () = cancellation.cancelled() => {}
+        () = handler.handle(queued.command) => {}
+    }
+}
+
+fn reject_lane(receiver: &mut mpsc::Receiver<QueuedLocalBrokerCommand>) {
+    receiver.close();
+    while let Ok(queued) = receiver.try_recv() {
+        queued.command.reject_unavailable();
+    }
+}
+
+impl LocalBrokerCommand {
+    pub(crate) fn execution_class(&self) -> LocalExecutionClass {
+        match self {
+            Self::QueryRoute { .. }
+            | Self::QueryTopicMessageType { .. }
+            | Self::QuerySubscriptionGroup { .. }
+            | Self::QueryAssignment { .. } => LocalExecutionClass::Control,
+            Self::ProcessRemoting { request, .. } => match RequestCode::from(request.code()) {
+                RequestCode::PopMessage | RequestCode::PullMessage => LocalExecutionClass::LongPoll,
+                RequestCode::AckMessage
+                | RequestCode::BatchAckMessage
+                | RequestCode::ChangeMessageInvisibleTime
+                | RequestCode::ConsumerSendMsgBack
+                | RequestCode::UpdateConsumerOffset
+                | RequestCode::QueryConsumerOffset => LocalExecutionClass::Control,
+                _ => LocalExecutionClass::ShortData,
+            },
+            Self::SendMessage { .. } | Self::RecallMessage { .. } | Self::EndTransaction { .. } => {
+                LocalExecutionClass::ShortData
+            }
+        }
+    }
+
+    fn ordering_key(&self) -> LocalOrderingKey {
+        match self {
+            Self::QueryRoute { topic, .. } | Self::QueryTopicMessageType { topic, .. } => {
+                resource_key("topic", [topic])
+            }
+            Self::QuerySubscriptionGroup { group, .. } => resource_key("consumer-control", [group]),
+            Self::QueryAssignment { topic, group, .. } => resource_key("consumer-control", [topic, group]),
+            Self::SendMessage {
+                client_id, request_id, ..
+            }
+            | Self::RecallMessage {
+                client_id, request_id, ..
+            }
+            | Self::EndTransaction {
+                client_id, request_id, ..
+            } => LocalOrderingKey::new("producer", [client_id.clone().unwrap_or_else(|| request_id.clone())]),
+            Self::ProcessRemoting { request, .. } => remoting_ordering_key(request),
+        }
+    }
+}
+
+fn resource_key<'a>(
+    domain: &'static str,
+    resources: impl IntoIterator<Item = &'a ResourceIdentity>,
+) -> LocalOrderingKey {
+    LocalOrderingKey::new(
+        domain,
+        resources
+            .into_iter()
+            .flat_map(|resource| [resource.namespace().to_owned(), resource.name().to_owned()]),
+    )
+}
+
+fn remoting_ordering_key(request: &rocketmq_protocol::protocol::remoting_command::RemotingCommand) -> LocalOrderingKey {
+    match RequestCode::from(request.code()) {
+        RequestCode::PopMessage => request
+            .decode_command_custom_header::<PopMessageRequestHeader>()
+            .map(|header| {
+                consumer_queue_key(
+                    "consumer-poll",
+                    header.consumer_group.as_str(),
+                    header.topic.as_str(),
+                    header.queue_id,
+                )
+            })
+            .unwrap_or_else(|_| fallback_remoting_key("consumer-poll", request)),
+        RequestCode::PullMessage => request
+            .decode_command_custom_header::<PullMessageRequestHeader>()
+            .map(|header| {
+                consumer_queue_key(
+                    "consumer-poll",
+                    header.consumer_group.as_str(),
+                    header.topic.as_str(),
+                    header.queue_id,
+                )
+            })
+            .unwrap_or_else(|_| fallback_remoting_key("consumer-poll", request)),
+        RequestCode::AckMessage => request
+            .decode_command_custom_header::<AckMessageRequestHeader>()
+            .map(|header| {
+                consumer_queue_key(
+                    "consumer-control",
+                    header.consumer_group.as_str(),
+                    header.topic.as_str(),
+                    header.queue_id,
+                )
+            })
+            .unwrap_or_else(|_| fallback_remoting_key("consumer-control", request)),
+        RequestCode::ChangeMessageInvisibleTime => request
+            .decode_command_custom_header::<ChangeInvisibleTimeRequestHeader>()
+            .map(|header| {
+                consumer_queue_key(
+                    "consumer-control",
+                    header.consumer_group.as_str(),
+                    header.topic.as_str(),
+                    header.queue_id,
+                )
+            })
+            .unwrap_or_else(|_| fallback_remoting_key("consumer-control", request)),
+        RequestCode::UpdateConsumerOffset => request
+            .decode_command_custom_header::<UpdateConsumerOffsetRequestHeader>()
+            .map(|header| {
+                consumer_queue_key(
+                    "consumer-offset",
+                    header.consumer_group.as_str(),
+                    header.topic.as_str(),
+                    header.queue_id,
+                )
+            })
+            .unwrap_or_else(|_| fallback_remoting_key("consumer-offset", request)),
+        RequestCode::QueryConsumerOffset => request
+            .decode_command_custom_header::<QueryConsumerOffsetRequestHeader>()
+            .map(|header| {
+                consumer_queue_key(
+                    "consumer-offset",
+                    header.consumer_group.as_str(),
+                    header.topic.as_str(),
+                    header.queue_id,
+                )
+            })
+            .unwrap_or_else(|_| fallback_remoting_key("consumer-offset", request)),
+        RequestCode::BatchAckMessage | RequestCode::ConsumerSendMsgBack => {
+            fallback_remoting_key("consumer-control", request)
+        }
+        _ => fallback_remoting_key("remoting", request),
+    }
+}
+
+fn consumer_queue_key(domain: &'static str, group: &str, topic: &str, queue_id: i32) -> LocalOrderingKey {
+    LocalOrderingKey::new(domain, [group.to_owned(), topic.to_owned(), queue_id.to_string()])
+}
+
+fn fallback_remoting_key(
+    domain: &'static str,
+    request: &rocketmq_protocol::protocol::remoting_command::RemotingCommand,
+) -> LocalOrderingKey {
+    LocalOrderingKey::new(domain, [request.code().to_string(), request.opaque().to_string()])
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
+    use std::time::Duration;
+    use std::time::Instant;
+
+    use cheetah_string::CheetahString;
+    use rocketmq_protocol::protocol::header::pop_message_request_header::PopMessageRequestHeader;
+    use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+    use tokio::sync::oneshot;
+    use tokio::sync::Semaphore;
+    use tokio_util::sync::CancellationToken;
+
+    use super::*;
+    use crate::local::LocalBrokerCommand;
+    use crate::local::QueuedLocalBrokerCommand;
+
+    struct BlockingHandler {
+        entered: mpsc::Sender<i32>,
+        release: Arc<Semaphore>,
+        current: AtomicUsize,
+        maximum: AtomicUsize,
+    }
+
+    impl LocalCommandHandler for BlockingHandler {
+        async fn handle(&self, command: LocalBrokerCommand) {
+            let id = match &command {
+                LocalBrokerCommand::ProcessRemoting { request, .. } => request.opaque(),
+                LocalBrokerCommand::QueryRoute { .. } => -1,
+                _ => -2,
+            };
+            let current = self.current.fetch_add(1, Ordering::AcqRel) + 1;
+            self.maximum.fetch_max(current, Ordering::AcqRel);
+            let _ = self.entered.send(id).await;
+            if let Ok(permit) = self.release.acquire().await {
+                permit.forget();
+            }
+            self.current.fetch_sub(1, Ordering::AcqRel);
+            command.reject_unavailable();
+        }
+    }
+
+    fn queued(command: LocalBrokerCommand) -> QueuedLocalBrokerCommand {
+        let count = Arc::new(Semaphore::new(1));
+        let bytes = Arc::new(Semaphore::new(1));
+        QueuedLocalBrokerCommand {
+            command,
+            enqueued_at: Instant::now(),
+            deadline_at: None,
+            timeout_budget: None,
+            _count_permit: count.try_acquire_owned().expect("count permit"),
+            _byte_permit: bytes.try_acquire_owned().expect("byte permit"),
+        }
+    }
+
+    fn pop_command(queue_id: i32, opaque: i32) -> LocalBrokerCommand {
+        let (reply, _receiver) = oneshot::channel();
+        let mut request = RemotingCommand::create_request_command(
+            RequestCode::PopMessage,
+            PopMessageRequestHeader {
+                consumer_group: CheetahString::from("GroupA"),
+                topic: CheetahString::from("TopicA"),
+                queue_id,
+                poll_time: 15_000,
+                ..Default::default()
+            },
+        )
+        .set_opaque(opaque);
+        request.make_custom_header_to_net();
+        LocalBrokerCommand::ProcessRemoting {
+            request,
+            timeout: Duration::from_millis(15_500),
+            reply,
+        }
+    }
+
+    fn route_command() -> LocalBrokerCommand {
+        let (reply, _receiver) = oneshot::channel();
+        LocalBrokerCommand::QueryRoute {
+            topic: ResourceIdentity::new("", "TopicA"),
+            reply,
+        }
+    }
+
+    fn execution_contexts(name: &str) -> (ChildServiceContext, ChildServiceContext) {
+        let runtime = rocketmq_runtime::RuntimeContext::try_from_current(name).expect("runtime context");
+        let service = runtime.service_context(format!("{name}.service"));
+        let lanes = service.component("lanes");
+        (service, lanes)
+    }
+
+    #[test]
+    fn long_poll_and_control_commands_use_independent_domains() {
+        let pop = RemotingCommand::create_request_command(
+            RequestCode::PopMessage,
+            PopMessageRequestHeader {
+                consumer_group: CheetahString::from("GroupA"),
+                topic: CheetahString::from("TopicA"),
+                queue_id: 1,
+                poll_time: 15_000,
+                ..Default::default()
+            },
+        );
+        let (pop_reply, _pop_receiver) = oneshot::channel();
+        let pop = LocalBrokerCommand::ProcessRemoting {
+            request: pop,
+            timeout: Duration::from_millis(15_500),
+            reply: pop_reply,
+        };
+        let (route_reply, _route_receiver) = oneshot::channel();
+        let route = LocalBrokerCommand::QueryRoute {
+            topic: ResourceIdentity::new("", "TopicA"),
+            reply: route_reply,
+        };
+
+        assert_eq!(pop.execution_class(), LocalExecutionClass::LongPoll);
+        assert_eq!(route.execution_class(), LocalExecutionClass::Control);
+        assert_ne!(pop.ordering_key(), route.ordering_key());
+    }
+
+    #[tokio::test]
+    async fn saturated_long_poll_lane_does_not_block_control_work() {
+        let config = LocalConfig {
+            command_queue_capacity: 4,
+            io_max_inflight: 2,
+            control_reserve: 1,
+            long_poll_max_inflight: 1,
+            ..LocalConfig::default()
+        };
+        let policy = LocalExecutionPolicy::from_config(&config);
+        let (sender, receiver) = mpsc::channel(4);
+        sender.send(queued(pop_command(0, 1))).await.expect("first poll");
+        sender.send(queued(pop_command(1, 2))).await.expect("second poll");
+        sender.send(queued(route_command())).await.expect("control command");
+        drop(sender);
+        let (entered_tx, mut entered_rx) = mpsc::channel(4);
+        let release = Arc::new(Semaphore::new(0));
+        let handler = Arc::new(BlockingHandler {
+            entered: entered_tx,
+            release: release.clone(),
+            current: AtomicUsize::new(0),
+            maximum: AtomicUsize::new(0),
+        });
+        let (service, lanes) = execution_contexts("proxy-local-long-poll-isolation");
+        let run = run_local_execution(
+            policy,
+            receiver,
+            CancellationToken::new(),
+            service.clone(),
+            lanes,
+            handler.clone(),
+            Duration::from_secs(1),
+        );
+        let observe = async {
+            let first = entered_rx.recv().await.expect("first active command");
+            let second = entered_rx.recv().await.expect("control command");
+            assert_ne!(first, second);
+            assert!([first, second].contains(&1));
+            assert!([first, second].contains(&-1));
+            assert!(matches!(entered_rx.try_recv(), Err(mpsc::error::TryRecvError::Empty)));
+            release.add_permits(2);
+            assert_eq!(entered_rx.recv().await, Some(2));
+            release.add_permits(1);
+        };
+        let ((), ()) = tokio::join!(run, observe);
+        assert_eq!(handler.maximum.load(Ordering::Acquire), 2);
+        let report = service.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+    }
+
+    #[tokio::test]
+    async fn same_consumer_queue_remains_fifo() {
+        let config = LocalConfig {
+            command_queue_capacity: 3,
+            long_poll_max_inflight: 2,
+            ..LocalConfig::default()
+        };
+        let (sender, receiver) = mpsc::channel(3);
+        sender.send(queued(pop_command(0, 1))).await.expect("first poll");
+        sender.send(queued(pop_command(0, 2))).await.expect("second poll");
+        drop(sender);
+        let (entered_tx, mut entered_rx) = mpsc::channel(3);
+        let release = Arc::new(Semaphore::new(0));
+        let handler = Arc::new(BlockingHandler {
+            entered: entered_tx,
+            release: release.clone(),
+            current: AtomicUsize::new(0),
+            maximum: AtomicUsize::new(0),
+        });
+        let (service, lanes) = execution_contexts("proxy-local-queue-fifo");
+        let run = run_local_execution(
+            LocalExecutionPolicy::from_config(&config),
+            receiver,
+            CancellationToken::new(),
+            service.clone(),
+            lanes,
+            handler.clone(),
+            Duration::from_secs(1),
+        );
+        let observe = async {
+            assert_eq!(entered_rx.recv().await, Some(1));
+            tokio::task::yield_now().await;
+            assert!(matches!(entered_rx.try_recv(), Err(mpsc::error::TryRecvError::Empty)));
+            release.add_permits(1);
+            assert_eq!(entered_rx.recv().await, Some(2));
+            release.add_permits(1);
+        };
+        let ((), ()) = tokio::join!(run, observe);
+        assert_eq!(handler.maximum.load(Ordering::Acquire), 1);
+        let report = service.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+    }
+}

--- a/rocketmq-proxy-local/src/lib.rs
+++ b/rocketmq-proxy-local/src/lib.rs
@@ -19,6 +19,7 @@
 //! Embedded Broker-backed local adapter for RocketMQ Proxy Core ports.
 
 mod config;
+mod execution;
 mod local;
 mod message;
 mod service;

--- a/rocketmq-proxy-local/src/local.rs
+++ b/rocketmq-proxy-local/src/local.rs
@@ -129,24 +129,33 @@ use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 
 use crate::config::LocalConfig;
+use crate::execution::run_local_execution;
+use crate::execution::LocalCommandHandler;
+use crate::execution::LocalExecutionPolicy;
 use crate::message::message_ext_to_core;
 use crate::message::message_properties_from_core;
 use crate::service::LocalServiceManager;
 
+const LOCAL_LONG_POLL_TIMEOUT_MARGIN: Duration = Duration::from_millis(500);
+
 #[derive(Clone)]
 pub struct LocalBrokerFacadeClient {
     sender: mpsc::Sender<QueuedLocalBrokerCommand>,
+    count_budget: Arc<Semaphore>,
     byte_budget: Arc<Semaphore>,
     broker_name: String,
 }
 
-struct QueuedLocalBrokerCommand {
-    command: LocalBrokerCommand,
-    enqueued_at: Instant,
-    _byte_permit: OwnedSemaphorePermit,
+pub(crate) struct QueuedLocalBrokerCommand {
+    pub(crate) command: LocalBrokerCommand,
+    pub(crate) enqueued_at: Instant,
+    pub(crate) deadline_at: Option<Instant>,
+    pub(crate) timeout_budget: Option<Duration>,
+    pub(crate) _count_permit: OwnedSemaphorePermit,
+    pub(crate) _byte_permit: OwnedSemaphorePermit,
 }
 
-enum LocalBrokerCommand {
+pub(crate) enum LocalBrokerCommand {
     QueryRoute {
         topic: ResourceIdentity,
         reply: oneshot::Sender<ProxyResult<TopicRouteData>>,
@@ -186,17 +195,38 @@ enum LocalBrokerCommand {
     },
     ProcessRemoting {
         request: RemotingCommand,
+        timeout: Duration,
         reply: oneshot::Sender<ProxyResult<RemotingCommand>>,
     },
 }
 
 impl QueuedLocalBrokerCommand {
-    fn is_expired(&self, now: Instant, max_queue_age: Duration) -> bool {
+    pub(crate) fn is_expired(&self, now: Instant, max_queue_age: Duration) -> bool {
         now.saturating_duration_since(self.enqueued_at) >= max_queue_age
+    }
+
+    pub(crate) fn deadline_expired(&self, now: Instant) -> bool {
+        self.deadline_at.is_some_and(|deadline| now >= deadline)
+    }
+
+    pub(crate) fn apply_remaining_deadline(&mut self, now: Instant) {
+        let Some(deadline_at) = self.deadline_at else {
+            return;
+        };
+        if let LocalBrokerCommand::ProcessRemoting { timeout, .. } = &mut self.command {
+            *timeout = deadline_at.saturating_duration_since(now);
+        }
     }
 }
 
 impl LocalBrokerCommand {
+    fn timeout(&self) -> Option<Duration> {
+        match self {
+            Self::ProcessRemoting { timeout, .. } => Some(*timeout),
+            _ => None,
+        }
+    }
+
     fn estimated_bytes(&self) -> usize {
         let base = std::mem::size_of::<Self>();
         match self {
@@ -275,31 +305,53 @@ impl LocalBrokerCommand {
         .max(1)
     }
 
-    fn reject_overload(self) {
+    pub(crate) fn reject_overload(self) {
+        self.reject_with(local_queue_overloaded());
+    }
+
+    pub(crate) fn reject_unavailable(self) {
+        self.reject_with_transport("local broker command execution is unavailable".to_owned());
+    }
+
+    pub(crate) fn reject_with_transport(self, message: String) {
+        self.reject_with(ProxyError::Transport { message });
+    }
+
+    pub(crate) fn reject_timeout(self, timeout: Duration) {
+        self.reject_with(
+            RocketMQError::Timeout {
+                operation: "local broker command queue",
+                timeout_ms: timeout.as_millis().min(u128::from(u64::MAX)) as u64,
+            }
+            .into(),
+        );
+    }
+
+    fn reject_with(self, error: ProxyError) {
         match self {
             Self::QueryRoute { reply, .. } => {
-                let _ = reply.send(Err(local_queue_overloaded()));
+                let _ = reply.send(Err(error));
             }
             Self::QueryTopicMessageType { reply, .. } => {
-                let _ = reply.send(Err(local_queue_overloaded()));
+                let _ = reply.send(Err(error));
             }
             Self::QuerySubscriptionGroup { reply, .. } => {
-                let _ = reply.send(Err(local_queue_overloaded()));
+                let _ = reply.send(Err(error));
             }
             Self::QueryAssignment { reply, .. } => {
-                let _ = reply.send(Err(local_queue_overloaded()));
+                let _ = reply.send(Err(error));
             }
             Self::SendMessage { reply, .. } => {
-                let _ = reply.send(Err(local_queue_overloaded()));
+                let _ = reply.send(Err(error));
             }
             Self::RecallMessage { reply, .. } => {
-                let _ = reply.send(Err(local_queue_overloaded()));
+                let _ = reply.send(Err(error));
             }
             Self::EndTransaction { reply, .. } => {
-                let _ = reply.send(Err(local_queue_overloaded()));
+                let _ = reply.send(Err(error));
             }
             Self::ProcessRemoting { reply, .. } => {
-                let _ = reply.send(Err(local_queue_overloaded()));
+                let _ = reply.send(Err(error));
             }
         }
     }
@@ -325,6 +377,21 @@ fn validate_local_queue_config(config: &LocalConfig) -> ProxyResult<()> {
             message: "local command queue maximum age must be greater than zero".to_owned(),
         });
     }
+    if config.control_reserve == 0 || config.io_max_inflight <= config.control_reserve {
+        return Err(ProxyError::Transport {
+            message: "local io_max_inflight must be greater than a nonzero control_reserve".to_owned(),
+        });
+    }
+    if config.long_poll_max_inflight == 0 {
+        return Err(ProxyError::Transport {
+            message: "local long_poll_max_inflight must be greater than zero".to_owned(),
+        });
+    }
+    if config.execution_lane_idle_timeout().is_zero() {
+        return Err(ProxyError::Transport {
+            message: "local execution lane idle timeout must be greater than zero".to_owned(),
+        });
+    }
     Ok(())
 }
 
@@ -337,6 +404,7 @@ impl LocalBrokerFacadeClient {
         validate_local_queue_config(&config)?;
         let broker_config = build_broker_config(&config);
         let (sender, receiver) = mpsc::channel(config.command_queue_capacity);
+        let count_budget = Arc::new(Semaphore::new(config.command_queue_capacity));
         let byte_budget = Arc::new(Semaphore::new(config.command_queue_max_bytes));
         let max_queue_age = config.command_queue_max_age();
         let broker_name = config.broker_name.clone();
@@ -352,15 +420,26 @@ impl LocalBrokerFacadeClient {
             })?;
         let shutdown_context = service_context.clone();
         let cancellation = worker_context.task_group().cancellation_token();
+        let lane_context = worker_context.component("command-lanes");
         worker_context
             .spawn_service("proxy.local.worker", async move {
-                run_local_broker_worker(config, facade, receiver, cancellation, shutdown_context, max_queue_age).await;
+                run_local_broker_worker(
+                    config,
+                    facade,
+                    receiver,
+                    cancellation,
+                    shutdown_context,
+                    lane_context,
+                    max_queue_age,
+                )
+                .await;
             })
             .map_err(|error| ProxyError::Transport {
                 message: format!("failed to spawn proxy local worker: {error}"),
             })?;
         Ok(Self {
             sender,
+            count_budget,
             byte_budget,
             broker_name,
         })
@@ -411,8 +490,22 @@ impl LocalBrokerFacadeClient {
     }
 
     pub async fn process_remoting(&self, request: RemotingCommand) -> ProxyResult<RemotingCommand> {
-        self.execute(|reply| LocalBrokerCommand::ProcessRemoting { request, reply })
+        self.process_remoting_with_timeout(request, Duration::from_secs(3))
             .await
+    }
+
+    pub async fn process_remoting_with_timeout(
+        &self,
+        mut request: RemotingCommand,
+        timeout: Duration,
+    ) -> ProxyResult<RemotingCommand> {
+        request.make_custom_header_to_net();
+        self.execute(|reply| LocalBrokerCommand::ProcessRemoting {
+            request,
+            timeout,
+            reply,
+        })
+        .await
     }
 
     pub async fn send_message(
@@ -477,13 +570,22 @@ impl LocalBrokerFacadeClient {
         let (reply_tx, reply_rx) = oneshot::channel();
         let command = build(reply_tx);
         let estimated_bytes = command.estimated_bytes();
+        let count_permit = Arc::clone(&self.count_budget)
+            .try_acquire_owned()
+            .map_err(|_| local_queue_overloaded())?;
         let byte_permits = u32::try_from(estimated_bytes).map_err(|_| local_queue_overloaded())?;
         let byte_permit = Arc::clone(&self.byte_budget)
             .try_acquire_many_owned(byte_permits)
             .map_err(|_| local_queue_overloaded())?;
+        let timeout_budget = command.timeout();
+        let enqueued_at = Instant::now();
+        let deadline_at = timeout_budget.map(|timeout| enqueued_at.checked_add(timeout).unwrap_or(enqueued_at));
         let queued = QueuedLocalBrokerCommand {
             command,
-            enqueued_at: Instant::now(),
+            enqueued_at,
+            deadline_at,
+            timeout_budget,
+            _count_permit: count_permit,
             _byte_permit: byte_permit,
         };
         match self.sender.try_send(queued) {
@@ -696,18 +798,18 @@ impl LocalConsumerService {
 impl ConsumerService for LocalConsumerService {
     fn receive_message<'a>(
         &'a self,
-        _context: &'a ProxyContext,
+        context: &'a ProxyContext,
         request: &'a ReceiveMessageRequest,
     ) -> ProxyServiceFuture<'a, ReceiveMessagePlan> {
-        Box::pin(async move { receive_message_via_broker(&self.client, request).await })
+        Box::pin(async move { receive_message_via_broker(&self.client, request, context.deadline()).await })
     }
 
     fn pull_message<'a>(
         &'a self,
-        _context: &'a ProxyContext,
+        context: &'a ProxyContext,
         request: &'a PullMessageRequest,
     ) -> ProxyServiceFuture<'a, PullMessagePlan> {
-        Box::pin(async move { pull_message_via_broker(&self.client, request).await })
+        Box::pin(async move { pull_message_via_broker(&self.client, request, context.deadline()).await })
     }
 
     fn ack_message<'a>(
@@ -802,6 +904,7 @@ async fn run_local_broker_worker(
     mut receiver: mpsc::Receiver<QueuedLocalBrokerCommand>,
     cancellation: CancellationToken,
     shutdown_context: ChildServiceContext,
+    lane_context: ChildServiceContext,
     max_queue_age: Duration,
 ) {
     let initialization = tokio::select! {
@@ -849,52 +952,44 @@ async fn run_local_broker_worker(
         }
     };
 
-    loop {
-        let queued = tokio::select! {
-            biased;
-            () = cancellation.cancelled() => {
-                drain_local_commands(
-                    &facade,
-                    startup_error.as_deref(),
-                    &mut receiver,
-                    max_queue_age,
-                    shutdown_deadline(&shutdown_context, &config),
-                )
-                .await;
-                break;
-            },
-            command = receiver.recv() => match command {
-                Some(command) => command,
-                None => break,
-            },
-        };
-        if queued.is_expired(Instant::now(), max_queue_age) {
-            queued.command.reject_overload();
-            continue;
-        }
-        let QueuedLocalBrokerCommand {
-            command,
-            enqueued_at: _,
-            _byte_permit,
-        } = queued;
-        tokio::select! {
-            biased;
-            () = cancellation.cancelled() => break,
-            () = handle_local_broker_command(&facade, startup_error.as_deref(), command) => {}
-        }
-    }
+    let policy = LocalExecutionPolicy::from_config(&config);
+    let shutdown_timeout = config.shutdown_timeout();
+    let facade = Arc::new(facade);
+    let handler = Arc::new(BrokerLocalCommandHandler {
+        facade: facade.clone(),
+        startup_error: startup_error.map(Arc::<str>::from),
+    });
+    run_local_execution(
+        policy,
+        receiver,
+        cancellation,
+        shutdown_context.clone(),
+        lane_context,
+        handler.clone(),
+        shutdown_timeout,
+    )
+    .await;
+    drop(handler);
 
-    if cancellation.is_cancelled() {
-        drain_local_commands(
-            &facade,
-            startup_error.as_deref(),
-            &mut receiver,
-            max_queue_age,
-            shutdown_deadline(&shutdown_context, &config),
-        )
-        .await;
+    match Arc::try_unwrap(facade) {
+        Ok(mut facade) => {
+            shutdown_local_broker(&mut facade, shutdown_deadline(&shutdown_context, &config)).await;
+        }
+        Err(_) => {
+            tracing::error!("proxy local command lanes retained the embedded Broker facade during shutdown");
+        }
     }
-    shutdown_local_broker(&mut facade, shutdown_deadline(&shutdown_context, &config)).await;
+}
+
+struct BrokerLocalCommandHandler {
+    facade: Arc<ProxyBrokerFacade>,
+    startup_error: Option<Arc<str>>,
+}
+
+impl LocalCommandHandler for BrokerLocalCommandHandler {
+    async fn handle(&self, command: LocalBrokerCommand) {
+        handle_local_broker_command(&self.facade, self.startup_error.as_deref(), command).await;
+    }
 }
 
 fn shutdown_deadline(shutdown_context: &ChildServiceContext, config: &LocalConfig) -> ShutdownDeadline {
@@ -923,6 +1018,9 @@ async fn drain_local_commands(
         let QueuedLocalBrokerCommand {
             command,
             enqueued_at: _,
+            deadline_at: _,
+            timeout_budget: _,
+            _count_permit,
             _byte_permit,
         } = queued;
         if tokio::time::timeout(
@@ -1044,13 +1142,20 @@ async fn handle_local_broker_command(
             };
             let _ = reply.send(result);
         }
-        LocalBrokerCommand::ProcessRemoting { request, reply } => {
+        LocalBrokerCommand::ProcessRemoting {
+            request,
+            timeout,
+            reply,
+        } => {
             let result = if let Some(message) = startup_error {
                 Err(ProxyError::Transport {
                     message: message.to_owned(),
                 })
             } else {
-                facade.process_request(request).await.map_err(Into::into)
+                facade
+                    .process_request_with_timeout(request, timeout)
+                    .await
+                    .map_err(Into::into)
             };
             let _ = reply.send(result);
         }
@@ -1226,10 +1331,14 @@ async fn end_transaction(
 async fn receive_message_via_broker(
     client: &LocalBrokerFacadeClient,
     request: &ReceiveMessageRequest,
+    caller_deadline: Option<Duration>,
 ) -> ProxyResult<ReceiveMessagePlan> {
     let header = build_pop_request_header(client.broker_name(), request);
     let response = client
-        .process_remoting(RemotingCommand::create_request_command(RequestCode::PopMessage, header))
+        .process_remoting_with_timeout(
+            RemotingCommand::create_request_command(RequestCode::PopMessage, header),
+            local_long_poll_timeout(request.long_polling_timeout, caller_deadline),
+        )
         .await?;
     process_pop_response(
         response,
@@ -1242,15 +1351,21 @@ async fn receive_message_via_broker(
 async fn pull_message_via_broker(
     client: &LocalBrokerFacadeClient,
     request: &PullMessageRequest,
+    caller_deadline: Option<Duration>,
 ) -> ProxyResult<PullMessagePlan> {
     let header = build_pull_request_header(client.broker_name(), request);
     let response = client
-        .process_remoting(RemotingCommand::create_request_command(
-            RequestCode::PullMessage,
-            header,
-        ))
+        .process_remoting_with_timeout(
+            RemotingCommand::create_request_command(RequestCode::PullMessage, header),
+            local_long_poll_timeout(request.long_polling_timeout, caller_deadline),
+        )
         .await?;
     process_pull_response(response)
+}
+
+fn local_long_poll_timeout(long_polling_timeout: Duration, caller_deadline: Option<Duration>) -> Duration {
+    let broker_timeout = long_polling_timeout.saturating_add(LOCAL_LONG_POLL_TIMEOUT_MARGIN);
+    caller_deadline.map_or(broker_timeout, |deadline| deadline.min(broker_timeout))
 }
 
 async fn ack_message_via_broker(
@@ -2207,8 +2322,10 @@ mod tests {
     use super::build_pull_request_header;
     use super::build_send_message_request;
     use super::convert_topic_message_type;
+    use super::local_long_poll_timeout;
     use super::parse_receipt_handle;
     use super::transaction_resolution_flag;
+    use super::validate_local_queue_config;
     use super::LocalBrokerFacadeClient;
     use crate::LocalConfig;
 
@@ -2354,6 +2471,52 @@ mod tests {
         );
     }
 
+    #[test]
+    fn local_long_poll_timeout_adds_margin_without_extending_the_caller_deadline() {
+        assert_eq!(
+            local_long_poll_timeout(Duration::from_secs(15), None),
+            Duration::from_millis(15_500)
+        );
+        assert_eq!(
+            local_long_poll_timeout(Duration::from_secs(15), Some(Duration::from_secs(10))),
+            Duration::from_secs(10)
+        );
+        assert_eq!(
+            local_long_poll_timeout(Duration::from_secs(15), Some(Duration::from_secs(20))),
+            Duration::from_millis(15_500)
+        );
+    }
+
+    #[test]
+    fn local_execution_config_rejects_invalid_concurrency_limits() {
+        let cases = [
+            LocalConfig {
+                control_reserve: 0,
+                ..LocalConfig::default()
+            },
+            LocalConfig {
+                io_max_inflight: 2,
+                control_reserve: 2,
+                ..LocalConfig::default()
+            },
+            LocalConfig {
+                long_poll_max_inflight: 0,
+                ..LocalConfig::default()
+            },
+            LocalConfig {
+                execution_lane_idle_timeout_millis: 0,
+                ..LocalConfig::default()
+            },
+        ];
+
+        for config in cases {
+            assert!(matches!(
+                validate_local_queue_config(&config),
+                Err(ProxyError::Transport { .. })
+            ));
+        }
+    }
+
     #[tokio::test]
     async fn local_command_queue_is_bounded_by_count_and_bytes() {
         let runtime =
@@ -2391,6 +2554,7 @@ mod tests {
         let (sender, _receiver) = tokio::sync::mpsc::channel(1);
         let client = LocalBrokerFacadeClient {
             sender,
+            count_budget: Arc::new(tokio::sync::Semaphore::new(1)),
             byte_budget: Arc::new(tokio::sync::Semaphore::new(4_096)),
             broker_name: "broker-a".to_owned(),
         };
@@ -2422,6 +2586,10 @@ mod tests {
         let permit = byte_budget
             .try_acquire_owned()
             .expect("test byte permit should be available");
+        let count_budget = Arc::new(tokio::sync::Semaphore::new(1));
+        let count_permit = count_budget
+            .try_acquire_owned()
+            .expect("test count permit should be available");
         let enqueued_at = Instant::now();
         let queued = super::QueuedLocalBrokerCommand {
             command: super::LocalBrokerCommand::QueryRoute {
@@ -2429,6 +2597,9 @@ mod tests {
                 reply,
             },
             enqueued_at,
+            deadline_at: None,
+            timeout_budget: None,
+            _count_permit: count_permit,
             _byte_permit: permit,
         };
 
@@ -2488,7 +2659,7 @@ mod tests {
         let deadline = ShutdownDeadline::after(Duration::from_secs(5));
         let report = service.task_group().shutdown_until(deadline).await;
         assert!(report.is_healthy(), "{}", report.to_json());
-        assert!(report.to_json().contains("embedded-broker-store"));
+        assert!(report.to_json().contains("command-lanes"), "{}", report.to_json());
         assert_eq!(service.task_group().task_count(), 0);
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9231

### Brief Description

- Freeze gRPC timeouts as absolute request deadlines and propagate the remaining budget through local-proxy queueing.
- Add an explicit-timeout embedded Broker facade API while preserving the existing three-second compatibility wrapper.
- Replace the single local-proxy execution actor with lifecycle-owned, globally bounded per-key FIFO lanes.
- Isolate long polls from short-data and control concurrency so ACK and offset traffic can progress while polls are parked.
- Retain request count and byte permits through execution, and cancel and await all lanes during shutdown.

### How Did You Test This Change?

- `cargo test -p rocketmq-proxy-local` (15 passed)
- `cargo test -p rocketmq-proxy-core context --lib` (8 passed)
- `cargo test -p rocketmq-proxy-cluster` (31 passed)
- `cargo test -p rocketmq-broker proxy_facade --lib` (2 passed)
- `cargo clippy -p rocketmq-proxy-core -p rocketmq-proxy-local -p rocketmq-broker --no-deps --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check` (WSL)
- `cargo check --manifest-path fuzz/Cargo.toml --all-targets`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `.\scripts\check-error-hygiene.ps1` reached the unrelated pre-existing Dashboard `AppConfig` redacted-Debug finding after all preceding guards passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for caller-defined request timeouts.
  * Added configurable local processing limits for I/O, control messages, long polling, and execution-lane idle timeouts.
  * Added improved request deadline tracking across broker and proxy operations.

* **Performance & Reliability**
  * Improved concurrency management and fairness across command types.
  * Preserved FIFO ordering for related requests.
  * Added protection against expired or overloaded queues, with clearer timeout and availability errors.
  * Improved shutdown handling and long-poll responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->