### PR TITLE
[ISSUE #9270]✨Add message path release qualification

### DIFF
--- a/rocketmq-client/examples/benchmark/client_production_benchmark.rs
+++ b/rocketmq-client/examples/benchmark/client_production_benchmark.rs
@@ -17,7 +17,7 @@
 #[path = "../support/mod.rs"]
 mod support;
 
-use std::sync::atomic::AtomicU64;
+use std::path::PathBuf;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -26,6 +26,7 @@ use std::time::Instant;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
+use parking_lot::Mutex;
 use rocketmq_client_rust::AclClientRPCHook;
 use rocketmq_client_rust::ClientRuntime;
 use rocketmq_client_rust::DefaultLitePullConsumer;
@@ -35,9 +36,11 @@ use rocketmq_client_rust::SendStatus;
 use rocketmq_client_rust::SessionCredentials;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
+use rocketmq_model::common::consumer::consume_from_where::ConsumeFromWhere;
 use rocketmq_model::common::message::message_ext::MessageExt;
 use rocketmq_model::common::message::message_queue::MessageQueue;
 use rocketmq_model::common::message::message_single::Message;
+use serde::Serialize;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Scenario {
@@ -90,6 +93,13 @@ impl Operation {
             Self::Consume => "Consume",
         }
     }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Send => "send",
+            Self::Consume => "consume",
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -106,6 +116,8 @@ struct Config {
     access_key: Option<String>,
     secret_key: Option<String>,
     security_token: Option<String>,
+    output_json: Option<PathBuf>,
+    run_id: String,
 }
 
 #[derive(Debug, Default)]
@@ -113,8 +125,55 @@ struct Stats {
     success_count: usize,
     send_failed_count: usize,
     response_failed_count: usize,
-    total_rt_ms: u128,
-    max_rt_ms: u128,
+    latency_us: Vec<u64>,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+struct LatencySummary {
+    samples: usize,
+    average: f64,
+    p50: u64,
+    p95: u64,
+    p99: u64,
+    p999: u64,
+    max: u64,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+struct BenchmarkTarget<'a> {
+    namesrv_addr: &'a str,
+    topic: &'a str,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+struct BenchmarkWorkload {
+    message_count: usize,
+    message_size_bytes: usize,
+    batch_size: usize,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+struct BenchmarkResult {
+    duration_us: u64,
+    success_count: usize,
+    send_failed_count: usize,
+    response_failed_count: usize,
+    throughput_messages_per_second: f64,
+    payload_mib_per_second: f64,
+    latency_us: LatencySummary,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+struct BenchmarkReport<'a> {
+    schema_version: u8,
+    artifact_kind: &'static str,
+    run_id: &'a str,
+    generated_at_epoch_ms: u128,
+    scenario: &'static str,
+    operation: &'static str,
+    target: BenchmarkTarget<'a>,
+    workload: BenchmarkWorkload,
+    result: BenchmarkResult,
 }
 
 #[tokio::main]
@@ -155,7 +214,10 @@ pub async fn main() -> RocketMQResult<()> {
         Scenario::LitePull => run_lite_pull(client_runtime, &config, &body).await?,
     };
 
-    print_complete_summary(stats, elapsed, config.scenario.operation());
+    print_complete_summary(&stats, elapsed, config.scenario.operation());
+    if let Some(output_json) = &config.output_json {
+        write_json_report(output_json, &config, &stats, elapsed)?;
+    }
     example_runtime.shutdown().await;
 
     Ok(())
@@ -185,10 +247,16 @@ fn build_lite_pull_consumer(
     client_runtime: Arc<ClientRuntime>,
     config: &Config,
 ) -> RocketMQResult<DefaultLitePullConsumer> {
+    let broker_suspend_ms = lite_pull_broker_suspend_ms(config.timeout_ms);
+    let pull_timeout_ms = broker_suspend_ms.saturating_add(1_000);
     let mut builder = DefaultLitePullConsumer::builder(client_runtime.clone())
         .consumer_group(unique_consumer_group())
         .name_server_addr(config.namesrv_addr.clone())
+        .consume_from_where(ConsumeFromWhere::ConsumeFromFirstOffset)
         .pull_batch_size(config.batch_size.min(i32::MAX as usize) as i32)
+        .broker_suspend_max_time_millis(broker_suspend_ms)
+        .consumer_timeout_millis_when_suspend(pull_timeout_ms)
+        .consumer_pull_timeout_millis(pull_timeout_ms)
         .poll_timeout_millis(config.timeout_ms.min(1_000))
         .auto_commit(false)
         .use_tls(config.use_tls);
@@ -204,6 +272,10 @@ fn build_lite_pull_consumer(
     }
 
     builder.build()
+}
+
+fn lite_pull_broker_suspend_ms(operation_timeout_ms: u64) -> u64 {
+    operation_timeout_ms.clamp(100, 1_000)
 }
 
 async fn run_sync(producer: &mut DefaultMQProducer, config: &Config, body: &[u8]) -> RocketMQResult<Stats> {
@@ -236,24 +308,25 @@ async fn run_async(producer: &mut DefaultMQProducer, config: &Config, body: &[u8
     let success_count = Arc::new(AtomicUsize::new(0));
     let send_failed_count = Arc::new(AtomicUsize::new(0));
     let response_failed_count = Arc::new(AtomicUsize::new(0));
-    let total_rt_ms = Arc::new(AtomicU64::new(0));
-    let max_rt_ms = Arc::new(AtomicU64::new(0));
+    let latency_us = Arc::new(Mutex::new(Vec::with_capacity(config.message_count)));
 
     for _ in 0..config.message_count {
         let begin = Instant::now();
         let success_count_inner = Arc::clone(&success_count);
         let send_failed_count_inner = Arc::clone(&send_failed_count);
         let response_failed_count_inner = Arc::clone(&response_failed_count);
-        let total_rt_ms_inner = Arc::clone(&total_rt_ms);
-        let max_rt_ms_inner = Arc::clone(&max_rt_ms);
+        let latency_us_inner = Arc::clone(&latency_us);
+        let completed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let completed_inner = Arc::clone(&completed);
 
         if let Err(error) = producer
             .send_with_callback_timeout(
                 message(&config.topic, "RustAsyncBenchmark", body),
                 move |result: Option<&SendResult>, error: Option<&RocketMQError>| {
-                    let elapsed_ms = elapsed_ms_u64(begin.elapsed());
-                    total_rt_ms_inner.fetch_add(elapsed_ms, Ordering::Relaxed);
-                    update_max(&max_rt_ms_inner, elapsed_ms);
+                    if completed_inner.swap(true, Ordering::AcqRel) {
+                        return;
+                    }
+                    latency_us_inner.lock().push(elapsed_us_u64(begin.elapsed()));
 
                     match (result, error) {
                         (Some(send_result), None) if send_result.send_status == SendStatus::SendOk => {
@@ -271,7 +344,10 @@ async fn run_async(producer: &mut DefaultMQProducer, config: &Config, body: &[u8
             )
             .await
         {
-            send_failed_count.fetch_add(1, Ordering::Relaxed);
+            if !completed.swap(true, Ordering::AcqRel) {
+                send_failed_count.fetch_add(1, Ordering::Relaxed);
+                latency_us.lock().push(elapsed_us_u64(begin.elapsed()));
+            }
             eprintln!("async send failed before callback: {error}");
         }
     }
@@ -285,15 +361,20 @@ async fn run_async(producer: &mut DefaultMQProducer, config: &Config, body: &[u8
 
     let observed = observed_count(&success_count, &send_failed_count, &response_failed_count);
     if observed < config.message_count {
-        send_failed_count.fetch_add(config.message_count - observed, Ordering::Relaxed);
+        let missing = config.message_count - observed;
+        send_failed_count.fetch_add(missing, Ordering::Relaxed);
+        latency_us.lock().extend(std::iter::repeat_n(
+            config.timeout_ms.saturating_mul(2).saturating_mul(1_000),
+            missing,
+        ));
     }
 
+    let latency_us = latency_us.lock().clone();
     Ok(Stats {
         success_count: success_count.load(Ordering::Relaxed),
         send_failed_count: send_failed_count.load(Ordering::Relaxed),
         response_failed_count: response_failed_count.load(Ordering::Relaxed),
-        total_rt_ms: total_rt_ms.load(Ordering::Relaxed) as u128,
-        max_rt_ms: max_rt_ms.load(Ordering::Relaxed) as u128,
+        latency_us,
     })
 }
 
@@ -337,25 +418,24 @@ async fn run_lite_pull(
     config: &Config,
     body: &[u8],
 ) -> RocketMQResult<(Stats, Duration)> {
-    const TAG: &str = "RustLitePullBenchmark";
+    let tag = format!("RustLitePullBenchmark-{}", config.run_id);
 
     let mut producer = build_producer(client_runtime.clone(), config)?;
     let consumer = build_lite_pull_consumer(client_runtime, config)?;
 
     producer.start().await?;
-    consumer.set_sub_expression_for_assign(&config.topic, TAG).await?;
+    consumer
+        .set_sub_expression_for_assign(&config.topic, tag.as_str())
+        .await?;
     consumer.start().await?;
 
     let queues = consumer.fetch_message_queues(&config.topic).await?;
     let queue = first_queue(queues)?;
-    consumer.assign(vec![queue.clone()]).await?;
-    let offset = producer.max_offset(&queue).await?.max(0);
-    consumer.seek(&queue, offset).await?;
-
-    seed_lite_pull_messages(&mut producer, config, body, TAG, &queue).await?;
+    seed_lite_pull_messages(&mut producer, config, body, tag.as_str(), &queue).await?;
+    consumer.assign(vec![queue]).await?;
 
     let start = Instant::now();
-    let stats = consume_lite_pull_messages(&consumer, config, TAG, start).await;
+    let stats = consume_lite_pull_messages(&consumer, config, tag.as_str(), start).await;
     let elapsed = start.elapsed();
 
     consumer.commit().await;
@@ -467,20 +547,14 @@ fn record_response_failure(stats: &mut Stats, elapsed: Duration) {
 }
 
 fn record_latency(stats: &mut Stats, elapsed: Duration) {
-    let elapsed_ms = elapsed.as_millis();
-    stats.total_rt_ms += elapsed_ms;
-    stats.max_rt_ms = stats.max_rt_ms.max(elapsed_ms);
+    stats.latency_us.push(elapsed_us_u64(elapsed));
 }
 
-fn print_complete_summary(stats: Stats, elapsed: Duration, operation: Operation) {
-    let total = stats.success_count + stats.send_failed_count;
+fn print_complete_summary(stats: &Stats, elapsed: Duration, operation: Operation) {
+    let total = stats.success_count + stats.send_failed_count + stats.response_failed_count;
     let elapsed_secs = elapsed.as_secs_f64().max(0.001);
     let tps = (stats.success_count as f64 / elapsed_secs).round() as u64;
-    let average_rt = if stats.success_count == 0 {
-        0.0
-    } else {
-        stats.total_rt_ms as f64 / stats.success_count as f64
-    };
+    let latency = latency_summary(&stats.latency_us);
     let label = operation.label();
 
     println!(
@@ -490,12 +564,94 @@ fn print_complete_summary(stats: Stats, elapsed: Duration, operation: Operation)
         total,
         label,
         tps,
-        stats.max_rt_ms,
-        average_rt,
+        latency.max as f64 / 1_000.0,
+        latency.average / 1_000.0,
         label,
         stats.send_failed_count,
         stats.response_failed_count
     );
+}
+
+fn write_json_report(path: &PathBuf, config: &Config, stats: &Stats, elapsed: Duration) -> RocketMQResult<()> {
+    if let Some(parent) = path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| RocketMQError::internal("create benchmark report directory", error))?;
+    }
+    let report = benchmark_report(config, stats, elapsed);
+    let body = serde_json::to_vec_pretty(&report)
+        .map_err(|error| RocketMQError::internal("serialize benchmark report", error))?;
+    std::fs::write(path, body).map_err(|error| RocketMQError::internal("write benchmark report", error))
+}
+
+fn benchmark_report<'a>(config: &'a Config, stats: &Stats, elapsed: Duration) -> BenchmarkReport<'a> {
+    let elapsed_secs = elapsed.as_secs_f64().max(0.000_001);
+    let successful_bytes = stats.success_count.saturating_mul(config.message_size);
+    BenchmarkReport {
+        schema_version: 1,
+        artifact_kind: "rocketmq_message_path_measurement",
+        run_id: &config.run_id,
+        generated_at_epoch_ms: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_millis())
+            .unwrap_or_default(),
+        scenario: config.scenario.as_str(),
+        operation: config.scenario.operation().as_str(),
+        target: BenchmarkTarget {
+            namesrv_addr: &config.namesrv_addr,
+            topic: &config.topic,
+        },
+        workload: BenchmarkWorkload {
+            message_count: config.message_count,
+            message_size_bytes: config.message_size,
+            batch_size: config.batch_size,
+        },
+        result: BenchmarkResult {
+            duration_us: elapsed_us_u64(elapsed),
+            success_count: stats.success_count,
+            send_failed_count: stats.send_failed_count,
+            response_failed_count: stats.response_failed_count,
+            throughput_messages_per_second: stats.success_count as f64 / elapsed_secs,
+            payload_mib_per_second: successful_bytes as f64 / (1024.0 * 1024.0) / elapsed_secs,
+            latency_us: latency_summary(&stats.latency_us),
+        },
+    }
+}
+
+fn latency_summary(samples: &[u64]) -> LatencySummary {
+    if samples.is_empty() {
+        return LatencySummary {
+            samples: 0,
+            average: 0.0,
+            p50: 0,
+            p95: 0,
+            p99: 0,
+            p999: 0,
+            max: 0,
+        };
+    }
+
+    let mut sorted = samples.to_vec();
+    sorted.sort_unstable();
+    let total = sorted
+        .iter()
+        .fold(0_u128, |sum, value| sum.saturating_add(*value as u128));
+    LatencySummary {
+        samples: sorted.len(),
+        average: total as f64 / sorted.len() as f64,
+        p50: percentile(&sorted, 50, 100),
+        p95: percentile(&sorted, 95, 100),
+        p99: percentile(&sorted, 99, 100),
+        p999: percentile(&sorted, 999, 1_000),
+        max: sorted.last().copied().unwrap_or_default(),
+    }
+}
+
+fn percentile(sorted: &[u64], numerator: usize, denominator: usize) -> u64 {
+    if sorted.is_empty() || denominator == 0 {
+        return 0;
+    }
+    let rank = sorted.len().saturating_mul(numerator).saturating_add(denominator - 1) / denominator;
+    sorted[rank.clamp(1, sorted.len()) - 1]
 }
 
 fn observed_count(
@@ -508,18 +664,8 @@ fn observed_count(
         + response_failed_count.load(Ordering::Relaxed)
 }
 
-fn elapsed_ms_u64(elapsed: Duration) -> u64 {
-    elapsed.as_millis().try_into().unwrap_or(u64::MAX)
-}
-
-fn update_max(max_rt_ms: &AtomicU64, candidate: u64) {
-    let mut current = max_rt_ms.load(Ordering::Relaxed);
-    while candidate > current {
-        match max_rt_ms.compare_exchange_weak(current, candidate, Ordering::Relaxed, Ordering::Relaxed) {
-            Ok(_) => break,
-            Err(next) => current = next,
-        }
-    }
+fn elapsed_us_u64(elapsed: Duration) -> u64 {
+    elapsed.as_micros().try_into().unwrap_or(u64::MAX)
 }
 
 impl Config {
@@ -537,6 +683,8 @@ impl Config {
             access_key: env_non_empty("ROCKETMQ_ACL_ACCESS_KEY"),
             secret_key: env_non_empty("ROCKETMQ_ACL_SECRET_KEY"),
             security_token: env_non_empty("ROCKETMQ_ACL_SECURITY_TOKEN"),
+            output_json: None,
+            run_id: unique_run_id(),
         };
 
         let mut args = std::env::args().skip(1);
@@ -574,6 +722,10 @@ impl Config {
                 "--access-key" => config.access_key = Some(next_arg(&mut args, "--access-key")?),
                 "--secret-key" => config.secret_key = Some(next_arg(&mut args, "--secret-key")?),
                 "--security-token" => config.security_token = Some(next_arg(&mut args, "--security-token")?),
+                "--output-json" => {
+                    config.output_json = Some(PathBuf::from(next_arg(&mut args, "--output-json")?));
+                }
+                "--run-id" => config.run_id = next_arg(&mut args, "--run-id")?,
                 other => return Err(RocketMQError::illegal_argument(format!("unknown argument: {other}"))),
             }
         }
@@ -583,6 +735,16 @@ impl Config {
         }
         if config.topic.trim().is_empty() {
             return Err(RocketMQError::illegal_argument("--topic must not be blank"));
+        }
+        if config.run_id.trim().is_empty() {
+            return Err(RocketMQError::illegal_argument("--run-id must not be blank"));
+        }
+        if config
+            .output_json
+            .as_ref()
+            .is_some_and(|path| path.as_os_str().is_empty())
+        {
+            return Err(RocketMQError::illegal_argument("--output-json must not be blank"));
         }
         if config.access_key.is_some() != config.secret_key.is_some() {
             return Err(RocketMQError::illegal_argument(
@@ -651,4 +813,82 @@ fn unique_consumer_group() -> String {
         .map(|duration| duration.as_millis())
         .unwrap_or_default();
     format!("rocketmq-rust-benchmark-lite-pull-{millis}")
+}
+
+fn unique_run_id() -> String {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default();
+    format!("message-path-{millis}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> Config {
+        Config {
+            namesrv_addr: "127.0.0.1:19876".to_string(),
+            topic: "QualificationTopic".to_string(),
+            producer_group: "qualification-producer".to_string(),
+            scenario: Scenario::Sync,
+            message_count: 4,
+            message_size: 1_024,
+            batch_size: 1,
+            timeout_ms: 3_000,
+            use_tls: false,
+            access_key: None,
+            secret_key: None,
+            security_token: None,
+            output_json: None,
+            run_id: "qualification-run".to_string(),
+        }
+    }
+
+    #[test]
+    fn latency_summary_uses_nearest_rank_percentiles() {
+        let summary = latency_summary(&[100, 200, 300, 400, 500]);
+
+        assert_eq!(5, summary.samples);
+        assert_eq!(300, summary.p50);
+        assert_eq!(500, summary.p95);
+        assert_eq!(500, summary.p99);
+        assert_eq!(500, summary.p999);
+        assert_eq!(500, summary.max);
+        assert_eq!(300.0, summary.average);
+    }
+
+    #[test]
+    fn benchmark_report_has_stable_machine_readable_contract() {
+        let config = test_config();
+        let stats = Stats {
+            success_count: 4,
+            send_failed_count: 0,
+            response_failed_count: 0,
+            latency_us: vec![100, 200, 300, 400],
+        };
+
+        let report = benchmark_report(&config, &stats, Duration::from_secs(2));
+        let value = serde_json::to_value(report).expect("benchmark report should serialize");
+
+        assert_eq!(1, value["schema_version"]);
+        assert_eq!("rocketmq_message_path_measurement", value["artifact_kind"]);
+        assert_eq!("qualification-run", value["run_id"]);
+        assert_eq!("sync", value["scenario"]);
+        assert_eq!("send", value["operation"]);
+        assert_eq!(4, value["result"]["success_count"]);
+        assert_eq!(2.0, value["result"]["throughput_messages_per_second"]);
+        assert_eq!(400, value["result"]["latency_us"]["p95"]);
+    }
+
+    #[test]
+    fn lite_pull_uses_short_long_poll_with_rpc_safety_margin() {
+        let short_suspend = lite_pull_broker_suspend_ms(50);
+        let normal_suspend = lite_pull_broker_suspend_ms(30_000);
+
+        assert_eq!(100, short_suspend);
+        assert_eq!(1_000, normal_suspend);
+        assert!(normal_suspend.saturating_add(1_000) > normal_suspend);
+    }
 }

--- a/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
@@ -1711,24 +1711,8 @@ impl DefaultLitePullConsumerImpl {
                     )
                     .await;
                 if result_is_current && !messages.is_empty() {
-                    let dispatch_to_consume = process_queue.put_message(&messages).await;
-                    if dispatch_to_consume {
-                        let retry_offset = messages.first().map_or(pull_offset, |message| message.queue_offset);
-                        let cached_messages = messages.clone();
-                        if let Err(error) = self.enqueue_consume_request(LitePullConsumeRequest::new(
-                            messages,
-                            mq.clone(),
-                            process_queue.clone(),
-                        )) {
-                            self.consume_request_flow_control_times.fetch_add(1, Ordering::Relaxed);
-                            process_queue.remove_message(&cached_messages).await;
-                            process_queue.set_consuming(false);
-                            self.assigned_message_queue
-                                .update_pull_offset(mq, retry_offset, process_queue)
-                                .await;
-                            return Err(error);
-                        }
-                    }
+                    self.cache_lite_pull_batch(messages, mq, process_queue, pull_offset)
+                        .await?;
                 }
 
                 Ok(0)
@@ -1761,6 +1745,30 @@ impl DefaultLitePullConsumerImpl {
                     .await)
             }
         }
+    }
+
+    async fn cache_lite_pull_batch(
+        &self,
+        messages: Vec<Arc<MessageExt>>,
+        mq: &MessageQueue,
+        process_queue: &Arc<crate::consumer::consumer_impl::process_queue::ProcessQueue>,
+        pull_offset: i64,
+    ) -> RocketMQResult<()> {
+        let retry_offset = messages.first().map_or(pull_offset, |message| message.queue_offset);
+        let cached_messages = messages.clone();
+        process_queue.put_message(&messages).await;
+        if let Err(error) =
+            self.enqueue_consume_request(LitePullConsumeRequest::new(messages, mq.clone(), process_queue.clone()))
+        {
+            self.consume_request_flow_control_times.fetch_add(1, Ordering::Relaxed);
+            process_queue.remove_message(&cached_messages).await;
+            process_queue.set_consuming(false);
+            self.assigned_message_queue
+                .update_pull_offset(mq, retry_offset, process_queue)
+                .await;
+            return Err(error);
+        }
+        Ok(())
     }
 
     async fn assignment_operation(
@@ -4380,6 +4388,50 @@ mod tests {
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].queue_offset, 7);
         assert_eq!(impl_.assigned_message_queue.get_consume_offset(&mq).await, 8);
+    }
+
+    #[tokio::test]
+    async fn consecutive_lite_pull_batches_each_publish_a_poll_request() {
+        let impl_ = DefaultLitePullConsumerImpl::new(
+            crate::runtime::test_client_runtime("lite-pull-consecutive-batches-test"),
+            Arc::new(ClientConfig::default()),
+            Arc::new(LitePullConsumerConfig {
+                consumer_group: CheetahString::from_static_str("lite_pull_consecutive_batches_group"),
+                auto_commit: false,
+                ..Default::default()
+            }),
+        );
+        impl_.set_service_state(ServiceState::Running);
+
+        let mq = MessageQueue::from_parts("topic-consecutive-batches", "broker-a", 0);
+        impl_.assigned_message_queue.put(mq.clone()).await;
+        let process_queue = impl_
+            .assigned_message_queue
+            .get_process_queue(&mq)
+            .await
+            .expect("assigned queue should have a process queue");
+
+        for offset in [0_i64, 1] {
+            impl_
+                .cache_lite_pull_batch(
+                    vec![Arc::new(MessageExt {
+                        queue_offset: offset,
+                        ..Default::default()
+                    })],
+                    &mq,
+                    &process_queue,
+                    offset,
+                )
+                .await
+                .expect("each pull result should publish a poll request");
+        }
+
+        assert_eq!(impl_.consume_request_queue_snapshot().depth, 2);
+        let first = impl_.poll(0).await.expect("first batch should be pollable");
+        let second = impl_.poll(0).await.expect("second batch should be pollable");
+        assert_eq!(first[0].queue_offset, 0);
+        assert_eq!(second[0].queue_offset, 1);
+        assert_eq!(impl_.assigned_message_queue.get_consume_offset(&mq).await, 2);
     }
 
     #[test]

--- a/rocketmq-doc/en/message-path-release-qualification.md
+++ b/rocketmq-doc/en/message-path-release-qualification.md
@@ -1,0 +1,71 @@
+# Message-path release qualification
+
+The message-path qualification harness verifies producer send, Broker persistence, and LitePull consumption on an explicitly confirmed target. It records machine-readable latency and throughput evidence without changing RocketMQ wire or storage formats.
+
+The compatibility contract is business behavior: the Rust implementation must preserve the message semantics and externally visible results expected by Java clients while remaining free to use Rust-native scheduling, ownership, batching, and backpressure. The project has one implementation path and one set of effective configuration values. Durability is selected through the existing flush, replica acknowledgement, and clean-election settings and is recorded as an explicit contract string in every run.
+
+DLedger is intentionally outside the Rust product scope. The qualification matrix covers Controller-based high availability and does not reserve a DLedger migration or compatibility gate.
+
+## Safety boundary
+
+The runner never discovers or guesses a target. Both `--namesrv` and an identical `--confirm-target` are required. Commands are executed as argument vectors without a shell, reports exclude credentials and message bodies, and an existing run directory is never overwritten. Release mode additionally requires a clean Git worktree and validated performance-comparison, fault-matrix, and six-hour soak evidence.
+
+Validate the committed policy and inspect the concrete commands without connecting to a Broker:
+
+```powershell
+python scripts/message_path_qualification.py validate-policy
+python scripts/message_path_qualification.py plan `
+  --mode smoke `
+  --namesrv 127.0.0.1:19876 `
+  --confirm-target 127.0.0.1:19876 `
+  --topic QualificationTopic `
+  --durability-contract async-flush-single-replica
+```
+
+## Managed local smoke
+
+The existing functional harness can start a local Rust NameServer and Broker and then run the four bounded smoke workloads:
+
+```powershell
+.\scripts\run_client_broker_functional_tests.ps1 `
+  -SkipBaseGates `
+  -SkipRustClientJavaBroker `
+  -SkipJavaClientRustBroker `
+  -SkipMixedMatrix `
+  -RunMessagePathQualification
+```
+
+Smoke mode verifies that all messages complete without send or response failures and records sync, async, batch, and LitePull metrics. A passing smoke report deliberately has `release_qualified=false`.
+
+## Release evidence
+
+Release mode uses the broader payload and batch matrix from `scripts/message-path-qualification-policy.json`, at least five repetitions per workload, and one warm-up run. It accepts only:
+
+- a performance comparison whose `status` is `pass`;
+- a dynamic Kubernetes fault-matrix evidence directory accepted by `scripts/fault_matrix_guard.py`;
+- a six-hour soak report with no detected monotonic resource growth and the same durability contract.
+
+```powershell
+python scripts/message_path_qualification.py run `
+  --mode release `
+  --namesrv 10.0.0.15:9876 `
+  --confirm-target 10.0.0.15:9876 `
+  --topic ReleaseQualification `
+  --durability-contract sync-flush-required-replica-acks `
+  --performance-comparison target/evidence/performance-comparison.json `
+  --fault-evidence target/evidence/fault-matrix/run-001 `
+  --soak-report target/evidence/soak-report.json
+```
+
+The resulting `qualification-report.json` binds the Git commit, hardware fingerprint, confirmed endpoint, workload parameters, raw artifact hashes, median throughput, median payload bandwidth, and median p99 latency. It fails closed when any message is missing, any response fails, evidence is absent, the worktree is dirty, or the target confirmation differs.
+
+Compare two reports only when they used the same policy, hardware, business contract, durability contract, and workload parameters:
+
+```powershell
+python scripts/message_path_qualification.py compare `
+  --baseline target/evidence/baseline/qualification-report.json `
+  --candidate target/evidence/candidate/qualification-report.json `
+  --output target/evidence/message-path-comparison.json
+```
+
+The default gates reject throughput regression above 10% and p99 latency regression above 15%. Estimates and broker-free microbenchmarks are supporting analysis only; they are not accepted as release qualification.

--- a/scripts/message-path-qualification-policy.json
+++ b/scripts/message-path-qualification-policy.json
@@ -1,0 +1,135 @@
+{
+  "schema_version": 1,
+  "artifact_kind": "rocketmq_message_path_qualification_policy",
+  "comparison_thresholds": {
+    "maximum_throughput_regression_percent": 10.0,
+    "maximum_p99_latency_regression_percent": 15.0
+  },
+  "modes": {
+    "smoke": {
+      "minimum_repetitions": 1,
+      "warmup_runs": 0,
+      "require_clean_git": false,
+      "required_external_evidence": [],
+      "workloads": [
+        {
+          "id": "sync-128b",
+          "scenario": "sync",
+          "message_count": 100,
+          "message_size_bytes": 128,
+          "batch_size": 1,
+          "timeout_ms": 30000
+        },
+        {
+          "id": "async-1k",
+          "scenario": "async",
+          "message_count": 200,
+          "message_size_bytes": 1024,
+          "batch_size": 1,
+          "timeout_ms": 30000
+        },
+        {
+          "id": "batch16-1k",
+          "scenario": "batch",
+          "message_count": 256,
+          "message_size_bytes": 1024,
+          "batch_size": 16,
+          "timeout_ms": 30000
+        },
+        {
+          "id": "lite-pull-1k",
+          "scenario": "lite-pull",
+          "message_count": 100,
+          "message_size_bytes": 1024,
+          "batch_size": 16,
+          "timeout_ms": 30000
+        }
+      ]
+    },
+    "release": {
+      "minimum_repetitions": 5,
+      "warmup_runs": 1,
+      "require_clean_git": true,
+      "required_external_evidence": [
+        "performance_comparison",
+        "fault_matrix",
+        "soak"
+      ],
+      "minimum_soak_seconds": 21600,
+      "workloads": [
+        {
+          "id": "sync-128b",
+          "scenario": "sync",
+          "message_count": 10000,
+          "message_size_bytes": 128,
+          "batch_size": 1,
+          "timeout_ms": 30000
+        },
+        {
+          "id": "sync-1k",
+          "scenario": "sync",
+          "message_count": 10000,
+          "message_size_bytes": 1024,
+          "batch_size": 1,
+          "timeout_ms": 30000
+        },
+        {
+          "id": "sync-128k",
+          "scenario": "sync",
+          "message_count": 1000,
+          "message_size_bytes": 131072,
+          "batch_size": 1,
+          "timeout_ms": 30000
+        },
+        {
+          "id": "sync-1m",
+          "scenario": "sync",
+          "message_count": 200,
+          "message_size_bytes": 1048576,
+          "batch_size": 1,
+          "timeout_ms": 60000
+        },
+        {
+          "id": "async-1k",
+          "scenario": "async",
+          "message_count": 20000,
+          "message_size_bytes": 1024,
+          "batch_size": 1,
+          "timeout_ms": 30000
+        },
+        {
+          "id": "batch16-1k",
+          "scenario": "batch",
+          "message_count": 32000,
+          "message_size_bytes": 1024,
+          "batch_size": 16,
+          "timeout_ms": 30000
+        },
+        {
+          "id": "batch16-16k",
+          "scenario": "batch",
+          "message_count": 8000,
+          "message_size_bytes": 16384,
+          "batch_size": 16,
+          "timeout_ms": 30000
+        },
+        {
+          "id": "lite-pull-1k",
+          "scenario": "lite-pull",
+          "message_count": 10000,
+          "message_size_bytes": 1024,
+          "batch_size": 32,
+          "timeout_ms": 30000
+        },
+        {
+          "id": "lite-pull-128k",
+          "scenario": "lite-pull",
+          "message_count": 1000,
+          "message_size_bytes": 131072,
+          "batch_size": 16,
+          "timeout_ms": 60000
+        }
+      ]
+    }
+  }
+}

--- a/scripts/message_path_qualification.py
+++ b/scripts/message_path_qualification.py
@@ -1,0 +1,678 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run fail-closed message-path smoke and release qualification."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import platform
+import re
+import shutil
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_POLICY = ROOT / "scripts" / "message-path-qualification-policy.json"
+DEFAULT_OUTPUT_ROOT = ROOT / "target" / "message-path-qualification"
+RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{2,127}$")
+TOPIC_RE = re.compile(r"^[A-Za-z0-9_%.-]{1,127}$")
+SCENARIOS = {"sync", "async", "batch", "lite-pull"}
+EXTERNAL_EVIDENCE = {"performance_comparison", "fault_matrix", "soak"}
+
+
+class QualificationError(RuntimeError):
+    """Raised when qualification cannot safely continue."""
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    exit_code: int
+    stdout: str
+    stderr: str
+    duration_ms: int
+
+
+CommandExecutor = Callable[[list[str], Path, int], CommandResult]
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise QualificationError(f"cannot load JSON {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise QualificationError(f"JSON document must be an object: {path}")
+    return value
+
+
+def write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def canonical_sha256(value: Any) -> str:
+    body = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(body).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def execute_command(command: list[str], cwd: Path, timeout_seconds: int) -> CommandResult:
+    started = time.monotonic()
+    try:
+        result = subprocess.run(
+            command,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout_seconds,
+            shell=False,
+            check=False,
+        )
+        return CommandResult(result.returncode, result.stdout, result.stderr, round((time.monotonic() - started) * 1000))
+    except subprocess.TimeoutExpired as error:
+        stdout = error.stdout.decode("utf-8", errors="replace") if isinstance(error.stdout, bytes) else error.stdout or ""
+        stderr = error.stderr.decode("utf-8", errors="replace") if isinstance(error.stderr, bytes) else error.stderr or ""
+        return CommandResult(124, stdout, stderr + "\ncommand timed out", round((time.monotonic() - started) * 1000))
+    except OSError as error:
+        return CommandResult(127, "", str(error), round((time.monotonic() - started) * 1000))
+
+
+def positive_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
+def validate_policy(policy: dict[str, Any]) -> list[str]:
+    findings: list[str] = []
+    expected = {"schema_version", "artifact_kind", "comparison_thresholds", "modes"}
+    if set(policy) != expected:
+        findings.append(f"policy keys must be exactly {sorted(expected)}")
+    if policy.get("schema_version") != 1:
+        findings.append("policy schema_version must be 1")
+    if policy.get("artifact_kind") != "rocketmq_message_path_qualification_policy":
+        findings.append("policy artifact_kind is invalid")
+
+    thresholds = policy.get("comparison_thresholds")
+    expected_thresholds = {
+        "maximum_throughput_regression_percent",
+        "maximum_p99_latency_regression_percent",
+    }
+    if not isinstance(thresholds, dict) or set(thresholds) != expected_thresholds:
+        findings.append("comparison_thresholds has an invalid shape")
+    else:
+        for key in expected_thresholds:
+            value = thresholds.get(key)
+            if not isinstance(value, (int, float)) or isinstance(value, bool) or not 0 < float(value) <= 100:
+                findings.append(f"comparison_thresholds.{key} must be >0 and <=100")
+
+    modes = policy.get("modes")
+    if not isinstance(modes, dict) or set(modes) != {"smoke", "release"}:
+        findings.append("policy modes must be exactly smoke and release")
+        return findings
+
+    expected_mode_keys = {
+        "minimum_repetitions",
+        "warmup_runs",
+        "require_clean_git",
+        "required_external_evidence",
+        "workloads",
+    }
+    for mode_name, mode in modes.items():
+        if not isinstance(mode, dict):
+            findings.append(f"modes.{mode_name} must be an object")
+            continue
+        allowed_keys = expected_mode_keys | ({"minimum_soak_seconds"} if mode_name == "release" else set())
+        if set(mode) != allowed_keys:
+            findings.append(f"modes.{mode_name} keys must be exactly {sorted(allowed_keys)}")
+        if not positive_int(mode.get("minimum_repetitions")):
+            findings.append(f"modes.{mode_name}.minimum_repetitions must be positive")
+        if not isinstance(mode.get("warmup_runs"), int) or isinstance(mode.get("warmup_runs"), bool) or mode["warmup_runs"] < 0:
+            findings.append(f"modes.{mode_name}.warmup_runs must be non-negative")
+        if not isinstance(mode.get("require_clean_git"), bool):
+            findings.append(f"modes.{mode_name}.require_clean_git must be boolean")
+        required = mode.get("required_external_evidence")
+        if not isinstance(required, list) or len(required) != len(set(required or [])):
+            findings.append(f"modes.{mode_name}.required_external_evidence must be a unique list")
+        elif not set(required).issubset(EXTERNAL_EVIDENCE):
+            findings.append(f"modes.{mode_name}.required_external_evidence contains an unknown kind")
+        if mode_name == "smoke" and required != []:
+            findings.append("smoke must not require external release evidence")
+        if mode_name == "release":
+            if mode.get("minimum_repetitions", 0) < 5:
+                findings.append("release requires at least five repetitions")
+            if set(required or []) != EXTERNAL_EVIDENCE:
+                findings.append("release must require performance, fault, and soak evidence")
+            if mode.get("minimum_soak_seconds", 0) < 21_600:
+                findings.append("release minimum soak must be at least six hours")
+
+        workloads = mode.get("workloads")
+        if not isinstance(workloads, list) or not workloads:
+            findings.append(f"modes.{mode_name}.workloads must be a non-empty list")
+            continue
+        seen: set[str] = set()
+        workload_keys = {"id", "scenario", "message_count", "message_size_bytes", "batch_size", "timeout_ms"}
+        for index, workload in enumerate(workloads):
+            context = f"modes.{mode_name}.workloads[{index}]"
+            if not isinstance(workload, dict) or set(workload) != workload_keys:
+                findings.append(f"{context} has an invalid shape")
+                continue
+            identity = workload.get("id")
+            if not isinstance(identity, str) or not RUN_ID_RE.fullmatch(identity):
+                findings.append(f"{context}.id is invalid")
+            elif identity in seen:
+                findings.append(f"{context}.id is duplicated")
+            else:
+                seen.add(identity)
+            if workload.get("scenario") not in SCENARIOS:
+                findings.append(f"{context}.scenario is invalid")
+            for key in ("message_count", "message_size_bytes", "batch_size", "timeout_ms"):
+                if not positive_int(workload.get(key)):
+                    findings.append(f"{context}.{key} must be positive")
+    return findings
+
+
+def git_snapshot(root: Path) -> tuple[str, bool]:
+    commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=root, capture_output=True, text=True, encoding="utf-8", check=False
+    )
+    status = subprocess.run(
+        ["git", "status", "--porcelain"], cwd=root, capture_output=True, text=True, encoding="utf-8", check=False
+    )
+    if commit.returncode != 0 or status.returncode != 0:
+        raise QualificationError("cannot bind qualification to the current Git snapshot")
+    return commit.stdout.strip(), bool(status.stdout.strip())
+
+
+def tool_version(command: list[str]) -> str:
+    result = subprocess.run(command, cwd=ROOT, capture_output=True, text=True, encoding="utf-8", check=False)
+    return result.stdout.strip() if result.returncode == 0 else "unavailable"
+
+
+def environment_record() -> dict[str, Any]:
+    identity = "|".join(
+        [platform.node(), platform.machine(), platform.processor(), str(os.cpu_count() or 0), platform.platform()]
+    )
+    return {
+        "hardware_id": f"sha256:{hashlib.sha256(identity.encode('utf-8')).hexdigest()}",
+        "os": platform.system(),
+        "kernel": platform.release(),
+        "architecture": platform.machine(),
+        "logical_cpus": os.cpu_count() or 0,
+        "rustc": tool_version(["rustc", "--version"]),
+        "cargo": tool_version(["cargo", "--version"]),
+    }
+
+
+def validate_target(namesrv: str, confirmation: str, topic: str, durability_contract: str) -> None:
+    if not namesrv.strip() or namesrv != confirmation:
+        raise QualificationError("--confirm-target must exactly match the non-empty --namesrv value")
+    if not TOPIC_RE.fullmatch(topic):
+        raise QualificationError("--topic must contain only RocketMQ-safe topic characters")
+    if not durability_contract.strip():
+        raise QualificationError("--durability-contract must be explicit and non-empty")
+
+
+def benchmark_command(
+    workload: dict[str, Any], namesrv: str, topic: str, run_id: str, output_json: Path
+) -> list[str]:
+    return [
+        "cargo",
+        "run",
+        "--release",
+        "--quiet",
+        "-p",
+        "rocketmq-client-rust",
+        "--example",
+        "client-production-benchmark",
+        "--",
+        "--namesrv",
+        namesrv,
+        "--topic",
+        topic,
+        "--scenario",
+        str(workload["scenario"]),
+        "--message-count",
+        str(workload["message_count"]),
+        "--message-size",
+        str(workload["message_size_bytes"]),
+        "--batch-size",
+        str(workload["batch_size"]),
+        "--timeout-ms",
+        str(workload["timeout_ms"]),
+        "--run-id",
+        run_id,
+        "--output-json",
+        str(output_json),
+    ]
+
+
+def build_plan(
+    policy: dict[str, Any], mode: str, namesrv: str, topic: str, run_id: str, repetitions: int
+) -> dict[str, Any]:
+    mode_policy = policy["modes"][mode]
+    commands: list[list[str]] = []
+    for workload in mode_policy["workloads"]:
+        for repetition in range(mode_policy["warmup_runs"] + repetitions):
+            sample_id = f"{run_id}-{workload['id']}-{repetition + 1}"
+            commands.append(benchmark_command(workload, namesrv, topic, sample_id, Path("<run-dir>") / f"{sample_id}.json"))
+    return {
+        "schema_version": 1,
+        "artifact_kind": "rocketmq_message_path_qualification_plan",
+        "mode": mode,
+        "run_id": run_id,
+        "target": {"namesrv_addr": namesrv, "topic": topic},
+        "warmup_runs_per_workload": mode_policy["warmup_runs"],
+        "repetitions_per_workload": repetitions,
+        "commands": commands,
+        "required_external_evidence": mode_policy["required_external_evidence"],
+    }
+
+
+def validate_measurement(
+    measurement: dict[str, Any], workload: dict[str, Any], namesrv: str, topic: str, sample_id: str
+) -> list[str]:
+    findings: list[str] = []
+    if measurement.get("schema_version") != 1:
+        findings.append("measurement schema_version must be 1")
+    if measurement.get("artifact_kind") != "rocketmq_message_path_measurement":
+        findings.append("measurement artifact_kind is invalid")
+    if measurement.get("run_id") != sample_id:
+        findings.append("measurement run_id does not match the requested sample")
+    if measurement.get("scenario") != workload["scenario"]:
+        findings.append("measurement scenario does not match the workload")
+    target = measurement.get("target")
+    if target != {"namesrv_addr": namesrv, "topic": topic}:
+        findings.append("measurement target does not match the confirmed target")
+    expected_workload = {
+        "message_count": workload["message_count"],
+        "message_size_bytes": workload["message_size_bytes"],
+        "batch_size": workload["batch_size"],
+    }
+    if measurement.get("workload") != expected_workload:
+        findings.append("measurement workload does not match policy")
+    result = measurement.get("result")
+    if not isinstance(result, dict):
+        findings.append("measurement result must be an object")
+        return findings
+    success = result.get("success_count")
+    send_failed = result.get("send_failed_count")
+    response_failed = result.get("response_failed_count")
+    if success != workload["message_count"] or send_failed != 0 or response_failed != 0:
+        findings.append("measurement must complete every message without send or response failures")
+    for metric in ("duration_us", "throughput_messages_per_second", "payload_mib_per_second"):
+        value = result.get(metric)
+        if not isinstance(value, (int, float)) or isinstance(value, bool) or not math.isfinite(float(value)) or value <= 0:
+            findings.append(f"measurement result.{metric} must be finite and positive")
+    latency = result.get("latency_us")
+    if not isinstance(latency, dict) or latency.get("samples") != workload["message_count"]:
+        findings.append("measurement latency sample count must equal message_count")
+    elif not positive_int(latency.get("p99")):
+        findings.append("measurement latency p99 must be positive")
+    return findings
+
+
+def record_artifact(run_dir: Path, path: Path) -> dict[str, str]:
+    return {"path": path.relative_to(run_dir).as_posix(), "sha256": sha256_file(path)}
+
+
+def copy_external(run_dir: Path, source: Path, name: str) -> dict[str, str]:
+    target = run_dir / "external" / name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, target)
+    return record_artifact(run_dir, target)
+
+
+def validate_release_evidence(
+    mode_policy: dict[str, Any], args: argparse.Namespace, run_dir: Path, executor: CommandExecutor
+) -> tuple[list[str], dict[str, Any], list[dict[str, str]]]:
+    findings: list[str] = []
+    evidence: dict[str, Any] = {}
+    artifacts: list[dict[str, str]] = []
+    if not mode_policy["required_external_evidence"]:
+        return findings, evidence, artifacts
+
+    if args.performance_comparison is None:
+        findings.append("release requires --performance-comparison")
+    else:
+        comparison = load_json(args.performance_comparison)
+        if comparison.get("status") != "pass":
+            findings.append("performance comparison status must be pass")
+        artifact = copy_external(run_dir, args.performance_comparison, "performance-comparison.json")
+        evidence["performance_comparison"] = artifact
+        artifacts.append(artifact)
+
+    if args.soak_report is None:
+        findings.append("release requires --soak-report")
+    else:
+        soak = load_json(args.soak_report)
+        if soak.get("schema_version") != 1 or soak.get("artifact_kind") != "rocketmq_message_path_soak_report":
+            findings.append("soak report contract is invalid")
+        if soak.get("status") != "pass" or soak.get("monotonic_growth_detected") is not False:
+            findings.append("soak report must pass without monotonic resource growth")
+        if soak.get("duration_seconds", 0) < mode_policy["minimum_soak_seconds"]:
+            findings.append("soak duration is below the release minimum")
+        if soak.get("durability_contract") != args.durability_contract:
+            findings.append("soak durability contract differs from the qualification run")
+        artifact = copy_external(run_dir, args.soak_report, "soak-report.json")
+        evidence["soak"] = artifact
+        artifacts.append(artifact)
+
+    if args.fault_evidence is None:
+        findings.append("release requires --fault-evidence")
+    else:
+        fault_dir = args.fault_evidence.resolve()
+        run_json = fault_dir / "run.json"
+        result = executor(
+            [sys.executable, str(ROOT / "scripts" / "fault_matrix_guard.py"), "--root", str(ROOT), "--evidence", str(fault_dir)],
+            ROOT,
+            600,
+        )
+        if result.exit_code != 0:
+            findings.append(f"fault matrix evidence validation failed: {result.stderr.strip() or result.stdout.strip()}")
+        if not run_json.is_file():
+            findings.append("fault matrix evidence is missing run.json")
+        else:
+            artifact = copy_external(run_dir, run_json, "fault-matrix-run.json")
+            evidence["fault_matrix"] = artifact
+            artifacts.append(artifact)
+    return findings, evidence, artifacts
+
+
+def aggregate_samples(samples: list[dict[str, Any]]) -> dict[str, float]:
+    throughputs = [float(item["result"]["throughput_messages_per_second"]) for item in samples]
+    payload_rates = [float(item["result"]["payload_mib_per_second"]) for item in samples]
+    p99_values = [float(item["result"]["latency_us"]["p99"]) for item in samples]
+    return {
+        "throughput_messages_per_second_median": statistics.median(throughputs),
+        "payload_mib_per_second_median": statistics.median(payload_rates),
+        "p99_latency_us_median": statistics.median(p99_values),
+    }
+
+
+def run_qualification(
+    policy: dict[str, Any], args: argparse.Namespace, executor: CommandExecutor = execute_command
+) -> tuple[dict[str, Any], Path]:
+    findings = validate_policy(policy)
+    if findings:
+        raise QualificationError("invalid qualification policy: " + "; ".join(findings))
+    validate_target(args.namesrv, args.confirm_target, args.topic, args.durability_contract)
+    if args.mode not in policy["modes"]:
+        raise QualificationError(f"unknown qualification mode: {args.mode}")
+    mode_policy = policy["modes"][args.mode]
+    repetitions = args.repetitions or mode_policy["minimum_repetitions"]
+    if repetitions < mode_policy["minimum_repetitions"]:
+        raise QualificationError(f"{args.mode} requires at least {mode_policy['minimum_repetitions']} repetitions")
+    if not RUN_ID_RE.fullmatch(args.run_id):
+        raise QualificationError("--run-id must contain 3-128 safe characters")
+
+    commit, dirty = git_snapshot(ROOT)
+    if mode_policy["require_clean_git"] and dirty:
+        raise QualificationError("release qualification requires a clean Git worktree")
+    run_dir = args.output_dir.resolve() / args.run_id
+    if run_dir.exists():
+        raise QualificationError(f"qualification output already exists: {run_dir}")
+    run_dir.mkdir(parents=True)
+
+    artifacts: list[dict[str, str]] = []
+    failures, external_evidence, external_artifacts = validate_release_evidence(mode_policy, args, run_dir, executor)
+    artifacts.extend(external_artifacts)
+    workload_reports: list[dict[str, Any]] = []
+
+    if not failures:
+        for workload in mode_policy["workloads"]:
+            measured: list[dict[str, Any]] = []
+            sample_records: list[dict[str, Any]] = []
+            total_runs = mode_policy["warmup_runs"] + repetitions
+            for run_index in range(total_runs):
+                warmup = run_index < mode_policy["warmup_runs"]
+                ordinal = run_index + 1 if warmup else run_index - mode_policy["warmup_runs"] + 1
+                phase = "warmup" if warmup else "sample"
+                sample_id = f"{args.run_id}-{workload['id']}-{phase}-{ordinal}"
+                raw_path = run_dir / "raw" / workload["id"] / f"{phase}-{ordinal}.json"
+                stdout_path = raw_path.with_suffix(".stdout.log")
+                stderr_path = raw_path.with_suffix(".stderr.log")
+                raw_path.parent.mkdir(parents=True, exist_ok=True)
+                command = benchmark_command(workload, args.namesrv, args.topic, sample_id, raw_path)
+                result = executor(command, ROOT, args.command_timeout_seconds)
+                stdout_path.write_text(result.stdout, encoding="utf-8")
+                stderr_path.write_text(result.stderr, encoding="utf-8")
+                artifacts.extend([record_artifact(run_dir, stdout_path), record_artifact(run_dir, stderr_path)])
+                if result.exit_code != 0:
+                    failures.append(f"{sample_id} failed with exit code {result.exit_code}")
+                    break
+                if not raw_path.is_file():
+                    failures.append(f"{sample_id} did not produce its JSON measurement")
+                    break
+                measurement = load_json(raw_path)
+                sample_findings = validate_measurement(measurement, workload, args.namesrv, args.topic, sample_id)
+                artifacts.append(record_artifact(run_dir, raw_path))
+                if sample_findings:
+                    failures.extend(f"{sample_id}: {finding}" for finding in sample_findings)
+                    break
+                sample_record = {
+                    "phase": phase,
+                    "ordinal": ordinal,
+                    "duration_ms": result.duration_ms,
+                    "measurement": measurement,
+                    "raw_data": record_artifact(run_dir, raw_path),
+                }
+                sample_records.append(sample_record)
+                if not warmup:
+                    measured.append(measurement)
+            workload_report: dict[str, Any] = {
+                "id": workload["id"],
+                "parameters": workload,
+                "runs": sample_records,
+            }
+            if len(measured) == repetitions:
+                workload_report["aggregate"] = aggregate_samples(measured)
+            workload_reports.append(workload_report)
+            if failures:
+                break
+
+    report = {
+        "schema_version": 1,
+        "artifact_kind": "rocketmq_message_path_qualification_report",
+        "run_id": args.run_id,
+        "generated_at": utc_now(),
+        "mode": args.mode,
+        "status": "fail" if failures else "pass",
+        "release_qualified": args.mode == "release" and not failures,
+        "business_contract": "java-equivalent-message-semantics",
+        "implementation_strategy": "rust-native",
+        "durability_contract": args.durability_contract,
+        "policy_sha256": canonical_sha256(policy),
+        "git": {"commit": commit, "dirty": dirty},
+        "environment": environment_record(),
+        "target": {"namesrv_addr": args.namesrv, "topic": args.topic},
+        "repetitions_per_workload": repetitions,
+        "workloads": workload_reports,
+        "external_evidence": external_evidence,
+        "failures": failures,
+        "artifacts": sorted(artifacts, key=lambda item: item["path"]),
+    }
+    report_path = run_dir / "qualification-report.json"
+    write_json(report_path, report)
+    return report, report_path
+
+
+def regression_percent(direction: str, baseline: float, candidate: float) -> float:
+    if baseline <= 0:
+        raise QualificationError("baseline comparison metric must be positive")
+    if direction == "higher":
+        return (baseline - candidate) / baseline * 100.0
+    return (candidate - baseline) / baseline * 100.0
+
+
+def compare_reports(policy: dict[str, Any], baseline: dict[str, Any], candidate: dict[str, Any]) -> dict[str, Any]:
+    failures = validate_policy(policy)
+    for label, report in (("baseline", baseline), ("candidate", candidate)):
+        if report.get("schema_version") != 1 or report.get("artifact_kind") != "rocketmq_message_path_qualification_report":
+            failures.append(f"{label} report contract is invalid")
+        if report.get("status") != "pass":
+            failures.append(f"{label} report status must be pass")
+        if report.get("policy_sha256") != canonical_sha256(policy):
+            failures.append(f"{label} report policy hash differs")
+    if failures:
+        return {"schema_version": 1, "artifact_kind": "rocketmq_message_path_comparison", "status": "fail", "failures": failures, "comparisons": []}
+    if baseline.get("mode") != candidate.get("mode"):
+        failures.append("baseline and candidate modes differ")
+    if baseline.get("durability_contract") != candidate.get("durability_contract"):
+        failures.append("baseline and candidate durability contracts differ")
+    if baseline.get("business_contract") != candidate.get("business_contract"):
+        failures.append("baseline and candidate business contracts differ")
+    if baseline.get("environment", {}).get("hardware_id") != candidate.get("environment", {}).get("hardware_id"):
+        failures.append("baseline and candidate hardware identities differ")
+
+    baseline_workloads = {item["id"]: item for item in baseline.get("workloads", []) if isinstance(item, dict) and "id" in item}
+    candidate_workloads = {item["id"]: item for item in candidate.get("workloads", []) if isinstance(item, dict) and "id" in item}
+    if set(baseline_workloads) != set(candidate_workloads):
+        failures.append("baseline and candidate workload sets differ")
+    comparisons: list[dict[str, Any]] = []
+    thresholds = policy["comparison_thresholds"]
+    for workload_id in sorted(set(baseline_workloads) & set(candidate_workloads)):
+        baseline_item = baseline_workloads[workload_id]
+        candidate_item = candidate_workloads[workload_id]
+        if baseline_item.get("parameters") != candidate_item.get("parameters"):
+            failures.append(f"{workload_id}: workload parameters differ")
+            continue
+        baseline_aggregate = baseline_item.get("aggregate", {})
+        candidate_aggregate = candidate_item.get("aggregate", {})
+        throughput_regression = regression_percent(
+            "higher",
+            float(baseline_aggregate.get("throughput_messages_per_second_median", 0)),
+            float(candidate_aggregate.get("throughput_messages_per_second_median", 0)),
+        )
+        p99_regression = regression_percent(
+            "lower",
+            float(baseline_aggregate.get("p99_latency_us_median", 0)),
+            float(candidate_aggregate.get("p99_latency_us_median", 0)),
+        )
+        status = "pass"
+        if throughput_regression > thresholds["maximum_throughput_regression_percent"]:
+            failures.append(f"{workload_id}: throughput regression exceeds the policy threshold")
+            status = "fail"
+        if p99_regression > thresholds["maximum_p99_latency_regression_percent"]:
+            failures.append(f"{workload_id}: p99 latency regression exceeds the policy threshold")
+            status = "fail"
+        comparisons.append(
+            {
+                "workload": workload_id,
+                "status": status,
+                "throughput_regression_percent": round(throughput_regression, 6),
+                "p99_latency_regression_percent": round(p99_regression, 6),
+            }
+        )
+    return {
+        "schema_version": 1,
+        "artifact_kind": "rocketmq_message_path_comparison",
+        "generated_at": utc_now(),
+        "status": "fail" if failures else "pass",
+        "release_comparison_qualified": not failures and baseline.get("release_qualified") is True and candidate.get("release_qualified") is True,
+        "failures": failures,
+        "comparisons": comparisons,
+    }
+
+
+def add_target_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--mode", choices=("smoke", "release"), required=True)
+    parser.add_argument("--namesrv", required=True)
+    parser.add_argument("--confirm-target", required=True)
+    parser.add_argument("--topic", required=True)
+    parser.add_argument("--durability-contract", required=True)
+    parser.add_argument("--run-id", default=f"message-path-{int(time.time())}")
+    parser.add_argument("--repetitions", type=int)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--policy", type=Path, default=DEFAULT_POLICY)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("validate-policy")
+
+    plan_parser = subparsers.add_parser("plan")
+    add_target_arguments(plan_parser)
+
+    run_parser = subparsers.add_parser("run")
+    add_target_arguments(run_parser)
+    run_parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    run_parser.add_argument("--command-timeout-seconds", type=int, default=1800)
+    run_parser.add_argument("--performance-comparison", type=Path)
+    run_parser.add_argument("--fault-evidence", type=Path)
+    run_parser.add_argument("--soak-report", type=Path)
+
+    compare_parser = subparsers.add_parser("compare")
+    compare_parser.add_argument("--baseline", type=Path, required=True)
+    compare_parser.add_argument("--candidate", type=Path, required=True)
+    compare_parser.add_argument("--output", type=Path, required=True)
+
+    args = parser.parse_args()
+    try:
+        policy = load_json(args.policy)
+        findings = validate_policy(policy)
+        if args.command == "validate-policy":
+            if findings:
+                raise QualificationError("; ".join(findings))
+            print(f"message-path qualification policy passed: sha256={canonical_sha256(policy)}")
+            return 0
+        if findings:
+            raise QualificationError("invalid qualification policy: " + "; ".join(findings))
+        if args.command == "compare":
+            comparison = compare_reports(policy, load_json(args.baseline), load_json(args.candidate))
+            write_json(args.output, comparison)
+            print(f"message-path comparison {comparison['status']}: {args.output}")
+            return 0 if comparison["status"] == "pass" else 1
+
+        validate_target(args.namesrv, args.confirm_target, args.topic, args.durability_contract)
+        repetitions = args.repetitions or policy["modes"][args.mode]["minimum_repetitions"]
+        if repetitions <= 0:
+            raise QualificationError("--repetitions must be positive")
+        if args.command == "plan":
+            print(json.dumps(build_plan(policy, args.mode, args.namesrv, args.topic, args.run_id, repetitions), indent=2))
+            return 0
+        report, report_path = run_qualification(policy, args)
+        print(f"message-path qualification {report['status']}: {report_path}")
+        return 0 if report["status"] == "pass" else 1
+    except QualificationError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_client_broker_functional_tests.ps1
+++ b/scripts/run_client_broker_functional_tests.ps1
@@ -24,6 +24,9 @@ param(
     [switch]$SkipJavaClientRustBroker,
     [switch]$SkipMixedMatrix,
     [switch]$RunProductionReadiness,
+    [switch]$RunMessagePathQualification,
+    [ValidateRange(1, 100)][int]$MessagePathQualificationRepetitions = 1,
+    [string]$MessagePathDurabilityContract = "async-flush-single-replica",
     [switch]$UseExistingJavaClasses,
     [bool]$EnableCreateTopicSmoke = $true,
     [switch]$EnableAclSmoke,
@@ -460,6 +463,10 @@ function Invoke-LoggedCommandUntilMatch {
                 -TimeoutSeconds $TimeoutSeconds `
                 -Environment $Environment
 
+            if ($DryRun) {
+                return ""
+            }
+
             $output = if (Test-Path $OutputFile) { Get-Content -Raw -Path $OutputFile } else { "" }
             $missingValues = @()
             foreach ($value in $RequiredValues) {
@@ -640,12 +647,11 @@ function Write-RustBrokerConfig {
     $rustBrokerDataRoot = Join-Path $dataRoot "rust-broker"
     New-Directory $rustBrokerDataRoot
     $content = @"
+[broker]
 namesrvAddr = "$namesrvAddr"
 brokerIp1 = "$NamesrvHost"
 listenPort = $BrokerPort
 storePathRootDir = "$($rustBrokerDataRoot -replace '\\','/')"
-storePathCommitLog = "$((Join-Path $rustBrokerDataRoot 'commitlog') -replace '\\','/')"
-mappedFileSizeCommitLog = 67108864
 enableControllerMode = false
 autoCreateTopicEnable = true
 autoCreateSubscriptionGroup = true
@@ -662,27 +668,36 @@ aclFile = $(ConvertTo-TomlBasicString ($rustAclFilePath -replace '\\','/'))
 innerClientAuthenticationCredentials = $(ConvertTo-TomlBasicString $innerCredentials)
 "@
     }
+    $content += @"
+
+[broker.brokerServerConfig]
+bindAddress = "0.0.0.0"
+"@
     if ($EnableTlsSmoke) {
         $content += @"
 
-tls.enable = true
-tls.test.mode.enable = true
-tls.server.mode = "permissive"
-tls.server.need.client.auth = "none"
-tls.server.authClient = false
-tls.client.authServer = false
+[broker.brokerServerConfig.tlsConfig]
+enable = true
+testModeEnable = true
+clientAuthServer = false
+
+[broker.brokerServerConfig.tlsConfig.server]
+mode = "permissive"
+needClientAuth = "none"
+authClient = false
 "@
     }
     $content += @"
 
-[brokerServerConfig]
-listenPort = $BrokerPort
-bindAddress = "0.0.0.0"
-
-[brokerIdentity]
+[broker.brokerIdentity]
 brokerName = "$BrokerName"
 brokerClusterName = "$ClusterName"
 brokerId = 0
+
+[store]
+storePathRootDir = "$($rustBrokerDataRoot -replace '\\','/')"
+storePathCommitLog = "$((Join-Path $rustBrokerDataRoot 'commitlog') -replace '\\','/')"
+mappedFileSizeCommitLog = 67108864
 "@
     Write-AsciiFile -Path $Path -Content $content
 }
@@ -948,9 +963,11 @@ function Start-RustTopology {
     }
     New-Directory $RocketMQHome
 
-    $rustNamesrvArgs = @(
-        "run", "-p", "rocketmq-namesrv", "--bin", "rocketmq-namesrv-rust", "--"
-    )
+    $rustNamesrvArgs = @("run")
+    if ($RunMessagePathQualification) {
+        $rustNamesrvArgs += "--release"
+    }
+    $rustNamesrvArgs += @("-p", "rocketmq-namesrv", "--bin", "rocketmq-namesrv-rust", "--")
     if ($EnableTlsSmoke) {
         $rustNamesrvArgs += @("-c", $rustNamesrvConfigPath)
     }
@@ -969,14 +986,20 @@ function Start-RustTopology {
         -Environment @{ ROCKETMQ_HOME = $RocketMQHome }
     Wait-ForTcpPort -EndpointHost $NamesrvHost -Port $NamesrvPort -TimeoutSeconds $StartupTimeoutSeconds
 
+    $rustBrokerArgs = @("run")
+    if ($RunMessagePathQualification) {
+        $rustBrokerArgs += "--release"
+    }
+    $rustBrokerArgs += @(
+        "-p", "rocketmq-broker", "--bin", "rocketmq-broker-rust", "--",
+        "-c", $rustBrokerConfig,
+        "-n", $namesrvAddr
+    )
+
     $script:processes += Start-LoggedProcess `
         -Name "rust-broker" `
         -FilePath "cargo" `
-        -ArgumentList @(
-            "run", "-p", "rocketmq-broker", "--bin", "rocketmq-broker-rust", "--",
-            "-c", $rustBrokerConfig,
-            "-n", $namesrvAddr
-        ) `
+        -ArgumentList $rustBrokerArgs `
         -WorkingDirectory $workspaceRoot `
         -LogPath (Join-Path $logRoot "rust-broker.log") `
         -Environment @{ ROCKETMQ_HOME = $RocketMQHome }
@@ -1014,6 +1037,40 @@ function Invoke-RustBrokerBackedSmoke {
         if (-not ($explicitOkLine -or $singleTestOkResult)) {
             throw "$Name-$testName did not report a single-test ok result. See $outputFile"
         }
+    }
+}
+
+function Invoke-MessagePathQualification {
+    $qualificationScript = Join-Path $PSScriptRoot "message_path_qualification.py"
+    $qualificationOutputRoot = Join-Path $runRoot "message-path-qualification"
+    $qualificationRunId = "functional-$runStamp-$PID"
+    $qualificationReport = Join-Path $qualificationOutputRoot (Join-Path $qualificationRunId "qualification-report.json")
+    $command = "python $(Format-CommandArgument $qualificationScript) run " +
+        "--mode smoke --namesrv $(Format-CommandArgument $namesrvAddr) " +
+        "--confirm-target $(Format-CommandArgument $namesrvAddr) --topic $(Format-CommandArgument $Topic) " +
+        "--durability-contract $(Format-CommandArgument $MessagePathDurabilityContract) " +
+        "--run-id $(Format-CommandArgument $qualificationRunId) " +
+        "--repetitions $MessagePathQualificationRepetitions " +
+        "--output-dir $(Format-CommandArgument $qualificationOutputRoot)"
+
+    Invoke-LoggedCommand `
+        -Name "message-path-qualification" `
+        -Command $command `
+        -WorkingDirectory $workspaceRoot `
+        -OutputFile (Join-Path $logRoot "message-path-qualification.log") `
+        -TimeoutSeconds $CommandTimeoutSeconds `
+        -Environment (Get-SmokeEnvironment)
+
+    "messagePathQualificationReport=$qualificationReport" | Add-Content -Path $summaryFile
+    if ($DryRun) {
+        return
+    }
+    if (-not (Test-Path $qualificationReport)) {
+        throw "Message-path qualification did not produce $qualificationReport"
+    }
+    $report = Get-Content -Raw -Path $qualificationReport | ConvertFrom-Json
+    if ($report.artifact_kind -ne "rocketmq_message_path_qualification_report" -or $report.status -ne "pass") {
+        throw "Message-path qualification report is not a passing report: $qualificationReport"
     }
 }
 
@@ -1146,6 +1203,10 @@ Initialize-OptionalGateFiles
 "aclAccessKey=$AclAccessKey" | Add-Content -Path $summaryFile
 "javaRuntimeHome=$javaRuntimeHome" | Add-Content -Path $summaryFile
 "enableTlsSmoke=$EnableTlsSmoke" | Add-Content -Path $summaryFile
+"runMessagePathQualification=$RunMessagePathQualification" | Add-Content -Path $summaryFile
+"messagePathQualificationRepetitions=$MessagePathQualificationRepetitions" | Add-Content -Path $summaryFile
+"messagePathDurabilityContract=$MessagePathDurabilityContract" | Add-Content -Path $summaryFile
+"rustTopologyBuildProfile=$(if ($RunMessagePathQualification) { 'release' } else { 'debug' })" | Add-Content -Path $summaryFile
 "dryRun=$DryRun" | Add-Content -Path $summaryFile
 "" | Add-Content -Path $summaryFile
 
@@ -1170,7 +1231,7 @@ try {
         Add-ExternalGate -Gates $externalGates -Gate "Rust client against Java broker skipped by -SkipRustClientJavaBroker"
     }
 
-    if ((-not $SkipRustClientRustBroker) -or (-not $SkipJavaClientRustBroker)) {
+    if ((-not $SkipRustClientRustBroker) -or (-not $SkipJavaClientRustBroker) -or $RunMessagePathQualification) {
         try {
             Start-RustTopology
             if (-not $SkipRustClientRustBroker) {
@@ -1183,6 +1244,11 @@ try {
             } else {
                 Add-ExternalGate -Gates $externalGates -Gate "Java client against Rust broker skipped by -SkipJavaClientRustBroker"
             }
+            if ($RunMessagePathQualification) {
+                Invoke-MessagePathQualification
+            } else {
+                Add-ExternalGate -Gates $externalGates -Gate "message-path qualification skipped; pass -RunMessagePathQualification"
+            }
         }
         finally {
             Stop-StartedProcesses
@@ -1190,6 +1256,7 @@ try {
     } else {
         Add-ExternalGate -Gates $externalGates -Gate "Rust client against Rust broker skipped by -SkipRustClientRustBroker"
         Add-ExternalGate -Gates $externalGates -Gate "Java client against Rust broker skipped by -SkipJavaClientRustBroker"
+        Add-ExternalGate -Gates $externalGates -Gate "message-path qualification skipped; pass -RunMessagePathQualification"
     }
 
     if (-not $SkipMixedMatrix) {

--- a/scripts/tests/test_message_path_qualification.py
+++ b/scripts/tests/test_message_path_qualification.py
@@ -1,0 +1,244 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import message_path_qualification as qualification  # noqa: E402
+
+
+class FakeExecutor:
+    def __init__(self, *, fail_first: bool = False) -> None:
+        self.calls: list[list[str]] = []
+        self.fail_first = fail_first
+
+    def __call__(self, command: list[str], cwd: Path, timeout_seconds: int) -> qualification.CommandResult:
+        del cwd, timeout_seconds
+        self.calls.append(command)
+        if self.fail_first and len(self.calls) == 1:
+            return qualification.CommandResult(2, "", "injected benchmark failure", 1)
+        output = Path(command[command.index("--output-json") + 1])
+        output.parent.mkdir(parents=True, exist_ok=True)
+        scenario = command[command.index("--scenario") + 1]
+        count = int(command[command.index("--message-count") + 1])
+        size = int(command[command.index("--message-size") + 1])
+        batch_size = int(command[command.index("--batch-size") + 1])
+        run_id = command[command.index("--run-id") + 1]
+        namesrv = command[command.index("--namesrv") + 1]
+        topic = command[command.index("--topic") + 1]
+        measurement = {
+            "schema_version": 1,
+            "artifact_kind": "rocketmq_message_path_measurement",
+            "run_id": run_id,
+            "scenario": scenario,
+            "operation": "consume" if scenario == "lite-pull" else "send",
+            "target": {"namesrv_addr": namesrv, "topic": topic},
+            "workload": {
+                "message_count": count,
+                "message_size_bytes": size,
+                "batch_size": batch_size,
+            },
+            "result": {
+                "duration_us": 1_000_000,
+                "success_count": count,
+                "send_failed_count": 0,
+                "response_failed_count": 0,
+                "throughput_messages_per_second": float(count),
+                "payload_mib_per_second": max(0.001, count * size / 1024 / 1024),
+                "latency_us": {
+                    "samples": count,
+                    "average": 900.0,
+                    "p50": 800,
+                    "p95": 950,
+                    "p99": 1_000,
+                    "p999": 1_100,
+                    "max": 1_200,
+                },
+            },
+        }
+        output.write_text(json.dumps(measurement), encoding="utf-8")
+        return qualification.CommandResult(0, "benchmark passed", "", 10)
+
+
+class MessagePathQualificationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.policy = qualification.load_json(qualification.DEFAULT_POLICY)
+
+    def args(self, output_dir: Path, **overrides: object) -> argparse.Namespace:
+        values: dict[str, object] = {
+            "mode": "smoke",
+            "namesrv": "127.0.0.1:19876",
+            "confirm_target": "127.0.0.1:19876",
+            "topic": "QualificationTopic",
+            "durability_contract": "async-flush-single-replica",
+            "run_id": "qualification-test",
+            "repetitions": 1,
+            "output_dir": output_dir,
+            "command_timeout_seconds": 30,
+            "performance_comparison": None,
+            "fault_evidence": None,
+            "soak_report": None,
+        }
+        values.update(overrides)
+        return argparse.Namespace(**values)
+
+    def test_committed_policy_is_valid_and_release_is_evidence_gated(self) -> None:
+        self.assertEqual([], qualification.validate_policy(self.policy))
+        release = self.policy["modes"]["release"]
+        self.assertGreaterEqual(release["minimum_repetitions"], 5)
+        self.assertEqual(21_600, release["minimum_soak_seconds"])
+        self.assertEqual(qualification.EXTERNAL_EVIDENCE, set(release["required_external_evidence"]))
+
+    def test_plan_is_pure_and_uses_exact_argument_vectors(self) -> None:
+        plan = qualification.build_plan(
+            self.policy,
+            "smoke",
+            "127.0.0.1:19876",
+            "QualificationTopic",
+            "planned-run",
+            1,
+        )
+
+        self.assertEqual("rocketmq_message_path_qualification_plan", plan["artifact_kind"])
+        self.assertEqual(4, len(plan["commands"]))
+        self.assertTrue(all(command[0] == "cargo" and "--output-json" in command for command in plan["commands"]))
+        self.assertTrue(
+            all(
+                command[command.index("--example") + 1] == "client-production-benchmark"
+                for command in plan["commands"]
+            )
+        )
+
+    def test_target_confirmation_mismatch_rejects_before_execution(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            executor = FakeExecutor()
+            args = self.args(Path(temporary), confirm_target="127.0.0.1:9876")
+
+            with self.assertRaisesRegex(qualification.QualificationError, "exactly match"):
+                qualification.run_qualification(self.policy, args, executor)
+
+            self.assertEqual([], executor.calls)
+
+    def test_successful_smoke_writes_hash_bound_report(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            executor = FakeExecutor()
+            args = self.args(Path(temporary))
+            with mock.patch.object(qualification, "git_snapshot", return_value=("a" * 40, True)), mock.patch.object(
+                qualification,
+                "environment_record",
+                return_value={"hardware_id": "sha256:test"},
+            ):
+                report, report_path = qualification.run_qualification(self.policy, args, executor)
+
+            self.assertEqual("pass", report["status"])
+            self.assertFalse(report["release_qualified"])
+            self.assertEqual(4, len(report["workloads"]))
+            self.assertEqual(4, len(executor.calls))
+            self.assertTrue(report_path.is_file())
+            self.assertTrue(all(item["sha256"] for item in report["artifacts"]))
+
+    def test_benchmark_failure_is_recorded_and_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            executor = FakeExecutor(fail_first=True)
+            args = self.args(Path(temporary), run_id="qualification-failure")
+            with mock.patch.object(qualification, "git_snapshot", return_value=("a" * 40, False)), mock.patch.object(
+                qualification,
+                "environment_record",
+                return_value={"hardware_id": "sha256:test"},
+            ):
+                report, _ = qualification.run_qualification(self.policy, args, executor)
+
+            self.assertEqual("fail", report["status"])
+            self.assertFalse(report["release_qualified"])
+            self.assertIn("exit code 2", report["failures"][0])
+
+    def test_release_cannot_run_without_external_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            executor = FakeExecutor()
+            args = self.args(
+                Path(temporary),
+                mode="release",
+                run_id="qualification-release",
+                repetitions=5,
+                durability_contract="sync-flush-required-replica-acks",
+            )
+            with mock.patch.object(qualification, "git_snapshot", return_value=("b" * 40, False)), mock.patch.object(
+                qualification,
+                "environment_record",
+                return_value={"hardware_id": "sha256:test"},
+            ):
+                report, _ = qualification.run_qualification(self.policy, args, executor)
+
+            self.assertEqual("fail", report["status"])
+            self.assertFalse(report["release_qualified"])
+            self.assertEqual(0, len(executor.calls))
+            self.assertEqual(3, len(report["failures"]))
+
+    def test_comparison_requires_matching_contract_and_thresholds(self) -> None:
+        policy_hash = qualification.canonical_sha256(self.policy)
+        baseline = {
+            "schema_version": 1,
+            "artifact_kind": "rocketmq_message_path_qualification_report",
+            "status": "pass",
+            "mode": "smoke",
+            "release_qualified": False,
+            "policy_sha256": policy_hash,
+            "business_contract": "java-equivalent-message-semantics",
+            "durability_contract": "async-flush-single-replica",
+            "environment": {"hardware_id": "sha256:test"},
+            "workloads": [
+                {
+                    "id": "sync-128b",
+                    "parameters": {"scenario": "sync"},
+                    "aggregate": {
+                        "throughput_messages_per_second_median": 1000.0,
+                        "p99_latency_us_median": 1000.0,
+                    },
+                }
+            ],
+        }
+        candidate = copy.deepcopy(baseline)
+        candidate["workloads"][0]["aggregate"]["throughput_messages_per_second_median"] = 950.0
+        candidate["workloads"][0]["aggregate"]["p99_latency_us_median"] = 1100.0
+
+        passed = qualification.compare_reports(self.policy, baseline, candidate)
+        self.assertEqual("pass", passed["status"])
+
+        candidate["workloads"][0]["aggregate"]["throughput_messages_per_second_median"] = 800.0
+        failed = qualification.compare_reports(self.policy, baseline, candidate)
+        self.assertEqual("fail", failed["status"])
+        self.assertTrue(any("throughput regression" in finding for finding in failed["failures"]))
+
+        candidate = copy.deepcopy(baseline)
+        candidate["durability_contract"] = "sync-flush-required-replica-acks"
+        mismatched = qualification.compare_reports(self.policy, baseline, candidate)
+        self.assertEqual("fail", mismatched["status"])
+        self.assertTrue(any("durability contracts differ" in finding for finding in mismatched["failures"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

Closes #9270

### Brief Description

Add a fail-closed message-path qualification policy and runner with explicit target confirmation, smoke/release modes, hash-bound raw artifacts, contract-aware performance comparison, and external fault/soak evidence gates. Extend the production benchmark with versioned JSON latency/throughput output, integrate managed qualification with the functional Broker harness, and document the Rust-native business-semantics contract. Fix LitePull so every successful pull batch publishes a bounded poll request instead of exposing only the first batch.

### How Did You Test This Change?

- `python -m unittest scripts.tests.test_message_path_qualification -v` (7 passed)
- `python scripts/message_path_qualification.py validate-policy` (passed)
- `cargo test -p rocketmq-client-rust --example client-production-benchmark` (3 passed)
- `cargo test -p rocketmq-client-rust --lib` (1043 passed)
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` (passed)
- `wsl bash -lc 'cargo fmt --all -- --check'` from the worktree (passed; native Windows command hit OS path-length error 206)
- Managed Rust NameServer + Rust Broker functional suite and message-path smoke (passed): sync 100/100, async 200/200, batch 256/256, LitePull 100/100; zero send/response failures. This smoke report intentionally has `release_qualified=false`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added message-path qualification workflows for smoke and release validation.
  * Added configurable workload repetitions, durability contracts, target confirmation, artifact recording, and regression comparisons.
  * Added benchmark latency percentiles, throughput metrics, and optional JSON reports.
  * Added support for validating release evidence and fail-closed qualification results.

* **Bug Fixes**
  * Improved LitePull batch handling to preserve message order and recover safely when polling requests cannot be queued.

* **Documentation**
  * Added guidance covering qualification requirements, execution, evidence, durability, and performance thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->