### PR TITLE
[ISSUE #9321]♻️Add an explicit remoting command factory

### DIFF
--- a/rocketmq-protocol/src/protocol/remoting_command.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command.rs
@@ -32,7 +32,6 @@ use serde::Serializer;
 use super::RemotingCommandType;
 use super::SerializeType;
 use crate::code::request_code::RequestCode;
-use crate::code::response_code::RemotingSysResponseCode;
 use crate::protocol::command_custom_header::CommandCustomHeader;
 use crate::protocol::command_custom_header::FromMap;
 use crate::protocol::command_custom_header::HeaderEncodeCapability;
@@ -41,14 +40,14 @@ use crate::protocol::header_codec::BinaryHeaderFields;
 use crate::protocol::header_codec::HeaderCodecError;
 use crate::protocol::header_codec::JsonHeaderFields;
 use crate::protocol::header_field_merge::merge_header_and_dynamic;
-use crate::protocol::remoting_command_defaults::application_remoting_command_defaults;
+use crate::protocol::remoting_command_defaults::application_remoting_command_factory;
+use crate::protocol::remoting_command_defaults::RemotingCommandDefaults;
 use crate::protocol::LanguageCode;
 use crate::rocketmq_serializable::RocketMQSerializable;
 
 pub const SERIALIZE_TYPE_PROPERTY: &str = "rocketmq.serialize.type";
 pub const SERIALIZE_TYPE_ENV: &str = "ROCKETMQ_SERIALIZE_TYPE";
 pub const REMOTING_VERSION_KEY: &str = "rocketmq.remoting.version";
-const JAVA_DEFAULT_RESPONSE_REMARK: &str = "not set any response code";
 
 static REQUEST_ID: std::sync::LazyLock<Arc<AtomicI32>> = std::sync::LazyLock::new(|| Arc::new(AtomicI32::new(0)));
 
@@ -188,11 +187,6 @@ impl Default for RemotingCommand {
 }
 
 impl RemotingCommand {
-    fn with_application_defaults() -> Self {
-        let defaults = application_remoting_command_defaults();
-        Self::with_resolved_defaults(defaults.version(), defaults.serialize_type())
-    }
-
     /// Constructs a command from defaults resolved by the owning facade.
     ///
     /// The protocol crate deliberately does not read process environment or configuration files.
@@ -223,15 +217,14 @@ impl RemotingCommand {
 
 impl RemotingCommand {
     pub fn new_request(code: impl Into<i32>, body: impl Into<Bytes>) -> Self {
-        Self::with_application_defaults().set_code(code).set_body(body)
+        application_remoting_command_factory().create_request(code, body)
     }
 
     pub fn create_request_command<T>(code: impl Into<i32>, header: T) -> Self
     where
         T: CommandCustomHeader + Sync + Send + 'static,
     {
-        let defaults = application_remoting_command_defaults();
-        Self::create_request_command_with_defaults(code, header, defaults.version(), defaults.serialize_type())
+        application_remoting_command_factory().create_request_command(code, header)
     }
 
     /// Creates a request using defaults resolved by the transport/facade owner.
@@ -244,14 +237,15 @@ impl RemotingCommand {
     where
         T: CommandCustomHeader + Sync + Send + 'static,
     {
-        Self::with_resolved_defaults(version, serialize_type)
-            .set_code(code.into())
-            .set_command_custom_header(header)
+        crate::protocol::remoting_command_defaults::RemotingCommandFactory::new(RemotingCommandDefaults::new(
+            version,
+            serialize_type,
+        ))
+        .create_request_command(code, header)
     }
 
     pub fn create_remoting_command(code: impl Into<i32>) -> Self {
-        let command = Self::with_application_defaults();
-        command.set_code(code.into())
+        application_remoting_command_factory().create_remoting_command(code)
     }
 
     pub fn get_and_add() -> i32 {
@@ -259,7 +253,7 @@ impl RemotingCommand {
     }
 
     pub fn create_response_command_with_code(code: impl Into<i32>) -> Self {
-        Self::with_application_defaults().set_code(code).mark_response_type()
+        application_remoting_command_factory().create_response_command_with_code(code)
     }
 
     /// Creates a response with an explicit code and typed custom header.
@@ -267,41 +261,35 @@ impl RemotingCommand {
         code: impl Into<i32>,
         header: impl CommandCustomHeader + Sync + Send + 'static,
     ) -> Self {
-        Self::create_response_command_with_code(code).set_command_custom_header(header)
+        application_remoting_command_factory().create_response_command_with_code_and_header(code, header)
     }
 
     pub fn create_response_command_with_code_remark(code: impl Into<i32>, remark: impl Into<CheetahString>) -> Self {
-        Self::with_application_defaults()
-            .set_code(code)
-            .set_remark_option(Some(remark.into()))
-            .mark_response_type()
+        application_remoting_command_factory().create_response_command_with_code_remark(code, remark)
     }
 
     /// Creates an explicitly successful response.
     pub fn create_success_response_command() -> Self {
-        Self::create_response_command_with_code(RemotingSysResponseCode::Success)
+        application_remoting_command_factory().create_success_response_command()
     }
 
     /// Creates an explicitly successful response with a typed custom header.
     pub fn create_success_response_command_with_header(
         header: impl CommandCustomHeader + Sync + Send + 'static,
     ) -> Self {
-        Self::create_response_command_with_code_and_header(RemotingSysResponseCode::Success, header)
+        application_remoting_command_factory().create_success_response_command_with_header(header)
     }
 
     /// Creates the unset error response used by Java's typed-header factory.
     pub fn create_java_default_error_response_command() -> Self {
-        Self::create_response_command_with_code_remark(
-            RemotingSysResponseCode::SystemError,
-            JAVA_DEFAULT_RESPONSE_REMARK,
-        )
+        application_remoting_command_factory().create_java_default_error_response_command()
     }
 
     /// Creates the unset Java-compatible error response with a typed header.
     pub fn create_java_default_error_response_command_with_header(
         header: impl CommandCustomHeader + Sync + Send + 'static,
     ) -> Self {
-        Self::create_java_default_error_response_command().set_command_custom_header(header)
+        application_remoting_command_factory().create_java_default_error_response_command_with_header(header)
     }
 
     /// Legacy ambiguous-success response factory.

--- a/rocketmq-protocol/src/protocol/remoting_command_compat.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command_compat.rs
@@ -27,6 +27,7 @@ use crate::protocol::remoting_command::RemotingCommand;
 use crate::protocol::remoting_command_defaults::initialize_remoting_command_defaults;
 use crate::protocol::remoting_command_defaults::RemotingCommandDefaults;
 use crate::protocol::remoting_command_defaults::RemotingCommandDefaultsConflict;
+use crate::protocol::remoting_command_defaults::RemotingCommandFactory;
 use crate::protocol::SerializeType;
 
 use super::remoting_command::REMOTING_VERSION_KEY;
@@ -215,30 +216,38 @@ pub fn initialize_remoting_version(version: i32) -> Result<(), RemotingVersionCo
     initialize_version(&REMOTING_VERSION, version)
 }
 
+fn compatibility_factory() -> RemotingCommandFactory {
+    RemotingCommandFactory::new(RemotingCommandDefaults::new(
+        resolve_remoting_version(&REMOTING_VERSION),
+        *SERIALIZE_TYPE,
+    ))
+}
+
 pub fn create_remoting_command(code: impl Into<i32>) -> RemotingCommand {
-    RemotingCommand::with_resolved_defaults(resolve_remoting_version(&REMOTING_VERSION), *SERIALIZE_TYPE).set_code(code)
+    compatibility_factory().create_remoting_command(code)
 }
 
 pub fn create_request_command<T>(code: impl Into<i32>, header: T) -> RemotingCommand
 where
     T: CommandCustomHeader + Sync + Send + 'static,
 {
-    RemotingCommand::create_request_command_with_defaults(
-        code,
-        header,
-        resolve_remoting_version(&REMOTING_VERSION),
-        *SERIALIZE_TYPE,
-    )
+    compatibility_factory().create_request_command(code, header)
 }
 
 pub fn create_response_command() -> RemotingCommand {
-    create_remoting_command(crate::code::response_code::RemotingSysResponseCode::Success).mark_response_type()
+    compatibility_factory().create_success_response_command()
 }
 
 #[cfg(test)]
 mod tests {
     use std::sync::OnceLock;
 
+    use crate::protocol::header::empty_header::EmptyHeader;
+
+    use super::compatibility_factory;
+    use super::create_remoting_command;
+    use super::create_request_command;
+    use super::create_response_command;
     use super::initialize_version;
     use super::RemotingVersionConflict;
 
@@ -264,5 +273,20 @@ mod tests {
             })
         );
         assert_eq!(version.get(), Some(&321));
+    }
+
+    #[test]
+    fn compatibility_constructors_share_factory_defaults() {
+        let expected_defaults = compatibility_factory().defaults();
+        let commands = [
+            create_remoting_command(10),
+            create_request_command(11, EmptyHeader {}),
+            create_response_command(),
+        ];
+
+        for command in commands {
+            assert_eq!(command.version(), expected_defaults.version());
+            assert_eq!(command.serialize_type(), expected_defaults.serialize_type());
+        }
     }
 }

--- a/rocketmq-protocol/src/protocol/remoting_command_defaults.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command_defaults.rs
@@ -12,12 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Immutable process defaults for business `RemotingCommand` factories.
+//! Immutable defaults and factories for business `RemotingCommand` values.
 
 use std::fmt;
 use std::sync::OnceLock;
 
+use bytes::Bytes;
+use cheetah_string::CheetahString;
+
+use crate::code::response_code::RemotingSysResponseCode;
+use crate::protocol::command_custom_header::CommandCustomHeader;
+use crate::protocol::remoting_command::RemotingCommand;
 use crate::protocol::SerializeType;
+
+const JAVA_DEFAULT_RESPONSE_REMARK: &str = "not set any response code";
 
 /// Wire defaults shared by all business command factories in a process.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -46,6 +54,117 @@ impl RemotingCommandDefaults {
 impl Default for RemotingCommandDefaults {
     fn default() -> Self {
         Self::new(crate::version::CURRENT_VERSION as i32, SerializeType::JSON)
+    }
+}
+
+/// Builds business commands from one immutable set of wire defaults.
+///
+/// A factory does not read process configuration. Application owners may keep
+/// the process-default compatibility path or inject explicit factories when
+/// multiple remoting configurations must coexist in one process.
+///
+/// # Examples
+///
+/// ```
+/// use rocketmq_protocol::protocol::remoting_command_defaults::{
+///     RemotingCommandDefaults, RemotingCommandFactory,
+/// };
+/// use rocketmq_protocol::protocol::SerializeType;
+///
+/// let json = RemotingCommandFactory::new(RemotingCommandDefaults::new(101, SerializeType::JSON));
+/// let binary = RemotingCommandFactory::new(RemotingCommandDefaults::new(202, SerializeType::ROCKETMQ));
+///
+/// assert_eq!(json.create_remoting_command(10).version(), 101);
+/// assert_eq!(binary.create_remoting_command(10).version(), 202);
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RemotingCommandFactory {
+    defaults: RemotingCommandDefaults,
+}
+
+impl RemotingCommandFactory {
+    /// Creates a factory with explicit version and serialization defaults.
+    pub const fn new(defaults: RemotingCommandDefaults) -> Self {
+        Self { defaults }
+    }
+
+    /// Returns the immutable defaults owned by this factory.
+    pub const fn defaults(&self) -> RemotingCommandDefaults {
+        self.defaults
+    }
+
+    /// Creates a base command with an explicit code.
+    pub fn create_remoting_command(&self, code: impl Into<i32>) -> RemotingCommand {
+        RemotingCommand::with_resolved_defaults(self.defaults.version(), self.defaults.serialize_type()).set_code(code)
+    }
+
+    /// Creates a request with an external body.
+    pub fn create_request(&self, code: impl Into<i32>, body: impl Into<Bytes>) -> RemotingCommand {
+        self.create_remoting_command(code).set_body(body)
+    }
+
+    /// Creates a request with a typed custom header.
+    pub fn create_request_command<T>(&self, code: impl Into<i32>, header: T) -> RemotingCommand
+    where
+        T: CommandCustomHeader + Sync + Send + 'static,
+    {
+        self.create_remoting_command(code).set_command_custom_header(header)
+    }
+
+    /// Creates a response with an explicit response code.
+    pub fn create_response_command_with_code(&self, code: impl Into<i32>) -> RemotingCommand {
+        self.create_remoting_command(code).mark_response_type()
+    }
+
+    /// Creates a response with an explicit code and typed custom header.
+    pub fn create_response_command_with_code_and_header(
+        &self,
+        code: impl Into<i32>,
+        header: impl CommandCustomHeader + Sync + Send + 'static,
+    ) -> RemotingCommand {
+        self.create_response_command_with_code(code)
+            .set_command_custom_header(header)
+    }
+
+    /// Creates a response with an explicit code and remark.
+    pub fn create_response_command_with_code_remark(
+        &self,
+        code: impl Into<i32>,
+        remark: impl Into<CheetahString>,
+    ) -> RemotingCommand {
+        self.create_remoting_command(code)
+            .set_remark_option(Some(remark.into()))
+            .mark_response_type()
+    }
+
+    /// Creates an explicitly successful response.
+    pub fn create_success_response_command(&self) -> RemotingCommand {
+        self.create_response_command_with_code(RemotingSysResponseCode::Success)
+    }
+
+    /// Creates an explicitly successful response with a typed custom header.
+    pub fn create_success_response_command_with_header(
+        &self,
+        header: impl CommandCustomHeader + Sync + Send + 'static,
+    ) -> RemotingCommand {
+        self.create_response_command_with_code_and_header(RemotingSysResponseCode::Success, header)
+    }
+
+    /// Creates Java's unset error response.
+    pub fn create_java_default_error_response_command(&self) -> RemotingCommand {
+        self.create_response_command_with_code_remark(
+            RemotingSysResponseCode::SystemError,
+            JAVA_DEFAULT_RESPONSE_REMARK,
+        )
+    }
+
+    /// Creates Java's unset error response with a typed custom header.
+    pub fn create_java_default_error_response_command_with_header(
+        &self,
+        header: impl CommandCustomHeader + Sync + Send + 'static,
+    ) -> RemotingCommand {
+        self.create_java_default_error_response_command()
+            .set_command_custom_header(header)
     }
 }
 
@@ -117,6 +236,10 @@ pub fn initialize_remoting_command_defaults(
 
 pub(crate) fn application_remoting_command_defaults() -> RemotingCommandDefaults {
     *APPLICATION_DEFAULTS.get_or_init(RemotingCommandDefaults::default)
+}
+
+pub(crate) fn application_remoting_command_factory() -> RemotingCommandFactory {
+    RemotingCommandFactory::new(application_remoting_command_defaults())
 }
 
 #[cfg(test)]

--- a/rocketmq-protocol/tests/remoting_command_application_defaults.rs
+++ b/rocketmq-protocol/tests/remoting_command_application_defaults.rs
@@ -16,6 +16,7 @@ use bytes::Bytes;
 use rocketmq_protocol::protocol::header::empty_header::EmptyHeader;
 use rocketmq_protocol::protocol::remoting_command_defaults::initialize_remoting_command_defaults;
 use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandDefaults;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 use rocketmq_protocol::protocol::SerializeType;
 use rocketmq_protocol::RemotingCommand;
 
@@ -23,6 +24,7 @@ use rocketmq_protocol::RemotingCommand;
 fn business_factories_share_immutable_application_defaults() {
     let defaults = RemotingCommandDefaults::new(4242, SerializeType::ROCKETMQ);
     initialize_remoting_command_defaults(defaults).expect("application defaults should initialize");
+    let explicit_factory = RemotingCommandFactory::new(defaults);
 
     let commands = [
         RemotingCommand::new_request(10, Bytes::from_static(b"body")),
@@ -35,6 +37,9 @@ fn business_factories_share_immutable_application_defaults() {
         RemotingCommand::create_success_response_command_with_header(EmptyHeader {}),
         RemotingCommand::create_java_default_error_response_command(),
         RemotingCommand::create_java_default_error_response_command_with_header(EmptyHeader {}),
+        explicit_factory.create_request_command(13, EmptyHeader {}),
+        explicit_factory.create_success_response_command(),
+        explicit_factory.create_java_default_error_response_command(),
     ];
 
     for command in commands {

--- a/rocketmq-protocol/tests/remoting_command_factory.rs
+++ b/rocketmq-protocol/tests/remoting_command_factory.rs
@@ -1,0 +1,122 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::Bytes;
+use rocketmq_protocol::code::response_code::RemotingSysResponseCode;
+use rocketmq_protocol::protocol::header::client_request_header::GetRouteInfoRequestHeader;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandDefaults;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
+use rocketmq_protocol::protocol::SerializeType;
+
+#[test]
+fn explicit_factories_isolate_request_and_response_defaults() {
+    let json_factory = RemotingCommandFactory::new(RemotingCommandDefaults::new(101, SerializeType::JSON));
+    let rocketmq_factory = RemotingCommandFactory::new(RemotingCommandDefaults::new(202, SerializeType::ROCKETMQ));
+
+    let json_request = json_factory.create_request_command(11, GetRouteInfoRequestHeader::new("json-topic", None));
+    let json_response = json_factory.create_success_response_command();
+    let rocketmq_request =
+        rocketmq_factory.create_request_command(22, GetRouteInfoRequestHeader::new("rocketmq-topic", None));
+    let rocketmq_response = rocketmq_factory.create_success_response_command();
+
+    for command in [&json_request, &json_response] {
+        assert_eq!(command.version(), 101);
+        assert_eq!(command.get_serialize_type(), SerializeType::JSON);
+    }
+    for command in [&rocketmq_request, &rocketmq_response] {
+        assert_eq!(command.version(), 202);
+        assert_eq!(command.get_serialize_type(), SerializeType::ROCKETMQ);
+    }
+
+    assert_eq!(json_request.code(), 11);
+    assert!(json_response.is_response_type());
+    assert_eq!(rocketmq_request.code(), 22);
+    assert!(rocketmq_response.is_response_type());
+    assert_eq!(
+        json_factory.defaults(),
+        RemotingCommandDefaults::new(101, SerializeType::JSON)
+    );
+    assert_eq!(
+        rocketmq_factory.defaults(),
+        RemotingCommandDefaults::new(202, SerializeType::ROCKETMQ)
+    );
+}
+
+#[test]
+fn factory_exposes_explicit_request_and_response_semantics() {
+    let factory = RemotingCommandFactory::new(RemotingCommandDefaults::new(303, SerializeType::ROCKETMQ));
+    let cloned = factory;
+
+    let body_request = cloned.create_request(31, Bytes::from_static(b"body"));
+    assert_eq!(body_request.code(), 31);
+    assert_eq!(body_request.body().map(Bytes::as_ref), Some(b"body".as_ref()));
+
+    let coded = factory.create_response_command_with_code(44);
+    assert_eq!(coded.code(), 44);
+    assert!(coded.is_response_type());
+
+    let remarked = factory.create_response_command_with_code_remark(45, "reason");
+    assert_eq!(remarked.code(), 45);
+    assert_eq!(remarked.remark().map(|remark| remark.as_str()), Some("reason"));
+
+    let success = factory.create_success_response_command();
+    assert_eq!(success.code(), RemotingSysResponseCode::Success as i32);
+
+    let success_with_header = factory
+        .create_success_response_command_with_header(GetRouteInfoRequestHeader::new("success-topic", Some(true)));
+    let success_header = success_with_header
+        .read_custom_header_ref::<GetRouteInfoRequestHeader>()
+        .expect("successful response should retain its typed header");
+    assert_eq!(success_header.topic.as_str(), "success-topic");
+
+    let coded_with_header =
+        factory.create_response_command_with_code_and_header(46, GetRouteInfoRequestHeader::new("error-topic", None));
+    assert_eq!(coded_with_header.code(), 46);
+    assert!(coded_with_header.is_response_type());
+    assert!(coded_with_header
+        .read_custom_header_ref::<GetRouteInfoRequestHeader>()
+        .is_some());
+
+    let java_default = factory.create_java_default_error_response_command();
+    assert_eq!(java_default.code(), RemotingSysResponseCode::SystemError as i32);
+    assert_eq!(
+        java_default.remark().map(|remark| remark.as_str()),
+        Some("not set any response code")
+    );
+
+    let java_default_with_header = factory.create_java_default_error_response_command_with_header(
+        GetRouteInfoRequestHeader::new("java-default-topic", None),
+    );
+    assert_eq!(
+        java_default_with_header.code(),
+        RemotingSysResponseCode::SystemError as i32
+    );
+    assert!(java_default_with_header
+        .read_custom_header_ref::<GetRouteInfoRequestHeader>()
+        .is_some());
+
+    for command in [
+        &body_request,
+        &coded,
+        &remarked,
+        &success,
+        &success_with_header,
+        &coded_with_header,
+        &java_default,
+        &java_default_with_header,
+    ] {
+        assert_eq!(command.version(), 303);
+        assert_eq!(command.get_serialize_type(), SerializeType::ROCKETMQ);
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9321

### Brief Description

- Add a cloneable, immutable `RemotingCommandFactory` that owns explicit version and serialization defaults.
- Delegate the static business constructors, the positional compatibility constructor, and the legacy facade constructors to the same factory implementation.
- Preserve the protocol-neutral `RemotingCommand::default()`, existing process-default behavior, response semantics, and wire encoding.
- Add isolated multi-factory, typed request/response, compatibility-facade, application-default, and Rustdoc coverage without adding environment reads to the factory.

### How Did You Test This Change?

- `cargo test -p rocketmq-protocol --all-features` (passed, including 1,482 library tests and all integration, UI, golden, Java-compatibility, and documentation tests)
- `cargo test -p rocketmq-transport --features test-support --test protocol_compatibility` (passed, 10 tests)
- `cargo fmt -p <package> -- --check` for all 28 root workspace packages (passed; used as the Windows `os error 206` equivalent of the aggregate command)
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` (passed)
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/` (passed)
- `cargo fmt -p rocketmq-example -- --check` and `cargo clippy --all-targets -- -D warnings` from `rocketmq-example/` (passed)
- `cargo test -p rocketmq-protocol --doc` and `cargo doc -p rocketmq-protocol --all-features --no-deps` (passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized creation of protocol requests and responses using consistent application and wire-format defaults.
  * Improved consistency across standard and compatibility command constructors, including versions, serialization settings, headers, bodies, and remarks.
  * Added support for success responses and Java-compatible default error responses.
  * Expanded validation to cover request, response, header, serialization, and compatibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->