### PR TITLE
[ISSUE #9292]✨Bind release evidence and rehearse rollback recovery

### DIFF
--- a/scripts/message-path-qualification-policy.json
+++ b/scripts/message-path-qualification-policy.json
@@ -58,7 +58,8 @@
         "performance_comparison",
         "fault_matrix",
         "rpo",
-        "soak"
+        "soak",
+        "rollback"
       ],
       "minimum_soak_seconds": 21600,
       "workloads": [

--- a/scripts/message-path-release-evidence-schema.json
+++ b/scripts/message-path-release-evidence-schema.json
@@ -1,0 +1,167 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rocketmq.apache.org/schemas/message-path-release-evidence-v1.json",
+  "title": "RocketMQ Rust message-path release evidence",
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "pattern": "^(?!/)(?![A-Za-z]:)(?!.*(?:^|/)\\.\\.(?:/|$))[A-Za-z0-9._/-]+$"
+        },
+        "sha256": { "$ref": "#/$defs/sha256" },
+        "size_bytes": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "transition_step": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["direction", "status", "target_release_id", "checkpoint_set_id", "verified_at"],
+      "properties": {
+        "direction": { "enum": ["rollback", "forward"] },
+        "status": { "const": "pass" },
+        "target_release_id": { "type": "string", "minLength": 1 },
+        "checkpoint_set_id": { "type": "string", "minLength": 1 },
+        "verified_at": { "type": "string", "format": "date-time" }
+      }
+    },
+    "rollback_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "artifact_kind",
+        "generated_at",
+        "status",
+        "rehearsal_qualified",
+        "dynamic_execution",
+        "fixture",
+        "candidate_commit",
+        "candidate_measurement_sha256",
+        "deployment_digest",
+        "target_id",
+        "cluster_uid",
+        "effective_config_sha256",
+        "durability_contract",
+        "baseline_release_id",
+        "candidate_release_id",
+        "steps",
+        "assertions",
+        "artifacts"
+      ],
+      "properties": {
+        "schema_version": { "const": 1 },
+        "artifact_kind": { "const": "rocketmq_message_path_rollback_evidence" },
+        "generated_at": { "type": "string", "format": "date-time" },
+        "status": { "const": "pass" },
+        "rehearsal_qualified": { "const": true },
+        "dynamic_execution": { "const": true },
+        "fixture": { "const": false },
+        "candidate_commit": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "candidate_measurement_sha256": { "$ref": "#/$defs/digest" },
+        "deployment_digest": { "$ref": "#/$defs/digest" },
+        "target_id": { "type": "string", "minLength": 1 },
+        "cluster_uid": { "type": "string", "minLength": 1 },
+        "effective_config_sha256": { "$ref": "#/$defs/digest" },
+        "durability_contract": { "type": "string", "minLength": 1 },
+        "baseline_release_id": { "type": "string", "minLength": 1 },
+        "candidate_release_id": { "type": "string", "minLength": 1 },
+        "steps": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "allOf": [
+                { "$ref": "#/$defs/transition_step" },
+                { "properties": { "direction": { "const": "rollback" } } }
+              ]
+            },
+            {
+              "allOf": [
+                { "$ref": "#/$defs/transition_step" },
+                { "properties": { "direction": { "const": "forward" } } }
+              ]
+            }
+          ],
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "assertions": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "acknowledged_messages_preserved",
+            "consumer_offsets_preserved",
+            "wal_retained",
+            "persistent_volumes_reused",
+            "storage_generation_unchanged",
+            "candidate_restored"
+          ],
+          "properties": {
+            "acknowledged_messages_preserved": { "const": true },
+            "consumer_offsets_preserved": { "const": true },
+            "wal_retained": { "const": true },
+            "persistent_volumes_reused": { "const": true },
+            "storage_generation_unchanged": { "const": true },
+            "candidate_restored": { "const": true }
+          }
+        },
+        "artifacts": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/artifact" },
+          "minItems": 1
+        }
+      }
+    },
+    "artifact_inventory": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "artifact_kind",
+        "generated_at",
+        "candidate_commit",
+        "release_qualified",
+        "bundle_sha256",
+        "qualification_report_sha256",
+        "artifact_count",
+        "artifacts",
+        "subject",
+        "target",
+        "durability_contract"
+      ],
+      "properties": {
+        "schema_version": { "const": 1 },
+        "artifact_kind": { "const": "rocketmq_message_path_artifact_inventory" },
+        "generated_at": { "type": "string", "format": "date-time" },
+        "candidate_commit": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "release_qualified": { "const": true },
+        "bundle_sha256": { "$ref": "#/$defs/sha256" },
+        "qualification_report_sha256": { "$ref": "#/$defs/sha256" },
+        "artifact_count": { "type": "integer", "minimum": 1 },
+        "artifacts": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/artifact" },
+          "minItems": 1
+        },
+        "subject": { "type": "object" },
+        "target": { "type": "object" },
+        "durability_contract": { "type": "string", "minLength": 1 }
+      }
+    }
+  },
+  "oneOf": [
+    { "$ref": "#/$defs/rollback_evidence" },
+    { "$ref": "#/$defs/artifact_inventory" }
+  ]
+}

--- a/scripts/message_path_qualification.py
+++ b/scripts/message_path_qualification.py
@@ -41,7 +41,7 @@ DEFAULT_OUTPUT_ROOT = ROOT / "target" / "message-path-qualification"
 RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{2,127}$")
 TOPIC_RE = re.compile(r"^[A-Za-z0-9_%.-]{1,127}$")
 SCENARIOS = {"sync", "async", "batch", "lite-pull"}
-EXTERNAL_EVIDENCE = {"performance_comparison", "fault_matrix", "rpo", "soak"}
+EXTERNAL_EVIDENCE = {"performance_comparison", "fault_matrix", "rpo", "soak", "rollback"}
 GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 
@@ -719,6 +719,7 @@ def validate_final_evidence(
         "fault_matrix": evidence_path(args.fault_evidence, "run.json"),
         "rpo": evidence_path(args.rpo_evidence, "ack-failover-run.json"),
         "soak": evidence_path(args.soak_report, "soak-report.json"),
+        "rollback": evidence_path(args.rollback_evidence, "rollback-evidence.json"),
     }
     documents = {key: load_json(path) for key, path in paths.items()}
     candidate = documents["candidate_measurement"]
@@ -726,6 +727,7 @@ def validate_final_evidence(
     fault = documents["fault_matrix"]
     rpo = documents["rpo"]
     soak = documents["soak"]
+    rollback = documents["rollback"]
     findings = validate_measurement_set(policy, candidate, "candidate", expected_role="candidate")
     subject = candidate.get("subject", {})
     target = candidate.get("target", {})
@@ -868,6 +870,88 @@ def validate_final_evidence(
             item.get("raw_artifact_sha256") not in inventory_digests for item in soak["series"]
         ):
             findings.append("soak resource series references a digest outside the artifact inventory")
+
+    if rollback.get("schema_version") != 1 or rollback.get("artifact_kind") != "rocketmq_message_path_rollback_evidence":
+        findings.append("rollback evidence contract is invalid")
+    if (
+        rollback.get("status") != "pass"
+        or rollback.get("rehearsal_qualified") is not True
+        or rollback.get("dynamic_execution") is not True
+        or rollback.get("fixture") is not False
+    ):
+        findings.append("rollback evidence must be a qualified dynamic non-fixture rehearsal")
+    for key, expected in (
+        ("candidate_commit", expected_commit),
+        ("candidate_measurement_sha256", candidate_hash),
+        ("deployment_digest", expected_deployment),
+        ("target_id", expected_target),
+        ("cluster_uid", expected_cluster),
+        ("effective_config_sha256", expected_config),
+        ("durability_contract", expected_durability),
+    ):
+        if rollback.get(key) != expected:
+            findings.append(f"rollback evidence {key} differs")
+    baseline_release_id = rollback.get("baseline_release_id")
+    candidate_release_id = rollback.get("candidate_release_id")
+    if (
+        not isinstance(baseline_release_id, str)
+        or not baseline_release_id
+        or not isinstance(candidate_release_id, str)
+        or not candidate_release_id
+        or baseline_release_id == candidate_release_id
+    ):
+        findings.append("rollback evidence release identities are invalid")
+    steps = rollback.get("steps")
+    expected_directions = ("rollback", "forward")
+    if not isinstance(steps, list) or tuple(step.get("direction") for step in steps if isinstance(step, dict)) != expected_directions:
+        findings.append("rollback evidence must contain rollback and forward steps in order")
+    elif (
+        steps[0].get("target_release_id") != baseline_release_id
+        or steps[1].get("target_release_id") != candidate_release_id
+        or any(
+            step.get("status") != "pass" or not step.get("checkpoint_set_id") or not step.get("verified_at")
+            for step in steps
+        )
+    ):
+        findings.append("rollback evidence contains an incomplete transition step")
+    assertions = rollback.get("assertions")
+    required_assertions = {
+        "acknowledged_messages_preserved",
+        "consumer_offsets_preserved",
+        "wal_retained",
+        "persistent_volumes_reused",
+        "storage_generation_unchanged",
+        "candidate_restored",
+    }
+    if (
+        not isinstance(assertions, dict)
+        or set(assertions) != required_assertions
+        or any(value is not True for value in assertions.values())
+    ):
+        findings.append("rollback evidence did not prove every preservation and recovery assertion")
+    rollback_artifacts = rollback.get("artifacts")
+    if not isinstance(rollback_artifacts, list) or not rollback_artifacts:
+        findings.append("rollback evidence artifact inventory is missing")
+    else:
+        rollback_root = paths["rollback"].parent.resolve()
+        artifact_paths: set[str] = set()
+        for artifact in rollback_artifacts:
+            relative = Path(str(artifact.get("path", ""))) if isinstance(artifact, dict) else Path()
+            digest = str(artifact.get("sha256", "")) if isinstance(artifact, dict) else ""
+            artifact_path = (rollback_root / relative).resolve()
+            if (
+                relative.is_absolute()
+                or ".." in relative.parts
+                or not re.fullmatch(r"[0-9a-f]{64}", digest)
+                or rollback_root not in artifact_path.parents
+                or not artifact_path.is_file()
+                or sha256_file(artifact_path) != digest
+            ):
+                findings.append(f"rollback artifact is missing or tampered: {relative.as_posix()}")
+            elif relative.as_posix() in artifact_paths:
+                findings.append(f"rollback artifact is duplicated: {relative.as_posix()}")
+            else:
+                artifact_paths.add(relative.as_posix())
     return findings, paths, documents
 
 
@@ -954,6 +1038,7 @@ def main() -> int:
     qualify_parser.add_argument("--fault-evidence", type=Path, required=True)
     qualify_parser.add_argument("--rpo-evidence", type=Path, required=True)
     qualify_parser.add_argument("--soak-report", type=Path, required=True)
+    qualify_parser.add_argument("--rollback-evidence", type=Path, required=True)
     qualify_parser.add_argument("--run-id", default=f"message-path-release-{int(time.time())}")
     qualify_parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_ROOT)
 

--- a/scripts/message_path_release.py
+++ b/scripts/message_path_release.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build and verify fail-closed message-path release evidence bundles."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SCHEMA = ROOT / "scripts" / "message-path-release-evidence-schema.json"
+GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+REQUIRED_RELEASE_DIRECTORIES = {"environment", "ab", "fault", "rpo", "soak", "qualification"}
+INVENTORY_PATH = Path("qualification/artifact-inventory.json")
+CHECKSUM_PATH = Path("qualification/bundle-sha256.txt")
+SIGNATURE_PATH = Path("qualification/bundle-sha256.txt.minisig")
+FORBIDDEN_PATH_TOKENS = {
+    "secret",
+    "secrets",
+    "token",
+    "tokens",
+    "credential",
+    "credentials",
+    "password",
+    "passwd",
+    "private-key",
+    "private_key",
+}
+
+
+class ReleaseError(RuntimeError):
+    """Raised when release evidence is incomplete, mutable, or inconsistent."""
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ReleaseError(f"cannot read JSON {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise ReleaseError(f"JSON document must be an object: {path}")
+    return value
+
+
+def write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def canonical_sha256(value: Any) -> str:
+    encoded = json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ReleaseError(message)
+
+
+def required_object(value: Any, context: str) -> dict[str, Any]:
+    require(isinstance(value, dict), f"{context} must be an object")
+    return value
+
+
+def validate_schema_contract(schema: dict[str, Any]) -> None:
+    require(schema.get("$schema") == "https://json-schema.org/draft/2020-12/schema", "release schema draft differs")
+    definitions = required_object(schema.get("$defs"), "release schema $defs")
+    for name in ("rollback_evidence", "artifact_inventory"):
+        definition = required_object(definitions.get(name), f"release schema $defs.{name}")
+        require(definition.get("additionalProperties") is False, f"release schema {name} must be closed")
+        require(isinstance(definition.get("required"), list) and definition["required"], f"release schema {name} required fields missing")
+
+
+def validate_transition_proof(
+    proof: dict[str, Any],
+    checkpoint: dict[str, Any],
+    target_state: dict[str, Any],
+    direction: str,
+) -> None:
+    require(proof.get("schema_version") == 1, f"{direction} proof schema is invalid")
+    require(proof.get("checkpoint_set_id") == checkpoint.get("checkpointSetId"), f"{direction} proof checkpoint differs")
+    require(proof.get("target_release_id") == target_state.get("release_id"), f"{direction} proof target differs")
+    require(proof.get("generation") == checkpoint.get("generation"), f"{direction} proof generation differs")
+    require(proof.get("fencing_token") == checkpoint.get("fencingToken"), f"{direction} proof fence differs")
+    for field in (
+        "acknowledged_messages_preserved",
+        "consumer_offsets_preserved",
+        "wal_retained",
+        "persistent_volumes_reused",
+    ):
+        require(proof.get(field) is True, f"{direction} proof did not establish {field}")
+    stores = checkpoint.get("stores")
+    require(isinstance(stores, list) and stores, f"{direction} checkpoint stores are missing")
+    expected_ids = sorted(str(item.get("artifact", {}).get("checkpointId", "")) for item in stores)
+    actual_ids = sorted(str(item) for item in proof.get("store_checkpoint_ids", []))
+    require("" not in expected_ids and actual_ids == expected_ids, f"{direction} proof Store checkpoints differ")
+    try:
+        dt.datetime.fromisoformat(str(proof.get("verified_at", "")).replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ReleaseError(f"{direction} proof verified_at is invalid") from error
+
+
+def copy_bound_artifact(source: Path, destination_root: Path, name: str) -> dict[str, Any]:
+    require(source.is_file(), f"bound artifact is missing: {source}")
+    destination = destination_root / name
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if source.resolve() != destination.resolve():
+        shutil.copy2(source, destination)
+    return {"path": destination.relative_to(destination_root.parent).as_posix(), "sha256": sha256_file(destination)}
+
+
+def build_rollback_evidence(args: argparse.Namespace) -> dict[str, Any]:
+    candidate = read_json(args.candidate_measurement)
+    baseline_state = read_json(args.baseline_state)
+    candidate_state = read_json(args.candidate_state)
+    rollback_checkpoint = read_json(args.rollback_checkpoint)
+    forward_checkpoint = read_json(args.forward_checkpoint)
+    rollback_proof = read_json(args.rollback_proof)
+    forward_proof = read_json(args.forward_proof)
+    subject = required_object(candidate.get("subject"), "candidate subject")
+    target = required_object(candidate.get("target"), "candidate target")
+    commit = str(subject.get("commit", ""))
+    require(GIT_SHA_RE.fullmatch(commit) is not None, "candidate commit is invalid")
+    require(subject.get("role") == "candidate", "measurement subject must be candidate")
+    require(candidate.get("measurement_qualified") is True and candidate.get("status") == "pass", "candidate measurement is not qualified")
+    require(candidate_state.get("source_commit") == commit, "candidate ReleaseState commit differs")
+    require(candidate_state.get("identity", {}).get("commit") == commit, "candidate ReleaseState identity differs")
+    require(candidate_state.get("identity", {}).get("config_digest") == target.get("effective_config_sha256"), "candidate ReleaseState config differs")
+    require(baseline_state.get("source_commit") != commit, "baseline and candidate commits must differ")
+    require(baseline_state.get("release_id") != candidate_state.get("release_id"), "baseline and candidate releases must differ")
+    require(baseline_state.get("storage_generation") == candidate_state.get("storage_generation"), "storage generations differ")
+    require(rollback_checkpoint.get("releaseId") == candidate_state.get("release_id"), "rollback checkpoint source differs")
+    require(forward_checkpoint.get("releaseId") == baseline_state.get("release_id"), "forward checkpoint source differs")
+    validate_transition_proof(rollback_proof, rollback_checkpoint, baseline_state, "rollback")
+    validate_transition_proof(forward_proof, forward_checkpoint, candidate_state, "forward")
+
+    rollback_log = args.rollback_log.read_text(encoding="utf-8")
+    forward_log = args.forward_log.read_text(encoding="utf-8")
+    rollback_marker = f"direction=Rollback target_release_id={baseline_state['release_id']}"
+    forward_marker = f"direction=Forward target_release_id={candidate_state['release_id']}"
+    require("RELEASE_ROLLBACK_OK" in rollback_log and rollback_marker in rollback_log, "rollback completion marker is missing")
+    require("RELEASE_ROLLBACK_OK" in forward_log and forward_marker in forward_log, "forward completion marker is missing")
+
+    output_root = args.output.parent
+    artifact_root = output_root / "artifacts"
+    bindings = (
+        (args.baseline_state, "baseline-release-state.json"),
+        (args.candidate_state, "candidate-release-state.json"),
+        (args.rollback_checkpoint, "rollback-checkpoint-set.json"),
+        (args.forward_checkpoint, "forward-checkpoint-set.json"),
+        (args.rollback_proof, "rollback-preservation-proof.json"),
+        (args.forward_proof, "forward-preservation-proof.json"),
+        (args.rollback_log, "rollback.log"),
+        (args.forward_log, "forward.log"),
+    )
+    artifacts = [copy_bound_artifact(source, artifact_root, name) for source, name in bindings]
+    assertions = {
+        "acknowledged_messages_preserved": True,
+        "consumer_offsets_preserved": True,
+        "wal_retained": True,
+        "persistent_volumes_reused": True,
+        "storage_generation_unchanged": True,
+        "candidate_restored": True,
+    }
+    evidence = {
+        "schema_version": 1,
+        "artifact_kind": "rocketmq_message_path_rollback_evidence",
+        "generated_at": utc_now(),
+        "status": "pass",
+        "rehearsal_qualified": True,
+        "dynamic_execution": True,
+        "fixture": False,
+        "candidate_commit": commit,
+        "candidate_measurement_sha256": "sha256:" + sha256_file(args.candidate_measurement),
+        "deployment_digest": subject.get("deployment_digest"),
+        "target_id": target.get("target_id"),
+        "cluster_uid": target.get("cluster_uid"),
+        "effective_config_sha256": target.get("effective_config_sha256"),
+        "durability_contract": candidate.get("durability_contract"),
+        "baseline_release_id": baseline_state.get("release_id"),
+        "candidate_release_id": candidate_state.get("release_id"),
+        "steps": [
+            {
+                "direction": "rollback",
+                "status": "pass",
+                "target_release_id": baseline_state.get("release_id"),
+                "checkpoint_set_id": rollback_checkpoint.get("checkpointSetId"),
+                "verified_at": rollback_proof.get("verified_at"),
+            },
+            {
+                "direction": "forward",
+                "status": "pass",
+                "target_release_id": candidate_state.get("release_id"),
+                "checkpoint_set_id": forward_checkpoint.get("checkpointSetId"),
+                "verified_at": forward_proof.get("verified_at"),
+            },
+        ],
+        "assertions": assertions,
+        "artifacts": sorted(artifacts, key=lambda item: item["path"]),
+    }
+    for field in ("candidate_measurement_sha256", "deployment_digest", "effective_config_sha256"):
+        require(DIGEST_RE.fullmatch(str(evidence.get(field, ""))) is not None, f"rollback {field} is invalid")
+    for field in ("target_id", "cluster_uid", "durability_contract"):
+        require(isinstance(evidence.get(field), str) and evidence[field], f"rollback {field} is missing")
+    write_json(args.output, evidence)
+    return evidence
+
+
+def forbidden_evidence_path(relative: Path) -> bool:
+    lowered = relative.as_posix().lower()
+    tokens = set(re.split(r"[^a-z0-9_]+", lowered))
+    return bool(tokens & FORBIDDEN_PATH_TOKENS) or lowered.endswith((".key", ".pem", ".p12", ".pfx"))
+
+
+def evidence_files(root: Path) -> list[Path]:
+    excluded = {INVENTORY_PATH.as_posix(), CHECKSUM_PATH.as_posix(), SIGNATURE_PATH.as_posix()}
+    result: list[Path] = []
+    for path in sorted(root.rglob("*")):
+        relative = path.relative_to(root)
+        if path.is_symlink():
+            raise ReleaseError(f"evidence bundle contains a symbolic link: {relative.as_posix()}")
+        if path.is_file() and relative.as_posix() not in excluded:
+            if forbidden_evidence_path(relative):
+                raise ReleaseError(f"evidence bundle contains a forbidden secret-like path: {relative.as_posix()}")
+            result.append(path)
+    return result
+
+
+def inventory_entries(root: Path) -> list[dict[str, Any]]:
+    return [
+        {
+            "path": path.relative_to(root).as_posix(),
+            "sha256": sha256_file(path),
+            "size_bytes": path.stat().st_size,
+        }
+        for path in evidence_files(root)
+    ]
+
+
+def verify_release_documents(root: Path, qualification_relative: Path, rollback_relative: Path) -> tuple[str, dict[str, Any]]:
+    qualification = read_json(root / qualification_relative)
+    rollback = read_json(root / rollback_relative)
+    require(qualification.get("artifact_kind") == "rocketmq_message_path_qualification_report", "qualification report kind differs")
+    require(qualification.get("status") == "pass" and qualification.get("release_qualified") is True, "qualification report is NO-GO")
+    require(rollback.get("artifact_kind") == "rocketmq_message_path_rollback_evidence", "rollback report kind differs")
+    require(rollback.get("status") == "pass" and rollback.get("rehearsal_qualified") is True, "rollback rehearsal is not qualified")
+    commit = str(qualification.get("candidate_commit", ""))
+    require(GIT_SHA_RE.fullmatch(commit) is not None, "qualification candidate commit is invalid")
+    require(rollback.get("candidate_commit") == commit, "rollback and qualification candidate commits differ")
+    return commit, qualification
+
+
+def package_bundle(args: argparse.Namespace) -> dict[str, Any]:
+    source = args.source_root.resolve()
+    archive = args.archive_output.resolve()
+    require(source.is_dir(), f"release source root is missing: {source}")
+    require(not archive.exists(), f"archive output already exists: {archive}")
+    require(source not in archive.parents and archive not in source.parents, "source and archive paths overlap")
+    root_entries = {path.name for path in source.iterdir()}
+    require(root_entries == REQUIRED_RELEASE_DIRECTORIES, "release source root must contain exactly the canonical directories")
+    evidence_files(source)
+    shutil.copytree(source, archive, copy_function=shutil.copy2)
+    commit, qualification = verify_release_documents(archive, args.qualification_report, args.rollback_evidence)
+    artifacts = inventory_entries(archive)
+    require(artifacts, "release bundle contains no evidence")
+    bundle_digest = canonical_sha256(artifacts)
+    inventory = {
+        "schema_version": 1,
+        "artifact_kind": "rocketmq_message_path_artifact_inventory",
+        "generated_at": utc_now(),
+        "candidate_commit": commit,
+        "release_qualified": True,
+        "bundle_sha256": bundle_digest,
+        "qualification_report_sha256": sha256_file(archive / args.qualification_report),
+        "artifact_count": len(artifacts),
+        "artifacts": artifacts,
+        "subject": qualification.get("subject"),
+        "target": qualification.get("target"),
+        "durability_contract": qualification.get("durability_contract"),
+    }
+    write_json(archive / INVENTORY_PATH, inventory)
+    (archive / CHECKSUM_PATH).write_text(f"{bundle_digest}  rocketmq-message-path-release-bundle\n", encoding="utf-8")
+    if args.minisign_secret_key is not None:
+        command = [
+            "minisign",
+            "-S",
+            "-s",
+            str(args.minisign_secret_key.resolve()),
+            "-m",
+            str((archive / CHECKSUM_PATH).resolve()),
+            "-x",
+            str((archive / SIGNATURE_PATH).resolve()),
+        ]
+        result = subprocess.run(command, capture_output=True, text=True, check=False, shell=False)
+        require(result.returncode == 0, f"minisign failed: {result.stderr.strip()}")
+    if args.read_only:
+        for path in archive.rglob("*"):
+            if path.is_file():
+                path.chmod(0o444)
+    return inventory
+
+
+def verify_bundle(args: argparse.Namespace) -> dict[str, Any]:
+    root = args.bundle.resolve()
+    inventory = read_json(root / INVENTORY_PATH)
+    require(inventory.get("artifact_kind") == "rocketmq_message_path_artifact_inventory", "artifact inventory kind differs")
+    artifacts = inventory.get("artifacts")
+    require(isinstance(artifacts, list) and artifacts, "artifact inventory is empty")
+    expected_paths = {str(item.get("path", "")) for item in artifacts if isinstance(item, dict)}
+    actual = inventory_entries(root)
+    require({item["path"] for item in actual} == expected_paths, "bundle files differ from the inventory")
+    require(actual == artifacts, "bundle artifact hash or size differs")
+    require(canonical_sha256(actual) == inventory.get("bundle_sha256"), "bundle aggregate SHA-256 differs")
+    checksum = (root / CHECKSUM_PATH).read_text(encoding="utf-8").strip()
+    require(checksum == f"{inventory['bundle_sha256']}  rocketmq-message-path-release-bundle", "bundle checksum differs")
+    verify_release_documents(root, args.qualification_report, args.rollback_evidence)
+    if args.minisign_public_key is not None:
+        require((root / SIGNATURE_PATH).is_file(), "bundle minisign signature is missing")
+        result = subprocess.run(
+            [
+                "minisign",
+                "-V",
+                "-p",
+                str(args.minisign_public_key.resolve()),
+                "-m",
+                str((root / CHECKSUM_PATH).resolve()),
+                "-x",
+                str((root / SIGNATURE_PATH).resolve()),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            shell=False,
+        )
+        require(result.returncode == 0, f"minisign verification failed: {result.stderr.strip()}")
+    return inventory
+
+
+def add_release_document_paths(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--qualification-report",
+        type=Path,
+        default=Path("qualification/qualification-report.json"),
+    )
+    parser.add_argument(
+        "--rollback-evidence",
+        type=Path,
+        default=Path("qualification/rollback/rollback-evidence.json"),
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    commands = parser.add_subparsers(dest="command", required=True)
+    commands.add_parser("validate-schema")
+    rollback = commands.add_parser("build-rollback-evidence")
+    for name in (
+        "candidate-measurement",
+        "baseline-state",
+        "candidate-state",
+        "rollback-checkpoint",
+        "forward-checkpoint",
+        "rollback-proof",
+        "forward-proof",
+        "rollback-log",
+        "forward-log",
+        "output",
+    ):
+        rollback.add_argument("--" + name, type=Path, required=True)
+    package = commands.add_parser("package")
+    package.add_argument("--source-root", type=Path, required=True)
+    package.add_argument("--archive-output", type=Path, required=True)
+    package.add_argument("--minisign-secret-key", type=Path)
+    package.add_argument("--read-only", action="store_true")
+    add_release_document_paths(package)
+    verify = commands.add_parser("verify")
+    verify.add_argument("--bundle", type=Path, required=True)
+    verify.add_argument("--minisign-public-key", type=Path)
+    add_release_document_paths(verify)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        schema = read_json(args.schema)
+        validate_schema_contract(schema)
+        if args.command == "validate-schema":
+            print("MESSAGE_PATH_RELEASE_SCHEMA_OK")
+            return 0
+        if args.command == "build-rollback-evidence":
+            evidence = build_rollback_evidence(args)
+            print(json.dumps({"status": evidence["status"], "output": str(args.output.resolve())}, sort_keys=True))
+            return 0
+        if args.command == "package":
+            inventory = package_bundle(args)
+            print(json.dumps({"status": "pass", "bundle_sha256": inventory["bundle_sha256"]}, sort_keys=True))
+            return 0
+        inventory = verify_bundle(args)
+        print(json.dumps({"status": "pass", "bundle_sha256": inventory["bundle_sha256"]}, sort_keys=True))
+        return 0
+    except (ReleaseError, OSError) as error:
+        print(f"MESSAGE_PATH_RELEASE_ERROR: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-message-path-release.ps1
+++ b/scripts/run-message-path-release.ps1
@@ -1,0 +1,296 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[CmdletBinding()]
+param(
+    [ValidateSet("Validate", "Run")]
+    [string]$Mode = "Validate",
+    [string]$CandidateCommit,
+    [string]$ReleaseRoot,
+    [string]$CandidateMeasurement,
+    [string]$PerformanceComparison,
+    [string]$FaultEvidence,
+    [string]$RpoEvidence,
+    [string]$SoakReport,
+    [string]$BaselineState,
+    [string]$CandidateState,
+    [string]$RollbackCheckpointSet,
+    [string]$ForwardCheckpointSet,
+    [string]$RollbackPreservationProof,
+    [string]$ForwardPreservationProof,
+    [string]$ArchiveOutput,
+    [string]$RunId,
+    [string]$ReleaseName = "rocketmq",
+    [string]$Namespace = "rocketmq-system",
+    [string]$OperatorIdentity,
+    [string]$MinisignSecretKey,
+    [string]$MinisignPublicKey
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$RepositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$QualificationScript = Join-Path $PSScriptRoot "message_path_qualification.py"
+$ReleaseScript = Join-Path $PSScriptRoot "message_path_release.py"
+$RollbackRunner = Join-Path $PSScriptRoot "run-architecture-release-rollback.ps1"
+$RequiredDirectories = @("environment", "ab", "fault", "rpo", "soak", "qualification")
+
+function Invoke-Checked {
+    param(
+        [Parameter(Mandatory)][string]$Executable,
+        [Parameter(Mandatory)][string[]]$Arguments,
+        [string]$LogPath,
+        [switch]$AllowFailure
+    )
+
+    $content = (& $Executable @Arguments 2>&1 | Out-String).TrimEnd()
+    $exitCode = $LASTEXITCODE
+    if (-not [string]::IsNullOrWhiteSpace($LogPath)) {
+        $parent = Split-Path $LogPath -Parent
+        if (-not [string]::IsNullOrWhiteSpace($parent)) {
+            New-Item -ItemType Directory -Force -Path $parent | Out-Null
+        }
+        [IO.File]::WriteAllText($LogPath, $content + "`n", [Text.UTF8Encoding]::new($false))
+    }
+    if ($exitCode -ne 0 -and -not $AllowFailure) {
+        throw "$Executable failed with exit code $exitCode`n$content"
+    }
+    [pscustomobject]@{ ExitCode = $exitCode; Output = $content }
+}
+
+function Require-Command {
+    param([Parameter(Mandatory)][string]$Name)
+
+    $command = Get-Command $Name -ErrorAction SilentlyContinue
+    if ($null -eq $command) {
+        throw "required command is unavailable: $Name"
+    }
+    $command.Source
+}
+
+function Resolve-ExistingPath {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string]$Label,
+        [switch]$Directory,
+        [switch]$Any
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        throw "$Label is required"
+    }
+    $exists = if ($Any) {
+        Test-Path -LiteralPath $Path
+    } else {
+        $pathType = if ($Directory) { "Container" } else { "Leaf" }
+        Test-Path -LiteralPath $Path -PathType $pathType
+    }
+    if (-not $exists) {
+        throw "$Label does not exist: $Path"
+    }
+    (Resolve-Path -LiteralPath $Path).Path
+}
+
+function Assert-UnderReleaseRoot {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string]$Root,
+        [Parameter(Mandatory)][string]$Label
+    )
+
+    $fullPath = [IO.Path]::GetFullPath($Path)
+    $prefix = $Root.TrimEnd("\", "/") + [IO.Path]::DirectorySeparatorChar
+    if (-not $fullPath.StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "$Label must remain below ReleaseRoot"
+    }
+    $fullPath
+}
+
+function Invoke-RollbackTransition {
+    param(
+        [Parameter(Mandatory)][string]$PowerShell,
+        [Parameter(Mandatory)][ValidateSet("Rollback", "Forward")][string]$Direction,
+        [Parameter(Mandatory)][string]$CheckpointSet,
+        [Parameter(Mandatory)][string]$Proof,
+        [Parameter(Mandatory)][string]$LogPath
+    )
+
+    Invoke-Checked -Executable $PowerShell -Arguments @(
+        "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $RollbackRunner,
+        "-Apply", "-Direction", $Direction,
+        "-BaselineStatePath", $script:BaselineStatePath,
+        "-CandidateStatePath", $script:CandidateStatePath,
+        "-CheckpointSetPath", $CheckpointSet,
+        "-PreservationProofPath", $Proof,
+        "-ReleaseName", $ReleaseName,
+        "-Namespace", $Namespace,
+        "-OperatorIdentity", $OperatorIdentity
+    ) -LogPath $LogPath | Out-Null
+}
+
+$python = Require-Command "python"
+$policyResult = Invoke-Checked $python @($QualificationScript, "validate-policy")
+$schemaResult = Invoke-Checked $python @($ReleaseScript, "validate-schema")
+$powerShell = (Get-Process -Id $PID).Path
+$rollbackValidation = Invoke-Checked $powerShell @(
+    "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $RollbackRunner, "-ValidateOnly"
+)
+
+if ($Mode -eq "Validate") {
+    Write-Host "MESSAGE_PATH_RELEASE_VALIDATION_OK policy=$($policyResult.Output) schema=$($schemaResult.Output) rollback=$($rollbackValidation.Output)"
+    return
+}
+
+if ($PSVersionTable.PSVersion.Major -lt 7) {
+    throw "Run mode requires PowerShell 7 or newer"
+}
+if ($CandidateCommit -notmatch "^[0-9a-f]{40}$") {
+    throw "CandidateCommit must be a full lowercase Git SHA"
+}
+if ([string]::IsNullOrWhiteSpace($OperatorIdentity)) {
+    throw "OperatorIdentity is required"
+}
+if ([string]::IsNullOrWhiteSpace($RunId)) {
+    $RunId = "message-path-release-$([DateTimeOffset]::UtcNow.ToUnixTimeSeconds())"
+}
+if ($RunId -notmatch "^[A-Za-z0-9][A-Za-z0-9._-]{2,127}$") {
+    throw "RunId must contain 3-128 safe characters"
+}
+if ([string]::IsNullOrWhiteSpace($MinisignSecretKey) -ne [string]::IsNullOrWhiteSpace($MinisignPublicKey)) {
+    throw "MinisignSecretKey and MinisignPublicKey must be supplied together"
+}
+
+$releaseRootPath = Resolve-ExistingPath $ReleaseRoot "ReleaseRoot" -Directory
+foreach ($directory in $RequiredDirectories) {
+    if (-not (Test-Path -LiteralPath (Join-Path $releaseRootPath $directory) -PathType Container)) {
+        throw "ReleaseRoot is missing canonical directory: $directory"
+    }
+}
+$archivePath = [IO.Path]::GetFullPath($ArchiveOutput)
+if (Test-Path -LiteralPath $archivePath) {
+    throw "ArchiveOutput already exists and will not be overwritten: $archivePath"
+}
+$releasePrefix = $releaseRootPath.TrimEnd("\", "/") + [IO.Path]::DirectorySeparatorChar
+if ($archivePath.StartsWith($releasePrefix, [StringComparison]::OrdinalIgnoreCase)) {
+    throw "ArchiveOutput must be outside ReleaseRoot"
+}
+
+$inputs = [ordered]@{
+    CandidateMeasurement = $CandidateMeasurement
+    PerformanceComparison = $PerformanceComparison
+    FaultEvidence = $FaultEvidence
+    RpoEvidence = $RpoEvidence
+    SoakReport = $SoakReport
+    BaselineState = $BaselineState
+    CandidateState = $CandidateState
+    RollbackCheckpointSet = $RollbackCheckpointSet
+    ForwardCheckpointSet = $ForwardCheckpointSet
+    RollbackPreservationProof = $RollbackPreservationProof
+    ForwardPreservationProof = $ForwardPreservationProof
+}
+foreach ($entry in @($inputs.GetEnumerator())) {
+    $allowDirectory = $entry.Key -in @("FaultEvidence", "RpoEvidence", "SoakReport")
+    $resolved = Resolve-ExistingPath ([string]$entry.Value) $entry.Key -Any:$allowDirectory
+    $inputs[$entry.Key] = Assert-UnderReleaseRoot $resolved $releaseRootPath $entry.Key
+}
+$script:BaselineStatePath = $inputs.BaselineState
+$script:CandidateStatePath = $inputs.CandidateState
+
+$rollbackDirectory = Join-Path $releaseRootPath "qualification/rollback"
+New-Item -ItemType Directory -Force -Path $rollbackDirectory | Out-Null
+$rollbackLog = Join-Path $rollbackDirectory "rollback.log"
+$forwardLog = Join-Path $rollbackDirectory "forward.log"
+$rollbackEvidence = Join-Path $rollbackDirectory "rollback-evidence.json"
+foreach ($path in @($rollbackLog, $forwardLog, $rollbackEvidence)) {
+    if (Test-Path -LiteralPath $path) {
+        throw "release evidence output already exists: $path"
+    }
+}
+
+Invoke-RollbackTransition $powerShell "Rollback" $inputs.RollbackCheckpointSet `
+    $inputs.RollbackPreservationProof $rollbackLog
+Invoke-RollbackTransition $powerShell "Forward" $inputs.ForwardCheckpointSet `
+    $inputs.ForwardPreservationProof $forwardLog
+
+Invoke-Checked $python @(
+    $ReleaseScript, "build-rollback-evidence",
+    "--candidate-measurement", $inputs.CandidateMeasurement,
+    "--baseline-state", $inputs.BaselineState,
+    "--candidate-state", $inputs.CandidateState,
+    "--rollback-checkpoint", $inputs.RollbackCheckpointSet,
+    "--forward-checkpoint", $inputs.ForwardCheckpointSet,
+    "--rollback-proof", $inputs.RollbackPreservationProof,
+    "--forward-proof", $inputs.ForwardPreservationProof,
+    "--rollback-log", $rollbackLog,
+    "--forward-log", $forwardLog,
+    "--output", $rollbackEvidence
+) | Out-Null
+
+$stageRoot = Join-Path $releaseRootPath ".qualification-stage"
+if (Test-Path -LiteralPath $stageRoot) {
+    throw "qualification staging directory already exists: $stageRoot"
+}
+$qualificationResult = Invoke-Checked $python @(
+    $QualificationScript, "qualify",
+    "--candidate-commit", $CandidateCommit,
+    "--candidate-measurement", $inputs.CandidateMeasurement,
+    "--performance-comparison", $inputs.PerformanceComparison,
+    "--fault-evidence", $inputs.FaultEvidence,
+    "--rpo-evidence", $inputs.RpoEvidence,
+    "--soak-report", $inputs.SoakReport,
+    "--rollback-evidence", $rollbackEvidence,
+    "--run-id", $RunId,
+    "--output-dir", $stageRoot
+) -AllowFailure
+$stageRun = Join-Path $stageRoot $RunId
+$qualificationDirectory = Join-Path $releaseRootPath "qualification"
+$qualificationReport = Join-Path $qualificationDirectory "qualification-report.json"
+try {
+    if (Test-Path -LiteralPath (Join-Path $stageRun "qualification-report.json") -PathType Leaf) {
+        if (Test-Path -LiteralPath $qualificationReport) {
+            throw "qualification report already exists: $qualificationReport"
+        }
+        Move-Item -LiteralPath (Join-Path $stageRun "qualification-report.json") -Destination $qualificationReport
+        if (Test-Path -LiteralPath (Join-Path $stageRun "external") -PathType Container) {
+            Move-Item -LiteralPath (Join-Path $stageRun "external") -Destination (Join-Path $qualificationDirectory "external")
+        }
+    }
+}
+finally {
+    if (Test-Path -LiteralPath $stageRoot) {
+        Remove-Item -LiteralPath $stageRoot -Recurse -Force
+    }
+}
+if ($qualificationResult.ExitCode -ne 0) {
+    throw "final qualification returned NO-GO; the report was retained at $qualificationReport`n$($qualificationResult.Output)"
+}
+
+$packageArguments = @(
+    $ReleaseScript, "package",
+    "--source-root", $releaseRootPath,
+    "--archive-output", $archivePath,
+    "--read-only"
+)
+if (-not [string]::IsNullOrWhiteSpace($MinisignSecretKey)) {
+    $packageArguments += @("--minisign-secret-key", (Resolve-ExistingPath $MinisignSecretKey "MinisignSecretKey"))
+}
+Invoke-Checked $python $packageArguments | Out-Null
+
+$verifyArguments = @($ReleaseScript, "verify", "--bundle", $archivePath)
+if (-not [string]::IsNullOrWhiteSpace($MinisignPublicKey)) {
+    $verifyArguments += @("--minisign-public-key", (Resolve-ExistingPath $MinisignPublicKey "MinisignPublicKey"))
+}
+$verifyResult = Invoke-Checked $python $verifyArguments
+Write-Host "MESSAGE_PATH_RELEASE_COMPLETE candidate=$CandidateCommit archive=$archivePath verification=$($verifyResult.Output)"

--- a/scripts/tests/test_message_path_qualification.py
+++ b/scripts/tests/test_message_path_qualification.py
@@ -387,8 +387,63 @@ class MessagePathQualificationTest(unittest.TestCase):
                 "series": [{"status": "pass", "raw_artifact_sha256": "sha256:" + raw_digest}],
                 "artifacts": [{"path": raw_samples.name, "sha256": raw_digest}],
             }
+            rollback_log = root / "rollback.log"
+            rollback_log.write_text("rollback passed\n", encoding="utf-8")
+            forward_log = root / "forward.log"
+            forward_log.write_text("forward passed\n", encoding="utf-8")
+            rollback = {
+                "schema_version": 1,
+                "artifact_kind": "rocketmq_message_path_rollback_evidence",
+                "status": "pass",
+                "rehearsal_qualified": True,
+                "dynamic_execution": True,
+                "fixture": False,
+                "candidate_commit": "b" * 40,
+                "candidate_measurement_sha256": "sha256:" + qualification.sha256_file(candidate_path),
+                "deployment_digest": "sha256:" + "2" * 64,
+                "target_id": "target-a",
+                "cluster_uid": "cluster-a",
+                "effective_config_sha256": "sha256:" + "4" * 64,
+                "durability_contract": "strict",
+                "steps": [
+                    {
+                        "direction": "rollback",
+                        "status": "pass",
+                        "target_release_id": "baseline",
+                        "checkpoint_set_id": "rollback-checkpoint",
+                        "verified_at": "2026-08-12T10:00:00Z",
+                    },
+                    {
+                        "direction": "forward",
+                        "status": "pass",
+                        "target_release_id": "candidate",
+                        "checkpoint_set_id": "forward-checkpoint",
+                        "verified_at": "2026-08-12T10:01:00Z",
+                    },
+                ],
+                "baseline_release_id": "baseline",
+                "candidate_release_id": "candidate",
+                "assertions": {
+                    "acknowledged_messages_preserved": True,
+                    "consumer_offsets_preserved": True,
+                    "wal_retained": True,
+                    "persistent_volumes_reused": True,
+                    "storage_generation_unchanged": True,
+                    "candidate_restored": True,
+                },
+                "artifacts": [
+                    {"path": rollback_log.name, "sha256": qualification.sha256_file(rollback_log)},
+                    {"path": forward_log.name, "sha256": qualification.sha256_file(forward_log)},
+                ],
+            }
             paths = {}
-            for name, value in (("comparison", comparison), ("fault", fault), ("rpo", rpo), ("soak", soak)):
+            for name, value in (
+                ("comparison", comparison),
+                ("fault", fault),
+                ("rpo", rpo),
+                ("soak", soak),
+                ("rollback", rollback),
+            ):
                 path = root / f"{name}.json"
                 path.write_text(json.dumps(value), encoding="utf-8")
                 paths[name] = path
@@ -399,11 +454,22 @@ class MessagePathQualificationTest(unittest.TestCase):
                 fault_evidence=paths["fault"],
                 rpo_evidence=paths["rpo"],
                 soak_report=paths["soak"],
+                rollback_evidence=paths["rollback"],
             )
 
             findings, _, _ = qualification.validate_final_evidence(self.policy, args)
 
             self.assertIn("soak release identity target_id differs", findings)
+
+            rollback["fixture"] = True
+            rollback["candidate_commit"] = "c" * 40
+            del rollback["assertions"]["wal_retained"]
+            paths["rollback"].write_text(json.dumps(rollback), encoding="utf-8")
+            findings, _, _ = qualification.validate_final_evidence(self.policy, args)
+
+            self.assertIn("rollback evidence must be a qualified dynamic non-fixture rehearsal", findings)
+            self.assertIn("rollback evidence candidate_commit differs", findings)
+            self.assertIn("rollback evidence did not prove every preservation and recovery assertion", findings)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_message_path_release.py
+++ b/scripts/tests/test_message_path_release.py
@@ -1,0 +1,286 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import message_path_release as release  # noqa: E402
+
+
+RUNNER = ROOT / "scripts" / "run-message-path-release.ps1"
+
+
+class MessagePathReleaseTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.powershell = shutil.which("pwsh") or shutil.which("powershell")
+
+    def write_json(self, path: Path, value: object) -> Path:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+        return path
+
+    def rollback_inputs(self, root: Path) -> argparse.Namespace:
+        commit = "b" * 40
+        candidate = {
+            "status": "pass",
+            "measurement_qualified": True,
+            "durability_contract": "sync-flush-required-replica-acks",
+            "subject": {
+                "role": "candidate",
+                "commit": commit,
+                "deployment_digest": "sha256:" + "2" * 64,
+            },
+            "target": {
+                "target_id": "kind-local-qualified",
+                "cluster_uid": "cluster-uid",
+                "effective_config_sha256": "sha256:" + "3" * 64,
+            },
+        }
+        baseline = {
+            "release_id": "baseline-release",
+            "source_commit": "a" * 40,
+            "storage_generation": 7,
+            "identity": {"commit": "a" * 40, "config_digest": "sha256:" + "3" * 64},
+        }
+        candidate_state = {
+            "release_id": "candidate-release",
+            "source_commit": commit,
+            "storage_generation": 7,
+            "identity": {"commit": commit, "config_digest": "sha256:" + "3" * 64},
+        }
+
+        def checkpoint(release_id: str, checkpoint_id: str, fence: int) -> dict[str, object]:
+            return {
+                "checkpointSetId": checkpoint_id,
+                "releaseId": release_id,
+                "generation": 7,
+                "fencingToken": fence,
+                "stores": [{"artifact": {"checkpointId": checkpoint_id + "-store"}}],
+            }
+
+        rollback_checkpoint = checkpoint("candidate-release", "rollback-checkpoint", 11)
+        forward_checkpoint = checkpoint("baseline-release", "forward-checkpoint", 12)
+
+        def proof(checkpoint_value: dict[str, object], target: str) -> dict[str, object]:
+            checkpoint_id = str(checkpoint_value["checkpointSetId"])
+            return {
+                "schema_version": 1,
+                "checkpoint_set_id": checkpoint_id,
+                "target_release_id": target,
+                "generation": 7,
+                "fencing_token": checkpoint_value["fencingToken"],
+                "verified_at": "2026-08-12T10:00:00Z",
+                "acknowledged_messages_preserved": True,
+                "consumer_offsets_preserved": True,
+                "wal_retained": True,
+                "persistent_volumes_reused": True,
+                "store_checkpoint_ids": [checkpoint_id + "-store"],
+            }
+
+        paths = {
+            "candidate_measurement": self.write_json(root / "candidate.json", candidate),
+            "baseline_state": self.write_json(root / "baseline-state.json", baseline),
+            "candidate_state": self.write_json(root / "candidate-state.json", candidate_state),
+            "rollback_checkpoint": self.write_json(root / "rollback-checkpoint.json", rollback_checkpoint),
+            "forward_checkpoint": self.write_json(root / "forward-checkpoint.json", forward_checkpoint),
+            "rollback_proof": self.write_json(
+                root / "rollback-proof.json", proof(rollback_checkpoint, "baseline-release")
+            ),
+            "forward_proof": self.write_json(
+                root / "forward-proof.json", proof(forward_checkpoint, "candidate-release")
+            ),
+        }
+        rollback_log = root / "rollback-source.log"
+        rollback_log.write_text(
+            "RELEASE_ROLLBACK_OK operation_id=one direction=Rollback target_release_id=baseline-release\n",
+            encoding="utf-8",
+        )
+        forward_log = root / "forward-source.log"
+        forward_log.write_text(
+            "RELEASE_ROLLBACK_OK operation_id=two direction=Forward target_release_id=candidate-release\n",
+            encoding="utf-8",
+        )
+        return argparse.Namespace(
+            **paths,
+            rollback_log=rollback_log,
+            forward_log=forward_log,
+            output=root / "rollback" / "rollback-evidence.json",
+        )
+
+    def test_committed_schema_is_closed(self) -> None:
+        schema = release.read_json(release.DEFAULT_SCHEMA)
+        release.validate_schema_contract(schema)
+
+    def test_release_runner_validates_all_owned_contracts(self) -> None:
+        if self.powershell is None:
+            self.skipTest("PowerShell is required for release runner tests")
+        result = subprocess.run(
+            [
+                self.powershell,
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                str(RUNNER),
+                "-Mode",
+                "Validate",
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("MESSAGE_PATH_RELEASE_VALIDATION_OK", result.stdout)
+        self.assertIn("RELEASE_ROLLBACK_VALIDATION_OK", result.stdout)
+
+    def test_release_runner_requires_bidirectional_safe_rehearsal(self) -> None:
+        source = RUNNER.read_text(encoding="utf-8")
+        for contract in (
+            'Invoke-RollbackTransition $powerShell "Rollback"',
+            'Invoke-RollbackTransition $powerShell "Forward"',
+            '"--rollback-evidence", $rollbackEvidence',
+            '$ReleaseScript, "package"',
+            '$ReleaseScript, "verify"',
+        ):
+            self.assertIn(contract, source)
+        lowered = source.lower()
+        self.assertNotIn("helm uninstall", lowered)
+        self.assertNotIn("delete persistentvolumeclaim", lowered)
+
+    def test_build_rollback_evidence_binds_both_transitions(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="rocketmq-release-") as temporary:
+            args = self.rollback_inputs(Path(temporary))
+            evidence = release.build_rollback_evidence(args)
+
+            self.assertTrue(evidence["rehearsal_qualified"])
+            self.assertEqual(["rollback", "forward"], [step["direction"] for step in evidence["steps"]])
+            self.assertTrue(all(evidence["assertions"].values()))
+            self.assertEqual("sha256:" + release.sha256_file(args.candidate_measurement), evidence["candidate_measurement_sha256"])
+            self.assertEqual(8, len(evidence["artifacts"]))
+            self.assertTrue(args.output.is_file())
+
+    def test_build_rollback_evidence_rejects_preservation_drift(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="rocketmq-release-") as temporary:
+            args = self.rollback_inputs(Path(temporary))
+            proof = release.read_json(args.rollback_proof)
+            proof["acknowledged_messages_preserved"] = False
+            self.write_json(args.rollback_proof, proof)
+
+            with self.assertRaisesRegex(release.ReleaseError, "acknowledged_messages_preserved"):
+                release.build_rollback_evidence(args)
+
+    def bundle_source(self, root: Path, commit: str = "b" * 40) -> Path:
+        for name in release.REQUIRED_RELEASE_DIRECTORIES:
+            (root / name).mkdir(parents=True, exist_ok=True)
+        (root / "environment" / "toolchain-lock.json").write_text("{}\n", encoding="utf-8")
+        for name in ("ab", "fault", "rpo", "soak"):
+            (root / name / "raw.json").write_text("{}\n", encoding="utf-8")
+        qualification = {
+            "artifact_kind": "rocketmq_message_path_qualification_report",
+            "status": "pass",
+            "release_qualified": True,
+            "candidate_commit": commit,
+            "subject": {"commit": commit},
+            "target": {"target_id": "kind-local-qualified"},
+            "durability_contract": "sync-flush-required-replica-acks",
+        }
+        rollback = {
+            "artifact_kind": "rocketmq_message_path_rollback_evidence",
+            "status": "pass",
+            "rehearsal_qualified": True,
+            "candidate_commit": commit,
+        }
+        self.write_json(root / "qualification" / "qualification-report.json", qualification)
+        self.write_json(root / "qualification" / "rollback" / "rollback-evidence.json", rollback)
+        return root
+
+    def package_args(self, source: Path, archive: Path) -> argparse.Namespace:
+        return argparse.Namespace(
+            source_root=source,
+            archive_output=archive,
+            qualification_report=Path("qualification/qualification-report.json"),
+            rollback_evidence=Path("qualification/rollback/rollback-evidence.json"),
+            minisign_secret_key=None,
+            read_only=False,
+        )
+
+    def verify_args(self, bundle: Path) -> argparse.Namespace:
+        return argparse.Namespace(
+            bundle=bundle,
+            qualification_report=Path("qualification/qualification-report.json"),
+            rollback_evidence=Path("qualification/rollback/rollback-evidence.json"),
+            minisign_public_key=None,
+        )
+
+    def test_package_and_verify_bind_every_file(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="rocketmq-release-") as temporary:
+            root = Path(temporary)
+            source = self.bundle_source(root / "source")
+            archive = root / "archive"
+            inventory = release.package_bundle(self.package_args(source, archive))
+
+            self.assertGreaterEqual(inventory["artifact_count"], 7)
+            self.assertEqual(inventory, release.verify_bundle(self.verify_args(archive)))
+
+            (archive / "fault" / "raw.json").write_text('{"tampered":true}\n', encoding="utf-8")
+            with self.assertRaisesRegex(release.ReleaseError, "hash or size differs"):
+                release.verify_bundle(self.verify_args(archive))
+
+    def test_package_rejects_secret_like_paths_and_existing_output(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="rocketmq-release-") as temporary:
+            root = Path(temporary)
+            source = self.bundle_source(root / "source")
+            (source / "environment" / "runtime-secret.yaml").write_text("forbidden\n", encoding="utf-8")
+            with self.assertRaisesRegex(release.ReleaseError, "secret-like"):
+                release.package_bundle(self.package_args(source, root / "archive"))
+
+            source = self.bundle_source(root / "source-plural")
+            (source / "environment" / "credentials.json").write_text("forbidden\n", encoding="utf-8")
+            with self.assertRaisesRegex(release.ReleaseError, "secret-like"):
+                release.package_bundle(self.package_args(source, root / "archive-plural"))
+
+            source = self.bundle_source(root / "source-clean")
+            archive = root / "existing"
+            archive.mkdir()
+            with self.assertRaisesRegex(release.ReleaseError, "already exists"):
+                release.package_bundle(self.package_args(source, archive))
+
+    def test_rollback_candidate_binding_is_not_inferred(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="rocketmq-release-") as temporary:
+            args = self.rollback_inputs(Path(temporary))
+            state = release.read_json(args.candidate_state)
+            state = copy.deepcopy(state)
+            state["source_commit"] = "c" * 40
+            self.write_json(args.candidate_state, state)
+            with self.assertRaisesRegex(release.ReleaseError, "commit differs"):
+                release.build_rollback_evidence(args)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9292

### Brief Description

This change completes the fail-closed message-path release qualification flow. It requires a dynamic rollback and forward-recovery rehearsal, binds both transitions to immutable ReleaseState, checkpoint, preservation-proof, candidate, target, configuration, and durability identities, and packages the canonical A/B, fault, RPO, soak, and qualification evidence into a read-only hash inventory.

The orchestrator rejects missing assertions, fixture evidence, candidate drift, duplicate or tampered artifacts, secret-like paths, non-canonical bundle layouts, and incomplete rollback or forward transitions. DLedger remains explicitly outside the qualification scope.

### How Did You Test This Change?

- `python -m unittest discover -s scripts/tests -p "test_message_path*.py" -v` (32 passed)
- `python -m unittest scripts.tests.test_p3_release_rollback -v` (5 passed)
- `python -m py_compile scripts/message_path_ab.py scripts/message_path_qualification.py scripts/message_path_release.py scripts/message_path_soak.py`
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/run-message-path-release.ps1 -Mode Validate`
- `python scripts/message_path_release.py validate-schema`
- `python scripts/message_path_qualification.py validate-policy`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release tooling to collect, validate, package, and verify message-path release evidence.
  * Added support for rollback and forward transition evidence, preservation checks, artifact inventories, hashes, and optional signatures.
  * Added PowerShell orchestration for validation and complete release runs.
* **Bug Fixes**
  * Release qualification now requires valid rollback evidence and rejects mismatched, incomplete, or altered release artifacts.
* **Tests**
  * Added comprehensive coverage for evidence validation, packaging integrity, tamper detection, and release-runner contracts.
* **Documentation**
  * Added a public JSON Schema for release evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->