### PR TITLE
[ISSUE #9307]♻️Make server remoting response intent explicit

### DIFF
--- a/rocketmq-controller/src/controller.rs
+++ b/rocketmq-controller/src/controller.rs
@@ -528,29 +528,29 @@ impl Controller for MockController {
         &self,
         _request: &RegisterBrokerToControllerRequestHeader,
     ) -> RocketMQResult<Option<RemotingCommand>> {
-        Ok(Some(RemotingCommand::create_response_command()))
+        Ok(Some(RemotingCommand::create_success_response_command()))
     }
 
     async fn get_next_broker_id(
         &self,
         _request: &GetNextBrokerIdRequestHeader,
     ) -> RocketMQResult<Option<RemotingCommand>> {
-        Ok(Some(RemotingCommand::create_response_command()))
+        Ok(Some(RemotingCommand::create_success_response_command()))
     }
 
     async fn apply_broker_id(&self, _request: &ApplyBrokerIdRequestHeader) -> RocketMQResult<Option<RemotingCommand>> {
-        Ok(Some(RemotingCommand::create_response_command()))
+        Ok(Some(RemotingCommand::create_success_response_command()))
     }
 
     async fn clean_broker_data(
         &self,
         _request: &CleanBrokerDataRequestHeader,
     ) -> RocketMQResult<Option<RemotingCommand>> {
-        Ok(Some(RemotingCommand::create_response_command()))
+        Ok(Some(RemotingCommand::create_success_response_command()))
     }
 
     async fn elect_master(&self, _request: &ElectMasterRequestHeader) -> RocketMQResult<Option<RemotingCommand>> {
-        Ok(Some(RemotingCommand::create_response_command()))
+        Ok(Some(RemotingCommand::create_success_response_command()))
     }
 
     async fn alter_sync_state_set(
@@ -558,22 +558,22 @@ impl Controller for MockController {
         _request: &AlterSyncStateSetRequestHeader,
         _sync_state_set: SyncStateSet,
     ) -> RocketMQResult<Option<RemotingCommand>> {
-        Ok(Some(RemotingCommand::create_response_command()))
+        Ok(Some(RemotingCommand::create_success_response_command()))
     }
 
     async fn get_replica_info(
         &self,
         _request: &GetReplicaInfoRequestHeader,
     ) -> RocketMQResult<Option<RemotingCommand>> {
-        Ok(Some(RemotingCommand::create_response_command()))
+        Ok(Some(RemotingCommand::create_success_response_command()))
     }
 
     async fn get_controller_metadata(&self) -> RocketMQResult<Option<RemotingCommand>> {
-        Ok(Some(RemotingCommand::create_response_command()))
+        Ok(Some(RemotingCommand::create_success_response_command()))
     }
 
     async fn get_sync_state_data(&self, _broker_names: &[CheetahString]) -> RocketMQResult<Option<RemotingCommand>> {
-        Ok(Some(RemotingCommand::create_response_command()))
+        Ok(Some(RemotingCommand::create_success_response_command()))
     }
 
     fn register_broker_lifecycle_listener(&self, _listener: Arc<dyn BrokerLifecycleListener>) {

--- a/rocketmq-controller/src/controller/open_raft_controller.rs
+++ b/rocketmq-controller/src/controller/open_raft_controller.rs
@@ -338,12 +338,12 @@ impl OpenRaftController {
         T: CommandCustomHeader + Sync + Send + 'static,
     {
         let (_events, header, body, response_code, remark) = result.into_parts();
-        let mut response = RemotingCommand::create_response_command().set_code(response_code);
+        let mut response = match header {
+            Some(header) => RemotingCommand::create_response_command_with_code_and_header(response_code, header),
+            None => RemotingCommand::create_response_command_with_code(response_code),
+        };
         if let Some(remark) = remark {
             response = response.set_remark(remark);
-        }
-        if let Some(header) = header {
-            response = response.set_command_custom_header(header);
         }
         if let Some(body) = body {
             response = response.set_body(body);
@@ -353,7 +353,7 @@ impl OpenRaftController {
 
     fn command_from_result_without_header(&self, result: EventControllerResult<()>) -> RemotingCommand {
         let (_events, _header, body, response_code, remark) = result.into_parts();
-        let mut response = RemotingCommand::create_response_command().set_code(response_code);
+        let mut response = RemotingCommand::create_response_command_with_code(response_code);
         if let Some(remark) = remark {
             response = response.set_remark(remark);
         }
@@ -1087,9 +1087,7 @@ impl Controller for OpenRaftController {
             }
         }
 
-        let mut command = RemotingCommand::create_response_command()
-            .set_code(ResponseCode::Success)
-            .set_command_custom_header(register_header.clone());
+        let mut command = RemotingCommand::create_success_response_command_with_header(register_header.clone());
         if let Some(body) = replica_info.body().cloned() {
             if let Ok(sync_state_set) = SyncStateSet::decode(body.as_ref()) {
                 register_header.sync_state_set_epoch = Some(sync_state_set.get_sync_state_set_epoch());
@@ -1274,9 +1272,9 @@ impl Controller for OpenRaftController {
                 applied_log_index,
             }
         };
-        Ok(Some(
-            RemotingCommand::create_response_command().set_command_custom_header(controller_metadata_info),
-        ))
+        Ok(Some(RemotingCommand::create_success_response_command_with_header(
+            controller_metadata_info,
+        )))
     }
 
     async fn get_sync_state_data(&self, broker_names: &[CheetahString]) -> RocketMQResult<Option<RemotingCommand>> {

--- a/rocketmq-controller/src/controller/raft_controller.rs
+++ b/rocketmq-controller/src/controller/raft_controller.rs
@@ -318,12 +318,10 @@ mod tests {
 
     #[test]
     fn election_outcome_is_bounded_and_does_not_expose_response_codes() {
-        let success = Ok(Some(
-            RemotingCommand::create_response_command().set_code(ResponseCode::Success),
-        ));
-        let rejected = Ok(Some(
-            RemotingCommand::create_response_command().set_code(ResponseCode::ControllerElectMasterFailed),
-        ));
+        let success = Ok(Some(RemotingCommand::create_success_response_command()));
+        let rejected = Ok(Some(RemotingCommand::create_response_command_with_code(
+            ResponseCode::ControllerElectMasterFailed,
+        )));
         let unavailable = Ok(None);
 
         assert_eq!(election_outcome(&success), "success");

--- a/rocketmq-controller/src/processor/controller_request_processor.rs
+++ b/rocketmq-controller/src/processor/controller_request_processor.rs
@@ -310,11 +310,7 @@ impl ControllerRequestProcessor {
         };
         let body = serde_json::to_vec(&response)
             .map_err(|error| RocketMQError::internal("encode maintenance capabilities", error))?;
-        Ok(Some(
-            RemotingCommand::create_response_command()
-                .set_code(ResponseCode::Success)
-                .set_body(body),
-        ))
+        Ok(Some(RemotingCommand::create_success_response_command().set_body(body)))
     }
 
     async fn handle_create_release_snapshot(
@@ -336,11 +332,7 @@ impl ControllerRequestProcessor {
             .await?;
         let body = serde_json::to_vec(&snapshot.manifest)
             .map_err(|error| RocketMQError::internal("encode Controller release snapshot manifest", error))?;
-        Ok(Some(
-            RemotingCommand::create_response_command()
-                .set_code(ResponseCode::Success)
-                .set_body(body),
-        ))
+        Ok(Some(RemotingCommand::create_success_response_command().set_body(body)))
     }
 
     async fn handle_verify_release_snapshot(
@@ -357,11 +349,7 @@ impl ControllerRequestProcessor {
             .await?;
         let body = serde_json::to_vec(&manifest)
             .map_err(|error| RocketMQError::internal("encode verified Controller snapshot manifest", error))?;
-        Ok(Some(
-            RemotingCommand::create_response_command()
-                .set_code(ResponseCode::Success)
-                .set_body(body),
-        ))
+        Ok(Some(RemotingCommand::create_success_response_command().set_body(body)))
     }
 
     async fn handle_restore_verify(
@@ -379,11 +367,7 @@ impl ControllerRequestProcessor {
             .await?;
         let body = serde_json::to_vec(&verification)
             .map_err(|error| RocketMQError::internal("encode Controller restore-verification proof", error))?;
-        Ok(Some(
-            RemotingCommand::create_response_command()
-                .set_code(ResponseCode::Success)
-                .set_body(body),
-        ))
+        Ok(Some(RemotingCommand::create_success_response_command().set_body(body)))
     }
 
     /// Handle ALTER_SYNC_STATE_SET request
@@ -631,7 +615,7 @@ impl ControllerRequestProcessor {
                 return controller_manager.controller().get_sync_state_data(&broker_names).await;
             }
         }
-        Ok(Some(RemotingCommand::create_response_command()))
+        Ok(Some(RemotingCommand::create_success_response_command()))
     }
 
     /// Handle UPDATE_CONTROLLER_CONFIG request
@@ -683,7 +667,7 @@ impl ControllerRequestProcessor {
         controller_manager.update_config(properties).await?;
 
         // Return success
-        Ok(Some(RemotingCommand::create_response_command()))
+        Ok(Some(RemotingCommand::create_success_response_command()))
     }
     // Helper function to parse properties
     async fn parse_properties_from_string(body: &[u8]) -> RocketMQResult<HashMap<String, String>> {
@@ -725,7 +709,7 @@ impl ControllerRequestProcessor {
         let controller_config = self.controller_manager()?.controller_config();
         let config_string = controller_config.to_properties_string();
 
-        let response = RemotingCommand::create_response_command().set_body(config_string.into_bytes());
+        let response = RemotingCommand::create_success_response_command().set_body(config_string.into_bytes());
         Ok(Some(response))
     }
 

--- a/rocketmq-controller/src/typ.rs
+++ b/rocketmq-controller/src/typ.rs
@@ -241,22 +241,72 @@ impl ControllerResponse {
     }
 
     pub fn into_remoting_command(self) -> RemotingCommand {
-        let mut command = RemotingCommand::create_response_command().set_code(self.response_code);
+        let mut command = match self.header {
+            Some(ControllerResponseHeader::ApplyBrokerId(header)) => {
+                RemotingCommand::create_response_command_with_code_and_header(self.response_code, header)
+            }
+            Some(ControllerResponseHeader::RegisterBroker(header)) => {
+                RemotingCommand::create_response_command_with_code_and_header(self.response_code, header)
+            }
+            Some(ControllerResponseHeader::AlterSyncStateSet(header)) => {
+                RemotingCommand::create_response_command_with_code_and_header(self.response_code, header)
+            }
+            Some(ControllerResponseHeader::ElectMaster(header)) => {
+                RemotingCommand::create_response_command_with_code_and_header(self.response_code, header)
+            }
+            None => RemotingCommand::create_response_command_with_code(self.response_code),
+        };
         if let Some(remark) = self.remark {
             command = command.set_remark(remark);
-        }
-        if let Some(header) = self.header {
-            command = match header {
-                ControllerResponseHeader::ApplyBrokerId(header) => command.set_command_custom_header(header),
-                ControllerResponseHeader::RegisterBroker(header) => command.set_command_custom_header(header),
-                ControllerResponseHeader::AlterSyncStateSet(header) => command.set_command_custom_header(header),
-                ControllerResponseHeader::ElectMaster(header) => command.set_command_custom_header(header),
-            };
         }
         if let Some(body) = self.body {
             command = command.set_body(Bytes::from(body));
         }
         command
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cheetah_string::CheetahString;
+
+    use super::*;
+
+    #[test]
+    fn controller_response_preserves_success_contract() {
+        let command = ControllerResponse::success().into_remoting_command();
+
+        assert_eq!(ResponseCode::from(command.code()), ResponseCode::Success);
+        assert!(command.is_response_type());
+        assert!(command.remark().is_none());
+        assert!(command.body().is_none());
+    }
+
+    #[test]
+    fn controller_response_preserves_code_header_remark_and_body() {
+        let command = ControllerResponse::new(
+            ResponseCode::ControllerElectMasterFailed.into(),
+            Some("election rejected".to_owned()),
+            Some(ControllerResponseHeader::ApplyBrokerId(ApplyBrokerIdResponseHeader {
+                cluster_name: Some(CheetahString::from_static_str("cluster-a")),
+                broker_name: Some(CheetahString::from_static_str("broker-a")),
+            })),
+            Some(vec![1, 2, 3]),
+        )
+        .into_remoting_command();
+
+        assert_eq!(
+            ResponseCode::from(command.code()),
+            ResponseCode::ControllerElectMasterFailed
+        );
+        assert!(command.is_response_type());
+        assert_eq!(command.remark().map(CheetahString::as_str), Some("election rejected"));
+        assert_eq!(command.body().map(Bytes::as_ref), Some(&[1, 2, 3][..]));
+        let header = command
+            .read_custom_header_ref::<ApplyBrokerIdResponseHeader>()
+            .expect("controller response header");
+        assert_eq!(header.cluster_name.as_deref(), Some("cluster-a"));
+        assert_eq!(header.broker_name.as_deref(), Some("broker-a"));
     }
 }
 

--- a/rocketmq-namesrv/src/processor/default_request_processor.rs
+++ b/rocketmq-namesrv/src/processor/default_request_processor.rs
@@ -161,7 +161,7 @@ impl DefaultRequestProcessor {
                 MetadataDeadline::after(Duration::from_secs(5)),
             )
             .await?;
-        Ok(RemotingCommand::create_response_command())
+        Ok(RemotingCommand::create_success_response_command())
     }
 
     fn get_kv_config(&self, request: &mut RemotingCommand) -> rocketmq_error::RocketMQResult<RemotingCommand> {
@@ -173,8 +173,9 @@ impl DefaultRequestProcessor {
             .get_kvconfig(&request_header.namespace, &request_header.key);
 
         if value.is_some() {
-            return Ok(RemotingCommand::create_response_command()
-                .set_command_custom_header(GetKVConfigResponseHeader::new(value)));
+            return Ok(RemotingCommand::create_success_response_command_with_header(
+                GetKVConfigResponseHeader::new(value),
+            ));
         }
         Ok(query_not_found_with_remark(format!(
             "No config item, Namespace: {} Key: {}",
@@ -193,7 +194,7 @@ impl DefaultRequestProcessor {
                 MetadataDeadline::after(Duration::from_secs(5)),
             )
             .await?;
-        Ok(RemotingCommand::create_response_command())
+        Ok(RemotingCommand::create_success_response_command())
     }
 
     fn query_broker_topic_config(
@@ -225,8 +226,8 @@ impl DefaultRequestProcessor {
             );
 
         // Build response with changed flag
-        let mut command = RemotingCommand::create_response_command()
-            .set_command_custom_header(QueryDataVersionResponseHeader::new(changed));
+        let mut command =
+            RemotingCommand::create_success_response_command_with_header(QueryDataVersionResponseHeader::new(changed));
 
         // Query and attach broker topic config if available
         if let Some(topic_config) = self
@@ -266,7 +267,7 @@ impl DefaultRequestProcessor {
             return Ok(invalid_parameter_with_remark("crc32 not match"));
         }
 
-        let mut response_command = RemotingCommand::create_response_command();
+        let mut response_command = RemotingCommand::create_success_response_command();
         let broker_version = RocketMqVersion::try_from(request.version() as u32)?;
         let decode_started = Instant::now();
         let wire_bytes = request.body().map_or(0, bytes::Bytes::len);
@@ -350,7 +351,7 @@ impl DefaultRequestProcessor {
             warn!("Couldn't submit the unregister broker request to handler");
             return Ok(internal_error("could not submit unregister broker request to handler"));
         }
-        Ok(RemotingCommand::create_response_command())
+        Ok(RemotingCommand::create_success_response_command())
     }
 }
 
@@ -363,7 +364,7 @@ impl DefaultRequestProcessor {
         self.name_server_runtime_inner
             .route_info_manager()
             .update_broker_info_update_timestamp(request_header.cluster_name, request_header.broker_addr);
-        Ok(RemotingCommand::create_response_command())
+        Ok(RemotingCommand::create_success_response_command())
     }
 
     fn get_broker_member_group(
@@ -378,7 +379,7 @@ impl DefaultRequestProcessor {
             .get_broker_member_group(request_header.cluster_name, request_header.broker_name);
         let response_body = GetBrokerMemberGroupResponseBody { broker_member_group };
         let body = response_body.encode()?;
-        Ok(RemotingCommand::create_response_command().set_body(body))
+        Ok(RemotingCommand::create_success_response_command().set_body(body))
     }
 
     fn get_broker_cluster_info(
@@ -402,8 +403,9 @@ impl DefaultRequestProcessor {
             .name_server_runtime_inner
             .route_info_manager()
             .wipe_write_perm_of_broker_by_lock(request_header.broker_name.to_string());
-        Ok(RemotingCommand::create_response_command()
-            .set_command_custom_header(WipeWritePermOfBrokerResponseHeader::new(wipe_topic_cnt)))
+        Ok(RemotingCommand::create_success_response_command_with_header(
+            WipeWritePermOfBrokerResponseHeader::new(wipe_topic_cnt),
+        ))
     }
 
     fn add_write_perm_of_broker(
@@ -415,8 +417,9 @@ impl DefaultRequestProcessor {
             .name_server_runtime_inner
             .route_info_manager()
             .add_write_perm_of_broker_by_lock(request_header.broker_name.to_string());
-        Ok(RemotingCommand::create_response_command()
-            .set_command_custom_header(AddWritePermOfBrokerResponseHeader::new(add_topic_cnt)))
+        Ok(RemotingCommand::create_success_response_command_with_header(
+            AddWritePermOfBrokerResponseHeader::new(add_topic_cnt),
+        ))
     }
 
     fn get_all_topic_list_from_nameserver(
@@ -433,7 +436,7 @@ impl DefaultRequestProcessor {
                 broker_addr: None,
             };
             let body = topics.encode()?;
-            return Ok(RemotingCommand::create_response_command().set_body(body));
+            return Ok(RemotingCommand::create_success_response_command().set_body(body));
         }
         Ok(internal_error("disable"))
     }
@@ -446,7 +449,7 @@ impl DefaultRequestProcessor {
         self.name_server_runtime_inner
             .route_info_manager()
             .delete_topic(request_header.topic, request_header.cluster_name);
-        Ok(RemotingCommand::create_response_command())
+        Ok(RemotingCommand::create_success_response_command())
     }
 
     fn register_topic_to_name_srv(
@@ -467,7 +470,7 @@ impl DefaultRequestProcessor {
                     .register_topic(request_header.topic, topic_route_data.queue_datas)
             }
         }
-        Ok(RemotingCommand::create_response_command())
+        Ok(RemotingCommand::create_success_response_command())
     }
 
     fn get_kv_list_by_namespace(
@@ -480,7 +483,7 @@ impl DefaultRequestProcessor {
             .kvconfig_manager()
             .get_kv_list_by_namespace(&request_header.namespace);
         if let Some(value) = value {
-            return Ok(RemotingCommand::create_response_command().set_body(value));
+            return Ok(RemotingCommand::create_success_response_command().set_body(value));
         }
         Ok(query_not_found_with_remark(format!(
             "No config item, Namespace: {}",
@@ -502,7 +505,7 @@ impl DefaultRequestProcessor {
             broker_addr: None,
         };
         let body = topics_by_cluster.encode()?;
-        Ok(RemotingCommand::create_response_command().set_body(body))
+        Ok(RemotingCommand::create_success_response_command().set_body(body))
     }
 
     fn get_system_topic_list_from_ns(
@@ -514,14 +517,14 @@ impl DefaultRequestProcessor {
             .route_info_manager()
             .get_system_topic_list();
         let body = topic_list.encode()?;
-        Ok(RemotingCommand::create_response_command().set_body(body))
+        Ok(RemotingCommand::create_success_response_command().set_body(body))
     }
 
     fn get_unit_topic_list(&self, _request: &mut RemotingCommand) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         if self.name_server_runtime_inner.name_server_config().enable_topic_list {
             let topic_list = self.name_server_runtime_inner.route_info_manager().get_unit_topics();
             let body = topic_list.encode()?;
-            return Ok(RemotingCommand::create_response_command().set_body(body));
+            return Ok(RemotingCommand::create_success_response_command().set_body(body));
         }
         Ok(internal_error("disable"))
     }
@@ -536,7 +539,7 @@ impl DefaultRequestProcessor {
                 .route_info_manager()
                 .get_has_unit_sub_topic_list();
             let body = topic_list.encode()?;
-            return Ok(RemotingCommand::create_response_command().set_body(body));
+            return Ok(RemotingCommand::create_success_response_command().set_body(body));
         }
         Ok(internal_error("disable"))
     }
@@ -550,7 +553,7 @@ impl DefaultRequestProcessor {
                 .name_server_runtime_inner
                 .route_info_manager()
                 .get_has_unit_sub_ununit_topic_list();
-            return Ok(RemotingCommand::create_response_command().set_body(topic_list.encode()?));
+            return Ok(RemotingCommand::create_success_response_command().set_body(topic_list.encode()?));
         }
         Ok(internal_error("disable"))
     }

--- a/rocketmq-proxy/src/remoting.rs
+++ b/rocketmq-proxy/src/remoting.rs
@@ -612,7 +612,7 @@ where
                 .collect(),
         );
 
-        let mut response = RemotingCommand::create_response_command().set_opaque(request.opaque());
+        let mut response = RemotingCommand::create_success_response_command().set_opaque(request.opaque());
         response.add_ext_field(IS_SUPPORT_HEART_BEAT_V2, true.to_string());
         response.add_ext_field(IS_SUB_CHANGE, changed.to_string());
         response
@@ -628,7 +628,7 @@ where
             header.producer_group.as_deref(),
             header.consumer_group.as_deref(),
         );
-        RemotingCommand::create_response_command().set_opaque(request.opaque())
+        RemotingCommand::create_success_response_command().set_opaque(request.opaque())
     }
 
     async fn dispatch_get_consumer_list_by_group(&self, request: &RemotingCommand) -> RemotingCommand {
@@ -1559,7 +1559,7 @@ fn response_with_header<H>(
 where
     H: CommandCustomHeader + Send + Sync + 'static,
 {
-    let mut response = RemotingCommand::create_response_command_with_header(header).set_code(code);
+    let mut response = RemotingCommand::create_response_command_with_code_and_header(code, header);
     if let Some(remark) = remark {
         response = response.set_remark(remark);
     }
@@ -1700,6 +1700,7 @@ mod tests {
     use rocketmq_transport::test_support::LocalRequestHarness;
     use tokio::time::timeout;
 
+    use super::response_with_header;
     use super::ProxyRemotingBackend;
     use super::ProxyRemotingDispatcher;
     use super::ProxyRequestProcessor;
@@ -2229,6 +2230,7 @@ mod tests {
 
         let heartbeat_response = dispatcher.dispatch(&test_context(), &heartbeat_request).await;
         assert_eq!(ResponseCode::from(heartbeat_response.code()), ResponseCode::Success);
+        assert_eq!(heartbeat_response.opaque(), heartbeat_request.opaque());
         let heartbeat_ext_fields = heartbeat_response.ext_fields().expect("heartbeat response ext fields");
         assert_eq!(
             heartbeat_ext_fields
@@ -2366,7 +2368,29 @@ mod tests {
         unregister_request.make_custom_header_to_net();
         let response = dispatcher.dispatch(&test_context(), &unregister_request).await;
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        assert_eq!(response.opaque(), unregister_request.opaque());
         assert!(sessions.consumer_client_ids("GroupA").is_empty());
+    }
+
+    #[test]
+    fn response_with_header_preserves_explicit_contract() {
+        let response = response_with_header(
+            42,
+            ResponseCode::QueryNotFound,
+            QueryConsumerOffsetResponseHeader { offset: Some(7) },
+            Some("offset unavailable".to_owned()),
+            Some(Bytes::from_static(b"body")),
+        );
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::QueryNotFound);
+        assert!(response.is_response_type());
+        assert_eq!(response.opaque(), 42);
+        assert_eq!(response.remark().map(CheetahString::as_str), Some("offset unavailable"));
+        assert_eq!(response.body().map(Bytes::as_ref), Some(b"body".as_slice()));
+        let header = response
+            .decode_command_custom_header::<QueryConsumerOffsetResponseHeader>()
+            .expect("query offset response header");
+        assert_eq!(header.offset, Some(7));
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9307

### Brief Description

Replace all legacy ambiguous response factory calls in NameServer, Controller, and Proxy with factories that state the intended response semantics.

Intentional successes now use explicit success factories. Dynamic Controller and Proxy response codes use code-aware factories, and typed headers are attached atomically during construction. The response code, response flag, header, remark, body, opaque value, and heartbeat extension fields remain unchanged.

Add focused Controller and Proxy contract tests for success and non-success response shapes. The three migrated owner crates now contain zero calls to the two legacy ambiguous factories.

### How Did You Test This Change?

- `cargo test -p rocketmq-controller` passed, including library, integration, and documentation tests. One initial multi-node learner synchronization race passed on exact rerun and on the final full-package rerun.
- `cargo test -p rocketmq-proxy --lib` passed with 95 tests.
- `cargo test -p rocketmq-namesrv processor::default_request_processor::tests --lib` passed with 14 tests.
- `cargo test -p rocketmq-namesrv --lib` passed 250 of 251 tests. The only failure is the pre-existing `config::tests::test_namesrv_config` assertion that expects `allow_insecure_public_listener` to be false while the current default sets it to true; the exact test fails identically on clean `main`.
- `cargo test -p rocketmq-proxy` passed all 95 library tests, 6 binary tests, and 9 gRPC integration tests before the pre-existing `local_mode_excludes_cluster_client_dependencies` feature-closure failure. The exact test fails identically on clean `main`.
- Metadata-driven per-package `cargo fmt -- --check` passed for all 28 root workspace packages.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed with one build job and the Windows stack-size workaround.
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` passed in `fuzz/`.
- `git diff --check` passed, and a repository search confirmed zero legacy factory calls in NameServer, Controller, and Proxy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized successful response handling across controller, NameServer, and proxy operations.
  - Preserved response status codes, headers, remarks, payloads, and request identifiers.
  - Improved consistency for heartbeat, client registration, snapshots, configuration, synchronization, and maintenance responses.

- **Bug Fixes**
  - Ensured response metadata remains intact when commands are created or forwarded.

- **Tests**
  - Added coverage confirming success responses preserve custom headers, status information, remarks, bodies, and opaque values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->