### PR TITLE
[ISSUE #9287]✨Audit every PutOk across clean Broker failover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4270,6 +4270,7 @@ dependencies = [
  "prost",
  "protoc-bin-vendored",
  "rocketmq-auth",
+ "rocketmq-client-rust",
  "rocketmq-error",
  "rocketmq-model",
  "rocketmq-observability",

--- a/distribution/config/ack-failover-evidence-schema.json
+++ b/distribution/config/ack-failover-evidence-schema.json
@@ -87,5 +87,56 @@
     "detached_still_running_must_equal": 0,
     "artifact_hash": "sha256",
     "commit_and_image_digest_match_required": true
+  },
+  "put_ok_rpo_audit": {
+    "artifact_kind": "controller_failover_qualification_evidence",
+    "schema_version": 1,
+    "minimum_put_ok_messages": 10000,
+    "minimum_clean_failover_repetitions": 5,
+    "durability_contract": "strict-sync-required-ack-clean-election",
+    "required_identity_fields": [
+      "candidate_commit",
+      "deployment_digest",
+      "target_id",
+      "cluster_uid",
+      "effective_config_sha256",
+      "durability_contract",
+      "ledger_sha256"
+    ],
+    "required_ledger_fields": [
+      "sequence",
+      "audit_id",
+      "unique_key",
+      "broker_message_id",
+      "offset_message_id",
+      "broker_name",
+      "queue_id",
+      "queue_offset",
+      "commit_log_offset",
+      "store_size",
+      "end_offset",
+      "payload_sha256",
+      "put_ok_at_utc"
+    ],
+    "required_milestones": [
+      "fault_injected",
+      "controller_leader_elected",
+      "broker_master_elected",
+      "store_write_authority_granted",
+      "route_converged",
+      "producer_recovered"
+    ],
+    "pass_conditions": {
+      "missing_count": 0,
+      "duplicate_count": 0,
+      "unexpected_count": 0,
+      "payload_mismatch_count": 0,
+      "offset_mismatch_count": 0,
+      "confirm_offset_violations": 0,
+      "single_writable_master_required": true,
+      "ambiguous_sends_excluded_from_rpo_denominator": true,
+      "unclean_election_forbidden": true,
+      "dledger_supported": false
+    }
   }
 }

--- a/distribution/helm/rocketmq-rust/templates/configmaps.yaml
+++ b/distribution/helm/rocketmq-rust/templates/configmaps.yaml
@@ -64,6 +64,14 @@ data:
     haListenPort = 10912
     storePathRootDir = "/var/lib/rocketmq/store"
     storePathBrokerIdentity = "/var/lib/rocketmq/store/brokerIdentity.json"
+    flushDiskType = {{ $.Values.services.broker.durability.flushDiskType | quote }}
+    totalReplicas = {{ $.Values.services.broker.durability.totalReplicas }}
+    inSyncReplicas = {{ $.Values.services.broker.durability.inSyncReplicas }}
+    minInSyncReplicas = {{ $.Values.services.broker.durability.minInSyncReplicas }}
+    allAckInSyncStateSet = {{ $.Values.services.broker.durability.allAckInSyncStateSet }}
+    enableAutoInSyncReplicas = false
+    slaveTimeout = {{ $.Values.services.broker.durability.slaveTimeoutMillis }}
+    haMaxTimeSlaveNotCatchup = {{ $.Values.services.broker.durability.maxSlaveLagMillis }}
 {{- end }}
 ---
 apiVersion: v1

--- a/distribution/helm/rocketmq-rust/values-production-controller-ha.yaml
+++ b/distribution/helm/rocketmq-rust/values-production-controller-ha.yaml
@@ -23,6 +23,15 @@ services:
   broker:
     replicas: 3
     replicaGroupName: rocketmq-broker
+    durability:
+      flushDiskType: SYNC_FLUSH
+      totalReplicas: 3
+      inSyncReplicas: 3
+      minInSyncReplicas: 2
+      allAckInSyncStateSet: true
+      slaveTimeoutMillis: 3000
+      maxSlaveLagMillis: 15000
+      cleanElection: true
     image:
       repository: rocketmq-rust/broker
       tag: local

--- a/distribution/helm/rocketmq-rust/values.schema.json
+++ b/distribution/helm/rocketmq-rust/values.schema.json
@@ -540,6 +540,7 @@
         "replicaGroupName",
         "autoCreateTopicEnable",
         "logFilterReloadEnabled",
+        "durability",
         "image",
         "persistence",
         "pdb",
@@ -560,6 +561,30 @@
         },
         "logFilterReloadEnabled": {
           "type": "boolean"
+        },
+        "durability": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "flushDiskType",
+            "totalReplicas",
+            "inSyncReplicas",
+            "minInSyncReplicas",
+            "allAckInSyncStateSet",
+            "slaveTimeoutMillis",
+            "maxSlaveLagMillis",
+            "cleanElection"
+          ],
+          "properties": {
+            "flushDiskType": { "const": "SYNC_FLUSH" },
+            "totalReplicas": { "type": "integer", "minimum": 3, "maximum": 9 },
+            "inSyncReplicas": { "type": "integer", "minimum": 2, "maximum": 9 },
+            "minInSyncReplicas": { "type": "integer", "minimum": 2, "maximum": 9 },
+            "allAckInSyncStateSet": { "const": true },
+            "slaveTimeoutMillis": { "type": "integer", "minimum": 1, "maximum": 60000 },
+            "maxSlaveLagMillis": { "type": "integer", "minimum": 1, "maximum": 300000 },
+            "cleanElection": { "const": true }
+          }
         },
         "image": {
           "$ref": "#/definitions/image"

--- a/distribution/helm/rocketmq-rust/values.yaml
+++ b/distribution/helm/rocketmq-rust/values.yaml
@@ -67,6 +67,15 @@ services:
     replicaGroupName: rocketmq-broker
     autoCreateTopicEnable: false
     logFilterReloadEnabled: false
+    durability:
+      flushDiskType: SYNC_FLUSH
+      totalReplicas: 3
+      inSyncReplicas: 3
+      minInSyncReplicas: 2
+      allAckInSyncStateSet: true
+      slaveTimeoutMillis: 3000
+      maxSlaveLagMillis: 15000
+      cleanElection: true
     image:
       repository: rocketmq-rust/broker
       tag: local

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -235,20 +235,29 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 set -eux
 cargo build --locked --release --package rocketmq-admin-cli --bin rocketmq-admin-cli
 cargo build --locked --release --package rocketmq-proxy --example proxy_live_fault_driver
+cargo build --locked --release --package rocketmq-controller --example controller-failover-qualification
 install -D -m 0555 /workspace/target/release/rocketmq-admin-cli /opt/rocketmq-binaries/rocketmq-admin-cli
 install -D -m 0555 /workspace/target/release/examples/proxy_live_fault_driver /opt/rocketmq-binaries/proxy-live-fault-driver
+install -D -m 0555 /workspace/target/release/examples/controller-failover-qualification /opt/rocketmq-binaries/controller-failover-qualification
 EOF
 
 FROM runtime-base AS fault-driver
 
 COPY --from=fault-driver-builder --chmod=0555 /opt/rocketmq-binaries/rocketmq-admin-cli /usr/local/bin/rocketmq-admin-cli
 COPY --from=fault-driver-builder --chmod=0555 /opt/rocketmq-binaries/proxy-live-fault-driver /usr/local/bin/proxy-live-fault-driver
+COPY --from=fault-driver-builder --chmod=0555 /opt/rocketmq-binaries/controller-failover-qualification /usr/local/bin/controller-failover-qualification
 
 LABEL org.opencontainers.image.title="RocketMQ Rust architecture fault driver" \
     io.rocketmq.image.role="fault-driver-test-only" \
     io.rocketmq.image.production="forbidden"
 
 ENTRYPOINT ["/usr/local/bin/rocketmq-admin-cli"]
+
+# Test-only image used by clean-failover qualification. Production service targets do not
+# contain the client driver or its append-only evidence volume.
+FROM fault-driver AS qualification-driver
+
+ENTRYPOINT ["/usr/local/bin/controller-failover-qualification"]
 
 FROM service-runtime AS broker
 

--- a/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
@@ -25,6 +25,7 @@ use rocketmq_model::common::mix_all;
 use rocketmq_model::common::mq_version::CURRENT_VERSION;
 use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::body::ha_runtime_info::HARuntimeInfo;
 use rocketmq_protocol::protocol::body::kv_table::KVTable;
 use rocketmq_protocol::protocol::header::export_rocksdb_config_to_json_request_header::ExportRocksdbConfigToJsonRequestHeader;
 #[cfg(feature = "rocksdb_store")]
@@ -732,6 +733,14 @@ impl<MS: BrokerAdminStore> BrokerConfigRequestHandler<MS> {
         if let Some(ha) = message_store.get_ha_runtime_info() {
             runtime_info.insert("haDiagnosticsSupported".to_string(), "true".to_string());
             runtime_info.insert(
+                "storeConfirmOffset".to_string(),
+                message_store.get_confirm_offset().max(0).to_string(),
+            );
+            runtime_info.insert(
+                "haLegalInSyncAckOffset".to_string(),
+                legal_in_sync_ack_offset(&ha).to_string(),
+            );
+            runtime_info.insert(
                 "haRole".to_string(),
                 if ha.master { "master" } else { "replica" }.to_string(),
             );
@@ -1033,6 +1042,17 @@ impl<MS: BrokerAdminStore> BrokerConfigRequestHandler<MS> {
     }
 }
 
+fn legal_in_sync_ack_offset(runtime: &HARuntimeInfo) -> u64 {
+    runtime
+        .ha_connection_info
+        .iter()
+        .filter(|connection| connection.in_sync)
+        .map(|connection| connection.slave_ack_offset)
+        .chain(std::iter::once(runtime.master_commit_log_max_offset))
+        .min()
+        .unwrap_or_default()
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -1040,6 +1060,8 @@ mod tests {
     use std::fs;
     use std::sync::Arc;
     use std::time::SystemTime;
+
+    use super::legal_in_sync_ack_offset;
 
     use crate::config::broker_config::BrokerConfig;
     #[cfg(feature = "rocksdb_store")]
@@ -1054,6 +1076,7 @@ mod tests {
     use rocketmq_model::common::message::MessageConst;
     use rocketmq_protocol::code::request_code::RequestCode;
     use rocketmq_protocol::code::response_code::ResponseCode;
+    use rocketmq_protocol::protocol::body::ha_runtime_info::HARuntimeInfo;
     use rocketmq_protocol::protocol::header::export_rocksdb_config_to_json_request_header::ExportRocksdbConfigToJsonRequestHeader;
     use rocketmq_protocol::protocol::header::get_broker_config_response_header::GetBrokerConfigResponseHeader;
     use rocketmq_protocol::protocol::header::update_broker_config_request_header::UpdateBrokerConfigRequestHeader;
@@ -1254,6 +1277,8 @@ mod tests {
             Some("1")
         );
         assert_eq!(initial.get("storeWriteable").map(|value| value.as_str()), Some("true"));
+        assert!(initial.contains_key("storeConfirmOffset"));
+        assert!(initial.contains_key("haLegalInSyncAckOffset"));
         assert_eq!(
             initial.get("sreLogFilterControlSupported").map(|value| value.as_str()),
             Some("false")
@@ -1277,6 +1302,36 @@ mod tests {
         );
 
         let _ = fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
+    }
+
+    #[test]
+    fn legal_in_sync_ack_uses_the_slowest_in_sync_replica() {
+        use rocketmq_protocol::protocol::body::ha_connection_runtime_info::HAConnectionRuntimeInfo;
+
+        let runtime = HARuntimeInfo {
+            master: true,
+            master_commit_log_max_offset: 300,
+            ha_connection_info: vec![
+                HAConnectionRuntimeInfo {
+                    slave_ack_offset: 240,
+                    in_sync: true,
+                    ..Default::default()
+                },
+                HAConnectionRuntimeInfo {
+                    slave_ack_offset: 180,
+                    in_sync: true,
+                    ..Default::default()
+                },
+                HAConnectionRuntimeInfo {
+                    slave_ack_offset: 20,
+                    in_sync: false,
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        assert_eq!(legal_in_sync_ack_offset(&runtime), 180);
     }
 
     #[tokio::test]

--- a/rocketmq-controller/Cargo.toml
+++ b/rocketmq-controller/Cargo.toml
@@ -91,9 +91,14 @@ tonic-prost-build   = "0.14.6"
 
 [dev-dependencies]
 criterion          = { version = "0.8", features = ["async_tokio"] }
+rocketmq-client-rust = { workspace = true }
 rocketmq-transport = { workspace = true, features = ["test-support"] }
 tempfile           = "3.27"
 tracing-subscriber = { workspace = true }
+
+[[example]]
+name = "controller-failover-qualification"
+path = "examples/controller_failover_qualification.rs"
 
 [[bench]]
 name    = "controller_bench"

--- a/rocketmq-controller/examples/controller_failover_qualification.rs
+++ b/rocketmq-controller/examples/controller_failover_qualification.rs
@@ -1,0 +1,502 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![recursion_limit = "256"]
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::BufRead;
+use std::io::BufReader;
+use std::io::BufWriter;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+use anyhow::Context;
+use clap::Args;
+use clap::Parser;
+use clap::Subcommand;
+use rocketmq_client_rust::AclClientRPCHook;
+use rocketmq_client_rust::ClientRuntime;
+use rocketmq_client_rust::ClientRuntimeConfig;
+use rocketmq_client_rust::DefaultLitePullConsumer;
+use rocketmq_client_rust::DefaultMQProducer;
+use rocketmq_client_rust::SendStatus;
+use rocketmq_client_rust::SessionCredentials;
+use rocketmq_model::common::consumer::consume_from_where::ConsumeFromWhere;
+use rocketmq_model::common::message::message_ext::MessageExt;
+use rocketmq_model::common::message::message_single::Message;
+use rocketmq_protocol::common::message::message_decoder::decode_message_id;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use serde::Deserialize;
+use serde::Serialize;
+use sha2::Digest;
+use sha2::Sha256;
+
+#[derive(Debug, Parser)]
+#[command(about = "Create and verify an append-only PutOk failover ledger")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    Seed(SeedArgs),
+    Verify(VerifyArgs),
+}
+
+#[derive(Debug, Clone, Args)]
+struct ConnectionArgs {
+    #[arg(long)]
+    namesrv: String,
+    #[arg(long)]
+    topic: String,
+    #[arg(long, default_value_t = 10_000)]
+    timeout_millis: u64,
+}
+
+#[derive(Debug, Args)]
+struct SeedArgs {
+    #[command(flatten)]
+    connection: ConnectionArgs,
+    #[arg(long)]
+    run_id: String,
+    #[arg(long, default_value_t = 10_000)]
+    message_count: usize,
+    #[arg(long, default_value_t = 256)]
+    message_size: usize,
+    #[arg(long)]
+    ledger: PathBuf,
+    #[arg(long)]
+    ambiguous_ledger: PathBuf,
+}
+
+#[derive(Debug, Args)]
+struct VerifyArgs {
+    #[command(flatten)]
+    connection: ConnectionArgs,
+    #[arg(long)]
+    ledger: PathBuf,
+    #[arg(long)]
+    observations: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct PutOkLedgerEntry {
+    sequence: usize,
+    audit_id: String,
+    unique_key: String,
+    broker_message_id: String,
+    offset_message_id: String,
+    broker_name: String,
+    queue_id: i32,
+    queue_offset: u64,
+    commit_log_offset: u64,
+    store_size: u64,
+    end_offset: u64,
+    payload_sha256: String,
+    put_ok_at_utc: String,
+}
+
+#[derive(Debug, Serialize)]
+struct AmbiguousSend {
+    sequence: usize,
+    audit_id: String,
+    unique_key: String,
+    observed_at_utc: String,
+    outcome: String,
+}
+
+#[derive(Debug, Serialize)]
+struct RecoveryObservation {
+    audit_id: String,
+    unique_key: String,
+    broker_name: String,
+    queue_id: i32,
+    queue_offset: u64,
+    commit_log_offset: u64,
+    store_size: u64,
+    end_offset: u64,
+    payload_sha256: String,
+}
+
+struct QualificationRuntime {
+    owner: RuntimeOwner,
+    client: Arc<ClientRuntime>,
+    telemetry: rocketmq_observability::TelemetryRuntimeGuard,
+}
+
+impl QualificationRuntime {
+    fn create() -> anyhow::Result<Self> {
+        let owner = RuntimeOwner::new(RuntimeConfig {
+            thread_name: "rocketmq-failover-qualification".to_string(),
+            ..Default::default()
+        })
+        .context("create qualification runtime")?;
+        let telemetry =
+            rocketmq_observability::install_global(&rocketmq_observability::TelemetryBootstrapConfig::default())
+                .context("initialize qualification telemetry")?;
+        let client = ClientRuntime::try_new(
+            owner.root_context().component("failover-qualification"),
+            ClientRuntimeConfig::default(),
+            telemetry.handle(),
+        )
+        .context("create RocketMQ client runtime")?;
+        Ok(Self {
+            owner,
+            client,
+            telemetry,
+        })
+    }
+
+    async fn shutdown(self) -> anyhow::Result<()> {
+        let client = self.client.shutdown().await;
+        anyhow::ensure!(
+            client.is_healthy(),
+            "client shutdown was unhealthy: {}",
+            client.to_json()
+        );
+        let tasks = self.owner.shutdown_tasks().await;
+        anyhow::ensure!(tasks.is_healthy(), "task shutdown was unhealthy: {}", tasks.to_json());
+        let background = self.owner.shutdown_background();
+        anyhow::ensure!(
+            background.is_healthy(),
+            "background shutdown was unhealthy: {}",
+            background.to_json()
+        );
+        let telemetry = self.telemetry.shutdown();
+        anyhow::ensure!(
+            telemetry.is_healthy(),
+            "telemetry shutdown was unhealthy: {}",
+            telemetry.to_json()
+        );
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    match Cli::parse().command {
+        Command::Seed(args) => seed(args).await,
+        Command::Verify(args) => verify(args).await,
+    }
+}
+
+async fn seed(args: SeedArgs) -> anyhow::Result<()> {
+    anyhow::ensure!(args.message_count > 0, "message-count must be positive");
+    anyhow::ensure!(args.message_size >= 64, "message-size must be at least 64 bytes");
+    anyhow::ensure!(!args.run_id.trim().is_empty(), "run-id must not be empty");
+    prepare_output(&args.ledger)?;
+    prepare_output(&args.ambiguous_ledger)?;
+
+    let runtime = QualificationRuntime::create()?;
+    let mut producer_builder = DefaultMQProducer::builder(Arc::clone(&runtime.client))
+        .producer_group(format!("rpo-seed-{}", args.run_id))
+        .name_server_addr(args.connection.namesrv.clone());
+    if let Some(hook) = acl_hook() {
+        producer_builder = producer_builder.rpc_hook(hook);
+    }
+    let mut producer = producer_builder.build();
+    let consumer = build_query_consumer(Arc::clone(&runtime.client), &args.connection, &args.run_id)?;
+    producer.start().await.context("start qualification producer")?;
+    consumer.start().await.context("start qualification query client")?;
+
+    let ledger_file = File::create(&args.ledger).context("create PutOk ledger")?;
+    let ambiguous_file = File::create(&args.ambiguous_ledger).context("create ambiguous-send ledger")?;
+    let mut ledger = BufWriter::new(ledger_file);
+    let mut ambiguous = BufWriter::new(ambiguous_file);
+    let mut sequence = 0_usize;
+    let maximum_attempts = args.message_count.saturating_mul(3);
+    let mut put_ok_count = 0_usize;
+
+    while put_ok_count < args.message_count && sequence < maximum_attempts {
+        let (audit_id, unique_key, body) = message_identity(&args.run_id, sequence, args.message_size);
+        let message = Message::builder()
+            .topic(args.connection.topic.as_str())
+            .keys(vec![unique_key.clone()])
+            .body_slice(&body)
+            .build()?;
+        match producer
+            .send_with_timeout(message, args.connection.timeout_millis)
+            .await
+        {
+            Ok(Some(result)) if result.send_status == SendStatus::SendOk => {
+                let offset_message_id = result
+                    .offset_msg_id
+                    .clone()
+                    .context("PutOk result did not contain an offset message ID")?;
+                let stored = wait_for_stored_message(
+                    &consumer,
+                    &args.connection.topic,
+                    &offset_message_id,
+                    args.connection.timeout_millis,
+                )
+                .await?;
+                let decoded = decode_message_id(&offset_message_id)
+                    .map_err(anyhow::Error::msg)
+                    .context("decode offset message ID")?;
+                let commit_log_offset = u64::try_from(decoded.offset).context("negative CommitLog offset")?;
+                let store_size = u64::try_from(stored.store_size()).context("negative store size")?;
+                let queue = result
+                    .message_queue
+                    .context("PutOk result did not contain a message queue")?;
+                let entry = PutOkLedgerEntry {
+                    sequence,
+                    audit_id,
+                    unique_key,
+                    broker_message_id: result.msg_id.map_or_else(String::new, |value| value.to_string()),
+                    offset_message_id,
+                    broker_name: queue.broker_name().to_string(),
+                    queue_id: queue.queue_id(),
+                    queue_offset: result.queue_offset,
+                    commit_log_offset,
+                    store_size,
+                    end_offset: commit_log_offset.saturating_add(store_size),
+                    payload_sha256: sha256(&body),
+                    put_ok_at_utc: utc_now(),
+                };
+                append_json_line(&mut ledger, &entry)?;
+                ledger.flush().context("flush PutOk ledger entry")?;
+                put_ok_count += 1;
+            }
+            outcome => {
+                let outcome = match outcome {
+                    Ok(Some(result)) => format!("response:{}", result.send_status),
+                    Ok(None) => "unknown:no-send-result".to_string(),
+                    Err(error) => format!("unknown:{error}"),
+                };
+                append_json_line(
+                    &mut ambiguous,
+                    &AmbiguousSend {
+                        sequence,
+                        audit_id,
+                        unique_key,
+                        observed_at_utc: utc_now(),
+                        outcome,
+                    },
+                )?;
+                ambiguous.flush().context("flush ambiguous-send entry")?;
+            }
+        }
+        sequence += 1;
+    }
+
+    ledger.flush().context("flush PutOk ledger")?;
+    ledger.get_ref().sync_all().context("fsync PutOk ledger")?;
+    ambiguous.flush().context("flush ambiguous-send ledger")?;
+    ambiguous.get_ref().sync_all().context("fsync ambiguous-send ledger")?;
+    producer.shutdown().await;
+    consumer.shutdown().await;
+    runtime.shutdown().await?;
+    anyhow::ensure!(
+        put_ok_count == args.message_count,
+        "only {put_ok_count} of {} required PutOk messages were recorded in {maximum_attempts} attempts",
+        args.message_count
+    );
+    println!("put_ok_count={put_ok_count} attempts={sequence}");
+    Ok(())
+}
+
+async fn verify(args: VerifyArgs) -> anyhow::Result<()> {
+    let expected = read_ledger(&args.ledger)?;
+    anyhow::ensure!(!expected.is_empty(), "PutOk ledger is empty");
+    prepare_output(&args.observations)?;
+    let runtime = QualificationRuntime::create()?;
+    let consumer = build_query_consumer(Arc::clone(&runtime.client), &args.connection, "verify")?;
+    consumer.start().await.context("start qualification query client")?;
+    let file = File::create(&args.observations).context("create recovery observations")?;
+    let mut output = BufWriter::new(file);
+    let mut observations = 0_usize;
+
+    for entry in expected.values() {
+        let result = consumer
+            .query_message(&args.connection.topic, &entry.unique_key, 16, 0, u64::MAX)
+            .await;
+        let Ok(result) = result else {
+            continue;
+        };
+        for message in result.message_list() {
+            if !message_has_key(message, &entry.unique_key) {
+                continue;
+            }
+            let commit_log_offset = u64::try_from(message.commit_log_offset()).unwrap_or_default();
+            let store_size = u64::try_from(message.store_size()).unwrap_or_default();
+            let body = message.body().unwrap_or_default();
+            append_json_line(
+                &mut output,
+                &RecoveryObservation {
+                    audit_id: entry.audit_id.clone(),
+                    unique_key: entry.unique_key.clone(),
+                    broker_name: message.broker_name().to_string(),
+                    queue_id: message.queue_id(),
+                    queue_offset: u64::try_from(message.queue_offset()).unwrap_or_default(),
+                    commit_log_offset,
+                    store_size,
+                    end_offset: commit_log_offset.saturating_add(store_size),
+                    payload_sha256: sha256(body.as_ref()),
+                },
+            )?;
+            observations += 1;
+        }
+    }
+    output.flush().context("flush recovery observations")?;
+    output.get_ref().sync_all().context("fsync recovery observations")?;
+    consumer.shutdown().await;
+    runtime.shutdown().await?;
+    println!("expected={} observations={observations}", expected.len());
+    Ok(())
+}
+
+fn build_query_consumer(
+    runtime: Arc<ClientRuntime>,
+    connection: &ConnectionArgs,
+    suffix: &str,
+) -> anyhow::Result<DefaultLitePullConsumer> {
+    let mut builder = DefaultLitePullConsumer::builder(runtime)
+        .consumer_group(format!("rpo-query-{suffix}"))
+        .name_server_addr(connection.namesrv.clone())
+        .consume_from_where(ConsumeFromWhere::ConsumeFromFirstOffset)
+        .auto_commit(false);
+    if let Some(hook) = acl_hook() {
+        builder = builder.rpc_hook(hook);
+    }
+    builder.build().context("build qualification query client")
+}
+
+fn acl_hook() -> Option<Arc<AclClientRPCHook>> {
+    let access_key = std::env::var("ROCKETMQ_ACL_ACCESS_KEY").ok()?;
+    let secret_key = std::env::var("ROCKETMQ_ACL_SECRET_KEY").ok()?;
+    Some(Arc::new(AclClientRPCHook::new(SessionCredentials::with_keys(
+        access_key, secret_key,
+    ))))
+}
+
+async fn wait_for_stored_message(
+    consumer: &DefaultLitePullConsumer,
+    topic: &str,
+    offset_message_id: &str,
+    timeout_millis: u64,
+) -> anyhow::Result<MessageExt> {
+    let deadline = tokio::time::Instant::now() + Duration::from_millis(timeout_millis.max(1_000));
+    loop {
+        match consumer.view_message(topic, offset_message_id).await {
+            Ok(message) => return Ok(message),
+            Err(error) if tokio::time::Instant::now() < deadline => {
+                tracing::debug!(error = %error, "waiting for PutOk message visibility");
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            Err(error) => return Err(error).context("query PutOk message before ledger append"),
+        }
+    }
+}
+
+fn message_identity(run_id: &str, sequence: usize, size: usize) -> (String, String, Vec<u8>) {
+    let audit_id = format!("{run_id}-{sequence:012}");
+    let unique_key = format!("rpo-{audit_id}");
+    let prefix = format!("{audit_id}|");
+    let mut body = Vec::with_capacity(size);
+    while body.len() < size {
+        body.extend_from_slice(prefix.as_bytes());
+    }
+    body.truncate(size);
+    (audit_id, unique_key, body)
+}
+
+fn message_has_key(message: &MessageExt, expected: &str) -> bool {
+    message
+        .message_inner()
+        .keys()
+        .is_some_and(|keys| keys.iter().any(|key| key == expected))
+}
+
+fn read_ledger(path: &Path) -> anyhow::Result<HashMap<String, PutOkLedgerEntry>> {
+    let file = File::open(path).context("open PutOk ledger")?;
+    let mut result = HashMap::new();
+    for line in BufReader::new(file).lines() {
+        let entry: PutOkLedgerEntry =
+            serde_json::from_str(&line.context("read PutOk ledger line")?).context("decode PutOk ledger line")?;
+        anyhow::ensure!(
+            result.insert(entry.audit_id.clone(), entry).is_none(),
+            "PutOk ledger contains duplicate audit IDs"
+        );
+    }
+    Ok(result)
+}
+
+fn prepare_output(path: &Path) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).context("create evidence output directory")?;
+    }
+    anyhow::ensure!(!path.exists(), "refusing to overwrite evidence: {}", path.display());
+    Ok(())
+}
+
+fn append_json_line(writer: &mut BufWriter<File>, value: &impl Serialize) -> anyhow::Result<()> {
+    serde_json::to_writer(&mut *writer, value).context("encode evidence entry")?;
+    writer.write_all(b"\n").context("write evidence delimiter")
+}
+
+fn sha256(value: &[u8]) -> String {
+    format!("sha256:{}", hex::encode(Sha256::digest(value)))
+}
+
+fn utc_now() -> String {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    format!("{millis}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn message_identity_is_deterministic_and_bounded() {
+        let first = message_identity("run-a", 7, 128);
+        let second = message_identity("run-a", 7, 128);
+        assert_eq!(first, second);
+        assert_eq!(first.2.len(), 128);
+        assert!(first.1.contains(&first.0));
+    }
+
+    #[test]
+    fn ledger_entry_round_trips_without_message_body() {
+        let entry = PutOkLedgerEntry {
+            sequence: 1,
+            audit_id: "audit-1".to_string(),
+            unique_key: "key-1".to_string(),
+            broker_message_id: "message-1".to_string(),
+            offset_message_id: "offset-1".to_string(),
+            broker_name: "broker-a".to_string(),
+            queue_id: 0,
+            queue_offset: 1,
+            commit_log_offset: 100,
+            store_size: 64,
+            end_offset: 164,
+            payload_sha256: format!("sha256:{}", "a".repeat(64)),
+            put_ok_at_utc: "1".to_string(),
+        };
+        let json = serde_json::to_string(&entry).expect("encode ledger entry");
+        assert!(!json.contains("message body"));
+        assert_eq!(entry, serde_json::from_str(&json).expect("decode ledger entry"));
+    }
+}

--- a/rocketmq-controller/src/lib.rs
+++ b/rocketmq-controller/src/lib.rs
@@ -144,6 +144,7 @@ pub use qualification::ConfirmOffsetAuditReport;
 pub use qualification::ConfirmOffsetViolation;
 pub use qualification::ConfirmOffsetViolationKind;
 pub use qualification::DurabilityEvidence;
+pub use qualification::FailoverEvidenceBinding;
 pub use qualification::FailoverMilestone;
 pub use qualification::FailoverMilestoneRecord;
 pub use qualification::FailoverQualificationReport;

--- a/rocketmq-controller/src/qualification.rs
+++ b/rocketmq-controller/src/qualification.rs
@@ -461,6 +461,48 @@ pub struct DurabilityEvidence {
     pub clean_election: bool,
 }
 
+/// Immutable identities that bind one failover report to its source ledger and deployment.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FailoverEvidenceBinding {
+    pub run_id: String,
+    pub candidate_commit: String,
+    pub target: String,
+    pub effective_config_sha256: String,
+    pub durability_contract: String,
+    pub ledger_sha256: String,
+}
+
+impl FailoverEvidenceBinding {
+    fn rejection_reasons(&self) -> Vec<String> {
+        let mut reasons = Vec::new();
+        if self.run_id.is_empty()
+            || self.run_id.len() > 128
+            || !self
+                .run_id
+                .bytes()
+                .all(|value| value.is_ascii_alphanumeric() || matches!(value, b'-' | b'_' | b'.'))
+        {
+            reasons.push("run identity is missing or invalid".to_string());
+        }
+        if !is_lower_hex(&self.candidate_commit, 40) || self.candidate_commit.bytes().all(|value| value == b'0') {
+            reasons.push("candidate commit is not a non-zero full Git SHA".to_string());
+        }
+        if self.target.trim().is_empty() {
+            reasons.push("target identity is missing".to_string());
+        }
+        if !is_sha256(&self.effective_config_sha256) {
+            reasons.push("effective configuration digest is invalid".to_string());
+        }
+        if self.durability_contract != "strict-sync-required-ack-clean-election" {
+            reasons.push("durability contract is not the strict failover contract".to_string());
+        }
+        if !is_sha256(&self.ledger_sha256) {
+            reasons.push("PutOk ledger digest is invalid".to_string());
+        }
+        reasons
+    }
+}
+
 impl DurabilityEvidence {
     /// Returns whether the run was configured to make a strict RPO=0 claim meaningful.
     #[must_use]
@@ -475,6 +517,8 @@ pub struct FailoverQualificationReport {
     pub schema_version: u32,
     pub artifact_kind: String,
     pub scenario: String,
+    pub status: String,
+    pub binding: FailoverEvidenceBinding,
     pub durability: DurabilityEvidence,
     pub timeline: FailoverTimelineSnapshot,
     pub put_ok_messages: PutOkMessageAuditReport,
@@ -488,6 +532,7 @@ impl FailoverQualificationReport {
     #[must_use]
     pub fn new(
         scenario: impl Into<String>,
+        binding: FailoverEvidenceBinding,
         durability: DurabilityEvidence,
         timeline: FailoverTimelineSnapshot,
         put_ok_messages: PutOkMessageAuditReport,
@@ -515,11 +560,14 @@ impl FailoverQualificationReport {
         if confirm_offset.observations == 0 {
             rejection_reasons.push("no confirmOffset observations were recorded".to_string());
         }
+        rejection_reasons.extend(binding.rejection_reasons());
         let strict_qualification_passed = rejection_reasons.is_empty();
         Self {
             schema_version: 1,
             artifact_kind: "controller_failover_qualification_evidence".to_string(),
             scenario: scenario.into(),
+            status: if strict_qualification_passed { "pass" } else { "fail" }.to_string(),
+            binding,
             durability,
             timeline,
             put_ok_messages,
@@ -537,6 +585,19 @@ impl FailoverQualificationReport {
     pub fn to_pretty_json(&self) -> serde_json::Result<String> {
         serde_json::to_string_pretty(self)
     }
+}
+
+fn is_lower_hex(value: &str, length: usize) -> bool {
+    value.len() == length
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn is_sha256(value: &str) -> bool {
+    value
+        .strip_prefix("sha256:")
+        .is_some_and(|digest| is_lower_hex(digest, 64))
 }
 
 /// Errors caused by invalid qualification input or event ordering.

--- a/rocketmq-controller/tests/controller_failover_slo.rs
+++ b/rocketmq-controller/tests/controller_failover_slo.rs
@@ -19,6 +19,7 @@ use std::time::Duration;
 use rocketmq_controller::ConfirmOffsetAudit;
 use rocketmq_controller::ConfirmOffsetViolationKind;
 use rocketmq_controller::DurabilityEvidence;
+use rocketmq_controller::FailoverEvidenceBinding;
 use rocketmq_controller::FailoverMilestone;
 use rocketmq_controller::FailoverQualificationReport;
 use rocketmq_controller::FailoverTimeline;
@@ -39,6 +40,17 @@ fn complete_timeline() -> FailoverTimeline {
             .expect("record ordered milestone");
     }
     timeline
+}
+
+fn evidence_binding() -> FailoverEvidenceBinding {
+    FailoverEvidenceBinding {
+        run_id: "clean-failover-1".to_string(),
+        candidate_commit: "a".repeat(40),
+        target: "kind/rocketmq-system".to_string(),
+        effective_config_sha256: format!("sha256:{}", "b".repeat(64)),
+        durability_contract: "strict-sync-required-ack-clean-election".to_string(),
+        ledger_sha256: format!("sha256:{}", "c".repeat(64)),
+    }
 }
 
 #[test]
@@ -150,6 +162,7 @@ fn strict_report_requires_complete_timeline_durability_and_exact_recovery() {
 
     let report = FailoverQualificationReport::new(
         "clean-master-kill",
+        evidence_binding(),
         DurabilityEvidence {
             synchronous_local_flush: true,
             required_replica_acks: true,
@@ -172,6 +185,7 @@ fn strict_report_requires_complete_timeline_durability_and_exact_recovery() {
 fn async_or_unclean_runs_cannot_be_reported_as_strict_rpo_zero() {
     let report = FailoverQualificationReport::new(
         "async-unclean-negative-control",
+        evidence_binding(),
         DurabilityEvidence {
             synchronous_local_flush: false,
             required_replica_acks: false,
@@ -212,6 +226,7 @@ fn strict_settings_do_not_hide_missing_messages_or_authority_violations() {
 
     let report = FailoverQualificationReport::new(
         "strict-negative-control",
+        evidence_binding(),
         DurabilityEvidence {
             synchronous_local_flush: true,
             required_replica_acks: true,
@@ -233,4 +248,35 @@ fn strict_settings_do_not_hide_missing_messages_or_authority_violations() {
         .rejection_reasons
         .iter()
         .any(|reason| reason.contains("confirmOffset violated")));
+}
+
+#[test]
+fn strict_report_rejects_unbound_or_mismatched_evidence() {
+    let mut message_audit = PutOkMessageAudit::default();
+    message_audit.record_put_ok("message-a", 100).expect("record message");
+    message_audit.observe_recovered("message-a", 100);
+    let mut confirm_audit = ConfirmOffsetAudit::default();
+    confirm_audit.observe(1, 100, 100);
+    let mut binding = evidence_binding();
+    binding.ledger_sha256 = "sha256:not-a-digest".to_string();
+
+    let report = FailoverQualificationReport::new(
+        "invalid-binding",
+        binding,
+        DurabilityEvidence {
+            synchronous_local_flush: true,
+            required_replica_acks: true,
+            clean_election: true,
+        },
+        complete_timeline().snapshot(),
+        message_audit.report(),
+        confirm_audit.report(),
+    );
+
+    assert_eq!(report.status, "fail");
+    assert!(!report.strict_qualification_passed);
+    assert!(report
+        .rejection_reasons
+        .iter()
+        .any(|reason| reason.contains("ledger digest")));
 }

--- a/scripts/kubernetes_assets_guard.py
+++ b/scripts/kubernetes_assets_guard.py
@@ -485,6 +485,26 @@ def validate_source_assets(guard: Guard) -> None:
         "deploymentProfile: production-controller-ha" in production_values,
         "production Helm profile selection drifted",
     )
+    strict_durability = (
+        "flushDiskType: SYNC_FLUSH",
+        "totalReplicas: 3",
+        "inSyncReplicas: 3",
+        "minInSyncReplicas: 2",
+        "allAckInSyncStateSet: true",
+        "slaveTimeoutMillis: 3000",
+        "maxSlaveLagMillis: 15000",
+        "cleanElection: true",
+    )
+    for snippet in strict_durability:
+        guard.require(snippet in values, f"default Controller HA durability contract missing {snippet}")
+        guard.require(snippet in production_values, f"production Controller HA durability contract missing {snippet}")
+    for snippet in (
+        "flushDiskType = {{ $.Values.services.broker.durability.flushDiskType | quote }}",
+        "allAckInSyncStateSet = {{ $.Values.services.broker.durability.allAckInSyncStateSet }}",
+        "enableAutoInSyncReplicas = false",
+        "enableElectUncleanMaster = false",
+    ):
+        guard.require(snippet in controller_config_template, f"strict HA rendered configuration missing {snippet}")
     for service in EXPECTED_SERVICES:
         repository = f"repository: rocketmq-rust/{service}"
         guard.require(repository in values, f"default Helm local repository missing for {service}")

--- a/scripts/message_path_qualification.py
+++ b/scripts/message_path_qualification.py
@@ -783,6 +783,27 @@ def validate_final_evidence(
     ):
         if rpo.get(key) != expected:
             findings.append(f"RPO evidence {key} differs")
+    if not DIGEST_RE.fullmatch(str(rpo.get("ledger_sha256", ""))):
+        findings.append("RPO evidence does not bind a PutOk ledger digest")
+    messages = rpo.get("put_ok_messages", {})
+    if messages.get("put_ok_count", 0) < 10_000 or messages.get("recovered_once_count") != messages.get("put_ok_count"):
+        findings.append("RPO evidence did not recover at least 10,000 PutOk messages")
+    for key in (
+        "missing_count",
+        "duplicate_count",
+        "unexpected_count",
+        "payload_mismatch_count",
+        "offset_mismatch_count",
+    ):
+        if messages.get(key) != 0:
+            findings.append(f"RPO evidence {key} must be zero")
+    if messages.get("rpo_zero") is not True or messages.get("exact_recovery") is not True:
+        findings.append("RPO evidence did not prove exact RPO=0 recovery")
+    confirm = rpo.get("confirm_offset", {})
+    if confirm.get("valid") is not True or confirm.get("observations", 0) <= 0 or confirm.get("violation_count") != 0:
+        findings.append("RPO confirmOffset evidence is missing or invalid")
+    if rpo.get("repetitions", 0) < 5:
+        findings.append("RPO evidence contains fewer than five clean failovers")
 
     if soak.get("schema_version") != 1 or soak.get("artifact_kind") != "rocketmq_message_path_soak_report":
         findings.append("soak report contract is invalid")

--- a/scripts/put_ok_rpo_audit.py
+++ b/scripts/put_ok_rpo_audit.py
@@ -1,0 +1,307 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Validate commit-bound, per-message PutOk evidence after clean failover."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+STRICT_CONTRACT = "strict-sync-required-ack-clean-election"
+MILESTONES = [
+    "fault_injected",
+    "controller_leader_elected",
+    "broker_master_elected",
+    "store_write_authority_granted",
+    "route_converged",
+    "producer_recovered",
+]
+
+
+class AuditError(RuntimeError):
+    """Raised when evidence cannot safely be qualified."""
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def read_ndjson(path: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8") as stream:
+        for line_number, line in enumerate(stream, 1):
+            if not line.strip():
+                continue
+            value = json.loads(line)
+            if not isinstance(value, dict):
+                raise AuditError(f"{path}:{line_number} must contain a JSON object")
+            records.append(value)
+    return records
+
+
+def load_json(path: Path) -> Any:
+    with path.open(encoding="utf-8") as stream:
+        return json.load(stream)
+
+
+def validate_identity(args: argparse.Namespace, findings: list[str]) -> None:
+    for name in ("candidate_commit",):
+        value = getattr(args, name)
+        if not SHA_RE.fullmatch(value) or set(value) == {"0"}:
+            findings.append(f"{name} must be a non-zero full Git SHA")
+    for name in ("deployment_digest", "effective_config_sha256"):
+        if not DIGEST_RE.fullmatch(getattr(args, name)):
+            findings.append(f"{name} must be a SHA-256 digest")
+    if args.durability_contract != STRICT_CONTRACT:
+        findings.append("durability contract is not the strict clean-election contract")
+    for name in ("run_id", "target_id", "cluster_uid"):
+        if not str(getattr(args, name)).strip():
+            findings.append(f"{name} must not be empty")
+
+
+def validate_ledger(records: list[dict[str, Any]], minimum: int, findings: list[str]) -> dict[str, dict[str, Any]]:
+    required = {
+        "sequence",
+        "audit_id",
+        "unique_key",
+        "broker_message_id",
+        "offset_message_id",
+        "broker_name",
+        "queue_id",
+        "queue_offset",
+        "commit_log_offset",
+        "store_size",
+        "end_offset",
+        "payload_sha256",
+        "put_ok_at_utc",
+    }
+    if len(records) < minimum:
+        findings.append(f"PutOk ledger contains {len(records)} messages; at least {minimum} are required")
+    indexed: dict[str, dict[str, Any]] = {}
+    sequences: set[int] = set()
+    for index, entry in enumerate(records):
+        missing = required - entry.keys()
+        if missing:
+            findings.append(f"ledger entry {index} is missing {sorted(missing)}")
+            continue
+        audit_id = str(entry["audit_id"])
+        if not audit_id or audit_id in indexed:
+            findings.append(f"ledger audit_id is empty or duplicated: {audit_id!r}")
+        else:
+            indexed[audit_id] = entry
+        sequence = entry["sequence"]
+        if not isinstance(sequence, int) or sequence < 0 or sequence in sequences:
+            findings.append(f"ledger sequence is invalid or duplicated: {sequence!r}")
+        else:
+            sequences.add(sequence)
+        if not DIGEST_RE.fullmatch(str(entry["payload_sha256"])):
+            findings.append(f"ledger entry {audit_id!r} has an invalid payload digest")
+        for field in ("queue_id", "queue_offset", "commit_log_offset", "store_size", "end_offset"):
+            if not isinstance(entry[field], int) or entry[field] < 0:
+                findings.append(f"ledger entry {audit_id!r} has invalid {field}")
+        if isinstance(entry["commit_log_offset"], int) and isinstance(entry["store_size"], int):
+            if entry["end_offset"] != entry["commit_log_offset"] + entry["store_size"]:
+                findings.append(f"ledger entry {audit_id!r} has an inconsistent end_offset")
+    return indexed
+
+
+def validate_observations(
+    expected: dict[str, dict[str, Any]],
+    observation_paths: list[Path],
+    findings: list[str],
+) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    mismatches = {"payload": 0, "offset": 0}
+    for path in observation_paths:
+        for observed in read_ndjson(path):
+            audit_id = str(observed.get("audit_id", ""))
+            counts[audit_id] += 1
+            source = expected.get(audit_id)
+            if source is None:
+                continue
+            if observed.get("payload_sha256") != source.get("payload_sha256"):
+                mismatches["payload"] += 1
+            comparable = ("broker_name", "queue_id", "queue_offset", "commit_log_offset", "store_size", "end_offset")
+            if any(observed.get(field) != source.get(field) for field in comparable):
+                mismatches["offset"] += 1
+    expected_observations = len(observation_paths)
+    missing = sum(max(0, expected_observations - counts[audit_id]) for audit_id in expected)
+    duplicate = sum(max(0, counts[audit_id] - expected_observations) for audit_id in expected)
+    unexpected = sum(count for audit_id, count in counts.items() if audit_id not in expected)
+    if missing:
+        findings.append(f"{missing} PutOk messages were not recovered")
+    if duplicate:
+        findings.append(f"{duplicate} duplicate recovery observations were recorded")
+    if unexpected:
+        findings.append(f"{unexpected} unexpected messages were recovered")
+    if mismatches["payload"]:
+        findings.append(f"{mismatches['payload']} payload hashes differ")
+    if mismatches["offset"]:
+        findings.append(f"{mismatches['offset']} storage positions differ")
+    return {
+        "put_ok_count": len(expected),
+        "recovered_once_count": sum(1 for audit_id in expected if counts[audit_id] == expected_observations),
+        "missing_count": missing,
+        "duplicate_count": duplicate,
+        "unexpected_count": unexpected,
+        "payload_mismatch_count": mismatches["payload"],
+        "offset_mismatch_count": mismatches["offset"],
+    }
+
+
+def validate_timelines(path: Path, repetitions: int, max_rto_ms: int, findings: list[str]) -> list[dict[str, Any]]:
+    timelines = load_json(path)
+    if not isinstance(timelines, list) or len(timelines) < repetitions:
+        findings.append(f"at least {repetitions} failover timelines are required")
+        return []
+    for index, timeline in enumerate(timelines):
+        records = timeline.get("milestones", []) if isinstance(timeline, dict) else []
+        names = [record.get("milestone") for record in records if isinstance(record, dict)]
+        elapsed = [record.get("elapsed_millis") for record in records if isinstance(record, dict)]
+        if names != MILESTONES or len(elapsed) != len(MILESTONES):
+            findings.append(f"timeline {index} does not contain ordered T0-T5 milestones")
+            continue
+        if any(not isinstance(value, int) or value < 0 for value in elapsed) or elapsed != sorted(elapsed):
+            findings.append(f"timeline {index} contains invalid or regressing times")
+        elif elapsed[-1] > max_rto_ms:
+            findings.append(f"timeline {index} exceeds the {max_rto_ms}ms RTO limit")
+        if timeline.get("single_writable_master") is not True:
+            findings.append(f"timeline {index} did not prove a single writable master")
+    return timelines
+
+
+def validate_confirm_offsets(path: Path, findings: list[str]) -> dict[str, Any]:
+    observations = read_ndjson(path)
+    previous_epoch: int | None = None
+    previous_confirm: int | None = None
+    violations = 0
+    for item in observations:
+        epoch = item.get("authority_epoch")
+        confirm = item.get("confirm_offset")
+        legal = item.get("legal_in_sync_ack_offset")
+        if not all(isinstance(value, int) and value >= 0 for value in (epoch, confirm, legal)):
+            violations += 1
+            continue
+        if previous_epoch is not None and epoch < previous_epoch:
+            violations += 1
+        if (previous_confirm is not None and confirm < previous_confirm) or confirm > legal:
+            violations += 1
+        previous_epoch = epoch
+        previous_confirm = confirm if previous_confirm is None else max(confirm, previous_confirm)
+    if not observations:
+        findings.append("confirmOffset audit has no observations")
+    if violations:
+        findings.append(f"confirmOffset audit contains {violations} boundary violations")
+    return {"observations": len(observations), "violation_count": violations, "valid": bool(observations) and violations == 0}
+
+
+def qualify(args: argparse.Namespace) -> dict[str, Any]:
+    findings: list[str] = []
+    validate_identity(args, findings)
+    ledger = read_ndjson(args.ledger)
+    expected = validate_ledger(ledger, args.minimum_messages, findings)
+    messages = validate_observations(expected, args.observations, findings)
+    timelines = validate_timelines(args.timelines, args.repetitions, args.max_rto_millis, findings)
+    confirm = validate_confirm_offsets(args.confirm_offsets, findings)
+    ledger_digest = sha256_file(args.ledger)
+    strict = not findings
+    return {
+        "schema_version": 1,
+        "artifact_kind": "controller_failover_qualification_evidence",
+        "status": "pass" if strict else "fail",
+        "strict_qualification_passed": strict,
+        "run_id": args.run_id,
+        "candidate_commit": args.candidate_commit,
+        "deployment_digest": args.deployment_digest,
+        "target_id": args.target_id,
+        "cluster_uid": args.cluster_uid,
+        "effective_config_sha256": args.effective_config_sha256,
+        "durability_contract": args.durability_contract,
+        "ledger_sha256": ledger_digest,
+        "durability": {
+            "synchronous_local_flush": True,
+            "required_replica_acks": True,
+            "clean_election": True,
+        },
+        "repetitions": len(timelines),
+        "put_ok_messages": {
+            **messages,
+            "rpo_zero": messages["missing_count"] == 0,
+            "exact_recovery": all(messages[key] == 0 for key in (
+                "missing_count", "duplicate_count", "unexpected_count", "payload_mismatch_count", "offset_mismatch_count"
+            )),
+        },
+        "confirm_offset": confirm,
+        "timelines": timelines,
+        "artifacts": {
+            "ledger": {"path": str(args.ledger), "sha256": ledger_digest},
+            "observations": [
+                {"path": str(path), "sha256": sha256_file(path)} for path in args.observations
+            ],
+            "confirm_offsets": {"path": str(args.confirm_offsets), "sha256": sha256_file(args.confirm_offsets)},
+            "timelines": {"path": str(args.timelines), "sha256": sha256_file(args.timelines)},
+        },
+        "rejection_reasons": findings,
+    }
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("--ledger", type=Path, required=True)
+    result.add_argument("--observations", type=Path, action="append", required=True)
+    result.add_argument("--timelines", type=Path, required=True)
+    result.add_argument("--confirm-offsets", type=Path, required=True)
+    result.add_argument("--output", type=Path, required=True)
+    result.add_argument("--run-id", required=True)
+    result.add_argument("--candidate-commit", required=True)
+    result.add_argument("--deployment-digest", required=True)
+    result.add_argument("--target-id", required=True)
+    result.add_argument("--cluster-uid", required=True)
+    result.add_argument("--effective-config-sha256", required=True)
+    result.add_argument("--durability-contract", default=STRICT_CONTRACT)
+    result.add_argument("--minimum-messages", type=int, default=10_000)
+    result.add_argument("--repetitions", type=int, default=5)
+    result.add_argument("--max-rto-millis", type=int, default=180_000)
+    return result
+
+
+def main() -> int:
+    try:
+        args = parser().parse_args()
+        report = qualify(args)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        print(f"PutOk RPO audit {report['status']}: {args.output}")
+        return 0 if report["strict_qualification_passed"] else 1
+    except (AuditError, OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"PutOk RPO audit failed closed: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-put-ok-rpo-audit.ps1
+++ b/scripts/run-put-ok-rpo-audit.ps1
@@ -1,0 +1,313 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[CmdletBinding()]
+param(
+    [ValidateSet('Validate', 'Run')][string]$Mode = 'Validate',
+    [ValidateSet('kind', 'k3d')][string]$Backend = 'kind',
+    [string]$ClusterName = 'rocketmq-architecture-refactor',
+    [string]$Namespace = 'rocketmq-system',
+    [string]$CandidateCommit,
+    [string]$CandidateImageMap,
+    [string]$DeploymentDigest,
+    [string]$EffectiveConfigSha256,
+    [string]$TargetId,
+    [ValidateRange(10000, 1000000)][int]$MessageCount = 10000,
+    [ValidateRange(5, 50)][int]$Repetitions = 5,
+    [ValidateSet('strict-sync-required-ack-clean-election')]
+    [string]$DurabilityContract = 'strict-sync-required-ack-clean-election',
+    [string]$OutputRoot = 'target/message-path-rpo',
+    [switch]$KeepDriverPod
+)
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+$Root = Split-Path -Parent $PSScriptRoot
+$AuditScript = Join-Path $PSScriptRoot 'put_ok_rpo_audit.py'
+$HelperPath = Join-Path $PSScriptRoot 'kubernetes/live_faults.ps1'
+
+function Invoke-Native {
+    param([Parameter(Mandatory)][string]$Command, [Parameter(Mandatory)][string[]]$Arguments, [switch]$AllowFailure)
+    $output = & $Command @Arguments 2>&1 | Out-String
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0 -and -not $AllowFailure) {
+        throw "$Command $($Arguments -join ' ') failed with exit code $exitCode`n$output"
+    }
+    [pscustomobject]@{ ExitCode = $exitCode; Output = $output.TrimEnd() }
+}
+
+function Assert-True {
+    param([Parameter(Mandatory)][bool]$Condition, [Parameter(Mandatory)][string]$Message)
+    if (-not $Condition) { throw "PutOk RPO assertion failed: $Message" }
+}
+
+function Require-Command {
+    param([Parameter(Mandatory)][string]$Name)
+    Assert-True ($null -ne (Get-Command $Name -ErrorAction SilentlyContinue)) "required command '$Name' is unavailable"
+}
+
+function Get-ElapsedMilliseconds {
+    param([Parameter(Mandatory)][DateTimeOffset]$Started)
+    [int64]([DateTimeOffset]::UtcNow - $Started).TotalMilliseconds
+}
+
+function Invoke-Driver {
+    param([Parameter(Mandatory)][string[]]$Arguments, [switch]$AllowFailure)
+    Invoke-Native kubectl (@('-n', $Namespace, 'exec', $DriverPod, '--', '/usr/local/bin/controller-failover-qualification') + $Arguments) -AllowFailure:$AllowFailure
+}
+
+function Invoke-Admin {
+    param([Parameter(Mandatory)][string[]]$Arguments, [switch]$AllowFailure)
+    Invoke-Native kubectl (@('-n', $Namespace, 'exec', $DriverPod, '--', '/usr/local/bin/rocketmq-admin-cli') + $Arguments) -AllowFailure:$AllowFailure
+}
+
+function Wait-Admin {
+    param([Parameter(Mandatory)][scriptblock]$Probe, [ValidateRange(1, 600)][int]$TimeoutSeconds = 180)
+    $deadline = [DateTimeOffset]::UtcNow.AddSeconds($TimeoutSeconds)
+    do {
+        $result = & $Probe
+        if ($result.ExitCode -eq 0) { return $result }
+        Start-Sleep -Seconds 1
+    } while ([DateTimeOffset]::UtcNow -lt $deadline)
+    throw "administrative probe did not converge before ${TimeoutSeconds}s`n$($result.Output)"
+}
+
+function Get-BrokerRuntime {
+    param([Parameter(Mandatory)][string]$Pod)
+    $address = "$Pod.rocketmq-broker-headless.$Namespace.svc.cluster.local:10911"
+    $result = Invoke-Admin @('broker', 'brokerStatus', '-b', $address) -AllowFailure
+    if ($result.ExitCode -ne 0) { return $result }
+    foreach ($key in @('storeConfirmOffset', 'haLegalInSyncAckOffset', 'haMasterEpoch', 'storeWriteable')) {
+        Assert-True ($result.Output -match "(?m)^$key\s*:\s*\S+") "Broker runtime output is missing $key"
+    }
+    $result
+}
+
+function Add-ConfirmOffsetSample {
+    param([Parameter(Mandatory)][string]$Pod, [Parameter(Mandatory)][int]$Repetition, [Parameter(Mandatory)][string]$Moment)
+    $runtime = Wait-Admin { Get-BrokerRuntime -Pod $Pod }
+    $epoch = [regex]::Match($runtime.Output, '(?m)^haMasterEpoch\s*:\s*(\d+)').Groups[1].Value
+    $confirm = [regex]::Match($runtime.Output, '(?m)^storeConfirmOffset\s*:\s*(\d+)').Groups[1].Value
+    $legal = [regex]::Match($runtime.Output, '(?m)^haLegalInSyncAckOffset\s*:\s*(\d+)').Groups[1].Value
+    $record = [ordered]@{
+        repetition = $Repetition
+        moment = $Moment
+        authority_epoch = [uint64]$epoch
+        confirm_offset = [uint64]$confirm
+        legal_in_sync_ack_offset = [uint64]$legal
+        observed_at_utc = [DateTimeOffset]::UtcNow.ToString('o')
+    }
+    ($record | ConvertTo-Json -Compress) | Add-Content -LiteralPath $ConfirmPath -Encoding utf8
+    $runtime
+}
+
+function Wait-PodReplacement {
+    param([Parameter(Mandatory)][string]$Pod, [Parameter(Mandatory)][string]$OldUid)
+    $deadline = [DateTimeOffset]::UtcNow.AddSeconds(240)
+    do {
+        $state = Invoke-Native kubectl @('-n', $Namespace, 'get', 'pod', $Pod, '-o', 'json') -AllowFailure
+        if ($state.ExitCode -eq 0) {
+            $value = $state.Output | ConvertFrom-Json
+            $ready = @($value.status.conditions | Where-Object { $_.type -eq 'Ready' -and $_.status -eq 'True' }).Count -eq 1
+            if ($value.metadata.uid -ne $OldUid -and $ready) { return }
+        }
+        Start-Sleep -Seconds 2
+    } while ([DateTimeOffset]::UtcNow -lt $deadline)
+    throw "$Pod was not recreated and Ready before the deadline"
+}
+
+if (-not (Test-Path -LiteralPath $HelperPath -PathType Leaf)) { throw "live fault helper is missing: $HelperPath" }
+. $HelperPath -HelperMode Library
+
+if ($Mode -eq 'Validate') {
+    Require-Command python
+    Invoke-Native python @($AuditScript, '--help') | Out-Null
+    Write-Output 'PutOk RPO audit validation passed without dynamic execution.'
+    exit 0
+}
+
+foreach ($command in @('python', 'git', 'docker', 'kubectl', $Backend)) { Require-Command $command }
+Assert-True ($CandidateCommit -match '^[0-9a-f]{40}$') 'CandidateCommit must be a full lowercase Git SHA'
+Assert-True ($CandidateCommit -eq (Invoke-Native git @('-C', $Root, 'rev-parse', 'HEAD')).Output) 'CandidateCommit must equal checkout HEAD'
+Assert-True ($DeploymentDigest -match '^sha256:[0-9a-f]{64}$') 'DeploymentDigest must be a SHA-256 digest'
+Assert-True ($EffectiveConfigSha256 -match '^sha256:[0-9a-f]{64}$') 'EffectiveConfigSha256 must be a SHA-256 digest'
+Assert-True (Test-Path -LiteralPath $CandidateImageMap -PathType Leaf) 'CandidateImageMap is required'
+$images = Get-Content -Raw -LiteralPath $CandidateImageMap | ConvertFrom-Json -AsHashtable
+$expectedServices = @('broker', 'namesrv', 'controller', 'proxy', 'mcp')
+Assert-True ((@($images.Keys | Sort-Object) -join ',') -eq (@($expectedServices | Sort-Object) -join ',')) 'candidate image map must contain exactly five services'
+foreach ($service in $expectedServices) {
+    Assert-True ($images[$service] -match '^[^@\s]+@sha256:[0-9a-f]{64}$') "candidate $service image must be digest pinned"
+}
+
+$currentContext = (Invoke-Native kubectl @('config', 'current-context')).Output
+Assert-True ($currentContext -match [regex]::Escape($ClusterName)) 'kubectl context does not identify the requested cluster'
+$clusterUid = (Invoke-Native kubectl @('get', 'namespace', 'kube-system', '-o', 'jsonpath={.metadata.uid}')).Output
+if ([string]::IsNullOrWhiteSpace($TargetId)) { $TargetId = "$Backend/$ClusterName/$Namespace" }
+$runId = "put-ok-rpo-$([DateTimeOffset]::UtcNow.ToString('yyyyMMddTHHmmssZ'))"
+$outputBase = if ([IO.Path]::IsPathRooted($OutputRoot)) { $OutputRoot } else { Join-Path $Root $OutputRoot }
+$runDirectory = Join-Path ([IO.Path]::GetFullPath($outputBase)) $runId
+New-Item -ItemType Directory -Force -Path $runDirectory | Out-Null
+$LedgerPath = Join-Path $runDirectory 'put-ok-ledger.ndjson'
+$AmbiguousPath = Join-Path $runDirectory 'ambiguous-sends.ndjson'
+$ConfirmPath = Join-Path $runDirectory 'confirm-offsets.ndjson'
+$TimelinePath = Join-Path $runDirectory 'timelines.json'
+$ReportPath = Join-Path $runDirectory 'controller-failover-qualification.json'
+$DriverPod = "put-ok-rpo-$([Guid]::NewGuid().ToString('N').Substring(0, 10))"
+$driverImage = "rocketmq-rust/qualification-driver:$runId"
+$namesrv = "rocketmq-namesrv-discovery.$Namespace.svc.cluster.local:9876"
+$topic = "PutOkRpo$($runId.Replace('-', ''))"
+$podCreated = $false
+
+try {
+    foreach ($service in $expectedServices) {
+        $kind = if ($service -in @('proxy', 'mcp')) { 'deployment' } else { 'statefulset' }
+        $actualImage = (Invoke-Native kubectl @(
+            '-n', $Namespace, 'get', "$kind/rocketmq-$service", '-o',
+            "jsonpath={.spec.template.spec.containers[?(@.name=='$service')].image}"
+        )).Output
+        Assert-True ($actualImage -eq $images[$service]) "live $service image is not the bound candidate digest"
+    }
+    $brokerWorkload = (Invoke-Native kubectl @('-n', $Namespace, 'get', 'statefulset/rocketmq-broker', '-o', 'json')).Output | ConvertFrom-Json
+    $liveConfigDigest = @(
+        $brokerWorkload.spec.template.spec.containers |
+            Where-Object { $_.name -eq 'broker' } |
+            ForEach-Object { $_.env } |
+            Where-Object { $_.name -eq 'ROCKETMQ_RELEASE_CONFIG_DIGEST' } |
+            ForEach-Object { $_.value }
+    )
+    Assert-True ($liveConfigDigest.Count -eq 1 -and $liveConfigDigest[0] -eq $EffectiveConfigSha256) 'live Broker configuration digest differs from evidence binding'
+    $brokerConfig = (Invoke-Native kubectl @('-n', $Namespace, 'get', 'configmap', 'rocketmq-broker-config', '-o', 'json')).Output | ConvertFrom-Json
+    $brokerConfigText = ($brokerConfig.data.PSObject.Properties.Value | Out-String)
+    foreach ($required in @(
+        'flushDiskType = "SYNC_FLUSH"', 'totalReplicas = 3', 'inSyncReplicas = 3',
+        'minInSyncReplicas = 2', 'allAckInSyncStateSet = true', 'slaveTimeout = 3000',
+        'haMaxTimeSlaveNotCatchup = 15000'
+    )) {
+        Assert-True ($brokerConfigText.Contains($required)) "live Broker configuration is missing strict setting: $required"
+    }
+    $controllerConfig = (Invoke-Native kubectl @('-n', $Namespace, 'get', 'configmap', 'rocketmq-controller-config', '-o', 'json')).Output | ConvertFrom-Json
+    Assert-True ((($controllerConfig.data.PSObject.Properties.Value | Out-String) -match 'enableElectUncleanMaster = false')) 'Controller unclean election must be disabled'
+
+    Invoke-Native docker @(
+        'build', '--file', (Join-Path $Root 'docker/Dockerfile.base'), '--target', 'qualification-driver',
+        '--build-arg', "SOURCE_REVISION=$CandidateCommit", '--tag', $driverImage, $Root
+    ) | Out-Null
+    if ($Backend -eq 'kind') {
+        Invoke-Native kind @('load', 'docker-image', $driverImage, '--name', $ClusterName) | Out-Null
+    } else {
+        Invoke-Native k3d @('image', 'import', $driverImage, '--cluster', $ClusterName) | Out-Null
+    }
+
+    $manifest = @"
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $DriverPod
+  namespace: $Namespace
+  labels: { app.kubernetes.io/name: put-ok-rpo-driver }
+spec:
+  restartPolicy: Never
+  automountServiceAccountToken: false
+  securityContext: { runAsNonRoot: true, runAsUser: 10001, runAsGroup: 10001, seccompProfile: { type: RuntimeDefault } }
+  containers:
+    - name: driver
+      image: $driverImage
+      imagePullPolicy: Never
+      command: ["/bin/sh", "-c", "sleep 86400"]
+      envFrom: [{ secretRef: { name: rocketmq-fault-driver-baseline } }]
+      securityContext: { allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: { drop: ["ALL"] } }
+      volumeMounts: [{ name: evidence, mountPath: /evidence }, { name: tmp, mountPath: /tmp }]
+  volumes:
+    - { name: evidence, emptyDir: { sizeLimit: 256Mi } }
+    - { name: tmp, emptyDir: { sizeLimit: 32Mi } }
+"@
+    $manifestPath = Join-Path $runDirectory 'driver-pod.yaml'
+    [IO.File]::WriteAllText($manifestPath, $manifest, [Text.UTF8Encoding]::new($false))
+    Invoke-Native kubectl @('apply', '-f', $manifestPath) | Out-Null
+    $podCreated = $true
+    Invoke-Native kubectl @('-n', $Namespace, 'wait', "pod/$DriverPod", '--for=condition=Ready', '--timeout=180s') | Out-Null
+
+    $topicResult = Wait-Admin {
+        Invoke-Admin @('topic', 'updateTopic', '-c', 'RocketmqRust', '-t', $topic, '-r', '1', '-w', '1', '-p', '6', '-n', $namesrv) -AllowFailure
+    }
+    Assert-True ($topicResult.ExitCode -eq 0) 'dedicated RPO topic was not created'
+    Invoke-Driver @(
+        'seed', '--namesrv', $namesrv, '--topic', $topic, '--run-id', $runId,
+        '--message-count', "$MessageCount", '--ledger', '/evidence/put-ok-ledger.ndjson',
+        '--ambiguous-ledger', '/evidence/ambiguous-sends.ndjson'
+    ) | Out-Null
+    Invoke-Native kubectl @('-n', $Namespace, 'cp', "$DriverPod`:/evidence/put-ok-ledger.ndjson", $LedgerPath) | Out-Null
+    Invoke-Native kubectl @('-n', $Namespace, 'cp', "$DriverPod`:/evidence/ambiguous-sends.ndjson", $AmbiguousPath) | Out-Null
+
+    $timelines = [System.Collections.Generic.List[object]]::new()
+    $observationPaths = [System.Collections.Generic.List[string]]::new()
+    for ($repetition = 1; $repetition -le $Repetitions; $repetition++) {
+        $before = Wait-LiveSingleMaster -Namespace $Namespace
+        $oldMaster = $before.Master
+        $null = Add-ConfirmOffsetSample -Pod $oldMaster.Pod -Repetition $repetition -Moment 'before'
+        $started = [DateTimeOffset]::UtcNow
+        $milestones = [System.Collections.Generic.List[object]]::new()
+        $milestones.Add([ordered]@{ milestone = 'fault_injected'; elapsed_millis = 0 })
+        Invoke-Native kubectl @('-n', $Namespace, 'delete', 'pod', $oldMaster.Pod, '--wait=false') | Out-Null
+
+        $controllerAddress = "rocketmq-controller-0.rocketmq-controller-headless.$Namespace.svc.cluster.local:60109"
+        $null = Wait-Admin { Invoke-Admin @('controller', 'getControllerMetaData', '-a', $controllerAddress) -AllowFailure }
+        $milestones.Add([ordered]@{ milestone = 'controller_leader_elected'; elapsed_millis = Get-ElapsedMilliseconds $started })
+        $promoted = Wait-LiveSingleMaster -Namespace $Namespace -ExcludedPod $oldMaster.Pod -TimeoutSeconds 180
+        $milestones.Add([ordered]@{ milestone = 'broker_master_elected'; elapsed_millis = Get-ElapsedMilliseconds $started })
+        $writeAuthority = Wait-Admin { Get-BrokerRuntime -Pod $promoted.Master.Pod }
+        Assert-True ($writeAuthority.Output -match '(?m)^storeWriteable\s*:\s*true') 'promoted master did not obtain store write authority'
+        $milestones.Add([ordered]@{ milestone = 'store_write_authority_granted'; elapsed_millis = Get-ElapsedMilliseconds $started })
+        $null = Wait-Admin { Invoke-Admin @('topic', 'topicRoute', '-t', $topic, '-n', $namesrv) -AllowFailure }
+        $milestones.Add([ordered]@{ milestone = 'route_converged'; elapsed_millis = Get-ElapsedMilliseconds $started })
+        Invoke-Driver @(
+            'seed', '--namesrv', $namesrv, '--topic', $topic, '--run-id', "$runId-recovery-$repetition",
+            '--message-count', '1', '--ledger', "/evidence/recovery-$repetition.ndjson",
+            '--ambiguous-ledger', "/evidence/recovery-$repetition-ambiguous.ndjson"
+        ) | Out-Null
+        $milestones.Add([ordered]@{ milestone = 'producer_recovered'; elapsed_millis = Get-ElapsedMilliseconds $started })
+
+        $remoteObservation = "/evidence/observations-$repetition.ndjson"
+        Invoke-Driver @('verify', '--namesrv', $namesrv, '--topic', $topic, '--ledger', '/evidence/put-ok-ledger.ndjson', '--observations', $remoteObservation) | Out-Null
+        $observationPath = Join-Path $runDirectory "observations-$repetition.ndjson"
+        Invoke-Native kubectl @('-n', $Namespace, 'cp', "$DriverPod`:$remoteObservation", $observationPath) | Out-Null
+        $observationPaths.Add($observationPath)
+        $null = Add-ConfirmOffsetSample -Pod $promoted.Master.Pod -Repetition $repetition -Moment 'after'
+        $timelines.Add([ordered]@{
+            repetition = $repetition
+            old_master = $oldMaster.Pod
+            new_master = $promoted.Master.Pod
+            single_writable_master = $promoted.Snapshot.Masters.Count -eq 1
+            milestones = @($milestones)
+        })
+        Wait-PodReplacement -Pod $oldMaster.Pod -OldUid $oldMaster.Uid
+        $null = Wait-LiveSingleMaster -Namespace $Namespace
+    }
+    [IO.File]::WriteAllText($TimelinePath, ($timelines | ConvertTo-Json -Depth 8), [Text.UTF8Encoding]::new($false))
+
+    $auditArgs = @(
+        $AuditScript, '--ledger', $LedgerPath, '--timelines', $TimelinePath, '--confirm-offsets', $ConfirmPath,
+        '--output', $ReportPath, '--run-id', $runId, '--candidate-commit', $CandidateCommit,
+        '--deployment-digest', $DeploymentDigest, '--target-id', $TargetId, '--cluster-uid', $clusterUid,
+        '--effective-config-sha256', $EffectiveConfigSha256, '--durability-contract', $DurabilityContract,
+        '--minimum-messages', "$MessageCount", '--repetitions', "$Repetitions"
+    )
+    foreach ($path in $observationPaths) { $auditArgs += @('--observations', $path) }
+    Invoke-Native python $auditArgs | Out-Null
+    Write-Output "PutOk RPO qualification passed: $ReportPath"
+} finally {
+    if ($podCreated -and -not $KeepDriverPod) {
+        Invoke-Native kubectl @('-n', $Namespace, 'delete', 'pod', $DriverPod, '--ignore-not-found=true', '--wait=false') -AllowFailure | Out-Null
+    }
+}

--- a/scripts/tests/test_m11_kubernetes_assets.py
+++ b/scripts/tests/test_m11_kubernetes_assets.py
@@ -138,6 +138,15 @@ class KubernetesAssetsGuardTests(unittest.TestCase):
         result = self.run_guard(expect_success=False)
         self.assertIn("five-second Kubernetes recovery election window", result.stderr)
 
+    def test_strict_controller_ha_durability_regression_is_rejected(self) -> None:
+        self.mutate_text(
+            "distribution/helm/rocketmq-rust/values-production-controller-ha.yaml",
+            "flushDiskType: SYNC_FLUSH",
+            "flushDiskType: ASYNC_FLUSH",
+        )
+        result = self.run_guard(expect_success=False)
+        self.assertIn("durability contract", result.stderr)
+
     def test_controller_ordinal_config_path_regression_is_rejected(self) -> None:
         self.mutate_text(
             "distribution/kubernetes/base/manifest.yaml",

--- a/scripts/tests/test_message_path_qualification.py
+++ b/scripts/tests/test_message_path_qualification.py
@@ -339,6 +339,20 @@ class MessagePathQualificationTest(unittest.TestCase):
                 "cluster_uid": "cluster-a",
                 "effective_config_sha256": "sha256:" + "4" * 64,
                 "durability_contract": "strict",
+                "ledger_sha256": "sha256:" + "6" * 64,
+                "repetitions": 5,
+                "put_ok_messages": {
+                    "put_ok_count": 10000,
+                    "recovered_once_count": 10000,
+                    "missing_count": 0,
+                    "duplicate_count": 0,
+                    "unexpected_count": 0,
+                    "payload_mismatch_count": 0,
+                    "offset_mismatch_count": 0,
+                    "rpo_zero": True,
+                    "exact_recovery": True,
+                },
+                "confirm_offset": {"valid": True, "observations": 10, "violation_count": 0},
             }
             soak = {
                 "schema_version": 1,

--- a/scripts/tests/test_put_ok_rpo_audit.py
+++ b/scripts/tests/test_put_ok_rpo_audit.py
@@ -1,0 +1,116 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+import put_ok_rpo_audit as audit  # noqa: E402
+
+
+class PutOkRpoAuditTest(unittest.TestCase):
+    def write_ndjson(self, path: Path, records: list[dict]) -> None:
+        path.write_text("".join(json.dumps(record) + "\n" for record in records), encoding="utf-8")
+
+    def fixture(self, root: Path, count: int = 3) -> argparse.Namespace:
+        ledger = []
+        for sequence in range(count):
+            ledger.append({
+                "sequence": sequence,
+                "audit_id": f"audit-{sequence}",
+                "unique_key": f"key-{sequence}",
+                "broker_message_id": f"msg-{sequence}",
+                "offset_message_id": f"offset-{sequence}",
+                "broker_name": "rocketmq-broker",
+                "queue_id": 0,
+                "queue_offset": sequence,
+                "commit_log_offset": sequence * 100,
+                "store_size": 100,
+                "end_offset": (sequence + 1) * 100,
+                "payload_sha256": "sha256:" + f"{sequence + 1:x}" * 64,
+                "put_ok_at_utc": "2026-08-12T00:00:00Z",
+            })
+        ledger_path = root / "ledger.ndjson"
+        observed_path = root / "observed.ndjson"
+        confirm_path = root / "confirm.ndjson"
+        timelines_path = root / "timelines.json"
+        self.write_ndjson(ledger_path, ledger)
+        self.write_ndjson(observed_path, ledger)
+        self.write_ndjson(confirm_path, [{"authority_epoch": 1, "confirm_offset": 100, "legal_in_sync_ack_offset": 100}])
+        timelines_path.write_text(json.dumps([{
+            "single_writable_master": True,
+            "milestones": [
+                {"milestone": name, "elapsed_millis": index * 10}
+                for index, name in enumerate(audit.MILESTONES)
+            ],
+        }]), encoding="utf-8")
+        return argparse.Namespace(
+            ledger=ledger_path,
+            observations=[observed_path],
+            timelines=timelines_path,
+            confirm_offsets=confirm_path,
+            output=root / "report.json",
+            run_id="audit-run",
+            candidate_commit="a" * 40,
+            deployment_digest="sha256:" + "b" * 64,
+            target_id="kind-a",
+            cluster_uid="cluster-a",
+            effective_config_sha256="sha256:" + "c" * 64,
+            durability_contract=audit.STRICT_CONTRACT,
+            minimum_messages=count,
+            repetitions=1,
+            max_rto_millis=1_000,
+        )
+
+    def test_exact_recovery_passes_with_bound_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            report = audit.qualify(self.fixture(Path(temporary)))
+        self.assertEqual("pass", report["status"])
+        self.assertTrue(report["strict_qualification_passed"])
+        self.assertEqual(3, report["put_ok_messages"]["recovered_once_count"])
+
+    def test_missing_duplicate_and_payload_drift_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            args = self.fixture(Path(temporary))
+            records = audit.read_ndjson(args.observations[0])
+            records[0]["payload_sha256"] = "sha256:" + "f" * 64
+            self.write_ndjson(args.observations[0], [records[0], records[0], records[1]])
+            report = audit.qualify(args)
+        self.assertEqual("fail", report["status"])
+        self.assertEqual(1, report["put_ok_messages"]["missing_count"])
+        self.assertEqual(1, report["put_ok_messages"]["duplicate_count"])
+        self.assertGreater(report["put_ok_messages"]["payload_mismatch_count"], 0)
+
+    def test_bad_identity_timeline_and_confirm_boundary_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            args = self.fixture(Path(temporary))
+            args.candidate_commit = "not-a-commit"
+            timelines = json.loads(args.timelines.read_text(encoding="utf-8"))
+            timelines[0]["milestones"].reverse()
+            args.timelines.write_text(json.dumps(timelines), encoding="utf-8")
+            self.write_ndjson(args.confirm_offsets, [{"authority_epoch": 1, "confirm_offset": 101, "legal_in_sync_ack_offset": 100}])
+            report = audit.qualify(args)
+        self.assertFalse(report["strict_qualification_passed"])
+        self.assertTrue(any("candidate_commit" in reason for reason in report["rejection_reasons"]))
+        self.assertTrue(any("T0-T5" in reason for reason in report["rejection_reasons"]))
+        self.assertFalse(report["confirm_offset"]["valid"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9287

### Brief Description

- add a test-only qualification driver that records only acknowledged PutOk messages and verifies every message after clean Broker failover
- add a fail-closed RPO evidence analyzer with candidate, target, configuration, ledger, timeline, and confirm-offset bindings
- expose Broker confirm-offset diagnostics and render strict synchronous durability settings for Controller HA deployments
- add a reusable Kubernetes runner for 10,000 acknowledged messages across five live clean-master failovers
- deepen release qualification so incomplete, mismatched, duplicated, or corrupted RPO evidence cannot pass

DLedger remains explicitly out of scope. This qualification path exercises Controller-managed clean election only.

### How Did You Test This Change?

- `python -m unittest scripts.tests.test_message_path_qualification scripts.tests.test_put_ok_rpo_audit scripts.tests.test_m11_kubernetes_assets`
- `python scripts/kubernetes_assets_guard.py --root .`
- `python scripts/fault_matrix_guard.py --policy-only`
- `python scripts/message_path_qualification.py validate-policy`
- `pwsh -NoProfile -File ./scripts/run-put-ok-rpo-audit.ps1 -Mode Validate`
- `helm lint distribution/helm/rocketmq-rust --strict -f distribution/helm/rocketmq-rust/values-production-controller-ha.yaml`
- `docker buildx build --check --file docker/Dockerfile.base --target qualification-driver --build-arg SOURCE_REVISION=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa .`
- `cargo test -p rocketmq-controller --example controller-failover-qualification`
- `cargo test -p rocketmq-controller --test controller_failover_slo`
- `cargo test -p rocketmq-broker legal_in_sync_ack_uses_the_slowest_in_sync_replica --lib`
- `cargo test -p rocketmq-broker runtime_diagnostics_generation_comes_from_the_atomic_config_snapshot --lib`
- `cargo check --manifest-path fuzz/Cargo.toml --all-targets`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check` under WSL because the Windows invocation hits OS path-length error 206
- `pwsh ./scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `pwsh ./scripts/check-agents-routing.ps1`
- `git diff --check`

The live failover runner is delivered in this change; executing the local Kind evidence bundle is handled by the final qualification work package after the soak instrumentation and runner are merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added strict durability settings for controller high-availability deployments, including synchronous flushing, replication, quorum acknowledgments, lag limits, and safe elections.
  - Added automated failover qualification workflows for seeding, recovery verification, and evidence collection.
  - Added pass/fail reporting for zero-loss, zero-duplication, and message recovery validation.

- **Improvements**
  - Enhanced broker diagnostics with replication confirmation offsets.
  - Added validation for configuration integrity, failover milestones, ledger consistency, and recovery observations.

- **Tests**
  - Added coverage for durability configuration, failover qualification, evidence validation, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->