### PR TITLE
[ISSUE #9295]🐛Support the Java NODE_JS remoting language code

### DIFF
--- a/rocketmq-protocol/src/protocol.rs
+++ b/rocketmq-protocol/src/protocol.rs
@@ -312,6 +312,8 @@ pub enum LanguageCode {
     OMS,
     #[default]
     RUST,
+    #[allow(non_camel_case_types, reason = "matches the Java remoting wire language name")]
+    NODE_JS,
 }
 
 impl fmt::Display for LanguageCode {
@@ -366,6 +368,7 @@ impl LanguageCode {
             10 => Self::PHP,
             11 => Self::OMS,
             12 => Self::RUST,
+            13 => Self::NODE_JS,
             _ => Self::OTHER,
         })
     }
@@ -389,6 +392,7 @@ impl LanguageCode {
             "PHP" => Some(Self::PHP),
             "OMS" => Some(Self::OMS),
             "RUST" => Some(Self::RUST),
+            "NODE_JS" => Some(Self::NODE_JS),
             _ => None,
         }
     }

--- a/rocketmq-protocol/src/protocol/remoting_command.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command.rs
@@ -72,6 +72,7 @@ const fn language_name(language: LanguageCode) -> &'static str {
         LanguageCode::PHP => "PHP",
         LanguageCode::OMS => "OMS",
         LanguageCode::RUST => "RUST",
+        LanguageCode::NODE_JS => "NODE_JS",
     }
 }
 

--- a/rocketmq-protocol/src/protocol/remoting_command/json_decode.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command/json_decode.rs
@@ -437,6 +437,7 @@ fn language(value: &[u8]) -> Option<LanguageCode> {
         b"PHP" => LanguageCode::PHP,
         b"OMS" => LanguageCode::OMS,
         b"RUST" => LanguageCode::RUST,
+        b"NODE_JS" => LanguageCode::NODE_JS,
         _ => return None,
     })
 }
@@ -781,6 +782,16 @@ mod tests {
                 Some("id")
             );
         }
+    }
+
+    #[test]
+    fn decodes_node_js_language_on_fast_path() {
+        let input = br#"{"code":10,"language":"NODE_JS","version":501,"opaque":7,"flag":0,"remark":null,"extFields":null,"serializeTypeCurrentRPC":"JSON"}"#;
+
+        let command = decode(input).expect("NODE_JS JSON should use the fast parser");
+
+        assert_eq!(command.language, LanguageCode::NODE_JS);
+        assert_eq!(command.version, 501);
     }
 
     #[test]

--- a/rocketmq-protocol/tests/remoting_command_java_business_compatibility.rs
+++ b/rocketmq-protocol/tests/remoting_command_java_business_compatibility.rs
@@ -19,6 +19,7 @@
 
 use bytes::BytesMut;
 use cheetah_string::CheetahString;
+use rocketmq_protocol::protocol::LanguageCode;
 use rocketmq_protocol::protocol::SerializeType;
 use rocketmq_protocol::RemotingCommand;
 
@@ -69,4 +70,49 @@ fn add_ext_field_if_not_exist_on_absent_matches_java() {
             Some("true")
         );
     }
+}
+
+#[test]
+fn node_js_language_code_matches_java() {
+    const EXISTING_CODES: [(u8, LanguageCode); 13] = [
+        (0, LanguageCode::JAVA),
+        (1, LanguageCode::CPP),
+        (2, LanguageCode::DOTNET),
+        (3, LanguageCode::PYTHON),
+        (4, LanguageCode::DELPHI),
+        (5, LanguageCode::ERLANG),
+        (6, LanguageCode::RUBY),
+        (7, LanguageCode::OTHER),
+        (8, LanguageCode::HTTP),
+        (9, LanguageCode::GO),
+        (10, LanguageCode::PHP),
+        (11, LanguageCode::OMS),
+        (12, LanguageCode::RUST),
+    ];
+
+    for (code, language) in EXISTING_CODES {
+        assert_eq!(language.get_code(), code);
+        assert_eq!(LanguageCode::value_of(code), Some(language));
+    }
+
+    assert_eq!(LanguageCode::NODE_JS.get_code(), 13);
+    assert_eq!(LanguageCode::value_of(13), Some(LanguageCode::NODE_JS));
+    assert_eq!(LanguageCode::value_of(14), Some(LanguageCode::OTHER));
+    assert_eq!(LanguageCode::get_code_from_name("NODE_JS"), Some(LanguageCode::NODE_JS));
+
+    for serialize_type in [SerializeType::JSON, SerializeType::ROCKETMQ] {
+        let command = RemotingCommand::create_response_command()
+            .set_language(LanguageCode::NODE_JS)
+            .set_serialize_type(serialize_type);
+        let decoded = round_trip(command);
+
+        assert_eq!(decoded.language(), LanguageCode::NODE_JS);
+        assert_eq!(decoded.get_serialize_type(), serialize_type);
+    }
+
+    let serde_fallback: RemotingCommand = serde_json::from_str(
+        r#"{"code":0,"language":"NODE_JS","version":0,"opaque":0,"flag":1,"remark":null,"serializeTypeCurrentRPC":"JSON"}"#,
+    )
+    .expect("serde fallback should recognize NODE_JS");
+    assert_eq!(serde_fallback.language(), LanguageCode::NODE_JS);
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9295

### Brief Description

- Add the Java-compatible `LanguageCode::NODE_JS` variant with binary code 13.
- Support `NODE_JS` in name resolution, canonical JSON encoding, and the fast JSON decoder.
- Preserve existing language codes 0 through 12 and the current unknown-code fallback.
- Add JSON, ROCKETMQ, Serde fallback, and old-code stability coverage.

### How Did You Test This Change?

- `cargo test -p rocketmq-protocol --test remoting_command_java_business_compatibility`
- `cargo test -p rocketmq-protocol protocol::remoting_command::json_decode::tests --lib`
- `cargo test -p rocketmq-protocol protocol::remoting_command::tests --lib`
- `cargo test -p rocketmq-protocol --test remoting_wire_golden`
- `cargo test -p rocketmq-protocol --test request_header_java_compatibility`
- `cargo test -p rocketmq-transport --features test-support --test protocol_compatibility`
- Workspace format check run package-by-package for all 28 packages because Windows rejects `cargo fmt --all -- --check` with OS error 206.
- `CARGO_BUILD_JOBS=1 RUST_MIN_STACK=67108864 cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`
- Rustfmt checks for all 23 Rust sources, `cargo clippy --all-targets -- -D warnings`, and `cargo build --example request-code-smoke` from `rocketmq-example/`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for identifying Node.js clients through the `NODE_JS` language code.
  - Node.js language values are now recognized during command encoding and decoding.

- **Bug Fixes**
  - Improved compatibility for Node.js command headers and cross-language command round trips.
  - Unknown language codes continue to fall back safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->