### PR TITLE
[ISSUE #9283]✨Add paired same-host message-path A/B qualification

### DIFF
--- a/scripts/message-path-qualification-policy.json
+++ b/scripts/message-path-qualification-policy.json
@@ -5,6 +5,10 @@
     "maximum_throughput_regression_percent": 10.0,
     "maximum_p99_latency_regression_percent": 15.0
   },
+  "stability_thresholds": {
+    "maximum_throughput_normalized_mad_percent": 10.0,
+    "maximum_p99_latency_normalized_mad_percent": 15.0
+  },
   "modes": {
     "smoke": {
       "minimum_repetitions": 1,

--- a/scripts/message_path_ab.py
+++ b/scripts/message_path_ab.py
@@ -1,0 +1,506 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Plan, execute, and assemble paired same-target message-path A/B evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import random
+import re
+import statistics
+import sys
+from pathlib import Path
+from typing import Any
+
+import message_path_qualification as qualification
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVICES = ("broker", "namesrv", "controller", "proxy", "mcp")
+IMAGE_REFERENCE = re.compile(r"^[^@\s]+@sha256:[0-9a-f]{64}$")
+
+
+class AbError(RuntimeError):
+    """Raised when paired A/B evidence cannot safely continue."""
+
+
+def digest(path: Path) -> str:
+    return f"sha256:{qualification.sha256_file(path)}"
+
+
+def load_image_map(path: Path, label: str) -> dict[str, str]:
+    document = qualification.load_json(path)
+    if set(document) != set(SERVICES):
+        raise AbError(f"{label} image map must contain exactly {', '.join(SERVICES)}")
+    result = {service: str(document[service]) for service in SERVICES}
+    for service, reference in result.items():
+        if not IMAGE_REFERENCE.fullmatch(reference):
+            raise AbError(f"{label} {service} image must use a registry manifest digest")
+    return result
+
+
+def subject_binding(
+    provenance: dict[str, Any], role: str, commit: str, image_map_path: Path
+) -> dict[str, Any]:
+    subject = provenance.get(role)
+    if not isinstance(subject, dict) or subject.get("commit") != commit:
+        raise AbError(f"{role} provenance commit differs from the requested commit")
+    map_hash = digest(image_map_path)
+    if subject.get("image_map_sha256") != map_hash:
+        raise AbError(f"{role} image map hash differs from provenance")
+    deployment_digest = subject.get("deployment_digest")
+    if not isinstance(deployment_digest, str) or not qualification.DIGEST_RE.fullmatch(deployment_digest):
+        raise AbError(f"{role} deployment digest is invalid")
+    return {
+        "commit": commit,
+        "artifact_manifest_sha256": map_hash,
+        "deployment_digest": deployment_digest,
+        "image_map_sha256": map_hash,
+    }
+
+
+def alternating_arms(repetitions: int, seed: int, warmup_runs: int) -> list[dict[str, Any]]:
+    if repetitions < 5:
+        raise AbError("paired release A/B requires at least five repetitions")
+    if warmup_runs < 1:
+        raise AbError("paired release A/B requires at least one warmup per subject")
+    generator = random.Random(seed)
+    arms: list[dict[str, Any]] = []
+    for phase, count in (("warmup", warmup_runs), ("sample", repetitions)):
+        for ordinal in range(1, count + 1):
+            pair = ["baseline", "candidate"]
+            generator.shuffle(pair)
+            for role in pair:
+                arms.append(
+                    {
+                        "index": len(arms),
+                        "role": role,
+                        "phase": phase,
+                        "ordinal": ordinal,
+                    }
+                )
+    return arms
+
+
+def create_plan(args: argparse.Namespace) -> dict[str, Any]:
+    policy = qualification.load_json(args.policy)
+    findings = qualification.validate_policy(policy)
+    if findings:
+        raise AbError("invalid qualification policy: " + "; ".join(findings))
+    if not qualification.RUN_ID_RE.fullmatch(args.run_id):
+        raise AbError("run ID must contain 3-128 safe characters")
+    if not qualification.GIT_SHA_RE.fullmatch(args.baseline_commit):
+        raise AbError("baseline commit must be a full lowercase Git SHA")
+    if not qualification.GIT_SHA_RE.fullmatch(args.candidate_commit):
+        raise AbError("candidate commit must be a full lowercase Git SHA")
+    if args.baseline_commit == args.candidate_commit:
+        raise AbError("baseline and candidate commits must differ")
+    if not qualification.GIT_SHA_RE.fullmatch(args.driver_commit):
+        raise AbError("benchmark driver commit must be a full lowercase Git SHA")
+    qualification.validate_target(args.namesrv, args.namesrv, args.topic_prefix, args.durability_contract)
+    if not args.target_id.strip() or not args.cluster_uid.strip():
+        raise AbError("target ID and cluster UID must be explicit")
+    if not args.effective_config.is_file():
+        raise AbError("effective configuration artifact is missing")
+
+    load_image_map(args.baseline_image_map, "baseline")
+    load_image_map(args.candidate_image_map, "candidate")
+    provenance = qualification.load_json(args.image_provenance)
+    if provenance.get("schema_version") != 1 or provenance.get(
+        "artifact_kind"
+    ) != "rocketmq_local_evidence_image_provenance":
+        raise AbError("image provenance contract is invalid")
+    release = policy["modes"]["release"]
+    repetitions = args.repetitions or release["minimum_repetitions"]
+    subjects = {
+        "baseline": subject_binding(provenance, "baseline", args.baseline_commit, args.baseline_image_map),
+        "candidate": subject_binding(provenance, "candidate", args.candidate_commit, args.candidate_image_map),
+    }
+    return {
+        "schema_version": 1,
+        "artifact_kind": "rocketmq_message_path_ab_plan",
+        "run_id": args.run_id,
+        "generated_at": qualification.utc_now(),
+        "mode": "release",
+        "seed": args.seed,
+        "warmup_runs_per_subject": release["warmup_runs"],
+        "repetitions_per_subject": repetitions,
+        "policy_sha256": f"sha256:{qualification.canonical_sha256(policy)}",
+        "durability_contract": args.durability_contract,
+        "driver": {"commit": args.driver_commit},
+        "target": {
+            "target_id": args.target_id,
+            "cluster_uid": args.cluster_uid,
+            "namesrv_addr": args.namesrv,
+            "topic_prefix": args.topic_prefix,
+            "effective_config_sha256": digest(args.effective_config),
+        },
+        "subjects": subjects,
+        "arms": alternating_arms(repetitions, args.seed, release["warmup_runs"]),
+    }
+
+
+def validate_plan(plan: dict[str, Any], policy: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    if plan.get("schema_version") != 1 or plan.get("artifact_kind") != "rocketmq_message_path_ab_plan":
+        failures.append("A/B plan contract is invalid")
+        return failures
+    if plan.get("policy_sha256") != f"sha256:{qualification.canonical_sha256(policy)}":
+        failures.append("A/B plan policy hash differs")
+    repetitions = plan.get("repetitions_per_subject")
+    warmups = plan.get("warmup_runs_per_subject")
+    if not isinstance(repetitions, int) or repetitions < 5:
+        failures.append("A/B plan requires at least five repetitions per subject")
+    if not isinstance(warmups, int) or warmups < 1:
+        failures.append("A/B plan requires at least one warmup per subject")
+    arms = plan.get("arms")
+    if not isinstance(arms, list):
+        failures.append("A/B plan arms are missing")
+        return failures
+    expected = {(role, "warmup", ordinal) for role in ("baseline", "candidate") for ordinal in range(1, warmups + 1)}
+    expected |= {(role, "sample", ordinal) for role in ("baseline", "candidate") for ordinal in range(1, repetitions + 1)}
+    actual: set[tuple[Any, Any, Any]] = set()
+    for index, arm in enumerate(arms):
+        if not isinstance(arm, dict) or arm.get("index") != index:
+            failures.append("A/B plan arm indexes must be contiguous")
+            continue
+        actual.add((arm.get("role"), arm.get("phase"), arm.get("ordinal")))
+    if actual != expected or len(arms) != len(expected):
+        failures.append("A/B plan does not contain every required arm exactly once")
+    if plan.get("subjects", {}).get("baseline", {}).get("commit") == plan.get("subjects", {}).get(
+        "candidate", {}
+    ).get("commit"):
+        failures.append("A/B plan subject commits must differ")
+    return failures
+
+
+def arm_directory(output_root: Path, arm: dict[str, Any]) -> Path:
+    return output_root / "arms" / f"{arm['index']:03d}-{arm['role']}-{arm['phase']}-{arm['ordinal']}"
+
+
+def execute_arm(
+    plan: dict[str, Any], plan_path: Path, arm_index: int, output_root: Path, timeout_seconds: int
+) -> tuple[dict[str, Any], Path]:
+    policy = qualification.load_json(qualification.DEFAULT_POLICY)
+    findings = validate_plan(plan, policy)
+    if findings:
+        raise AbError("; ".join(findings))
+    arms = plan["arms"]
+    if arm_index < 0 or arm_index >= len(arms):
+        raise AbError("arm index is outside the execution plan")
+    arm = arms[arm_index]
+    run_dir = arm_directory(output_root, arm)
+    report_path = run_dir / "arm-report.json"
+    if report_path.exists():
+        raise AbError(f"arm was already executed and cannot be overwritten: {report_path}")
+    run_dir.mkdir(parents=True, exist_ok=True)
+    failures: list[str] = []
+    records: list[dict[str, Any]] = []
+    topic_prefix = plan["target"]["topic_prefix"]
+    for workload in policy["modes"]["release"]["workloads"]:
+        topic = f"{topic_prefix}_{arm['role'][0]}{arm['phase'][0]}{arm['ordinal']}_{workload['id'].replace('-', '_')}"
+        sample_id = f"{plan['run_id']}-{arm['role']}-{arm['phase']}-{arm['ordinal']}-{workload['id']}"
+        raw_path = run_dir / "raw" / f"{workload['id']}.json"
+        raw_path.parent.mkdir(parents=True, exist_ok=True)
+        command = qualification.benchmark_command(
+            workload, plan["target"]["namesrv_addr"], topic, sample_id, raw_path
+        )
+        result = qualification.execute_command(command, ROOT, timeout_seconds)
+        stdout_path = raw_path.with_suffix(".stdout.log")
+        stderr_path = raw_path.with_suffix(".stderr.log")
+        stdout_path.write_text(result.stdout, encoding="utf-8")
+        stderr_path.write_text(result.stderr, encoding="utf-8")
+        record: dict[str, Any] = {
+            "workload": workload["id"],
+            "command": command,
+            "exit_code": result.exit_code,
+            "duration_ms": result.duration_ms,
+            "stdout_sha256": digest(stdout_path),
+            "stderr_sha256": digest(stderr_path),
+        }
+        if result.exit_code != 0 or not raw_path.is_file():
+            failures.append(f"{sample_id} failed with exit code {result.exit_code}")
+            records.append(record)
+            break
+        measurement = qualification.load_json(raw_path)
+        sample_findings = qualification.validate_measurement(
+            measurement, workload, plan["target"]["namesrv_addr"], topic, sample_id
+        )
+        record["measurement"] = measurement
+        record["raw_sha256"] = digest(raw_path)
+        records.append(record)
+        if sample_findings:
+            failures.extend(f"{sample_id}: {finding}" for finding in sample_findings)
+            break
+    report = {
+        "schema_version": 1,
+        "artifact_kind": "rocketmq_message_path_ab_arm",
+        "generated_at": qualification.utc_now(),
+        "plan_sha256": digest(plan_path),
+        "arm": arm,
+        "status": "fail" if failures else "pass",
+        "failures": failures,
+        "records": records,
+    }
+    qualification.write_json(report_path, report)
+    return report, report_path
+
+
+def normalized_mad_percent(values: list[float]) -> float:
+    median = statistics.median(values)
+    if median <= 0:
+        raise AbError("stability values must have a positive median")
+    return statistics.median(abs(value - median) for value in values) / median * 100.0
+
+
+def subject_artifacts(plan: dict[str, Any], output_root: Path, role: str) -> list[dict[str, str]]:
+    artifacts: list[dict[str, str]] = []
+    for arm in plan["arms"]:
+        if arm["role"] != role:
+            continue
+        directory = arm_directory(output_root, arm)
+        for path in sorted(item for item in directory.rglob("*") if item.is_file()):
+            artifacts.append({"path": path.relative_to(output_root).as_posix(), "sha256": digest(path)})
+    return artifacts
+
+
+def paired_bootstrap(baseline: list[float], candidate: list[float], seed: int) -> dict[str, float]:
+    if len(baseline) != len(candidate) or len(baseline) < 5:
+        raise AbError("paired bootstrap requires at least five matched samples")
+    differences = [candidate[index] - baseline[index] for index in range(len(baseline))]
+    generator = random.Random(seed)
+    estimates = sorted(
+        statistics.median(generator.choice(differences) for _ in differences) for _ in range(10_000)
+    )
+    lower = estimates[math.floor(0.025 * (len(estimates) - 1))]
+    upper = estimates[math.floor(0.975 * (len(estimates) - 1))]
+    return {
+        "median_difference": statistics.median(differences),
+        "confidence_95_lower": lower,
+        "confidence_95_upper": upper,
+    }
+
+
+def assemble(plan: dict[str, Any], plan_path: Path, output_root: Path) -> tuple[dict[str, Any], Path]:
+    policy = qualification.load_json(qualification.DEFAULT_POLICY)
+    failures = validate_plan(plan, policy)
+    reports: dict[tuple[str, str, int], tuple[dict[str, Any], Path]] = {}
+    for arm in plan.get("arms", []):
+        path = arm_directory(output_root, arm) / "arm-report.json"
+        if not path.is_file():
+            failures.append(f"missing arm report: {arm['index']}")
+            continue
+        report = qualification.load_json(path)
+        key = (arm["role"], arm["phase"], arm["ordinal"])
+        if report.get("plan_sha256") != digest(plan_path) or report.get("arm") != arm:
+            failures.append(f"arm {arm['index']} binding differs from the plan")
+        if report.get("status") != "pass" or report.get("failures"):
+            failures.append(f"arm {arm['index']} did not pass")
+        reports[key] = (report, path)
+    if failures:
+        raise AbError("; ".join(failures))
+
+    environment = qualification.environment_record()
+    measurement_paths: dict[str, Path] = {}
+    measurements: dict[str, dict[str, Any]] = {}
+    thresholds = policy["stability_thresholds"]
+    for role in ("baseline", "candidate"):
+        workload_reports: list[dict[str, Any]] = []
+        for workload in policy["modes"]["release"]["workloads"]:
+            runs: list[dict[str, Any]] = []
+            samples: list[dict[str, Any]] = []
+            for phase, count in (
+                ("warmup", plan["warmup_runs_per_subject"]),
+                ("sample", plan["repetitions_per_subject"]),
+            ):
+                for ordinal in range(1, count + 1):
+                    arm_report, arm_path = reports[(role, phase, ordinal)]
+                    record = next((item for item in arm_report["records"] if item["workload"] == workload["id"]), None)
+                    if not isinstance(record, dict) or "measurement" not in record:
+                        raise AbError(f"{role} {phase} {ordinal} is missing {workload['id']}")
+                    runs.append(
+                        {
+                            "phase": phase,
+                            "ordinal": ordinal,
+                            "measurement": record["measurement"],
+                            "arm_report_sha256": digest(arm_path),
+                        }
+                    )
+                    if phase == "sample":
+                        samples.append(record["measurement"])
+            throughputs = [float(item["result"]["throughput_messages_per_second"]) for item in samples]
+            p99s = [float(item["result"]["latency_us"]["p99"]) for item in samples]
+            stability = {
+                "throughput_normalized_mad_percent": normalized_mad_percent(throughputs),
+                "p99_normalized_mad_percent": normalized_mad_percent(p99s),
+            }
+            stability["status"] = (
+                "pass"
+                if stability["throughput_normalized_mad_percent"]
+                <= thresholds["maximum_throughput_normalized_mad_percent"]
+                and stability["p99_normalized_mad_percent"]
+                <= thresholds["maximum_p99_latency_normalized_mad_percent"]
+                else "fail"
+            )
+            if stability["status"] != "pass":
+                raise AbError(f"{role} {workload['id']} sample stability exceeds the A/B contract")
+            workload_reports.append(
+                {
+                    "id": workload["id"],
+                    "parameters": workload,
+                    "runs": runs,
+                    "aggregate": qualification.aggregate_samples(samples),
+                    "stability": stability,
+                }
+            )
+        subject = {"role": role, **plan["subjects"][role]}
+        report = {
+            "schema_version": 2,
+            "artifact_kind": "rocketmq_message_path_measurement_set",
+            "run_id": f"{plan['run_id']}-{role}",
+            "generated_at": qualification.utc_now(),
+            "mode": "release",
+            "status": "pass",
+            "measurement_qualified": True,
+            "business_contract": "java-equivalent-message-semantics",
+            "implementation_strategy": "rust-native",
+            "durability_contract": plan["durability_contract"],
+            "policy_sha256": qualification.canonical_sha256(policy),
+            "git": {"commit": plan["driver"]["commit"], "dirty": False},
+            "subject": subject,
+            "environment": environment,
+            "target": {
+                "target_id": plan["target"]["target_id"],
+                "cluster_uid": plan["target"]["cluster_uid"],
+                "namesrv_addr": plan["target"]["namesrv_addr"],
+                "topic": plan["target"]["topic_prefix"],
+                "effective_config_sha256": plan["target"]["effective_config_sha256"],
+            },
+            "paired_ab": {"plan_sha256": digest(plan_path), "seed": plan["seed"]},
+            "repetitions_per_workload": plan["repetitions_per_subject"],
+            "workloads": workload_reports,
+            "failures": [],
+            "artifacts": subject_artifacts(plan, output_root, role),
+        }
+        path = output_root / role / "measurement-set.json"
+        qualification.write_json(path, report)
+        measurement_paths[role] = path
+        measurements[role] = report
+
+    comparison = qualification.compare_reports(
+        policy,
+        measurements["baseline"],
+        measurements["candidate"],
+        baseline_sha256=digest(measurement_paths["baseline"]),
+        candidate_sha256=digest(measurement_paths["candidate"]),
+    )
+    for item in comparison.get("comparisons", []):
+        workload_id = item["workload"]
+        baseline_item = next(entry for entry in measurements["baseline"]["workloads"] if entry["id"] == workload_id)
+        candidate_item = next(entry for entry in measurements["candidate"]["workloads"] if entry["id"] == workload_id)
+        baseline_runs = [entry["measurement"] for entry in baseline_item["runs"] if entry["phase"] == "sample"]
+        candidate_runs = [entry["measurement"] for entry in candidate_item["runs"] if entry["phase"] == "sample"]
+        item["paired_bootstrap_95_ci"] = {
+            "throughput_messages_per_second": paired_bootstrap(
+                [float(entry["result"]["throughput_messages_per_second"]) for entry in baseline_runs],
+                [float(entry["result"]["throughput_messages_per_second"]) for entry in candidate_runs],
+                plan["seed"],
+            ),
+            "p99_latency_us": paired_bootstrap(
+                [float(entry["result"]["latency_us"]["p99"]) for entry in baseline_runs],
+                [float(entry["result"]["latency_us"]["p99"]) for entry in candidate_runs],
+                plan["seed"] + 1,
+            ),
+        }
+    comparison["ab_plan_sha256"] = digest(plan_path)
+    comparison_path = output_root / "performance-comparison.json"
+    qualification.write_json(comparison_path, comparison)
+    return comparison, comparison_path
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    subparsers = result.add_subparsers(dest="command", required=True)
+    plan = subparsers.add_parser("plan")
+    plan.add_argument("--policy", type=Path, default=qualification.DEFAULT_POLICY)
+    plan.add_argument("--run-id", required=True)
+    plan.add_argument("--baseline-commit", required=True)
+    plan.add_argument("--candidate-commit", required=True)
+    plan.add_argument("--driver-commit", required=True)
+    plan.add_argument("--baseline-image-map", type=Path, required=True)
+    plan.add_argument("--candidate-image-map", type=Path, required=True)
+    plan.add_argument("--image-provenance", type=Path, required=True)
+    plan.add_argument("--effective-config", type=Path, required=True)
+    plan.add_argument("--target-id", required=True)
+    plan.add_argument("--cluster-uid", required=True)
+    plan.add_argument("--namesrv", required=True)
+    plan.add_argument("--topic-prefix", required=True)
+    plan.add_argument("--durability-contract", required=True)
+    plan.add_argument("--repetitions", type=int, default=5)
+    plan.add_argument("--seed", type=int, default=20260812)
+    plan.add_argument("--output", type=Path, required=True)
+
+    execute = subparsers.add_parser("execute-arm")
+    execute.add_argument("--plan", type=Path, required=True)
+    execute.add_argument("--arm-index", type=int, required=True)
+    execute.add_argument("--output-root", type=Path, required=True)
+    execute.add_argument("--command-timeout-seconds", type=int, default=1800)
+
+    assemble_parser = subparsers.add_parser("assemble")
+    assemble_parser.add_argument("--plan", type=Path, required=True)
+    assemble_parser.add_argument("--output-root", type=Path, required=True)
+
+    validate = subparsers.add_parser("validate")
+    validate.add_argument("--plan", type=Path, required=True)
+    validate.add_argument("--output-root", type=Path)
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        if args.command == "plan":
+            plan = create_plan(args)
+            qualification.write_json(args.output, plan)
+            print(f"message-path A/B plan ready: {args.output}")
+            return 0
+        plan = qualification.load_json(args.plan)
+        if args.command == "execute-arm":
+            report, path = execute_arm(plan, args.plan, args.arm_index, args.output_root, args.command_timeout_seconds)
+            print(f"message-path A/B arm {report['status']}: {path}")
+            return 0 if report["status"] == "pass" else 1
+        if args.command == "assemble":
+            comparison, path = assemble(plan, args.plan, args.output_root)
+            print(f"message-path A/B comparison {comparison['status']}: {path}")
+            return 0 if comparison["status"] == "pass" else 1
+        findings = validate_plan(plan, qualification.load_json(qualification.DEFAULT_POLICY))
+        if findings:
+            raise AbError("; ".join(findings))
+        if args.output_root:
+            comparison = qualification.load_json(args.output_root / "performance-comparison.json")
+            if comparison.get("status") != "pass" or comparison.get("ab_plan_sha256") != digest(args.plan):
+                raise AbError("A/B comparison is not a passing result bound to this plan")
+        print("MESSAGE_PATH_AB_VALID")
+        return 0
+    except (AbError, qualification.QualificationError, OSError, ValueError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/message_path_qualification.py
+++ b/scripts/message_path_qualification.py
@@ -122,7 +122,7 @@ def positive_int(value: Any) -> bool:
 
 def validate_policy(policy: dict[str, Any]) -> list[str]:
     findings: list[str] = []
-    expected = {"schema_version", "artifact_kind", "comparison_thresholds", "modes"}
+    expected = {"schema_version", "artifact_kind", "comparison_thresholds", "stability_thresholds", "modes"}
     if set(policy) != expected:
         findings.append(f"policy keys must be exactly {sorted(expected)}")
     if policy.get("schema_version") != 1:
@@ -142,6 +142,19 @@ def validate_policy(policy: dict[str, Any]) -> list[str]:
             value = thresholds.get(key)
             if not isinstance(value, (int, float)) or isinstance(value, bool) or not 0 < float(value) <= 100:
                 findings.append(f"comparison_thresholds.{key} must be >0 and <=100")
+
+    stability = policy.get("stability_thresholds")
+    expected_stability = {
+        "maximum_throughput_normalized_mad_percent",
+        "maximum_p99_latency_normalized_mad_percent",
+    }
+    if not isinstance(stability, dict) or set(stability) != expected_stability:
+        findings.append("stability_thresholds has an invalid shape")
+    else:
+        for key in expected_stability:
+            value = stability.get(key)
+            if not isinstance(value, (int, float)) or isinstance(value, bool) or not 0 < float(value) <= 100:
+                findings.append(f"stability_thresholds.{key} must be >0 and <=100")
 
     modes = policy.get("modes")
     if not isinstance(modes, dict) or set(modes) != {"smoke", "release"}:
@@ -421,12 +434,14 @@ def measurement_identity(
 def aggregate_samples(samples: list[dict[str, Any]]) -> dict[str, float]:
     throughputs = [float(item["result"]["throughput_messages_per_second"]) for item in samples]
     payload_rates = [float(item["result"]["payload_mib_per_second"]) for item in samples]
-    p99_values = [float(item["result"]["latency_us"]["p99"]) for item in samples]
-    return {
+    result = {
         "throughput_messages_per_second_median": statistics.median(throughputs),
         "payload_mib_per_second_median": statistics.median(payload_rates),
-        "p99_latency_us_median": statistics.median(p99_values),
     }
+    for percentile in ("p50", "p95", "p99", "p999", "average"):
+        values = [float(item["result"]["latency_us"][percentile]) for item in samples]
+        result[f"{percentile}_latency_us_median"] = statistics.median(values)
+    return result
 
 
 def run_qualification(

--- a/scripts/run-message-path-ab.ps1
+++ b/scripts/run-message-path-ab.ps1
@@ -1,0 +1,344 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[CmdletBinding()]
+param(
+    [ValidateSet("Validate", "Plan", "Run")]
+    [string]$Mode = "Validate",
+    [ValidateSet("kind", "target")]
+    [string]$Backend = "kind",
+    [string]$BaselineCommit,
+    [string]$CandidateCommit,
+    [string]$BaselineImageMap,
+    [string]$CandidateImageMap,
+    [string]$ImageProvenance,
+    [string]$EffectiveConfig,
+    [string]$TargetId,
+    [string]$ClusterUid,
+    [string]$DurabilityContract,
+    [string]$Namespace = "rocketmq-system",
+    [string]$ReleaseName = "rocketmq",
+    [string]$NamesrvAddress = "127.0.0.1:19876",
+    [int]$NamesrvLocalPort = 19876,
+    [string]$TopicPrefix = "MessagePathAB",
+    [int]$Repetitions = 5,
+    [int]$Seed = 20260812,
+    [string]$RunId,
+    [string]$OutputRoot = "target/message-path-ab",
+    [string]$Kubectl = "kubectl",
+    [int]$MinimumFreeDiskGiB = 50,
+    [int]$StableSeconds = 15,
+    [switch]$AllowBusyHost
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+$RepositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$PythonScript = Join-Path $PSScriptRoot "message_path_ab.py"
+$PolicyPath = Join-Path $PSScriptRoot "message-path-qualification-policy.json"
+$Services = @("broker", "namesrv", "controller", "proxy", "mcp")
+
+function Require-Command {
+    param([Parameter(Mandatory)][string]$Name)
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "required command is unavailable: $Name"
+    }
+}
+
+function Invoke-Checked {
+    param(
+        [Parameter(Mandatory)][string]$Executable,
+        [Parameter(Mandatory)][string[]]$Arguments,
+        [switch]$AllowFailure
+    )
+    $content = (& $Executable @Arguments 2>&1 | Out-String).TrimEnd()
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0 -and -not $AllowFailure) {
+        throw "$Executable failed with exit code $exitCode`n$content"
+    }
+    [pscustomobject]@{ ExitCode = $exitCode; Output = $content }
+}
+
+function Resolve-RepositoryOutput {
+    param([Parameter(Mandatory)][string]$Path)
+    $resolved = if ([IO.Path]::IsPathRooted($Path)) {
+        [IO.Path]::GetFullPath($Path)
+    } else {
+        [IO.Path]::GetFullPath((Join-Path $RepositoryRoot $Path))
+    }
+    $prefix = $RepositoryRoot.TrimEnd("\", "/") + [IO.Path]::DirectorySeparatorChar
+    if (-not $resolved.StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "OutputRoot must remain inside the repository"
+    }
+    $resolved
+}
+
+function Require-File {
+    param([Parameter(Mandatory)][string]$Path, [Parameter(Mandatory)][string]$Label)
+    if ([string]::IsNullOrWhiteSpace($Path) -or -not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "$Label file is required"
+    }
+    (Resolve-Path -LiteralPath $Path).Path
+}
+
+function Read-ImageMap {
+    param([Parameter(Mandatory)][string]$Path)
+    $map = Get-Content -Raw -LiteralPath $Path | ConvertFrom-Json -AsHashtable
+    if ((@($map.Keys | Sort-Object) -join ",") -ne (@($Services | Sort-Object) -join ",")) {
+        throw "image map must contain exactly five RocketMQ services"
+    }
+    $map
+}
+
+function Get-RunDirectory {
+    param([Parameter(Mandatory)][string]$Root, [Parameter(Mandatory)][string]$Identity)
+    Join-Path $Root $Identity
+}
+
+function Save-CommandOutput {
+    param(
+        [Parameter(Mandatory)][string[]]$Arguments,
+        [Parameter(Mandatory)][string]$Path,
+        [switch]$Required
+    )
+    $result = Invoke-Checked -Executable $Kubectl -Arguments $Arguments -AllowFailure
+    [IO.File]::WriteAllText($Path, $result.Output + "`n", [Text.UTF8Encoding]::new($false))
+    if ($result.ExitCode -ne 0) {
+        [IO.File]::WriteAllText("$Path.failed", "$($result.ExitCode)`n", [Text.UTF8Encoding]::new($false))
+        if ($Required) { throw "required Kubernetes evidence command failed: $($Arguments -join ' ')" }
+    }
+}
+
+function Save-ClusterSnapshot {
+    param([Parameter(Mandatory)][string]$Directory, [Parameter(Mandatory)][string]$Prefix)
+    New-Item -ItemType Directory -Force -Path $Directory | Out-Null
+    $podsPath = Join-Path $Directory "$Prefix-pods.json"
+    Save-CommandOutput @("-n", $Namespace, "get", "pods", "-o", "json") $podsPath -Required
+    Save-CommandOutput @("-n", $Namespace, "get", "statefulset,deployment", "-o", "json") (Join-Path $Directory "$Prefix-workloads.json") -Required
+    Save-CommandOutput @("-n", $Namespace, "top", "pods", "--containers") (Join-Path $Directory "$Prefix-pod-resources.txt")
+    Save-CommandOutput @("get", "nodes", "-o", "wide") (Join-Path $Directory "$Prefix-nodes.txt") -Required
+    $pods = Get-Content -Raw -LiteralPath $podsPath | ConvertFrom-Json
+    $resourceCommand = 'printf "memory_current="; cat /sys/fs/cgroup/memory.current 2>/dev/null || true; cat /proc/1/status; set -- /proc/1/task/*; echo task_count=$#; set -- /proc/1/fd/*; echo fd_count=$#'
+    foreach ($pod in $pods.items) {
+        $name = [string]$pod.metadata.name
+        Save-CommandOutput @(
+            "-n", $Namespace, "exec", $name, "--", "/bin/sh", "-c", $resourceCommand
+        ) (Join-Path $Directory "$Prefix-$name-process.txt") -Required
+    }
+}
+
+function Assert-NoContainerRestart {
+    $pods = (Invoke-Checked $Kubectl @("-n", $Namespace, "get", "pods", "-o", "json")).Output | ConvertFrom-Json
+    foreach ($pod in $pods.items) {
+        foreach ($status in @($pod.status.containerStatuses)) {
+            if ([int]$status.restartCount -ne 0) {
+                throw "container restart detected before measurement: $($pod.metadata.name)/$($status.name)"
+            }
+        }
+    }
+}
+
+function Wait-WorkloadsStable {
+    $workloads = @(
+        "statefulset/$ReleaseName-broker",
+        "statefulset/$ReleaseName-namesrv",
+        "statefulset/$ReleaseName-controller",
+        "deployment/$ReleaseName-proxy",
+        "deployment/$ReleaseName-mcp"
+    )
+    foreach ($workload in $workloads) {
+        Invoke-Checked $Kubectl @("-n", $Namespace, "rollout", "status", $workload, "--timeout=300s") | Out-Null
+    }
+    $first = (Invoke-Checked $Kubectl @("-n", $Namespace, "get", "statefulset,deployment", "-o", "json")).Output
+    Start-Sleep -Seconds $StableSeconds
+    $second = (Invoke-Checked $Kubectl @("-n", $Namespace, "get", "statefulset,deployment", "-o", "json")).Output
+    $firstState = $first | ConvertFrom-Json
+    $secondState = $second | ConvertFrom-Json
+    foreach ($state in @($firstState.items) + @($secondState.items)) {
+        if ([int]$state.status.readyReplicas -ne [int]$state.spec.replicas) {
+            throw "workload is not fully Ready: $($state.metadata.name)"
+        }
+    }
+    Assert-NoContainerRestart
+}
+
+function Set-SubjectImages {
+    param([Parameter(Mandatory)][hashtable]$Images)
+    foreach ($service in @("broker", "namesrv", "controller")) {
+        Invoke-Checked $Kubectl @(
+            "-n", $Namespace, "set", "image", "statefulset/$ReleaseName-$service", "$service=$($Images[$service])"
+        ) | Out-Null
+    }
+    foreach ($service in @("proxy", "mcp")) {
+        Invoke-Checked $Kubectl @(
+            "-n", $Namespace, "set", "image", "deployment/$ReleaseName-$service", "$service=$($Images[$service])"
+        ) | Out-Null
+    }
+    Wait-WorkloadsStable
+    foreach ($service in $Services) {
+        $kind = if ($service -in @("broker", "namesrv", "controller")) { "statefulset" } else { "deployment" }
+        $actual = (Invoke-Checked $Kubectl @(
+            "-n", $Namespace, "get", "$kind/$ReleaseName-$service", "-o", "jsonpath={.spec.template.spec.containers[?(@.name=='$service')].image}"
+        )).Output
+        if ($actual -ne $Images[$service]) {
+            throw "$service workload image differs from the requested immutable reference"
+        }
+    }
+}
+
+function Assert-HostReady {
+    $drive = [IO.DriveInfo]::new([IO.Path]::GetPathRoot($RepositoryRoot))
+    $freeGiB = [math]::Floor($drive.AvailableFreeSpace / 1GB)
+    if ($freeGiB -lt $MinimumFreeDiskGiB) {
+        throw "free disk ${freeGiB}GiB is below the ${MinimumFreeDiskGiB}GiB A/B minimum"
+    }
+    if (-not $AllowBusyHost -and $IsWindows) {
+        $cpu = Get-CimInstance Win32_Processor | Measure-Object -Property LoadPercentage -Average
+        if ($cpu.Average -gt 20) {
+            throw "host CPU is not idle enough for paired A/B measurement: $([math]::Round($cpu.Average, 2))%"
+        }
+    }
+    if ($Backend -eq "kind") {
+        Require-Command "docker"
+        Invoke-Checked "docker" @("info") | Out-Null
+    }
+}
+
+function Wait-TcpPort {
+    param([Parameter(Mandatory)][int]$Port)
+    $deadline = [DateTimeOffset]::UtcNow.AddSeconds(30)
+    do {
+        $client = [Net.Sockets.TcpClient]::new()
+        try {
+            $pending = $client.ConnectAsync("127.0.0.1", $Port)
+            if ($pending.Wait(500) -and $client.Connected) { return }
+        } catch {
+        } finally {
+            $client.Dispose()
+        }
+        Start-Sleep -Milliseconds 250
+    } while ([DateTimeOffset]::UtcNow -lt $deadline)
+    throw "NameServer port-forward did not become ready on 127.0.0.1:$Port"
+}
+
+Require-Command "python"
+if ($Mode -eq "Validate") {
+    Invoke-Checked "python" @($PythonScript, "--help") | Out-Null
+    Invoke-Checked "python" @((Join-Path $PSScriptRoot "message_path_qualification.py"), "validate-policy") | Out-Null
+    Write-Host "MESSAGE_PATH_AB_RUNNER_VALID"
+    return
+}
+
+if ([string]::IsNullOrWhiteSpace($RunId)) {
+    $RunId = "message-path-ab-$([DateTimeOffset]::UtcNow.ToString('yyyyMMddTHHmmssZ'))"
+}
+$baselineMapPath = Require-File $BaselineImageMap "baseline image map"
+$candidateMapPath = Require-File $CandidateImageMap "candidate image map"
+$provenancePath = Require-File $ImageProvenance "image provenance"
+$configPath = Require-File $EffectiveConfig "effective configuration"
+$outputBase = Resolve-RepositoryOutput $OutputRoot
+$runDirectory = Get-RunDirectory $outputBase $RunId
+if (Test-Path -LiteralPath $runDirectory) {
+    throw "A/B run directory already exists and will not be overwritten: $runDirectory"
+}
+New-Item -ItemType Directory -Force -Path $runDirectory | Out-Null
+$planPath = Join-Path $runDirectory "ab-plan.json"
+
+if ($Mode -eq "Run") {
+    if ($PSVersionTable.PSVersion.Major -lt 7) { throw "Run mode requires PowerShell 7 or newer" }
+    Require-Command $Kubectl
+    Assert-HostReady
+    Invoke-Checked $Kubectl @("cluster-info") | Out-Null
+    Invoke-Checked $Kubectl @("-n", $Namespace, "get", "statefulset/$ReleaseName-broker") | Out-Null
+    if ([string]::IsNullOrWhiteSpace($ClusterUid)) {
+        $ClusterUid = (Invoke-Checked $Kubectl @("get", "namespace", $Namespace, "-o", "jsonpath={.metadata.uid}")).Output
+    }
+}
+if ([string]::IsNullOrWhiteSpace($ClusterUid)) { throw "ClusterUid is required in Plan mode" }
+if ([string]::IsNullOrWhiteSpace($TargetId)) { throw "TargetId is required" }
+if ([string]::IsNullOrWhiteSpace($DurabilityContract)) { throw "DurabilityContract is required" }
+$driverCommit = (Invoke-Checked "git" @("rev-parse", "HEAD")).Output.Trim()
+$dirty = (Invoke-Checked "git" @("status", "--porcelain")).Output
+if (-not [string]::IsNullOrWhiteSpace($dirty)) { throw "paired A/B requires a clean benchmark-driver worktree" }
+
+Invoke-Checked "python" @(
+    $PythonScript, "plan",
+    "--run-id", $RunId,
+    "--baseline-commit", $BaselineCommit,
+    "--candidate-commit", $CandidateCommit,
+    "--driver-commit", $driverCommit,
+    "--baseline-image-map", $baselineMapPath,
+    "--candidate-image-map", $candidateMapPath,
+    "--image-provenance", $provenancePath,
+    "--effective-config", $configPath,
+    "--target-id", $TargetId,
+    "--cluster-uid", $ClusterUid,
+    "--namesrv", $NamesrvAddress,
+    "--topic-prefix", $TopicPrefix,
+    "--durability-contract", $DurabilityContract,
+    "--repetitions", "$Repetitions",
+    "--seed", "$Seed",
+    "--output", $planPath
+) | Out-Null
+if ($Mode -eq "Plan") {
+    Write-Host "MESSAGE_PATH_AB_PLAN_READY plan=$planPath"
+    return
+}
+
+$baselineImages = Read-ImageMap $baselineMapPath
+$candidateImages = Read-ImageMap $candidateMapPath
+$plan = Get-Content -Raw -LiteralPath $planPath | ConvertFrom-Json
+$portForwardOut = Join-Path $runDirectory "port-forward.stdout.log"
+$portForwardErr = Join-Path $runDirectory "port-forward.stderr.log"
+$startParameters = @{
+    FilePath = $Kubectl
+    ArgumentList = @("-n", $Namespace, "port-forward", "service/$ReleaseName-namesrv-discovery", "${NamesrvLocalPort}:9876")
+    PassThru = $true
+    RedirectStandardOutput = $portForwardOut
+    RedirectStandardError = $portForwardErr
+}
+if ($IsWindows) { $startParameters.WindowStyle = "Hidden" }
+$portForward = Start-Process @startParameters
+try {
+    Wait-TcpPort $NamesrvLocalPort
+    $currentRole = ""
+    foreach ($arm in $plan.arms) {
+        $role = [string]$arm.role
+        if ($role -ne $currentRole) {
+            $images = if ($role -eq "baseline") { $baselineImages } else { $candidateImages }
+            Set-SubjectImages $images
+            $currentRole = $role
+        }
+        $armDirectory = Join-Path $runDirectory ("arms/{0:D3}-{1}-{2}-{3}" -f $arm.index, $role, $arm.phase, $arm.ordinal)
+        Save-ClusterSnapshot $armDirectory "before"
+        $execution = Invoke-Checked "python" @(
+            $PythonScript, "execute-arm", "--plan", $planPath,
+            "--arm-index", "$($arm.index)", "--output-root", $runDirectory
+        ) -AllowFailure
+        [IO.File]::WriteAllText((Join-Path $armDirectory "runner.log"), $execution.Output + "`n", [Text.UTF8Encoding]::new($false))
+        Save-ClusterSnapshot $armDirectory "after"
+        Assert-NoContainerRestart
+        if ($execution.ExitCode -ne 0) {
+            throw "A/B arm $($arm.index) failed; its evidence was retained and will not be retried"
+        }
+    }
+    Invoke-Checked "python" @($PythonScript, "assemble", "--plan", $planPath, "--output-root", $runDirectory) | Out-Null
+    Invoke-Checked "python" @($PythonScript, "validate", "--plan", $planPath, "--output-root", $runDirectory) | Out-Null
+    Write-Host "MESSAGE_PATH_AB_COMPLETE output=$runDirectory"
+} finally {
+    if ($null -ne $portForward -and -not $portForward.HasExited) {
+        Stop-Process -Id $portForward.Id -Force -ErrorAction SilentlyContinue
+        $portForward.WaitForExit(5000) | Out-Null
+    }
+}

--- a/scripts/tests/test_message_path_ab.py
+++ b/scripts/tests/test_message_path_ab.py
@@ -1,0 +1,259 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import message_path_ab as ab  # noqa: E402
+import message_path_qualification as qualification  # noqa: E402
+
+
+SERVICES = ("broker", "namesrv", "controller", "proxy", "mcp")
+
+
+class MessagePathAbTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.policy = qualification.load_json(qualification.DEFAULT_POLICY)
+
+    def create_inputs(self, root: Path) -> argparse.Namespace:
+        baseline_map = {
+            service: f"registry.local/rocketmq/{service}@sha256:{str(index + 1) * 64}"
+            for index, service in enumerate(SERVICES)
+        }
+        candidate_map = {
+            service: f"registry.local/rocketmq/{service}@sha256:{chr(97 + index) * 64}"
+            for index, service in enumerate(SERVICES)
+        }
+        baseline_path = root / "baseline-images.json"
+        candidate_path = root / "candidate-images.json"
+        qualification.write_json(baseline_path, baseline_map)
+        qualification.write_json(candidate_path, candidate_map)
+        effective_config = root / "effective-config.json"
+        effective_config.write_text('{"flush":"sync"}\n', encoding="utf-8")
+        provenance = {
+            "schema_version": 1,
+            "artifact_kind": "rocketmq_local_evidence_image_provenance",
+            "baseline": {
+                "commit": "1" * 40,
+                "image_map_sha256": ab.digest(baseline_path),
+                "deployment_digest": "sha256:" + "3" * 64,
+            },
+            "candidate": {
+                "commit": "2" * 40,
+                "image_map_sha256": ab.digest(candidate_path),
+                "deployment_digest": "sha256:" + "4" * 64,
+            },
+        }
+        provenance_path = root / "image-provenance.json"
+        qualification.write_json(provenance_path, provenance)
+        return argparse.Namespace(
+            policy=qualification.DEFAULT_POLICY,
+            run_id="paired-ab-test",
+            baseline_commit="1" * 40,
+            candidate_commit="2" * 40,
+            driver_commit="5" * 40,
+            baseline_image_map=baseline_path,
+            candidate_image_map=candidate_path,
+            image_provenance=provenance_path,
+            effective_config=effective_config,
+            target_id="kind-engineering-rehearsal",
+            cluster_uid="cluster-uid-1",
+            namesrv="127.0.0.1:19876",
+            topic_prefix="MessagePathAB",
+            durability_contract="strict-sync-required-ack-clean-election",
+            repetitions=5,
+            seed=42,
+        )
+
+    def test_plan_is_deterministic_and_pairs_every_subject(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            args = self.create_inputs(Path(temporary))
+            first = ab.create_plan(args)
+            second = ab.create_plan(args)
+
+        self.assertEqual(first["arms"], second["arms"])
+        self.assertEqual(12, len(first["arms"]))
+        self.assertEqual([], ab.validate_plan(first, self.policy))
+        for phase, count in (("warmup", 1), ("sample", 5)):
+            for ordinal in range(1, count + 1):
+                roles = [
+                    arm["role"]
+                    for arm in first["arms"]
+                    if arm["phase"] == phase and arm["ordinal"] == ordinal
+                ]
+                self.assertCountEqual(("baseline", "candidate"), roles)
+
+    def test_plan_rejects_mutable_image_reference(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            args = self.create_inputs(root)
+            image_map = qualification.load_json(args.baseline_image_map)
+            image_map["broker"] = "registry.local/rocketmq/broker:latest"
+            qualification.write_json(args.baseline_image_map, image_map)
+
+            with self.assertRaisesRegex(ab.AbError, "manifest digest"):
+                ab.create_plan(args)
+
+    @staticmethod
+    def measurement(plan: dict, arm: dict, workload: dict, value: float) -> dict:
+        topic = f"{plan['target']['topic_prefix']}_{arm['role'][0]}{arm['phase'][0]}{arm['ordinal']}_{workload['id'].replace('-', '_')}"
+        sample_id = f"{plan['run_id']}-{arm['role']}-{arm['phase']}-{arm['ordinal']}-{workload['id']}"
+        count = workload["message_count"]
+        return {
+            "schema_version": 1,
+            "artifact_kind": "rocketmq_message_path_measurement",
+            "run_id": sample_id,
+            "scenario": workload["scenario"],
+            "operation": "consume" if workload["scenario"] == "lite-pull" else "send",
+            "target": {"namesrv_addr": plan["target"]["namesrv_addr"], "topic": topic},
+            "workload": {
+                "message_count": count,
+                "message_size_bytes": workload["message_size_bytes"],
+                "batch_size": workload["batch_size"],
+            },
+            "result": {
+                "duration_us": 1_000_000,
+                "success_count": count,
+                "send_failed_count": 0,
+                "response_failed_count": 0,
+                "throughput_messages_per_second": value,
+                "payload_mib_per_second": value / 1000,
+                "latency_us": {
+                    "samples": count,
+                    "average": value,
+                    "p50": value,
+                    "p95": value,
+                    "p99": value,
+                    "p999": value,
+                    "max": value,
+                },
+            },
+        }
+
+    def write_arms(self, plan: dict, plan_path: Path, output: Path) -> None:
+        for arm in plan["arms"]:
+            value = 1000.0 + arm["ordinal"] + (20.0 if arm["role"] == "candidate" else 0.0)
+            records = [
+                {
+                    "workload": workload["id"],
+                    "measurement": self.measurement(plan, arm, workload, value),
+                }
+                for workload in self.policy["modes"]["release"]["workloads"]
+            ]
+            report = {
+                "schema_version": 1,
+                "artifact_kind": "rocketmq_message_path_ab_arm",
+                "plan_sha256": ab.digest(plan_path),
+                "arm": arm,
+                "status": "pass",
+                "failures": [],
+                "records": records,
+            }
+            qualification.write_json(ab.arm_directory(output, arm) / "arm-report.json", report)
+
+    def test_assemble_requires_all_arms_and_binds_report_hashes(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            args = self.create_inputs(root)
+            plan = ab.create_plan(args)
+            plan_path = root / "ab-plan.json"
+            qualification.write_json(plan_path, plan)
+            output = root / "evidence"
+            self.write_arms(plan, plan_path, output)
+            with mock.patch.object(
+                qualification,
+                "environment_record",
+                return_value={"hardware_id": "sha256:" + "6" * 64},
+            ):
+                comparison, comparison_path = ab.assemble(plan, plan_path, output)
+
+            baseline_path = output / "baseline" / "measurement-set.json"
+            candidate_path = output / "candidate" / "measurement-set.json"
+            self.assertEqual("pass", comparison["status"])
+            self.assertTrue(comparison["release_comparison_qualified"])
+            self.assertEqual(ab.digest(plan_path), comparison["ab_plan_sha256"])
+            self.assertEqual(ab.digest(baseline_path), comparison["baseline"]["report_sha256"])
+            self.assertEqual(ab.digest(candidate_path), comparison["candidate"]["report_sha256"])
+            self.assertTrue(comparison_path.is_file())
+            self.assertEqual(9, len(comparison["comparisons"]))
+            self.assertIn("paired_bootstrap_95_ci", comparison["comparisons"][0])
+            baseline = qualification.load_json(baseline_path)
+            self.assertTrue(any(item["path"].endswith("arm-report.json") for item in baseline["artifacts"]))
+
+    def test_assemble_does_not_replace_a_missing_or_failed_arm(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            args = self.create_inputs(root)
+            plan = ab.create_plan(args)
+            plan_path = root / "ab-plan.json"
+            qualification.write_json(plan_path, plan)
+            output = root / "evidence"
+            self.write_arms(plan, plan_path, output)
+            missing = ab.arm_directory(output, plan["arms"][-1]) / "arm-report.json"
+            missing.unlink()
+
+            with self.assertRaisesRegex(ab.AbError, "missing arm report"):
+                ab.assemble(plan, plan_path, output)
+
+    def test_validation_rejects_plan_with_duplicate_arm(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            plan = ab.create_plan(self.create_inputs(Path(temporary)))
+        plan["arms"][-1] = copy.deepcopy(plan["arms"][0])
+        plan["arms"][-1]["index"] = len(plan["arms"]) - 1
+
+        findings = ab.validate_plan(plan, self.policy)
+
+        self.assertTrue(any("every required arm" in finding for finding in findings))
+
+    def test_powershell_runner_exposes_non_destructive_validation(self) -> None:
+        powershell = shutil.which("pwsh") or shutil.which("powershell")
+        if powershell is None:
+            self.skipTest("PowerShell is unavailable")
+        result = subprocess.run(
+            [
+                powershell,
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                str(ROOT / "scripts" / "run-message-path-ab.ps1"),
+                "-Mode",
+                "Validate",
+            ],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("MESSAGE_PATH_AB_RUNNER_VALID", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9283

### Brief Description

Add deterministic same-target message-path A/B qualification. The Python planner creates a seeded paired schedule with one warmup and at least five baseline and candidate samples, validates immutable image/provenance/configuration bindings, executes one policy workload set per arm, preserves failed arms, assembles both measurement sets, and emits a hash-bound policy comparison with normalized MAD stability gates and paired bootstrap 95% confidence intervals.

Add a PowerShell runner that rolls an existing Kubernetes deployment between digest-pinned subjects, waits for every workload, rejects container restarts, forwards the NameServer endpoint, captures Pod/workload/node and per-process RSS/task/FD evidence, and retains every raw artifact. The qualification aggregate now includes p50, p95, p99, p999, and average latency medians. Repository documentation is intentionally excluded.

### How Did You Test This Change?

- `python -m unittest scripts.tests.test_message_path_ab scripts.tests.test_message_path_qualification -v` - passed, 15 tests.
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/run-message-path-ab.ps1 -Mode Validate` - passed.
- PowerShell AST parse for `scripts/run-message-path-ab.ps1` - passed without syntax errors.
- `python scripts/message_path_qualification.py validate-policy` - passed.
- `python -m json.tool scripts/message-path-qualification-policy.json` - passed.
- `python -m compileall -q scripts/message_path_ab.py scripts/message_path_qualification.py scripts/tests/test_message_path_ab.py` - passed.
- `git diff --check` - passed.

The live Docker/Kubernetes A/B run was not executed because the local Docker Desktop engine is not running. This PR delivers and deterministically tests the fail-closed execution and evidence contracts; it does not claim target-environment performance results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added paired baseline/candidate A/B qualification for RocketMQ message-path performance.
  - Added planning, execution, result assembly, validation, and PowerShell runner workflows.
  - Added randomized runs, provenance tracking, artifact verification, stability checks, and bootstrap comparisons.
  - Added throughput and latency stability thresholds to qualification policies.

- **Enhancements**
  - Expanded reported latency metrics to include p50, p95, p99, p999, and average percentiles.

- **Tests**
  - Added comprehensive coverage for deterministic planning, validation, report assembly, artifact integrity, and safe validation mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->