### PR TITLE
[ISSUE #9237]✨Bound Broker fast-failure pending work

### DIFF
--- a/rocketmq-broker/src/config/broker_config.rs
+++ b/rocketmq-broker/src/config/broker_config.rs
@@ -653,6 +653,14 @@ mod defaults {
         true
     }
 
+    pub const fn broker_fast_failure_pending_max_count() -> usize {
+        4_096
+    }
+
+    pub const fn broker_fast_failure_pending_max_bytes() -> usize {
+        64 * 1024 * 1024
+    }
+
     pub const fn send_request_executor_detached_enable() -> bool {
         false
     }
@@ -918,6 +926,12 @@ pub struct BrokerConfig {
 
     #[serde(default = "defaults::broker_fast_failure_enable")]
     pub broker_fast_failure_enable: bool,
+
+    #[serde(default = "defaults::broker_fast_failure_pending_max_count")]
+    pub broker_fast_failure_pending_max_count: usize,
+
+    #[serde(default = "defaults::broker_fast_failure_pending_max_bytes")]
+    pub broker_fast_failure_pending_max_bytes: usize,
 
     #[serde(default = "defaults::send_request_executor_detached_enable")]
     pub send_request_executor_detached_enable: bool,
@@ -1454,6 +1468,8 @@ impl Default for BrokerConfig {
             register_name_server_period: 1000 * 30,
             send_heartbeat_timeout_millis: 1000,
             broker_fast_failure_enable: defaults::broker_fast_failure_enable(),
+            broker_fast_failure_pending_max_count: defaults::broker_fast_failure_pending_max_count(),
+            broker_fast_failure_pending_max_bytes: defaults::broker_fast_failure_pending_max_bytes(),
             send_request_executor_detached_enable: defaults::send_request_executor_detached_enable(),
             wait_time_mills_in_send_queue: defaults::wait_time_mills_in_send_queue(),
             sync_flush_backlog_reject_depth: defaults::sync_flush_backlog_reject_depth(),
@@ -1867,6 +1883,14 @@ impl BrokerConfig {
         properties.insert(
             "brokerFastFailureEnable".into(),
             self.broker_fast_failure_enable.to_string().into(),
+        );
+        properties.insert(
+            "brokerFastFailurePendingMaxCount".into(),
+            self.broker_fast_failure_pending_max_count.to_string().into(),
+        );
+        properties.insert(
+            "brokerFastFailurePendingMaxBytes".into(),
+            self.broker_fast_failure_pending_max_bytes.to_string().into(),
         );
         properties.insert(
             "sendRequestExecutorDetachedEnable".into(),
@@ -2384,6 +2408,8 @@ mod tests {
         let config = BrokerConfig::default();
 
         assert!(config.broker_fast_failure_enable);
+        assert_eq!(config.broker_fast_failure_pending_max_count, 4_096);
+        assert_eq!(config.broker_fast_failure_pending_max_bytes, 64 * 1024 * 1024);
         assert!(!config.async_topic_create_persist_enable);
         assert!(!config.send_request_executor_detached_enable);
         assert_eq!(config.wait_time_mills_in_send_queue, 200);
@@ -2554,6 +2580,18 @@ mod tests {
         );
         assert_eq!(
             properties
+                .get("brokerFastFailurePendingMaxCount")
+                .map(|value| value.as_str()),
+            Some("4096")
+        );
+        assert_eq!(
+            properties
+                .get("brokerFastFailurePendingMaxBytes")
+                .map(|value| value.as_str()),
+            Some("67108864")
+        );
+        assert_eq!(
+            properties
                 .get("sendRequestExecutorDetachedEnable")
                 .map(|value| value.as_str()),
             Some("false")
@@ -2673,6 +2711,8 @@ mod tests {
         let config: BrokerConfig = serde_json::from_str(
             r#"{
                 "brokerFastFailureEnable": false,
+                "brokerFastFailurePendingMaxCount": 17,
+                "brokerFastFailurePendingMaxBytes": 65537,
                 "asyncTopicCreatePersistEnable": true,
                 "sendRequestExecutorDetachedEnable": true,
                 "waitTimeMillsInSendQueue": 201,
@@ -2692,6 +2732,8 @@ mod tests {
         .expect("broker config should deserialize Java fast failure keys");
 
         assert!(!config.broker_fast_failure_enable);
+        assert_eq!(config.broker_fast_failure_pending_max_count, 17);
+        assert_eq!(config.broker_fast_failure_pending_max_bytes, 65_537);
         assert!(config.async_topic_create_persist_enable);
         assert!(config.send_request_executor_detached_enable);
         assert_eq!(config.wait_time_mills_in_send_queue, 201);

--- a/rocketmq-broker/src/config/sections.rs
+++ b/rocketmq-broker/src/config/sections.rs
@@ -747,6 +747,20 @@ fn validate_security(broker: &BrokerConfig) -> Result<SecurityConfig, BrokerConf
 }
 
 fn validate_resources(broker: &BrokerConfig, store: &MessageStoreConfig) -> Result<ResourceConfig, BrokerConfigError> {
+    if broker.broker_fast_failure_pending_max_count == 0 {
+        return Err(BrokerConfigError::invalid(
+            ConfigSection::Resources,
+            "broker.brokerFastFailurePendingMaxCount",
+            "must be greater than zero",
+        ));
+    }
+    if broker.broker_fast_failure_pending_max_bytes == 0 {
+        return Err(BrokerConfigError::invalid(
+            ConfigSection::Resources,
+            "broker.brokerFastFailurePendingMaxBytes",
+            "must be greater than zero",
+        ));
+    }
     if broker.max_lite_subscription_count == 0 {
         return Err(BrokerConfigError::invalid(
             ConfigSection::Resources,
@@ -1036,5 +1050,31 @@ mod tests {
         let error = validate_resources(&broker, &store).expect_err("undersized timer queue must fail startup");
 
         assert!(error.to_string().contains("store.timerPipelineBudget"));
+    }
+
+    #[test]
+    fn resource_validation_rejects_zero_fast_failure_pending_count() {
+        let broker = BrokerConfig {
+            broker_fast_failure_pending_max_count: 0,
+            ..BrokerConfig::default()
+        };
+
+        let error = validate_resources(&broker, &MessageStoreConfig::default())
+            .expect_err("zero fast-failure pending count must fail startup");
+
+        assert!(error.to_string().contains("broker.brokerFastFailurePendingMaxCount"));
+    }
+
+    #[test]
+    fn resource_validation_rejects_zero_fast_failure_pending_bytes() {
+        let broker = BrokerConfig {
+            broker_fast_failure_pending_max_bytes: 0,
+            ..BrokerConfig::default()
+        };
+
+        let error = validate_resources(&broker, &MessageStoreConfig::default())
+            .expect_err("zero fast-failure pending bytes must fail startup");
+
+        assert!(error.to_string().contains("broker.brokerFastFailurePendingMaxBytes"));
     }
 }

--- a/rocketmq-broker/src/latency/broker_fast_failure.rs
+++ b/rocketmq-broker/src/latency/broker_fast_failure.rs
@@ -27,7 +27,14 @@ use parking_lot::Mutex;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_runtime::common::time_utils::current_millis;
+use rocketmq_runtime::BudgetDimension;
+use rocketmq_runtime::BudgetLimit;
+use rocketmq_runtime::BudgetSnapshot;
 use rocketmq_runtime::ChildServiceContext;
+use rocketmq_runtime::FullPolicy;
+use rocketmq_runtime::ResourceBudget;
+use rocketmq_runtime::ResourceBudgetTree;
+use rocketmq_runtime::ResourcePermit;
 use rocketmq_runtime::ScheduledTaskConfig;
 use rocketmq_runtime::ScheduledTaskGroup;
 use rocketmq_runtime::ScheduledTaskSnapshot;
@@ -92,6 +99,7 @@ pub(crate) struct FastFailureTask {
     created_timestamp_millis: u64,
     opaque: i32,
     state: AtomicU8,
+    pending_permit: Mutex<Option<ResourcePermit>>,
     response_tx: Mutex<Option<oneshot::Sender<Option<RemotingCommand>>>>,
 }
 
@@ -100,6 +108,7 @@ impl FastFailureTask {
         id: u64,
         opaque: i32,
         created_timestamp_millis: u64,
+        pending_permit: ResourcePermit,
         response_tx: oneshot::Sender<Option<RemotingCommand>>,
     ) -> Self {
         Self {
@@ -107,6 +116,7 @@ impl FastFailureTask {
             created_timestamp_millis,
             opaque,
             state: AtomicU8::new(TASK_STATE_PENDING),
+            pending_permit: Mutex::new(Some(pending_permit)),
             response_tx: Mutex::new(Some(response_tx)),
         }
     }
@@ -122,7 +132,8 @@ impl FastFailureTask {
     }
 
     fn mark_running(&self) -> bool {
-        self.state
+        if self
+            .state
             .compare_exchange(
                 TASK_STATE_PENDING,
                 TASK_STATE_RUNNING,
@@ -130,6 +141,12 @@ impl FastFailureTask {
                 Ordering::Acquire,
             )
             .is_ok()
+        {
+            self.release_pending_permit();
+            return true;
+        }
+
+        false
     }
 
     fn complete(&self, response: Option<RemotingCommand>) -> bool {
@@ -161,6 +178,7 @@ impl FastFailureTask {
             )
             .is_ok()
         {
+            self.release_pending_permit();
             self.send_response(Some(response));
             return true;
         }
@@ -172,6 +190,17 @@ impl FastFailureTask {
         if let Some(response_tx) = self.response_tx.lock().take() {
             let _ = response_tx.send(response);
         }
+    }
+
+    fn release_pending_permit(&self) {
+        self.pending_permit.lock().take();
+    }
+
+    fn response_closed(&self) -> bool {
+        self.response_tx
+            .lock()
+            .as_ref()
+            .is_none_or(tokio::sync::oneshot::Sender::is_closed)
     }
 }
 
@@ -275,9 +304,10 @@ impl FastFailureQueue {
                     tasks.pop_front();
                 }
                 TASK_STATE_PENDING => {
-                    let expired = max_wait_millis.is_none_or(|max_wait_millis| {
-                        now_millis.saturating_sub(front.created_timestamp_millis()) >= max_wait_millis
-                    });
+                    let expired = front.response_closed()
+                        || max_wait_millis.is_none_or(|max_wait_millis| {
+                            now_millis.saturating_sub(front.created_timestamp_millis()) >= max_wait_millis
+                        });
                     if !expired {
                         return None;
                     }
@@ -295,6 +325,23 @@ impl FastFailureQueue {
                 }
             }
         }
+    }
+
+    fn cancel_all_pending(&self) -> usize {
+        let tasks = self.tasks.lock().drain(..).collect::<Vec<_>>();
+        let mut canceled = 0;
+        for task in tasks {
+            let response = system_busy_response(
+                task.opaque,
+                "[BROKER_SHUTDOWN]",
+                current_millis().saturating_sub(task.created_timestamp_millis()),
+                self.pending_count(),
+            );
+            if self.cancel_pending(&task, response) {
+                canceled += 1;
+            }
+        }
+        canceled
     }
 }
 
@@ -365,6 +412,7 @@ struct BrokerFastFailureInner {
     broker_config: Arc<BrokerConfig>,
     service_context: ChildServiceContext,
     queues: FastFailureQueues,
+    pending_budget: ResourceBudget,
     next_task_id: AtomicU64,
     running: AtomicBool,
     lifecycle: Mutex<FastFailureLifecycle>,
@@ -388,11 +436,22 @@ impl BrokerFastFailure {
         broker_config: Arc<BrokerConfig>,
         service_context: ChildServiceContext,
     ) -> Self {
+        let pending_budget = ResourceBudgetTree::new(
+            "broker.fast-failure.pending",
+            BudgetLimit::new(
+                broker_config.broker_fast_failure_pending_max_count,
+                broker_config.broker_fast_failure_pending_max_bytes,
+                FullPolicy::Reject,
+            ),
+        )
+        .expect("validated Broker fast-failure limits must produce a resource budget")
+        .root();
         Self {
             inner: Arc::new(BrokerFastFailureInner {
                 broker_config,
                 service_context,
                 queues: FastFailureQueues::new(),
+                pending_budget,
                 next_task_id: AtomicU64::new(0),
                 running: AtomicBool::new(false),
                 lifecycle: Mutex::new(FastFailureLifecycle::default()),
@@ -475,6 +534,9 @@ impl BrokerFastFailure {
 
     pub(crate) async fn shutdown_with_report(&self) -> Option<ShutdownReport> {
         self.inner.running.store(false, Ordering::Release);
+        for kind in ALL_QUEUE_KINDS {
+            self.inner.queues.get(kind).cancel_all_pending();
+        }
         let task_group = {
             let mut lifecycle = self.inner.lifecycle.lock();
             lifecycle.scheduled_tasks.take();
@@ -526,30 +588,70 @@ impl BrokerFastFailure {
             .collect()
     }
 
+    pub(crate) fn pending_budget_snapshot(&self) -> BudgetSnapshot {
+        self.inner.pending_budget.snapshot()
+    }
+
+    pub(crate) fn try_enqueue(
+        &self,
+        kind: FastFailureQueueKind,
+        opaque: i32,
+        retained_bytes: usize,
+    ) -> Result<(Arc<FastFailureTask>, oneshot::Receiver<Option<RemotingCommand>>), RemotingCommand> {
+        self.try_enqueue_with_timestamp(kind, opaque, retained_bytes, current_millis())
+    }
+
+    #[cfg(test)]
     pub(crate) fn enqueue(
         &self,
         kind: FastFailureQueueKind,
         opaque: i32,
     ) -> (Arc<FastFailureTask>, oneshot::Receiver<Option<RemotingCommand>>) {
-        self.enqueue_with_timestamp(kind, opaque, current_millis())
+        match self.try_enqueue(kind, opaque, 1) {
+            Ok(admitted) => admitted,
+            Err(_) => panic!("test fast-failure request should fit the configured pending budget"),
+        }
     }
 
+    #[cfg(test)]
     fn enqueue_with_timestamp(
         &self,
         kind: FastFailureQueueKind,
         opaque: i32,
         created_timestamp_millis: u64,
     ) -> (Arc<FastFailureTask>, oneshot::Receiver<Option<RemotingCommand>>) {
+        match self.try_enqueue_with_timestamp(kind, opaque, 1, created_timestamp_millis) {
+            Ok(admitted) => admitted,
+            Err(_) => panic!("test fast-failure request should fit the configured pending budget"),
+        }
+    }
+
+    fn try_enqueue_with_timestamp(
+        &self,
+        kind: FastFailureQueueKind,
+        opaque: i32,
+        retained_bytes: usize,
+        created_timestamp_millis: u64,
+    ) -> Result<(Arc<FastFailureTask>, oneshot::Receiver<Option<RemotingCommand>>), RemotingCommand> {
+        let pending_permit = self
+            .inner
+            .pending_budget
+            .try_acquire_data(retained_bytes)
+            .map_err(|error| {
+                let usage = self.inner.pending_budget.snapshot();
+                pending_budget_busy_response(opaque, kind, retained_bytes, &usage, error.dimension())
+            })?;
         let (response_tx, response_rx) = oneshot::channel();
         let task_id = self.inner.next_task_id.fetch_add(1, Ordering::AcqRel);
         let task = Arc::new(FastFailureTask::new(
             task_id,
             opaque,
             created_timestamp_millis,
+            pending_permit,
             response_tx,
         ));
         self.inner.queues.get(kind).enqueue(task.clone());
-        (task, response_rx)
+        Ok((task, response_rx))
     }
 
     pub(crate) async fn acquire_permit(&self, kind: FastFailureQueueKind) -> Option<OwnedSemaphorePermit> {
@@ -667,6 +769,26 @@ fn system_busy_response(
     .set_opaque(opaque)
 }
 
+fn pending_budget_busy_response(
+    opaque: i32,
+    kind: FastFailureQueueKind,
+    retained_bytes: usize,
+    usage: &BudgetSnapshot,
+    dimension: BudgetDimension,
+) -> RemotingCommand {
+    RemotingCommand::create_response_command_with_code_remark(
+        ResponseCode::SystemBusy,
+        format!(
+            "[PENDING_BUDGET]broker busy, retry later, queue: {}, exhausted: {dimension:?}, request bytes: \
+             {retained_bytes}, pending count: {}, pending bytes: {}",
+            kind.name(),
+            usage.current_count,
+            usage.current_bytes
+        ),
+    )
+    .set_opaque(opaque)
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::AtomicBool;
@@ -687,6 +809,90 @@ mod tests {
             wait_time_mills_in_admin_broker_queue: wait_millis,
             ..BrokerConfig::default()
         })
+    }
+
+    fn config_with_pending_budget(max_count: usize, max_bytes: usize) -> Arc<BrokerConfig> {
+        Arc::new(BrokerConfig {
+            broker_fast_failure_pending_max_count: max_count,
+            broker_fast_failure_pending_max_bytes: max_bytes,
+            ..BrokerConfig::default()
+        })
+    }
+
+    fn expect_admitted(
+        result: Result<(Arc<FastFailureTask>, oneshot::Receiver<Option<RemotingCommand>>), RemotingCommand>,
+    ) -> (Arc<FastFailureTask>, oneshot::Receiver<Option<RemotingCommand>>) {
+        match result {
+            Ok(admitted) => admitted,
+            Err(_) => panic!("request should fit the configured pending budget"),
+        }
+    }
+
+    fn expect_rejected(
+        result: Result<(Arc<FastFailureTask>, oneshot::Receiver<Option<RemotingCommand>>), RemotingCommand>,
+    ) -> RemotingCommand {
+        match result {
+            Ok(_) => panic!("request should exceed the configured pending budget"),
+            Err(response) => response,
+        }
+    }
+
+    #[tokio::test]
+    async fn pending_budget_rejects_count_before_creating_another_task() {
+        let fast_failure = BrokerFastFailure::new(config_with_pending_budget(1, 1_024));
+        let (task, _response_rx) = expect_admitted(fast_failure.try_enqueue(FastFailureQueueKind::Send, 1, 128));
+
+        let response = expect_rejected(fast_failure.try_enqueue(FastFailureQueueKind::Send, 2, 128));
+        let usage = fast_failure.pending_budget_snapshot();
+
+        assert_eq!(response.code(), ResponseCode::SystemBusy.to_i32());
+        assert_eq!(response.opaque(), 2);
+        assert!(response.remark().is_some_and(|remark| remark.contains("Count")));
+        assert_eq!(usage.current_count, 1);
+        assert_eq!(usage.current_bytes, 128);
+        assert_eq!(usage.rejected_count, 1);
+
+        assert!(fast_failure.cancel(
+            FastFailureQueueKind::Send,
+            &task,
+            system_busy_response(1, "[TEST]", 0, 0),
+        ));
+        assert_eq!(fast_failure.pending_budget_snapshot().current_count, 0);
+    }
+
+    #[tokio::test]
+    async fn pending_budget_rejects_bytes_and_releases_on_running() {
+        let fast_failure = BrokerFastFailure::new(config_with_pending_budget(4, 256));
+        let (task, response_rx) = expect_admitted(fast_failure.try_enqueue(FastFailureQueueKind::Pull, 3, 192));
+
+        let response = expect_rejected(fast_failure.try_enqueue(FastFailureQueueKind::Pull, 4, 65));
+        assert!(response.remark().is_some_and(|remark| remark.contains("Bytes")));
+        assert_eq!(fast_failure.pending_budget_snapshot().current_bytes, 192);
+
+        assert!(fast_failure.try_mark_running(FastFailureQueueKind::Pull, &task));
+        assert_eq!(fast_failure.pending_budget_snapshot().current_count, 0);
+        assert_eq!(fast_failure.pending_budget_snapshot().current_bytes, 0);
+        fast_failure.complete(FastFailureQueueKind::Pull, &task, None);
+        assert!(response_rx.await.expect("completion response").is_none());
+    }
+
+    #[tokio::test]
+    async fn closed_response_and_shutdown_release_pending_budget() {
+        let fast_failure = BrokerFastFailure::new(config_with_pending_budget(2, 512));
+        let (_closed_task, closed_rx) = expect_admitted(fast_failure.try_enqueue(FastFailureQueueKind::Ack, 5, 128));
+        drop(closed_rx);
+        fast_failure.clean_expired_request();
+        assert_eq!(fast_failure.pending_budget_snapshot().current_count, 0);
+
+        let (_shutdown_task, shutdown_rx) =
+            expect_admitted(fast_failure.try_enqueue(FastFailureQueueKind::Ack, 6, 128));
+        fast_failure.shutdown().await;
+        let response = shutdown_rx.await.expect("shutdown response").expect("shutdown command");
+        assert!(response
+            .remark()
+            .is_some_and(|remark| remark.starts_with("[BROKER_SHUTDOWN]")));
+        assert_eq!(fast_failure.pending_budget_snapshot().current_count, 0);
+        assert_eq!(fast_failure.pending_budget_snapshot().current_bytes, 0);
     }
 
     #[tokio::test]
@@ -716,6 +922,8 @@ mod tests {
         assert!(response
             .remark()
             .is_some_and(|remark| remark.starts_with("[TIMEOUT_CLEAN_QUEUE]")));
+        assert_eq!(fast_failure.pending_budget_snapshot().current_count, 0);
+        assert_eq!(fast_failure.pending_budget_snapshot().current_bytes, 0);
     }
 
     #[tokio::test]

--- a/rocketmq-broker/src/lib.rs
+++ b/rocketmq-broker/src/lib.rs
@@ -645,7 +645,11 @@ pub mod bench_support {
             broker_config,
             service_context,
         );
-        let (_task, response_rx) = service.enqueue(crate::latency::broker_fast_failure::FastFailureQueueKind::Send, 77);
+        let (_task, response_rx) =
+            match service.try_enqueue(crate::latency::broker_fast_failure::FastFailureQueueKind::Send, 77, 1) {
+                Ok(admitted) => admitted,
+                Err(_) => panic!("lifecycle probe request should fit the default pending budget"),
+            };
         service.start_with_schedule(Duration::ZERO, Duration::from_millis(1));
 
         let mut snapshots = service.schedule_snapshot();

--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -458,8 +458,12 @@ where
         }
 
         let opaque = request.opaque();
+        let retained_bytes = estimate_fast_failure_retained_bytes(request);
+        let (task, response_rx) = match broker_fast_failure.try_enqueue(queue_kind, opaque, retained_bytes) {
+            Ok(admitted) => admitted,
+            Err(response) => return Ok(Some(response)),
+        };
         let queued_request = request.clone();
-        let (task, response_rx) = broker_fast_failure.enqueue(queue_kind, opaque);
         let broker_fast_failure = broker_fast_failure.clone();
         let detach_response = should_detach_fast_failure_response(
             queue_kind,
@@ -620,6 +624,26 @@ where
     }
 }
 
+fn estimate_fast_failure_retained_bytes(request: &RemotingCommand) -> usize {
+    let mut retained_bytes = std::mem::size_of::<RemotingCommand>();
+    retained_bytes = retained_bytes.saturating_add(request.body().map_or(0, bytes::Bytes::len));
+    retained_bytes = retained_bytes.saturating_add(request.remark().map_or(0, |remark| remark.len()));
+    if let Some(ext_fields) = request.ext_fields() {
+        retained_bytes = retained_bytes.saturating_add(
+            ext_fields
+                .iter()
+                .map(|(key, value)| {
+                    std::mem::size_of_val(key)
+                        .saturating_add(std::mem::size_of_val(value))
+                        .saturating_add(key.len())
+                        .saturating_add(value.len())
+                })
+                .fold(0usize, usize::saturating_add),
+        );
+    }
+    retained_bytes.max(1)
+}
+
 fn should_detach_fast_failure_response(
     queue_kind: FastFailureQueueKind,
     send_request_executor_detached_enabled: bool,
@@ -740,6 +764,20 @@ mod tests {
             fast_failure_queue_kind(RequestCode::BatchAckMessage as i32, false),
             Some(FastFailureQueueKind::Ack)
         );
+    }
+
+    #[test]
+    fn fast_failure_retained_bytes_include_body_remark_and_extension_fields() {
+        let base = RemotingCommand::create_remoting_command(RequestCode::SendMessage).set_opaque(1);
+        let base_bytes = estimate_fast_failure_retained_bytes(&base);
+        let request = RemotingCommand::new_request(RequestCode::SendMessage, bytes::Bytes::from(vec![1; 1_024]))
+            .set_opaque(2)
+            .set_remark("busy-budget-test")
+            .set_ext_fields(std::collections::HashMap::from([("topic".into(), "orders".into())]));
+
+        let retained_bytes = estimate_fast_failure_retained_bytes(&request);
+
+        assert!(retained_bytes >= base_bytes + 1_024 + "busy-budget-test".len() + "topic".len() + "orders".len());
     }
 
     #[test]

--- a/rocketmq-broker/tests/config_contract.rs
+++ b/rocketmq-broker/tests/config_contract.rs
@@ -121,6 +121,41 @@ fn omitted_store_fields_use_the_production_defaults() {
 }
 
 #[test]
+fn fast_failure_pending_budget_defaults_and_explicit_values_cross_validation() {
+    let default = ValidatedBrokerConfig::try_from_parts(BrokerConfig::default(), MessageStoreConfig::default())
+        .expect("default fast-failure pending budget should validate");
+    assert_eq!(default.broker().broker_fast_failure_pending_max_count, 4_096);
+    assert_eq!(default.broker().broker_fast_failure_pending_max_bytes, 64 * 1024 * 1024);
+
+    let raw = load_inline_config(
+        "[broker]\nbrokerFastFailurePendingMaxCount = 17\nbrokerFastFailurePendingMaxBytes = 65537\n",
+    )
+    .expect("explicit fast-failure budget should deserialize");
+    let explicit = ValidatedBrokerConfig::try_from(raw).expect("explicit fast-failure budget should validate");
+    assert_eq!(explicit.broker().broker_fast_failure_pending_max_count, 17);
+    assert_eq!(explicit.broker().broker_fast_failure_pending_max_bytes, 65_537);
+}
+
+#[test]
+fn zero_fast_failure_pending_budget_fails_before_broker_startup() {
+    for broker in [
+        BrokerConfig {
+            broker_fast_failure_pending_max_count: 0,
+            ..BrokerConfig::default()
+        },
+        BrokerConfig {
+            broker_fast_failure_pending_max_bytes: 0,
+            ..BrokerConfig::default()
+        },
+    ] {
+        assert_invalid_section(
+            ValidatedBrokerConfig::try_from_parts(broker, MessageStoreConfig::default()),
+            ConfigSection::Resources,
+        );
+    }
+}
+
+#[test]
 fn explicit_store_overrides_remain_authoritative() {
     let raw = load_inline_config("[store]\nflushDiskType = \"SYNC_FLUSH\"\nallAckInSyncStateSet = true\n")
         .expect("explicit durability overrides should deserialize");


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9237

### Brief Description

- Add configurable Broker fast-failure pending limits with production defaults of 4,096 requests and 64 MiB, and reject zero capacities during validated startup.
- Estimate logical retained command bytes and acquire the shared pending budget before cloning a request or creating lifecycle-owned processing work; return the existing `SYSTEM_BUSY` status with a retry-later remark when count or bytes are exhausted.
- Hold an RAII reservation only while a request is pending and release it on running, timeout, page-cache rejection, cancellation, response-channel loss, spawn failure, or Broker shutdown while preserving existing per-queue age and execution semaphore behavior.
- Expose effective configuration properties and budget snapshots, and add focused count, bytes, release, shutdown, retained-size, Serde, and validation coverage.

### How Did You Test This Change?

- `cargo test -p rocketmq-broker broker_fast_failure --lib` (17 passed)
- `cargo test -p rocketmq-broker --test config_contract` (20 passed)
- `cargo test -p rocketmq-broker --lib -- --test-threads=1` (773 passed, 2 ignored; the pre-existing ExtendedTimer policy-generation test remains failing outside this diff)
- `cargo clippy -p rocketmq-broker --no-deps --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo check --manifest-path fuzz/Cargo.toml --all-targets`
- `wsl -e bash -lc 'cargo fmt --all -- --check'`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `.\scripts\check-error-hygiene.ps1` (all relevant guards passed; the command still reports the pre-existing Dashboard `AppConfig` sensitive `Debug` finding)
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable limits for pending fast-failure requests: 4,096 requests and 64 MiB by default.
  * Added memory-aware admission control for fast-failure requests.
* **Bug Fixes**
  * Requests exceeding configured count or memory limits now receive an immediate busy response.
  * Improved cleanup during request expiration, closed connections, and broker shutdown.
  * Invalid zero-value resource limits are rejected during configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->