### PR TITLE
[ISSUE #9274]✨Add message path release and rollback handoff

### DIFF
--- a/rocketmq-doc/en/message-path-delivery-checklist.md
+++ b/rocketmq-doc/en/message-path-delivery-checklist.md
@@ -1,0 +1,141 @@
+# Message-path delivery checklist
+
+This checklist closes the message send, Broker/store/high-availability, gRPC Proxy, and consumer optimization program. It measures Java alignment by business semantics and externally visible results, not by copying Java implementation structure. Rust-native ownership, scheduling, batching, resource budgets, and zero-copy techniques are expected.
+
+The program has one optimal implementation path and one set of effective configuration values. It does not include legacy or Java compatibility profiles. DLedger is intentionally unsupported and excluded from implementation, migration, performance, scoring, and release qualification.
+
+## Evidence states
+
+Keep these states separate in reviews and release decisions:
+
+1. **Implemented:** code and focused regression tests demonstrate the intended behavior.
+2. **Locally smoke-validated:** a managed Rust NameServer and Rust Broker completed bounded end-to-end workloads.
+3. **Release-qualified:** the target environment passed same-contract performance comparison, dynamic fault injection, and a six-hour resource-growth run, producing `status: "pass"` and `release_qualified: true`.
+
+The requested implementation program is complete and locally smoke-validated. It is not yet release-qualified because target-environment fault, soak, and repeated same-hardware comparison evidence remains an operational release activity.
+
+## Delivery register
+
+| Area | Issue / PR | Delivered evidence |
+|---|---|---|
+| Baseline and evidence schema | #9211 / #9214 | Reproducible collector and metric contract |
+| Producer retry, permission, transaction | #9216 / #9220 | Sync/async parity, fail-fast validation, owned blocking work |
+| Mapped-file exact range | #9221 / #9222 | Bounded selection and copy metrics |
+| POP non-blocking scheduling | #9225 / #9226 | Concurrent in-flight POP and owned shutdown |
+| Single optimal store defaults | #9227 / #9228 | Validated production defaults without profiles |
+| Cluster long-poll/control isolation | #9229 / #9230 | Independent lanes and ordering domains |
+| Local Proxy concurrency/deadlines | #9231 / #9232 | Bounded concurrent execution and absolute deadlines |
+| Deadline-driven receipt renewal | #9233 / #9234 | Earliest-deadline scheduler and control routing |
+| HA notification and ACK frontier | #9235 / #9236 | No idle busy-poll and no high-offset head-of-line block |
+| Broker pending budget | #9237 / #9238 | Count/bytes/age bound before large-body cloning |
+| Proxy admission dimensions | #9239 / #9240 | Independent inflight, rate, request, and response budgets |
+| Owner-backed mapped range | #9241 / #9242 | Lease, generation, retirement, and fallback contracts |
+| Range-first HA/pull transfer | #9243 / #9244 | Zero payload heap-copy range path and wire parity |
+| Reput ordered lanes | #9245 / #9246 | Required-lane frontier, bounded queues, recovery parity |
+| Producer hot path | #9247 / #9248 | Direct batch encoding and Broker tracker isolation |
+| POP BatchAck | #9249 / #9250 | Checkpoint grouping, partial mapping, bounded fallback |
+| gRPC body ownership and egress | #9251 / #9252 | `Bytes` sharing, lazy response frames, output budget |
+| LitePull and consumer workers | #9253 / #9260 | Effective pull concurrency, fixed workers, owned DelayQueue |
+| RocksDB and Timer | #9261 / #9262 | Shared cache/WBM and segmented timer decode |
+| gRPC business capabilities | #9263 / #9267 | Priority, LiteTopic, GZIP, compatible Broker batch, Pull ADR |
+| Controller qualification evidence | #9268 / #9269 | T0-T5 and strict acknowledged-message audit schemas |
+| End-to-end qualification harness | #9270 / #9273 | Policy, safe target confirmation, local four-workload smoke |
+| Release and rollback handoff | #9274 | This checklist and the rollback runbook |
+
+## Business-function checklist
+
+### Send and Broker ingress
+
+- [x] Sync and async retries use the same response-code policy and one absolute timeout budget.
+- [x] Final callback and after-hook complete once per logical send.
+- [x] Read-only Brokers reject normal, ordered, V1/V2, and batch sends consistently.
+- [x] Compaction topics reject missing or blank keys.
+- [x] Initial transaction listeners run in owned blocking work.
+- [x] Compatible gRPC messages use Broker batch; FIFO, delay, transaction, or incompatible queues preserve their required semantics.
+- [x] Broker pending work is bounded by count, retained bytes, and age before expensive cloning/task creation.
+
+### Store and read path
+
+- [x] Exact selection never copies the unread mapped-file tail.
+- [x] Owner-backed ranges prevent retirement or unmapping while data is in use.
+- [x] HA and pull range paths avoid payload heap copies when the platform supports them; fallbacks copy only the exact range.
+- [x] CommitLog, ConsumeQueue, Index, Timer, transaction, and offset layouts remain compatible.
+- [x] Reput publishes only through the minimum durable frontier of required ordered lanes.
+- [x] RocksDB column families share a process-level cache/write-buffer budget without changing keys, values, WAL policy, or rebuild semantics.
+- [x] Timer reads borrow mapped ranges and allocate only for a message crossing a range boundary.
+
+### High availability
+
+- [x] Caught-up HA connections sleep on append notification or heartbeat deadline instead of busy-polling.
+- [x] Notification registration does not lose a concurrent append wake-up.
+- [x] ACK completion uses authority- and membership-aware frontiers; high offsets do not block satisfied lower offsets.
+- [x] Clean election remains the only accepted production failover mode.
+- [x] Acknowledgements cannot complete before the configured local durability and replica requirements.
+- [ ] Target environment proves segmented clean-failover RTO and strict acknowledged-message RPO.
+
+### Consumer
+
+- [x] POP dispatch does not wait synchronously for the network long poll and does not silently discard rejected schedule tokens.
+- [x] Same-queue ordering is fenced while different queues can progress concurrently.
+- [x] BatchAck preserves per-entry results, bounds malformed input, and falls back only for affected entries.
+- [x] LitePull `pull_thread_nums` limits actual network concurrency.
+- [x] Listener and retry work use fixed, bounded, lifecycle-owned workers.
+- [x] Consecutive successful LitePull batches each create a pollable consume request.
+
+### gRPC and Proxy
+
+- [x] Long polls, short data operations, and control operations have independent bounded execution lanes.
+- [x] ACK, renewal, and offset operations are not ordered behind a group-wide long poll.
+- [x] Local Proxy execution is concurrent and deadline-aware rather than one global serial actor.
+- [x] Receipt renewal wakes at the earliest deadline and uses a control lane.
+- [x] Protobuf-to-Proxy-to-remoting body ownership uses reference-counted bytes.
+- [x] Receive/Pull responses are emitted incrementally with response-byte backpressure and drop cleanup.
+- [x] Priority, LiteTopic, and GZIP have validation and end-to-end business contracts.
+
+### Scope and compatibility
+
+- [x] Java alignment is expressed as message semantics, ordering, statuses, retry/DLQ, offsets, transaction, delay, FIFO, and gRPC behavior.
+- [x] Rust internals remain free to use more efficient scheduling and memory ownership.
+- [x] No compatibility-profile or legacy-default branch exists.
+- [x] DLedger remains a typed unsupported configuration and is excluded from all delivery gates.
+- [x] Deprecated pull APIs remain diagnosable with a LitePull migration path rather than false support.
+
+## Local end-to-end smoke evidence
+
+The managed run used a real Rust NameServer and Rust Broker. It is candidate-only smoke evidence, not a baseline/candidate performance comparison and not a production SLO.
+
+| Workload | Completed | Throughput | p99 |
+|---|---:|---:|---:|
+| Sync send, 128 B | 100 / 100 | 65.871 msg/s | 16,430 us |
+| Async send, 1 KiB | 200 / 200 | 262.411 msg/s | 723,747 us |
+| Batch 16, 1 KiB | 256 / 256 | 964.860 msg/s | 37,542 us |
+| LitePull, 1 KiB | 100 / 100 | 4,008.835 msg/s | 689 us |
+
+All four workloads recorded zero send and response failures. The report deliberately recorded `release_qualified: false` because it was a single local smoke run.
+
+## Performance evidence boundary
+
+- Direct producer batch encoding reduced the existing same-machine microbenchmark latency by approximately 16.4% to 22.0%; this is a microbenchmark, not Broker TPS.
+- A compatible 32-message POP acknowledgement is represented by one BatchAck RPC instead of 32 single ACK RPCs; target-environment latency still requires measurement.
+- Exact-range selection bounds copied bytes to the requested length, and the owner-backed HA range path records zero payload heap-copy by invariant tests; end-to-end CPU and throughput remain environment-dependent.
+- The LitePull regression that exposed only the first pollable batch completed 4 of 100 messages in an earlier run; the fixed managed smoke completed 100 of 100. This is functional regression evidence, not an isolated throughput A/B result.
+- Estimates from the original audit remain hypotheses until the same policy, hardware, durability contract, and workload produce a versioned comparison report.
+
+## Target-environment release gates
+
+- [ ] Candidate worktree is clean and artifact SHA matches the qualification report.
+- [ ] Baseline and candidate use the same hardware fingerprint, policy, business contract, durability contract, and workload parameters.
+- [ ] Every workload has one warm-up and at least five measured repetitions.
+- [ ] Every workload has zero missing messages and zero failed responses.
+- [ ] Median throughput regression is at most 10% and median p99 regression is at most 15%.
+- [ ] Dynamic Controller/Broker/process/network/storage fault evidence passes and artifact hashes validate.
+- [ ] Six-hour RSS, task, descriptor, queue-age, cache, and pending-request series has no prohibited monotonic growth.
+- [ ] Strict durability runs audit every `PutOk` message ID after clean failover with zero missing IDs.
+- [ ] The final report contains `status: "pass"` and `release_qualified: true`.
+- [ ] Operators have rehearsed the [message-path rollback runbook](message-path-rollback-runbook.md) in an isolated environment.
+
+## Go / no-go rule
+
+Release is **GO** only when every target-environment gate above is checked and the immutable evidence bundle is signed by the release owner. Any missing, mismatched, dirty, stale, or unverifiable evidence is **NO-GO**. Local smoke, Criterion, code-derived ratios, and estimates cannot override that decision.
+
+Use [message-path release qualification](message-path-release-qualification.md) to generate evidence and [message-path release and rollback runbook](message-path-rollback-runbook.md) to deploy or recover it.

--- a/rocketmq-doc/en/message-path-release-qualification.md
+++ b/rocketmq-doc/en/message-path-release-qualification.md
@@ -69,3 +69,9 @@ python scripts/message_path_qualification.py compare `
 ```
 
 The default gates reject throughput regression above 10% and p99 latency regression above 15%. Estimates and broker-free microbenchmarks are supporting analysis only; they are not accepted as release qualification.
+
+## Operational handoff
+
+Before promotion, review the [message-path delivery checklist](message-path-delivery-checklist.md). It distinguishes implemented behavior, local smoke evidence, and target-environment release qualification.
+
+Use the [message-path release and rollback runbook](message-path-rollback-runbook.md) for staged deployment, abort conditions, component-specific rollback, and post-rollback message auditing. Rollback restores the previous immutable binary and explicit configuration; it never relies on a legacy or Java compatibility profile and never rewrites message data or consumer offsets.

--- a/rocketmq-doc/en/message-path-rollback-runbook.md
+++ b/rocketmq-doc/en/message-path-rollback-runbook.md
@@ -1,0 +1,146 @@
+# Message-path release and rollback runbook
+
+This runbook covers the Rust producer, Proxy, Broker, store, consumer, and Controller message paths. It is the operational handoff for a release candidate that has already passed focused tests.
+
+The compatibility contract is externally visible business behavior: the Rust implementation must produce the same message semantics and results expected by Java clients, but its scheduling, ownership, batching, backpressure, storage leases, and high-availability internals remain Rust-native. The project has one optimal implementation path; it does not use legacy or Java compatibility profiles.
+
+DLedger is intentionally outside the Rust product scope. Do not add a DLedger migration, deployment, disk-format, performance, or rollback gate to this runbook. A DLedger configuration must fail fast with the existing typed unsupported result.
+
+## Non-negotiable rollback invariants
+
+- Do not delete, truncate, convert, or copy back CommitLog, ConsumeQueue, Index, Timer, RocksDB, or tiered-store data as part of rollback.
+- Do not rewrite consumer offsets, receipt handles, transaction state, confirm offset, or Controller epochs.
+- Do not enable unclean election to make a rollback appear successful.
+- Do not weaken the configured flush or replica-ack contract during rollback.
+- Roll back binaries and explicit configuration together. There is no compatibility-profile switch.
+- Keep request codes, headers, response codes, message order, retry/DLQ behavior, and persisted layouts unchanged.
+
+## Release inputs
+
+Record these values before any deployment:
+
+- candidate and rollback Git SHAs, immutable artifact or image digests, and build metadata;
+- the exact NameServer endpoint, topic, consumer group, and target-environment owner;
+- the effective Broker, store, Proxy, client, and Controller configuration;
+- the durability contract, including flush mode, required replica acknowledgements, ISR requirements, and clean-election policy;
+- the candidate `qualification-report.json`, same-environment performance comparison, fault-matrix directory, and six-hour soak report;
+- the dashboard or query links for send failures, latency, replication lag, queue age, renewal lateness, resource budgets, process CPU, RSS, and task count.
+
+The candidate is release-qualified only when `qualification-report.json` contains both `status: "pass"` and `release_qualified: true`. A passing local smoke report is useful functional evidence, but is not release approval.
+
+## Preflight
+
+1. Validate the committed policy and inspect the exact workload commands without connecting to a Broker:
+
+   ```powershell
+   python scripts/message_path_qualification.py validate-policy
+   python scripts/message_path_qualification.py plan `
+     --mode release `
+     --namesrv 10.0.0.15:9876 `
+     --confirm-target 10.0.0.15:9876 `
+     --topic ReleaseQualification `
+     --durability-contract sync-flush-required-replica-acks
+   ```
+
+2. Verify that the release worktree is clean and that the report SHA matches the candidate artifact.
+3. Confirm Controller quorum, Broker roles, ISR membership, confirm offset, replication lag, disk headroom, and clean-election policy.
+4. Export effective configuration and routing metadata. Keep the previous immutable artifact and its matching configuration immediately available.
+5. Confirm that dashboards and alerts can distinguish client queueing, Proxy admission, Broker processing, store/flush, HA wait, ACK/renew, and consumer lag.
+6. Stop if any required evidence is absent, belongs to different hardware or durability settings, or contains an unknown schema version.
+
+## Staged rollout
+
+### Stage 1: evidence freeze
+
+- Archive the qualification report and all referenced raw artifacts by content hash.
+- Record the operator, start time, candidate SHA, rollback SHA, and approval decision.
+- Freeze unrelated configuration and topic changes until rollout completes.
+
+### Stage 2: client and Proxy canary
+
+- Route a bounded producer and consumer cohort through one candidate Proxy or client deployment.
+- Exercise sync, async, batch, POP/LitePull, ACK/change-invisible-time, retry, DLQ, FIFO, delay, transaction, Priority, LiteTopic, Identity, and GZIP behavior that the deployment uses.
+- Hold the canary long enough to cross message invisibility, retry, rebalance, and route-refresh windows.
+- Compare success count, duplicate count, throughput, p99 latency, queue age, renew lateness, response-byte budget, CPU, and RSS with the frozen baseline.
+
+### Stage 3: Broker and store canary
+
+- Upgrade one eligible replica at a time while maintaining quorum and required ISR.
+- Wait for role, route, confirm-offset, replication-lag, and store-health convergence before promoting the next replica.
+- Run bounded write/read verification and confirm that every acknowledged message can be consumed once the business retry policy is applied.
+- Never remove the rollback binary until the canary has completed recovery and restart checks.
+
+### Stage 4: Controller and availability-zone waves
+
+- Change one Controller member at a time and preserve quorum.
+- Verify linearizable metadata reads, Broker authority, clean election, route convergence, and segmented T0-T5 failover evidence.
+- Expand by availability zone or another independently reversible wave. Re-run the short qualification workload after every wave.
+
+### Stage 5: full rollout and observation
+
+- Promote only after every prior stage remains inside the approved gates.
+- Continue observation through the six-hour resource-growth window.
+- Archive the final report, configuration, dashboards, and operator decision.
+
+## Abort triggers
+
+Stop promotion and start rollback when any of these conditions is confirmed:
+
+- a message acknowledged as `PutOk` is missing, corrupted, assigned an invalid offset, or violates the configured ordering contract;
+- unexpected duplicate delivery exceeds the business retry/visibility contract;
+- send, receive, ACK, renewal, offset, retry, DLQ, transaction, delay, FIFO, Priority, or LiteTopic behavior differs from the accepted contract;
+- same-environment throughput regresses by more than 10% or p99 latency regresses by more than 15%;
+- ACK/change-invisible-time is starved by long polling, renewal occurs after its safety deadline, or a local long poll expires before its requested wait;
+- count, byte, age, cache, write-buffer, response-stream, or task ownership limits are exceeded or leak after cancellation;
+- confirm offset regresses or exceeds a legal in-sync durable acknowledgement, clean election fails, or the accepted RPO/RTO evidence is violated;
+- the six-hour run detects monotonic RSS, task, file-descriptor, queue-age, cache, or pending-request growth;
+- operators cannot explain a schema mismatch, dirty worktree, target mismatch, or missing raw artifact.
+
+## Rollback procedure
+
+1. Stop promotion immediately and record the trigger, first bad timestamp, affected wave, and evidence links.
+2. Stop routing new producer traffic to the affected canary. Allow bounded in-flight requests to complete or reach their original absolute deadline; do not extend deadlines during rollback.
+3. Drain or pause affected consumers and Proxies so ACK, renewal, and offset operations are not abandoned midway. Keep healthy control lanes available.
+4. Restore the previous immutable client or Proxy binary and its matching explicit configuration. Re-enable traffic gradually after route and session checks pass.
+5. For Broker/store rollback, verify quorum and ISR first, then replace one replica at a time. Wait for replication and confirm-offset convergence between replicas. Do not roll all replicas simultaneously.
+6. For Controller rollback, maintain a majority throughout, verify the active authority epoch after every member, and keep clean election enabled.
+7. Reuse the existing data directories unchanged. If the previous binary cannot read them, stop and escalate; do not attempt an ad hoc data conversion.
+8. Re-run the bounded managed smoke or an equivalent isolated target-environment smoke against the restored version.
+9. Verify routes, Broker role, Controller quorum, ISR, confirm offset, consumer offsets, retry/DLQ, ACK/renew, and all `PutOk` message IDs captured during the affected interval.
+10. Keep the rollout closed until the incident owner signs off the message audit and resource usage has returned to a stable baseline.
+
+## Component rollback matrix
+
+| Component | Safe rollback unit | Preserve | Mandatory verification |
+|---|---|---|---|
+| Producer/client | One deployment cohort | unique IDs, timeout budget, retry policy | sync/async/batch results, callback once, no missing acknowledged IDs |
+| gRPC Proxy | One instance or traffic slice | session/receipt contract, absolute deadlines | send/receive streams, ACK/renew control lane, response budgets |
+| Broker/store | One replica | all data files, offsets, confirm state | write/read, recovery, CQ visibility, flush and replica ACK contract |
+| Controller | One quorum member | Raft state, authority epoch, clean election | quorum, linearizable read, Broker authority, route convergence |
+| Qualification tooling | One pinned Git SHA | policy and report schema | policy validation, artifact hashes, target confirmation |
+
+## Post-rollback verification
+
+- [ ] The restored artifact and configuration digests match the recorded rollback set.
+- [ ] NameServer routes, Controller quorum, Broker roles, ISR, and confirm offset are healthy.
+- [ ] All acknowledged audit message IDs are readable; missing and unexpected duplicate counts are zero.
+- [ ] Sync, async, batch, POP/LitePull, ACK, retry, DLQ, FIFO, delay, and transaction smoke checks pass.
+- [ ] Production-used Priority, LiteTopic, and GZIP paths pass their contract checks.
+- [ ] Queue, byte, cache, write-buffer, response-stream, and task usage return below configured limits.
+- [ ] No data directory or consumer offset was deleted, rewritten, or migrated.
+- [ ] Incident evidence, owner, timestamps, root cause, and the next release decision are archived.
+
+## Sign-off record
+
+| Field | Value |
+|---|---|
+| Candidate SHA / artifact | |
+| Rollback SHA / artifact | |
+| Durability contract | |
+| Confirmed target | |
+| Qualification report hash | |
+| Performance comparison hash | |
+| Fault-matrix evidence hash | |
+| Soak report hash | |
+| Release or rollback operator | |
+| Decision and timestamp | |


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

Closes #9274

### Brief Description

Adds the final message-path delivery checklist and staged release/rollback runbook, and links both from the release qualification guide. The handoff defines Java alignment by externally visible business semantics while keeping one Rust-native implementation path, excludes DLedger from product scope, and separates implemented, local-smoke, and release-qualified evidence states.

### How Did You Test This Change?

- `python scripts/message_path_qualification.py validate-policy`
- `python scripts/message_path_qualification.py plan --mode release --namesrv 10.0.0.15:9876 --confirm-target 10.0.0.15:9876 --topic ReleaseQualification --durability-contract sync-flush-required-replica-acks`
- validated all relative Markdown links across `rocketmq-doc/en/message-path-*.md`
- verified the handoff contains no compatibility-profile identifiers
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive message delivery checklist covering implementation evidence, validation, performance, compatibility, and release-readiness criteria.
  * Added operational handoff guidance for promotion reviews, staged deployments, rollback procedures, and post-rollback auditing.
  * Added a release and rollback runbook covering preflight checks, rollout gates, abort triggers, component recovery, verification, and sign-off requirements.
  * Documented unsupported DLedger migration scope and required handling for related configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->