### PR TITLE
[ISSUE #9285]✨Replace model fault checks with live Kubernetes injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4473,6 +4473,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "cheetah-string",
+ "chrono",
  "config",
  "criterion",
  "dashmap",

--- a/distribution/helm/rocketmq-rust/templates/configmaps.yaml
+++ b/distribution/helm/rocketmq-rust/templates/configmaps.yaml
@@ -120,6 +120,8 @@ data:
     listenAddr = "0.0.0.0:60109"
     electionTimeoutMs = 5000
     heartbeatIntervalMs = 300
+    snapshotLogsSinceLast = {{ $.Values.services.controller.snapshotLogsSinceLast }}
+    snapshotMaxLogEntriesToKeep = {{ $.Values.services.controller.snapshotMaxLogEntriesToKeep }}
     storagePath = "/var/lib/rocketmq/controller/node-{{ add $ordinal 1 }}"
     storageBackend = {{ $.Values.services.controller.storageBackend | quote }}
     enableElectUncleanMasterLocal = false

--- a/distribution/helm/rocketmq-rust/values.schema.json
+++ b/distribution/helm/rocketmq-rust/values.schema.json
@@ -633,6 +633,8 @@
         "peerServiceClusterIPs",
         "autoInitializeCluster",
         "storageBackend",
+        "snapshotLogsSinceLast",
+        "snapshotMaxLogEntriesToKeep",
         "image",
         "persistence",
         "pdb",
@@ -662,6 +664,14 @@
             "Memory",
             "RocksDB"
           ]
+        },
+        "snapshotLogsSinceLast": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "snapshotMaxLogEntriesToKeep": {
+          "type": "integer",
+          "minimum": 1
         },
         "image": {
           "$ref": "#/definitions/image"

--- a/distribution/helm/rocketmq-rust/values.yaml
+++ b/distribution/helm/rocketmq-rust/values.yaml
@@ -104,6 +104,8 @@ services:
       limits: {cpu: 1000m, memory: 1Gi}
   controller:
     replicas: 3
+    snapshotLogsSinceLast: 5000
+    snapshotMaxLogEntriesToKeep: 1000
     peerServiceClusterIPs:
       - 10.96.0.201
       - 10.96.0.202

--- a/distribution/kubernetes/fault-matrix-policy.json
+++ b/distribution/kubernetes/fault-matrix-policy.json
@@ -374,23 +374,23 @@
       "timeout_seconds": 420,
       "precondition": "Controller state has advanced beyond a recorded snapshot boundary",
       "injection": "restart a lagging follower while it is installing a Raft snapshot",
-      "observable": "snapshot transfer attempt, interrupted follower state, checksum/replay result, leader identity, and catch-up",
+      "observable": "snapshot transfer attempt, interrupted follower state, partial-install publication guard, leader identity, and catch-up",
       "rpo_seconds": 0,
       "rto_seconds": 180,
-      "abort_condition": "the follower applies a corrupt snapshot, leadership duplicates, or committed state regresses",
+      "abort_condition": "the follower publishes a partial snapshot, leadership duplicates, or committed state regresses",
       "cleanup": "allow the follower to restart and complete snapshot installation",
-      "cleanup_verification": "the follower catches up, checksum validation passes, and one leader remains",
+      "cleanup_verification": "the follower catches up without publishing partial state and one leader remains",
       "required_assertions": [
         "snapshot_install_started",
         "install_interrupted",
-        "corrupt_snapshot_rejected",
+        "partial_snapshot_not_published",
         "follower_caught_up",
         "single_leader_observed"
       ],
       "required_evidence": [
         "snapshot_before",
         "interruption_status",
-        "checksum_validation",
+        "snapshot_integrity",
         "snapshot_after",
         "leadership_status"
       ]

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -234,12 +234,15 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/workspace/target,sharing=locked <<EOF
 set -eux
 cargo build --locked --release --package rocketmq-admin-cli --bin rocketmq-admin-cli
+cargo build --locked --release --package rocketmq-proxy --example proxy_live_fault_driver
 install -D -m 0555 /workspace/target/release/rocketmq-admin-cli /opt/rocketmq-binaries/rocketmq-admin-cli
+install -D -m 0555 /workspace/target/release/examples/proxy_live_fault_driver /opt/rocketmq-binaries/proxy-live-fault-driver
 EOF
 
 FROM runtime-base AS fault-driver
 
 COPY --from=fault-driver-builder --chmod=0555 /opt/rocketmq-binaries/rocketmq-admin-cli /usr/local/bin/rocketmq-admin-cli
+COPY --from=fault-driver-builder --chmod=0555 /opt/rocketmq-binaries/proxy-live-fault-driver /usr/local/bin/proxy-live-fault-driver
 
 LABEL org.opencontainers.image.title="RocketMQ Rust architecture fault driver" \
     io.rocketmq.image.role="fault-driver-test-only" \

--- a/rocketmq-controller/src/config/controller_config.rs
+++ b/rocketmq-controller/src/config/controller_config.rs
@@ -60,6 +60,14 @@ pub enum StorageBackendType {
     Memory,
 }
 
+const fn default_snapshot_logs_since_last() -> u64 {
+    5000
+}
+
+const fn default_snapshot_max_log_entries_to_keep() -> u64 {
+    1000
+}
+
 impl fmt::Display for StorageBackendType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -250,6 +258,14 @@ pub struct ControllerConfig {
     /// Heartbeat interval (ms) used by Raft
     pub heartbeat_interval_ms: u64,
 
+    /// Number of applied Raft log entries between automatic snapshots.
+    #[serde(default = "default_snapshot_logs_since_last")]
+    pub snapshot_logs_since_last: u64,
+
+    /// Maximum number of log entries retained after a snapshot.
+    #[serde(default = "default_snapshot_max_log_entries_to_keep")]
+    pub snapshot_max_log_entries_to_keep: u64,
+
     /// Local storage path for controller artifacts
     pub storage_path: String,
 
@@ -304,6 +320,8 @@ impl Clone for ControllerConfig {
             controller_peers: self.controller_peers.clone(),
             election_timeout_ms: self.election_timeout_ms,
             heartbeat_interval_ms: self.heartbeat_interval_ms,
+            snapshot_logs_since_last: self.snapshot_logs_since_last,
+            snapshot_max_log_entries_to_keep: self.snapshot_max_log_entries_to_keep,
             storage_path: self.storage_path.clone(),
             storage_backend: self.storage_backend.clone(),
             enable_elect_unclean_master_local: self.enable_elect_unclean_master_local,
@@ -388,6 +406,8 @@ impl Default for ControllerConfig {
             controller_peers: Vec::new(),
             election_timeout_ms: 1000,
             heartbeat_interval_ms: 300,
+            snapshot_logs_since_last: 5000,
+            snapshot_max_log_entries_to_keep: 1000,
             storage_path: String::new(),
             storage_backend: StorageBackendType::RocksDB,
             enable_elect_unclean_master_local: false,
@@ -543,6 +563,18 @@ impl ControllerConfig {
         self
     }
 
+    /// Set the number of applied Raft log entries between snapshots.
+    pub fn with_snapshot_logs_since_last(mut self, entries: u64) -> Self {
+        self.snapshot_logs_since_last = entries;
+        self
+    }
+
+    /// Set the maximum number of log entries retained after a snapshot.
+    pub fn with_snapshot_max_log_entries_to_keep(mut self, entries: u64) -> Self {
+        self.snapshot_max_log_entries_to_keep = entries;
+        self
+    }
+
     /// Set local storage path for this node
     pub fn with_storage_path(mut self, path: impl Into<String>) -> Self {
         self.storage_path = path.into();
@@ -676,6 +708,14 @@ impl ControllerConfig {
             return Err("elect_master_max_retry_count must be greater than 0".to_string());
         }
 
+        if self.snapshot_logs_since_last == 0 {
+            return Err("snapshot_logs_since_last must be greater than 0".to_string());
+        }
+
+        if self.snapshot_max_log_entries_to_keep == 0 {
+            return Err("snapshot_max_log_entries_to_keep must be greater than 0".to_string());
+        }
+
         if self.authorization_enabled && !self.authentication_enabled {
             return Err("authorization_enabled requires authentication_enabled".to_string());
         }
@@ -800,6 +840,8 @@ impl ControllerConfig {
 
         write_property!("electionTimeoutMs={}", self.election_timeout_ms);
         write_property!("heartbeatIntervalMs={}", self.heartbeat_interval_ms);
+        write_property!("snapshotLogsSinceLast={}", self.snapshot_logs_since_last);
+        write_property!("snapshotMaxLogEntriesToKeep={}", self.snapshot_max_log_entries_to_keep);
         write_property!("storagePath={}", self.storage_path);
         write_property!("storageBackend={}", self.storage_backend);
         write_property!(
@@ -980,6 +1022,15 @@ impl ControllerConfig {
                     self.heartbeat_interval_ms = parse_update_value::<u64>("heartbeatIntervalMs", value)?;
                 }
 
+                "snapshotLogsSinceLast" => {
+                    self.snapshot_logs_since_last = parse_update_value::<u64>("snapshotLogsSinceLast", value)?;
+                }
+
+                "snapshotMaxLogEntriesToKeep" => {
+                    self.snapshot_max_log_entries_to_keep =
+                        parse_update_value::<u64>("snapshotMaxLogEntriesToKeep", value)?;
+                }
+
                 "storagePath" => {
                     self.storage_path = value.clone();
                 }
@@ -1035,6 +1086,8 @@ mod tests {
             "maintenancePolicyVersion",
             "maintenancePolicySha256",
             "maintenanceCheckpointRoot",
+            "snapshotLogsSinceLast",
+            "snapshotMaxLogEntriesToKeep",
         ] {
             object.remove(field);
         }
@@ -1047,6 +1100,8 @@ mod tests {
         assert!(config.auth_config_path.is_empty());
         assert!(config.acl_file.is_empty());
         assert_eq!(config.maintenance_policy_version, 0);
+        assert_eq!(config.snapshot_logs_since_last, 5000);
+        assert_eq!(config.snapshot_max_log_entries_to_keep, 1000);
         assert!(config.validate().is_ok());
     }
 
@@ -1114,6 +1169,25 @@ mod tests {
         let config = ControllerConfig::new();
 
         assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn snapshot_thresholds_are_positive_and_exported() {
+        let config = ControllerConfig::new()
+            .with_snapshot_logs_since_last(32)
+            .with_snapshot_max_log_entries_to_keep(16);
+
+        assert!(config.validate().is_ok());
+        let properties = config.to_properties_string();
+        assert!(properties.contains("snapshotLogsSinceLast=32"));
+        assert!(properties.contains("snapshotMaxLogEntriesToKeep=16"));
+
+        let mut invalid = config.clone();
+        invalid.snapshot_logs_since_last = 0;
+        assert!(invalid.validate().is_err());
+        invalid.snapshot_logs_since_last = 32;
+        invalid.snapshot_max_log_entries_to_keep = 0;
+        assert!(invalid.validate().is_err());
     }
 
     #[test]

--- a/rocketmq-controller/src/openraft/node.rs
+++ b/rocketmq-controller/src/openraft/node.rs
@@ -88,8 +88,8 @@ impl RaftNodeManager {
             heartbeat_interval: startup_config.heartbeat_interval_ms,
             election_timeout_min: startup_config.election_timeout_ms,
             election_timeout_max: startup_config.election_timeout_ms * 2,
-            max_in_snapshot_log_to_keep: 1000,
-            snapshot_policy: openraft::SnapshotPolicy::LogsSinceLast(5000),
+            max_in_snapshot_log_to_keep: startup_config.snapshot_max_log_entries_to_keep,
+            snapshot_policy: openraft::SnapshotPolicy::LogsSinceLast(startup_config.snapshot_logs_since_last.max(1)),
             allow_log_reversion: Some(true),
             ..Default::default()
         };

--- a/rocketmq-proxy/Cargo.toml
+++ b/rocketmq-proxy/Cargo.toml
@@ -63,6 +63,7 @@ tokio-util   = { workspace = true }
 
 serde  = { workspace = true }
 config = { workspace = true }
+chrono = "0.4.45"
 
 dashmap        = { workspace = true }
 bytes          = { workspace = true }
@@ -72,6 +73,9 @@ flate2         = { workspace = true }
 uuid           = { workspace = true }
 cheetah-string = { workspace = true }
 thiserror      = { workspace = true }
+hex            = "0.4"
+hmac           = "0.13.0"
+sha1           = "0.11"
 
 async-trait = "0.1"
 prost-types = "0.14"
@@ -80,9 +84,6 @@ tonic       = { version = "0.14.6", features = ["transport", "codegen"] }
 [dev-dependencies]
 rocketmq-transport = { workspace = true, features = ["test-support"] }
 tokio = { workspace = true, features = ["test-util"] }
-hex = "0.4"
-hmac = "0.13.0"
-sha1 = "0.11"
 criterion = { version = "0.8", features = ["html_reports"] }
 serde_json = { workspace = true }
 trybuild = "1.0.116"

--- a/rocketmq-proxy/examples/proxy_live_fault_driver.rs
+++ b/rocketmq-proxy/examples/proxy_live_fault_driver.rs
@@ -1,0 +1,212 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::env;
+use std::time::Duration;
+
+use bytes::Bytes;
+use chrono::Utc;
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
+use hmac::digest::KeyInit;
+use hmac::Hmac;
+use hmac::Mac;
+use rocketmq_proxy::v2;
+use rocketmq_proxy::v2::messaging_service_client::MessagingServiceClient;
+use sha1::Sha1;
+use tonic::metadata::MetadataValue;
+use tonic::Request;
+
+type HmacSha1 = Hmac<Sha1>;
+
+fn required_env(name: &str) -> Result<String, String> {
+    env::var(name).map_err(|_| format!("missing required environment variable {name}"))
+}
+
+fn positive_usize(name: &str) -> Result<usize, String> {
+    let raw = required_env(name)?;
+    raw.parse::<usize>()
+        .ok()
+        .filter(|value| *value > 0)
+        .ok_or_else(|| format!("{name} must be a positive integer"))
+}
+
+fn authenticated_request<T>(
+    value: T,
+    client_id: &str,
+    access_key: &str,
+    secret_key: &str,
+) -> Result<Request<T>, String> {
+    let date_time = Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
+    let mut mac = HmacSha1::new_from_slice(secret_key.as_bytes()).map_err(|error| error.to_string())?;
+    mac.update(date_time.as_bytes());
+    let signature = hex::encode(mac.finalize().into_bytes());
+    let authorization =
+        format!("MQv2-HMAC-SHA1 Credential={access_key}, SignedHeaders=x-mq-date-time, Signature={signature}");
+
+    let mut request = Request::new(value);
+    request.metadata_mut().insert(
+        "x-mq-date-time",
+        MetadataValue::try_from(date_time).map_err(|error| error.to_string())?,
+    );
+    request.metadata_mut().insert(
+        "authorization",
+        MetadataValue::try_from(authorization).map_err(|error| error.to_string())?,
+    );
+    request.metadata_mut().insert(
+        "channel-id",
+        MetadataValue::try_from(client_id).map_err(|error| error.to_string())?,
+    );
+    request.metadata_mut().insert(
+        "x-mq-client-id",
+        MetadataValue::try_from(client_id).map_err(|error| error.to_string())?,
+    );
+    Ok(request)
+}
+
+fn resource(name: &str) -> v2::Resource {
+    v2::Resource {
+        resource_namespace: String::new(),
+        name: name.to_owned(),
+    }
+}
+
+fn receive_request(topic: &str, group: &str, queue_id: i32) -> v2::ReceiveMessageRequest {
+    v2::ReceiveMessageRequest {
+        group: Some(resource(group)),
+        message_queue: Some(v2::MessageQueue {
+            topic: Some(resource(topic)),
+            id: queue_id,
+            permission: v2::Permission::ReadWrite as i32,
+            broker: None,
+            accept_message_types: vec![v2::MessageType::Normal as i32],
+        }),
+        filter_expression: None,
+        batch_size: 1,
+        invisible_duration: Some(prost_types::Duration { seconds: 30, nanos: 0 }),
+        auto_renew: false,
+        long_polling_timeout: Some(prost_types::Duration { seconds: 20, nanos: 0 }),
+        attempt_id: None,
+    }
+}
+
+fn send_request(topic: &str, run_token: &str, sequence: usize) -> v2::SendMessageRequest {
+    v2::SendMessageRequest {
+        messages: vec![v2::Message {
+            topic: Some(resource(topic)),
+            user_properties: HashMap::new(),
+            system_properties: Some(v2::SystemProperties {
+                message_id: format!("{run_token}-{sequence}"),
+                body_encoding: v2::Encoding::Identity as i32,
+                message_type: v2::MessageType::Normal as i32,
+                ..Default::default()
+            }),
+            body: Bytes::from(format!("proxy-live-{sequence}")),
+        }],
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let endpoint = required_env("PROXY_ENDPOINT")?;
+    let topic = required_env("FAULT_TOPIC")?;
+    let group = required_env("FAULT_GROUP")?;
+    let run_token = required_env("FAULT_RUN_TOKEN")?;
+    let access_key = required_env("ROCKETMQ_ACL_ACCESS_KEY")?;
+    let secret_key = required_env("ROCKETMQ_ACL_SECRET_KEY")?;
+    let long_pollers = positive_usize("LONG_POLLERS")?;
+    let ordered_sends = positive_usize("ORDERED_SENDS")?;
+    let client = MessagingServiceClient::connect(endpoint.clone()).await?;
+
+    let mut receives = FuturesUnordered::new();
+    for index in 0..long_pollers {
+        let mut receive_client = client.clone();
+        let request = authenticated_request(
+            receive_request(&topic, &group, (index % 8) as i32),
+            &format!("{run_token}-receive-{index}"),
+            &access_key,
+            &secret_key,
+        )?;
+        receives.push(tokio::spawn(async move {
+            match receive_client.receive_message(request).await {
+                Ok(response) => {
+                    let mut stream = response.into_inner();
+                    while let Some(item) = stream.next().await {
+                        item?;
+                    }
+                    Ok::<_, tonic::Status>("completed")
+                }
+                Err(status) => Err(status),
+            }
+        }));
+    }
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    let mut send_client = client.clone();
+    let mut sends_ok = 0usize;
+    for sequence in 0..ordered_sends {
+        let request = authenticated_request(
+            send_request(&topic, &run_token, sequence),
+            &format!("{run_token}-send"),
+            &access_key,
+            &secret_key,
+        )?;
+        let response = tokio::time::timeout(Duration::from_secs(30), send_client.send_message(request)).await??;
+        let payload = response.into_inner();
+        if payload.entries.len() == 1
+            && payload.entries[0]
+                .status
+                .as_ref()
+                .is_some_and(|status| status.code == v2::Code::Ok as i32)
+        {
+            sends_ok += 1;
+            println!("send-sequence={sequence} status=OK");
+        } else {
+            println!("send-sequence={sequence} status={payload:?}");
+        }
+    }
+
+    let mut receive_completed = 0usize;
+    let mut receive_overloaded = 0usize;
+    let mut receive_other_error = 0usize;
+    while let Some(joined) = receives.next().await {
+        match joined? {
+            Ok(_) => receive_completed += 1,
+            Err(status)
+                if matches!(
+                    status.code(),
+                    tonic::Code::ResourceExhausted | tonic::Code::Unavailable | tonic::Code::DeadlineExceeded
+                ) =>
+            {
+                receive_overloaded += 1;
+                println!("receive-overload code={:?} message={}", status.code(), status.message());
+            }
+            Err(status) => {
+                receive_other_error += 1;
+                println!("receive-error code={:?} message={}", status.code(), status.message());
+            }
+        }
+    }
+    println!(
+        "proxy-live-summary long_pollers={long_pollers} receive_completed={receive_completed} \
+         receive_overloaded={receive_overloaded} receive_other_error={receive_other_error} \
+         sends_ok={sends_ok} ordered_sends={ordered_sends}"
+    );
+
+    if sends_ok != ordered_sends || receive_overloaded == 0 {
+        return Err("live Proxy load did not preserve send progress and produce typed overload".into());
+    }
+    Ok(())
+}

--- a/scripts/fault_matrix_guard.py
+++ b/scripts/fault_matrix_guard.py
@@ -235,6 +235,7 @@ def validate_policy(guard: Guard, policy: dict[str, Any]) -> None:
 
 def validate_sources(guard: Guard) -> None:
     runner = guard.read("scripts/kind-architecture-refactor-e2e.ps1")
+    live_faults = guard.read("scripts/kubernetes/live_faults.ps1")
     secret_generator = guard.read("scripts/new-m11-evidence-secrets.ps1")
     workflow = guard.read(".github/workflows/kubernetes-fault-matrix.yml")
     publication_verifier = guard.read("scripts/verify_service_image_publication.py")
@@ -288,18 +289,19 @@ def validate_sources(guard: Guard) -> None:
         "Set-StatefulSetReplicas 'rocketmq-namesrv' 1",
         "Set-StatefulSetReplicas 'rocketmq-controller' 1",
         "Set-NodeNetworkImpairment $networkNode @('delay', '200ms', '50ms', 'loss', '10%')",
-        "disk_full_state_rejects_new_writes_without_losing_acknowledged_data",
+        "Start-LiveBrokerDiskFull",
+        "Clear-LiveBrokerDiskFull",
         "i=0; : > /tmp/rocketmq/phase06-fsync.pids; while",
         "attempt=0; active=1; while",
         'case "$state" in ""|Z*)',
         "/tmp/rocketmq/phase06-fsync-",
-        "sync_master_without_slave_ack_returns_flush_slave_timeout",
-        "three_controller_two_broker_controller_mode_failover_and_rejoin",
-        "interrupted_snapshot_install_is_rejected_and_full_retry_recovers",
-        "unrelated_route_progresses_while_pull_is_blocked",
-        "same_consumer_key_is_fifo_without_serializing_distinct_keys",
-        "data_saturation_preserves_readiness_capacity_and_releases_all_permits",
-        "leaked=0 detached_still_running=0",
+        "Wait-LiveSingleMaster",
+        "Set-LivePodPortImpairment",
+        "Invoke-LiveControllerWriteBurst",
+        "Get-LiveSnapshotObservation",
+        "Invoke-LiveProxyMixedLoad",
+        "Get-LivePodMetrics",
+        "Assert-LiveFaultCleanup",
         "Invoke-Native docker @('pull', $image)",
         "'org.opencontainers.image.revision'",
         "@($revisions | Sort-Object -Unique)",
@@ -348,6 +350,20 @@ def validate_sources(guard: Guard) -> None:
         "semantic_query=$($rotationResult.DeniedSucceeded)",
     ):
         guard.require(marker in runner, f"fault runner contract marker missing: {marker}")
+    guard.require("Invoke-ModelTest" not in runner, "dynamic fault runner must not substitute Cargo model tests")
+    guard.require("Invoke-Native cargo" not in runner, "dynamic fault runner must not execute Cargo tests")
+    for marker in (
+        "function Start-LiveBrokerDiskFull",
+        "MaximumFillMiB",
+        "function Get-LiveBrokerRoleSnapshot",
+        "function Set-LivePodPortImpairment",
+        "match ip dport",
+        "function Get-LiveSnapshotObservation",
+        "function Wait-LiveSnapshotInstall",
+        "function Get-LivePodMetrics",
+        "function Assert-LiveFaultCleanup",
+    ):
+        guard.require(marker in live_faults, f"live Kubernetes fault helper contract missing: {marker}")
     minority_start = runner.find("$minorityPod =")
     minority_end = runner.find("$majorityScale =", minority_start)
     guard.require(

--- a/scripts/kind-architecture-refactor-e2e.ps1
+++ b/scripts/kind-architecture-refactor-e2e.ps1
@@ -48,6 +48,7 @@ $CreatedCluster = $false
 $RunSucceeded = $false
 $RunStarted = [DateTimeOffset]::UtcNow
 $RunId = "m11-11-$Backend-$($RunStarted.ToString('yyyyMMddTHHmmssZ'))"
+$LiveFaultToken = "fault-$($RunStarted.ToString('yyyyMMddHHmmss'))"
 $EvidenceBase = if ([IO.Path]::IsPathRooted($EvidenceRoot)) {
     [IO.Path]::GetFullPath($EvidenceRoot)
 } else {
@@ -82,6 +83,12 @@ function Invoke-Native {
     }
     [pscustomobject]@{ ExitCode = $exitCode; Output = $output.TrimEnd() }
 }
+
+$LiveFaultHelperPath = Join-Path $PSScriptRoot 'kubernetes/live_faults.ps1'
+if (-not (Test-Path -LiteralPath $LiveFaultHelperPath -PathType Leaf)) {
+    throw "live Kubernetes fault helper is missing: $LiveFaultHelperPath"
+}
+. $LiveFaultHelperPath -HelperMode Library
 
 $PolicySha256 = (Invoke-Native python @(
     (Join-Path $Root 'scripts/fault_matrix_guard.py'),
@@ -213,7 +220,9 @@ services:
     replicas: 3
     autoCreateTopicEnable: true
     image: { repository: $($repositories['broker']), digest: $(Get-ImageDigest $Images['broker']), pullPolicy: Never }
-    persistence: { storageClassName: $StorageClass, size: 10Gi }
+    # The fault-only cluster uses a bounded PVC so ENOSPC injection cannot fill
+    # the Docker Desktop storage pool. Production values remain unchanged.
+    persistence: { storageClassName: $StorageClass, size: 2Gi }
     resources:
       requests: { cpu: 500m, memory: 1Gi }
       limits: { cpu: 2000m, memory: 4Gi }
@@ -227,6 +236,8 @@ services:
       limits: { cpu: 500m, memory: 512Mi }
   controller:
     replicas: 3
+    snapshotLogsSinceLast: 32
+    snapshotMaxLogEntriesToKeep: 16
     peerServiceClusterIPs: [$(($controllerIps | ForEach-Object { '"' + $_ + '"' }) -join ', ')]
     image: { repository: $($repositories['controller']), digest: $(Get-ImageDigest $Images['controller']), pullPolicy: Never }
     persistence: { storageClassName: $StorageClass, size: 2Gi }
@@ -297,6 +308,7 @@ function Invoke-FaultDriver {
     param(
         [Parameter(Mandatory)][string]$SecretName,
         [Parameter(Mandatory)][string[]]$Arguments,
+        [string]$Endpoint = $NamesrvAddress,
         [switch]$AllowFailure
     )
     $job = "fault-driver-$([Guid]::NewGuid().ToString('N').Substring(0, 12))"
@@ -329,7 +341,7 @@ spec:
           args: $commandJson
           env:
             - name: NAMESRV_ADDR
-              value: $NamesrvAddress
+              value: $Endpoint
           envFrom:
             - secretRef: { name: $SecretName }
           securityContext:
@@ -365,6 +377,153 @@ spec:
             throw "fault driver $condition`n$logs"
         }
         [pscustomobject]@{ ExitCode = $exitCode; Output = $logs }
+    } finally {
+        Invoke-Native kubectl @('-n', $Namespace, 'delete', 'job', $job, '--ignore-not-found=true', '--wait=false') -AllowFailure | Out-Null
+        Remove-Item -LiteralPath $manifestPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Invoke-LiveProxyMixedLoad {
+    param(
+        [Parameter(Mandatory)][ValidateRange(1, 512)][int]$LongPollers,
+        [Parameter(Mandatory)][ValidateRange(1, 64)][int]$OrderedSends
+    )
+    $job = "proxy-live-$([Guid]::NewGuid().ToString('N').Substring(0, 12))"
+    $proxyEndpoint = "http://rocketmq-proxy.$Namespace.svc.cluster.local:8081"
+    $manifest = @"
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: $job
+  namespace: $Namespace
+  labels: { rocketmq.apache.org/live-fault: proxy-slow-backend }
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 300
+  activeDeadlineSeconds: 180
+  template:
+    metadata:
+      labels: { rocketmq.apache.org/live-fault: proxy-slow-backend }
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: mixed-load
+          image: $FaultDriverImage
+          imagePullPolicy: IfNotPresent
+          command: ["/usr/local/bin/proxy-live-fault-driver"]
+          env:
+            - { name: PROXY_ENDPOINT, value: "$proxyEndpoint" }
+            - { name: LONG_POLLERS, value: "$LongPollers" }
+            - { name: ORDERED_SENDS, value: "$OrderedSends" }
+            - { name: FAULT_TOPIC, value: "$Topic" }
+            - { name: FAULT_GROUP, value: "proxy-live-$LiveFaultToken" }
+            - { name: FAULT_RUN_TOKEN, value: "$LiveFaultToken" }
+          envFrom:
+            - secretRef: { name: rocketmq-fault-driver-baseline }
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: { drop: ["ALL"] }
+          volumeMounts:
+            - { name: tmp, mountPath: /tmp }
+      volumes:
+        - name: tmp
+          emptyDir: { sizeLimit: 64Mi }
+"@
+    $manifestPath = Join-Path $RunDirectory "$job.yaml"
+    [IO.File]::WriteAllText($manifestPath, $manifest, [Text.UTF8Encoding]::new($false))
+    try {
+        Invoke-Native kubectl @('apply', '-f', $manifestPath) | Out-Null
+        $wait = Invoke-Native kubectl @('-n', $Namespace, 'wait', "job/$job", '--for=condition=Complete', '--timeout=180s') -AllowFailure
+        $logs = Invoke-Native kubectl @('-n', $Namespace, 'logs', "job/$job") -AllowFailure
+        [pscustomobject]@{ ExitCode = $wait.ExitCode; Output = $logs.Output; WaitOutput = $wait.Output }
+    } finally {
+        Invoke-Native kubectl @('-n', $Namespace, 'delete', 'job', $job, '--ignore-not-found=true', '--wait=false') -AllowFailure | Out-Null
+        Remove-Item -LiteralPath $manifestPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Invoke-LiveControllerWriteBurst {
+    param(
+        [Parameter(Mandatory)][string]$ControllerAddress,
+        [Parameter(Mandatory)][ValidateRange(0, [long]::MaxValue)][long]$BrokerControllerId,
+        [ValidateRange(1, 256)][int]$Count = 64
+    )
+    $job = "controller-live-$([Guid]::NewGuid().ToString('N').Substring(0, 12))"
+    $script = @'
+set -eu
+i=0
+while [ "$i" -lt "${WRITE_COUNT}" ]; do
+  /usr/local/bin/rocketmq-admin-cli controller electMaster \
+    -a "${CONTROLLER_ADDRESS}" -b "${BROKER_CONTROLLER_ID}" \
+    --brokerName rocketmq-broker -c RocketmqRust -n "${NAMESRV_ADDR}"
+  i=$((i + 1))
+done
+echo "controller-writes=${i}"
+'@
+    $manifest = @"
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: $job
+  namespace: $Namespace
+  labels: { rocketmq.apache.org/live-fault: controller-snapshot }
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 300
+  activeDeadlineSeconds: 240
+  template:
+    metadata:
+      labels: { rocketmq.apache.org/live-fault: controller-snapshot }
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: controller-writes
+          image: $FaultDriverImage
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+$(($script -split "`r?`n" | ForEach-Object { '              ' + $_ }) -join "`n")
+          env:
+            - { name: NAMESRV_ADDR, value: "$NamesrvAddress" }
+            - { name: CONTROLLER_ADDRESS, value: "$ControllerAddress" }
+            - { name: BROKER_CONTROLLER_ID, value: "$BrokerControllerId" }
+            - { name: WRITE_COUNT, value: "$Count" }
+          envFrom:
+            - secretRef: { name: rocketmq-fault-driver-baseline }
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: { drop: ["ALL"] }
+          volumeMounts:
+            - { name: tmp, mountPath: /tmp }
+      volumes:
+        - name: tmp
+          emptyDir: { sizeLimit: 32Mi }
+"@
+    $manifestPath = Join-Path $RunDirectory "$job.yaml"
+    [IO.File]::WriteAllText($manifestPath, $manifest, [Text.UTF8Encoding]::new($false))
+    try {
+        Invoke-Native kubectl @('apply', '-f', $manifestPath) | Out-Null
+        $wait = Invoke-Native kubectl @('-n', $Namespace, 'wait', "job/$job", '--for=condition=Complete', '--timeout=240s') -AllowFailure
+        $logs = Invoke-Native kubectl @('-n', $Namespace, 'logs', "job/$job") -AllowFailure
+        if ($wait.ExitCode -ne 0 -or $logs.Output -notmatch "controller-writes=$Count") {
+            throw "live Controller write burst failed`n$($wait.Output)`n$($logs.Output)"
+        }
+        $logs
     } finally {
         Invoke-Native kubectl @('-n', $Namespace, 'delete', 'job', $job, '--ignore-not-found=true', '--wait=false') -AllowFailure | Out-Null
         Remove-Item -LiteralPath $manifestPath -Force -ErrorAction SilentlyContinue
@@ -744,21 +903,13 @@ function Wait-ControllerPodRecreatedAndReady {
         -TimeoutSeconds $TimeoutSeconds
 }
 
-function Invoke-ModelTest {
-    param(
-        [Parameter(Mandatory)][string]$Package,
-        [Parameter(Mandatory)][string[]]$Arguments
-    )
-    $command = @('test', '-p', $Package) + $Arguments + @('--', '--exact', '--nocapture')
-    Invoke-Native cargo $command
-}
-
 function Invoke-BrokerShell {
     param(
         [Parameter(Mandatory)][string]$Script,
+        [string]$Pod = 'rocketmq-broker-0',
         [switch]$AllowFailure
     )
-    Invoke-Native kubectl @('-n', $Namespace, 'exec', 'rocketmq-broker-0', '--', '/bin/sh', '-c', $Script) -AllowFailure:$AllowFailure
+    Invoke-Native kubectl @('-n', $Namespace, 'exec', $Pod, '--', '/bin/sh', '-c', $Script) -AllowFailure:$AllowFailure
 }
 
 function Set-NodeNetworkImpairment {
@@ -993,7 +1144,7 @@ if ($Mode -eq "Validate") {
     exit 0
 }
 
-foreach ($command in @('python', 'git', 'cargo', 'docker', 'kubectl', 'helm')) { Require-Command $command }
+foreach ($command in @('python', 'git', 'docker', 'kubectl', 'helm')) { Require-Command $command }
 Require-Command $Backend
 foreach ($path in @($BaselineImageMap, $CandidateImageMap, $RuntimeSecretManifest, $RotatedRuntimeSecretManifest, $BaselineDriverSecretManifest, $RotatedDriverSecretManifest)) {
     Assert-True (-not [string]::IsNullOrWhiteSpace($path) -and (Test-Path -LiteralPath $path -PathType Leaf)) "Run mode requires every image/secret input file"
@@ -1409,26 +1560,46 @@ spec: { selector: { app.kubernetes.io/name: otel-collector }, ports: [{ name: ot
         node_status = "$($taintCleanup.Output)`n$($simulationTaintCleanup.Output)`n$pressureStatus"
     })
 
-    $diskBefore = Invoke-BrokerShell 'df -Pk /var/lib/rocketmq'
-    $diskFullModel = Invoke-ModelTest 'rocketmq-store' @(
-        '--test',
-        'architecture_correctness',
-        'disk_full_state_rejects_new_writes_without_losing_acknowledged_data'
+    $diskMaster = (Wait-LiveSingleMaster -Namespace $Namespace).Master
+    $diskBefore = Invoke-BrokerShell -Pod $diskMaster.Pod -Script 'df -Pk /var/lib/rocketmq'
+    $diskFault = $null
+    $diskWriteProbe = $null
+    try {
+        $diskFault = Start-LiveBrokerDiskFull `
+            -Namespace $Namespace `
+            -Pod $diskMaster.Pod `
+            -RunToken $LiveFaultToken `
+            -MaximumFillMiB 2048
+        $diskWriteTimer = [Diagnostics.Stopwatch]::StartNew()
+        $diskWriteProbe = Invoke-BrokerShell `
+            -Pod $diskMaster.Pod `
+            -Script "dd if=/dev/zero of='/var/lib/rocketmq/.live-enospc-probe-$LiveFaultToken' bs=1048576 count=4 conv=fsync" `
+            -AllowFailure
+        $diskWriteTimer.Stop()
+        $diskFullMessage = Query-AcknowledgedMessage $ack.Id
+    } finally {
+        $diskCleanup = Clear-LiveBrokerDiskFull -Namespace $Namespace -Pod $diskMaster.Pod -RunToken $LiveFaultToken
+        Invoke-BrokerShell `
+            -Pod $diskMaster.Pod `
+            -Script "rm -f '/var/lib/rocketmq/.live-enospc-probe-$LiveFaultToken'; sync" `
+            -AllowFailure | Out-Null
+    }
+    $diskRecoveryProbe = Invoke-FaultDriver -SecretName 'rocketmq-fault-driver-baseline' -Arguments @(
+        'message', 'sendMessage', '-t', $Topic, '-p', 'disk-recovered', '-k', "disk-recovered-$LiveFaultToken"
     )
-    $diskFullMessage = Query-AcknowledgedMessage $ack.Id
-    $diskAfter = Invoke-BrokerShell 'df -Pk /var/lib/rocketmq'
+    $diskAfter = Invoke-BrokerShell -Pod $diskMaster.Pod -Script 'df -Pk /var/lib/rocketmq'
     Complete-Scenario 'disk_full' ([ordered]@{
-        disk_full_state_injected = $diskFullModel.Output -match 'disk_full_state_rejects_new_writes_without_losing_acknowledged_data .* ok'
-        write_failure_bounded = $diskFullModel.ExitCode -eq 0
+        disk_full_state_injected = $diskFault.Kind -eq 'broker-pvc-disk-full' -and $diskFault.RemainingMiB -le 18
+        write_failure_bounded = $diskWriteProbe.ExitCode -ne 0 -and $diskWriteTimer.Elapsed.TotalSeconds -lt 30
         acknowledged_message_visible = $diskFullMessage.QueueOffset -eq $before.QueueOffset
-        disk_state_cleared = $diskFullModel.ExitCode -eq 0
-        broker_recovered = ((Invoke-Native kubectl @('-n', $Namespace, 'get', 'pod', 'rocketmq-broker-0', '-o', 'jsonpath={.status.containerStatuses[0].ready}')).Output -eq 'true')
+        disk_state_cleared = $diskCleanup.ExitCode -eq 0 -and $diskAfter.Output -notmatch [regex]::Escape(".live-disk-full-$LiveFaultToken")
+        broker_recovered = $diskRecoveryProbe.ExitCode -eq 0
     }) ([ordered]@{
         disk_before = $diskBefore.Output
-        fault_injection = 'production disk-full running state injected by architecture_correctness test; host capacity was not consumed'
-        write_probe = $diskFullModel.Output
+        fault_injection = $diskFault.Output
+        write_probe = "seconds=$($diskWriteTimer.Elapsed.TotalSeconds) exit=$($diskWriteProbe.ExitCode)`n$($diskWriteProbe.Output)"
         message_after = $diskFullMessage.Output
-        disk_after = $diskAfter.Output
+        disk_after = "$($diskCleanup.Output)`n$($diskRecoveryProbe.Output)`n$($diskAfter.Output)"
     })
 
     $latencyBeforeTimer = [Diagnostics.Stopwatch]::StartNew()
@@ -1439,10 +1610,6 @@ spec: { selector: { app.kubernetes.io/name: otel-collector }, ports: [{ name: ot
     $latencyDuringTimer = [Diagnostics.Stopwatch]::StartNew()
     $latencyDuringMessage = Query-AcknowledgedMessage $ack.Id
     $latencyDuringTimer.Stop()
-    $slowDiskModel = Invoke-ModelTest 'rocketmq-store' @(
-        '--lib',
-        'log_file::group_commit_request::tests::test_timeout'
-    )
     $contentionCleanupScript = 'attempt=0; active=1; while [ "$attempt" -lt 120 ]; do active=0; for pid in $(cat /tmp/rocketmq/phase06-fsync.pids 2>/dev/null); do state=$(ps -o stat= -p "$pid" 2>/dev/null | tr -d " "); case "$state" in ""|Z*) ;; *) active=1 ;; esac; done; [ "$active" -eq 0 ] && break; sleep 1; attempt=$((attempt + 1)); done; for pid in $(cat /tmp/rocketmq/phase06-fsync.pids 2>/dev/null); do kill "$pid" 2>/dev/null || true; done; rm -f /var/lib/rocketmq/.phase06-fsync-* /tmp/rocketmq/phase06-fsync-*.log /tmp/rocketmq/phase06-fsync.pids; sync; echo "active=$active attempts=$attempt"'
     $contentionCleanup = Invoke-BrokerShell $contentionCleanupScript
     $brokerReadyAfterContention = (Invoke-Native kubectl @('-n', $Namespace, 'get', 'pod', 'rocketmq-broker-0', '-o', 'jsonpath={.status.containerStatuses[0].ready}')).Output
@@ -1457,7 +1624,7 @@ spec: { selector: { app.kubernetes.io/name: otel-collector }, ports: [{ name: ot
         contention_status = $contentionStart.Output
         latency_during = "seconds=$($latencyDuringTimer.Elapsed.TotalSeconds)`n$($latencyDuringMessage.Output)"
         message_after = $latencyDuringMessage.Output
-        cleanup_status = "$($contentionCleanup.Output)`n$($slowDiskModel.Output)"
+        cleanup_status = $contentionCleanup.Output
     })
 
     $failureLeaderBefore = Wait-ControllerLeadershipStable
@@ -1587,103 +1754,187 @@ spec: { selector: { app.kubernetes.io/name: otel-collector }, ports: [{ name: ot
         network_after = "$($networkCordon.Output)`n$($networkCleanup.Output)`n$($networkReady.Output)`n$($networkUncordon.Output)`n$networkAfter"
     })
 
-    $haPreparationTimer = [Diagnostics.Stopwatch]::StartNew()
-    Invoke-Native cargo @(
-        'test', '-p', 'rocketmq-store',
-        '--test', 'ha_semantics_tests',
-        '--no-run'
-    ) | Out-Null
-    Invoke-Native cargo @(
-        'test', '-p', 'rocketmq-broker',
-        '--lib',
-        '--no-run'
-    ) | Out-Null
-    $haPreparationTimer.Stop()
-    $haTimer = [Diagnostics.Stopwatch]::StartNew()
-    $haLagModel = Invoke-ModelTest 'rocketmq-store' @(
-        '--test',
-        'ha_semantics_tests',
-        'sync_master_without_slave_ack_returns_flush_slave_timeout'
-    )
-    $haModel = Invoke-ModelTest 'rocketmq-broker' @(
-        '--lib',
-        'broker_runtime::tests::three_controller_two_broker_controller_mode_failover_and_rejoin'
-    )
-    $haTimer.Stop()
-    $haMessage = Query-AcknowledgedMessage $ack.Id
-    $brokerStatus = (Invoke-Native kubectl @('-n', $Namespace, 'get', 'pods', '-l', 'rocketmq.apache.org/service=broker', '-o', 'wide')).Output
+    $haBefore = Wait-LiveSingleMaster -Namespace $Namespace
+    $haOldMaster = $haBefore.Master
+    $haTargetSlave = $haBefore.Snapshot.Records |
+        Where-Object { $_.Role -eq 'Slave' -and $_.Ready -and $_.Pod -ne $haOldMaster.Pod } |
+        Select-Object -First 1
+    Assert-True ($null -ne $haTargetSlave) 'live HA fault requires a Ready slave'
+    $haRuleTag = "ha-$($LiveFaultToken.Substring([math]::Max(0, $LiveFaultToken.Length - 12)))"
+    $haFault = $null
+    $haCordon = $null
+    $haDelete = $null
+    $haPromotion = $null
+    $haTimer = [Diagnostics.Stopwatch]::new()
+    try {
+        $haFault = Set-LivePodPortImpairment `
+            -Node $haOldMaster.Node `
+            -PodIp $haTargetSlave.PodIp `
+            -Port 10912 `
+            -DelayMilliseconds 0 `
+            -LossPercent 100 `
+            -RuleTag $haRuleTag
+        Start-Sleep -Seconds 5
+        $haLagProbe = Invoke-FaultDriver -SecretName 'rocketmq-fault-driver-baseline' -Arguments @(
+            'message', 'sendMessage', '-t', $Topic, '-p', 'ha-lag-window', '-k', "ha-lag-$LiveFaultToken"
+        ) -AllowFailure
+        $haCordon = Invoke-Native kubectl @('cordon', $haOldMaster.Node)
+        $haTimer.Start()
+        $haDelete = Invoke-Native kubectl @('-n', $Namespace, 'delete', 'pod', $haOldMaster.Pod, '--wait=false')
+        $haPromotion = Wait-LiveSingleMaster -Namespace $Namespace -ExcludedPod $haOldMaster.Pod -TimeoutSeconds 180
+        $haMessage = Query-AcknowledgedMessage $ack.Id
+        $haTimer.Stop()
+    } finally {
+        if ($haTimer.IsRunning) { $haTimer.Stop() }
+        if ($null -ne $haFault) {
+            $haNetworkCleanup = Clear-LivePodPortImpairment -Node $haOldMaster.Node -RuleTag $haRuleTag
+        }
+        if ($null -ne $haCordon) {
+            $haUncordon = Invoke-Native kubectl @('uncordon', $haOldMaster.Node) -AllowFailure
+        }
+    }
+    $null = Wait-PodRecreatedAndReady -Pod $haOldMaster.Pod -PreviousUid $haOldMaster.Uid -TimeoutSeconds 180
+    $haRestored = Wait-LiveSingleMaster -Namespace $Namespace
     Complete-Scenario 'ha_replication_lag' ([ordered]@{
-        replication_lag_observed = $haLagModel.Output -match 'sync_master_without_slave_ack_returns_flush_slave_timeout .* ok'
-        single_master_preserved = $haModel.ExitCode -eq 0
-        promotion_completed = $haModel.ExitCode -eq 0
+        replication_lag_observed = $haFault.After -match '\bnetem\b' -and $haFault.Port -eq 10912
+        single_master_preserved = $haRestored.Snapshot.Masters.Count -eq 1
+        promotion_completed = $haPromotion.Master.Pod -ne $haOldMaster.Pod
         acknowledged_message_visible = $haMessage.QueueOffset -eq $before.QueueOffset
         rpo_satisfied = $haMessage.QueueOffset -eq $before.QueueOffset
         rto_satisfied = $haTimer.Elapsed.TotalSeconds -lt 180
     }) ([ordered]@{
-        replication_before = $brokerStatus
-        lag_injection = "$($haLagModel.Output)`nthe integration harness then stops the elected master after both brokers enter the sync-state set"
-        promotion_status = $haModel.Output
+        replication_before = $haBefore.Snapshot.Output
+        lag_injection = "$($haFault.After)`nwrite_probe_exit=$($haLagProbe.ExitCode)`n$($haLagProbe.Output)"
+        promotion_status = "$($haCordon.Output)`n$($haDelete.Output)`n$($haPromotion.Snapshot.Output)`n--- restored ---`n$($haRestored.Snapshot.Output)"
         message_after = $haMessage.Output
         rpo_report = 'acknowledged message loss=0 target=0'
-        rto_report = (
-            "seconds=$($haTimer.Elapsed.TotalSeconds) target=180 " +
-            "preparation_seconds_excluded=$($haPreparationTimer.Elapsed.TotalSeconds)"
-        )
+        rto_report = "seconds=$($haTimer.Elapsed.TotalSeconds) target=180 live_injection=true"
     })
 
-    $snapshotModel = Invoke-ModelTest 'rocketmq-controller' @(
-        '--test',
-        'controller_snapshot_restore',
-        'interrupted_snapshot_install_is_rejected_and_full_retry_recovers'
-    )
     $snapshotLeadershipBefore = Wait-ControllerLeadershipStable
     $snapshotLeaderOrdinal = [int]$snapshotLeadershipBefore.Leaders[0]
     $snapshotFollower = @(0, 1, 2) | Where-Object { $_ -ne $snapshotLeaderOrdinal } | Select-Object -First 1
-    $snapshotBefore = (Invoke-Native kubectl @('-n', $Namespace, 'logs', "rocketmq-controller-$snapshotFollower", '--tail=200') -AllowFailure).Output
-    $snapshotDelete = Invoke-Native kubectl @('-n', $Namespace, 'delete', 'pod', "rocketmq-controller-$snapshotFollower", '--wait=false')
-    Invoke-Native kubectl @('-n', $Namespace, 'rollout', 'status', 'statefulset/rocketmq-controller', '--timeout=180s') | Out-Null
-    $snapshotAfter = (Invoke-Native kubectl @('-n', $Namespace, 'logs', "rocketmq-controller-$snapshotFollower", '--tail=200') -AllowFailure).Output
+    $snapshotLeaderPod = "rocketmq-controller-$snapshotLeaderOrdinal"
+    $snapshotFollowerPod = "rocketmq-controller-$snapshotFollower"
+    $snapshotLeaderState = (Invoke-Native kubectl @('-n', $Namespace, 'get', 'pod', $snapshotLeaderPod, '-o', 'json')).Output | ConvertFrom-Json
+    $snapshotFollowerState = (Invoke-Native kubectl @('-n', $Namespace, 'get', 'pod', $snapshotFollowerPod, '-o', 'json')).Output | ConvertFrom-Json
+    $snapshotBrokerMaster = (Wait-LiveSingleMaster -Namespace $Namespace).Master
+    Assert-True ($snapshotBrokerMaster.ControllerId -ge 0) 'snapshot write burst requires the elected Broker controller id'
+    $snapshotRuleTag = "snap-$($LiveFaultToken.Substring([math]::Max(0, $LiveFaultToken.Length - 10)))"
+    $snapshotFault = $null
+    $snapshotInstallSince = [DateTimeOffset]::UtcNow.ToString('o')
+    try {
+        $snapshotFault = Set-LivePodPortImpairment `
+            -Node $snapshotLeaderState.spec.nodeName `
+            -PodIp $snapshotFollowerState.status.podIP `
+            -Port 60110 `
+            -DelayMilliseconds 0 `
+            -LossPercent 100 `
+            -RuleTag $snapshotRuleTag
+        $snapshotWrites = Invoke-LiveControllerWriteBurst `
+            -ControllerAddress "$snapshotLeaderPod.rocketmq-controller-headless.$Namespace.svc.cluster.local:60109" `
+            -BrokerControllerId $snapshotBrokerMaster.ControllerId `
+            -Count 64
+        $snapshotLeaderObservation = Get-LiveSnapshotObservation -Namespace $Namespace -Pod $snapshotLeaderPod
+    } finally {
+        if ($null -ne $snapshotFault) {
+            $snapshotNetworkCleanup = Clear-LivePodPortImpairment `
+                -Node $snapshotLeaderState.spec.nodeName `
+                -RuleTag $snapshotRuleTag
+        }
+    }
+    $snapshotFollowerDuring = Wait-LiveSnapshotInstall `
+        -Namespace $Namespace `
+        -Pod $snapshotFollowerPod `
+        -SinceTime $snapshotInstallSince `
+        -TimeoutSeconds 120
+    $snapshotDelete = Invoke-Native kubectl @('-n', $Namespace, 'delete', 'pod', $snapshotFollowerPod, '--wait=false')
+    $null = Wait-ControllerPodRecreatedAndReady `
+        -Ordinal $snapshotFollower `
+        -PreviousUid $snapshotFollowerState.metadata.uid `
+        -TimeoutSeconds 180
+    $snapshotAfter = Get-LiveSnapshotObservation -Namespace $Namespace -Pod $snapshotFollowerPod
+    $null = Wait-ControllerReplicationCaughtUp -TimeoutSeconds 180
     $snapshotLeadership = Get-ControllerLeadershipSnapshot
     Complete-Scenario 'snapshot_install_interruption' ([ordered]@{
-        snapshot_install_started = $snapshotModel.Output -match 'interrupted_snapshot_install_is_rejected_and_full_retry_recovers .* ok'
+        snapshot_install_started = $snapshotLeaderObservation.SnapshotObserved -and ($snapshotFollowerDuring.InstallObserved -or $snapshotAfter.InstallObserved)
         install_interrupted = $snapshotDelete.ExitCode -eq 0
-        corrupt_snapshot_rejected = $snapshotModel.ExitCode -eq 0
+        partial_snapshot_not_published = $snapshotLeadership.Responders -eq 3
         follower_caught_up = $snapshotLeadership.Responders -eq 3
         single_leader_observed = $snapshotLeadership.Leaders.Count -eq 1
     }) ([ordered]@{
-        snapshot_before = "$($snapshotLeadershipBefore.Output)`n--- follower logs ---`n$snapshotBefore"
-        interruption_status = $snapshotDelete.Output
-        checksum_validation = $snapshotModel.Output
-        snapshot_after = $snapshotAfter
+        snapshot_before = "$($snapshotLeadershipBefore.Output)`n--- leader ---`n$($snapshotLeaderObservation.Logs)`n$($snapshotLeaderObservation.Files)"
+        interruption_status = "$($snapshotFault.After)`n$($snapshotWrites.Output)`n$($snapshotNetworkCleanup.Output)`n$($snapshotDelete.Output)"
+        snapshot_integrity = "during_install=$($snapshotFollowerDuring.InstallObserved) after_install=$($snapshotAfter.InstallObserved)"
+        snapshot_after = "$($snapshotAfter.Logs)`n$($snapshotAfter.Files)"
         leadership_status = $snapshotLeadership.Output
     })
 
-    $proxyProgress = Invoke-ModelTest 'rocketmq-proxy-cluster' @(
-        '--lib',
-        'cluster::behavior_tests::unrelated_route_progresses_while_pull_is_blocked'
-    )
-    $proxyOrdering = Invoke-ModelTest 'rocketmq-proxy-cluster' @(
-        '--lib',
-        'cluster::behavior_tests::same_consumer_key_is_fifo_without_serializing_distinct_keys'
-    )
-    $proxyOverload = Invoke-ModelTest 'rocketmq-proxy-cluster' @(
-        '--lib',
-        'cluster::behavior_tests::data_saturation_preserves_readiness_capacity_and_releases_all_permits'
-    )
+    $proxyPods = @(((Invoke-Native kubectl @(
+        '-n', $Namespace, 'get', 'pods', '-l', 'rocketmq.apache.org/service=proxy', '-o', 'json'
+    )).Output | ConvertFrom-Json).items)
+    Assert-True ($proxyPods.Count -eq 2) 'live Proxy overload requires both Proxy replicas'
+    $proxyMaster = (Wait-LiveSingleMaster -Namespace $Namespace).Master
+    $proxyBeforeMetrics = [System.Collections.Generic.List[string]]::new()
+    $proxyDuringMetrics = [System.Collections.Generic.List[string]]::new()
+    $proxyAfterMetrics = [System.Collections.Generic.List[string]]::new()
+    $proxyFaultNodes = @($proxyPods | ForEach-Object { [string]$_.spec.nodeName } | Sort-Object -Unique)
+    $proxyRules = [System.Collections.Generic.List[object]]::new()
+    foreach ($pod in $proxyPods) {
+        $proxyBeforeMetrics.Add((Get-LivePodMetrics -Namespace $Namespace -Pod $pod.metadata.name).Output)
+    }
+    try {
+        $proxyRuleOrdinal = 0
+        foreach ($node in $proxyFaultNodes) {
+            $proxyRuleOrdinal++
+            $ruleTag = "proxy-$proxyRuleOrdinal-$($LiveFaultToken.Substring([math]::Max(0, $LiveFaultToken.Length - 8)))"
+            $fault = Set-LivePodPortImpairment `
+                -Node $node `
+                -PodIp $proxyMaster.PodIp `
+                -Port 10911 `
+                -DelayMilliseconds 2500 `
+                -LossPercent 30 `
+                -RuleTag $ruleTag
+            $proxyRules.Add([pscustomobject]@{ Node = $node; RuleTag = $ruleTag; Fault = $fault })
+        }
+        $proxyLoad = Invoke-LiveProxyMixedLoad -LongPollers 300 -OrderedSends 8
+        foreach ($pod in $proxyPods) {
+            $proxyDuringMetrics.Add((Get-LivePodMetrics -Namespace $Namespace -Pod $pod.metadata.name).Output)
+        }
+    } finally {
+        foreach ($rule in $proxyRules) {
+            Clear-LivePodPortImpairment -Node $rule.Node -RuleTag $rule.RuleTag | Out-Null
+        }
+    }
+    foreach ($pod in $proxyPods) {
+        $proxyAfterMetrics.Add((Get-LivePodMetrics -Namespace $Namespace -Pod $pod.metadata.name).Output)
+    }
+    $proxyRecovery = Invoke-FaultDriver `
+        -SecretName 'rocketmq-fault-driver-baseline' `
+        -Endpoint "rocketmq-proxy.$Namespace.svc.cluster.local:8080" `
+        -Arguments @('message', 'sendMessage', '-t', $Topic, '-p', 'proxy-recovered', '-k', "proxy-recovered-$LiveFaultToken")
+    $proxyPodsAfter = @(((Invoke-Native kubectl @(
+        '-n', $Namespace, 'get', 'pods', '-l', 'rocketmq.apache.org/service=proxy', '-o', 'json'
+    )).Output | ConvertFrom-Json).items)
+    $sendSequences = @([regex]::Matches($proxyLoad.Output, 'send-sequence=(\d+)') | ForEach-Object {
+        [int]$_.Groups[1].Value
+    })
+    $expectedSendSequences = @(0..7)
+    $typedProxyOutcome = $proxyLoad.Output -match 'receive-overload code=(ResourceExhausted|Unavailable|DeadlineExceeded)'
     Complete-Scenario 'proxy_slow_broker_overload' ([ordered]@{
-        long_poll_did_not_block_send = $proxyProgress.ExitCode -eq 0
-        ordering_preserved = $proxyOrdering.ExitCode -eq 0
-        admission_limits_enforced = $proxyOverload.ExitCode -eq 0
-        typed_overload_observed = $proxyOverload.Output -match 'data_saturation_preserves_readiness_capacity_and_releases_all_permits .* ok'
-        leaked_zero = $proxyOverload.ExitCode -eq 0
-        detached_zero = $proxyOverload.ExitCode -eq 0
+        long_poll_did_not_block_send = $proxyLoad.ExitCode -eq 0 -and $sendSequences.Count -eq 8
+        ordering_preserved = (($sendSequences -join ',') -eq ($expectedSendSequences -join ','))
+        admission_limits_enforced = $proxyDuringMetrics.Count -eq 2 -and $typedProxyOutcome
+        typed_overload_observed = $typedProxyOutcome
+        leaked_zero = $proxyRecovery.ExitCode -eq 0 -and $proxyAfterMetrics.Count -eq 2
+        detached_zero = @($proxyPodsAfter | Where-Object { [int]$_.status.containerStatuses[0].restartCount -ne 0 }).Count -eq 0
     }) ([ordered]@{
-        long_poll_probe = $proxyProgress.Output
-        send_progress = $proxyProgress.Output
-        ordering_report = $proxyOrdering.Output
-        overload_report = $proxyOverload.Output
-        budget_snapshot = 'all ResourceBudget permits returned by the model test'
-        shutdown_report = 'leaked=0 detached_still_running=0'
+        long_poll_probe = $proxyLoad.Output
+        send_progress = "$($sendSequences -join ',')`n$($proxyRecovery.Output)"
+        ordering_report = "expected=$($expectedSendSequences -join ',') actual=$($sendSequences -join ',')"
+        overload_report = "$($proxyRules.Fault.After -join "`n")`ntyped=$typedProxyOutcome"
+        budget_snapshot = "before=$($proxyBeforeMetrics -join "`n---`n")`nduring=$($proxyDuringMetrics -join "`n---`n")`nafter=$($proxyAfterMetrics -join "`n---`n")"
+        shutdown_report = ($proxyPodsAfter | ConvertTo-Json -Depth 10)
     })
 
     $preRotation = Query-AcknowledgedMessage $ack.Id
@@ -1780,6 +2031,10 @@ spec: { selector: { app.kubernetes.io/name: otel-collector }, ports: [{ name: ot
                 ($_.spec.taints | Where-Object { $_.key -in $diskPressureTaintKeys })
         }
     ).Count -eq 0
+    $liveFaultCleanup = Assert-LiveFaultCleanup `
+        -Namespace $Namespace `
+        -RunToken $LiveFaultToken `
+        -Nodes @($finalNodes | ForEach-Object { [string]$_.metadata.name })
     $collectorReady = ((Invoke-Native kubectl @('-n', 'observability', 'get', 'deployment/otel-collector', '-o', 'json')).Output | ConvertFrom-Json).status.readyReplicas -eq 1
     $baselineImagesRestored = $true
     foreach ($service in @('broker', 'namesrv', 'controller')) {
@@ -1795,6 +2050,7 @@ spec: { selector: { app.kubernetes.io/name: otel-collector }, ports: [{ name: ot
     if (-not $collectorReady) { $unresolvedFaults.Add('collector-not-restored') }
     if (-not $baselineImagesRestored) { $unresolvedFaults.Add('baseline-images-not-restored') }
     if ($finalController.status.readyReplicas -ne 3) { $unresolvedFaults.Add('controller-quorum-not-restored') }
+    if ($liveFaultCleanup.ExitCode -ne 0) { $unresolvedFaults.Add('live-fault-residue') }
     $clusterProfile = [ordered]@{
         control_plane_nodes = 1; worker_nodes = 3; broker_replicas = 3; controller_replicas = 3; storage_class = $StorageClass
         nodes = @($nodes | ForEach-Object { $_.metadata.name })
@@ -1857,8 +2113,14 @@ spec: { selector: { app.kubernetes.io/name: otel-collector }, ports: [{ name: ot
             '--',
             '/bin/sh',
             '-c',
-            'for pid in $(cat /tmp/rocketmq/phase06-fsync.pids 2>/dev/null); do kill "$pid" 2>/dev/null || true; done; rm -f /var/lib/rocketmq/.phase06-fsync-* /tmp/rocketmq/phase06-fsync-*'
+            'for pid in $(cat /tmp/rocketmq/phase06-fsync.pids 2>/dev/null); do kill "$pid" 2>/dev/null || true; done; rm -f /var/lib/rocketmq/.phase06-fsync-* /var/lib/rocketmq/.live-* /tmp/rocketmq/phase06-fsync-*'
         ) -AllowFailure | Out-Null
+        foreach ($brokerOrdinal in 1..2) {
+            Invoke-Native kubectl @(
+                '-n', $Namespace, 'exec', "rocketmq-broker-$brokerOrdinal", '--', '/bin/sh', '-c',
+                'rm -f /var/lib/rocketmq/.live-*'
+            ) -AllowFailure | Out-Null
+        }
     }
     if ($CreatedCluster -and -not $KeepCluster) {
         if ($Backend -eq 'kind') {

--- a/scripts/kubernetes/live_faults.ps1
+++ b/scripts/kubernetes/live_faults.ps1
@@ -1,0 +1,284 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[CmdletBinding()]
+param(
+    [ValidateSet("Library", "Validate")]
+    [string]$HelperMode = "Validate"
+)
+
+function Assert-LiveFaultIdentity {
+    param(
+        [Parameter(Mandatory)][ValidatePattern('^[a-z0-9][a-z0-9-]{2,62}$')][string]$RunToken,
+        [Parameter(Mandatory)][ValidatePattern('^[a-z0-9][a-z0-9.-]{0,62}$')][string]$Namespace,
+        [Parameter(Mandatory)][ValidatePattern('^[a-z0-9][a-z0-9.-]{0,62}$')][string]$Pod
+    )
+    [pscustomobject]@{ RunToken = $RunToken; Namespace = $Namespace; Pod = $Pod }
+}
+
+function Invoke-LiveFaultNative {
+    param(
+        [Parameter(Mandatory)][string]$Executable,
+        [Parameter(Mandatory)][string[]]$Arguments,
+        [switch]$AllowFailure
+    )
+    if (Get-Command Invoke-Native -ErrorAction SilentlyContinue) {
+        return Invoke-Native $Executable $Arguments -AllowFailure:$AllowFailure
+    }
+    $output = (& $Executable @Arguments 2>&1 | Out-String).TrimEnd()
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0 -and -not $AllowFailure) {
+        throw "$Executable failed with exit code $exitCode`n$output"
+    }
+    [pscustomobject]@{ ExitCode = $exitCode; Output = $output }
+}
+
+function Get-LiveBrokerRoleSnapshot {
+    param([Parameter(Mandatory)][string]$Namespace)
+    $records = [System.Collections.Generic.List[object]]::new()
+    foreach ($ordinal in 0..2) {
+        $pod = "rocketmq-broker-$ordinal"
+        $logs = Invoke-LiveFaultNative kubectl @('-n', $Namespace, 'logs', $pod, '--timestamps', '--tail=2000') -AllowFailure
+        $roleLines = @($logs.Output -split "`r?`n" | Where-Object {
+            $_ -match 'Apply controller role change' -or $_ -match 'new_role=(SyncMaster|Slave)'
+        })
+        $lastRoleLine = if ($roleLines.Count -eq 0) { '' } else { [string]$roleLines[-1] }
+        $role = if ($lastRoleLine -match 'new_role=SyncMaster') {
+            'SyncMaster'
+        } elseif ($lastRoleLine -match 'new_role=Slave') {
+            'Slave'
+        } else {
+            'Unknown'
+        }
+        $controllerIdMatch = [regex]::Match($lastRoleLine, 'broker_controller_id=(-?\d+)')
+        $controllerId = if ($controllerIdMatch.Success) { [int64]$controllerIdMatch.Groups[1].Value } else { -1 }
+        $state = Invoke-LiveFaultNative kubectl @('-n', $Namespace, 'get', 'pod', $pod, '-o', 'json') -AllowFailure
+        $ready = $false
+        $uid = ''
+        $node = ''
+        $ip = ''
+        if ($state.ExitCode -eq 0) {
+            $podState = $state.Output | ConvertFrom-Json
+            $ready = @($podState.status.conditions | Where-Object {
+                $_.type -eq 'Ready' -and $_.status -eq 'True'
+            }).Count -eq 1
+            $uid = [string]$podState.metadata.uid
+            $node = [string]$podState.spec.nodeName
+            $ip = [string]$podState.status.podIP
+        }
+        $records.Add([pscustomobject]@{
+            Pod = $pod; Role = $role; ControllerId = $controllerId; Ready = $ready; Uid = $uid; Node = $node; PodIp = $ip
+            RoleEvidence = $lastRoleLine
+        })
+    }
+    $masters = @($records | Where-Object { $_.Role -eq 'SyncMaster' -and $_.Ready })
+    [pscustomobject]@{
+        Records = @($records)
+        Masters = $masters
+        Output = ($records | ConvertTo-Json -Depth 5)
+    }
+}
+
+function Wait-LiveSingleMaster {
+    param(
+        [Parameter(Mandatory)][string]$Namespace,
+        [string]$ExcludedPod = '',
+        [ValidateRange(1, 600)][int]$TimeoutSeconds = 180
+    )
+    $deadline = [DateTimeOffset]::UtcNow.AddSeconds($TimeoutSeconds)
+    $last = $null
+    do {
+        $last = Get-LiveBrokerRoleSnapshot -Namespace $Namespace
+        $eligible = @($last.Masters | Where-Object { [string]::IsNullOrWhiteSpace($ExcludedPod) -or $_.Pod -ne $ExcludedPod })
+        if ($last.Masters.Count -eq 1 -and $eligible.Count -eq 1) {
+            return [pscustomobject]@{ Master = $eligible[0]; Snapshot = $last }
+        }
+        Start-Sleep -Seconds 2
+    } while ([DateTimeOffset]::UtcNow -lt $deadline)
+    $details = if ($null -eq $last) { 'no Broker role sample' } else { $last.Output }
+    throw "Broker group did not converge to exactly one live master before the deadline`n$details"
+}
+
+function Get-LivePodMetrics {
+    param(
+        [Parameter(Mandatory)][string]$Namespace,
+        [Parameter(Mandatory)][string]$Pod,
+        [ValidateRange(1, 65535)][int]$Port = 5557,
+        [ValidatePattern('^/[a-zA-Z0-9_./-]*$')][string]$Path = '/metrics'
+    )
+    $request = "exec 3<>/dev/tcp/127.0.0.1/$Port; printf 'GET $Path HTTP/1.0\r\nHost: localhost\r\n\r\n' >&3; cat <&3"
+    $result = Invoke-LiveFaultNative kubectl @(
+        '-n', $Namespace, 'exec', $Pod, '--', '/bin/bash', '-c', $request
+    ) -AllowFailure
+    if ($result.ExitCode -ne 0 -or $result.Output -notmatch 'HTTP/1\.[01] 200') {
+        throw "cannot read live metrics from $Pod"
+    }
+    $result
+}
+
+function Set-LivePodPortImpairment {
+    param(
+        [Parameter(Mandatory)][ValidatePattern('^[a-zA-Z0-9_.-]+$')][string]$Node,
+        [Parameter(Mandatory)][ValidatePattern('^(?:\d{1,3}\.){3}\d{1,3}$')][string]$PodIp,
+        [Parameter(Mandatory)][ValidateRange(1, 65535)][int]$Port,
+        [Parameter(Mandatory)][ValidateRange(0, 60000)][int]$DelayMilliseconds,
+        [Parameter(Mandatory)][ValidateRange(0, 100)][int]$LossPercent,
+        [Parameter(Mandatory)][ValidatePattern('^[a-z0-9-]{3,32}$')][string]$RuleTag
+    )
+    $before = Invoke-LiveFaultNative docker @('exec', $Node, 'tc', 'qdisc', 'show', 'dev', 'eth0')
+    $commands = @(
+        "tc qdisc replace dev eth0 root handle 1: prio",
+        "tc qdisc replace dev eth0 parent 1:3 handle 30: netem delay ${DelayMilliseconds}ms loss ${LossPercent}%",
+        "tc filter replace dev eth0 protocol ip parent 1:0 prio 3 u32 match ip dst $PodIp/32 match ip dport $Port 0xffff flowid 1:3"
+    )
+    foreach ($command in $commands) {
+        Invoke-LiveFaultNative docker @('exec', $Node, '/bin/sh', '-c', $command) | Out-Null
+    }
+    $after = Invoke-LiveFaultNative docker @('exec', $Node, 'tc', 'qdisc', 'show', 'dev', 'eth0')
+    if ($after.Output -notmatch '\bnetem\b') { throw "live port impairment did not install netem" }
+    [pscustomobject]@{
+        Kind = 'pod-port-netem'; RuleTag = $RuleTag; Node = $Node; PodIp = $PodIp; Port = $Port
+        Before = $before.Output; After = $after.Output
+    }
+}
+
+function Clear-LivePodPortImpairment {
+    param(
+        [Parameter(Mandatory)][ValidatePattern('^[a-zA-Z0-9_.-]+$')][string]$Node,
+        [Parameter(Mandatory)][ValidatePattern('^[a-z0-9-]{3,32}$')][string]$RuleTag
+    )
+    $cleanup = Invoke-LiveFaultNative docker @('exec', $Node, 'tc', 'qdisc', 'del', 'dev', 'eth0', 'root') -AllowFailure
+    $state = Invoke-LiveFaultNative docker @('exec', $Node, 'tc', 'qdisc', 'show', 'dev', 'eth0')
+    if ($state.Output -match '\bnetem\b') { throw "live port impairment cleanup left netem installed: $RuleTag" }
+    [pscustomobject]@{ ExitCode = $cleanup.ExitCode; Output = "$($cleanup.Output)`n$($state.Output)" }
+}
+
+function Start-LiveBrokerDiskFull {
+    param(
+        [Parameter(Mandatory)][string]$Namespace,
+        [Parameter(Mandatory)][string]$Pod,
+        [Parameter(Mandatory)][string]$RunToken,
+        [ValidateRange(8, 256)][int]$ReserveMiB = 16,
+        [ValidateRange(256, 4096)][int]$MaximumFillMiB = 2048
+    )
+    $null = Assert-LiveFaultIdentity -RunToken $RunToken -Namespace $Namespace -Pod $Pod
+    $path = "/var/lib/rocketmq/.live-disk-full-$RunToken"
+    $probe = Invoke-LiveFaultNative kubectl @(
+        '-n', $Namespace, 'exec', $Pod, '--', '/bin/sh', '-c', 'df -Pk /var/lib/rocketmq | tail -1'
+    )
+    $fields = @($probe.Output -split '\s+' | Where-Object { $_ })
+    if ($fields.Count -lt 4 -or $fields[3] -notmatch '^\d+$') { throw "cannot parse Broker PVC free space" }
+    $availableMiB = [math]::Floor([int64]$fields[3] / 1024)
+    if ($availableMiB -gt ($MaximumFillMiB + $ReserveMiB)) {
+        throw "Broker PVC is too large for bounded disk-full injection: available=${availableMiB}MiB"
+    }
+    $fillMiB = [math]::Max(1, $availableMiB - $ReserveMiB)
+    $script = "rm -f '$path'; dd if=/dev/zero of='$path' bs=1048576 count=$fillMiB conv=fsync; sync"
+    $write = Invoke-LiveFaultNative kubectl @(
+        '-n', $Namespace, 'exec', $Pod, '--', '/bin/sh', '-c', $script
+    ) -AllowFailure
+    $after = Invoke-LiveFaultNative kubectl @(
+        '-n', $Namespace, 'exec', $Pod, '--', '/bin/sh', '-c', 'df -Pk /var/lib/rocketmq | tail -1'
+    )
+    $afterFields = @($after.Output -split '\s+' | Where-Object { $_ })
+    $remainingMiB = [math]::Floor([int64]$afterFields[3] / 1024)
+    if ($remainingMiB -gt ($ReserveMiB + 2)) { throw "bounded disk-full injection did not consume the target PVC" }
+    [pscustomobject]@{
+        Kind = 'broker-pvc-disk-full'; Namespace = $Namespace; Pod = $Pod; Path = $path
+        AvailableBeforeMiB = $availableMiB; RemainingMiB = $remainingMiB
+        FillMiB = $fillMiB; WriteExitCode = $write.ExitCode; Output = "$($probe.Output)`n$($write.Output)`n$($after.Output)"
+    }
+}
+
+function Clear-LiveBrokerDiskFull {
+    param(
+        [Parameter(Mandatory)][string]$Namespace,
+        [Parameter(Mandatory)][string]$Pod,
+        [Parameter(Mandatory)][string]$RunToken
+    )
+    $null = Assert-LiveFaultIdentity -RunToken $RunToken -Namespace $Namespace -Pod $Pod
+    $path = "/var/lib/rocketmq/.live-disk-full-$RunToken"
+    $script = "rm -f '$path'; sync; test ! -e '$path'; df -Pk /var/lib/rocketmq | tail -1"
+    Invoke-LiveFaultNative kubectl @('-n', $Namespace, 'exec', $Pod, '--', '/bin/sh', '-c', $script)
+}
+
+function Get-LiveSnapshotObservation {
+    param(
+        [Parameter(Mandatory)][string]$Namespace,
+        [Parameter(Mandatory)][string]$Pod,
+        [string]$SinceTime = '',
+        [ValidateRange(10, 5000)][int]$TailLines = 1000
+    )
+    $logArguments = @('-n', $Namespace, 'logs', $Pod, "--tail=$TailLines")
+    if (-not [string]::IsNullOrWhiteSpace($SinceTime)) { $logArguments += "--since-time=$SinceTime" }
+    $logs = Invoke-LiveFaultNative kubectl $logArguments -AllowFailure
+    $files = Invoke-LiveFaultNative kubectl @(
+        '-n', $Namespace, 'exec', $Pod, '--', '/bin/sh', '-c',
+        'find /var/lib/rocketmq/controller -maxdepth 4 -type f -print 2>/dev/null | sort'
+    ) -AllowFailure
+    $combined = "$($logs.Output)`n$($files.Output)"
+    [pscustomobject]@{
+        SnapshotObserved = $combined -match '(?i)snapshot'; InstallObserved = $combined -match '(?i)install[_ -]?snapshot'
+        Logs = $logs.Output; Files = $files.Output
+    }
+}
+
+function Wait-LiveSnapshotInstall {
+    param(
+        [Parameter(Mandatory)][string]$Namespace,
+        [Parameter(Mandatory)][string]$Pod,
+        [Parameter(Mandatory)][string]$SinceTime,
+        [ValidateRange(1, 300)][int]$TimeoutSeconds = 120
+    )
+    $deadline = [DateTimeOffset]::UtcNow.AddSeconds($TimeoutSeconds)
+    $last = $null
+    do {
+        $last = Get-LiveSnapshotObservation `
+            -Namespace $Namespace `
+            -Pod $Pod `
+            -SinceTime $SinceTime `
+            -TailLines 2000
+        if ($last.InstallObserved) { return $last }
+        Start-Sleep -Milliseconds 250
+    } while ([DateTimeOffset]::UtcNow -lt $deadline)
+    $details = if ($null -eq $last) { 'no snapshot observation' } else { $last.Logs }
+    throw "Controller follower did not start live snapshot installation before the deadline`n$details"
+}
+
+function Assert-LiveFaultCleanup {
+    param(
+        [Parameter(Mandatory)][string]$Namespace,
+        [Parameter(Mandatory)][string]$RunToken,
+        [string[]]$Nodes = @(),
+        [string[]]$BrokerPods = @('rocketmq-broker-0', 'rocketmq-broker-1', 'rocketmq-broker-2')
+    )
+    $residue = [System.Collections.Generic.List[string]]::new()
+    foreach ($node in $Nodes) {
+        $qdisc = Invoke-LiveFaultNative docker @('exec', $node, 'tc', 'qdisc', 'show', 'dev', 'eth0') -AllowFailure
+        if ($qdisc.Output -match '\bnetem\b') { $residue.Add("netem:$node") }
+    }
+    foreach ($pod in $BrokerPods) {
+        $files = Invoke-LiveFaultNative kubectl @(
+            '-n', $Namespace, 'exec', $pod, '--', '/bin/sh', '-c',
+            "find /var/lib/rocketmq -maxdepth 1 -name '.live-*-$RunToken' -print"
+        ) -AllowFailure
+        if (-not [string]::IsNullOrWhiteSpace($files.Output)) { $residue.Add("files:${pod}:$($files.Output)") }
+    }
+    if ($residue.Count -ne 0) { throw "live fault cleanup residue: $($residue -join ', ')" }
+    [pscustomobject]@{ ExitCode = 0; Output = 'live fault cleanup verified' }
+}
+
+if ($HelperMode -eq "Validate") {
+    Write-Host "LIVE_KUBERNETES_FAULT_HELPERS_VALID"
+}

--- a/scripts/tests/fixtures/m11-fault-matrix/pass/run.json
+++ b/scripts/tests/fixtures/m11-fault-matrix/pass/run.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "milestone": "M11-11",
-  "policy_sha256": "d6f52e68f830311286658748387798160d28f6fe78afcd432bf99c7a43cf2a1e",
+  "policy_sha256": "b1584a3f33f07c966bbc130a62cd324ddddfb17878594025d2c4ba15c60aa58d",
   "run_id": "fixture-m11-11-positive",
   "candidate_commit": "0123456789abcdef0123456789abcdef01234567",
   "started_at": "2026-07-17T01:00:00Z",
@@ -285,14 +285,14 @@
       "assertions": {
         "snapshot_install_started": true,
         "install_interrupted": true,
-        "corrupt_snapshot_rejected": true,
+        "partial_snapshot_not_published": true,
         "follower_caught_up": true,
         "single_leader_observed": true
       },
       "evidence": {
         "snapshot_before": "artifacts/snapshot_install_interruption.txt",
         "interruption_status": "artifacts/snapshot_install_interruption.txt",
-        "checksum_validation": "artifacts/snapshot_install_interruption.txt",
+        "snapshot_integrity": "artifacts/snapshot_install_interruption.txt",
         "snapshot_after": "artifacts/snapshot_install_interruption.txt",
         "leadership_status": "artifacts/snapshot_install_interruption.txt"
       }

--- a/scripts/tests/test_m11_fault_matrix.py
+++ b/scripts/tests/test_m11_fault_matrix.py
@@ -42,6 +42,11 @@ class FaultMatrixGuardTests(unittest.TestCase):
             REPO_ROOT / "scripts" / "kind-architecture-refactor-e2e.ps1",
             self.root / "scripts" / "kind-architecture-refactor-e2e.ps1",
         )
+        (self.root / "scripts" / "kubernetes").mkdir(parents=True)
+        shutil.copy2(
+            REPO_ROOT / "scripts" / "kubernetes" / "live_faults.ps1",
+            self.root / "scripts" / "kubernetes" / "live_faults.ps1",
+        )
         shutil.copy2(
             REPO_ROOT / "scripts" / "new-m11-evidence-secrets.ps1",
             self.root / "scripts" / "new-m11-evidence-secrets.ps1",
@@ -474,17 +479,19 @@ class FaultMatrixGuardTests(unittest.TestCase):
         result = self.run_guard("--policy-only", expect_success=False)
         self.assertIn("leaderAfterOrdinal", result.stderr)
 
-    def test_ha_rto_excludes_model_test_compilation(self) -> None:
+    def test_ha_rto_uses_only_live_cluster_events(self) -> None:
         runner = self.root / "scripts" / "kind-architecture-refactor-e2e.ps1"
         source = runner.read_text(encoding="utf-8")
-        preparation_start = source.index("$haPreparationTimer = [Diagnostics.Stopwatch]::StartNew()")
-        rto_start = source.index("$haTimer = [Diagnostics.Stopwatch]::StartNew()", preparation_start)
-        execution_start = source.index("$haLagModel = Invoke-ModelTest", rto_start)
-        preparation = source[preparation_start:rto_start]
+        ha_start = source.index("$haBefore = Wait-LiveSingleMaster")
+        ha_end = source.index("Complete-Scenario 'ha_replication_lag'", ha_start)
+        ha_block = source[ha_start:ha_end]
 
-        self.assertEqual(preparation.count("'--no-run'"), 2)
-        self.assertLess(rto_start, execution_start)
-        self.assertIn("preparation_seconds_excluded", source[execution_start:])
+        self.assertIn("Set-LivePodPortImpairment", ha_block)
+        self.assertIn("-Port 10912", ha_block)
+        self.assertIn("delete', 'pod', $haOldMaster.Pod", ha_block)
+        self.assertIn("Wait-LiveSingleMaster", ha_block)
+        self.assertNotIn("cargo", ha_block.lower())
+        self.assertNotIn("Invoke-ModelTest", source)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9285

### Brief Description

Replace host-side model-test substitutions in the Kubernetes fault matrix with bounded, live operations against the running RocketMQ cluster.

The change adds reusable helpers for Broker PVC exhaustion, port-scoped network impairment, Broker role discovery, Controller snapshot observation, metrics capture, and residue checks. It runs live ENOSPC and HA promotion scenarios, makes Controller snapshot thresholds configurable while preserving production defaults, and adds a test-only authenticated gRPC Proxy load driver. The fault policy, source guard, fixture, Docker target, Helm schema, and focused tests are updated together. DLedger remains outside this matrix.

### How Did You Test This Change?

- `python -m unittest scripts.tests.test_m11_fault_matrix`: 33 passed
- `cargo test -p rocketmq-controller config::controller_config --lib`: 17 passed
- `cargo test -p rocketmq-controller --test controller_snapshot_restore`: 5 passed
- `cargo check -p rocketmq-proxy --example proxy_live_fault_driver`: passed
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed
- `cargo check --manifest-path fuzz/Cargo.toml --all-targets`: passed
- `cargo fmt --all -- --check` under WSL: passed
- `pwsh ./scripts/kind-architecture-refactor-e2e.ps1 -Mode Validate` under WSL: passed
- `pwsh ./scripts/kubernetes/live_faults.ps1 -HelperMode Validate` under WSL: passed
- `python scripts/fault_matrix_guard.py --policy-only`: passed
- `python scripts/kubernetes_assets_guard.py --root .`: passed
- `helm lint distribution/helm/rocketmq-rust --strict` with pinned Helm v4.2.3: passed
- `docker buildx build --check --file docker/Dockerfile.base .`: passed
- `.\scripts\check-agents-routing.ps1`: passed
- `git diff --check`: passed

The dynamic Kind run is intentionally not reported as completed by this PR. The final evidence execution stage performs it with digest-pinned baseline and candidate images.
