### PR TITLE
[ISSUE #9316]♻️Deprecate ambiguous response factory aliases

### DIFF
--- a/rocketmq-protocol/src/protocol/remoting_command.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command.rs
@@ -307,7 +307,12 @@ impl RemotingCommand {
     /// Legacy ambiguous-success response factory.
     ///
     /// New code should call [`Self::create_success_response_command`] so the
-    /// response intent is visible during review.
+    /// response intent is visible during review. Call
+    /// [`Self::create_java_default_error_response_command`] when matching
+    /// Java's unset-response behavior instead.
+    #[deprecated(
+        note = "use create_success_response_command for SUCCESS or create_java_default_error_response_command for Java-compatible unset errors"
+    )]
     pub fn create_response_command() -> Self {
         Self::create_success_response_command()
     }
@@ -315,6 +320,11 @@ impl RemotingCommand {
     /// Legacy ambiguous-success typed-header response factory.
     ///
     /// New code should call [`Self::create_success_response_command_with_header`].
+    /// Call [`Self::create_java_default_error_response_command_with_header`]
+    /// when matching Java's unset-response behavior instead.
+    #[deprecated(
+        note = "use create_success_response_command_with_header for SUCCESS or create_java_default_error_response_command_with_header for Java-compatible unset errors"
+    )]
     pub fn create_response_command_with_header(header: impl CommandCustomHeader + Sync + Send + 'static) -> Self {
         Self::create_success_response_command_with_header(header)
     }

--- a/rocketmq-protocol/tests/remoting_response_factory_contract.rs
+++ b/rocketmq-protocol/tests/remoting_response_factory_contract.rs
@@ -80,3 +80,28 @@ fn response_command_explicit_semantics() {
     assert_eq!(java_default_header.topic.as_str(), "topic-b");
     assert_eq!(java_default_header.accept_standard_json_only, None);
 }
+
+#[test]
+#[allow(
+    deprecated,
+    reason = "verifies compatibility aliases retain their legacy SUCCESS semantics during the deprecation window"
+)]
+fn deprecated_response_factory_aliases_preserve_legacy_success_semantics() {
+    let response = RemotingCommand::create_response_command();
+    assert_eq!(response.code(), RemotingSysResponseCode::Success as i32);
+    assert!(response.is_response_type());
+    assert!(response.remark().is_none());
+
+    let response_with_header = RemotingCommand::create_response_command_with_header(GetRouteInfoRequestHeader::new(
+        "legacy-topic",
+        Some(false),
+    ));
+    assert_eq!(response_with_header.code(), RemotingSysResponseCode::Success as i32);
+    assert!(response_with_header.is_response_type());
+    assert!(response_with_header.remark().is_none());
+    let header = response_with_header
+        .read_custom_header_ref::<GetRouteInfoRequestHeader>()
+        .expect("legacy response should retain its typed header");
+    assert_eq!(header.topic.as_str(), "legacy-topic");
+    assert_eq!(header.accept_standard_json_only, Some(false));
+}

--- a/rocketmq-protocol/tests/remoting_response_factory_deprecation_ui.rs
+++ b/rocketmq-protocol/tests/remoting_response_factory_deprecation_ui.rs
@@ -1,0 +1,19 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[test]
+fn ambiguous_response_factory_aliases_emit_migration_diagnostics() {
+    let tests = trybuild::TestCases::new();
+    tests.compile_fail("tests/ui/remoting_response_factory_deprecation/fail/*.rs");
+}

--- a/rocketmq-protocol/tests/ui/remoting_response_factory_deprecation/fail/ambiguous_aliases.rs
+++ b/rocketmq-protocol/tests/ui/remoting_response_factory_deprecation/fail/ambiguous_aliases.rs
@@ -1,0 +1,9 @@
+#![deny(deprecated)]
+
+use rocketmq_protocol::protocol::header::client_request_header::GetRouteInfoRequestHeader;
+use rocketmq_protocol::RemotingCommand;
+
+fn main() {
+    let _ = RemotingCommand::create_response_command();
+    let _ = RemotingCommand::create_response_command_with_header(GetRouteInfoRequestHeader::new("topic-a", None));
+}

--- a/rocketmq-protocol/tests/ui/remoting_response_factory_deprecation/fail/ambiguous_aliases.stderr
+++ b/rocketmq-protocol/tests/ui/remoting_response_factory_deprecation/fail/ambiguous_aliases.stderr
@@ -1,0 +1,17 @@
+error: use of deprecated associated function `rocketmq_protocol::RemotingCommand::create_response_command`: use create_success_response_command for SUCCESS or create_java_default_error_response_command for Java-compatible unset errors
+ --> tests/ui/remoting_response_factory_deprecation/fail/ambiguous_aliases.rs:7:30
+  |
+7 |     let _ = RemotingCommand::create_response_command();
+  |                              ^^^^^^^^^^^^^^^^^^^^^^^
+  |
+note: the lint level is defined here
+ --> tests/ui/remoting_response_factory_deprecation/fail/ambiguous_aliases.rs:1:9
+  |
+1 | #![deny(deprecated)]
+  |         ^^^^^^^^^^
+
+error: use of deprecated associated function `rocketmq_protocol::RemotingCommand::create_response_command_with_header`: use create_success_response_command_with_header for SUCCESS or create_java_default_error_response_command_with_header for Java-compatible unset errors
+ --> tests/ui/remoting_response_factory_deprecation/fail/ambiguous_aliases.rs:8:30
+  |
+8 |     let _ = RemotingCommand::create_response_command_with_header(GetRouteInfoRequestHeader::new("topic-a", None));
+  |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9316

### Brief Description

- Deprecates the two ambiguous response factory aliases without changing their legacy `SUCCESS` behavior.
- Directs callers to explicit success factories or Java-compatible default-error factories through compiler diagnostics and Rustdoc.
- Adds trybuild coverage that fails callers using either alias under `deny(deprecated)`.
- Adds compatibility coverage proving both aliases retain response flags, clean remarks, and typed headers during the migration window.
- Confirms that no repository source uses either alias outside the dedicated diagnostic and compatibility tests.

### How Did You Test This Change?

- Before implementation, `cargo test -p rocketmq-protocol --test remoting_response_factory_deprecation_ui -- --nocapture` failed because the compile-fail fixture unexpectedly compiled.
- `cargo test -p rocketmq-protocol --test remoting_response_factory_deprecation_ui`: passed, 1 test.
- `cargo test -p rocketmq-protocol --test remoting_response_factory_contract`: passed, 2 tests.
- `cargo test -p rocketmq-protocol --all-features`: passed, including 1,480 library tests and all integration, UI, and documentation tests.
- `cargo doc -p rocketmq-protocol --no-deps --all-features`: passed.
- `cargo test -p rocketmq-transport --features test-support --test protocol_compatibility`: passed, 10 tests.
- Per-package `cargo fmt -p <package> -- --check` for all 28 root workspace packages: passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`: passed.
- `cargo clippy --all-targets -- -D warnings` from `rocketmq-example/`: passed.
- `cargo fmt --all -- --check` from `rocketmq-example/` could not execute on Windows because path dependency expansion exceeded the OS command-line limit (OS error 206); the equivalent `cargo fmt -p rocketmq-example -- --check` passed.
- `git diff --check` and the repository-wide unexpected alias call search: passed; zero unexpected calls remain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deprecation**
  - Marked legacy response-command factory methods as deprecated.
  - Added clear migration guidance for explicit success and Java-compatible error factories.
  - Preserved existing behavior and response typing for compatibility.

- **Tests**
  - Added coverage confirming deprecated factories continue producing valid response commands.
  - Added compiler-diagnostic checks to ensure deprecated usage provides actionable replacement guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->