### PR TITLE
[ISSUE #9290]🐛Initialize dynamic extension fields on first write

### DIFF
--- a/rocketmq-broker/src/processor/client_manage_processor.rs
+++ b/rocketmq-broker/src/processor/client_manage_processor.rs
@@ -633,6 +633,12 @@ mod tests {
         let ext_fields = response.ext_fields().expect("ext fields should exist");
         assert_eq!(
             ext_fields
+                .get(&CheetahString::from_static_str(IS_SUPPORT_HEART_BEAT_V2))
+                .map(|value| value.as_str()),
+            Some("true")
+        );
+        assert_eq!(
+            ext_fields
                 .get(&CheetahString::from_static_str(IS_SUB_CHANGE))
                 .map(|value| value.as_str()),
             Some("true")

--- a/rocketmq-broker/src/processor/recall_message_processor.rs
+++ b/rocketmq-broker/src/processor/recall_message_processor.rs
@@ -56,6 +56,10 @@ use crate::topic::manager::topic_config_manager::TopicConfigManager;
 
 const RECALL_MESSAGE_TAG: &str = "_RECALL_TAG_";
 
+fn add_recall_response_region(response: &mut RemotingCommand, region_id: CheetahString) {
+    response.add_ext_field(MessageConst::PROPERTY_MSG_REGION, region_id);
+}
+
 #[derive(Clone)]
 pub(crate) struct RecallMessagePolicy {
     region_id: CheetahString,
@@ -254,7 +258,7 @@ where
         response.set_opaque_mut(request.opaque());
 
         let region_id = self.context.policy.region_id.clone();
-        response.add_ext_field(MessageConst::PROPERTY_MSG_REGION, region_id);
+        add_recall_response_region(&mut response, region_id);
 
         let request_header = request.decode_command_custom_header::<RecallMessageRequestHeader>()?;
 
@@ -602,7 +606,34 @@ fn recall_response_header_missing() -> RocketMQError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rocketmq_protocol::protocol::SerializeType;
     use rocketmq_store::StorePorts;
+
+    #[test]
+    fn recall_response_keeps_region_field() {
+        for serialize_type in [SerializeType::JSON, SerializeType::ROCKETMQ] {
+            let mut response =
+                RemotingCommand::create_response_command_with_header(RecallMessageResponseHeader::new("msg-id"))
+                    .set_serialize_type(serialize_type);
+            add_recall_response_region(&mut response, CheetahString::from_static_str("region-c"));
+            let mut encoded = bytes::BytesMut::new();
+
+            response
+                .try_fast_header_encode(&mut encoded)
+                .expect("recall response should encode");
+            let decoded = RemotingCommand::decode(&mut encoded)
+                .expect("recall response should decode")
+                .expect("recall response frame should be complete");
+
+            assert_eq!(
+                decoded
+                    .ext_fields()
+                    .and_then(|fields| fields.get(MessageConst::PROPERTY_MSG_REGION))
+                    .map(CheetahString::as_str),
+                Some("region-c")
+            );
+        }
+    }
 
     #[test]
     fn test_recall_message_tag_constant() {

--- a/rocketmq-broker/src/processor/reply_message_processor.rs
+++ b/rocketmq-broker/src/processor/reply_message_processor.rs
@@ -50,6 +50,12 @@ use crate::transaction::transactional_message_service::TransactionalMessageServi
 
 const PUSH_REPLY_MESSAGE_TO_CLIENT_TIMEOUT_MILLIS: u64 = 10_000;
 
+fn add_reply_response_metadata(response: &mut RemotingCommand, region_id: &str, trace_on: bool) {
+    response
+        .add_ext_field(MessageConst::PROPERTY_MSG_REGION, region_id)
+        .add_ext_field(MessageConst::PROPERTY_TRACE_SWITCH, trace_on.to_string());
+}
+
 fn push_reply_call_failed_remark(sender_id: &str) -> String {
     format!("push reply message to {sender_id}fail.")
 }
@@ -223,9 +229,7 @@ where
             )
         };
 
-        response
-            .add_ext_field(MessageConst::PROPERTY_MSG_REGION, region_id.as_str())
-            .add_ext_field(MessageConst::PROPERTY_TRACE_SWITCH, trace_on.to_string());
+        add_reply_response_metadata(&mut response, region_id.as_str(), trace_on);
 
         if current_millis() < start_timstamp {
             return response
@@ -636,11 +640,42 @@ mod tests {
     use rocketmq_model::common::message::message_ext_broker_inner::MessageExtBrokerInner;
     use rocketmq_model::common::message::MessageConst;
     use rocketmq_model::common::message::MessageTrait;
+    use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+    use rocketmq_protocol::protocol::SerializeType;
 
+    use super::add_reply_response_metadata;
     use super::get_correlation_id_with_fallback;
     use super::push_reply_call_failed_remark;
     use super::PushReplyResult;
     use super::PUSH_REPLY_MESSAGE_TO_CLIENT_TIMEOUT_MILLIS;
+
+    #[test]
+    fn reply_response_keeps_region_and_trace_fields() {
+        for serialize_type in [SerializeType::JSON, SerializeType::ROCKETMQ] {
+            let mut response = RemotingCommand::create_response_command().set_serialize_type(serialize_type);
+            add_reply_response_metadata(&mut response, "region-b", false);
+            let mut encoded = bytes::BytesMut::new();
+
+            response
+                .try_fast_header_encode(&mut encoded)
+                .expect("reply response should encode");
+            let decoded = RemotingCommand::decode(&mut encoded)
+                .expect("reply response should decode")
+                .expect("reply response frame should be complete");
+
+            let fields = decoded.ext_fields().expect("reply response ext fields");
+            assert_eq!(
+                fields.get(MessageConst::PROPERTY_MSG_REGION).map(CheetahString::as_str),
+                Some("region-b")
+            );
+            assert_eq!(
+                fields
+                    .get(MessageConst::PROPERTY_TRACE_SWITCH)
+                    .map(CheetahString::as_str),
+                Some("false")
+            );
+        }
+    }
 
     #[test]
     fn test_get_correlation_id_with_fallback_new_property() {

--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -117,6 +117,14 @@ struct ParsedSendRequest {
     properties: HashMap<CheetahString, CheetahString>,
 }
 
+fn add_send_response_metadata(response: &mut RemotingCommand, region_id: CheetahString, trace_on: bool) {
+    response.add_ext_field(MessageConst::PROPERTY_MSG_REGION, region_id);
+    response.add_ext_field(
+        MessageConst::PROPERTY_TRACE_SWITCH,
+        CheetahString::from_static_str(if trace_on { "true" } else { "false" }),
+    );
+}
+
 impl<MS: BrokerWriteStore, TS> Clone for SendMessageProcessor<MS, TS> {
     fn clone(&self) -> Self {
         Self {
@@ -1068,11 +1076,7 @@ where
         let policy = self.inner.context.policy.snapshot();
         // set opaque
         response.with_opaque(request.opaque());
-        response.add_ext_field(MessageConst::PROPERTY_MSG_REGION, policy.region_id.clone());
-        response.add_ext_field(
-            MessageConst::PROPERTY_TRACE_SWITCH,
-            CheetahString::from_static_str(if policy.trace_on { "true" } else { "false" }),
-        );
+        add_send_response_metadata(&mut response, policy.region_id.clone(), policy.trace_on);
         let start_timestamp = policy.start_accept_send_request_time_stamp;
         let store_now = self.inner.context.store.now().unwrap_or_default();
         if store_now < (start_timestamp as u64) {
@@ -1998,7 +2002,9 @@ mod tests {
     use rocketmq_protocol::code::request_code::RequestCode;
     use rocketmq_protocol::code::response_code::RemotingSysResponseCode;
     use rocketmq_protocol::code::response_code::ResponseCode;
+    use rocketmq_protocol::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader;
     use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+    use rocketmq_protocol::protocol::SerializeType;
     use rocketmq_store::store_append_receipt;
     use rocketmq_store::PutMessageResult;
     use rocketmq_store::PutMessageStatus;
@@ -2012,6 +2018,7 @@ mod tests {
     use crate::mqtrace::send_message_hook::SendMessageHook;
     use crate::send_message_constants::error_messages;
 
+    use super::add_send_response_metadata;
     use super::append_message_with_store;
     use super::apply_topic_delivery_properties;
     use super::broker_send_permission_denied;
@@ -2024,6 +2031,42 @@ mod tests {
     use super::store_health_reject_remark;
     use super::store_health_reject_remark_from;
     use super::sync_flush_backlog_reject_remark;
+
+    #[test]
+    fn send_response_keeps_region_and_trace_fields() {
+        for serialize_type in [SerializeType::JSON, SerializeType::ROCKETMQ] {
+            let mut response = RemotingCommand::create_response_command_with_header(SendMessageResponseHeader::new(
+                CheetahString::from_static_str("msg-id"),
+                0,
+                0,
+                None,
+                None,
+                None,
+            ))
+            .set_serialize_type(serialize_type);
+            add_send_response_metadata(&mut response, CheetahString::from_static_str("region-a"), true);
+            let mut encoded = bytes::BytesMut::new();
+
+            response
+                .try_fast_header_encode(&mut encoded)
+                .expect("send response should encode");
+            let decoded = RemotingCommand::decode(&mut encoded)
+                .expect("send response should decode")
+                .expect("send response frame should be complete");
+
+            let fields = decoded.ext_fields().expect("send response ext fields");
+            assert_eq!(
+                fields.get(MessageConst::PROPERTY_MSG_REGION).map(CheetahString::as_str),
+                Some("region-a")
+            );
+            assert_eq!(
+                fields
+                    .get(MessageConst::PROPERTY_TRACE_SWITCH)
+                    .map(CheetahString::as_str),
+                Some("true")
+            );
+        }
+    }
 
     #[test]
     fn broker_receive_spans_bind_remote_parent_before_instrumentation() {

--- a/rocketmq-protocol/src/protocol/remoting_command.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command.rs
@@ -1135,9 +1135,7 @@ impl RemotingCommand {
     }
 
     pub fn add_ext_field(&mut self, key: impl Into<CheetahString>, value: impl Into<CheetahString>) -> &mut Self {
-        if let Some(ext) = self.ext_fields.as_map_mut() {
-            ext.insert(key.into(), value.into());
-        }
+        self.ext_fields.get_or_insert_map().insert(key.into(), value.into());
         self
     }
 
@@ -1285,9 +1283,10 @@ impl RemotingCommand {
 
     #[inline]
     pub fn add_ext_field_if_not_exist(&mut self, key: impl Into<CheetahString>, value: impl Into<CheetahString>) {
-        if let Some(ext) = self.ext_fields.as_map_mut() {
-            ext.entry(key.into()).or_insert(value.into());
-        }
+        self.ext_fields
+            .get_or_insert_map()
+            .entry(key.into())
+            .or_insert(value.into());
     }
 
     /// Ensures the extension fields map is initialized.
@@ -1471,6 +1470,117 @@ mod tests {
              extFields\":{},\"serializeTypeCurrentRPC\":\"JSON\"}",
             serde_json::to_string(&command).unwrap()
         );
+    }
+
+    #[test]
+    fn add_ext_field_initializes_absent() {
+        let mut command = RemotingCommand::create_response_command();
+        assert!(command.ext_fields.is_absent());
+
+        command.add_ext_field("key", "value");
+
+        assert_eq!(
+            command
+                .ext_fields()
+                .and_then(|fields| fields.get("key"))
+                .map(CheetahString::as_str),
+            Some("value")
+        );
+    }
+
+    #[test]
+    fn add_ext_field_if_not_exist_initializes_absent() {
+        let mut command = RemotingCommand::create_response_command();
+        assert!(command.ext_fields.is_absent());
+
+        command.add_ext_field_if_not_exist("key", "first");
+        command.add_ext_field_if_not_exist("key", "second");
+
+        assert_eq!(
+            command
+                .ext_fields()
+                .and_then(|fields| fields.get("key"))
+                .map(CheetahString::as_str),
+            Some("first")
+        );
+    }
+
+    #[test]
+    fn add_ext_field_preserves_materialized_fields() {
+        let mut command = RemotingCommand::create_response_command().set_ext_fields(HashMap::from([(
+            CheetahString::from_static_str("existing"),
+            CheetahString::from_static_str("preserved"),
+        )]));
+
+        command.add_ext_field("added", "value");
+
+        let fields = command.ext_fields().expect("extension fields should exist");
+        assert_eq!(fields.get("existing").map(CheetahString::as_str), Some("preserved"));
+        assert_eq!(fields.get("added").map(CheetahString::as_str), Some("value"));
+    }
+
+    #[test]
+    fn add_ext_field_preserves_json_raw_fields() {
+        let mut header = json_header_with_ext_fields(r#"{"existing":"preserved"}"#);
+        let header_length = header.len();
+        let mut command = RemotingCommand::header_decode(&mut header, header_length, SerializeType::JSON)
+            .unwrap()
+            .unwrap();
+        assert!(command.ext_fields.is_json_raw());
+
+        command.add_ext_field("added", "value");
+
+        let fields = command.ext_fields().expect("extension fields should exist");
+        assert_eq!(fields.get("existing").map(CheetahString::as_str), Some("preserved"));
+        assert_eq!(fields.get("added").map(CheetahString::as_str), Some("value"));
+    }
+
+    #[test]
+    fn add_ext_field_preserves_rocketmq_raw_fields() {
+        let mut source = RemotingCommand::create_response_command()
+            .set_serialize_type(SerializeType::ROCKETMQ)
+            .set_ext_fields(HashMap::from([(
+                CheetahString::from_static_str("existing"),
+                CheetahString::from_static_str("preserved"),
+            )]));
+        let mut encoded = BytesMut::new();
+        source.try_fast_header_encode(&mut encoded).unwrap();
+        let mut command = RemotingCommand::decode(&mut encoded).unwrap().unwrap();
+        assert!(command.ext_fields.is_rocketmq_raw());
+
+        command.add_ext_field("added", "value");
+
+        let fields = command.ext_fields().expect("extension fields should exist");
+        assert_eq!(fields.get("existing").map(CheetahString::as_str), Some("preserved"));
+        assert_eq!(fields.get("added").map(CheetahString::as_str), Some("value"));
+    }
+
+    #[test]
+    fn add_ext_field_coexists_with_typed_header() {
+        for serialize_type in [SerializeType::JSON, SerializeType::ROCKETMQ] {
+            let mut command = RemotingCommand::create_response_command_with_header(TestCustomHeader { value: 7 })
+                .set_serialize_type(serialize_type);
+            command.add_ext_field("dynamic", "preserved");
+            let mut encoded = BytesMut::new();
+
+            command.try_fast_header_encode(&mut encoded).unwrap();
+            let decoded = RemotingCommand::decode(&mut encoded).unwrap().unwrap();
+
+            assert_eq!(
+                decoded
+                    .ext_fields()
+                    .and_then(|fields| fields.get("value"))
+                    .map(CheetahString::as_str),
+                Some("7")
+            );
+            assert_eq!(
+                decoded
+                    .ext_fields()
+                    .and_then(|fields| fields.get("dynamic"))
+                    .map(CheetahString::as_str),
+                Some("preserved")
+            );
+        }
     }
 
     #[test]

--- a/rocketmq-protocol/tests/remoting_command_java_business_compatibility.rs
+++ b/rocketmq-protocol/tests/remoting_command_java_business_compatibility.rs
@@ -1,0 +1,72 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Business compatibility tests for Java `RemotingCommand` behavior.
+//!
+//! The reference behavior is `RemotingCommand.addExtField` in Apache RocketMQ:
+//! the extension-field map is initialized on the first write.
+
+use bytes::BytesMut;
+use cheetah_string::CheetahString;
+use rocketmq_protocol::protocol::SerializeType;
+use rocketmq_protocol::RemotingCommand;
+
+fn round_trip(mut command: RemotingCommand) -> RemotingCommand {
+    let mut encoded = BytesMut::new();
+    command
+        .try_fast_header_encode(&mut encoded)
+        .expect("command should encode");
+    RemotingCommand::decode(&mut encoded)
+        .expect("command should decode")
+        .expect("command frame should be complete")
+}
+
+#[test]
+fn add_ext_field_on_absent_matches_java() {
+    for serialize_type in [SerializeType::JSON, SerializeType::ROCKETMQ] {
+        let mut command = RemotingCommand::create_response_command().set_serialize_type(serialize_type);
+        assert!(command.ext_fields().is_none());
+
+        command.add_ext_field("regionId", "DefaultRegion");
+        let decoded = round_trip(command);
+
+        assert_eq!(
+            decoded
+                .ext_fields()
+                .and_then(|fields| fields.get("regionId"))
+                .map(CheetahString::as_str),
+            Some("DefaultRegion")
+        );
+    }
+}
+
+#[test]
+fn add_ext_field_if_not_exist_on_absent_matches_java() {
+    for serialize_type in [SerializeType::JSON, SerializeType::ROCKETMQ] {
+        let mut command = RemotingCommand::create_response_command().set_serialize_type(serialize_type);
+        assert!(command.ext_fields().is_none());
+
+        command.add_ext_field_if_not_exist("traceOn", "true");
+        command.add_ext_field_if_not_exist("traceOn", "false");
+        let decoded = round_trip(command);
+
+        assert_eq!(
+            decoded
+                .ext_fields()
+                .and_then(|fields| fields.get("traceOn"))
+                .map(CheetahString::as_str),
+            Some("true")
+        );
+    }
+}

--- a/rocketmq-proxy/src/remoting.rs
+++ b/rocketmq-proxy/src/remoting.rs
@@ -1647,6 +1647,8 @@ mod tests {
     use rocketmq_model::common::message::message_queue_assignment::MessageQueueAssignment;
     use rocketmq_model::common::message::message_single::Message;
     use rocketmq_model::common::message::MessageConst;
+    use rocketmq_model::common::mix_all::IS_SUB_CHANGE;
+    use rocketmq_model::common::mix_all::IS_SUPPORT_HEART_BEAT_V2;
     use rocketmq_model::result::SendResult;
     use rocketmq_model::result::SendStatus;
     use rocketmq_protocol::code::request_code::RequestCode;
@@ -2227,6 +2229,17 @@ mod tests {
 
         let heartbeat_response = dispatcher.dispatch(&test_context(), &heartbeat_request).await;
         assert_eq!(ResponseCode::from(heartbeat_response.code()), ResponseCode::Success);
+        let heartbeat_ext_fields = heartbeat_response.ext_fields().expect("heartbeat response ext fields");
+        assert_eq!(
+            heartbeat_ext_fields
+                .get(IS_SUPPORT_HEART_BEAT_V2)
+                .map(CheetahString::as_str),
+            Some("true")
+        );
+        assert_eq!(
+            heartbeat_ext_fields.get(IS_SUB_CHANGE).map(CheetahString::as_str),
+            Some("true")
+        );
         assert_eq!(sessions.consumer_client_ids("GroupA"), vec!["client-a".to_owned()]);
 
         let mut get_request = RemotingCommand::create_request_command(


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9290

### Brief Description

- Lazily initialize `ExtensionFields` on the first `add_ext_field` or `add_ext_field_if_not_exist` write.
- Preserve existing materialized, JSON-raw, and ROCKETMQ-raw fields while adding dynamic metadata.
- Add JSON and ROCKETMQ round-trip coverage for Java-compatible behavior and broker/proxy response paths.

### How Did You Test This Change?

- `cargo test -p rocketmq-protocol --test remoting_command_java_business_compatibility -- --nocapture`
- `cargo test -p rocketmq-protocol protocol::remoting_command::tests --lib`
- `cargo test -p rocketmq-protocol --test remoting_wire_golden`
- `cargo test -p rocketmq-protocol --test request_header_java_compatibility`
- `cargo test -p rocketmq-transport --features test-support --test protocol_compatibility`
- `cargo test -p rocketmq-broker response_keeps --lib -- --nocapture`
- `cargo test -p rocketmq-broker heart_beat_v2_without_sub_registers_consumer_and_marks_sub_change --lib -- --nocapture`
- `cargo test -p rocketmq-proxy dispatch_heartbeat_and_get_consumer_list_tracks_membership --lib -- --nocapture`
- Workspace format check run package-by-package for all 28 packages because Windows rejected `cargo fmt --all -- --check` with OS error 206.
- `CARGO_BUILD_JOBS=1 RUST_MIN_STACK=67108864 cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`
- Rustfmt checks for all 23 Rust sources, `cargo clippy --all-targets -- -D warnings`, and `cargo build --example request-code-smoke` from `rocketmq-example/`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved message send, reply, and recall responses so region and tracing metadata remain available across supported serialization formats.
  - Ensured response extension fields are initialized and preserved when commands are encoded or decoded.
  - Improved heartbeat responses to advertise Heartbeat V2 and subscription-change support.

- **Compatibility**
  - Added validation for interoperability with Java-based remoting clients, including consistent extension-field behavior and value preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->