### PR TITLE
[ISSUE #9329]🐛Fix client Clippy without DNS discovery

### DIFF
--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -833,11 +833,11 @@ impl MQClientInstance {
 
         #[cfg(not(feature = "nameserver-dns-discovery"))]
         {
-            return Err(RocketMQError::ConfigInvalidValue {
+            Err(RocketMQError::ConfigInvalidValue {
                 key: "nameserver_discovery.dns",
                 value: "enabled".to_string(),
                 reason: "requires the nameserver-dns-discovery Cargo feature".to_string(),
-            });
+            })
         }
 
         #[cfg(feature = "nameserver-dns-discovery")]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9329

### Brief Description

Use the feature-disabled DNS discovery error as the block's tail expression. This removes `clippy::needless_return` when `nameserver-dns-discovery` is disabled while preserving the existing `ConfigInvalidValue` behavior.

### How Did You Test This Change?

Passed:

- `cargo fmt -p rocketmq-client-rust -- --check`
- `cargo clippy -p rocketmq-client-rust --all-targets -- -D warnings`
- `cargo clippy -p rocketmq-client-rust --all-targets --features nameserver-dns-discovery -- -D warnings`
- `cargo clippy -p rocketmq-client-rust --all-targets --all-features -- -D warnings`
- `cargo test -p rocketmq-client-rust --test client_runtime_ownership typed_dns_discovery_requires_its_opt_in_feature_before_client_start -- --exact`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo fmt -p rocketmq-example -- --check`
- `cargo clippy --all-targets -- -D warnings` from `rocketmq-example`
- The required SRE format check, `cargo check --locked --workspace`, strict Clippy, docs, source layout check, and execution dependency boundary check
- `git diff --check`

The SRE all-features test run compiled the client successfully but stopped on two unrelated Windows `STATUS_STACK_OVERFLOW` failures in connector engine tests.

The root and example `cargo fmt --all -- --check` commands remain blocked on Windows by the pre-existing OS 206 aggregate command-line limit. The affected packages pass package-scoped format checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal error handling for nameserver discovery without changing runtime behavior or error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->