### PR TITLE
[ISSUE #9241]✨Add owner-backed mapped read ranges

### DIFF
--- a/rocketmq-store-local/src/mapped_file.rs
+++ b/rocketmq-store-local/src/mapped_file.rs
@@ -30,6 +30,7 @@ mod mapped_buffer;
 mod mapped_file_error;
 mod memory;
 mod metrics;
+mod read_range;
 mod select_result;
 
 pub mod io_uring_impl;
@@ -136,6 +137,7 @@ pub use memory::ReadOnlyMappedMemory;
 pub type MmapRegionSlice = MappedReadLease<NativeReadOnlyMappedMemory>;
 pub use metrics::MappedFileMetrics;
 pub use raw::MappedFileRawCore;
+pub use read_range::MappedReadRange;
 pub use select_result::SelectMappedBufferCacheState;
 pub use select_result::SelectMappedBufferResult;
 pub use select_result::SelectMappedBufferSourceKind;

--- a/rocketmq-store-local/src/mapped_file/default_mapped_file.rs
+++ b/rocketmq-store-local/src/mapped_file/default_mapped_file.rs
@@ -83,6 +83,7 @@ use crate::mapped_file::retirement::identity::PhysicalFileKey;
 use crate::mapped_file::retirement::state::reconciliation::ReconciledSegmentFile;
 use crate::mapped_file::MappedFileLifecycleSnapshot;
 use crate::mapped_file::MappedFileOperation;
+use crate::mapped_file::MappedReadRange;
 use crate::utils::ffi::advise_memory;
 use crate::utils::ffi::get_page_size;
 use crate::utils::ffi::lock_memory_region;
@@ -513,6 +514,35 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
         MappedReadLease::try_new(generation, admission, offset, len)
             .map(Some)
             .map_err(|_| MappedFileError::out_of_bounds(offset, len, self.raw_core.file_size()))
+    }
+
+    /// Acquires an immutable mapped range with authoritative global and file-local coordinates.
+    ///
+    /// Active writable segments return `Ok(None)`. Once a segment is sealed, the returned range
+    /// keeps its exact mapping generation and read admission alive until the final derived range
+    /// is dropped.
+    ///
+    /// # Errors
+    ///
+    /// Returns a lifecycle error after close, or [`MappedFileError::OutOfBounds`] when the range
+    /// or its absolute offset cannot be represented safely.
+    pub fn try_mapped_read_range(
+        &self,
+        offset: usize,
+        len: usize,
+    ) -> MappedFileResult<Option<MappedReadRange<M::ReadOnly>>> {
+        let file_offset = u64::try_from(offset)
+            .map_err(|_| MappedFileError::out_of_bounds(offset, len, self.raw_core.file_size()))?;
+        let file_from_offset = self.physical_owners.storage.lock().file_from_offset();
+        let start_offset = file_from_offset
+            .checked_add(file_offset)
+            .ok_or_else(|| MappedFileError::out_of_bounds(offset, len, self.raw_core.file_size()))?;
+        let Some(lease) = self.try_mapped_read_lease(offset, len)? else {
+            return Ok(None);
+        };
+        MappedReadRange::try_new(lease, start_offset, file_offset, self.metrics.clone())
+            .map(Some)
+            .ok_or_else(|| MappedFileError::out_of_bounds(offset, len, self.raw_core.file_size()))
     }
 
     #[inline]
@@ -1518,6 +1548,27 @@ impl<M: MappedMemory> MappedFile for DefaultMappedFile<M> {
                 .fetch_add(1, Ordering::AcqRel);
 
             let is_in_cache = self.record_cache_residency_admitted(&admission, pos as i64, size as usize);
+            if let Some(generation) = self.physical_owners.mapping.load_read_only() {
+                let file_offset = pos as u64;
+                let start_offset = self
+                    .physical_owners
+                    .storage
+                    .lock()
+                    .file_from_offset()
+                    .checked_add(file_offset)
+                    .ok_or_else(|| {
+                        MappedFileError::out_of_bounds(pos as usize, size as usize, self.raw_core.file_size())
+                    })?;
+                let range =
+                    MappedReadLease::try_new(generation, admission, pos as usize, size as usize).map_err(|_| {
+                        MappedFileError::out_of_bounds(pos as usize, size as usize, self.raw_core.file_size())
+                    })?;
+                let range = MappedReadRange::try_new(range, start_offset, file_offset, self.metrics.clone())
+                    .ok_or_else(|| {
+                        MappedFileError::out_of_bounds(pos as usize, size as usize, self.raw_core.file_size())
+                    })?;
+                return Ok(SelectMappedBufferResult::from_mapped_range(range, is_in_cache));
+            }
             Ok(self
                 .copy_range_admitted(&admission, pos as usize, size as usize, None)?
                 .and_then(|bytes| {
@@ -1885,6 +1936,20 @@ impl<M: MappedMemory> MappedFile for DefaultMappedFile<M> {
         self.mapped_byte_buffer_access_count_since_last_swap
             .fetch_add(1, Ordering::AcqRel);
         let is_in_cache = self.record_cache_residency_admitted(&admission, pos as i64, size as usize);
+
+        if let Some(generation) = self.physical_owners.mapping.load_read_only() {
+            let file_offset = pos as u64;
+            let start_offset = self.get_file_from_offset().checked_add(file_offset).ok_or_else(|| {
+                MappedFileError::out_of_bounds(pos as usize, size as usize, self.raw_core.file_size())
+            })?;
+            let range = MappedReadLease::try_new(generation, admission, pos as usize, size as usize)
+                .map_err(|_| MappedFileError::out_of_bounds(pos as usize, size as usize, self.raw_core.file_size()))?;
+            let range =
+                MappedReadRange::try_new(range, start_offset, file_offset, self.metrics.clone()).ok_or_else(|| {
+                    MappedFileError::out_of_bounds(pos as usize, size as usize, self.raw_core.file_size())
+                })?;
+            return Ok(SelectMappedBufferResult::from_mapped_range(range, is_in_cache));
+        }
 
         Ok(self
             .copy_range_admitted(&admission, pos as usize, size as usize, None)?

--- a/rocketmq-store-local/src/mapped_file/generation.rs
+++ b/rocketmq-store-local/src/mapped_file/generation.rs
@@ -332,6 +332,11 @@ impl<R: ReadOnlyMappedMemory> MappedReadLease<R> {
         self.inner.generation().id()
     }
 
+    #[inline]
+    pub(crate) fn file_owner(&self) -> Arc<FileOwner> {
+        Arc::clone(self.inner.generation().file_owner())
+    }
+
     /// Returns the mapped range length.
     #[inline]
     pub fn len(&self) -> usize {

--- a/rocketmq-store-local/src/mapped_file/read_range.rs
+++ b/rocketmq-store-local/src/mapped_file/read_range.rs
@@ -1,0 +1,173 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+
+use super::file::FileOwner;
+use super::MappedFileMetrics;
+use super::MappedReadLease;
+use super::MappingGenerationId;
+use super::ReadOnlyMappedMemory;
+
+/// Immutable mapped bytes with authoritative store and file-local coordinates.
+///
+/// The underlying mapping generation and its read admission are inseparable from this value.
+/// Clones and derived ranges share that protection, so retirement cannot unmap the storage before
+/// the final alias is dropped. Byte access is closure-scoped to keep the mapping borrow from
+/// escaping independently of its owner.
+#[must_use = "dropping the range immediately releases its mapped-file read ownership"]
+pub struct MappedReadRange<R: ReadOnlyMappedMemory> {
+    lease: MappedReadLease<R>,
+    start_offset: u64,
+    file_offset: u64,
+    metrics: Option<Arc<MappedFileMetrics>>,
+}
+
+impl<R: ReadOnlyMappedMemory> MappedReadRange<R> {
+    pub(crate) fn try_new(
+        lease: MappedReadLease<R>,
+        start_offset: u64,
+        file_offset: u64,
+        metrics: Option<Arc<MappedFileMetrics>>,
+    ) -> Option<Self> {
+        start_offset.checked_sub(file_offset)?;
+        Some(Self {
+            lease,
+            start_offset,
+            file_offset,
+            metrics,
+        })
+    }
+
+    /// Returns the absolute CommitLog-style offset of the first selected byte.
+    #[inline]
+    pub const fn start_offset(&self) -> u64 {
+        self.start_offset
+    }
+
+    /// Returns the selected position inside the mapped file.
+    #[inline]
+    pub const fn file_offset(&self) -> u64 {
+        self.file_offset
+    }
+
+    /// Returns the immutable base offset identifying the mapped file.
+    #[inline]
+    pub const fn file_from_offset(&self) -> u64 {
+        self.start_offset - self.file_offset
+    }
+
+    /// Returns the mapping generation retained by this range.
+    #[inline]
+    pub fn generation_id(&self) -> MappingGenerationId {
+        self.lease.generation_id()
+    }
+
+    /// Returns the selected byte length.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.lease.len()
+    }
+
+    /// Returns whether this range contains no bytes.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.lease.is_empty()
+    }
+
+    /// Runs one synchronous operation against the selected bytes.
+    ///
+    /// The higher-ranked callback prevents the mapped slice from being returned independently of
+    /// this owner-bearing range.
+    #[inline]
+    pub fn with_slice<T>(&self, operation: impl for<'a> FnOnce(&'a [u8]) -> T) -> T {
+        operation(self.lease.as_ref())
+    }
+
+    /// Copies exactly this range into an immutable compatibility buffer.
+    #[inline]
+    pub fn to_bytes(&self) -> Bytes {
+        let bytes = self.with_slice(Bytes::copy_from_slice);
+        if let Some(metrics) = self.metrics.as_ref() {
+            metrics.record_selection_copy(bytes.len());
+        }
+        bytes
+    }
+
+    /// Returns a checked subrange relative to this range's first byte.
+    ///
+    /// Returns `None` when `offset + len` overflows or exceeds this range.
+    pub fn slice(&self, offset: usize, len: usize) -> Option<Self> {
+        let end = offset.checked_add(len)?;
+        if end > self.len() {
+            return None;
+        }
+        let (_, tail) = self.lease.split_at(offset)?;
+        let (selected, _) = tail.split_at(len)?;
+        let relative = u64::try_from(offset).ok()?;
+        Some(Self {
+            lease: selected,
+            start_offset: self.start_offset.checked_add(relative)?,
+            file_offset: self.file_offset.checked_add(relative)?,
+            metrics: self.metrics.clone(),
+        })
+    }
+
+    /// Creates two checked aliases split at `mid` bytes relative to this range.
+    ///
+    /// The original remains valid. Returns `None` when `mid` exceeds this range.
+    pub fn split_at(&self, mid: usize) -> Option<(Self, Self)> {
+        let (left, right) = self.lease.split_at(mid)?;
+        let relative = u64::try_from(mid).ok()?;
+        let right_start = self.start_offset.checked_add(relative)?;
+        let right_file_offset = self.file_offset.checked_add(relative)?;
+        Some((
+            Self {
+                lease: left,
+                start_offset: self.start_offset,
+                file_offset: self.file_offset,
+                metrics: self.metrics.clone(),
+            },
+            Self {
+                lease: right,
+                start_offset: right_start,
+                file_offset: right_file_offset,
+                metrics: self.metrics.clone(),
+            },
+        ))
+    }
+
+    #[inline]
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        self.lease.as_ref()
+    }
+
+    #[inline]
+    pub(crate) fn file_owner(&self) -> Arc<FileOwner> {
+        self.lease.file_owner()
+    }
+}
+
+impl<R: ReadOnlyMappedMemory> Clone for MappedReadRange<R> {
+    fn clone(&self) -> Self {
+        Self {
+            lease: self.lease.clone(),
+            start_offset: self.start_offset,
+            file_offset: self.file_offset,
+            metrics: self.metrics.clone(),
+        }
+    }
+}

--- a/rocketmq-store-local/src/mapped_file/select_result.rs
+++ b/rocketmq-store-local/src/mapped_file/select_result.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::sync::Arc;
+use std::sync::OnceLock;
 
 use bytes::Bytes;
 
@@ -21,6 +22,7 @@ use super::DefaultMappedFile;
 use super::MappedFile;
 use super::MappedFileOperation;
 use super::MappedMemory;
+use super::MappedReadRange;
 use super::NativeMappedMemory;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -39,6 +41,7 @@ pub enum SelectMappedBufferCacheState {
 pub(crate) type SelectMappedBufferTransferParts<M> = (
     u64,
     Option<Bytes>,
+    Option<MappedReadRange<<M as MappedMemory>::ReadOnly>>,
     i32,
     Option<(MappedFileLease, Arc<DefaultMappedFile<M>>)>,
     u64,
@@ -59,7 +62,8 @@ impl SelectMappedBufferCacheState {
 pub struct SelectMappedBufferResult<M: MappedMemory = NativeMappedMemory> {
     /// The start offset.
     start_offset: u64,
-    bytes: Option<Bytes>,
+    bytes: OnceLock<Bytes>,
+    mapped_range: Option<MappedReadRange<M::ReadOnly>>,
     /// The size.
     size: i32,
     /// The mapped file and the admission lease protecting it.
@@ -80,7 +84,8 @@ impl<M: MappedMemory> Default for SelectMappedBufferResult<M> {
     fn default() -> Self {
         Self {
             start_offset: 0,
-            bytes: None,
+            bytes: OnceLock::new(),
+            mapped_range: None,
             size: 0,
             mapped_source: None,
             is_in_cache: true,
@@ -114,13 +119,34 @@ impl<M: MappedMemory> SelectMappedBufferResult<M> {
         let size = i32::try_from(bytes.len()).ok()?;
         Some(Self {
             start_offset,
-            bytes: Some(bytes),
+            bytes: OnceLock::from(bytes),
+            mapped_range: None,
             size,
             mapped_source: None,
             is_in_cache,
             source_kind: SelectMappedBufferSourceKind::Bytes,
             file_offset,
             cache_state,
+        })
+    }
+
+    /// Creates a selection backed directly by an immutable mapped range.
+    ///
+    /// No payload snapshot is allocated until a compatibility caller explicitly requests owned
+    /// [`Bytes`].
+    pub fn from_mapped_range(range: MappedReadRange<M::ReadOnly>, is_in_cache: bool) -> Option<Self> {
+        let size = i32::try_from(range.len()).ok()?;
+        let file_offset = range.file_offset();
+        Some(Self {
+            start_offset: range.start_offset(),
+            bytes: OnceLock::new(),
+            mapped_range: Some(range),
+            size,
+            mapped_source: None,
+            is_in_cache,
+            source_kind: SelectMappedBufferSourceKind::MappedFile,
+            file_offset,
+            cache_state: SelectMappedBufferCacheState::from_residency(is_in_cache),
         })
     }
 
@@ -149,10 +175,10 @@ impl<M: MappedMemory> SelectMappedBufferResult<M> {
     /// The immutable byte snapshot remains available when the mapped file can no longer be held,
     /// so callers can safely fall back to the copied representation.
     pub fn try_attach_mapped_file(&mut self, mapped_file: Arc<DefaultMappedFile<M>>) -> bool {
-        if self.mapped_source.is_some() {
+        if self.mapped_range.is_some() || self.mapped_source.is_some() {
             return false;
         }
-        let Some(bytes) = self.bytes.as_ref() else {
+        let Some(bytes) = self.bytes.get() else {
             return false;
         };
         let Ok(size) = usize::try_from(self.size) else {
@@ -209,22 +235,44 @@ impl<M: MappedMemory> SelectMappedBufferResult<M> {
     ///
     /// # Panics
     ///
-    /// Panics when an internal producer constructs a selection without its required immutable
-    /// byte snapshot.
+    /// Panics when an internal producer constructs a selection without either an immutable byte
+    /// snapshot or an owner-backed mapped range.
     pub fn get_buffer(&self) -> &[u8] {
-        self.bytes
-            .as_deref()
-            .expect("selected mapped buffers must own an immutable byte snapshot")
+        if let Some(bytes) = self.bytes.get() {
+            return bytes.as_ref();
+        }
+        self.mapped_range
+            .as_ref()
+            .map(MappedReadRange::as_slice)
+            .expect("selected mapped buffers must own bytes or an immutable mapped range")
     }
 
     #[inline]
     pub fn get_bytes(&self) -> Option<Bytes> {
-        self.bytes.clone()
+        self.get_bytes_ref().cloned()
     }
 
+    /// Returns an immutable byte snapshot, materializing and caching an exact fallback when this
+    /// selection is range-backed.
     #[inline]
     pub fn get_bytes_ref(&self) -> Option<&Bytes> {
-        self.bytes.as_ref()
+        if let Some(bytes) = self.bytes.get() {
+            return Some(bytes);
+        }
+        let range = self.mapped_range.as_ref()?;
+        Some(self.bytes.get_or_init(|| range.to_bytes()))
+    }
+
+    /// Returns whether the authoritative payload is still an owner-backed mapped range.
+    #[inline]
+    pub fn is_range_backed(&self) -> bool {
+        self.mapped_range.is_some()
+    }
+
+    /// Returns whether an owned compatibility snapshot has already been materialized.
+    #[inline]
+    pub fn has_byte_snapshot(&self) -> bool {
+        self.bytes.get().is_some()
     }
 
     #[inline]
@@ -232,12 +280,34 @@ impl<M: MappedMemory> SelectMappedBufferResult<M> {
         if self.mapped_source.take().is_some() {
             self.source_kind = SelectMappedBufferSourceKind::Bytes;
         }
-        self.bytes.as_mut()
+        let range_fallback = if self.bytes.get().is_none() {
+            self.mapped_range.as_ref().map(MappedReadRange::to_bytes)
+        } else {
+            None
+        };
+        if self.mapped_range.take().is_some() {
+            self.source_kind = SelectMappedBufferSourceKind::Bytes;
+        }
+        if self.bytes.get().is_none() {
+            if let Some(bytes) = range_fallback {
+                let _ = self.bytes.set(bytes);
+            }
+        }
+        self.bytes.get_mut()
     }
 
     /// Removes and returns the immutable byte snapshot.
     #[inline]
     pub fn take(&mut self) -> Option<Bytes> {
+        if self.bytes.get().is_none() {
+            if let Some(range) = self.mapped_range.take() {
+                let _ = self.bytes.set(range.to_bytes());
+                self.source_kind = SelectMappedBufferSourceKind::Bytes;
+            }
+        }
+        self.mapped_range.take();
+        self.mapped_source.take();
+        self.source_kind = SelectMappedBufferSourceKind::Bytes;
         self.bytes.take()
     }
 
@@ -246,18 +316,32 @@ impl<M: MappedMemory> SelectMappedBufferResult<M> {
         let Ok(size) = i32::try_from(new_len) else {
             return false;
         };
-        let Some(bytes) = self.bytes.as_mut() else {
-            return false;
-        };
-        if new_len > bytes.len() {
+        let mut truncated_any = false;
+        if let Some(range) = self.mapped_range.as_ref() {
+            let Some(truncated) = range.slice(0, new_len) else {
+                return false;
+            };
+            self.mapped_range = Some(truncated);
+            truncated_any = true;
+        }
+        if let Some(bytes) = self.bytes.get_mut() {
+            if new_len > bytes.len() {
+                return false;
+            }
+            bytes.truncate(new_len);
+            truncated_any = true;
+        }
+        if !truncated_any {
             return false;
         }
-        bytes.truncate(new_len);
         self.size = size;
         true
     }
 
     pub fn is_in_mem(&self) -> bool {
+        if self.mapped_range.is_some() {
+            return true;
+        }
         match self.mapped_source.as_ref() {
             None => true,
             Some((_lease, inner)) => {
@@ -273,6 +357,7 @@ impl<M: MappedMemory> SelectMappedBufferResult<M> {
         (
             self.start_offset,
             self.bytes.take(),
+            self.mapped_range.take(),
             self.size,
             self.mapped_source.take(),
             self.file_offset,

--- a/rocketmq-store-local/src/transfer/segment.rs
+++ b/rocketmq-store-local/src/transfer/segment.rs
@@ -26,7 +26,9 @@ use crate::mapped_file::lifecycle::MappedFileLease;
 use crate::mapped_file::DefaultMappedFile;
 use crate::mapped_file::MappedFile;
 use crate::mapped_file::MappedFileMetrics;
+use crate::mapped_file::MappedReadRange;
 use crate::mapped_file::NativeMappedMemory;
+use crate::mapped_file::NativeReadOnlyMappedMemory;
 use crate::mapped_file::SelectMappedBufferCacheState;
 use crate::mapped_file::SelectMappedBufferResult;
 
@@ -73,6 +75,9 @@ struct CheckedFileRange {
 enum FileRangeOperationLease {
     Mapped {
         _lease: MappedFileLease,
+    },
+    MappedRead {
+        _range: MappedReadRange<NativeReadOnlyMappedMemory>,
     },
     Standalone,
     #[cfg(test)]
@@ -277,7 +282,8 @@ impl SegmentLease {
 
     /// Compatibility adapter for callers that already carry a separate global offset.
     pub fn from_select_result(global_offset: i64, result: NativeSelectMappedBufferResult) -> Option<Self> {
-        let (_start_offset, bytes, size, mapped_source, position_in_file, cache_state) = result.into_transfer_parts();
+        let (_start_offset, bytes, mapped_range, size, mapped_source, position_in_file, cache_state) =
+            result.into_transfer_parts();
         if size <= 0 {
             return None;
         }
@@ -315,6 +321,7 @@ impl SegmentLease {
             None => SegmentSource::Bytes,
         };
 
+        let bytes = bytes.or_else(|| mapped_range.map(|range| range.to_bytes()));
         Some(Self {
             segment: CommitLogSegment {
                 global_offset,
@@ -532,6 +539,24 @@ impl FileRangeLease {
     #[cfg(test)]
     fn read_exact_for_test(&self, output: &mut [u8]) -> io::Result<()> {
         self.aliases.owner().read_exact_at_for_test(self.position(), output)
+    }
+}
+
+impl MappedReadRange<NativeReadOnlyMappedMemory> {
+    /// Converts this mapped range into a checked file-transfer range without copying payload.
+    ///
+    /// The returned capability retains this range's generation and read admission, so native
+    /// transfer cannot outlive the mapped-file lifecycle protection.
+    pub fn try_into_file_range(self) -> Result<FileRangeLease, FileRangeError> {
+        let owner = self.file_owner();
+        let position = self.file_offset();
+        let len = self.len();
+        FileRangeLease::try_new(
+            owner,
+            position,
+            len,
+            FileRangeOperationLease::MappedRead { _range: self },
+        )
     }
 }
 

--- a/rocketmq-store-local/tests/mapped_read_range.rs
+++ b/rocketmq-store-local/tests/mapped_read_range.rs
@@ -1,0 +1,179 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use cheetah_string::CheetahString;
+use rocketmq_store_local::mapped_file::DefaultMappedFile;
+use rocketmq_store_local::mapped_file::MappedFile;
+use rocketmq_store_local::mapped_file::NativeMappedMemory;
+use rocketmq_store_local::mapped_file::SelectMappedBufferSourceKind;
+
+type NativeMappedFile = DefaultMappedFile<NativeMappedMemory>;
+
+fn mapped_file(file_from_offset: u64) -> (tempfile::TempDir, Arc<NativeMappedFile>) {
+    let directory = tempfile::tempdir().expect("temporary mapped-file directory");
+    let path = directory.path().join(format!("{file_from_offset:020}"));
+    let mapped_file =
+        NativeMappedFile::try_new(CheetahString::from(path.to_string_lossy().into_owned()), 64).expect("mapped file");
+    (directory, Arc::new(mapped_file))
+}
+
+#[test]
+fn mapped_read_range_keeps_retirement_fenced_until_the_final_alias_drops() {
+    let (_directory, mapped_file) = mapped_file(128);
+    assert!(mapped_file.append_message_bytes(b"owner-backed"));
+    assert!(mapped_file.try_seal_readable().expect("seal mapped file"));
+
+    let range = mapped_file
+        .try_mapped_read_range(0, b"owner-backed".len())
+        .expect("range selection")
+        .expect("sealed range");
+    let (left, right) = range.split_at(5).expect("checked split");
+    let right_alias = right.clone();
+
+    assert_eq!(mapped_file.lifecycle_snapshot().active_leases, 1);
+    MappedFile::shutdown(mapped_file.as_ref(), u64::MAX);
+    assert_eq!(mapped_file.lifecycle_snapshot().active_leases, 1);
+    assert_eq!(left.with_slice(<[u8]>::to_vec), b"owner");
+    assert_eq!(right.with_slice(<[u8]>::to_vec), b"-backed");
+
+    drop(range);
+    drop(left);
+    drop(right);
+    assert_eq!(mapped_file.lifecycle_snapshot().active_leases, 1);
+    drop(right_alias);
+    assert_eq!(mapped_file.lifecycle_snapshot().active_leases, 0);
+    assert!(mapped_file.lifecycle_snapshot().logical_cleanup_marked);
+}
+
+#[test]
+fn mapped_read_range_retains_its_generation_across_a_mapping_swap() {
+    let (_directory, mapped_file) = mapped_file(256);
+    assert!(mapped_file.append_message_bytes(b"generation"));
+    assert!(mapped_file.try_seal_readable().expect("seal mapped file"));
+
+    let before = mapped_file
+        .try_mapped_read_range(0, b"generation".len())
+        .expect("range selection")
+        .expect("sealed range");
+    let before_generation = before.generation_id();
+    assert!(mapped_file.swap_map());
+    let after = mapped_file
+        .try_mapped_read_range(0, b"generation".len())
+        .expect("range selection")
+        .expect("replacement range");
+
+    assert_ne!(before_generation, after.generation_id());
+    assert_eq!(before.with_slice(<[u8]>::to_vec), b"generation");
+    assert_eq!(after.with_slice(<[u8]>::to_vec), b"generation");
+}
+
+#[test]
+fn mapped_read_range_checks_readable_bounds_and_derived_coordinates() {
+    let (_directory, mapped_file) = mapped_file(512);
+    assert!(mapped_file.append_message_bytes(b"0123456789"));
+    assert!(mapped_file
+        .try_mapped_read_range(0, 10)
+        .expect("active selection")
+        .is_none());
+    assert!(mapped_file.try_seal_readable().expect("seal mapped file"));
+    assert!(mapped_file
+        .try_mapped_read_range(8, 3)
+        .expect("bounded selection")
+        .is_none());
+
+    let range = mapped_file
+        .try_mapped_read_range(2, 6)
+        .expect("range selection")
+        .expect("sealed range");
+    assert_eq!(range.start_offset(), 514);
+    assert_eq!(range.file_from_offset(), 512);
+    assert_eq!(range.file_offset(), 2);
+    assert_eq!(range.len(), 6);
+    assert!(!range.is_empty());
+    assert_eq!(range.to_bytes().as_ref(), b"234567");
+
+    let middle = range.slice(2, 3).expect("checked subrange");
+    assert_eq!(middle.start_offset(), 516);
+    assert_eq!(middle.file_offset(), 4);
+    assert_eq!(middle.with_slice(<[u8]>::to_vec), b"456");
+    assert!(range.slice(5, 2).is_none());
+    assert!(range.slice(usize::MAX, 1).is_none());
+    assert!(range.split_at(7).is_none());
+}
+
+#[test]
+fn sealed_selection_is_range_backed_until_owned_bytes_are_requested() {
+    let (_directory, mapped_file) = mapped_file(640);
+    assert!(mapped_file.append_message_bytes(b"range-first"));
+    assert!(mapped_file.try_seal_readable().expect("seal mapped file"));
+
+    let mut selected = mapped_file
+        .select_mapped_buffer(0, b"range-first".len() as i32)
+        .expect("sealed selection");
+    assert_eq!(selected.source_kind(), SelectMappedBufferSourceKind::MappedFile);
+    assert!(selected.is_range_backed());
+    assert!(!selected.has_byte_snapshot());
+    assert_eq!(selected.get_buffer(), b"range-first");
+    assert!(!selected.has_byte_snapshot());
+
+    assert_eq!(selected.get_bytes_ref().map(Bytes::as_ref), Some(&b"range-first"[..]));
+    assert!(selected.has_byte_snapshot());
+    *selected.bytes_mut().expect("materialized compatibility bytes") = Bytes::from_static(b"Range-first");
+    assert!(!selected.is_range_backed());
+    assert_eq!(selected.source_kind(), SelectMappedBufferSourceKind::Bytes);
+    assert_eq!(selected.get_buffer(), b"Range-first");
+}
+
+#[test]
+fn range_selection_truncates_the_range_and_cached_compatibility_snapshot_together() {
+    let (_directory, mapped_file) = mapped_file(768);
+    assert!(mapped_file.append_message_bytes(b"truncate-range"));
+    assert!(mapped_file.try_seal_readable().expect("seal mapped file"));
+
+    let mut selected = mapped_file
+        .select_mapped_buffer(0, b"truncate-range".len() as i32)
+        .expect("sealed selection");
+    assert_eq!(
+        selected.get_bytes_ref().map(Bytes::as_ref),
+        Some(&b"truncate-range"[..])
+    );
+    assert!(selected.try_truncate(8));
+
+    assert_eq!(selected.size(), 8);
+    assert_eq!(selected.get_buffer(), b"truncate");
+    assert_eq!(selected.get_bytes_ref().map(Bytes::as_ref), Some(&b"truncate"[..]));
+}
+
+#[test]
+fn mapped_read_range_converts_to_a_file_range_without_releasing_admission() {
+    let (_directory, mapped_file) = mapped_file(896);
+    assert!(mapped_file.append_message_bytes(b"file-range"));
+    assert!(mapped_file.try_seal_readable().expect("seal mapped file"));
+
+    let range = mapped_file
+        .try_mapped_read_range(2, 4)
+        .expect("range selection")
+        .expect("sealed range");
+    let file_range = range.try_into_file_range().expect("checked file range");
+    assert_eq!(file_range.position(), 2);
+    assert_eq!(file_range.len(), 4);
+
+    MappedFile::shutdown(mapped_file.as_ref(), u64::MAX);
+    assert_eq!(mapped_file.lifecycle_snapshot().active_leases, 1);
+    drop(file_range);
+    assert_eq!(mapped_file.lifecycle_snapshot().active_leases, 0);
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9241

### Brief Description

- add an owner-backed `MappedReadRange` with checked global and file-local coordinates
- retain the exact mapping generation and read admission across clones, slices, and file-range conversion
- make sealed mapped-file selections range-first while preserving exact `Bytes` fallback for active segments and compatibility callers
- lazily materialize compatibility snapshots without changing wire or persisted formats

### How Did You Test This Change?

- `cargo test -p rocketmq-store-local`
- `cargo test -p rocketmq-store-local --test mapped_read_range --test ha_transfer_boundary`
- `cargo clippy -p rocketmq-store-local --no-deps --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`
- `cargo fmt --all -- --check` under WSL
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added zero-copy mapped read ranges for efficient access to file data.
  * Added support for slicing, splitting, cloning, and converting mapped ranges to byte snapshots or file-transfer ranges.
  * Preserved read access safely across mapping updates and lifecycle changes.
* **Bug Fixes**
  * Added validation for invalid offsets, lengths, and range boundaries.
  * Improved compatibility with existing buffer and truncation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->