### PR TITLE
[ISSUE #9323]🐛Mark broker processor replies as response commands

### DIFF
--- a/rocketmq-broker/src/processor/end_transaction_processor.rs
+++ b/rocketmq-broker/src/processor/end_transaction_processor.rs
@@ -421,9 +421,7 @@ where
             OperationResult::default()
         };
 
-        Ok(Some(
-            RemotingCommand::create_remoting_command(response_code).set_remark_option(response_remark),
-        ))
+        Ok(Some(final_end_transaction_response(response_code, response_remark)))
     }
 
     pub fn reject_commit_or_rollback(&self, from_transaction_check: bool, message_ext: &MessageExt) -> bool {
@@ -514,6 +512,10 @@ where
 fn message_store_unavailable_response() -> RemotingCommand {
     RemotingCommand::create_response_command_with_code(ResponseCode::ServiceNotAvailable)
         .set_remark("Message store is unavailable now.")
+}
+
+fn final_end_transaction_response(response_code: ResponseCode, response_remark: Option<String>) -> RemotingCommand {
+    RemotingCommand::create_response_command_with_code(response_code).set_remark_option(response_remark)
 }
 
 fn build_put_message_response(
@@ -651,7 +653,31 @@ fn end_message_transaction(msg_ext: &mut MessageExt) -> MessageExtBrokerInner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rocketmq_protocol::protocol::SerializeType;
     use rocketmq_store::StorePorts;
+
+    #[test]
+    fn final_end_transaction_reply_preserves_error_semantics_on_both_wire_formats() {
+        for serialize_type in [SerializeType::JSON, SerializeType::ROCKETMQ] {
+            let mut response =
+                final_end_transaction_response(ResponseCode::SystemError, Some("transaction failed".to_owned()))
+                    .set_serialize_type(serialize_type);
+            assert_eq!(ResponseCode::from(response.code()), ResponseCode::SystemError);
+            assert_eq!(response.remark().map(CheetahString::as_str), Some("transaction failed"));
+            assert!(response.is_response_type());
+
+            let mut encoded = bytes::BytesMut::new();
+            response
+                .try_fast_header_encode(&mut encoded)
+                .expect("end-transaction response should encode");
+            let decoded = RemotingCommand::decode(&mut encoded)
+                .expect("end-transaction response should decode")
+                .expect("encoded response should contain one frame");
+            assert_eq!(ResponseCode::from(decoded.code()), ResponseCode::SystemError);
+            assert_eq!(decoded.remark().map(CheetahString::as_str), Some("transaction failed"));
+            assert!(decoded.is_response_type());
+        }
+    }
 
     #[test]
     fn end_message_transaction_with_valid_message() {

--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -1500,7 +1500,7 @@ where
 
         // Early return: no retry queues configured
         if subscription_group_config.retry_queue_nums() <= 0 {
-            return Ok(Some(RemotingCommand::create_remoting_command(ResponseCode::Success)));
+            return Ok(Some(no_retry_queue_response()));
         }
         let mut new_topic = CheetahString::from_string(mix_all::get_retry_topic(request_header.group.as_str()));
         let mut queue_id_int = rand::rng().random_range(0..subscription_group_config.retry_queue_nums());
@@ -1991,6 +1991,10 @@ fn message_store_not_initialized() -> RocketMQError {
     RocketMQError::not_initialized("message_store")
 }
 
+fn no_retry_queue_response() -> RemotingCommand {
+    RemotingCommand::create_success_response_command()
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -2029,9 +2033,29 @@ mod tests {
     use super::map_store_api_error;
     use super::message_body_limit_violation;
     use super::message_store_not_initialized;
+    use super::no_retry_queue_response;
     use super::store_health_reject_remark;
     use super::store_health_reject_remark_from;
     use super::sync_flush_backlog_reject_remark;
+
+    #[test]
+    fn zero_retry_queue_reply_is_a_response_on_both_wire_formats() {
+        for serialize_type in [SerializeType::JSON, SerializeType::ROCKETMQ] {
+            let mut response = no_retry_queue_response().set_serialize_type(serialize_type);
+            assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+            assert!(response.is_response_type());
+
+            let mut encoded = bytes::BytesMut::new();
+            response
+                .try_fast_header_encode(&mut encoded)
+                .expect("zero-retry response should encode");
+            let decoded = RemotingCommand::decode(&mut encoded)
+                .expect("zero-retry response should decode")
+                .expect("encoded response should contain one frame");
+            assert_eq!(ResponseCode::from(decoded.code()), ResponseCode::Success);
+            assert!(decoded.is_response_type());
+        }
+    }
 
     #[test]
     fn send_response_keeps_region_and_trace_fields() {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)
- Fixes #9323

### Brief Description

Mark the two remaining Broker processor replies that used the base request constructor as explicit response commands.

- the zero-retry-queue consumer send-back branch now returns an explicit success response;
- the final end-transaction result now preserves its code and optional remark through an explicit coded response;
- focused tests verify code, remark, response-type flag, and JSON/ROCKETMQ round trips.

The base `create_remoting_command` request semantics and transport-wide response handling remain unchanged.

### How Did You Test This Change?

- `cargo test -p rocketmq-broker --lib zero_retry_queue_reply_is_a_response_on_both_wire_formats -- --nocapture`
- `cargo test -p rocketmq-broker --lib final_end_transaction_reply_preserves_error_semantics_on_both_wire_formats -- --nocapture`
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`
- root workspace formatting checked package-by-package because `cargo fmt --all -- --check` exceeds the Windows command-line length limit (OS error 206)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-transaction responses so error codes, messages, and response formatting remain consistent.
  * Fixed consumer send-back requests for subscription groups without retry queues to return a successful response.
  * Added coverage to verify response behavior across supported JSON and RocketMQ wire formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->