### PR TITLE
[ISSUE #9320]🐛Refresh POP state before recording consumer lag

### DIFF
--- a/rocketmq-broker/src/broker_runtime/control_plane.rs
+++ b/rocketmq-broker/src/broker_runtime/control_plane.rs
@@ -13,11 +13,14 @@
 // limitations under the License.
 
 use super::*;
+#[cfg(feature = "otel-metrics")]
+use crate::metrics::consumer_lag_snapshot::ConsumerLagSnapshotService;
 use rocketmq_store::BrokerReadStore;
 use rocketmq_store::BrokerReplicationStore;
 #[derive(Default)]
 pub(super) struct BrokerControlPlane {
     pub(super) broadcast_offset_scan_started: bool,
+    pub(super) consumer_lag_observability_initialized: bool,
 }
 
 impl BrokerControlPlane {
@@ -92,20 +95,6 @@ impl BrokerRuntime {
                             .collect()
                     },
                 );
-                let consumer_offset_manager = self.composition.state.consumer_offset_manager_handle();
-                metrics_manager.register_consumer_lag_observable_gauge(move || {
-                    consumer_offset_manager
-                        .consumer_lag_snapshot()
-                        .into_iter()
-                        .map(|observation| {
-                            crate::metrics::broker_metrics_manager::ConsumerLagAttributes::new(
-                                observation.topic,
-                                observation.consumer_group,
-                                observation.lag_messages,
-                            )
-                        })
-                        .collect()
-                });
             }
 
             if let Some(metrics_manager) = self.composition.state.pop_metrics_manager.clone() {
@@ -232,6 +221,62 @@ impl BrokerRuntime {
                             .unwrap_or_default()
                     });
             }
+        }
+    }
+
+    pub(super) fn initialize_consumer_lag_observability(&mut self) {
+        #[cfg(feature = "otel-metrics")]
+        {
+            if self.composition.control_plane.consumer_lag_observability_initialized {
+                return;
+            }
+            let Some(metrics_manager) = self.composition.state.broker_metrics_manager.clone() else {
+                return;
+            };
+            let Some(pop_processor) = self.composition.state.pop_message_processor.clone() else {
+                warn!("Consumer lag observability requires an initialized POP processor");
+                return;
+            };
+            let broker_config = self.composition.state.broker_config();
+            let consumer_lag_snapshot = Arc::new(ConsumerLagSnapshotService::new(
+                self.composition.state.consumer_offset_manager_handle(),
+                self.composition.state.consumer_manager.clone_shared_state(),
+                pop_processor,
+                broker_config.enable_notify_before_pop_calculate_lag,
+            ));
+            let refresh_interval = Duration::from_millis(broker_config.metrics_export_interval_millis.max(1));
+            let refresh_snapshot = Arc::clone(&consumer_lag_snapshot);
+            let schedule_result = self
+                .lifecycle
+                .scheduled_task_manager
+                .add_fixed_rate_no_overlap_task_async(Duration::ZERO, refresh_interval, move |ctx| {
+                    let refresh_snapshot = Arc::clone(&refresh_snapshot);
+                    async move {
+                        if !ctx.is_cancelled() {
+                            refresh_snapshot.refresh().await;
+                        }
+                        Ok(())
+                    }
+                });
+            if let Err(error) = schedule_result {
+                error!(%error, "Failed to start consumer lag snapshot refresh");
+                return;
+            }
+
+            metrics_manager.register_consumer_lag_observable_gauge(move || {
+                consumer_lag_snapshot
+                    .current()
+                    .iter()
+                    .map(|observation| {
+                        crate::metrics::broker_metrics_manager::ConsumerLagAttributes::new(
+                            observation.topic.clone(),
+                            observation.consumer_group.clone(),
+                            observation.lag_messages,
+                        )
+                    })
+                    .collect()
+            });
+            self.composition.control_plane.consumer_lag_observability_initialized = true;
         }
     }
 

--- a/rocketmq-broker/src/broker_runtime/request_pipeline/startup.rs
+++ b/rocketmq-broker/src/broker_runtime/request_pipeline/startup.rs
@@ -36,6 +36,7 @@ impl BrokerRuntime {
             });
         }
         let (request_processor, fast_request_processor) = self.init_processor_checked()?;
+        self.initialize_consumer_lag_observability();
         let service_context =
             self.composition
                 .state

--- a/rocketmq-broker/src/config/broker_config.rs
+++ b/rocketmq-broker/src/config/broker_config.rs
@@ -458,6 +458,10 @@ mod defaults {
         10_000
     }
 
+    pub fn enable_notify_before_pop_calculate_lag() -> bool {
+        true
+    }
+
     pub fn pop_ck_max_buffer_size() -> i64 {
         200_000
     }
@@ -1223,6 +1227,9 @@ pub struct BrokerConfig {
     #[serde(default = "defaults::pop_inflight_message_threshold")]
     pub pop_inflight_message_threshold: i64,
 
+    #[serde(default = "defaults::enable_notify_before_pop_calculate_lag")]
+    pub enable_notify_before_pop_calculate_lag: bool,
+
     #[serde(default = "defaults::pop_ck_max_buffer_size")]
     pub pop_ck_max_buffer_size: i64,
 
@@ -1575,6 +1582,7 @@ impl Default for BrokerConfig {
             pop_polling_size: 1024,
             enable_pop_message_threshold: false,
             pop_inflight_message_threshold: 10_000,
+            enable_notify_before_pop_calculate_lag: true,
             pop_ck_max_buffer_size: 200_000,
             pop_ck_offset_max_queue_size: 20_000,
             delay_offset_update_version_step: 200,
@@ -2112,6 +2120,10 @@ impl BrokerConfig {
             self.enable_pop_message_threshold.to_string().into(),
         );
         properties.insert(
+            "enableNotifyBeforePopCalculateLag".into(),
+            self.enable_notify_before_pop_calculate_lag.to_string().into(),
+        );
+        properties.insert(
             "validateSystemTopicWhenUpdateTopic".into(),
             self.validate_system_topic_when_update_topic.to_string().into(),
         );
@@ -2460,6 +2472,7 @@ mod tests {
         assert!(!config.pop_consumer_kv_service_init);
         assert!(!config.pop_consumer_kv_service_enable);
         assert!(!config.enable_pop_message_threshold);
+        assert!(config.enable_notify_before_pop_calculate_lag);
 
         let properties = config.get_properties();
         assert_eq!(
@@ -2481,6 +2494,12 @@ mod tests {
         assert_eq!(
             properties.get("enablePopMessageThreshold").map(|value| value.as_str()),
             Some("false")
+        );
+        assert_eq!(
+            properties
+                .get("enableNotifyBeforePopCalculateLag")
+                .map(|value| value.as_str()),
+            Some("true")
         );
     }
 

--- a/rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service.rs
+++ b/rocketmq-broker/src/long_polling/long_polling_service/pop_long_polling_service.rs
@@ -39,6 +39,7 @@ use rocketmq_store::ArcMessageFilter;
 use rocketmq_store::CqExtUnit;
 use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use tokio::select;
+use tokio::sync::oneshot;
 use tokio::sync::Mutex as AsyncMutex;
 use tracing::error;
 use tracing::info;
@@ -117,6 +118,43 @@ pub(crate) trait LocalPopLongPollingRequestProcessor {
         ctx: ConnectionHandlerContext,
         request: RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PopWakeupOutcome {
+    ProcessingCompleted,
+    ProcessingFailed,
+    InactiveChannel,
+    AlreadyCompleted,
+    ProcessorUnavailable,
+    ServiceNotRunning,
+    ServiceCancelled,
+}
+
+pub(crate) type PopWakeupCompletion = oneshot::Receiver<PopWakeupOutcome>;
+
+struct PopWakeupObserver {
+    sender: Option<oneshot::Sender<PopWakeupOutcome>>,
+}
+
+impl PopWakeupObserver {
+    fn new(sender: oneshot::Sender<PopWakeupOutcome>) -> Self {
+        Self { sender: Some(sender) }
+    }
+
+    fn complete(mut self, outcome: PopWakeupOutcome) {
+        if let Some(sender) = self.sender.take() {
+            let _ = sender.send(outcome);
+        }
+    }
+}
+
+impl Drop for PopWakeupObserver {
+    fn drop(&mut self) {
+        if let Some(sender) = self.sender.take() {
+            let _ = sender.send(PopWakeupOutcome::ServiceCancelled);
+        }
+    }
 }
 
 impl<RP: PopLongPollingRequestProcessor + Sync + 'static> PopLongPollingService<RP> {
@@ -319,42 +357,81 @@ impl<RP: PopLongPollingRequestProcessor + Sync + 'static> PopLongPollingService<
         filter_bit_map: Option<Vec<u8>>,
         properties: Option<&HashMap<CheetahString, CheetahString>>,
     ) -> bool {
+        self.take_matching_request(
+            topic,
+            queue_id,
+            cid,
+            false,
+            tags_code,
+            msg_store_time,
+            filter_bit_map,
+            properties,
+        )
+        .is_some_and(|pop_request| self.wake_up(pop_request))
+    }
+
+    pub(crate) fn notify_message_arriving_before_lag(
+        &self,
+        topic: &CheetahString,
+        cid: &CheetahString,
+    ) -> Option<PopWakeupCompletion> {
+        self.take_matching_request(topic, -1, cid, true, None, 0, None, None)
+            .map(|pop_request| self.wake_up_with_completion(pop_request))
+    }
+
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "the long-polling match boundary mirrors the message-arrival metadata"
+    )]
+    fn take_matching_request(
+        &self,
+        topic: &CheetahString,
+        queue_id: i32,
+        cid: &CheetahString,
+        force: bool,
+        tags_code: Option<i64>,
+        msg_store_time: i64,
+        filter_bit_map: Option<Vec<u8>>,
+        properties: Option<&HashMap<CheetahString, CheetahString>>,
+    ) -> Option<Arc<PopRequest>> {
         let key = CheetahString::from_string(KeyBuilder::build_polling_key(topic, cid, queue_id));
         if let Some(remoting_commands) = self.polling_map.get(&key) {
             let value_ = remoting_commands.value();
             if value_.is_empty() {
-                return false;
+                return None;
             }
 
             if let Some(pop_request) = self.poll_remoting_commands(value_) {
                 let (message_filter, subscription_data) =
                     (pop_request.get_message_filter(), pop_request.get_subscription_data());
 
-                if let (Some(message_filter), Some(_subscription_data)) = (message_filter, subscription_data) {
-                    let mut match_result = message_filter.is_matched_by_consume_queue(
-                        tags_code,
-                        Some(&CqExtUnit::new(
-                            tags_code.unwrap_or_default(),
-                            msg_store_time,
-                            filter_bit_map,
-                        )),
-                    );
-                    if match_result {
-                        if let Some(props) = properties {
-                            match_result = message_filter.is_matched_by_commit_log(None, Some(props));
+                if !force {
+                    if let (Some(message_filter), Some(_subscription_data)) = (message_filter, subscription_data) {
+                        let mut match_result = message_filter.is_matched_by_consume_queue(
+                            tags_code,
+                            Some(&CqExtUnit::new(
+                                tags_code.unwrap_or_default(),
+                                msg_store_time,
+                                filter_bit_map,
+                            )),
+                        );
+                        if match_result {
+                            if let Some(props) = properties {
+                                match_result = message_filter.is_matched_by_commit_log(None, Some(props));
+                            }
                         }
-                    }
-                    if !match_result {
-                        remoting_commands.value().insert(pop_request);
-                        self.total_polling_num.fetch_add(1, Ordering::AcqRel);
-                        return false;
+                        if !match_result {
+                            remoting_commands.value().insert(pop_request);
+                            self.total_polling_num.fetch_add(1, Ordering::AcqRel);
+                            return None;
+                        }
                     }
                 }
 
-                return self.wake_up(pop_request);
+                return Some(pop_request);
             }
         }
-        false
+        None
     }
 
     /// Notifies that a message has arrived on a retry topic.
@@ -520,15 +597,42 @@ impl<RP: PopLongPollingRequestProcessor + Sync + 'static> PopLongPollingService<
 
     // wake up and try process request
     pub fn wake_up(&self, pop_request: Arc<PopRequest>) -> bool {
+        self.wake_up_inner(pop_request, None)
+    }
+
+    pub(crate) fn wake_up_with_completion(&self, pop_request: Arc<PopRequest>) -> PopWakeupCompletion {
+        let (sender, receiver) = oneshot::channel();
+        self.wake_up_inner(pop_request, Some(PopWakeupObserver::new(sender)));
+        receiver
+    }
+
+    fn wake_up_inner(&self, pop_request: Arc<PopRequest>, completion: Option<PopWakeupObserver>) -> bool {
         if !pop_request.complete() {
+            if let Some(completion) = completion {
+                completion.complete(PopWakeupOutcome::AlreadyCompleted);
+            }
+            return false;
+        }
+        if !pop_request.get_channel().connection_ref().is_healthy() {
+            if let Some(completion) = completion {
+                completion.complete(PopWakeupOutcome::InactiveChannel);
+            }
             return false;
         }
         match self.processor.upgrade() {
-            None => false,
+            None => {
+                if let Some(completion) = completion {
+                    completion.complete(PopWakeupOutcome::ProcessorUnavailable);
+                }
+                false
+            }
             Some(processor) => {
                 let task_group = self.task_group.lock().as_ref().cloned();
                 let Some(task_group) = task_group else {
                     warn!("PopLongPollingService wake-up skipped because task group is not running");
+                    if let Some(completion) = completion {
+                        completion.complete(PopWakeupOutcome::ServiceNotRunning);
+                    }
                     return false;
                 };
 
@@ -541,6 +645,9 @@ impl<RP: PopLongPollingRequestProcessor + Sync + 'static> PopLongPollingService<
                         .await;
                     match response {
                         Ok(result) => {
+                            if let Some(completion) = completion {
+                                completion.complete(PopWakeupOutcome::ProcessingCompleted);
+                            }
                             if let Some(mut response) = result {
                                 let channel = pop_request.get_channel();
                                 response.set_opaque_mut(opaque);
@@ -549,6 +656,9 @@ impl<RP: PopLongPollingRequestProcessor + Sync + 'static> PopLongPollingService<
                         }
                         Err(e) => {
                             error!("ExecuteRequestWhenWakeup run {}", e);
+                            if let Some(completion) = completion {
+                                completion.complete(PopWakeupOutcome::ProcessingFailed);
+                            }
                         }
                     }
                 });
@@ -622,5 +732,287 @@ where
 {
     fn polling_count(&self, key: &str) -> i32 {
         self.get_polling_num(key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use cheetah_string::CheetahString;
+    use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+    use rocketmq_runtime::common::time_utils::current_millis;
+    use rocketmq_store::MessageFilter;
+    use rocketmq_store::MessageStoreConfig;
+    use rocketmq_transport::api::v1::Channel;
+    use rocketmq_transport::api::v1::ConnectionHandlerContextWrapper;
+    use rocketmq_transport::test_support::Connection;
+    use tokio::sync::Notify;
+
+    use super::PopLongPollingRequestProcessor;
+    use super::PopLongPollingService;
+    use super::PopLongPollingServiceContext;
+    use super::PopWakeupOutcome;
+    use crate::broker_runtime::BrokerRuntime;
+    use crate::config::broker_config::BrokerConfig;
+    use crate::long_polling::long_polling_service::pop_long_polling_service::PopLongPollingPolicy;
+    use crate::long_polling::polling_header::PollingHeader;
+    use crate::long_polling::pop_request::PopRequest;
+
+    struct RejectAllFilter;
+
+    impl MessageFilter for RejectAllFilter {
+        fn is_matched_by_consume_queue(
+            &self,
+            _tags_code: Option<i64>,
+            _cq_ext_unit: Option<&rocketmq_store::CqExtUnit>,
+        ) -> bool {
+            false
+        }
+
+        fn is_matched_by_commit_log(
+            &self,
+            _msg_buffer: Option<&[u8]>,
+            _properties: Option<&std::collections::HashMap<CheetahString, CheetahString>>,
+        ) -> bool {
+            false
+        }
+    }
+
+    struct FailingProcessor {
+        calls: AtomicUsize,
+    }
+
+    struct ControlledProcessor {
+        calls: AtomicUsize,
+        started: Notify,
+        release: Notify,
+    }
+
+    impl PopLongPollingRequestProcessor for FailingProcessor {
+        async fn process_request_when_wakeup(
+            &self,
+            _channel: Channel,
+            _ctx: rocketmq_transport::api::v1::ConnectionHandlerContext,
+            _request: RemotingCommand,
+        ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+            self.calls.fetch_add(1, Ordering::AcqRel);
+            Err(rocketmq_error::RocketMQError::illegal_argument(
+                "deterministic POP processing failure",
+            ))
+        }
+    }
+
+    impl PopLongPollingRequestProcessor for ControlledProcessor {
+        async fn process_request_when_wakeup(
+            &self,
+            _channel: Channel,
+            _ctx: rocketmq_transport::api::v1::ConnectionHandlerContext,
+            _request: RemotingCommand,
+        ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+            self.calls.fetch_add(1, Ordering::AcqRel);
+            self.started.notify_one();
+            self.release.notified().await;
+            Ok(None)
+        }
+    }
+
+    fn test_service<RP>(processor: &Arc<RP>) -> Arc<PopLongPollingService<RP>>
+    where
+        RP: PopLongPollingRequestProcessor + Sync + 'static,
+    {
+        let mut runtime = BrokerRuntime::new(
+            Arc::new(BrokerConfig::default()),
+            Arc::new(MessageStoreConfig::default()),
+        );
+        let state = runtime.runtime_state_mut();
+        let context = PopLongPollingServiceContext::new(
+            PopLongPollingPolicy::from_config(&state.broker_config()),
+            state.topic_config_manager_handle(),
+            state.subscription_group_manager().config_lookup(),
+            state.broker_service_context(),
+        );
+        Arc::new(PopLongPollingService::new(context, false, Arc::downgrade(processor)))
+    }
+
+    async fn test_pop_request() -> Arc<PopRequest> {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local test listener");
+        let local_addr = listener.local_addr().expect("local listener addr");
+        let stream = std::net::TcpStream::connect(local_addr).expect("connect local test listener");
+        stream.set_nonblocking(true).expect("set nonblocking");
+        let stream = tokio::net::TcpStream::from_std(stream).expect("convert tcp stream");
+        let connection = Connection::new(stream);
+        let channel = rocketmq_transport::test_support::TestChannelBuilder::new(
+            connection,
+            crate::test_task_group("pop-lag-refresh-channel"),
+        )
+        .addresses(local_addr, local_addr)
+        .build()
+        .expect("build test channel");
+        let ctx = Arc::new(ConnectionHandlerContextWrapper::new(channel));
+        Arc::new(PopRequest::new(
+            RemotingCommand::create_remoting_command(0),
+            ctx,
+            current_millis() + 60_000,
+            None,
+            None,
+        ))
+    }
+
+    async fn test_context() -> rocketmq_transport::api::v1::ConnectionHandlerContext {
+        test_pop_request().await.get_ctx().clone()
+    }
+
+    #[tokio::test]
+    async fn observed_wakeup_reports_processing_failure_exactly_once() {
+        let processor = Arc::new(FailingProcessor {
+            calls: AtomicUsize::new(0),
+        });
+        let service = test_service(&processor);
+        PopLongPollingService::start(&service).await;
+
+        let request = test_pop_request().await;
+        let completion = service.wake_up_with_completion(request);
+
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), completion)
+                .await
+                .expect("completion must be bounded")
+                .expect("completion sender must stay owned"),
+            PopWakeupOutcome::ProcessingFailed
+        );
+        assert_eq!(processor.calls.load(Ordering::Acquire), 1);
+
+        service.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn lag_refresh_force_wakes_a_filtered_suspended_request() {
+        let processor = Arc::new(FailingProcessor {
+            calls: AtomicUsize::new(0),
+        });
+        let service = test_service(&processor);
+        PopLongPollingService::start(&service).await;
+        let topic = CheetahString::from_static_str("lag-topic");
+        let group = CheetahString::from_static_str("lag-group");
+        let header = rocketmq_protocol::protocol::header::pop_message_request_header::PopMessageRequestHeader {
+            consumer_group: group.clone(),
+            topic: topic.clone(),
+            queue_id: -1,
+            max_msg_nums: 1,
+            invisible_time: 30_000,
+            poll_time: 60_000,
+            born_time: current_millis(),
+            init_mode: 0,
+            exp_type: None,
+            exp: None,
+            order: Some(false),
+            attempt_id: None,
+            topic_request_header: None,
+        };
+        let mut command = RemotingCommand::create_remoting_command(0);
+        assert_eq!(
+            service.polling(
+                test_context().await,
+                &mut command,
+                PollingHeader::new_from_pop_message_request_header(&header),
+                Some(rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData::default()),
+                Some(Arc::new(RejectAllFilter)),
+            ),
+            crate::long_polling::polling_result::PollingResult::PollingSuc
+        );
+
+        assert!(!service.notify_message_arriving(&topic, -1, &group, None, 0, None, None));
+        let completion = service
+            .notify_message_arriving_before_lag(&topic, &group)
+            .expect("forced lag refresh should claim the suspended request");
+        assert_eq!(
+            completion.await.expect("completion sender must stay owned"),
+            PopWakeupOutcome::ProcessingFailed
+        );
+        assert_eq!(processor.calls.load(Ordering::Acquire), 1);
+
+        service.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn observed_wakeup_completes_after_processing_and_rejects_duplicate_claim() {
+        let processor = Arc::new(ControlledProcessor {
+            calls: AtomicUsize::new(0),
+            started: Notify::new(),
+            release: Notify::new(),
+        });
+        let service = test_service(&processor);
+        PopLongPollingService::start(&service).await;
+        let request = test_pop_request().await;
+
+        let mut first = service.wake_up_with_completion(Arc::clone(&request));
+        processor.started.notified().await;
+        assert_eq!(first.try_recv(), Err(tokio::sync::oneshot::error::TryRecvError::Empty));
+
+        let duplicate = service.wake_up_with_completion(request);
+        assert_eq!(
+            duplicate.await.expect("duplicate completion must be reported"),
+            PopWakeupOutcome::AlreadyCompleted
+        );
+
+        processor.release.notify_one();
+        assert_eq!(
+            first.await.expect("processing completion must be reported"),
+            PopWakeupOutcome::ProcessingCompleted
+        );
+        assert_eq!(processor.calls.load(Ordering::Acquire), 1);
+        service.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn observed_wakeup_reports_inactive_channel_without_processing() {
+        let processor = Arc::new(FailingProcessor {
+            calls: AtomicUsize::new(0),
+        });
+        let service = test_service(&processor);
+        PopLongPollingService::start(&service).await;
+        let request = test_pop_request().await;
+        request.get_channel().connection_ref().close();
+
+        let completion = service.wake_up_with_completion(request);
+
+        assert_eq!(
+            completion.await.expect("inactive channel must be reported"),
+            PopWakeupOutcome::InactiveChannel
+        );
+        assert_eq!(processor.calls.load(Ordering::Acquire), 0);
+        service.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn observed_wakeup_reports_service_cancellation() {
+        let processor = Arc::new(ControlledProcessor {
+            calls: AtomicUsize::new(0),
+            started: Notify::new(),
+            release: Notify::new(),
+        });
+        let service = test_service(&processor);
+        PopLongPollingService::start(&service).await;
+        let request = test_pop_request().await;
+        let completion = service.wake_up_with_completion(request);
+        processor.started.notified().await;
+
+        let report = service
+            .task_group_for_test()
+            .expect("service task group must exist")
+            .shutdown_now();
+        assert!(report.aborted > 0);
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), completion)
+                .await
+                .expect("cancelled completion must be bounded")
+                .expect("completion observer must send cancellation"),
+            PopWakeupOutcome::ServiceCancelled
+        );
+        service.shutdown().await;
     }
 }

--- a/rocketmq-broker/src/metrics.rs
+++ b/rocketmq-broker/src/metrics.rs
@@ -15,6 +15,7 @@
 pub(crate) mod broker_metrics_constant;
 pub(crate) mod broker_metrics_manager;
 pub(crate) mod consumer_attr;
+pub(crate) mod consumer_lag_snapshot;
 pub(crate) mod invocation_status;
 pub(crate) mod pop_metrics_constant;
 pub(crate) mod pop_metrics_manager;

--- a/rocketmq-broker/src/metrics/consumer_lag_snapshot.rs
+++ b/rocketmq-broker/src/metrics/consumer_lag_snapshot.rs
@@ -1,0 +1,250 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use arc_swap::ArcSwap;
+use cheetah_string::CheetahString;
+use futures::future::join_all;
+use rocketmq_protocol::protocol::heartbeat::consume_type::ConsumeType;
+use rocketmq_store::BrokerReadWriteStore;
+use tokio::time::Instant;
+use tracing::warn;
+
+use crate::client::manager::consumer_manager::ConsumerManager;
+use crate::long_polling::long_polling_service::pop_long_polling_service::PopWakeupOutcome;
+use crate::offset::manager::consumer_offset_manager::ConsumerLagAdjustment;
+use crate::offset::manager::consumer_offset_manager::ConsumerLagAdjustments;
+use crate::offset::manager::consumer_offset_manager::ConsumerLagObservation;
+use crate::offset::manager::consumer_offset_manager::ConsumerLagTarget;
+use crate::offset::manager::consumer_offset_manager::ConsumerOffsetManager;
+use crate::processor::pop_message_processor::PopMessageProcessor;
+
+const POP_REFRESH_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub(crate) struct ConsumerLagSnapshotService<MS: BrokerReadWriteStore> {
+    offsets: Arc<ConsumerOffsetManager<MS>>,
+    consumers: ConsumerManager,
+    pop_processor: Arc<PopMessageProcessor<MS>>,
+    notify_before_pop_calculate_lag: bool,
+    refresh_timeout: Duration,
+    current: ArcSwap<Vec<ConsumerLagObservation>>,
+}
+
+impl<MS: BrokerReadWriteStore> ConsumerLagSnapshotService<MS> {
+    pub(crate) fn new(
+        offsets: Arc<ConsumerOffsetManager<MS>>,
+        consumers: ConsumerManager,
+        pop_processor: Arc<PopMessageProcessor<MS>>,
+        notify_before_pop_calculate_lag: bool,
+    ) -> Self {
+        Self {
+            offsets,
+            consumers,
+            pop_processor,
+            notify_before_pop_calculate_lag,
+            refresh_timeout: POP_REFRESH_TIMEOUT,
+            // Fail closed until the owned refresh task has sampled POP state.
+            current: ArcSwap::from_pointee(Vec::new()),
+        }
+    }
+
+    pub(crate) fn current(&self) -> Arc<Vec<ConsumerLagObservation>> {
+        self.current.load_full()
+    }
+
+    pub(crate) async fn refresh(&self) {
+        let pop_processor = &self.pop_processor;
+
+        let targets = self.offsets.consumer_lag_targets();
+        let pop_targets = targets
+            .iter()
+            .filter(|target| self.is_pop_consumer(target))
+            .collect::<Vec<_>>();
+        let mut failed_targets = HashSet::new();
+
+        if self.notify_before_pop_calculate_lag {
+            let completions = pop_targets.iter().filter_map(|target| {
+                pop_processor
+                    .notify_message_arriving_before_lag(&target.topic, &target.consumer_group)
+                    .map(|completion| (target.topic_group.clone(), completion))
+            });
+            failed_targets = await_pop_refreshes(completions.collect(), self.refresh_timeout).await;
+        }
+
+        let mut adjustments = ConsumerLagAdjustments::new();
+        for target in pop_targets {
+            let queue_adjustments = if failed_targets.contains(&target.topic_group) {
+                target
+                    .queue_offsets
+                    .iter()
+                    .map(|(queue_id, _)| {
+                        (
+                            *queue_id,
+                            ConsumerLagAdjustment {
+                                pull_offset: -1,
+                                inflight_messages: 0,
+                            },
+                        )
+                    })
+                    .collect::<HashMap<_, _>>()
+            } else {
+                let mut queue_adjustments = HashMap::with_capacity(target.queue_offsets.len());
+                for (queue_id, committed_offset) in &target.queue_offsets {
+                    if let Some(adjustment) = pop_processor
+                        .consumer_lag_adjustment(&target.topic, &target.consumer_group, *queue_id, *committed_offset)
+                        .await
+                    {
+                        queue_adjustments.insert(*queue_id, adjustment);
+                    }
+                }
+                queue_adjustments
+            };
+            if !queue_adjustments.is_empty() {
+                adjustments.insert(target.topic_group.clone(), queue_adjustments);
+            }
+        }
+
+        self.current.store(Arc::new(
+            self.offsets
+                .consumer_lag_snapshot_for_targets_with_adjustments(&targets, &adjustments),
+        ));
+    }
+
+    fn is_pop_consumer(&self, target: &ConsumerLagTarget) -> bool {
+        is_pop_consumer(&self.consumers, target)
+    }
+}
+
+fn is_pop_consumer(consumers: &ConsumerManager, target: &ConsumerLagTarget) -> bool {
+    consumers
+        .get_consumer_group_info_internal(&target.consumer_group, true)
+        .is_some_and(|info| info.get_consume_type() == ConsumeType::ConsumePop)
+}
+
+async fn await_pop_refreshes(
+    completions: Vec<(
+        CheetahString,
+        crate::long_polling::long_polling_service::pop_long_polling_service::PopWakeupCompletion,
+    )>,
+    timeout: Duration,
+) -> HashSet<CheetahString> {
+    let deadline = Instant::now() + timeout;
+    let completions = completions.into_iter().map(|(topic_group, completion)| async move {
+        let outcome = tokio::time::timeout_at(deadline, completion).await;
+        (topic_group, outcome)
+    });
+    let mut failed = HashSet::new();
+    for (topic_group, outcome) in join_all(completions).await {
+        match outcome {
+            Ok(Ok(PopWakeupOutcome::ProcessingCompleted)) => {}
+            Ok(Ok(other)) => {
+                warn!(?other, topic_group = %topic_group, "POP lag refresh wake-up did not complete");
+                failed.insert(topic_group);
+            }
+            Ok(Err(_)) => {
+                warn!(topic_group = %topic_group, "POP lag refresh completion sender was dropped");
+                failed.insert(topic_group);
+            }
+            Err(_) => {
+                warn!(topic_group = %topic_group, "POP lag refresh timed out");
+                failed.insert(topic_group);
+            }
+        }
+    }
+    failed
+}
+
+#[cfg(test)]
+mod tests {
+    use std::any::Any;
+    use std::sync::Arc;
+
+    use super::await_pop_refreshes;
+    use super::is_pop_consumer;
+    use crate::client::consumer_group_event::ConsumerGroupEvent;
+    use crate::client::consumer_ids_change_listener::ConsumerIdsChangeListener;
+    use crate::client::manager::consumer_manager::ConsumerManager;
+    use crate::long_polling::long_polling_service::pop_long_polling_service::PopWakeupOutcome;
+    use cheetah_string::CheetahString;
+    use rocketmq_protocol::protocol::heartbeat::consume_type::ConsumeType;
+    use rocketmq_protocol::protocol::heartbeat::message_model::MessageModel;
+
+    struct NoopListener;
+
+    impl ConsumerIdsChangeListener for NoopListener {
+        fn handle(&self, _event: ConsumerGroupEvent, _group: &str, _args: &[&dyn Any]) {}
+
+        fn shutdown(&self) {}
+    }
+
+    #[test]
+    fn pop_refresh_targets_only_pop_consumers() {
+        let consumers = ConsumerManager::new(Arc::new(NoopListener), 60_000);
+        let pop_group = CheetahString::from_static_str("pop-group");
+        let pull_group = CheetahString::from_static_str("pull-group");
+        consumers.compensate_basic_consumer_info(&pop_group, ConsumeType::ConsumePop, MessageModel::Clustering);
+        consumers.compensate_basic_consumer_info(&pull_group, ConsumeType::ConsumePassively, MessageModel::Clustering);
+        let pop_target = crate::offset::manager::consumer_offset_manager::ConsumerLagTarget {
+            topic_group: CheetahString::from_static_str("topic-a@pop-group"),
+            topic: CheetahString::from_static_str("topic-a"),
+            consumer_group: pop_group,
+            queue_offsets: vec![(0, 0)],
+        };
+        let pull_target = crate::offset::manager::consumer_offset_manager::ConsumerLagTarget {
+            topic_group: CheetahString::from_static_str("topic-a@pull-group"),
+            topic: CheetahString::from_static_str("topic-a"),
+            consumer_group: pull_group,
+            queue_offsets: vec![(0, 0)],
+        };
+
+        assert!(is_pop_consumer(&consumers, &pop_target));
+        assert!(!is_pop_consumer(&consumers, &pull_target));
+    }
+
+    #[tokio::test]
+    async fn pop_refresh_wait_is_bounded_and_marks_non_success_outcomes_failed() {
+        let (success_tx, success_rx) = tokio::sync::oneshot::channel();
+        success_tx
+            .send(PopWakeupOutcome::ProcessingCompleted)
+            .expect("send success completion");
+        let (failed_tx, failed_rx) = tokio::sync::oneshot::channel();
+        failed_tx
+            .send(PopWakeupOutcome::ProcessingFailed)
+            .expect("send failure completion");
+        let (timeout_tx, timeout_rx) = tokio::sync::oneshot::channel();
+
+        let failed = await_pop_refreshes(
+            vec![
+                (CheetahString::from_static_str("success"), success_rx),
+                (CheetahString::from_static_str("failed"), failed_rx),
+                (CheetahString::from_static_str("timeout"), timeout_rx),
+            ],
+            std::time::Duration::ZERO,
+        )
+        .await;
+        drop(timeout_tx);
+
+        assert_eq!(
+            failed,
+            std::collections::HashSet::from([
+                CheetahString::from_static_str("failed"),
+                CheetahString::from_static_str("timeout"),
+            ])
+        );
+    }
+}

--- a/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
+++ b/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
@@ -86,6 +86,22 @@ pub(crate) struct ConsumerLagObservation {
     pub(crate) lag_messages: i64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ConsumerLagAdjustment {
+    pub(crate) pull_offset: i64,
+    pub(crate) inflight_messages: i64,
+}
+
+pub(crate) type ConsumerLagAdjustments = HashMap<CheetahString, HashMap<i32, ConsumerLagAdjustment>>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ConsumerLagTarget {
+    pub(crate) topic_group: CheetahString,
+    pub(crate) topic: CheetahString,
+    pub(crate) consumer_group: CheetahString,
+    pub(crate) queue_offsets: Vec<(i32, i64)>,
+}
+
 pub(crate) struct ConsumerOffsetManager<MS: BrokerReadStore> {
     broker_config: Arc<BrokerConfig>,
     message_store_config: Arc<MessageStoreConfig>,
@@ -519,12 +535,43 @@ where
         self.consumer_offset_wrapper.offset_table.read().len()
     }
 
-    pub(crate) fn consumer_lag_snapshot(&self) -> Vec<ConsumerLagObservation> {
+    pub(crate) fn consumer_lag_targets(&self) -> Vec<ConsumerLagTarget> {
+        self.consumer_lag_targets_with_limit(self.broker_config.metrics_cardinality_limit)
+    }
+
+    fn consumer_lag_targets_with_limit(&self, limit: usize) -> Vec<ConsumerLagTarget> {
+        let mut targets = self
+            .offset_table_snapshot()
+            .into_iter()
+            .filter_map(|(topic_group, offsets)| {
+                let (topic, consumer_group) = split_topic_group_key(&topic_group)?;
+                let mut queue_offsets = offsets.into_iter().collect::<Vec<_>>();
+                queue_offsets.sort_unstable_by_key(|(queue_id, _)| *queue_id);
+                Some(ConsumerLagTarget {
+                    topic_group: topic_group.clone(),
+                    topic: CheetahString::from_slice(topic),
+                    consumer_group: CheetahString::from_slice(consumer_group),
+                    queue_offsets,
+                })
+            })
+            .collect::<Vec<_>>();
+        targets.sort_unstable_by(|left, right| {
+            (&left.topic, &left.consumer_group).cmp(&(&right.topic, &right.consumer_group))
+        });
+        targets.truncate(limit);
+        targets
+    }
+
+    pub(crate) fn consumer_lag_snapshot_for_targets_with_adjustments(
+        &self,
+        targets: &[ConsumerLagTarget],
+        adjustments: &ConsumerLagAdjustments,
+    ) -> Vec<ConsumerLagObservation> {
         let Some(message_store) = self.message_store.provider() else {
             return Vec::new();
         };
 
-        self.consumer_lag_snapshot_with(self.broker_config.metrics_cardinality_limit, |topic, queue_id| {
+        self.consumer_lag_snapshot_for_targets_with(targets, adjustments, |topic, queue_id| {
             message_store.get_max_offset_from_local_store(topic, queue_id).ok()
         })
     }
@@ -533,42 +580,51 @@ where
     where
         F: FnMut(&CheetahString, i32) -> Option<i64>,
     {
-        let mut entries = self
-            .offset_table_snapshot()
-            .into_iter()
-            .filter_map(|(topic_group, offsets)| {
-                let (topic, group) = split_topic_group_key(&topic_group)?;
-                Some((topic.to_owned(), group.to_owned(), offsets))
-            })
-            .collect::<Vec<_>>();
-        entries.sort_unstable_by(|left, right| (&left.0, &left.1).cmp(&(&right.0, &right.1)));
+        self.consumer_lag_snapshot_for_targets_with(
+            &self.consumer_lag_targets_with_limit(limit),
+            &ConsumerLagAdjustments::new(),
+            &mut max_offset,
+        )
+    }
 
-        entries
-            .into_iter()
-            .take(limit)
-            .filter_map(|(topic, consumer_group, offsets)| {
-                if offsets.is_empty() {
+    fn consumer_lag_snapshot_for_targets_with<F>(
+        &self,
+        targets: &[ConsumerLagTarget],
+        adjustments: &ConsumerLagAdjustments,
+        mut max_offset: F,
+    ) -> Vec<ConsumerLagObservation>
+    where
+        F: FnMut(&CheetahString, i32) -> Option<i64>,
+    {
+        targets
+            .iter()
+            .filter_map(|target| {
+                if target.queue_offsets.is_empty() {
                     return None;
                 }
 
-                let topic_key = CheetahString::from_slice(&topic);
-                let mut queue_offsets = offsets.into_iter().collect::<Vec<_>>();
-                queue_offsets.sort_unstable_by_key(|(queue_id, _)| *queue_id);
                 let mut lag_messages = 0i64;
-                for (queue_id, consumer_offset) in queue_offsets {
-                    if consumer_offset < 0 {
+                for (queue_id, committed_offset) in &target.queue_offsets {
+                    let adjustment = adjustments
+                        .get(&target.topic_group)
+                        .and_then(|queue_adjustments| queue_adjustments.get(queue_id));
+                    let consumer_offset = adjustment.map_or(*committed_offset, |value| value.pull_offset);
+                    let inflight_messages = adjustment.map_or(0, |value| value.inflight_messages);
+                    if consumer_offset < 0 || inflight_messages < 0 {
                         return None;
                     }
-                    let queue_max_offset = max_offset(&topic_key, queue_id)?;
+                    let queue_max_offset = max_offset(&target.topic, *queue_id)?;
                     if queue_max_offset < 0 {
                         return None;
                     }
-                    lag_messages = lag_messages.saturating_add(queue_max_offset.saturating_sub(consumer_offset).max(0));
+                    lag_messages = lag_messages
+                        .saturating_add(queue_max_offset.saturating_sub(consumer_offset).max(0))
+                        .saturating_add(inflight_messages);
                 }
 
                 Some(ConsumerLagObservation {
-                    topic,
-                    consumer_group,
+                    topic: target.topic.to_string(),
+                    consumer_group: target.consumer_group.to_string(),
                     lag_messages,
                 })
             })
@@ -1225,6 +1281,40 @@ mod tests {
             (topic.as_str() != "topic-c" || queue_id == 0).then_some(10)
         });
         assert!(fail_closed.iter().all(|observation| observation.topic != "topic-c"));
+    }
+
+    #[test]
+    fn consumer_lag_snapshot_applies_pop_pull_offset_and_inflight_messages() {
+        let manager = new_manager();
+        manager.consumer_offset_wrapper.offset_table.write().insert(
+            CheetahString::from_static_str("topic-a@group-a"),
+            HashMap::from([(0, 10)]),
+        );
+        let adjustments = super::ConsumerLagAdjustments::from([(
+            CheetahString::from_static_str("topic-a@group-a"),
+            HashMap::from([(
+                0,
+                super::ConsumerLagAdjustment {
+                    pull_offset: 18,
+                    inflight_messages: 3,
+                },
+            )]),
+        )]);
+
+        let observations = manager.consumer_lag_snapshot_for_targets_with(
+            &manager.consumer_lag_targets_with_limit(1),
+            &adjustments,
+            |_topic, _queue_id| Some(20),
+        );
+
+        assert_eq!(
+            observations,
+            vec![super::ConsumerLagObservation {
+                topic: "topic-a".to_owned(),
+                consumer_group: "group-a".to_owned(),
+                lag_messages: 5,
+            }]
+        );
     }
 
     #[test]

--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -83,8 +83,10 @@ use crate::long_polling::long_polling_service::pop_long_polling_service::Polling
 use crate::long_polling::long_polling_service::pop_long_polling_service::PopLongPollingRequestProcessor;
 use crate::long_polling::long_polling_service::pop_long_polling_service::PopLongPollingService;
 use crate::long_polling::long_polling_service::pop_long_polling_service::PopLongPollingServiceContext;
+use crate::long_polling::long_polling_service::pop_long_polling_service::PopWakeupCompletion;
 use crate::long_polling::polling_header::PollingHeader;
 use crate::long_polling::polling_result::PollingResult;
+use crate::offset::manager::consumer_offset_manager::ConsumerLagAdjustment;
 #[cfg(feature = "rocksdb_store")]
 use crate::pop::rocksdb_store::pop_rocksdb_path;
 #[cfg(feature = "rocksdb_store")]
@@ -1369,6 +1371,45 @@ where
     pub(crate) fn polling_count_provider(&self) -> Weak<dyn PollingCountProvider> {
         let provider: Arc<dyn PollingCountProvider> = self.pop_long_polling_service.clone();
         Arc::downgrade(&provider)
+    }
+
+    pub(crate) fn notify_message_arriving_before_lag(
+        &self,
+        topic: &CheetahString,
+        consumer_group: &CheetahString,
+    ) -> Option<PopWakeupCompletion> {
+        self.pop_long_polling_service
+            .notify_message_arriving_before_lag(topic, consumer_group)
+    }
+
+    pub(crate) async fn consumer_lag_adjustment(
+        &self,
+        topic: &CheetahString,
+        consumer_group: &CheetahString,
+        queue_id: i32,
+        committed_offset: i64,
+    ) -> Option<ConsumerLagAdjustment> {
+        if self.context.policy.snapshot().pop_consumer_kv_service_enable {
+            return None;
+        }
+
+        let buffered_offset = self
+            .pop_buffer_merge_service
+            .get_latest_offset_full(topic, consumer_group, queue_id)
+            .await;
+        let pull_offset = if buffered_offset >= 0 {
+            buffered_offset
+        } else {
+            committed_offset
+        };
+        Some(ConsumerLagAdjustment {
+            pull_offset,
+            inflight_messages: self.context.inflight.get_group_pop_in_flight_message_num(
+                topic,
+                consumer_group,
+                queue_id,
+            ),
+        })
     }
 
     pub fn notify_message_arriving(&self, topic: &CheetahString, queue_id: i32, cid: &CheetahString) {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)
- Fixes #9320

### Brief Description

Refresh POP processing state before publishing Broker consumer-lag metrics without adding transient callback state to the wire-level `RemotingCommand`.

- force-wake an eligible suspended POP request and report its processing outcome exactly once through an owned oneshot completion;
- refresh an immutable consumer-lag snapshot on the Broker scheduled-task lifecycle so the synchronous OpenTelemetry gauge stays non-blocking;
- apply the POP buffer pull offset and in-flight message count using the Java lag formula;
- bound completion waits to ten seconds and omit failed or timed-out POP targets instead of publishing stale committed-offset samples;
- preserve ordinary notification filtering and avoid an additional full offset-table copy per refresh.

### How Did You Test This Change?

- `cargo test -p rocketmq-broker --lib observed_wakeup -- --nocapture`
- `cargo test -p rocketmq-broker --lib lag_refresh_force_wakes_a_filtered_suspended_request -- --nocapture`
- `cargo test -p rocketmq-broker --lib pop_refresh_ -- --nocapture`
- `cargo test -p rocketmq-broker --lib consumer_lag_snapshot_ -- --nocapture`
- `cargo test -p rocketmq-broker --lib default_broker_config_uses_java_pop_kv_defaults -- --nocapture`
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings`
- seven scoped Broker/rocketmq-observability check, Clippy, and test feature combinations from the CI observability matrix
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`
- `./scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`

The full Broker library suite completed with 792 passed, 3 failed, and 2 ignored. One shutdown timing test passed when rerun alone. The two deterministic failures are unchanged on `origin/main`: an existing source-guard assertion in `default_pull_message_result_handler.rs` and an `extended_timeline` capability assertion executed without that feature. The focused tests and all changed-scope gates passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added periodic consumer lag snapshots for pull and POP consumers.
  * Consumer lag metrics now account for in-flight and recently received messages for more accurate reporting.
  * Added optional notifications to refresh POP consumer lag before calculations.
  * Added the `enableNotifyBeforePopCalculateLag` broker setting, enabled by default.
* **Bug Fixes**
  * Improved handling of delayed, failed, cancelled, or unavailable POP requests during lag refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->