### PR TITLE
[ISSUE #9301]🐛Preserve explicit response codes with custom headers

### DIFF
--- a/rocketmq-protocol/src/protocol/remoting_command.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command.rs
@@ -48,6 +48,7 @@ use crate::rocketmq_serializable::RocketMQSerializable;
 pub const SERIALIZE_TYPE_PROPERTY: &str = "rocketmq.serialize.type";
 pub const SERIALIZE_TYPE_ENV: &str = "ROCKETMQ_SERIALIZE_TYPE";
 pub const REMOTING_VERSION_KEY: &str = "rocketmq.remoting.version";
+const JAVA_DEFAULT_RESPONSE_REMARK: &str = "not set any response code";
 
 static REQUEST_ID: std::sync::LazyLock<Arc<AtomicI32>> = std::sync::LazyLock::new(|| Arc::new(AtomicI32::new(0)));
 
@@ -261,6 +262,14 @@ impl RemotingCommand {
         Self::with_application_defaults().set_code(code).mark_response_type()
     }
 
+    /// Creates a response with an explicit code and typed custom header.
+    pub fn create_response_command_with_code_and_header(
+        code: impl Into<i32>,
+        header: impl CommandCustomHeader + Sync + Send + 'static,
+    ) -> Self {
+        Self::create_response_command_with_code(code).set_command_custom_header(header)
+    }
+
     pub fn create_response_command_with_code_remark(code: impl Into<i32>, remark: impl Into<CheetahString>) -> Self {
         Self::with_application_defaults()
             .set_code(code)
@@ -268,17 +277,46 @@ impl RemotingCommand {
             .mark_response_type()
     }
 
-    pub fn create_response_command() -> Self {
-        Self::with_application_defaults()
-            .set_code(RemotingSysResponseCode::Success)
-            .mark_response_type()
+    /// Creates an explicitly successful response.
+    pub fn create_success_response_command() -> Self {
+        Self::create_response_command_with_code(RemotingSysResponseCode::Success)
     }
 
+    /// Creates an explicitly successful response with a typed custom header.
+    pub fn create_success_response_command_with_header(
+        header: impl CommandCustomHeader + Sync + Send + 'static,
+    ) -> Self {
+        Self::create_response_command_with_code_and_header(RemotingSysResponseCode::Success, header)
+    }
+
+    /// Creates the unset error response used by Java's typed-header factory.
+    pub fn create_java_default_error_response_command() -> Self {
+        Self::create_response_command_with_code_remark(
+            RemotingSysResponseCode::SystemError,
+            JAVA_DEFAULT_RESPONSE_REMARK,
+        )
+    }
+
+    /// Creates the unset Java-compatible error response with a typed header.
+    pub fn create_java_default_error_response_command_with_header(
+        header: impl CommandCustomHeader + Sync + Send + 'static,
+    ) -> Self {
+        Self::create_java_default_error_response_command().set_command_custom_header(header)
+    }
+
+    /// Legacy ambiguous-success response factory.
+    ///
+    /// New code should call [`Self::create_success_response_command`] so the
+    /// response intent is visible during review.
+    pub fn create_response_command() -> Self {
+        Self::create_success_response_command()
+    }
+
+    /// Legacy ambiguous-success typed-header response factory.
+    ///
+    /// New code should call [`Self::create_success_response_command_with_header`].
     pub fn create_response_command_with_header(header: impl CommandCustomHeader + Sync + Send + 'static) -> Self {
-        Self::with_application_defaults()
-            .set_code(RemotingSysResponseCode::Success)
-            .set_command_custom_header(header)
-            .mark_response_type()
+        Self::create_success_response_command_with_header(header)
     }
 
     pub fn set_command_custom_header<T>(mut self, command_custom_header: T) -> Self

--- a/rocketmq-protocol/tests/remoting_command_application_defaults.rs
+++ b/rocketmq-protocol/tests/remoting_command_application_defaults.rs
@@ -29,9 +29,14 @@ fn business_factories_share_immutable_application_defaults() {
         RemotingCommand::create_request_command(11, EmptyHeader {}),
         RemotingCommand::create_remoting_command(12),
         RemotingCommand::create_response_command(),
+        RemotingCommand::create_success_response_command(),
         RemotingCommand::create_response_command_with_code(1),
+        RemotingCommand::create_response_command_with_code_and_header(1, EmptyHeader {}),
         RemotingCommand::create_response_command_with_code_remark(1, "error"),
         RemotingCommand::create_response_command_with_header(EmptyHeader {}),
+        RemotingCommand::create_success_response_command_with_header(EmptyHeader {}),
+        RemotingCommand::create_java_default_error_response_command(),
+        RemotingCommand::create_java_default_error_response_command_with_header(EmptyHeader {}),
     ];
 
     for command in commands {

--- a/rocketmq-protocol/tests/remoting_response_factory_contract.rs
+++ b/rocketmq-protocol/tests/remoting_response_factory_contract.rs
@@ -1,0 +1,82 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_protocol::code::response_code::RemotingSysResponseCode;
+use rocketmq_protocol::protocol::header::client_request_header::GetRouteInfoRequestHeader;
+use rocketmq_protocol::RemotingCommand;
+
+#[test]
+fn response_command_explicit_semantics() {
+    let success = RemotingCommand::create_success_response_command();
+    assert_eq!(success.code(), RemotingSysResponseCode::Success as i32);
+    assert!(success.is_response_type());
+    assert!(success.remark().is_none());
+
+    let explicit_error = RemotingCommand::create_response_command_with_code_remark(17, "explicit error");
+    assert_eq!(explicit_error.code(), 17);
+    assert!(explicit_error.is_response_type());
+    assert_eq!(
+        explicit_error.remark().map(|remark| remark.as_str()),
+        Some("explicit error")
+    );
+
+    let success_with_header = RemotingCommand::create_success_response_command_with_header(
+        GetRouteInfoRequestHeader::new("topic-a", Some(true)),
+    );
+    assert_eq!(success_with_header.code(), RemotingSysResponseCode::Success as i32);
+    assert!(success_with_header.is_response_type());
+    let success_header = success_with_header
+        .read_custom_header_ref::<GetRouteInfoRequestHeader>()
+        .expect("success response should retain its typed header");
+    assert_eq!(success_header.topic.as_str(), "topic-a");
+    assert_eq!(success_header.accept_standard_json_only, Some(true));
+
+    let explicit_code_with_header = RemotingCommand::create_response_command_with_code_and_header(
+        23,
+        GetRouteInfoRequestHeader::new("topic-explicit", None),
+    );
+    assert_eq!(explicit_code_with_header.code(), 23);
+    assert!(explicit_code_with_header.is_response_type());
+    let explicit_header = explicit_code_with_header
+        .read_custom_header_ref::<GetRouteInfoRequestHeader>()
+        .expect("explicit-code response should retain its typed header");
+    assert_eq!(explicit_header.topic.as_str(), "topic-explicit");
+    assert_eq!(explicit_header.accept_standard_json_only, None);
+
+    let java_default = RemotingCommand::create_java_default_error_response_command();
+    assert_eq!(java_default.code(), RemotingSysResponseCode::SystemError as i32);
+    assert!(java_default.is_response_type());
+    assert_eq!(
+        java_default.remark().map(|remark| remark.as_str()),
+        Some("not set any response code")
+    );
+
+    let java_default_with_header = RemotingCommand::create_java_default_error_response_command_with_header(
+        GetRouteInfoRequestHeader::new("topic-b", None),
+    );
+    assert_eq!(
+        java_default_with_header.code(),
+        RemotingSysResponseCode::SystemError as i32
+    );
+    assert!(java_default_with_header.is_response_type());
+    assert_eq!(
+        java_default_with_header.remark().map(|remark| remark.as_str()),
+        Some("not set any response code")
+    );
+    let java_default_header = java_default_with_header
+        .read_custom_header_ref::<GetRouteInfoRequestHeader>()
+        .expect("Java-compatible response should retain its typed header");
+    assert_eq!(java_default_header.topic.as_str(), "topic-b");
+    assert_eq!(java_default_header.accept_standard_json_only, None);
+}

--- a/rocketmq-transport/src/rpc/rpc_client_utils.rs
+++ b/rocketmq-transport/src/rpc/rpc_client_utils.rs
@@ -55,7 +55,8 @@ impl RpcClientUtils {
     pub fn create_command_for_rpc_response(mut rpc_response: RpcResponse) -> RemotingCommand {
         let mut cmd = match rpc_response.header.take() {
             None => RemotingCommand::create_response_command_with_code(rpc_response.code),
-            Some(value) => RemotingCommand::create_response_command().set_command_custom_header_boxed(value),
+            Some(value) => RemotingCommand::create_response_command_with_code(rpc_response.code)
+                .set_command_custom_header_boxed(value),
         };
         match rpc_response.exception {
             None => {}
@@ -171,5 +172,24 @@ mod tests {
                 .topic,
             CheetahString::from_static_str("owned-topic")
         );
+    }
+
+    #[test]
+    fn rpc_response_with_header_preserves_response_code() {
+        let response = RpcResponse::new(
+            17,
+            Box::new(GetRouteInfoRequestHeader::new("owned-topic", Some(true))),
+            None,
+        );
+
+        let command = RpcClientUtils::create_command_for_rpc_response(response);
+
+        assert_eq!(command.code(), 17);
+        assert!(command.is_response_type());
+        let header = command
+            .read_custom_header_ref::<GetRouteInfoRequestHeader>()
+            .expect("RPC response should retain its typed header");
+        assert_eq!(header.topic.as_str(), "owned-topic");
+        assert_eq!(header.accept_standard_json_only, Some(true));
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9301

### Brief Description

Add explicitly named response factories for success, explicit response codes with typed headers, and Java-compatible unset-error responses. Keep the legacy implicit-success factories source compatible while documenting the explicit replacements.

Fix `RpcClientUtils::create_command_for_rpc_response` so a response with an owned custom header preserves its supplied response code instead of silently becoming `SUCCESS`. Add contract and regression tests that verify response flags, codes, remarks, typed-header values, and immutable application defaults.

### How Did You Test This Change?

- `cargo test -p rocketmq-protocol`: passed, including 1,480 unit tests, integration/UI tests, wire golden tests, and doc tests.
- `cargo test -p rocketmq-transport --lib`: passed, 193 tests.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- Metadata-driven `cargo fmt -p <workspace-package> -- --check` for all 28 root workspace packages: passed; the single `cargo fmt --all -- --check` invocation exceeds the Windows command-line length limit.
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` in `fuzz/`: passed.
- Rust 2024 per-file `rustfmt --check` and `cargo clippy --all-targets -- -D warnings` in `rocketmq-example/`: passed.
- Full `rocketmq-sre/` fmt, locked workspace check, all-features tests, all-targets/all-features Clippy, docs, source-layout check, and execution-dependency-boundary check: passed. The tests use `RUST_MIN_STACK=67108864` on Windows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expanded response-command creation options, including successful responses, custom status codes, typed headers, and Java-compatible default errors.
  * Preserved typed header information when creating RPC responses.

* **Bug Fixes**
  * RPC responses now retain their original response code when custom headers are included.

* **Tests**
  * Added coverage for response factories, status codes, response classification, remarks, headers, and application defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->