### PR TITLE
[ISSUE #9249]✨Add bounded POP BatchAck aggregation and error propagation

### DIFF
--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
@@ -492,18 +492,29 @@ impl ConsumeMessagePopConcurrentlyService {
         }
 
         if ack_index >= 0 {
-            for i in 0..=ack_index {
-                let msg = &consume_request.msgs[i as usize];
-                if let Some(default_mqpush_consumer_impl) = self.consumer_impl() {
-                    default_mqpush_consumer_impl
-                        .ack_async(msg.as_ref(), &self.consumer_group)
-                        .await;
-                } else {
-                    warn!(
-                        "pop consume ack skipped: DefaultMQPushConsumerImpl is not initialized, group={}, mq={}",
-                        self.consumer_group, consume_request.message_queue
-                    );
+            let acked_messages = &consume_request.msgs[..=ack_index as usize];
+            if let Some(default_mqpush_consumer_impl) = self.consumer_impl() {
+                for (entry_index, result) in default_mqpush_consumer_impl
+                    .ack_batch_async(acked_messages, &self.consumer_group)
+                    .await
+                {
+                    if let Err(error) = result {
+                        warn!(
+                            "pop consume ACK failed and will rely on redelivery: group={}, mq={}, msg_id={}, error={}",
+                            self.consumer_group,
+                            consume_request.message_queue,
+                            acked_messages[entry_index].msg_id,
+                            error
+                        );
+                    }
                 }
+            } else {
+                warn!(
+                    "pop consume ack skipped: DefaultMQPushConsumerImpl is not initialized, group={}, mq={}",
+                    self.consumer_group, consume_request.message_queue
+                );
+            }
+            for _ in acked_messages {
                 consume_request.process_queue.ack();
             }
         }

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
@@ -509,12 +509,6 @@ impl ConsumeMessagePopOrderlyService {
         }
     }
 
-    async fn ack_message(&self, msg: &MessageExt) {
-        if let Some(impl_) = self.consumer_impl() {
-            impl_.ack_async(msg, &self.consumer_group).await;
-        }
-    }
-
     async fn change_invisible_time(&self, msg: &MessageExt, invisible_time: u64) {
         if let Some(impl_) = self.consumer_impl() {
             if let Some(extra_info) = msg.property(&CheetahString::from_static_str("POP_CK")) {
@@ -556,9 +550,7 @@ impl ConsumeMessagePopOrderlyService {
 
         match status {
             ConsumeOrderlyStatus::Success => {
-                for msg in msgs {
-                    self.ack_message(msg.as_ref()).await;
-                }
+                self.ack_messages(msgs).await;
                 true
             }
             ConsumeOrderlyStatus::SuspendCurrentQueueAMoment => {
@@ -574,9 +566,7 @@ impl ConsumeMessagePopOrderlyService {
             }
             #[allow(deprecated)]
             ConsumeOrderlyStatus::Commit => {
-                for msg in msgs {
-                    self.ack_message(msg.as_ref()).await;
-                }
+                self.ack_messages(msgs).await;
                 true
             }
             #[allow(deprecated)]
@@ -589,6 +579,24 @@ impl ConsumeMessagePopOrderlyService {
                     self.change_invisible_time(msg.as_ref(), 1000).await;
                 }
                 false
+            }
+        }
+    }
+
+    async fn ack_messages(&self, messages: &[Arc<MessageExt>]) {
+        let Some(impl_) = self.consumer_impl() else {
+            warn!(
+                "pop orderly ACK skipped: consumer is not initialized, group={}",
+                self.consumer_group
+            );
+            return;
+        };
+        for (entry_index, result) in impl_.ack_batch_async(messages, &self.consumer_group).await {
+            if let Err(error) = result {
+                warn!(
+                    "pop orderly ACK failed and will rely on redelivery: group={}, msg_id={}, error={}",
+                    self.consumer_group, messages[entry_index].msg_id, error
+                );
             }
         }
     }

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -42,6 +42,8 @@ use rocketmq_model::common::sys_flag::pull_sys_flag::PullSysFlag;
 use rocketmq_model::common::FAQUrl;
 use rocketmq_observability::metrics::client::ClientMetrics;
 use rocketmq_observability::TelemetryHandle;
+use rocketmq_protocol::protocol::body::batch_ack_builder::build_batch_ack_requests;
+use rocketmq_protocol::protocol::body::batch_ack_builder::BatchAckInput;
 use rocketmq_protocol::protocol::body::consume_message_directly_result::ConsumeMessageDirectlyResult;
 use rocketmq_protocol::protocol::body::consumer_running_info::ConsumerRunningInfo;
 use rocketmq_protocol::protocol::body::pop_process_queue_info::PopProcessQueueInfo;
@@ -1832,73 +1834,116 @@ impl DefaultMQPushConsumerImpl {
     }
 
     pub(crate) async fn ack_async(&self, message: &MessageExt, consumer_group: &CheetahString) {
+        if let Err(error) = self.ack_message_result(message, consumer_group).await {
+            error!("ackAsync error: {}", error);
+        }
+    }
+
+    pub(crate) async fn ack_batch_async(
+        &self,
+        messages: &[Arc<MessageExt>],
+        consumer_group: &CheetahString,
+    ) -> Vec<(usize, rocketmq_error::RocketMQResult<AckResult>)> {
+        let pop_ck = CheetahString::from_static_str(MessageConst::PROPERTY_POP_CK);
+        let receipt_handles = messages
+            .iter()
+            .map(|message| message.property(&pop_ck).unwrap_or_default())
+            .collect::<Vec<_>>();
+        let inputs = messages
+            .iter()
+            .zip(&receipt_handles)
+            .enumerate()
+            .map(|(entry_index, (message, receipt_handle))| BatchAckInput {
+                entry_index,
+                consumer_group,
+                topic: message.topic().as_str(),
+                receipt_handle,
+            })
+            .collect::<Vec<_>>();
+        let built = build_batch_ack_requests(&inputs);
+        let mut results = Vec::with_capacity(messages.len());
+
+        for failure in built.failures {
+            let result = self
+                .ack_message_result(&messages[failure.entry_index], consumer_group)
+                .await;
+            results.push((failure.entry_index, result));
+        }
+
+        for request in built.requests {
+            let Some(first_ack) = request.body.acks.first() else {
+                continue;
+            };
+            let topic = first_ack.topic.clone();
+            let ack_consumer_group = first_ack.consumer_group.clone();
+            let retry = first_ack.retry.clone();
+            let queue_id = first_ack.queue_id;
+            let batch_result = async {
+                let route_topic = CheetahString::from_string(ExtraInfoUtil::get_real_topic_with_retry(
+                    &topic,
+                    &ack_consumer_group,
+                    &retry,
+                )?);
+                let (client_instance, broker_addr) = self
+                    .resolve_ack_broker_address(&request.broker_name, &route_topic, queue_id)
+                    .await?;
+                let api = client_instance
+                    .mq_client_api_impl
+                    .load_full()
+                    .ok_or_else(|| RocketMQError::not_initialized("MQClientAPIImpl"))?;
+                api.batch_ack_message(&broker_addr, request.body, ASYNC_TIMEOUT).await
+            }
+            .await;
+
+            match batch_result {
+                Ok(ack_result) => {
+                    results.extend(
+                        request
+                            .entry_indexes
+                            .into_iter()
+                            .map(|entry_index| (entry_index, Ok(ack_result.clone()))),
+                    );
+                }
+                Err(batch_error) => {
+                    warn!(
+                        "BatchAck failed for broker {}, falling back to {} single ACKs: {}",
+                        request.broker_name,
+                        request.entry_indexes.len(),
+                        batch_error
+                    );
+                    for entry_index in request.entry_indexes {
+                        let result = self.ack_message_result(&messages[entry_index], consumer_group).await;
+                        results.push((entry_index, result));
+                    }
+                }
+            }
+        }
+
+        results.sort_by_key(|(entry_index, _)| *entry_index);
+        results
+    }
+
+    async fn ack_message_result(
+        &self,
+        message: &MessageExt,
+        consumer_group: &CheetahString,
+    ) -> rocketmq_error::RocketMQResult<AckResult> {
         let extra_info = message
             .property(&CheetahString::from_static_str(MessageConst::PROPERTY_POP_CK))
             .unwrap_or_default();
-        let extra_info_strs = ExtraInfoUtil::split(extra_info.as_str());
-        /*        if extra_info_strs.is_err() {
-            error!("ackAsync error: {}", extra_info_strs.unwrap_err());
-            return;
-        }
-        let extra_info_strs = extra_info_strs.unwrap();*/
-        let queue_id = ExtraInfoUtil::get_queue_id(extra_info_strs.as_slice());
-        let queue_id = match queue_id {
-            Ok(queue_id) => queue_id,
-            Err(e) => {
-                error!("ackAsync error: {}", e);
-                return;
-            }
-        };
-        let queue_offset = ExtraInfoUtil::get_queue_offset(extra_info_strs.as_slice());
-        let queue_offset = match queue_offset {
-            Ok(queue_offset) => queue_offset,
-            Err(e) => {
-                error!("ackAsync error: {}", e);
-                return;
-            }
-        };
-        let broker_name =
-            CheetahString::from(ExtraInfoUtil::get_broker_name(extra_info_strs.as_slice()).unwrap_or_default());
+        let parsed = ExtraInfoUtil::parse_ack_extra_info(&extra_info)?;
+        let queue_id = parsed.queue_id;
+        let queue_offset = parsed.queue_offset;
+        let broker_name = CheetahString::from(parsed.broker_name);
         let topic = message.topic();
-
-        let Some(client_instance) = self.get_mq_client_factory() else {
-            error!("ackAsync error: MQClientInstance is not initialized");
-            return;
-        };
-        let des_broker_name =
-            if !broker_name.is_empty() && broker_name.starts_with(mix_all::LOGICAL_QUEUE_MOCK_BROKER_PREFIX) {
-                let mq = self
-                    .client_config_snapshot()
-                    .queue_with_resolved_namespace(MessageQueue::from_parts(topic, broker_name.clone(), queue_id));
-                client_instance.get_broker_name_from_message_queue(&mq).await
-            } else {
-                broker_name.clone()
-            };
-
-        let mut find_broker_result = client_instance
-            .find_broker_address_in_subscribe(&des_broker_name, mix_all::MASTER_ID, true)
-            .await;
-        if find_broker_result.is_none() {
-            client_instance
-                .update_topic_route_info_from_name_server_topic(topic)
-                .await;
-            find_broker_result = client_instance
-                .find_broker_address_in_subscribe(&des_broker_name, mix_all::MASTER_ID, true)
-                .await;
-        }
-        if find_broker_result.is_none() {
-            error!("The broker[{}] not exist", des_broker_name);
-            return;
-        }
-        let Some(find_broker_result) = find_broker_result else {
-            error!("The broker[{}] not exist", des_broker_name);
-            return;
-        };
+        let (client_instance, broker_addr) = self.resolve_ack_broker_address(&broker_name, topic, queue_id).await?;
         let request_header = AckMessageRequestHeader {
             consumer_group: consumer_group.clone(),
-            topic: CheetahString::from_string(
-                ExtraInfoUtil::get_real_topic(extra_info_strs.as_slice(), topic, consumer_group).unwrap_or_default(),
-            ),
+            topic: CheetahString::from_string(ExtraInfoUtil::get_real_topic_with_retry(
+                topic,
+                consumer_group,
+                parsed.retry,
+            )?),
             queue_id,
             extra_info,
             offset: queue_offset,
@@ -1911,30 +1956,47 @@ impl DefaultMQPushConsumerImpl {
                 lo: None,
             }),
         };
-        struct DefaultAckCallback;
-        impl AckCallback for DefaultAckCallback {
-            fn on_success(&self, _ack_result: AckResult) {}
-
-            fn on_exception(&self, _e: rocketmq_error::RocketMQError) {}
-        }
-        let Some(mq_client_api_impl) = client_instance.mq_client_api_impl.load_full() else {
-            error!("ackAsync error: MQClientAPIImpl is not initialized");
-            return;
-        };
-        match mq_client_api_impl
-            .ack_message_async(
-                &find_broker_result.broker_addr,
-                request_header,
-                ASYNC_TIMEOUT,
-                DefaultAckCallback,
-            )
+        client_instance
+            .mq_client_api_impl
+            .load_full()
+            .ok_or_else(|| RocketMQError::not_initialized("MQClientAPIImpl"))?
+            .ack_message(&broker_addr, request_header, ASYNC_TIMEOUT)
             .await
-        {
-            Ok(_) => {}
-            Err(e) => {
-                error!("ackAsync error: {}", e);
-            }
+    }
+
+    async fn resolve_ack_broker_address(
+        &self,
+        broker_name: &CheetahString,
+        topic: &CheetahString,
+        queue_id: i32,
+    ) -> rocketmq_error::RocketMQResult<(Arc<MQClientInstance>, CheetahString)> {
+        let client_instance = self
+            .get_mq_client_factory()
+            .ok_or_else(|| RocketMQError::not_initialized("MQClientInstance"))?;
+        let destination_broker =
+            if !broker_name.is_empty() && broker_name.starts_with(mix_all::LOGICAL_QUEUE_MOCK_BROKER_PREFIX) {
+                let queue = self
+                    .client_config_snapshot()
+                    .queue_with_resolved_namespace(MessageQueue::from_parts(topic, broker_name.clone(), queue_id));
+                client_instance.get_broker_name_from_message_queue(&queue).await
+            } else {
+                broker_name.clone()
+            };
+        let mut broker = client_instance
+            .find_broker_address_in_subscribe(&destination_broker, mix_all::MASTER_ID, true)
+            .await;
+        if broker.is_none() {
+            client_instance
+                .update_topic_route_info_from_name_server_topic(topic)
+                .await;
+            broker = client_instance
+                .find_broker_address_in_subscribe(&destination_broker, mix_all::MASTER_ID, true)
+                .await;
         }
+        let broker = broker.ok_or_else(|| RocketMQError::BrokerNotFound {
+            name: destination_broker.to_string(),
+        })?;
+        Ok((client_instance, broker.broker_addr))
     }
 
     pub(crate) async fn change_pop_invisible_time_async(

--- a/rocketmq-client/src/implementation/mq_client_api_impl/consumer.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl/consumer.rs
@@ -1593,6 +1593,16 @@ impl MQClientAPIImpl {
             .await
     }
 
+    pub async fn ack_message(
+        &self,
+        addr: &CheetahString,
+        request_header: AckMessageRequestHeader,
+        timeout_millis: u64,
+    ) -> rocketmq_error::RocketMQResult<AckResult> {
+        self.ack_message_inner(addr, Some(request_header), None, timeout_millis)
+            .await
+    }
+
     pub async fn ack_lite_message_async(
         &self,
         addr: &CheetahString,
@@ -1615,6 +1625,16 @@ impl MQClientAPIImpl {
             .await
     }
 
+    pub async fn batch_ack_message(
+        &self,
+        addr: &CheetahString,
+        request_body: BatchAckMessageRequestBody,
+        timeout_millis: u64,
+    ) -> rocketmq_error::RocketMQResult<AckResult> {
+        self.ack_message_inner(addr, None, Some(request_body), timeout_millis)
+            .await
+    }
+
     pub(self) async fn ack_message_async_inner(
         &self,
         addr: &CheetahString,
@@ -1623,6 +1643,29 @@ impl MQClientAPIImpl {
         timeout_millis: u64,
         ack_callback: impl AckCallback,
     ) -> rocketmq_error::RocketMQResult<()> {
+        match self
+            .ack_message_inner(addr, request_header, request_body, timeout_millis)
+            .await
+        {
+            Ok(ack_result) => {
+                ack_callback.on_success(ack_result);
+                Ok(())
+            }
+            Err(error) => {
+                let propagated = mq_client_err!(error.to_string());
+                ack_callback.on_exception(error);
+                Err(propagated)
+            }
+        }
+    }
+
+    async fn ack_message_inner(
+        &self,
+        addr: &CheetahString,
+        request_header: Option<AckMessageRequestHeader>,
+        request_body: Option<BatchAckMessageRequestBody>,
+        timeout_millis: u64,
+    ) -> rocketmq_error::RocketMQResult<AckResult> {
         let request = if let Some(header) = request_header {
             RemotingCommand::create_request_command(RequestCode::AckMessage, header)
         } else {
@@ -1630,30 +1673,21 @@ impl MQClientAPIImpl {
                 request_body.ok_or_else(|| mq_client_err!("BatchAckMessage request body is required".to_string()))?;
             RemotingCommand::new_request(RequestCode::BatchAckMessage, body.encode()?)
         };
-        match self
+        let response = self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
-            .await
-        {
-            Ok(response) => {
-                let response_code = ResponseCode::from(response.code());
-                let ack_result = if response_code == ResponseCode::Success {
-                    AckResult {
-                        status: AckStatus::Ok,
-                        ..Default::default()
-                    }
-                } else {
-                    AckResult {
-                        status: AckStatus::NotExist,
-                        ..Default::default()
-                    }
-                };
-                ack_callback.on_success(ack_result);
+            .await?;
+        let response_code = ResponseCode::from(response.code());
+        Ok(if response_code == ResponseCode::Success {
+            AckResult {
+                status: AckStatus::Ok,
+                ..Default::default()
             }
-            Err(e) => {
-                ack_callback.on_exception(e);
+        } else {
+            AckResult {
+                status: AckStatus::NotExist,
+                ..Default::default()
             }
-        }
-        Ok(())
+        })
     }
 }

--- a/rocketmq-client/src/lib.rs
+++ b/rocketmq-client/src/lib.rs
@@ -283,17 +283,23 @@ mod cluster_session {
             timeout_millis: u64,
         ) -> rocketmq_error::RocketMQResult<crate::consumer::ack_result::AckResult> {
             let _operation = self.operation().await;
-            let (sender, receiver) = tokio::sync::oneshot::channel();
             self.inner
                 .get_mq_client_api_impl()?
-                .ack_message_async(broker_addr, request, timeout_millis, OwnedAckCallback::new(sender))
-                .await?;
-            receiver.await.unwrap_or_else(|source| {
-                Err(rocketmq_error::RocketMQError::internal(
-                    "receive client ack callback result",
-                    source,
-                ))
-            })
+                .ack_message(broker_addr, request, timeout_millis)
+                .await
+        }
+
+        pub async fn batch_ack_message(
+            &self,
+            broker_addr: &CheetahString,
+            request: rocketmq_protocol::protocol::body::batch_ack_message_request_body::BatchAckMessageRequestBody,
+            timeout_millis: u64,
+        ) -> rocketmq_error::RocketMQResult<crate::consumer::ack_result::AckResult> {
+            let _operation = self.operation().await;
+            self.inner
+                .get_mq_client_api_impl()?
+                .batch_ack_message(broker_addr, request, timeout_millis)
+                .await
         }
 
         pub async fn change_invisible_time(

--- a/rocketmq-protocol/src/protocol/body.rs
+++ b/rocketmq-protocol/src/protocol/body.rs
@@ -26,6 +26,7 @@ pub mod consumer_connection;
 
 pub mod acl_info;
 pub mod batch_ack;
+pub mod batch_ack_builder;
 pub mod batch_ack_message_request_body;
 pub mod broker_replicas_info;
 pub mod broker_stats_item;

--- a/rocketmq-protocol/src/protocol/body/batch_ack.rs
+++ b/rocketmq-protocol/src/protocol/body/batch_ack.rs
@@ -20,7 +20,7 @@ use serde::Deserializer;
 use serde::Serialize;
 use serde::Serializer;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct BatchAck {
     #[serde(rename = "c", alias = "consumerGroup")]
     pub consumer_group: CheetahString,
@@ -50,6 +50,7 @@ pub struct BatchAck {
     pub bit_set: SerializableBitVec,
 }
 
+#[derive(Debug)]
 pub struct SerializableBitVec(pub BitVec<u64, Lsb0>);
 
 impl Serialize for SerializableBitVec {

--- a/rocketmq-protocol/src/protocol/body/batch_ack_builder.rs
+++ b/rocketmq-protocol/src/protocol/body/batch_ack_builder.rs
@@ -1,0 +1,320 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use bitvec::prelude::BitVec;
+use bitvec::prelude::Lsb0;
+use cheetah_string::CheetahString;
+use rocketmq_error::RocketMQError;
+
+use crate::protocol::body::batch_ack::BatchAck;
+use crate::protocol::body::batch_ack::SerializableBitVec;
+use crate::protocol::body::batch_ack_message_request_body::BatchAckMessageRequestBody;
+use crate::protocol::header::extra_info_util::AckExtraInfo;
+use crate::protocol::header::extra_info_util::ExtraInfoUtil;
+
+pub const DEFAULT_MAX_BATCH_ACK_ENTRIES: usize = 4096;
+pub const DEFAULT_MAX_BATCH_ACK_OFFSET_SPAN: usize = 1_048_576;
+
+#[derive(Debug, Clone, Copy)]
+pub struct BatchAckBuildLimits {
+    pub max_entries: usize,
+    pub max_offset_span: usize,
+}
+
+impl Default for BatchAckBuildLimits {
+    fn default() -> Self {
+        Self {
+            max_entries: DEFAULT_MAX_BATCH_ACK_ENTRIES,
+            max_offset_span: DEFAULT_MAX_BATCH_ACK_OFFSET_SPAN,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct BatchAckInput<'a> {
+    pub entry_index: usize,
+    pub consumer_group: &'a str,
+    pub topic: &'a str,
+    pub receipt_handle: &'a str,
+}
+
+#[derive(Debug)]
+pub struct BatchAckBuildFailure {
+    pub entry_index: usize,
+    pub error: RocketMQError,
+}
+
+#[derive(Debug)]
+pub struct BatchAckBrokerRequest {
+    pub broker_name: CheetahString,
+    pub body: BatchAckMessageRequestBody,
+    pub entry_indexes: Vec<usize>,
+}
+
+#[derive(Debug, Default)]
+pub struct BatchAckBuildResult {
+    pub requests: Vec<BatchAckBrokerRequest>,
+    pub failures: Vec<BatchAckBuildFailure>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct CheckpointKey {
+    consumer_group: String,
+    topic: String,
+    retry: String,
+    start_offset: i64,
+    queue_id: i32,
+    revive_queue_id: i32,
+    pop_time: i64,
+    invisible_time: i64,
+}
+
+struct PendingAck {
+    ack: BatchAck,
+    entry_indexes: Vec<usize>,
+}
+
+pub fn build_batch_ack_requests(inputs: &[BatchAckInput<'_>]) -> BatchAckBuildResult {
+    build_batch_ack_requests_with_limits(inputs, BatchAckBuildLimits::default())
+}
+
+pub fn build_batch_ack_requests_with_limits(
+    inputs: &[BatchAckInput<'_>],
+    limits: BatchAckBuildLimits,
+) -> BatchAckBuildResult {
+    let mut result = BatchAckBuildResult::default();
+    let mut brokers: BTreeMap<String, BTreeMap<CheckpointKey, PendingAck>> = BTreeMap::new();
+
+    for (position, input) in inputs.iter().enumerate() {
+        if position >= limits.max_entries {
+            result.failures.push(BatchAckBuildFailure {
+                entry_index: input.entry_index,
+                error: RocketMQError::illegal_argument(format!(
+                    "batch ACK input exceeds the configured {} entry limit",
+                    limits.max_entries
+                )),
+            });
+            continue;
+        }
+
+        match parse_input(*input, limits.max_offset_span) {
+            Ok((extra, bit_index)) => {
+                let key = CheckpointKey {
+                    consumer_group: input.consumer_group.to_owned(),
+                    topic: input.topic.to_owned(),
+                    retry: extra.retry.to_owned(),
+                    start_offset: extra.ck_queue_offset,
+                    queue_id: extra.queue_id,
+                    revive_queue_id: extra.revive_queue_id,
+                    pop_time: extra.pop_time,
+                    invisible_time: extra.invisible_time,
+                };
+                let pending = brokers
+                    .entry(extra.broker_name.to_owned())
+                    .or_default()
+                    .entry(key)
+                    .or_insert_with(|| PendingAck {
+                        ack: BatchAck {
+                            consumer_group: CheetahString::from(input.consumer_group),
+                            topic: CheetahString::from(input.topic),
+                            retry: CheetahString::from(extra.retry),
+                            start_offset: extra.ck_queue_offset,
+                            queue_id: extra.queue_id,
+                            revive_queue_id: extra.revive_queue_id,
+                            pop_time: extra.pop_time,
+                            invisible_time: extra.invisible_time,
+                            bit_set: SerializableBitVec(BitVec::<u64, Lsb0>::new()),
+                        },
+                        entry_indexes: Vec::new(),
+                    });
+                if pending.ack.bit_set.0.len() <= bit_index {
+                    pending.ack.bit_set.0.resize(bit_index + 1, false);
+                }
+                pending.ack.bit_set.0.set(bit_index, true);
+                pending.entry_indexes.push(input.entry_index);
+            }
+            Err(error) => result.failures.push(BatchAckBuildFailure {
+                entry_index: input.entry_index,
+                error,
+            }),
+        }
+    }
+
+    result.requests = brokers
+        .into_iter()
+        .map(|(broker_name, checkpoints)| {
+            let mut acks = Vec::with_capacity(checkpoints.len());
+            let mut entry_indexes = Vec::new();
+            for pending in checkpoints.into_values() {
+                acks.push(pending.ack);
+                entry_indexes.extend(pending.entry_indexes);
+            }
+            let broker_name = CheetahString::from_string(broker_name);
+            BatchAckBrokerRequest {
+                body: BatchAckMessageRequestBody {
+                    broker_name: broker_name.clone(),
+                    acks,
+                },
+                broker_name,
+                entry_indexes,
+            }
+        })
+        .collect();
+    result
+}
+
+fn parse_input<'a>(
+    input: BatchAckInput<'a>,
+    max_offset_span: usize,
+) -> Result<(AckExtraInfo<'a>, usize), RocketMQError> {
+    if input.consumer_group.trim().is_empty() {
+        return Err(RocketMQError::illegal_argument("batch ACK consumer group is blank"));
+    }
+    if input.topic.trim().is_empty() {
+        return Err(RocketMQError::illegal_argument("batch ACK topic is blank"));
+    }
+
+    let extra = ExtraInfoUtil::parse_ack_extra_info(input.receipt_handle)?;
+    let delta = extra
+        .queue_offset
+        .checked_sub(extra.ck_queue_offset)
+        .ok_or_else(|| RocketMQError::illegal_argument("batch ACK queue offset overflow"))?;
+    let bit_index = usize::try_from(delta)
+        .map_err(|_| RocketMQError::illegal_argument("batch ACK queue offset precedes checkpoint offset"))?;
+    if bit_index >= max_offset_span {
+        return Err(RocketMQError::illegal_argument(format!(
+            "batch ACK offset span {bit_index} exceeds the configured {max_offset_span} bit limit"
+        )));
+    }
+    Ok((extra, bit_index))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::header::extra_info_util::ExtraInfoUtil;
+
+    fn receipt(start: i64, broker: &str, queue_id: i32, offset: i64) -> String {
+        ExtraInfoUtil::build_extra_info_with_offset(start, 100, 15_000, 0, "topic", broker, queue_id, offset)
+    }
+
+    #[test]
+    fn thirty_two_offsets_share_one_broker_request_and_checkpoint_bitmap() {
+        let receipts = (0..32)
+            .map(|offset| receipt(10, "broker-a", 1, 10 + offset))
+            .collect::<Vec<_>>();
+        let inputs = receipts
+            .iter()
+            .enumerate()
+            .map(|(entry_index, receipt_handle)| BatchAckInput {
+                entry_index,
+                consumer_group: "group",
+                topic: "topic",
+                receipt_handle,
+            })
+            .collect::<Vec<_>>();
+
+        let built = build_batch_ack_requests(&inputs);
+        assert!(built.failures.is_empty());
+        assert_eq!(built.requests.len(), 1);
+        assert_eq!(built.requests[0].body.acks.len(), 1);
+        assert_eq!(built.requests[0].entry_indexes.len(), 32);
+        assert!(built.requests[0].body.acks[0].bit_set.0.iter().by_vals().all(|bit| bit));
+    }
+
+    #[test]
+    fn broker_and_checkpoint_identity_are_grouped_without_mixing() {
+        let receipts = [
+            receipt(10, "broker-a", 1, 10),
+            receipt(20, "broker-a", 1, 20),
+            receipt(10, "broker-b", 1, 11),
+        ];
+        let inputs = receipts
+            .iter()
+            .enumerate()
+            .map(|(entry_index, receipt_handle)| BatchAckInput {
+                entry_index,
+                consumer_group: "group",
+                topic: "topic",
+                receipt_handle,
+            })
+            .collect::<Vec<_>>();
+
+        let built = build_batch_ack_requests(&inputs);
+        assert!(built.failures.is_empty());
+        assert_eq!(built.requests.len(), 2);
+        assert_eq!(built.requests[0].body.acks.len(), 2);
+        assert_eq!(built.requests[1].body.acks.len(), 1);
+    }
+
+    #[test]
+    fn malformed_and_huge_spans_are_failures_without_large_bitmaps() {
+        let huge = receipt(0, "broker-a", 1, i64::MAX);
+        let inputs = [
+            BatchAckInput {
+                entry_index: 3,
+                consumer_group: "group",
+                topic: "topic",
+                receipt_handle: "bad",
+            },
+            BatchAckInput {
+                entry_index: 7,
+                consumer_group: "group",
+                topic: "topic",
+                receipt_handle: &huge,
+            },
+        ];
+
+        let built = build_batch_ack_requests_with_limits(
+            &inputs,
+            BatchAckBuildLimits {
+                max_entries: 32,
+                max_offset_span: 64,
+            },
+        );
+        assert!(built.requests.is_empty());
+        assert_eq!(
+            built
+                .failures
+                .iter()
+                .map(|failure| failure.entry_index)
+                .collect::<Vec<_>>(),
+            vec![3, 7]
+        );
+    }
+
+    #[test]
+    fn duplicate_offsets_preserve_all_entry_indexes() {
+        let receipt = receipt(10, "broker-a", 1, 10);
+        let inputs = [
+            BatchAckInput {
+                entry_index: 1,
+                consumer_group: "group",
+                topic: "topic",
+                receipt_handle: &receipt,
+            },
+            BatchAckInput {
+                entry_index: 2,
+                consumer_group: "group",
+                topic: "topic",
+                receipt_handle: &receipt,
+            },
+        ];
+        let built = build_batch_ack_requests(&inputs);
+        assert_eq!(built.requests[0].entry_indexes, vec![1, 2]);
+        assert_eq!(built.requests[0].body.acks[0].bit_set.0.count_ones(), 1);
+    }
+}

--- a/rocketmq-protocol/src/protocol/body/batch_ack_message_request_body.rs
+++ b/rocketmq-protocol/src/protocol/body/batch_ack_message_request_body.rs
@@ -18,7 +18,7 @@ use serde::Serialize;
 
 use crate::protocol::body::batch_ack::BatchAck;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BatchAckMessageRequestBody {
     pub broker_name: CheetahString,

--- a/rocketmq-protocol/src/protocol/header/extra_info_util.rs
+++ b/rocketmq-protocol/src/protocol/header/extra_info_util.rs
@@ -24,6 +24,18 @@ use rocketmq_model::common::key_builder::KeyBuilder;
 
 pub struct ExtraInfoUtil;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AckExtraInfo<'a> {
+    pub ck_queue_offset: i64,
+    pub pop_time: i64,
+    pub invisible_time: i64,
+    pub revive_queue_id: i32,
+    pub retry: &'a str,
+    pub broker_name: &'a str,
+    pub queue_id: i32,
+    pub queue_offset: i64,
+}
+
 const NORMAL_TOPIC: &str = "0";
 const RETRY_TOPIC: &str = "1";
 const RETRY_TOPIC_V2: &str = "2";
@@ -35,6 +47,55 @@ fn illegal_argument(message: impl Into<String>) -> RocketMQError {
 }
 
 impl ExtraInfoUtil {
+    /// Parses the fixed POP receipt-handle prefix without allocating its fields.
+    pub fn parse_ack_extra_info(extra_info: &str) -> RocketMQResult<AckExtraInfo<'_>> {
+        let mut parts = extra_info.split(KEY_SEPARATOR);
+        let mut next = |name: &str| {
+            parts
+                .next()
+                .ok_or_else(|| illegal_argument(format!("parse POP receipt handle: missing {name}")))
+        };
+
+        let ck_queue_offset = next("checkpoint queue offset")?
+            .parse::<i64>()
+            .map_err(|_| illegal_argument("parse ck_queue_offset error"))?;
+        let pop_time = next("pop time")?
+            .parse::<i64>()
+            .map_err(|_| illegal_argument("parse pop_time error"))?;
+        let invisible_time = next("invisible time")?
+            .parse::<i64>()
+            .map_err(|_| illegal_argument("parse invisible_time error"))?;
+        let revive_queue_id = next("revive queue id")?
+            .parse::<i32>()
+            .map_err(|_| illegal_argument("parse revive_qid error"))?;
+        let retry = next("retry marker")?;
+        let broker_name = next("broker name")?;
+        let queue_id = next("queue id")?
+            .parse::<i32>()
+            .map_err(|_| illegal_argument("parse queue_id error"))?;
+        let queue_offset = next("queue offset")?
+            .parse::<i64>()
+            .map_err(|_| illegal_argument("parse queue_offset error"))?;
+
+        if broker_name.trim().is_empty() {
+            return Err(illegal_argument("parse POP receipt handle: broker name is blank"));
+        }
+        if !matches!(retry, NORMAL_TOPIC | RETRY_TOPIC | RETRY_TOPIC_V2) {
+            return Err(illegal_argument("parse POP receipt handle: invalid retry marker"));
+        }
+
+        Ok(AckExtraInfo {
+            ck_queue_offset,
+            pop_time,
+            invisible_time,
+            revive_queue_id,
+            retry,
+            broker_name,
+            queue_id,
+            queue_offset,
+        })
+    }
+
     /// Split the extra info string using the key separator
     pub fn split(extra_info: &str) -> Vec<String> {
         extra_info.split(KEY_SEPARATOR).map(|s| s.to_string()).collect()

--- a/rocketmq-proxy-cluster/src/cluster.rs
+++ b/rocketmq-proxy-cluster/src/cluster.rs
@@ -54,6 +54,9 @@ use rocketmq_model::result::PullStatus;
 use rocketmq_model::result::SendResult;
 use rocketmq_protocol::common::message::message_decoder as MessageDecoder;
 use rocketmq_protocol::protocol::body::acl_info::AclInfo;
+use rocketmq_protocol::protocol::body::batch_ack_builder::build_batch_ack_requests;
+use rocketmq_protocol::protocol::body::batch_ack_builder::BatchAckInput;
+use rocketmq_protocol::protocol::body::batch_ack_message_request_body::BatchAckMessageRequestBody;
 use rocketmq_protocol::protocol::body::broker_body::cluster_info::ClusterInfo;
 use rocketmq_protocol::protocol::body::request::lock_batch_request_body::LockBatchRequestBody;
 use rocketmq_protocol::protocol::body::response::lock_batch_response_body::LockBatchResponseBody;
@@ -269,6 +272,13 @@ trait ClusterClientIo: Send + Sync {
         &self,
         broker_addr: &CheetahString,
         request: AckMessageRequestHeader,
+        timeout_millis: u64,
+    ) -> Result<AckResult, RocketMQError>;
+
+    async fn batch_ack_message(
+        &self,
+        broker_addr: &CheetahString,
+        request: BatchAckMessageRequestBody,
         timeout_millis: u64,
     ) -> Result<AckResult, RocketMQError>;
 
@@ -501,6 +511,15 @@ impl ClusterClientIo for ClientInstanceHandle {
         timeout_millis: u64,
     ) -> Result<AckResult, RocketMQError> {
         self.ack_message(broker_addr, request, timeout_millis).await
+    }
+
+    async fn batch_ack_message(
+        &self,
+        broker_addr: &CheetahString,
+        request: BatchAckMessageRequestBody,
+        timeout_millis: u64,
+    ) -> Result<AckResult, RocketMQError> {
+        self.batch_ack_message(broker_addr, request, timeout_millis).await
     }
 
     async fn change_invisible_time(
@@ -1791,13 +1810,112 @@ async fn ack_message_inner(
 ) -> ProxyResult<Vec<AckMessageResultEntry>> {
     let timeout_ms = effective_request_timeout_ms(config.mq_client_api_timeout_ms, deadline);
     let client = state.client(config).await?;
-    let mut results = Vec::with_capacity(request.entries.len());
+    let group_name = request.group.to_string();
+    let topics = request
+        .entries
+        .iter()
+        .map(|entry| entry.lite_topic.clone().unwrap_or_else(|| request.topic.to_string()))
+        .collect::<Vec<_>>();
+    let batch_inputs = request
+        .entries
+        .iter()
+        .zip(&topics)
+        .enumerate()
+        .filter(|(_, (entry, _))| entry.lite_topic.is_none())
+        .map(|(entry_index, (entry, topic))| BatchAckInput {
+            entry_index,
+            consumer_group: group_name.as_str(),
+            topic,
+            receipt_handle: entry.receipt_handle.as_str(),
+        })
+        .collect::<Vec<_>>();
+    let built = build_batch_ack_requests(&batch_inputs);
+    let mut statuses = std::iter::repeat_with(|| None)
+        .take(request.entries.len())
+        .collect::<Vec<Option<ProxyPayloadStatus>>>();
+    let mut fallback_indexes = request
+        .entries
+        .iter()
+        .enumerate()
+        .filter_map(|(index, entry)| entry.lite_topic.is_some().then_some(index))
+        .chain(built.failures.into_iter().map(|failure| failure.entry_index))
+        .collect::<Vec<_>>();
 
-    for entry in &request.entries {
-        results.push(ack_message_entry(client.as_ref(), &request.group, &request.topic, entry, timeout_ms).await);
+    for batch_request in built.requests {
+        let Some(first_ack) = batch_request.body.acks.first() else {
+            continue;
+        };
+        let topic = first_ack.topic.clone();
+        let ack_consumer_group = first_ack.consumer_group.clone();
+        let retry = first_ack.retry.clone();
+        let queue_id = first_ack.queue_id;
+        let batch_result = async {
+            let route_topic = CheetahString::from_string(ExtraInfoUtil::get_real_topic_with_retry(
+                &topic,
+                &ack_consumer_group,
+                &retry,
+            )?);
+            let actual_broker_name =
+                resolve_subscription_broker_name(client.as_ref(), &route_topic, &batch_request.broker_name, queue_id)
+                    .await;
+            let broker_addr = find_subscribe_broker_addr(client.as_ref(), &actual_broker_name, &route_topic)
+                .await
+                .ok_or_else(|| RocketMQError::BrokerNotFound {
+                    name: actual_broker_name.to_string(),
+                })?;
+            client
+                .batch_ack_message(&broker_addr, batch_request.body, timeout_ms)
+                .await
+        }
+        .await;
+
+        match batch_result {
+            Ok(ack_result) => {
+                let status = ack_status_to_payload(&ack_result);
+                for index in batch_request.entry_indexes {
+                    statuses[index] = Some(status.clone());
+                }
+            }
+            Err(error) => {
+                tracing::warn!(
+                    broker = %batch_request.broker_name,
+                    entries = batch_request.entry_indexes.len(),
+                    error = %error,
+                    "cluster BatchAck failed; falling back to single ACK"
+                );
+                fallback_indexes.extend(batch_request.entry_indexes);
+            }
+        }
     }
 
-    Ok(results)
+    fallback_indexes.sort_unstable();
+    fallback_indexes.dedup();
+    for index in fallback_indexes {
+        statuses[index] = Some(
+            ack_message_entry_inner(
+                client.as_ref(),
+                &request.group,
+                &request.topic,
+                &request.entries[index],
+                timeout_ms,
+            )
+            .await
+            .unwrap_or_else(|error| ProxyStatusMapper::from_error_payload(&error)),
+        );
+    }
+
+    Ok(request
+        .entries
+        .iter()
+        .enumerate()
+        .map(|(index, entry)| AckMessageResultEntry {
+            message_id: entry.message_id.clone(),
+            receipt_handle: entry.receipt_handle.clone(),
+            status: statuses[index].take().unwrap_or_else(|| {
+                ProxyStatusMapper::from_payload_code(v2::Code::InternalError, "ACK result was not produced")
+            }),
+        })
+        .collect())
 }
 
 async fn forward_message_to_dead_letter_queue_inner(
@@ -2116,25 +2234,6 @@ async fn resolve_broker_target(
         broker_name,
         broker_addr,
     })
-}
-
-async fn ack_message_entry(
-    client: &dyn ClusterClientIo,
-    group: &ResourceIdentity,
-    topic: &ResourceIdentity,
-    entry: &AckMessageEntry,
-    timeout_ms: u64,
-) -> AckMessageResultEntry {
-    let status = match ack_message_entry_inner(client, group, topic, entry, timeout_ms).await {
-        Ok(status) => status,
-        Err(error) => ProxyStatusMapper::from_error_payload(&error),
-    };
-
-    AckMessageResultEntry {
-        message_id: entry.message_id.clone(),
-        receipt_handle: entry.receipt_handle.clone(),
-        status,
-    }
 }
 
 async fn ack_message_entry_inner(

--- a/rocketmq-proxy-cluster/src/cluster_behavior_tests.rs
+++ b/rocketmq-proxy-cluster/src/cluster_behavior_tests.rs
@@ -149,6 +149,13 @@ impl ScriptedClientIo {
             .push_back(Ok(result));
     }
 
+    fn push_ack_error(&self, message: &str) {
+        self.acks
+            .lock()
+            .expect("ack script lock poisoned")
+            .push_back(Err(RocketMQError::IllegalArgument(message.to_owned())));
+    }
+
     fn fail_broker_lookup_times(&self, count: usize) {
         self.broker_lookup_misses.store(count, Ordering::Release);
     }
@@ -261,6 +268,17 @@ impl ClusterClientIo for ScriptedClientIo {
         self.record("client.ack");
         self.ack_calls.fetch_add(1, Ordering::AcqRel);
         Self::scripted(&self.acks, "ack_message")
+    }
+
+    async fn batch_ack_message(
+        &self,
+        _broker_addr: &CheetahString,
+        _request: BatchAckMessageRequestBody,
+        _timeout_millis: u64,
+    ) -> Result<AckResult, RocketMQError> {
+        self.record("client.batch-ack");
+        self.ack_calls.fetch_add(1, Ordering::AcqRel);
+        Self::scripted(&self.acks, "batch_ack_message")
     }
 
     async fn change_invisible_time(
@@ -676,6 +694,115 @@ fn ack_request(group: &str) -> AckMessageRequest {
             lite_topic: None,
         }],
     }
+}
+
+fn batch_ack_request(group: &str, count: usize) -> AckMessageRequest {
+    AckMessageRequest {
+        group: ResourceIdentity::new("", group),
+        topic: ResourceIdentity::new("", "TopicA"),
+        entries: (0..count)
+            .map(|offset| AckMessageEntry {
+                message_id: format!("message-{offset}"),
+                receipt_handle: ExtraInfoUtil::build_extra_info_with_offset(
+                    100,
+                    1,
+                    30_000,
+                    0,
+                    "TopicA",
+                    "broker-a",
+                    0,
+                    100 + offset as i64,
+                ),
+                lite_topic: None,
+            })
+            .collect(),
+    }
+}
+
+#[tokio::test]
+async fn compatible_ack_entries_use_one_broker_batch() {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let client = Arc::new(ScriptedClientIo::new(events.clone()));
+    client.push_ack(AckResult::default());
+    let factory = Arc::new(ScriptedProducerFactory {
+        events: events.clone(),
+        send_results: Arc::new(Mutex::new(VecDeque::new())),
+        start_control: None,
+    });
+
+    run_test_worker(client.clone(), factory, |executor, cancellation| async move {
+        let results = executor
+            .ack_message(batch_ack_request("GroupA", 32), Some(Duration::from_secs(1)))
+            .await
+            .expect("batch ACK command");
+        assert_eq!(results.len(), 32);
+        assert!(results.iter().all(|result| result.status.is_ok()));
+        assert_eq!(client.ack_calls.load(Ordering::Acquire), 1);
+        assert_eq!(
+            events
+                .lock()
+                .expect("event log lock poisoned")
+                .iter()
+                .filter(|event| **event == "client.batch-ack")
+                .count(),
+            1
+        );
+        cancellation.cancel();
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn failed_batch_falls_back_once_per_entry() {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let client = Arc::new(ScriptedClientIo::new(events.clone()));
+    client.push_ack_error("batch unavailable");
+    client.push_ack(AckResult::default());
+    client.push_ack(AckResult::default());
+    let factory = Arc::new(ScriptedProducerFactory {
+        events,
+        send_results: Arc::new(Mutex::new(VecDeque::new())),
+        start_control: None,
+    });
+
+    run_test_worker(client.clone(), factory, |executor, cancellation| async move {
+        let results = executor
+            .ack_message(batch_ack_request("GroupA", 2), Some(Duration::from_secs(1)))
+            .await
+            .expect("fallback ACK command");
+        assert!(results.iter().all(|result| result.status.is_ok()));
+        assert_eq!(client.ack_calls.load(Ordering::Acquire), 3);
+        cancellation.cancel();
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn malformed_receipt_failure_is_mapped_to_only_that_entry() {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let client = Arc::new(ScriptedClientIo::new(events.clone()));
+    client.push_ack(AckResult::default());
+    let factory = Arc::new(ScriptedProducerFactory {
+        events,
+        send_results: Arc::new(Mutex::new(VecDeque::new())),
+        start_control: None,
+    });
+    let mut request = batch_ack_request("GroupA", 2);
+    request.entries[1].receipt_handle = "malformed".to_owned();
+
+    run_test_worker(client.clone(), factory, |executor, cancellation| async move {
+        let results = executor
+            .ack_message(request, Some(Duration::from_secs(1)))
+            .await
+            .expect("partially valid ACK command");
+        assert_eq!(results.len(), 2);
+        assert!(results[0].status.is_ok());
+        assert!(!results[1].status.is_ok());
+        assert_eq!(results[1].status.code(), v2::Code::InvalidReceiptHandle as i32);
+        assert_eq!(client.ack_calls.load(Ordering::Acquire), 1);
+        cancellation.cancel();
+    })
+    .await;
 }
 
 async fn wait_until(mut condition: impl FnMut() -> bool) {

--- a/rocketmq-proxy-local/src/local.rs
+++ b/rocketmq-proxy-local/src/local.rs
@@ -40,6 +40,8 @@ use rocketmq_observability::TelemetryHandle;
 use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::common::message::message_decoder as MessageDecoder;
+use rocketmq_protocol::protocol::body::batch_ack_builder::build_batch_ack_requests;
+use rocketmq_protocol::protocol::body::batch_ack_builder::BatchAckInput;
 use rocketmq_protocol::protocol::body::query_assignment_request_body::QueryAssignmentRequestBody;
 use rocketmq_protocol::protocol::body::query_assignment_response_body::QueryAssignmentResponseBody;
 use rocketmq_protocol::protocol::header::ack_message_request_header::AckMessageRequestHeader;
@@ -1372,19 +1374,95 @@ async fn ack_message_via_broker(
     client: &LocalBrokerFacadeClient,
     request: &AckMessageRequest,
 ) -> ProxyResult<Vec<AckMessageResultEntry>> {
-    let mut results = Vec::with_capacity(request.entries.len());
-    for entry in &request.entries {
-        let status = match ack_message_entry_via_broker(client, request, entry).await {
+    let group_name = request.group.to_string();
+    let topics = request
+        .entries
+        .iter()
+        .map(|entry| entry.lite_topic.clone().unwrap_or_else(|| request.topic.to_string()))
+        .collect::<Vec<_>>();
+    let batch_inputs = request
+        .entries
+        .iter()
+        .zip(&topics)
+        .enumerate()
+        .filter(|(_, (entry, _))| entry.lite_topic.is_none())
+        .map(|(entry_index, (entry, topic))| BatchAckInput {
+            entry_index,
+            consumer_group: group_name.as_str(),
+            topic,
+            receipt_handle: entry.receipt_handle.as_str(),
+        })
+        .collect::<Vec<_>>();
+    let built = build_batch_ack_requests(&batch_inputs);
+    let mut statuses = std::iter::repeat_with(|| None)
+        .take(request.entries.len())
+        .collect::<Vec<Option<rocketmq_proxy_core::ProxyPayloadStatus>>>();
+
+    let mut fallback_indexes = request
+        .entries
+        .iter()
+        .enumerate()
+        .filter_map(|(index, entry)| entry.lite_topic.is_some().then_some(index))
+        .chain(built.failures.into_iter().map(|failure| failure.entry_index))
+        .collect::<Vec<_>>();
+
+    for batch_request in built.requests {
+        let command = RemotingCommand::new_request(RequestCode::BatchAckMessage, batch_request.body.encode()?);
+        match client.process_remoting(command).await {
+            Ok(response) => {
+                let status = if ResponseCode::from(response.code()) == ResponseCode::Success {
+                    ProxyStatusMapper::ok_payload()
+                } else {
+                    invalid_receipt_handle_status()
+                };
+                for index in batch_request.entry_indexes {
+                    statuses[index] = Some(status.clone());
+                }
+            }
+            Err(error) => {
+                tracing::warn!(
+                    broker = %batch_request.broker_name,
+                    entries = batch_request.entry_indexes.len(),
+                    error = %error,
+                    "local BatchAck failed; falling back to single ACK"
+                );
+                fallback_indexes.extend(batch_request.entry_indexes);
+            }
+        }
+    }
+
+    fallback_indexes.sort_unstable();
+    fallback_indexes.dedup();
+    for index in fallback_indexes {
+        let status = match ack_message_entry_via_broker(client, request, &request.entries[index]).await {
             Ok(status) => status,
             Err(error) => ProxyStatusMapper::from_error_payload(&error),
         };
-        results.push(AckMessageResultEntry {
+        statuses[index] = Some(status);
+    }
+
+    Ok(request
+        .entries
+        .iter()
+        .enumerate()
+        .map(|(index, entry)| AckMessageResultEntry {
             message_id: entry.message_id.clone(),
             receipt_handle: entry.receipt_handle.clone(),
-            status,
-        });
-    }
-    Ok(results)
+            status: statuses[index].take().unwrap_or_else(|| {
+                ProxyStatusMapper::from_payload_code(
+                    rocketmq_proxy_core::proto::v2::Code::InternalError,
+                    "ACK result was not produced",
+                )
+            }),
+        })
+        .collect())
+}
+
+fn invalid_receipt_handle_status() -> rocketmq_proxy_core::ProxyPayloadStatus {
+    ProxyStatusMapper::from_payload_code(
+        rocketmq_proxy_core::proto::v2::Code::InvalidReceiptHandle,
+        "receipt handle has expired or message no longer exists",
+    )
 }
 
 async fn ack_message_entry_via_broker(
@@ -1420,10 +1498,7 @@ async fn ack_message_entry_via_broker(
     Ok(if ResponseCode::from(response.code()) == ResponseCode::Success {
         ProxyStatusMapper::ok_payload()
     } else {
-        ProxyStatusMapper::from_payload_code(
-            rocketmq_proxy_core::proto::v2::Code::InvalidReceiptHandle,
-            "receipt handle has expired or message no longer exists",
-        )
+        invalid_receipt_handle_status()
     })
 }
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9249

### Brief Description

Add a bounded, Java-compatible POP BatchAck builder and use it across the Rust push consumer and Local/Cluster Proxy paths. The implementation groups receipt handles by broker and complete POP checkpoint identity, validates bitmap ranges before allocation, preserves per-entry results, and falls back to single ACK only for entries affected by malformed input or a failed batch transport.

The client ACK API now returns typed results instead of reporting callback failures as success. POP concurrent and orderly consumption retain their existing delivery and ordering semantics while reducing compatible batches from one ACK RPC per message to one BatchAck RPC per broker request.

### How Did You Test This Change?

- `cargo test -p rocketmq-protocol batch_ack_builder --lib`
- `cargo test -p rocketmq-protocol --test request_header_java_compatibility`
- `cargo test -p rocketmq-client-rust --lib`
- `cargo test -p rocketmq-proxy-local --lib`
- `cargo test -p rocketmq-proxy-cluster --lib`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo check --manifest-path fuzz/Cargo.toml --all-targets`
- Required downstream checks for `rocketmq-example`, the renamed dependency fixture, `rocketmq-sre`, and `rocketmq-tools/rocketmq-mcp`

The repository error-hygiene guards still report the same two pre-existing findings on both this branch and `main`; this change introduces no new finding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch acknowledgment support for POP messages.
  * Grouped acknowledgments by broker to improve processing efficiency.
  * Added validation and parsing for acknowledgment receipt handles.
* **Bug Fixes**
  * Failed batch acknowledgments now report individual message failures, allowing affected messages to be redelivered.
  * Added automatic fallback to individual acknowledgments when batch requests fail or messages are not eligible.
  * Improved broker routing and error reporting for acknowledgment requests.
* **Tests**
  * Added coverage for successful batch acknowledgments, malformed receipt handles, and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->