### PR TITLE
[ISSUE #9247]✨Optimize producer batch encoding and send hot paths

### DIFF
--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -52,7 +52,6 @@ use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::code::response_code::ResponseCode::SystemError;
 use rocketmq_protocol::common::message::message_decoder as MessageDecoder;
 use rocketmq_protocol::common::message::message_decoder::message_properties_to_string;
-#[cfg(feature = "otel-traces")]
 use rocketmq_protocol::common::message::message_decoder::string_to_message_properties;
 use rocketmq_protocol::protocol::header::consumer_send_msg_back_request_header::ConsumerSendMsgBackRequestHeader;
 use rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header::parse_request_header;
@@ -104,12 +103,17 @@ mod message_builder;
 use capability::SendMessagePolicy;
 use capability::SendMessageProcessorContext;
 use message_builder::clear_reserved_properties;
-use message_builder::enrich_send_message_request_properties;
+use message_builder::enrich_parsed_send_message_request_properties;
 use message_builder::recall_handle_topic_and_timestamp;
 use message_builder::should_create_uniq_key;
 
 pub struct SendMessageProcessor<MS: BrokerWriteStore, TS> {
     inner: Arc<Inner<MS, TS>>,
+}
+
+struct ParsedSendRequest {
+    header: SendMessageRequestHeader,
+    properties: HashMap<CheetahString, CheetahString>,
 }
 
 impl<MS: BrokerWriteStore, TS> Clone for SendMessageProcessor<MS, TS> {
@@ -131,8 +135,8 @@ where
         ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let receive_span = self.receive_span_with_remote_parent(request);
-        self.process_request_mut(channel, ctx, request)
+        let (receive_span, parsed_request) = self.receive_span_and_request(request);
+        self.process_request_mut(channel, ctx, request, parsed_request)
             .instrument(receive_span)
             .await
     }
@@ -188,49 +192,54 @@ where
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let mut processor = self.clone();
-        let receive_span = self.receive_span_with_remote_parent(request);
+        let (receive_span, parsed_request) = self.receive_span_and_request(request);
         processor
-            .process_request_mut(channel, ctx, request)
+            .process_request_mut(channel, ctx, request, parsed_request)
             .instrument(receive_span)
             .await
     }
 
-    fn receive_span_with_remote_parent(&self, request: &RemotingCommand) -> tracing::Span {
+    fn receive_span_and_request(&self, request: &RemotingCommand) -> (tracing::Span, Option<ParsedSendRequest>) {
         let span = rocketmq_observability::trace::broker::receive_send_span(
             &self.inner.context.telemetry,
             request.code(),
             request.opaque(),
         );
+        let request_code = RequestCode::from(request.code());
+        let parsed_request = matches!(
+            request_code,
+            RequestCode::SendMessage | RequestCode::SendMessageV2 | RequestCode::SendBatchMessage
+        )
+        .then(|| {
+            parse_request_header(request, request_code).ok().map(|header| {
+                let properties = string_to_message_properties(header.properties.as_ref());
+                ParsedSendRequest { header, properties }
+            })
+        })
+        .flatten();
         #[cfg(feature = "otel-traces")]
         {
-            let request_code = RequestCode::from(request.code());
-            if matches!(
-                request_code,
-                RequestCode::SendMessage | RequestCode::SendMessageV2 | RequestCode::SendBatchMessage
-            ) {
-                if let Ok(header) = parse_request_header(request, request_code) {
-                    let properties = string_to_message_properties(header.properties.as_ref());
-                    if let Err(error) = rocketmq_observability::set_span_parent_from_properties_with_handle(
+            if let Some(parsed_request) = parsed_request.as_ref() {
+                if let Err(error) = rocketmq_observability::set_span_parent_from_properties_with_handle(
+                    &self.inner.context.telemetry,
+                    &span,
+                    &parsed_request.properties,
+                ) {
+                    rocketmq_observability::record_span_parent_assignment_error(
                         &self.inner.context.telemetry,
-                        &span,
-                        &properties,
-                    ) {
-                        rocketmq_observability::record_span_parent_assignment_error(
-                            &self.inner.context.telemetry,
-                            "broker.receive_send",
-                            error,
-                        );
-                    }
-                    rocketmq_observability::trace::record_message_properties_with_handle(
-                        &self.inner.context.telemetry,
-                        &span,
-                        &properties,
-                        request.body().map(|body| body.len()),
+                        "broker.receive_send",
+                        error,
                     );
                 }
+                rocketmq_observability::trace::record_message_properties_with_handle(
+                    &self.inner.context.telemetry,
+                    &span,
+                    &parsed_request.properties,
+                    request.body().map(|body| body.len()),
+                );
             }
         }
-        span
+        (span, parsed_request)
     }
 
     async fn process_request_mut(
@@ -238,6 +247,7 @@ where
         channel: Channel,
         ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
+        parsed_request: Option<ParsedSendRequest>,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_code = RequestCode::from(request.code());
         debug!("SendMessageProcessor received request code: {:?}", request_code);
@@ -245,7 +255,10 @@ where
             RequestCode::SendMessage
             | RequestCode::SendMessageV2
             | RequestCode::SendBatchMessage
-            | RequestCode::ConsumerSendMsgBack => self.process_request_inner(channel, ctx, request_code, request).await,
+            | RequestCode::ConsumerSendMsgBack => {
+                self.process_request_inner_with_parsed_request(channel, ctx, request_code, request, parsed_request)
+                    .await
+            }
             _ => {
                 warn!("SendMessageProcessor received unknown request code: {:?}", request_code);
                 let response = request_code_not_supported_with_remark_and_opaque(
@@ -272,14 +285,36 @@ where
     pub async fn process_request_inner(
         &mut self,
         channel: Channel,
+        ctx: ConnectionHandlerContext,
+        request_code: RequestCode,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        self.process_request_inner_with_parsed_request(channel, ctx, request_code, request, None)
+            .await
+    }
+
+    async fn process_request_inner_with_parsed_request(
+        &mut self,
+        channel: Channel,
         mut ctx: ConnectionHandlerContext,
         request_code: RequestCode,
         request: &mut RemotingCommand,
+        parsed_request: Option<ParsedSendRequest>,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         match request_code {
             RequestCode::ConsumerSendMsgBack => self.inner.consumer_send_msg_back(&channel, &ctx, request).await,
             _ => {
-                let mut request_header = parse_request_header(request, request_code)?;
+                let ParsedSendRequest {
+                    header: mut request_header,
+                    properties: parsed_properties,
+                } = match parsed_request {
+                    Some(parsed_request) => parsed_request,
+                    None => {
+                        let header = parse_request_header(request, request_code)?;
+                        let properties = string_to_message_properties(header.properties.as_ref());
+                        ParsedSendRequest { header, properties }
+                    }
+                };
                 let mapping_context = self
                     .inner
                     .context
@@ -291,9 +326,13 @@ where
                     return Ok(rewrite_result);
                 }
 
-                let (send_message_context, mut request_properties) =
-                    self.inner
-                        .build_msg_context(&channel, &ctx, &mut request_header, request);
+                let (send_message_context, mut request_properties) = self.inner.build_msg_context_with_properties(
+                    &channel,
+                    &ctx,
+                    &mut request_header,
+                    request,
+                    parsed_properties,
+                );
                 self.inner.execute_send_message_hook_before(&send_message_context);
                 clear_reserved_properties(&mut request_header, &mut request_properties);
 
@@ -1391,17 +1430,17 @@ where
         response: Option<&mut RemotingCommand>,
         context: &mut SendMessageContext,
     ) {
-        for hook in self.send_message_hook_vec.iter() {
-            if let Some(ref response) = response {
-                if let Ok(ref header) = response.decode_command_custom_header::<SendMessageResponseHeader>() {
-                    context.msg_id = header.msg_id().clone();
-                    context.queue_id = Some(header.queue_id());
-                    context.queue_offset = Some(header.queue_offset());
-                    context.code = response.code();
-                    context.error_msg = response.remark().cloned().unwrap_or_default();
-                }
+        if let Some(response) = response {
+            if let Ok(header) = response.decode_command_custom_header::<SendMessageResponseHeader>() {
+                context.msg_id = header.msg_id().clone();
+                context.queue_id = Some(header.queue_id());
+                context.queue_offset = Some(header.queue_offset());
+                context.code = response.code();
+                context.error_msg = response.remark().cloned().unwrap_or_default();
             }
+        }
 
+        for hook in self.send_message_hook_vec.iter() {
             hook.send_message_after(context);
         }
     }
@@ -1675,9 +1714,21 @@ where
     pub(crate) fn build_msg_context(
         &self,
         channel: &Channel,
+        ctx: &ConnectionHandlerContext,
+        request_header: &mut SendMessageRequestHeader,
+        request: &RemotingCommand,
+    ) -> (SendMessageContext, HashMap<CheetahString, CheetahString>) {
+        let properties = string_to_message_properties(request_header.properties.as_ref());
+        self.build_msg_context_with_properties(channel, ctx, request_header, request, properties)
+    }
+
+    fn build_msg_context_with_properties(
+        &self,
+        channel: &Channel,
         _ctx: &ConnectionHandlerContext,
         request_header: &mut SendMessageRequestHeader,
         request: &RemotingCommand,
+        properties: HashMap<CheetahString, CheetahString>,
     ) -> (SendMessageContext, HashMap<CheetahString, CheetahString>) {
         let namespace = NamespaceUtil::get_namespace_from_resource(request_header.topic.as_str());
         let policy = self.context.policy.snapshot();
@@ -1703,7 +1754,12 @@ where
                 send_message_context.commercial_owner(value.clone());
             }
         }
-        let properties = enrich_send_message_request_properties(request_header, region_id.as_str(), policy.trace_on);
+        let properties = enrich_parsed_send_message_request_properties(
+            request_header,
+            properties,
+            region_id.as_str(),
+            policy.trace_on,
+        );
 
         if let Some(unique_key) = properties.get(MessageConst::PROPERTY_UNIQ_CLIENT_MESSAGE_ID_KEYIDX) {
             send_message_context.msg_unique_key = CheetahString::from_slice(unique_key);
@@ -1934,9 +1990,18 @@ mod tests {
         let record_with_handle = concat!("record_message_properties", "_with_handle");
         let late_record_with_handle = concat!("record_current_message_properties", "_with_handle");
 
+        assert_eq!(production.matches("receive_span_and_request(request)").count(), 2);
         assert_eq!(
-            production.matches("receive_span_with_remote_parent(request)").count(),
+            production
+                .matches("parse_request_header(request, request_code)")
+                .count(),
             2
+        );
+        assert_eq!(
+            production
+                .matches("decode_command_custom_header::<SendMessageResponseHeader>()")
+                .count(),
+            1
         );
         assert_eq!(production.matches(parent_with_handle).count(), 1);
         assert_eq!(production.matches(late_parent_with_handle).count(), 0);

--- a/rocketmq-broker/src/processor/send_message_processor/message_builder.rs
+++ b/rocketmq-broker/src/processor/send_message_processor/message_builder.rs
@@ -54,7 +54,16 @@ pub(super) fn enrich_send_message_request_properties(
     region_id: &str,
     trace_on: bool,
 ) -> HashMap<CheetahString, CheetahString> {
-    let mut properties = string_to_message_properties(request_header.properties.as_ref());
+    let properties = string_to_message_properties(request_header.properties.as_ref());
+    enrich_parsed_send_message_request_properties(request_header, properties, region_id, trace_on)
+}
+
+pub(super) fn enrich_parsed_send_message_request_properties(
+    request_header: &mut SendMessageRequestHeader,
+    mut properties: HashMap<CheetahString, CheetahString>,
+    region_id: &str,
+    trace_on: bool,
+) -> HashMap<CheetahString, CheetahString> {
     properties.insert(
         CheetahString::from_static_str(MessageConst::PROPERTY_MSG_REGION),
         CheetahString::from_slice(region_id),

--- a/rocketmq-client/benches/client_hot_path_benchmark.rs
+++ b/rocketmq-client/benches/client_hot_path_benchmark.rs
@@ -28,6 +28,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use bytes::Bytes;
+use bytes::BytesMut;
 use cheetah_string::CheetahString;
 use criterion::criterion_group;
 use criterion::criterion_main;
@@ -235,6 +236,15 @@ fn build_producer_batch_messages(batch_size: usize, body_size: usize) -> Vec<Mes
         .collect()
 }
 
+fn encode_batch_with_per_message_temporaries(messages: &[Message]) -> Bytes {
+    let mut aggregate = BytesMut::new();
+    for message in messages {
+        let encoded = rocketmq_protocol::common::message::message_decoder::encode_message(message);
+        aggregate.extend_from_slice(&encoded);
+    }
+    aggregate.freeze()
+}
+
 fn bench_producer_batch_encode(c: &mut Criterion) {
     let mut group = c.benchmark_group("producer_batch_encode");
 
@@ -244,12 +254,12 @@ fn bench_producer_batch_encode(c: &mut Criterion) {
 
         let messages = build_producer_batch_messages(batch_size, body_size);
         group.bench_with_input(
-            BenchmarkId::new("generate_from_messages", format!("{batch_size}x{body_size}")),
+            BenchmarkId::new("generate_from_vec_owned", format!("{batch_size}x{body_size}")),
             &messages,
             |b, messages| {
                 b.iter_batched(
                     || messages.clone(),
-                    |messages| black_box(MessageBatch::generate_from_messages(messages).unwrap()),
+                    |messages| black_box(MessageBatch::generate_from_vec(messages).unwrap()),
                     BatchSize::SmallInput,
                 )
             },
@@ -257,7 +267,12 @@ fn bench_producer_batch_encode(c: &mut Criterion) {
 
         let batch = MessageBatch::generate_from_messages(messages).unwrap();
         group.bench_with_input(
-            BenchmarkId::new("encode", format!("{batch_size}x{body_size}")),
+            BenchmarkId::new("encode_per_message_temporaries", format!("{batch_size}x{body_size}")),
+            &batch,
+            |b, batch| b.iter(|| black_box(encode_batch_with_per_message_temporaries(&batch.messages))),
+        );
+        group.bench_with_input(
+            BenchmarkId::new("encode_aggregate_buffer", format!("{batch_size}x{body_size}")),
             &batch,
             |b, batch| {
                 b.iter(|| {

--- a/rocketmq-client/src/producer/produce_accumulator.rs
+++ b/rocketmq-client/src/producer/produce_accumulator.rs
@@ -975,27 +975,11 @@ fn split_send_results(send_result: &SendResult, count: usize) -> rocketmq_error:
 }
 
 fn build_message_batch(
-    messages: Vec<Box<dyn MessageTrait + Send + Sync + 'static>>,
+    messages: Vec<Message>,
     aggregate_key: &AggregateKey,
     keys: &HashSet<String>,
 ) -> rocketmq_error::RocketMQResult<MessageBatch> {
-    let mut concrete_messages = Vec::with_capacity(messages.len());
-    for boxed_msg in messages {
-        if let Some(msg) = boxed_msg.as_any().downcast_ref::<Message>() {
-            concrete_messages.push(msg.clone());
-        } else {
-            let mut msg = Message::default();
-            msg.set_topic(boxed_msg.topic().clone());
-            if let Some(body) = boxed_msg.get_body() {
-                msg.set_body(Some(body.clone()));
-            }
-            msg.set_flag(boxed_msg.get_flag());
-            msg.set_properties(boxed_msg.get_properties().clone());
-            concrete_messages.push(msg);
-        }
-    }
-
-    let mut batch = MessageBatch::generate_from_messages(concrete_messages)?;
+    let mut batch = MessageBatch::generate_from_messages(messages)?;
     batch.set_topic(aggregate_key.topic.clone());
     batch.set_wait_store_msg_ok(aggregate_key.wait_store_msg_ok);
     if let Some(tag) = aggregate_key.tag.as_ref() {
@@ -1703,7 +1687,7 @@ impl Hash for AggregateKey {
 
 struct MessageAccumulation {
     default_mq_producer: DefaultMQProducer,
-    messages: Vec<Box<dyn MessageTrait + Send + Sync + 'static>>,
+    messages: Vec<Message>,
     resource_permits: Vec<ResourcePermit>,
     send_callbacks: Vec<ArcSendCallback>,
     keys: HashSet<String>,
@@ -1901,7 +1885,7 @@ impl MessageAccumulation {
         }
 
         // Add message to batch
-        self.messages.push(Box::new(msg));
+        self.messages.push(msg.into_message());
         if let Some(resource_permit) = resource_permit {
             self.resource_permits.push(resource_permit);
         }

--- a/rocketmq-model/src/common/message.rs
+++ b/rocketmq-model/src/common/message.rs
@@ -306,6 +306,29 @@ pub trait MessageTrait: Any + Display + Debug {
     /// Takes ownership of the message body, leaving it empty.
     fn take_body(&mut self) -> Option<Bytes>;
 
+    /// Converts this value into the concrete producer message representation.
+    ///
+    /// Implementations that already own a [`message_single::Message`] should override this method
+    /// so the body and property map can be moved without cloning. The default keeps custom message
+    /// implementations source-compatible and normalizes their public fields into a producer
+    /// message.
+    fn into_message(self) -> message_single::Message
+    where
+        Self: Sized,
+    {
+        let mut message = message_single::Message::default();
+        message.set_topic(self.topic().clone());
+        if let Some(body) = self.get_body() {
+            message.set_body(Some(body.clone()));
+        }
+        message.set_flag(self.get_flag());
+        if let Some(transaction_id) = self.transaction_id() {
+            message.set_transaction_id(transaction_id.clone());
+        }
+        message.set_properties(self.get_properties().clone());
+        message
+    }
+
     /// Returns a reference to the message as a trait object.
     fn as_any(&self) -> &dyn Any;
 

--- a/rocketmq-model/src/common/message/message_batch.rs
+++ b/rocketmq-model/src/common/message/message_batch.rs
@@ -74,24 +74,7 @@ impl MessageBatch {
             ));
         }
 
-        let mut message_list = Vec::with_capacity(messages.len());
-        for msg in messages {
-            if let Some(m) = msg.as_any().downcast_ref::<Message>() {
-                message_list.push(m.clone());
-            } else {
-                let mut m = Message::default();
-                m.set_topic(msg.topic().clone());
-                if let Some(body) = msg.get_body() {
-                    m.set_body(Some(body.clone()));
-                }
-                m.set_flag(msg.get_flag());
-                if let Some(transaction_id) = msg.transaction_id() {
-                    m.set_transaction_id(transaction_id.clone());
-                }
-                m.set_properties(msg.get_properties().clone());
-                message_list.push(m);
-            }
-        }
+        let message_list = messages.into_iter().map(MessageTrait::into_message).collect();
 
         Self::generate_from_messages(message_list)
     }
@@ -308,6 +291,18 @@ mod tests {
         assert_eq!(batch.messages.len(), 2);
         assert_eq!(batch.len(), 2);
         assert!(!batch.is_empty());
+    }
+
+    #[test]
+    fn generate_from_vec_moves_concrete_message_body_storage() {
+        let mut message = create_test_message("topic1");
+        let body = Bytes::from(vec![b'x'; 128]);
+        let body_ptr = body.as_ptr();
+        message.set_body(Some(body));
+
+        let batch = MessageBatch::generate_from_vec(vec![message]).expect("batch should build");
+
+        assert_eq!(batch.messages[0].get_body().expect("message body").as_ptr(), body_ptr);
     }
 
     #[test]

--- a/rocketmq-model/src/common/message/message_single.rs
+++ b/rocketmq-model/src/common/message/message_single.rs
@@ -564,6 +564,11 @@ impl Display for Message {
 #[allow(unused_variables)]
 impl MessageTrait for Message {
     #[inline]
+    fn into_message(self) -> Message {
+        self
+    }
+
+    #[inline]
     fn put_property(&mut self, key: CheetahString, value: CheetahString) {
         self.properties.as_map_mut().insert(key, value);
     }

--- a/rocketmq-protocol/src/common/message/message_decoder.rs
+++ b/rocketmq-protocol/src/common/message/message_decoder.rs
@@ -277,16 +277,23 @@ pub fn count_inner_msg_num(bytes: Option<Bytes>) -> u32 {
 
 pub fn encode_messages(messages: &[Message]) -> Bytes {
     let mut bytes = BytesMut::new();
-    //let mut all_size = 0;
     for message in messages {
-        let message_bytes = encode_message(message);
-        //all_size += message_bytes.len();
-        bytes.put_slice(&message_bytes);
+        encode_message_into(message, &mut bytes);
     }
     bytes.freeze()
 }
 
 pub fn encode_message(message: &Message) -> Bytes {
+    let mut bytes = BytesMut::new();
+    encode_message_into(message, &mut bytes);
+    bytes.freeze()
+}
+
+/// Encodes one producer message directly into an existing aggregate buffer.
+///
+/// This uses the same Java-compatible batch wire layout as [`encode_message`] while avoiding a
+/// temporary allocation for every message in a batch.
+pub fn encode_message_into(message: &Message, bytes: &mut BytesMut) {
     let empty_body = Bytes::new();
     let body = message.get_body().unwrap_or(&empty_body);
     let body_len = body.len();
@@ -301,7 +308,7 @@ pub fn encode_message(message: &Message) -> Bytes {
              + 4 + body_len // 4 BODY
              + 2 + properties_length;
 
-    let mut bytes = BytesMut::with_capacity(store_size);
+    bytes.reserve(store_size);
 
     // 1 TOTALSIZE
     bytes.put_i32(store_size as i32);
@@ -322,8 +329,6 @@ pub fn encode_message(message: &Message) -> Bytes {
     // 6 PROPERTIES
     bytes.put_i16(properties_length as i16);
     bytes.put_slice(properties_bytes);
-
-    bytes.freeze()
 }
 
 pub fn decodes_batch(byte_buffer: &mut Bytes, read_body: bool, decompress_body: bool) -> Vec<MessageExt> {
@@ -889,6 +894,28 @@ mod tests {
         message_ext.set_queue_offset(queue_offset);
         message_ext.set_commit_log_offset(queue_offset * 1024);
         message_ext
+    }
+
+    #[test]
+    fn encode_messages_matches_concatenated_single_message_wire_bytes() {
+        let messages = vec![
+            Message::builder()
+                .topic("BatchTopic")
+                .tags("TagA")
+                .body_slice(b"first")
+                .build_unchecked(),
+            Message::builder()
+                .topic("BatchTopic")
+                .keys(vec!["key-a".to_string(), "key-b".to_string()])
+                .body_slice(b"second-message")
+                .build_unchecked(),
+        ];
+        let mut expected = BytesMut::new();
+        for message in &messages {
+            expected.put_slice(&encode_message(message));
+        }
+
+        assert_eq!(encode_messages(&messages), expected.freeze());
     }
 
     #[test]

--- a/rocketmq-transport/src/clients/rocketmq_tokio_client.rs
+++ b/rocketmq-transport/src/clients/rocketmq_tokio_client.rs
@@ -1226,6 +1226,17 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
 }
 
 impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
+    fn record_nameserver_outcome(&self, addr: Option<&CheetahString>, latency: Duration, success: bool) {
+        let Some(addr) = addr else {
+            return;
+        };
+        if success {
+            self.latency_tracker.record_success(addr, latency);
+        } else {
+            self.latency_tracker.record_error(addr);
+        }
+    }
+
     async fn invoke_oneway_until(
         &self,
         addr: &CheetahString,
@@ -1233,18 +1244,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
         deadline: RequestDeadline,
         permit: Option<ResourcePermit>,
     ) -> RocketMQResult<()> {
-        let started_at = time::Instant::now();
-        let result = self.invoke_oneway_until_inner(addr, request, deadline, permit).await;
-        let latency = started_at.elapsed();
-        match &result {
-            Ok(()) => {
-                self.latency_tracker.record_success(addr, latency);
-            }
-            Err(_) => {
-                self.latency_tracker.record_error(addr);
-            }
-        }
-        result
+        self.invoke_oneway_until_inner(addr, request, deadline, permit).await
     }
 
     async fn invoke_oneway_until_inner(
@@ -1344,29 +1344,40 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
                 })
             }
             RequestTarget::NameServer => {
-                deadline.ensure_before_send("<nameserver>")?;
-                let Some(mut client) = self.get_and_create_client_until(None, deadline).await? else {
-                    return Err(RocketMQError::network_connection_failed(
-                        "<nameserver>",
-                        "one-way nameserver client unavailable",
-                    ));
-                };
-                let endpoint = CheetahString::from_string(client.remote_address().to_string());
-                let mut request = request;
-                if let Some(hooks) = self.cmd_handler.hook_snapshot() {
-                    request.make_custom_header_to_net();
-                    self.cmd_handler.do_before_rpc_hooks_with_snapshot(
-                        Some(hooks.as_ref()),
-                        client.remote_address(),
-                        Some(&mut request),
-                    )?;
+                let started_at = time::Instant::now();
+                let result = async {
+                    deadline.ensure_before_send("<nameserver>")?;
+                    let Some(mut client) = self.get_and_create_client_until(None, deadline).await? else {
+                        return Err(RocketMQError::network_connection_failed(
+                            "<nameserver>",
+                            "one-way nameserver client unavailable",
+                        ));
+                    };
+                    let endpoint = CheetahString::from_string(client.remote_address().to_string());
+                    let mut request = request;
+                    if let Some(hooks) = self.cmd_handler.hook_snapshot() {
+                        request.make_custom_header_to_net();
+                        self.cmd_handler.do_before_rpc_hooks_with_snapshot(
+                            Some(hooks.as_ref()),
+                            client.remote_address(),
+                            Some(&mut request),
+                        )?;
+                    }
+                    request.mark_oneway_rpc_ref();
+                    client.send_until(request, deadline).await?;
+                    Ok(SendReceipt {
+                        endpoint,
+                        written_at_millis: current_millis(),
+                    })
                 }
-                request.mark_oneway_rpc_ref();
-                client.send_until(request, deadline).await?;
-                Ok(SendReceipt {
-                    endpoint,
-                    written_at_millis: current_millis(),
-                })
+                .await;
+                let metric_addr = result
+                    .as_ref()
+                    .ok()
+                    .map(|receipt| receipt.endpoint.clone())
+                    .or_else(|| self.namesrv_addr_choosed.read().clone());
+                self.record_nameserver_outcome(metric_addr.as_ref(), started_at.elapsed(), result.is_ok());
+                result
             }
         }
     }
@@ -1424,7 +1435,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
         request: RemotingCommand,
         deadline: RequestDeadline,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
-        // Record start time for latency tracking
+        let nameserver_request = addr.is_none();
         let start = time::Instant::now();
         let timeout_millis = deadline.budget_millis();
         let target = addr.map_or_else(|| "<nameserver>".to_string(), ToString::to_string);
@@ -1451,8 +1462,10 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
             }
 
             // Record connection error
-            if let Some(ref addr) = target_addr {
-                self.latency_tracker.record_error(addr);
+            if nameserver_request {
+                if let Some(ref addr) = target_addr {
+                    self.latency_tracker.record_error(addr);
+                }
             }
 
             RocketMQError::network_connection_failed(target.clone(), "Failed to connect")
@@ -1464,6 +1477,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
 
         let mut request = request;
         let remote_address = client.remote_address();
+        let nameserver_metric_addr = nameserver_request.then(|| CheetahString::from_string(remote_address.to_string()));
         deadline.ensure_before_send(remote_address.to_string())?;
         let hooks = self.cmd_handler.hook_snapshot();
         let request_for_after = if let Some(hooks) = hooks {
@@ -1500,9 +1514,8 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
                     }
                 }
 
+                self.record_nameserver_outcome(nameserver_metric_addr.as_ref(), latency, true);
                 if let Some(ref addr) = target_addr {
-                    self.latency_tracker.record_success(addr, latency);
-
                     debug!(
                         remote_addr = %addr,
                         elapsed_ms = latency.as_millis() as u64,
@@ -1521,9 +1534,8 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
                         self.connection_tables.remove(addr);
                     }
                 }
+                self.record_nameserver_outcome(nameserver_metric_addr.as_ref(), latency, false);
                 if let Some(ref addr) = target_addr {
-                    self.latency_tracker.record_error(addr);
-
                     warn!(
                         remote_addr = %addr,
                         elapsed_ms = latency.as_millis() as u64,
@@ -1997,6 +2009,104 @@ mod tests {
         assert_eq!(hook.before_count.load(Ordering::SeqCst), 1);
         assert_eq!(hook.after_count.load(Ordering::SeqCst), 0);
 
+        server.await.expect("server task");
+        client.shutdown();
+    }
+
+    #[tokio::test]
+    async fn explicit_broker_requests_do_not_update_nameserver_latency() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
+        let addr = listener.local_addr().expect("listener addr");
+        let server = tokio::spawn(async move {
+            let (socket, _) = listener.accept().await.expect("accept client");
+            let mut connection = Connection::new(socket);
+            let request = connection
+                .receive_command()
+                .await
+                .expect("request frame")
+                .expect("request command");
+            connection
+                .send_command(
+                    RemotingCommand::create_response_command_with_code(ResponseCode::Success)
+                        .set_opaque(request.opaque()),
+                )
+                .await
+                .expect("send response");
+            connection
+                .receive_command()
+                .await
+                .expect("oneway frame")
+                .expect("oneway command");
+        });
+        let client = TransportClient::build_for_test(
+            Arc::new(TransportClientConfig::default()),
+            DefaultRequestProcessor,
+            test_service_context("explicit-broker-latency-test"),
+        );
+        let target = CheetahString::from_string(addr.to_string());
+
+        client
+            .invoke_request(
+                Some(&target),
+                RemotingCommand::create_remoting_command(RequestCode::GetBrokerClusterInfo),
+                3_000,
+            )
+            .await
+            .expect("explicit Broker request");
+        client
+            .invoke_request_oneway(
+                &target,
+                RemotingCommand::create_remoting_command(RequestCode::GetBrokerClusterInfo),
+                3_000,
+            )
+            .await
+            .expect("explicit Broker oneway");
+
+        assert_eq!(client.latency_tracker.get_p99(&target), None);
+        assert_eq!(client.latency_tracker.get_error_count(&target), 0);
+        server.await.expect("server task");
+        client.shutdown();
+    }
+
+    #[tokio::test]
+    async fn nameserver_request_updates_latency_and_failover_state() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
+        let addr = listener.local_addr().expect("listener addr");
+        let server = tokio::spawn(async move {
+            let (socket, _) = listener.accept().await.expect("accept client");
+            let mut connection = Connection::new(socket);
+            let request = connection
+                .receive_command()
+                .await
+                .expect("request frame")
+                .expect("request command");
+            connection
+                .send_command(
+                    RemotingCommand::create_response_command_with_code(ResponseCode::Success)
+                        .set_opaque(request.opaque()),
+                )
+                .await
+                .expect("send response");
+        });
+        let client = TransportClient::build_for_test(
+            Arc::new(TransportClientConfig::default()),
+            DefaultRequestProcessor,
+            test_service_context("nameserver-latency-test"),
+        );
+        let target = CheetahString::from_string(addr.to_string());
+        client.update_name_server_address_list_sync(vec![target.clone()]);
+
+        client
+            .invoke_request(
+                None,
+                RemotingCommand::create_remoting_command(RequestCode::GetBrokerClusterInfo),
+                3_000,
+            )
+            .await
+            .expect("NameServer request");
+
+        assert!(client.latency_tracker.get_p99(&target).is_some());
+        assert_eq!(client.latency_tracker.get_error_count(&target), 0);
         server.await.expect("server task");
         client.shutdown();
     }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9247

### Brief Description

- Move standard producer messages into batch accumulation without cloning bodies or property maps.
- Encode batch entries directly into one aggregate `BytesMut` while preserving the existing wire bytes and validation rules.
- Keep NameServer latency tracking off explicit Broker request paths while retaining actual NameServer health metrics.
- Reuse one parsed send header and property map across Broker tracing and processing, and decode the response header once before after-hooks.
- Add focused ownership, wire-compatibility, routing, and microbenchmark coverage.

### How Did You Test This Change?

- `cargo test -p rocketmq-model`
- `cargo test -p rocketmq-protocol --lib`
- `cargo test -p rocketmq-protocol --test request_header_java_compatibility`
- `cargo test -p rocketmq-transport --lib`
- `cargo test -p rocketmq-client-rust --lib`
- `cargo test -p rocketmq-broker broker_receive_spans_bind_remote_parent_before_instrumentation --lib`
- `cargo check -p rocketmq-broker --features otel-traces`
- `cargo check --manifest-path fuzz/Cargo.toml --all-targets`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo bench -p rocketmq-client-rust --features test-support --bench client_hot_path_benchmark -- producer_batch_encode --sample-size 10 --warm-up-time 0.1 --measurement-time 0.3 --noplot`
- WSL `cargo fmt --all -- --check` (Windows reports OS error 206 for the workspace path length)
- Standalone example, SRE, and MCP consumer checks required by their local `AGENTS.md` files.

The unchanged main branch reproduces two unrelated Broker source-contract/Timer test failures. The unchanged main branch also reproduces the Windows SRE connector stack overflow; the affected connector tests pass with `RUST_MIN_STACK=8388608`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved message batching and encoding efficiency, reducing unnecessary copying and temporary allocations.
  * Streamlined producer batch handling for faster message accumulation and delivery.

* **Monitoring**
  * Improved tracing and message metadata handling during send operations.
  * Nameserver latency metrics now accurately reflect nameserver requests and exclude broker-only traffic.

* **Reliability**
  * Added validation coverage for batch encoding, tracing, response handling, and latency measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->