### PR TITLE
[ISSUE #9261]✨Share RocksDB budgets and segment timer payload reads

### DIFF
--- a/rocketmq-store-local/src/mapped_file/select_result.rs
+++ b/rocketmq-store-local/src/mapped_file/select_result.rs
@@ -83,6 +83,14 @@ pub struct SelectMappedBufferResult<M: MappedMemory = NativeMappedMemory> {
     cache_state: SelectMappedBufferCacheState,
 }
 
+struct SelectMappedBufferOwner<M: MappedMemory>(SelectMappedBufferResult<M>);
+
+impl<M: MappedMemory> AsRef<[u8]> for SelectMappedBufferOwner<M> {
+    fn as_ref(&self) -> &[u8] {
+        self.0.get_buffer()
+    }
+}
+
 impl<M: MappedMemory> Default for SelectMappedBufferResult<M> {
     fn default() -> Self {
         Self {
@@ -280,6 +288,16 @@ impl<M: MappedMemory> SelectMappedBufferResult<M> {
     #[inline]
     pub fn get_bytes(&self) -> Option<Bytes> {
         self.get_bytes_ref().cloned()
+    }
+
+    /// Converts this selection into immutable bytes while retaining its owner.
+    ///
+    /// Mapped selections keep their read lease and mapping generation inside
+    /// the returned value, so this conversion does not copy payload bytes.
+    /// File-range-only fallbacks may still materialize their exact selected
+    /// range when first read.
+    pub fn into_owner_bytes(self) -> Bytes {
+        Bytes::from_owner(SelectMappedBufferOwner(self))
     }
 
     /// Returns an immutable byte snapshot, materializing and caching an exact fallback when this
@@ -526,6 +544,29 @@ mod tests {
         assert_eq!(mapped_file.lifecycle_snapshot().active_leases, 1);
 
         drop(selected);
+        assert_eq!(mapped_file.lifecycle_snapshot().active_leases, 0);
+    }
+
+    #[test]
+    fn owner_bytes_keep_mapped_range_alive_without_snapshot_copy() {
+        let (_directory, mapped_file) = mapped_file();
+        assert!(mapped_file.append_message_bytes(b"mapped"));
+        assert!(mapped_file.try_seal_readable().expect("seal read-only generation"));
+        let selected = mapped_file
+            .select_mapped_buffer(0, 6)
+            .expect("mapped range should be selectable");
+        assert!(selected.is_range_backed());
+        assert!(!selected.has_byte_snapshot());
+        let selected_pointer = selected.get_buffer().as_ptr();
+
+        let bytes = selected.into_owner_bytes();
+
+        assert_eq!(bytes.as_ptr(), selected_pointer);
+        assert_eq!(bytes.as_ref(), b"mapped");
+        MappedFile::shutdown(mapped_file.as_ref(), u64::MAX);
+        assert_eq!(bytes.as_ref(), b"mapped");
+        assert_eq!(mapped_file.lifecycle_snapshot().active_leases, 1);
+        drop(bytes);
         assert_eq!(mapped_file.lifecycle_snapshot().active_leases, 0);
     }
 }

--- a/rocketmq-store-rocksdb/src/config.rs
+++ b/rocketmq-store-rocksdb/src/config.rs
@@ -34,6 +34,14 @@ pub trait RocksDbConfigSource {
     fn rocksdb_backup_interval_ms(&self) -> usize;
 
     fn rocksdb_backup_dir(&self) -> Option<&str>;
+
+    fn rocksdb_block_cache_budget_bytes(&self) -> usize {
+        DEFAULT_ROCKSDB_BLOCK_CACHE_BUDGET_BYTES
+    }
+
+    fn rocksdb_write_buffer_budget_bytes(&self) -> usize {
+        DEFAULT_ROCKSDB_WRITE_BUFFER_BUDGET_BYTES
+    }
 }
 
 const ROCKSDB_MESSAGE_DIRECTORY: &str = "rocksdbstore";
@@ -44,6 +52,8 @@ const GB: usize = 1024 * MB;
 const KB_U64: u64 = 1024;
 const MB_U64: u64 = 1024 * KB_U64;
 const GB_U64: u64 = 1024 * MB_U64;
+pub const DEFAULT_ROCKSDB_BLOCK_CACHE_BUDGET_BYTES: usize = GB;
+pub const DEFAULT_ROCKSDB_WRITE_BUFFER_BUDGET_BYTES: usize = 512 * MB;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum RocksDbCompressionType {
@@ -382,6 +392,8 @@ pub struct RocksDbConfig {
     pub write_buffer_size: usize,
     pub max_write_buffer_number: i32,
     pub block_cache_size: usize,
+    pub block_cache_budget_bytes: usize,
+    pub write_buffer_budget_bytes: usize,
     pub block_size: usize,
     pub bloom_filter_bits: f64,
     pub compression_type: RocksDbCompressionType,
@@ -424,6 +436,8 @@ impl Default for RocksDbConfig {
             write_buffer_size: 128 * 1024 * 1024,
             max_write_buffer_number: 4,
             block_cache_size: 1024 * 1024 * 1024,
+            block_cache_budget_bytes: DEFAULT_ROCKSDB_BLOCK_CACHE_BUDGET_BYTES,
+            write_buffer_budget_bytes: DEFAULT_ROCKSDB_WRITE_BUFFER_BUDGET_BYTES,
             block_size: 32 * 1024,
             bloom_filter_bits: 16.0,
             compression_type: RocksDbCompressionType::Lz4,
@@ -565,6 +579,8 @@ impl RocksDbConfig {
         S: RocksDbConfigSource + ?Sized,
     {
         Self {
+            block_cache_budget_bytes: message_store_config.rocksdb_block_cache_budget_bytes(),
+            write_buffer_budget_bytes: message_store_config.rocksdb_write_buffer_budget_bytes(),
             flush_interval_ms: message_store_config.mem_table_flush_interval_ms(),
             compaction_interval_ms: message_store_config
                 .clean_rocksdb_dirty_cq_interval_min()
@@ -589,6 +605,20 @@ impl RocksDbConfig {
                 key: "rocksdb.write_buffer_size",
                 value: self.write_buffer_size.to_string(),
                 reason: "write buffer size must be greater than zero".to_string(),
+            });
+        }
+        if self.block_cache_budget_bytes == 0 {
+            return Err(RocketMQError::ConfigInvalidValue {
+                key: "rocksdb.block_cache_budget_bytes",
+                value: self.block_cache_budget_bytes.to_string(),
+                reason: "shared block-cache budget must be greater than zero".to_string(),
+            });
+        }
+        if self.write_buffer_budget_bytes == 0 {
+            return Err(RocketMQError::ConfigInvalidValue {
+                key: "rocksdb.write_buffer_budget_bytes",
+                value: self.write_buffer_budget_bytes.to_string(),
+                reason: "shared write-buffer budget must be greater than zero".to_string(),
             });
         }
         for column_family in &self.column_families {

--- a/rocketmq-store-rocksdb/src/lib.rs
+++ b/rocketmq-store-rocksdb/src/lib.rs
@@ -27,6 +27,7 @@ pub mod message;
 pub mod message_store;
 pub mod options;
 pub mod release_checkpoint;
+pub mod resource_budget;
 #[doc(hidden)]
 pub mod runtime;
 pub mod snapshot;
@@ -38,4 +39,5 @@ pub mod value;
 pub use config::RocksDbConfig;
 pub use error::RocksDbErrorKind;
 pub use error::RocksDbResultExt;
+pub use resource_budget::RocksDbResourceBudget;
 pub use store::RocksDbStore;

--- a/rocketmq-store-rocksdb/src/message.rs
+++ b/rocketmq-store-rocksdb/src/message.rs
@@ -29,6 +29,7 @@ use crate::key::deal_time_to_hour_stamps;
 use crate::key::IndexRocksDbKey;
 use crate::key::TimerRocksDbKey;
 use crate::key::TransRocksDbKey;
+use crate::resource_budget::RocksDbResourceBudget;
 use crate::store::KeyValueStore;
 use crate::store::RocksDbStore;
 use crate::value::IndexRocksDbValue;
@@ -60,8 +61,21 @@ impl MessageRocksDbStorage {
         config: RocksDbConfig,
         metrics: rocketmq_observability::metrics::rocksdb::RocksDbMetricsRecorder,
     ) -> Result<Self, RocketMQError> {
+        let resource_budget = Arc::new(RocksDbResourceBudget::from_config(&config)?);
+        Self::open_with_metrics_and_resource_budget(config, metrics, resource_budget)
+    }
+
+    pub fn open_with_metrics_and_resource_budget(
+        config: RocksDbConfig,
+        metrics: rocketmq_observability::metrics::rocksdb::RocksDbMetricsRecorder,
+        resource_budget: Arc<RocksDbResourceBudget>,
+    ) -> Result<Self, RocketMQError> {
         Ok(Self {
-            store: Arc::new(RocksDbStore::open_with_metrics(config, metrics)?),
+            store: Arc::new(RocksDbStore::open_with_metrics_and_resource_budget(
+                config,
+                metrics,
+                resource_budget,
+            )?),
             timer_delete_cache: Mutex::new(TimerDeleteCache::new(TIMER_DELETE_CACHE_CAPACITY)),
         })
     }

--- a/rocketmq-store-rocksdb/src/message_store.rs
+++ b/rocketmq-store-rocksdb/src/message_store.rs
@@ -33,6 +33,7 @@ use crate::index::RocksDbIndexBuildConfig;
 use crate::index::RocksDbIndexBuildService;
 use crate::maintenance::RocksDbMaintenanceService;
 use crate::message::MessageRocksDbStorage;
+use crate::resource_budget::RocksDbResourceBudget;
 use crate::runtime::RocksDbRuntimeScope;
 use crate::store::RocksDbStore;
 use crate::timer::RocksDbTimerBuildConfig;
@@ -189,16 +190,19 @@ impl RocksDbDerivedStore {
 
         let rocksdb_config = RocksDbConfig::consume_queue_from_message_store_config(source);
         rocksdb_config.validate()?;
-        let rocksdb_store = Arc::new(RocksDbStore::open_with_metrics(
+        let resource_budget = Arc::new(RocksDbResourceBudget::from_config(&rocksdb_config)?);
+        let rocksdb_store = Arc::new(RocksDbStore::open_with_metrics_and_resource_budget(
             rocksdb_config.clone(),
             metrics.clone(),
+            Arc::clone(&resource_budget),
         )?);
         let consume_queue_store = RocksDbConsumeQueueStore::new(Arc::clone(&rocksdb_store));
         let message_rocksdb_config = RocksDbConfig::message_from_message_store_config(source);
         message_rocksdb_config.validate()?;
-        let message_rocksdb_storage = Arc::new(MessageRocksDbStorage::open_with_metrics(
+        let message_rocksdb_storage = Arc::new(MessageRocksDbStorage::open_with_metrics_and_resource_budget(
             message_rocksdb_config.clone(),
             metrics,
+            resource_budget,
         )?);
         let rocksdb_maintenance_service = RocksDbMaintenanceService::new(
             Arc::clone(&rocksdb_store),
@@ -254,6 +258,10 @@ impl RocksDbDerivedStore {
 
     pub fn rocksdb_store(&self) -> Arc<RocksDbStore> {
         Arc::clone(&self.rocksdb_store)
+    }
+
+    pub fn resource_budget(&self) -> Arc<RocksDbResourceBudget> {
+        self.rocksdb_store.resource_budget()
     }
 
     pub const fn consume_queue_store(&self) -> &RocksDbConsumeQueueStore {

--- a/rocketmq-store-rocksdb/src/options.rs
+++ b/rocketmq-store-rocksdb/src/options.rs
@@ -21,6 +21,8 @@ use crate::config::RocksDbCompressionType;
 use crate::config::RocksDbConfig;
 use crate::config::RocksDbDataBlockIndexType;
 use crate::config::RocksDbWalRecoveryMode;
+use crate::config::DEFAULT_ROCKSDB_WRITE_BUFFER_BUDGET_BYTES;
+use crate::resource_budget::RocksDbResourceBudget;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RocksDbWriteProfile {
@@ -33,6 +35,14 @@ pub struct RocksDbOptionsFactory;
 
 impl RocksDbOptionsFactory {
     pub fn db_options(config: &RocksDbConfig) -> Result<::rocksdb::Options, RocketMQError> {
+        let resource_budget = RocksDbResourceBudget::from_config(config)?;
+        Self::db_options_with_resource_budget(config, &resource_budget)
+    }
+
+    pub fn db_options_with_resource_budget(
+        config: &RocksDbConfig,
+        resource_budget: &RocksDbResourceBudget,
+    ) -> Result<::rocksdb::Options, RocketMQError> {
         config.validate()?;
         let mut options = ::rocksdb::Options::default();
         options.create_if_missing(true);
@@ -44,6 +54,7 @@ impl RocksDbOptionsFactory {
         options.set_atomic_flush(true);
         options.set_write_buffer_size(config.write_buffer_size);
         options.set_max_write_buffer_number(config.max_write_buffer_number);
+        options.set_write_buffer_manager(resource_budget.write_buffer_manager());
         options.set_compression_type(to_rocksdb_compression(config.compression_type));
         options.set_bottommost_compression_type(to_rocksdb_compression(config.bottommost_compression_type));
         options.set_compaction_style(to_rocksdb_compaction_style(config.compaction_style));
@@ -73,6 +84,15 @@ impl RocksDbOptionsFactory {
     }
 
     pub fn cf_options(config: &RocksDbColumnFamilyConfig) -> Result<::rocksdb::Options, RocketMQError> {
+        let resource_budget =
+            RocksDbResourceBudget::new(config.block_cache_size, DEFAULT_ROCKSDB_WRITE_BUFFER_BUDGET_BYTES)?;
+        Self::cf_options_with_resource_budget(config, &resource_budget)
+    }
+
+    pub fn cf_options_with_resource_budget(
+        config: &RocksDbColumnFamilyConfig,
+        resource_budget: &RocksDbResourceBudget,
+    ) -> Result<::rocksdb::Options, RocketMQError> {
         config.validate()?;
         let mut options = ::rocksdb::Options::default();
         options.set_write_buffer_size(config.write_buffer_size);
@@ -118,7 +138,7 @@ impl RocksDbOptionsFactory {
             block_options.set_metadata_block_size(metadata_block_size);
         }
         block_options.set_bloom_filter(config.bloom_filter_bits, false);
-        block_options.set_block_cache(&::rocksdb::Cache::new_lru_cache(config.block_cache_size));
+        block_options.set_block_cache(resource_budget.block_cache());
         block_options.set_cache_index_and_filter_blocks(config.cache_index_and_filter_blocks);
         block_options.set_pin_l0_filter_and_index_blocks_in_cache(config.pin_l0_filter_and_index_blocks_in_cache);
         block_options.set_pin_top_level_index_and_filter(config.pin_top_level_index_and_filter);

--- a/rocketmq-store-rocksdb/src/resource_budget.rs
+++ b/rocketmq-store-rocksdb/src/resource_budget.rs
@@ -1,0 +1,96 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_error::RocketMQError;
+
+use crate::config::RocksDbConfig;
+
+/// Shared native-memory ownership for a group of RocksDB databases.
+///
+/// Every database and column family opened with this value shares one block
+/// cache and one write-buffer manager. The write-buffer manager stalls writers
+/// at its configured limit instead of allowing independent memtables to grow
+/// without a process-level bound.
+pub struct RocksDbResourceBudget {
+    block_cache: ::rocksdb::Cache,
+    write_buffer_manager: ::rocksdb::WriteBufferManager,
+    block_cache_budget_bytes: usize,
+    write_buffer_budget_bytes: usize,
+}
+
+impl RocksDbResourceBudget {
+    /// Creates a shared RocksDB native-memory budget.
+    ///
+    /// # Errors
+    ///
+    /// Returns a configuration error when either budget is zero.
+    pub fn new(block_cache_budget_bytes: usize, write_buffer_budget_bytes: usize) -> Result<Self, RocketMQError> {
+        if block_cache_budget_bytes == 0 {
+            return Err(RocketMQError::ConfigInvalidValue {
+                key: "rocksdb.block_cache_budget_bytes",
+                value: block_cache_budget_bytes.to_string(),
+                reason: "shared block-cache budget must be greater than zero".to_string(),
+            });
+        }
+        if write_buffer_budget_bytes == 0 {
+            return Err(RocketMQError::ConfigInvalidValue {
+                key: "rocksdb.write_buffer_budget_bytes",
+                value: write_buffer_budget_bytes.to_string(),
+                reason: "shared write-buffer budget must be greater than zero".to_string(),
+            });
+        }
+
+        let block_cache = ::rocksdb::Cache::new_lru_cache(block_cache_budget_bytes);
+        let write_buffer_manager =
+            ::rocksdb::WriteBufferManager::new_write_buffer_manager(write_buffer_budget_bytes, true);
+        Ok(Self {
+            block_cache,
+            write_buffer_manager,
+            block_cache_budget_bytes,
+            write_buffer_budget_bytes,
+        })
+    }
+
+    pub(crate) fn from_config(config: &RocksDbConfig) -> Result<Self, RocketMQError> {
+        Self::new(config.block_cache_budget_bytes, config.write_buffer_budget_bytes)
+    }
+
+    pub(crate) const fn block_cache(&self) -> &::rocksdb::Cache {
+        &self.block_cache
+    }
+
+    pub(crate) const fn write_buffer_manager(&self) -> &::rocksdb::WriteBufferManager {
+        &self.write_buffer_manager
+    }
+
+    /// Returns the configured shared block-cache limit.
+    pub const fn block_cache_budget_bytes(&self) -> usize {
+        self.block_cache_budget_bytes
+    }
+
+    /// Returns the configured shared memtable limit.
+    pub const fn write_buffer_budget_bytes(&self) -> usize {
+        self.write_buffer_budget_bytes
+    }
+
+    /// Returns current native block-cache usage.
+    pub fn block_cache_usage_bytes(&self) -> usize {
+        self.block_cache.get_usage()
+    }
+
+    /// Returns current native memtable usage tracked by RocksDB.
+    pub fn write_buffer_usage_bytes(&self) -> usize {
+        self.write_buffer_manager.get_usage()
+    }
+}

--- a/rocketmq-store-rocksdb/src/store.rs
+++ b/rocketmq-store-rocksdb/src/store.rs
@@ -34,6 +34,7 @@ use crate::iterator::RocksDbRangeScanOptions;
 use crate::iterator::RocksDbScanItem;
 use crate::iterator::RocksDbScanOptions;
 use crate::options::RocksDbOptionsFactory;
+use crate::resource_budget::RocksDbResourceBudget;
 use crate::runtime::RocksDbRuntimeScope;
 use crate::snapshot::RocksDbSnapshot;
 use rocketmq_observability::metrics::rocksdb::RocksDbMetrics;
@@ -79,6 +80,7 @@ pub struct RocksDbStore {
     db: Arc<::rocksdb::DB>,
     path: PathBuf,
     db_options: ::rocksdb::Options,
+    resource_budget: Arc<RocksDbResourceBudget>,
     state: AtomicU8,
     write_options: ::rocksdb::WriteOptions,
     metrics: Arc<RocksDbMetricsCollector>,
@@ -94,8 +96,27 @@ impl RocksDbStore {
         config: RocksDbConfig,
         otel_metrics: RocksDbMetricsRecorder,
     ) -> Result<Self, RocketMQError> {
-        let db_options = RocksDbOptionsFactory::db_options(&config)?;
-        Self::open_with_column_families(config.clone(), db_options, config.column_families, otel_metrics)
+        let resource_budget = Arc::new(RocksDbResourceBudget::from_config(&config)?);
+        Self::open_with_metrics_and_resource_budget(config, otel_metrics, resource_budget)
+    }
+
+    /// Opens a database using a caller-owned native-memory budget.
+    ///
+    /// Reusing the same budget across database instances makes their block
+    /// cache and memtables obey one process-level limit.
+    pub fn open_with_metrics_and_resource_budget(
+        config: RocksDbConfig,
+        otel_metrics: RocksDbMetricsRecorder,
+        resource_budget: Arc<RocksDbResourceBudget>,
+    ) -> Result<Self, RocketMQError> {
+        let db_options = RocksDbOptionsFactory::db_options_with_resource_budget(&config, resource_budget.as_ref())?;
+        Self::open_with_column_families(
+            config.clone(),
+            db_options,
+            config.column_families,
+            otel_metrics,
+            resource_budget,
+        )
     }
 
     pub fn open_with_existing_column_families(config: RocksDbConfig) -> Result<Self, RocketMQError> {
@@ -106,9 +127,10 @@ impl RocksDbStore {
         config: RocksDbConfig,
         otel_metrics: RocksDbMetricsRecorder,
     ) -> Result<Self, RocketMQError> {
-        let db_options = RocksDbOptionsFactory::db_options(&config)?;
+        let resource_budget = Arc::new(RocksDbResourceBudget::from_config(&config)?);
+        let db_options = RocksDbOptionsFactory::db_options_with_resource_budget(&config, resource_budget.as_ref())?;
         let column_families = merge_existing_column_families(&config, &db_options)?;
-        Self::open_with_column_families(config, db_options, column_families, otel_metrics)
+        Self::open_with_column_families(config, db_options, column_families, otel_metrics, resource_budget)
     }
 
     fn open_with_column_families(
@@ -116,12 +138,13 @@ impl RocksDbStore {
         db_options: ::rocksdb::Options,
         column_families: Vec<RocksDbColumnFamilyConfig>,
         otel_metrics: RocksDbMetricsRecorder,
+        resource_budget: Arc<RocksDbResourceBudget>,
     ) -> Result<Self, RocketMQError> {
         let path = config.path.clone();
         let descriptors = column_families
             .iter()
             .map(|column_family| {
-                RocksDbOptionsFactory::cf_options(column_family)
+                RocksDbOptionsFactory::cf_options_with_resource_budget(column_family, resource_budget.as_ref())
                     .map(|options| ::rocksdb::ColumnFamilyDescriptor::new(column_family.name.clone(), options))
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -136,6 +159,7 @@ impl RocksDbStore {
             db: Arc::new(db),
             path,
             db_options,
+            resource_budget,
             state: AtomicU8::new(RocksDbStoreState::Open.as_u8()),
             write_options: RocksDbOptionsFactory::write_options(config.write_profile()),
             metrics: Arc::new(RocksDbMetricsCollector::default()),
@@ -148,13 +172,19 @@ impl RocksDbStore {
         &self.path
     }
 
+    /// Returns the native-memory budget shared by this database and its column families.
+    pub fn resource_budget(&self) -> Arc<RocksDbResourceBudget> {
+        Arc::clone(&self.resource_budget)
+    }
+
     pub fn create_cf_if_missing(&self, column_family: RocksDbColumnFamilyConfig) -> Result<(), RocketMQError> {
         self.ensure_open()?;
         if self.db.cf_handle(&column_family.name).is_some() {
             return Ok(());
         }
         column_family.validate()?;
-        let options = RocksDbOptionsFactory::cf_options(&column_family)?;
+        let options =
+            RocksDbOptionsFactory::cf_options_with_resource_budget(&column_family, self.resource_budget.as_ref())?;
         let result = self
             .db
             .create_cf(&column_family.name, &options)

--- a/rocketmq-store-rocksdb/tests/foundation.rs
+++ b/rocketmq-store-rocksdb/tests/foundation.rs
@@ -20,6 +20,7 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::process::Stdio;
 use std::sync::mpsc;
+use std::sync::Arc;
 use std::time::Duration;
 
 use rocketmq_store_rocksdb::column_family::RocksDbColumnFamily;
@@ -27,6 +28,7 @@ use rocketmq_store_rocksdb::config::RocksDbConfig;
 use rocketmq_store_rocksdb::config::RocksDbConfigSource;
 use rocketmq_store_rocksdb::store::KeyValueStore;
 use rocketmq_store_rocksdb::store::RocksDbStore;
+use rocketmq_store_rocksdb::RocksDbResourceBudget;
 use tempfile::TempDir;
 
 const WAL_CRASH_ROOT_ENV: &str = "ROCKETMQ_ROCKSDB_WAL_CRASH_ROOT";
@@ -90,6 +92,13 @@ fn config_projection_is_owned_without_store_facade_types() {
     assert_eq!(consume_queue.checkpoint_interval_ms, 60_000);
     assert_eq!(consume_queue.backup_interval_ms, 3_600_000);
     assert_eq!(consume_queue.backup_dir.as_deref(), Some(source.backup.as_path()));
+    assert_eq!(consume_queue.block_cache_budget_bytes, 1024 * 1024 * 1024);
+    assert_eq!(consume_queue.write_buffer_budget_bytes, 512 * 1024 * 1024);
+    assert_eq!(message.block_cache_budget_bytes, consume_queue.block_cache_budget_bytes);
+    assert_eq!(
+        message.write_buffer_budget_bytes,
+        consume_queue.write_buffer_budget_bytes
+    );
 }
 
 #[test]
@@ -122,6 +131,54 @@ fn native_store_snapshot_and_reopen_preserve_column_family_data() {
             .as_deref(),
         Some(b"value".as_slice())
     );
+}
+
+#[test]
+fn multiple_databases_share_one_cache_and_write_buffer_budget() {
+    let root = TempDir::new().expect("create test root");
+    let block_cache_budget = 8 * 1024 * 1024;
+    let write_buffer_budget = 4 * 1024 * 1024;
+    let budget = Arc::new(
+        RocksDbResourceBudget::new(block_cache_budget, write_buffer_budget).expect("create shared resource budget"),
+    );
+    let first_config = RocksDbConfig {
+        enabled: true,
+        path: root.path().join("first"),
+        block_cache_budget_bytes: block_cache_budget,
+        write_buffer_budget_bytes: write_buffer_budget,
+        ..RocksDbConfig::default()
+    };
+    let second_config = RocksDbConfig {
+        path: root.path().join("second"),
+        ..first_config.clone()
+    };
+    let first = RocksDbStore::open_with_metrics_and_resource_budget(
+        first_config,
+        rocketmq_observability::metrics::rocksdb::RocksDbMetricsRecorder::noop(),
+        Arc::clone(&budget),
+    )
+    .expect("open first database");
+    let second = RocksDbStore::open_with_metrics_and_resource_budget(
+        second_config,
+        rocketmq_observability::metrics::rocksdb::RocksDbMetricsRecorder::noop(),
+        Arc::clone(&budget),
+    )
+    .expect("open second database");
+
+    assert!(Arc::ptr_eq(&first.resource_budget(), &second.resource_budget()));
+    assert!(Arc::ptr_eq(&first.resource_budget(), &budget));
+    assert_eq!(budget.block_cache_budget_bytes(), block_cache_budget);
+    assert_eq!(budget.write_buffer_budget_bytes(), write_buffer_budget);
+
+    let default_cf = RocksDbColumnFamily::Default.name();
+    first
+        .put_cf(default_cf, b"first", b"value")
+        .expect("write first database");
+    second
+        .put_cf(default_cf, b"second", b"value")
+        .expect("write second database");
+    assert!(budget.block_cache_usage_bytes() <= block_cache_budget);
+    assert!(budget.write_buffer_usage_bytes() <= write_buffer_budget);
 }
 
 #[test]

--- a/rocketmq-store/src/config/message_store_config.rs
+++ b/rocketmq-store/src/config/message_store_config.rs
@@ -167,6 +167,14 @@ mod defaults {
         32 * 1024 * 1024
     }
 
+    pub fn rocksdb_block_cache_budget_bytes() -> usize {
+        1024 * 1024 * 1024
+    }
+
+    pub fn rocksdb_write_buffer_budget_bytes() -> usize {
+        512 * 1024 * 1024
+    }
+
     pub fn timer_recall_to_time_wheel_enable() -> bool {
         true
     }
@@ -1363,6 +1371,12 @@ pub struct MessageStoreConfig {
     #[serde(default)]
     pub rocksdb_backup_dir: Option<CheetahString>,
 
+    #[serde(default = "defaults::rocksdb_block_cache_budget_bytes")]
+    pub rocksdb_block_cache_budget_bytes: usize,
+
+    #[serde(default = "defaults::rocksdb_write_buffer_budget_bytes")]
+    pub rocksdb_write_buffer_budget_bytes: usize,
+
     #[serde(default)]
     pub real_time_persist_rocksdb_config: bool,
 
@@ -1647,6 +1661,8 @@ impl Default for MessageStoreConfig {
             rocksdb_checkpoint_interval_ms: 0,
             rocksdb_backup_interval_ms: 0,
             rocksdb_backup_dir: None,
+            rocksdb_block_cache_budget_bytes: defaults::rocksdb_block_cache_budget_bytes(),
+            rocksdb_write_buffer_budget_bytes: defaults::rocksdb_write_buffer_budget_bytes(),
             real_time_persist_rocksdb_config: false,
             enable_rocksdb_log: false,
             topic_queue_lock_num: 32,
@@ -2585,6 +2601,14 @@ impl MessageStoreConfig {
                 .map_or_else(String::new, ToString::to_string),
         );
         properties.insert(
+            "rocksdbBlockCacheBudgetBytes".into(),
+            self.rocksdb_block_cache_budget_bytes.to_string(),
+        );
+        properties.insert(
+            "rocksdbWriteBufferBudgetBytes".into(),
+            self.rocksdb_write_buffer_budget_bytes.to_string(),
+        );
+        properties.insert(
             "realTimePersistRocksdbConfig".into(),
             self.real_time_persist_rocksdb_config.to_string(),
         );
@@ -2944,6 +2968,8 @@ mod tests {
         assert_eq!(config.max_rocksdb_index_query_days, 7);
         assert_eq!(config.pop_rocksdb_block_cache_size, 256 * 1024 * 1024);
         assert_eq!(config.pop_rocksdb_write_buffer_size, 32 * 1024 * 1024);
+        assert_eq!(config.rocksdb_block_cache_budget_bytes, 1024 * 1024 * 1024);
+        assert_eq!(config.rocksdb_write_buffer_budget_bytes, 512 * 1024 * 1024);
         assert!(config.use_separate_store_path_for_rocksdb_cq);
 
         let properties = config.get_properties();
@@ -2990,6 +3016,14 @@ mod tests {
         assert_eq!(properties["rocksdbCheckpointIntervalMs"], "0");
         assert_eq!(properties["rocksdbBackupIntervalMs"], "0");
         assert_eq!(properties["rocksdbBackupDir"], "");
+        assert_eq!(
+            properties["rocksdbBlockCacheBudgetBytes"],
+            (1024 * 1024 * 1024).to_string()
+        );
+        assert_eq!(
+            properties["rocksdbWriteBufferBudgetBytes"],
+            (512 * 1024 * 1024).to_string()
+        );
     }
 
     #[test]
@@ -2998,7 +3032,9 @@ mod tests {
             r#"{
                 "rocksdbCheckpointIntervalMs": 60000,
                 "rocksdbBackupIntervalMs": 3600000,
-                "rocksdbBackupDir": "store/backup"
+                "rocksdbBackupDir": "store/backup",
+                "rocksdbBlockCacheBudgetBytes": 268435456,
+                "rocksdbWriteBufferBudgetBytes": 134217728
             }"#,
         )?;
 
@@ -3008,6 +3044,8 @@ mod tests {
             config.rocksdb_backup_dir.as_ref().map(|path| path.as_str()),
             Some("store/backup")
         );
+        assert_eq!(config.rocksdb_block_cache_budget_bytes, 256 * 1024 * 1024);
+        assert_eq!(config.rocksdb_write_buffer_budget_bytes, 128 * 1024 * 1024);
         Ok(())
     }
 

--- a/rocketmq-store/src/public_api.rs
+++ b/rocketmq-store/src/public_api.rs
@@ -281,6 +281,7 @@ mod rocksdb_api {
     pub use crate::rocksdb::message::TIMER_TIMELINE_CHECKPOINT;
     pub use crate::rocksdb::options::RocksDbOptionsFactory;
     pub use crate::rocksdb::options::RocksDbWriteProfile;
+    pub use crate::rocksdb::resource_budget::RocksDbResourceBudget;
     pub use crate::rocksdb::runtime::RocksDbRuntimeScope;
     pub use crate::rocksdb::snapshot::RocksDbSnapshot;
     pub use crate::rocksdb::store::KeyValueStore;

--- a/rocketmq-store/src/rocksdb/config.rs
+++ b/rocketmq-store/src/rocksdb/config.rs
@@ -55,4 +55,12 @@ impl RocksDbConfigSource for MessageStoreConfig {
     fn rocksdb_backup_dir(&self) -> Option<&str> {
         self.rocksdb_backup_dir.as_ref().map(|path| path.as_str())
     }
+
+    fn rocksdb_block_cache_budget_bytes(&self) -> usize {
+        self.rocksdb_block_cache_budget_bytes
+    }
+
+    fn rocksdb_write_buffer_budget_bytes(&self) -> usize {
+        self.rocksdb_write_buffer_budget_bytes
+    }
 }

--- a/rocketmq-store/src/rocksdb/resource_budget.rs
+++ b/rocketmq-store/src/rocksdb/resource_budget.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The RocketMQ Rust Authors
+// Copyright 2026 The RocketMQ Rust Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,23 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod batch;
-pub mod checkpoint;
-pub mod codec;
-pub mod column_family;
-pub mod config;
-pub mod consume_queue;
-pub mod error;
-pub mod index;
-pub mod iterator;
-pub mod key;
-pub mod maintenance;
-pub mod message;
-pub mod options;
-pub mod resource_budget;
-pub mod runtime;
-pub mod snapshot;
-pub mod store;
-pub mod timer;
-pub mod transaction;
-pub mod value;
+pub use rocketmq_store_rocksdb::resource_budget::RocksDbResourceBudget;

--- a/rocketmq-store/src/timer.rs
+++ b/rocketmq-store/src/timer.rs
@@ -19,6 +19,7 @@ pub(crate) mod engine;
 pub(crate) mod error;
 pub(crate) mod index;
 pub(crate) mod java_compat;
+pub(crate) mod payload_cursor;
 pub(crate) mod pipeline;
 pub(crate) mod request;
 pub(crate) mod role;

--- a/rocketmq-store/src/timer/payload_cursor.rs
+++ b/rocketmq-store/src/timer/payload_cursor.rs
@@ -1,0 +1,166 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::VecDeque;
+
+use bytes::BufMut;
+use bytes::Bytes;
+use bytes::BytesMut;
+
+use crate::base::select_result::SelectMappedBufferResult;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TimerPayloadCursorError {
+    InvalidFrameSize,
+    ShortRead,
+}
+
+/// Sequential frame reader over owner-backed CommitLog selections.
+///
+/// A frame wholly contained in one mapped range becomes a zero-copy `Bytes`
+/// slice. Only a frame that crosses a mapped-file boundary receives an exact,
+/// message-sized scratch allocation.
+pub(crate) struct TimerPayloadCursor {
+    segments: VecDeque<Bytes>,
+    segment_position: usize,
+    remaining: usize,
+    copied_bytes: usize,
+}
+
+impl TimerPayloadCursor {
+    pub(crate) fn new(segments: Vec<SelectMappedBufferResult>) -> Self {
+        let segments = segments
+            .into_iter()
+            .map(SelectMappedBufferResult::into_owner_bytes)
+            .collect::<VecDeque<_>>();
+        let remaining = segments.iter().map(Bytes::len).sum();
+        Self {
+            segments,
+            segment_position: 0,
+            remaining,
+            copied_bytes: 0,
+        }
+    }
+
+    pub(crate) const fn remaining(&self) -> usize {
+        self.remaining
+    }
+
+    pub(crate) fn take_frame(&mut self, size: usize) -> Result<Bytes, TimerPayloadCursorError> {
+        if size == 0 {
+            return Err(TimerPayloadCursorError::InvalidFrameSize);
+        }
+        if size > self.remaining {
+            return Err(TimerPayloadCursorError::ShortRead);
+        }
+        self.discard_empty_segments();
+
+        let available = self
+            .segments
+            .front()
+            .map(|segment| segment.len().saturating_sub(self.segment_position))
+            .unwrap_or_default();
+        if available >= size {
+            let start = self.segment_position;
+            let end = start + size;
+            let Some(segment) = self.segments.front() else {
+                return Err(TimerPayloadCursorError::ShortRead);
+            };
+            let frame = segment.slice(start..end);
+            self.segment_position = end;
+            self.remaining -= size;
+            self.discard_empty_segments();
+            return Ok(frame);
+        }
+
+        let mut frame = BytesMut::with_capacity(size);
+        while frame.len() < size {
+            self.discard_empty_segments();
+            let segment = self.segments.front().ok_or(TimerPayloadCursorError::ShortRead)?;
+            let needed = size - frame.len();
+            let available = segment.len().saturating_sub(self.segment_position);
+            let take = available.min(needed);
+            frame.put_slice(&segment[self.segment_position..self.segment_position + take]);
+            self.segment_position += take;
+        }
+        self.remaining -= size;
+        self.copied_bytes += size;
+        self.discard_empty_segments();
+        Ok(frame.freeze())
+    }
+
+    fn discard_empty_segments(&mut self) {
+        while self
+            .segments
+            .front()
+            .is_some_and(|segment| self.segment_position == segment.len())
+        {
+            self.segments.pop_front();
+            self.segment_position = 0;
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn copied_bytes(&self) -> usize {
+        self.copied_bytes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn selection(start_offset: u64, bytes: Bytes) -> SelectMappedBufferResult {
+        SelectMappedBufferResult::from_bytes(start_offset, bytes).expect("test selection must fit")
+    }
+
+    #[test]
+    fn frame_inside_one_segment_keeps_owner_without_copy() {
+        let source = Bytes::from_static(b"abcdefgh");
+        let source_ptr = source.as_ptr();
+        let mut cursor = TimerPayloadCursor::new(vec![selection(0, source)]);
+
+        let frame = cursor.take_frame(4).expect("read first frame");
+
+        assert_eq!(frame.as_ref(), b"abcd");
+        assert_eq!(frame.as_ptr(), source_ptr);
+        assert_eq!(cursor.copied_bytes(), 0);
+        assert_eq!(cursor.remaining(), 4);
+    }
+
+    #[test]
+    fn frame_crossing_segments_copies_exactly_one_frame() {
+        let mut cursor = TimerPayloadCursor::new(vec![
+            selection(10, Bytes::from_static(b"abc")),
+            selection(13, Bytes::from_static(b"defghi")),
+        ]);
+
+        let frame = cursor.take_frame(6).expect("read cross-segment frame");
+
+        assert_eq!(frame.as_ref(), b"abcdef");
+        assert_eq!(cursor.copied_bytes(), 6);
+        assert_eq!(cursor.remaining(), 3);
+        assert_eq!(cursor.take_frame(3).expect("read tail").as_ref(), b"ghi");
+        assert_eq!(cursor.copied_bytes(), 6);
+    }
+
+    #[test]
+    fn short_read_fails_without_partial_consumption() {
+        let mut cursor = TimerPayloadCursor::new(vec![selection(0, Bytes::from_static(b"abc"))]);
+
+        assert_eq!(cursor.take_frame(4), Err(TimerPayloadCursorError::ShortRead));
+        assert_eq!(cursor.remaining(), 3);
+        assert_eq!(cursor.copied_bytes(), 0);
+    }
+}

--- a/rocketmq-store/src/timer/timer_message_store.rs
+++ b/rocketmq-store/src/timer/timer_message_store.rs
@@ -22,7 +22,6 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
-use bytes::Bytes;
 use cheetah_string::CheetahString;
 use parking_lot::Mutex;
 use parking_lot::RwLock;
@@ -82,6 +81,8 @@ use crate::timer::error::QuarantineManifest;
 use crate::timer::error::QuarantineRecord;
 use crate::timer::error::TimerWorkResult;
 use crate::timer::java_compat::JavaCompatEngine;
+use crate::timer::payload_cursor::TimerPayloadCursor;
+use crate::timer::payload_cursor::TimerPayloadCursorError;
 use crate::timer::pipeline::TimerPipeline;
 use crate::timer::pipeline::TimerPipelineDiagnostics;
 use crate::timer::role::TimerRoleState;
@@ -577,24 +578,25 @@ impl TimerMessageStore {
                 retained_bytes = retained_bytes.saturating_add(run_bytes);
                 continue;
             };
-            let mut contiguous = Vec::with_capacity(run_bytes);
-            for segment in segments {
-                contiguous.extend_from_slice(segment.get_buffer());
-            }
-            if contiguous.len() != run_bytes {
+            let mut payload_cursor = TimerPayloadCursor::new(segments);
+            if payload_cursor.remaining() != run_bytes {
                 output.extend((run_start..cursor).map(|_| Err(TimerPayloadReadError::ShortRead)));
                 retained_bytes = retained_bytes.saturating_add(run_bytes);
                 continue;
             }
-            let mut relative = 0usize;
             for (_, size) in &locators[run_start..cursor] {
                 let size = *size as usize;
-                let mut bytes = Bytes::copy_from_slice(&contiguous[relative..relative + size]);
-                output.push(
-                    MessageDecoder::decode(&mut bytes, true, false, false, false, false)
-                        .ok_or(TimerPayloadReadError::Decode),
-                );
-                relative += size;
+                let result = payload_cursor
+                    .take_frame(size)
+                    .map_err(|error| match error {
+                        TimerPayloadCursorError::InvalidFrameSize => TimerPayloadReadError::InvalidLocator,
+                        TimerPayloadCursorError::ShortRead => TimerPayloadReadError::ShortRead,
+                    })
+                    .and_then(|mut bytes| {
+                        MessageDecoder::decode(&mut bytes, true, false, false, false, false)
+                            .ok_or(TimerPayloadReadError::Decode)
+                    });
+                output.push(result);
             }
             retained_bytes = retained_bytes.saturating_add(run_bytes);
         }

--- a/rocketmq-store/tests/capability_conformance_tests.rs
+++ b/rocketmq-store/tests/capability_conformance_tests.rs
@@ -348,6 +348,10 @@ async fn rocksdb_backend_conforms_to_the_canonical_lifecycle() {
     let mut store = RocksDbDerivedStore::open(&config, RocksDbMessageStoreOptions::default(), context)
         .expect("open RocksDB derived store");
 
+    let consume_queue_budget = store.rocksdb_store().resource_budget();
+    let message_budget = store.message_rocksdb_storage().store_arc().resource_budget();
+    assert!(std::sync::Arc::ptr_eq(&consume_queue_budget, &message_budget));
+
     assert!(store.load().await.expect("RocksDB store load"));
     store.start().await.expect("RocksDB store start");
     store.start().await.expect("idempotent RocksDB store start");


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9261

### Brief Description

- share one configurable block cache and write-buffer manager across the RocksDB consume-queue and message databases and all of their column families
- retain the existing options factory API while routing production database opens through the shared resource budget
- expose bounded RocksDB resource usage without changing column-family names, key/value formats, WAL policy, checkpoints, or CommitLog rebuild behavior
- add owner-backed mapped-file bytes and a timer payload cursor that avoids payload copies within one mapped range and copies exactly one frame across ranges

### How Did You Test This Change?

- `cargo test -p rocketmq-store timer::payload_cursor --lib`
- `cargo test -p rocketmq-store --test timer_java_compat_tests`
- `cargo test -p rocketmq-store --test timer_pipeline_tests`
- `cargo test -p rocketmq-store --test timer_recovery_integration_tests`
- `cargo test -p rocketmq-store-rocksdb --test foundation`
- `cargo test -p rocketmq-store --features rocksdb_store --test rocksdb_foundation_tests`
- `cargo test -p rocketmq-store --features rocksdb_store --test rocksdb_store_semantics_tests`
- `cargo test -p rocketmq-store --features rocksdb_store --test capability_conformance_tests rocksdb_backend_conforms_to_the_canonical_lifecycle`
- `cargo test -p rocketmq-broker --features rocksdb_store rocksdb`
- `cargo test -p rocketmq-broker --features rocksdb_store pop_consumer`
- `cargo check --manifest-path fuzz/Cargo.toml --all-targets`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable memory budgets for RocksDB block caching and write buffers, with sensible defaults and validation.
  - Added shared resource management across message and consume-queue storage to keep usage within configured limits.
  - Exposed RocksDB resource-budget controls and usage information through the public API.

- **Performance**
  - Improved timer-message payload processing by reducing unnecessary memory copies while preserving reliable cross-segment reads.

- **Bug Fixes**
  - Improved mapped-buffer lifetime handling during selected-buffer reads and storage shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->