### PR TITLE
[ISSUE #9299]🐛Reject invalid remoting serialization defaults at startup

### DIFF
--- a/rocketmq-broker/src/bin/broker_bootstrap_server.rs
+++ b/rocketmq-broker/src/bin/broker_bootstrap_server.rs
@@ -28,7 +28,7 @@ use rocketmq_broker::config::validated::ValidatedBrokerConfig;
 use rocketmq_broker::Builder;
 use rocketmq_model::common::mq_version::CURRENT_VERSION;
 use rocketmq_model::utils::env_utils::EnvUtils;
-use rocketmq_protocol::protocol::remoting_command_facade::initialize_remoting_version;
+use rocketmq_protocol::protocol::remoting_command_facade::initialize_remoting_defaults;
 use rocketmq_runtime::ChildServiceContext;
 use rocketmq_runtime::RuntimeComponent;
 use rocketmq_runtime::RuntimeConfig;
@@ -92,8 +92,8 @@ fn broker_runtime_config() -> RuntimeConfig {
 }
 
 async fn run(service_context: ChildServiceContext, lifecycle: ServiceLifecycle) -> Result<()> {
-    initialize_remoting_version(CURRENT_VERSION as i32)
-        .context("failed to initialize the immutable broker remoting version")?;
+    initialize_remoting_defaults(CURRENT_VERSION as i32)
+        .context("failed to initialize the immutable broker remoting defaults")?;
 
     // Parse and validate command line arguments
     let args = Args::parse();

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -70,7 +70,6 @@ use rocketmq_model::common::message::message_queue_assignment::MessageQueueAssig
 use rocketmq_model::common::message::MessageConst;
 use rocketmq_model::common::message::MessageTrait;
 use rocketmq_model::common::mix_all;
-use rocketmq_model::common::mq_version::CURRENT_VERSION;
 use rocketmq_model::common::sys_flag::pull_sys_flag::PullSysFlag;
 use rocketmq_model::common::topic::TopicValidator;
 use rocketmq_model::utils::serde_json_utils::SerdeJsonUtils;
@@ -283,7 +282,6 @@ use rocketmq_protocol::protocol::heartbeat::message_model::MessageModel;
 use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
 use rocketmq_protocol::protocol::namespace_util::NamespaceUtil;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
-use rocketmq_protocol::protocol::remoting_command_facade;
 use rocketmq_protocol::protocol::route::topic_route_data::TopicRouteData;
 use rocketmq_protocol::protocol::static_topic::topic_config_and_queue_mapping::TopicConfigAndQueueMapping;
 #[cfg(feature = "admin-mutation")]

--- a/rocketmq-client/src/implementation/mq_client_api_impl/admin.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl/admin.rs
@@ -2559,16 +2559,6 @@ impl MQClientAPIImpl {
         ))
     }
 
-    pub fn init_remoting_version() {
-        if let Err(error) = remoting_command_facade::initialize_remoting_version(CURRENT_VERSION as i32) {
-            warn!(
-                initialized = error.initialized(),
-                requested = error.requested(),
-                "client retained the remoting version selected earlier in process bootstrap"
-            );
-        }
-    }
-
     pub(crate) async fn get_all_topic_config(
         &self,
         addr: &CheetahString,

--- a/rocketmq-client/src/implementation/mq_client_api_impl/transport.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl/transport.rs
@@ -29,8 +29,6 @@ impl MQClientAPIImpl {
         service_context: ChildServiceContext,
         telemetry_handle: rocketmq_observability::TelemetryHandle,
     ) -> Self {
-        Self::init_remoting_version();
-
         let mut remoting_config = (*tokio_client_config).clone();
         remoting_config.tls = client_config.tls_config.clone();
         remoting_config.tls.enable = client_config.use_tls;

--- a/rocketmq-client/src/implementation/mq_client_manager.rs
+++ b/rocketmq-client/src/implementation/mq_client_manager.rs
@@ -22,6 +22,7 @@ use dashmap::DashMap;
 use parking_lot::RwLock;
 use rocketmq_observability::metrics::client::ClientMetrics;
 use rocketmq_observability::TelemetryHandle;
+use rocketmq_protocol::protocol::remoting_command_facade::initialize_remoting_defaults;
 use rocketmq_runtime::ChildServiceContext;
 use rocketmq_runtime::ResourceBudget;
 use rocketmq_runtime::ShutdownDeadline;
@@ -156,6 +157,13 @@ impl ClientPool {
         options: ClientOptions,
         rpc_hook: Option<Arc<dyn RPCHook>>,
     ) -> rocketmq_error::RocketMQResult<PooledClient> {
+        initialize_remoting_defaults(rocketmq_model::version::CURRENT_VERSION as i32).map_err(|error| {
+            rocketmq_error::RocketMQError::ConfigParseFailed {
+                key: "remoting.command.defaults",
+                reason: error.to_string(),
+            }
+        })?;
+
         let _admission = self.inner.admission.read();
         if self.inner.closed.load(Ordering::Acquire) {
             return Err(mq_client_err!("ClientRuntime is shutting down"));

--- a/rocketmq-client/tests/remoting_defaults_startup.rs
+++ b/rocketmq-client/tests/remoting_defaults_startup.rs
@@ -1,0 +1,60 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_client_rust::ClientConfig;
+use rocketmq_client_rust::ClientRuntime;
+use rocketmq_client_rust::ClientRuntimeConfig;
+use rocketmq_client_rust::TelemetryHandle;
+use rocketmq_error::RocketMQError;
+use rocketmq_protocol::protocol::remoting_command::SERIALIZE_TYPE_PROPERTY;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+
+#[test]
+fn client_pool_rejects_invalid_remoting_serialization_before_admission() {
+    // SAFETY: this integration-test binary contains one test, so no concurrent thread can read or
+    // mutate this process environment key while the assertion runs.
+    unsafe {
+        std::env::set_var(SERIALIZE_TYPE_PROPERTY, "CBOR");
+    }
+
+    let owner = RuntimeOwner::new(RuntimeConfig {
+        thread_name: "remoting-defaults-startup-test".to_string(),
+        ..Default::default()
+    })
+    .expect("test runtime owner should start");
+    let runtime = ClientRuntime::try_new(
+        owner.root_context().component("client"),
+        ClientRuntimeConfig::default(),
+        TelemetryHandle::noop(),
+    )
+    .expect("client runtime should be valid");
+
+    let error = match runtime.pool().get_or_create(ClientConfig::default(), None) {
+        Ok(_) => panic!("invalid remoting serialization must reject client admission"),
+        Err(error) => error,
+    };
+    assert!(matches!(
+        error,
+        RocketMQError::ConfigParseFailed {
+            key: "remoting.command.defaults",
+            ..
+        }
+    ));
+    assert_eq!(runtime.pool().instance_count(), 0);
+
+    owner
+        .shutdown_runtime_blocking()
+        .expect("test runtime should shut down cleanly");
+}

--- a/rocketmq-controller/src/bin/controller_bootstrap.rs
+++ b/rocketmq-controller/src/bin/controller_bootstrap.rs
@@ -33,7 +33,7 @@ use rocketmq_controller::ControllerManager;
 use rocketmq_controller::Node;
 use rocketmq_error::ControllerError;
 use rocketmq_model::common::mq_version::CURRENT_VERSION;
-use rocketmq_protocol::protocol::remoting_command_facade::initialize_remoting_version;
+use rocketmq_protocol::protocol::remoting_command_facade::initialize_remoting_defaults;
 use rocketmq_runtime::common::parse_config_file;
 use rocketmq_runtime::ChildServiceContext;
 use rocketmq_runtime::RuntimeComponent;
@@ -123,8 +123,8 @@ fn controller_runtime_config() -> RuntimeConfig {
 }
 
 async fn run(service_context: ChildServiceContext, lifecycle: ServiceLifecycle) -> Result<()> {
-    initialize_remoting_version(CURRENT_VERSION as i32)
-        .context("failed to initialize the immutable Controller remoting version")?;
+    initialize_remoting_defaults(CURRENT_VERSION as i32)
+        .context("failed to initialize the immutable Controller remoting defaults")?;
 
     // Parse command line and load configuration
     let (cli, config) = parse_command_line()?;

--- a/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
+++ b/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
@@ -44,7 +44,7 @@ use rocketmq_namesrv::security::NameServerTransportPolicy;
 use rocketmq_namesrv::NamesrvConfig;
 #[cfg(feature = "embedded-controller")]
 use rocketmq_observability::MetricsExporterType;
-use rocketmq_protocol::protocol::remoting_command_facade::initialize_remoting_version;
+use rocketmq_protocol::protocol::remoting_command_facade::initialize_remoting_defaults;
 use rocketmq_runtime::common::parse_config_file;
 use rocketmq_runtime::ChildServiceContext;
 use rocketmq_runtime::RuntimeComponent;
@@ -122,8 +122,8 @@ async fn run(service_context: ChildServiceContext, lifecycle: ServiceLifecycle) 
     // Parse command line arguments first
     let args = Args::parse();
 
-    initialize_remoting_version(CURRENT_VERSION as i32)
-        .context("failed to initialize the immutable NameServer remoting version")?;
+    initialize_remoting_defaults(CURRENT_VERSION as i32)
+        .context("failed to initialize the immutable NameServer remoting defaults")?;
 
     // Parse and merge configurations
     let (namesrv_config, server_config, tokio_client_config, controller_config, logging_overrides) =

--- a/rocketmq-protocol/src/protocol/remoting_command_compat.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command_compat.rs
@@ -24,6 +24,9 @@ use std::sync::OnceLock;
 
 use crate::protocol::command_custom_header::CommandCustomHeader;
 use crate::protocol::remoting_command::RemotingCommand;
+use crate::protocol::remoting_command_defaults::initialize_remoting_command_defaults;
+use crate::protocol::remoting_command_defaults::RemotingCommandDefaults;
+use crate::protocol::remoting_command_defaults::RemotingCommandDefaultsConflict;
 use crate::protocol::SerializeType;
 
 use super::remoting_command::REMOTING_VERSION_KEY;
@@ -75,6 +78,105 @@ static SERIALIZE_TYPE: LazyLock<SerializeType> = LazyLock::new(|| {
         })
         .unwrap_or(SerializeType::JSON)
 });
+
+/// An unsupported value selected for the process remoting serialization type.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InvalidRemotingSerializeType {
+    key: &'static str,
+    value: String,
+}
+
+impl InvalidRemotingSerializeType {
+    pub const fn key(&self) -> &'static str {
+        self.key
+    }
+
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+}
+
+impl fmt::Display for InvalidRemotingSerializeType {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "invalid remoting serialization type for {}: {:?}; expected JSON or ROCKETMQ",
+            self.key, self.value
+        )
+    }
+}
+
+impl std::error::Error for InvalidRemotingSerializeType {}
+
+/// Failure while resolving or initializing process remoting defaults.
+#[derive(Debug, thiserror::Error)]
+pub enum RemotingDefaultsError {
+    #[error(transparent)]
+    InvalidSerializeType(#[from] InvalidRemotingSerializeType),
+    #[error(transparent)]
+    Conflict(#[from] RemotingCommandDefaultsConflict),
+}
+
+/// Resolves the serialization type with Java-compatible configuration precedence.
+///
+/// The property-style value takes precedence over the environment fallback.
+/// When neither value is configured, JSON is selected.
+///
+/// # Errors
+///
+/// Returns [`InvalidRemotingSerializeType`] when the selected value is not
+/// exactly `JSON` or `ROCKETMQ`.
+pub fn resolve_remoting_serialize_type(
+    property_value: Option<&str>,
+    environment_value: Option<&str>,
+) -> Result<SerializeType, InvalidRemotingSerializeType> {
+    let (key, value) = property_value
+        .map(|value| (SERIALIZE_TYPE_PROPERTY, value))
+        .or_else(|| environment_value.map(|value| (SERIALIZE_TYPE_ENV, value)))
+        .unwrap_or((SERIALIZE_TYPE_PROPERTY, "JSON"));
+
+    match value {
+        "JSON" => Ok(SerializeType::JSON),
+        "ROCKETMQ" => Ok(SerializeType::ROCKETMQ),
+        _ => Err(InvalidRemotingSerializeType {
+            key,
+            value: value.to_string(),
+        }),
+    }
+}
+
+fn read_environment_value(key: &'static str) -> Result<Option<String>, InvalidRemotingSerializeType> {
+    match std::env::var(key) {
+        Ok(value) => Ok(Some(value)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(value)) => Err(InvalidRemotingSerializeType {
+            key,
+            value: value.to_string_lossy().into_owned(),
+        }),
+    }
+}
+
+/// Initializes the immutable defaults used by all business command factories.
+///
+/// `rocketmq.serialize.type` takes precedence over
+/// `ROCKETMQ_SERIALIZE_TYPE`. Unsupported values fail startup instead of
+/// silently selecting JSON.
+///
+/// # Errors
+///
+/// Returns [`RemotingDefaultsError`] when configuration is invalid or a
+/// different process default was initialized earlier.
+pub fn initialize_remoting_defaults(version: i32) -> Result<(), RemotingDefaultsError> {
+    let property_value = read_environment_value(SERIALIZE_TYPE_PROPERTY)?;
+    let environment_value = if property_value.is_none() {
+        read_environment_value(SERIALIZE_TYPE_ENV)?
+    } else {
+        None
+    };
+    let serialize_type = resolve_remoting_serialize_type(property_value.as_deref(), environment_value.as_deref())?;
+    initialize_remoting_command_defaults(RemotingCommandDefaults::new(version, serialize_type))?;
+    Ok(())
+}
 
 fn resolve_remoting_version(cell: &OnceLock<i32>) -> i32 {
     *cell.get_or_init(|| {

--- a/rocketmq-protocol/tests/remoting_command_defaults.rs
+++ b/rocketmq-protocol/tests/remoting_command_defaults.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use rocketmq_protocol::protocol::header::get_min_offset_request_header::GetMinOffsetRequestHeader;
+use rocketmq_protocol::protocol::remoting_command_facade::initialize_remoting_defaults;
 use rocketmq_protocol::protocol::SerializeType;
+use rocketmq_protocol::RemotingCommand;
 
 #[test]
 fn environment_defaults_are_resolved_before_command_construction() {
@@ -24,10 +26,8 @@ fn environment_defaults_are_resolved_before_command_construction() {
         std::env::set_var("rocketmq.serialize.type", "ROCKETMQ");
     }
 
-    let command = rocketmq_protocol::protocol::remoting_command_facade::create_request_command(
-        31,
-        GetMinOffsetRequestHeader::default(),
-    );
+    initialize_remoting_defaults(4242).expect("valid process defaults should initialize");
+    let command = RemotingCommand::create_request_command(31, GetMinOffsetRequestHeader::default());
 
     assert_eq!(command.version(), 4242);
     assert_eq!(command.serialize_type(), SerializeType::ROCKETMQ);

--- a/rocketmq-protocol/tests/remoting_command_invalid_defaults.rs
+++ b/rocketmq-protocol/tests/remoting_command_invalid_defaults.rs
@@ -1,0 +1,33 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_protocol::protocol::remoting_command::SERIALIZE_TYPE_PROPERTY;
+use rocketmq_protocol::protocol::remoting_command_facade::initialize_remoting_defaults;
+use rocketmq_protocol::protocol::remoting_command_facade::RemotingDefaultsError;
+
+#[test]
+fn invalid_process_configuration_fails_before_defaults_are_initialized() {
+    // SAFETY: this integration-test binary contains one test, so no concurrent thread can read or
+    // mutate this process environment key while the assertion runs.
+    unsafe {
+        std::env::set_var(SERIALIZE_TYPE_PROPERTY, "CBOR");
+    }
+
+    let error = initialize_remoting_defaults(4242).expect_err("invalid serialization config must fail startup");
+    let RemotingDefaultsError::InvalidSerializeType(error) = error else {
+        panic!("expected invalid serialization type error");
+    };
+    assert_eq!(error.key(), SERIALIZE_TYPE_PROPERTY);
+    assert_eq!(error.value(), "CBOR");
+}

--- a/rocketmq-protocol/tests/remoting_serialize_type_resolution.rs
+++ b/rocketmq-protocol/tests/remoting_serialize_type_resolution.rs
@@ -1,0 +1,56 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_protocol::protocol::remoting_command::SERIALIZE_TYPE_ENV;
+use rocketmq_protocol::protocol::remoting_command::SERIALIZE_TYPE_PROPERTY;
+use rocketmq_protocol::protocol::remoting_command_facade::resolve_remoting_serialize_type;
+use rocketmq_protocol::protocol::SerializeType;
+
+#[test]
+fn resolver_defaults_to_json_without_configuration() {
+    assert_eq!(resolve_remoting_serialize_type(None, None), Ok(SerializeType::JSON));
+}
+
+#[test]
+fn property_has_precedence_over_environment() {
+    assert_eq!(
+        resolve_remoting_serialize_type(Some("JSON"), Some("ROCKETMQ")),
+        Ok(SerializeType::JSON)
+    );
+    assert_eq!(
+        resolve_remoting_serialize_type(Some("ROCKETMQ"), Some("JSON")),
+        Ok(SerializeType::ROCKETMQ)
+    );
+}
+
+#[test]
+fn environment_is_used_when_property_is_absent() {
+    assert_eq!(
+        resolve_remoting_serialize_type(None, Some("ROCKETMQ")),
+        Ok(SerializeType::ROCKETMQ)
+    );
+}
+
+#[test]
+fn unsupported_values_report_the_selected_key_and_value() {
+    let property_error = resolve_remoting_serialize_type(Some("CBOR"), Some("ROCKETMQ"))
+        .expect_err("an invalid property must not fall back to the environment");
+    assert_eq!(property_error.key(), SERIALIZE_TYPE_PROPERTY);
+    assert_eq!(property_error.value(), "CBOR");
+
+    let environment_error =
+        resolve_remoting_serialize_type(None, Some("CBOR")).expect_err("an invalid environment value must fail");
+    assert_eq!(environment_error.key(), SERIALIZE_TYPE_ENV);
+    assert_eq!(environment_error.value(), "CBOR");
+}

--- a/rocketmq-proxy/src/bin/rocketmq-proxy-rust.rs
+++ b/rocketmq-proxy/src/bin/rocketmq-proxy-rust.rs
@@ -18,6 +18,8 @@ use std::env;
 use std::path::PathBuf;
 
 use rocketmq_error::RocketMQError;
+use rocketmq_model::version::CURRENT_VERSION;
+use rocketmq_protocol::protocol::remoting_command_facade::initialize_remoting_defaults;
 #[cfg(test)]
 use rocketmq_proxy::GrpcConfig;
 use rocketmq_proxy::ProxyConfig;
@@ -90,6 +92,11 @@ fn proxy_runtime_error(action: &'static str) -> impl FnOnce(rocketmq_runtime::Ru
 }
 
 async fn run(service_context: ChildServiceContext, lifecycle: ServiceLifecycle) -> ProxyResult<()> {
+    initialize_remoting_defaults(CURRENT_VERSION as i32).map_err(|error| RocketMQError::ConfigParseFailed {
+        key: "remoting.command.defaults",
+        reason: error.to_string(),
+    })?;
+
     let args = Args::parse()?;
     let mut config = match args.config_file {
         Some(ref path) => ProxyConfig::load_from_file(path)?,

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/main.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/main.rs
@@ -21,7 +21,7 @@ use rocketmq_admin_core::client_adapter::TelemetryHandle;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_model::common::mq_version::CURRENT_VERSION;
-use rocketmq_protocol::protocol::remoting_command_facade::initialize_remoting_version;
+use rocketmq_protocol::protocol::remoting_command_facade::initialize_remoting_defaults;
 use rocketmq_runtime::RuntimeConfig;
 use rocketmq_runtime::RuntimeOwner;
 
@@ -57,6 +57,11 @@ fn main() {
 }
 
 fn run_cli_main_thread() -> RocketMQResult<i32> {
+    initialize_remoting_defaults(CURRENT_VERSION as i32).map_err(|error| RocketMQError::ConfigParseFailed {
+        key: "remoting.command.defaults",
+        reason: error.to_string(),
+    })?;
+
     let owner = RuntimeOwner::new(admin_cli_runtime_config())
         .map_err(|source| RocketMQError::internal("build rocketmq-admin-cli runtime", source))?;
     let client_runtime = ClientRuntime::try_new(
@@ -91,11 +96,6 @@ fn admin_cli_runtime_config() -> RuntimeConfig {
 }
 
 async fn async_main(client_runtime: std::sync::Arc<ClientRuntime>) -> i32 {
-    if let Err(error) = initialize_remoting_version(CURRENT_VERSION as i32) {
-        eprintln!("failed to initialize the immutable admin CLI remoting version: {error}");
-        return 1;
-    }
-
     let cli = RocketMQCli::parse_from_java_compatible_args();
     cli.handle(client_runtime).await
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9299

### Brief Description

Add a strict remoting serialization resolver that applies `rocketmq.serialize.type` before `ROCKETMQ_SERIALIZE_TYPE`, accepts only `JSON` or `ROCKETMQ`, and returns typed errors instead of silently falling back. Broker, NameServer, Controller, Proxy, admin CLI, and the fallible client-pool admission boundary now initialize the same immutable defaults used by core `RemotingCommand` factories. The legacy version initializer remains available for source compatibility, while its production call sites are removed.

Add deterministic resolver, environment initialization, invalid startup configuration, and client admission regression tests. `RemotingCommand::default()` remains protocol-neutral.

### How Did You Test This Change?

- Passed the focused protocol resolver, valid/invalid environment initialization, immutable factory, Java business compatibility, and wire golden tests.
- Passed `cargo test -p rocketmq-client-rust --test remoting_defaults_startup -- --test-threads=1` and `cargo test -p rocketmq-client-rust --lib` (1,047 tests).
- Passed the combined production-entry `cargo check` for broker, NameServer, Controller, Proxy, client, and admin CLI.
- Passed formatting checks for all 28 root workspace packages and all 23 Rust files in `rocketmq-example`.
- Passed `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` with one build job and a larger compiler stack on Windows.
- Passed `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` in `fuzz`.
- Passed `rocketmq-example` Clippy and `cargo build --example request-code-smoke`.
- Passed the `rocketmq-sre` locked workspace check, all-feature tests, all-target Clippy, documentation build, source-layout guard, and execution-dependency boundary guard.
- `scripts/check-error-hygiene.ps1` reported no finding in this change, but its repository-wide result remains nonzero because of pre-existing source-stringification and dashboard redaction findings outside this PR.
- Passed `git diff --cached --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent remoting protocol default initialization across brokers, clients, controllers, NameServers, proxies, and the admin CLI.
  * Serialization settings now support property-over-environment precedence, with JSON as the default and RocketMQ as a supported option.

* **Bug Fixes**
  * Invalid serialization settings are rejected during startup with clear configuration errors, preventing partially initialized clients or services.

* **Tests**
  * Added coverage for configuration precedence, unsupported values, startup rejection, and clean shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->