### PR TITLE
[ISSUE #9309]♻️Make broker messaging responses explicit

### DIFF
--- a/rocketmq-broker/src/client/net/broker_to_client.rs
+++ b/rocketmq-broker/src/client/net/broker_to_client.rs
@@ -203,7 +203,7 @@ impl Broker2Client {
         is_force: bool,
         is_c: bool,
     ) -> RemotingCommand {
-        let mut response = RemotingCommand::create_response_command();
+        let mut response = RemotingCommand::create_java_default_error_response_command();
 
         // Check if topic exists
         let topic_config = broker_inner.topic_config_manager().select_topic_config(topic);
@@ -361,10 +361,8 @@ impl Broker2Client {
             return response;
         }
 
-        response.set_code_ref(ResponseCode::Success);
         let res_body = ResetOffsetBody { offset_table };
-        response.set_body_mut_ref(res_body.encode());
-        response
+        RemotingCommand::create_success_response_command().set_body(res_body.encode())
     }
 
     /// Get consumer status from connected clients.
@@ -384,7 +382,7 @@ impl Broker2Client {
         group: &CheetahString,
         origin_client_id: Option<&CheetahString>,
     ) -> RemotingCommand {
-        let mut result = RemotingCommand::create_response_command();
+        let mut result = RemotingCommand::create_java_default_error_response_command();
 
         let request_header = GetConsumerStatusRequestHeader::new(topic.clone(), group.clone());
         let request = RemotingCommand::create_request_command(RequestCode::GetConsumerStatusFromClient, request_header);
@@ -465,12 +463,10 @@ impl Broker2Client {
             }
         }
 
-        result.set_code_ref(ResponseCode::Success);
         let res_body = GetConsumerStatusBody {
             message_queue_table: HashMap::new(),
             consumer_table: consumer_status_table,
         };
-        result.set_body_mut_ref(res_body.encode());
-        result
+        RemotingCommand::create_success_response_command().set_body(res_body.encode())
     }
 }

--- a/rocketmq-broker/src/out_api/pull.rs
+++ b/rocketmq-broker/src/out_api/pull.rs
@@ -159,7 +159,7 @@ mod tests {
             ..Default::default()
         };
         let mut command =
-            RemotingCommand::create_response_command_with_header(header).set_code(ResponseCode::PullNotFound);
+            RemotingCommand::create_response_command_with_code_and_header(ResponseCode::PullNotFound, header);
         command.make_custom_header_to_net();
 
         let response = process_pull_response(command, &"127.0.0.1:10911".into()).expect("pull response should map");

--- a/rocketmq-broker/src/out_api/send.rs
+++ b/rocketmq-broker/src/out_api/send.rs
@@ -110,7 +110,7 @@ mod tests {
     #[test]
     fn send_response_maps_success_to_model_result() {
         let header = SendMessageResponseHeader::new("offset-id".into(), 2, 17, None, None, None);
-        let mut command = RemotingCommand::create_response_command_with_header(header).set_code(ResponseCode::Success);
+        let mut command = RemotingCommand::create_success_response_command_with_header(header);
         command.make_custom_header_to_net();
 
         let result = process_send_response(&"broker-a".into(), "client-id".into(), 2, "topic-a".into(), &command)

--- a/rocketmq-broker/src/processor/ack_message_processor.rs
+++ b/rocketmq-broker/src/processor/ack_message_processor.rs
@@ -438,7 +438,7 @@ where
                 error_msg,
             )));
         }
-        let mut response = RemotingCommand::create_response_command();
+        let mut response = RemotingCommand::create_success_response_command();
         self.append_ack(Some(request_header), &mut response, None, &channel, None)
             .await?;
         Ok(Some(response))
@@ -462,7 +462,7 @@ where
                 ResponseCode::NoMessage,
             )));
         }
-        let mut response = RemotingCommand::create_response_command();
+        let mut response = RemotingCommand::create_success_response_command();
         let broker_name = &req_body.broker_name;
         for ack in req_body.acks {
             self.append_ack(None, &mut response, Some(ack), &_channel, Some(broker_name))

--- a/rocketmq-broker/src/processor/change_invisible_time_processor.rs
+++ b/rocketmq-broker/src/processor/change_invisible_time_processor.rs
@@ -388,7 +388,7 @@ where
             revive_qid,
             invisible_time: request_header.invisible_time,
         };
-        Ok(Some(RemotingCommand::create_response_command_with_header(
+        Ok(Some(RemotingCommand::create_success_response_command_with_header(
             response_header,
         )))
     }
@@ -523,7 +523,7 @@ where
             request_header.queue_id,
         );
         if old_offset > request_header.offset {
-            return Ok(Some(RemotingCommand::create_response_command()));
+            return Ok(Some(RemotingCommand::create_success_response_command()));
         }
         while !self
             .context
@@ -541,7 +541,7 @@ where
             request_header.queue_id,
         );
         if old_offset > request_header.offset {
-            return Ok(Some(RemotingCommand::create_response_command()));
+            return Ok(Some(RemotingCommand::create_success_response_command()));
         }
         let next_visible_time = current_millis() + request_header.invisible_time as u64;
         let updated = self.context.consumer_order_info.update_next_visible_time(
@@ -572,7 +572,7 @@ where
                 "consumer order info is not available",
             )));
         }
-        Ok(Some(RemotingCommand::create_response_command_with_header(
+        Ok(Some(RemotingCommand::create_success_response_command_with_header(
             response_header,
         )))
     }

--- a/rocketmq-broker/src/processor/client_manage_processor.rs
+++ b/rocketmq-broker/src/processor/client_manage_processor.rs
@@ -152,7 +152,7 @@ where
         &self,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_success_response_command();
         let Some(body) = request.body() else {
             return Ok(Some(response));
         };
@@ -222,7 +222,7 @@ where
             );
         }
 
-        Ok(Some(RemotingCommand::create_response_command()))
+        Ok(Some(RemotingCommand::create_success_response_command()))
     }
 
     async fn heart_beat(
@@ -311,7 +311,7 @@ where
             self.producer_registration
                 .register_producer(&producer_data.group_name, &client_channel_info);
         }
-        let mut response_command = RemotingCommand::create_response_command();
+        let mut response_command = RemotingCommand::create_success_response_command();
         response_command.ensure_ext_fields_initialized();
         response_command.add_ext_field(IS_SUPPORT_HEART_BEAT_V2.to_string(), true.to_string());
         response_command.add_ext_field(IS_SUB_CHANGE.to_string(), true.to_string());
@@ -413,7 +413,7 @@ where
             self.producer_registration
                 .register_producer(&producer_data.group_name, &client_channel_info);
         }
-        let mut response_command = RemotingCommand::create_response_command();
+        let mut response_command = RemotingCommand::create_success_response_command();
         response_command.ensure_ext_fields_initialized();
         response_command.add_ext_field(IS_SUPPORT_HEART_BEAT_V2.to_string(), true.to_string());
         response_command.add_ext_field(IS_SUB_CHANGE.to_string(), is_sub_change.to_string());

--- a/rocketmq-broker/src/processor/consumer_manage_processor.rs
+++ b/rocketmq-broker/src/processor/consumer_manage_processor.rs
@@ -166,7 +166,7 @@ where
         ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_success_response_command();
         let request_header = request.decode_command_custom_header::<GetConsumerListByGroupRequestHeader>()?;
         let consumer_group_info = self.consumer_view.client_ids_if_present(&request_header.consumer_group);
 
@@ -225,7 +225,7 @@ where
         let group = request_header.consumer_group.as_ref();
         let queue_id = request_header.queue_id;
         let offset = request_header.commit_offset;
-        let response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_success_response_command();
         if !self.subscription_group_lookup.contains_subscription_group(group) {
             return Ok(Some(
                 response
@@ -299,7 +299,7 @@ where
             request_header.topic.as_ref(),
             request_header.queue_id,
         );
-        let mut response = RemotingCommand::create_response_command();
+        let mut response = RemotingCommand::create_success_response_command();
         let mut response_header = QueryConsumerOffsetResponseHeader::default();
         if offset >= 0 {
             response_header.offset = Some(offset);
@@ -518,7 +518,7 @@ where
                 }
             }
         }
-        let mut response = RemotingCommand::create_response_command();
+        let mut response = RemotingCommand::create_success_response_command();
         let mut response_header = QueryConsumerOffsetResponseHeader { offset: None };
         if offset >= 0 {
             response_header.offset = Some(offset);

--- a/rocketmq-broker/src/processor/end_transaction_processor.rs
+++ b/rocketmq-broker/src/processor/end_transaction_processor.rs
@@ -455,7 +455,7 @@ where
         // params: &(String, i64, i64),
         request_header: &EndTransactionRequestHeader,
     ) -> RemotingCommand {
-        let mut command = RemotingCommand::create_response_command();
+        let mut command = RemotingCommand::create_success_response_command();
         if let Some(message_ext) = message_ext {
             let pgroup_read =
                 message_ext.property(&CheetahString::from_static_str(MessageConst::PROPERTY_PRODUCER_GROUP));
@@ -522,7 +522,7 @@ fn build_put_message_response(
     topic: &CheetahString,
     put_message_result: PutMessageResult,
 ) -> RemotingCommand {
-    let mut response = RemotingCommand::create_response_command();
+    let mut response = RemotingCommand::create_success_response_command();
     match put_message_result.put_message_status() {
         PutMessageStatus::PutOk
         | PutMessageStatus::FlushDiskTimeout
@@ -800,6 +800,31 @@ mod tests {
         );
         assert_eq!(ResponseCode::from(timer_disabled.code()), ResponseCode::SystemError);
         assert!(timer_disabled.remark().is_some_and(|remark| remark.contains("false")));
+    }
+
+    #[test]
+    fn end_transaction_put_ok_returns_explicit_success() {
+        let policy = EndTransactionPolicy {
+            transaction_timeout: 1,
+            max_message_size: 4_321,
+            timer_congest_num_each_slot: 77,
+            timer_max_delay_sec: 88,
+            timer_wheel_enable: false,
+        };
+        let broker_stats_manager = BrokerStatsManager::new(
+            Arc::new(rocketmq_store::StoreRuntimeConfig::default()),
+            crate::test_task_group("broker-stats"),
+        );
+
+        let response = build_put_message_response(
+            &policy,
+            &broker_stats_manager,
+            &CheetahString::from_static_str("transaction-topic"),
+            PutMessageResult::new_default(PutMessageStatus::PutOk),
+        );
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        assert!(response.remark().is_none());
     }
 
     #[test]

--- a/rocketmq-broker/src/processor/lite_manager_processor.rs
+++ b/rocketmq-broker/src/processor/lite_manager_processor.rs
@@ -575,7 +575,7 @@ impl<MS: BrokerReadWriteStore> LiteManagerProcessor<MS> {
         }
 
         Ok(Some(
-            RemotingCommand::create_response_command().set_opaque(request.opaque()),
+            RemotingCommand::create_success_response_command().set_opaque(request.opaque()),
         ))
     }
 

--- a/rocketmq-broker/src/processor/lite_subscription_ctl_processor.rs
+++ b/rocketmq-broker/src/processor/lite_subscription_ctl_processor.rs
@@ -239,7 +239,7 @@ impl<MS: BrokerStorePort> LiteSubscriptionCtlProcessor<MS> {
         }
 
         Ok(Some(
-            RemotingCommand::create_response_command().set_opaque(request.opaque()),
+            RemotingCommand::create_success_response_command().set_opaque(request.opaque()),
         ))
     }
 }

--- a/rocketmq-broker/src/processor/maintenance_request_processor.rs
+++ b/rocketmq-broker/src/processor/maintenance_request_processor.rs
@@ -20,7 +20,6 @@ use rocketmq_auth::AuthRuntime;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_protocol::code::request_code::RequestCode;
-use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::body::release_checkpoint::MaintenanceCapabilitiesResponse;
 use rocketmq_protocol::protocol::body::release_checkpoint::MaintenanceStoreCapabilities;
 use rocketmq_protocol::protocol::body::release_checkpoint::ReleaseCheckpointArtifact;
@@ -238,9 +237,7 @@ fn required_body<'a>(request: &'a RemotingCommand, operation: &'static str) -> R
 
 fn encode_success<T: serde::Serialize>(value: &T, operation: &'static str) -> RocketMQResult<RemotingCommand> {
     let body = serde_json::to_vec(value).map_err(|error| RocketMQError::internal(operation, error))?;
-    Ok(RemotingCommand::create_response_command()
-        .set_code(ResponseCode::Success)
-        .set_body(body))
+    Ok(RemotingCommand::create_success_response_command().set_body(body))
 }
 
 fn checkpoint_error(error: impl std::error::Error + Send + Sync + 'static) -> RocketMQError {

--- a/rocketmq-broker/src/processor/notification_processor.rs
+++ b/rocketmq-broker/src/processor/notification_processor.rs
@@ -311,7 +311,7 @@ where
         }
         let channel = ctx.channel();
 
-        let mut response = RemotingCommand::create_response_command();
+        let mut response = RemotingCommand::create_java_default_error_response_command();
         let request_header = request.decode_command_custom_header::<NotificationRequestHeader>()?;
 
         response.set_opaque_mut(request.opaque());
@@ -471,10 +471,13 @@ where
             }
         }
 
-        response.set_code_ref(ResponseCode::Success);
-        response.set_command_custom_header_ref(NotificationResponseHeader { has_msg, polling_full });
-
-        Ok(Some(response))
+        Ok(Some(
+            RemotingCommand::create_success_response_command_with_header(NotificationResponseHeader {
+                has_msg,
+                polling_full,
+            })
+            .set_opaque(request.opaque()),
+        ))
     }
 }
 

--- a/rocketmq-broker/src/processor/peek_message_processor.rs
+++ b/rocketmq-broker/src/processor/peek_message_processor.rs
@@ -217,8 +217,9 @@ impl<MS: BrokerReadWriteStore> PeekMessageProcessor<MS> {
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let begin_time_mills = self.context.message_store.now();
 
-        let mut response = RemotingCommand::create_response_command_with_header(PopMessageResponseHeader::default())
-            .set_opaque(request.opaque());
+        let mut response =
+            RemotingCommand::create_success_response_command_with_header(PopMessageResponseHeader::default())
+                .set_opaque(request.opaque());
 
         // Decode request header
         let request_header = match request.decode_command_custom_header::<PeekMessageRequestHeader>() {

--- a/rocketmq-broker/src/processor/polling_info_processor.rs
+++ b/rocketmq-broker/src/processor/polling_info_processor.rs
@@ -104,7 +104,7 @@ impl PollingInfoProcessor {
         channel: Channel,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut response = RemotingCommand::create_response_command();
+        let mut response = RemotingCommand::create_java_default_error_response_command();
 
         // Decode request header
         let request_header = request
@@ -203,10 +203,8 @@ impl PollingInfoProcessor {
         let polling_num = self.get_polling_num(&key);
 
         let response_header = PollingInfoResponseHeader { polling_num };
-        let final_response = response
-            .set_command_custom_header(response_header)
-            .set_code(ResponseCode::Success)
-            .set_opaque(request.opaque());
+        let final_response =
+            RemotingCommand::create_success_response_command_with_header(response_header).set_opaque(request.opaque());
 
         Ok(Some(final_response))
     }

--- a/rocketmq-broker/src/processor/pop_lite_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_lite_message_processor.rs
@@ -627,7 +627,7 @@ impl<MS: BrokerReadWriteStore> PopLiteMessageProcessor<MS> {
             order_count_info: (fetched_count > 0).then_some(order_count_info).flatten(),
         };
         let mut response =
-            RemotingCommand::create_response_command_with_header(response_header).set_opaque(request.opaque());
+            RemotingCommand::create_success_response_command_with_header(response_header).set_opaque(request.opaque());
 
         match body {
             Some(body) => {

--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -659,7 +659,7 @@ where
                 .await
             };
         }
-        let mut final_response = RemotingCommand::create_response_command();
+        let mut final_response = RemotingCommand::create_success_response_command();
         final_response.set_opaque_mut(opaque);
         if !get_message_result.message_mapped_list().is_empty() {
             get_message_result.set_status(Some(GetMessageStatus::Found));

--- a/rocketmq-broker/src/processor/pull_message_processor.rs
+++ b/rocketmq-broker/src/processor/pull_message_processor.rs
@@ -712,9 +712,10 @@ pub(super) fn rewrite_response_for_static_topic(
     response_header.offset_delta = Some(current_item.compute_offset_delta());
 
     if code != ResponseCode::Success {
-        Ok(Some(
-            RemotingCommand::create_response_command_with_header(response_header.clone()).set_code(response_code),
-        ))
+        Ok(Some(RemotingCommand::create_response_command_with_code_and_header(
+            response_code,
+            response_header.clone(),
+        )))
     } else {
         Ok(None)
     }
@@ -767,7 +768,7 @@ where
         broker_allow_suspend: bool,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let begin_time_mills = current_millis();
-        let mut response = RemotingCommand::create_response_command();
+        let mut response = RemotingCommand::create_java_default_error_response_command();
         response.set_opaque_mut(request.opaque());
         let mut request_header =
             request.decode_required_header_fast::<PullMessageRequestHeader>("decode pull-message request header")?;
@@ -1499,7 +1500,7 @@ mod tests {
                 ..PullMessageResponseHeader::default()
             };
 
-            let response = match rewrite_response_for_static_topic(
+            let mut response = match rewrite_response_for_static_topic(
                 &request_header,
                 &mut response_header,
                 &mut mapping_context,
@@ -1510,6 +1511,31 @@ mod tests {
             };
 
             assert_eq!(response.code(), response_code as i32);
+            let encoded_header = response
+                .read_custom_header_mut::<PullMessageResponseHeader>()
+                .expect("rewritten pull response should retain its typed header");
+            assert_eq!(
+                (
+                    encoded_header.suggest_which_broker_id,
+                    encoded_header.next_begin_offset,
+                    encoded_header.min_offset,
+                    encoded_header.max_offset,
+                    encoded_header.offset_delta,
+                    encoded_header.topic_sys_flag,
+                    encoded_header.group_sys_flag,
+                    encoded_header.forbidden_type,
+                ),
+                (
+                    response_header.suggest_which_broker_id,
+                    response_header.next_begin_offset,
+                    response_header.min_offset,
+                    response_header.max_offset,
+                    response_header.offset_delta,
+                    response_header.topic_sys_flag,
+                    response_header.group_sys_flag,
+                    response_header.forbidden_type,
+                )
+            );
         }
     }
 
@@ -1685,9 +1711,10 @@ mod tests {
         let processor = new_processor(Arc::clone(&context));
         let request_header = request_with_subscription("topic-a", "group-a", "color = 'blue'", 11);
 
-        let result = match processor
-            .get_subscription_data_with_flag(&request_header, &RemotingCommand::create_response_command())
-        {
+        let result = match processor.get_subscription_data_with_flag(
+            &request_header,
+            &RemotingCommand::create_java_default_error_response_command(),
+        ) {
             Ok(result) => result,
             Err(_) => panic!("subscription with flag should parse"),
         };
@@ -1727,9 +1754,10 @@ mod tests {
         let processor = new_processor(Arc::clone(&context));
         let request_header = request_with_subscription("topic-a", "group-a", "color = 'blue'", 11);
 
-        let result = match processor
-            .get_subscription_data_with_flag(&request_header, &RemotingCommand::create_response_command())
-        {
+        let result = match processor.get_subscription_data_with_flag(
+            &request_header,
+            &RemotingCommand::create_java_default_error_response_command(),
+        ) {
             Ok(result) => result,
             Err(_) => panic!("subscription with flag should parse"),
         };
@@ -1761,7 +1789,7 @@ mod tests {
         let response = match processor.get_subscription_data_without_flag(
             &request_header,
             &SubscriptionGroupConfig::new("group-a".into()),
-            &RemotingCommand::create_response_command(),
+            &RemotingCommand::create_java_default_error_response_command(),
             &mut response_header,
         ) {
             Ok(_) => panic!("missing consumer filter data should be rejected"),
@@ -1799,7 +1827,7 @@ mod tests {
         let response = match processor.get_subscription_data_without_flag(
             &request_header,
             &SubscriptionGroupConfig::new("group-a".into()),
-            &RemotingCommand::create_response_command(),
+            &RemotingCommand::create_java_default_error_response_command(),
             &mut response_header,
         ) {
             Ok(_) => panic!("stale consumer filter data should be rejected"),

--- a/rocketmq-broker/src/processor/query_assignment_processor.rs
+++ b/rocketmq-broker/src/processor/query_assignment_processor.rs
@@ -315,7 +315,7 @@ impl QueryAssignmentProcessor {
             message_queue_assignments: assignments,
         };
         Ok(Some(
-            RemotingCommand::create_response_command().set_body(body.encode()?),
+            RemotingCommand::create_success_response_command().set_body(body.encode()?),
         ))
     }
 

--- a/rocketmq-broker/src/processor/query_message_processor.rs
+++ b/rocketmq-broker/src/processor/query_message_processor.rs
@@ -217,7 +217,8 @@ where
         _ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut response = RemotingCommand::create_response_command_with_header(QueryMessageResponseHeader::default());
+        let mut response =
+            RemotingCommand::create_success_response_command_with_header(QueryMessageResponseHeader::default());
         let mut request_header = request.decode_command_custom_header::<QueryMessageRequestHeader>()?;
         response.set_opaque_mut(request.opaque());
         let Some(ext_fields) = request.ext_fields() else {
@@ -297,7 +298,7 @@ where
         _ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut response = RemotingCommand::create_response_command();
+        let mut response = RemotingCommand::create_success_response_command();
         let request_header = request.decode_command_custom_header::<ViewMessageRequestHeader>()?;
 
         let select_mapped_buffer_result = match self.query_store.select_message_by_offset(request_header.offset) {

--- a/rocketmq-broker/src/processor/recall_message_processor.rs
+++ b/rocketmq-broker/src/processor/recall_message_processor.rs
@@ -254,7 +254,8 @@ where
         ctx: &ConnectionHandlerContext,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
-        let mut response = RemotingCommand::create_response_command_with_header(RecallMessageResponseHeader::default());
+        let mut response =
+            RemotingCommand::create_success_response_command_with_header(RecallMessageResponseHeader::default());
         response.set_opaque_mut(request.opaque());
 
         let region_id = self.context.policy.region_id.clone();
@@ -612,9 +613,10 @@ mod tests {
     #[test]
     fn recall_response_keeps_region_field() {
         for serialize_type in [SerializeType::JSON, SerializeType::ROCKETMQ] {
-            let mut response =
-                RemotingCommand::create_response_command_with_header(RecallMessageResponseHeader::new("msg-id"))
-                    .set_serialize_type(serialize_type);
+            let mut response = RemotingCommand::create_success_response_command_with_header(
+                RecallMessageResponseHeader::new("msg-id"),
+            )
+            .set_serialize_type(serialize_type);
             add_recall_response_region(&mut response, CheetahString::from_static_str("region-c"));
             let mut encoded = bytes::BytesMut::new();
 

--- a/rocketmq-broker/src/processor/reply_message_processor.rs
+++ b/rocketmq-broker/src/processor/reply_message_processor.rs
@@ -216,7 +216,7 @@ where
         send_message_context: &mut SendMessageContext,
         request_header: SendMessageRequestHeader,
     ) -> RemotingCommand {
-        let mut response = RemotingCommand::create_response_command().set_opaque(request.opaque());
+        let mut response = RemotingCommand::create_success_response_command().set_opaque(request.opaque());
 
         // Keep one coherent policy generation for the request admission decision.
         let (region_id, trace_on, start_timstamp, store_reply_message_enable) = {
@@ -652,7 +652,7 @@ mod tests {
     #[test]
     fn reply_response_keeps_region_and_trace_fields() {
         for serialize_type in [SerializeType::JSON, SerializeType::ROCKETMQ] {
-            let mut response = RemotingCommand::create_response_command().set_serialize_type(serialize_type);
+            let mut response = RemotingCommand::create_success_response_command().set_serialize_type(serialize_type);
             add_reply_response_metadata(&mut response, "region-b", false);
             let mut encoded = bytes::BytesMut::new();
 

--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -1072,7 +1072,8 @@ where
         request: &RemotingCommand,
         request_header: &SendMessageRequestHeader,
     ) -> RemotingCommand {
-        let mut response = RemotingCommand::create_response_command_with_header(SendMessageResponseHeader::default());
+        let mut response =
+            RemotingCommand::create_success_response_command_with_header(SendMessageResponseHeader::default());
         let policy = self.inner.context.policy.snapshot();
         // set opaque
         response.with_opaque(request.opaque());
@@ -1646,7 +1647,7 @@ where
                         metrics.inc_send_to_dlq_messages(inner_topic.as_str(), request_header.group.as_str(), 1);
                     }
                 }
-                (RemotingCommand::create_response_command(), true)
+                (RemotingCommand::create_success_response_command(), true)
             }
 
             _ => (
@@ -2035,14 +2036,9 @@ mod tests {
     #[test]
     fn send_response_keeps_region_and_trace_fields() {
         for serialize_type in [SerializeType::JSON, SerializeType::ROCKETMQ] {
-            let mut response = RemotingCommand::create_response_command_with_header(SendMessageResponseHeader::new(
-                CheetahString::from_static_str("msg-id"),
-                0,
-                0,
-                None,
-                None,
-                None,
-            ))
+            let mut response = RemotingCommand::create_success_response_command_with_header(
+                SendMessageResponseHeader::new(CheetahString::from_static_str("msg-id"), 0, 0, None, None, None),
+            )
             .set_serialize_type(serialize_type);
             add_send_response_metadata(&mut response, CheetahString::from_static_str("region-a"), true);
             let mut encoded = bytes::BytesMut::new();
@@ -2487,7 +2483,7 @@ mod tests {
         ];
 
         for (legacy, expected_code, expected_remark) in cases {
-            let mut response = RemotingCommand::create_response_command();
+            let mut response = RemotingCommand::create_success_response_command();
 
             map_put_status_to_response(legacy, &mut response);
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)
- Fixes #9309

### Brief Description

Replace all 45 legacy ambiguous response-factory calls in non-admin Broker messaging and runtime paths with explicit success, Java-compatible fail-closed error, or code-aware typed-header factories. Preserve observable response codes, remarks, opaque values, bodies, flags, and extension fields across send, pull, pop, query, heartbeat, transaction, and broker-to-client flows. Add regression coverage that retains every rewritten pull header field and verifies successful transaction puts return a clean success response.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-broker`
- Per-package workspace format checks for all 28 workspace members (`cargo fmt -p <package> -- --check`), used because `cargo fmt --all -- --check` hits Windows OS error 206
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- Focused send/reply/recall metadata, send/pull response mapping, heartbeat V2, static-topic code/header, and transaction-success tests
- `cargo test -p rocketmq-broker --lib`: 784 passed, 2 ignored, with two failures reproduced unchanged from clean `main` (`pull_processors_depend_only_on_explicit_context` and `extended_timer_capability_is_published_from_one_policy_generation`)
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`
- Verified non-admin Broker legacy ambiguous factory calls changed from 45 to 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency and compatibility of broker responses across message delivery, acknowledgments, transactions, notifications, polling, consumer management, and client operations.
  - Successful requests now reliably return success statuses, while error responses follow compatible default behavior.
  - Preserved response metadata, request identifiers, headers, encoded bodies, and region information during processing.
  - Improved validation of response serialization and transaction success handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->