### PR TITLE
[ISSUE #9279]✨Bind qualification evidence to immutable release identity

### DIFF
--- a/scripts/message-path-performance-comparison-schema.json
+++ b/scripts/message-path-performance-comparison-schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rocketmq.apache.org/schemas/message-path-performance-comparison-v2.json",
+  "title": "RocketMQ Rust message-path performance comparison",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "generated_at",
+    "status",
+    "release_comparison_qualified",
+    "policy_sha256",
+    "durability_contract",
+    "hardware_id",
+    "target",
+    "baseline",
+    "candidate",
+    "failures",
+    "comparisons"
+  ],
+  "properties": {
+    "schema_version": { "const": 2 },
+    "artifact_kind": { "const": "rocketmq_message_path_comparison" },
+    "generated_at": { "type": "string", "minLength": 1 },
+    "status": { "enum": ["pass", "fail"] },
+    "release_comparison_qualified": { "type": "boolean" },
+    "policy_sha256": { "$ref": "#/$defs/digest" },
+    "durability_contract": { "type": "string", "minLength": 1 },
+    "hardware_id": { "$ref": "#/$defs/digest" },
+    "target": { "type": "object" },
+    "baseline": { "$ref": "#/$defs/binding" },
+    "candidate": { "$ref": "#/$defs/binding" },
+    "failures": { "type": "array", "items": { "type": "string" } },
+    "comparisons": { "type": "array", "items": { "type": "object" } }
+  },
+  "$defs": {
+    "digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "report_sha256",
+        "commit",
+        "artifact_manifest_sha256",
+        "deployment_digest",
+        "target_id",
+        "cluster_uid",
+        "effective_config_sha256"
+      ],
+      "properties": {
+        "report_sha256": { "$ref": "#/$defs/digest" },
+        "commit": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "artifact_manifest_sha256": { "$ref": "#/$defs/digest" },
+        "deployment_digest": { "$ref": "#/$defs/digest" },
+        "target_id": { "type": "string", "minLength": 1 },
+        "cluster_uid": { "type": "string", "minLength": 1 },
+        "effective_config_sha256": { "$ref": "#/$defs/digest" }
+      }
+    }
+  }
+}

--- a/scripts/message-path-qualification-policy.json
+++ b/scripts/message-path-qualification-policy.json
@@ -53,6 +53,7 @@
       "required_external_evidence": [
         "performance_comparison",
         "fault_matrix",
+        "rpo",
         "soak"
       ],
       "minimum_soak_seconds": 21600,

--- a/scripts/message-path-soak-report-schema.json
+++ b/scripts/message-path-soak-report-schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rocketmq.apache.org/schemas/message-path-soak-report-v1.json",
+  "title": "RocketMQ Rust message-path soak report",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "status",
+    "monotonic_growth_detected",
+    "duration_seconds",
+    "release_identity",
+    "sampling",
+    "pods",
+    "series",
+    "artifacts"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "artifact_kind": { "const": "rocketmq_message_path_soak_report" },
+    "status": { "enum": ["pass", "fail"] },
+    "monotonic_growth_detected": { "type": "boolean" },
+    "duration_seconds": { "type": "integer", "minimum": 21600 },
+    "release_identity": {
+      "type": "object",
+      "required": [
+        "commit",
+        "deployment_digest",
+        "target_id",
+        "cluster_uid",
+        "effective_config_sha256",
+        "durability_contract"
+      ]
+    },
+    "sampling": {
+      "type": "object",
+      "required": ["interval_seconds", "expected", "observed", "coverage_percent", "max_gap_seconds"]
+    },
+    "pods": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name", "uid", "restarts", "oom_killed"]
+      }
+    },
+    "series": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["metric", "scope", "status", "raw_artifact_sha256"]
+      }
+    },
+    "artifacts": { "type": "array", "minItems": 1 }
+  }
+}

--- a/scripts/message_path_qualification.py
+++ b/scripts/message_path_qualification.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Run fail-closed message-path smoke and release qualification."""
+"""Measure, compare, and qualify fail-closed message-path releases."""
 
 from __future__ import annotations
 
@@ -41,7 +41,9 @@ DEFAULT_OUTPUT_ROOT = ROOT / "target" / "message-path-qualification"
 RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{2,127}$")
 TOPIC_RE = re.compile(r"^[A-Za-z0-9_%.-]{1,127}$")
 SCENARIOS = {"sync", "async", "batch", "lite-pull"}
-EXTERNAL_EVIDENCE = {"performance_comparison", "fault_matrix", "soak"}
+EXTERNAL_EVIDENCE = {"performance_comparison", "fault_matrix", "rpo", "soak"}
+GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 
 class QualificationError(RuntimeError):
@@ -177,7 +179,7 @@ def validate_policy(policy: dict[str, Any]) -> list[str]:
             if mode.get("minimum_repetitions", 0) < 5:
                 findings.append("release requires at least five repetitions")
             if set(required or []) != EXTERNAL_EVIDENCE:
-                findings.append("release must require performance, fault, and soak evidence")
+                findings.append("release must require performance, fault, RPO, and soak evidence")
             if mode.get("minimum_soak_seconds", 0) < 21_600:
                 findings.append("release minimum soak must be at least six hours")
 
@@ -358,60 +360,62 @@ def copy_external(run_dir: Path, source: Path, name: str) -> dict[str, str]:
     return record_artifact(run_dir, target)
 
 
-def validate_release_evidence(
-    mode_policy: dict[str, Any], args: argparse.Namespace, run_dir: Path, executor: CommandExecutor
-) -> tuple[list[str], dict[str, Any], list[dict[str, str]]]:
+def bound_file(path: Path | None, label: str, *, required: bool) -> tuple[str | None, list[str]]:
+    if path is None:
+        return None, [f"release measurement requires --{label}"] if required else []
+    resolved = path.resolve()
+    if not resolved.is_file():
+        return None, [f"--{label} is not a file: {resolved}"]
+    return f"sha256:{sha256_file(resolved)}", []
+
+
+def measurement_identity(
+    args: argparse.Namespace, commit: str, dirty: bool, *, release: bool
+) -> tuple[dict[str, Any], dict[str, Any], list[str]]:
     findings: list[str] = []
-    evidence: dict[str, Any] = {}
-    artifacts: list[dict[str, str]] = []
-    if not mode_policy["required_external_evidence"]:
-        return findings, evidence, artifacts
-
-    if args.performance_comparison is None:
-        findings.append("release requires --performance-comparison")
-    else:
-        comparison = load_json(args.performance_comparison)
-        if comparison.get("status") != "pass":
-            findings.append("performance comparison status must be pass")
-        artifact = copy_external(run_dir, args.performance_comparison, "performance-comparison.json")
-        evidence["performance_comparison"] = artifact
-        artifacts.append(artifact)
-
-    if args.soak_report is None:
-        findings.append("release requires --soak-report")
-    else:
-        soak = load_json(args.soak_report)
-        if soak.get("schema_version") != 1 or soak.get("artifact_kind") != "rocketmq_message_path_soak_report":
-            findings.append("soak report contract is invalid")
-        if soak.get("status") != "pass" or soak.get("monotonic_growth_detected") is not False:
-            findings.append("soak report must pass without monotonic resource growth")
-        if soak.get("duration_seconds", 0) < mode_policy["minimum_soak_seconds"]:
-            findings.append("soak duration is below the release minimum")
-        if soak.get("durability_contract") != args.durability_contract:
-            findings.append("soak durability contract differs from the qualification run")
-        artifact = copy_external(run_dir, args.soak_report, "soak-report.json")
-        evidence["soak"] = artifact
-        artifacts.append(artifact)
-
-    if args.fault_evidence is None:
-        findings.append("release requires --fault-evidence")
-    else:
-        fault_dir = args.fault_evidence.resolve()
-        run_json = fault_dir / "run.json"
-        result = executor(
-            [sys.executable, str(ROOT / "scripts" / "fault_matrix_guard.py"), "--root", str(ROOT), "--evidence", str(fault_dir)],
-            ROOT,
-            600,
-        )
-        if result.exit_code != 0:
-            findings.append(f"fault matrix evidence validation failed: {result.stderr.strip() or result.stdout.strip()}")
-        if not run_json.is_file():
-            findings.append("fault matrix evidence is missing run.json")
-        else:
-            artifact = copy_external(run_dir, run_json, "fault-matrix-run.json")
-            evidence["fault_matrix"] = artifact
-            artifacts.append(artifact)
-    return findings, evidence, artifacts
+    subject_commit = getattr(args, "subject_commit", None) or commit
+    if not GIT_SHA_RE.fullmatch(subject_commit):
+        findings.append("subject commit must be a full lowercase Git SHA")
+    if subject_commit != commit:
+        findings.append("subject commit must equal the checked-out commit")
+    role = getattr(args, "subject_role", None) or ("candidate" if release else "smoke")
+    if role not in {"baseline", "candidate", "smoke"}:
+        findings.append("subject role must be baseline, candidate, or smoke")
+    artifact_hash, artifact_findings = bound_file(
+        getattr(args, "artifact_manifest", None), "artifact-manifest", required=release
+    )
+    config_hash, config_findings = bound_file(
+        getattr(args, "effective_config", None), "effective-config", required=release
+    )
+    findings.extend(artifact_findings)
+    findings.extend(config_findings)
+    deployment_digest = getattr(args, "deployment_digest", None)
+    if release and not isinstance(deployment_digest, str):
+        findings.append("release measurement requires --deployment-digest")
+    elif deployment_digest is not None and not DIGEST_RE.fullmatch(deployment_digest):
+        findings.append("deployment digest must use sha256:<64 lowercase hex>")
+    target_id = getattr(args, "target_id", None)
+    cluster_uid = getattr(args, "cluster_uid", None)
+    if release and not target_id:
+        findings.append("release measurement requires --target-id")
+    if release and not cluster_uid:
+        findings.append("release measurement requires --cluster-uid")
+    if release and dirty:
+        findings.append("release measurement requires a clean Git worktree")
+    subject = {
+        "role": role,
+        "commit": subject_commit,
+        "artifact_manifest_sha256": artifact_hash,
+        "deployment_digest": deployment_digest,
+    }
+    target = {
+        "target_id": target_id or "local-smoke",
+        "cluster_uid": cluster_uid or "local-smoke",
+        "namesrv_addr": args.namesrv,
+        "topic": args.topic,
+        "effective_config_sha256": config_hash,
+    }
+    return subject, target, findings
 
 
 def aggregate_samples(samples: list[dict[str, Any]]) -> dict[str, float]:
@@ -450,8 +454,7 @@ def run_qualification(
     run_dir.mkdir(parents=True)
 
     artifacts: list[dict[str, str]] = []
-    failures, external_evidence, external_artifacts = validate_release_evidence(mode_policy, args, run_dir, executor)
-    artifacts.extend(external_artifacts)
+    subject, target, failures = measurement_identity(args, commit, dirty, release=args.mode == "release")
     workload_reports: list[dict[str, Any]] = []
 
     if not failures:
@@ -507,27 +510,27 @@ def run_qualification(
                 break
 
     report = {
-        "schema_version": 1,
-        "artifact_kind": "rocketmq_message_path_qualification_report",
+        "schema_version": 2,
+        "artifact_kind": "rocketmq_message_path_measurement_set",
         "run_id": args.run_id,
         "generated_at": utc_now(),
         "mode": args.mode,
         "status": "fail" if failures else "pass",
-        "release_qualified": args.mode == "release" and not failures,
+        "measurement_qualified": not failures,
         "business_contract": "java-equivalent-message-semantics",
         "implementation_strategy": "rust-native",
         "durability_contract": args.durability_contract,
         "policy_sha256": canonical_sha256(policy),
         "git": {"commit": commit, "dirty": dirty},
+        "subject": subject,
         "environment": environment_record(),
-        "target": {"namesrv_addr": args.namesrv, "topic": args.topic},
+        "target": target,
         "repetitions_per_workload": repetitions,
         "workloads": workload_reports,
-        "external_evidence": external_evidence,
         "failures": failures,
         "artifacts": sorted(artifacts, key=lambda item: item["path"]),
     }
-    report_path = run_dir / "qualification-report.json"
+    report_path = run_dir / "measurement-set.json"
     write_json(report_path, report)
     return report, report_path
 
@@ -540,25 +543,92 @@ def regression_percent(direction: str, baseline: float, candidate: float) -> flo
     return (candidate - baseline) / baseline * 100.0
 
 
-def compare_reports(policy: dict[str, Any], baseline: dict[str, Any], candidate: dict[str, Any]) -> dict[str, Any]:
+def measurement_binding(report: dict[str, Any], report_sha256: str | None) -> dict[str, Any]:
+    subject = report.get("subject", {})
+    target = report.get("target", {})
+    return {
+        "report_sha256": report_sha256,
+        "commit": subject.get("commit"),
+        "artifact_manifest_sha256": subject.get("artifact_manifest_sha256"),
+        "deployment_digest": subject.get("deployment_digest"),
+        "target_id": target.get("target_id"),
+        "cluster_uid": target.get("cluster_uid"),
+        "effective_config_sha256": target.get("effective_config_sha256"),
+    }
+
+
+def validate_measurement_set(
+    policy: dict[str, Any], report: dict[str, Any], label: str, *, expected_role: str | None = None
+) -> list[str]:
+    failures: list[str] = []
+    if report.get("schema_version") != 2 or report.get("artifact_kind") != "rocketmq_message_path_measurement_set":
+        failures.append(f"{label} measurement contract is invalid")
+    if report.get("status") != "pass" or report.get("measurement_qualified") is not True:
+        failures.append(f"{label} measurement must be qualified and pass")
+    if report.get("policy_sha256") != canonical_sha256(policy):
+        failures.append(f"{label} measurement policy hash differs")
+    subject = report.get("subject")
+    if not isinstance(subject, dict):
+        failures.append(f"{label} subject binding is missing")
+    else:
+        if expected_role is not None and subject.get("role") != expected_role:
+            failures.append(f"{label} subject role must be {expected_role}")
+        if not isinstance(subject.get("commit"), str) or not GIT_SHA_RE.fullmatch(subject["commit"]):
+            failures.append(f"{label} subject commit is invalid")
+        for key in ("artifact_manifest_sha256", "deployment_digest"):
+            value = subject.get(key)
+            if report.get("mode") == "release" and (not isinstance(value, str) or not DIGEST_RE.fullmatch(value)):
+                failures.append(f"{label} subject {key} is invalid")
+    target = report.get("target")
+    if not isinstance(target, dict):
+        failures.append(f"{label} target binding is missing")
+    elif report.get("mode") == "release":
+        for key in ("target_id", "cluster_uid"):
+            if not isinstance(target.get(key), str) or not target[key].strip():
+                failures.append(f"{label} target {key} is missing")
+        value = target.get("effective_config_sha256")
+        if not isinstance(value, str) or not DIGEST_RE.fullmatch(value):
+            failures.append(f"{label} target effective_config_sha256 is invalid")
+    if report.get("mode") == "release":
+        minimum = policy["modes"]["release"]["minimum_repetitions"]
+        if report.get("repetitions_per_workload", 0) < minimum:
+            failures.append(f"{label} measurement has fewer than {minimum} repetitions")
+    return failures
+
+
+def compare_reports(
+    policy: dict[str, Any],
+    baseline: dict[str, Any],
+    candidate: dict[str, Any],
+    *,
+    baseline_sha256: str | None = None,
+    candidate_sha256: str | None = None,
+) -> dict[str, Any]:
     failures = validate_policy(policy)
-    for label, report in (("baseline", baseline), ("candidate", candidate)):
-        if report.get("schema_version") != 1 or report.get("artifact_kind") != "rocketmq_message_path_qualification_report":
-            failures.append(f"{label} report contract is invalid")
-        if report.get("status") != "pass":
-            failures.append(f"{label} report status must be pass")
-        if report.get("policy_sha256") != canonical_sha256(policy):
-            failures.append(f"{label} report policy hash differs")
+    failures.extend(validate_measurement_set(policy, baseline, "baseline", expected_role="baseline"))
+    failures.extend(validate_measurement_set(policy, candidate, "candidate", expected_role="candidate"))
     if failures:
-        return {"schema_version": 1, "artifact_kind": "rocketmq_message_path_comparison", "status": "fail", "failures": failures, "comparisons": []}
+        return {
+            "schema_version": 2,
+            "artifact_kind": "rocketmq_message_path_comparison",
+            "status": "fail",
+            "release_comparison_qualified": False,
+            "failures": failures,
+            "comparisons": [],
+        }
     if baseline.get("mode") != candidate.get("mode"):
         failures.append("baseline and candidate modes differ")
+    if baseline.get("subject", {}).get("commit") == candidate.get("subject", {}).get("commit"):
+        failures.append("baseline and candidate commits must differ")
     if baseline.get("durability_contract") != candidate.get("durability_contract"):
         failures.append("baseline and candidate durability contracts differ")
     if baseline.get("business_contract") != candidate.get("business_contract"):
         failures.append("baseline and candidate business contracts differ")
     if baseline.get("environment", {}).get("hardware_id") != candidate.get("environment", {}).get("hardware_id"):
         failures.append("baseline and candidate hardware identities differ")
+    for key in ("target_id", "cluster_uid", "effective_config_sha256"):
+        if baseline.get("target", {}).get(key) != candidate.get("target", {}).get(key):
+            failures.append(f"baseline and candidate {key} bindings differ")
 
     baseline_workloads = {item["id"]: item for item in baseline.get("workloads", []) if isinstance(item, dict) and "id" in item}
     candidate_workloads = {item["id"]: item for item in candidate.get("workloads", []) if isinstance(item, dict) and "id" in item}
@@ -600,17 +670,175 @@ def compare_reports(policy: dict[str, Any], baseline: dict[str, Any], candidate:
             }
         )
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "artifact_kind": "rocketmq_message_path_comparison",
         "generated_at": utc_now(),
         "status": "fail" if failures else "pass",
-        "release_comparison_qualified": not failures and baseline.get("release_qualified") is True and candidate.get("release_qualified") is True,
+        "release_comparison_qualified": not failures and baseline.get("mode") == "release",
+        "policy_sha256": canonical_sha256(policy),
+        "durability_contract": candidate.get("durability_contract"),
+        "hardware_id": candidate.get("environment", {}).get("hardware_id"),
+        "target": candidate.get("target"),
+        "baseline": measurement_binding(baseline, baseline_sha256),
+        "candidate": measurement_binding(candidate, candidate_sha256),
         "failures": failures,
         "comparisons": comparisons,
     }
 
 
-def add_target_arguments(parser: argparse.ArgumentParser) -> None:
+def evidence_path(path: Path, name: str) -> Path:
+    resolved = path.resolve()
+    if resolved.is_dir():
+        resolved = resolved / name
+    if not resolved.is_file():
+        raise QualificationError(f"evidence file does not exist: {resolved}")
+    return resolved
+
+
+def validate_final_evidence(
+    policy: dict[str, Any], args: argparse.Namespace
+) -> tuple[list[str], dict[str, Path], dict[str, dict[str, Any]]]:
+    paths = {
+        "candidate_measurement": evidence_path(args.candidate_measurement, "measurement-set.json"),
+        "performance_comparison": evidence_path(args.performance_comparison, "performance-comparison.json"),
+        "fault_matrix": evidence_path(args.fault_evidence, "run.json"),
+        "rpo": evidence_path(args.rpo_evidence, "ack-failover-run.json"),
+        "soak": evidence_path(args.soak_report, "soak-report.json"),
+    }
+    documents = {key: load_json(path) for key, path in paths.items()}
+    candidate = documents["candidate_measurement"]
+    comparison = documents["performance_comparison"]
+    fault = documents["fault_matrix"]
+    rpo = documents["rpo"]
+    soak = documents["soak"]
+    findings = validate_measurement_set(policy, candidate, "candidate", expected_role="candidate")
+    subject = candidate.get("subject", {})
+    target = candidate.get("target", {})
+    expected_commit = subject.get("commit")
+    expected_deployment = subject.get("deployment_digest")
+    expected_target = target.get("target_id")
+    expected_cluster = target.get("cluster_uid")
+    expected_config = target.get("effective_config_sha256")
+    expected_durability = candidate.get("durability_contract")
+    candidate_hash = f"sha256:{sha256_file(paths['candidate_measurement'])}"
+    if args.candidate_commit != expected_commit:
+        findings.append("--candidate-commit differs from the candidate measurement")
+
+    if comparison.get("schema_version") != 2 or comparison.get("artifact_kind") != "rocketmq_message_path_comparison":
+        findings.append("performance comparison contract is invalid")
+    if comparison.get("status") != "pass" or comparison.get("release_comparison_qualified") is not True:
+        findings.append("performance comparison is not release-qualified")
+    comparison_candidate = comparison.get("candidate", {})
+    for key, expected in (
+        ("report_sha256", candidate_hash),
+        ("commit", expected_commit),
+        ("deployment_digest", expected_deployment),
+        ("target_id", expected_target),
+        ("cluster_uid", expected_cluster),
+        ("effective_config_sha256", expected_config),
+    ):
+        if comparison_candidate.get(key) != expected:
+            findings.append(f"performance comparison candidate {key} differs")
+    if comparison.get("durability_contract") != expected_durability:
+        findings.append("performance comparison durability differs")
+
+    fault_identity = fault.get("release_identity", {})
+    if fault.get("candidate_commit") != expected_commit or fault_identity.get("deployment_digest") != expected_deployment:
+        findings.append("fault evidence candidate identity differs")
+    if fault.get("dynamic_execution") is not True or fault.get("fixture") is not False:
+        findings.append("fault evidence must be a dynamic non-fixture run")
+    if fault_identity.get("target_id") != expected_target or fault_identity.get("cluster_uid") != expected_cluster:
+        findings.append("fault evidence target differs")
+    if fault_identity.get("effective_config_sha256") != expected_config:
+        findings.append("fault evidence effective configuration differs")
+    if fault_identity.get("durability_contract") != expected_durability:
+        findings.append("fault evidence durability differs")
+
+    if rpo.get("schema_version") != 1 or rpo.get("artifact_kind") != "controller_failover_qualification_evidence":
+        findings.append("RPO evidence contract is invalid")
+    if rpo.get("status") != "pass" or rpo.get("strict_qualification_passed") is not True:
+        findings.append("RPO evidence is not strict-qualified")
+    for key, expected in (
+        ("candidate_commit", expected_commit),
+        ("deployment_digest", expected_deployment),
+        ("target_id", expected_target),
+        ("cluster_uid", expected_cluster),
+        ("effective_config_sha256", expected_config),
+        ("durability_contract", expected_durability),
+    ):
+        if rpo.get(key) != expected:
+            findings.append(f"RPO evidence {key} differs")
+
+    if soak.get("schema_version") != 1 or soak.get("artifact_kind") != "rocketmq_message_path_soak_report":
+        findings.append("soak report contract is invalid")
+    if soak.get("status") != "pass" or soak.get("monotonic_growth_detected") is not False:
+        findings.append("soak report must pass without monotonic resource growth")
+    if soak.get("duration_seconds", 0) < policy["modes"]["release"]["minimum_soak_seconds"]:
+        findings.append("soak duration is below the release minimum")
+    soak_identity = soak.get("release_identity", {})
+    for key, expected in (
+        ("commit", expected_commit),
+        ("deployment_digest", expected_deployment),
+        ("target_id", expected_target),
+        ("cluster_uid", expected_cluster),
+        ("effective_config_sha256", expected_config),
+        ("durability_contract", expected_durability),
+    ):
+        if soak_identity.get(key) != expected:
+            findings.append(f"soak release identity {key} differs")
+    sampling = soak.get("sampling", {})
+    if sampling.get("coverage_percent", 0) < 99 or sampling.get("max_gap_seconds", math.inf) > 90:
+        findings.append("soak sampling coverage or maximum gap is outside the release contract")
+    if not isinstance(soak.get("pods"), list) or not soak["pods"]:
+        findings.append("soak report must include pod identity and restart evidence")
+    elif any(pod.get("restarts") != 0 or pod.get("oom_killed") is not False for pod in soak["pods"]):
+        findings.append("soak report contains a restarted or OOM-killed pod")
+    if not isinstance(soak.get("series"), list) or not soak["series"]:
+        findings.append("soak report must include analyzed resource series")
+    elif any(item.get("status") != "pass" or not DIGEST_RE.fullmatch(str(item.get("raw_artifact_sha256", ""))) for item in soak["series"]):
+        findings.append("soak resource series must pass and bind raw artifact hashes")
+    return findings, paths, documents
+
+
+def run_final_qualification(policy: dict[str, Any], args: argparse.Namespace) -> tuple[dict[str, Any], Path]:
+    if not GIT_SHA_RE.fullmatch(args.candidate_commit):
+        raise QualificationError("--candidate-commit must be a full lowercase Git SHA")
+    if not RUN_ID_RE.fullmatch(args.run_id):
+        raise QualificationError("--run-id must contain 3-128 safe characters")
+    run_dir = args.output_dir.resolve() / args.run_id
+    if run_dir.exists():
+        raise QualificationError(f"qualification output already exists: {run_dir}")
+    findings, source_paths, documents = validate_final_evidence(policy, args)
+    run_dir.mkdir(parents=True)
+    evidence: dict[str, Any] = {}
+    artifacts: list[dict[str, str]] = []
+    for key, source in source_paths.items():
+        artifact = copy_external(run_dir, source, source.name)
+        evidence[key] = artifact
+        artifacts.append(artifact)
+    candidate = documents["candidate_measurement"]
+    report = {
+        "schema_version": 2,
+        "artifact_kind": "rocketmq_message_path_qualification_report",
+        "run_id": args.run_id,
+        "generated_at": utc_now(),
+        "status": "fail" if findings else "pass",
+        "release_qualified": not findings,
+        "candidate_commit": args.candidate_commit,
+        "subject": candidate.get("subject"),
+        "target": candidate.get("target"),
+        "durability_contract": candidate.get("durability_contract"),
+        "policy_sha256": canonical_sha256(policy),
+        "evidence": evidence,
+        "failures": findings,
+        "artifacts": sorted(artifacts, key=lambda item: item["path"]),
+    }
+    report_path = run_dir / "qualification-report.json"
+    write_json(report_path, report)
+    return report, report_path
+
+
+def add_target_arguments(parser: argparse.ArgumentParser, *, measurement: bool = False) -> None:
     parser.add_argument("--mode", choices=("smoke", "release"), required=True)
     parser.add_argument("--namesrv", required=True)
     parser.add_argument("--confirm-target", required=True)
@@ -618,6 +846,14 @@ def add_target_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--durability-contract", required=True)
     parser.add_argument("--run-id", default=f"message-path-{int(time.time())}")
     parser.add_argument("--repetitions", type=int)
+    if measurement:
+        parser.add_argument("--subject-role", choices=("baseline", "candidate", "smoke"))
+        parser.add_argument("--subject-commit")
+        parser.add_argument("--artifact-manifest", type=Path)
+        parser.add_argument("--deployment-digest")
+        parser.add_argument("--target-id")
+        parser.add_argument("--cluster-uid")
+        parser.add_argument("--effective-config", type=Path)
 
 
 def main() -> int:
@@ -629,18 +865,26 @@ def main() -> int:
     plan_parser = subparsers.add_parser("plan")
     add_target_arguments(plan_parser)
 
-    run_parser = subparsers.add_parser("run")
-    add_target_arguments(run_parser)
-    run_parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_ROOT)
-    run_parser.add_argument("--command-timeout-seconds", type=int, default=1800)
-    run_parser.add_argument("--performance-comparison", type=Path)
-    run_parser.add_argument("--fault-evidence", type=Path)
-    run_parser.add_argument("--soak-report", type=Path)
+    for command in ("measure", "run"):
+        measure_parser = subparsers.add_parser(command)
+        add_target_arguments(measure_parser, measurement=True)
+        measure_parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_ROOT)
+        measure_parser.add_argument("--command-timeout-seconds", type=int, default=1800)
 
     compare_parser = subparsers.add_parser("compare")
     compare_parser.add_argument("--baseline", type=Path, required=True)
     compare_parser.add_argument("--candidate", type=Path, required=True)
     compare_parser.add_argument("--output", type=Path, required=True)
+
+    qualify_parser = subparsers.add_parser("qualify")
+    qualify_parser.add_argument("--candidate-commit", required=True)
+    qualify_parser.add_argument("--candidate-measurement", type=Path, required=True)
+    qualify_parser.add_argument("--performance-comparison", type=Path, required=True)
+    qualify_parser.add_argument("--fault-evidence", type=Path, required=True)
+    qualify_parser.add_argument("--rpo-evidence", type=Path, required=True)
+    qualify_parser.add_argument("--soak-report", type=Path, required=True)
+    qualify_parser.add_argument("--run-id", default=f"message-path-release-{int(time.time())}")
+    qualify_parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_ROOT)
 
     args = parser.parse_args()
     try:
@@ -654,10 +898,20 @@ def main() -> int:
         if findings:
             raise QualificationError("invalid qualification policy: " + "; ".join(findings))
         if args.command == "compare":
-            comparison = compare_reports(policy, load_json(args.baseline), load_json(args.candidate))
+            comparison = compare_reports(
+                policy,
+                load_json(args.baseline),
+                load_json(args.candidate),
+                baseline_sha256=f"sha256:{sha256_file(args.baseline)}",
+                candidate_sha256=f"sha256:{sha256_file(args.candidate)}",
+            )
             write_json(args.output, comparison)
             print(f"message-path comparison {comparison['status']}: {args.output}")
             return 0 if comparison["status"] == "pass" else 1
+        if args.command == "qualify":
+            report, report_path = run_final_qualification(policy, args)
+            print(f"message-path qualification {report['status']}: {report_path}")
+            return 0 if report["status"] == "pass" else 1
 
         validate_target(args.namesrv, args.confirm_target, args.topic, args.durability_contract)
         repetitions = args.repetitions or policy["modes"][args.mode]["minimum_repetitions"]
@@ -667,7 +921,7 @@ def main() -> int:
             print(json.dumps(build_plan(policy, args.mode, args.namesrv, args.topic, args.run_id, repetitions), indent=2))
             return 0
         report, report_path = run_qualification(policy, args)
-        print(f"message-path qualification {report['status']}: {report_path}")
+        print(f"message-path measurement {report['status']}: {report_path}")
         return 0 if report["status"] == "pass" else 1
     except QualificationError as error:
         print(f"ERROR: {error}", file=sys.stderr)

--- a/scripts/tests/test_message_path_qualification.py
+++ b/scripts/tests/test_message_path_qualification.py
@@ -99,9 +99,13 @@ class MessagePathQualificationTest(unittest.TestCase):
             "repetitions": 1,
             "output_dir": output_dir,
             "command_timeout_seconds": 30,
-            "performance_comparison": None,
-            "fault_evidence": None,
-            "soak_report": None,
+            "subject_role": None,
+            "subject_commit": None,
+            "artifact_manifest": None,
+            "deployment_digest": None,
+            "target_id": None,
+            "cluster_uid": None,
+            "effective_config": None,
         }
         values.update(overrides)
         return argparse.Namespace(**values)
@@ -155,7 +159,8 @@ class MessagePathQualificationTest(unittest.TestCase):
                 report, report_path = qualification.run_qualification(self.policy, args, executor)
 
             self.assertEqual("pass", report["status"])
-            self.assertFalse(report["release_qualified"])
+            self.assertTrue(report["measurement_qualified"])
+            self.assertEqual("rocketmq_message_path_measurement_set", report["artifact_kind"])
             self.assertEqual(4, len(report["workloads"]))
             self.assertEqual(4, len(executor.calls))
             self.assertTrue(report_path.is_file())
@@ -173,10 +178,10 @@ class MessagePathQualificationTest(unittest.TestCase):
                 report, _ = qualification.run_qualification(self.policy, args, executor)
 
             self.assertEqual("fail", report["status"])
-            self.assertFalse(report["release_qualified"])
+            self.assertFalse(report["measurement_qualified"])
             self.assertIn("exit code 2", report["failures"][0])
 
-    def test_release_cannot_run_without_external_evidence(self) -> None:
+    def test_release_measurement_requires_immutable_identity_before_execution(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             executor = FakeExecutor()
             args = self.args(
@@ -194,22 +199,36 @@ class MessagePathQualificationTest(unittest.TestCase):
                 report, _ = qualification.run_qualification(self.policy, args, executor)
 
             self.assertEqual("fail", report["status"])
-            self.assertFalse(report["release_qualified"])
+            self.assertFalse(report["measurement_qualified"])
             self.assertEqual(0, len(executor.calls))
-            self.assertEqual(3, len(report["failures"]))
+            self.assertTrue(any("artifact-manifest" in finding for finding in report["failures"]))
+            self.assertTrue(any("deployment-digest" in finding for finding in report["failures"]))
+            self.assertTrue(any("target-id" in finding for finding in report["failures"]))
 
     def test_comparison_requires_matching_contract_and_thresholds(self) -> None:
         policy_hash = qualification.canonical_sha256(self.policy)
         baseline = {
-            "schema_version": 1,
-            "artifact_kind": "rocketmq_message_path_qualification_report",
+            "schema_version": 2,
+            "artifact_kind": "rocketmq_message_path_measurement_set",
             "status": "pass",
-            "mode": "smoke",
-            "release_qualified": False,
+            "mode": "release",
+            "measurement_qualified": True,
             "policy_sha256": policy_hash,
             "business_contract": "java-equivalent-message-semantics",
             "durability_contract": "async-flush-single-replica",
+            "subject": {
+                "role": "baseline",
+                "commit": "a" * 40,
+                "artifact_manifest_sha256": "sha256:" + "1" * 64,
+                "deployment_digest": "sha256:" + "2" * 64,
+            },
             "environment": {"hardware_id": "sha256:test"},
+            "target": {
+                "target_id": "target-a",
+                "cluster_uid": "cluster-a",
+                "effective_config_sha256": "sha256:" + "3" * 64,
+            },
+            "repetitions_per_workload": 5,
             "workloads": [
                 {
                     "id": "sync-128b",
@@ -222,6 +241,9 @@ class MessagePathQualificationTest(unittest.TestCase):
             ],
         }
         candidate = copy.deepcopy(baseline)
+        candidate["subject"]["role"] = "candidate"
+        candidate["subject"]["commit"] = "b" * 40
+        candidate["subject"]["deployment_digest"] = "sha256:" + "4" * 64
         candidate["workloads"][0]["aggregate"]["throughput_messages_per_second_median"] = 950.0
         candidate["workloads"][0]["aggregate"]["p99_latency_us_median"] = 1100.0
 
@@ -234,10 +256,125 @@ class MessagePathQualificationTest(unittest.TestCase):
         self.assertTrue(any("throughput regression" in finding for finding in failed["failures"]))
 
         candidate = copy.deepcopy(baseline)
+        candidate["subject"]["role"] = "candidate"
+        candidate["subject"]["commit"] = "b" * 40
+        candidate["subject"]["deployment_digest"] = "sha256:" + "4" * 64
         candidate["durability_contract"] = "sync-flush-required-replica-acks"
         mismatched = qualification.compare_reports(self.policy, baseline, candidate)
         self.assertEqual("fail", mismatched["status"])
         self.assertTrue(any("durability contracts differ" in finding for finding in mismatched["failures"]))
+
+    def test_comparison_rejects_unbound_status_only_document(self) -> None:
+        result = qualification.compare_reports(self.policy, {"status": "pass"}, {"status": "pass"})
+
+        self.assertEqual("fail", result["status"])
+        self.assertFalse(result["release_comparison_qualified"])
+        self.assertTrue(any("contract is invalid" in finding for finding in result["failures"]))
+
+    def test_final_qualification_rejects_candidate_and_soak_binding_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            candidate = {
+                "schema_version": 2,
+                "artifact_kind": "rocketmq_message_path_measurement_set",
+                "status": "pass",
+                "measurement_qualified": True,
+                "mode": "release",
+                "policy_sha256": qualification.canonical_sha256(self.policy),
+                "business_contract": "java-equivalent-message-semantics",
+                "durability_contract": "strict",
+                "subject": {
+                    "role": "candidate",
+                    "commit": "b" * 40,
+                    "artifact_manifest_sha256": "sha256:" + "1" * 64,
+                    "deployment_digest": "sha256:" + "2" * 64,
+                },
+                "environment": {"hardware_id": "sha256:" + "3" * 64},
+                "target": {
+                    "target_id": "target-a",
+                    "cluster_uid": "cluster-a",
+                    "effective_config_sha256": "sha256:" + "4" * 64,
+                },
+                "repetitions_per_workload": 5,
+                "workloads": [],
+            }
+            candidate_path = root / "candidate.json"
+            candidate_path.write_text(json.dumps(candidate), encoding="utf-8")
+            candidate_hash = "sha256:" + qualification.sha256_file(candidate_path)
+            comparison = {
+                "schema_version": 2,
+                "artifact_kind": "rocketmq_message_path_comparison",
+                "status": "pass",
+                "release_comparison_qualified": True,
+                "durability_contract": "strict",
+                "candidate": {
+                    "report_sha256": candidate_hash,
+                    "commit": "b" * 40,
+                    "deployment_digest": "sha256:" + "2" * 64,
+                    "target_id": "target-a",
+                    "cluster_uid": "cluster-a",
+                    "effective_config_sha256": "sha256:" + "4" * 64,
+                },
+            }
+            fault = {
+                "candidate_commit": "b" * 40,
+                "dynamic_execution": True,
+                "fixture": False,
+                "release_identity": {
+                    "deployment_digest": "sha256:" + "2" * 64,
+                    "target_id": "target-a",
+                    "cluster_uid": "cluster-a",
+                    "effective_config_sha256": "sha256:" + "4" * 64,
+                    "durability_contract": "strict",
+                },
+            }
+            rpo = {
+                "schema_version": 1,
+                "artifact_kind": "controller_failover_qualification_evidence",
+                "status": "pass",
+                "strict_qualification_passed": True,
+                "candidate_commit": "b" * 40,
+                "deployment_digest": "sha256:" + "2" * 64,
+                "target_id": "target-a",
+                "cluster_uid": "cluster-a",
+                "effective_config_sha256": "sha256:" + "4" * 64,
+                "durability_contract": "strict",
+            }
+            soak = {
+                "schema_version": 1,
+                "artifact_kind": "rocketmq_message_path_soak_report",
+                "status": "pass",
+                "monotonic_growth_detected": False,
+                "duration_seconds": 21600,
+                "release_identity": {
+                    "commit": "b" * 40,
+                    "deployment_digest": "sha256:" + "2" * 64,
+                    "target_id": "wrong-target",
+                    "cluster_uid": "cluster-a",
+                    "effective_config_sha256": "sha256:" + "4" * 64,
+                    "durability_contract": "strict",
+                },
+                "sampling": {"coverage_percent": 99.9, "max_gap_seconds": 60},
+                "pods": [{"restarts": 0, "oom_killed": False}],
+                "series": [{"status": "pass", "raw_artifact_sha256": "sha256:" + "5" * 64}],
+            }
+            paths = {}
+            for name, value in (("comparison", comparison), ("fault", fault), ("rpo", rpo), ("soak", soak)):
+                path = root / f"{name}.json"
+                path.write_text(json.dumps(value), encoding="utf-8")
+                paths[name] = path
+            args = argparse.Namespace(
+                candidate_commit="b" * 40,
+                candidate_measurement=candidate_path,
+                performance_comparison=paths["comparison"],
+                fault_evidence=paths["fault"],
+                rpo_evidence=paths["rpo"],
+                soak_report=paths["soak"],
+            )
+
+            findings, _, _ = qualification.validate_final_evidence(self.policy, args)
+
+            self.assertIn("soak release identity target_id differs", findings)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9279

### Brief Description

Split message-path release qualification into independent measurement, comparison, and final qualification contracts. Bind candidate measurements and external performance, fault, RPO, and soak evidence to immutable commits, deployment digests, targets, cluster identities, effective configuration hashes, durability contracts, and raw artifact hashes. Add strict comparison and soak schemas plus fail-closed regression coverage for forged or mismatched evidence.

### How Did You Test This Change?

- `python -m unittest scripts.tests.test_message_path_qualification -v` - passed, 9 tests.
- `python scripts/message_path_qualification.py validate-policy` - passed.
- `python -m json.tool scripts/message-path-performance-comparison-schema.json` - passed.
- `python -m json.tool scripts/message-path-soak-report-schema.json` - passed.
- `python -m compileall -q scripts/message_path_qualification.py scripts/tests/test_message_path_qualification.py` - passed.
- `git diff --check` - passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added structured schemas for message-path performance comparisons and soak reports.
  - Introduced separate measurement, comparison, and final qualification workflows.
  - Added immutable identity, deployment, target, configuration, and artifact bindings to reports.
  - Added SHA-256 tracking for comparison source reports.
  - Release qualification now requires RPO evidence.

- **Bug Fixes**
  - Improved validation to reject missing identity data, unbound reports, and inconsistent evidence bindings.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->