### PR TITLE
[ISSUE #9243]✨Transfer mapped store ranges without payload snapshots

### DIFF
--- a/rocketmq-broker/src/filter/expression_for_retry_message_filter.rs
+++ b/rocketmq-broker/src/filter/expression_for_retry_message_filter.rs
@@ -22,6 +22,10 @@ pub struct ExpressionForRetryMessageFilter;
 
 #[allow(unused_variables)]
 impl MessageFilter for ExpressionForRetryMessageFilter {
+    fn requires_commit_log_payload(&self) -> bool {
+        false
+    }
+
     fn is_matched_by_consume_queue(&self, tags_code: Option<i64>, cq_ext_unit: Option<&CqExtUnit>) -> bool {
         true
     }

--- a/rocketmq-broker/src/filter/expression_message_filter.rs
+++ b/rocketmq-broker/src/filter/expression_message_filter.rs
@@ -59,6 +59,22 @@ impl ExpressionMessageFilter {
 
 #[allow(unused_variables)]
 impl MessageFilter for ExpressionMessageFilter {
+    fn requires_commit_log_payload(&self) -> bool {
+        let Some(subscription_data) = self.subscription_data.as_ref() else {
+            return false;
+        };
+        if subscription_data.class_filter_mode
+            || ExpressionType::is_tag_type(Some(subscription_data.expression_type.as_str()))
+        {
+            return false;
+        }
+        self.consumer_filter_data.as_ref().is_some_and(|filter| {
+            filter.expression().is_some()
+                && filter.expression_type().is_some()
+                && filter.compiled_expression().is_some()
+        })
+    }
+
     fn is_matched_by_consume_queue(&self, tags_code: Option<i64>, cq_ext_unit: Option<&CqExtUnit>) -> bool {
         if self.subscription_data.is_none() {
             return true;
@@ -309,6 +325,7 @@ mod tests {
         );
         let properties = HashMap::from([(CheetahString::from_slice("color"), CheetahString::from_slice("blue"))]);
 
+        assert!(filter.requires_commit_log_payload());
         assert!(filter.is_matched_by_commit_log(Some(&[]), Some(&properties)));
     }
 
@@ -354,6 +371,7 @@ mod tests {
         let subscription = FilterAPI::build_subscription_data(&topic, &CheetahString::from_static_str("blue"))
             .expect("tag subscription should build");
         let filter = ExpressionMessageFilter::new(Some(subscription), None, Arc::new(new_manager()));
+        assert!(!filter.requires_commit_log_payload());
 
         let mut store = new_store(&temp_root, &topic);
         store.init().await.expect("init store");

--- a/rocketmq-broker/src/processor/default_pull_message_result_handler.rs
+++ b/rocketmq-broker/src/processor/default_pull_message_result_handler.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::fs::File;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -40,11 +41,15 @@ use rocketmq_runtime::common::time_utils::current_millis;
 use rocketmq_store::ArcMessageFilter;
 use rocketmq_store::BrokerReadStore;
 use rocketmq_store::BrokerStatsManager;
+use rocketmq_store::FileRangeTransferHandle;
 use rocketmq_store::GetMessageResult;
 use rocketmq_store::GetMessageStatus;
 use rocketmq_store::StatsType;
 use rocketmq_transport::api::v1::Channel;
 use rocketmq_transport::api::v1::ConnectionHandlerContext;
+use rocketmq_transport::api::v1::FileRegion;
+use rocketmq_transport::api::v1::FileRegionLease;
+use rocketmq_transport::api::v1::FileRegionSequence;
 use tracing::debug;
 use tracing::info;
 use tracing::warn;
@@ -64,6 +69,29 @@ pub struct DefaultPullMessageResultHandler<MS: BrokerReadStore> {
     context: Arc<PullMessageProcessorContext<MS>>,
     consume_message_hook_list: Arc<Vec<Box<dyn ConsumeMessageHook>>>,
     broker_metrics_manager: Option<Arc<BrokerMetricsManager>>,
+}
+
+struct PullFileRegionLease {
+    handle: FileRangeTransferHandle,
+}
+
+impl FileRegionLease for PullFileRegionLease {
+    fn file(&self) -> &File {
+        self.handle.file()
+    }
+}
+
+fn pull_file_regions(get_message_result: &GetMessageResult) -> Option<FileRegionSequence> {
+    let mut regions = Vec::with_capacity(get_message_result.message_mapped_list().len());
+    for selected in get_message_result.message_mapped_list() {
+        let range = selected.file_range()?;
+        let position = range.position();
+        let len = u64::try_from(range.len()).ok()?;
+        let handle = range.try_transfer_handle().ok()?;
+        let region = FileRegion::try_new(Arc::new(PullFileRegionLease { handle }), position, len).ok()?;
+        regions.push(region);
+    }
+    FileRegionSequence::try_new(regions).ok()
 }
 
 impl<MS: BrokerReadStore> DefaultPullMessageResultHandler<MS> {
@@ -202,7 +230,13 @@ impl<MS: BrokerReadStore> PullMessageResultHandler for DefaultPullMessageResultH
                     }
                     Some(response)
                 } else {
-                    //zero copy transfer
+                    if let Some(regions) = pull_file_regions(&get_message_result) {
+                        if let Err(error) = channel.send_file_regions_response(response, regions).await {
+                            warn!(%error, "Failed to send owner-backed pull response");
+                        }
+                        return None;
+                    }
+
                     if let Some(header_bytes) =
                         response.encode_header_with_body_length(get_message_result.buffer_total_size() as usize)
                     {
@@ -643,5 +677,42 @@ impl<MS: BrokerReadStore> DefaultPullMessageResultHandler<MS> {
                 proxy_pull_broadcast,
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rocketmq_store::DefaultMappedFile;
+    use rocketmq_store::MappedFile;
+
+    #[test]
+    fn pull_file_regions_preserve_multiple_store_ranges_without_snapshots() {
+        let directory = tempfile::tempdir().expect("temporary pull range directory");
+        let path = directory.path().join("00000000000000000000");
+        let mapped_file = DefaultMappedFile::try_new(CheetahString::from(path.to_string_lossy().into_owned()), 64)
+            .expect("mapped file");
+        assert!(mapped_file.append_message_bytes(b"ordered-regions"));
+
+        let first = mapped_file
+            .try_file_range_selection(0, 8)
+            .expect("first selection")
+            .expect("first range");
+        let second = mapped_file
+            .try_file_range_selection(8, 7)
+            .expect("second selection")
+            .expect("second range");
+        assert!(!first.has_byte_snapshot());
+        assert!(!second.has_byte_snapshot());
+
+        let mut result = GetMessageResult::new_result_size(2);
+        result.add_message(first, 0, 1);
+        result.add_message(second, 1, 1);
+        let regions = pull_file_regions(&result).expect("owner-backed region sequence");
+        assert_eq!(regions.len(), 15);
+        assert!(result
+            .message_mapped_list()
+            .iter()
+            .all(|selected| !selected.has_byte_snapshot()));
     }
 }

--- a/rocketmq-store-local/src/filter.rs
+++ b/rocketmq-store-local/src/filter.rs
@@ -21,6 +21,15 @@ use crate::consume_queue::extension::CqExtUnit;
 
 /// A trait for filtering messages.
 pub trait MessageFilter: Send + Sync {
+    /// Reports whether commit-log payload bytes are required after consume-queue matching.
+    ///
+    /// Implementations that can decide entirely from consume-queue metadata should return
+    /// `false`, allowing the store to retain an owner-backed transfer range instead of creating a
+    /// payload snapshot.
+    fn requires_commit_log_payload(&self) -> bool {
+        true
+    }
+
     /// Checks if the message is matched by the consume queue.
     ///
     /// # Arguments

--- a/rocketmq-store-local/src/ha/transfer_engine.rs
+++ b/rocketmq-store-local/src/ha/transfer_engine.rs
@@ -235,9 +235,15 @@ pub(crate) fn batch_body_chunks(batch: &TransferBatch) -> TransferResult<Vec<Byt
 
     let mut chunks = Vec::with_capacity(batch.segments.len());
     for segment in &batch.segments {
-        let bytes = segment.as_bytes().ok_or(TransferError::UnsupportedSegmentSource(
-            "byte-backed segment required for bytes or vectored HA transfer",
-        ))?;
+        let bytes = match segment.as_bytes() {
+            Some(bytes) => bytes,
+            None => segment
+                .as_file_range()
+                .ok_or(TransferError::UnsupportedSegmentSource(
+                    "HA segment has neither bytes nor a file range",
+                ))?
+                .to_bytes()?,
+        };
         let len = bytes.len().min(remaining);
         if len > 0 {
             chunks.push(bytes.slice(..len));

--- a/rocketmq-store-local/src/mapped_file/default_mapped_file.rs
+++ b/rocketmq-store-local/src/mapped_file/default_mapped_file.rs
@@ -84,6 +84,7 @@ use crate::mapped_file::retirement::state::reconciliation::ReconciledSegmentFile
 use crate::mapped_file::MappedFileLifecycleSnapshot;
 use crate::mapped_file::MappedFileOperation;
 use crate::mapped_file::MappedReadRange;
+use crate::transfer::segment::FileRangeLease;
 use crate::utils::ffi::advise_memory;
 use crate::utils::ffi::get_page_size;
 use crate::utils::ffi::lock_memory_region;
@@ -543,6 +544,51 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
         MappedReadRange::try_new(lease, start_offset, file_offset, self.metrics.clone())
             .map(Some)
             .ok_or_else(|| MappedFileError::out_of_bounds(offset, len, self.raw_core.file_size()))
+    }
+
+    /// Selects an exact payload range backed by the canonical file owner.
+    ///
+    /// Unlike mapped slices, this capability is safe for the immutable published prefix of an
+    /// active append segment: the read admission prevents retirement while later appends remain
+    /// outside the checked range.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the range overflows, mapped-file admission is unavailable, or the
+    /// canonical file owner cannot be retained. An unpublished range returns `Ok(None)`.
+    pub fn try_file_range_selection(
+        &self,
+        offset: usize,
+        len: usize,
+    ) -> MappedFileResult<Option<SelectMappedBufferResult<M>>> {
+        let end = offset
+            .checked_add(len)
+            .ok_or_else(|| MappedFileError::out_of_bounds(offset, len, self.raw_core.file_size()))?;
+        let readable_position =
+            usize::try_from(self.get_read_position()).map_err(|_| MappedFileError::InvalidWritePosition {
+                position: self.get_read_position(),
+                capacity: self.raw_core.file_size(),
+            })?;
+        if end > readable_position {
+            return Ok(None);
+        }
+        let file_offset = u64::try_from(offset)
+            .map_err(|_| MappedFileError::out_of_bounds(offset, len, self.raw_core.file_size()))?;
+        let admission = self.acquire_owned(MappedFileOperation::Read)?;
+        let is_in_cache = self.record_cache_residency_admitted(&admission, offset as i64, len);
+        let owner = self.file_owner_admitted(&admission)?;
+        let range = FileRangeLease::try_from_mapped_file(owner, file_offset, len, admission)
+            .map_err(|error| MappedFileError::Custom(error.to_string()))?;
+        let start_offset = self
+            .get_file_from_offset()
+            .checked_add(file_offset)
+            .ok_or_else(|| MappedFileError::out_of_bounds(offset, len, self.raw_core.file_size()))?;
+        Ok(SelectMappedBufferResult::from_file_range(
+            start_offset,
+            file_offset,
+            range,
+            is_in_cache,
+        ))
     }
 
     #[inline]

--- a/rocketmq-store-local/src/mapped_file/file.rs
+++ b/rocketmq-store-local/src/mapped_file/file.rs
@@ -365,6 +365,10 @@ impl FileOwner {
         operation(self.handle.as_file())
     }
 
+    pub(crate) fn try_clone_for_transfer(&self) -> io::Result<File> {
+        self.handle.as_file().try_clone()
+    }
+
     /// Creates a writable mapping without exposing or cloning the owned file handle.
     ///
     /// # Safety
@@ -406,15 +410,26 @@ impl FileOwner {
         operation(self.handle.as_file(), len)
     }
 
+    pub(crate) fn read_exact_at(&self, mut offset: u64, mut output: &mut [u8]) -> io::Result<()> {
+        while !output.is_empty() {
+            let read = read_at(self.handle.as_file(), output, offset)?;
+            if read == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "mapped-file transfer range ended before its validated length",
+                ));
+            }
+            offset = offset
+                .checked_add(read as u64)
+                .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "mapped-file read offset overflow"))?;
+            output = &mut output[read..];
+        }
+        Ok(())
+    }
+
     #[cfg(test)]
     pub(crate) fn read_exact_at_for_test(&self, offset: u64, output: &mut [u8]) -> io::Result<()> {
-        use std::io::Read;
-        use std::io::Seek;
-        use std::io::SeekFrom;
-
-        let mut file = self.handle.as_file();
-        file.seek(SeekFrom::Start(offset))?;
-        file.read_exact(output)
+        self.read_exact_at(offset, output)
     }
 
     /// Returns the current file length without exposing the handle.
@@ -483,6 +498,28 @@ impl FileOwner {
         }
         operation(out_fd, self.raw_fd(), offset, len)
     }
+}
+
+#[cfg(unix)]
+fn read_at(file: &File, output: &mut [u8], offset: u64) -> io::Result<usize> {
+    use std::os::unix::fs::FileExt;
+
+    file.read_at(output, offset)
+}
+
+#[cfg(windows)]
+fn read_at(file: &File, output: &mut [u8], offset: u64) -> io::Result<usize> {
+    use std::os::windows::fs::FileExt;
+
+    file.seek_read(output, offset)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn read_at(_file: &File, _output: &mut [u8], _offset: u64) -> io::Result<usize> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "positional mapped-file reads are unsupported on this platform",
+    ))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/rocketmq-store-local/src/mapped_file/select_result.rs
+++ b/rocketmq-store-local/src/mapped_file/select_result.rs
@@ -24,6 +24,7 @@ use super::MappedFileOperation;
 use super::MappedMemory;
 use super::MappedReadRange;
 use super::NativeMappedMemory;
+use crate::transfer::segment::FileRangeLease;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SelectMappedBufferSourceKind {
@@ -42,6 +43,7 @@ pub(crate) type SelectMappedBufferTransferParts<M> = (
     u64,
     Option<Bytes>,
     Option<MappedReadRange<<M as MappedMemory>::ReadOnly>>,
+    Option<FileRangeLease>,
     i32,
     Option<(MappedFileLease, Arc<DefaultMappedFile<M>>)>,
     u64,
@@ -64,6 +66,7 @@ pub struct SelectMappedBufferResult<M: MappedMemory = NativeMappedMemory> {
     start_offset: u64,
     bytes: OnceLock<Bytes>,
     mapped_range: Option<MappedReadRange<M::ReadOnly>>,
+    file_range: Option<FileRangeLease>,
     /// The size.
     size: i32,
     /// The mapped file and the admission lease protecting it.
@@ -86,6 +89,7 @@ impl<M: MappedMemory> Default for SelectMappedBufferResult<M> {
             start_offset: 0,
             bytes: OnceLock::new(),
             mapped_range: None,
+            file_range: None,
             size: 0,
             mapped_source: None,
             is_in_cache: true,
@@ -121,6 +125,7 @@ impl<M: MappedMemory> SelectMappedBufferResult<M> {
             start_offset,
             bytes: OnceLock::from(bytes),
             mapped_range: None,
+            file_range: None,
             size,
             mapped_source: None,
             is_in_cache,
@@ -141,6 +146,29 @@ impl<M: MappedMemory> SelectMappedBufferResult<M> {
             start_offset: range.start_offset(),
             bytes: OnceLock::new(),
             mapped_range: Some(range),
+            file_range: None,
+            size,
+            mapped_source: None,
+            is_in_cache,
+            source_kind: SelectMappedBufferSourceKind::MappedFile,
+            file_offset,
+            cache_state: SelectMappedBufferCacheState::from_residency(is_in_cache),
+        })
+    }
+
+    /// Creates a selection backed by an admission-fenced file range.
+    pub(crate) fn from_file_range(
+        start_offset: u64,
+        file_offset: u64,
+        range: FileRangeLease,
+        is_in_cache: bool,
+    ) -> Option<Self> {
+        let size = i32::try_from(range.len()).ok()?;
+        Some(Self {
+            start_offset,
+            bytes: OnceLock::new(),
+            mapped_range: None,
+            file_range: Some(range),
             size,
             mapped_source: None,
             is_in_cache,
@@ -175,7 +203,7 @@ impl<M: MappedMemory> SelectMappedBufferResult<M> {
     /// The immutable byte snapshot remains available when the mapped file can no longer be held,
     /// so callers can safely fall back to the copied representation.
     pub fn try_attach_mapped_file(&mut self, mapped_file: Arc<DefaultMappedFile<M>>) -> bool {
-        if self.mapped_range.is_some() || self.mapped_source.is_some() {
+        if self.mapped_range.is_some() || self.file_range.is_some() || self.mapped_source.is_some() {
             return false;
         }
         let Some(bytes) = self.bytes.get() else {
@@ -241,10 +269,12 @@ impl<M: MappedMemory> SelectMappedBufferResult<M> {
         if let Some(bytes) = self.bytes.get() {
             return bytes.as_ref();
         }
-        self.mapped_range
-            .as_ref()
-            .map(MappedReadRange::as_slice)
-            .expect("selected mapped buffers must own bytes or an immutable mapped range")
+        if let Some(range) = self.mapped_range.as_ref() {
+            return range.as_slice();
+        }
+        self.get_bytes_ref()
+            .map(Bytes::as_ref)
+            .expect("selected mapped buffers must own bytes, an immutable mapped range, or a readable file range")
     }
 
     #[inline]
@@ -259,14 +289,25 @@ impl<M: MappedMemory> SelectMappedBufferResult<M> {
         if let Some(bytes) = self.bytes.get() {
             return Some(bytes);
         }
-        let range = self.mapped_range.as_ref()?;
-        Some(self.bytes.get_or_init(|| range.to_bytes()))
+        if let Some(range) = self.mapped_range.as_ref() {
+            return Some(self.bytes.get_or_init(|| range.to_bytes()));
+        }
+        let range = self.file_range.as_ref()?;
+        let bytes = range.to_bytes().ok()?;
+        let _ = self.bytes.set(bytes);
+        self.bytes.get()
     }
 
     /// Returns whether the authoritative payload is still an owner-backed mapped range.
     #[inline]
     pub fn is_range_backed(&self) -> bool {
-        self.mapped_range.is_some()
+        self.mapped_range.is_some() || self.file_range.is_some()
+    }
+
+    /// Returns the admission-fenced file range when no compatibility conversion has detached it.
+    #[inline]
+    pub fn file_range(&self) -> Option<FileRangeLease> {
+        self.file_range.clone()
     }
 
     /// Returns whether an owned compatibility snapshot has already been materialized.
@@ -281,11 +322,17 @@ impl<M: MappedMemory> SelectMappedBufferResult<M> {
             self.source_kind = SelectMappedBufferSourceKind::Bytes;
         }
         let range_fallback = if self.bytes.get().is_none() {
-            self.mapped_range.as_ref().map(MappedReadRange::to_bytes)
+            self.mapped_range
+                .as_ref()
+                .map(MappedReadRange::to_bytes)
+                .or_else(|| self.file_range.as_ref().and_then(|range| range.to_bytes().ok()))
         } else {
             None
         };
         if self.mapped_range.take().is_some() {
+            self.source_kind = SelectMappedBufferSourceKind::Bytes;
+        }
+        if self.file_range.take().is_some() {
             self.source_kind = SelectMappedBufferSourceKind::Bytes;
         }
         if self.bytes.get().is_none() {
@@ -303,9 +350,15 @@ impl<M: MappedMemory> SelectMappedBufferResult<M> {
             if let Some(range) = self.mapped_range.take() {
                 let _ = self.bytes.set(range.to_bytes());
                 self.source_kind = SelectMappedBufferSourceKind::Bytes;
+            } else if let Some(range) = self.file_range.take() {
+                if let Ok(bytes) = range.to_bytes() {
+                    let _ = self.bytes.set(bytes);
+                    self.source_kind = SelectMappedBufferSourceKind::Bytes;
+                }
             }
         }
         self.mapped_range.take();
+        self.file_range.take();
         self.mapped_source.take();
         self.source_kind = SelectMappedBufferSourceKind::Bytes;
         self.bytes.take()
@@ -324,6 +377,13 @@ impl<M: MappedMemory> SelectMappedBufferResult<M> {
             self.mapped_range = Some(truncated);
             truncated_any = true;
         }
+        if let Some(range) = self.file_range.as_mut() {
+            if new_len > range.len() {
+                return false;
+            }
+            range.truncate_to(new_len);
+            truncated_any = true;
+        }
         if let Some(bytes) = self.bytes.get_mut() {
             if new_len > bytes.len() {
                 return false;
@@ -339,8 +399,8 @@ impl<M: MappedMemory> SelectMappedBufferResult<M> {
     }
 
     pub fn is_in_mem(&self) -> bool {
-        if self.mapped_range.is_some() {
-            return true;
+        if self.mapped_range.is_some() || self.file_range.is_some() {
+            return self.is_in_cache;
         }
         match self.mapped_source.as_ref() {
             None => true,
@@ -358,6 +418,7 @@ impl<M: MappedMemory> SelectMappedBufferResult<M> {
             self.start_offset,
             self.bytes.take(),
             self.mapped_range.take(),
+            self.file_range.take(),
             self.size,
             self.mapped_source.take(),
             self.file_offset,

--- a/rocketmq-store-local/src/transfer/batch.rs
+++ b/rocketmq-store-local/src/transfer/batch.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::io;
+
 use bytes::Bytes;
 
 use crate::transfer::segment::SegmentLease;
@@ -56,6 +58,43 @@ impl TransferBatch {
                 Some(Bytes::from(bytes))
             }
         }
+    }
+
+    /// Materializes only file-backed segments into exact byte ranges.
+    ///
+    /// Callers must run this operation on the storage I/O lane because positional file reads may
+    /// block. Existing byte-backed segments retain their shared buffers.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error when an exact file range cannot be read or a segment has no readable
+    /// backing source.
+    pub fn into_bytes_backed(self) -> io::Result<Self> {
+        let mut materialized = Vec::with_capacity(self.segments.len());
+        for segment in self.segments {
+            let bytes = match segment.as_bytes() {
+                Some(bytes) => bytes,
+                None => segment
+                    .as_file_range()
+                    .ok_or_else(|| io::Error::other("HA segment has neither bytes nor a file range"))?
+                    .to_bytes()?,
+            };
+            let bytes = bytes.slice(..segment.len().min(bytes.len()));
+            materialized.push(SegmentLease::from_bytes(
+                segment.segment().global_offset(),
+                segment.segment().position_in_file(),
+                bytes,
+                segment.segment().cache_state(),
+            ));
+        }
+        Ok(Self {
+            frame_header: self.frame_header,
+            segments: materialized,
+            total_body_len: self.total_body_len,
+            start_offset: self.start_offset,
+            next_offset: self.next_offset,
+            kind: self.kind,
+        })
     }
 }
 

--- a/rocketmq-store-local/src/transfer/segment.rs
+++ b/rocketmq-store-local/src/transfer/segment.rs
@@ -106,7 +106,6 @@ struct FileRangeAliasInner {
 }
 
 impl FileRangeAliasInner {
-    #[cfg(any(unix, test))]
     #[inline]
     fn owner(&self) -> &FileOwner {
         self.owner
@@ -138,6 +137,20 @@ impl Drop for FileRangeAliasInner {
 pub struct FileRangeLease {
     aliases: Arc<FileRangeAliasInner>,
     range: CheckedFileRange,
+}
+
+/// Duplicated transfer descriptor that cannot outlive its mapped-file range guard.
+pub struct FileRangeTransferHandle {
+    file: File,
+    _range: FileRangeLease,
+}
+
+impl FileRangeTransferHandle {
+    /// Returns the duplicated descriptor protected by the retained mapped-file range admission.
+    #[inline]
+    pub fn file(&self) -> &File {
+        &self.file
+    }
 }
 
 /// Legacy type name for the checked owner-bearing range capability.
@@ -282,7 +295,7 @@ impl SegmentLease {
 
     /// Compatibility adapter for callers that already carry a separate global offset.
     pub fn from_select_result(global_offset: i64, result: NativeSelectMappedBufferResult) -> Option<Self> {
-        let (_start_offset, bytes, mapped_range, size, mapped_source, position_in_file, cache_state) =
+        let (_start_offset, bytes, mapped_range, file_range, size, mapped_source, position_in_file, cache_state) =
             result.into_transfer_parts();
         if size <= 0 {
             return None;
@@ -293,6 +306,34 @@ impl SegmentLease {
             .map(|(_lease, mapped_file)| mapped_file.get_file_from_offset())
             .unwrap_or_else(|| global_offset.saturating_sub(position_in_file as i64) as u64);
         let cache_state = cache_state.into();
+        if let Some(lease) = file_range {
+            return Some(Self {
+                segment: CommitLogSegment {
+                    global_offset,
+                    file_offset,
+                    position_in_file,
+                    len,
+                    source: SegmentSource::FileRange { lease },
+                    cache_state,
+                },
+                bytes,
+            });
+        }
+        if let Some(range) = mapped_range.as_ref() {
+            if let Ok(lease) = range.clone().try_into_file_range() {
+                return Some(Self {
+                    segment: CommitLogSegment {
+                        global_offset,
+                        file_offset: range.file_from_offset(),
+                        position_in_file: range.file_offset(),
+                        len,
+                        source: SegmentSource::FileRange { lease },
+                        cache_state,
+                    },
+                    bytes,
+                });
+            }
+        }
         let source = match mapped_source {
             Some((lease, mapped_file)) => match mapped_file.file_owner_admitted(&lease) {
                 Ok(owner) => match Self::try_from_file_owner_range(
@@ -451,6 +492,20 @@ impl FileRangeLease {
         })
     }
 
+    pub(crate) fn try_from_mapped_file(
+        owner: Arc<FileOwner>,
+        position: u64,
+        len: usize,
+        operation: MappedFileLease,
+    ) -> Result<Self, FileRangeError> {
+        Self::try_new(
+            owner,
+            position,
+            len,
+            FileRangeOperationLease::Mapped { _lease: operation },
+        )
+    }
+
     #[inline]
     pub fn position(&self) -> u64 {
         self.range.position()
@@ -464,6 +519,34 @@ impl FileRangeLease {
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.range.bounds.is_empty()
+    }
+
+    /// Copies exactly this checked range for compatibility engines that cannot consume file
+    /// regions directly.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error when the validated file range can no longer be read completely.
+    pub fn to_bytes(&self) -> io::Result<Bytes> {
+        let mut output = vec![0_u8; self.len()];
+        self.aliases.owner().read_exact_at(self.position(), &mut output)?;
+        Ok(Bytes::from(output))
+    }
+
+    /// Creates a descriptor adapter while retaining this range's admission and owner guard.
+    ///
+    /// The descriptor field intentionally precedes the range guard so Windows closes the duplicate
+    /// before releasing the final retirement admission.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error when the operating-system descriptor cannot be duplicated.
+    pub fn try_transfer_handle(&self) -> io::Result<FileRangeTransferHandle> {
+        let file = self.aliases.owner().try_clone_for_transfer()?;
+        Ok(FileRangeTransferHandle {
+            file,
+            _range: self.clone(),
+        })
     }
 
     /// Splits this capability at a relative byte offset.
@@ -495,7 +578,6 @@ impl FileRangeLease {
         Ok((self, right))
     }
 
-    #[cfg(unix)]
     #[inline]
     pub(crate) fn truncate_to(&mut self, maximum_len: usize) {
         let retained = self.len().min(maximum_len);

--- a/rocketmq-store/src/consume_queue/mapped_file_queue.rs
+++ b/rocketmq-store/src/consume_queue/mapped_file_queue.rs
@@ -346,6 +346,18 @@ impl MappedFileQueueReadHandle {
         result
     }
 
+    pub(crate) fn get_message_for_transfer(&self, offset: i64, size: i32) -> Option<SelectMappedBufferResult> {
+        if offset < 0 || size <= 0 {
+            return None;
+        }
+        let mapped_file = self.find_mapped_file_by_offset(offset, offset == 0)?;
+        let position = usize::try_from(offset % self.mapped_file_size as i64).ok()?;
+        mapped_file
+            .try_file_range_selection(position, size as usize)
+            .ok()
+            .flatten()
+    }
+
     pub(crate) fn get_bulk_data(&self, offset: i64, size: i32) -> Option<Vec<SelectMappedBufferResult>> {
         if size <= 0 {
             return Some(Vec::new());
@@ -369,6 +381,38 @@ impl MappedFileQueueReadHandle {
 
             results.push(result);
             current_offset += take as i64;
+            remaining -= take;
+        }
+
+        Some(results)
+    }
+
+    pub(crate) fn get_bulk_transfer_data(&self, offset: i64, size: i32) -> Option<Vec<SelectMappedBufferResult>> {
+        if offset < 0 {
+            return None;
+        }
+        if size <= 0 {
+            return Some(Vec::new());
+        }
+
+        let mapped_file_size = self.mapped_file_size as i64;
+        let mut current_offset = offset;
+        let mut remaining = size as usize;
+        let mut results = Vec::new();
+
+        while remaining > 0 {
+            let mapped_file = self.find_mapped_file_by_offset(current_offset, current_offset == offset)?;
+            let position = usize::try_from(current_offset % mapped_file_size).ok()?;
+            let readable = usize::try_from(mapped_file.get_read_position())
+                .ok()?
+                .checked_sub(position)?;
+            if readable == 0 {
+                return None;
+            }
+            let take = readable.min(remaining);
+            let result = mapped_file.try_file_range_selection(position, take).ok().flatten()?;
+            results.push(result);
+            current_offset = current_offset.checked_add(take as i64)?;
             remaining -= take;
         }
 

--- a/rocketmq-store/src/ha/default_ha_connection.rs
+++ b/rocketmq-store/src/ha/default_ha_connection.rs
@@ -24,6 +24,7 @@ use bytes::Bytes;
 use bytes::BytesMut;
 use futures_util::StreamExt;
 use rocketmq_runtime::common::time_utils::current_millis;
+use rocketmq_runtime::BlockingExecutor;
 use tokio::io::AsyncWrite;
 use tokio::net::tcp::OwnedReadHalf;
 use tokio::net::tcp::OwnedWriteHalf;
@@ -296,6 +297,7 @@ impl HAConnection for DefaultHAConnection {
             self.message_store_config.clone(),
             connection_runtime,
             self.next_transfer_from_where.clone(),
+            self.runtime_scope.storage_io(),
         )
         .await?;
 
@@ -594,6 +596,7 @@ impl ReadSocketService {
 /// Write Socket Service
 pub struct WriteSocketService {
     writer: HaTransferEngine<OwnedWriteHalf>,
+    storage_io: BlockingExecutor,
     client_address: String,
     connection_context: DefaultHAConnectionContext,
     current_state: Arc<RwLock<HAConnectionState>>,
@@ -628,6 +631,7 @@ impl WriteSocketService {
         message_store_config: Arc<MessageStoreConfig>,
         connection_runtime: HAConnectionRuntimeHandle,
         next_transfer_from_where: Arc<AtomicI64>,
+        storage_io: BlockingExecutor,
     ) -> Result<Self, HAConnectionError> {
         let enable_controller_mode = message_store_config.enable_controller_mode;
         let preference = transfer_engine_preference(&message_store_config);
@@ -661,6 +665,7 @@ impl WriteSocketService {
         let writer = HaTransferEngine::from_selection(writer, selection.engine);
         Ok(Self {
             writer,
+            storage_io,
             client_address,
             connection_context,
             current_state,
@@ -915,6 +920,22 @@ impl WriteSocketService {
     }
 
     async fn send_data(&mut self, mut batch: TransferBatch) -> HAConnectionResult<()> {
+        let requires_materialization = match self.writer.kind() {
+            TransferEngineKind::Bytes | TransferEngineKind::Vectored | TransferEngineKind::IoUring => {
+                batch.segments.iter().any(|segment| segment.as_bytes().is_none())
+            }
+            TransferEngineKind::Sendfile => {
+                batch.segments.iter().any(|segment| segment.as_file_range().is_none())
+                    && batch.segments.iter().any(|segment| segment.as_bytes().is_none())
+            }
+        };
+        if requires_materialization {
+            batch = self
+                .storage_io
+                .spawn_io("ha-materialize-file-ranges", move || batch.into_bytes_backed())
+                .await
+                .map_err(|error| HAConnectionError::Service(error.to_string()))??;
+        }
         let confirm_offset = self.connection_context.replica_store().get_confirm_offset();
         let header_bytes = encode_transfer_header(
             &mut self.byte_buffer_header,

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -1003,6 +1003,10 @@ impl CommitLog {
         }
     }
 
+    pub(crate) fn get_message_for_transfer(&self, offset: i64, size: i32) -> Option<SelectMappedBufferResult> {
+        self.read_handle().get_message_for_transfer(offset, size)
+    }
+
     pub fn set_confirm_offset(&mut self, phy_offset: i64) {
         self.publish_confirm_offset(phy_offset);
     }
@@ -3962,6 +3966,7 @@ mod tests {
             .await
             .expect("append second chunk"));
 
+        let before = store.get_commit_log().selection_stats();
         let segments = store
             .get_commit_log()
             .select_segments(12, 8, false)
@@ -3971,13 +3976,17 @@ mod tests {
         assert_eq!(segments[0].segment().global_offset(), 12);
         assert_eq!(segments[0].segment().position_in_file(), 12);
         assert_eq!(segments[0].len(), 4);
-        assert_eq!(
-            segments[0].as_bytes().expect("segment bytes"),
-            Bytes::from_static(b"CDEF")
-        );
+        assert!(segments[0].as_bytes().is_none());
         let file_range = segments[0].as_file_range().expect("file range");
         assert_eq!(file_range.position(), 12);
         assert_eq!(file_range.len(), 4);
+        assert_eq!(
+            file_range.to_bytes().expect("exact fallback"),
+            Bytes::from_static(b"CDEF")
+        );
+        let after = store.get_commit_log().selection_stats();
+        assert_eq!(after.copied_bytes, before.copied_bytes);
+        assert_eq!(after.compared_bytes, before.compared_bytes);
 
         let _ = fs::remove_dir_all(temp_root);
     }

--- a/rocketmq-store/src/log_file/commit_log/handles.rs
+++ b/rocketmq-store/src/log_file/commit_log/handles.rs
@@ -97,6 +97,10 @@ impl CommitLogReadHandle {
         self.mapped_file_queue.get_message(offset, size)
     }
 
+    pub(crate) fn get_message_for_transfer(&self, offset: i64, size: i32) -> Option<SelectMappedBufferResult> {
+        self.mapped_file_queue.get_message_for_transfer(offset, size)
+    }
+
     pub(crate) fn get_bulk_data(&self, offset: i64, size: i32) -> Option<Vec<SelectMappedBufferResult>> {
         self.mapped_file_queue.get_bulk_data(offset, size)
     }
@@ -198,7 +202,7 @@ impl CommitLogReadHandle {
             max_bytes = max_bytes.min(mapped_file_size.saturating_sub(position_in_file));
         }
 
-        let Some(results) = self.get_bulk_data(offset, max_bytes as i32) else {
+        let Some(results) = self.mapped_file_queue.get_bulk_transfer_data(offset, max_bytes as i32) else {
             return Ok(Vec::new());
         };
         Ok(results.into_iter().filter_map(SegmentLease::from_selection).collect())

--- a/rocketmq-store/src/message_store/local_file_message_store/read_path.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/read_path.rs
@@ -242,7 +242,15 @@ impl LocalFileMessageStore {
                                 }
                             }
 
-                            let Some(select_result) = self.commit_log.get_message(offset_py, size_py) else {
+                            let requires_payload = message_filter
+                                .as_ref()
+                                .is_some_and(|filter| filter.requires_commit_log_payload());
+                            let selected = if requires_payload {
+                                self.commit_log.get_message(offset_py, size_py)
+                            } else {
+                                self.commit_log.get_message_for_transfer(offset_py, size_py)
+                            };
+                            let Some(select_result) = selected else {
                                 if get_result_ref.buffer_total_size() == 0 {
                                     status = GetMessageStatus::MessageWasRemoving;
                                 }
@@ -257,7 +265,8 @@ impl LocalFileMessageStore {
                             }
 
                             if let Some(filter) = message_filter.as_ref() {
-                                if !filter.is_matched_by_commit_log(Some(select_result.get_buffer()), None) {
+                                let message = requires_payload.then(|| select_result.get_buffer());
+                                if !filter.is_matched_by_commit_log(message, None) {
                                     if get_result_ref.buffer_total_size() == 0 {
                                         status = GetMessageStatus::NoMatchedMessage;
                                     }

--- a/rocketmq-store/src/public_api.rs
+++ b/rocketmq-store/src/public_api.rs
@@ -220,6 +220,8 @@ pub use crate::transfer::error::TransferError;
 pub use crate::transfer::planner::TransferPlanInput;
 pub use crate::transfer::planner::TransferPlanner;
 pub use crate::transfer::planner::DEFAULT_TRANSFER_BATCH_SIZE;
+pub use crate::transfer::segment::FileRangeLease;
+pub use crate::transfer::segment::FileRangeTransferHandle;
 pub use crate::transfer::segment::SegmentLease;
 pub use crate::transfer::segment::TransferCacheState;
 

--- a/rocketmq-transport/src/connection.rs
+++ b/rocketmq-transport/src/connection.rs
@@ -42,6 +42,7 @@ use crate::codec::remoting_command_codec::RemotingCommandCodec;
 use crate::codec::remoting_command_codec::SessionCommandDecoder;
 use crate::deadline::RequestDeadline;
 use crate::file_region::FileRegion;
+use crate::file_region::FileRegionSequence;
 use crate::file_region::FileTransferMode;
 use crate::telemetry::TransportTelemetry;
 use crate::write_strategy::FrameWriteMode;
@@ -945,24 +946,52 @@ impl Connection {
         body: FileRegion,
         deadline: RequestDeadline,
     ) -> rocketmq_error::RocketMQResult<()> {
+        self.send_file_regions_command(command_without_body, FileRegionSequence::single(body), deadline)
+            .await
+    }
+
+    /// Sends one command whose body is an ordered sequence of leased file regions.
+    pub async fn send_file_regions_command(
+        &mut self,
+        command_without_body: RemotingCommand,
+        body: FileRegionSequence,
+        deadline: RequestDeadline,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        self.send_file_regions_inner(command_without_body, body, Some(deadline))
+            .await
+    }
+
+    /// Sends a server response backed by ordered file regions under the writer's own stall bound.
+    pub async fn send_file_regions_response(
+        &mut self,
+        command_without_body: RemotingCommand,
+        body: FileRegionSequence,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        self.send_file_regions_inner(command_without_body, body, None).await
+    }
+
+    async fn send_file_regions_inner(
+        &mut self,
+        command_without_body: RemotingCommand,
+        body: FileRegionSequence,
+        deadline: Option<RequestDeadline>,
+    ) -> rocketmq_error::RocketMQResult<()> {
         let target = "transport-file-region-writer".to_string();
-        deadline.ensure_before_send(target.clone())?;
+        if let Some(deadline) = deadline {
+            deadline.ensure_before_send(target.clone())?;
+        }
         let class = self
             .response_class()
             .unwrap_or_else(|| AdmissionClass::for_request_code(command_without_body.code()));
         let body_len = usize::try_from(body.len()).map_err(|_| {
-            rocketmq_error::RocketMQError::illegal_argument("file region length exceeds this platform's usize")
+            rocketmq_error::RocketMQError::illegal_argument("file region sequence length exceeds this platform's usize")
         })?;
         let head = EncodedFrameHead::from_command_and_body_len(command_without_body, body_len)?;
-        deadline.ensure_before_send(target.clone())?;
-        self.send_payload(
-            OutboundPayload::FileFrame { head, body },
-            class,
-            None,
-            Some(deadline),
-            target,
-        )
-        .await
+        if let Some(deadline) = deadline {
+            deadline.ensure_before_send(target.clone())?;
+        }
+        self.send_payload(OutboundPayload::FileFrame { head, body }, class, None, deadline, target)
+            .await
     }
 
     /// Sends one command while transferring an existing process-budget

--- a/rocketmq-transport/src/file_region.rs
+++ b/rocketmq-transport/src/file_region.rs
@@ -50,6 +50,57 @@ pub struct FileRegion {
     sendfile_supported: Arc<OnceLock<bool>>,
 }
 
+/// Ordered external body regions written as one RocketMQ frame.
+#[derive(Clone, Debug)]
+pub struct FileRegionSequence {
+    regions: Vec<FileRegion>,
+    len: u64,
+}
+
+impl FileRegionSequence {
+    /// Validates a non-empty ordered region sequence and its aggregate length.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed argument error when no region is supplied or the aggregate length
+    /// overflows `u64`.
+    pub fn try_new(regions: Vec<FileRegion>) -> RocketMQResult<Self> {
+        if regions.is_empty() {
+            return Err(RocketMQError::illegal_argument(
+                "file region sequence must contain at least one region",
+            ));
+        }
+        let len = regions.iter().try_fold(0_u64, |total, region| {
+            total
+                .checked_add(region.len())
+                .ok_or_else(|| RocketMQError::illegal_argument("file region sequence length overflowed u64"))
+        })?;
+        Ok(Self { regions, len })
+    }
+
+    pub(crate) fn single(region: FileRegion) -> Self {
+        Self {
+            len: region.len(),
+            regions: vec![region],
+        }
+    }
+
+    #[inline]
+    pub const fn len(&self) -> u64 {
+        self.len
+    }
+
+    #[inline]
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    #[inline]
+    pub(crate) fn regions(&self) -> &[FileRegion] {
+        &self.regions
+    }
+}
+
 impl std::fmt::Debug for FileRegion {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter

--- a/rocketmq-transport/src/net/channel.rs
+++ b/rocketmq-transport/src/net/channel.rs
@@ -45,6 +45,7 @@ use crate::connection::ConnectionStateHandle;
 use crate::deadline::RequestDeadline;
 use crate::dispatch::ResponseSink;
 use crate::file_region::FileRegion;
+use crate::file_region::FileRegionSequence;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 
 pub type ChannelId = CheetahString;
@@ -247,6 +248,27 @@ impl Channel {
         self.inner
             .send_file_region_command(command_without_body, body, deadline)
             .await
+    }
+
+    /// Sends a command whose external body is an ordered file-region sequence.
+    pub async fn send_file_regions_command(
+        &self,
+        command_without_body: RemotingCommand,
+        body: FileRegionSequence,
+        deadline: RequestDeadline,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        self.inner
+            .send_file_regions_command(command_without_body, body, deadline)
+            .await
+    }
+
+    /// Sends a server response backed by ordered file regions.
+    pub async fn send_file_regions_response(
+        &self,
+        command_without_body: RemotingCommand,
+        body: FileRegionSequence,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        self.inner.send_file_regions_response(command_without_body, body).await
     }
 
     /// Sends a borrowed command through the serialized connection writer.
@@ -765,6 +787,49 @@ impl ChannelInner {
                     .lock()
                     .await
                     .send_file_region_command(command_without_body, body, deadline)
+                    .await
+            }
+            ChannelIo::Local(_) => Err(RocketMQError::network_connection_failed(
+                "embedded-response",
+                "file-region transfer requires a network channel",
+            )),
+        }
+    }
+
+    /// Sends one network command with an ordered leased external body.
+    pub async fn send_file_regions_command(
+        &self,
+        command_without_body: RemotingCommand,
+        body: FileRegionSequence,
+        deadline: RequestDeadline,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        match &self.connection {
+            ChannelIo::Network(connection) => {
+                connection
+                    .lock()
+                    .await
+                    .send_file_regions_command(command_without_body, body, deadline)
+                    .await
+            }
+            ChannelIo::Local(_) => Err(RocketMQError::network_connection_failed(
+                "embedded-response",
+                "file-region transfer requires a network channel",
+            )),
+        }
+    }
+
+    /// Sends one network response with an ordered leased external body.
+    pub async fn send_file_regions_response(
+        &self,
+        command_without_body: RemotingCommand,
+        body: FileRegionSequence,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        match &self.connection {
+            ChannelIo::Network(connection) => {
+                connection
+                    .lock()
+                    .await
+                    .send_file_regions_response(command_without_body, body)
                     .await
             }
             ChannelIo::Local(_) => Err(RocketMQError::network_connection_failed(

--- a/rocketmq-transport/src/public_api.rs
+++ b/rocketmq-transport/src/public_api.rs
@@ -70,6 +70,7 @@ pub use crate::dispatch::ResponseSink;
 pub use crate::dispatch::ResponseSinkError;
 pub use crate::file_region::FileRegion;
 pub use crate::file_region::FileRegionLease;
+pub use crate::file_region::FileRegionSequence;
 pub use crate::file_region::FileTransferMode;
 pub use crate::file_region_writer::file_transfer_snapshot;
 pub use crate::file_region_writer::FileTransferSnapshot;

--- a/rocketmq-transport/src/write_strategy.rs
+++ b/rocketmq-transport/src/write_strategy.rs
@@ -33,6 +33,7 @@ use crate::admission::AdmissionPermit;
 use crate::backend::WriteBackend;
 use crate::deadline::RequestDeadline;
 use crate::file_region::FileRegion;
+use crate::file_region::FileRegionSequence;
 use crate::file_region::FileTransferMode;
 use crate::file_region_writer::record_body_failure;
 use crate::file_region_writer::record_fallback_unsupported;
@@ -109,7 +110,7 @@ pub(crate) enum OutboundPayload {
     Frame(EncodedFrame),
     FileFrame {
         head: EncodedFrameHead,
-        body: FileRegion,
+        body: FileRegionSequence,
     },
     Batch {
         frames: Vec<EncodedFrame>,
@@ -473,14 +474,19 @@ impl FrameWriter<WriteBackend> {
         Ok(())
     }
 
-    async fn write_file_frame(&mut self, head: &EncodedFrameHead, body: &FileRegion, max_iov: usize) -> io::Result<()> {
+    async fn write_file_frame(
+        &mut self,
+        head: &EncodedFrameHead,
+        body: &FileRegionSequence,
+        max_iov: usize,
+    ) -> io::Result<()> {
         self.ensure_healthy()?;
         let body_len = usize::try_from(body.len())
             .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "file-region length exceeds usize"))?;
         if head.body_len() != body_len {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "encoded frame head body length does not match the leased file region",
+                "encoded frame head body length does not match the leased file-region sequence",
             ));
         }
         if let Some(max_plaintext_frame_bytes) = tls_plaintext_bound(self.mode) {
@@ -491,56 +497,61 @@ impl FrameWriter<WriteBackend> {
                 ));
             }
         }
-        let native_eligible = matches!(self.mode, FrameWriteMode::PlainVectored)
-            && matches!(&self.io, WriteBackend::Tcp(_))
-            && native_file_region_eligible(body);
-        let auto_native_eligible = native_eligible && body.len() >= AUTO_SENDFILE_MIN_BYTES;
-        let selected = select_file_transfer(
-            self.file_transfer_mode,
-            self.file_region_blocking.clone(),
-            native_eligible,
-            auto_native_eligible,
-            body,
-        )
-        .await;
-        let selected = match selected {
-            Ok(selected) => selected,
-            Err(error) => {
-                record_selection_failure();
-                return Err(error);
+        let mut selections = Vec::with_capacity(body.regions().len());
+        for region in body.regions() {
+            let native_eligible = matches!(self.mode, FrameWriteMode::PlainVectored)
+                && matches!(&self.io, WriteBackend::Tcp(_))
+                && native_file_region_eligible(region);
+            let auto_native_eligible = native_eligible && region.len() >= AUTO_SENDFILE_MIN_BYTES;
+            match select_file_transfer(
+                self.file_transfer_mode,
+                self.file_region_blocking.clone(),
+                native_eligible,
+                auto_native_eligible,
+                region,
+            )
+            .await
+            {
+                Ok(selected) => selections.push(selected),
+                Err(error) => {
+                    record_selection_failure();
+                    return Err(error);
+                }
             }
-        };
+        }
         let mut cancellation = WriteCancellationGuard::new(&mut self.poisoned);
         if let Err(error) = write_vectored_segments(&mut self.io, &head.segments(), max_iov.max(1)).await {
             record_head_failure();
             return Err(error);
         }
-        let body_result = match selected {
-            SelectedFileTransfer::Portable { blocking, fallback } => {
-                if fallback {
-                    record_fallback_unsupported();
-                }
-                let written = write_portable_file_region(&mut self.io, body, &blocking).await;
-                if let Ok(written) = written {
-                    record_portable_bytes(written);
-                }
-                written
-            }
-            #[cfg(all(target_os = "linux", feature = "linux-sendfile"))]
-            SelectedFileTransfer::Sendfile => match &mut self.io {
-                WriteBackend::Tcp(writer) => {
-                    let written = crate::linux::sendfile::send_file_region(writer, body).await;
+        for (region, selected) in body.regions().iter().zip(selections) {
+            let body_result = match selected {
+                SelectedFileTransfer::Portable { blocking, fallback } => {
+                    if fallback {
+                        record_fallback_unsupported();
+                    }
+                    let written = write_portable_file_region(&mut self.io, region, &blocking).await;
                     if let Ok(written) = written {
-                        record_sendfile_bytes(written);
+                        record_portable_bytes(written);
                     }
                     written
                 }
-                WriteBackend::Compat(_) => unreachable!("native selection requires a plaintext TCP backend"),
-            },
-        };
-        if let Err(error) = body_result {
-            record_body_failure();
-            return Err(error);
+                #[cfg(all(target_os = "linux", feature = "linux-sendfile"))]
+                SelectedFileTransfer::Sendfile => match &mut self.io {
+                    WriteBackend::Tcp(writer) => {
+                        let written = crate::linux::sendfile::send_file_region(writer, region).await;
+                        if let Ok(written) = written {
+                            record_sendfile_bytes(written);
+                        }
+                        written
+                    }
+                    WriteBackend::Compat(_) => unreachable!("native selection requires a plaintext TCP backend"),
+                },
+            };
+            if let Err(error) = body_result {
+                record_body_failure();
+                return Err(error);
+            }
         }
         if let Err(error) = self.io.flush().await {
             record_body_failure();
@@ -850,6 +861,7 @@ mod file_frame_tests {
     use super::OutboundPayload;
     use crate::file_region::FileRegion;
     use crate::file_region::FileRegionLease;
+    use crate::file_region::FileRegionSequence;
 
     struct DropLease {
         file: std::fs::File,
@@ -884,7 +896,10 @@ mod file_frame_tests {
         )
         .expect("frame head");
         let expected_wire_bytes = head.encoded_len();
-        let payload = OutboundPayload::FileFrame { head, body: region };
+        let payload = OutboundPayload::FileFrame {
+            head,
+            body: FileRegionSequence::single(region),
+        };
 
         drop(lease);
         assert_eq!(drops.load(Ordering::SeqCst), 0, "queued payload must retain the lease");

--- a/rocketmq-transport/tests/file_region_connection.rs
+++ b/rocketmq-transport/tests/file_region_connection.rs
@@ -24,6 +24,7 @@ use rocketmq_runtime::RuntimeOwner;
 use rocketmq_transport::api::v1::file_transfer_snapshot;
 use rocketmq_transport::api::v1::ConnectionState;
 use rocketmq_transport::api::v1::FileRegion;
+use rocketmq_transport::api::v1::FileRegionSequence;
 use rocketmq_transport::api::v1::FileTransferMode;
 use rocketmq_transport::api::v1::RequestDeadline;
 use rocketmq_transport::test_support::Connection;
@@ -85,6 +86,38 @@ fn portable_file_region_round_trips_with_nonzero_offset() {
 
     let after = file_transfer_snapshot();
     assert!(after.portable_bytes.saturating_sub(before.portable_bytes) >= expected_bytes);
+}
+
+#[test]
+fn portable_file_region_sequence_round_trips_as_one_frame() {
+    let owner = runtime_owner();
+    let blocking = owner
+        .root_context()
+        .component("file-region-sequence")
+        .storage_io()
+        .clone();
+    let (_first_file, first) = region_with_prefix(11, b"ordered-");
+    let (_second_file, second) = region_with_prefix(7, b"regions");
+    let body = FileRegionSequence::try_new(vec![first, second]).expect("valid region sequence");
+
+    owner.block_on(async move {
+        let (client, accepted) = tcp_pair().await;
+        let mut sender = Connection::new(client).with_file_region_io(blocking, FileTransferMode::Portable);
+        let mut receiver = Connection::new(accepted);
+        let (sent, received) = tokio::join!(
+            sender.send_file_regions_command(
+                RemotingCommand::create_remoting_command(328),
+                body,
+                RequestDeadline::after(Duration::from_secs(5)),
+            ),
+            receiver.receive_command()
+        );
+
+        sent.expect("portable region sequence should send");
+        let received = received.expect("peer frame").expect("decoded peer frame");
+        assert_eq!(received.code(), 328);
+        assert_eq!(received.body().expect("sequence body").as_ref(), b"ordered-regions");
+    });
 }
 
 #[test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9243

### Brief Description

Adds admission-fenced file-range selections for published CommitLog bytes and carries them through HA replication and Broker Pull without eagerly creating payload snapshots. Transport now writes an ordered file-region sequence as one RocketMQ frame, while portable engines materialize exact bounded ranges through the managed storage I/O lane. TAG and no-op filters retain the range path; property filters keep the existing payload semantics.

### How Did You Test This Change?

- Focused mapped-range, HA, Pull-filter, Broker Pull, and transport file-region tests on Windows.
- Linux/WSL HA sendfile and transport sendfile integration tests.
- Affected-crate and full-workspace Clippy with all features and warnings denied.
- Fixed-nightly fuzz workspace check and enforcing runtime ownership audit.
- WSL full-workspace rustfmt check; Windows equivalent is blocked by OS error 206.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for transferring message data directly from storage files, reducing unnecessary data copying.
  - Enabled ordered transfers composed of multiple file regions.
  - Added automatic fallback to byte-based transfers when direct file transfer is unavailable.
  - Improved message filtering to retrieve commit-log payloads only when required.

- **Bug Fixes**
  - Added validation for transfer ranges, offsets, lengths, overflow, and premature end-of-file conditions.
  - Preserved ordering and metadata across multi-region transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->