### PR TITLE
[ISSUE #9289]✨Qualify six-hour message-path resource stability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4520,6 +4520,7 @@ dependencies = [
  "rocketmq-client-rust",
  "rocketmq-error",
  "rocketmq-model",
+ "rocketmq-observability",
  "rocketmq-protocol",
  "rocketmq-proxy-core",
  "rocketmq-runtime",

--- a/rocketmq-broker/src/bin/broker_bootstrap_server.rs
+++ b/rocketmq-broker/src/bin/broker_bootstrap_server.rs
@@ -169,9 +169,12 @@ async fn run(service_context: ChildServiceContext, lifecycle: ServiceLifecycle) 
         }
         return Err(error).context("failed to start broker lifecycle boundary");
     }
-    if let Err(error) =
-        rocketmq_observability::start_runtime_diagnostics_endpoint_from_env(&service_context, RuntimeComponent::Broker)
-            .await
+    if let Err(error) = rocketmq_observability::start_runtime_diagnostics_endpoint_from_env_with_telemetry(
+        &service_context,
+        RuntimeComponent::Broker,
+        &telemetry_guard.handle(),
+    )
+    .await
     {
         lifecycle.mark_failed();
         let request = lifecycle.request_shutdown(ShutdownReason::Internal);

--- a/rocketmq-broker/src/broker_runtime/composition.rs
+++ b/rocketmq-broker/src/broker_runtime/composition.rs
@@ -1130,8 +1130,11 @@ impl BrokerRuntime {
 
         let should_start_time = Arc::new(AtomicU64::new(0));
         let pop_inflight_message_counter = PopInflightMessageCounter::new(should_start_time);
-        let broker_fast_failure =
-            BrokerFastFailure::new_with_service_context(broker_config.clone(), service_context.clone());
+        let broker_fast_failure = BrokerFastFailure::new_with_service_context_and_telemetry(
+            broker_config.clone(),
+            service_context.clone(),
+            telemetry_handle.clone(),
+        );
         #[cfg(feature = "rocksdb_store")]
         let rocksdb_config_managers =
             open_broker_rocksdb_config_managers(broker_config.as_ref(), message_store_config.as_ref());

--- a/rocketmq-broker/src/latency/broker_fast_failure.rs
+++ b/rocketmq-broker/src/latency/broker_fast_failure.rs
@@ -262,6 +262,16 @@ impl FastFailureQueue {
         self.pending_count.load(Ordering::Acquire)
     }
 
+    fn oldest_pending_age_millis(&self, now_millis: u64) -> u64 {
+        self.tasks
+            .lock()
+            .iter()
+            .filter(|task| task.state() == TASK_STATE_PENDING)
+            .map(|task| now_millis.saturating_sub(task.created_timestamp_millis()))
+            .max()
+            .unwrap_or_default()
+    }
+
     fn clean_expired(&self, now_millis: u64, max_wait_millis: u64, batch_limit: usize) -> usize {
         self.clean_pending(now_millis, Some(max_wait_millis), batch_limit, "[TIMEOUT_CLEAN_QUEUE]")
     }
@@ -436,6 +446,20 @@ impl BrokerFastFailure {
         broker_config: Arc<BrokerConfig>,
         service_context: ChildServiceContext,
     ) -> Self {
+        Self::new_with_service_context_and_telemetry(
+            broker_config,
+            service_context,
+            rocketmq_observability::TelemetryHandle::noop(),
+        )
+    }
+
+    pub(crate) fn new_with_service_context_and_telemetry(
+        broker_config: Arc<BrokerConfig>,
+        service_context: ChildServiceContext,
+        telemetry: rocketmq_observability::TelemetryHandle,
+    ) -> Self {
+        let capacity_count = broker_config.broker_fast_failure_pending_max_count;
+        let capacity_bytes = broker_config.broker_fast_failure_pending_max_bytes;
         let pending_budget = ResourceBudgetTree::new(
             "broker.fast-failure.pending",
             BudgetLimit::new(
@@ -446,7 +470,7 @@ impl BrokerFastFailure {
         )
         .expect("validated Broker fast-failure limits must produce a resource budget")
         .root();
-        Self {
+        let this = Self {
             inner: Arc::new(BrokerFastFailureInner {
                 broker_config,
                 service_context,
@@ -459,7 +483,25 @@ impl BrokerFastFailure {
                 jstack_time_millis: AtomicI64::new(current_millis() as i64),
                 scan_batch_limit: DEFAULT_SCAN_BATCH_LIMIT,
             }),
-        }
+        };
+        let source = this.clone();
+        rocketmq_observability::metrics::resource::ResourceStabilityMetrics::from_handle(
+            &telemetry,
+            rocketmq_observability::BROKER_METER_SCOPE,
+        )
+        .register_queue("broker", "fast-failure", "aggregate", move || {
+            let budget = source.pending_budget_snapshot();
+            rocketmq_observability::metrics::resource::ResourceQueueSnapshot {
+                items: budget.current_count as u64,
+                bytes: budget.current_bytes as u64,
+                oldest_age_millis: source.oldest_pending_age_millis(),
+                capacity_items: capacity_count as u64,
+                capacity_bytes: capacity_bytes as u64,
+                active: source.running_count() as u64,
+                rejected_total: budget.rejected_count,
+            }
+        });
+        this
     }
 
     fn task_group(&self) -> TaskGroup {
@@ -590,6 +632,22 @@ impl BrokerFastFailure {
 
     pub(crate) fn pending_budget_snapshot(&self) -> BudgetSnapshot {
         self.inner.pending_budget.snapshot()
+    }
+
+    fn oldest_pending_age_millis(&self) -> u64 {
+        let now_millis = current_millis();
+        ALL_QUEUE_KINDS
+            .into_iter()
+            .map(|kind| self.inner.queues.get(kind).oldest_pending_age_millis(now_millis))
+            .max()
+            .unwrap_or_default()
+    }
+
+    fn running_count(&self) -> usize {
+        ALL_QUEUE_KINDS
+            .into_iter()
+            .map(|kind| self.inner.queues.get(kind).running_count.load(Ordering::Acquire))
+            .sum()
     }
 
     pub(crate) fn try_enqueue(

--- a/rocketmq-controller/src/bin/controller_bootstrap.rs
+++ b/rocketmq-controller/src/bin/controller_bootstrap.rs
@@ -206,9 +206,10 @@ async fn run(service_context: ChildServiceContext, lifecycle: ServiceLifecycle) 
             ControllerError::ConfigError(format!("failed to start Controller lifecycle boundary: {error}")).into(),
         );
     }
-    if let Err(error) = rocketmq_observability::start_runtime_diagnostics_endpoint_from_env(
+    if let Err(error) = rocketmq_observability::start_runtime_diagnostics_endpoint_from_env_with_telemetry(
         &service_context,
         RuntimeComponent::Controller,
+        &telemetry_handle,
     )
     .await
     {

--- a/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
+++ b/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
@@ -189,9 +189,10 @@ async fn run(service_context: ChildServiceContext, lifecycle: ServiceLifecycle) 
         }
         return Err(error).context("failed to start NameServer lifecycle boundary");
     }
-    if let Err(error) = rocketmq_observability::start_runtime_diagnostics_endpoint_from_env(
+    if let Err(error) = rocketmq_observability::start_runtime_diagnostics_endpoint_from_env_with_telemetry(
         &service_context,
         RuntimeComponent::NameServer,
+        &telemetry_guard.handle(),
     )
     .await
     {

--- a/rocketmq-namesrv/src/bootstrap.rs
+++ b/rocketmq-namesrv/src/bootstrap.rs
@@ -1201,7 +1201,19 @@ impl Builder {
         let kv_mutation_batch_size = name_server_config.kv_mutation_batch_size;
         let kv_config_target = PathBuf::from(&name_server_config.kv_config_path);
         let kv_mutation_context = service_context.component("namesrv.kv-mutation");
+        let route_response_cache_budget = name_server_config.namesrv_route_response_cache_max_bytes.max(1);
         let route_response_cache = Arc::new(RouteResponseCache::from_namesrv_config(&name_server_config));
+        let route_response_cache_metrics = Arc::clone(&route_response_cache);
+        rocketmq_observability::metrics::resource::ResourceStabilityMetrics::from_handle(
+            &self.telemetry,
+            rocketmq_observability::NAMESRV_METER_SCOPE,
+        )
+        .register_cache("namesrv", "route-response-cache", move || {
+            rocketmq_observability::metrics::resource::ResourceCacheSnapshot {
+                usage_bytes: route_response_cache_metrics.stats().weighted_size,
+                budget_bytes: route_response_cache_budget,
+            }
+        });
         let workload_admission = Arc::new(NameServerWorkloadAdmission::from_namesrv_config(&name_server_config));
         let initial_config = Arc::new(NameServerRuntimeConfig {
             name_server_config: Arc::new(name_server_config),

--- a/rocketmq-observability/src/lib.rs
+++ b/rocketmq-observability/src/lib.rs
@@ -117,6 +117,7 @@ pub use propagation::TRACEPARENT;
 pub use propagation::TRACESTATE;
 pub use runtime_diagnostics::start_runtime_diagnostics_endpoint;
 pub use runtime_diagnostics::start_runtime_diagnostics_endpoint_from_env;
+pub use runtime_diagnostics::start_runtime_diagnostics_endpoint_from_env_with_telemetry;
 pub use runtime_diagnostics::RuntimeDiagnosticsEndpointConfig;
 pub use runtime_diagnostics::RuntimeDiagnosticsEndpointHandle;
 pub use runtime_diagnostics::RUNTIME_DIAGNOSTICS_ALLOW_INSECURE_HTTP_ENV;

--- a/rocketmq-observability/src/metrics.rs
+++ b/rocketmq-observability/src/metrics.rs
@@ -38,6 +38,7 @@ pub mod pop_revive_message_type;
 pub mod proxy;
 pub mod release_identity;
 pub mod remoting;
+pub mod resource;
 pub mod rocksdb;
 pub mod runtime;
 pub mod store;

--- a/rocketmq-observability/src/metrics/catalog.rs
+++ b/rocketmq-observability/src/metrics/catalog.rs
@@ -157,6 +157,8 @@ const MCP_OPERATION_RESULT_LABELS: &[&str] = &[labels::OPERATION_KIND, labels::O
 const RUNTIME_TASK_LABELS: &[&str] = &[labels::COMPONENT, labels::TASK_TYPE];
 const RUNTIME_BLOCKING_LABELS: &[&str] = &[labels::COMPONENT, labels::BLOCKING_LANE];
 const RUNTIME_LIFECYCLE_LABELS: &[&str] = &[labels::COMPONENT, labels::STATE, labels::RESULT, labels::REASON];
+const RESOURCE_QUEUE_LABELS: &[&str] = &[labels::COMPONENT, labels::BUDGET, labels::LANE];
+const RESOURCE_CACHE_LABELS: &[&str] = &[labels::COMPONENT, labels::BUDGET, labels::LANE];
 const CLIENT_NAMESRV_REFRESH_LABELS: &[&str] = &[labels::SOURCE_KIND, labels::RESULT];
 const CLIENT_NAMESRV_ENDPOINT_LABELS: &[&str] = &[labels::SOURCE_KIND, labels::ADDRESS_FAMILY];
 const CLIENT_NAMESRV_STATE_LABELS: &[&str] = &[labels::SOURCE_KIND, labels::FRESHNESS];
@@ -1571,6 +1573,83 @@ pub const RUST_METRICS: &[MetricDescriptor] = &[
         labels: RUNTIME_LIFECYCLE_LABELS,
         source: MetricSource::Runtime,
     },
+    MetricDescriptor {
+        name: metrics::RESOURCE_QUEUE_ITEMS,
+        kind: MetricKind::ObservableGauge,
+        unit: "{item}",
+        labels: RESOURCE_QUEUE_LABELS,
+        source: MetricSource::Runtime,
+    },
+    MetricDescriptor {
+        name: metrics::RESOURCE_QUEUE_BYTES,
+        kind: MetricKind::ObservableGauge,
+        unit: "By",
+        labels: RESOURCE_QUEUE_LABELS,
+        source: MetricSource::Runtime,
+    },
+    MetricDescriptor {
+        name: metrics::RESOURCE_QUEUE_OLDEST_AGE_MILLIS,
+        kind: MetricKind::ObservableGauge,
+        unit: "ms",
+        labels: RESOURCE_QUEUE_LABELS,
+        source: MetricSource::Runtime,
+    },
+    MetricDescriptor {
+        name: metrics::RESOURCE_QUEUE_CAPACITY_ITEMS,
+        kind: MetricKind::ObservableGauge,
+        unit: "{item}",
+        labels: RESOURCE_QUEUE_LABELS,
+        source: MetricSource::Runtime,
+    },
+    MetricDescriptor {
+        name: metrics::RESOURCE_QUEUE_CAPACITY_BYTES,
+        kind: MetricKind::ObservableGauge,
+        unit: "By",
+        labels: RESOURCE_QUEUE_LABELS,
+        source: MetricSource::Runtime,
+    },
+    MetricDescriptor {
+        name: metrics::RESOURCE_QUEUE_ACTIVE,
+        kind: MetricKind::ObservableGauge,
+        unit: "{operation}",
+        labels: RESOURCE_QUEUE_LABELS,
+        source: MetricSource::Runtime,
+    },
+    MetricDescriptor {
+        name: metrics::RESOURCE_QUEUE_REJECTED_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "{rejection}",
+        labels: RESOURCE_QUEUE_LABELS,
+        source: MetricSource::Runtime,
+    },
+    MetricDescriptor {
+        name: metrics::RESOURCE_CACHE_USAGE_BYTES,
+        kind: MetricKind::ObservableGauge,
+        unit: "By",
+        labels: RESOURCE_CACHE_LABELS,
+        source: MetricSource::Runtime,
+    },
+    MetricDescriptor {
+        name: metrics::RESOURCE_CACHE_BUDGET_BYTES,
+        kind: MetricKind::ObservableGauge,
+        unit: "By",
+        labels: RESOURCE_CACHE_LABELS,
+        source: MetricSource::Runtime,
+    },
+    MetricDescriptor {
+        name: metrics::RECEIPT_RENEWAL_DUE_LAG_MICROS,
+        kind: MetricKind::ObservableGauge,
+        unit: "us",
+        labels: &[labels::COMPONENT],
+        source: MetricSource::Runtime,
+    },
+    MetricDescriptor {
+        name: metrics::RECEIPT_RENEWAL_EXPIRED_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "{receipt}",
+        labels: &[labels::COMPONENT],
+        source: MetricSource::Runtime,
+    },
 ];
 
 pub const fn java_metrics() -> &'static [MetricDescriptor] {
@@ -1735,8 +1814,8 @@ mod tests {
             .collect::<HashSet<_>>();
 
         assert_eq!(JAVA_METRICS.len(), 94);
-        assert_eq!(RUST_METRICS.len(), 105);
-        assert_eq!(combined.len(), 199, "duplicate metric names across catalogs");
+        assert_eq!(RUST_METRICS.len(), 116);
+        assert_eq!(combined.len(), 210, "duplicate metric names across catalogs");
     }
 
     #[test]

--- a/rocketmq-observability/src/metrics/resource.rs
+++ b/rocketmq-observability/src/metrics/resource.rs
@@ -1,0 +1,269 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Low-cardinality bounded-resource gauges used by long-running qualification.
+
+/// Current state of one bounded queue or in-flight resource.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ResourceQueueSnapshot {
+    pub items: u64,
+    pub bytes: u64,
+    pub oldest_age_millis: u64,
+    pub capacity_items: u64,
+    pub capacity_bytes: u64,
+    pub active: u64,
+    pub rejected_total: u64,
+}
+
+/// Current state of one bounded cache or native-memory owner.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ResourceCacheSnapshot {
+    pub usage_bytes: u64,
+    pub budget_bytes: u64,
+}
+
+/// Current receipt-renewal scheduler health.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ReceiptRenewalSnapshot {
+    pub max_due_lag_micros: u64,
+    pub expired_before_renewal: u64,
+}
+
+/// Registers observable resource gauges on one fixed component meter.
+#[derive(Clone)]
+pub struct ResourceStabilityMetrics {
+    #[cfg(feature = "otel-metrics")]
+    telemetry: crate::TelemetryRecorder,
+}
+
+impl ResourceStabilityMetrics {
+    #[must_use]
+    pub fn from_handle(handle: &crate::TelemetryHandle, scope: &'static str) -> Self {
+        #[cfg(feature = "otel-metrics")]
+        {
+            Self {
+                telemetry: handle.child(scope),
+            }
+        }
+        #[cfg(not(feature = "otel-metrics"))]
+        {
+            let _ = (handle, scope);
+            Self {}
+        }
+    }
+
+    pub fn register_queue<F>(&self, component: &'static str, budget: &'static str, lane: &'static str, source: F)
+    where
+        F: Fn() -> ResourceQueueSnapshot + Send + Sync + 'static,
+    {
+        #[cfg(feature = "otel-metrics")]
+        if let Some(meter) = self.telemetry.meter() {
+            register_queue_observers(&meter, component, budget, lane, source);
+        }
+        #[cfg(not(feature = "otel-metrics"))]
+        let _ = (component, budget, lane, source);
+    }
+
+    pub fn register_cache<F>(&self, component: &'static str, budget: &'static str, source: F)
+    where
+        F: Fn() -> ResourceCacheSnapshot + Send + Sync + 'static,
+    {
+        #[cfg(feature = "otel-metrics")]
+        if let Some(meter) = self.telemetry.meter() {
+            register_cache_observers(&meter, component, budget, source);
+        }
+        #[cfg(not(feature = "otel-metrics"))]
+        let _ = (component, budget, source);
+    }
+
+    pub fn register_receipt_renewal<F>(&self, component: &'static str, source: F)
+    where
+        F: Fn() -> ReceiptRenewalSnapshot + Send + Sync + 'static,
+    {
+        #[cfg(feature = "otel-metrics")]
+        if let Some(meter) = self.telemetry.meter() {
+            register_receipt_renewal_observers(&meter, component, source);
+        }
+        #[cfg(not(feature = "otel-metrics"))]
+        let _ = (component, source);
+    }
+}
+
+#[cfg(feature = "otel-metrics")]
+fn resource_attributes(
+    component: &'static str,
+    budget: &'static str,
+    lane: &'static str,
+) -> [opentelemetry::KeyValue; 3] {
+    [
+        opentelemetry::KeyValue::new(crate::semantic::labels::COMPONENT, component),
+        opentelemetry::KeyValue::new(crate::semantic::labels::BUDGET, budget),
+        opentelemetry::KeyValue::new(crate::semantic::labels::LANE, lane),
+    ]
+}
+
+#[cfg(feature = "otel-metrics")]
+fn register_queue_observers<F>(
+    meter: &opentelemetry::metrics::Meter,
+    component: &'static str,
+    budget: &'static str,
+    lane: &'static str,
+    source: F,
+) where
+    F: Fn() -> ResourceQueueSnapshot + Send + Sync + 'static,
+{
+    use std::sync::Arc;
+
+    let source = Arc::new(source);
+    macro_rules! gauge {
+        ($name:expr, $description:expr, $unit:expr, $field:ident) => {{
+            let source = Arc::clone(&source);
+            let _instrument = meter
+                .u64_observable_gauge($name)
+                .with_description($description)
+                .with_unit($unit)
+                .with_callback(move |observer| {
+                    observer.observe(source().$field, &resource_attributes(component, budget, lane));
+                })
+                .build();
+        }};
+    }
+    gauge!(
+        crate::semantic::metrics::RESOURCE_QUEUE_ITEMS,
+        "Items retained by a bounded queue or in-flight budget",
+        "{item}",
+        items
+    );
+    gauge!(
+        crate::semantic::metrics::RESOURCE_QUEUE_BYTES,
+        "Bytes retained by a bounded queue or in-flight budget",
+        "By",
+        bytes
+    );
+    gauge!(
+        crate::semantic::metrics::RESOURCE_QUEUE_OLDEST_AGE_MILLIS,
+        "Age of the oldest queued item",
+        "ms",
+        oldest_age_millis
+    );
+    gauge!(
+        crate::semantic::metrics::RESOURCE_QUEUE_CAPACITY_ITEMS,
+        "Configured bounded item capacity",
+        "{item}",
+        capacity_items
+    );
+    gauge!(
+        crate::semantic::metrics::RESOURCE_QUEUE_CAPACITY_BYTES,
+        "Configured bounded byte capacity",
+        "By",
+        capacity_bytes
+    );
+    gauge!(
+        crate::semantic::metrics::RESOURCE_QUEUE_ACTIVE,
+        "Active operations using the bounded resource",
+        "{operation}",
+        active
+    );
+    let rejected_source = Arc::clone(&source);
+    let _rejected = meter
+        .u64_observable_counter(crate::semantic::metrics::RESOURCE_QUEUE_REJECTED_TOTAL)
+        .with_description("Cumulative admissions rejected by the bounded resource")
+        .with_unit("{rejection}")
+        .with_callback(move |observer| {
+            observer.observe(
+                rejected_source().rejected_total,
+                &resource_attributes(component, budget, lane),
+            );
+        })
+        .build();
+}
+
+#[cfg(feature = "otel-metrics")]
+pub(crate) fn register_cache_observers<F>(
+    meter: &opentelemetry::metrics::Meter,
+    component: &'static str,
+    budget: &'static str,
+    source: F,
+) where
+    F: Fn() -> ResourceCacheSnapshot + Send + Sync + 'static,
+{
+    use std::sync::Arc;
+
+    let source = Arc::new(source);
+    let usage_source = Arc::clone(&source);
+    let _usage = meter
+        .u64_observable_gauge(crate::semantic::metrics::RESOURCE_CACHE_USAGE_BYTES)
+        .with_description("Current native or heap cache usage")
+        .with_unit("By")
+        .with_callback(move |observer| {
+            observer.observe(
+                usage_source().usage_bytes,
+                &resource_attributes(component, budget, "cache"),
+            );
+        })
+        .build();
+    let _budget = meter
+        .u64_observable_gauge(crate::semantic::metrics::RESOURCE_CACHE_BUDGET_BYTES)
+        .with_description("Configured cache or native-memory budget")
+        .with_unit("By")
+        .with_callback(move |observer| {
+            observer.observe(source().budget_bytes, &resource_attributes(component, budget, "cache"));
+        })
+        .build();
+}
+
+#[cfg(feature = "otel-metrics")]
+fn register_receipt_renewal_observers<F>(meter: &opentelemetry::metrics::Meter, component: &'static str, source: F)
+where
+    F: Fn() -> ReceiptRenewalSnapshot + Send + Sync + 'static,
+{
+    use std::sync::Arc;
+
+    let source = Arc::new(source);
+    let lag_source = Arc::clone(&source);
+    let attributes = [opentelemetry::KeyValue::new(
+        crate::semantic::labels::COMPONENT,
+        component,
+    )];
+    let lag_attributes = attributes.clone();
+    let _lag = meter
+        .u64_observable_gauge(crate::semantic::metrics::RECEIPT_RENEWAL_DUE_LAG_MICROS)
+        .with_description("Largest receipt-renewal deadline lateness")
+        .with_unit("us")
+        .with_callback(move |observer| observer.observe(lag_source().max_due_lag_micros, &lag_attributes))
+        .build();
+    let _expired = meter
+        .u64_observable_counter(crate::semantic::metrics::RECEIPT_RENEWAL_EXPIRED_TOTAL)
+        .with_description("Receipt handles that expired before renewal")
+        .with_unit("{receipt}")
+        .with_callback(move |observer| observer.observe(source().expired_before_renewal, &attributes))
+        .build();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noop_registration_accepts_bounded_snapshots() {
+        let metrics = ResourceStabilityMetrics::from_handle(&crate::TelemetryHandle::noop(), crate::PROXY_METER_SCOPE);
+        metrics.register_queue("proxy", "commands", "control", || ResourceQueueSnapshot {
+            items: 1,
+            capacity_items: 8,
+            ..ResourceQueueSnapshot::default()
+        });
+        metrics.register_cache("store", "rocksdb", ResourceCacheSnapshot::default);
+        metrics.register_receipt_renewal("proxy", ReceiptRenewalSnapshot::default);
+    }
+}

--- a/rocketmq-observability/src/metrics/rocksdb.rs
+++ b/rocketmq-observability/src/metrics/rocksdb.rs
@@ -210,6 +210,20 @@ impl RocksDbMetricsRecorder {
         #[cfg(not(feature = "otel-metrics"))]
         let _ = source;
     }
+
+    /// Registers one low-cardinality native-memory budget for soak qualification.
+    pub fn register_resource_cache<F>(&self, budget: &'static str, source: F)
+    where
+        F: Fn() -> crate::metrics::resource::ResourceCacheSnapshot + Send + Sync + 'static,
+    {
+        #[cfg(feature = "otel-metrics")]
+        if let Some(meter) = self.telemetry.meter() {
+            crate::metrics::resource::register_cache_observers(&meter, "store", budget, source);
+        }
+
+        #[cfg(not(feature = "otel-metrics"))]
+        let _ = (budget, source);
+    }
 }
 
 #[cfg(not(feature = "otel-metrics"))]

--- a/rocketmq-observability/src/runtime_diagnostics.rs
+++ b/rocketmq-observability/src/runtime_diagnostics.rs
@@ -165,10 +165,30 @@ pub async fn start_runtime_diagnostics_endpoint_from_env(
     service_context: &ChildServiceContext,
     component: RuntimeComponent,
 ) -> Result<Option<RuntimeDiagnosticsEndpointHandle>, ObservabilityError> {
+    start_runtime_diagnostics_endpoint_from_env_with_telemetry(
+        service_context,
+        component,
+        &crate::TelemetryHandle::noop(),
+    )
+    .await
+}
+
+/// Starts the opt-in runtime diagnostics endpoint and records snapshots into
+/// the caller-owned telemetry pipeline.
+///
+/// # Errors
+///
+/// Returns a sanitized error when configuration, the initial token read, the
+/// listener bind, or lifecycle task registration fails.
+pub async fn start_runtime_diagnostics_endpoint_from_env_with_telemetry(
+    service_context: &ChildServiceContext,
+    component: RuntimeComponent,
+    telemetry: &crate::TelemetryHandle,
+) -> Result<Option<RuntimeDiagnosticsEndpointHandle>, ObservabilityError> {
     let Some(config) = RuntimeDiagnosticsEndpointConfig::from_env()? else {
         return Ok(None);
     };
-    start_runtime_diagnostics_endpoint(service_context, component, config)
+    start_runtime_diagnostics_endpoint_with_telemetry(service_context, component, config, telemetry)
         .await
         .map(Some)
 }
@@ -184,6 +204,21 @@ pub async fn start_runtime_diagnostics_endpoint(
     component: RuntimeComponent,
     config: RuntimeDiagnosticsEndpointConfig,
 ) -> Result<RuntimeDiagnosticsEndpointHandle, ObservabilityError> {
+    start_runtime_diagnostics_endpoint_with_telemetry(
+        service_context,
+        component,
+        config,
+        &crate::TelemetryHandle::noop(),
+    )
+    .await
+}
+
+async fn start_runtime_diagnostics_endpoint_with_telemetry(
+    service_context: &ChildServiceContext,
+    component: RuntimeComponent,
+    config: RuntimeDiagnosticsEndpointConfig,
+    telemetry: &crate::TelemetryHandle,
+) -> Result<RuntimeDiagnosticsEndpointHandle, ObservabilityError> {
     read_token(service_context, config.token_file.clone()).await?;
     let listener = TcpListener::bind(config.bind_addr)
         .await
@@ -193,25 +228,24 @@ pub async fn start_runtime_diagnostics_endpoint(
         .map_err(|_| ObservabilityError::invalid_config("runtime diagnostics listener address is unavailable"))?;
 
     let sampler_context = service_context.clone();
+    let runtime_metrics = crate::metrics::runtime::RuntimeMetricsRecorder::from_handle(telemetry, component);
+    let sampler_metrics = runtime_metrics.clone();
     service_context
         .scheduled_tasks("runtime-diagnostics.sampler")
         .schedule_fixed_delay(
             ScheduledTaskConfig::fixed_delay("runtime-diagnostics.sample", config.sample_interval),
             move || {
                 let sampler_context = sampler_context.clone();
+                let sampler_metrics = sampler_metrics.clone();
                 async move {
                     let view = sampler_context.diagnostics_view_v1(component);
-                    crate::metrics::runtime::record_snapshot(&view);
+                    sampler_metrics.record_snapshot(&view);
                 }
             },
         )
         .map_err(|_| ObservabilityError::invalid_config("runtime diagnostics sampler cannot start"))?;
 
-    crate::metrics::runtime::record_lifecycle(
-        component,
-        RuntimeLifecycleState::Starting,
-        RuntimeLifecycleReason::Startup,
-    );
+    runtime_metrics.record_lifecycle(RuntimeLifecycleState::Starting, RuntimeLifecycleReason::Startup);
 
     let server_context = service_context.clone();
     let server_cancellation = service_context.task_group().cancellation_token();
@@ -223,6 +257,7 @@ pub async fn start_runtime_diagnostics_endpoint(
                 component,
                 config.token_file,
                 server_cancellation,
+                runtime_metrics,
             )
             .await;
         })
@@ -243,6 +278,7 @@ async fn serve(
     component: RuntimeComponent,
     token_file: PathBuf,
     cancellation: tokio_util::sync::CancellationToken,
+    runtime_metrics: crate::metrics::runtime::RuntimeMetricsRecorder,
 ) {
     loop {
         tokio::select! {
@@ -250,7 +286,7 @@ async fn serve(
             accepted = listener.accept() => {
                 match accepted {
                     Ok((stream, _peer)) => {
-                        handle_connection(stream, &service_context, component, &token_file).await;
+                        handle_connection(stream, &service_context, component, &token_file, &runtime_metrics).await;
                     }
                     Err(error) => {
                         tracing::warn!(
@@ -271,9 +307,10 @@ async fn handle_connection(
     service_context: &ChildServiceContext,
     component: RuntimeComponent,
     token_file: &Path,
+    runtime_metrics: &crate::metrics::runtime::RuntimeMetricsRecorder,
 ) {
     let response = match tokio::time::timeout(REQUEST_TIMEOUT, read_request(&mut stream)).await {
-        Ok(Ok(request)) => route_request(&request, service_context, component, token_file).await,
+        Ok(Ok(request)) => route_request(&request, service_context, component, token_file, runtime_metrics).await,
         Ok(Err(status)) => error_response(status),
         Err(_) => error_response(HttpStatus::RequestTimeout),
     };
@@ -286,6 +323,7 @@ async fn route_request(
     service_context: &ChildServiceContext,
     component: RuntimeComponent,
     token_file: &Path,
+    runtime_metrics: &crate::metrics::runtime::RuntimeMetricsRecorder,
 ) -> Vec<u8> {
     let Ok(request) = ParsedRequest::parse(request) else {
         return error_response(HttpStatus::BadRequest);
@@ -311,7 +349,7 @@ async fn route_request(
     }
 
     let view = service_context.diagnostics_view_v1(component);
-    crate::metrics::runtime::record_snapshot(&view);
+    runtime_metrics.record_snapshot(&view);
     let envelope = RuntimeDiagnosticsEndpointEnvelopeV1 {
         schema_version: RUNTIME_DIAGNOSTICS_ENDPOINT_SCHEMA,
         source: "rocketmq_process",

--- a/rocketmq-observability/src/semantic.rs
+++ b/rocketmq-observability/src/semantic.rs
@@ -215,6 +215,17 @@ pub mod metrics {
     pub const RUNTIME_BLOCKING_RUNNING: &str = "rocketmq_runtime_blocking_running";
     pub const RUNTIME_BLOCKING_TIMEOUTS: &str = "rocketmq_runtime_blocking_timeouts";
     pub const RUNTIME_LIFECYCLE_TRANSITIONS_TOTAL: &str = "rocketmq_runtime_lifecycle_transitions_total";
+    pub const RESOURCE_QUEUE_ITEMS: &str = "rocketmq_resource_queue_items";
+    pub const RESOURCE_QUEUE_BYTES: &str = "rocketmq_resource_queue_bytes";
+    pub const RESOURCE_QUEUE_OLDEST_AGE_MILLIS: &str = "rocketmq_resource_queue_oldest_age_millis";
+    pub const RESOURCE_QUEUE_CAPACITY_ITEMS: &str = "rocketmq_resource_queue_capacity_items";
+    pub const RESOURCE_QUEUE_CAPACITY_BYTES: &str = "rocketmq_resource_queue_capacity_bytes";
+    pub const RESOURCE_QUEUE_ACTIVE: &str = "rocketmq_resource_queue_active";
+    pub const RESOURCE_QUEUE_REJECTED_TOTAL: &str = "rocketmq_resource_queue_rejected_total";
+    pub const RESOURCE_CACHE_USAGE_BYTES: &str = "rocketmq_resource_cache_usage_bytes";
+    pub const RESOURCE_CACHE_BUDGET_BYTES: &str = "rocketmq_resource_cache_budget_bytes";
+    pub const RECEIPT_RENEWAL_DUE_LAG_MICROS: &str = "rocketmq_receipt_renewal_due_lag_micros";
+    pub const RECEIPT_RENEWAL_EXPIRED_TOTAL: &str = "rocketmq_receipt_renewal_expired_total";
 }
 
 pub mod labels {
@@ -279,6 +290,8 @@ pub mod labels {
     pub const COMPONENT: &str = "component";
     pub const TASK_TYPE: &str = "task_type";
     pub const BLOCKING_LANE: &str = "blocking_lane";
+    pub const BUDGET: &str = "budget";
+    pub const LANE: &str = "lane";
 }
 
 /// Stable event identifiers consumed by structured-log exporters and guards.

--- a/rocketmq-proxy-cluster/Cargo.toml
+++ b/rocketmq-proxy-cluster/Cargo.toml
@@ -28,13 +28,14 @@ rust-version.workspace = true
 [features]
 default = []
 bench-support = []
-observability = ["rocketmq-client-rust/observability-metrics"]
+observability = ["rocketmq-client-rust/observability-metrics", "rocketmq-observability/otel-metrics"]
 observability-traces = ["rocketmq-client-rust/observability"]
 
 [dependencies]
 rocketmq-client-rust = { workspace = true, features = ["admin-mutation"] }
 rocketmq-error = { workspace = true }
 rocketmq-model = { workspace = true }
+rocketmq-observability = { workspace = true }
 rocketmq-proxy-core = { workspace = true }
 rocketmq-protocol = { workspace = true }
 rocketmq-runtime = { workspace = true }

--- a/rocketmq-proxy-cluster/src/cluster_execution.rs
+++ b/rocketmq-proxy-cluster/src/cluster_execution.rs
@@ -214,6 +214,7 @@ impl ClusterTaskExecutor {
         telemetry_handle: TelemetryHandle,
     ) -> ProxyResult<Self> {
         let worker_context = service_context.component("command-worker");
+        let execution_telemetry = telemetry_handle.clone();
         let client_runtime = ClientRuntime::try_new(
             worker_context.component("client-runtime"),
             ClientRuntimeConfig::default(),
@@ -231,6 +232,7 @@ impl ClusterTaskExecutor {
             Arc::new(DefaultClusterClientFactory),
             Arc::new(DefaultClusterProducerFactory),
             policy,
+            execution_telemetry,
         )
         .map(|(executor, _)| executor)
     }
@@ -261,6 +263,7 @@ impl ClusterTaskExecutor {
             client_factory,
             producer_factory,
             policy,
+            rocketmq_observability::TelemetryHandle::noop(),
         )
     }
 
@@ -278,8 +281,43 @@ impl ClusterTaskExecutor {
         client_factory: Arc<dyn ClusterClientFactory>,
         producer_factory: Arc<dyn ClusterProducerFactory>,
         policy: ClusterExecutionPolicy,
+        telemetry: rocketmq_observability::TelemetryHandle,
     ) -> ProxyResult<(Self, tokio_util::sync::CancellationToken)> {
         let lanes = Arc::new(ClusterExecutionLanes::new(policy)?);
+        let source = Arc::clone(&lanes);
+        let long_poll_source = Arc::clone(&lanes);
+        let lane_capacity_items = config.command_queue_capacity as u64;
+        let lane_capacity_bytes = config.command_queue_max_bytes as u64;
+        let aggregate_capacity_items = lane_capacity_items.saturating_mul(2);
+        let aggregate_capacity_bytes = lane_capacity_bytes.saturating_mul(2);
+        let resource_metrics = rocketmq_observability::metrics::resource::ResourceStabilityMetrics::from_handle(
+            &telemetry,
+            rocketmq_observability::PROXY_METER_SCOPE,
+        );
+        resource_metrics.register_queue("proxy-cluster", "commands", "aggregate", move || {
+            let snapshot = source.snapshot();
+            rocketmq_observability::metrics::resource::ResourceQueueSnapshot {
+                items: snapshot.queued_and_active as u64,
+                bytes: snapshot.retained_bytes as u64,
+                oldest_age_millis: snapshot.oldest_queued_age_ms.unwrap_or_default(),
+                capacity_items: aggregate_capacity_items,
+                capacity_bytes: aggregate_capacity_bytes,
+                active: snapshot.current_inflight as u64,
+                rejected_total: snapshot.rejected,
+            }
+        });
+        resource_metrics.register_queue("proxy-cluster", "commands", "long-poll", move || {
+            let snapshot = long_poll_source.snapshot();
+            rocketmq_observability::metrics::resource::ResourceQueueSnapshot {
+                items: snapshot.long_poll_queued_and_active as u64,
+                bytes: snapshot.long_poll_retained_bytes as u64,
+                oldest_age_millis: snapshot.oldest_queued_age_ms.unwrap_or_default(),
+                capacity_items: lane_capacity_items,
+                capacity_bytes: lane_capacity_bytes,
+                active: snapshot.current_long_poll_inflight as u64,
+                rejected_total: snapshot.rejected,
+            }
+        });
         let cancellation = worker_context.task_group().cancellation_token();
         let runtime = Arc::new(ClusterExecutionRuntime {
             config: config.clone(),

--- a/rocketmq-proxy-local/src/local.rs
+++ b/rocketmq-proxy-local/src/local.rs
@@ -13,6 +13,8 @@
 //  limitations under the License.
 
 use std::collections::HashMap;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
@@ -150,6 +152,7 @@ pub struct LocalBrokerFacadeClient {
     sender: mpsc::Sender<QueuedLocalBrokerCommand>,
     count_budget: Arc<Semaphore>,
     byte_budget: Arc<Semaphore>,
+    rejected: Arc<AtomicU64>,
     broker_name: String,
 }
 
@@ -413,6 +416,27 @@ impl LocalBrokerFacadeClient {
         let (sender, receiver) = mpsc::channel(config.command_queue_capacity);
         let count_budget = Arc::new(Semaphore::new(config.command_queue_capacity));
         let byte_budget = Arc::new(Semaphore::new(config.command_queue_max_bytes));
+        let rejected = Arc::new(AtomicU64::new(0));
+        let capacity_items = config.command_queue_capacity;
+        let capacity_bytes = config.command_queue_max_bytes;
+        let metric_count_budget = Arc::clone(&count_budget);
+        let metric_byte_budget = Arc::clone(&byte_budget);
+        let metric_rejected = Arc::clone(&rejected);
+        rocketmq_observability::metrics::resource::ResourceStabilityMetrics::from_handle(
+            &telemetry_handle,
+            rocketmq_observability::PROXY_METER_SCOPE,
+        )
+        .register_queue("proxy-local", "commands", "aggregate", move || {
+            rocketmq_observability::metrics::resource::ResourceQueueSnapshot {
+                items: capacity_items.saturating_sub(metric_count_budget.available_permits()) as u64,
+                bytes: capacity_bytes.saturating_sub(metric_byte_budget.available_permits()) as u64,
+                capacity_items: capacity_items as u64,
+                capacity_bytes: capacity_bytes as u64,
+                active: 0,
+                rejected_total: metric_rejected.load(Ordering::Relaxed),
+                ..rocketmq_observability::metrics::resource::ResourceQueueSnapshot::default()
+            }
+        });
         let max_queue_age = config.command_queue_max_age();
         let broker_name = config.broker_name.clone();
         let worker_context = service_context.component("command-worker");
@@ -448,6 +472,7 @@ impl LocalBrokerFacadeClient {
             sender,
             count_budget,
             byte_budget,
+            rejected,
             broker_name,
         })
     }
@@ -579,11 +604,11 @@ impl LocalBrokerFacadeClient {
         let estimated_bytes = command.estimated_bytes();
         let count_permit = Arc::clone(&self.count_budget)
             .try_acquire_owned()
-            .map_err(|_| local_queue_overloaded())?;
-        let byte_permits = u32::try_from(estimated_bytes).map_err(|_| local_queue_overloaded())?;
+            .map_err(|_| self.queue_overloaded())?;
+        let byte_permits = u32::try_from(estimated_bytes).map_err(|_| self.queue_overloaded())?;
         let byte_permit = Arc::clone(&self.byte_budget)
             .try_acquire_many_owned(byte_permits)
-            .map_err(|_| local_queue_overloaded())?;
+            .map_err(|_| self.queue_overloaded())?;
         let timeout_budget = command.timeout();
         let enqueued_at = Instant::now();
         let deadline_at = timeout_budget.map(|timeout| enqueued_at.checked_add(timeout).unwrap_or(enqueued_at));
@@ -597,7 +622,7 @@ impl LocalBrokerFacadeClient {
         };
         match self.sender.try_send(queued) {
             Ok(()) => {}
-            Err(TrySendError::Full(_)) => return Err(local_queue_overloaded()),
+            Err(TrySendError::Full(_)) => return Err(self.queue_overloaded()),
             Err(TrySendError::Closed(_)) => {
                 return Err(ProxyError::Transport {
                     message: "local broker worker is not available".to_owned(),
@@ -605,6 +630,11 @@ impl LocalBrokerFacadeClient {
             }
         }
         Ok(reply_rx)
+    }
+
+    fn queue_overloaded(&self) -> ProxyError {
+        self.rejected.fetch_add(1, Ordering::Relaxed);
+        local_queue_overloaded()
     }
 }
 
@@ -2835,6 +2865,7 @@ mod tests {
             sender,
             count_budget: Arc::new(tokio::sync::Semaphore::new(1)),
             byte_budget: Arc::new(tokio::sync::Semaphore::new(4_096)),
+            rejected: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             broker_name: "broker-a".to_owned(),
         };
         let _first_reply = client

--- a/rocketmq-proxy/src/bin/rocketmq-proxy-rust.rs
+++ b/rocketmq-proxy/src/bin/rocketmq-proxy-rust.rs
@@ -158,9 +158,12 @@ async fn run(service_context: ChildServiceContext, lifecycle: ServiceLifecycle) 
         )
         .await;
     }
-    if let Err(error) =
-        rocketmq_observability::start_runtime_diagnostics_endpoint_from_env(&service_context, RuntimeComponent::Proxy)
-            .await
+    if let Err(error) = rocketmq_observability::start_runtime_diagnostics_endpoint_from_env_with_telemetry(
+        &service_context,
+        RuntimeComponent::Proxy,
+        &telemetry_guard.handle(),
+    )
+    .await
     {
         lifecycle.mark_failed();
         let request = lifecycle.request_shutdown(ShutdownReason::Internal);

--- a/rocketmq-proxy/src/bootstrap.rs
+++ b/rocketmq-proxy/src/bootstrap.rs
@@ -231,10 +231,37 @@ impl ProxyRuntimeBuilder {
                 remoting_backend: self.remoting_backend,
                 context: None,
             },
-            None => default_service_manager_and_backend(&self.config, &service_context, telemetry)?,
+            None => default_service_manager_and_backend(&self.config, &service_context, telemetry.clone())?,
         };
         let auth_metadata_service = Some(backend.service_manager.metadata_service());
         let session_registry = self.session_registry.unwrap_or_default();
+        let resource_metrics = rocketmq_observability::metrics::resource::ResourceStabilityMetrics::from_handle(
+            &telemetry,
+            rocketmq_observability::PROXY_METER_SCOPE,
+        );
+        let response_guards = grpc_guards.clone();
+        let response_capacity_items = self.config.runtime.consumer_response_permits as u64;
+        let response_capacity_bytes = self.config.runtime.consumer_response_bytes as u64;
+        resource_metrics.register_queue("proxy-grpc", "consumer-response", "stream", move || {
+            let snapshot = response_guards.consumer_response_snapshot();
+            rocketmq_observability::metrics::resource::ResourceQueueSnapshot {
+                items: snapshot.current_count as u64,
+                bytes: snapshot.current_bytes as u64,
+                capacity_items: response_capacity_items,
+                capacity_bytes: response_capacity_bytes,
+                active: snapshot.current_count as u64,
+                rejected_total: snapshot.rejected_count,
+                ..rocketmq_observability::metrics::resource::ResourceQueueSnapshot::default()
+            }
+        });
+        let renewal_sessions = session_registry.clone();
+        resource_metrics.register_receipt_renewal("proxy-grpc", move || {
+            let snapshot = renewal_sessions.receipt_renewal_metrics_snapshot();
+            rocketmq_observability::metrics::resource::ReceiptRenewalSnapshot {
+                max_due_lag_micros: snapshot.max_due_lag_micros,
+                expired_before_renewal: snapshot.expired_before_renewal,
+            }
+        });
         let processor = Arc::new(DefaultMessagingProcessor::new(backend.service_manager));
         Ok(ProxyRuntime::from_processor_with_local_mode_support_and_guards(
             self.config,

--- a/rocketmq-store-rocksdb/src/message_store.rs
+++ b/rocketmq-store-rocksdb/src/message_store.rs
@@ -191,6 +191,20 @@ impl RocksDbDerivedStore {
         let rocksdb_config = RocksDbConfig::consume_queue_from_message_store_config(source);
         rocksdb_config.validate()?;
         let resource_budget = Arc::new(RocksDbResourceBudget::from_config(&rocksdb_config)?);
+        let block_cache_budget = Arc::clone(&resource_budget);
+        metrics.register_resource_cache("rocksdb-block-cache", move || {
+            rocketmq_observability::metrics::resource::ResourceCacheSnapshot {
+                usage_bytes: block_cache_budget.block_cache_usage_bytes() as u64,
+                budget_bytes: block_cache_budget.block_cache_budget_bytes() as u64,
+            }
+        });
+        let write_buffer_budget = Arc::clone(&resource_budget);
+        metrics.register_resource_cache("rocksdb-write-buffer", move || {
+            rocketmq_observability::metrics::resource::ResourceCacheSnapshot {
+                usage_bytes: write_buffer_budget.write_buffer_usage_bytes() as u64,
+                budget_bytes: write_buffer_budget.write_buffer_budget_bytes() as u64,
+            }
+        });
         let rocksdb_store = Arc::new(RocksDbStore::open_with_metrics_and_resource_budget(
             rocksdb_config.clone(),
             metrics.clone(),

--- a/scripts/message-path-soak-policy.json
+++ b/scripts/message-path-soak-policy.json
@@ -1,0 +1,79 @@
+{
+  "schema_version": 1,
+  "artifact_kind": "rocketmq_message_path_soak_policy",
+  "profiles": {
+    "smoke": {
+      "warmup_seconds": 0,
+      "observation_seconds": 60,
+      "cooldown_seconds": 15,
+      "sample_interval_seconds": 5,
+      "minimum_coverage_percent": 80.0,
+      "maximum_gap_seconds": 15
+    },
+    "full": {
+      "warmup_seconds": 1800,
+      "observation_seconds": 21600,
+      "cooldown_seconds": 900,
+      "sample_interval_seconds": 60,
+      "minimum_coverage_percent": 99.0,
+      "maximum_gap_seconds": 90
+    }
+  },
+  "windows": {
+    "comparison_seconds": 1800,
+    "cooldown_seconds": 300
+  },
+  "required_series": [
+    { "metric": "process_rss_bytes", "kind": "rss", "minimum_scopes": 1, "capacity_metric": "process_memory_limit_bytes" },
+    { "metric": "process_tasks", "kind": "task", "minimum_scopes": 1 },
+    { "metric": "process_threads", "kind": "task", "minimum_scopes": 1 },
+    { "metric": "process_open_fds", "kind": "fd", "minimum_scopes": 1 },
+    { "metric": "rocketmq_runtime_tasks", "kind": "task", "minimum_scopes": 1 },
+    { "metric": "rocketmq_resource_queue_items", "kind": "queue", "minimum_scopes": 1, "capacity_metric": "rocketmq_resource_queue_capacity_items" },
+    { "metric": "rocketmq_resource_queue_bytes", "kind": "queue", "minimum_scopes": 1, "capacity_metric": "rocketmq_resource_queue_capacity_bytes" },
+    { "metric": "rocketmq_resource_cache_usage_bytes", "kind": "cache", "minimum_scopes": 1, "capacity_metric": "rocketmq_resource_cache_budget_bytes" },
+    { "metric": "rocketmq_storage_flush_behind_bytes", "kind": "lag", "minimum_scopes": 1 },
+    { "metric": "rocketmq_storage_dispatch_behind_bytes", "kind": "lag", "minimum_scopes": 1 },
+    { "metric": "rocketmq_store_ha_replication_lag_bytes", "kind": "lag", "minimum_scopes": 1 },
+    { "metric": "rocketmq_receipt_renewal_due_lag_micros", "kind": "renewal", "minimum_scopes": 1 }
+  ],
+  "thresholds": {
+    "rss": {
+      "maximum_limit_ratio": 0.90,
+      "maximum_delta_ratio": 0.10,
+      "maximum_delta_bytes": 268435456,
+      "minimum_leak_slope_bytes_per_hour": 8388608,
+      "minimum_kendall_tau": 0.60
+    },
+    "task": {
+      "maximum_delta_ratio": 0.05,
+      "maximum_delta_absolute": 10,
+      "minimum_leak_slope_per_hour": 0.5,
+      "minimum_kendall_tau": 0.60
+    },
+    "fd": {
+      "maximum_delta_ratio": 0.05,
+      "maximum_delta_absolute": 32,
+      "minimum_leak_slope_per_hour": 1.0,
+      "minimum_kendall_tau": 0.60
+    },
+    "queue": {
+      "maximum_p99_capacity_ratio": 0.80,
+      "maximum_cooldown_ratio": 0.02
+    },
+    "cache": {
+      "maximum_budget_ratio": 1.0,
+      "maximum_delta_ratio": 0.05,
+      "maximum_delta_bytes": 16777216,
+      "minimum_leak_slope_budget_ratio_per_hour": 0.005,
+      "minimum_kendall_tau": 0.60
+    },
+    "lag": {
+      "maximum_sustained_bytes": 67108864,
+      "maximum_sustained_seconds": 600
+    },
+    "renewal": {
+      "maximum_due_lag_micros": 250000
+    }
+  }
+}

--- a/scripts/message-path-soak-report-schema.json
+++ b/scripts/message-path-soak-report-schema.json
@@ -8,6 +8,9 @@
     "artifact_kind",
     "status",
     "monotonic_growth_detected",
+    "profile",
+    "started_at",
+    "finished_at",
     "duration_seconds",
     "release_identity",
     "sampling",
@@ -20,7 +23,10 @@
     "artifact_kind": { "const": "rocketmq_message_path_soak_report" },
     "status": { "enum": ["pass", "fail"] },
     "monotonic_growth_detected": { "type": "boolean" },
-    "duration_seconds": { "type": "integer", "minimum": 21600 },
+    "profile": { "enum": ["smoke", "full"] },
+    "started_at": { "type": "string" },
+    "finished_at": { "type": "string" },
+    "duration_seconds": { "type": "integer", "minimum": 60 },
     "release_identity": {
       "type": "object",
       "required": [
@@ -49,7 +55,20 @@
       "minItems": 1,
       "items": {
         "type": "object",
-        "required": ["metric", "scope", "status", "raw_artifact_sha256"]
+        "required": [
+          "metric",
+          "scope",
+          "kind",
+          "status",
+          "first_window_median",
+          "last_window_median",
+          "p95",
+          "p99",
+          "max",
+          "theil_sen_slope_per_hour",
+          "kendall_tau",
+          "raw_artifact_sha256"
+        ]
       }
     },
     "artifacts": { "type": "array", "minItems": 1 }

--- a/scripts/message_path_qualification.py
+++ b/scripts/message_path_qualification.py
@@ -807,6 +807,8 @@ def validate_final_evidence(
 
     if soak.get("schema_version") != 1 or soak.get("artifact_kind") != "rocketmq_message_path_soak_report":
         findings.append("soak report contract is invalid")
+    if soak.get("profile") != "full":
+        findings.append("soak report must use the full profile")
     if soak.get("status") != "pass" or soak.get("monotonic_growth_detected") is not False:
         findings.append("soak report must pass without monotonic resource growth")
     if soak.get("duration_seconds", 0) < policy["modes"]["release"]["minimum_soak_seconds"]:
@@ -827,12 +829,45 @@ def validate_final_evidence(
         findings.append("soak sampling coverage or maximum gap is outside the release contract")
     if not isinstance(soak.get("pods"), list) or not soak["pods"]:
         findings.append("soak report must include pod identity and restart evidence")
-    elif any(pod.get("restarts") != 0 or pod.get("oom_killed") is not False for pod in soak["pods"]):
+    elif any(
+        not pod.get("name")
+        or not pod.get("uid")
+        or pod.get("restarts") != 0
+        or pod.get("oom_killed") is not False
+        for pod in soak["pods"]
+    ):
         findings.append("soak report contains a restarted or OOM-killed pod")
     if not isinstance(soak.get("series"), list) or not soak["series"]:
         findings.append("soak report must include analyzed resource series")
     elif any(item.get("status") != "pass" or not DIGEST_RE.fullmatch(str(item.get("raw_artifact_sha256", ""))) for item in soak["series"]):
         findings.append("soak resource series must pass and bind raw artifact hashes")
+    workload = soak.get("workload", {})
+    attempted = workload.get("attempted") if isinstance(workload, dict) else None
+    if not isinstance(attempted, int) or attempted <= 0 or workload.get("put_ok") != attempted or workload.get("consumed") != attempted:
+        findings.append("soak workload must consume every PutOk message")
+    elif any(workload.get(key) != 0 for key in ("send_failures", "consume_failures", "missing", "duplicates", "corrupt")):
+        findings.append("soak workload contains failures, loss, duplicates, or corruption")
+    artifacts = soak.get("artifacts")
+    if not isinstance(artifacts, list) or not artifacts:
+        findings.append("soak report must include a raw artifact inventory")
+    else:
+        soak_root = paths["soak"].parent.resolve()
+        inventory_digests: set[str] = set()
+        for artifact in artifacts:
+            relative = Path(str(artifact.get("path", ""))) if isinstance(artifact, dict) else Path()
+            digest = str(artifact.get("sha256", "")) if isinstance(artifact, dict) else ""
+            if relative.is_absolute() or ".." in relative.parts or not re.fullmatch(r"[0-9a-f]{64}", digest):
+                findings.append("soak artifact inventory contains an invalid path or digest")
+                continue
+            artifact_path = (soak_root / relative).resolve()
+            if soak_root not in artifact_path.parents or not artifact_path.is_file() or sha256_file(artifact_path) != digest:
+                findings.append(f"soak artifact is missing or tampered: {relative.as_posix()}")
+                continue
+            inventory_digests.add("sha256:" + digest)
+        if isinstance(soak.get("series"), list) and any(
+            item.get("raw_artifact_sha256") not in inventory_digests for item in soak["series"]
+        ):
+            findings.append("soak resource series references a digest outside the artifact inventory")
     return findings, paths, documents
 
 

--- a/scripts/message_path_soak.py
+++ b/scripts/message_path_soak.py
@@ -1,0 +1,600 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Analyze fail-closed message-path resource-soak evidence."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import math
+import statistics
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_POLICY = ROOT / "scripts" / "message-path-soak-policy.json"
+HEX64 = set("0123456789abcdef")
+
+
+class SoakError(RuntimeError):
+    """Raised when evidence is incomplete or violates its contract."""
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise SoakError(f"cannot read JSON {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise SoakError(f"JSON root must be an object: {path}")
+    return value
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def is_sha256(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    digest = value.removeprefix("sha256:")
+    return len(digest) == 64 and all(char in HEX64 for char in digest)
+
+
+def finite_number(value: object) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(float(value))
+
+
+def validate_policy(policy: dict[str, Any]) -> list[str]:
+    findings: list[str] = []
+    if policy.get("schema_version") != 1 or policy.get("artifact_kind") != "rocketmq_message_path_soak_policy":
+        findings.append("policy schema_version/artifact_kind is invalid")
+    profiles = policy.get("profiles")
+    if not isinstance(profiles, dict) or set(profiles) != {"smoke", "full"}:
+        findings.append("policy profiles must contain exactly smoke and full")
+    else:
+        for name, profile in profiles.items():
+            if not isinstance(profile, dict):
+                findings.append(f"profile {name} must be an object")
+                continue
+            for key in ("observation_seconds", "sample_interval_seconds", "maximum_gap_seconds"):
+                if not isinstance(profile.get(key), int) or profile[key] <= 0:
+                    findings.append(f"profile {name}.{key} must be a positive integer")
+            for key in ("warmup_seconds", "cooldown_seconds"):
+                if not isinstance(profile.get(key), int) or profile[key] < 0:
+                    findings.append(f"profile {name}.{key} must be a non-negative integer")
+            coverage = profile.get("minimum_coverage_percent")
+            if not finite_number(coverage) or not 0 < float(coverage) <= 100:
+                findings.append(f"profile {name}.minimum_coverage_percent must be in (0,100]")
+    if isinstance(profiles, dict) and isinstance(profiles.get("full"), dict):
+        full = profiles["full"]
+        if full.get("warmup_seconds", 0) < 1800 or full.get("observation_seconds", 0) < 21600:
+            findings.append("full profile must retain at least 30m warmup and 6h observation")
+        if full.get("cooldown_seconds", 0) < 900:
+            findings.append("full profile must retain at least 15m cooldown")
+    required = policy.get("required_series")
+    if not isinstance(required, list) or not required:
+        findings.append("required_series must be a non-empty array")
+    else:
+        names: set[str] = set()
+        for rule in required:
+            if not isinstance(rule, dict) or not isinstance(rule.get("metric"), str):
+                findings.append("every required_series rule needs a metric")
+                continue
+            if rule["metric"] in names:
+                findings.append(f"required metric is duplicated: {rule['metric']}")
+            names.add(rule["metric"])
+            if rule.get("kind") not in {"rss", "task", "fd", "queue", "cache", "lag", "renewal"}:
+                findings.append(f"required metric {rule['metric']} has an unknown kind")
+            if not isinstance(rule.get("minimum_scopes"), int) or rule["minimum_scopes"] <= 0:
+                findings.append(f"required metric {rule['metric']} minimum_scopes must be positive")
+    return findings
+
+
+def load_samples(path: Path) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    samples: list[dict[str, Any]] = []
+    pod_observations: list[dict[str, Any]] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as error:
+        raise SoakError(f"cannot read sample file {path}: {error}") from error
+    for line_number, line in enumerate(lines, 1):
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise SoakError(f"invalid NDJSON at {path}:{line_number}: {error}") from error
+        if not isinstance(record, dict) or not finite_number(record.get("timestamp")):
+            raise SoakError(f"sample {line_number} must contain a finite timestamp")
+        if "pod" in record:
+            pod = record["pod"]
+            if not isinstance(pod, dict):
+                raise SoakError(f"pod sample {line_number} must contain an object")
+            pod_observations.append({"timestamp": float(record["timestamp"]), **pod})
+            continue
+        metric = record.get("metric")
+        scope = record.get("scope")
+        value = record.get("value")
+        if not isinstance(metric, str) or not metric or not isinstance(scope, str) or not scope:
+            raise SoakError(f"metric sample {line_number} needs non-empty metric and scope")
+        if not finite_number(value) or float(value) < 0:
+            raise SoakError(f"metric sample {line_number} value must be finite and non-negative")
+        samples.append(
+            {
+                "timestamp": float(record["timestamp"]),
+                "metric": metric,
+                "scope": scope,
+                "value": float(value),
+            }
+        )
+    if not samples:
+        raise SoakError("sample file contains no metric samples")
+    return samples, pod_observations
+
+
+def percentile(values: list[float], ratio: float) -> float:
+    if not values:
+        raise SoakError("cannot calculate a percentile over no values")
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, math.ceil(ratio * len(ordered)) - 1))
+    return ordered[index]
+
+
+def theil_sen_slope_per_hour(points: list[tuple[float, float]]) -> float:
+    slopes: list[float] = []
+    for index, (left_time, left_value) in enumerate(points):
+        for right_time, right_value in points[index + 1 :]:
+            delta = right_time - left_time
+            if delta > 0:
+                slopes.append((right_value - left_value) / delta * 3600.0)
+    return statistics.median(slopes) if slopes else 0.0
+
+
+def kendall_tau(points: list[tuple[float, float]]) -> float:
+    concordant = 0
+    discordant = 0
+    for index, (_, left_value) in enumerate(points):
+        for _, right_value in points[index + 1 :]:
+            if right_value > left_value:
+                concordant += 1
+            elif right_value < left_value:
+                discordant += 1
+    pairs = concordant + discordant
+    return (concordant - discordant) / pairs if pairs else 0.0
+
+
+def maximum_gap(points: list[tuple[float, float]]) -> float:
+    ordered = sorted(timestamp for timestamp, _ in points)
+    return max((right - left for left, right in zip(ordered, ordered[1:])), default=0.0)
+
+
+def longest_above(points: list[tuple[float, float]], threshold: float) -> float:
+    started: float | None = None
+    longest = 0.0
+    previous = 0.0
+    for timestamp, value in points:
+        if value > threshold:
+            started = timestamp if started is None else started
+            previous = timestamp
+        elif started is not None:
+            longest = max(longest, previous - started)
+            started = None
+    if started is not None:
+        longest = max(longest, previous - started)
+    return longest
+
+
+def pair_capacity_metric(rule: dict[str, Any], groups: dict[tuple[str, str], list[tuple[float, float]]], scope: str) -> float | None:
+    capacity_metric = rule.get("capacity_metric")
+    if not capacity_metric:
+        return None
+    points = groups.get((capacity_metric, scope), [])
+    if not points:
+        return None
+    capacities = {value for _, value in points}
+    if len(capacities) != 1:
+        raise SoakError(f"capacity changed during the run: {capacity_metric}/{scope}")
+    return capacities.pop()
+
+
+def analyze_series(
+    metric: str,
+    scope: str,
+    kind: str,
+    points: list[tuple[float, float]],
+    capacity: float | None,
+    observation_start: float,
+    observation_end: float,
+    cooldown_end: float,
+    comparison_seconds: int,
+    thresholds: dict[str, Any],
+    raw_digest: str,
+) -> dict[str, Any]:
+    observed = [(timestamp, value) for timestamp, value in sorted(points) if observation_start <= timestamp <= observation_end]
+    if not observed:
+        raise SoakError(f"series has no observation samples: {metric}/{scope}")
+    first_values = [value for timestamp, value in observed if timestamp <= observation_start + comparison_seconds]
+    last_values = [value for timestamp, value in observed if timestamp >= observation_end - comparison_seconds]
+    if not first_values or not last_values:
+        raise SoakError(f"series lacks first/last comparison windows: {metric}/{scope}")
+    values = [value for _, value in observed]
+    first_median = statistics.median(first_values)
+    last_median = statistics.median(last_values)
+    delta = last_median - first_median
+    slope = theil_sen_slope_per_hour(observed)
+    tau = kendall_tau(observed)
+    failures: list[str] = []
+    leak = False
+
+    if kind == "rss":
+        limit = capacity
+        config = thresholds[kind]
+        if limit is None or limit <= 0:
+            failures.append("memory limit is missing")
+        elif max(values) >= limit * float(config["maximum_limit_ratio"]):
+            failures.append("RSS reached the configured memory-limit ceiling")
+        allowed_delta = max(
+            first_median * float(config["maximum_delta_ratio"]),
+            float(config["maximum_delta_bytes"]),
+        )
+        if delta > allowed_delta:
+            failures.append("RSS endpoint delta exceeds the stability allowance")
+        leak = (
+            tau >= float(config["minimum_kendall_tau"])
+            and slope > float(config["minimum_leak_slope_bytes_per_hour"])
+            and delta > allowed_delta
+        )
+    elif kind in {"task", "fd"}:
+        config = thresholds[kind]
+        allowed_delta = max(
+            first_median * float(config["maximum_delta_ratio"]),
+            float(config["maximum_delta_absolute"]),
+        )
+        if delta > allowed_delta:
+            failures.append(f"{kind} endpoint delta exceeds the stability allowance")
+        leak = (
+            tau >= float(config["minimum_kendall_tau"])
+            and slope > float(config["minimum_leak_slope_per_hour"])
+            and delta > allowed_delta
+        )
+    elif kind == "queue":
+        config = thresholds[kind]
+        if capacity is None or capacity <= 0:
+            failures.append("queue capacity is missing")
+        else:
+            if max(values) > capacity:
+                failures.append("queue exceeded its hard capacity")
+            if percentile(values, 0.99) > capacity * float(config["maximum_p99_capacity_ratio"]):
+                failures.append("queue p99 occupancy exceeds the stability allowance")
+            cooldown = [value for timestamp, value in points if observation_end < timestamp <= cooldown_end]
+            if not cooldown:
+                failures.append("queue cooldown samples are missing")
+            elif statistics.median(cooldown) > capacity * float(config["maximum_cooldown_ratio"]):
+                failures.append("queue did not drain during cooldown")
+    elif kind == "cache":
+        config = thresholds[kind]
+        if capacity is None or capacity <= 0:
+            failures.append("cache budget is missing")
+        else:
+            if max(values) > capacity * float(config["maximum_budget_ratio"]):
+                failures.append("cache exceeded its hard budget")
+            allowed_delta = max(
+                capacity * float(config["maximum_delta_ratio"]),
+                float(config["maximum_delta_bytes"]),
+            )
+            leak = (
+                tau >= float(config["minimum_kendall_tau"])
+                and slope > capacity * float(config["minimum_leak_slope_budget_ratio_per_hour"])
+                and delta > allowed_delta
+            )
+            if leak:
+                failures.append("cache shows sustained monotonic growth instead of a plateau")
+    elif kind == "lag":
+        config = thresholds[kind]
+        if longest_above(observed, float(config["maximum_sustained_bytes"])) > float(
+            config["maximum_sustained_seconds"]
+        ):
+            failures.append("lag remained above the sustained threshold")
+    elif kind == "renewal":
+        if max(values) > float(thresholds[kind]["maximum_due_lag_micros"]):
+            failures.append("receipt renewal due-lag exceeded its deadline allowance")
+
+    if leak and not failures:
+        failures.append("monotonic growth detected")
+    return {
+        "metric": metric,
+        "scope": scope,
+        "kind": kind,
+        "status": "pass" if not failures else "fail",
+        "sample_count": len(observed),
+        "first_window_median": first_median,
+        "last_window_median": last_median,
+        "delta": delta,
+        "p95": percentile(values, 0.95),
+        "p99": percentile(values, 0.99),
+        "max": max(values),
+        "capacity": capacity,
+        "theil_sen_slope_per_hour": slope,
+        "kendall_tau": tau,
+        "monotonic_growth": leak,
+        "failures": failures,
+        "raw_artifact_sha256": "sha256:" + raw_digest,
+    }
+
+
+def summarize_pods(observations: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[str]]:
+    by_name: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for item in observations:
+        name = item.get("name")
+        if isinstance(name, str) and name:
+            by_name[name].append(item)
+    findings: list[str] = []
+    pods: list[dict[str, Any]] = []
+    for name, items in sorted(by_name.items()):
+        uids = {str(item.get("uid", "")) for item in items}
+        restarts = max((int(item.get("restarts", 0)) for item in items), default=0)
+        oom_killed = any(bool(item.get("oom_killed", False)) for item in items)
+        if len(uids) != 1 or "" in uids:
+            findings.append(f"pod identity changed or is missing: {name}")
+        if restarts != 0 or oom_killed:
+            findings.append(f"pod restarted or was OOM-killed: {name}")
+        pods.append({"name": name, "uid": sorted(uids)[0] if uids else "", "restarts": restarts, "oom_killed": oom_killed})
+    if not pods:
+        findings.append("pod identity/restart observations are missing")
+    return pods, findings
+
+
+def analyze(
+    policy: dict[str, Any],
+    profile_name: str,
+    samples_path: Path,
+    identity_path: Path,
+    output_path: Path,
+    workload_path: Path | None,
+    policy_digest: str | None = None,
+) -> dict[str, Any]:
+    findings = validate_policy(policy)
+    if findings:
+        raise SoakError("invalid soak policy: " + "; ".join(findings))
+    profile = policy["profiles"].get(profile_name)
+    if profile is None:
+        raise SoakError(f"unknown soak profile: {profile_name}")
+    identity = read_json(identity_path)
+    required_identity = {
+        "commit",
+        "deployment_digest",
+        "target_id",
+        "cluster_uid",
+        "effective_config_sha256",
+        "durability_contract",
+    }
+    missing_identity = sorted(required_identity - identity.keys())
+    if missing_identity:
+        raise SoakError("release identity is missing: " + ", ".join(missing_identity))
+    samples, pod_observations = load_samples(samples_path)
+    timestamps = sorted({sample["timestamp"] for sample in samples})
+    run_start = timestamps[0]
+    observation_start = run_start + profile["warmup_seconds"]
+    observation_end = observation_start + profile["observation_seconds"]
+    cooldown_end = observation_end + profile["cooldown_seconds"]
+    if timestamps[-1] < cooldown_end:
+        raise SoakError("sample timeline does not cover warmup, observation, and cooldown")
+
+    groups: dict[tuple[str, str], list[tuple[float, float]]] = defaultdict(list)
+    for sample in samples:
+        groups[(sample["metric"], sample["scope"])].append((sample["timestamp"], sample["value"]))
+    raw_digest = sha256_file(samples_path)
+    expected = profile["observation_seconds"] // profile["sample_interval_seconds"] + 1
+    observed_counts: list[int] = []
+    max_gap_seconds = 0.0
+    series: list[dict[str, Any]] = []
+    failures: list[str] = []
+    for rule in policy["required_series"]:
+        matching = sorted((scope, points) for (metric, scope), points in groups.items() if metric == rule["metric"])
+        if len(matching) < rule["minimum_scopes"]:
+            failures.append(
+                f"required metric {rule['metric']} has {len(matching)} scopes; {rule['minimum_scopes']} required"
+            )
+            continue
+        for scope, points in matching:
+            observed_points = [point for point in points if observation_start <= point[0] <= observation_end]
+            observed_counts.append(len(observed_points))
+            max_gap_seconds = max(max_gap_seconds, maximum_gap(observed_points))
+            capacity = pair_capacity_metric(rule, groups, scope)
+            result = analyze_series(
+                rule["metric"],
+                scope,
+                rule["kind"],
+                points,
+                capacity,
+                observation_start,
+                observation_end,
+                cooldown_end,
+                min(policy["windows"]["comparison_seconds"], max(1, profile["observation_seconds"] // 2)),
+                policy["thresholds"],
+                raw_digest,
+            )
+            series.append(result)
+            failures.extend(f"{result['metric']}/{scope}: {message}" for message in result["failures"])
+
+    observed = min(observed_counts, default=0)
+    coverage = observed / expected * 100.0 if expected else 0.0
+    if coverage < float(profile["minimum_coverage_percent"]):
+        failures.append("sampling coverage is below the profile minimum")
+    if max_gap_seconds > float(profile["maximum_gap_seconds"]):
+        failures.append("sampling maximum gap exceeds the profile limit")
+    pods, pod_findings = summarize_pods(pod_observations)
+    failures.extend(pod_findings)
+
+    workload: dict[str, Any] | None = None
+    artifacts = [
+        {"path": samples_path.name, "sha256": raw_digest},
+        {"path": identity_path.name, "sha256": sha256_file(identity_path)},
+    ]
+    if workload_path is not None:
+        workload = read_json(workload_path)
+        workload_digest = sha256_file(workload_path)
+        artifacts.append({"path": workload_path.name, "sha256": workload_digest})
+        attempted = workload.get("attempted")
+        put_ok = workload.get("put_ok")
+        consumed = workload.get("consumed")
+        if not isinstance(attempted, int) or attempted <= 0 or put_ok != attempted or consumed != put_ok:
+            failures.append("workload did not consume every PutOk message")
+        for key in ("send_failures", "consume_failures", "missing", "duplicates", "corrupt"):
+            if workload.get(key) != 0:
+                failures.append(f"workload {key} must be zero")
+    elif profile_name == "full":
+        failures.append("full soak requires a workload summary")
+
+    growth = any(item["monotonic_growth"] for item in series)
+    report = {
+        "schema_version": 1,
+        "artifact_kind": "rocketmq_message_path_soak_report",
+        "profile": profile_name,
+        "status": "pass" if not failures else "fail",
+        "monotonic_growth_detected": growth,
+        "started_at": dt.datetime.fromtimestamp(observation_start, dt.timezone.utc).isoformat(),
+        "finished_at": dt.datetime.fromtimestamp(observation_end, dt.timezone.utc).isoformat(),
+        "duration_seconds": int(profile["observation_seconds"]),
+        "release_identity": identity,
+        "sampling": {
+            "interval_seconds": profile["sample_interval_seconds"],
+            "expected": expected,
+            "observed": observed,
+            "coverage_percent": coverage,
+            "max_gap_seconds": max_gap_seconds,
+        },
+        "workload": workload,
+        "pods": pods,
+        "series": series,
+        "failures": failures,
+        "policy_sha256": policy_digest
+        or hashlib.sha256(json.dumps(policy, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest(),
+        "artifacts": artifacts,
+    }
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return report
+
+
+def validate_report(policy: dict[str, Any], report_path: Path) -> list[str]:
+    findings = validate_policy(policy)
+    report = read_json(report_path)
+    if report.get("schema_version") != 1 or report.get("artifact_kind") != "rocketmq_message_path_soak_report":
+        findings.append("report schema_version/artifact_kind is invalid")
+    profile_name = report.get("profile")
+    if profile_name not in policy.get("profiles", {}):
+        findings.append("report profile is invalid")
+        return findings
+    profile = policy["profiles"][profile_name]
+    if report.get("duration_seconds", 0) < profile["observation_seconds"]:
+        findings.append("report duration is below the selected profile")
+    sampling = report.get("sampling")
+    if not isinstance(sampling, dict):
+        findings.append("report sampling is missing")
+    else:
+        if sampling.get("coverage_percent", 0) < profile["minimum_coverage_percent"]:
+            findings.append("report coverage is below policy")
+        if sampling.get("max_gap_seconds", math.inf) > profile["maximum_gap_seconds"]:
+            findings.append("report maximum gap is above policy")
+    identity = report.get("release_identity")
+    if not isinstance(identity, dict):
+        findings.append("report release_identity is missing")
+    pods = report.get("pods")
+    if not isinstance(pods, list) or not pods:
+        findings.append("report pod evidence is missing")
+    elif any(pod.get("restarts") != 0 or pod.get("oom_killed") is not False for pod in pods):
+        findings.append("report contains restarted or OOM-killed pods")
+    series = report.get("series")
+    if not isinstance(series, list) or not series:
+        findings.append("report series is missing")
+    elif any(item.get("status") != "pass" or not is_sha256(item.get("raw_artifact_sha256")) for item in series):
+        findings.append("report contains failed or unbound resource series")
+    artifacts = report.get("artifacts")
+    if not isinstance(artifacts, list) or not artifacts:
+        findings.append("report artifact inventory is missing")
+    else:
+        for artifact in artifacts:
+            if not isinstance(artifact, dict) or not is_sha256(artifact.get("sha256")):
+                findings.append("report artifact inventory contains an invalid digest")
+                continue
+            path = report_path.parent / str(artifact.get("path", ""))
+            if not path.is_file() or sha256_file(path) != artifact["sha256"]:
+                findings.append(f"report artifact is missing or tampered: {artifact.get('path')}")
+    if report.get("status") != "pass" or report.get("monotonic_growth_detected") is not False:
+        findings.append("report did not pass resource stability qualification")
+    return findings
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("--policy", type=Path, default=DEFAULT_POLICY)
+    commands = result.add_subparsers(dest="command", required=True)
+    commands.add_parser("validate-policy")
+    analyze_command = commands.add_parser("analyze")
+    analyze_command.add_argument("--profile", choices=("smoke", "full"), required=True)
+    analyze_command.add_argument("--samples", type=Path, required=True)
+    analyze_command.add_argument("--identity", type=Path, required=True)
+    analyze_command.add_argument("--workload-summary", type=Path)
+    analyze_command.add_argument("--output", type=Path, required=True)
+    report_command = commands.add_parser("validate-report")
+    report_command.add_argument("--report", type=Path, required=True)
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    try:
+        policy = read_json(args.policy)
+        if args.command == "validate-policy":
+            findings = validate_policy(policy)
+            if findings:
+                raise SoakError("; ".join(findings))
+            print("MESSAGE_PATH_SOAK_POLICY_OK")
+            return 0
+        if args.command == "analyze":
+            report = analyze(
+                policy,
+                args.profile,
+                args.samples,
+                args.identity,
+                args.output,
+                args.workload_summary,
+                sha256_file(args.policy),
+            )
+            print(json.dumps({"status": report["status"], "report": str(args.output.resolve())}, sort_keys=True))
+            return 0 if report["status"] == "pass" else 2
+        findings = validate_report(policy, args.report)
+        if findings:
+            raise SoakError("; ".join(findings))
+        print("MESSAGE_PATH_SOAK_REPORT_OK")
+        return 0
+    except SoakError as error:
+        print(f"MESSAGE_PATH_SOAK_ERROR: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-message-path-soak.ps1
+++ b/scripts/run-message-path-soak.ps1
@@ -1,0 +1,243 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[CmdletBinding()]
+param(
+    [ValidateSet("Validate", "Smoke", "Full")]
+    [string]$Mode = "Validate",
+
+    [string]$PrometheusUrl,
+    [string]$ReleaseIdentity,
+    [string]$WorkloadSummary,
+    [string]$Namespace = "rocketmq-system",
+    [string]$LoadDriverDeployment = "rocketmq-slo-message-probe",
+    [string]$EvidenceRoot = "target/message-path-soak"
+)
+
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+Set-StrictMode -Version Latest
+
+$Root = Split-Path -Parent $PSScriptRoot
+$PolicyPath = Join-Path $PSScriptRoot "message-path-soak-policy.json"
+$Analyzer = Join-Path $PSScriptRoot "message_path_soak.py"
+
+function Assert-True {
+    param([Parameter(Mandatory)][bool]$Condition, [Parameter(Mandatory)][string]$Message)
+    if (-not $Condition) {
+        throw "message-path soak assertion failed: $Message"
+    }
+}
+
+function Resolve-RepositoryPath {
+    param([Parameter(Mandatory)][string]$Path)
+    if ([IO.Path]::IsPathRooted($Path)) {
+        return [IO.Path]::GetFullPath($Path)
+    }
+    [IO.Path]::GetFullPath((Join-Path $Root $Path))
+}
+
+function Invoke-Native {
+    param([Parameter(Mandatory)][string]$Command, [Parameter(Mandatory)][string[]]$Arguments)
+    $output = & $Command @Arguments 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Command $($Arguments -join ' ') failed with exit code ${LASTEXITCODE}:`n$output"
+    }
+    $output.TrimEnd()
+}
+
+function Write-Ndjson {
+    param([Parameter(Mandatory)][string]$Path, [Parameter(Mandatory)][hashtable]$Record)
+    $line = $Record | ConvertTo-Json -Depth 12 -Compress
+    [IO.File]::AppendAllText($Path, $line + "`n", [Text.UTF8Encoding]::new($false))
+}
+
+function Get-PrometheusSeries {
+    param([Parameter(Mandatory)][string]$Metric)
+    $query = [Uri]::EscapeDataString($Metric)
+    $url = $PrometheusUrl.TrimEnd('/') + "/api/v1/query?query=$query"
+    $response = Invoke-RestMethod -Method Get -Uri $url -TimeoutSec 15
+    Assert-True ($response.status -eq "success") "Prometheus query failed for $Metric"
+    @($response.data.result)
+}
+
+function Get-SeriesScope {
+    param([Parameter(Mandatory)]$Labels)
+    $pairs = @($Labels.PSObject.Properties |
+        Where-Object { $_.Name -ne "__name__" } |
+        Sort-Object Name |
+        ForEach-Object { "$($_.Name)=$($_.Value)" })
+    if ($pairs.Count -eq 0) { return "global" }
+    $pairs -join ","
+}
+
+function Collect-PrometheusSamples {
+    param([Parameter(Mandatory)][long]$Timestamp, [Parameter(Mandatory)][string]$OutputPath)
+    $metrics = @(
+        "rocketmq_runtime_tasks",
+        "rocketmq_resource_queue_items",
+        "rocketmq_resource_queue_bytes",
+        "rocketmq_resource_queue_capacity_items",
+        "rocketmq_resource_queue_capacity_bytes",
+        "rocketmq_resource_cache_usage_bytes",
+        "rocketmq_resource_cache_budget_bytes",
+        "rocketmq_storage_flush_behind_bytes",
+        "rocketmq_storage_dispatch_behind_bytes",
+        "rocketmq_store_ha_replication_lag_bytes",
+        "rocketmq_receipt_renewal_due_lag_micros"
+    )
+    foreach ($metric in $metrics) {
+        foreach ($series in @(Get-PrometheusSeries -Metric $metric)) {
+            $value = [double]$series.value[1]
+            Assert-True (-not [double]::IsNaN($value) -and -not [double]::IsInfinity($value) -and $value -ge 0) `
+                "Prometheus returned an invalid value for $metric"
+            Write-Ndjson -Path $OutputPath -Record @{
+                timestamp = $Timestamp
+                metric = $metric
+                scope = Get-SeriesScope -Labels $series.metric
+                value = $value
+            }
+        }
+    }
+}
+
+function Collect-PodSamples {
+    param([Parameter(Mandatory)][long]$Timestamp, [Parameter(Mandatory)][string]$OutputPath)
+    $podList = Invoke-Native kubectl @(
+        "-n", $Namespace, "get", "pods", "-l", "app.kubernetes.io/part-of=rocketmq-rust", "-o", "json"
+    ) | ConvertFrom-Json
+    Assert-True (@($podList.items).Count -gt 0) "no RocketMQ pods were found"
+    foreach ($pod in @($podList.items)) {
+        Assert-True ($pod.status.phase -eq "Running") "pod $($pod.metadata.name) is not Running"
+        $containerStatuses = @($pod.status.containerStatuses)
+        $restarts = ($containerStatuses | Measure-Object -Property restartCount -Sum).Sum
+        if ($null -eq $restarts) { $restarts = 0 }
+        $oomKilled = @($containerStatuses | Where-Object {
+            $lastTermination = $_.lastState.terminated
+            $currentTermination = $_.state.terminated
+            ($null -ne $lastTermination -and $lastTermination.reason -eq "OOMKilled") -or
+                ($null -ne $currentTermination -and $currentTermination.reason -eq "OOMKilled")
+        }).Count -gt 0
+        Write-Ndjson -Path $OutputPath -Record @{
+            timestamp = $Timestamp
+            pod = @{
+                name = [string]$pod.metadata.name
+                uid = [string]$pod.metadata.uid
+                restarts = [int]$restarts
+                oom_killed = [bool]$oomKilled
+            }
+        }
+
+        $probe = 'rss=$(awk ''/VmRSS:/ {print $2 * 1024}'' /proc/1/status); tasks=$(find /proc/1/task -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l); threads=$(awk ''/Threads:/ {print $2}'' /proc/1/status); fds=$(find /proc/1/fd -mindepth 1 -maxdepth 1 2>/dev/null | wc -l); limit=$(cat /sys/fs/cgroup/memory.max 2>/dev/null || cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null || echo 0); [ "$limit" = max ] && limit=0; printf "%s,%s,%s,%s,%s" "$rss" "$tasks" "$threads" "$fds" "$limit"'
+        $values = (Invoke-Native kubectl @(
+            "-n", $Namespace, "exec", [string]$pod.metadata.name, "--", "sh", "-c", $probe
+        )).Trim().Split(',')
+        Assert-True ($values.Count -eq 5) "pod resource probe returned an invalid payload for $($pod.metadata.name)"
+        $scope = "pod/$($pod.metadata.name)"
+        $measurements = @{
+            process_rss_bytes = [double]$values[0]
+            process_tasks = [double]$values[1]
+            process_threads = [double]$values[2]
+            process_open_fds = [double]$values[3]
+            process_memory_limit_bytes = [double]$values[4]
+        }
+        foreach ($entry in $measurements.GetEnumerator()) {
+            Write-Ndjson -Path $OutputPath -Record @{
+                timestamp = $Timestamp
+                metric = $entry.Key
+                scope = $scope
+                value = $entry.Value
+            }
+        }
+    }
+}
+
+Invoke-Native python @($Analyzer, "--policy", $PolicyPath, "validate-policy") | Write-Output
+if ($Mode -eq "Validate") {
+    Write-Output "MESSAGE_PATH_SOAK_RUNNER_OK full_observation_seconds=21600"
+    exit 0
+}
+
+foreach ($command in @("python", "kubectl")) {
+    Assert-True ($null -ne (Get-Command $command -ErrorAction SilentlyContinue)) "required command is unavailable: $command"
+}
+Assert-True (-not [string]::IsNullOrWhiteSpace($PrometheusUrl)) "PrometheusUrl is required"
+Assert-True (-not [string]::IsNullOrWhiteSpace($ReleaseIdentity)) "ReleaseIdentity is required"
+$identityPath = Resolve-RepositoryPath $ReleaseIdentity
+Assert-True (Test-Path -LiteralPath $identityPath -PathType Leaf) "release identity file is missing"
+
+$policy = Get-Content -Raw -LiteralPath $PolicyPath | ConvertFrom-Json
+$profileName = $Mode.ToLowerInvariant()
+$profile = $policy.profiles.$profileName
+if ($Mode -eq "Full") {
+    Assert-True (-not [string]::IsNullOrWhiteSpace($WorkloadSummary)) "Full mode requires WorkloadSummary"
+}
+
+$runId = "message-path-soak-$profileName-$([DateTimeOffset]::UtcNow.ToString('yyyyMMddTHHmmssZ'))"
+$runDirectory = Join-Path (Resolve-RepositoryPath $EvidenceRoot) $runId
+Assert-True (-not (Test-Path -LiteralPath $runDirectory)) "evidence directory already exists: $runDirectory"
+New-Item -ItemType Directory -Path $runDirectory | Out-Null
+$samplesPath = Join-Path $runDirectory "raw-samples.ndjson"
+$reportPath = Join-Path $runDirectory "soak-report.json"
+$boundIdentityPath = Join-Path $runDirectory "release-identity.json"
+Copy-Item -LiteralPath $identityPath -Destination $boundIdentityPath
+$boundWorkloadPath = $null
+$resolvedWorkload = $null
+if (-not [string]::IsNullOrWhiteSpace($WorkloadSummary)) {
+    $resolvedWorkload = Resolve-RepositoryPath $WorkloadSummary
+    Assert-True (Test-Path -LiteralPath $resolvedWorkload -PathType Leaf) "workload summary file is missing"
+    $boundWorkloadPath = Join-Path $runDirectory "workload-summary.json"
+}
+
+$ready = Invoke-RestMethod -Method Get -Uri ($PrometheusUrl.TrimEnd('/') + "/-/ready") -TimeoutSec 10
+Assert-True (([string]$ready).Trim() -eq "Prometheus Server is Ready.") "Prometheus is not ready"
+$start = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+$observationEnd = $start + [int]$profile.warmup_seconds + [int]$profile.observation_seconds
+$end = $observationEnd + [int]$profile.cooldown_seconds
+$driverStopped = $false
+
+while ($true) {
+    $timestamp = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+    if (-not $driverStopped -and $timestamp -ge $observationEnd) {
+        if (-not [string]::IsNullOrWhiteSpace($LoadDriverDeployment)) {
+            Invoke-Native kubectl @(
+                "-n", $Namespace, "scale", "deployment/$LoadDriverDeployment", "--replicas=0"
+            ) | Out-Null
+        }
+        $driverStopped = $true
+    }
+    Collect-PodSamples -Timestamp $timestamp -OutputPath $samplesPath
+    Collect-PrometheusSamples -Timestamp $timestamp -OutputPath $samplesPath
+    if ($timestamp -ge $end) { break }
+    $sleepSeconds = [Math]::Min([int]$profile.sample_interval_seconds, [Math]::Max(1, $end - $timestamp))
+    Start-Sleep -Seconds $sleepSeconds
+}
+
+# Bind the final workload counters after the observation and cooldown windows.
+# The long-running probe may update its summary until it is scaled down.
+if ($null -ne $boundWorkloadPath) {
+    Assert-True (Test-Path -LiteralPath $resolvedWorkload -PathType Leaf) "final workload summary file is missing"
+    Copy-Item -LiteralPath $resolvedWorkload -Destination $boundWorkloadPath
+}
+
+$arguments = @(
+    $Analyzer, "--policy", $PolicyPath, "analyze", "--profile", $profileName,
+    "--samples", $samplesPath, "--identity", $boundIdentityPath, "--output", $reportPath
+)
+if ($null -ne $boundWorkloadPath) {
+    $arguments += @("--workload-summary", $boundWorkloadPath)
+}
+Invoke-Native python $arguments | Write-Output
+Invoke-Native python @($Analyzer, "--policy", $PolicyPath, "validate-report", "--report", $reportPath) | Write-Output
+Write-Output "MESSAGE_PATH_SOAK_COMPLETE evidence=$runDirectory"

--- a/scripts/tests/test_message_path_qualification.py
+++ b/scripts/tests/test_message_path_qualification.py
@@ -354,9 +354,13 @@ class MessagePathQualificationTest(unittest.TestCase):
                 },
                 "confirm_offset": {"valid": True, "observations": 10, "violation_count": 0},
             }
+            raw_samples = root / "raw-samples.ndjson"
+            raw_samples.write_text('{"sample":1}\n', encoding="utf-8")
+            raw_digest = qualification.sha256_file(raw_samples)
             soak = {
                 "schema_version": 1,
                 "artifact_kind": "rocketmq_message_path_soak_report",
+                "profile": "full",
                 "status": "pass",
                 "monotonic_growth_detected": False,
                 "duration_seconds": 21600,
@@ -369,8 +373,19 @@ class MessagePathQualificationTest(unittest.TestCase):
                     "durability_contract": "strict",
                 },
                 "sampling": {"coverage_percent": 99.9, "max_gap_seconds": 60},
-                "pods": [{"restarts": 0, "oom_killed": False}],
-                "series": [{"status": "pass", "raw_artifact_sha256": "sha256:" + "5" * 64}],
+                "workload": {
+                    "attempted": 10000,
+                    "put_ok": 10000,
+                    "consumed": 10000,
+                    "send_failures": 0,
+                    "consume_failures": 0,
+                    "missing": 0,
+                    "duplicates": 0,
+                    "corrupt": 0,
+                },
+                "pods": [{"name": "broker-0", "uid": "pod-uid", "restarts": 0, "oom_killed": False}],
+                "series": [{"status": "pass", "raw_artifact_sha256": "sha256:" + raw_digest}],
+                "artifacts": [{"path": raw_samples.name, "sha256": raw_digest}],
             }
             paths = {}
             for name, value in (("comparison", comparison), ("fault", fault), ("rpo", rpo), ("soak", soak)):

--- a/scripts/tests/test_message_path_soak.py
+++ b/scripts/tests/test_message_path_soak.py
@@ -1,0 +1,164 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import message_path_soak as soak  # noqa: E402
+
+
+class MessagePathSoakTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.policy = soak.read_json(ROOT / "scripts" / "message-path-soak-policy.json")
+        self.temp = tempfile.TemporaryDirectory()
+        self.directory = Path(self.temp.name)
+        self.identity = self.directory / "release-identity.json"
+        self.identity.write_text(
+            json.dumps(
+                {
+                    "commit": "a" * 40,
+                    "deployment_digest": "sha256:" + "b" * 64,
+                    "target_id": "kind-local",
+                    "cluster_uid": "cluster-uid",
+                    "effective_config_sha256": "sha256:" + "c" * 64,
+                    "durability_contract": "sync-flush-required-replica-acks",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def write_samples(
+        self,
+        *,
+        rss_growth: bool = False,
+        queue_overflow: bool = False,
+        restart: bool = False,
+        omit_metric: str | None = None,
+        skip_timestamps: set[int] | None = None,
+    ) -> Path:
+        path = self.directory / "raw-samples.ndjson"
+        records: list[dict[str, object]] = []
+        skip_timestamps = skip_timestamps or set()
+        for step in range(16):
+            if step in skip_timestamps:
+                continue
+            timestamp = 1_700_000_000 + step * 5
+            records.append(
+                {
+                    "timestamp": timestamp,
+                    "pod": {
+                        "name": "broker-0",
+                        "uid": "pod-uid",
+                        "restarts": 1 if restart and step == 15 else 0,
+                        "oom_killed": False,
+                    },
+                }
+            )
+            rss = 128 * 1024 * 1024 + (step * 48 * 1024 * 1024 if rss_growth else step * 1024)
+            queue = 120 if queue_overflow and step == 7 else (0 if step > 12 else 10)
+            metrics = {
+                "process_rss_bytes": ("pod/broker-0", rss),
+                "process_memory_limit_bytes": ("pod/broker-0", 1024 * 1024 * 1024),
+                "process_tasks": ("pod/broker-0", 12),
+                "process_threads": ("pod/broker-0", 8),
+                "process_open_fds": ("pod/broker-0", 32),
+                "rocketmq_runtime_tasks": ("component=broker", 12),
+                "rocketmq_resource_queue_items": ("budget=commands", queue),
+                "rocketmq_resource_queue_capacity_items": ("budget=commands", 100),
+                "rocketmq_resource_queue_bytes": ("budget=commands", queue * 1024),
+                "rocketmq_resource_queue_capacity_bytes": ("budget=commands", 100 * 1024),
+                "rocketmq_resource_cache_usage_bytes": ("budget=rocksdb", 128 * 1024 * 1024),
+                "rocketmq_resource_cache_budget_bytes": ("budget=rocksdb", 512 * 1024 * 1024),
+                "rocketmq_storage_flush_behind_bytes": ("component=store", 0),
+                "rocketmq_storage_dispatch_behind_bytes": ("component=store", 0),
+                "rocketmq_store_ha_replication_lag_bytes": ("component=store", 0),
+                "rocketmq_receipt_renewal_due_lag_micros": ("component=proxy", 10_000),
+            }
+            for metric, (scope, value) in metrics.items():
+                if metric == omit_metric:
+                    continue
+                records.append({"timestamp": timestamp, "metric": metric, "scope": scope, "value": value})
+        path.write_text("\n".join(json.dumps(record) for record in records) + "\n", encoding="utf-8")
+        return path
+
+    def analyze(self, samples: Path) -> dict[str, object]:
+        output = self.directory / "soak-report.json"
+        return soak.analyze(self.policy, "smoke", samples, self.identity, output, None)
+
+    def test_policy_preserves_six_hour_release_contract(self) -> None:
+        self.assertEqual([], soak.validate_policy(self.policy))
+        full = self.policy["profiles"]["full"]
+        self.assertEqual(1800, full["warmup_seconds"])
+        self.assertEqual(21600, full["observation_seconds"])
+        self.assertEqual(900, full["cooldown_seconds"])
+
+    def test_stable_series_pass_and_bind_raw_artifact(self) -> None:
+        report = self.analyze(self.write_samples())
+        self.assertEqual("pass", report["status"])
+        self.assertFalse(report["monotonic_growth_detected"])
+        self.assertEqual([], soak.validate_report(self.policy, self.directory / "soak-report.json"))
+
+    def test_rss_monotonic_growth_fails(self) -> None:
+        report = self.analyze(self.write_samples(rss_growth=True))
+        self.assertEqual("fail", report["status"])
+        self.assertTrue(report["monotonic_growth_detected"])
+
+    def test_queue_capacity_violation_fails(self) -> None:
+        report = self.analyze(self.write_samples(queue_overflow=True))
+        self.assertEqual("fail", report["status"])
+        self.assertTrue(any("hard capacity" in finding for finding in report["failures"]))
+
+    def test_missing_required_metric_fails_closed(self) -> None:
+        report = self.analyze(self.write_samples(omit_metric="rocketmq_runtime_tasks"))
+        self.assertEqual("fail", report["status"])
+        self.assertTrue(any("required metric rocketmq_runtime_tasks" in finding for finding in report["failures"]))
+
+    def test_restart_fails(self) -> None:
+        report = self.analyze(self.write_samples(restart=True))
+        self.assertEqual("fail", report["status"])
+        self.assertTrue(any("restarted" in finding for finding in report["failures"]))
+
+    def test_sampling_gap_fails(self) -> None:
+        report = self.analyze(self.write_samples(skip_timestamps={4, 5, 6}))
+        self.assertEqual("fail", report["status"])
+        self.assertTrue(any("maximum gap" in finding for finding in report["failures"]))
+
+    def test_artifact_tamper_is_rejected(self) -> None:
+        samples = self.write_samples()
+        self.analyze(samples)
+        samples.write_text(samples.read_text(encoding="utf-8") + "{}\n", encoding="utf-8")
+        findings = soak.validate_report(self.policy, self.directory / "soak-report.json")
+        self.assertTrue(any("tampered" in finding for finding in findings))
+
+    def test_invalid_full_duration_policy_is_rejected(self) -> None:
+        invalid = copy.deepcopy(self.policy)
+        invalid["profiles"]["full"]["observation_seconds"] = 3600
+        self.assertTrue(any("6h observation" in finding for finding in soak.validate_policy(invalid)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9289

### Brief Description

- exports low-cardinality queue, cache, receipt-renewal, and runtime task stability metrics from the production telemetry handle
- adds bounded resource observations for Broker fast-failure, Proxy execution/egress, NameServer route cache, and RocksDB native memory
- adds fail-closed smoke/full soak policy, runner, analyzer, schema, artifact hashing, Pod identity/restart checks, and deep qualification validation
- binds final workload counters after cooldown and keeps the full release profile at 30 minutes warmup, 6 hours observation, and 15 minutes cooldown

### How Did You Test This Change?

- `python -m unittest scripts.tests.test_message_path_soak scripts.tests.test_message_path_qualification`
- `python scripts/message_path_soak.py --policy scripts/message-path-soak-policy.json validate-policy`
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/run-message-path-soak.ps1 -Mode Validate`
- `cargo test -p rocketmq-observability --all-features`
- `cargo test -p rocketmq-namesrv weight_floor_enforces_entry_count_and_total_bytes --lib`
- `cargo test -p rocketmq-broker pending_budget_rejects_count_before_creating_another_task --lib`
- RocksDB Clippy and all four repository RocksDB/POP specialized tests
- observability feature-matrix checks and Clippy
- `cargo check --manifest-path fuzz/Cargo.toml --all-targets`
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- affected-package `cargo fmt -- --check`, `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`, and `git diff --check`

`cargo fmt --all -- --check` cannot start on this Windows checkout because rustfmt exceeds the OS command-line length limit (os error 206); every affected package passed the non-mutating format check.
