### PR TITLE
[ISSUE #9297]🐛Use one immutable default for remoting command factories

### DIFF
--- a/rocketmq-protocol/src/protocol.rs
+++ b/rocketmq-protocol/src/protocol.rs
@@ -47,6 +47,7 @@ pub mod namespace_util;
 pub mod namesrv;
 pub mod remoting_command;
 pub mod remoting_command_compat;
+pub mod remoting_command_defaults;
 pub mod request_source;
 pub mod request_type;
 pub mod rocketmq_serializable;

--- a/rocketmq-protocol/src/protocol/remoting_command.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command.rs
@@ -41,6 +41,7 @@ use crate::protocol::header_codec::BinaryHeaderFields;
 use crate::protocol::header_codec::HeaderCodecError;
 use crate::protocol::header_codec::JsonHeaderFields;
 use crate::protocol::header_field_merge::merge_header_and_dynamic;
+use crate::protocol::remoting_command_defaults::application_remoting_command_defaults;
 use crate::protocol::LanguageCode;
 use crate::rocketmq_serializable::RocketMQSerializable;
 
@@ -186,6 +187,11 @@ impl Default for RemotingCommand {
 }
 
 impl RemotingCommand {
+    fn with_application_defaults() -> Self {
+        let defaults = application_remoting_command_defaults();
+        Self::with_resolved_defaults(defaults.version(), defaults.serialize_type())
+    }
+
     /// Constructs a command from defaults resolved by the owning facade.
     ///
     /// The protocol crate deliberately does not read process environment or configuration files.
@@ -216,19 +222,15 @@ impl RemotingCommand {
 
 impl RemotingCommand {
     pub fn new_request(code: impl Into<i32>, body: impl Into<Bytes>) -> Self {
-        Self::default().set_code(code).set_body(body)
+        Self::with_application_defaults().set_code(code).set_body(body)
     }
 
     pub fn create_request_command<T>(code: impl Into<i32>, header: T) -> Self
     where
         T: CommandCustomHeader + Sync + Send + 'static,
     {
-        Self::create_request_command_with_defaults(
-            code,
-            header,
-            rocketmq_model::version::CURRENT_VERSION as i32,
-            SerializeType::JSON,
-        )
+        let defaults = application_remoting_command_defaults();
+        Self::create_request_command_with_defaults(code, header, defaults.version(), defaults.serialize_type())
     }
 
     /// Creates a request using defaults resolved by the transport/facade owner.
@@ -247,7 +249,7 @@ impl RemotingCommand {
     }
 
     pub fn create_remoting_command(code: impl Into<i32>) -> Self {
-        let command = Self::default();
+        let command = Self::with_application_defaults();
         command.set_code(code.into())
     }
 
@@ -256,24 +258,24 @@ impl RemotingCommand {
     }
 
     pub fn create_response_command_with_code(code: impl Into<i32>) -> Self {
-        Self::default().set_code(code).mark_response_type()
+        Self::with_application_defaults().set_code(code).mark_response_type()
     }
 
     pub fn create_response_command_with_code_remark(code: impl Into<i32>, remark: impl Into<CheetahString>) -> Self {
-        Self::default()
+        Self::with_application_defaults()
             .set_code(code)
             .set_remark_option(Some(remark.into()))
             .mark_response_type()
     }
 
     pub fn create_response_command() -> Self {
-        Self::default()
+        Self::with_application_defaults()
             .set_code(RemotingSysResponseCode::Success)
             .mark_response_type()
     }
 
     pub fn create_response_command_with_header(header: impl CommandCustomHeader + Sync + Send + 'static) -> Self {
-        Self::default()
+        Self::with_application_defaults()
             .set_code(RemotingSysResponseCode::Success)
             .set_command_custom_header(header)
             .mark_response_type()
@@ -1467,8 +1469,11 @@ mod tests {
             .set_remark_option(Some("remark".to_string()));
 
         assert_eq!(
-            "{\"code\":1,\"language\":\"JAVA\",\"version\":0,\"opaque\":1,\"flag\":1,\"remark\":\"remark\",\"\
-             extFields\":{},\"serializeTypeCurrentRPC\":\"JSON\"}",
+            format!(
+                "{{\"code\":1,\"language\":\"JAVA\",\"version\":{},\"opaque\":1,\"flag\":1,\"remark\":\"remark\",\
+                 \"extFields\":{{}},\"serializeTypeCurrentRPC\":\"JSON\"}}",
+                crate::version::CURRENT_VERSION as i32
+            ),
             serde_json::to_string(&command).unwrap()
         );
     }

--- a/rocketmq-protocol/src/protocol/remoting_command_defaults.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command_defaults.rs
@@ -1,0 +1,142 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Immutable process defaults for business `RemotingCommand` factories.
+
+use std::fmt;
+use std::sync::OnceLock;
+
+use crate::protocol::SerializeType;
+
+/// Wire defaults shared by all business command factories in a process.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RemotingCommandDefaults {
+    version: i32,
+    serialize_type: SerializeType,
+}
+
+impl RemotingCommandDefaults {
+    pub const fn new(version: i32, serialize_type: SerializeType) -> Self {
+        Self {
+            version,
+            serialize_type,
+        }
+    }
+
+    pub const fn version(self) -> i32 {
+        self.version
+    }
+
+    pub const fn serialize_type(self) -> SerializeType {
+        self.serialize_type
+    }
+}
+
+impl Default for RemotingCommandDefaults {
+    fn default() -> Self {
+        Self::new(crate::version::CURRENT_VERSION as i32, SerializeType::JSON)
+    }
+}
+
+/// Returned when a process attempts to replace initialized command defaults.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RemotingCommandDefaultsConflict {
+    initialized: RemotingCommandDefaults,
+    requested: RemotingCommandDefaults,
+}
+
+impl RemotingCommandDefaultsConflict {
+    pub const fn initialized(self) -> RemotingCommandDefaults {
+        self.initialized
+    }
+
+    pub const fn requested(self) -> RemotingCommandDefaults {
+        self.requested
+    }
+}
+
+impl fmt::Display for RemotingCommandDefaultsConflict {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "remoting command defaults are already initialized to {:?}, requested {:?}",
+            self.initialized, self.requested
+        )
+    }
+}
+
+impl std::error::Error for RemotingCommandDefaultsConflict {}
+
+static APPLICATION_DEFAULTS: OnceLock<RemotingCommandDefaults> = OnceLock::new();
+
+fn initialize_defaults(
+    cell: &OnceLock<RemotingCommandDefaults>,
+    defaults: RemotingCommandDefaults,
+) -> Result<(), RemotingCommandDefaultsConflict> {
+    match cell.set(defaults) {
+        Ok(()) => Ok(()),
+        Err(requested) => {
+            // OnceLock returns Err only after retaining the previously initialized value.
+            let initialized = *cell
+                .get()
+                .expect("failed OnceLock::set always retains an initialized value");
+            if initialized == requested {
+                Ok(())
+            } else {
+                Err(RemotingCommandDefaultsConflict { initialized, requested })
+            }
+        }
+    }
+}
+
+/// Initializes the immutable defaults used by business command factories.
+///
+/// Repeating initialization with the same value is idempotent. A different
+/// value is rejected so wire defaults cannot change after command creation.
+///
+/// # Errors
+///
+/// Returns [`RemotingCommandDefaultsConflict`] when different defaults were
+/// initialized earlier in the process.
+pub fn initialize_remoting_command_defaults(
+    defaults: RemotingCommandDefaults,
+) -> Result<(), RemotingCommandDefaultsConflict> {
+    initialize_defaults(&APPLICATION_DEFAULTS, defaults)
+}
+
+pub(crate) fn application_remoting_command_defaults() -> RemotingCommandDefaults {
+    *APPLICATION_DEFAULTS.get_or_init(RemotingCommandDefaults::default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initialization_is_idempotent_and_rejects_conflicts() {
+        let cell = OnceLock::new();
+        let first = RemotingCommandDefaults::new(1, SerializeType::JSON);
+        let second = RemotingCommandDefaults::new(2, SerializeType::ROCKETMQ);
+
+        assert_eq!(initialize_defaults(&cell, first), Ok(()));
+        assert_eq!(initialize_defaults(&cell, first), Ok(()));
+        assert_eq!(
+            initialize_defaults(&cell, second),
+            Err(RemotingCommandDefaultsConflict {
+                initialized: first,
+                requested: second,
+            })
+        );
+    }
+}

--- a/rocketmq-protocol/tests/remoting_command_application_defaults.rs
+++ b/rocketmq-protocol/tests/remoting_command_application_defaults.rs
@@ -1,0 +1,45 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::Bytes;
+use rocketmq_protocol::protocol::header::empty_header::EmptyHeader;
+use rocketmq_protocol::protocol::remoting_command_defaults::initialize_remoting_command_defaults;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandDefaults;
+use rocketmq_protocol::protocol::SerializeType;
+use rocketmq_protocol::RemotingCommand;
+
+#[test]
+fn business_factories_share_immutable_application_defaults() {
+    let defaults = RemotingCommandDefaults::new(4242, SerializeType::ROCKETMQ);
+    initialize_remoting_command_defaults(defaults).expect("application defaults should initialize");
+
+    let commands = [
+        RemotingCommand::new_request(10, Bytes::from_static(b"body")),
+        RemotingCommand::create_request_command(11, EmptyHeader {}),
+        RemotingCommand::create_remoting_command(12),
+        RemotingCommand::create_response_command(),
+        RemotingCommand::create_response_command_with_code(1),
+        RemotingCommand::create_response_command_with_code_remark(1, "error"),
+        RemotingCommand::create_response_command_with_header(EmptyHeader {}),
+    ];
+
+    for command in commands {
+        assert_eq!(command.version(), 4242);
+        assert_eq!(command.serialize_type(), SerializeType::ROCKETMQ);
+    }
+
+    let neutral = RemotingCommand::default();
+    assert_eq!(neutral.version(), 0);
+    assert_eq!(neutral.serialize_type(), SerializeType::JSON);
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9297

### Brief Description

Introduce an immutable, process-wide `RemotingCommandDefaults` value for business command factories. Factory-created requests and responses now share the configured protocol version and serialization type, repeated initialization with the same value is idempotent, conflicting initialization returns a typed error, and `RemotingCommand::default()` remains a neutral protocol value. Add focused coverage for factory consistency and initialization conflicts.

### How Did You Test This Change?

- Passed `cargo test -p rocketmq-protocol --test remoting_command_application_defaults`.
- Passed `cargo test -p rocketmq-protocol protocol::remoting_command_defaults::tests --lib`.
- Passed `cargo test -p rocketmq-protocol --test remoting_command_defaults`.
- Passed `cargo test -p rocketmq-protocol protocol::remoting_command::tests --lib`.
- Passed `cargo test -p rocketmq-protocol --test remoting_command_java_business_compatibility`.
- Passed `cargo test -p rocketmq-protocol --test remoting_wire_golden`.
- Passed `cargo test -p rocketmq-protocol --test request_header_java_compatibility`.
- Passed `cargo test -p rocketmq-transport --features test-support --test protocol_compatibility`.
- Passed the workspace format check by running `rustfmt --check` with each package edition across all 28 workspace packages; the aggregate Windows `cargo fmt --all -- --check` invocation exceeds the operating-system command-line limit.
- Passed `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` with one build job and a larger compiler stack on Windows.
- Passed `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` in `fuzz`.
- Passed the standalone `rocketmq-example` format check across 23 Rust files, `cargo clippy --all-targets -- -D warnings`, and `cargo build --example request-code-smoke`.
- Passed `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable application-wide defaults for remoting command versions and serialization formats.
  * Remoting command factories now automatically use the configured application defaults.
  * Added safeguards to detect conflicting attempts to reconfigure established defaults.

* **Bug Fixes**
  * Preserved neutral defaults for directly created remoting commands while applying configured defaults to business commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->