### PR TITLE
[ISSUE #9318]🐛Enforce Java-compatible extension key lengths

### DIFF
--- a/rocketmq-protocol/src/protocol/header_codec/error.rs
+++ b/rocketmq-protocol/src/protocol/header_codec/error.rs
@@ -113,7 +113,7 @@ pub enum HeaderCodecError {
     #[error("ROCKETMQ extension-field payload exceeds the signed 32-bit wire limit")]
     ExtensionFieldsLengthOverflow,
 
-    /// A dynamic extension-field key exceeded its unsigned 16-bit length.
+    /// A dynamic extension-field key exceeded Java's signed 16-bit length.
     #[error("dynamic header key length exceeds the ROCKETMQ wire limit")]
     DynamicKeyLengthOverflow,
 

--- a/rocketmq-protocol/src/protocol/rocketmq_serializable.rs
+++ b/rocketmq-protocol/src/protocol/rocketmq_serializable.rs
@@ -271,7 +271,9 @@ impl RocketMQSerializable {
 
     #[inline]
     fn checked_dynamic_key_length(length: usize) -> Result<u16, HeaderCodecError> {
-        u16::try_from(length).map_err(|_| HeaderCodecError::DynamicKeyLengthOverflow)
+        i16::try_from(length)
+            .map(|length| length as u16)
+            .map_err(|_| HeaderCodecError::DynamicKeyLengthOverflow)
     }
 
     #[inline]
@@ -636,20 +638,30 @@ mod tests {
             Err(HeaderCodecError::ExtensionFieldsLengthOverflow)
         ));
         assert_eq!(
-            RocketMQSerializable::checked_dynamic_key_length(u16::MAX as usize).unwrap(),
-            u16::MAX
-        );
-        assert!(matches!(
-            RocketMQSerializable::checked_dynamic_key_length(u16::MAX as usize + 1),
-            Err(HeaderCodecError::DynamicKeyLengthOverflow)
-        ));
-        assert_eq!(
             RocketMQSerializable::checked_dynamic_value_length(i32::MAX as usize).unwrap(),
             i32::MAX
         );
         assert!(matches!(
             RocketMQSerializable::checked_dynamic_value_length(i32::MAX as usize + 1),
             Err(HeaderCodecError::DynamicValueLengthOverflow)
+        ));
+    }
+
+    #[test]
+    fn dynamic_key_length_java_compatible() {
+        let maximum = i16::MAX as usize;
+
+        assert_eq!(
+            RocketMQSerializable::checked_dynamic_key_length(maximum - 1).unwrap(),
+            (i16::MAX - 1) as u16
+        );
+        assert_eq!(
+            RocketMQSerializable::checked_dynamic_key_length(maximum).unwrap(),
+            i16::MAX as u16
+        );
+        assert!(matches!(
+            RocketMQSerializable::checked_dynamic_key_length(maximum + 1),
+            Err(HeaderCodecError::DynamicKeyLengthOverflow)
         ));
     }
 

--- a/rocketmq-protocol/tests/remoting_command_java_business_compatibility.rs
+++ b/rocketmq-protocol/tests/remoting_command_java_business_compatibility.rs
@@ -116,3 +116,49 @@ fn node_js_language_code_matches_java() {
     .expect("serde fallback should recognize NODE_JS");
     assert_eq!(serde_fallback.language(), LanguageCode::NODE_JS);
 }
+
+#[test]
+fn ext_key_length_matches_java_signed_short_boundary() {
+    let maximum = i16::MAX as usize;
+
+    for key_length in [maximum - 1, maximum] {
+        let key = "k".repeat(key_length);
+        let mut command =
+            RemotingCommand::create_success_response_command().set_serialize_type(SerializeType::ROCKETMQ);
+        command.add_ext_field(key.clone(), "value");
+
+        let decoded = round_trip(command);
+        assert_eq!(
+            decoded
+                .ext_fields()
+                .and_then(|fields| fields.get(key.as_str()))
+                .map(CheetahString::as_str),
+            Some("value")
+        );
+    }
+
+    let oversized_key = "k".repeat(maximum + 1);
+    let mut binary_command =
+        RemotingCommand::create_success_response_command().set_serialize_type(SerializeType::ROCKETMQ);
+    binary_command.add_ext_field(oversized_key.clone(), "value");
+    let mut destination = BytesMut::from(&b"prefix"[..]);
+
+    let error = binary_command
+        .try_fast_header_encode(&mut destination)
+        .expect_err("a key larger than Java's signed-short range must be rejected");
+    assert_eq!(destination.as_ref(), b"prefix");
+    assert!(error
+        .to_string()
+        .contains("dynamic header key length exceeds the ROCKETMQ wire limit"));
+
+    let mut json_command = RemotingCommand::create_success_response_command().set_serialize_type(SerializeType::JSON);
+    json_command.add_ext_field(oversized_key.clone(), "value");
+    let decoded = round_trip(json_command);
+    assert_eq!(
+        decoded
+            .ext_fields()
+            .and_then(|fields| fields.get(oversized_key.as_str()))
+            .map(CheetahString::as_str),
+        Some("value")
+    );
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9318

### Brief Description

Limit outbound ROCKETMQ dynamic extension-field keys to Java's maximum positive signed-short length (`i16::MAX`). The wire representation remains two-byte big-endian for all accepted keys, while `i16::MAX + 1` now returns the existing `DynamicKeyLengthOverflow` error and preserves destination-buffer rollback.

Add unit and cross-format compatibility coverage for `i16::MAX - 1`, `i16::MAX`, and `i16::MAX + 1`. JSON remains unaffected because it does not use the binary signed-short key-length field.

The inactive infallible legacy byte helper was audited and has no internal production callers; its public behavior is intentionally unchanged in this focused fallible production-path fix.

### How Did You Test This Change?

- Verified the pre-fix Rust tests fail because 32,768-byte ROCKETMQ keys are accepted.
- Ran a local Java oracle against `RocketMQSerializable`: 32,767 bytes round-trip and 32,768 bytes are rejected after signed-short decoding.
- `cargo test -p rocketmq-protocol dynamic_key_length_java_compatible -- --nocapture`
- `cargo test -p rocketmq-protocol --test remoting_command_java_business_compatibility ext_key_length -- --nocapture`
- `cargo test -p rocketmq-protocol --all-features`
- `cargo test -p rocketmq-transport --features test-support --test protocol_compatibility`
- Equivalent package-scoped format checks for all 28 root workspace packages (Windows `cargo fmt --all` path-length workaround)
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`
- `cargo fmt -p rocketmq-example -- --check` and `cargo clippy --all-targets -- -D warnings` from `rocketmq-example/`
- `cargo doc -p rocketmq-protocol --no-deps --all-features`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected extension-field key length handling to match Java-compatible signed 16-bit limits.
  * Keys up to the supported boundary now encode correctly, while oversized keys are rejected safely without altering the output.
  * Preserved JSON round-trip support for oversized extension-field keys.

* **Tests**
  * Added compatibility coverage for boundary-length keys and oversized-key error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->