### PR TITLE
[ISSUE #9245]✨Add required ordered lanes to the Reput pipeline

### DIFF
--- a/rocketmq-store/src/base/commit_log_dispatcher.rs
+++ b/rocketmq-store/src/base/commit_log_dispatcher.rs
@@ -17,8 +17,32 @@ use std::pin::Pin;
 
 use crate::base::dispatch_request::DispatchRequest;
 
+/// Execution boundary required by one Reput derived-state lane.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommitLogDispatchExecution {
+    /// The dispatcher is short, non-blocking work and may run on the coordinator task.
+    Inline,
+    /// The dispatcher performs synchronous storage I/O and must use the managed storage lane.
+    Blocking,
+    /// The dispatcher supplies an asynchronous, backpressure-aware implementation.
+    Async,
+}
+
 pub trait CommitLogDispatcher: Send + Sync + 'static {
     fn dispatch(&self, dispatch_request: &mut DispatchRequest);
+
+    /// Returns whether this dispatcher is independent of mutations made by sibling dispatchers.
+    ///
+    /// The ordered-lane coordinator only parallelizes a snapshot when every dispatcher opts in.
+    /// External dispatchers keep serial semantics unless they explicitly establish this invariant.
+    fn supports_parallel_dispatch(&self) -> bool {
+        false
+    }
+
+    /// Returns the execution boundary used by the ordered-lane coordinator.
+    fn dispatch_execution(&self) -> CommitLogDispatchExecution {
+        CommitLogDispatchExecution::Inline
+    }
 
     /// Dispatches one request while allowing bounded derived sinks to apply backpressure.
     fn dispatch_async<'a>(

--- a/rocketmq-store/src/config/message_store_config.rs
+++ b/rocketmq-store/src/config/message_store_config.rs
@@ -475,6 +475,10 @@ mod defaults {
         32
     }
 
+    pub fn enable_async_reput() -> bool {
+        true
+    }
+
     pub const fn max_checksum_range() -> usize {
         1024 * 1024 * 1024
     }
@@ -1167,7 +1171,9 @@ pub struct MessageStoreConfig {
     #[serde(default)]
     pub dispatch_cq_cache_num: usize,
 
-    #[serde(default)]
+    /// Enables required ordered-lane execution for Reput derived state. Set to `false` for the
+    /// serial operational rollback path.
+    #[serde(default = "defaults::enable_async_reput")]
     pub enable_async_reput: bool,
 
     #[serde(default)]
@@ -1579,7 +1585,7 @@ impl Default for MessageStoreConfig {
             max_batch_delete_files_num: 0,
             dispatch_cq_threads: 0,
             dispatch_cq_cache_num: 0,
-            enable_async_reput: false,
+            enable_async_reput: true,
             recheck_reput_offset_from_cq: false,
             max_topic_length: 0,
             auto_message_version_on_topic_len: true,
@@ -2633,16 +2639,21 @@ mod tests {
         assert_eq!(config.min_in_sync_replicas, 1);
         assert_eq!(config.ha_max_time_slave_not_catchup, 15_000);
         assert!(!config.all_ack_in_sync_state_set);
+        assert!(config.enable_async_reput);
+        assert_eq!(config.get_properties()["enableAsyncReput"], "true");
     }
 
     #[test]
     fn serde_requires_an_explicit_wave_b_opt_in() -> Result<(), serde_json::Error> {
         let legacy: MessageStoreConfig = serde_json::from_str("{}")?;
         let enabled: MessageStoreConfig = serde_json::from_str(r#"{"enableMappedFileLifecycleWaveB":true}"#)?;
+        let serial_reput: MessageStoreConfig = serde_json::from_str(r#"{"enableAsyncReput":false}"#)?;
 
         assert!(!legacy.enable_mapped_file_lifecycle_wave_b);
+        assert!(legacy.enable_async_reput);
         assert!(enabled.enable_mapped_file_lifecycle_wave_b);
         assert_eq!(enabled.get_properties()["enableMappedFileLifecycleWaveB"], "true");
+        assert!(!serial_reput.enable_async_reput);
         Ok(())
     }
 

--- a/rocketmq-store/src/index/index_dispatch.rs
+++ b/rocketmq-store/src/index/index_dispatch.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use rocketmq_store_local::index::dispatch::IndexDispatchRoot;
 
+use crate::base::commit_log_dispatcher::CommitLogDispatchExecution;
 use crate::base::commit_log_dispatcher::CommitLogDispatcher;
 use crate::base::dispatch_request::DispatchRequest;
 use crate::config::message_store_config::MessageStoreConfig;
@@ -44,6 +45,14 @@ impl CommitLogDispatcherBuildIndex {
 }
 
 impl CommitLogDispatcher for CommitLogDispatcherBuildIndex {
+    fn supports_parallel_dispatch(&self) -> bool {
+        true
+    }
+
+    fn dispatch_execution(&self) -> CommitLogDispatchExecution {
+        CommitLogDispatchExecution::Blocking
+    }
+
     fn dispatch(&self, dispatch_request: &mut DispatchRequest) {
         let enabled = self.root.adapter().message_store_config.message_index_enable;
         self.root.dispatch(enabled, dispatch_request, |adapter, request| {

--- a/rocketmq-store/src/kv/compaction_dispatch.rs
+++ b/rocketmq-store/src/kv/compaction_dispatch.rs
@@ -55,6 +55,10 @@ impl CommitLogDispatcherCompaction {
 }
 
 impl CommitLogDispatcher for CommitLogDispatcherCompaction {
+    fn supports_parallel_dispatch(&self) -> bool {
+        true
+    }
+
     fn dispatch(&self, dispatch_request: &mut DispatchRequest) {
         if !dispatch_request.success
             || dispatch_request.msg_size <= 0

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -229,6 +229,7 @@ mod managed_recovery;
 mod mapped_file_retirement_service;
 mod read_path;
 mod recovery;
+mod reput_pipeline;
 mod root_lock;
 mod write_path;
 

--- a/rocketmq-store/src/message_store/local_file_message_store/dispatch.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/dispatch.rs
@@ -300,6 +300,7 @@ impl LocalFileMessageStore {
         let runtime_context = self.reput_runtime_context();
         self.reput_message_service
             .run_once(
+                &self.runtime_scope,
                 self.commit_log.read_handle(),
                 self.composition.reput(),
                 self.dispatcher.handle(),
@@ -313,6 +314,7 @@ impl LocalFileMessageStore {
 pub struct CommitLogDispatcherDefault {
     pub(super) dispatcher_vec: Vec<Arc<dyn CommitLogDispatcher>>,
     published: Arc<ArcSwap<Vec<Arc<dyn CommitLogDispatcher>>>>,
+    published_frontier: Arc<AtomicI64>,
 }
 
 impl Default for CommitLogDispatcherDefault {
@@ -324,6 +326,7 @@ impl Default for CommitLogDispatcherDefault {
 #[derive(Clone)]
 pub(crate) struct CommitLogDispatchHandle {
     published: Arc<ArcSwap<Vec<Arc<dyn CommitLogDispatcher>>>>,
+    published_frontier: Arc<AtomicI64>,
 }
 
 impl CommitLogDispatcherDefault {
@@ -336,6 +339,7 @@ impl CommitLogDispatcherDefault {
         Self {
             dispatcher_vec,
             published,
+            published_frontier: Arc::new(AtomicI64::new(-1)),
         }
     }
 
@@ -343,6 +347,7 @@ impl CommitLogDispatcherDefault {
     pub(crate) fn handle(&self) -> CommitLogDispatchHandle {
         CommitLogDispatchHandle {
             published: Arc::clone(&self.published),
+            published_frontier: Arc::clone(&self.published_frontier),
         }
     }
 
@@ -369,6 +374,28 @@ impl CommitLogDispatcherDefault {
             .iter()
             .filter_map(|dispatcher| dispatcher.dispatch_progress_offset(commit_log_min_offset))
             .min()
+    }
+
+    #[inline]
+    pub fn published_dispatch_offset(&self) -> i64 {
+        self.published_frontier.load(Ordering::Acquire)
+    }
+}
+
+impl CommitLogDispatchHandle {
+    #[inline]
+    pub(super) fn snapshot(&self) -> Arc<Vec<Arc<dyn CommitLogDispatcher>>> {
+        self.published.load_full()
+    }
+
+    #[inline]
+    pub(super) fn publish_frontier(&self, offset: i64) {
+        self.published_frontier.fetch_max(offset, Ordering::Release);
+    }
+
+    #[inline]
+    pub(super) fn published_frontier(&self) -> i64 {
+        self.published_frontier.load(Ordering::Acquire)
     }
 }
 
@@ -521,12 +548,18 @@ impl ReputMessageService {
             .reput_from_offset
             .get_or_insert_with(|| Arc::new(AtomicI64::new(0)))
             .clone();
+        let dispatch_pipeline = super::reput_pipeline::ReputDispatchPipeline::new(
+            dispatcher.clone(),
+            runtime_scope,
+            runtime_context.message_store_config.enable_async_reput,
+            reput_read_max_bytes(runtime_context.message_store_config.as_ref()),
+        );
 
         let mut inner = ReputMessageServiceInner {
             reput_from_offset,
             commit_log,
             policy,
-            dispatcher: dispatcher.clone(),
+            dispatch_pipeline: dispatch_pipeline.clone(),
             notify_message_arrive_in_batch,
             runtime_context: runtime_context.clone(),
         };
@@ -624,7 +657,7 @@ impl ReputMessageService {
                 tokio::select! {
                     Some(mut batch) = dispatch_rx.recv() => {
                         dispatch_reput_batch(
-                            &dispatcher,
+                            &dispatch_pipeline,
                             &runtime_context,
                             notify_message_arrive_in_batch,
                             &mut batch,
@@ -637,7 +670,7 @@ impl ReputMessageService {
                         // Process remaining messages in channel before shutdown
                         while let Ok(mut batch) = dispatch_rx.try_recv() {
                             dispatch_reput_batch(
-                                &dispatcher,
+                                &dispatch_pipeline,
                                 &runtime_context,
                                 notify_message_arrive_in_batch,
                                 &mut batch,
@@ -700,6 +733,7 @@ impl ReputMessageService {
 
     pub async fn run_once(
         &mut self,
+        runtime_scope: &StoreRuntimeScope,
         commit_log: CommitLogReadHandle,
         policy: ReputPolicy,
         dispatcher: CommitLogDispatchHandle,
@@ -722,11 +756,17 @@ impl ReputMessageService {
                 .reput_from_offset
                 .get_or_insert_with(|| Arc::new(AtomicI64::new(0)))
                 .clone();
+            let dispatch_pipeline = super::reput_pipeline::ReputDispatchPipeline::new(
+                dispatcher,
+                runtime_scope,
+                runtime_context.message_store_config.enable_async_reput,
+                reput_read_max_bytes(runtime_context.message_store_config.as_ref()),
+            );
             self.inner = Some(ReputMessageServiceInner {
                 reput_from_offset,
                 commit_log,
                 policy,
-                dispatcher,
+                dispatch_pipeline,
                 notify_message_arrive_in_batch,
                 runtime_context,
             });
@@ -794,7 +834,7 @@ pub(super) struct ReputMessageServiceInner {
     pub(super) reput_from_offset: Arc<AtomicI64>,
     pub(super) commit_log: CommitLogReadHandle,
     pub(super) policy: ReputPolicy,
-    pub(super) dispatcher: CommitLogDispatchHandle,
+    pub(super) dispatch_pipeline: super::reput_pipeline::ReputDispatchPipeline,
     pub(super) notify_message_arrive_in_batch: bool,
     pub(super) runtime_context: ReputRuntimeContext,
 }
@@ -802,7 +842,7 @@ pub(super) struct ReputMessageServiceInner {
 const MIN_REPUT_READ_BYTES: usize = 1024 * 1024;
 const COMMIT_LOG_RECORD_OVERHEAD_BUDGET: i32 = 64 * 1024;
 
-fn reput_read_max_bytes(config: &MessageStoreConfig) -> usize {
+pub(super) fn reput_read_max_bytes(config: &MessageStoreConfig) -> usize {
     let max_message_size = config.max_message_size.max(0);
     let max_record_size = if i32::MAX - max_message_size >= COMMIT_LOG_RECORD_OVERHEAD_BUDGET {
         max_message_size + COMMIT_LOG_RECORD_OVERHEAD_BUDGET
@@ -839,14 +879,14 @@ fn reput_record_is_complete(bytes: &Bytes) -> bool {
 }
 
 async fn dispatch_reput_batch(
-    dispatcher: &CommitLogDispatchHandle,
+    dispatch_pipeline: &super::reput_pipeline::ReputDispatchPipeline,
     runtime_context: &ReputRuntimeContext,
     notify_message_arrive_in_batch: bool,
     dispatch_batch: &mut [DispatchRequest],
 ) {
     let batch_size = dispatch_batch.len();
     let started = Instant::now();
-    dispatcher.dispatch_batch_async(dispatch_batch).await;
+    dispatch_pipeline.dispatch_batch(dispatch_batch).await;
     runtime_context
         .store_stats_service
         .record_reput_dispatch_batch(batch_size, started.elapsed());
@@ -940,7 +980,7 @@ impl ReputMessageServiceInner {
                             // Dispatch batch when reaching threshold or at end
                             if dispatch_batch.len() >= 32 {
                                 dispatch_reput_batch(
-                                    &self.dispatcher,
+                                    &self.dispatch_pipeline,
                                     &self.runtime_context,
                                     self.notify_message_arrive_in_batch,
                                     &mut dispatch_batch,
@@ -982,7 +1022,7 @@ impl ReputMessageServiceInner {
         // Dispatch remaining messages in batch
         if !dispatch_batch.is_empty() {
             dispatch_reput_batch(
-                &self.dispatcher,
+                &self.dispatch_pipeline,
                 &self.runtime_context,
                 self.notify_message_arrive_in_batch,
                 &mut dispatch_batch,

--- a/rocketmq-store/src/message_store/local_file_message_store/mapped_file_retirement_service/tests.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/mapped_file_retirement_service/tests.rs
@@ -123,7 +123,11 @@ async fn start_cancel_drain_and_await_uses_the_owned_runtime_boundaries() {
     assert_eq!(driver.drain_batch_limit.load(Ordering::Acquire), 1);
     assert_eq!(driver.shutdown_calls.load(Ordering::Acquire), 1);
     assert!(running_flags.is_writeable());
-    assert_eq!(scope.blocking_snapshot().blocking_still_running, 0);
+    assert!(!scope
+        .blocking_snapshot()
+        .tasks
+        .iter()
+        .any(|task| task.name == "mapped-file-retirement-batch"));
     assert!(service.task_group.is_none());
     assert!(service.scheduled_tasks.is_none());
 }

--- a/rocketmq-store/src/message_store/local_file_message_store/reput_pipeline.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/reput_pipeline.rs
@@ -1,0 +1,423 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::mem::size_of;
+use std::sync::Arc;
+
+use futures_util::future::join_all;
+use rocketmq_runtime::BudgetClass;
+use rocketmq_runtime::BudgetLimit;
+use rocketmq_runtime::FullPolicy;
+use rocketmq_runtime::ResourceBudget;
+use tracing::warn;
+
+use crate::base::commit_log_dispatcher::CommitLogDispatchExecution;
+use crate::base::commit_log_dispatcher::CommitLogDispatcher;
+use crate::base::dispatch_request::DispatchRequest;
+use crate::runtime::StoreRuntimeScope;
+
+use super::dispatch::CommitLogDispatchHandle;
+
+const MIN_CLONE_BUDGET_BYTES: usize = 16 * 1024 * 1024;
+const MAX_CLONE_BUDGET_BYTES: usize = 512 * 1024 * 1024;
+
+/// Dispatches one CommitLog batch to independent required derived-state lanes.
+///
+/// The Reput reader still admits only one batch at a time to this coordinator. That preserves
+/// strict batch order for every lane while allowing CQ, Index, RocksDB, Timer, and Tiered sinks
+/// to process the current batch concurrently. The published frontier advances only after every
+/// required lane completes.
+#[derive(Clone)]
+pub(super) struct ReputDispatchPipeline {
+    dispatcher: CommitLogDispatchHandle,
+    runtime_scope: StoreRuntimeScope,
+    parallel_enabled: bool,
+    clone_budget: ResourceBudget,
+}
+
+impl ReputDispatchPipeline {
+    pub(super) fn new(
+        dispatcher: CommitLogDispatchHandle,
+        runtime_scope: &StoreRuntimeScope,
+        parallel_enabled: bool,
+        read_budget_bytes: usize,
+    ) -> Self {
+        let store_budget = runtime_scope.resource_budget();
+        let capacity = read_budget_bytes
+            .saturating_mul(16)
+            .clamp(MIN_CLONE_BUDGET_BYTES, MAX_CLONE_BUDGET_BYTES)
+            .min(store_budget.limit().capacity.bytes);
+        let clone_budget = store_budget
+            .child(
+                "reput-required-lanes",
+                BudgetLimit::new(1, capacity, FullPolicy::Reject),
+            )
+            .expect("Reput clone budget must fit the validated Store runtime budget");
+        Self::with_clone_budget(dispatcher, runtime_scope, parallel_enabled, clone_budget)
+    }
+
+    fn with_clone_budget(
+        dispatcher: CommitLogDispatchHandle,
+        runtime_scope: &StoreRuntimeScope,
+        parallel_enabled: bool,
+        clone_budget: ResourceBudget,
+    ) -> Self {
+        Self {
+            dispatcher,
+            runtime_scope: runtime_scope.clone(),
+            parallel_enabled,
+            clone_budget,
+        }
+    }
+
+    pub(super) async fn dispatch_batch(&self, dispatch_batch: &mut [DispatchRequest]) {
+        let frontier = batch_end_offset(dispatch_batch);
+        let dispatchers = self.dispatcher.snapshot();
+        if !self.parallel_enabled
+            || dispatchers.is_empty()
+            || dispatchers
+                .iter()
+                .any(|dispatcher| !dispatcher.supports_parallel_dispatch())
+        {
+            self.dispatch_serial(dispatch_batch, frontier).await;
+            return;
+        }
+
+        let retained_bytes = estimate_batch_bytes(dispatch_batch).saturating_mul(dispatchers.len().saturating_add(1));
+        let Ok(_permit) = self.clone_budget.try_acquire(retained_bytes, BudgetClass::Data) else {
+            warn!(
+                retained_bytes,
+                lanes = dispatchers.len(),
+                "Reput required-lane clone budget is full; preserving delivery with serial dispatch"
+            );
+            self.dispatch_serial(dispatch_batch, frontier).await;
+            return;
+        };
+
+        let source = Arc::new(dispatch_batch.to_vec());
+        join_all(
+            dispatchers
+                .iter()
+                .cloned()
+                .map(|dispatcher| execute_lane(dispatcher, Arc::clone(&source), self.runtime_scope.clone())),
+        )
+        .await;
+        if let Some(frontier) = frontier {
+            self.dispatcher.publish_frontier(frontier);
+        }
+    }
+
+    async fn dispatch_serial(&self, dispatch_batch: &mut [DispatchRequest], frontier: Option<i64>) {
+        self.dispatcher.dispatch_batch_async(dispatch_batch).await;
+        if let Some(frontier) = frontier {
+            self.dispatcher.publish_frontier(frontier);
+        }
+    }
+
+    #[cfg(test)]
+    fn published_frontier(&self) -> i64 {
+        self.dispatcher.published_frontier()
+    }
+}
+
+async fn execute_lane(
+    dispatcher: Arc<dyn CommitLogDispatcher>,
+    source: Arc<Vec<DispatchRequest>>,
+    runtime_scope: StoreRuntimeScope,
+) {
+    match dispatcher.dispatch_execution() {
+        CommitLogDispatchExecution::Inline => {
+            let mut batch = source.as_ref().clone();
+            dispatcher.dispatch_batch(&mut batch);
+        }
+        CommitLogDispatchExecution::Async => {
+            let mut batch = source.as_ref().clone();
+            dispatcher.dispatch_batch_async(&mut batch).await;
+        }
+        CommitLogDispatchExecution::Blocking => loop {
+            let owned_dispatcher = Arc::clone(&dispatcher);
+            let owned_source = Arc::clone(&source);
+            match runtime_scope
+                .spawn_io("reput-required-lane", move || {
+                    let mut batch = owned_source.as_ref().clone();
+                    owned_dispatcher.dispatch_batch(&mut batch);
+                })
+                .await
+            {
+                Ok(()) => break,
+                Err(error) => {
+                    warn!(%error, "managed Reput blocking lane rejected work; retrying without publishing");
+                    tokio::task::yield_now().await;
+                }
+            }
+        },
+    }
+}
+
+fn batch_end_offset(dispatch_batch: &[DispatchRequest]) -> Option<i64> {
+    dispatch_batch
+        .iter()
+        .filter(|request| request.success)
+        .filter_map(|request| {
+            if request.next_reput_from_offset > request.commit_log_offset {
+                Some(request.next_reput_from_offset)
+            } else {
+                let size = if request.buffer_size >= 0 {
+                    request.buffer_size
+                } else {
+                    request.msg_size
+                };
+                (size > 0).then(|| request.commit_log_offset.saturating_add(i64::from(size)))
+            }
+        })
+        .max()
+}
+
+fn estimate_batch_bytes(dispatch_batch: &[DispatchRequest]) -> usize {
+    dispatch_batch.iter().fold(0usize, |total, request| {
+        let properties_bytes = request.properties_map.as_ref().map_or(0, |properties| {
+            properties.iter().fold(0usize, |size, (key, value)| {
+                size.saturating_add(key.len()).saturating_add(value.len())
+            })
+        });
+        total
+            .saturating_add(size_of::<DispatchRequest>())
+            .saturating_add(request.topic.len())
+            .saturating_add(request.keys.len())
+            .saturating_add(request.uniq_key.as_ref().map_or(0, |value| value.len()))
+            .saturating_add(request.bit_map.as_ref().map_or(0, Vec::len))
+            .saturating_add(request.offset_id.as_ref().map_or(0, |value| value.len()))
+            .saturating_add(properties_bytes)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::Arc;
+
+    use parking_lot::Mutex;
+    use rocketmq_runtime::BudgetLimit;
+    use rocketmq_runtime::FullPolicy;
+    use tokio::sync::mpsc;
+    use tokio::sync::Semaphore;
+
+    use super::*;
+    use crate::message_store::local_file_message_store::dispatch::CommitLogDispatcherDefault;
+
+    struct GateDispatcher {
+        name: &'static str,
+        supports_parallel: bool,
+        started: mpsc::UnboundedSender<(&'static str, i64)>,
+        release: Arc<Semaphore>,
+        observed: Arc<Mutex<Vec<i64>>>,
+    }
+
+    impl CommitLogDispatcher for GateDispatcher {
+        fn dispatch(&self, dispatch_request: &mut DispatchRequest) {
+            self.observed.lock().push(dispatch_request.commit_log_offset);
+        }
+
+        fn supports_parallel_dispatch(&self) -> bool {
+            self.supports_parallel
+        }
+
+        fn dispatch_execution(&self) -> CommitLogDispatchExecution {
+            CommitLogDispatchExecution::Async
+        }
+
+        fn dispatch_batch_async<'a>(
+            &'a self,
+            dispatch_requests: &'a mut [DispatchRequest],
+        ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+            Box::pin(async move {
+                let offset = dispatch_requests[0].commit_log_offset;
+                self.observed.lock().push(offset);
+                let _ = self.started.send((self.name, offset));
+                let permit = self.release.acquire().await.expect("test gate must remain open");
+                permit.forget();
+            })
+        }
+    }
+
+    struct RecordingDispatcher {
+        observed: Arc<Mutex<Vec<i64>>>,
+    }
+
+    impl CommitLogDispatcher for RecordingDispatcher {
+        fn dispatch(&self, dispatch_request: &mut DispatchRequest) {
+            self.observed.lock().push(dispatch_request.commit_log_offset);
+        }
+
+        fn supports_parallel_dispatch(&self) -> bool {
+            true
+        }
+
+        fn dispatch_execution(&self) -> CommitLogDispatchExecution {
+            CommitLogDispatchExecution::Async
+        }
+
+        fn dispatch_batch_async<'a>(
+            &'a self,
+            dispatch_requests: &'a mut [DispatchRequest],
+        ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+            Box::pin(async move {
+                self.observed
+                    .lock()
+                    .extend(dispatch_requests.iter().map(|request| request.commit_log_offset));
+            })
+        }
+    }
+
+    fn dispatch_request(offset: i64) -> DispatchRequest {
+        DispatchRequest {
+            commit_log_offset: offset,
+            msg_size: 5,
+            buffer_size: -1,
+            success: true,
+            ..DispatchRequest::default()
+        }
+    }
+
+    fn gate_dispatcher(
+        name: &'static str,
+        supports_parallel: bool,
+        started: mpsc::UnboundedSender<(&'static str, i64)>,
+    ) -> (Arc<GateDispatcher>, Arc<Semaphore>, Arc<Mutex<Vec<i64>>>) {
+        let release = Arc::new(Semaphore::new(0));
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        (
+            Arc::new(GateDispatcher {
+                name,
+                supports_parallel,
+                started,
+                release: Arc::clone(&release),
+                observed: Arc::clone(&observed),
+            }),
+            release,
+            observed,
+        )
+    }
+
+    #[tokio::test]
+    async fn required_lanes_run_concurrently_and_publish_after_every_lane() {
+        let scope = crate::runtime::test_scope("reput-parallel-required-lanes-test");
+        let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+        let (first, first_release, _) = gate_dispatcher("first", true, started_tx.clone());
+        let (second, second_release, _) = gate_dispatcher("second", true, started_tx);
+        let dispatcher = CommitLogDispatcherDefault::with_dispatchers(vec![first, second]);
+        let pipeline = ReputDispatchPipeline::new(dispatcher.handle(), &scope, true, 1024 * 1024);
+        let task_pipeline = pipeline.clone();
+        let task = tokio::spawn(async move {
+            let mut batch = vec![dispatch_request(10)];
+            task_pipeline.dispatch_batch(&mut batch).await;
+        });
+
+        let mut started = vec![
+            started_rx.recv().await.expect("first lane must start").0,
+            started_rx.recv().await.expect("second lane must start").0,
+        ];
+        started.sort_unstable();
+        assert_eq!(started, vec!["first", "second"]);
+        assert_eq!(pipeline.published_frontier(), -1);
+
+        first_release.add_permits(1);
+        tokio::task::yield_now().await;
+        assert_eq!(pipeline.published_frontier(), -1);
+        second_release.add_permits(1);
+        task.await.expect("pipeline task must finish");
+        assert_eq!(pipeline.published_frontier(), 15);
+    }
+
+    #[tokio::test]
+    async fn every_lane_observes_batches_in_commit_log_order() {
+        let scope = crate::runtime::test_scope("reput-lane-order-test");
+        let first_observed = Arc::new(Mutex::new(Vec::new()));
+        let second_observed = Arc::new(Mutex::new(Vec::new()));
+        let dispatcher = CommitLogDispatcherDefault::with_dispatchers(vec![
+            Arc::new(RecordingDispatcher {
+                observed: Arc::clone(&first_observed),
+            }),
+            Arc::new(RecordingDispatcher {
+                observed: Arc::clone(&second_observed),
+            }),
+        ]);
+        let pipeline = ReputDispatchPipeline::new(dispatcher.handle(), &scope, true, 1024 * 1024);
+
+        let mut first_batch = vec![dispatch_request(10), dispatch_request(15)];
+        pipeline.dispatch_batch(&mut first_batch).await;
+        let mut second_batch = vec![dispatch_request(20), dispatch_request(25)];
+        pipeline.dispatch_batch(&mut second_batch).await;
+
+        assert_eq!(*first_observed.lock(), vec![10, 15, 20, 25]);
+        assert_eq!(*second_observed.lock(), vec![10, 15, 20, 25]);
+        assert_eq!(pipeline.published_frontier(), 30);
+    }
+
+    #[tokio::test]
+    async fn unknown_dispatcher_preserves_serial_semantics() {
+        let scope = crate::runtime::test_scope("reput-serial-extension-test");
+        let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+        let (first, first_release, _) = gate_dispatcher("first", false, started_tx.clone());
+        let (second, second_release, _) = gate_dispatcher("second", true, started_tx);
+        let dispatcher = CommitLogDispatcherDefault::with_dispatchers(vec![first, second]);
+        let pipeline = ReputDispatchPipeline::new(dispatcher.handle(), &scope, true, 1024 * 1024);
+        let task_pipeline = pipeline.clone();
+        let task = tokio::spawn(async move {
+            let mut batch = vec![dispatch_request(30)];
+            task_pipeline.dispatch_batch(&mut batch).await;
+        });
+
+        assert_eq!(started_rx.recv().await, Some(("first", 30)));
+        tokio::task::yield_now().await;
+        assert!(matches!(started_rx.try_recv(), Err(mpsc::error::TryRecvError::Empty)));
+        first_release.add_permits(1);
+        assert_eq!(started_rx.recv().await, Some(("second", 30)));
+        second_release.add_permits(1);
+        task.await.expect("pipeline task must finish");
+        assert_eq!(pipeline.published_frontier(), 35);
+    }
+
+    #[tokio::test]
+    async fn clone_budget_rejection_falls_back_without_dropping_lanes() {
+        let scope = crate::runtime::test_scope("reput-clone-budget-test");
+        let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+        let (first, first_release, first_observed) = gate_dispatcher("first", true, started_tx.clone());
+        let (second, second_release, second_observed) = gate_dispatcher("second", true, started_tx);
+        let dispatcher = CommitLogDispatcherDefault::with_dispatchers(vec![first, second]);
+        let clone_budget = scope
+            .resource_budget()
+            .child("reput-tiny-clone-budget", BudgetLimit::new(1, 1, FullPolicy::Reject))
+            .expect("tiny test budget must fit Store budget");
+        let pipeline = ReputDispatchPipeline::with_clone_budget(dispatcher.handle(), &scope, true, clone_budget);
+        let task_pipeline = pipeline.clone();
+        let task = tokio::spawn(async move {
+            let mut batch = vec![dispatch_request(40)];
+            task_pipeline.dispatch_batch(&mut batch).await;
+        });
+
+        assert_eq!(started_rx.recv().await, Some(("first", 40)));
+        tokio::task::yield_now().await;
+        assert!(matches!(started_rx.try_recv(), Err(mpsc::error::TryRecvError::Empty)));
+        first_release.add_permits(1);
+        assert_eq!(started_rx.recv().await, Some(("second", 40)));
+        second_release.add_permits(1);
+        task.await.expect("pipeline task must finish");
+
+        assert_eq!(*first_observed.lock(), vec![40]);
+        assert_eq!(*second_observed.lock(), vec![40]);
+        assert_eq!(pipeline.published_frontier(), 45);
+    }
+}

--- a/rocketmq-store/src/queue/build_consume_queue.rs
+++ b/rocketmq-store/src/queue/build_consume_queue.rs
@@ -33,6 +33,10 @@ impl CommitLogDispatcherBuildConsumeQueue {
 }
 
 impl CommitLogDispatcher for CommitLogDispatcherBuildConsumeQueue {
+    fn supports_parallel_dispatch(&self) -> bool {
+        true
+    }
+
     fn dispatch(&self, dispatch_request: &mut DispatchRequest) {
         let tran_type = MessageSysFlag::get_transaction_value(dispatch_request.sys_flag);
         let eligible = matches!(

--- a/rocketmq-store/src/rocksdb/consume_queue.rs
+++ b/rocketmq-store/src/rocksdb/consume_queue.rs
@@ -17,6 +17,7 @@ use std::sync::Weak;
 use tracing::error;
 use tracing::warn;
 
+use crate::base::commit_log_dispatcher::CommitLogDispatchExecution;
 use crate::base::commit_log_dispatcher::CommitLogDispatcher;
 use crate::base::dispatch_request::DispatchRequest;
 use crate::queue::local_file_consume_queue_store::ConsumeQueueStore;
@@ -104,6 +105,14 @@ impl CommitLogDispatcherBuildRocksDbConsumeQueue {
 }
 
 impl CommitLogDispatcher for CommitLogDispatcherBuildRocksDbConsumeQueue {
+    fn supports_parallel_dispatch(&self) -> bool {
+        true
+    }
+
+    fn dispatch_execution(&self) -> CommitLogDispatchExecution {
+        CommitLogDispatchExecution::Blocking
+    }
+
     fn dispatch(&self, dispatch_request: &mut DispatchRequest) {
         let Some(consume_queue_store) = self.consume_queue_store() else {
             warn!("RocksDB consume queue dispatcher skipped because store owner was dropped");

--- a/rocketmq-store/src/rocksdb/index.rs
+++ b/rocketmq-store/src/rocksdb/index.rs
@@ -19,6 +19,7 @@ use rocketmq_model::common::message::MessageConst;
 use rocketmq_model::common::sys_flag::message_sys_flag::MessageSysFlag;
 use tracing::warn;
 
+use crate::base::commit_log_dispatcher::CommitLogDispatchExecution;
 use crate::base::commit_log_dispatcher::CommitLogDispatcher;
 use crate::base::dispatch_request::DispatchRequest;
 use crate::config::message_store_config::MessageStoreConfig;
@@ -83,6 +84,14 @@ impl CommitLogDispatcherBuildRocksDbIndex {
 }
 
 impl CommitLogDispatcher for CommitLogDispatcherBuildRocksDbIndex {
+    fn supports_parallel_dispatch(&self) -> bool {
+        true
+    }
+
+    fn dispatch_execution(&self) -> CommitLogDispatchExecution {
+        CommitLogDispatchExecution::Blocking
+    }
+
     fn dispatch(&self, dispatch_request: &mut DispatchRequest) {
         if !self.message_store_config.message_index_enable {
             return;

--- a/rocketmq-store/src/rocksdb/timer.rs
+++ b/rocketmq-store/src/rocksdb/timer.rs
@@ -18,6 +18,7 @@ use std::sync::Weak;
 use rocketmq_model::common::message::MessageConst;
 use tracing::warn;
 
+use crate::base::commit_log_dispatcher::CommitLogDispatchExecution;
 use crate::base::commit_log_dispatcher::CommitLogDispatcher;
 use crate::base::dispatch_request::DispatchRequest;
 use crate::config::message_store_config::MessageStoreConfig;
@@ -105,6 +106,14 @@ impl CommitLogDispatcherBuildRocksDbTimer {
 }
 
 impl CommitLogDispatcher for CommitLogDispatcherBuildRocksDbTimer {
+    fn supports_parallel_dispatch(&self) -> bool {
+        true
+    }
+
+    fn dispatch_execution(&self) -> CommitLogDispatchExecution {
+        CommitLogDispatchExecution::Blocking
+    }
+
     fn dispatch(&self, dispatch_request: &mut DispatchRequest) {
         if !self.message_store_config.timer_rocksdb_enable || self.message_store_config.timer_rocksdb_stop_scan {
             return;

--- a/rocketmq-store/src/rocksdb/transaction.rs
+++ b/rocketmq-store/src/rocksdb/transaction.rs
@@ -18,6 +18,7 @@ use std::sync::Weak;
 use rocketmq_model::common::message::MessageConst;
 use tracing::warn;
 
+use crate::base::commit_log_dispatcher::CommitLogDispatchExecution;
 use crate::base::commit_log_dispatcher::CommitLogDispatcher;
 use crate::base::dispatch_request::DispatchRequest;
 use crate::config::message_store_config::MessageStoreConfig;
@@ -93,6 +94,14 @@ impl CommitLogDispatcherBuildRocksDbTrans {
 }
 
 impl CommitLogDispatcher for CommitLogDispatcherBuildRocksDbTrans {
+    fn supports_parallel_dispatch(&self) -> bool {
+        true
+    }
+
+    fn dispatch_execution(&self) -> CommitLogDispatchExecution {
+        CommitLogDispatchExecution::Blocking
+    }
+
     fn dispatch(&self, dispatch_request: &mut DispatchRequest) {
         if !self.message_store_config.trans_rocksdb_enable {
             return;

--- a/rocketmq-store/src/tieredstore.rs
+++ b/rocketmq-store/src/tieredstore.rs
@@ -37,6 +37,7 @@ use rocketmq_tieredstore::TieredStoreConfig;
 use tracing::debug;
 use tracing::warn;
 
+use crate::base::commit_log_dispatcher::CommitLogDispatchExecution;
 use crate::base::commit_log_dispatcher::CommitLogDispatcher;
 use crate::base::dispatch_request::DispatchRequest;
 use crate::base::get_message_result::GetMessageResult;
@@ -400,6 +401,14 @@ impl<P> CommitLogDispatcher for TieredCommitLogDispatcher<P>
 where
     P: TieredStoreProvider,
 {
+    fn supports_parallel_dispatch(&self) -> bool {
+        true
+    }
+
+    fn dispatch_execution(&self) -> CommitLogDispatchExecution {
+        CommitLogDispatchExecution::Async
+    }
+
     fn dispatch(&self, dispatch_request: &mut DispatchRequest) {
         if !dispatch_request.success {
             return;

--- a/rocketmq-store/src/timer/timeline/receipt_reconciler.rs
+++ b/rocketmq-store/src/timer/timeline/receipt_reconciler.rs
@@ -65,6 +65,10 @@ impl TimelineCompletionWake {
 }
 
 impl CommitLogDispatcher for TimelineCompletionWake {
+    fn supports_parallel_dispatch(&self) -> bool {
+        true
+    }
+
     fn dispatch(&self, request: &mut DispatchRequest) {
         if !request.success || request.commit_log_offset < 0 || request.msg_size <= 0 {
             return;

--- a/rocketmq-store/tests/message_store/local_file_message_store/unit.rs
+++ b/rocketmq-store/tests/message_store/local_file_message_store/unit.rs
@@ -1086,13 +1086,20 @@ fn install_recording_arriving_listener(
 
 fn reput_inner_for_store(store: &LocalFileMessageStore) -> ReputMessageServiceInner {
     let policy = store.composition.reput();
+    let runtime_context = store.reput_runtime_context();
+    let dispatch_pipeline = super::reput_pipeline::ReputDispatchPipeline::new(
+        store.dispatcher.handle(),
+        &store.runtime_scope,
+        store.message_store_config.enable_async_reput,
+        super::dispatch::reput_read_max_bytes(store.message_store_config.as_ref()),
+    );
     ReputMessageServiceInner {
         reput_from_offset: Arc::new(AtomicI64::new(0)),
         commit_log: store.commit_log.read_handle(),
         policy,
-        dispatcher: store.dispatcher.handle(),
+        dispatch_pipeline,
         notify_message_arrive_in_batch: false,
-        runtime_context: store.reput_runtime_context(),
+        runtime_context,
     }
 }
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9245

### Brief Description

- Add a bounded required-lane Reput coordinator that runs independent derived stores concurrently while preserving CommitLog order between batches.
- Advance the published dispatch frontier only after every required lane completes, and keep `enableAsyncReput=false` as a serial operational rollback.
- Route synchronous Index and RocksDB dispatchers through the managed storage I/O executor while retaining async backpressure for Tiered Store.
- Default new configurations to the optimal ordered-lane path without adding compatibility profiles or changing wire and storage formats.

### How Did You Test This Change?

- `cargo test -p rocketmq-store reput_pipeline --all-features --lib`
- `cargo test -p rocketmq-store --lib --all-features -- --test-threads=1`
- `cargo clippy -p rocketmq-store --features rocksdb_store --all-targets -- -D warnings`
- `cargo clippy -p rocketmq-broker --features rocksdb_store --all-targets -- -D warnings`
- `cargo test -p rocketmq-store --features rocksdb_store --test rocksdb_foundation_tests`
- `cargo test -p rocketmq-store --features rocksdb_store --test rocksdb_store_semantics_tests`
- `cargo test -p rocketmq-broker --features rocksdb_store rocksdb`
- `cargo test -p rocketmq-broker --features rocksdb_store pop_consumer`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `cargo fmt -p rocketmq-store -- --check`
- Workspace-wide `cargo fmt --all -- --check` through WSL

Windows `cargo fmt --all -- --check` still hits the repository's existing OS error 206 command-length limit; the package check and equivalent WSL workspace check pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reputation processing is enabled asynchronously by default.
  * Commit-log updates can be dispatched concurrently across compatible storage and indexing tasks.
  * Processing preserves dispatch order and publishes progress only after required tasks complete.
  * Configurable read limits help control memory usage during batch processing.

* **Bug Fixes**
  * Improved handling of blocking I/O failures with retry behavior.
  * Added safer fallback to serial processing when parallel execution is unavailable or exceeds resource limits.

* **Tests**
  * Expanded coverage for concurrency, ordering, fallback behavior, configuration defaults, and task shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->