### PR TITLE
[ISSUE #9266]🚀Add TTL-aware NameServer DNS discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1852,6 +1852,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "hickory-proto",
+ "idna",
+ "ipnet",
+ "jni",
+ "rand 0.10.2",
+ "thiserror 2.0.19",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.2",
+ "ring",
+ "thiserror 2.0.19",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto",
+ "ipconfig",
+ "ipnet",
+ "jni",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.2",
+ "resolv-conf",
+ "smallvec",
+ "system-configuration",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "hmac"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2187,10 +2257,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2 0.6.5",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "ipnetwork"
@@ -2605,6 +2691,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "neli"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2809,6 +2901,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -3337,6 +3433,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
 ]
 
 [[package]]
@@ -3939,6 +4046,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4114,6 +4227,7 @@ dependencies = [
  "criterion",
  "dashmap",
  "futures",
+ "hickory-resolver",
  "num_cpus",
  "parking_lot",
  "rand 0.10.2",
@@ -6342,6 +6456,12 @@ dependencies = [
  "serde",
  "wezterm-dynamic",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,6 +161,7 @@ uuid = { version = "1.23.3", features = [
 
 
 futures = "0.3"
+hickory-resolver = { version = "0.26.1", default-features = false, features = ["system-config", "tokio"] }
 
 cheetah-string = { version = "3.0.0", features = ["serde", "bytes", "simd"] }
 

--- a/rocketmq-client/Cargo.toml
+++ b/rocketmq-client/Cargo.toml
@@ -38,6 +38,7 @@ observability = [
 ]
 observability-metrics = ["rocketmq-observability/otel-metrics", "rocketmq-transport/observability"]
 otlp-traces = ["observability", "rocketmq-observability/otlp-traces"]
+nameserver-dns-discovery = ["dep:hickory-resolver"]
 test-support = []
 
 [dependencies]
@@ -72,6 +73,7 @@ smallvec    = { workspace = true }
 
 futures        = { workspace = true }
 cheetah-string = { workspace = true }
+hickory-resolver = { workspace = true, optional = true }
 
 [dev-dependencies]
 rocketmq-transport = { workspace = true, features = ["test-support"] }

--- a/rocketmq-client/src/base/client_options.rs
+++ b/rocketmq-client/src/base/client_options.rs
@@ -1,0 +1,121 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cheetah_string::CheetahString;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+
+use super::client_config::ClientConfig;
+use crate::nameserver_discovery::NameServerDiscoveryConfig;
+
+/// Client configuration plus an optional typed NameServer discovery source.
+#[derive(Clone)]
+pub struct ClientOptions {
+    client: ClientConfig,
+    nameserver_discovery: Option<NameServerDiscoveryConfig>,
+}
+
+impl ClientOptions {
+    /// Wraps an existing client configuration with legacy discovery behavior.
+    #[must_use]
+    pub fn legacy(client: ClientConfig) -> Self {
+        Self {
+            client,
+            nameserver_discovery: None,
+        }
+    }
+
+    /// Adds a typed NameServer discovery source.
+    #[must_use]
+    pub fn with_nameserver_discovery(mut self, discovery: NameServerDiscoveryConfig) -> Self {
+        self.nameserver_discovery = Some(discovery);
+        self
+    }
+
+    /// Returns the underlying legacy-compatible client configuration.
+    #[must_use]
+    pub fn client_config(&self) -> &ClientConfig {
+        &self.client
+    }
+
+    /// Returns the typed discovery configuration when present.
+    #[must_use]
+    pub fn nameserver_discovery(&self) -> Option<&NameServerDiscoveryConfig> {
+        self.nameserver_discovery.as_ref()
+    }
+
+    pub(crate) fn from_parts(client: ClientConfig, nameserver_discovery: Option<NameServerDiscoveryConfig>) -> Self {
+        Self {
+            client,
+            nameserver_discovery,
+        }
+    }
+
+    pub(crate) fn into_normalized_parts(mut self) -> RocketMQResult<(ClientConfig, Option<NameServerDiscoveryConfig>)> {
+        let Some(discovery) = self.nameserver_discovery else {
+            self.client.normalize_namesrv_addr()?;
+            return Ok((self.client, None));
+        };
+
+        if let Some(legacy) = self.client.namesrv_addr.as_ref() {
+            return Err(RocketMQError::ConfigInvalidValue {
+                key: "nameserver_discovery",
+                value: discovery.fingerprint(),
+                reason: format!("typed NameServer discovery cannot be combined with legacy namesrv_addr={legacy}"),
+            });
+        }
+        discovery.validate()?;
+        if let Some(canonical) = discovery.static_canonical() {
+            self.client.namesrv_addr = Some(CheetahString::from_string(canonical));
+        }
+        Ok((self.client, Some(discovery)))
+    }
+}
+
+impl Default for ClientOptions {
+    fn default() -> Self {
+        Self::legacy(ClientConfig::default())
+    }
+}
+
+impl From<ClientConfig> for ClientOptions {
+    fn from(value: ClientConfig) -> Self {
+        Self::legacy(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nameserver_discovery::NameServerSource;
+
+    #[test]
+    fn legacy_options_preserve_existing_configuration() {
+        let options = ClientOptions::legacy(ClientConfig::default());
+        assert!(options.nameserver_discovery().is_none());
+    }
+
+    #[test]
+    fn typed_discovery_conflicts_with_legacy_address() {
+        let client = ClientConfig {
+            namesrv_addr: Some(CheetahString::from_static_str("ns-a:9876")),
+            ..Default::default()
+        };
+        let discovery = NameServerDiscoveryConfig::new(NameServerSource::dns("namesrv.default.svc", 9876).unwrap());
+        assert!(ClientOptions::legacy(client)
+            .with_nameserver_discovery(discovery)
+            .into_normalized_parts()
+            .is_err());
+    }
+}

--- a/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
@@ -70,6 +70,7 @@ use tracing::info;
 use tracing::warn;
 
 use crate::base::client_config::ClientConfig;
+use crate::base::client_options::ClientOptions;
 use crate::base::query_result::QueryResult;
 use crate::consumer::allocate_message_queue_strategy::AllocateMessageQueueStrategy;
 use crate::consumer::consumer_impl::assigned_message_queue::AssignedMessageQueue;
@@ -95,6 +96,7 @@ use crate::hook::filter_message_hook::FilterMessageHook;
 use crate::implementation::communication_mode::CommunicationMode;
 use crate::implementation::mq_client_manager::ClientPool;
 use crate::implementation::mq_client_manager::ClientPoolToken;
+use crate::nameserver_discovery::NameServerDiscoveryConfig;
 use crate::runtime::spawn_client_task_with_context;
 use crate::runtime::spawn_client_tracked_task_with_context;
 use crate::runtime::ClientRuntime;
@@ -341,6 +343,7 @@ pub struct DefaultLitePullConsumerImpl {
     service_context: ChildServiceContext,
     client_pool: ClientPool,
     client_pool_token: Mutex<Option<ClientPoolToken>>,
+    nameserver_discovery: Option<NameServerDiscoveryConfig>,
     // Configuration
     pub(crate) client_config: ArcSwap<ClientConfig>,
     consumer_config: ArcSwap<LitePullConsumerConfig>,
@@ -425,7 +428,23 @@ impl DefaultLitePullConsumerImpl {
         C: AsRef<ClientConfig>,
         L: AsRef<LitePullConsumerConfig>,
     {
-        let client_config = client_config.as_ref().clone();
+        Self::try_new_with_options(
+            client_runtime,
+            ClientOptions::legacy(client_config.as_ref().clone()),
+            consumer_config,
+        )
+    }
+
+    pub(crate) fn try_new_with_options<L>(
+        client_runtime: Arc<ClientRuntime>,
+        options: ClientOptions,
+        consumer_config: L,
+    ) -> RocketMQResult<Self>
+    where
+        L: AsRef<LitePullConsumerConfig>,
+    {
+        let client_config = options.client_config().clone();
+        let nameserver_discovery = options.nameserver_discovery().cloned();
         let consumer_config = consumer_config.as_ref().clone();
         let pull_thread_nums = consumer_config.pull_thread_nums;
         let consume_requests = Self::build_consume_request_queue(&consumer_config, &client_runtime.resource_budget())?;
@@ -435,6 +454,7 @@ impl DefaultLitePullConsumerImpl {
             service_context: client_runtime.component(format!("lite-consumer-{}", consumer_config.consumer_group)),
             client_pool: client_runtime.pool().clone(),
             client_pool_token: Mutex::new(None),
+            nameserver_discovery,
             client_config: ArcSwap::from_pointee(client_config),
             consumer_config: ArcSwap::from_pointee(consumer_config),
             lifecycle_transition: Mutex::new(()),
@@ -946,9 +966,11 @@ impl DefaultLitePullConsumerImpl {
                 }
 
                 let client_config = self.client_config.load_full();
+                let options =
+                    ClientOptions::from_parts(client_config.as_ref().clone(), self.nameserver_discovery.clone());
                 let pooled = self
                     .client_pool
-                    .get_or_create(client_config.as_ref().clone(), self.rpc_hook_snapshot())?;
+                    .get_or_create_with_options(options, self.rpc_hook_snapshot())?;
                 let (client_instance, token) = pooled.into_parts();
                 *self.client_pool_token.lock().await = Some(token);
                 *self

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -68,6 +68,7 @@ use tracing::info;
 use tracing::warn;
 
 use crate::base::client_config::ClientConfig;
+use crate::base::client_options::ClientOptions;
 use crate::base::query_result::QueryResult;
 use crate::base::validators::Validators;
 use crate::consumer::ack_callback::AckCallback;
@@ -105,6 +106,7 @@ use crate::hook::filter_message_hook::FilterMessageHook;
 use crate::implementation::communication_mode::CommunicationMode;
 use crate::implementation::mq_client_manager::ClientPool;
 use crate::implementation::mq_client_manager::ClientPoolToken;
+use crate::nameserver_discovery::NameServerDiscoveryConfig;
 use crate::runtime::ClientRuntime;
 
 const PULL_TIME_DELAY_MILLS_WHEN_CACHE_FLOW_CONTROL: u64 = 50;
@@ -127,6 +129,7 @@ pub struct DefaultMQPushConsumerImpl {
     telemetry_handle: TelemetryHandle,
     client_metrics: ClientMetrics,
     client_pool_token: Mutex<Option<ClientPoolToken>>,
+    nameserver_discovery: Option<NameServerDiscoveryConfig>,
     pub(crate) global_lock: Arc<Mutex<()>>,
     lifecycle_transition: Mutex<()>,
     pub(crate) pull_time_delay_mills_when_exception: u64,
@@ -165,6 +168,16 @@ impl DefaultMQPushConsumerImpl {
         consumer_config: ConsumerConfig,
         rpc_hook: Option<Arc<dyn RPCHook>>,
     ) -> Self {
+        Self::new_with_discovery(client_runtime, client_config, None, consumer_config, rpc_hook)
+    }
+
+    fn new_with_discovery(
+        client_runtime: Arc<ClientRuntime>,
+        client_config: ClientConfig,
+        nameserver_discovery: Option<NameServerDiscoveryConfig>,
+        consumer_config: ConsumerConfig,
+        rpc_hook: Option<Arc<dyn RPCHook>>,
+    ) -> Self {
         let service_context = client_runtime.component(format!("push-consumer-{}", consumer_config.consumer_group));
         let consumer_config = Arc::new(ArcSwap::from_pointee(consumer_config));
         let rebalance_consumer_config = (*consumer_config.load_full()).clone();
@@ -174,6 +187,7 @@ impl DefaultMQPushConsumerImpl {
             telemetry_handle: client_runtime.telemetry_handle().clone(),
             client_metrics: client_runtime.client_metrics().clone(),
             client_pool_token: Mutex::new(None),
+            nameserver_discovery,
             global_lock: Arc::new(Default::default()),
             lifecycle_transition: Mutex::new(()),
             pull_time_delay_mills_when_exception: 3_000,
@@ -213,6 +227,25 @@ impl DefaultMQPushConsumerImpl {
     ) -> Self {
         let initial_config = (*consumer_config.load_full()).clone();
         let mut this = Self::new(client_runtime, client_config, initial_config, rpc_hook);
+        this.consumer_config = consumer_config;
+        this
+    }
+
+    pub(crate) fn new_with_config_store_and_discovery(
+        client_runtime: Arc<ClientRuntime>,
+        client_config: ClientConfig,
+        nameserver_discovery: Option<NameServerDiscoveryConfig>,
+        consumer_config: Arc<ArcSwap<ConsumerConfig>>,
+        rpc_hook: Option<Arc<dyn RPCHook>>,
+    ) -> Self {
+        let initial_config = (*consumer_config.load_full()).clone();
+        let mut this = Self::new_with_discovery(
+            client_runtime,
+            client_config,
+            nameserver_discovery,
+            initial_config,
+            rpc_hook,
+        );
         this.consumer_config = consumer_config;
         this
     }
@@ -401,9 +434,11 @@ impl DefaultMQPushConsumerImpl {
                     });
                 }
                 let client_config = self.client_config_snapshot();
+                let options =
+                    ClientOptions::from_parts(client_config.as_ref().clone(), self.nameserver_discovery.clone());
                 let pooled = self
                     .client_pool
-                    .get_or_create(client_config.as_ref().clone(), self.rpc_hook.clone())?;
+                    .get_or_create_with_options(options, self.rpc_hook.clone())?;
                 let (client_instance, token) = pooled.into_parts();
                 *self.client_pool_token.lock().await = Some(token);
                 self.set_component(&self.client_instance, Some(client_instance.clone()));

--- a/rocketmq-client/src/consumer/default_lite_pull_consumer.rs
+++ b/rocketmq-client/src/consumer/default_lite_pull_consumer.rs
@@ -35,6 +35,7 @@ use tokio::sync::OnceCell;
 use tokio::sync::RwLock;
 
 use crate::base::client_config::ClientConfig;
+use crate::base::client_options::ClientOptions;
 use crate::base::query_result::QueryResult;
 use crate::consumer::allocate_message_queue_strategy::AllocateMessageQueueStrategy;
 use crate::consumer::consumer_impl::default_lite_pull_consumer_impl::validate_lite_pull_consume_from_where;
@@ -52,6 +53,7 @@ use crate::consumer::mq_consumer::MQConsumer;
 use crate::consumer::mq_consumer_inner::MQConsumerInner;
 use crate::consumer::store::offset_store::OffsetStore;
 use crate::consumer::topic_message_queue_change_listener::TopicMessageQueueChangeListener;
+use crate::nameserver_discovery::NameServerDiscoveryConfig;
 use crate::runtime::ClientRuntime;
 use crate::session::ClientSession;
 use crate::session::ClientSessionProvider;
@@ -151,6 +153,7 @@ pub struct DefaultLitePullConsumer {
     session: ClientSession,
     /// Client configuration (network, instance name, etc.)
     client_config: Arc<ArcSwap<ClientConfig>>,
+    nameserver_discovery: Option<NameServerDiscoveryConfig>,
 
     /// Consumer-specific configuration (pull batch size, flow control, etc.)
     consumer_config: Arc<ArcSwap<LitePullConsumerConfig>>,
@@ -190,9 +193,30 @@ impl DefaultLitePullConsumer {
         enable_msg_trace: bool,
         custom_trace_topic: Option<CheetahString>,
     ) -> Self {
+        Self::new_with_options(
+            client_runtime,
+            ClientOptions::legacy(client_config),
+            consumer_config,
+            rpc_hook,
+            trace_dispatcher,
+            enable_msg_trace,
+            custom_trace_topic,
+        )
+    }
+
+    pub(crate) fn new_with_options(
+        client_runtime: Arc<ClientRuntime>,
+        options: ClientOptions,
+        consumer_config: LitePullConsumerConfig,
+        rpc_hook: Option<Arc<dyn RPCHook>>,
+        trace_dispatcher: Option<Arc<dyn TraceDispatcher + Send + Sync>>,
+        enable_msg_trace: bool,
+        custom_trace_topic: Option<CheetahString>,
+    ) -> Self {
         Self {
             session: ClientSession::new(client_runtime),
-            client_config: Arc::new(ArcSwap::from_pointee(client_config)),
+            client_config: Arc::new(ArcSwap::from_pointee(options.client_config().clone())),
+            nameserver_discovery: options.nameserver_discovery().cloned(),
             consumer_config: Arc::new(ArcSwap::from_pointee(consumer_config)),
             default_lite_pull_consumer_impl: Arc::new(OnceCell::new()),
             rpc_hook,
@@ -1072,9 +1096,12 @@ impl DefaultLitePullConsumer {
     async fn get_or_init_impl(&self) -> RocketMQResult<&Arc<DefaultLitePullConsumerImpl>> {
         self.default_lite_pull_consumer_impl
             .get_or_try_init(|| async {
-                let impl_ = Arc::new(DefaultLitePullConsumerImpl::try_new(
+                let impl_ = Arc::new(DefaultLitePullConsumerImpl::try_new_with_options(
                     self.session.runtime(),
-                    self.client_config_snapshot(),
+                    ClientOptions::from_parts(
+                        self.client_config_snapshot().as_ref().clone(),
+                        self.nameserver_discovery.clone(),
+                    ),
                     self.consumer_config_snapshot(),
                 )?);
                 impl_.bind_self();

--- a/rocketmq-client/src/consumer/default_lite_pull_consumer_builder.rs
+++ b/rocketmq-client/src/consumer/default_lite_pull_consumer_builder.rs
@@ -22,13 +22,14 @@ use rocketmq_model::common::mix_all;
 use rocketmq_protocol::protocol::heartbeat::message_model::MessageModel;
 use rocketmq_transport::api::v1::RPCHook;
 
-use crate::base::client_config::ClientConfig;
+use crate::base::client_options::ClientOptions;
 use crate::consumer::allocate_message_queue_strategy::AllocateMessageQueueStrategy;
 use crate::consumer::consumer_impl::default_lite_pull_consumer_impl::default_lite_pull_consume_timestamp;
 use crate::consumer::consumer_impl::default_lite_pull_consumer_impl::validate_lite_pull_consume_from_where;
 use crate::consumer::consumer_impl::default_lite_pull_consumer_impl::LitePullConsumerConfig;
 use crate::consumer::default_lite_pull_consumer::DefaultLitePullConsumer;
 use crate::consumer::rebalance_strategy::allocate_message_queue_averagely::AllocateMessageQueueAveragely;
+use crate::nameserver_discovery::NameServerDiscoveryConfig;
 use crate::runtime::ClientRuntime;
 use crate::trace::trace_dispatcher::TraceDispatcher;
 
@@ -50,6 +51,7 @@ pub(crate) const MIN_AUTOCOMMIT_INTERVAL_MILLIS: u64 = 1000;
 /// ```
 pub struct DefaultLitePullConsumerBuilder {
     client_runtime: Arc<ClientRuntime>,
+    client_options: Option<ClientOptions>,
     // Client configuration
     name_server_addr: Option<CheetahString>,
     client_ip: Option<CheetahString>,
@@ -109,6 +111,7 @@ impl DefaultLitePullConsumerBuilder {
     pub fn new(client_runtime: Arc<ClientRuntime>) -> Self {
         Self {
             client_runtime,
+            client_options: None,
             name_server_addr: None,
             client_ip: None,
             instance_name: None,
@@ -156,6 +159,19 @@ impl DefaultLitePullConsumerBuilder {
     /// ```
     pub fn name_server_addr(mut self, addr: impl Into<CheetahString>) -> Self {
         self.name_server_addr = Some(addr.into());
+        self
+    }
+
+    /// Sets the complete client options, including typed NameServer discovery.
+    pub fn client_options(mut self, options: ClientOptions) -> Self {
+        self.client_options = Some(options);
+        self
+    }
+
+    /// Sets typed NameServer discovery on the current client options.
+    pub fn nameserver_discovery(mut self, discovery: NameServerDiscoveryConfig) -> Self {
+        let options = self.client_options.take().unwrap_or_default();
+        self.client_options = Some(options.with_nameserver_discovery(discovery));
         self
     }
 
@@ -377,7 +393,9 @@ impl DefaultLitePullConsumerBuilder {
         };
         validate_lite_pull_consume_from_where(self.consume_from_where)?;
 
-        let mut client_config = ClientConfig::default();
+        let options = self.client_options.unwrap_or_default();
+        let mut client_config = options.client_config().clone();
+        let nameserver_discovery = options.nameserver_discovery().cloned();
         client_config.set_enable_stream_request_type(true);
         if let Some(name_server_addr) = self.name_server_addr {
             client_config.set_namesrv_addr(name_server_addr);
@@ -424,9 +442,9 @@ impl DefaultLitePullConsumerBuilder {
             message_request_mode: self.message_request_mode,
         };
 
-        Ok(DefaultLitePullConsumer::new(
+        Ok(DefaultLitePullConsumer::new_with_options(
             self.client_runtime,
-            client_config,
+            ClientOptions::from_parts(client_config, nameserver_discovery),
             consumer_config,
             self.rpc_hook,
             self.trace_dispatcher,

--- a/rocketmq-client/src/consumer/default_mq_push_consumer.rs
+++ b/rocketmq-client/src/consumer/default_mq_push_consumer.rs
@@ -29,6 +29,7 @@ use rocketmq_runtime::common::util_all;
 use rocketmq_transport::api::v1::RPCHook;
 
 use crate::base::client_config::ClientConfig;
+use crate::base::client_options::ClientOptions;
 use crate::base::query_result::QueryResult;
 use crate::consumer::allocate_message_queue_strategy::AllocateMessageQueueStrategy;
 use crate::consumer::consumer_impl::default_mq_push_consumer_impl::DefaultMQPushConsumerImpl;
@@ -1394,11 +1395,22 @@ impl DefaultMQPushConsumer {
         client_config: ClientConfig,
         consumer_config: ConsumerConfig,
     ) -> DefaultMQPushConsumer {
+        Self::new_with_options(client_runtime, ClientOptions::legacy(client_config), consumer_config)
+    }
+
+    pub(crate) fn new_with_options(
+        client_runtime: Arc<ClientRuntime>,
+        options: ClientOptions,
+        consumer_config: ConsumerConfig,
+    ) -> DefaultMQPushConsumer {
         let rpc_hook = consumer_config.rpc_hook.clone();
+        let client_config = options.client_config().clone();
+        let nameserver_discovery = options.nameserver_discovery().cloned();
         let consumer_config = Arc::new(ArcSwap::from_pointee(consumer_config));
-        let default_mqpush_consumer_impl = Arc::new(DefaultMQPushConsumerImpl::new_with_config_store(
+        let default_mqpush_consumer_impl = Arc::new(DefaultMQPushConsumerImpl::new_with_config_store_and_discovery(
             Arc::clone(&client_runtime),
             client_config.clone(),
+            nameserver_discovery,
             consumer_config.clone(),
             rpc_hook,
         ));

--- a/rocketmq-client/src/consumer/default_mq_push_consumer_builder.rs
+++ b/rocketmq-client/src/consumer/default_mq_push_consumer_builder.rs
@@ -21,17 +21,20 @@ use rocketmq_protocol::protocol::heartbeat::message_model::MessageModel;
 use rocketmq_transport::api::v1::RPCHook;
 
 use crate::base::client_config::ClientConfig;
+use crate::base::client_options::ClientOptions;
 use crate::consumer::allocate_message_queue_strategy::AllocateMessageQueueStrategy;
 use crate::consumer::default_mq_push_consumer::ConsumerConfig;
 use crate::consumer::default_mq_push_consumer::ConsumerTuningProfile;
 use crate::consumer::default_mq_push_consumer::DefaultMQPushConsumer;
 use crate::consumer::message_queue_listener::ArcMessageQueueListener;
+use crate::nameserver_discovery::NameServerDiscoveryConfig;
 use crate::runtime::ClientRuntime;
 use crate::trace::trace_dispatcher::ArcTraceDispatcher;
 
 pub struct DefaultMQPushConsumerBuilder {
     client_runtime: Arc<ClientRuntime>,
     client_config: ClientConfig,
+    nameserver_discovery: Option<NameServerDiscoveryConfig>,
     consumer_group: Option<CheetahString>,
     message_model: Option<MessageModel>,
     consume_from_where: Option<ConsumeFromWhere>,
@@ -74,6 +77,7 @@ impl DefaultMQPushConsumerBuilder {
         Self {
             client_runtime,
             client_config: ClientConfig::default(),
+            nameserver_discovery: None,
             consumer_group: None,
             message_model: None,
             consume_from_where: None,
@@ -120,6 +124,20 @@ impl DefaultMQPushConsumerBuilder {
     #[inline]
     pub fn client_config(mut self, client_config: ClientConfig) -> Self {
         self.client_config = client_config;
+        self.nameserver_discovery = None;
+        self
+    }
+
+    #[inline]
+    pub fn client_options(mut self, options: ClientOptions) -> Self {
+        self.client_config = options.client_config().clone();
+        self.nameserver_discovery = options.nameserver_discovery().cloned();
+        self
+    }
+
+    #[inline]
+    pub fn nameserver_discovery(mut self, discovery: NameServerDiscoveryConfig) -> Self {
+        self.nameserver_discovery = Some(discovery);
         self
     }
 
@@ -419,7 +437,11 @@ impl DefaultMQPushConsumerBuilder {
         }
         consumer_config.rpc_hook = self.rpc_hook.clone();
 
-        DefaultMQPushConsumer::new(self.client_runtime, self.client_config, consumer_config)
+        DefaultMQPushConsumer::new_with_options(
+            self.client_runtime,
+            ClientOptions::from_parts(self.client_config, self.nameserver_discovery),
+            consumer_config,
+        )
     }
 }
 

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -96,6 +96,9 @@ use crate::implementation::communication_mode::CommunicationMode;
 use crate::implementation::find_broker_result::FindBrokerResult;
 use crate::implementation::mq_admin_impl::MQAdminImpl;
 use crate::implementation::mq_client_api_impl::MQClientAPIImpl;
+use crate::nameserver_discovery::supervisor::NameServerDiscoverySupervisor;
+use crate::nameserver_discovery::NameServerDiscoveryConfig;
+use crate::nameserver_discovery::NameServerSource;
 use crate::producer::default_mq_producer::DefaultMQProducer;
 use crate::producer::default_mq_producer::ProducerConfig;
 use crate::producer::producer_impl::mq_producer_inner::MQProducerInnerImpl;
@@ -197,6 +200,8 @@ pub struct MQClientInstance {
     client_metrics: ClientMetrics,
     request_future_holder: Arc<RequestFutureHolder>,
     pub(crate) client_config: Arc<ClientConfig>,
+    nameserver_discovery_config: Option<NameServerDiscoveryConfig>,
+    nameserver_discovery_supervisor: Mutex<Option<Arc<NameServerDiscoverySupervisor>>>,
     pub(crate) client_id: CheetahString,
     boot_timestamp: u64,
     /**
@@ -312,6 +317,32 @@ impl MQClientInstance {
 
     pub(crate) fn new_arc_with_resource_budget(
         client_config: ClientConfig,
+        instance_generation: u64,
+        client_id: impl Into<CheetahString>,
+        rpc_hook: Option<Arc<dyn RPCHook>>,
+        service_context: ChildServiceContext,
+        request_future_holder: Arc<RequestFutureHolder>,
+        resource_budget: ResourceBudget,
+        telemetry_handle: TelemetryHandle,
+        client_metrics: ClientMetrics,
+    ) -> Arc<MQClientInstance> {
+        Self::new_arc_with_resource_budget_and_discovery(
+            client_config,
+            None,
+            instance_generation,
+            client_id,
+            rpc_hook,
+            service_context,
+            request_future_holder,
+            resource_budget,
+            telemetry_handle,
+            client_metrics,
+        )
+    }
+
+    pub(crate) fn new_arc_with_resource_budget_and_discovery(
+        client_config: ClientConfig,
+        nameserver_discovery_config: Option<NameServerDiscoveryConfig>,
         _instance_generation: u64,
         client_id: impl Into<CheetahString>,
         rpc_hook: Option<Arc<dyn RPCHook>>,
@@ -365,6 +396,8 @@ impl MQClientInstance {
             client_metrics,
             request_future_holder,
             client_config: shared_config,
+            nameserver_discovery_config,
+            nameserver_discovery_supervisor: Mutex::new(None),
             client_id,
             boot_timestamp: current_millis(),
             producer_table,
@@ -583,8 +616,9 @@ impl MQClientInstance {
         match self.service_state() {
             ServiceState::CreateJust => {
                 self.set_service_state(ServiceState::StartFailed);
+                self.start_nameserver_discovery().await?;
                 // If not specified,looking address from name remoting_server
-                if self.client_config.namesrv_addr.is_none() {
+                if self.nameserver_discovery_config.is_none() && self.client_config.namesrv_addr.is_none() {
                     let Some(mq_client_api_impl) = self.mq_client_api_impl.load_full() else {
                         return Err(mq_client_err!("mq_client_api_impl is None"));
                     };
@@ -638,6 +672,7 @@ impl MQClientInstance {
                     "MQClientInstance shutdown called but state is {:?}, ignoring shutdown request",
                     self.service_state()
                 );
+                self.shutdown_nameserver_discovery().await;
                 if let Some(mq_client_api_impl) = self.mq_client_api_impl.load_full() {
                     if !mq_client_api_impl
                         .shutdown_background_tasks(Duration::from_secs(1))
@@ -667,6 +702,8 @@ impl MQClientInstance {
                 );
             }
         }
+
+        self.shutdown_nameserver_discovery().await;
 
         info!("MQClientInstance[{}] shutting down rebalance service", self.client_id);
         if let Err(e) = self.rebalance_service.shutdown(3000).await {
@@ -753,6 +790,56 @@ impl MQClientInstance {
         self.set_service_state(ServiceState::ShutdownAlready);
 
         info!("MQClientInstance[{}] shutdown completed successfully", self.client_id);
+    }
+
+    async fn start_nameserver_discovery(&self) -> RocketMQResult<()> {
+        let Some(config) = self.nameserver_discovery_config.clone() else {
+            return Ok(());
+        };
+        if matches!(config.source(), NameServerSource::Static(_)) {
+            return Ok(());
+        }
+
+        #[cfg(not(feature = "nameserver-dns-discovery"))]
+        {
+            return Err(RocketMQError::ConfigInvalidValue {
+                key: "nameserver_discovery.dns",
+                value: "enabled".to_string(),
+                reason: "requires the nameserver-dns-discovery Cargo feature".to_string(),
+            });
+        }
+
+        #[cfg(feature = "nameserver-dns-discovery")]
+        {
+            let Some(api) = self.mq_client_api_impl.load_full() else {
+                return Err(mq_client_err!("mq_client_api_impl is None"));
+            };
+            let publisher = Arc::new(
+                move |endpoints: Arc<[crate::nameserver_discovery::ResolvedNameServerEndpoint]>| {
+                    let addresses = endpoints
+                        .iter()
+                        .map(|endpoint| CheetahString::from(endpoint.socket_addr().to_string()))
+                        .collect();
+                    api.update_name_server_targets_sync(addresses);
+                },
+            );
+            let supervisor = NameServerDiscoverySupervisor::start_dns(
+                config,
+                &self.service_context,
+                self.client_id.as_str(),
+                publisher,
+            )
+            .await?;
+            *self.nameserver_discovery_supervisor.lock().await = Some(supervisor);
+            Ok(())
+        }
+    }
+
+    async fn shutdown_nameserver_discovery(&self) {
+        let supervisor = self.nameserver_discovery_supervisor.lock().await.take();
+        if let Some(supervisor) = supervisor {
+            supervisor.shutdown().await;
+        }
     }
 
     async fn shutdown_connection_event_listener(&self, timeout: Duration) {

--- a/rocketmq-client/src/implementation/mq_client_manager.rs
+++ b/rocketmq-client/src/implementation/mq_client_manager.rs
@@ -29,7 +29,9 @@ use rocketmq_transport::api::v1::RPCHook;
 use tracing::info;
 
 use crate::base::client_config::ClientConfig;
+use crate::base::client_options::ClientOptions;
 use crate::factory::mq_client_instance::MQClientInstance;
+use crate::nameserver_discovery::NameServerDiscoveryConfig;
 use crate::producer::produce_accumulator::ProduceAccumulator;
 use crate::producer::request_future_holder::RequestFutureHolder;
 
@@ -43,6 +45,7 @@ struct ClientPoolEntry {
 #[derive(Clone, Eq, PartialEq)]
 struct ClientPoolIdentity {
     namesrv_addr: Option<CheetahString>,
+    discovery_fingerprint: Option<CheetahString>,
     use_tls: bool,
     vip_channel_enabled: bool,
     api_timeout_millis: u64,
@@ -50,9 +53,14 @@ struct ClientPoolIdentity {
 }
 
 impl ClientPoolIdentity {
-    fn new(client_config: &ClientConfig, rpc_hook: Option<&Arc<dyn RPCHook>>) -> Self {
+    fn new(
+        client_config: &ClientConfig,
+        discovery: Option<&NameServerDiscoveryConfig>,
+        rpc_hook: Option<&Arc<dyn RPCHook>>,
+    ) -> Self {
         Self {
             namesrv_addr: client_config.namesrv_addr.clone(),
+            discovery_fingerprint: discovery.map(|config| CheetahString::from_string(config.fingerprint())),
             use_tls: client_config.use_tls,
             vip_channel_enabled: client_config.vip_channel_enabled,
             api_timeout_millis: client_config.mq_client_api_timeout,
@@ -137,16 +145,24 @@ impl ClientPool {
 
     pub fn get_or_create(
         &self,
-        mut client_config: ClientConfig,
+        client_config: ClientConfig,
+        rpc_hook: Option<Arc<dyn RPCHook>>,
+    ) -> rocketmq_error::RocketMQResult<PooledClient> {
+        self.get_or_create_with_options(ClientOptions::legacy(client_config), rpc_hook)
+    }
+
+    pub fn get_or_create_with_options(
+        &self,
+        options: ClientOptions,
         rpc_hook: Option<Arc<dyn RPCHook>>,
     ) -> rocketmq_error::RocketMQResult<PooledClient> {
         let _admission = self.inner.admission.read();
         if self.inner.closed.load(Ordering::Acquire) {
             return Err(mq_client_err!("ClientRuntime is shutting down"));
         }
-        client_config.normalize_namesrv_addr()?;
+        let (client_config, discovery) = options.into_normalized_parts()?;
         let client_id = CheetahString::from_string(client_config.build_mq_client_id());
-        let identity = ClientPoolIdentity::new(&client_config, rpc_hook.as_ref());
+        let identity = ClientPoolIdentity::new(&client_config, discovery.as_ref(), rpc_hook.as_ref());
 
         let mut entry = self.inner.factory_table.entry(client_id.clone()).or_insert_with(|| {
             let generation = self.inner.next_generation.fetch_add(1, Ordering::AcqRel) + 1;
@@ -155,8 +171,9 @@ impl ClientPool {
                 generation,
                 "Created new MQClientInstance in ClientPool"
             );
-            let instance = MQClientInstance::new_arc_with_resource_budget(
+            let instance = MQClientInstance::new_arc_with_resource_budget_and_discovery(
                 client_config,
+                discovery,
                 generation,
                 client_id.clone(),
                 rpc_hook,

--- a/rocketmq-client/src/lib.rs
+++ b/rocketmq-client/src/lib.rs
@@ -84,6 +84,7 @@ mod implementation;
 mod latency;
 mod legacy;
 mod lock;
+mod nameserver_discovery;
 pub mod prelude;
 mod producer;
 mod public_api;

--- a/rocketmq-client/src/nameserver_discovery.rs
+++ b/rocketmq-client/src/nameserver_discovery.rs
@@ -12,16 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod access_channel;
-pub mod client_config;
-pub mod client_config_builder;
-pub mod client_config_validation;
-pub mod client_options;
-pub mod mq_admin;
-pub mod mq_client_admin;
-pub mod query_result;
-pub mod validators;
+mod config;
+#[cfg(feature = "nameserver-dns-discovery")]
+pub(crate) mod dns;
+mod snapshot;
+pub(crate) mod supervisor;
 
-pub use mq_admin::MQAdmin;
-pub use mq_client_admin::MqClientAdmin;
-pub use mq_client_admin::MqClientAdminInner;
+pub use config::DnsName;
+pub use config::NameServerAuthority;
+pub use config::NameServerDiscoveryConfig;
+pub use config::NameServerSource;
+#[cfg(feature = "nameserver-dns-discovery")]
+pub(crate) use snapshot::EndpointSnapshot;
+#[cfg(feature = "nameserver-dns-discovery")]
+pub(crate) use snapshot::Freshness;
+pub use snapshot::ResolvedNameServerEndpoint;

--- a/rocketmq-client/src/nameserver_discovery/config.rs
+++ b/rocketmq-client/src/nameserver_discovery/config.rs
@@ -1,0 +1,342 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+use std::num::NonZeroU16;
+use std::sync::Arc;
+use std::time::Duration;
+
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+
+use crate::config_support::name_server_target::parse_legacy_namesrv_addr;
+
+const DEFAULT_MIN_REFRESH: Duration = Duration::from_secs(5);
+const DEFAULT_MAX_REFRESH: Duration = Duration::from_secs(60);
+const DEFAULT_STALE_MAX: Duration = Duration::from_secs(5 * 60);
+const DEFAULT_ENDPOINT_LIMIT: usize = 64;
+const MAX_ENDPOINT_LIMIT: usize = 64;
+
+/// A normalized ASCII DNS name used as a logical NameServer authority.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct DnsName(Arc<str>);
+
+impl DnsName {
+    /// Parses and normalizes a DNS name.
+    pub fn parse(value: impl AsRef<str>) -> RocketMQResult<Self> {
+        let normalized = value.as_ref().trim().trim_end_matches('.').to_ascii_lowercase();
+        validate_dns_name(&normalized)?;
+        Ok(Self(Arc::from(normalized)))
+    }
+
+    /// Returns the canonical DNS name without a trailing dot.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for DnsName {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// A canonical `host:port` NameServer authority.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct NameServerAuthority(Arc<str>);
+
+impl NameServerAuthority {
+    /// Parses exactly one canonical NameServer authority.
+    pub fn parse(value: impl AsRef<str>) -> RocketMQResult<Self> {
+        let parsed = parse_legacy_namesrv_addr(value.as_ref())?;
+        let addresses = parsed.into_addresses();
+        if addresses.len() != 1 {
+            return Err(invalid_config(
+                "nameserver_discovery.static",
+                value.as_ref(),
+                "must contain exactly one host:port authority",
+            ));
+        }
+        Ok(Self(Arc::from(addresses[0].as_str())))
+    }
+
+    /// Returns the canonical authority.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for NameServerAuthority {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// Supported NameServer discovery sources.
+#[non_exhaustive]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum NameServerSource {
+    /// A fixed canonical list. This preserves existing transport behavior.
+    Static(Vec<NameServerAuthority>),
+    /// DNS A/AAAA discovery for a logical authority.
+    Dns { host: DnsName, port: NonZeroU16 },
+}
+
+impl NameServerSource {
+    /// Creates a DNS A/AAAA source.
+    pub fn dns(host: impl AsRef<str>, port: u16) -> RocketMQResult<Self> {
+        let port = NonZeroU16::new(port)
+            .ok_or_else(|| invalid_config("nameserver_discovery.port", port, "must be between 1 and 65535"))?;
+        Ok(Self::Dns {
+            host: DnsName::parse(host)?,
+            port,
+        })
+    }
+
+    /// Creates a validated static source.
+    pub fn static_endpoints(endpoints: Vec<NameServerAuthority>) -> RocketMQResult<Self> {
+        if endpoints.is_empty() {
+            return Err(invalid_config(
+                "nameserver_discovery.static",
+                "[]",
+                "must contain at least one endpoint",
+            ));
+        }
+        if endpoints.len() > MAX_ENDPOINT_LIMIT {
+            return Err(invalid_config(
+                "nameserver_discovery.static",
+                endpoints.len(),
+                "must not contain more than 64 endpoints",
+            ));
+        }
+        Ok(Self::Static(endpoints))
+    }
+}
+
+/// Typed NameServer discovery configuration.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NameServerDiscoveryConfig {
+    source: NameServerSource,
+    min_refresh: Duration,
+    max_refresh: Duration,
+    stale_max: Duration,
+    endpoint_limit: usize,
+}
+
+impl NameServerDiscoveryConfig {
+    /// Creates a discovery configuration with cloud-native defaults.
+    #[must_use]
+    pub fn new(source: NameServerSource) -> Self {
+        Self {
+            source,
+            min_refresh: DEFAULT_MIN_REFRESH,
+            max_refresh: DEFAULT_MAX_REFRESH,
+            stale_max: DEFAULT_STALE_MAX,
+            endpoint_limit: DEFAULT_ENDPOINT_LIMIT,
+        }
+    }
+
+    /// Sets the inclusive refresh interval clamp.
+    pub fn with_refresh_bounds(mut self, min: Duration, max: Duration) -> RocketMQResult<Self> {
+        if min.is_zero() || max < min {
+            return Err(invalid_config(
+                "nameserver_discovery.refresh",
+                format!("{min:?}..={max:?}"),
+                "minimum must be non-zero and no greater than maximum",
+            ));
+        }
+        self.min_refresh = min;
+        self.max_refresh = max;
+        Ok(self)
+    }
+
+    /// Sets how long the last-known-good endpoint set may remain usable.
+    pub fn with_stale_max(mut self, stale_max: Duration) -> RocketMQResult<Self> {
+        if stale_max.is_zero() {
+            return Err(invalid_config(
+                "nameserver_discovery.stale_max",
+                "0",
+                "must be non-zero",
+            ));
+        }
+        self.stale_max = stale_max;
+        Ok(self)
+    }
+
+    /// Sets the resolved endpoint cap. Values above 64 are rejected.
+    pub fn with_endpoint_limit(mut self, endpoint_limit: usize) -> RocketMQResult<Self> {
+        if !(1..=MAX_ENDPOINT_LIMIT).contains(&endpoint_limit) {
+            return Err(invalid_config(
+                "nameserver_discovery.endpoint_limit",
+                endpoint_limit,
+                "must be between 1 and 64",
+            ));
+        }
+        self.endpoint_limit = endpoint_limit;
+        Ok(self)
+    }
+
+    /// Returns the configured source.
+    #[must_use]
+    pub fn source(&self) -> &NameServerSource {
+        &self.source
+    }
+
+    #[must_use]
+    pub(crate) fn min_refresh(&self) -> Duration {
+        self.min_refresh
+    }
+
+    #[must_use]
+    pub(crate) fn max_refresh(&self) -> Duration {
+        self.max_refresh
+    }
+
+    #[must_use]
+    pub(crate) fn stale_max(&self) -> Duration {
+        self.stale_max
+    }
+
+    #[must_use]
+    pub(crate) fn endpoint_limit(&self) -> usize {
+        self.endpoint_limit
+    }
+
+    pub(crate) fn validate(&self) -> RocketMQResult<()> {
+        match &self.source {
+            NameServerSource::Static(endpoints) if endpoints.is_empty() => Err(invalid_config(
+                "nameserver_discovery.static",
+                "[]",
+                "must contain at least one endpoint",
+            )),
+            NameServerSource::Static(endpoints) if endpoints.len() > self.endpoint_limit => Err(invalid_config(
+                "nameserver_discovery.static",
+                endpoints.len(),
+                "exceeds the configured endpoint limit",
+            )),
+            _ => Ok(()),
+        }
+    }
+
+    pub(crate) fn fingerprint(&self) -> String {
+        let source = match &self.source {
+            NameServerSource::Static(endpoints) => {
+                let mut endpoints = endpoints.iter().map(NameServerAuthority::as_str).collect::<Vec<_>>();
+                endpoints.sort_unstable();
+                endpoints.dedup();
+                format!("static:{}", endpoints.join(";"))
+            }
+            NameServerSource::Dns { host, port } => format!("dns:{}:{}", host.as_str(), port.get()),
+        };
+        format!(
+            "{source}|refresh={}-{}|stale={}|limit={}",
+            self.min_refresh.as_millis(),
+            self.max_refresh.as_millis(),
+            self.stale_max.as_millis(),
+            self.endpoint_limit
+        )
+    }
+
+    pub(crate) fn static_canonical(&self) -> Option<String> {
+        let NameServerSource::Static(endpoints) = &self.source else {
+            return None;
+        };
+        let mut seen = std::collections::HashSet::new();
+        Some(
+            endpoints
+                .iter()
+                .filter(|endpoint| seen.insert(endpoint.as_str()))
+                .map(NameServerAuthority::as_str)
+                .collect::<Vec<_>>()
+                .join(";"),
+        )
+    }
+}
+
+fn validate_dns_name(value: &str) -> RocketMQResult<()> {
+    if value.is_empty() || value.len() > 253 {
+        return Err(invalid_config(
+            "nameserver_discovery.dns_name",
+            value,
+            "must contain between 1 and 253 ASCII characters",
+        ));
+    }
+    for label in value.split('.') {
+        if label.is_empty() || label.len() > 63 {
+            return Err(invalid_config(
+                "nameserver_discovery.dns_name",
+                value,
+                "each DNS label must contain between 1 and 63 characters",
+            ));
+        }
+        if !label
+            .bytes()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, b'-' | b'_'))
+            || label.starts_with('-')
+            || label.ends_with('-')
+        {
+            return Err(invalid_config(
+                "nameserver_discovery.dns_name",
+                value,
+                "contains an invalid DNS label",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn invalid_config(key: &'static str, value: impl ToString, reason: impl Into<String>) -> RocketMQError {
+    RocketMQError::ConfigInvalidValue {
+        key,
+        value: value.to_string(),
+        reason: reason.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dns_source_normalizes_name_and_rejects_invalid_port() {
+        let source = NameServerSource::dns("NameSrv.Default.Svc.", 9876).expect("DNS source");
+        assert!(matches!(
+            source,
+            NameServerSource::Dns { ref host, port }
+                if host.as_str() == "namesrv.default.svc" && port.get() == 9876
+        ));
+        assert!(NameServerSource::dns("namesrv.default.svc", 0).is_err());
+    }
+
+    #[test]
+    fn discovery_fingerprint_is_stable_for_equivalent_static_sets() {
+        let first = NameServerDiscoveryConfig::new(
+            NameServerSource::static_endpoints(vec![
+                NameServerAuthority::parse("ns-b:9876").unwrap(),
+                NameServerAuthority::parse("ns-a:9876").unwrap(),
+            ])
+            .unwrap(),
+        );
+        let second = NameServerDiscoveryConfig::new(
+            NameServerSource::static_endpoints(vec![
+                NameServerAuthority::parse("NS-A:9876").unwrap(),
+                NameServerAuthority::parse("ns-b:9876").unwrap(),
+            ])
+            .unwrap(),
+        );
+        assert_eq!(first.fingerprint(), second.fingerprint());
+    }
+}

--- a/rocketmq-client/src/nameserver_discovery/dns.rs
+++ b/rocketmq-client/src/nameserver_discovery/dns.rs
@@ -1,0 +1,399 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future::Future;
+use std::net::IpAddr;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use hickory_resolver::net::DnsError;
+use hickory_resolver::net::NetError;
+use hickory_resolver::proto::op::ResponseCode;
+use hickory_resolver::proto::rr::RData;
+use hickory_resolver::TokioResolver;
+
+use super::DnsName;
+use super::NameServerAuthority;
+use super::NameServerDiscoveryConfig;
+use super::NameServerSource;
+use super::ResolvedNameServerEndpoint;
+
+pub(super) type LookupFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<DnsFamilyResult, DnsResolutionError>> + Send + 'a>>;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum AddressFamily {
+    Ipv4,
+    Ipv6,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum DnsErrorKind {
+    Empty,
+    NxDomain,
+    ServFail,
+    Timeout,
+    Other,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct DnsResolutionError {
+    kind: DnsErrorKind,
+    message: Arc<str>,
+}
+
+impl DnsResolutionError {
+    pub(crate) fn new(kind: DnsErrorKind, message: impl Into<Arc<str>>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
+
+    pub(crate) fn kind(&self) -> DnsErrorKind {
+        self.kind
+    }
+}
+
+impl std::fmt::Display for DnsResolutionError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{:?}: {}", self.kind, self.message)
+    }
+}
+
+impl std::error::Error for DnsResolutionError {}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct DnsFamilyResult {
+    addresses: Vec<IpAddr>,
+    valid_for: Duration,
+}
+
+impl DnsFamilyResult {
+    #[cfg(any(test, feature = "test-support"))]
+    pub(super) fn new(addresses: Vec<IpAddr>, valid_for: Duration) -> Self {
+        Self { addresses, valid_for }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ResolvedDnsEndpoints {
+    pub(crate) endpoints: Vec<ResolvedNameServerEndpoint>,
+    pub(crate) ttl: Duration,
+}
+
+pub(crate) trait DnsLookup: Send + Sync {
+    fn lookup(&self, host: &DnsName, family: AddressFamily) -> LookupFuture<'_>;
+}
+
+pub(crate) struct HickoryDnsLookup {
+    resolver: Arc<TokioResolver>,
+}
+
+impl HickoryDnsLookup {
+    pub(crate) fn new() -> Result<Self, DnsResolutionError> {
+        let builder = TokioResolver::builder_tokio().map_err(classify_hickory_error)?;
+        let resolver = builder.build().map_err(classify_hickory_error)?;
+        Ok(Self {
+            resolver: Arc::new(resolver),
+        })
+    }
+}
+
+impl DnsLookup for HickoryDnsLookup {
+    fn lookup(&self, host: &DnsName, family: AddressFamily) -> LookupFuture<'_> {
+        let resolver = self.resolver.clone();
+        let query = format!("{}.", host.as_str());
+        Box::pin(async move {
+            let lookup = match family {
+                AddressFamily::Ipv4 => resolver.ipv4_lookup(query).await,
+                AddressFamily::Ipv6 => resolver.ipv6_lookup(query).await,
+            }
+            .map_err(classify_hickory_error)?;
+
+            let addresses = lookup
+                .answers()
+                .iter()
+                .filter_map(|record| match &record.data {
+                    RData::A(address) => Some(IpAddr::V4(address.0)),
+                    RData::AAAA(address) => Some(IpAddr::V6(address.0)),
+                    _ => None,
+                })
+                .collect();
+            let valid_for = lookup
+                .valid_until()
+                .saturating_duration_since(std::time::Instant::now());
+            Ok(DnsFamilyResult { addresses, valid_for })
+        })
+    }
+}
+
+pub(crate) async fn resolve_dns(
+    resolver: &dyn DnsLookup,
+    config: &NameServerDiscoveryConfig,
+) -> Result<ResolvedDnsEndpoints, DnsResolutionError> {
+    let NameServerSource::Dns { host, port } = config.source() else {
+        return Err(DnsResolutionError::new(
+            DnsErrorKind::Other,
+            "DNS resolver received a non-DNS source",
+        ));
+    };
+
+    let (ipv4, ipv6) = tokio::join!(
+        resolver.lookup(host, AddressFamily::Ipv4),
+        resolver.lookup(host, AddressFamily::Ipv6)
+    );
+
+    let mut addresses = Vec::new();
+    let mut successful_ttls = Vec::new();
+    let mut failures = Vec::new();
+    for result in [ipv4, ipv6] {
+        match result {
+            Ok(result) if !result.addresses.is_empty() => {
+                addresses.extend(result.addresses);
+                successful_ttls.push(result.valid_for);
+            }
+            Ok(_) => failures.push(DnsResolutionError::new(
+                DnsErrorKind::Empty,
+                "DNS family lookup returned no addresses",
+            )),
+            Err(error) => failures.push(error),
+        }
+    }
+
+    addresses.sort_unstable();
+    addresses.dedup();
+    addresses.truncate(config.endpoint_limit());
+    if addresses.is_empty() {
+        return Err(preferred_error(failures));
+    }
+
+    let ttl = successful_ttls
+        .into_iter()
+        .min()
+        .unwrap_or_else(|| config.min_refresh())
+        .clamp(config.min_refresh(), config.max_refresh());
+    let authority = NameServerAuthority::parse(format!("{}:{}", host.as_str(), port.get()))
+        .map_err(|error| DnsResolutionError::new(DnsErrorKind::Other, error.to_string()))?;
+    let endpoints = addresses
+        .into_iter()
+        .map(|address| ResolvedNameServerEndpoint::new(authority.clone(), SocketAddr::new(address, port.get())))
+        .collect();
+
+    Ok(ResolvedDnsEndpoints { endpoints, ttl })
+}
+
+fn preferred_error(errors: Vec<DnsResolutionError>) -> DnsResolutionError {
+    errors
+        .into_iter()
+        .max_by_key(|error| match error.kind() {
+            DnsErrorKind::Timeout => 5,
+            DnsErrorKind::ServFail => 4,
+            DnsErrorKind::NxDomain => 3,
+            DnsErrorKind::Other => 2,
+            DnsErrorKind::Empty => 1,
+        })
+        .unwrap_or_else(|| DnsResolutionError::new(DnsErrorKind::Empty, "DNS lookup returned no addresses"))
+}
+
+fn classify_hickory_error(error: NetError) -> DnsResolutionError {
+    let kind = match &error {
+        NetError::Timeout => DnsErrorKind::Timeout,
+        NetError::Dns(DnsError::ResponseCode(ResponseCode::ServFail)) => DnsErrorKind::ServFail,
+        NetError::Dns(DnsError::ResponseCode(ResponseCode::NXDomain)) => DnsErrorKind::NxDomain,
+        NetError::Dns(DnsError::NoRecordsFound(no_records)) if no_records.response_code == ResponseCode::NXDomain => {
+            DnsErrorKind::NxDomain
+        }
+        NetError::Dns(DnsError::NoRecordsFound(_)) => DnsErrorKind::Empty,
+        _ => DnsErrorKind::Other,
+    };
+    DnsResolutionError::new(kind, error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::net::Ipv4Addr;
+    use std::net::Ipv6Addr;
+
+    use super::*;
+
+    struct FakeDnsLookup {
+        results: HashMap<AddressFamily, Result<DnsFamilyResult, DnsResolutionError>>,
+    }
+
+    impl DnsLookup for FakeDnsLookup {
+        fn lookup(&self, _host: &DnsName, family: AddressFamily) -> LookupFuture<'_> {
+            let result = self.results[&family].clone();
+            Box::pin(async move { result })
+        }
+    }
+
+    fn config(min: Duration, max: Duration) -> NameServerDiscoveryConfig {
+        NameServerDiscoveryConfig::new(NameServerSource::dns("namesrv.default.svc", 9876).unwrap())
+            .with_refresh_bounds(min, max)
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn resolves_a_and_aaaa_with_stable_deduplication_and_minimum_ttl() {
+        let resolver = FakeDnsLookup {
+            results: HashMap::from([
+                (
+                    AddressFamily::Ipv4,
+                    Ok(DnsFamilyResult::new(
+                        vec![
+                            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+                            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+                            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+                        ],
+                        Duration::from_secs(45),
+                    )),
+                ),
+                (
+                    AddressFamily::Ipv6,
+                    Ok(DnsFamilyResult::new(
+                        vec![IpAddr::V6(Ipv6Addr::LOCALHOST)],
+                        Duration::from_secs(30),
+                    )),
+                ),
+            ]),
+        };
+
+        let resolved = resolve_dns(&resolver, &config(Duration::from_secs(5), Duration::from_secs(60)))
+            .await
+            .unwrap();
+
+        assert_eq!(resolved.ttl, Duration::from_secs(30));
+        assert_eq!(resolved.endpoints.len(), 3);
+        assert_eq!(resolved.endpoints[0].socket_addr(), "10.0.0.1:9876".parse().unwrap());
+        assert_eq!(resolved.endpoints[1].socket_addr(), "10.0.0.2:9876".parse().unwrap());
+        assert_eq!(resolved.endpoints[2].socket_addr(), "[::1]:9876".parse().unwrap());
+    }
+
+    #[tokio::test]
+    async fn keeps_successful_family_and_clamps_ttl() {
+        let resolver = FakeDnsLookup {
+            results: HashMap::from([
+                (
+                    AddressFamily::Ipv4,
+                    Ok(DnsFamilyResult::new(
+                        vec![IpAddr::V4(Ipv4Addr::LOCALHOST)],
+                        Duration::from_secs(1),
+                    )),
+                ),
+                (
+                    AddressFamily::Ipv6,
+                    Err(DnsResolutionError::new(DnsErrorKind::Timeout, "timed out")),
+                ),
+            ]),
+        };
+
+        let resolved = resolve_dns(&resolver, &config(Duration::from_secs(5), Duration::from_secs(60)))
+            .await
+            .unwrap();
+
+        assert_eq!(resolved.ttl, Duration::from_secs(5));
+        assert_eq!(resolved.endpoints.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn supports_aaaa_only_and_clamps_maximum_ttl() {
+        let resolver = FakeDnsLookup {
+            results: HashMap::from([
+                (
+                    AddressFamily::Ipv4,
+                    Ok(DnsFamilyResult::new(Vec::new(), Duration::from_secs(120))),
+                ),
+                (
+                    AddressFamily::Ipv6,
+                    Ok(DnsFamilyResult::new(
+                        vec![IpAddr::V6(Ipv6Addr::LOCALHOST)],
+                        Duration::from_secs(120),
+                    )),
+                ),
+            ]),
+        };
+
+        let resolved = resolve_dns(&resolver, &config(Duration::from_secs(5), Duration::from_secs(60)))
+            .await
+            .unwrap();
+        assert_eq!(resolved.ttl, Duration::from_secs(60));
+        assert_eq!(resolved.endpoints[0].socket_addr(), "[::1]:9876".parse().unwrap());
+    }
+
+    #[tokio::test]
+    async fn caps_resolved_endpoint_count_at_64() {
+        let resolver = FakeDnsLookup {
+            results: HashMap::from([
+                (
+                    AddressFamily::Ipv4,
+                    Ok(DnsFamilyResult::new(
+                        (1..=70).map(|last| IpAddr::V4(Ipv4Addr::new(10, 0, 0, last))).collect(),
+                        Duration::from_secs(30),
+                    )),
+                ),
+                (
+                    AddressFamily::Ipv6,
+                    Ok(DnsFamilyResult::new(Vec::new(), Duration::from_secs(30))),
+                ),
+            ]),
+        };
+
+        let resolved = resolve_dns(&resolver, &config(Duration::from_secs(5), Duration::from_secs(60)))
+            .await
+            .unwrap();
+        assert_eq!(resolved.endpoints.len(), 64);
+    }
+
+    #[test]
+    fn classifies_hickory_nxdomain_servfail_and_timeout_errors() {
+        use hickory_resolver::net::NoRecords;
+        use hickory_resolver::proto::op::Query;
+
+        let nxdomain = NetError::Dns(DnsError::NoRecordsFound(NoRecords::new(
+            Query::default(),
+            ResponseCode::NXDomain,
+        )));
+        assert_eq!(classify_hickory_error(nxdomain).kind(), DnsErrorKind::NxDomain);
+        assert_eq!(
+            classify_hickory_error(NetError::Dns(DnsError::ResponseCode(ResponseCode::ServFail))).kind(),
+            DnsErrorKind::ServFail
+        );
+        assert_eq!(classify_hickory_error(NetError::Timeout).kind(), DnsErrorKind::Timeout);
+    }
+
+    #[tokio::test]
+    async fn classifies_empty_dual_family_result() {
+        let resolver = FakeDnsLookup {
+            results: HashMap::from([
+                (
+                    AddressFamily::Ipv4,
+                    Ok(DnsFamilyResult::new(Vec::new(), Duration::from_secs(30))),
+                ),
+                (
+                    AddressFamily::Ipv6,
+                    Ok(DnsFamilyResult::new(Vec::new(), Duration::from_secs(30))),
+                ),
+            ]),
+        };
+
+        let error = resolve_dns(&resolver, &config(Duration::from_secs(5), Duration::from_secs(60)))
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), DnsErrorKind::Empty);
+    }
+}

--- a/rocketmq-client/src/nameserver_discovery/snapshot.rs
+++ b/rocketmq-client/src/nameserver_discovery/snapshot.rs
@@ -1,0 +1,91 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use tokio::time::Instant;
+
+use super::NameServerAuthority;
+
+/// A physical endpoint resolved from a logical NameServer authority.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResolvedNameServerEndpoint {
+    authority: NameServerAuthority,
+    socket_addr: SocketAddr,
+}
+
+impl ResolvedNameServerEndpoint {
+    pub(crate) fn new(authority: NameServerAuthority, socket_addr: SocketAddr) -> Self {
+        Self { authority, socket_addr }
+    }
+
+    /// Returns the logical authority used for DNS and future TLS identity checks.
+    #[must_use]
+    pub fn authority(&self) -> &NameServerAuthority {
+        &self.authority
+    }
+
+    /// Returns the physical socket address used to establish a connection.
+    #[must_use]
+    pub fn socket_addr(&self) -> SocketAddr {
+        self.socket_addr
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Freshness {
+    Fresh,
+    Stale,
+    Unavailable,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct EndpointSnapshot {
+    pub(crate) generation: u64,
+    pub(crate) resolved_at: Instant,
+    pub(crate) valid_until: Instant,
+    pub(crate) freshness: Freshness,
+    pub(crate) endpoints: Arc<[ResolvedNameServerEndpoint]>,
+}
+
+impl EndpointSnapshot {
+    pub(crate) fn unavailable(now: Instant) -> Self {
+        Self {
+            generation: 0,
+            resolved_at: now,
+            valid_until: now,
+            freshness: Freshness::Unavailable,
+            endpoints: Arc::from([]),
+        }
+    }
+
+    pub(crate) fn same_endpoint_set(&self, other: &[ResolvedNameServerEndpoint]) -> bool {
+        if self.endpoints.len() != other.len() {
+            return false;
+        }
+        let mut current = self
+            .endpoints
+            .iter()
+            .map(ResolvedNameServerEndpoint::socket_addr)
+            .collect::<Vec<_>>();
+        let mut candidate = other
+            .iter()
+            .map(ResolvedNameServerEndpoint::socket_addr)
+            .collect::<Vec<_>>();
+        current.sort_unstable();
+        candidate.sort_unstable();
+        current == candidate
+    }
+}

--- a/rocketmq-client/src/nameserver_discovery/supervisor.rs
+++ b/rocketmq-client/src/nameserver_discovery/supervisor.rs
@@ -1,0 +1,584 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "nameserver-dns-discovery")]
+use std::sync::Arc;
+#[cfg(feature = "nameserver-dns-discovery")]
+use std::time::Duration;
+
+#[cfg(feature = "nameserver-dns-discovery")]
+use arc_swap::ArcSwap;
+#[cfg(feature = "nameserver-dns-discovery")]
+use rocketmq_error::RocketMQError;
+#[cfg(feature = "nameserver-dns-discovery")]
+use rocketmq_error::RocketMQResult;
+#[cfg(feature = "nameserver-dns-discovery")]
+use rocketmq_runtime::ChildServiceContext;
+#[cfg(feature = "nameserver-dns-discovery")]
+use tokio::time::Instant;
+#[cfg(feature = "nameserver-dns-discovery")]
+use tracing::warn;
+
+#[cfg(feature = "nameserver-dns-discovery")]
+use super::dns::resolve_dns;
+#[cfg(feature = "nameserver-dns-discovery")]
+use super::dns::DnsLookup;
+#[cfg(feature = "nameserver-dns-discovery")]
+use super::dns::HickoryDnsLookup;
+#[cfg(feature = "nameserver-dns-discovery")]
+use super::dns::ResolvedDnsEndpoints;
+#[cfg(feature = "nameserver-dns-discovery")]
+use super::EndpointSnapshot;
+#[cfg(feature = "nameserver-dns-discovery")]
+use super::Freshness;
+#[cfg(feature = "nameserver-dns-discovery")]
+use super::NameServerDiscoveryConfig;
+#[cfg(feature = "nameserver-dns-discovery")]
+use super::ResolvedNameServerEndpoint;
+#[cfg(feature = "nameserver-dns-discovery")]
+use crate::runtime::spawn_client_adaptive_task_with_context;
+#[cfg(feature = "nameserver-dns-discovery")]
+use crate::runtime::ClientAdaptiveTaskControl;
+#[cfg(feature = "nameserver-dns-discovery")]
+use crate::runtime::ClientAdaptiveTaskHandle;
+
+#[cfg(feature = "nameserver-dns-discovery")]
+const RETRY_BASE: Duration = Duration::from_secs(1);
+#[cfg(feature = "nameserver-dns-discovery")]
+const RETRY_MAX: Duration = Duration::from_secs(60);
+#[cfg(feature = "nameserver-dns-discovery")]
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
+
+#[cfg(feature = "nameserver-dns-discovery")]
+type EndpointPublisher = Arc<dyn Fn(Arc<[ResolvedNameServerEndpoint]>) + Send + Sync>;
+
+pub(crate) struct NameServerDiscoverySupervisor {
+    #[cfg(feature = "nameserver-dns-discovery")]
+    state: Arc<ArcSwap<EndpointSnapshot>>,
+    #[cfg(feature = "nameserver-dns-discovery")]
+    task_handle: ClientAdaptiveTaskHandle,
+}
+
+impl NameServerDiscoverySupervisor {
+    #[cfg(feature = "nameserver-dns-discovery")]
+    pub(crate) async fn start_dns(
+        config: NameServerDiscoveryConfig,
+        parent: &ChildServiceContext,
+        client_id: &str,
+        publish: EndpointPublisher,
+    ) -> RocketMQResult<Arc<Self>> {
+        let resolver = Arc::new(HickoryDnsLookup::new().map_err(initial_resolution_error)?);
+        Self::start_with_resolver(config, parent, client_id, resolver, publish).await
+    }
+
+    #[cfg(feature = "nameserver-dns-discovery")]
+    async fn start_with_resolver(
+        config: NameServerDiscoveryConfig,
+        parent: &ChildServiceContext,
+        client_id: &str,
+        resolver: Arc<dyn DnsLookup>,
+        publish: EndpointPublisher,
+    ) -> RocketMQResult<Arc<Self>> {
+        let initial = resolve_dns(resolver.as_ref(), &config)
+            .await
+            .map_err(initial_resolution_error)?;
+        let now = Instant::now();
+        let initial_snapshot = success_snapshot(&EndpointSnapshot::unavailable(now), initial.clone(), now);
+        let initial_endpoints = initial_snapshot.endpoints.clone();
+        let state = Arc::new(ArcSwap::from_pointee(initial_snapshot));
+
+        let client_id = Arc::<str>::from(client_id);
+        let initial_delay = jittered_refresh(initial.ttl, &client_id);
+        let refresh_state = Arc::new(tokio::sync::Mutex::new(RefreshLoopState {
+            retry_attempt: 0,
+            last_success: now,
+        }));
+        let task_state = state.clone();
+        let refresh_publisher = publish.clone();
+        let task_handle =
+            spawn_client_adaptive_task_with_context(parent, "nameserver-discovery.refresh", initial_delay, move || {
+                let resolver = resolver.clone();
+                let config = config.clone();
+                let state = task_state.clone();
+                let refresh_state = refresh_state.clone();
+                let publish = refresh_publisher.clone();
+                let client_id = client_id.clone();
+                async move {
+                    let resolved = resolve_dns(resolver.as_ref(), &config).await;
+                    let mut refresh_state = refresh_state.lock().await;
+                    let now = Instant::now();
+                    match resolved {
+                        Ok(resolved) => {
+                            let current = state.load_full();
+                            let next = success_snapshot(&current, resolved.clone(), now);
+                            let changed = next.generation != current.generation;
+                            state.store(Arc::new(next));
+                            if changed {
+                                publish(state.load().endpoints.clone());
+                            }
+                            refresh_state.last_success = now;
+                            refresh_state.retry_attempt = 0;
+                            ClientAdaptiveTaskControl::ContinueAfter(jittered_refresh(resolved.ttl, &client_id))
+                        }
+                        Err(error) => {
+                            let current = state.load_full();
+                            let (next, changed) =
+                                failure_snapshot(&current, now, refresh_state.last_success, config.stale_max());
+                            let generation = next.generation;
+                            state.store(Arc::new(next));
+                            if changed {
+                                publish(state.load().endpoints.clone());
+                            }
+                            warn!(
+                                error_kind = ?error.kind(),
+                                generation,
+                                "NameServer DNS refresh failed; retained bounded last-known-good state"
+                            );
+                            let delay = retry_delay(&client_id, refresh_state.retry_attempt);
+                            refresh_state.retry_attempt = refresh_state.retry_attempt.saturating_add(1);
+                            ClientAdaptiveTaskControl::ContinueAfter(delay)
+                        }
+                    }
+                }
+            })
+            .map_err(|error| RocketMQError::internal("spawn NameServer discovery refresh task", error))?;
+        let supervisor = Arc::new(Self { state, task_handle });
+        publish(initial_endpoints);
+
+        Ok(supervisor)
+    }
+
+    #[cfg(feature = "nameserver-dns-discovery")]
+    pub(crate) fn snapshot(&self) -> Arc<EndpointSnapshot> {
+        self.state.load_full()
+    }
+
+    #[cfg(feature = "nameserver-dns-discovery")]
+    pub(crate) fn task_count(&self) -> usize {
+        self.task_handle.task_count()
+    }
+
+    pub(crate) async fn shutdown(&self) {
+        #[cfg(feature = "nameserver-dns-discovery")]
+        {
+            let report = self.task_handle.shutdown(SHUTDOWN_TIMEOUT).await;
+            if !report.is_healthy() {
+                warn!(report = %report.to_json(), "NameServer discovery shutdown was unhealthy");
+            }
+        }
+    }
+}
+
+#[cfg(feature = "nameserver-dns-discovery")]
+struct RefreshLoopState {
+    retry_attempt: u32,
+    last_success: Instant,
+}
+
+#[cfg(feature = "nameserver-dns-discovery")]
+fn initial_resolution_error(error: super::dns::DnsResolutionError) -> RocketMQError {
+    RocketMQError::ConfigInvalidValue {
+        key: "nameserver_discovery.dns",
+        value: "initial lookup".to_string(),
+        reason: error.to_string(),
+    }
+}
+
+#[cfg(feature = "nameserver-dns-discovery")]
+fn success_snapshot(current: &EndpointSnapshot, resolved: ResolvedDnsEndpoints, now: Instant) -> EndpointSnapshot {
+    let generation = if current.same_endpoint_set(&resolved.endpoints) {
+        current.generation
+    } else {
+        current.generation.saturating_add(1)
+    };
+    EndpointSnapshot {
+        generation,
+        resolved_at: now,
+        valid_until: now + resolved.ttl,
+        freshness: Freshness::Fresh,
+        endpoints: Arc::from(resolved.endpoints),
+    }
+}
+
+#[cfg(feature = "nameserver-dns-discovery")]
+fn failure_snapshot(
+    current: &EndpointSnapshot,
+    now: Instant,
+    last_success: Instant,
+    stale_max: Duration,
+) -> (EndpointSnapshot, bool) {
+    if !current.endpoints.is_empty() && now.saturating_duration_since(last_success) <= stale_max {
+        return (
+            EndpointSnapshot {
+                generation: current.generation,
+                resolved_at: current.resolved_at,
+                valid_until: current.valid_until,
+                freshness: Freshness::Stale,
+                endpoints: current.endpoints.clone(),
+            },
+            false,
+        );
+    }
+
+    let changed = !current.endpoints.is_empty();
+    (
+        EndpointSnapshot {
+            generation: current.generation.saturating_add(u64::from(changed)),
+            resolved_at: current.resolved_at,
+            valid_until: current.valid_until,
+            freshness: Freshness::Unavailable,
+            endpoints: Arc::from([]),
+        },
+        changed,
+    )
+}
+
+#[cfg(feature = "nameserver-dns-discovery")]
+fn jittered_refresh(ttl: Duration, client_id: &str) -> Duration {
+    let permille = 800_u128 + u128::from(stable_hash(client_id.as_bytes(), 0) % 201);
+    let nanos = ttl.as_nanos().saturating_mul(permille) / 1_000;
+    Duration::from_nanos(u64::try_from(nanos).unwrap_or(u64::MAX))
+}
+
+#[cfg(feature = "nameserver-dns-discovery")]
+fn retry_delay(client_id: &str, attempt: u32) -> Duration {
+    let multiplier = 1_u32 << attempt.min(6);
+    let ceiling = RETRY_BASE.saturating_mul(multiplier).min(RETRY_MAX);
+    let ceiling_millis = u64::try_from(ceiling.as_millis()).unwrap_or(u64::MAX);
+    let jitter_millis = stable_hash(client_id.as_bytes(), attempt.saturating_add(1)) % ceiling_millis.saturating_add(1);
+    Duration::from_millis(jitter_millis.max(1))
+}
+
+#[cfg(feature = "nameserver-dns-discovery")]
+fn stable_hash(value: &[u8], discriminator: u32) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325_u64;
+    for byte in value.iter().copied().chain(discriminator.to_le_bytes()) {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x100_0000_01b3);
+    }
+    hash
+}
+
+#[cfg(all(feature = "nameserver-dns-discovery", any(test, feature = "test-support")))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NameServerDiscoveryLifecycleProbe {
+    pub initial_generation: u64,
+    pub initial_fresh: bool,
+    pub initial_task_count: usize,
+    pub publish_count: usize,
+    pub task_count_after_shutdown: usize,
+}
+
+#[cfg(all(feature = "nameserver-dns-discovery", any(test, feature = "test-support")))]
+pub async fn run_nameserver_discovery_lifecycle_probe(
+    service_context: ChildServiceContext,
+) -> NameServerDiscoveryLifecycleProbe {
+    use std::future::pending;
+    use std::net::IpAddr;
+    use std::net::Ipv4Addr;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
+    use super::dns::AddressFamily;
+    use super::dns::DnsFamilyResult;
+    use super::dns::DnsResolutionError;
+    use super::dns::LookupFuture;
+    use super::DnsName;
+    use super::NameServerSource;
+
+    struct ProbeDnsLookup {
+        calls: AtomicUsize,
+        refresh_started: tokio::sync::Notify,
+    }
+
+    impl DnsLookup for ProbeDnsLookup {
+        fn lookup(&self, _host: &DnsName, family: AddressFamily) -> LookupFuture<'_> {
+            let call = self.calls.fetch_add(1, Ordering::AcqRel);
+            if call < 2 {
+                let addresses = match family {
+                    AddressFamily::Ipv4 => vec![IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))],
+                    AddressFamily::Ipv6 => Vec::new(),
+                };
+                return Box::pin(async move { Ok(DnsFamilyResult::new(addresses, Duration::from_millis(5))) });
+            }
+            self.refresh_started.notify_waiters();
+            Box::pin(pending::<Result<DnsFamilyResult, DnsResolutionError>>())
+        }
+    }
+
+    let resolver = Arc::new(ProbeDnsLookup {
+        calls: AtomicUsize::new(0),
+        refresh_started: tokio::sync::Notify::new(),
+    });
+    let config = NameServerDiscoveryConfig::new(NameServerSource::dns("namesrv.default.svc", 9876).unwrap())
+        .with_refresh_bounds(Duration::from_millis(5), Duration::from_millis(5))
+        .unwrap();
+    let published = Arc::new(AtomicUsize::new(0));
+    let publish_count = published.clone();
+    let supervisor = NameServerDiscoverySupervisor::start_with_resolver(
+        config,
+        &service_context,
+        "probe-client",
+        resolver.clone(),
+        Arc::new(move |_| {
+            publish_count.fetch_add(1, Ordering::AcqRel);
+        }),
+    )
+    .await
+    .expect("fake NameServer discovery should start");
+    let initial = supervisor.snapshot();
+    let initial_generation = initial.generation;
+    let initial_fresh = initial.freshness == Freshness::Fresh;
+    let initial_task_count = supervisor.task_count();
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if resolver.calls.load(Ordering::Acquire) > 2 {
+                break;
+            }
+            resolver.refresh_started.notified().await;
+        }
+    })
+    .await
+    .expect("fake NameServer refresh should enter its lookup");
+    supervisor.shutdown().await;
+
+    NameServerDiscoveryLifecycleProbe {
+        initial_generation,
+        initial_fresh,
+        initial_task_count,
+        publish_count: published.load(Ordering::Acquire),
+        task_count_after_shutdown: supervisor.task_count(),
+    }
+}
+
+#[cfg(all(test, feature = "nameserver-dns-discovery"))]
+mod tests {
+    use std::future::pending;
+    use std::net::IpAddr;
+    use std::net::Ipv4Addr;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
+    use super::*;
+    use crate::nameserver_discovery::dns::AddressFamily;
+    use crate::nameserver_discovery::dns::DnsFamilyResult;
+    use crate::nameserver_discovery::dns::DnsResolutionError;
+    use crate::nameserver_discovery::dns::LookupFuture;
+    use crate::nameserver_discovery::DnsName;
+
+    struct BlockingAfterInitialLookup {
+        calls: AtomicUsize,
+        refresh_started: tokio::sync::Notify,
+    }
+
+    impl BlockingAfterInitialLookup {
+        fn new() -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                refresh_started: tokio::sync::Notify::new(),
+            }
+        }
+
+        async fn wait_for_refresh(&self) {
+            loop {
+                if self.calls.load(Ordering::Acquire) > 2 {
+                    return;
+                }
+                self.refresh_started.notified().await;
+            }
+        }
+    }
+
+    impl DnsLookup for BlockingAfterInitialLookup {
+        fn lookup(&self, _host: &DnsName, family: AddressFamily) -> LookupFuture<'_> {
+            let call = self.calls.fetch_add(1, Ordering::AcqRel);
+            if call < 2 {
+                let addresses = match family {
+                    AddressFamily::Ipv4 => vec![IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))],
+                    AddressFamily::Ipv6 => Vec::new(),
+                };
+                return Box::pin(async move { Ok(DnsFamilyResult::new(addresses, Duration::from_millis(5))) });
+            }
+            self.refresh_started.notify_waiters();
+            Box::pin(pending::<Result<DnsFamilyResult, DnsResolutionError>>())
+        }
+    }
+
+    struct AlwaysFailingLookup;
+
+    impl DnsLookup for AlwaysFailingLookup {
+        fn lookup(&self, _host: &DnsName, _family: AddressFamily) -> LookupFuture<'_> {
+            Box::pin(async {
+                Err(DnsResolutionError::new(
+                    super::super::dns::DnsErrorKind::Empty,
+                    "no endpoints",
+                ))
+            })
+        }
+    }
+    fn endpoint(address: [u8; 4]) -> ResolvedNameServerEndpoint {
+        ResolvedNameServerEndpoint::new(
+            super::super::NameServerAuthority::parse("namesrv.default.svc:9876").unwrap(),
+            (IpAddr::V4(Ipv4Addr::from(address)), 9876).into(),
+        )
+    }
+
+    #[test]
+    fn endpoint_changes_advance_generation_but_reordering_does_not() {
+        let now = Instant::now();
+        let unavailable = EndpointSnapshot::unavailable(now);
+        let first = success_snapshot(
+            &unavailable,
+            ResolvedDnsEndpoints {
+                endpoints: vec![endpoint([10, 0, 0, 1]), endpoint([10, 0, 0, 2])],
+                ttl: Duration::from_secs(30),
+            },
+            now,
+        );
+        assert_eq!(first.generation, 1);
+
+        let reordered = success_snapshot(
+            &first,
+            ResolvedDnsEndpoints {
+                endpoints: vec![endpoint([10, 0, 0, 2]), endpoint([10, 0, 0, 1])],
+                ttl: Duration::from_secs(30),
+            },
+            now,
+        );
+        assert_eq!(reordered.generation, 1);
+
+        let same = success_snapshot(
+            &first,
+            ResolvedDnsEndpoints {
+                endpoints: first.endpoints.to_vec(),
+                ttl: Duration::from_secs(30),
+            },
+            now,
+        );
+        assert_eq!(same.generation, 1);
+        assert_eq!(same.freshness, Freshness::Fresh);
+    }
+
+    #[test]
+    fn transient_failure_becomes_stale_then_unavailable() {
+        let now = Instant::now();
+        let fresh = EndpointSnapshot {
+            generation: 1,
+            resolved_at: now,
+            valid_until: now + Duration::from_secs(30),
+            freshness: Freshness::Fresh,
+            endpoints: Arc::from([endpoint([10, 0, 0, 1])]),
+        };
+        let (stale, changed) = failure_snapshot(&fresh, now + Duration::from_secs(10), now, Duration::from_secs(30));
+        assert!(!changed);
+        assert_eq!(stale.generation, 1);
+        assert_eq!(stale.freshness, Freshness::Stale);
+
+        let (unavailable, changed) =
+            failure_snapshot(&stale, now + Duration::from_secs(31), now, Duration::from_secs(30));
+        assert!(changed);
+        assert_eq!(unavailable.generation, 2);
+        assert_eq!(unavailable.freshness, Freshness::Unavailable);
+        assert!(unavailable.endpoints.is_empty());
+    }
+
+    #[test]
+    fn recovery_restores_freshness_without_advancing_an_unchanged_set() {
+        let now = Instant::now();
+        let stale = EndpointSnapshot {
+            generation: 1,
+            resolved_at: now,
+            valid_until: now,
+            freshness: Freshness::Stale,
+            endpoints: Arc::from([endpoint([10, 0, 0, 1])]),
+        };
+        let recovered = success_snapshot(
+            &stale,
+            ResolvedDnsEndpoints {
+                endpoints: stale.endpoints.to_vec(),
+                ttl: Duration::from_secs(30),
+            },
+            now + Duration::from_secs(10),
+        );
+        assert_eq!(recovered.generation, 1);
+        assert_eq!(recovered.freshness, Freshness::Fresh);
+        assert_eq!(recovered.resolved_at, now + Duration::from_secs(10));
+    }
+
+    #[test]
+    fn refresh_and_retry_jitter_are_deterministic_and_client_specific() {
+        let ttl = Duration::from_secs(30);
+        let first = jittered_refresh(ttl, "client-a");
+        assert_eq!(first, jittered_refresh(ttl, "client-a"));
+        assert!((Duration::from_secs(24)..=Duration::from_secs(30)).contains(&first));
+        assert_ne!(first, jittered_refresh(ttl, "client-b"));
+
+        let retry = retry_delay("client-a", 20);
+        assert!(retry <= RETRY_MAX);
+        assert!(!retry.is_zero());
+    }
+
+    #[tokio::test]
+    async fn shutdown_cancels_an_inflight_lookup_and_joins_the_refresh_task() {
+        let resolver = Arc::new(BlockingAfterInitialLookup::new());
+        let config =
+            NameServerDiscoveryConfig::new(super::super::NameServerSource::dns("namesrv.default.svc", 9876).unwrap())
+                .with_refresh_bounds(Duration::from_millis(5), Duration::from_millis(5))
+                .unwrap();
+        let published = Arc::new(AtomicUsize::new(0));
+        let publish_count = published.clone();
+        let supervisor = NameServerDiscoverySupervisor::start_with_resolver(
+            config,
+            &crate::runtime::test_service_context("nameserver-discovery-shutdown-test"),
+            "client-a",
+            resolver.clone(),
+            Arc::new(move |_| {
+                publish_count.fetch_add(1, Ordering::AcqRel);
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(supervisor.snapshot().generation, 1);
+        assert_eq!(supervisor.snapshot().freshness, Freshness::Fresh);
+        assert_eq!(supervisor.task_count(), 1);
+        tokio::time::timeout(Duration::from_secs(1), resolver.wait_for_refresh())
+            .await
+            .expect("refresh lookup should start");
+
+        supervisor.shutdown().await;
+        assert_eq!(supervisor.task_count(), 0);
+        assert_eq!(published.load(Ordering::Acquire), 1);
+    }
+
+    #[tokio::test]
+    async fn initial_dns_failure_prevents_start_without_spawning_a_task() {
+        let parent = crate::runtime::test_service_context("nameserver-discovery-initial-failure-test");
+        let initial_components = parent.task_group().component_count();
+        let config =
+            NameServerDiscoveryConfig::new(super::super::NameServerSource::dns("namesrv.default.svc", 9876).unwrap());
+        let result = NameServerDiscoverySupervisor::start_with_resolver(
+            config,
+            &parent,
+            "client-a",
+            Arc::new(AlwaysFailingLookup),
+            Arc::new(|_| {}),
+        )
+        .await;
+
+        assert!(matches!(result, Err(RocketMQError::ConfigInvalidValue { .. })));
+        assert_eq!(parent.task_group().component_count(), initial_components);
+    }
+}

--- a/rocketmq-client/src/prelude.rs
+++ b/rocketmq-client/src/prelude.rs
@@ -15,8 +15,11 @@
 //! Minimal imports for common Client producer and consumer use cases.
 
 pub use crate::ClientConfig;
+pub use crate::ClientOptions;
 pub use crate::DefaultLitePullConsumer;
 pub use crate::DefaultMQProducer;
 pub use crate::DefaultMQPushConsumer;
 pub use crate::MessageRecall;
 pub use crate::MessageSend;
+pub use crate::NameServerDiscoveryConfig;
+pub use crate::NameServerSource;

--- a/rocketmq-client/src/producer/default_mq_produce_builder.rs
+++ b/rocketmq-client/src/producer/default_mq_produce_builder.rs
@@ -21,6 +21,8 @@ use rocketmq_protocol::common::compression::compressor::Compressor;
 use rocketmq_transport::api::v1::RPCHook;
 
 use crate::base::client_config::ClientConfig;
+use crate::base::client_options::ClientOptions;
+use crate::nameserver_discovery::NameServerDiscoveryConfig;
 use crate::producer::default_mq_producer::DefaultMQProducer;
 use crate::producer::produce_accumulator::ProduceAccumulator;
 use crate::runtime::ClientRuntime;
@@ -30,6 +32,7 @@ use crate::trace::trace_dispatcher::ArcTraceDispatcher;
 pub struct DefaultMQProducerBuilder {
     client_runtime: Arc<ClientRuntime>,
     client_config: ClientConfig,
+    nameserver_discovery: Option<NameServerDiscoveryConfig>,
     retry_response_codes: Option<HashSet<i32>>,
     producer_group: Option<CheetahString>,
     topics: Option<Vec<CheetahString>>,
@@ -63,6 +66,7 @@ impl DefaultMQProducerBuilder {
         Self {
             client_runtime,
             client_config: ClientConfig::default(),
+            nameserver_discovery: None,
             retry_response_codes: None,
             producer_group: None,
             topics: None,
@@ -94,6 +98,22 @@ impl DefaultMQProducerBuilder {
     #[inline]
     pub fn client_config(mut self, client_config: ClientConfig) -> Self {
         self.client_config = client_config;
+        self.nameserver_discovery = None;
+        self
+    }
+
+    /// Sets the complete client options, including typed NameServer discovery.
+    #[inline]
+    pub fn client_options(mut self, options: ClientOptions) -> Self {
+        self.client_config = options.client_config().clone();
+        self.nameserver_discovery = options.nameserver_discovery().cloned();
+        self
+    }
+
+    /// Sets typed NameServer discovery while retaining the current client configuration.
+    #[inline]
+    pub fn nameserver_discovery(mut self, discovery: NameServerDiscoveryConfig) -> Self {
+        self.nameserver_discovery = Some(discovery);
         self
     }
 
@@ -354,12 +374,16 @@ impl DefaultMQProducerBuilder {
         }
 
         // Create and set the producer implementation
-        let producer_impl = crate::producer::producer_impl::default_mq_producer_impl::DefaultMQProducerImpl::new(
-            self.client_runtime,
-            mq_producer.client_config_snapshot().as_ref().clone(),
-            mq_producer.producer_config_snapshot().as_ref().clone(),
-            mq_producer.rpc_hook(),
-        );
+        let producer_impl =
+            crate::producer::producer_impl::default_mq_producer_impl::DefaultMQProducerImpl::new_with_options(
+                self.client_runtime,
+                ClientOptions::from_parts(
+                    mq_producer.client_config_snapshot().as_ref().clone(),
+                    self.nameserver_discovery,
+                ),
+                mq_producer.producer_config_snapshot().as_ref().clone(),
+                mq_producer.rpc_hook(),
+            );
         mq_producer.set_default_mqproducer_impl(producer_impl);
 
         mq_producer

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -72,6 +72,7 @@ use tokio_util::task::TaskTracker;
 use tracing::warn;
 
 use crate::base::client_config::ClientConfig;
+use crate::base::client_options::ClientOptions;
 use crate::base::query_result::QueryResult;
 use crate::base::validators::Validators;
 use crate::common::client_error_code::ClientErrorCode;
@@ -92,6 +93,7 @@ use crate::implementation::mq_client_manager::ClientPoolToken;
 use crate::latency::mq_fault_strategy::MQFaultStrategy;
 use crate::latency::resolver::Resolver;
 use crate::latency::service_detector::ServiceDetector;
+use crate::nameserver_discovery::NameServerDiscoveryConfig;
 use crate::producer::default_mq_producer::ProducerConfig;
 use crate::producer::default_mq_producer::MIN_BACK_PRESSURE_FOR_ASYNC_SEND_NUM;
 use crate::producer::default_mq_producer::MIN_BACK_PRESSURE_FOR_ASYNC_SEND_SIZE;
@@ -352,6 +354,7 @@ pub struct DefaultMQProducerImpl {
     service_context: ChildServiceContext,
     client_pool: Option<ClientPool>,
     client_pool_token: ParkingLotMutex<Option<ClientPoolToken>>,
+    nameserver_discovery: Option<NameServerDiscoveryConfig>,
     request_future_holder: Arc<RequestFutureHolder>,
     // ===== Immutable configuration =====
     runtime: ArcSwap<ProducerRuntimeSnapshot>,

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl/lifecycle.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl/lifecycle.rs
@@ -25,13 +25,30 @@ impl DefaultMQProducerImpl {
         producer_config: ProducerConfig,
         rpc_hook: Option<Arc<dyn RPCHook>>,
     ) -> Self {
+        Self::new_with_options(
+            client_runtime,
+            ClientOptions::legacy(client_config),
+            producer_config,
+            rpc_hook,
+        )
+    }
+
+    pub(crate) fn new_with_options(
+        client_runtime: Arc<ClientRuntime>,
+        options: ClientOptions,
+        producer_config: ProducerConfig,
+        rpc_hook: Option<Arc<dyn RPCHook>>,
+    ) -> Self {
         let service_context = client_runtime.component(format!("producer-{}", producer_config.producer_group()));
         let client_pool = client_runtime.pool().clone();
+        let client_config = options.client_config().clone();
+        let nameserver_discovery = options.nameserver_discovery().cloned();
         Self::new_with_runtime(
             Some(client_runtime),
             Some(client_pool),
             service_context,
             client_config,
+            nameserver_discovery,
             producer_config,
             rpc_hook,
         )
@@ -43,7 +60,15 @@ impl DefaultMQProducerImpl {
         producer_config: ProducerConfig,
         rpc_hook: Option<Arc<dyn RPCHook>>,
     ) -> Self {
-        Self::new_with_runtime(None, None, service_context, client_config, producer_config, rpc_hook)
+        Self::new_with_runtime(
+            None,
+            None,
+            service_context,
+            client_config,
+            None,
+            producer_config,
+            rpc_hook,
+        )
     }
 
     pub(super) fn new_with_runtime(
@@ -51,6 +76,7 @@ impl DefaultMQProducerImpl {
         client_pool: Option<ClientPool>,
         service_context: ChildServiceContext,
         client_config: ClientConfig,
+        nameserver_discovery: Option<NameServerDiscoveryConfig>,
         producer_config: ProducerConfig,
         rpc_hook: Option<Arc<dyn RPCHook>>,
     ) -> Self {
@@ -79,6 +105,7 @@ impl DefaultMQProducerImpl {
             service_context,
             client_pool,
             client_pool_token: ParkingLotMutex::new(None),
+            nameserver_discovery,
             request_future_holder,
             runtime: ArcSwap::from_pointee(runtime),
             config_update: ParkingLotMutex::new(()),
@@ -788,7 +815,8 @@ impl DefaultMQProducerImpl {
                 .client_pool
                 .as_ref()
                 .ok_or_else(|| mq_client_err!("internal producer must be pre-bound to its MQClientInstance"))?;
-            let pooled = client_pool.get_or_create(runtime.client_config.clone(), self.rpc_hook.read().clone())?;
+            let options = ClientOptions::from_parts(runtime.client_config.clone(), self.nameserver_discovery.clone());
+            let pooled = client_pool.get_or_create_with_options(options, self.rpc_hook.read().clone())?;
             let (instance, token) = pooled.into_parts();
             *self.client_pool_token.lock() = Some(token);
             instance

--- a/rocketmq-client/src/producer/transaction_mq_produce_builder.rs
+++ b/rocketmq-client/src/producer/transaction_mq_produce_builder.rs
@@ -21,6 +21,8 @@ use rocketmq_protocol::common::compression::compressor::Compressor;
 use rocketmq_transport::api::v1::RPCHook;
 
 use crate::base::client_config::ClientConfig;
+use crate::base::client_options::ClientOptions;
+use crate::nameserver_discovery::NameServerDiscoveryConfig;
 use crate::producer::default_mq_producer::DefaultMQProducer;
 use crate::producer::produce_accumulator::ProduceAccumulator;
 use crate::producer::producer_impl::default_mq_producer_impl::DefaultMQProducerImpl;
@@ -35,6 +37,7 @@ use crate::trace::trace_dispatcher::ArcTraceDispatcher;
 pub struct TransactionMQProducerBuilder {
     client_runtime: Arc<ClientRuntime>,
     client_config: Option<ClientConfig>,
+    nameserver_discovery: Option<NameServerDiscoveryConfig>,
     default_mqproducer_impl: Option<DefaultMQProducerImpl>,
     retry_response_codes: Option<HashSet<i32>>,
     producer_group: Option<CheetahString>,
@@ -68,6 +71,7 @@ impl TransactionMQProducerBuilder {
         Self {
             client_runtime,
             client_config: Some(Default::default()),
+            nameserver_discovery: None,
             default_mqproducer_impl: None,
             retry_response_codes: None,
             producer_group: None,
@@ -99,6 +103,18 @@ impl TransactionMQProducerBuilder {
 
     pub fn client_config(mut self, client_config: ClientConfig) -> Self {
         self.client_config = Some(client_config);
+        self.nameserver_discovery = None;
+        self
+    }
+
+    pub fn client_options(mut self, options: ClientOptions) -> Self {
+        self.client_config = Some(options.client_config().clone());
+        self.nameserver_discovery = options.nameserver_discovery().cloned();
+        self
+    }
+
+    pub fn nameserver_discovery(mut self, discovery: NameServerDiscoveryConfig) -> Self {
+        self.nameserver_discovery = Some(discovery);
         self
     }
 
@@ -337,9 +353,12 @@ impl TransactionMQProducerBuilder {
         if let Some(default_mqproducer_impl) = self.default_mqproducer_impl {
             mq_producer.set_default_mqproducer_impl(default_mqproducer_impl);
         } else {
-            let producer_impl = DefaultMQProducerImpl::new(
+            let producer_impl = DefaultMQProducerImpl::new_with_options(
                 self.client_runtime,
-                mq_producer.client_config_snapshot().as_ref().clone(),
+                ClientOptions::from_parts(
+                    mq_producer.client_config_snapshot().as_ref().clone(),
+                    self.nameserver_discovery,
+                ),
                 mq_producer.producer_config_snapshot().as_ref().clone(),
                 mq_producer.rpc_hook(),
             );

--- a/rocketmq-client/src/public_api.rs
+++ b/rocketmq-client/src/public_api.rs
@@ -53,6 +53,7 @@ pub use crate::admin::TopicConfigPatchOutcome;
 #[cfg(feature = "admin-read")]
 pub use crate::admin::TopicConfigVersioned;
 pub use crate::base::client_config::ClientConfig;
+pub use crate::base::client_options::ClientOptions;
 pub use crate::cluster_session::{
     client_config_for_managed_domain, rpc_hook_from_outbound_signer, ClientInstanceHandle, ClientRpcHook,
 };
@@ -63,6 +64,11 @@ pub use crate::consumer::DefaultLitePullConsumer;
 pub use crate::consumer::DefaultMQPushConsumer;
 pub use crate::consumer::MessagePoll;
 pub use crate::consumer::SubscriptionControl;
+pub use crate::nameserver_discovery::DnsName;
+pub use crate::nameserver_discovery::NameServerAuthority;
+pub use crate::nameserver_discovery::NameServerDiscoveryConfig;
+pub use crate::nameserver_discovery::NameServerSource;
+pub use crate::nameserver_discovery::ResolvedNameServerEndpoint;
 pub use crate::producer::DefaultMQProducer;
 pub use crate::producer::MessageQuery;
 pub use crate::producer::MessageRecall;

--- a/rocketmq-client/src/runtime.rs
+++ b/rocketmq-client/src/runtime.rs
@@ -439,6 +439,62 @@ where
     })
 }
 
+pub(crate) enum ClientAdaptiveTaskControl {
+    ContinueAfter(Duration),
+    Stop,
+}
+
+pub(crate) struct ClientAdaptiveTaskHandle {
+    task_group: TaskGroup,
+}
+
+impl ClientAdaptiveTaskHandle {
+    pub(crate) fn task_count(&self) -> usize {
+        self.task_group.task_count()
+    }
+
+    pub(crate) async fn shutdown(&self, timeout: Duration) -> ShutdownReport {
+        self.task_group.shutdown(timeout).await
+    }
+}
+
+pub(crate) fn spawn_client_adaptive_task_with_context<F, Fut>(
+    context: &ChildServiceContext,
+    task_name: &'static str,
+    initial_delay: Duration,
+    mut task: F,
+) -> io::Result<ClientAdaptiveTaskHandle>
+where
+    F: FnMut() -> Fut + Send + 'static,
+    Fut: Future<Output = ClientAdaptiveTaskControl> + Send + 'static,
+{
+    let component = context.try_component(task_name).map_err(io::Error::other)?;
+    let task_group = component.task_group().clone();
+    let cancellation = task_group.cancellation_token();
+    task_group
+        .spawn_service(task_name, async move {
+            let mut delay = initial_delay;
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = cancellation.cancelled() => break,
+                    _ = tokio::time::sleep(delay) => {}
+                }
+                let control = tokio::select! {
+                    biased;
+                    _ = cancellation.cancelled() => break,
+                    control = task() => control,
+                };
+                match control {
+                    ClientAdaptiveTaskControl::ContinueAfter(next_delay) => delay = next_delay,
+                    ClientAdaptiveTaskControl::Stop => break,
+                }
+            }
+        })
+        .map_err(io::Error::other)?;
+    Ok(ClientAdaptiveTaskHandle { task_group })
+}
+
 struct ClientTrackedTaskCompletion {
     completion_tx: Option<std_mpsc::Sender<()>>,
 }

--- a/rocketmq-client/src/test_support.rs
+++ b/rocketmq-client/src/test_support.rs
@@ -58,6 +58,10 @@ pub use crate::implementation::mq_client_api_factory::{
 pub use crate::latency::latency_fault_tolerance_impl::{
     run_latency_fault_detector_lifecycle_probe, LatencyFaultDetectorLifecycleProbe,
 };
+#[cfg(feature = "nameserver-dns-discovery")]
+pub use crate::nameserver_discovery::supervisor::{
+    run_nameserver_discovery_lifecycle_probe, NameServerDiscoveryLifecycleProbe,
+};
 pub use crate::producer::produce_accumulator::{
     run_produce_accumulator_guard_lifecycle_probe, ProduceAccumulatorGuardLifecycleProbe,
 };

--- a/rocketmq-client/tests/client_runtime_ownership.rs
+++ b/rocketmq-client/tests/client_runtime_ownership.rs
@@ -18,8 +18,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use rocketmq_client_rust::ClientConfig;
+use rocketmq_client_rust::ClientOptions;
 use rocketmq_client_rust::ClientRuntime;
 use rocketmq_client_rust::ClientRuntimeConfig;
+use rocketmq_client_rust::NameServerDiscoveryConfig;
+use rocketmq_client_rust::NameServerSource;
 use rocketmq_client_rust::TelemetryHandle;
 use rocketmq_runtime::RuntimeConfig;
 use rocketmq_runtime::RuntimeOwner;
@@ -237,6 +240,95 @@ fn client_pool_rejects_conflicting_configuration_for_the_same_client_id() {
     owner
         .shutdown_runtime_blocking()
         .expect("runtime should shut down cleanly");
+}
+
+#[test]
+fn discovery_identity_controls_runtime_local_pool_reuse() {
+    let owner = runtime_owner("client-runtime-discovery-identity");
+    let runtime = client_runtime(&owner, TelemetryHandle::noop());
+    let client_config = ClientConfig {
+        namesrv_addr: None,
+        ..Default::default()
+    };
+    let first_discovery =
+        NameServerDiscoveryConfig::new(NameServerSource::dns("namesrv-a.default.svc", 9876).expect("first DNS source"));
+    let equivalent_discovery = NameServerDiscoveryConfig::new(
+        NameServerSource::dns("NameSrv-A.Default.Svc.", 9876).expect("equivalent DNS source"),
+    );
+    let different_discovery = NameServerDiscoveryConfig::new(
+        NameServerSource::dns("namesrv-b.default.svc", 9876).expect("different DNS source"),
+    );
+
+    let first = runtime
+        .pool()
+        .get_or_create_with_options(
+            ClientOptions::legacy(client_config.clone()).with_nameserver_discovery(first_discovery),
+            None,
+        )
+        .expect("first discovery lease");
+    let equivalent = runtime
+        .pool()
+        .get_or_create_with_options(
+            ClientOptions::legacy(client_config.clone()).with_nameserver_discovery(equivalent_discovery),
+            None,
+        )
+        .expect("equivalent discovery lease");
+    assert!(Arc::ptr_eq(first.instance(), equivalent.instance()));
+
+    assert!(
+        runtime
+            .pool()
+            .get_or_create_with_options(
+                ClientOptions::legacy(client_config).with_nameserver_discovery(different_discovery),
+                None,
+            )
+            .is_err(),
+        "a different discovery fingerprint must not share the client-id owner"
+    );
+
+    owner.block_on(async {
+        assert!(!runtime.pool().release(first.into_parts().1).await);
+        assert!(runtime.pool().release(equivalent.into_parts().1).await);
+        let report = runtime.shutdown().await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+    });
+    owner
+        .shutdown_runtime_blocking()
+        .expect("runtime should shut down cleanly");
+}
+
+#[cfg(not(feature = "nameserver-dns-discovery"))]
+#[test]
+fn typed_dns_discovery_requires_its_opt_in_feature_before_client_start() {
+    let owner = runtime_owner("client-runtime-dns-feature-boundary");
+    let runtime = client_runtime(&owner, TelemetryHandle::noop());
+    let options = ClientOptions::legacy(ClientConfig {
+        namesrv_addr: None,
+        ..Default::default()
+    })
+    .with_nameserver_discovery(NameServerDiscoveryConfig::new(
+        NameServerSource::dns("namesrv.default.svc", 9876).unwrap(),
+    ));
+    let lease = runtime
+        .pool()
+        .get_or_create_with_options(options, None)
+        .expect("typed client should be allocated before lifecycle validation");
+
+    owner.block_on(async {
+        let error = lease
+            .instance()
+            .start()
+            .await
+            .expect_err("DNS discovery must reject start when the feature is disabled");
+        assert!(matches!(
+            error,
+            rocketmq_error::RocketMQError::ConfigInvalidValue { .. }
+        ));
+        assert!(runtime.pool().release(lease.into_parts().1).await);
+        let report = runtime.shutdown().await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+    });
+    owner.shutdown_runtime_blocking().unwrap();
 }
 
 #[test]

--- a/rocketmq-client/tests/nameserver_dns_discovery.rs
+++ b/rocketmq-client/tests/nameserver_dns_discovery.rs
@@ -1,0 +1,31 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(all(feature = "nameserver-dns-discovery", feature = "test-support"))]
+
+use rocketmq_client_rust::test_support::run_nameserver_discovery_lifecycle_probe;
+
+mod support;
+
+#[tokio::test]
+async fn dns_discovery_initializes_and_cancels_inflight_refresh_without_leaking_tasks() {
+    let runtime = support::client_runtime("nameserver-dns-discovery");
+    let probe = run_nameserver_discovery_lifecycle_probe(runtime.component("discovery")).await;
+
+    assert_eq!(probe.initial_generation, 1);
+    assert!(probe.initial_fresh);
+    assert_eq!(probe.initial_task_count, 1);
+    assert_eq!(probe.publish_count, 1);
+    assert_eq!(probe.task_count_after_shutdown, 0);
+}

--- a/rocketmq-client/tests/public_api_contract.rs
+++ b/rocketmq-client/tests/public_api_contract.rs
@@ -15,10 +15,19 @@
 #![recursion_limit = "256"]
 
 use rocketmq_client_rust::ClientConfig;
+use rocketmq_client_rust::ClientOptions;
+use rocketmq_client_rust::ClientRuntime;
 use rocketmq_client_rust::ClientRuntimeConfig;
+use rocketmq_client_rust::DefaultLitePullConsumer;
 use rocketmq_client_rust::DefaultMQProducer;
 use rocketmq_client_rust::DefaultMQPushConsumer;
 use rocketmq_client_rust::MQClientException;
+use rocketmq_client_rust::NameServerDiscoveryConfig;
+use rocketmq_client_rust::NameServerSource;
+use rocketmq_client_rust::TelemetryHandle;
+use rocketmq_client_rust::TransactionMQProducer;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
 
 #[test]
 fn client_consumers_use_only_intentional_root_exports() {
@@ -50,7 +59,32 @@ fn client_consumers_use_only_intentional_root_exports() {
     }
 
     let _ = ClientConfig::default();
-    let _ = ClientRuntimeConfig::default();
+    let discovery =
+        NameServerDiscoveryConfig::new(NameServerSource::dns("namesrv.default.svc", 9876).expect("public DNS source"));
+    let options = ClientOptions::legacy(ClientConfig {
+        namesrv_addr: None,
+        ..Default::default()
+    })
+    .with_nameserver_discovery(discovery.clone());
+    assert!(options.nameserver_discovery().is_some());
+
+    let owner = RuntimeOwner::new(RuntimeConfig::server_default("public-api-contract")).unwrap();
+    let runtime = ClientRuntime::try_new(
+        owner.root_context().component("client"),
+        ClientRuntimeConfig::default(),
+        TelemetryHandle::noop(),
+    )
+    .unwrap();
+    let _ = DefaultMQProducer::builder(runtime.clone()).client_options(options.clone());
+    let _ = TransactionMQProducer::builder(runtime.clone()).nameserver_discovery(discovery.clone());
+    let _ = DefaultMQPushConsumer::builder(runtime.clone()).client_options(options.clone());
+    let _ = DefaultLitePullConsumer::builder(runtime.clone()).nameserver_discovery(discovery);
+    owner.block_on(async {
+        let report = runtime.shutdown().await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+    });
+    owner.shutdown_runtime_blocking().unwrap();
+
     let _: Option<DefaultMQProducer> = None;
     let _: Option<DefaultMQPushConsumer> = None;
     let _: Option<MQClientException> = None;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9266

### Brief Description

- Add typed `ClientOptions` and static/DNS NameServer discovery configuration across producer, transaction producer, push consumer, and lite-pull consumer builders.
- Add optional Hickory-based parallel A/AAAA resolution with stable deduplication, endpoint limits, TTL clamping, and partial-family success.
- Add atomic endpoint snapshots, deterministic refresh jitter, bounded retry backoff, last-known-good freshness transitions, and lifecycle-owned cancellation before remoting shutdown.
- Include discovery configuration in client-pool identity so incompatible discovery sources cannot share an `MQClientInstance`.

### How Did You Test This Change?

- `cargo test -p rocketmq-client-rust --lib --all-features`
- `cargo test -p rocketmq-client-rust --all-features --test public_api_contract --test client_runtime_ownership --test nameserver_dns_discovery`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `cargo fmt -- --check` and `cargo clippy --all-targets -- -D warnings` from `rocketmq-example`
- Per-file `rustfmt --edition 2021 --check` for all changed Rust files and `git diff --check`

The repository-wide `cargo fmt --all -- --check` command is blocked on Windows by OS error 206 (command line too long); the per-file rustfmt checks passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable NameServer discovery using static endpoints or DNS.
  * Added automatic DNS resolution refresh, endpoint caching, stale-state handling, and graceful shutdown.
  * Added client options support across producer and consumer builders.
  * Added public configuration types for DNS names, authorities, sources, and resolved endpoints.
* **Compatibility**
  * Existing client configuration and constructors continue to work as before.
* **Validation**
  * Added comprehensive coverage for discovery configuration, DNS resolution, lifecycle behavior, and client reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->