### PR TITLE
[ISSUE #9235]✨Wake HA replication from append progress

### DIFF
--- a/rocketmq-store/src/ha.rs
+++ b/rocketmq-store/src/ha.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod ack_frontier;
 pub(crate) mod auto_switch;
 pub(crate) mod default_ha_client;
 mod default_ha_connection;

--- a/rocketmq-store/src/ha/ack_frontier.rs
+++ b/rocketmq-store/src/ha/ack_frontier.rs
@@ -1,0 +1,265 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+use std::collections::HashSet;
+
+use rocketmq_store_api::decide_replication;
+use rocketmq_store_api::AckPolicy;
+use rocketmq_store_api::HaRejectReason;
+use rocketmq_store_api::ReplicaAck;
+use rocketmq_store_api::ReplicationDecision;
+use rocketmq_store_api::ReplicationObservation;
+use rocketmq_store_api::SyncStateSet;
+use rocketmq_store_api::WriteAuthority;
+
+use crate::ha::ha_service::HAAckedReplicaSnapshot;
+
+/// One immutable view of authority, membership, and durable progress used to resolve a batch of
+/// group-transfer requests.
+pub(crate) enum AckFrontier {
+    Ready {
+        authority: WriteAuthority,
+        local_durable_watermark: i64,
+        replica_acks: Vec<ReplicaAck>,
+        replica_frontiers: BTreeMap<i64, i64>,
+        sync_state_set: SyncStateSet,
+        members: HashSet<i64>,
+    },
+    Rejected(HaRejectReason),
+}
+
+impl AckFrontier {
+    pub(crate) fn from_snapshots(
+        authority: Option<WriteAuthority>,
+        configured_sync_state_set: Option<HashSet<i64>>,
+        local_durable_watermark: i64,
+        snapshots: &[HAAckedReplicaSnapshot],
+        require_controller_ids: bool,
+    ) -> Self {
+        let Some(authority) = authority else {
+            return Self::Rejected(HaRejectReason::AuthorityMismatch);
+        };
+        let mut members = configured_sync_state_set.unwrap_or_else(|| HashSet::from([authority.broker_id()]));
+        let mut replica_frontiers = BTreeMap::<i64, i64>::new();
+        for (index, snapshot) in snapshots.iter().enumerate() {
+            let broker_id = match snapshot.slave_broker_id {
+                Some(broker_id) => broker_id,
+                None if !require_controller_ids => {
+                    match i64::try_from(index).ok().and_then(|value| value.checked_add(1)) {
+                        Some(broker_id) => broker_id,
+                        None => continue,
+                    }
+                }
+                None => continue,
+            };
+            let Ok(replica_ack) = ReplicaAck::try_new(broker_id, snapshot.slave_ack_offset) else {
+                continue;
+            };
+            members.insert(broker_id);
+            replica_frontiers
+                .entry(broker_id)
+                .and_modify(|offset| *offset = (*offset).max(replica_ack.durable_offset()))
+                .or_insert(replica_ack.durable_offset());
+        }
+        if !members.contains(&authority.broker_id()) {
+            return Self::Rejected(HaRejectReason::AuthorityMismatch);
+        }
+        let Ok(sync_state_set) = SyncStateSet::try_new(members.iter().copied()) else {
+            return Self::Rejected(HaRejectReason::AuthorityMismatch);
+        };
+        let replica_acks = replica_frontiers
+            .iter()
+            .filter_map(|(broker_id, offset)| ReplicaAck::try_new(*broker_id, *offset).ok())
+            .collect();
+
+        Self::Ready {
+            authority,
+            local_durable_watermark: local_durable_watermark.max(0),
+            replica_acks,
+            replica_frontiers,
+            sync_state_set,
+            members,
+        }
+    }
+
+    pub(crate) fn decide(
+        &self,
+        requested_authority: Option<WriteAuthority>,
+        policy: AckPolicy,
+        required_offset: i64,
+    ) -> ReplicationDecision {
+        let (authority, local_durable_watermark, replica_acks, sync_state_set) = match self {
+            Self::Ready {
+                authority,
+                local_durable_watermark,
+                replica_acks,
+                sync_state_set,
+                ..
+            } => (authority, local_durable_watermark, replica_acks, sync_state_set),
+            Self::Rejected(reason) => return ReplicationDecision::Reject(*reason),
+        };
+        let requested_authority = requested_authority.unwrap_or(*authority);
+        if requested_authority.master_epoch() < authority.master_epoch() {
+            return ReplicationDecision::Reject(HaRejectReason::StaleAuthority);
+        }
+        if requested_authority != *authority || required_offset < 0 {
+            return ReplicationDecision::Reject(HaRejectReason::AuthorityMismatch);
+        }
+        if required_offset > self.policy_frontier(policy) {
+            return ReplicationDecision::Wait { required_offset };
+        }
+
+        let observation = ReplicationObservation::try_new(
+            *authority,
+            requested_authority,
+            policy,
+            required_offset,
+            *local_durable_watermark,
+            replica_acks.clone(),
+            sync_state_set.clone(),
+        );
+        match observation {
+            Ok(observation) => decide_replication(&observation),
+            Err(_) => ReplicationDecision::Reject(HaRejectReason::AuthorityMismatch),
+        }
+    }
+
+    fn policy_frontier(&self, policy: AckPolicy) -> i64 {
+        let Self::Ready {
+            authority,
+            local_durable_watermark,
+            replica_frontiers,
+            members,
+            ..
+        } = self
+        else {
+            return -1;
+        };
+        let remote_frontier = match policy {
+            AckPolicy::LocalDurable => *local_durable_watermark,
+            AckPolicy::ReplicaCount(required) => {
+                let remote_required = required.get().saturating_sub(1);
+                let mut offsets = members
+                    .iter()
+                    .filter(|broker_id| **broker_id != authority.broker_id())
+                    .filter_map(|broker_id| replica_frontiers.get(broker_id).copied())
+                    .collect::<Vec<_>>();
+                if offsets.len() < remote_required {
+                    -1
+                } else {
+                    offsets.sort_unstable_by(|left, right| right.cmp(left));
+                    offsets[remote_required - 1]
+                }
+            }
+            AckPolicy::AllInSyncSet => members
+                .iter()
+                .filter(|broker_id| **broker_id != authority.broker_id())
+                .map(|broker_id| replica_frontiers.get(broker_id).copied().unwrap_or(-1))
+                .min()
+                .unwrap_or(*local_durable_watermark),
+        };
+        (*local_durable_watermark).min(remote_frontier)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use rocketmq_store_api::MasterEpoch;
+    use rocketmq_store_api::ReplicaCount;
+
+    use super::*;
+
+    fn authority(epoch: i32) -> WriteAuthority {
+        WriteAuthority::try_new(0, MasterEpoch::try_from(epoch).expect("positive epoch")).expect("valid authority")
+    }
+
+    #[test]
+    fn replica_count_frontier_uses_the_required_highest_unique_replica() {
+        let frontier = AckFrontier::from_snapshots(
+            Some(authority(3)),
+            Some(HashSet::from([0, 1, 2])),
+            200,
+            &[
+                HAAckedReplicaSnapshot {
+                    slave_broker_id: Some(1),
+                    slave_ack_offset: 180,
+                },
+                HAAckedReplicaSnapshot {
+                    slave_broker_id: Some(2),
+                    slave_ack_offset: 120,
+                },
+            ],
+            true,
+        );
+
+        assert!(matches!(
+            frontier.decide(
+                Some(authority(3)),
+                AckPolicy::ReplicaCount(ReplicaCount::try_new(2).expect("two replicas")),
+                180,
+            ),
+            ReplicationDecision::Acknowledge(_)
+        ));
+        assert!(matches!(
+            frontier.decide(
+                Some(authority(3)),
+                AckPolicy::ReplicaCount(ReplicaCount::try_new(3).expect("three replicas")),
+                180,
+            ),
+            ReplicationDecision::Wait { .. }
+        ));
+    }
+
+    #[test]
+    fn all_in_sync_frontier_waits_for_the_slowest_member() {
+        let frontier = AckFrontier::from_snapshots(
+            Some(authority(3)),
+            Some(HashSet::from([0, 1, 2])),
+            200,
+            &[
+                HAAckedReplicaSnapshot {
+                    slave_broker_id: Some(1),
+                    slave_ack_offset: 180,
+                },
+                HAAckedReplicaSnapshot {
+                    slave_broker_id: Some(2),
+                    slave_ack_offset: 120,
+                },
+            ],
+            true,
+        );
+
+        assert!(matches!(
+            frontier.decide(Some(authority(3)), AckPolicy::AllInSyncSet, 120),
+            ReplicationDecision::Acknowledge(_)
+        ));
+        assert!(matches!(
+            frontier.decide(Some(authority(3)), AckPolicy::AllInSyncSet, 121),
+            ReplicationDecision::Wait { .. }
+        ));
+    }
+
+    #[test]
+    fn authority_change_rejects_a_request_from_the_previous_epoch() {
+        let frontier = AckFrontier::from_snapshots(Some(authority(4)), None, 200, &[], false);
+
+        assert_eq!(
+            frontier.decide(Some(authority(3)), AckPolicy::LocalDurable, 100),
+            ReplicationDecision::Reject(HaRejectReason::StaleAuthority)
+        );
+    }
+}

--- a/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
+++ b/rocketmq-store/src/ha/auto_switch/auto_switch_ha_service.rs
@@ -102,6 +102,7 @@ impl AutoSwitchHAService {
         self.replication.set_local_broker_id(local_broker_id);
         self.delegate
             .set_ha_client_reported_broker_id((local_broker_id >= 0).then_some(local_broker_id));
+        self.delegate.notify_transfer_progress();
     }
 
     pub fn local_broker_id(&self) -> i64 {
@@ -124,6 +125,7 @@ impl AutoSwitchHAService {
         let current_confirm_offset = replica_store.get_confirm_offset_directly();
         let confirm_offset = self.compute_confirm_offset(current_confirm_offset, max_phy_offset);
         replica_store.publish_confirm_offset(confirm_offset);
+        self.delegate.notify_transfer_progress();
     }
 
     pub fn is_synchronizing_sync_state_set(&self) -> bool {
@@ -276,6 +278,7 @@ impl HAService for AutoSwitchHAService {
         self.replication.ensure_local_member();
         self.clear_master_target().await;
         self.refresh_confirm_offset_after_role_change();
+        self.delegate.notify_transfer_progress();
         Ok(true)
     }
 
@@ -301,6 +304,7 @@ impl HAService for AutoSwitchHAService {
         self.delegate.set_ha_client_reported_broker_id(slave_id);
         self.update_master_target(new_master_addr).await;
         self.refresh_confirm_offset_after_role_change();
+        self.delegate.notify_transfer_progress();
         Ok(true)
     }
 
@@ -332,6 +336,10 @@ impl HAService for AutoSwitchHAService {
 
     async fn put_request(&self, request: GroupCommitRequest) {
         self.delegate.put_request(request).await;
+    }
+
+    fn notify_transfer_progress(&self) {
+        self.delegate.notify_transfer_progress();
     }
 
     async fn put_group_connection_state_request(&self, request: HAConnectionStateNotificationRequest) {

--- a/rocketmq-store/src/ha/default_ha_connection.rs
+++ b/rocketmq-store/src/ha/default_ha_connection.rs
@@ -31,7 +31,6 @@ use tokio::net::TcpStream;
 use tokio::select;
 use tokio::sync::Mutex;
 use tokio::sync::RwLock;
-use tokio::time::sleep;
 use tokio::time::timeout;
 use tokio_util::codec::FramedRead;
 use tracing::error;
@@ -467,9 +466,13 @@ impl ReadSocketService {
                     self.last_read_timestamp.store(current_millis(), Ordering::Relaxed);
                     self.slave_ack_offset.store(offset, Ordering::Relaxed);
 
-                    if self.slave_request_offset.load(Ordering::Acquire) < 0 {
-                        self.slave_request_offset.store(offset, Ordering::Release);
+                    if self
+                        .slave_request_offset
+                        .compare_exchange(-1, offset, Ordering::AcqRel, Ordering::Acquire)
+                        .is_ok()
+                    {
                         info!("slave[{}] request offset {}", self.client_address, offset);
+                        self.connection_context.notify_append_progress();
                     }
                     if let Some(broker_id) = broker_id.filter(|broker_id| *broker_id >= 0) {
                         self.connection_runtime.set_slave_broker_id(broker_id);
@@ -548,9 +551,13 @@ impl ReadSocketService {
                 ]);
                 self.process_position = pos;
                 self.slave_ack_offset.store(read_offset, Ordering::Relaxed);
-                if self.slave_request_offset.load(Ordering::Acquire) < 0 {
-                    self.slave_request_offset.store(read_offset, Ordering::Release);
+                if self
+                    .slave_request_offset
+                    .compare_exchange(-1, read_offset, Ordering::AcqRel, Ordering::Acquire)
+                    .is_ok()
+                {
                     info!("slave[{}] request offset {}", self.client_address, read_offset);
+                    self.connection_context.notify_append_progress();
                 }
 
                 self.connection_context.notify_transfer_some(read_offset).await;
@@ -599,6 +606,15 @@ pub struct WriteSocketService {
     last_write_timestamp: AtomicU64,
     last_print_timestamp: AtomicU64,
     last_write_over: AtomicBool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TransferStep {
+    Progress,
+    CaughtUp,
+    WaitingForReplica,
+    FlowControlled,
+    Retry,
 }
 
 impl WriteSocketService {
@@ -664,37 +680,21 @@ impl WriteSocketService {
         info!("{} service started", self.get_service_name());
 
         loop {
-            let select_result = timeout(SELECT_TIMEOUT, async {
-                tokio::select! {
-                    _ = shutdown_rx.recv() => {
-                        info!("Received shutdown signal");
-                         false
-                    }
-                    _ = tokio::task::yield_now() => {
-                         true
-                    }
-                }
-            })
-            .await;
-
-            match select_result {
-                Ok(false) => {
+            let step = match self.process_transfer().await {
+                Ok(step) => step,
+                Err(error) => {
+                    error!("Transfer error: {}", error);
                     break;
                 }
-                Ok(true) => {
-                    if let Err(e) = self.process_transfer().await {
-                        error!("Transfer error: {}", e);
-                        break;
-                    }
-                }
-                Err(_) => {
-                    if let Err(e) = self.process_transfer().await {
-                        error!("Transfer error: {}", e);
-                        break;
-                    }
-                }
-            }
+            };
             if self.is_stopped().await {
+                break;
+            }
+            if step == TransferStep::Progress {
+                continue;
+            }
+            if !self.wait_for_transfer_event(step, &mut shutdown_rx).await {
+                info!("Received shutdown signal");
                 break;
             }
         }
@@ -703,11 +703,10 @@ impl WriteSocketService {
         info!("{} service end", self.get_service_name());
     }
 
-    async fn process_transfer(&mut self) -> HAConnectionResult<()> {
+    async fn process_transfer(&mut self) -> HAConnectionResult<TransferStep> {
         let slave_request_offset = self.slave_request_offset.load(Ordering::Relaxed);
         if slave_request_offset == -1 {
-            sleep(Duration::from_millis(10)).await;
-            return Ok(());
+            return Ok(TransferStep::WaitingForReplica);
         }
 
         if self.next_transfer_from_where.load(Ordering::Relaxed) == -1 {
@@ -738,14 +737,14 @@ impl WriteSocketService {
 
             let heartbeat_interval = self.message_store_config.ha_send_heartbeat_interval;
 
-            if interval > heartbeat_interval {
+            if interval >= heartbeat_interval {
                 match self.send_heartbeat().await {
                     Ok(_) => {
                         self.last_write_over.store(true, Ordering::Relaxed);
                     }
                     Err(_) => {
                         self.last_write_over.store(false, Ordering::Relaxed);
-                        return Ok(());
+                        return Ok(TransferStep::Retry);
                     }
                 }
             }
@@ -756,7 +755,7 @@ impl WriteSocketService {
                 }
                 Err(_) => {
                     self.last_write_over.store(false, Ordering::Relaxed);
-                    return Ok(());
+                    return Ok(TransferStep::Retry);
                 }
             }
         }
@@ -766,12 +765,12 @@ impl WriteSocketService {
         if next_offset >= max_commit_log_offset {
             self.connection_context
                 .handle_runtime_connection_caught_up(&self.connection_runtime);
-            return Ok(());
+            return Ok(TransferStep::CaughtUp);
         }
 
         let configured_max_batch_size =
             effective_ha_transfer_batch_size(self.message_store_config.ha_transfer_batch_size);
-        let can_transfer_max_bytes = self.flow_monitor.can_transfer_max_byte_num() as usize;
+        let can_transfer_max_bytes = self.flow_monitor.can_transfer_max_byte_num().max(0) as usize;
         self.maybe_log_flow_control(
             next_offset,
             max_commit_log_offset,
@@ -801,9 +800,65 @@ impl WriteSocketService {
             self.next_transfer_from_where
                 .store(batch.next_offset, Ordering::Relaxed);
             self.send_data(batch).await?;
+            return Ok(TransferStep::Progress);
         }
 
-        Ok(())
+        Ok(TransferStep::FlowControlled)
+    }
+
+    async fn wait_for_transfer_event(
+        &self,
+        step: TransferStep,
+        shutdown_rx: &mut tokio::sync::broadcast::Receiver<()>,
+    ) -> bool {
+        let wait_duration = match step {
+            TransferStep::WaitingForReplica => Duration::from_secs(3600),
+            TransferStep::CaughtUp => self.heartbeat_wait_duration(),
+            TransferStep::FlowControlled => self.heartbeat_wait_duration().min(SELECT_TIMEOUT),
+            TransferStep::Retry => SELECT_TIMEOUT,
+            TransferStep::Progress => Duration::ZERO,
+        };
+        if wait_duration.is_zero() {
+            return true;
+        }
+
+        if matches!(step, TransferStep::WaitingForReplica | TransferStep::CaughtUp) {
+            let notifier = self.connection_context.append_notifier();
+            let notified = notifier.notified();
+            tokio::pin!(notified);
+            let _ = notified.as_mut().enable();
+            if self.transfer_became_ready(step) {
+                return true;
+            }
+            return timeout(wait_duration, async {
+                tokio::select! {
+                    _ = shutdown_rx.recv() => false,
+                    _ = &mut notified => true,
+                }
+            })
+            .await
+            .unwrap_or(true);
+        }
+
+        timeout(wait_duration, shutdown_rx.recv()).await.is_err()
+    }
+
+    fn transfer_became_ready(&self, step: TransferStep) -> bool {
+        transfer_became_ready(
+            step,
+            self.slave_request_offset.load(Ordering::Acquire),
+            self.next_transfer_from_where.load(Ordering::Acquire),
+            self.connection_context.replica_store().get_max_phy_offset(),
+        )
+    }
+
+    fn heartbeat_wait_duration(&self) -> Duration {
+        let elapsed = current_millis().saturating_sub(self.last_write_timestamp.load(Ordering::Relaxed));
+        Duration::from_millis(
+            self.message_store_config
+                .ha_send_heartbeat_interval
+                .saturating_sub(elapsed),
+        )
     }
 
     fn maybe_log_flow_control(
@@ -899,6 +954,19 @@ impl WriteSocketService {
     }
 }
 
+fn transfer_became_ready(
+    step: TransferStep,
+    slave_request_offset: i64,
+    next_transfer_offset: i64,
+    max_commit_log_offset: i64,
+) -> bool {
+    match step {
+        TransferStep::WaitingForReplica => slave_request_offset >= 0,
+        TransferStep::CaughtUp => next_transfer_offset < max_commit_log_offset,
+        TransferStep::Progress | TransferStep::FlowControlled | TransferStep::Retry => true,
+    }
+}
+
 fn transfer_engine_preference(message_store_config: &MessageStoreConfig) -> TransferEnginePreference {
     match message_store_config.effective_linux_transfer_engine() {
         LinuxTransferEngine::Auto => TransferEnginePreference::Auto,
@@ -988,6 +1056,13 @@ mod tests {
     #[test]
     fn non_zero_configured_ha_transfer_batch_size_is_preserved() {
         assert_eq!(effective_ha_transfer_batch_size(64 * 1024), 64 * 1024);
+    }
+
+    #[test]
+    fn post_registration_offset_recheck_prevents_lost_append_wakeup() {
+        assert!(transfer_became_ready(TransferStep::CaughtUp, 0, 128, 129));
+        assert!(transfer_became_ready(TransferStep::WaitingForReplica, 128, -1, 0));
+        assert!(!transfer_became_ready(TransferStep::CaughtUp, 0, 128, 128));
     }
 
     #[test]

--- a/rocketmq-store/src/ha/default_ha_service.rs
+++ b/rocketmq-store/src/ha/default_ha_service.rs
@@ -154,6 +154,14 @@ impl DefaultHAConnectionContext {
         self.inner.ha_transfer_metrics.clone()
     }
 
+    pub(crate) fn append_notifier(&self) -> Arc<Notify> {
+        Arc::clone(&self.inner.wait_notify_object)
+    }
+
+    pub(crate) fn notify_append_progress(&self) {
+        self.inner.wait_notify_object.notify_waiters();
+    }
+
     pub(crate) async fn notify_transfer_some(&self, offset: i64) {
         self.inner.replication_progress.record_ack(offset);
         if let Some(service) = self.inner.group_transfer_service.get().and_then(Weak::upgrade) {
@@ -175,10 +183,16 @@ impl DefaultHAConnectionContext {
         if let Some(replication) = self.inner.auto_switch_replication.get() {
             self.handle_auto_switch_connection_added(replication, slave_broker_id, slave_ack_offset);
         }
+        if let Some(service) = self.inner.group_transfer_service.get().and_then(Weak::upgrade) {
+            service.notify_transfer_progress();
+        }
     }
 
     pub(crate) async fn remove_runtime_connection(&self, connection: &HAConnectionRuntimeHandle) {
         self.handle_runtime_connection_removed(connection);
+        if let Some(service) = self.inner.group_transfer_service.get().and_then(Weak::upgrade) {
+            service.notify_transfer_progress();
+        }
 
         if let Some(service) = self.inner.state_notification_service.get().and_then(Weak::upgrade) {
             let connection_state = connection.current_state().await;
@@ -687,6 +701,12 @@ impl HAService for DefaultHAService {
         }
     }
 
+    fn notify_transfer_progress(&self) {
+        if let Some(group_transfer_service) = &self.group_transfer_service {
+            group_transfer_service.notify_transfer_progress();
+        }
+    }
+
     async fn put_group_connection_state_request(&self, request: HAConnectionStateNotificationRequest) {
         if let Some(ref ha_connection_state_notification_service) = self.ha_connection_state_notification_service {
             ha_connection_state_notification_service.set_request(request).await;
@@ -1003,6 +1023,24 @@ mod tests {
         );
 
         assert_eq!(service.ha_transfer_metrics().snapshot().fallback_total, 1);
+        let _ = std::fs::remove_dir_all(temp_root);
+    }
+
+    #[tokio::test]
+    async fn append_progress_wakes_registered_connection_writer() {
+        let temp_root = std::env::temp_dir().join(format!("rocketmq-rust-default-ha-append-wake-{}", current_millis()));
+        let store = new_test_message_store(&temp_root, false);
+        let service = new_default_ha_service(&store);
+        let notifier = service.connection_context.append_notifier();
+        let notified = notifier.notified();
+        tokio::pin!(notified);
+        let _ = notified.as_mut().enable();
+
+        service.connection_context.notify_append_progress();
+
+        tokio::time::timeout(Duration::from_millis(100), &mut notified)
+            .await
+            .expect("append notification");
         let _ = std::fs::remove_dir_all(temp_root);
     }
 

--- a/rocketmq-store/src/ha/general_ha_service.rs
+++ b/rocketmq-store/src/ha/general_ha_service.rs
@@ -280,6 +280,13 @@ impl HAService for GeneralHAService {
         }
     }
 
+    fn notify_transfer_progress(&self) {
+        match self {
+            GeneralHAService::DefaultHAService(service) => service.notify_transfer_progress(),
+            GeneralHAService::AutoSwitchHAService(service) => service.notify_transfer_progress(),
+        }
+    }
+
     async fn put_group_connection_state_request(&self, request: HAConnectionStateNotificationRequest) {
         match self {
             GeneralHAService::DefaultHAService(service) => service.put_group_connection_state_request(request).await,

--- a/rocketmq-store/src/ha/group_transfer_service.rs
+++ b/rocketmq-store/src/ha/group_transfer_service.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::Duration;
@@ -28,27 +27,23 @@ use rocketmq_runtime::FullPolicy;
 use rocketmq_runtime::ProcessMemoryLimit;
 use rocketmq_runtime::RateLimit;
 use rocketmq_runtime::ResourceBudgetTree;
-use rocketmq_store_api::decide_replication;
+use rocketmq_runtime::ResourcePermit;
 use rocketmq_store_api::AckPolicy;
-use rocketmq_store_api::HaRejectReason;
-use rocketmq_store_api::ReplicaAck;
 use rocketmq_store_api::ReplicationDecision;
-use rocketmq_store_api::ReplicationObservation;
-use rocketmq_store_api::SyncStateSet;
-use tokio::sync::Notify;
-use tokio::time::timeout;
 use tracing::error;
 use tracing::warn;
 
 use crate::base::message_status_enum::PutMessageStatus;
-use crate::ha::general_ha_service::GeneralHAService;
+use crate::ha::ack_frontier::AckFrontier;
 use crate::ha::general_ha_service::GeneralHAServiceReference;
-use crate::ha::ha_service::HAAckedReplicaSnapshot;
 use crate::ha::ha_service::HAService;
 use crate::log_file::group_commit_request::GroupCommitRequest;
 use crate::store_error::HAError;
 use crate::store_error::HAResult;
 pub(crate) use rocketmq_store_local::ha::replication::GroupTransferRuntimeInfo;
+
+const PROGRESS_SAFETY_RECHECK_INTERVAL: Duration = Duration::from_millis(100);
+const IDLE_WAIT_INTERVAL: Duration = Duration::from_secs(3600);
 
 pub struct GroupTransferService {
     inner: Arc<GroupTransferServiceInner>,
@@ -93,20 +88,11 @@ impl GroupTransferService {
 
     pub fn notify_transfer_some(&self) {
         self.inner.record_ack_notify();
-        if self
-            .inner
-            .notified
-            .1
-            .compare_exchange(
-                false,
-                true,
-                std::sync::atomic::Ordering::SeqCst,
-                std::sync::atomic::Ordering::SeqCst,
-            )
-            .is_ok()
-        {
-            self.inner.notified.0.notify_one();
-        }
+        self.service_manager.wakeup();
+    }
+
+    pub fn notify_transfer_progress(&self) {
+        self.service_manager.wakeup();
     }
 
     pub(crate) fn runtime_info(&self) -> GroupTransferRuntimeInfo {
@@ -116,7 +102,6 @@ impl GroupTransferService {
 
 struct GroupTransferServiceInner {
     ha_service: GeneralHAServiceReference,
-    notified: (Arc<Notify>, AtomicBool),
     ack_notify_count: AtomicU64,
     pending_requests: BudgetedQueue<PendingGroupTransfer>,
 }
@@ -144,7 +129,6 @@ impl GroupTransferServiceInner {
             .map_err(|error| HAError::operation("build HA group-transfer budget", error))?;
         Ok(GroupTransferServiceInner {
             ha_service,
-            notified: (Arc::new(Notify::new()), AtomicBool::new(false)),
             ack_notify_count: AtomicU64::new(0),
             pending_requests: BudgetedQueue::new(queue_budget),
         })
@@ -179,115 +163,124 @@ impl GroupTransferServiceInner {
         }
     }
 
-    async fn load_acked_replicas(ha_service: &GeneralHAService) -> Vec<HAAckedReplicaSnapshot> {
-        ha_service.snapshot_acked_replicas().await
-    }
-
-    fn decide_transfer(
-        ha_service: &GeneralHAService,
-        policy: AckPolicy,
-        next_offset: i64,
-        snapshots: &[HAAckedReplicaSnapshot],
-    ) -> ReplicationDecision {
-        let Some(authority) = ha_service.write_authority() else {
-            return ReplicationDecision::Reject(HaRejectReason::AuthorityMismatch);
-        };
-        let mut members = ha_service
-            .sync_state_set()
-            .unwrap_or_else(|| std::collections::HashSet::from([authority.broker_id()]));
-        let require_controller_ids = ha_service.is_auto_switch_enabled();
-        let replica_acks = snapshots
-            .iter()
-            .enumerate()
-            .filter_map(|(index, snapshot)| {
-                let broker_id = match snapshot.slave_broker_id {
-                    Some(broker_id) => broker_id,
-                    None if !require_controller_ids => i64::try_from(index).ok()?.checked_add(1)?,
-                    None => return None,
-                };
-                members.insert(broker_id);
-                ReplicaAck::try_new(broker_id, snapshot.slave_ack_offset).ok()
-            })
-            .collect::<Vec<_>>();
-        let Ok(sync_state_set) = SyncStateSet::try_new(members) else {
-            return ReplicationDecision::Reject(HaRejectReason::AuthorityMismatch);
-        };
-        let Ok(observation) = ReplicationObservation::try_new(
-            authority,
-            authority,
-            policy,
-            next_offset,
-            ha_service.local_durable_watermark().max(0),
-            replica_acks,
-            sync_state_set,
-        ) else {
-            return ReplicationDecision::Reject(HaRejectReason::AuthorityMismatch);
-        };
-        decide_replication(&observation)
-    }
-
-    async fn do_wait_transfer(&self) {
-        let ha_service = self.ha_service.upgrade();
-
-        while let Some(pending) = self.pending_requests.try_pop_budgeted() {
-            let (mut pending, _permit, _) = pending.into_parts();
-            let request = pending.request_mut();
-            let mut transfer_ok = false;
-            let deadline = request.get_deadline();
-            let policy = match AckPolicy::try_from_legacy(request.get_ack_nums(), mix_all::ALL_ACK_IN_SYNC_STATE_SET) {
+    fn drain_new_requests(&self, active: &mut Vec<ActiveGroupTransfer>) {
+        while let Some(budgeted) = self.pending_requests.try_pop_budgeted() {
+            let (mut pending, permit, _) = budgeted.into_parts();
+            let policy = match AckPolicy::try_from_legacy(
+                pending.request_mut().get_ack_nums(),
+                mix_all::ALL_ACK_IN_SYNC_STATE_SET,
+            ) {
                 Ok(policy) => policy,
                 Err(error) => {
                     warn!(error = %error, "HA group-transfer request has an invalid ACK policy");
-                    request.wakeup_customer(PutMessageStatus::FlushSlaveTimeout);
+                    pending
+                        .request_mut()
+                        .wakeup_customer(PutMessageStatus::FlushSlaveTimeout);
                     pending.complete();
                     continue;
                 }
             };
-            let mut index = 0;
-            while !transfer_ok && Instant::now() < deadline {
-                if index > 0
-                    && timeout(Duration::from_millis(1), self.notified.0.notified())
-                        .await
-                        .is_ok()
-                {
-                    let _ = self.notified.1.compare_exchange(
-                        true,
-                        false,
-                        std::sync::atomic::Ordering::SeqCst,
-                        std::sync::atomic::Ordering::SeqCst,
-                    );
-                }
-                index += 1;
-                let Some(ha_service) = ha_service.as_ref() else {
-                    break;
-                };
-                let acked_replicas = Self::load_acked_replicas(ha_service).await;
-                match Self::decide_transfer(ha_service, policy, request.get_next_offset(), &acked_replicas) {
-                    ReplicationDecision::Acknowledge(_) => transfer_ok = true,
-                    ReplicationDecision::Wait { .. } => {}
-                    ReplicationDecision::Reject(reason) => {
-                        warn!(
-                            ?reason,
-                            "HA group-transfer request was rejected by the canonical decision"
-                        );
-                        break;
-                    }
-                }
-            }
-            if !transfer_ok {
-                warn!(
-                    "transfer message to slave timeout, offset : {}, request acks: {}",
-                    request.get_next_offset(),
-                    request.get_ack_nums()
-                );
-            }
-            request.wakeup_customer(if transfer_ok {
-                PutMessageStatus::PutOk
-            } else {
-                PutMessageStatus::FlushSlaveTimeout
-            });
-            pending.complete();
+            active.push(ActiveGroupTransfer::admitted(pending, policy, permit));
         }
+    }
+
+    async fn evaluate_pending(&self, active: &mut Vec<ActiveGroupTransfer>) -> Option<Instant> {
+        self.drain_new_requests(active);
+        if active.is_empty() {
+            return None;
+        }
+
+        let frontier = match self.ha_service.upgrade() {
+            Some(ha_service) => {
+                let snapshots = ha_service.snapshot_acked_replicas().await;
+                AckFrontier::from_snapshots(
+                    ha_service.write_authority(),
+                    ha_service.sync_state_set(),
+                    ha_service.local_durable_watermark(),
+                    &snapshots,
+                    ha_service.is_auto_switch_enabled(),
+                )
+            }
+            None => AckFrontier::from_snapshots(None, None, 0, &[], false),
+        };
+        Self::resolve_pending(active, &frontier, Instant::now());
+        active.iter().map(ActiveGroupTransfer::deadline).min()
+    }
+
+    fn resolve_pending(active: &mut Vec<ActiveGroupTransfer>, frontier: &AckFrontier, now: Instant) {
+        active.retain_mut(|pending| {
+            if now >= pending.deadline() {
+                pending.complete(PutMessageStatus::FlushSlaveTimeout);
+                warn!(
+                    offset = pending.next_offset(),
+                    ack_nums = pending.ack_nums(),
+                    "transfer message to slave timed out"
+                );
+                return false;
+            }
+            match frontier.decide(pending.requested_authority(), pending.policy, pending.next_offset()) {
+                ReplicationDecision::Acknowledge(_) => {
+                    pending.complete(PutMessageStatus::PutOk);
+                    false
+                }
+                ReplicationDecision::Wait { .. } => true,
+                ReplicationDecision::Reject(reason) => {
+                    warn!(
+                        ?reason,
+                        offset = pending.next_offset(),
+                        "HA group-transfer request was rejected by the canonical decision"
+                    );
+                    pending.complete(PutMessageStatus::FlushSlaveTimeout);
+                    false
+                }
+            }
+        });
+    }
+}
+
+struct ActiveGroupTransfer {
+    pending: PendingGroupTransfer,
+    policy: AckPolicy,
+    _permit: Option<ResourcePermit>,
+}
+
+impl ActiveGroupTransfer {
+    fn admitted(pending: PendingGroupTransfer, policy: AckPolicy, permit: ResourcePermit) -> Self {
+        Self {
+            pending,
+            policy,
+            _permit: Some(permit),
+        }
+    }
+
+    #[cfg(test)]
+    fn unadmitted(pending: PendingGroupTransfer, policy: AckPolicy) -> Self {
+        Self {
+            pending,
+            policy,
+            _permit: None,
+        }
+    }
+
+    fn deadline(&self) -> Instant {
+        self.pending.request.get_deadline()
+    }
+
+    fn next_offset(&self) -> i64 {
+        self.pending.request.get_next_offset()
+    }
+
+    fn ack_nums(&self) -> i32 {
+        self.pending.request.get_ack_nums()
+    }
+
+    fn requested_authority(&self) -> Option<rocketmq_store_api::WriteAuthority> {
+        self.pending.request.requested_authority()
+    }
+
+    fn complete(&mut self, status: PutMessageStatus) {
+        self.pending.request_mut().wakeup_customer(status);
+        self.pending.complete();
     }
 }
 
@@ -327,11 +320,19 @@ impl ServiceTask for GroupTransferServiceInner {
     }
 
     async fn run(&self, context: &ServiceTaskContext) {
+        let mut active = Vec::new();
         while !context.is_stopped() {
-            context.wait_for_running(std::time::Duration::from_millis(10)).await;
-            self.on_wait_end().await;
-            self.do_wait_transfer().await;
+            let next_deadline = self.evaluate_pending(&mut active).await;
+            if context.is_stopped() {
+                break;
+            }
+            let wait = next_deadline
+                .map(|deadline| deadline.saturating_duration_since(Instant::now()))
+                .map(|until_deadline| until_deadline.min(PROGRESS_SAFETY_RECHECK_INTERVAL))
+                .unwrap_or(IDLE_WAIT_INTERVAL);
+            context.wait_for_running(wait).await;
         }
+        self.drain_new_requests(&mut active);
     }
 
     async fn on_wait_end(&self) {}
@@ -341,6 +342,7 @@ impl ServiceTask for GroupTransferServiceInner {
 mod tests {
     use super::*;
     use crate::ha::default_ha_service::DefaultHAService;
+    use crate::ha::general_ha_service::GeneralHAService;
     use crate::ha::test_support::new_test_message_store;
 
     fn new_test_ha_service() -> GeneralHAService {
@@ -373,6 +375,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn new_request_wakes_the_event_driven_service() {
+        let ha_service = new_test_ha_service();
+        let reference = GeneralHAServiceReference::new();
+        reference.bind(&ha_service).expect("bind general ha service");
+        let service = GroupTransferService::new(reference);
+        service.start().await.expect("start group transfer service");
+        let (request, response) = GroupCommitRequest::with_ack_nums(0, 5_000, 1);
+
+        service.put_request(request).await;
+
+        assert_eq!(
+            tokio::time::timeout(Duration::from_millis(250), response.wait_for_result())
+                .await
+                .expect("event-driven response")
+                .expect("group transfer status"),
+            PutMessageStatus::PutOk
+        );
+        service.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn shutdown_completes_active_and_queued_waiters() {
+        let ha_service = new_test_ha_service();
+        let reference = GeneralHAServiceReference::new();
+        reference.bind(&ha_service).expect("bind general ha service");
+        let service = GroupTransferService::new(reference);
+        service.start().await.expect("start group transfer service");
+        let (request, response) = GroupCommitRequest::with_ack_nums(128, 5_000, 2);
+        service.put_request(request).await;
+
+        service.shutdown().await;
+
+        assert_eq!(
+            tokio::time::timeout(Duration::from_millis(250), response.wait_for_result())
+                .await
+                .expect("shutdown response")
+                .expect("group transfer status"),
+            PutMessageStatus::FlushSlaveTimeout
+        );
+    }
+
+    #[tokio::test]
     async fn overload_rejects_excess_group_transfers_without_growing_the_queue() {
         let ha_service = new_test_ha_service();
         let reference = GeneralHAServiceReference::new();
@@ -394,7 +438,6 @@ mod tests {
             .expect("queue budget");
         let inner = GroupTransferServiceInner {
             ha_service: reference,
-            notified: (Arc::new(Notify::new()), AtomicBool::new(false)),
             ack_notify_count: AtomicU64::new(0),
             pending_requests: BudgetedQueue::new(queue_budget),
         };
@@ -425,7 +468,8 @@ mod tests {
         let (request, mut response) = GroupCommitRequest::with_ack_nums(128, 0, 2);
 
         inner.put_request(request).await;
-        inner.do_wait_transfer().await;
+        let mut active = Vec::new();
+        inner.evaluate_pending(&mut active).await;
 
         assert_eq!(
             response.wait_for_result_with_timeout().await.expect("timeout status"),
@@ -442,13 +486,53 @@ mod tests {
         let (request, mut response) = GroupCommitRequest::with_ack_nums(0, 5_000, 0);
 
         inner.put_request(request).await;
-        inner.do_wait_transfer().await;
+        let mut active = Vec::new();
+        inner.evaluate_pending(&mut active).await;
 
         assert_eq!(
             response.wait_for_result_with_timeout().await.expect("rejected status"),
             PutMessageStatus::FlushSlaveTimeout
         );
         assert_eq!(inner.runtime_info().pending_request_count, 0);
+    }
+
+    #[tokio::test]
+    async fn satisfied_low_offset_is_not_blocked_by_an_unsatisfied_high_offset() {
+        use rocketmq_store_api::MasterEpoch;
+        use rocketmq_store_api::ReplicaCount;
+        use rocketmq_store_api::WriteAuthority;
+
+        let authority =
+            WriteAuthority::try_new(0, MasterEpoch::try_from(1).expect("positive epoch")).expect("valid authority");
+        let frontier = AckFrontier::from_snapshots(
+            Some(authority),
+            Some(std::collections::HashSet::from([0, 1])),
+            200,
+            &[crate::ha::ha_service::HAAckedReplicaSnapshot {
+                slave_broker_id: Some(1),
+                slave_ack_offset: 120,
+            }],
+            true,
+        );
+        let policy = AckPolicy::ReplicaCount(ReplicaCount::try_new(2).expect("two replicas"));
+        let (high_request, _high_response) = GroupCommitRequest::with_ack_nums_and_authority(180, 5_000, 2, authority);
+        let (low_request, mut low_response) = GroupCommitRequest::with_ack_nums_and_authority(120, 5_000, 2, authority);
+        let mut active = vec![
+            ActiveGroupTransfer::unadmitted(PendingGroupTransfer::new(high_request), policy),
+            ActiveGroupTransfer::unadmitted(PendingGroupTransfer::new(low_request), policy),
+        ];
+
+        GroupTransferServiceInner::resolve_pending(&mut active, &frontier, Instant::now());
+
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].next_offset(), 180);
+        assert_eq!(
+            low_response
+                .wait_for_result_with_timeout()
+                .await
+                .expect("low offset status"),
+            PutMessageStatus::PutOk
+        );
     }
 
     #[test]

--- a/rocketmq-store/src/ha/ha_service.rs
+++ b/rocketmq-store/src/ha/ha_service.rs
@@ -119,6 +119,10 @@ pub trait RocketHAService: Sync {
     /// * `request` - The commit request
     async fn put_request(&self, request: GroupCommitRequest);
 
+    /// Wake pending group-transfer requests after local durability, membership, or authority
+    /// progress changes.
+    fn notify_transfer_progress(&self);
+
     /// Put a connection state notification request
     ///
     /// # Parameters

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -1295,19 +1295,21 @@ impl CommitLog {
             return PutMessageStatus::PutOk;
         }
         let next_offset = put_message_result.wrote_offset + put_message_result.wrote_bytes as i64;
-
-        let (request, mut response) = GroupCommitRequest::with_ack_nums(
-            next_offset,
-            self.message_store_config.slave_timeout as u64,
-            need_ack_nums,
-        );
         let Some(ha_service) = self.store_context.ha_service() else {
             error!("HA service is not initialized for commit-log replication");
             return PutMessageStatus::UnknownError;
         };
+        let Some(authority) = ha_service.write_authority() else {
+            error!("HA write authority is unavailable for commit-log replication");
+            return PutMessageStatus::FlushSlaveTimeout;
+        };
+        let (request, mut response) = GroupCommitRequest::with_ack_nums_and_authority(
+            next_offset,
+            self.message_store_config.slave_timeout as u64,
+            need_ack_nums,
+            authority,
+        );
         ha_service.put_request(request).await;
-        //Notify the HA service to handle the request
-        ha_service.get_wait_notify_object().notify_waiters();
         match response.wait_for_result_with_timeout().await {
             Ok(PutMessageStatus::FlushDiskTimeout) => PutMessageStatus::FlushSlaveTimeout,
             Ok(status) => status,
@@ -1333,6 +1335,12 @@ impl CommitLog {
 
         self.store_metrics
             .record_flush_latency(start_time.elapsed().as_millis() as u64);
+
+        if status == PutMessageStatus::PutOk {
+            if let Some(ha_service) = self.store_context.ha_service() {
+                ha_service.notify_transfer_progress();
+            }
+        }
 
         status
     }

--- a/rocketmq-store/src/log_file/commit_log/append_sequencer.rs
+++ b/rocketmq-store/src/log_file/commit_log/append_sequencer.rs
@@ -54,6 +54,7 @@ use super::PutMessageContext;
 use super::PutMessageResult;
 use super::PutMessageStatus;
 use crate::base::message_result::AppendMessageResult;
+use crate::ha::ha_service::HAService;
 
 const APPEND_WORKER_NAME: &str = "commitlog-append-sequencer";
 const APPEND_WORKER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
@@ -491,6 +492,11 @@ impl CommitLogAppendProcessor {
         }
         let committed_requests = completions.iter().filter(|completion| completion.committed()).count();
         self.flush.wakeup_after_append_batch(committed_requests);
+        if committed_requests > 0 {
+            if let Some(ha_service) = self.store_context.ha_service() {
+                ha_service.get_wait_notify_object().notify_waiters();
+            }
+        }
         for (completion, permit) in completions.into_iter().zip(permits) {
             completion.complete();
             drop(permit);

--- a/rocketmq-store/src/log_file/group_commit_request.rs
+++ b/rocketmq-store/src/log_file/group_commit_request.rs
@@ -21,6 +21,7 @@ use tracing::warn;
 use crate::base::message_status_enum::PutMessageStatus;
 use crate::store_error::StoreError;
 use crate::store_error::StoreOperation;
+use rocketmq_store_api::WriteAuthority;
 
 fn group_commit_invalid_state(reason: impl Into<String>) -> StoreError {
     StoreError::invalid_state(
@@ -81,6 +82,7 @@ pub struct GroupCommitRequest {
     next_offset: i64,
     flush_ok_sender: Option<oneshot::Sender<PutMessageStatus>>,
     ack_nums: i32,
+    requested_authority: Option<WriteAuthority>,
     created_at: Instant,
     deadline: Instant,
 }
@@ -98,16 +100,31 @@ impl GroupCommitRequest {
 
     /// Create a new GroupCommitRequest with timeout in milliseconds
     pub fn new(next_offset: i64, timeout_millis: u64) -> (Self, GroupCommitResponse) {
-        Self::create_request(next_offset, timeout_millis, 1)
+        Self::create_request(next_offset, timeout_millis, 1, None)
     }
 
     /// Create a new GroupCommitRequest with timeout and ack numbers
     pub fn with_ack_nums(next_offset: i64, timeout_millis: u64, ack_nums: i32) -> (Self, GroupCommitResponse) {
-        Self::create_request(next_offset, timeout_millis, ack_nums)
+        Self::create_request(next_offset, timeout_millis, ack_nums, None)
+    }
+
+    /// Creates a request bound to the write authority that accepted the append.
+    pub(crate) fn with_ack_nums_and_authority(
+        next_offset: i64,
+        timeout_millis: u64,
+        ack_nums: i32,
+        requested_authority: WriteAuthority,
+    ) -> (Self, GroupCommitResponse) {
+        Self::create_request(next_offset, timeout_millis, ack_nums, Some(requested_authority))
     }
 
     #[inline]
-    fn create_request(next_offset: i64, timeout_millis: u64, ack_nums: i32) -> (Self, GroupCommitResponse) {
+    fn create_request(
+        next_offset: i64,
+        timeout_millis: u64,
+        ack_nums: i32,
+        requested_authority: Option<WriteAuthority>,
+    ) -> (Self, GroupCommitResponse) {
         let (sender, receiver) = oneshot::channel();
         let created_at = Instant::now();
         let instant = created_at + Duration::from_millis(timeout_millis);
@@ -116,6 +133,7 @@ impl GroupCommitRequest {
                 next_offset,
                 flush_ok_sender: Some(sender),
                 ack_nums,
+                requested_authority,
                 created_at,
                 deadline: instant,
             },
@@ -134,6 +152,11 @@ impl GroupCommitRequest {
     /// Get the number of acknowledgments needed
     pub fn get_ack_nums(&self) -> i32 {
         self.ack_nums
+    }
+
+    /// Returns the authority that accepted this append when the caller supplied one.
+    pub(crate) fn requested_authority(&self) -> Option<WriteAuthority> {
+        self.requested_authority
     }
 
     /// Get when this request was created.
@@ -158,6 +181,7 @@ impl std::fmt::Debug for GroupCommitRequest {
         f.debug_struct("GroupCommitRequest")
             .field("next_offset", &self.next_offset)
             .field("ack_nums", &self.ack_nums)
+            .field("requested_authority", &self.requested_authority)
             .field("created_at", &self.created_at)
             .field("has_sender", &self.flush_ok_sender.is_some())
             .finish()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9235

### Brief Description

- Wake caught-up HA writers once per successful CommitLog micro-batch and initial replica offset, then wait on append progress, heartbeat deadlines, bounded flow-control retry, or shutdown instead of continuously yielding.
- Add a canonical acknowledgement frontier that snapshots authority, SyncStateSet membership, local durability, and replica offsets once per event and completes every satisfied, rejected, or expired request without FIFO head-of-line blocking.
- Bind replicated writes to the accepting authority epoch, wake frontier evaluation on local durability and membership changes, retain bounded permits while requests are pending, and fail closed on shutdown.

### How Did You Test This Change?

- `cargo test -p rocketmq-store default_ha_connection --lib`
- `cargo test -p rocketmq-store group_transfer_service --lib`
- `cargo test -p rocketmq-store --all-features --lib -- --test-threads=1` (700 passed)
- `cargo test -p rocketmq-store --test group_commit_budget_tests`
- `cargo test -p rocketmq-store --test ha_semantics_tests`
- `cargo test -p rocketmq-store --test ha_master_slave_transfer`
- `cargo test -p rocketmq-store --test ha_connection_state`
- `cargo test -p rocketmq-store --test ha_transfer_metrics`
- `cargo test -p rocketmq-store --test ha_fault_smoke`
- `cargo clippy -p rocketmq-store --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `wsl -e bash -lc 'cargo fmt --all -- --check'`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `.\scripts\check-agents-routing.ps1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authority-aware replication tracking across configured replicas.
  * Improved replication decisions for synchronization policies, stale authority, invalid offsets, and insufficient replica progress.
  * Added event-driven transfer monitoring that responds promptly to acknowledgements, durability, membership, and role changes.

* **Bug Fixes**
  * Improved transfer waiting, retry, timeout, heartbeat, and shutdown behavior.
  * Prevented missed progress notifications and handled flow-control limits safely.
  * Replication requests now fail clearly when write authority is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->