### PR TITLE
[ISSUE #9327]🐛Stabilize broker source contracts and Controller learner promotion

### DIFF
--- a/rocketmq-broker/src/processor/pull_message_processor.rs
+++ b/rocketmq-broker/src/processor/pull_message_processor.rs
@@ -1691,7 +1691,10 @@ mod tests {
             .split("#[cfg(test)]")
             .next()
             .expect("production processor source");
-        let result_handler = include_str!("default_pull_message_result_handler.rs");
+        let result_handler = include_str!("default_pull_message_result_handler.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production result handler source");
 
         assert!(!processor.contains(concat!("WAKEUP_WRITE_", "LOCK_SHARDS")));
         assert!(!processor.contains("wakeup_write_locks"));

--- a/rocketmq-broker/tests/broker_runtime/unit.rs
+++ b/rocketmq-broker/tests/broker_runtime/unit.rs
@@ -1992,6 +1992,33 @@ where
     }
 }
 
+async fn wait_for_controller_learner_to_reach_committed_frontier(
+    manager: &TestControllerManager,
+    node_id: u64,
+    timeout: Duration,
+) -> u64 {
+    let start = std::time::Instant::now();
+    loop {
+        let membership = manager
+            .raft()
+            .consensus_membership()
+            .await
+            .expect("read controller membership while waiting for learner replication");
+        if membership.caught_up().contains(&node_id) {
+            return membership.version();
+        }
+        if start.elapsed() >= timeout {
+            panic!(
+                "Timed out waiting for controller learner {node_id} to reach the committed log frontier; \
+                 membership_version={}, caught_up={:?}",
+                membership.version(),
+                membership.caught_up()
+            );
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+}
+
 async fn wait_for_tcp_listener(addr: std::net::SocketAddr, context: &str) {
     wait_until(
         Duration::from_secs(5),
@@ -2203,14 +2230,15 @@ async fn start_controller_cluster(base_port: u16, root: &Path) -> (Vec<Arc<TestC
     }
 
     for controller_peer in controller_peers.iter().skip(1) {
-        let membership = bootstrap_manager
-            .raft()
-            .consensus_membership()
-            .await
-            .expect("read controller membership before promotion");
+        let membership_version = wait_for_controller_learner_to_reach_committed_frontier(
+            bootstrap_manager.as_ref(),
+            controller_peer.id,
+            Duration::from_secs(20),
+        )
+        .await;
         let request = MembershipChangeRequest::new(
             format!("broker-runtime-promote-controller-voter-{}", controller_peer.id),
-            membership.version(),
+            membership_version,
             MembershipChange::PromoteVoter {
                 node_id: controller_peer.id,
             },


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9327

### Brief Description

- Restrict the pull processor dependency contract to production source so test-only imports do not produce false violations.
- Wait for each Controller learner to reach the latest committed log frontier before requesting voter promotion.
- Preserve the production membership safety check and make the broker integration bootstrap honor its readiness contract explicitly.

### How Did You Test This Change?

Passed:

- `cargo test -p rocketmq-broker --lib processor::pull_message_processor::tests::pull_processors_depend_only_on_explicit_context -- --exact`
- `cargo test -p rocketmq-broker --lib broker_runtime::tests::three_controller_two_broker_controller_mode_failover -- --nocapture`
- `cargo fmt -p rocketmq-broker -- --check`
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `git diff --check`

The full `cargo test -p rocketmq-broker --lib` run passed all three failures reported by this issue. It completed with 795 passed, 2 ignored, and 2 unrelated failures: an extended timer capability counter assertion and a Windows Controller shutdown deadline.

The required root `cargo fmt --all -- --check` remains blocked on Windows by the pre-existing OS 206 aggregate command-line limit. The affected package format check passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved controller membership updates to ensure learner promotion uses the latest committed membership state.
  - Added safeguards that wait for membership changes to be fully visible before proceeding, improving test and runtime reliability.

- **Tests**
  - Enhanced validation around membership synchronization and learner promotion.
  - Refined dependency checks to focus on production behavior and avoid false positives from test-only code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->