### PR TITLE
[ISSUE #9253]✨Enforce LitePull concurrency and bound consume scheduling

### DIFF
--- a/rocketmq-client/Cargo.toml
+++ b/rocketmq-client/Cargo.toml
@@ -212,6 +212,10 @@ name = "lite_pull_assignment_registry_tests"
 required-features = ["test-support"]
 
 [[test]]
+name = "lite_pull_concurrency_contract_tests"
+required-features = ["test-support"]
+
+[[test]]
 name = "pull_message_service_test"
 required-features = ["test-support"]
 

--- a/rocketmq-client/src/consumer/consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl.rs
@@ -15,6 +15,7 @@
 use std::sync::LazyLock;
 
 pub(crate) mod assigned_message_queue;
+pub(crate) mod bounded_consume_scheduler;
 pub(crate) mod consume_message_concurrently_service;
 pub(crate) mod consume_message_orderly_service;
 pub(crate) mod consume_message_pop_concurrently_service;

--- a/rocketmq-client/src/consumer/consumer_impl/bounded_consume_scheduler.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/bounded_consume_scheduler.rs
@@ -1,0 +1,476 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+use std::future::Future;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::time::Duration;
+
+use futures::StreamExt;
+use rocketmq_error::RocketMQResult;
+use rocketmq_runtime::ChildServiceContext;
+use tokio::sync::mpsc;
+use tokio::sync::Mutex;
+use tokio::sync::OwnedSemaphorePermit;
+use tokio::sync::Semaphore;
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
+use tokio_util::time::DelayQueue;
+use tracing::warn;
+
+use crate::runtime::spawn_client_task_with_context;
+
+struct ScheduledItem<T> {
+    item: T,
+    _queued_permit: OwnedSemaphorePermit,
+}
+
+type DelayedCommand<T> = (ScheduledItem<T>, Duration);
+
+impl<T> ScheduledItem<T> {
+    fn into_item(self) -> T {
+        self.item
+    }
+}
+
+/// An enqueue failure that returns ownership of the rejected consume request.
+pub(crate) struct ConsumeScheduleError<T> {
+    item: T,
+}
+
+impl<T> ConsumeScheduleError<T> {
+    pub(crate) fn into_item(self) -> T {
+        self.item
+    }
+}
+
+impl<T> fmt::Debug for ConsumeScheduleError<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ConsumeScheduleError")
+            .field("reason", &"scheduler is stopping")
+            .finish()
+    }
+}
+
+/// A lifecycle-owned consume scheduler with a fixed worker set and one shared
+/// delayed-retry queue.
+pub(crate) struct BoundedConsumeScheduler<T> {
+    ready_tx: mpsc::Sender<ScheduledItem<T>>,
+    ready_rx: StdMutex<Option<mpsc::Receiver<ScheduledItem<T>>>>,
+    delayed_tx: mpsc::Sender<DelayedCommand<T>>,
+    delayed_rx: StdMutex<Option<mpsc::Receiver<DelayedCommand<T>>>>,
+    queued_slots: Arc<Semaphore>,
+    #[cfg(any(test, feature = "test-support"))]
+    capacity: usize,
+    stopping: CancellationToken,
+    force_stop: CancellationToken,
+    tasks: TaskTracker,
+    started: AtomicBool,
+}
+
+impl<T> BoundedConsumeScheduler<T>
+where
+    T: Send + 'static,
+{
+    pub(crate) fn new(capacity: usize) -> RocketMQResult<Self> {
+        if capacity == 0 {
+            return Err(crate::mq_client_err!(
+                "consume scheduler capacity must be greater than 0"
+            ));
+        }
+        let (ready_tx, ready_rx) = mpsc::channel(capacity);
+        let (delayed_tx, delayed_rx) = mpsc::channel(capacity);
+        Ok(Self {
+            ready_tx,
+            ready_rx: StdMutex::new(Some(ready_rx)),
+            delayed_tx,
+            delayed_rx: StdMutex::new(Some(delayed_rx)),
+            queued_slots: Arc::new(Semaphore::new(capacity)),
+            #[cfg(any(test, feature = "test-support"))]
+            capacity,
+            stopping: CancellationToken::new(),
+            force_stop: CancellationToken::new(),
+            tasks: TaskTracker::new(),
+            started: AtomicBool::new(false),
+        })
+    }
+
+    pub(crate) fn start<H, F>(
+        &self,
+        service_context: &ChildServiceContext,
+        worker_count: usize,
+        handler: H,
+    ) -> RocketMQResult<()>
+    where
+        H: Fn(T) -> F + Send + Sync + Clone + 'static,
+        F: Future<Output = ()> + Send + 'static,
+    {
+        if worker_count == 0 {
+            return Err(crate::mq_client_err!(
+                "consume scheduler worker count must be greater than 0"
+            ));
+        }
+        if self.started.swap(true, Ordering::AcqRel) {
+            return Ok(());
+        }
+
+        let ready_rx = self
+            .ready_rx
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take()
+            .ok_or_else(|| crate::mq_client_err!("consume scheduler ready receiver is unavailable"))?;
+        let delayed_rx = self
+            .delayed_rx
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take()
+            .ok_or_else(|| crate::mq_client_err!("consume scheduler delayed receiver is unavailable"))?;
+        let ready_rx = Arc::new(Mutex::new(ready_rx));
+
+        self.spawn_delayed_dispatcher(service_context, delayed_rx)?;
+        for _ in 0..worker_count {
+            self.spawn_worker(service_context, Arc::clone(&ready_rx), handler.clone())?;
+        }
+        Ok(())
+    }
+
+    fn spawn_delayed_dispatcher(
+        &self,
+        service_context: &ChildServiceContext,
+        mut delayed_rx: mpsc::Receiver<DelayedCommand<T>>,
+    ) -> RocketMQResult<()> {
+        let stopping = self.stopping.clone();
+        let ready_tx = self.ready_tx.clone();
+        let task = self.tasks.track_future(async move {
+            let mut delayed = DelayQueue::new();
+            loop {
+                if delayed.is_empty() {
+                    tokio::select! {
+                        biased;
+                        _ = stopping.cancelled() => break,
+                        command = delayed_rx.recv() => match command {
+                            Some((item, delay)) => { delayed.insert(item, delay); }
+                            None => break,
+                        }
+                    }
+                    continue;
+                }
+
+                tokio::select! {
+                    biased;
+                    _ = stopping.cancelled() => break,
+                    expired = delayed.next() => {
+                        if let Some(expired) = expired {
+                            let item = expired.into_inner();
+                            tokio::select! {
+                                biased;
+                                _ = stopping.cancelled() => break,
+                                result = ready_tx.send(item) => {
+                                    if result.is_err() {
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    command = delayed_rx.recv() => match command {
+                        Some((item, delay)) => { delayed.insert(item, delay); }
+                        None => break,
+                    }
+                }
+            }
+        });
+        spawn_client_task_with_context(service_context, "rocketmq-client-consume-delay-scheduler", task)
+            .map(|_| ())
+            .map_err(|error| crate::mq_client_err!(format!("failed to start consume delay scheduler: {error}")))
+    }
+
+    fn spawn_worker<H, F>(
+        &self,
+        service_context: &ChildServiceContext,
+        ready_rx: Arc<Mutex<mpsc::Receiver<ScheduledItem<T>>>>,
+        handler: H,
+    ) -> RocketMQResult<()>
+    where
+        H: Fn(T) -> F + Send + Sync + 'static,
+        F: Future<Output = ()> + Send + 'static,
+    {
+        let stopping = self.stopping.clone();
+        let force_stop = self.force_stop.clone();
+        let task = self.tasks.track_future(async move {
+            loop {
+                let scheduled = tokio::select! {
+                    biased;
+                    _ = stopping.cancelled() => break,
+                    item = async {
+                        let mut receiver = ready_rx.lock().await;
+                        receiver.recv().await
+                    } => item,
+                };
+                let Some(scheduled) = scheduled else {
+                    break;
+                };
+                let item = scheduled.into_item();
+                tokio::select! {
+                    biased;
+                    _ = force_stop.cancelled() => break,
+                    () = handler(item) => {}
+                }
+            }
+        });
+        spawn_client_task_with_context(service_context, "rocketmq-client-consume-worker", task)
+            .map(|_| ())
+            .map_err(|error| crate::mq_client_err!(format!("failed to start consume worker: {error}")))
+    }
+
+    pub(crate) async fn schedule(&self, item: T) -> Result<(), ConsumeScheduleError<T>> {
+        self.schedule_on(item, None).await
+    }
+
+    pub(crate) async fn schedule_after(&self, item: T, delay: Duration) -> Result<(), ConsumeScheduleError<T>> {
+        self.schedule_on(item, Some(delay)).await
+    }
+
+    async fn schedule_on(&self, item: T, delay: Option<Duration>) -> Result<(), ConsumeScheduleError<T>> {
+        if self.stopping.is_cancelled() {
+            return Err(ConsumeScheduleError { item });
+        }
+        let permit = tokio::select! {
+            biased;
+            _ = self.stopping.cancelled() => return Err(ConsumeScheduleError { item }),
+            permit = Arc::clone(&self.queued_slots).acquire_owned() => match permit {
+                Ok(permit) => permit,
+                Err(_) => return Err(ConsumeScheduleError { item }),
+            }
+        };
+        if self.stopping.is_cancelled() {
+            return Err(ConsumeScheduleError { item });
+        }
+        let scheduled = ScheduledItem {
+            item,
+            _queued_permit: permit,
+        };
+        match delay {
+            Some(delay) => self
+                .delayed_tx
+                .try_send((scheduled, delay))
+                .map_err(|error| ConsumeScheduleError {
+                    item: error.into_inner().0.into_item(),
+                }),
+            None => self.ready_tx.try_send(scheduled).map_err(|error| ConsumeScheduleError {
+                item: error.into_inner().into_item(),
+            }),
+        }
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub(crate) fn queued(&self) -> usize {
+        self.capacity.saturating_sub(self.queued_slots.available_permits())
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub(crate) fn task_count(&self) -> usize {
+        self.tasks.len()
+    }
+
+    pub(crate) async fn shutdown(&self, timeout: Duration) -> bool {
+        self.stopping.cancel();
+        self.tasks.close();
+        if tokio::time::timeout(timeout, self.tasks.wait()).await.is_ok() {
+            return true;
+        }
+        self.force_stop.cancel();
+        let stopped = tokio::time::timeout(Duration::from_secs(1), self.tasks.wait())
+            .await
+            .is_ok();
+        if !stopped {
+            warn!("bounded consume scheduler did not stop after forced cancellation");
+        }
+        stopped
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicUsize;
+
+    use super::*;
+    use tokio::sync::Notify;
+
+    fn update_peak(peak: &AtomicUsize, active: usize) {
+        let mut observed = peak.load(Ordering::Acquire);
+        while active > observed {
+            match peak.compare_exchange_weak(observed, active, Ordering::AcqRel, Ordering::Acquire) {
+                Ok(_) => return,
+                Err(current) => observed = current,
+            }
+        }
+    }
+
+    async fn wait_for(counter: &AtomicUsize, expected: usize, changed: &Notify) {
+        loop {
+            let notified = changed.notified();
+            if counter.load(Ordering::Acquire) >= expected {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    #[tokio::test]
+    async fn fixed_workers_bound_execution_and_shutdown_cleanly() {
+        let scheduler = BoundedConsumeScheduler::new(4).expect("scheduler config should be valid");
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let completed = Arc::new(AtomicUsize::new(0));
+        let changed = Arc::new(Notify::new());
+        let releases = Arc::new(Semaphore::new(0));
+
+        scheduler
+            .start(
+                &crate::runtime::test_service_context("bounded-consume-scheduler-test"),
+                2,
+                {
+                    let active = Arc::clone(&active);
+                    let peak = Arc::clone(&peak);
+                    let completed = Arc::clone(&completed);
+                    let changed = Arc::clone(&changed);
+                    let releases = Arc::clone(&releases);
+                    move |_item: usize| {
+                        let active = Arc::clone(&active);
+                        let peak = Arc::clone(&peak);
+                        let completed = Arc::clone(&completed);
+                        let changed = Arc::clone(&changed);
+                        let releases = Arc::clone(&releases);
+                        async move {
+                            let now_active = active.fetch_add(1, Ordering::AcqRel) + 1;
+                            update_peak(&peak, now_active);
+                            changed.notify_waiters();
+                            let permit = releases.acquire().await.expect("release semaphore stays open");
+                            permit.forget();
+                            active.fetch_sub(1, Ordering::AcqRel);
+                            completed.fetch_add(1, Ordering::AcqRel);
+                            changed.notify_waiters();
+                        }
+                    }
+                },
+            )
+            .expect("scheduler should start");
+
+        scheduler.schedule(1).await.expect("first item should enqueue");
+        scheduler.schedule(2).await.expect("second item should enqueue");
+        scheduler.schedule(3).await.expect("third item should enqueue");
+        wait_for(&active, 2, &changed).await;
+        assert_eq!(peak.load(Ordering::Acquire), 2);
+        assert_eq!(scheduler.task_count(), 3, "two workers plus one shared delay task");
+
+        releases.add_permits(2);
+        wait_for(&completed, 2, &changed).await;
+        releases.add_permits(1);
+        wait_for(&completed, 3, &changed).await;
+
+        assert!(scheduler.shutdown(Duration::from_secs(1)).await);
+        assert_eq!(scheduler.task_count(), 0);
+        assert_eq!(scheduler.queued(), 0);
+    }
+
+    #[tokio::test]
+    async fn delayed_retries_share_one_owned_scheduler_task() {
+        let scheduler = BoundedConsumeScheduler::new(64).expect("scheduler config should be valid");
+        let completed = Arc::new(AtomicUsize::new(0));
+        let changed = Arc::new(Notify::new());
+        scheduler
+            .start(
+                &crate::runtime::test_service_context("bounded-consume-delay-test"),
+                2,
+                {
+                    let completed = Arc::clone(&completed);
+                    let changed = Arc::clone(&changed);
+                    move |_item: usize| {
+                        let completed = Arc::clone(&completed);
+                        let changed = Arc::clone(&changed);
+                        async move {
+                            completed.fetch_add(1, Ordering::AcqRel);
+                            changed.notify_waiters();
+                        }
+                    }
+                },
+            )
+            .expect("scheduler should start");
+
+        for item in 0..64 {
+            scheduler
+                .schedule_after(item, Duration::from_millis(1))
+                .await
+                .expect("delayed item should enqueue");
+        }
+        assert_eq!(scheduler.task_count(), 3, "retry count must not create more tasks");
+        tokio::time::timeout(Duration::from_secs(1), wait_for(&completed, 64, &changed))
+            .await
+            .expect("all delayed retries should complete");
+        assert!(scheduler.shutdown(Duration::from_secs(1)).await);
+    }
+
+    #[tokio::test]
+    async fn shutdown_releases_blocked_admission_and_returns_item_ownership() {
+        let scheduler = BoundedConsumeScheduler::new(1).expect("scheduler config should be valid");
+        let entered = Arc::new(Notify::new());
+        let active = Arc::new(AtomicBool::new(false));
+        scheduler
+            .start(
+                &crate::runtime::test_service_context("bounded-consume-backpressure-test"),
+                1,
+                {
+                    let entered = Arc::clone(&entered);
+                    let active = Arc::clone(&active);
+                    move |_item: usize| {
+                        let entered = Arc::clone(&entered);
+                        let active = Arc::clone(&active);
+                        async move {
+                            active.store(true, Ordering::Release);
+                            entered.notify_waiters();
+                            futures::future::pending::<()>().await;
+                        }
+                    }
+                },
+            )
+            .expect("scheduler should start");
+
+        scheduler.schedule(1).await.expect("active item should enqueue");
+        loop {
+            let notified = entered.notified();
+            if active.load(Ordering::Acquire) {
+                break;
+            }
+            notified.await;
+        }
+        scheduler.schedule(2).await.expect("one queued item should fit");
+        let blocked = scheduler.schedule(3);
+        tokio::pin!(blocked);
+        tokio::select! {
+            result = &mut blocked => panic!("admission should wait while the queue is full: {result:?}"),
+            () = tokio::task::yield_now() => {}
+        }
+
+        assert!(scheduler.shutdown(Duration::ZERO).await);
+        let rejected = blocked.await.expect_err("shutdown must reject blocked admission");
+        assert_eq!(rejected.into_item(), 3);
+        assert_eq!(scheduler.queued(), 0);
+    }
+}

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::future::Future;
-use std::sync::atomic::AtomicU64;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -38,12 +37,12 @@ use rocketmq_runtime::common::time_utils::current_millis;
 use serde::Serialize;
 use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
-use tokio_util::task::TaskTracker;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
 
 use crate::base::client_config::ClientConfig;
+use crate::consumer::consumer_impl::bounded_consume_scheduler::BoundedConsumeScheduler;
 use crate::consumer::consumer_impl::consume_message_service::ConsumeMessageServiceTrait;
 use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
 use crate::consumer::consumer_impl::pop_process_queue::PopProcessQueue;
@@ -55,7 +54,6 @@ use crate::consumer::listener::consume_return_type::ConsumeReturnType;
 use crate::consumer::listener::message_listener_concurrently::ArcMessageListenerConcurrently;
 use crate::hook::consume_message_context::ConsumeMessageContext;
 use crate::runtime::spawn_client_blocking_io_with_context;
-use crate::runtime::spawn_client_task_with_context;
 use crate::runtime::spawn_client_tracked_task_with_context;
 use crate::runtime::ClientTrackedTaskHandle;
 use rocketmq_runtime::ChildServiceContext;
@@ -80,10 +78,10 @@ pub struct ConsumeMessageConcurrentlyService {
     shutdown_token: CancellationToken,
     /// Background task matching Java's cleanExpireMsgExecutors lifecycle.
     clean_expire_task_handle: Arc<Mutex<Option<ConcurrentTaskHandle>>>,
-    consume_task_tracker: TaskTracker,
-    force_stop_token: CancellationToken,
-    submitted_tasks: Arc<AtomicU64>,
+    consume_scheduler: BoundedConsumeScheduler<ConsumeRequest>,
 }
+
+const CONSUME_SCHEDULER_CAPACITY: usize = 4_096;
 
 enum ConcurrentTaskHandle {
     Tracked(ClientTrackedTaskHandle),
@@ -101,20 +99,6 @@ impl ConcurrentTaskHandle {
                     );
                 }
                 report.is_healthy()
-            }
-        }
-    }
-
-    fn abort(self) {
-        match self {
-            Self::Tracked(handle) => {
-                let report = handle.shutdown_now();
-                if !report.is_healthy() {
-                    warn!(
-                        report = %report.to_json(),
-                        "concurrent clean-expire task immediate shutdown report is unhealthy"
-                    );
-                }
             }
         }
     }
@@ -151,33 +135,6 @@ where
     }
 }
 
-fn spawn_tracked_concurrent_task<F>(
-    service_context: &ChildServiceContext,
-    thread_name: &'static str,
-    tracker: &TaskTracker,
-    force_stop_token: &CancellationToken,
-    submitted_tasks: &Arc<AtomicU64>,
-    task: F,
-) where
-    F: Future<Output = ()> + Send + 'static,
-{
-    submitted_tasks.fetch_add(1, Ordering::Relaxed);
-    let force_stop_token = force_stop_token.clone();
-    let tracked_task = tracker.track_future(async move {
-        let mut task = Box::pin(task);
-        tokio::select! {
-            biased;
-            _ = force_stop_token.cancelled() => {}
-            _ = &mut task => {}
-        }
-    });
-
-    if let Err(error) = spawn_client_task_with_context(service_context, thread_name, tracked_task) {
-        warn!("Failed to spawn {} background task: {}", thread_name, error);
-        warn!("Failed to track {} background task", thread_name);
-    }
-}
-
 impl ConsumeMessageConcurrentlyService {
     pub fn new(
         service_context: ChildServiceContext,
@@ -203,9 +160,8 @@ impl ConsumeMessageConcurrentlyService {
             max_concurrency: Arc::new(AtomicUsize::new(core_pool_size)),
             shutdown_token: CancellationToken::new(),
             clean_expire_task_handle: Arc::new(Mutex::new(None)),
-            consume_task_tracker: TaskTracker::new(),
-            force_stop_token: CancellationToken::new(),
-            submitted_tasks: Arc::new(AtomicU64::new(0)),
+            consume_scheduler: BoundedConsumeScheduler::new(CONSUME_SCHEDULER_CAPACITY)
+                .expect("the fixed consume scheduler capacity must be non-zero"),
         }
     }
 
@@ -344,7 +300,8 @@ impl ConsumeMessageConcurrentlyService {
                         this,
                         consume_request.process_queue.clone(),
                         consume_request.message_queue.clone(),
-                    );
+                    )
+                    .await;
                 }
             }
         }
@@ -373,29 +330,36 @@ impl ConsumeMessageConcurrentlyService {
         }
     }
 
-    fn submit_consume_request_later(
+    async fn submit_consume_request_later(
         &self,
         msgs: Vec<Arc<MessageExt>>,
-        this: Arc<Self>,
+        _this: Arc<Self>,
         process_queue: Arc<ProcessQueue>,
         message_queue: MessageQueue,
     ) {
-        let shutdown_token = self.shutdown_token.clone();
-        spawn_tracked_concurrent_task(
-            &self.service_context,
-            "rocketmq-client-concurrent-consume-delay",
-            &self.consume_task_tracker,
-            &self.force_stop_token,
-            &self.submitted_tasks,
-            async move {
-                tokio::select! {
-                    _ = shutdown_token.cancelled() => return,
-                    _ = tokio::time::sleep(Duration::from_secs(5)) => {}
-                }
-                this.submit_consume_request(this.clone(), msgs, process_queue, message_queue, true)
-                    .await;
-            },
-        );
+        let request = ConsumeRequest {
+            msgs,
+            message_listener: self.message_listener.clone(),
+            process_queue: process_queue.clone(),
+            message_queue: message_queue.clone(),
+            dispatch_to_consume: true,
+            consumer_group: self.consumer_group.clone(),
+            default_mqpush_consumer_impl: self.consumer_impl(),
+        };
+        if let Err(error) = self
+            .consume_scheduler
+            .schedule_after(request, Duration::from_secs(5))
+            .await
+        {
+            let request = error.into_item();
+            request.process_queue.set_consuming(false);
+            warn!(
+                "concurrent consume retry rejected during shutdown, group={}, mq={}, msgs={}",
+                self.consumer_group,
+                request.message_queue,
+                request.msgs.len()
+            );
+        }
     }
 
     pub async fn send_message_back(&self, msg: &mut MessageExt, context: &ConsumeConcurrentlyContext) -> bool {
@@ -423,6 +387,33 @@ impl ConsumeMessageConcurrentlyService {
 
 impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
     fn start(&self, this: Arc<Self>) {
+        let worker_service = Arc::clone(&this);
+        if let Err(error) = self.consume_scheduler.start(
+            &self.service_context,
+            self.consumer_config.consume_thread_max.max(1) as usize,
+            move |mut request| {
+                let service = Arc::clone(&worker_service);
+                async move {
+                    if service.shutdown_token.is_cancelled() {
+                        return;
+                    }
+                    let limiter = Arc::clone(&service.consume_semaphore);
+                    let permit = tokio::select! {
+                        biased;
+                        _ = service.shutdown_token.cancelled() => return,
+                        permit = limiter.acquire_owned() => match permit {
+                            Ok(permit) => permit,
+                            Err(_) => return,
+                        }
+                    };
+                    request.run(Arc::clone(&service)).await;
+                    drop(permit);
+                }
+            },
+        ) {
+            error!("Failed to start bounded concurrent consume scheduler: {error}");
+        }
+
         let shutdown_token = self.shutdown_token.clone();
         let service_context = this.service_context.clone();
         let handle = spawn_concurrent_lifecycle_task(
@@ -448,7 +439,7 @@ impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
 
     async fn shutdown(&self, await_terminate_millis: u64) {
         self.shutdown_token.cancel();
-        self.consume_task_tracker.close();
+        self.consume_semaphore.close();
         let shutdown_timeout = Duration::from_millis(await_terminate_millis);
         let clean_expire_handle = { self.clean_expire_task_handle.lock().take() };
         if let Some(handle) = clean_expire_handle {
@@ -460,25 +451,13 @@ impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
             }
         }
 
-        match tokio::time::timeout(shutdown_timeout, self.consume_task_tracker.wait()).await {
-            Ok(()) => {
-                info!("ConsumeMessageConcurrentlyService shutdown gracefully");
-            }
-            Err(_elapsed) => {
-                warn!(
-                    "ConsumeMessageConcurrentlyService shutdown timed out after {}ms; {} submitted consume tasks may \
-                     still be running",
-                    await_terminate_millis,
-                    self.submitted_tasks.load(Ordering::Acquire)
-                );
-                self.force_stop_token.cancel();
-                if tokio::time::timeout(Duration::from_secs(1), self.consume_task_tracker.wait())
-                    .await
-                    .is_err()
-                {
-                    warn!("ConsumeMessageConcurrentlyService force stop timed out");
-                }
-            }
+        if self.consume_scheduler.shutdown(shutdown_timeout).await {
+            info!("ConsumeMessageConcurrentlyService shutdown gracefully");
+        } else {
+            warn!(
+                "ConsumeMessageConcurrentlyService scheduler did not stop within {}ms",
+                await_terminate_millis
+            );
         }
     }
 
@@ -600,7 +579,7 @@ impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
 
     async fn submit_consume_request(
         &self,
-        this: Arc<Self>,
+        _this: Arc<Self>,
         msgs: Vec<Arc<MessageExt>>,
         process_queue: Arc<ProcessQueue>,
         message_queue: MessageQueue,
@@ -617,19 +596,16 @@ impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
 
         let consume_batch_size = self.consumer_config.consume_message_batch_max_size;
         if msgs.len() <= consume_batch_size as usize {
-            self.spawn_consume_task(this, msgs, process_queue, message_queue, dispatch_to_consume);
+            self.schedule_consume_request(msgs, process_queue, message_queue, dispatch_to_consume)
+                .await;
         } else {
-            msgs.chunks(consume_batch_size as usize)
-                .map(|chunk| chunk.to_vec())
-                .for_each(|chunk| {
-                    self.spawn_consume_task(
-                        this.clone(),
-                        chunk,
-                        process_queue.clone(),
-                        message_queue.clone(),
-                        dispatch_to_consume,
-                    );
-                });
+            for chunk in msgs
+                .chunks(consume_batch_size as usize)
+                .map(<[Arc<MessageExt>]>::to_vec)
+            {
+                self.schedule_consume_request(chunk, process_queue.clone(), message_queue.clone(), dispatch_to_consume)
+                    .await;
+            }
         }
     }
 
@@ -645,52 +621,36 @@ impl ConsumeMessageServiceTrait for ConsumeMessageConcurrentlyService {
 }
 
 impl ConsumeMessageConcurrentlyService {
-    /// Attempts to acquire a semaphore permit and, if successful, spawns a consume task on the
-    /// current Tokio runtime.  When all `consume_thread_max` permits are in use the request is
-    /// retried after 5 s, matching the Java SDK's `RejectedExecutionException` path.
-    fn spawn_consume_task(
+    async fn schedule_consume_request(
         &self,
-        this: Arc<Self>,
         msgs: Vec<Arc<MessageExt>>,
         process_queue: Arc<ProcessQueue>,
         message_queue: MessageQueue,
         dispatch_to_consume: bool,
     ) {
         if self.shutdown_token.is_cancelled() {
+            process_queue.set_consuming(false);
             return;
         }
 
-        match Arc::clone(&self.consume_semaphore).try_acquire_owned() {
-            Ok(permit) => {
-                let mut consume_request = ConsumeRequest {
-                    msgs,
-                    message_listener: self.message_listener.clone(),
-                    process_queue,
-                    message_queue,
-                    dispatch_to_consume,
-                    consumer_group: self.consumer_group.clone(),
-                    default_mqpush_consumer_impl: self.consumer_impl(),
-                };
-                spawn_tracked_concurrent_task(
-                    &self.service_context,
-                    "rocketmq-client-concurrent-consume",
-                    &self.consume_task_tracker,
-                    &self.force_stop_token,
-                    &self.submitted_tasks,
-                    async move {
-                        let _permit = permit;
-                        consume_request.run(this).await;
-                    },
-                );
-            }
-            Err(_saturated) => {
-                warn!(
-                    "consume semaphore saturated for group {}; will retry {} message(s) in 5 s",
-                    self.consumer_group,
-                    msgs.len()
-                );
-                self.submit_consume_request_later(msgs, this, process_queue, message_queue);
-            }
+        let request = ConsumeRequest {
+            msgs,
+            message_listener: self.message_listener.clone(),
+            process_queue: process_queue.clone(),
+            message_queue: message_queue.clone(),
+            dispatch_to_consume,
+            consumer_group: self.consumer_group.clone(),
+            default_mqpush_consumer_impl: self.consumer_impl(),
+        };
+        if let Err(error) = self.consume_scheduler.schedule(request).await {
+            let request = error.into_item();
+            request.process_queue.set_consuming(false);
+            warn!(
+                "concurrent consume request rejected during shutdown, group={}, mq={}, msgs={}",
+                self.consumer_group,
+                request.message_queue,
+                request.msgs.len()
+            );
         }
     }
 }
@@ -1274,104 +1234,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tracked_concurrent_task_shutdown_waits_for_completion() {
-        let tracker = TaskTracker::new();
-        let token = CancellationToken::new();
-        let submitted = Arc::new(AtomicU64::new(0));
-        let completed = Arc::new(AtomicBool::new(false));
-        let completed_in_task = completed.clone();
-
-        spawn_tracked_concurrent_task(
-            &test_context(),
-            "rocketmq-client-concurrent-tracker-test",
-            &tracker,
-            &token,
-            &submitted,
-            async move {
-                completed_in_task.store(true, Ordering::Release);
-            },
-        );
-        tracker.close();
-
-        tokio::time::timeout(Duration::from_secs(1), tracker.wait())
-            .await
-            .expect("tracked task should finish before timeout");
-
-        assert!(completed.load(Ordering::Acquire));
-        assert_eq!(submitted.load(Ordering::Acquire), 1);
-    }
-
-    #[tokio::test]
-    async fn tracked_concurrent_task_force_stop_cancels_pending_task() {
-        let tracker = TaskTracker::new();
-        let token = CancellationToken::new();
-        let submitted = Arc::new(AtomicU64::new(0));
-        let dropped = Arc::new(AtomicBool::new(false));
-        let dropped_in_task = dropped.clone();
-
-        spawn_tracked_concurrent_task(
-            &test_context(),
-            "rocketmq-client-concurrent-tracker-test",
-            &tracker,
-            &token,
-            &submitted,
-            async move {
-                let _drop_flag = DropFlag(dropped_in_task);
-                pending::<()>().await;
-            },
-        );
-        tracker.close();
-
-        assert!(tokio::time::timeout(Duration::from_millis(20), tracker.wait())
-            .await
-            .is_err());
-
-        token.cancel();
-
-        tokio::time::timeout(Duration::from_secs(1), tracker.wait())
-            .await
-            .expect("force stop should release pending tracked task");
-
-        assert!(dropped.load(Ordering::Acquire));
-        assert_eq!(submitted.load(Ordering::Acquire), 1);
-    }
-
-    #[test]
-    fn start_without_tokio_runtime_does_not_spawn_panic() {
-        let service = new_service(None);
-
-        service.start(Arc::new(new_service(None)));
-
+    async fn start_and_shutdown_use_the_injected_runtime_context() {
+        let service = Arc::new(new_service(None));
+        service.start(Arc::clone(&service));
         assert!(service.clean_expire_task_handle.lock().is_some());
-        service.shutdown_token.cancel();
-        let handle = { service.clean_expire_task_handle.lock().take() };
-        if let Some(handle) = handle {
-            handle.abort();
-        }
-    }
-
-    #[test]
-    fn submit_consume_request_later_without_tokio_runtime_does_not_spawn_panic() {
-        let service = new_service(None);
-        let this = Arc::new(new_service(None));
-
-        service.submit_consume_request_later(vec![], this, Arc::new(ProcessQueue::new()), message_queue());
-        service.shutdown_token.cancel();
-        std::thread::sleep(Duration::from_millis(30));
-    }
-
-    #[test]
-    fn spawn_consume_task_without_tokio_runtime_does_not_spawn_panic() {
-        let service = new_service(None);
-
-        service.spawn_consume_task(
-            Arc::new(new_service(None)),
-            vec![Arc::new(MessageExt::default())],
-            Arc::new(ProcessQueue::new()),
-            message_queue(),
-            true,
-        );
-        std::thread::sleep(Duration::from_millis(30));
+        assert_eq!(service.consume_scheduler.task_count(), 65);
+        service.shutdown(100).await;
+        assert_eq!(service.consume_scheduler.task_count(), 0);
     }
 
     #[tokio::test]

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_concurrently_service.rs
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::future::Future;
 use std::sync::atomic::AtomicBool;
-use std::sync::atomic::AtomicU64;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -36,8 +34,6 @@ use rocketmq_protocol::protocol::body::consume_message_directly_result::ConsumeM
 use rocketmq_protocol::protocol::header::extra_info_util::ExtraInfoUtil;
 use rocketmq_runtime::common::time_utils::current_millis;
 use tokio::sync::Semaphore;
-use tokio_util::sync::CancellationToken;
-use tokio_util::task::TaskTracker;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
@@ -45,6 +41,7 @@ use tracing::warn;
 use crate::base::client_config::ClientConfig;
 use crate::consumer::ack_callback::AckCallback;
 use crate::consumer::ack_result::AckResult;
+use crate::consumer::consumer_impl::bounded_consume_scheduler::BoundedConsumeScheduler;
 use crate::consumer::consumer_impl::consume_message_service::ConsumeMessageServiceTrait;
 use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
 use crate::consumer::consumer_impl::pop_process_queue::PopProcessQueue;
@@ -56,33 +53,9 @@ use crate::consumer::listener::consume_return_type::ConsumeReturnType;
 use crate::consumer::listener::message_listener_concurrently::ArcMessageListenerConcurrently;
 use crate::hook::consume_message_context::ConsumeMessageContext;
 use crate::runtime::spawn_client_blocking_io_with_context;
-use crate::runtime::spawn_client_task_with_context;
 use rocketmq_runtime::ChildServiceContext;
 
-fn spawn_tracked_pop_concurrent_task<F>(
-    service_context: &ChildServiceContext,
-    thread_name: &'static str,
-    tracker: &TaskTracker,
-    force_stop_token: &CancellationToken,
-    submitted_tasks: &Arc<AtomicU64>,
-    task: F,
-) where
-    F: Future<Output = ()> + Send + 'static,
-{
-    submitted_tasks.fetch_add(1, Ordering::Relaxed);
-    let force_stop_token = force_stop_token.clone();
-    let tracked_task = tracker.track_future(async move {
-        tokio::select! {
-            biased;
-            _ = force_stop_token.cancelled() => {}
-            _ = task => {}
-        }
-    });
-
-    if let Err(error) = spawn_client_task_with_context(service_context, thread_name, tracked_task) {
-        warn!("Failed to spawn {} background task: {}", thread_name, error);
-    }
-}
+const POP_CONCURRENT_SCHEDULER_CAPACITY: usize = 4_096;
 
 pub struct ConsumeMessagePopConcurrentlyService {
     service_context: ChildServiceContext,
@@ -97,9 +70,7 @@ pub struct ConsumeMessagePopConcurrentlyService {
     pub(crate) active_tasks: Arc<AtomicUsize>,
     pub(crate) concurrency_limiter: Arc<Semaphore>,
     pub(crate) max_concurrency: Arc<AtomicUsize>,
-    pop_task_tracker: TaskTracker,
-    force_stop_token: CancellationToken,
-    submitted_tasks: Arc<AtomicU64>,
+    consume_scheduler: BoundedConsumeScheduler<ConsumeRequest>,
 }
 
 impl ConsumeMessagePopConcurrentlyService {
@@ -127,9 +98,8 @@ impl ConsumeMessagePopConcurrentlyService {
             active_tasks: Arc::new(AtomicUsize::new(0)),
             concurrency_limiter: Arc::new(Semaphore::new(consume_thread as usize)),
             max_concurrency: Arc::new(AtomicUsize::new(consume_thread as usize)),
-            pop_task_tracker: TaskTracker::new(),
-            force_stop_token: CancellationToken::new(),
-            submitted_tasks: Arc::new(AtomicU64::new(0)),
+            consume_scheduler: BoundedConsumeScheduler::new(POP_CONCURRENT_SCHEDULER_CAPACITY)
+                .expect("the fixed POP consume scheduler capacity must be non-zero"),
         }
     }
 
@@ -161,7 +131,30 @@ impl ConsumeMessagePopConcurrentlyService {
 }
 
 impl ConsumeMessageServiceTrait for ConsumeMessagePopConcurrentlyService {
-    fn start(&self, _this: Arc<Self>) {}
+    fn start(&self, this: Arc<Self>) {
+        let worker_service = Arc::clone(&this);
+        if let Err(error) = self.consume_scheduler.start(
+            &self.service_context,
+            self.consumer_config.consume_thread_max.max(1) as usize,
+            move |request| {
+                let service = Arc::clone(&worker_service);
+                async move {
+                    if service.stopped.load(Ordering::Acquire) {
+                        return;
+                    }
+                    let limiter = Arc::clone(&service.concurrency_limiter);
+                    let permit = match limiter.acquire_owned().await {
+                        Ok(permit) => permit,
+                        Err(_) => return,
+                    };
+                    request.run(Arc::clone(&service)).await;
+                    drop(permit);
+                }
+            },
+        ) {
+            error!("Failed to start bounded POP concurrent consume scheduler: {error}");
+        }
+    }
 
     async fn shutdown(&self, await_terminate_millis: u64) {
         info!(
@@ -171,31 +164,13 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopConcurrentlyService {
 
         self.stopped.store(true, Ordering::Release);
         self.concurrency_limiter.close();
-        self.pop_task_tracker.close();
-
         let timeout = Duration::from_millis(await_terminate_millis);
-        match tokio::time::timeout(timeout, self.pop_task_tracker.wait()).await {
-            Ok(()) => {}
-            Err(_) => {
-                warn!(
-                    "{} ConsumeMessagePopConcurrentlyService shutdown timeout, {} active consume tasks, {} submitted \
-                     tasks; forcing remaining task futures to stop",
-                    self.consumer_group,
-                    self.active_tasks.load(Ordering::Acquire),
-                    self.submitted_tasks.load(Ordering::Acquire)
-                );
-                self.force_stop_token.cancel();
-                if tokio::time::timeout(Duration::from_secs(1), self.pop_task_tracker.wait())
-                    .await
-                    .is_err()
-                {
-                    warn!(
-                        "{} ConsumeMessagePopConcurrentlyService force stop timed out, {} active consume tasks remain",
-                        self.consumer_group,
-                        self.active_tasks.load(Ordering::Acquire)
-                    );
-                }
-            }
+        if !self.consume_scheduler.shutdown(timeout).await {
+            warn!(
+                "{} ConsumeMessagePopConcurrentlyService scheduler shutdown timed out, {} active tasks remain",
+                self.consumer_group,
+                self.active_tasks.load(Ordering::Acquire)
+            );
         }
 
         info!(
@@ -333,90 +308,31 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopConcurrentlyService {
 
     async fn submit_pop_consume_request(
         &self,
-        this: Arc<Self>,
+        _this: Arc<Self>,
         msgs: Vec<MessageExt>,
         process_queue: &PopProcessQueue,
         message_queue: &MessageQueue,
     ) {
         let consume_batch_size = self.consumer_config.consume_message_batch_max_size.max(1);
-        if msgs.len() <= consume_batch_size as usize {
+        for chunk in msgs.chunks(consume_batch_size as usize).map(<[MessageExt]>::to_vec) {
             let request = ConsumeRequest::new(
-                msgs,
+                chunk,
                 Arc::new(process_queue.clone()),
                 message_queue.clone(),
                 self.consumer_group.clone(),
                 self.message_listener.clone(),
                 self.consumer_impl(),
             );
-            let limiter = self.concurrency_limiter.clone();
-            let stopped = self.stopped.clone();
-            spawn_tracked_pop_concurrent_task(
-                &self.service_context,
-                "rocketmq-client-pop-concurrent-consume",
-                &self.pop_task_tracker,
-                &self.force_stop_token,
-                &self.submitted_tasks,
-                async move {
-                    if stopped.load(Ordering::Acquire) {
-                        return;
-                    }
-
-                    let permit = match limiter.acquire().await {
-                        Ok(p) => p,
-                        Err(_) => {
-                            warn!("Failed to acquire permit, semaphore closed");
-                            return;
-                        }
-                    };
-
-                    request.run(this).await;
-                    drop(permit);
-                },
-            );
-        } else {
-            let consumer_group = self.consumer_group.clone();
-            let message_listener = self.message_listener.clone();
-            let default_impl = self.consumer_impl();
-            let limiter = self.concurrency_limiter.clone();
-            let stopped = self.stopped.clone();
-            msgs.chunks(consume_batch_size as usize)
-                .map(|t| t.to_vec())
-                .for_each(|chunk| {
-                    let consume_request = ConsumeRequest::new(
-                        chunk,
-                        Arc::new(process_queue.clone()),
-                        message_queue.clone(),
-                        consumer_group.clone(),
-                        message_listener.clone(),
-                        default_impl.clone(),
-                    );
-                    let pop_service = this.clone();
-                    let limiter_clone = limiter.clone();
-                    let stopped_clone = stopped.clone();
-                    spawn_tracked_pop_concurrent_task(
-                        &self.service_context,
-                        "rocketmq-client-pop-concurrent-consume",
-                        &self.pop_task_tracker,
-                        &self.force_stop_token,
-                        &self.submitted_tasks,
-                        async move {
-                            if stopped_clone.load(Ordering::Acquire) {
-                                return;
-                            }
-
-                            let permit = match limiter_clone.acquire().await {
-                                Ok(p) => p,
-                                Err(_) => {
-                                    warn!("Failed to acquire permit, semaphore closed");
-                                    return;
-                                }
-                            };
-
-                            consume_request.run(pop_service).await;
-                            drop(permit);
-                        },
-                    );
-                });
+            if let Err(error) = self.consume_scheduler.schedule(request).await {
+                let request = error.into_item();
+                request.process_queue.inc_found_msg(request.msgs.len());
+                warn!(
+                    "POP concurrent consume request rejected during shutdown, group={}, mq={}, msgs={}",
+                    self.consumer_group,
+                    request.message_queue,
+                    request.msgs.len()
+                );
+            }
         }
     }
 }
@@ -425,36 +341,33 @@ impl ConsumeMessagePopConcurrentlyService {
     /// Submit consume request after 5 seconds delay for retry
     async fn submit_pop_consume_request_later(
         &self,
-        this: Arc<Self>,
+        _this: Arc<Self>,
         msgs: Vec<MessageExt>,
         process_queue: Arc<PopProcessQueue>,
         message_queue: MessageQueue,
     ) {
-        let stopped = self.stopped.clone();
-
-        spawn_tracked_pop_concurrent_task(
-            &self.service_context,
-            "rocketmq-client-pop-concurrent-consume-delay",
-            &self.pop_task_tracker,
-            &self.force_stop_token,
-            &self.submitted_tasks,
-            async move {
-                if stopped.load(Ordering::Acquire) {
-                    warn!("Service stopped, discard delayed consume request for {}", message_queue);
-                    return;
-                }
-
-                tokio::time::sleep(Duration::from_millis(5000)).await;
-
-                if stopped.load(Ordering::Acquire) {
-                    warn!("Service stopped, discard delayed consume request for {}", message_queue);
-                    return;
-                }
-
-                this.submit_pop_consume_request(this.clone(), msgs, &process_queue, &message_queue)
-                    .await;
-            },
+        let request = ConsumeRequest::new(
+            msgs,
+            process_queue,
+            message_queue,
+            self.consumer_group.clone(),
+            self.message_listener.clone(),
+            self.consumer_impl(),
         );
+        if let Err(error) = self
+            .consume_scheduler
+            .schedule_after(request, Duration::from_secs(5))
+            .await
+        {
+            let request = error.into_item();
+            request.process_queue.inc_found_msg(request.msgs.len());
+            warn!(
+                "POP concurrent retry rejected during shutdown, group={}, mq={}, msgs={}",
+                self.consumer_group,
+                request.message_queue,
+                request.msgs.len()
+            );
+        }
     }
 
     async fn process_consume_result(
@@ -765,11 +678,11 @@ impl ConsumeRequest {
         }
 
         let listener = self.message_listener.clone();
-        let msgs_cloned: Vec<MessageExt> = self.msgs.iter().map(|m| m.as_ref().clone()).collect();
+        let msgs_for_blocking = self.msgs.clone();
         let process_span = crate::consumer::consumer_impl::observability::consumer_process_span(
             &consume_message_concurrently_service.telemetry_handle,
-            msgs_cloned.iter(),
-            msgs_cloned.len(),
+            self.msgs.iter().map(|message| message.as_ref()),
+            self.msgs.len(),
             self.consumer_group.as_str(),
             &self.message_queue,
             "pop_concurrent",
@@ -785,7 +698,7 @@ impl ConsumeRequest {
             "client.pop_concurrent.consume",
             move || {
                 let _entered = process_span_for_blocking.enter();
-                let msgs_refs: Vec<&MessageExt> = msgs_cloned.iter().collect();
+                let msgs_refs: Vec<&MessageExt> = msgs_for_blocking.iter().map(|message| message.as_ref()).collect();
                 let result = listener.consume_message(&msgs_refs, &context);
                 (result, context)
             },
@@ -960,7 +873,6 @@ fn classify_pop_consume_return_type(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::future::pending;
 
     fn message_queue() -> MessageQueue {
         MessageQueue::from_parts("topic", "broker-a", 0)
@@ -1027,14 +939,6 @@ mod tests {
             CheetahString::from_string(extra_info),
         );
         message
-    }
-
-    struct DropFlag(Arc<AtomicBool>);
-
-    impl Drop for DropFlag {
-        fn drop(&mut self) {
-            self.0.store(true, Ordering::Release);
-        }
     }
 
     #[test]
@@ -1111,52 +1015,6 @@ mod tests {
         service.dec_core_pool_size();
 
         assert_eq!(service.get_core_pool_size(), 2);
-    }
-
-    #[test]
-    fn submit_single_pop_consume_request_without_tokio_runtime_does_not_spawn_panic() {
-        let service = new_service(None);
-        service.stopped.store(true, Ordering::Release);
-
-        futures::executor::block_on(service.submit_pop_consume_request(
-            Arc::new(new_service(None)),
-            vec![pop_message()],
-            &PopProcessQueue::new(),
-            &message_queue(),
-        ));
-        std::thread::sleep(Duration::from_millis(30));
-    }
-
-    #[test]
-    fn submit_split_pop_consume_request_without_tokio_runtime_does_not_spawn_panic() {
-        let config = ConsumerConfig {
-            consume_message_batch_max_size: 1,
-            ..Default::default()
-        };
-        let service = new_service_with_config(config);
-        service.stopped.store(true, Ordering::Release);
-
-        futures::executor::block_on(service.submit_pop_consume_request(
-            Arc::new(new_service(None)),
-            vec![pop_message(), pop_message()],
-            &PopProcessQueue::new(),
-            &message_queue(),
-        ));
-        std::thread::sleep(Duration::from_millis(30));
-    }
-
-    #[test]
-    fn submit_pop_consume_request_later_without_tokio_runtime_does_not_spawn_panic() {
-        let service = new_service(None);
-        service.stopped.store(true, Ordering::Release);
-
-        futures::executor::block_on(service.submit_pop_consume_request_later(
-            Arc::new(new_service(None)),
-            vec![pop_message()],
-            Arc::new(PopProcessQueue::new()),
-            message_queue(),
-        ));
-        std::thread::sleep(Duration::from_millis(30));
     }
 
     #[test]
@@ -1238,69 +1096,6 @@ mod tests {
         service.shutdown(100).await;
 
         assert!(service.concurrency_limiter.is_closed());
-    }
-
-    #[tokio::test]
-    async fn tracked_pop_concurrent_task_shutdown_waits_for_completion() {
-        let tracker = TaskTracker::new();
-        let token = CancellationToken::new();
-        let submitted = Arc::new(AtomicU64::new(0));
-        let completed = Arc::new(AtomicBool::new(false));
-        let completed_in_task = completed.clone();
-
-        spawn_tracked_pop_concurrent_task(
-            &test_context(),
-            "rocketmq-client-pop-concurrent-tracker-test",
-            &tracker,
-            &token,
-            &submitted,
-            async move {
-                completed_in_task.store(true, Ordering::Release);
-            },
-        );
-        tracker.close();
-
-        tokio::time::timeout(Duration::from_secs(1), tracker.wait())
-            .await
-            .expect("tracked task should finish before timeout");
-
-        assert!(completed.load(Ordering::Acquire));
-        assert_eq!(submitted.load(Ordering::Acquire), 1);
-    }
-
-    #[tokio::test]
-    async fn tracked_pop_concurrent_task_force_stop_cancels_pending_task() {
-        let tracker = TaskTracker::new();
-        let token = CancellationToken::new();
-        let submitted = Arc::new(AtomicU64::new(0));
-        let dropped = Arc::new(AtomicBool::new(false));
-        let dropped_in_task = dropped.clone();
-
-        spawn_tracked_pop_concurrent_task(
-            &test_context(),
-            "rocketmq-client-pop-concurrent-tracker-test",
-            &tracker,
-            &token,
-            &submitted,
-            async move {
-                let _drop_flag = DropFlag(dropped_in_task);
-                pending::<()>().await;
-            },
-        );
-        tracker.close();
-
-        assert!(tokio::time::timeout(Duration::from_millis(20), tracker.wait())
-            .await
-            .is_err());
-
-        token.cancel();
-
-        tokio::time::timeout(Duration::from_secs(1), tracker.wait())
-            .await
-            .expect("force stop should release pending tracked task");
-
-        assert!(dropped.load(Ordering::Acquire));
-        assert_eq!(submitted.load(Ordering::Acquire), 1);
     }
 
     #[tokio::test]

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_pop_orderly_service.rs
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::future::Future;
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::sync::atomic::AtomicBool;
-use std::sync::atomic::AtomicU64;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -42,14 +40,13 @@ use rocketmq_runtime::ScheduledTaskControl;
 use rocketmq_runtime::ScheduledTaskSnapshot;
 use serde::Serialize;
 use tokio::sync::Semaphore;
-use tokio_util::sync::CancellationToken;
-use tokio_util::task::TaskTracker;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
 
 use crate::base::client_config::ClientConfig;
 use crate::consumer::ack_result::AckResult;
+use crate::consumer::consumer_impl::bounded_consume_scheduler::BoundedConsumeScheduler;
 use crate::consumer::consumer_impl::consume_message_service::ConsumeMessageServiceTrait;
 use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
 use crate::consumer::consumer_impl::pop_process_queue::PopProcessQueue;
@@ -61,7 +58,6 @@ use crate::consumer::listener::message_listener_orderly::ArcMessageListenerOrder
 use crate::consumer::message_queue_lock::MessageQueueLock;
 use crate::runtime::schedule_client_fixed_delay_controlled_task_with_context;
 use crate::runtime::spawn_client_blocking_io_with_context;
-use crate::runtime::spawn_client_task_with_context;
 use crate::runtime::ClientRuntime;
 use crate::runtime::ClientScheduledTaskHandle;
 use rocketmq_runtime::ChildServiceContext;
@@ -82,10 +78,10 @@ pub struct ConsumeMessagePopOrderlyService {
     pub(crate) stopped: Arc<AtomicBool>,
     pub(crate) active_tasks: Arc<AtomicUsize>,
     pub(crate) lock_refresh_task: Arc<Mutex<Option<PopOrderlyTaskHandle>>>,
-    pop_orderly_task_tracker: TaskTracker,
-    force_stop_token: CancellationToken,
-    submitted_tasks: Arc<AtomicU64>,
+    consume_scheduler: BoundedConsumeScheduler<ConsumeRequest>,
 }
+
+const POP_ORDERLY_SCHEDULER_CAPACITY: usize = 4_096;
 
 pub(crate) struct PopOrderlyTaskHandle(ClientScheduledTaskHandle);
 
@@ -99,16 +95,6 @@ impl PopOrderlyTaskHandle {
             );
         }
         report.is_healthy()
-    }
-
-    fn abort(self) {
-        let report = self.0.shutdown_now();
-        if !report.is_healthy() {
-            warn!(
-                report = %report.to_json(),
-                "pop orderly lock refresh task shutdown_now report is unhealthy"
-            );
-        }
     }
 
     fn task_count(&self) -> usize {
@@ -131,32 +117,6 @@ pub struct PopOrderlyLockRefreshLifecycleProbe {
     pub scheduled_failures: u64,
     pub shutdown_elapsed_us: u128,
     pub healthy: bool,
-}
-
-fn spawn_tracked_pop_orderly_task<F>(
-    service_context: &ChildServiceContext,
-    thread_name: &'static str,
-    tracker: &TaskTracker,
-    force_stop_token: &CancellationToken,
-    submitted_tasks: &Arc<AtomicU64>,
-    task: F,
-) where
-    F: Future<Output = ()> + Send + 'static,
-{
-    submitted_tasks.fetch_add(1, Ordering::Relaxed);
-    let force_stop_token = force_stop_token.clone();
-    let tracked_task = tracker.track_future(async move {
-        tokio::select! {
-            biased;
-            _ = force_stop_token.cancelled() => {}
-            _ = task => {}
-        }
-    });
-
-    if let Err(error) = spawn_client_task_with_context(service_context, thread_name, tracked_task) {
-        warn!("Failed to spawn {} background task: {}", thread_name, error);
-        warn!("Failed to track {} background task", thread_name);
-    }
 }
 
 /// Default callback implementation for acknowledgment operations
@@ -232,9 +192,8 @@ impl ConsumeMessagePopOrderlyService {
             stopped: Arc::new(AtomicBool::new(false)),
             active_tasks: Arc::new(AtomicUsize::new(0)),
             lock_refresh_task: Arc::new(Mutex::new(None)),
-            pop_orderly_task_tracker: TaskTracker::new(),
-            force_stop_token: CancellationToken::new(),
-            submitted_tasks: Arc::new(AtomicU64::new(0)),
+            consume_scheduler: BoundedConsumeScheduler::new(POP_ORDERLY_SCHEDULER_CAPACITY)
+                .expect("the fixed POP orderly scheduler capacity must be non-zero"),
         }
     }
 
@@ -347,69 +306,45 @@ impl ConsumeMessagePopOrderlyService {
         }
     }
 
-    fn submit_consume_request(&self, this: Arc<Self>, mut request: ConsumeRequest, force: bool) {
+    async fn submit_consume_request(&self, _this: Arc<Self>, request: ConsumeRequest, force: bool) {
         if !force && !self.consume_request_set.insert(request.clone()) {
             return;
         }
-
-        let stopped = self.stopped.clone();
-        let active_tasks = self.active_tasks.clone();
-        let concurrency_limiter = self.concurrency_limiter.clone();
-
-        spawn_tracked_pop_orderly_task(
-            &self.service_context,
-            "rocketmq-client-pop-orderly-consume",
-            &self.pop_orderly_task_tracker,
-            &self.force_stop_token,
-            &self.submitted_tasks,
-            async move {
-                if stopped.load(Ordering::Acquire) {
-                    return;
-                }
-
-                let _permit = match concurrency_limiter.acquire().await {
-                    Ok(permit) => permit,
-                    Err(_) => return,
-                };
-
-                active_tasks.fetch_add(1, Ordering::SeqCst);
-
-                struct TaskGuard(Arc<AtomicUsize>);
-                impl Drop for TaskGuard {
-                    fn drop(&mut self) {
-                        self.0.fetch_sub(1, Ordering::SeqCst);
-                    }
-                }
-                let _guard = TaskGuard(active_tasks);
-
-                request.run(this).await;
-            },
-        );
+        if let Err(error) = self.consume_scheduler.schedule(request).await {
+            let request = error.into_item();
+            self.consume_request_set.remove(&request);
+            request.process_queue.dec_found_msg(request.msgs.len());
+            warn!(
+                "POP orderly consume request rejected during shutdown, group={}, mq={}, msgs={}",
+                self.consumer_group,
+                request.message_queue,
+                request.msgs.len()
+            );
+        }
     }
 
-    fn submit_consume_request_later(&self, this: Arc<Self>, request: ConsumeRequest, mut suspend_time_millis: u64) {
+    async fn submit_consume_request_later(
+        &self,
+        _this: Arc<Self>,
+        request: ConsumeRequest,
+        mut suspend_time_millis: u64,
+    ) {
         suspend_time_millis = suspend_time_millis.clamp(10, 30_000);
-
-        let stopped = self.stopped.clone();
-        let consume_request_set = self.consume_request_set.clone();
-
-        spawn_tracked_pop_orderly_task(
-            &self.service_context,
-            "rocketmq-client-pop-orderly-consume-delay",
-            &self.pop_orderly_task_tracker,
-            &self.force_stop_token,
-            &self.submitted_tasks,
-            async move {
-                tokio::time::sleep(Duration::from_millis(suspend_time_millis)).await;
-
-                if stopped.load(Ordering::Acquire) {
-                    return;
-                }
-
-                consume_request_set.insert(request.clone());
-                this.submit_consume_request(this.clone(), request, true);
-            },
-        );
+        if let Err(error) = self
+            .consume_scheduler
+            .schedule_after(request, Duration::from_millis(suspend_time_millis))
+            .await
+        {
+            let request = error.into_item();
+            self.consume_request_set.remove(&request);
+            request.process_queue.dec_found_msg(request.msgs.len());
+            warn!(
+                "POP orderly retry rejected during shutdown, group={}, mq={}, msgs={}",
+                self.consumer_group,
+                request.message_queue,
+                request.msgs.len()
+            );
+        }
     }
 
     async fn unlock_all_message_queues(&self) {
@@ -603,12 +538,41 @@ impl ConsumeMessagePopOrderlyService {
 }
 
 impl ConsumeMessageServiceTrait for ConsumeMessagePopOrderlyService {
-    fn start(&self, _this: Arc<Self>) {
-        if self.consumer_config.message_model != MessageModel::Clustering {
-            return;
+    fn start(&self, this: Arc<Self>) {
+        let worker_service = Arc::clone(&this);
+        if let Err(error) = self.consume_scheduler.start(
+            &self.service_context,
+            self.consumer_config.consume_thread_max.max(1) as usize,
+            move |mut request| {
+                let service = Arc::clone(&worker_service);
+                async move {
+                    if service.stopped.load(Ordering::Acquire) {
+                        return;
+                    }
+                    let limiter = Arc::clone(&service.concurrency_limiter);
+                    let permit = match limiter.acquire_owned().await {
+                        Ok(permit) => permit,
+                        Err(_) => return,
+                    };
+                    service.active_tasks.fetch_add(1, Ordering::SeqCst);
+                    struct ActiveTaskGuard(Arc<AtomicUsize>);
+                    impl Drop for ActiveTaskGuard {
+                        fn drop(&mut self) {
+                            self.0.fetch_sub(1, Ordering::SeqCst);
+                        }
+                    }
+                    let _active = ActiveTaskGuard(Arc::clone(&service.active_tasks));
+                    request.run(Arc::clone(&service)).await;
+                    drop(permit);
+                }
+            },
+        ) {
+            error!("Failed to start bounded POP orderly consume scheduler: {error}");
         }
 
-        self.start_lock_refresh_with_schedule(Duration::from_secs(1), Duration::from_millis(20_000));
+        if self.consumer_config.message_model == MessageModel::Clustering {
+            self.start_lock_refresh_with_schedule(Duration::from_secs(1), Duration::from_millis(20_000));
+        }
     }
 
     async fn shutdown(&self, await_terminate_millis: u64) {
@@ -620,7 +584,6 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopOrderlyService {
         self.stopped.store(true, Ordering::Release);
 
         self.concurrency_limiter.close();
-        self.pop_orderly_task_tracker.close();
 
         let lock_refresh_task = { self.lock_refresh_task.lock().take() };
         if let Some(task) = lock_refresh_task {
@@ -635,29 +598,12 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopOrderlyService {
 
         let timeout = Duration::from_millis(await_terminate_millis);
         let start_time = Instant::now();
-
-        match tokio::time::timeout(timeout, self.pop_orderly_task_tracker.wait()).await {
-            Ok(()) => {}
-            Err(_) => {
-                warn!(
-                    "{} ConsumeMessagePopOrderlyService shutdown timeout, {} active consume tasks, {} submitted \
-                     tasks; forcing remaining task futures to stop",
-                    self.consumer_group,
-                    self.active_tasks.load(Ordering::Acquire),
-                    self.submitted_tasks.load(Ordering::Acquire)
-                );
-                self.force_stop_token.cancel();
-                if tokio::time::timeout(Duration::from_secs(1), self.pop_orderly_task_tracker.wait())
-                    .await
-                    .is_err()
-                {
-                    warn!(
-                        "{} ConsumeMessagePopOrderlyService force stop timed out, {} active consume tasks remain",
-                        self.consumer_group,
-                        self.active_tasks.load(Ordering::Acquire)
-                    );
-                }
-            }
+        if !self.consume_scheduler.shutdown(timeout).await {
+            warn!(
+                "{} ConsumeMessagePopOrderlyService scheduler shutdown timed out, {} active tasks remain",
+                self.consumer_group,
+                self.active_tasks.load(Ordering::Acquire)
+            );
         }
 
         while self.active_tasks.load(Ordering::Acquire) > 0 {
@@ -805,7 +751,7 @@ impl ConsumeMessageServiceTrait for ConsumeMessagePopOrderlyService {
     ) {
         let arc_msgs: Vec<Arc<MessageExt>> = msgs.into_iter().map(Arc::new).collect();
         let request = ConsumeRequest::new(Arc::new(process_queue.clone()), message_queue.clone(), arc_msgs);
-        this.submit_consume_request(this.clone(), request, false);
+        this.submit_consume_request(this.clone(), request, false).await;
     }
 }
 
@@ -855,29 +801,29 @@ impl ConsumeRequest {
         let msgs = &mut self.msgs;
 
         if msgs.is_empty() {
-            consume_message_pop_orderly_service.submit_consume_request_later(
-                consume_message_pop_orderly_service.clone(),
-                self.clone(),
-                1000,
-            );
+            consume_message_pop_orderly_service
+                .submit_consume_request_later(consume_message_pop_orderly_service.clone(), self.clone(), 1000)
+                .await;
             return;
         }
 
         let suspend = consume_message_pop_orderly_service.check_reconsume_times(msgs).await;
         if suspend {
-            consume_message_pop_orderly_service.submit_consume_request_later(
-                consume_message_pop_orderly_service.clone(),
-                self.clone(),
-                consume_message_pop_orderly_service
-                    .consumer_config
-                    .suspend_current_queue_time_millis,
-            );
+            consume_message_pop_orderly_service
+                .submit_consume_request_later(
+                    consume_message_pop_orderly_service.clone(),
+                    self.clone(),
+                    consume_message_pop_orderly_service
+                        .consumer_config
+                        .suspend_current_queue_time_millis,
+                )
+                .await;
             return;
         }
 
         let begin_timestamp = Instant::now();
         let listener = consume_message_pop_orderly_service.message_listener.clone();
-        let msgs_cloned: Vec<MessageExt> = msgs.iter().map(|m| m.as_ref().clone()).collect();
+        let msgs_for_blocking = msgs.clone();
         let process_span = crate::consumer::consumer_impl::observability::consumer_process_span(
             &consume_message_pop_orderly_service.telemetry_handle,
             msgs.iter().map(|msg| msg.as_ref()),
@@ -894,7 +840,7 @@ impl ConsumeRequest {
             "client.pop_orderly.consume",
             move || {
                 let _entered = process_span_for_blocking.enter();
-                let msg_refs: Vec<&MessageExt> = msgs_cloned.iter().collect();
+                let msg_refs: Vec<&MessageExt> = msgs_for_blocking.iter().map(|message| message.as_ref()).collect();
                 let mut ctx = ConsumeOrderlyContext::new(mq);
                 let result = listener.consume_message(&msg_refs, &mut ctx);
                 (result, ctx)
@@ -926,11 +872,9 @@ impl ConsumeRequest {
 
         if continue_consume {
             drop(_guard);
-            consume_message_pop_orderly_service.submit_consume_request(
-                consume_message_pop_orderly_service.clone(),
-                self.clone(),
-                false,
-            );
+            consume_message_pop_orderly_service
+                .submit_consume_request(consume_message_pop_orderly_service.clone(), self.clone(), false)
+                .await;
         } else {
             let suspend_time = if context.get_suspend_current_queue_time_millis() > 0 {
                 context.get_suspend_current_queue_time_millis() as u64
@@ -940,11 +884,9 @@ impl ConsumeRequest {
                     .suspend_current_queue_time_millis
             };
             drop(_guard);
-            consume_message_pop_orderly_service.submit_consume_request_later(
-                consume_message_pop_orderly_service.clone(),
-                self.clone(),
-                suspend_time,
-            );
+            consume_message_pop_orderly_service
+                .submit_consume_request_later(consume_message_pop_orderly_service.clone(), self.clone(), suspend_time)
+                .await;
         }
     }
 }
@@ -1060,16 +1002,7 @@ pub async fn run_pop_orderly_lock_refresh_lifecycle_probe(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::future::pending;
     use std::sync::Arc;
-
-    struct DropFlag(Arc<AtomicBool>);
-
-    impl Drop for DropFlag {
-        fn drop(&mut self) {
-            self.0.store(true, Ordering::Release);
-        }
-    }
 
     fn listener() -> ArcMessageListenerOrderly {
         Arc::new(|_msgs: &[&MessageExt], _context: &mut ConsumeOrderlyContext| Ok(ConsumeOrderlyStatus::Success))
@@ -1166,69 +1099,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tracked_pop_orderly_task_shutdown_waits_for_completion() {
-        let tracker = TaskTracker::new();
-        let token = CancellationToken::new();
-        let submitted = Arc::new(AtomicU64::new(0));
-        let completed = Arc::new(AtomicBool::new(false));
-        let completed_in_task = completed.clone();
-
-        spawn_tracked_pop_orderly_task(
-            &test_context(),
-            "rocketmq-client-pop-orderly-tracker-test",
-            &tracker,
-            &token,
-            &submitted,
-            async move {
-                completed_in_task.store(true, Ordering::Release);
-            },
-        );
-        tracker.close();
-
-        tokio::time::timeout(Duration::from_secs(1), tracker.wait())
-            .await
-            .expect("tracked task should finish before timeout");
-
-        assert!(completed.load(Ordering::Acquire));
-        assert_eq!(submitted.load(Ordering::Acquire), 1);
-    }
-
-    #[tokio::test]
-    async fn tracked_pop_orderly_task_force_stop_cancels_pending_task() {
-        let tracker = TaskTracker::new();
-        let token = CancellationToken::new();
-        let submitted = Arc::new(AtomicU64::new(0));
-        let dropped = Arc::new(AtomicBool::new(false));
-        let dropped_in_task = dropped.clone();
-
-        spawn_tracked_pop_orderly_task(
-            &test_context(),
-            "rocketmq-client-pop-orderly-tracker-test",
-            &tracker,
-            &token,
-            &submitted,
-            async move {
-                let _drop_flag = DropFlag(dropped_in_task);
-                pending::<()>().await;
-            },
-        );
-        tracker.close();
-
-        assert!(tokio::time::timeout(Duration::from_millis(20), tracker.wait())
-            .await
-            .is_err());
-
-        token.cancel();
-
-        tokio::time::timeout(Duration::from_secs(1), tracker.wait())
-            .await
-            .expect("force stop should release pending tracked task");
-
-        assert!(dropped.load(Ordering::Acquire));
-        assert_eq!(submitted.load(Ordering::Acquire), 1);
-    }
-
-    #[tokio::test]
     async fn pop_orderly_lock_refresh_lifecycle_probe_reports_self_stop() {
         let probe =
             run_pop_orderly_lock_refresh_lifecycle_probe(crate::runtime::test_client_runtime("pop-orderly-probe"))
@@ -1239,39 +1109,6 @@ mod tests {
         assert_eq!(probe.task_count_after_shutdown, 0, "{probe:?}");
         assert_eq!(probe.scheduled_overlaps, 0, "{probe:?}");
         assert_eq!(probe.scheduled_failures, 0, "{probe:?}");
-    }
-
-    #[test]
-    fn start_without_tokio_runtime_does_not_spawn_panic() {
-        let service = new_service(Some(new_default_impl()));
-        let this = Arc::new(new_service(None));
-
-        service.start(this);
-        service.stopped.store(true, Ordering::Release);
-        let handle = { service.lock_refresh_task.lock().take() };
-        if let Some(handle) = handle {
-            handle.abort();
-        }
-    }
-
-    #[test]
-    fn submit_consume_request_without_tokio_runtime_does_not_spawn_panic() {
-        let service = new_service(None);
-        let this = Arc::new(new_service(None));
-        service.stopped.store(true, Ordering::Release);
-
-        ConsumeMessagePopOrderlyService::submit_consume_request(&service, this, consume_request(), true);
-        std::thread::sleep(Duration::from_millis(20));
-    }
-
-    #[test]
-    fn submit_consume_request_later_without_tokio_runtime_does_not_spawn_panic() {
-        let service = Arc::new(new_service(None));
-        let this = service.clone();
-
-        service.submit_consume_request_later(this, consume_request(), 10);
-        service.stopped.store(true, Ordering::Release);
-        std::thread::sleep(Duration::from_millis(30));
     }
 
     #[test]

--- a/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
@@ -18,6 +18,8 @@ use std::future::Future;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicI64;
 use std::sync::atomic::AtomicU64;
+#[cfg(any(test, feature = "test-support"))]
+use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
@@ -29,6 +31,10 @@ use std::time::Instant;
 
 use arc_swap::ArcSwap;
 use cheetah_string::CheetahString;
+#[cfg(any(test, feature = "test-support"))]
+use futures::stream::FuturesUnordered;
+#[cfg(any(test, feature = "test-support"))]
+use futures::StreamExt;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_model::common::consumer::consume_from_where::ConsumeFromWhere;
@@ -55,7 +61,9 @@ use rocketmq_runtime::ResourceBudget;
 use rocketmq_transport::api::v1::RPCHook;
 use serde::Serialize;
 use tokio::sync::Mutex;
+use tokio::sync::OwnedSemaphorePermit;
 use tokio::sync::RwLock;
+use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 use tracing::info;
@@ -313,6 +321,21 @@ fn lite_pull_request_sub_version(subscription_data: &SubscriptionData) -> i64 {
     }
 }
 
+#[cfg(any(test, feature = "test-support"))]
+#[derive(Debug, Clone, Serialize)]
+pub struct LitePullConcurrencyContractProbe {
+    pub configured_limit: usize,
+    pub queues: usize,
+    pub peak_inflight: usize,
+    pub cancelled_waiter_released: bool,
+    pub runtime_mutation_rejected: bool,
+}
+
+struct AssignmentPullContext {
+    entry: Arc<AssignmentEntry>,
+    generation: u64,
+}
+
 /// Core implementation of lite pull consumer.
 pub struct DefaultLitePullConsumerImpl {
     service_context: ChildServiceContext,
@@ -332,6 +355,7 @@ pub struct DefaultLitePullConsumerImpl {
     client_instance: StdRwLock<Option<Arc<MQClientInstance>>>,
     rebalance_impl: Arc<RebalanceLitePullImpl>,
     pull_api_wrapper: StdRwLock<Option<Arc<PullAPIWrapper>>>,
+    pull_concurrency_limiter: ArcSwap<Semaphore>,
     offset_store: StdRwLock<Option<Arc<OffsetStore>>>,
     rpc_hook: StdRwLock<Option<Arc<dyn RPCHook>>>,
 
@@ -403,6 +427,7 @@ impl DefaultLitePullConsumerImpl {
     {
         let client_config = client_config.as_ref().clone();
         let consumer_config = consumer_config.as_ref().clone();
+        let pull_thread_nums = consumer_config.pull_thread_nums;
         let consume_requests = Self::build_consume_request_queue(&consumer_config, &client_runtime.resource_budget())?;
         let rebalance_config = consumer_config.to_consumer_config();
 
@@ -419,6 +444,7 @@ impl DefaultLitePullConsumerImpl {
             client_instance: StdRwLock::new(None),
             rebalance_impl: Arc::new(RebalanceLitePullImpl::new(rebalance_config)),
             pull_api_wrapper: StdRwLock::new(None),
+            pull_concurrency_limiter: ArcSwap::from_pointee(Semaphore::new(pull_thread_nums)),
             offset_store: StdRwLock::new(None),
             rpc_hook: StdRwLock::new(None),
             assigned_message_queue: Arc::new(AssignedMessageQueue::new()),
@@ -672,6 +698,10 @@ impl DefaultLitePullConsumerImpl {
                 "pullBatchSize must be in [1, 1024], current value: {}",
                 config.pull_batch_size
             )));
+        }
+
+        if config.pull_thread_nums == 0 {
+            return Err(crate::mq_client_err!("pullThreadNums must be greater than 0"));
         }
 
         if config.pull_threshold_for_queue < 1 || config.pull_threshold_for_queue > 65535 {
@@ -1483,6 +1513,7 @@ impl DefaultLitePullConsumerImpl {
         let assignment_cancellation = entry.cancellation();
         let task_generation = entry.next_task_generation();
         let assignment_entry = Arc::downgrade(&entry);
+        let assignment_entry_for_task = Arc::clone(&entry);
         let (start_task_tx, start_task_rx) = tokio::sync::oneshot::channel();
         let assigned_mq = self.assigned_message_queue.clone();
         let mq_clone = mq.clone();
@@ -1531,7 +1562,11 @@ impl DefaultLitePullConsumerImpl {
                         continue;
                     }
 
-                    match default_impl.pull_inner(&mq_clone, &pq).await {
+                    let assignment = AssignmentPullContext {
+                        entry: Arc::clone(&assignment_entry_for_task),
+                        generation: task_generation,
+                    };
+                    match default_impl.pull_inner(&mq_clone, &pq, Some(&assignment)).await {
                         Ok(delay) => {
                             if delay > 0
                                 && !sleep_or_assignment_cancel(
@@ -1597,6 +1632,7 @@ impl DefaultLitePullConsumerImpl {
         &self,
         mq: &MessageQueue,
         process_queue: &Arc<crate::consumer::consumer_impl::process_queue::ProcessQueue>,
+        assignment: Option<&AssignmentPullContext>,
     ) -> RocketMQResult<u64> {
         struct NoopPullCallback;
 
@@ -1627,6 +1663,9 @@ impl DefaultLitePullConsumerImpl {
         let pull_api_wrapper = self
             .component_snapshot(&self.pull_api_wrapper)
             .ok_or_else(|| crate::mq_client_err!("PullAPIWrapper is not initialized"))?;
+        let Some(pull_permit) = self.acquire_pull_permit(mq, assignment).await? else {
+            return Ok(0);
+        };
         let mut pull_result = pull_api_wrapper
             .pull_kernel_impl(
                 mq,
@@ -1645,6 +1684,7 @@ impl DefaultLitePullConsumerImpl {
             )
             .await?
             .ok_or_else(|| crate::mq_client_err!("Synchronous lite pull returned no result"))?;
+        drop(pull_permit);
 
         pull_api_wrapper.process_pull_result(mq, &mut pull_result, &subscription_data);
 
@@ -2737,9 +2777,62 @@ impl DefaultLitePullConsumerImpl {
         self.consumer_config.load().pull_thread_nums
     }
 
-    /// Updates the configured number of pull worker threads.
-    pub fn set_pull_thread_nums(&self, pull_thread_nums: usize) {
+    /// Updates the configured number of concurrent pull RPCs before startup.
+    pub fn try_set_pull_thread_nums(&self, pull_thread_nums: usize) -> RocketMQResult<()> {
+        if pull_thread_nums == 0 {
+            return Err(crate::mq_client_err!("pullThreadNums must be greater than 0"));
+        }
+        if self.service_state() != ServiceState::CreateJust {
+            return Err(crate::mq_client_err!(
+                "pullThreadNums can not be changed after the lite pull consumer has started."
+            ));
+        }
         self.update_consumer_config(|config| config.pull_thread_nums = pull_thread_nums);
+        self.pull_concurrency_limiter
+            .store(Arc::new(Semaphore::new(pull_thread_nums)));
+        Ok(())
+    }
+
+    async fn acquire_pull_permit(
+        &self,
+        message_queue: &MessageQueue,
+        assignment: Option<&AssignmentPullContext>,
+    ) -> RocketMQResult<Option<OwnedSemaphorePermit>> {
+        let limiter = self.pull_concurrency_limiter.load_full();
+        let permit = if let Some(assignment) = assignment {
+            let cancellation = assignment.entry.cancellation();
+            tokio::select! {
+                biased;
+                _ = cancellation.cancelled() => return Ok(None),
+                permit = limiter.acquire_owned() => permit,
+            }
+        } else {
+            limiter.acquire_owned().await
+        }
+        .map_err(|_| crate::mq_client_err!("Lite pull concurrency limiter is closed"))?;
+
+        if let Some(assignment) = assignment {
+            if !self
+                .assignment_registry
+                .is_current(message_queue, &assignment.entry)
+                .await
+                || !assignment.entry.owns_task_generation(assignment.generation).await
+            {
+                return Ok(None);
+            }
+        }
+
+        Ok(Some(permit))
+    }
+
+    /// Compatibility setter for callers that do not consume configuration errors.
+    ///
+    /// Prefer [`Self::try_set_pull_thread_nums`] when configuration failure must
+    /// be reported to the caller.
+    pub fn set_pull_thread_nums(&self, pull_thread_nums: usize) {
+        if let Err(error) = self.try_set_pull_thread_nums(pull_thread_nums) {
+            warn!("Ignoring invalid pullThreadNums update: {error}");
+        }
     }
 
     /// Returns the total cached-message threshold across all queues.
@@ -2833,6 +2926,116 @@ impl DefaultLitePullConsumerImpl {
 
         self.consume_requests
             .retain(|request| request.message_queue != *message_queue);
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+#[doc(hidden)]
+pub async fn run_lite_pull_concurrency_contract_probe(
+    client_runtime: Arc<ClientRuntime>,
+    configured_limit: usize,
+    queues: usize,
+) -> LitePullConcurrencyContractProbe {
+    let configured_limit = configured_limit.max(1);
+    let queues = queues.max(configured_limit);
+    let consumer = Arc::new(DefaultLitePullConsumerImpl::new(
+        client_runtime,
+        Arc::new(ClientConfig::default()),
+        Arc::new(LitePullConsumerConfig {
+            consumer_group: CheetahString::from_static_str("lite_pull_concurrency_contract_probe_group"),
+            pull_thread_nums: configured_limit,
+            ..Default::default()
+        }),
+    ));
+    let message_queue = MessageQueue::from_parts("probe-topic", "probe-broker", 0);
+    let active = Arc::new(AtomicUsize::new(0));
+    let peak = Arc::new(AtomicUsize::new(0));
+    let changed = Arc::new(tokio::sync::Notify::new());
+    let releases = Arc::new(Semaphore::new(0));
+    let pulls = (0..queues)
+        .map(|_| {
+            let consumer = Arc::clone(&consumer);
+            let message_queue = message_queue.clone();
+            let active = Arc::clone(&active);
+            let peak = Arc::clone(&peak);
+            let changed = Arc::clone(&changed);
+            let releases = Arc::clone(&releases);
+            async move {
+                let _permit = consumer
+                    .acquire_pull_permit(&message_queue, None)
+                    .await
+                    .expect("probe limiter should stay open")
+                    .expect("unassigned probe acquisition returns a permit");
+                let now_active = active.fetch_add(1, Ordering::AcqRel) + 1;
+                let mut observed = peak.load(Ordering::Acquire);
+                while now_active > observed {
+                    match peak.compare_exchange_weak(observed, now_active, Ordering::AcqRel, Ordering::Acquire) {
+                        Ok(_) => break,
+                        Err(current) => observed = current,
+                    }
+                }
+                changed.notify_waiters();
+                let release = releases.acquire().await.expect("probe release semaphore stays open");
+                release.forget();
+                active.fetch_sub(1, Ordering::AcqRel);
+                changed.notify_waiters();
+            }
+        })
+        .collect::<FuturesUnordered<_>>();
+
+    let drive = async move {
+        let mut pulls = pulls;
+        while pulls.next().await.is_some() {}
+    };
+    let control = async {
+        loop {
+            let notified = changed.notified();
+            if peak.load(Ordering::Acquire) >= configured_limit {
+                break;
+            }
+            notified.await;
+        }
+        releases.add_permits(queues);
+    };
+    tokio::join!(drive, control);
+
+    let held = futures::future::join_all((0..configured_limit).map(|_| {
+        let consumer = Arc::clone(&consumer);
+        let message_queue = message_queue.clone();
+        async move {
+            consumer
+                .acquire_pull_permit(&message_queue, None)
+                .await
+                .expect("probe limiter should stay open")
+                .expect("probe should acquire configured permits")
+        }
+    }))
+    .await;
+    let entry = consumer
+        .assignment_registry
+        .ensure(message_queue.clone())
+        .await
+        .expect("probe assignment registry should be open");
+    let assignment = AssignmentPullContext { entry, generation: 1 };
+    let waiting = consumer.acquire_pull_permit(&message_queue, Some(&assignment));
+    tokio::pin!(waiting);
+    tokio::select! {
+        result = &mut waiting => panic!("probe waiter completed before assignment cancellation: {result:?}"),
+        () = tokio::task::yield_now() => {}
+    }
+    consumer.assignment_registry.remove(&message_queue).await;
+    let cancelled_waiter_released = waiting.await.ok().flatten().is_none();
+    drop(held);
+
+    consumer.set_service_state(ServiceState::Running);
+    let runtime_mutation_rejected = consumer.try_set_pull_thread_nums(configured_limit + 1).is_err();
+
+    LitePullConcurrencyContractProbe {
+        configured_limit,
+        queues,
+        peak_inflight: peak.load(Ordering::Acquire),
+        cancelled_waiter_released,
+        runtime_mutation_rejected,
     }
 }
 
@@ -3479,6 +3682,99 @@ mod tests {
             "Long polling mode, the consumer consumerTimeoutMillisWhenSuspend must greater than \
              brokerSuspendMaxTimeMillis"
         ));
+    }
+
+    #[test]
+    fn check_config_rejects_zero_pull_thread_nums() {
+        let impl_ = DefaultLitePullConsumerImpl::new(
+            crate::runtime::test_client_runtime("lite-pull-zero-concurrency-test"),
+            Arc::new(ClientConfig::default()),
+            Arc::new(LitePullConsumerConfig {
+                consumer_group: CheetahString::from_static_str("lite_pull_zero_concurrency_group"),
+                pull_thread_nums: 0,
+                ..Default::default()
+            }),
+        );
+
+        let error = impl_
+            .check_config()
+            .expect_err("zero concurrent pull RPCs cannot make progress");
+
+        assert!(error.to_string().contains("pullThreadNums must be greater than 0"));
+    }
+
+    #[tokio::test]
+    async fn pull_concurrency_permit_is_bounded_and_assignment_cancellation_aware() {
+        let impl_ = DefaultLitePullConsumerImpl::new(
+            crate::runtime::test_client_runtime("lite-pull-concurrency-permit-test"),
+            Arc::new(ClientConfig::default()),
+            Arc::new(LitePullConsumerConfig {
+                consumer_group: CheetahString::from_static_str("lite_pull_concurrency_permit_group"),
+                pull_thread_nums: 2,
+                ..Default::default()
+            }),
+        );
+        let mq = MessageQueue::from_parts("topic", "broker", 0);
+        let entry = impl_
+            .assignment_registry
+            .ensure(mq.clone())
+            .await
+            .expect("assignment registry should be open");
+        let first = impl_
+            .acquire_pull_permit(&mq, None)
+            .await
+            .expect("first permit acquisition should succeed")
+            .expect("first permit should exist");
+        let second = impl_
+            .acquire_pull_permit(&mq, None)
+            .await
+            .expect("second permit acquisition should succeed")
+            .expect("second permit should exist");
+        assert_eq!(impl_.pull_concurrency_limiter.load().available_permits(), 0);
+
+        let assignment = AssignmentPullContext { entry, generation: 1 };
+        let waiting = impl_.acquire_pull_permit(&mq, Some(&assignment));
+        tokio::pin!(waiting);
+        tokio::select! {
+            result = &mut waiting => panic!("third acquisition completed before capacity or cancellation: {result:?}"),
+            () = tokio::task::yield_now() => {}
+        }
+
+        impl_.assignment_registry.remove(&mq).await;
+        assert!(waiting
+            .await
+            .expect("assignment cancellation is not an acquisition error")
+            .is_none());
+        drop(first);
+        drop(second);
+        assert_eq!(impl_.pull_concurrency_limiter.load().available_permits(), 2);
+    }
+
+    #[test]
+    fn pull_thread_nums_updates_before_start_and_rejects_runtime_mutation() {
+        let impl_ = DefaultLitePullConsumerImpl::new(
+            crate::runtime::test_client_runtime("lite-pull-concurrency-config-test"),
+            Arc::new(ClientConfig::default()),
+            Arc::new(LitePullConsumerConfig {
+                consumer_group: CheetahString::from_static_str("lite_pull_concurrency_config_group"),
+                ..Default::default()
+            }),
+        );
+
+        impl_
+            .try_set_pull_thread_nums(3)
+            .expect("pre-start concurrency update should succeed");
+        assert_eq!(impl_.pull_thread_nums(), 3);
+        assert_eq!(impl_.pull_concurrency_limiter.load().available_permits(), 3);
+
+        impl_.set_service_state(ServiceState::Running);
+        let error = impl_
+            .try_set_pull_thread_nums(4)
+            .expect_err("running concurrency update should be rejected");
+        assert!(error
+            .to_string()
+            .contains("pullThreadNums can not be changed after the lite pull consumer has started"));
+        assert_eq!(impl_.pull_thread_nums(), 3);
     }
 
     #[test]
@@ -4410,7 +4706,7 @@ mod tests {
         process_queue.put_message(&queued_messages).await;
 
         let delay = impl_
-            .pull_inner(&mq, &process_queue)
+            .pull_inner(&mq, &process_queue, None)
             .await
             .expect("flow control should return a delay without broker access");
 

--- a/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl/assignment_registry.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl/assignment_registry.rs
@@ -97,6 +97,14 @@ impl AssignmentEntry {
         self.task.lock().await.is_some()
     }
 
+    pub(super) async fn owns_task_generation(&self, generation: u64) -> bool {
+        self.task
+            .lock()
+            .await
+            .as_ref()
+            .is_some_and(|task| task.generation == generation)
+    }
+
     pub(super) async fn take_task(&self) -> Option<LitePullTaskHandle> {
         self.task.lock().await.take().map(|task| task.handle)
     }

--- a/rocketmq-client/src/consumer/default_lite_pull_consumer.rs
+++ b/rocketmq-client/src/consumer/default_lite_pull_consumer.rs
@@ -548,6 +548,23 @@ impl DefaultLitePullConsumer {
         <Self as MessagePoll>::set_pull_thread_nums(self, pull_thread_nums).await;
     }
 
+    /// Sets the maximum number of concurrent broker pull RPCs before startup.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `pull_thread_nums` is zero or the consumer has
+    /// already started.
+    pub async fn try_set_pull_thread_nums(&self, pull_thread_nums: usize) -> RocketMQResult<()> {
+        if pull_thread_nums == 0 {
+            return Err(crate::mq_client_err!("pullThreadNums must be greater than 0"));
+        }
+        if let Some(impl_) = self.default_lite_pull_consumer_impl.get() {
+            impl_.try_set_pull_thread_nums(pull_thread_nums)?;
+        }
+        self.update_consumer_config(|config| config.pull_thread_nums = pull_thread_nums);
+        Ok(())
+    }
+
     /// Returns the all-queue pull threshold.
     pub async fn pull_threshold_for_all(&self) -> i64 {
         <Self as MessagePoll>::pull_threshold_for_all(self).await
@@ -1505,9 +1522,8 @@ impl MessagePoll for DefaultLitePullConsumer {
     }
 
     async fn set_pull_thread_nums(&self, pull_thread_nums: usize) {
-        self.update_consumer_config(|config| config.pull_thread_nums = pull_thread_nums);
-        if let Some(impl_) = self.default_lite_pull_consumer_impl.get() {
-            impl_.set_pull_thread_nums(pull_thread_nums);
+        if let Err(error) = self.try_set_pull_thread_nums(pull_thread_nums).await {
+            tracing::warn!("Ignoring invalid pullThreadNums update: {error}");
         }
     }
 

--- a/rocketmq-client/src/test_support.rs
+++ b/rocketmq-client/src/test_support.rs
@@ -27,7 +27,8 @@ pub use crate::consumer::consumer_impl::consume_message_pop_orderly_service::{
     run_pop_orderly_lock_refresh_lifecycle_probe, PopOrderlyLockRefreshLifecycleProbe,
 };
 pub use crate::consumer::consumer_impl::default_lite_pull_consumer_impl::{
-    run_lite_pull_assignment_registry_probe, run_lite_pull_task_lifecycle_probe, LitePullAssignmentRegistryProbe,
+    run_lite_pull_assignment_registry_probe, run_lite_pull_concurrency_contract_probe,
+    run_lite_pull_task_lifecycle_probe, LitePullAssignmentRegistryProbe, LitePullConcurrencyContractProbe,
     LitePullTaskLifecycleProbe,
 };
 pub use crate::consumer::consumer_impl::process_queue::{

--- a/rocketmq-client/tests/lite_pull_concurrency_contract_tests.rs
+++ b/rocketmq-client/tests/lite_pull_concurrency_contract_tests.rs
@@ -1,0 +1,30 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![recursion_limit = "256"]
+
+use rocketmq_client_rust::test_support::run_lite_pull_concurrency_contract_probe;
+
+mod support;
+
+#[tokio::test]
+async fn ten_assignments_observe_the_configured_two_pull_rpc_limit() {
+    let probe = run_lite_pull_concurrency_contract_probe(support::client_runtime("lite-pull-concurrency"), 2, 10).await;
+
+    assert_eq!(probe.configured_limit, 2, "{probe:?}");
+    assert_eq!(probe.queues, 10, "{probe:?}");
+    assert_eq!(probe.peak_inflight, 2, "{probe:?}");
+    assert!(probe.cancelled_waiter_released, "{probe:?}");
+    assert!(probe.runtime_mutation_rejected, "{probe:?}");
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9253

### Brief Description

- make `pullThreadNums` an effective pre-start limit on concurrent LitePull broker RPCs, with cancellation-aware assignment fencing
- replace task-per-batch and task-per-retry consumer execution with fixed lifecycle-owned workers, one shared delayed queue, and bounded queued admission
- preserve listener concurrency, ordering, retry, offset, and shutdown semantics while avoiding POP message body deep copies before blocking listener execution

### How Did You Test This Change?

- `cargo test -p rocketmq-client-rust start_and_shutdown_use_the_injected_runtime_context --lib`
- `cargo test -p rocketmq-client-rust --features test-support --test lite_pull_concurrency_contract_tests`
- `cargo test -p rocketmq-client-rust --features test-support --test lite_pull_assignment_registry_tests`
- `cargo test -p rocketmq-client-rust bounded_consume_scheduler --lib`
- `cargo test -p rocketmq-client-rust pull_thread_nums --lib`
- `cargo test -p rocketmq-client-rust consume_message_concurrently_service --lib`
- `cargo test -p rocketmq-client-rust consume_message_pop_concurrently_service --lib`
- `cargo test -p rocketmq-client-rust consume_message_pop_orderly_service --lib`
- `cargo clippy -p rocketmq-client-rust --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check` from WSL because the Windows invocation hits the repository's existing path-length limitation
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `git diff --check`

The full `cargo test -p rocketmq-client-rust --features test-support` run completed all 1,034 library tests and Broker smoke tests successfully, then stopped on the pre-existing `client_capability_boundaries` line-count guard because the unchanged `mq_client_api_impl/consumer.rs` already exceeds its 1,650-line reviewed limit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bounded scheduling for concurrent and orderly message consumption.
  * Added capacity limits, delayed retries, cancellation handling, and graceful shutdown.
  * Added LitePull concurrency controls with validation for pull-thread settings.
  * Added a fallible API for updating pull-thread counts.

* **Bug Fixes**
  * Prevented stale or cancelled pull assignments from continuing.
  * Restored message-processing counts when requests are rejected.
  * Improved cleanup and shutdown behavior for active consumption tasks.

* **Tests**
  * Added coverage for concurrency limits, delayed scheduling, cancellation, and runtime configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->