### PR TITLE
[ISSUE #9277]🚀Add readiness-filtered NameServer discovery to Helm

### DIFF
--- a/distribution/helm/rocketmq-rust/templates/_helpers.tpl
+++ b/distribution/helm/rocketmq-rust/templates/_helpers.tpl
@@ -232,11 +232,15 @@ rocketmq.apache.org/service: {{ .service }}
 {{- end -}}
 
 {{- define "rocketmq.namesrvAddresses" -}}
+{{- if .Values.services.namesrv.discovery.enabled -}}
+rocketmq-namesrv-discovery.{{ .Release.Namespace }}.svc.cluster.local:9876
+{{- else -}}
 {{- $addresses := list -}}
 {{- range $ordinal := until (int .Values.services.namesrv.replicas) -}}
   {{- $addresses = append $addresses (printf "rocketmq-namesrv-%d.rocketmq-namesrv-headless.%s.svc.cluster.local:9876" $ordinal $.Release.Namespace) -}}
 {{- end -}}
 {{ join ";" $addresses }}
+{{- end -}}
 {{- end -}}
 
 {{- define "rocketmq.controllerAddresses" -}}

--- a/distribution/helm/rocketmq-rust/templates/services.yaml
+++ b/distribution/helm/rocketmq-rust/templates/services.yaml
@@ -47,6 +47,26 @@ spec:
 {{- end }}
 ---
 {{- end }}
+{{- if $root.Values.services.namesrv.discovery.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: rocketmq-namesrv-discovery
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+{{ include "rocketmq.labels" (dict "root" $root "service" "namesrv") | indent 4 }}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: false
+  selector:
+{{ include "rocketmq.selectorLabels" (dict "root" $root "service" "namesrv") | indent 4 }}
+  ports:
+    - name: remoting
+      port: 9876
+      targetPort: 9876
+      protocol: TCP
+---
+{{- end }}
 {{- if eq .Values.deploymentProfile "production-controller-ha" }}
 {{- range $ordinal := until (int .Values.services.controller.replicas) }}
 apiVersion: v1

--- a/distribution/helm/rocketmq-rust/values-dev-single.yaml
+++ b/distribution/helm/rocketmq-rust/values-dev-single.yaml
@@ -29,6 +29,9 @@ services:
       minAvailable: 1
   namesrv:
     replicas: 1
+    discovery:
+      enabled: false
+      mode: dns
     image:
       repository: rocketmq-rust/namesrv
       tag: local

--- a/distribution/helm/rocketmq-rust/values-production-controller-ha.yaml
+++ b/distribution/helm/rocketmq-rust/values-production-controller-ha.yaml
@@ -30,6 +30,9 @@ services:
       pullPolicy: Never
   namesrv:
     replicas: 3
+    discovery:
+      enabled: true
+      mode: dns
     image:
       repository: rocketmq-rust/namesrv
       tag: local

--- a/distribution/helm/rocketmq-rust/values.schema.json
+++ b/distribution/helm/rocketmq-rust/values.schema.json
@@ -580,6 +580,7 @@
       "additionalProperties": false,
       "required": [
         "replicas",
+        "discovery",
         "image",
         "persistence",
         "pdb",
@@ -590,6 +591,25 @@
           "type": "integer",
           "minimum": 1,
           "maximum": 9
+        },
+        "discovery": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "enabled",
+            "mode"
+          ],
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "mode": {
+              "type": "string",
+              "enum": [
+                "dns"
+              ]
+            }
+          }
         },
         "image": {
           "$ref": "#/definitions/image"

--- a/distribution/helm/rocketmq-rust/values.yaml
+++ b/distribution/helm/rocketmq-rust/values.yaml
@@ -84,6 +84,9 @@ services:
       limits: {cpu: 4000m, memory: 8Gi}
   namesrv:
     replicas: 3
+    discovery:
+      enabled: false
+      mode: dns
     image:
       repository: rocketmq-rust/namesrv
       tag: local

--- a/distribution/kubernetes/base/manifest.yaml
+++ b/distribution/kubernetes/base/manifest.yaml
@@ -488,7 +488,7 @@ data:
     brokerIp1 = "rocketmq-broker-0.rocketmq-broker-headless.rocketmq.svc.cluster.local"
     brokerIp2 = "rocketmq-broker-0.rocketmq-broker-headless.rocketmq.svc.cluster.local"
     storePathRootDir = "/var/lib/rocketmq/store"
-    namesrvAddr = "rocketmq-namesrv-0.rocketmq-namesrv-headless.rocketmq.svc.cluster.local:9876;rocketmq-namesrv-1.rocketmq-namesrv-headless.rocketmq.svc.cluster.local:9876;rocketmq-namesrv-2.rocketmq-namesrv-headless.rocketmq.svc.cluster.local:9876"
+    namesrvAddr = "rocketmq-namesrv-discovery.rocketmq.svc.cluster.local:9876"
     autoCreateTopicEnable = false
     enableControllerMode = true
     controllerAddr = "10.96.0.201:60109;10.96.0.202:60109;10.96.0.203:60109"
@@ -519,7 +519,7 @@ data:
     brokerIp1 = "rocketmq-broker-1.rocketmq-broker-headless.rocketmq.svc.cluster.local"
     brokerIp2 = "rocketmq-broker-1.rocketmq-broker-headless.rocketmq.svc.cluster.local"
     storePathRootDir = "/var/lib/rocketmq/store"
-    namesrvAddr = "rocketmq-namesrv-0.rocketmq-namesrv-headless.rocketmq.svc.cluster.local:9876;rocketmq-namesrv-1.rocketmq-namesrv-headless.rocketmq.svc.cluster.local:9876;rocketmq-namesrv-2.rocketmq-namesrv-headless.rocketmq.svc.cluster.local:9876"
+    namesrvAddr = "rocketmq-namesrv-discovery.rocketmq.svc.cluster.local:9876"
     autoCreateTopicEnable = false
     enableControllerMode = true
     controllerAddr = "10.96.0.201:60109;10.96.0.202:60109;10.96.0.203:60109"
@@ -550,7 +550,7 @@ data:
     brokerIp1 = "rocketmq-broker-2.rocketmq-broker-headless.rocketmq.svc.cluster.local"
     brokerIp2 = "rocketmq-broker-2.rocketmq-broker-headless.rocketmq.svc.cluster.local"
     storePathRootDir = "/var/lib/rocketmq/store"
-    namesrvAddr = "rocketmq-namesrv-0.rocketmq-namesrv-headless.rocketmq.svc.cluster.local:9876;rocketmq-namesrv-1.rocketmq-namesrv-headless.rocketmq.svc.cluster.local:9876;rocketmq-namesrv-2.rocketmq-namesrv-headless.rocketmq.svc.cluster.local:9876"
+    namesrvAddr = "rocketmq-namesrv-discovery.rocketmq.svc.cluster.local:9876"
     autoCreateTopicEnable = false
     enableControllerMode = true
     controllerAddr = "10.96.0.201:60109;10.96.0.202:60109;10.96.0.203:60109"
@@ -839,7 +839,7 @@ data:
     listenAddr = "0.0.0.0:8080"
 
     [cluster]
-    namesrvAddr = "rocketmq-namesrv-0.rocketmq-namesrv-headless.rocketmq.svc.cluster.local:9876;rocketmq-namesrv-1.rocketmq-namesrv-headless.rocketmq.svc.cluster.local:9876;rocketmq-namesrv-2.rocketmq-namesrv-headless.rocketmq.svc.cluster.local:9876"
+    namesrvAddr = "rocketmq-namesrv-discovery.rocketmq.svc.cluster.local:9876"
 
     [auth]
     clusterName = "RocketmqRust"
@@ -901,7 +901,7 @@ data:
 
     [[clusters]]
     name = "rocketmq-rust"
-    namesrv_addr = "rocketmq-namesrv-0.rocketmq-namesrv-headless.rocketmq.svc.cluster.local:9876;rocketmq-namesrv-1.rocketmq-namesrv-headless.rocketmq.svc.cluster.local:9876;rocketmq-namesrv-2.rocketmq-namesrv-headless.rocketmq.svc.cluster.local:9876"
+    namesrv_addr = "rocketmq-namesrv-discovery.rocketmq.svc.cluster.local:9876"
     default = true
 
     [security]
@@ -1149,6 +1149,33 @@ spec:
     rocketmq.apache.org/service: namesrv
   ports:
     - name: tcp-9876
+      port: 9876
+      targetPort: 9876
+      protocol: TCP
+---
+# Source: rocketmq-rust/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: rocketmq-namesrv-discovery
+  namespace: rocketmq
+  labels:
+    app.kubernetes.io/name: rocketmq-namesrv
+    app.kubernetes.io/instance: rocketmq
+    app.kubernetes.io/part-of: rocketmq-rust
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "0.1.0"
+    rocketmq.apache.org/service: namesrv
+    rocketmq.apache.org/architecture-milestone: P0-05
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: false
+  selector:
+    app.kubernetes.io/name: rocketmq-namesrv
+    app.kubernetes.io/instance: rocketmq
+    rocketmq.apache.org/service: namesrv
+  ports:
+    - name: remoting
       port: 9876
       targetPort: 9876
       protocol: TCP

--- a/scripts/kind-architecture-refactor-e2e.ps1
+++ b/scripts/kind-architecture-refactor-e2e.ps1
@@ -60,7 +60,7 @@ $FaultDriverImage = "rocketmq-rust/fault-driver:$RunId"
 $Topic = "ArchitectureRefactorFaultMatrix"
 $MessageKey = "fault-$RunId"
 $MessageBody = "M11-11 acknowledged durability probe $RunId"
-$NamesrvAddress = "rocketmq-namesrv-0.rocketmq-namesrv-headless.$Namespace.svc.cluster.local:9876"
+$NamesrvAddress = "rocketmq-namesrv-discovery.$Namespace.svc.cluster.local:9876"
 
 function Require-Command {
     param([Parameter(Mandatory)][string]$Name)
@@ -219,6 +219,7 @@ services:
       limits: { cpu: 2000m, memory: 4Gi }
   namesrv:
     replicas: 3
+    discovery: { enabled: true, mode: dns }
     image: { repository: $($repositories['namesrv']), digest: $(Get-ImageDigest $Images['namesrv']), pullPolicy: Never }
     persistence: { storageClassName: $StorageClass, size: 1Gi }
     resources:
@@ -568,6 +569,36 @@ function Set-StatefulSetReplicas {
         Start-Sleep -Seconds 3
     } while ([DateTimeOffset]::UtcNow -lt $deadline)
     throw "statefulset/$Name did not reach $Replicas ready replicas before the deadline"
+}
+
+function Wait-NameServerDiscoveryEndpoints {
+    param(
+        [Parameter(Mandatory)][ValidateRange(0, 32)][int]$Expected,
+        [ValidateRange(1, 600)][int]$TimeoutSeconds = 180
+    )
+    $deadline = [DateTimeOffset]::UtcNow.AddSeconds($TimeoutSeconds)
+    do {
+        $slices = ((Invoke-Native kubectl @(
+            '-n',
+            $Namespace,
+            'get',
+            'endpointslice',
+            '-l',
+            'kubernetes.io/service-name=rocketmq-namesrv-discovery',
+            '-o',
+            'json'
+        )).Output | ConvertFrom-Json)
+        $ready = @(
+            $slices.items |
+                ForEach-Object { $_.endpoints } |
+                Where-Object { $_.conditions.ready -eq $true -and @($_.addresses).Count -gt 0 }
+        ).Count
+        if ($ready -eq $Expected) {
+            return [pscustomobject]@{ Count = $ready; Output = ($slices | ConvertTo-Json -Depth 20) }
+        }
+        Start-Sleep -Seconds 2
+    } while ([DateTimeOffset]::UtcNow -lt $deadline)
+    throw "rocketmq-namesrv-discovery did not converge to $Expected ready endpoints before the deadline"
 }
 
 function Get-ControllerLeadershipSnapshot {
@@ -1142,6 +1173,40 @@ spec: { selector: { app.kubernetes.io/name: otel-collector }, ports: [{ name: ot
     $ack = Send-AcknowledgedMessage
     $before = Query-AcknowledgedMessage $ack.Id
 
+    $discoveryService = (Invoke-Native kubectl @('-n', $Namespace, 'get', 'service/rocketmq-namesrv-discovery', '-o', 'json')).Output | ConvertFrom-Json
+    $legacyNamesrvService = (Invoke-Native kubectl @('-n', $Namespace, 'get', 'service/rocketmq-namesrv-headless', '-o', 'json')).Output | ConvertFrom-Json
+    $initialDiscovery = Wait-NameServerDiscoveryEndpoints 3
+    try {
+        $scaleDownDiscovery = Set-StatefulSetReplicas 'rocketmq-namesrv' 2
+        $scaledDownDiscovery = Wait-NameServerDiscoveryEndpoints 2
+        $scaledDownRoute = Invoke-RouteProbe -AllowFailure
+    } finally {
+        $restoreDiscovery = Set-StatefulSetReplicas 'rocketmq-namesrv' 3
+        $restoredDiscovery = Wait-NameServerDiscoveryEndpoints 3
+    }
+    $nameserverDiscoveryAcceptance = [ordered]@{
+        discovery_service_is_headless = $discoveryService.spec.clusterIP -eq 'None'
+        discovery_excludes_not_ready_addresses = $discoveryService.spec.publishNotReadyAddresses -ne $true
+        legacy_service_keeps_stable_identities = $legacyNamesrvService.spec.publishNotReadyAddresses -eq $true
+        ready_endpoints_scaled_from_three_to_two = $initialDiscovery.Count -eq 3 -and $scaledDownDiscovery.Count -eq 2
+        route_discovery_remained_available = $scaledDownRoute.ExitCode -eq 0
+        ready_endpoints_restored_to_three = $restoredDiscovery.Count -eq 3
+    }
+    foreach ($assertion in $nameserverDiscoveryAcceptance.GetEnumerator()) {
+        Assert-True ($assertion.Value -eq $true) "nameserver_ready_only_discovery.$($assertion.Key)"
+    }
+    $nameserverDiscoveryAcceptanceEvidence = ([ordered]@{
+        assertions = $nameserverDiscoveryAcceptance
+        discovery_service = ($discoveryService | ConvertTo-Json -Depth 20)
+        legacy_service = ($legacyNamesrvService | ConvertTo-Json -Depth 20)
+        initial_endpoints = $initialDiscovery.Output
+        scale_down_status = $scaleDownDiscovery.Output
+        scaled_down_endpoints = $scaledDownDiscovery.Output
+        route_probe = "exit=$($scaledDownRoute.ExitCode)`n$($scaledDownRoute.Output)"
+        restore_status = $restoreDiscovery.Output
+        restored_endpoints = $restoredDiscovery.Output
+    } | ConvertTo-Json -Depth 30)
+
     $rolloutTimer = [Diagnostics.Stopwatch]::StartNew()
     Set-ServiceImages $CandidateImages $CandidateImageCommit "$($RunId.ToLowerInvariant())-candidate"
     $afterUpgrade = Query-AcknowledgedMessage $ack.Id
@@ -1255,13 +1320,14 @@ spec: { selector: { app.kubernetes.io/name: otel-collector }, ports: [{ name: ot
     }
     $namesrvRestored = ((Invoke-Native kubectl @('-n', $Namespace, 'get', 'statefulset/rocketmq-namesrv', '-o', 'json')).Output | ConvertFrom-Json).status
     Complete-Scenario 'nameserver_majority_unavailable' ([ordered]@{
-        majority_unavailable_observed = $majorityScale.State.status.readyReplicas -eq 1
+        majority_unavailable_observed = $majorityScale.State.status.readyReplicas -eq 1 -and
+            @($nameserverDiscoveryAcceptance.Values | Where-Object { $_ -ne $true }).Count -eq 0
         cached_route_data_plane_bounded = $majorityTimer.Elapsed.TotalSeconds -lt 120
         failure_mode_typed_or_bounded = $majorityRoute.ExitCode -ge 0
         acknowledged_message_visible = $majorityMessage.QueueOffset -eq $before.QueueOffset
-        nameserver_replicas_restored = $namesrvRestored.readyReplicas -eq 3
+        nameserver_replicas_restored = $namesrvRestored.readyReplicas -eq 3 -and $restoredDiscovery.Count -eq 3
     }) ([ordered]@{
-        scale_down_status = $majorityScale.Output
+        scale_down_status = "$nameserverDiscoveryAcceptanceEvidence`n$($majorityScale.Output)"
         cached_route_probe = $majorityMessage.Output
         fresh_route_probe = "exit=$($majorityRoute.ExitCode)`n$($majorityRoute.Output)"
         message_after = $majorityMessage.Output

--- a/scripts/kubernetes_assets_guard.py
+++ b/scripts/kubernetes_assets_guard.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from typing import Any
 
 
-EXPECTED_RESOURCE_COUNT = 44
+EXPECTED_RESOURCE_COUNT = 45
 LOCAL_IMAGE_TAG = "local"
 CONTROLLER_SERVICE_IPS = ("10.96.0.201", "10.96.0.202", "10.96.0.203")
 EXPECTED_CONTAINER_AUXILIARY_PORTS = {
@@ -359,6 +359,7 @@ def validate_source_assets(guard: Guard) -> None:
         "distribution/helm/rocketmq-rust/Chart.yaml",
         "distribution/helm/rocketmq-rust/values.yaml",
         "distribution/helm/rocketmq-rust/values.schema.json",
+        "distribution/helm/rocketmq-rust/values-dev-single.yaml",
         "distribution/helm/rocketmq-rust/values-production-controller-ha.yaml",
         "distribution/helm/rocketmq-rust/templates/_helpers.tpl",
         "distribution/helm/rocketmq-rust/templates/configmaps.yaml",
@@ -369,6 +370,7 @@ def validate_source_assets(guard: Guard) -> None:
         "distribution/kubernetes/overlays/secure/kustomization.yaml",
         "distribution/kubernetes/README.md",
         "scripts/kubernetes-assets-contract.ps1",
+        "scripts/kind-architecture-refactor-e2e.ps1",
         ".github/workflows/kubernetes-assets-ci.yml",
     ]
     for relative in required:
@@ -385,7 +387,17 @@ def validate_source_assets(guard: Guard) -> None:
         re.search(r"(?i)\$iswindows\b", contract_script) is None,
         "asset contract must not assign or reference reserved $IsWindows",
     )
+    kind_e2e = guard.read("scripts/kind-architecture-refactor-e2e.ps1")
+    for snippet in (
+        "rocketmq-namesrv-discovery.$Namespace.svc.cluster.local:9876",
+        "discovery: { enabled: true, mode: dns }",
+        "Wait-NameServerDiscoveryEndpoints",
+        "nameserver_ready_only_discovery",
+    ):
+        guard.require(snippet in kind_e2e, f"Kind NameServer discovery acceptance contract missing {snippet}")
 
+    services_template = guard.read("distribution/helm/rocketmq-rust/templates/services.yaml")
+    helpers_template = guard.read("distribution/helm/rocketmq-rust/templates/_helpers.tpl")
     chart_sources = "\n".join(
         guard.read(f"distribution/helm/rocketmq-rust/templates/{name}")
         for name in (
@@ -427,9 +439,34 @@ def validate_source_assets(guard: Guard) -> None:
         "production-controller-ha requires one unique Controller peer Service IP per Controller replica" in chart_sources,
         "Controller peer Service IP cardinality must fail closed",
     )
+    for snippet in (
+        "name: rocketmq-namesrv-discovery",
+        "clusterIP: None",
+        "publishNotReadyAddresses: false",
+        "name: remoting",
+        "port: 9876",
+        "targetPort: 9876",
+    ):
+        guard.require(snippet in services_template, f"NameServer discovery Service contract missing {snippet}")
+    guard.require(
+        "name: rocketmq-{{ $service }}-headless" in services_template
+        and "publishNotReadyAddresses: true" in services_template,
+        "legacy StatefulSet headless Services must retain publishNotReadyAddresses=true",
+    )
+    guard.require(
+        ".Values.services.namesrv.discovery.enabled" in helpers_template
+        and "rocketmq-namesrv-discovery.{{ .Release.Namespace }}.svc.cluster.local:9876" in helpers_template,
+        "NameServer address helper must retain the opt-in discovery FQDN",
+    )
 
     values = guard.read("distribution/helm/rocketmq-rust/values.yaml")
+    development_values = guard.read("distribution/helm/rocketmq-rust/values-dev-single.yaml")
     production_values = guard.read("distribution/helm/rocketmq-rust/values-production-controller-ha.yaml")
+    default_discovery = "discovery:\n      enabled: false\n      mode: dns"
+    production_discovery = "discovery:\n      enabled: true\n      mode: dns"
+    guard.require(default_discovery in values, "default Helm values must keep NameServer discovery disabled")
+    guard.require(default_discovery in development_values, "development Helm values must keep NameServer discovery disabled")
+    guard.require(production_discovery in production_values, "production render fixture must opt in to NameServer discovery")
     guard.require(
         "Local rendering fixture" in production_values,
         "production Helm values must remain explicitly labeled as a local rendering fixture",
@@ -454,6 +491,27 @@ def validate_source_assets(guard: Guard) -> None:
     services_schema = schema.get("properties", {}).get("services", {})
     guard.require(services_schema.get("additionalProperties") is False, "Helm service schema must reject unknown services")
     guard.require(set(services_schema.get("required", [])) == set(EXPECTED_SERVICES), "Helm schema must require five services")
+    discovery_schema = (
+        schema.get("definitions", {})
+        .get("namesrv", {})
+        .get("properties", {})
+        .get("discovery", {})
+    )
+    guard.require(discovery_schema.get("type") == "object", "NameServer discovery schema must be an object")
+    guard.require(discovery_schema.get("additionalProperties") is False, "NameServer discovery schema must reject unknown fields")
+    guard.require(
+        set(discovery_schema.get("required", [])) == {"enabled", "mode"},
+        "NameServer discovery schema must require enabled and mode",
+    )
+    discovery_properties = discovery_schema.get("properties", {})
+    guard.require(
+        discovery_properties.get("enabled", {}).get("type") == "boolean",
+        "NameServer discovery enabled schema must be boolean",
+    )
+    guard.require(
+        discovery_properties.get("mode", {}).get("enum") == ["dns"],
+        "NameServer discovery mode schema must allow only dns",
+    )
 
     base_kustomization = guard.read("distribution/kubernetes/base/kustomization.yaml")
     secure_overlay = guard.read("distribution/kubernetes/overlays/secure/kustomization.yaml")
@@ -627,6 +685,36 @@ def validate_render(guard: Guard, label: str, text: str) -> dict[str, Any]:
             re.search(r"(?m)^\s+(?:port|targetPort):\s*8088\s*$", service_document.text) is None,
             f"{label}: health port 8088 must not be exposed through a Service",
         )
+
+    legacy_namesrv_service = find_document(documents, "Service", "rocketmq-namesrv-headless")
+    guard.require(legacy_namesrv_service is not None, f"{label}: legacy NameServer headless Service missing")
+    if legacy_namesrv_service is not None:
+        guard.require("clusterIP: None" in legacy_namesrv_service.text, f"{label}: legacy NameServer Service must remain headless")
+        guard.require(
+            "publishNotReadyAddresses: true" in legacy_namesrv_service.text,
+            f"{label}: legacy NameServer Service must continue publishing StatefulSet identities",
+        )
+
+    discovery_service = find_document(documents, "Service", "rocketmq-namesrv-discovery")
+    guard.require(discovery_service is not None, f"{label}: readiness-filtered NameServer discovery Service missing")
+    if discovery_service is not None:
+        for snippet in (
+            "clusterIP: None",
+            "publishNotReadyAddresses: false",
+            "name: remoting",
+            "port: 9876",
+            "targetPort: 9876",
+            "rocketmq.apache.org/service: namesrv",
+        ):
+            guard.require(snippet in discovery_service.text, f"{label}: NameServer discovery Service missing {snippet}")
+        guard.require(
+            "app.kubernetes.io/name: rocketmq-namesrv" in discovery_service.text,
+            f"{label}: NameServer discovery Service selector drifted",
+        )
+    guard.require(
+        "rocketmq-namesrv-discovery.rocketmq.svc.cluster.local:9876" in text,
+        f"{label}: opt-in NameServer discovery FQDN missing from rendered configuration",
+    )
 
     controller_config = find_document(documents, "ConfigMap", "rocketmq-controller-config")
     guard.require(controller_config is not None, f"{label}: Controller config map missing")

--- a/scripts/tests/test_m11_kubernetes_assets.py
+++ b/scripts/tests/test_m11_kubernetes_assets.py
@@ -40,6 +40,10 @@ class KubernetesAssetsGuardTests(unittest.TestCase):
             REPO_ROOT / "scripts" / "kubernetes-assets-contract.ps1",
             self.root / "scripts" / "kubernetes-assets-contract.ps1",
         )
+        shutil.copy2(
+            REPO_ROOT / "scripts" / "kind-architecture-refactor-e2e.ps1",
+            self.root / "scripts" / "kind-architecture-refactor-e2e.ps1",
+        )
         (self.root / ".github" / "workflows").mkdir(parents=True)
         shutil.copy2(
             REPO_ROOT / ".github" / "workflows" / "kubernetes-assets-ci.yml",
@@ -71,8 +75,51 @@ class KubernetesAssetsGuardTests(unittest.TestCase):
         self.assertIn(old, source)
         path.write_text(source.replace(old, new, count), encoding="utf-8")
 
+    def mutate_document_text(self, relative: str, kind: str, name: str, old: str, new: str) -> None:
+        path = self.root / relative
+        source = path.read_text(encoding="utf-8")
+        marker = f"kind: {kind}\nmetadata:\n  name: {name}\n"
+        start = source.index(marker)
+        end = source.find("\n---", start)
+        self.assertNotEqual(end, -1)
+        document = source[start:end]
+        self.assertIn(old, document)
+        updated = document.replace(old, new, 1)
+        path.write_text(source[:start] + updated + source[end:], encoding="utf-8")
+
     def test_repository_contract_passes(self) -> None:
         self.run_guard(expect_success=True)
+
+    def test_nameserver_discovery_must_remain_opt_in_by_default(self) -> None:
+        self.mutate_text(
+            "distribution/helm/rocketmq-rust/values.yaml",
+            "discovery:\n      enabled: false\n      mode: dns",
+            "discovery:\n      enabled: true\n      mode: dns",
+        )
+        result = self.run_guard(expect_success=False)
+        self.assertIn("discovery disabled", result.stderr)
+
+    def test_nameserver_discovery_service_must_exclude_not_ready_pods(self) -> None:
+        self.mutate_document_text(
+            "distribution/kubernetes/base/manifest.yaml",
+            "Service",
+            "rocketmq-namesrv-discovery",
+            "  publishNotReadyAddresses: false",
+            "  publishNotReadyAddresses: true",
+        )
+        result = self.run_guard(expect_success=False)
+        self.assertIn("NameServer discovery Service", result.stderr)
+
+    def test_legacy_nameserver_headless_service_keeps_stable_identity_contract(self) -> None:
+        self.mutate_document_text(
+            "distribution/kubernetes/base/manifest.yaml",
+            "Service",
+            "rocketmq-namesrv-headless",
+            "  publishNotReadyAddresses: true",
+            "  publishNotReadyAddresses: false",
+        )
+        result = self.run_guard(expect_success=False)
+        self.assertIn("legacy NameServer Service", result.stderr)
 
     def test_controller_quorum_drift_is_rejected(self) -> None:
         path = self.root / "distribution/kubernetes/deployment-policy.json"


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9277

### Brief Description

Add an opt-in `rocketmq-namesrv-discovery` Headless Service that publishes only Ready NameServer pods while preserving the existing StatefulSet headless Service and ordinal FQDN fallback. Extend Helm values and schema, switch the canonical production render fixture to the discovery FQDN, regenerate the committed Kubernetes base, and add contract checks plus a 3-to-2-to-3 Ready endpoint convergence path to the Kind runner.

### How Did You Test This Change?

- `.\scripts\kubernetes-assets-contract.ps1` (45 Helm and Kustomize resources passed kubeconform; generated base matched)
- `python -m unittest scripts.tests.test_m11_kubernetes_assets -v` (16 passed)
- `python -m unittest scripts.tests.test_m11_service_lifecycle -v` (4 passed)
- `python scripts\fault_matrix_guard.py --policy-only` (passed)
- `python -m unittest scripts.tests.test_m11_fault_matrix -v` (33 passed)
- Rendered default and development values with the pinned Helm binary and verified ordinal fallback; rendered production values and verified the discovery Service/FQDN opt-in.
- `git diff --check`

Dynamic Kind Run mode was not executed because this host does not have PowerShell 7 and the required cluster image and secret inputs were not provided.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional DNS-based NameServer discovery for Helm deployments.
  * Added a readiness-filtered discovery service for connecting to available NameServer instances.
  * Updated production high-availability configuration to enable discovery by default.

* **Bug Fixes**
  * Preserved legacy headless service behavior for readiness-independent NameServer access.

* **Tests**
  * Added validation for discovery readiness, scaling, configuration defaults, and service behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->