### PR TITLE
[ISSUE #9281]✨Prepare digest-pinned local evidence tools and images

### DIFF
--- a/distribution/kubernetes/deployment-policy.json
+++ b/distribution/kubernetes/deployment-policy.json
@@ -238,6 +238,16 @@
     }
   },
   "tools": {
+    "kind": {
+      "version": "v0.27.0",
+      "linux_amd64_sha256": "a6875aaea358acf0ac07786b1a6755d08fd640f4c79b7a2e46681cc13f49a04b",
+      "windows_amd64_sha256": "445ee4263d5de090d60d049453d9691a2587a17cb349aa5ab8f402a47e3c2490"
+    },
+    "kubectl": {
+      "version": "v1.32.2",
+      "linux_amd64_sha256": "4f6a959dcc5b702135f8354cc7109b542a2933c46b808b248a214c1f69f817ea",
+      "windows_amd64_sha256": "cf51a1c6bf3b6ba6a5b549d1debf8aa6afb00c4c5a3d5d4bb1072f54cbe4390f"
+    },
     "helm": {
       "version": "v4.2.3",
       "linux_amd64_sha256": "e9b88b4ee95b18c706839c28d3a0220e5bc470e9cd9262410c90793c45ff8b7c",

--- a/scripts/bootstrap-local-message-path-evidence.ps1
+++ b/scripts/bootstrap-local-message-path-evidence.ps1
@@ -1,0 +1,172 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[CmdletBinding()]
+param(
+    [ValidateSet("Validate", "Install")]
+    [string]$Mode = "Validate",
+    [string]$ToolsDirectory = "target/message-path-tools",
+    [string]$LockFile = "target/message-path-tools/toolchain-lock.json"
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Resolve-RepositoryPath {
+    param([Parameter(Mandatory)][string]$Root, [Parameter(Mandatory)][string]$Path)
+
+    $resolved = if ([System.IO.Path]::IsPathRooted($Path)) {
+        [System.IO.Path]::GetFullPath($Path)
+    }
+    else {
+        [System.IO.Path]::GetFullPath((Join-Path $Root $Path))
+    }
+    $prefix = $Root.TrimEnd("\", "/") + [System.IO.Path]::DirectorySeparatorChar
+    if (-not $resolved.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "evidence tool paths must remain inside the repository"
+    }
+    return $resolved
+}
+
+function Write-Json {
+    param([Parameter(Mandatory)][object]$Value, [Parameter(Mandatory)][string]$Path)
+
+    $parent = Split-Path -Parent $Path
+    New-Item -ItemType Directory -Force -Path $parent | Out-Null
+    $json = $Value | ConvertTo-Json -Depth 16
+    [System.IO.File]::WriteAllText($Path, ($json.TrimEnd() + "`n"), [System.Text.UTF8Encoding]::new($false))
+}
+
+function Install-VerifiedBinary {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$Url,
+        [Parameter(Mandatory)][string]$Sha256,
+        [Parameter(Mandatory)][string]$Destination
+    )
+
+    if (Test-Path -LiteralPath $Destination -PathType Leaf) {
+        $existing = (Get-FileHash -Algorithm SHA256 -LiteralPath $Destination).Hash.ToLowerInvariant()
+        if ($existing -eq $Sha256) {
+            return
+        }
+        throw "$Name exists with an unexpected SHA-256: $Destination"
+    }
+    $partial = "$Destination.partial"
+    try {
+        Invoke-WebRequest -UseBasicParsing -Uri $Url -OutFile $partial
+        $actual = (Get-FileHash -Algorithm SHA256 -LiteralPath $partial).Hash.ToLowerInvariant()
+        if ($actual -ne $Sha256) {
+            throw "$Name SHA-256 mismatch: expected $Sha256, got $actual"
+        }
+        Move-Item -LiteralPath $partial -Destination $Destination
+    }
+    finally {
+        if (Test-Path -LiteralPath $partial) {
+            Remove-Item -LiteralPath $partial -Force
+        }
+    }
+}
+
+$root = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$deploymentPolicyPath = Join-Path $root "distribution/kubernetes/deployment-policy.json"
+$faultPolicyPath = Join-Path $root "distribution/kubernetes/fault-matrix-policy.json"
+$deployment = Get-Content -Raw -LiteralPath $deploymentPolicyPath | ConvertFrom-Json
+$fault = Get-Content -Raw -LiteralPath $faultPolicyPath | ConvertFrom-Json
+
+if ($deployment.tools.kind.version -ne $fault.tools.kind) {
+    throw "Kind version differs between deployment and fault policies"
+}
+if ($deployment.tools.kubectl.version -ne $fault.tools.kubectl) {
+    throw "kubectl version differs between deployment and fault policies"
+}
+if ($deployment.tools.helm.version -ne $fault.tools.helm) {
+    throw "Helm version differs between deployment and fault policies"
+}
+
+$hostIsWindows = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
+    [System.Runtime.InteropServices.OSPlatform]::Windows
+)
+if (-not [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.Equals(
+        [System.Runtime.InteropServices.Architecture]::X64
+    )) {
+    throw "local message-path evidence supports only amd64 hosts"
+}
+$platform = if ($hostIsWindows) { "windows_amd64" } else { "linux_amd64" }
+$suffix = if ($hostIsWindows) { ".exe" } else { "" }
+$toolsRoot = Resolve-RepositoryPath -Root $root -Path $ToolsDirectory
+$lockPath = Resolve-RepositoryPath -Root $root -Path $LockFile
+$kind = $deployment.tools.kind
+$kubectl = $deployment.tools.kubectl
+$kindSha = [string]$kind.("${platform}_sha256")
+$kubectlSha = [string]$kubectl.("${platform}_sha256")
+$kindPlatform = if ($hostIsWindows) { "windows-amd64" } else { "linux-amd64" }
+$kubectlPlatform = if ($hostIsWindows) { "windows/amd64/kubectl.exe" } else { "linux/amd64/kubectl" }
+$toolPlan = @(
+    [ordered]@{
+        name = "kind"
+        version = [string]$kind.version
+        url = "https://github.com/kubernetes-sigs/kind/releases/download/$($kind.version)/kind-$kindPlatform"
+        sha256 = $kindSha
+        path = (Join-Path $toolsRoot "kind$suffix")
+    },
+    [ordered]@{
+        name = "kubectl"
+        version = [string]$kubectl.version
+        url = "https://dl.k8s.io/release/$($kubectl.version)/bin/$kubectlPlatform"
+        sha256 = $kubectlSha
+        path = (Join-Path $toolsRoot "kubectl$suffix")
+    }
+)
+
+if ($Mode -eq "Validate") {
+    $toolPlan | ForEach-Object { Write-Host "PINNED_TOOL name=$($_.name) version=$($_.version) sha256=$($_.sha256)" }
+    Write-Host "LOCAL_EVIDENCE_BOOTSTRAP_VALID"
+    return
+}
+
+New-Item -ItemType Directory -Force -Path $toolsRoot | Out-Null
+foreach ($tool in $toolPlan) {
+    Install-VerifiedBinary -Name $tool.name -Url $tool.url -Sha256 $tool.sha256 -Destination $tool.path
+    if (-not $hostIsWindows) {
+        & chmod 0755 $tool.path
+        if ($LASTEXITCODE -ne 0) { throw "failed to mark $($tool.name) executable" }
+    }
+}
+
+& (Join-Path $root "scripts/kubernetes-assets-contract.ps1") -ToolsDirectory $ToolsDirectory
+if ($LASTEXITCODE -ne 0) {
+    throw "pinned Kubernetes validation tool installation failed"
+}
+
+$installed = foreach ($tool in $toolPlan) {
+    [ordered]@{
+        name = $tool.name
+        version = $tool.version
+        sha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $tool.path).Hash.ToLowerInvariant()
+        path = [System.IO.Path]::GetRelativePath($root, $tool.path).Replace("\", "/")
+    }
+}
+$lock = [ordered]@{
+    schema_version = 1
+    artifact_kind = "rocketmq_local_evidence_toolchain_lock"
+    generated_at = [DateTimeOffset]::UtcNow.ToString("o")
+    platform = $platform
+    kubernetes_version = [string]$fault.kubernetes_version
+    kind_node_image = [string]$fault.cluster.kind_node_image
+    tools = @($installed)
+    modifies_system_path = $false
+}
+Write-Json -Value $lock -Path $lockPath
+Write-Host "LOCAL_EVIDENCE_TOOLS_READY lock=$lockPath"

--- a/scripts/kubernetes_assets_guard.py
+++ b/scripts/kubernetes_assets_guard.py
@@ -90,6 +90,16 @@ EXPECTED_SERVICES: dict[str, dict[str, Any]] = {
     },
 }
 EXPECTED_TOOLS = {
+    "kind": (
+        "v0.27.0",
+        "a6875aaea358acf0ac07786b1a6755d08fd640f4c79b7a2e46681cc13f49a04b",
+        "445ee4263d5de090d60d049453d9691a2587a17cb349aa5ab8f402a47e3c2490",
+    ),
+    "kubectl": (
+        "v1.32.2",
+        "4f6a959dcc5b702135f8354cc7109b542a2933c46b808b248a214c1f69f817ea",
+        "cf51a1c6bf3b6ba6a5b549d1debf8aa6afb00c4c5a3d5d4bb1072f54cbe4390f",
+    ),
     "helm": (
         "v4.2.3",
         "e9b88b4ee95b18c706839c28d3a0220e5bc470e9cd9262410c90793c45ff8b7c",

--- a/scripts/prepare-local-evidence-images.ps1
+++ b/scripts/prepare-local-evidence-images.ps1
@@ -1,0 +1,212 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[CmdletBinding()]
+param(
+    [ValidateSet("Plan", "Prepare", "Validate")]
+    [string]$Mode = "Plan",
+    [string]$BaselineRoot,
+    [string]$CandidateRoot,
+    [string]$OutputDirectory = "target/message-path-evidence-inputs",
+    [string]$Registry = "127.0.0.1:5001",
+    [string]$RegistryContainerName = "rocketmq-message-path-registry"
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+$Services = @("broker", "namesrv", "controller", "proxy", "mcp")
+
+function Invoke-Captured {
+    param([Parameter(Mandatory)][string]$Executable, [Parameter(ValueFromRemainingArguments)][string[]]$Arguments)
+
+    $value = (& $Executable @Arguments 2>&1 | Out-String).Trim()
+    if ($LASTEXITCODE -ne 0) { throw "$Executable failed with exit code $LASTEXITCODE`n$value" }
+    return $value
+}
+
+function Write-Json {
+    param([Parameter(Mandatory)][object]$Value, [Parameter(Mandatory)][string]$Path)
+
+    $json = $Value | ConvertTo-Json -Depth 32
+    [System.IO.File]::WriteAllText($Path, ($json.TrimEnd() + "`n"), [System.Text.UTF8Encoding]::new($false))
+}
+
+function Get-FileSha256 {
+    param([Parameter(Mandatory)][string]$Path)
+    return (Get-FileHash -Algorithm SHA256 -LiteralPath $Path).Hash.ToLowerInvariant()
+}
+
+function Get-TextSha256 {
+    param([Parameter(Mandatory)][string]$Text)
+    $algorithm = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $bytes = [System.Text.UTF8Encoding]::new($false).GetBytes($Text)
+        return [BitConverter]::ToString($algorithm.ComputeHash($bytes)).Replace("-", "").ToLowerInvariant()
+    }
+    finally { $algorithm.Dispose() }
+}
+
+function Resolve-CleanCheckout {
+    param([Parameter(Mandatory)][string]$Path, [Parameter(Mandatory)][string]$Role)
+
+    if ([string]::IsNullOrWhiteSpace($Path)) { throw "$Role root is required" }
+    $resolved = (Resolve-Path -LiteralPath $Path).Path
+    $inside = Invoke-Captured git -C $resolved rev-parse --is-inside-work-tree
+    if ($inside -ne "true") { throw "$Role root is not a Git worktree" }
+    $dirty = Invoke-Captured git -C $resolved status --porcelain --untracked-files=normal
+    if (-not [string]::IsNullOrWhiteSpace($dirty)) { throw "$Role worktree must be clean" }
+    return $resolved
+}
+
+function Test-ImageMap {
+    param([Parameter(Mandatory)][object]$Map, [Parameter(Mandatory)][string]$Role)
+
+    $names = @($Map.PSObject.Properties.Name | Sort-Object)
+    if (($names -join ",") -ne (($Services | Sort-Object) -join ",")) {
+        throw "$Role image map must contain exactly: $($Services -join ', ')"
+    }
+    foreach ($service in $Services) {
+        $value = [string]$Map.$service
+        if ($value -notmatch '^[^@\s]+@sha256:[0-9a-f]{64}$') {
+            throw "$Role $service must use a registry manifest digest"
+        }
+    }
+}
+
+$root = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$output = if ([System.IO.Path]::IsPathRooted($OutputDirectory)) {
+    [System.IO.Path]::GetFullPath($OutputDirectory)
+}
+else { [System.IO.Path]::GetFullPath((Join-Path $root $OutputDirectory)) }
+$rootPrefix = $root.TrimEnd("\", "/") + [System.IO.Path]::DirectorySeparatorChar
+if (-not $output.StartsWith($rootPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "OutputDirectory must remain inside the current repository"
+}
+if ($Registry -notmatch '^(?:localhost|127\.0\.0\.1):[1-9][0-9]{0,4}$') {
+    throw "Registry must be a loopback host and explicit port"
+}
+if ($RegistryContainerName -notmatch '^[a-z0-9][a-z0-9_.-]{2,62}$') {
+    throw "RegistryContainerName is invalid"
+}
+
+$baselineMapPath = Join-Path $output "baseline-images.json"
+$candidateMapPath = Join-Path $output "candidate-images.json"
+$provenancePath = Join-Path $output "image-provenance.json"
+if ($Mode -eq "Validate") {
+    foreach ($path in @($baselineMapPath, $candidateMapPath, $provenancePath)) {
+        if (-not (Test-Path -LiteralPath $path -PathType Leaf)) { throw "missing evidence image artifact: $path" }
+    }
+    $baselineMap = Get-Content -Raw -LiteralPath $baselineMapPath | ConvertFrom-Json
+    $candidateMap = Get-Content -Raw -LiteralPath $candidateMapPath | ConvertFrom-Json
+    Test-ImageMap -Map $baselineMap -Role "baseline"
+    Test-ImageMap -Map $candidateMap -Role "candidate"
+    $provenance = Get-Content -Raw -LiteralPath $provenancePath | ConvertFrom-Json
+    if ($provenance.schema_version -ne 1 -or $provenance.artifact_kind -ne "rocketmq_local_evidence_image_provenance") {
+        throw "image provenance contract is invalid"
+    }
+    if ($provenance.baseline.commit -eq $provenance.candidate.commit) {
+        throw "baseline and candidate commits must differ"
+    }
+    if ($provenance.baseline.image_map_sha256 -ne ("sha256:" + (Get-FileSha256 $baselineMapPath))) {
+        throw "baseline image map hash differs from provenance"
+    }
+    if ($provenance.candidate.image_map_sha256 -ne ("sha256:" + (Get-FileSha256 $candidateMapPath))) {
+        throw "candidate image map hash differs from provenance"
+    }
+    Write-Host "LOCAL_EVIDENCE_IMAGE_MAPS_VALID"
+    return
+}
+
+$baseline = Resolve-CleanCheckout -Path $BaselineRoot -Role "baseline"
+$candidate = Resolve-CleanCheckout -Path $CandidateRoot -Role "candidate"
+$baselineCommit = (Invoke-Captured git -C $baseline rev-parse HEAD).Trim()
+$candidateCommit = (Invoke-Captured git -C $candidate rev-parse HEAD).Trim()
+if ($baselineCommit -eq $candidateCommit) { throw "baseline and candidate commits must differ" }
+if ($Mode -eq "Plan") {
+    Write-Host "LOCAL_EVIDENCE_IMAGE_PLAN baseline=$baselineCommit candidate=$candidateCommit registry=$Registry"
+    return
+}
+
+foreach ($command in @("docker", "git")) {
+    if (-not (Get-Command $command -ErrorAction SilentlyContinue)) { throw "required command is unavailable: $command" }
+}
+Invoke-Captured docker info | Out-Null
+$registryState = (& docker container inspect --format '{{.State.Running}}' $RegistryContainerName 2>$null | Out-String).Trim()
+if ($LASTEXITCODE -ne 0) {
+    $port = ($Registry -split ':')[-1]
+    Invoke-Captured docker run -d --restart=no -p "$port`:5000" --name $RegistryContainerName registry:2.8.3 | Out-Null
+}
+elseif ($registryState -ne "true") {
+    Invoke-Captured docker start $RegistryContainerName | Out-Null
+}
+
+New-Item -ItemType Directory -Force -Path $output | Out-Null
+$roleData = [ordered]@{}
+foreach ($role in @("baseline", "candidate")) {
+    $checkout = if ($role -eq "baseline") { $baseline } else { $candidate }
+    $commit = if ($role -eq "baseline") { $baselineCommit } else { $candidateCommit }
+    $short = $commit.Substring(0, 12)
+    $buildOutput = ".rocketmq/evidence-$role"
+    & (Join-Path $checkout "scripts/build-production-images.ps1") `
+        -Load `
+        -OutputDirectory $buildOutput `
+        -IdentityNonce "evidence-$role-$short" `
+        -ClusterKind kind `
+        -ClusterName rocketmq-message-path-evidence
+    if ($LASTEXITCODE -ne 0) { throw "$role production image build failed" }
+    $releaseStatePath = Join-Path $checkout "$buildOutput/release-state.json"
+    $releaseState = Get-Content -Raw -LiteralPath $releaseStatePath | ConvertFrom-Json
+    if ($releaseState.source_commit -ne $commit) { throw "$role release state commit mismatch" }
+    $map = [ordered]@{}
+    foreach ($service in $Services) {
+        $localReference = [string]$releaseState.images.$service.reference
+        $remoteReference = "$Registry/rocketmq-evidence/$role-$service`:$short"
+        Invoke-Captured docker tag $localReference $remoteReference | Out-Null
+        Invoke-Captured docker push $remoteReference | Out-Null
+        Invoke-Captured docker pull $remoteReference | Out-Null
+        $repoDigests = Invoke-Captured docker image inspect --format '{{json .RepoDigests}}' $remoteReference | ConvertFrom-Json
+        $digestReference = @($repoDigests | Where-Object { $_ -like "$Registry/*@sha256:*" }) | Select-Object -First 1
+        if ([string]$digestReference -notmatch '^[^@\s]+@sha256:[0-9a-f]{64}$') {
+            throw "$role $service did not resolve to a registry manifest digest"
+        }
+        $revision = Invoke-Captured docker image inspect --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' $digestReference
+        if ($revision -ne $commit) { throw "$role $service OCI revision differs from the checkout" }
+        Invoke-Captured docker pull $digestReference | Out-Null
+        $map[$service] = [string]$digestReference
+    }
+    $mapPath = if ($role -eq "baseline") { $baselineMapPath } else { $candidateMapPath }
+    Write-Json -Value $map -Path $mapPath
+    Test-ImageMap -Map $map -Role $role
+    $manifest = (($Services | ForEach-Object { "$($_)=$($map[$_])" }) -join "`n") + "`n"
+    $roleData[$role] = [ordered]@{
+        commit = $commit
+        release_state_sha256 = "sha256:" + (Get-FileSha256 $releaseStatePath)
+        image_map_sha256 = "sha256:" + (Get-FileSha256 $mapPath)
+        deployment_digest = "sha256:" + (Get-TextSha256 $manifest)
+        images = $map
+    }
+}
+
+$provenance = [ordered]@{
+    schema_version = 1
+    artifact_kind = "rocketmq_local_evidence_image_provenance"
+    generated_at = [DateTimeOffset]::UtcNow.ToString("o")
+    registry = $Registry
+    registry_container = $RegistryContainerName
+    baseline = $roleData.baseline
+    candidate = $roleData.candidate
+    remote_registry_push_performed = $false
+}
+Write-Json -Value $provenance -Path $provenancePath
+Write-Host "LOCAL_EVIDENCE_IMAGES_READY output=$output"

--- a/scripts/tests/test_local_evidence_images.py
+++ b/scripts/tests/test_local_evidence_images.py
@@ -1,0 +1,200 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+POWERSHELL = shutil.which("pwsh") or shutil.which("powershell")
+SERVICES = ("broker", "namesrv", "controller", "proxy", "mcp")
+
+
+def run_powershell(script: str, *arguments: str) -> subprocess.CompletedProcess[str]:
+    if POWERSHELL is None:
+        raise unittest.SkipTest("PowerShell is unavailable")
+    return subprocess.run(
+        [
+            POWERSHELL,
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(ROOT / "scripts" / script),
+            *arguments,
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def git(*arguments: str, cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def create_checkout(path: Path, marker: str) -> str:
+    path.mkdir()
+    git("init", "--quiet", cwd=path)
+    git("config", "user.name", "RocketMQ Rust Test", cwd=path)
+    git("config", "user.email", "test@rocketmq.apache.org", cwd=path)
+    (path / "marker.txt").write_text(marker + "\n", encoding="utf-8")
+    git("add", "marker.txt", cwd=path)
+    git("commit", "--quiet", "-m", marker, cwd=path)
+    return git("rev-parse", "HEAD", cwd=path)
+
+
+class LocalEvidenceImagesTest(unittest.TestCase):
+    def test_bootstrap_validate_reports_pinned_tools(self) -> None:
+        result = run_powershell("bootstrap-local-message-path-evidence.ps1", "-Mode", "Validate")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("name=kind version=v0.27.0", result.stdout)
+        self.assertIn("name=kubectl version=v1.32.2", result.stdout)
+        self.assertIn("LOCAL_EVIDENCE_BOOTSTRAP_VALID", result.stdout)
+
+    def test_plan_requires_distinct_clean_checkouts(self) -> None:
+        target = ROOT / "target"
+        target.mkdir(exist_ok=True)
+        with tempfile.TemporaryDirectory(dir=target) as temporary:
+            temporary_root = Path(temporary)
+            baseline = temporary_root / "baseline"
+            candidate = temporary_root / "candidate"
+            baseline_commit = create_checkout(baseline, "baseline")
+            candidate_commit = create_checkout(candidate, "candidate")
+
+            result = run_powershell(
+                "prepare-local-evidence-images.ps1",
+                "-Mode",
+                "Plan",
+                "-BaselineRoot",
+                str(baseline),
+                "-CandidateRoot",
+                str(candidate),
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(f"baseline={baseline_commit}", result.stdout)
+        self.assertIn(f"candidate={candidate_commit}", result.stdout)
+        self.assertIn("registry=127.0.0.1:5001", result.stdout)
+
+    def test_validate_binds_maps_to_provenance_hashes(self) -> None:
+        target = ROOT / "target"
+        target.mkdir(exist_ok=True)
+        with tempfile.TemporaryDirectory(dir=target) as temporary:
+            output = Path(temporary)
+            baseline_map = {
+                service: f"127.0.0.1:5001/evidence/baseline-{service}@sha256:{'1' * 64}"
+                for service in SERVICES
+            }
+            candidate_map = {
+                service: f"127.0.0.1:5001/evidence/candidate-{service}@sha256:{'2' * 64}"
+                for service in SERVICES
+            }
+            baseline_path = output / "baseline-images.json"
+            candidate_path = output / "candidate-images.json"
+            baseline_path.write_text(json.dumps(baseline_map, indent=2) + "\n", encoding="utf-8")
+            candidate_path.write_text(json.dumps(candidate_map, indent=2) + "\n", encoding="utf-8")
+            provenance = {
+                "schema_version": 1,
+                "artifact_kind": "rocketmq_local_evidence_image_provenance",
+                "baseline": {
+                    "commit": "1" * 40,
+                    "image_map_sha256": "sha256:" + hashlib.sha256(baseline_path.read_bytes()).hexdigest(),
+                },
+                "candidate": {
+                    "commit": "2" * 40,
+                    "image_map_sha256": "sha256:" + hashlib.sha256(candidate_path.read_bytes()).hexdigest(),
+                },
+            }
+            (output / "image-provenance.json").write_text(
+                json.dumps(provenance, indent=2) + "\n", encoding="utf-8"
+            )
+
+            valid = run_powershell(
+                "prepare-local-evidence-images.ps1",
+                "-Mode",
+                "Validate",
+                "-OutputDirectory",
+                str(output),
+            )
+
+            incomplete_map = dict(candidate_map)
+            incomplete_map.pop("mcp")
+            candidate_path.write_text(json.dumps(incomplete_map) + "\n", encoding="utf-8")
+            provenance["candidate"]["image_map_sha256"] = (
+                "sha256:" + hashlib.sha256(candidate_path.read_bytes()).hexdigest()
+            )
+            (output / "image-provenance.json").write_text(
+                json.dumps(provenance, indent=2) + "\n", encoding="utf-8"
+            )
+            incomplete = run_powershell(
+                "prepare-local-evidence-images.ps1",
+                "-Mode",
+                "Validate",
+                "-OutputDirectory",
+                str(output),
+            )
+
+            mutable_map = {**candidate_map, "broker": "127.0.0.1:5001/evidence/broker:latest"}
+            candidate_path.write_text(json.dumps(mutable_map) + "\n", encoding="utf-8")
+            provenance["candidate"]["image_map_sha256"] = (
+                "sha256:" + hashlib.sha256(candidate_path.read_bytes()).hexdigest()
+            )
+            (output / "image-provenance.json").write_text(
+                json.dumps(provenance, indent=2) + "\n", encoding="utf-8"
+            )
+            mutable = run_powershell(
+                "prepare-local-evidence-images.ps1",
+                "-Mode",
+                "Validate",
+                "-OutputDirectory",
+                str(output),
+            )
+
+        self.assertEqual(valid.returncode, 0, valid.stderr)
+        self.assertIn("LOCAL_EVIDENCE_IMAGE_MAPS_VALID", valid.stdout)
+        self.assertNotEqual(incomplete.returncode, 0)
+        self.assertNotEqual(mutable.returncode, 0)
+
+    def test_output_directory_cannot_escape_repository(self) -> None:
+        with tempfile.TemporaryDirectory() as outside:
+            result = run_powershell(
+                "prepare-local-evidence-images.ps1",
+                "-Mode",
+                "Validate",
+                "-OutputDirectory",
+                outside,
+            )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must remain inside the current repository", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9281

### Brief Description

Add a fail-closed local evidence bootstrap that pins Kind and kubectl binaries by version and SHA-256 without modifying the system PATH. Add baseline/candidate image preparation for clean worktrees, a loopback registry, production image builds, registry manifest digest resolution, OCI source-revision verification, and provenance-bound image maps for the existing Kind evidence runner.

The image preparation workflow rejects mutable tags, incomplete service sets, identical source commits, unclean worktrees, unsafe output paths, and provenance hash mismatches. Repository documentation is intentionally excluded.

### How Did You Test This Change?

- `python -m unittest scripts.tests.test_local_evidence_images scripts.tests.test_m11_kubernetes_assets -v` - passed, 20 tests.
- `python scripts/kubernetes_assets_guard.py --root .` - passed.
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/bootstrap-local-message-path-evidence.ps1 -Mode Validate` - passed.
- `python -m json.tool distribution/kubernetes/deployment-policy.json` - passed.
- `python -m compileall -q scripts/kubernetes_assets_guard.py scripts/tests/test_local_evidence_images.py` - passed.
- `git diff --check` - passed.

Docker image publication was not executed because the local Docker Desktop engine is not running. The deterministic plan, immutable map validation, and tamper rejection paths were executed; the subsequent Kind execution work will run the real build/push flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added workflows to prepare and validate local Kubernetes evidence images.
  - Added support for planning, building, publishing, and validating digest-pinned image artifacts with provenance metadata.
  - Added pinned Kubernetes tool verification for `kind` and `kubectl` across supported platforms.

- **Bug Fixes**
  - Added safeguards for clean checkouts, repository-contained paths, immutable image references, and artifact integrity.

- **Tests**
  - Added integration coverage for tool validation, image provenance, checkout requirements, and output path restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->