### PR TITLE
[ISSUE #9311]♻️Make broker administration responses explicit

### DIFF
--- a/rocketmq-broker/src/processor/admin_broker_processor.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor.rs
@@ -792,19 +792,19 @@ mod tests {
     #[test]
     fn auth_admin_error_response_maps_auth_and_config_errors_consistently() {
         let response = map_auth_admin_error_response(
-            RemotingCommand::create_response_command(),
+            RemotingCommand::create_java_default_error_response_command(),
             RocketMQError::user_not_found("alice"),
         );
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::UserNotExist);
 
         let response = map_auth_admin_error_response(
-            RemotingCommand::create_response_command(),
+            RemotingCommand::create_java_default_error_response_command(),
             RocketMQError::authentication_failed("bad credentials"),
         );
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::NoPermission);
 
         let response = map_auth_admin_error_response(
-            RemotingCommand::create_response_command(),
+            RemotingCommand::create_java_default_error_response_command(),
             RocketMQError::ConfigInvalidValue {
                 key: "auth.authorization",
                 value: "local".to_owned(),
@@ -814,19 +814,19 @@ mod tests {
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::InvalidParameter);
 
         let response = map_auth_admin_error_response(
-            RemotingCommand::create_response_command(),
+            RemotingCommand::create_java_default_error_response_command(),
             RocketMQError::auth_config_invalid("auth.authorization", "provider not ready"),
         );
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::InvalidParameter);
 
         let response = map_auth_admin_error_response(
-            RemotingCommand::create_response_command(),
+            RemotingCommand::create_java_default_error_response_command(),
             RocketMQError::auth_hot_reload_failed("conf/plain_acl.yml", "watcher task failed"),
         );
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::SystemError);
 
         let response = map_auth_admin_error_response(
-            RemotingCommand::create_response_command(),
+            RemotingCommand::create_java_default_error_response_command(),
             RocketMQError::request_body_invalid("decode", "malformed auth admin body"),
         );
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::InvalidParameter);

--- a/rocketmq-broker/src/processor/admin_broker_processor/batch_mq_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/batch_mq_handler.rs
@@ -112,7 +112,7 @@ impl BatchMqHandler {
             lock_ok_mq_set: lock_ok_mqset,
         };
         Ok(Some(
-            RemotingCommand::create_response_command()
+            RemotingCommand::create_success_response_command()
                 .set_body(response_body.encode().expect("lockBatchMQ encode error")),
         ))
     }
@@ -148,6 +148,6 @@ impl BatchMqHandler {
                 }
             }
         }
-        Ok(Some(RemotingCommand::create_response_command()))
+        Ok(Some(RemotingCommand::create_success_response_command()))
     }
 }

--- a/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/broker_config_request_handler.rs
@@ -134,7 +134,7 @@ impl<MS: BrokerAdminStore> BrokerConfigRequestHandler<MS> {
         request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let response = RemotingCommand::create_response_command().set_opaque(request.opaque());
+        let response = RemotingCommand::create_java_default_error_response_command().set_opaque(request.opaque());
         let Some(body) = request.body() else {
             return Ok(Some(
                 response
@@ -228,15 +228,14 @@ impl<MS: BrokerAdminStore> BrokerConfigRequestHandler<MS> {
         };
 
         Ok(Some(
-            response
-                .set_command_custom_header(UpdateBrokerConfigResponseHeader {
-                    config_generation: generation.value(),
-                })
-                .set_code(ResponseCode::Success)
-                .set_remark(format!(
-                    "update broker config success, generation={}",
-                    generation.value()
-                )),
+            RemotingCommand::create_success_response_command_with_header(UpdateBrokerConfigResponseHeader {
+                config_generation: generation.value(),
+            })
+            .set_opaque(request.opaque())
+            .set_remark(format!(
+                "update broker config success, generation={}",
+                generation.value()
+            )),
         ))
     }
 
@@ -312,11 +311,15 @@ impl<MS: BrokerAdminStore> BrokerConfigRequestHandler<MS> {
             }
         };
         match control.apply(request).await {
-            Ok(resolved) => Ok(Some(response.set_code(ResponseCode::Success).set_remark(format!(
-                "log filter update success: effectiveFilter={}, baselineFilter={}",
-                resolved.filter(),
-                control.baseline().filter()
-            )))),
+            Ok(resolved) => Ok(Some(
+                RemotingCommand::create_success_response_command()
+                    .set_opaque(response.opaque())
+                    .set_remark(format!(
+                        "log filter update success: effectiveFilter={}, baselineFilter={}",
+                        resolved.filter(),
+                        control.baseline().filter()
+                    )),
+            )),
             Err(error) => {
                 tracing::error!(error = %error, "broker remote log filter update failed");
                 Ok(Some(response.set_code(ResponseCode::SystemError).set_remark(
@@ -333,7 +336,7 @@ impl<MS: BrokerAdminStore> BrokerConfigRequestHandler<MS> {
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut response = RemotingCommand::create_response_command();
+        let mut response = RemotingCommand::create_success_response_command();
         // broker config => broker config
         // default message store config => message store config
         let snapshot = self.broker_runtime_inner.runtime_config_snapshot();
@@ -374,7 +377,7 @@ impl<MS: BrokerAdminStore> BrokerConfigRequestHandler<MS> {
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut response = RemotingCommand::create_response_command();
+        let mut response = RemotingCommand::create_success_response_command();
         let runtime_info = self.prepare_runtime_info();
         let key_value_table = KVTable { table: runtime_info };
         response.set_body_mut_ref(serde_json::to_string(&key_value_table).unwrap());
@@ -388,7 +391,7 @@ impl<MS: BrokerAdminStore> BrokerConfigRequestHandler<MS> {
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
         let Some(ext_fields) = request.get_ext_fields() else {
             return Ok(Some(
                 response
@@ -422,11 +425,10 @@ impl<MS: BrokerAdminStore> BrokerConfigRequestHandler<MS> {
         };
 
         match self.broker_runtime_inner.set_commitlog_read_mode(read_mode) {
-            Ok(()) => {
-                Ok(Some(response.set_code(ResponseCode::Success).set_remark(format!(
-                    "set commitlog readahead mode success, mode: {mode}"
-                ))))
-            }
+            Ok(()) => Ok(Some(
+                RemotingCommand::create_success_response_command()
+                    .set_remark(format!("set commitlog readahead mode success, mode: {mode}")),
+            )),
             Err(error) => Ok(Some(
                 response
                     .set_code(ResponseCode::SystemError)
@@ -442,7 +444,7 @@ impl<MS: BrokerAdminStore> BrokerConfigRequestHandler<MS> {
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
         let request_header = request.decode_command_custom_header::<ExportRocksdbConfigToJsonRequestHeader>()?;
         let config_types = match request_header.fetch_config_type() {
             Ok(config_types) => config_types,
@@ -500,7 +502,7 @@ impl<MS: BrokerAdminStore> BrokerConfigRequestHandler<MS> {
             }
             if exported_count > 0 {
                 return Ok(Some(
-                    response.set_code(ResponseCode::Success).set_remark("export done."),
+                    RemotingCommand::create_success_response_command().set_remark("export done."),
                 ));
             }
         }
@@ -545,7 +547,7 @@ impl<MS: BrokerAdminStore> BrokerConfigRequestHandler<MS> {
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
 
         if !self.broker_runtime_inner.message_store_config().is_timer_wheel_enable() {
             return Ok(Some(
@@ -599,9 +601,7 @@ impl<MS: BrokerAdminStore> BrokerConfigRequestHandler<MS> {
         timer_message_store.start();
 
         Ok(Some(
-            response
-                .set_code(ResponseCode::Success)
-                .set_remark("switch timer engine success"),
+            RemotingCommand::create_success_response_command().set_remark("switch timer engine success"),
         ))
     }
 
@@ -1437,6 +1437,7 @@ mod tests {
         )
         .set_body("maxClientEventCount=7");
         request.make_custom_header_to_net();
+        let request_opaque = request.opaque();
 
         let response = handler
             .update_broker_config(channel, ctx, RequestCode::UpdateBrokerConfigCas, &mut request)
@@ -1445,11 +1446,16 @@ mod tests {
             .expect("CAS update should return a response");
 
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        assert_eq!(response.opaque(), request_opaque);
         assert_eq!(
             response
                 .read_custom_header_ref::<UpdateBrokerConfigResponseHeader>()
                 .map(|header| header.config_generation),
             Some(2)
+        );
+        assert_eq!(
+            response.remark().map(CheetahString::as_str),
+            Some("update broker config success, generation=2")
         );
         assert_eq!(admin.broker_config().max_client_event_count, 7);
 

--- a/rocketmq-broker/src/processor/admin_broker_processor/broker_epoch_cache_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/broker_epoch_cache_handler.rs
@@ -39,7 +39,7 @@ impl BrokerEpochCacheHandler {
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let broker_config = broker_runtime_inner.broker_config();
-        let response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
 
         if !broker_config.enable_controller_mode {
             return Ok(Some(
@@ -82,6 +82,6 @@ impl BrokerEpochCacheHandler {
         );
 
         let cache = entry_code.encode().unwrap_or_default();
-        Ok(Some(response.set_body(cache).set_code(ResponseCode::Success)))
+        Ok(Some(RemotingCommand::create_success_response_command().set_body(cache)))
     }
 }

--- a/rocketmq-broker/src/processor/admin_broker_processor/broker_stats_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/broker_stats_handler.rs
@@ -41,7 +41,7 @@ impl BrokerStatsHandler {
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
         let request_header = request.decode_command_custom_header::<ViewBrokerStatsDataRequestHeader>()?;
 
         let stats_name = request_header.stats_name.as_str();
@@ -62,8 +62,7 @@ impl BrokerStatsHandler {
                 );
 
                 let body = broker_stats_data.encode()?;
-                response.set_body_mut_ref(body);
-                Ok(Some(response))
+                Ok(Some(RemotingCommand::create_success_response_command().set_body(body)))
             }
             None => Ok(Some(response.set_code(ResponseCode::SystemError).set_remark(format!(
                 "No stats data for statsName={}, statsKey={}",

--- a/rocketmq-broker/src/processor/admin_broker_processor/consumer_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/consumer_request_handler.rs
@@ -74,7 +74,7 @@ impl ConsumerRequestHandler {
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
         let request_header = request.decode_command_custom_header::<GetConsumerConnectionListRequestHeader>()?;
         let consumer_group_info = broker_runtime_inner
             .consumer_manager()
@@ -99,8 +99,7 @@ impl ConsumerRequestHandler {
                     body_data.insert_connection(connection);
                 }
                 let body = body_data.encode()?;
-                response.set_body_mut_ref(body);
-                Ok(Some(response))
+                Ok(Some(RemotingCommand::create_success_response_command().set_body(body)))
             }
             None => Ok(Some(response.set_code(ResponseCode::ConsumerNotOnline).set_remark(
                 format!("the consumer group[{}] not online", request_header.get_consumer_group()),
@@ -116,7 +115,6 @@ impl ConsumerRequestHandler {
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut response = RemotingCommand::create_response_command();
         let request_header =
             request.decode_required_header::<GetConsumeStatsRequestHeader>("decode consume-stats request header")?;
         let mut consume_stats = ConsumeStats::new();
@@ -222,8 +220,7 @@ impl ConsumerRequestHandler {
             consume_stats.set_consume_tps(new_consume_tps);
         }
         let body = consume_stats.encode_java_compatible()?;
-        response.set_body_mut_ref(body);
-        Ok(Some(response))
+        Ok(Some(RemotingCommand::create_success_response_command().set_body(body)))
     }
 
     pub async fn get_broker_consume_stats<MS: BrokerAdminStore>(
@@ -278,9 +275,7 @@ impl ConsumerRequestHandler {
         };
 
         Ok(Some(
-            RemotingCommand::create_response_command()
-                .set_code(ResponseCode::Success)
-                .set_body(body.encode_java_compatible()?),
+            RemotingCommand::create_success_response_command().set_body(body.encode_java_compatible()?),
         ))
     }
 
@@ -315,8 +310,7 @@ impl ConsumerRequestHandler {
         }
 
         Ok(Some(
-            RemotingCommand::create_response_command()
-                .set_code(ResponseCode::Success)
+            RemotingCommand::create_success_response_command()
                 .set_body(QueryCorrectionOffsetBody { correction_offsets }.encode()?),
         ))
     }
@@ -335,18 +329,16 @@ impl ConsumerRequestHandler {
             .as_ref()
             .filter(|client_id| !client_id.is_empty())
         else {
-            return Ok(Some(
-                RemotingCommand::create_response_command()
-                    .set_code(ResponseCode::SystemError)
-                    .set_remark("clientId is missing"),
-            ));
+            return Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+                ResponseCode::SystemError,
+                "clientId is missing",
+            )));
         };
         let Some(msg_id) = request_header.msg_id.as_ref().filter(|msg_id| !msg_id.is_empty()) else {
-            return Ok(Some(
-                RemotingCommand::create_response_command()
-                    .set_code(ResponseCode::SystemError)
-                    .set_remark("msgId is missing"),
-            ));
+            return Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+                ResponseCode::SystemError,
+                "msgId is missing",
+            )));
         };
 
         request.ensure_ext_fields_initialized();
@@ -371,11 +363,10 @@ impl ConsumerRequestHandler {
         let message_id = match MessageDecoder::decode_message_id(msg_id.as_str()) {
             Ok(message_id) => message_id,
             Err(error) => {
-                return Ok(Some(
-                    RemotingCommand::create_response_command()
-                        .set_code(ResponseCode::SystemError)
-                        .set_remark(format!("invalid msgId: {error}")),
-                ));
+                return Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+                    ResponseCode::SystemError,
+                    format!("invalid msgId: {error}"),
+                )));
             }
         };
 
@@ -384,18 +375,16 @@ impl ConsumerRequestHandler {
             .unwrap()
             .select_one_message_by_offset(message_id.offset)
         else {
-            return Ok(Some(
-                RemotingCommand::create_response_command()
-                    .set_code(ResponseCode::SystemError)
-                    .set_remark("message not found by msgId"),
-            ));
+            return Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+                ResponseCode::SystemError,
+                "message not found by msgId",
+            )));
         };
         let Some(body) = select_result.get_bytes() else {
-            return Ok(Some(
-                RemotingCommand::create_response_command()
-                    .set_code(ResponseCode::SystemError)
-                    .set_remark("message bytes not available"),
-            ));
+            return Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+                ResponseCode::SystemError,
+                "message bytes not available",
+            )));
         };
         request.set_body_mut_ref(body);
 
@@ -498,11 +487,12 @@ impl ConsumerRequestHandler {
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
         let content = broker_runtime_inner.consumer_offset_manager().encode();
         if !content.is_empty() {
-            response.set_body_mut_ref(content);
-            Ok(Some(response))
+            Ok(Some(
+                RemotingCommand::create_success_response_command().set_body(content),
+            ))
         } else {
             Ok(Some(
                 response
@@ -520,7 +510,7 @@ impl ConsumerRequestHandler {
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
         let Some(query_assignment_processor) = broker_runtime_inner.query_assignment_processor() else {
             return Ok(Some(
                 response
@@ -543,8 +533,9 @@ impl ConsumerRequestHandler {
         }
 
         let body = MessageRequestModeSerializeWrapper::from_inner(message_request_mode_map);
-        response.set_body_mut_ref(body.encode()?);
-        Ok(Some(response.set_code(ResponseCode::Success)))
+        Ok(Some(
+            RemotingCommand::create_success_response_command().set_body(body.encode()?),
+        ))
     }
 
     pub async fn invoke_broker_to_reset_offset<MS: BrokerAdminStore>(
@@ -635,9 +626,7 @@ impl ConsumerRequestHandler {
         };
 
         Ok(Some(
-            RemotingCommand::create_response_command()
-                .set_body(response_body.encode()?)
-                .set_code(ResponseCode::Success),
+            RemotingCommand::create_success_response_command().set_body(response_body.encode()?),
         ))
     }
 
@@ -649,7 +638,7 @@ impl ConsumerRequestHandler {
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
         let request_header = request.decode_command_custom_header::<QueryConsumeTimeSpanRequestHeader>()?;
         let topic = request_header.topic;
         let Some(topic_config) = broker_runtime_inner.topic_config_manager().select_topic_config(&topic) else {
@@ -708,13 +697,14 @@ impl ConsumerRequestHandler {
             time_span_set.push(queue_time_span);
         }
 
-        response.set_body_mut_ref(
-            QueryConsumeTimeSpanBody {
-                consume_time_span_set: time_span_set,
-            }
-            .encode()?,
-        );
-        Ok(Some(response.set_code(ResponseCode::Success)))
+        Ok(Some(
+            RemotingCommand::create_success_response_command().set_body(
+                QueryConsumeTimeSpanBody {
+                    consume_time_span_set: time_span_set,
+                }
+                .encode()?,
+            ),
+        ))
     }
 
     pub async fn clone_group_offset<MS: BrokerAdminStore>(
@@ -770,9 +760,7 @@ impl ConsumerRequestHandler {
             );
         }
 
-        Ok(Some(
-            RemotingCommand::create_response_command().set_code(ResponseCode::Success),
-        ))
+        Ok(Some(RemotingCommand::create_success_response_command()))
     }
 
     pub async fn get_consumer_running_info<MS: BrokerAdminStore>(
@@ -786,9 +774,10 @@ impl ConsumerRequestHandler {
         let request_header = match request.decode_command_custom_header::<GetConsumerRunningInfoRequestHeader>() {
             Ok(header) => header,
             Err(e) => {
-                let response = RemotingCommand::create_response_command()
-                    .set_code(ResponseCode::SystemError)
-                    .set_remark(format!("decode GetConsumerRunningInfoRequestHeader failed: {}", e));
+                let response = RemotingCommand::create_response_command_with_code_remark(
+                    ResponseCode::SystemError,
+                    format!("decode GetConsumerRunningInfoRequestHeader failed: {}", e),
+                );
                 return Ok(Some(response));
             }
         };
@@ -809,7 +798,7 @@ impl ConsumerRequestHandler {
         consumer_group: &str,
         client_id: &str,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut response = RemotingCommand::create_response_command();
+        let mut response = RemotingCommand::create_java_default_error_response_command();
 
         let client_channel_info = broker_runtime_inner
             .consumer_manager()
@@ -867,7 +856,7 @@ impl ConsumerRequestHandler {
         timestamp: i64,
         offset: Option<i64>,
     ) -> RemotingCommand {
-        let mut response = RemotingCommand::create_response_command().set_code(ResponseCode::Success);
+        let response = RemotingCommand::create_java_default_error_response_command();
 
         if broker_runtime_inner.message_store_config().broker_role == BrokerRole::Slave {
             return response
@@ -942,8 +931,7 @@ impl ConsumerRequestHandler {
             );
         }
 
-        response.set_body_mut_ref(body.encode());
-        response
+        RemotingCommand::create_success_response_command().set_body(body.encode())
     }
 
     async fn resolve_reset_offset<MS: BrokerAdminStore>(
@@ -954,7 +942,7 @@ impl ConsumerRequestHandler {
         timestamp: i64,
         offset: Option<i64>,
     ) -> Result<i64, RemotingCommand> {
-        let mut response = RemotingCommand::create_response_command().set_code(ResponseCode::Success);
+        let mut response = RemotingCommand::create_java_default_error_response_command();
         let message_store = broker_runtime_inner
             .message_store()
             .expect("message store should be initialized before admin request");

--- a/rocketmq-broker/src/processor/admin_broker_processor/create_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/create_acl_request_handler.rs
@@ -44,7 +44,7 @@ impl CreateAclRequestHandler {
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request.decode_command_custom_header::<CreateAclRequestHeader>()?;
-        let response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
 
         if request_header.subject.is_empty() {
             return Ok(Some(
@@ -76,7 +76,7 @@ impl CreateAclRequestHandler {
         };
 
         match self.auth_admin_service.create_acl(acl).await {
-            Ok(()) => Ok(Some(response.set_code(ResponseCode::Success))),
+            Ok(()) => Ok(Some(RemotingCommand::create_success_response_command())),
             Err(error) => Ok(Some(map_error_response(response, error))),
         }
     }

--- a/rocketmq-broker/src/processor/admin_broker_processor/create_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/create_user_request_handler.rs
@@ -32,7 +32,7 @@ impl CreateUserRequestHandler {
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request.decode_command_custom_header::<CreateUserRequestHeader>()?;
-        let response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
 
         if request_header.username.is_empty() {
             return Ok(Some(
@@ -71,7 +71,7 @@ impl CreateUserRequestHandler {
         }
 
         match self.auth_admin_service.create_user(user).await {
-            Ok(()) => Ok(Some(response.set_code(ResponseCode::Success))),
+            Ok(()) => Ok(Some(RemotingCommand::create_success_response_command())),
             Err(error) => Ok(Some(map_error_response(response, error))),
         }
     }

--- a/rocketmq-broker/src/processor/admin_broker_processor/delete_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/delete_acl_request_handler.rs
@@ -28,7 +28,7 @@ impl DeleteAclRequestHandler {
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request.decode_command_custom_header::<DeleteAclRequestHeader>()?;
-        let response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
 
         if request_header.subject.is_empty() {
             return Ok(Some(
@@ -50,7 +50,7 @@ impl DeleteAclRequestHandler {
             )
             .await
         {
-            Ok(()) => Ok(Some(response.set_code(ResponseCode::Success))),
+            Ok(()) => Ok(Some(RemotingCommand::create_success_response_command())),
             Err(error) => Ok(Some(map_error_response(response, error))),
         }
     }

--- a/rocketmq-broker/src/processor/admin_broker_processor/delete_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/delete_user_request_handler.rs
@@ -29,7 +29,7 @@ impl DeleteUserRequestHandler {
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request.decode_command_custom_header::<DeleteUserRequestHeader>()?;
-        let response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
 
         if request_header.username.is_empty() {
             return Ok(Some(
@@ -62,7 +62,7 @@ impl DeleteUserRequestHandler {
             .delete_user(request_header.username.as_str())
             .await
         {
-            Ok(()) => Ok(Some(response.set_code(ResponseCode::Success))),
+            Ok(()) => Ok(Some(RemotingCommand::create_success_response_command())),
             Err(error) => Ok(Some(map_error_response(response, error))),
         }
     }

--- a/rocketmq-broker/src/processor/admin_broker_processor/get_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/get_acl_request_handler.rs
@@ -42,7 +42,7 @@ impl GetAclRequestHandler {
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request.decode_command_custom_header::<GetAclRequestHeader>()?;
-        let mut response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
 
         if request_header.subject.is_empty() {
             return Ok(Some(
@@ -53,11 +53,10 @@ impl GetAclRequestHandler {
         }
 
         match self.auth_admin_service.get_acl(request_header.subject.as_str()).await {
-            Ok(Some(acl_info)) => {
-                response.set_body_mut_ref(acl_info.encode()?);
-                Ok(Some(response.set_code(ResponseCode::Success)))
-            }
-            Ok(None) => Ok(Some(response.set_code(ResponseCode::Success))),
+            Ok(Some(acl_info)) => Ok(Some(
+                RemotingCommand::create_success_response_command().set_body(acl_info.encode()?),
+            )),
+            Ok(None) => Ok(Some(RemotingCommand::create_success_response_command())),
             Err(error) => Ok(Some(map_error_response(response, error))),
         }
     }
@@ -226,6 +225,7 @@ mod tests {
             .expect("create acl should succeed")
             .expect("create acl should return response");
         assert_eq!(ResponseCode::from(create_response.code()), ResponseCode::Success);
+        assert!(create_response.remark().is_none());
 
         let mut update_request = RemotingCommand::create_request_command(
             RequestCode::AuthUpdateAcl,
@@ -252,6 +252,7 @@ mod tests {
             .expect("update acl should succeed")
             .expect("update acl should return response");
         assert_eq!(ResponseCode::from(update_response.code()), ResponseCode::Success);
+        assert!(update_response.remark().is_none());
 
         let mut get_request = RemotingCommand::create_request_command(
             RequestCode::AuthGetAcl,
@@ -266,6 +267,7 @@ mod tests {
             .expect("get acl should succeed")
             .expect("get acl should return response");
         assert_eq!(ResponseCode::from(get_response.code()), ResponseCode::Success);
+        assert!(get_response.remark().is_none());
         let body = AclInfo::decode(
             get_response
                 .take_body()
@@ -440,6 +442,7 @@ mod tests {
             .expect("empty user list should return a response");
         assert_eq!(ResponseCode::from(list_users_response.code()), ResponseCode::Success);
         assert!(list_users_response.body().is_none());
+        assert!(list_users_response.remark().is_none());
 
         let mut list_acl_request = RemotingCommand::create_request_command(
             RequestCode::AuthListAcl,
@@ -461,6 +464,7 @@ mod tests {
             .expect("empty acl list should return a response");
         assert_eq!(ResponseCode::from(list_acl_response.code()), ResponseCode::Success);
         assert!(list_acl_response.body().is_none());
+        assert!(list_acl_response.remark().is_none());
 
         let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
     }

--- a/rocketmq-broker/src/processor/admin_broker_processor/get_broker_ha_status_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/get_broker_ha_status_handler.rs
@@ -36,7 +36,7 @@ impl GetBrokerHaStatusHandler {
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
 
         let message_store = match broker_runtime_inner.message_store() {
             Some(store) => store,
@@ -61,7 +61,7 @@ impl GetBrokerHaStatusHandler {
         };
 
         match serde_json::to_vec(&ha_runtime_info) {
-            Ok(body) => Ok(Some(response.set_body(body).set_code(ResponseCode::Success))),
+            Ok(body) => Ok(Some(RemotingCommand::create_success_response_command().set_body(body))),
             Err(e) => Ok(Some(
                 response
                     .set_code(ResponseCode::SystemError)

--- a/rocketmq-broker/src/processor/admin_broker_processor/get_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/get_user_request_handler.rs
@@ -41,7 +41,7 @@ impl GetUserRequestHandler {
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request.decode_command_custom_header::<GetUserRequestHeader>()?;
-        let mut response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
 
         if request_header.username.is_empty() {
             return Ok(Some(
@@ -52,11 +52,10 @@ impl GetUserRequestHandler {
         }
 
         match self.auth_admin_service.get_user(request_header.username.as_str()).await {
-            Ok(Some(user_info)) => {
-                response.set_body_mut_ref(user_info.encode()?);
-                Ok(Some(response.set_code(ResponseCode::Success)))
-            }
-            Ok(None) => Ok(Some(response.set_code(ResponseCode::Success))),
+            Ok(Some(user_info)) => Ok(Some(
+                RemotingCommand::create_success_response_command().set_body(user_info.encode()?),
+            )),
+            Ok(None) => Ok(Some(RemotingCommand::create_success_response_command())),
             Err(error) => Ok(Some(map_error_response(response, error))),
         }
     }

--- a/rocketmq-broker/src/processor/admin_broker_processor/list_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/list_acl_request_handler.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use rocketmq_error::RocketMQError;
 use rocketmq_protocol::code::request_code::RequestCode;
-use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::header::list_acl_request_header::ListAclRequestHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::RemotingSerializable;
@@ -29,7 +28,7 @@ impl ListAclRequestHandler {
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request.decode_command_custom_header::<ListAclRequestHeader>()?;
-        let mut response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
 
         match self
             .auth_admin_service
@@ -40,10 +39,12 @@ impl ListAclRequestHandler {
             .await
         {
             Ok(acls) => {
-                if !acls.is_empty() {
-                    response.set_body_mut_ref(acls.encode()?);
-                }
-                Ok(Some(response.set_code(ResponseCode::Success)))
+                let success = RemotingCommand::create_success_response_command();
+                Ok(Some(if acls.is_empty() {
+                    success
+                } else {
+                    success.set_body(acls.encode()?)
+                }))
             }
             Err(error) => Ok(Some(map_error_response(response, error))),
         }

--- a/rocketmq-broker/src/processor/admin_broker_processor/list_users_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/list_users_request_handler.rs
@@ -15,7 +15,6 @@
 use crate::auth::auth_admin_service::AuthAdminService;
 use rocketmq_error::RocketMQError;
 use rocketmq_protocol::code::request_code::RequestCode;
-use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::header::list_users_request_header::ListUsersRequestHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::RemotingSerializable;
@@ -41,7 +40,7 @@ impl ListUsersRequestHandler {
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request.decode_command_custom_header::<ListUsersRequestHeader>()?;
-        let mut response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
 
         match self
             .auth_admin_service
@@ -49,10 +48,12 @@ impl ListUsersRequestHandler {
             .await
         {
             Ok(users) => {
-                if !users.is_empty() {
-                    response.set_body_mut_ref(users.encode()?);
-                }
-                Ok(Some(response.set_code(ResponseCode::Success)))
+                let success = RemotingCommand::create_success_response_command();
+                Ok(Some(if users.is_empty() {
+                    success
+                } else {
+                    success.set_body(users.encode()?)
+                }))
             }
             Err(error) => Ok(Some(map_error_response(response, error))),
         }

--- a/rocketmq-broker/src/processor/admin_broker_processor/message_related_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/message_related_handler.rs
@@ -71,7 +71,7 @@ impl MessageRelatedHandler {
         if rewrite_result.is_some() {
             return Ok(rewrite_result);
         }
-        let response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
         let message_store = match broker_runtime_inner.message_store() {
             Some(store) => store,
             None => {
@@ -102,7 +102,9 @@ impl MessageRelatedHandler {
         };
         let response_header = SearchOffsetResponseHeader { offset };
 
-        Ok(Some(response.set_command_custom_header(response_header)))
+        Ok(Some(RemotingCommand::create_success_response_command_with_header(
+            response_header,
+        )))
     }
 
     pub async fn resume_check_half_message<MS: BrokerAdminStore>(
@@ -114,7 +116,7 @@ impl MessageRelatedHandler {
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request.decode_command_custom_header::<ResumeCheckHalfMessageRequestHeader>()?;
-        let response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
 
         let Some(msg_id) = request_header.msg_id.as_ref().filter(|msg_id| !msg_id.is_empty()) else {
             return Ok(Some(
@@ -168,7 +170,7 @@ impl MessageRelatedHandler {
         };
 
         if put_message_result.put_message_status() == PutMessageStatus::PutOk || put_message_result.is_ok() {
-            Ok(Some(response.set_code(ResponseCode::Success)))
+            Ok(Some(RemotingCommand::create_success_response_command()))
         } else {
             Ok(Some(
                 response
@@ -187,7 +189,7 @@ impl MessageRelatedHandler {
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request.decode_command_custom_header::<QueryConsumeQueueRequestHeader>()?;
-        let response = RemotingCommand::create_response_command().set_code(ResponseCode::Success);
+        let response = RemotingCommand::create_success_response_command();
         let Some(message_store) = broker_runtime_inner.message_store() else {
             return Ok(Some(
                 response
@@ -301,7 +303,7 @@ impl MessageRelatedHandler {
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_success_response_command();
         let Some(pop_message_processor) = broker_runtime_inner.pop_message_processor().cloned() else {
             return Ok(Some(response.set_code(ResponseCode::Success)));
         };
@@ -439,7 +441,7 @@ impl MessageRelatedHandler {
             }
         }
 
-        Ok(Some(RemotingCommand::create_response_command_with_header(
+        Ok(Some(RemotingCommand::create_success_response_command_with_header(
             SearchOffsetResponseHeader { offset },
         )))
     }

--- a/rocketmq-broker/src/processor/admin_broker_processor/notify_broker_role_change_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/notify_broker_role_change_handler.rs
@@ -42,7 +42,7 @@ impl NotifyBrokerRoleChangeHandler {
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_success_response_command();
 
         let request_header = match request.decode_command_custom_header::<NotifyBrokerRoleChangedRequestHeader>() {
             Ok(header) => header,

--- a/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/notify_min_broker_id_handler.rs
@@ -20,7 +20,6 @@ use cheetah_string::CheetahString;
 use rocketmq_model::common::mix_all;
 use rocketmq_model::common::mix_all::MASTER_ID;
 use rocketmq_protocol::code::request_code::RequestCode;
-use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::header::namesrv::brokerid_change_request_header::NotifyMinBrokerIdChangeRequestHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_runtime::tokio_lock::RocketMQTokioRwLock;
@@ -85,8 +84,7 @@ impl NotifyMinBrokerChangeIdHandler {
 
         self.update_min_broker(broker_runtime_inner, change_header).await?;
 
-        let response = RemotingCommand::create_response_command();
-        Ok(Some(response.set_code(ResponseCode::Success)))
+        Ok(Some(RemotingCommand::create_success_response_command()))
     }
 
     async fn update_min_broker<MS: BrokerAdminStore>(

--- a/rocketmq-broker/src/processor/admin_broker_processor/offset_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/offset_request_handler.rs
@@ -70,7 +70,7 @@ impl OffsetRequestHandler {
             .unwrap()
             .get_max_offset_in_queue(topic.as_ref(), queue_id);
         let response_header = GetMaxOffsetResponseHeader { offset };
-        Ok(Some(RemotingCommand::create_response_command_with_header(
+        Ok(Some(RemotingCommand::create_success_response_command_with_header(
             response_header,
         )))
     }
@@ -103,7 +103,7 @@ impl OffsetRequestHandler {
             .unwrap()
             .get_min_offset_in_queue(topic.as_ref(), queue_id);
         let response_header = GetMinOffsetResponseHeader { offset };
-        Ok(Some(RemotingCommand::create_response_command_with_header(
+        Ok(Some(RemotingCommand::create_success_response_command_with_header(
             response_header,
         )))
     }
@@ -168,7 +168,7 @@ impl OffsetRequestHandler {
                 }
             }
         };
-        Ok(Some(RemotingCommand::create_response_command_with_header(
+        Ok(Some(RemotingCommand::create_success_response_command_with_header(
             GetMinOffsetResponseHeader {
                 offset: max_item.compute_static_queue_offset_loosely(max_physical_offset),
             },
@@ -235,7 +235,7 @@ impl OffsetRequestHandler {
                 }
             }
         };
-        Ok(Some(RemotingCommand::create_response_command_with_header(
+        Ok(Some(RemotingCommand::create_success_response_command_with_header(
             GetMaxOffsetResponseHeader {
                 offset: max_item.compute_static_queue_offset_strictly(max_physical_offset),
             },
@@ -250,7 +250,7 @@ impl OffsetRequestHandler {
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut response_command = RemotingCommand::create_response_command();
+        let response_command = RemotingCommand::create_java_default_error_response_command();
         let content = broker_runtime_inner.schedule_message_service().encode_pretty(false);
         if content.is_empty() {
             return Ok(Some(
@@ -259,8 +259,9 @@ impl OffsetRequestHandler {
                     .set_remark("No delay offset in this broker"),
             ));
         }
-        response_command.set_body_mut_ref(content.into_bytes());
-        Ok(Some(response_command))
+        Ok(Some(
+            RemotingCommand::create_success_response_command().set_body(content.into_bytes()),
+        ))
     }
 
     pub async fn get_earliest_msg_store_time<MS: BrokerAdminStore>(
@@ -288,7 +289,7 @@ impl OffsetRequestHandler {
             .message_store()
             .unwrap()
             .get_earliest_message_time(topic.as_ref(), queue_id);
-        Ok(Some(RemotingCommand::create_response_command_with_header(
+        Ok(Some(RemotingCommand::create_success_response_command_with_header(
             GetEarliestMsgStoretimeResponseHeader { timestamp },
         )))
     }
@@ -305,9 +306,7 @@ impl OffsetRequestHandler {
             .message_store()
             .unwrap()
             .clean_expired_consumer_queue();
-        Ok(Some(
-            RemotingCommand::create_response_command().set_code(ResponseCode::Success),
-        ))
+        Ok(Some(RemotingCommand::create_success_response_command()))
     }
 
     pub async fn delete_expired_commitlog<MS: BrokerAdminStore>(
@@ -322,9 +321,7 @@ impl OffsetRequestHandler {
             .message_store()
             .unwrap()
             .execute_delete_files_manually();
-        Ok(Some(
-            RemotingCommand::create_response_command().set_code(ResponseCode::Success),
-        ))
+        Ok(Some(RemotingCommand::create_success_response_command()))
     }
 
     pub async fn check_rocksdb_cq_write_progress(
@@ -353,7 +350,7 @@ impl OffsetRequestHandler {
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut response_command = RemotingCommand::create_response_command();
+        let response_command = RemotingCommand::create_java_default_error_response_command();
         let content = broker_runtime_inner.subscription_group_manager().encode_pretty(false);
         if content.is_empty() {
             error!(
@@ -366,8 +363,9 @@ impl OffsetRequestHandler {
                     .set_remark("No subscription group config in this broker"),
             ));
         }
-        response_command.set_body_mut_ref(content.into_bytes());
-        Ok(Some(response_command))
+        Ok(Some(
+            RemotingCommand::create_success_response_command().set_body(content.into_bytes()),
+        ))
     }
 
     async fn rewrite_get_earliest_request_for_static_topic<MS: BrokerAdminStore>(
@@ -440,7 +438,7 @@ impl OffsetRequestHandler {
             }
         };
 
-        Ok(Some(RemotingCommand::create_response_command_with_header(
+        Ok(Some(RemotingCommand::create_success_response_command_with_header(
             GetEarliestMsgStoretimeResponseHeader { timestamp },
         )))
     }

--- a/rocketmq-broker/src/processor/admin_broker_processor/producer_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/producer_request_handler.rs
@@ -21,7 +21,7 @@ impl ProducerRequestHandler {
         _ctx: ConnectionHandlerContext,
         request: &RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
         let request_header = request.decode_command_custom_header_fast::<GetProducerConnectionListRequestHeader>()?;
         let mut producer_connection = ProducerConnection::new();
 
@@ -37,15 +37,13 @@ impl ProducerRequestHandler {
                 producer_connection.connection_set_mut().insert(connection);
             }
             let body = producer_connection.encode()?;
-            response = response.set_body(body).set_code(ResponseCode::Success);
-            return Ok(Some(response));
+            return Ok(Some(RemotingCommand::create_success_response_command().set_body(body)));
         }
 
-        response = response.set_code(ResponseCode::SystemError).set_remark(format!(
+        Ok(Some(response.set_code(ResponseCode::SystemError).set_remark(format!(
             "the producer group[{}] not exist",
             request_header.producer_group()
-        ));
-        Ok(Some(response))
+        ))))
     }
 
     pub async fn get_all_producer_info(
@@ -53,11 +51,9 @@ impl ProducerRequestHandler {
         _ctx: ConnectionHandlerContext,
         _request: &RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut response = RemotingCommand::create_response_command();
         let producer_table_info = self.producer_registry.producer_table();
         let body = producer_table_info.encode()?;
-        response = response.set_body(body).set_code(ResponseCode::Success);
-        Ok(Some(response))
+        Ok(Some(RemotingCommand::create_success_response_command().set_body(body)))
     }
 }
 

--- a/rocketmq-broker/src/processor/admin_broker_processor/reset_master_flusg_offset_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/reset_master_flusg_offset_handler.rs
@@ -14,7 +14,6 @@
 
 use rocketmq_model::common::mix_all::MASTER_ID;
 use rocketmq_protocol::code::request_code::RequestCode;
-use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::header::reset_master_flush_offset_header::ResetMasterFlushOffsetHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_store::BrokerAdminStore;
@@ -38,8 +37,6 @@ impl ResetMasterFlushOffsetHandler {
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let response = RemotingCommand::create_response_command();
-
         let broker_id = broker_runtime_inner.broker_config().broker_identity.broker_id;
         if broker_id != MASTER_ID {
             let request_header = request.decode_required_header::<ResetMasterFlushOffsetHeader>(
@@ -53,6 +50,6 @@ impl ResetMasterFlushOffsetHandler {
             }
         }
 
-        Ok(Some(response.set_code(ResponseCode::Success)))
+        Ok(Some(RemotingCommand::create_success_response_command()))
     }
 }

--- a/rocketmq-broker/src/processor/admin_broker_processor/subscription_group_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/subscription_group_handler.rs
@@ -55,7 +55,7 @@ impl SubscriptionGroupHandler {
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let start_time = current_millis() as i64;
 
-        let mut response = RemotingCommand::create_response_command();
+        let mut response = RemotingCommand::create_success_response_command();
 
         info!(
             "AdminBrokerProcessor#updateAndCreateSubscriptionGroup called by {}",
@@ -96,7 +96,7 @@ impl SubscriptionGroupHandler {
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let response = RemotingCommand::create_response_command().set_opaque(request.opaque());
+        let response = RemotingCommand::create_java_default_error_response_command().set_opaque(request.opaque());
         let request_header =
             match request.decode_command_custom_header::<UpdateSubscriptionGroupConfigCasRequestHeader>() {
                 Ok(header) => header,
@@ -237,14 +237,15 @@ impl SubscriptionGroupHandler {
         };
 
         Ok(Some(
-            response
-                .set_command_custom_header(UpdateSubscriptionGroupConfigCasResponseHeader {
+            RemotingCommand::create_success_response_command_with_header(
+                UpdateSubscriptionGroupConfigCasResponseHeader {
                     subscription_group_version,
-                })
-                .set_code(ResponseCode::Success)
-                .set_remark(format!(
-                    "Subscription Group configuration patch committed, version={subscription_group_version}"
-                )),
+                },
+            )
+            .set_opaque(request.opaque())
+            .set_remark(format!(
+                "Subscription Group configuration patch committed, version={subscription_group_version}"
+            )),
         ))
     }
 
@@ -256,7 +257,7 @@ impl SubscriptionGroupHandler {
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
         let request_header = request.decode_command_custom_header::<GetSubscriptionGroupConfigRequestHeader>()?;
         let group = &request_header.group;
         let group_config = broker_runtime_inner
@@ -264,13 +265,14 @@ impl SubscriptionGroupHandler {
             .select_subscription_group_config_with_version(group);
 
         match group_config {
-            Ok((config, subscription_group_version)) => {
-                response.set_body_mut_ref(config.encode()?);
-                response.set_command_custom_header_ref(UpdateSubscriptionGroupConfigCasResponseHeader {
-                    subscription_group_version,
-                });
-                Ok(Some(response.set_code(ResponseCode::Success)))
-            }
+            Ok((config, subscription_group_version)) => Ok(Some(
+                RemotingCommand::create_success_response_command_with_header(
+                    UpdateSubscriptionGroupConfigCasResponseHeader {
+                        subscription_group_version,
+                    },
+                )
+                .set_body(config.encode()?),
+            )),
             Err(SubscriptionGroupConfigCasError::GroupNotFound) => Ok(Some(
                 response
                     .set_code(ResponseCode::SubscriptionGroupNotExist)
@@ -308,7 +310,7 @@ impl SubscriptionGroupHandler {
             channel.remote_address()
         );
 
-        let response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
         let Some(body) = request.get_body() else {
             return Ok(Some(
                 response
@@ -329,7 +331,7 @@ impl SubscriptionGroupHandler {
         broker_runtime_inner
             .subscription_group_manager()
             .update_subscription_group_config_list(subscription_group_list.group_config_list);
-        Ok(Some(response.set_code(ResponseCode::Success)))
+        Ok(Some(RemotingCommand::create_success_response_command()))
     }
 
     pub async fn delete_subscription_group<MS: BrokerAdminStore>(
@@ -366,9 +368,7 @@ impl SubscriptionGroupHandler {
                 .clear_in_flight_message_num_by_group_name(&request_header.group_name);
         }
 
-        Ok(Some(
-            RemotingCommand::create_response_command().set_code(ResponseCode::Success),
-        ))
+        Ok(Some(RemotingCommand::create_success_response_command()))
     }
 
     pub async fn update_and_get_group_forbidden<MS: BrokerAdminStore>(
@@ -411,9 +411,7 @@ impl SubscriptionGroupHandler {
         );
         let body = GroupForbidden::new(request_header.topic, request_header.group, Some(readable));
         Ok(Some(
-            RemotingCommand::create_response_command()
-                .set_code(ResponseCode::Success)
-                .set_body(body.encode()?),
+            RemotingCommand::create_success_response_command().set_body(body.encode()?),
         ))
     }
 }
@@ -682,6 +680,7 @@ mod tests {
             },
         );
         request.make_custom_header_to_net();
+        let request_opaque = request.opaque();
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let response = handler
@@ -696,6 +695,15 @@ mod tests {
             .expect("Subscription Group CAS should run")
             .expect("Subscription Group CAS should return a response");
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        assert_eq!(response.opaque(), request_opaque);
+        let expected_remark = format!(
+            "Subscription Group configuration patch committed, version={}",
+            initial_version + 1
+        );
+        assert_eq!(
+            response.remark().map(CheetahString::as_str),
+            Some(expected_remark.as_str())
+        );
         let response_header = response
             .read_custom_header_ref::<UpdateSubscriptionGroupConfigCasResponseHeader>()
             .expect("success response should carry the committed version");

--- a/rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs
@@ -134,7 +134,7 @@ impl TopicRequestHandler {
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let broker_runtime_inner = broker_config_request_handler.broker_runtime_inner();
-        let response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
         let request_header =
             request.decode_required_header::<CreateTopicRequestHeader>("decode create-topic request header")?;
         info!(
@@ -209,7 +209,7 @@ impl TopicRequestHandler {
                 topic.as_str(),
                 channel.remote_address(),
             );
-            return Ok(Some(response.set_code(ResponseCode::Success)));
+            return Ok(Some(RemotingCommand::create_success_response_command()));
         }
         let update = broker_runtime_inner
             .topic_config_manager()
@@ -219,7 +219,7 @@ impl TopicRequestHandler {
             .persist_and_register_topic_updates(vec![update.topic_config], update.data_version)
             .await?;
 
-        Ok(Some(response.set_code(ResponseCode::Success)))
+        Ok(Some(RemotingCommand::create_success_response_command()))
     }
 
     pub async fn update_topic_config_cas<MS: BrokerAdminStore>(
@@ -231,7 +231,7 @@ impl TopicRequestHandler {
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let broker_runtime_inner = broker_config_request_handler.broker_runtime_inner();
-        let response = RemotingCommand::create_response_command().set_opaque(request.opaque());
+        let response = RemotingCommand::create_java_default_error_response_command().set_opaque(request.opaque());
         let request_header = match request.decode_command_custom_header::<UpdateTopicConfigCasRequestHeader>() {
             Ok(header) => header,
             Err(_) => {
@@ -379,10 +379,11 @@ impl TopicRequestHandler {
             .await?;
 
         Ok(Some(
-            response
-                .set_command_custom_header(UpdateTopicConfigCasResponseHeader { topic_version })
-                .set_code(ResponseCode::Success)
-                .set_remark(format!("Topic configuration patch committed, version={topic_version}")),
+            RemotingCommand::create_success_response_command_with_header(UpdateTopicConfigCasResponseHeader {
+                topic_version,
+            })
+            .set_opaque(request.opaque())
+            .set_remark(format!("Topic configuration patch committed, version={topic_version}")),
         ))
     }
 
@@ -395,7 +396,7 @@ impl TopicRequestHandler {
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let broker_runtime_inner = broker_config_request_handler.broker_runtime_inner();
-        let response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
         let request_header = request.decode_command_custom_header::<CreateTopicRequestHeader>()?;
         info!(
             "Broker receive request to update or create static topic={}, caller address={}",
@@ -483,7 +484,7 @@ impl TopicRequestHandler {
             .persist_and_register_topic_updates(vec![update.topic_config], update.data_version)
             .await?;
 
-        Ok(Some(response.set_code(ResponseCode::Success)))
+        Ok(Some(RemotingCommand::create_success_response_command()))
     }
 
     pub async fn update_and_create_topic_list<MS: BrokerAdminStore>(
@@ -506,7 +507,7 @@ impl TopicRequestHandler {
             topic_names,
             channel.remote_address()
         );
-        let response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
         for topic_config in request_body.topic_config_list.iter() {
             let topic = topic_config.topic_name.as_ref().unwrap().as_str();
             let result = TopicValidator::validate_topic(topic);
@@ -545,7 +546,7 @@ impl TopicRequestHandler {
                     topic,
                     channel.remote_address(),
                 );
-                return Ok(Some(response.set_code(ResponseCode::Success)));
+                return Ok(Some(RemotingCommand::create_success_response_command()));
             }
         }
 
@@ -557,7 +558,7 @@ impl TopicRequestHandler {
         broker_config_request_handler
             .persist_and_register_topic_updates(topic_config_list, data_version)
             .await?;
-        Ok(Some(response.set_code(ResponseCode::Success)))
+        Ok(Some(RemotingCommand::create_success_response_command()))
     }
 
     pub async fn delete_topic<MS: BrokerAdminStore>(
@@ -568,7 +569,7 @@ impl TopicRequestHandler {
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
         let request_header =
             request.decode_required_header::<DeleteTopicRequestHeader>("decode delete-topic request header")?;
         let topic = &request_header.topic;
@@ -643,7 +644,7 @@ impl TopicRequestHandler {
             .topic_config_coordinator()
             .persist_and_wait()
             .await?;
-        Ok(Some(response.set_code(ResponseCode::Success)))
+        Ok(Some(RemotingCommand::create_success_response_command()))
     }
 
     pub async fn get_all_topic_config<MS: BrokerAdminStore>(
@@ -654,7 +655,7 @@ impl TopicRequestHandler {
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut response = RemotingCommand::create_response_command();
+        let mut response = RemotingCommand::create_success_response_command();
         let (topic_config_table, topic_config_data_version) =
             broker_runtime_inner.topic_config_manager().metadata_snapshot();
         let topic_config_and_mapping_serialize_wrapper = TopicConfigAndMappingSerializeWrapper {
@@ -691,7 +692,7 @@ impl TopicRequestHandler {
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut response = RemotingCommand::create_response_command();
+        let mut response = RemotingCommand::create_success_response_command();
         let topics = TopicValidator::get_system_topic_set();
         let topic_list = TopicList {
             topic_list: topics,
@@ -709,7 +710,7 @@ impl TopicRequestHandler {
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
         let request_header =
             request.decode_required_header::<GetTopicStatsRequestHeader>("decode get-topic-stats request header")?;
         let topic = request_header.topic.as_ref();
@@ -758,8 +759,9 @@ impl TopicRequestHandler {
             map.insert(message_queue, topic_offset);
         }
         topic_stats_table.set_offset_table(map);
-        response.set_body_mut_ref(topic_stats_table.encode().expect("encode TopicStatsTable failed"));
-        Ok(Some(response))
+        Ok(Some(RemotingCommand::create_success_response_command().set_body(
+            topic_stats_table.encode().expect("encode TopicStatsTable failed"),
+        )))
     }
 
     pub async fn get_topic_config<MS: BrokerAdminStore>(
@@ -770,7 +772,7 @@ impl TopicRequestHandler {
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
         let request_header = request.decode_command_custom_header::<GetTopicConfigRequestHeader>()?;
         let topic = &request_header.topic;
         let (topic_config, topic_version) = match broker_runtime_inner
@@ -814,9 +816,12 @@ impl TopicRequestHandler {
         }
         let topic_config = (*topic_config).clone();
         let topic_config_and_queue_mapping = TopicConfigAndQueueMapping::new(topic_config, topic_queue_mapping_detail);
-        response.set_body_mut_ref(topic_config_and_queue_mapping.encode()?);
-        response.set_command_custom_header_ref(UpdateTopicConfigCasResponseHeader { topic_version });
-        Ok(Some(response))
+        Ok(Some(
+            RemotingCommand::create_success_response_command_with_header(UpdateTopicConfigCasResponseHeader {
+                topic_version,
+            })
+            .set_body(topic_config_and_queue_mapping.encode()?),
+        ))
     }
 
     pub async fn query_topic_consume_by_who<MS: BrokerAdminStore>(
@@ -827,7 +832,7 @@ impl TopicRequestHandler {
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut response = RemotingCommand::create_response_command();
+        let mut response = RemotingCommand::create_success_response_command();
         let request_header = request.decode_command_custom_header::<QueryTopicConsumeByWhoRequestHeader>()?;
         let topic = request_header.topic.as_ref();
         let mut groups = broker_runtime_inner
@@ -850,7 +855,7 @@ impl TopicRequestHandler {
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut response = RemotingCommand::create_response_command();
+        let mut response = RemotingCommand::create_success_response_command();
         let request_header = request.decode_required_header::<QueryTopicsByConsumerRequestHeader>(
             "decode query-topics-by-consumer request header",
         )?;
@@ -888,9 +893,7 @@ impl TopicRequestHandler {
             .message_store()
             .unwrap()
             .clean_unused_topic(&retain_topics);
-        Ok(Some(
-            RemotingCommand::create_response_command().set_code(ResponseCode::Success),
-        ))
+        Ok(Some(RemotingCommand::create_success_response_command()))
     }
 
     fn delete_topic_in_broker<MS: BrokerAdminStore>(
@@ -1108,6 +1111,7 @@ mod tests {
             },
         );
         request.make_custom_header_to_net();
+        let request_opaque = request.opaque();
         let channel = create_test_channel().await;
         let ctx = std::sync::Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let response = handler
@@ -1122,6 +1126,11 @@ mod tests {
             .expect("Topic CAS should run")
             .expect("Topic CAS should return a response");
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        assert_eq!(response.opaque(), request_opaque);
+        assert_eq!(
+            response.remark().map(CheetahString::as_str),
+            Some("Topic configuration patch committed, version=1")
+        );
         let response_header = response
             .read_custom_header_ref::<UpdateTopicConfigCasResponseHeader>()
             .expect("success response should carry the committed version");

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_acl_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_acl_request_handler.rs
@@ -44,7 +44,7 @@ impl UpdateAclRequestHandler {
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request.decode_command_custom_header::<UpdateAclRequestHeader>()?;
-        let response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
 
         if request_header.subject.is_empty() {
             return Ok(Some(
@@ -76,7 +76,7 @@ impl UpdateAclRequestHandler {
         };
 
         match self.auth_admin_service.update_acl(acl).await {
-            Ok(()) => Ok(Some(response.set_code(ResponseCode::Success))),
+            Ok(()) => Ok(Some(RemotingCommand::create_success_response_command())),
             Err(error) => Ok(Some(map_error_response(response, error))),
         }
     }

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_broker_ha_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_broker_ha_handler.rs
@@ -44,7 +44,7 @@ impl UpdateBrokerHaHandler {
             .decode_command_custom_header::<ExchangeHAInfoRequestHeader>()
             .unwrap_or_default();
 
-        let mut response = RemotingCommand::create_response_command_with_header(ExchangeHaInfoResponseHeader {
+        let mut response = RemotingCommand::create_success_response_command_with_header(ExchangeHaInfoResponseHeader {
             master_ha_address: None,
             master_flush_offset: None,
             master_address: None,
@@ -100,6 +100,6 @@ impl UpdateBrokerHaHandler {
             response.add_ext_field("masterAddress", master_address);
         }
 
-        Ok(Some(response.set_code(ResponseCode::Success)))
+        Ok(Some(response))
     }
 }

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_cold_data_flow_ctr_group_config.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_cold_data_flow_ctr_group_config.rs
@@ -41,7 +41,7 @@ impl UpdateColdDataFlowCtrGroupConfigRequestHandler {
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_success_response_command();
 
         let Some(body) = request.get_body() else {
             return Ok(Some(response.set_code(ResponseCode::Success)));
@@ -81,7 +81,7 @@ impl UpdateColdDataFlowCtrGroupConfigRequestHandler {
         _request_code: RequestCode,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_success_response_command();
         let Some(body) = request.get_body() else {
             return Ok(Some(response.set_code(ResponseCode::Success)));
         };
@@ -107,7 +107,7 @@ impl UpdateColdDataFlowCtrGroupConfigRequestHandler {
         _request_code: RequestCode,
         _request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
         let Some(service) = self.cold_data_cg_ctr_service.as_deref() else {
             return Ok(Some(
                 response
@@ -116,8 +116,9 @@ impl UpdateColdDataFlowCtrGroupConfigRequestHandler {
             ));
         };
 
-        response.set_body_mut_ref(service.get_cold_data_flow_ctr_info());
-        Ok(Some(response.set_code(ResponseCode::Success)))
+        Ok(Some(
+            RemotingCommand::create_success_response_command().set_body(service.get_cold_data_flow_ctr_info()),
+        ))
     }
 }
 

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_global_white_addrs_config_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_global_white_addrs_config_request_handler.rs
@@ -41,7 +41,7 @@ impl UpdateGlobalWhiteAddrsConfigRequestHandler {
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request.decode_command_custom_header::<UpdateGlobalWhiteAddrsConfigRequestHeader>()?;
-        let response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
         let global_white_addrs = parse_global_white_addrs(request_header.global_white_addrs.as_str());
 
         if global_white_addrs.is_empty() {
@@ -65,7 +65,7 @@ impl UpdateGlobalWhiteAddrsConfigRequestHandler {
             .update_global_white_remote_addresses(global_white_addrs)
             .await
         {
-            Ok(_) => Ok(Some(response.set_code(ResponseCode::Success))),
+            Ok(_) => Ok(Some(RemotingCommand::create_success_response_command())),
             Err(error) => Ok(Some(map_error_response(response, error))),
         }
     }

--- a/rocketmq-broker/src/processor/admin_broker_processor/update_user_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/update_user_request_handler.rs
@@ -31,7 +31,7 @@ impl UpdateUserRequestHandler {
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let request_header = request.decode_command_custom_header::<UpdateUserRequestHeader>()?;
 
-        let response = RemotingCommand::create_response_command();
+        let response = RemotingCommand::create_java_default_error_response_command();
 
         if request_header.username.is_empty() {
             return Ok(Some(
@@ -89,7 +89,7 @@ impl UpdateUserRequestHandler {
         }
 
         match self.auth_admin_service.update_user(user).await {
-            Ok(()) => Ok(Some(response.set_code(ResponseCode::Success))),
+            Ok(()) => Ok(Some(RemotingCommand::create_success_response_command())),
             Err(error) => Ok(Some(map_error_response(response, error))),
         }
     }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9311

### Brief Description

- Replaces all 88 ambiguous response factory calls in Broker administration handlers with explicit success or Java-compatible default-error factories.
- Builds fresh success responses after fallible administration operations so the Java default error remark cannot leak into successful replies.
- Preserves response codes, bodies, typed headers, request opaque values, and existing success remarks across broker configuration, topic, subscription group, authentication, offset, consumer, producer, HA, and message administration paths.
- Adds focused assertions for clean authentication success responses and versioned CAS response contracts.
- Leaves no legacy response factory call in Rust production or test sources.

### How Did You Test This Change?

- `cargo test -p rocketmq-broker admin_broker_processor --lib`: passed, 61 tests.
- `cargo test -p rocketmq-broker --lib`: 784 passed, 2 ignored, and 3 failed. Two failures reproduce on the clean baseline (`pull_processors_depend_only_on_explicit_context` and `extended_timer_capability_is_published_from_one_policy_generation`). The transient controller learner synchronization failure passed when rerun exactly.
- `cargo test -p rocketmq-broker broker_runtime::tests::three_controller_two_broker_controller_mode_failover_and_rejoin --lib -- --exact --nocapture`: passed.
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings`: passed.
- Per-package `cargo fmt -p <package> -- --check` for all 28 root workspace packages: passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`: passed.
- `git diff --check` and the repository-wide legacy response factory search: passed; zero legacy calls remain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized administrative broker success and error responses for improved Java protocol compatibility.
  * Preserved request identifiers, version headers, response bodies, and status remarks across configuration, topic, subscription, ACL, user, message, and offset operations.
  * Maintained existing validation, authorization, locking, and error-handling behavior.
* **Tests**
  * Expanded coverage for response metadata, including opaque values, committed versions, remarks, empty results, and error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->