### PR TITLE
[ISSUE #9326]♻️Inject remoting command factories into client owners

### DIFF
--- a/rocketmq-client/src/base/client_options.rs
+++ b/rocketmq-client/src/base/client_options.rs
@@ -15,6 +15,7 @@
 use cheetah_string::CheetahString;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 
 use super::client_config::ClientConfig;
 use crate::nameserver_discovery::NameServerDiscoveryConfig;
@@ -24,6 +25,7 @@ use crate::nameserver_discovery::NameServerDiscoveryConfig;
 pub struct ClientOptions {
     client: ClientConfig,
     nameserver_discovery: Option<NameServerDiscoveryConfig>,
+    remoting_command_factory: Option<RemotingCommandFactory>,
 }
 
 impl ClientOptions {
@@ -33,6 +35,7 @@ impl ClientOptions {
         Self {
             client,
             nameserver_discovery: None,
+            remoting_command_factory: None,
         }
     }
 
@@ -40,6 +43,13 @@ impl ClientOptions {
     #[must_use]
     pub fn with_nameserver_discovery(mut self, discovery: NameServerDiscoveryConfig) -> Self {
         self.nameserver_discovery = Some(discovery);
+        self
+    }
+
+    /// Overrides the runtime's remoting command factory for this client owner.
+    #[must_use]
+    pub fn with_remoting_command_factory(mut self, factory: RemotingCommandFactory) -> Self {
+        self.remoting_command_factory = Some(factory);
         self
     }
 
@@ -55,17 +65,31 @@ impl ClientOptions {
         self.nameserver_discovery.as_ref()
     }
 
+    /// Returns the explicitly configured command factory, if present.
+    #[must_use]
+    pub fn remoting_command_factory(&self) -> Option<RemotingCommandFactory> {
+        self.remoting_command_factory
+    }
+
     pub(crate) fn from_parts(client: ClientConfig, nameserver_discovery: Option<NameServerDiscoveryConfig>) -> Self {
         Self {
             client,
             nameserver_discovery,
+            remoting_command_factory: None,
         }
     }
 
-    pub(crate) fn into_normalized_parts(mut self) -> RocketMQResult<(ClientConfig, Option<NameServerDiscoveryConfig>)> {
+    pub(crate) fn into_normalized_parts(
+        mut self,
+    ) -> RocketMQResult<(
+        ClientConfig,
+        Option<NameServerDiscoveryConfig>,
+        Option<RemotingCommandFactory>,
+    )> {
+        let remoting_command_factory = self.remoting_command_factory;
         let Some(discovery) = self.nameserver_discovery else {
             self.client.normalize_namesrv_addr()?;
-            return Ok((self.client, None));
+            return Ok((self.client, None, remoting_command_factory));
         };
 
         if let Some(legacy) = self.client.namesrv_addr.as_ref() {
@@ -79,7 +103,7 @@ impl ClientOptions {
         if let Some(canonical) = discovery.static_canonical() {
             self.client.namesrv_addr = Some(CheetahString::from_string(canonical));
         }
-        Ok((self.client, Some(discovery)))
+        Ok((self.client, Some(discovery), remoting_command_factory))
     }
 }
 

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -59,6 +59,8 @@ use rocketmq_protocol::protocol::heartbeat::heartbeat_data::HeartbeatData;
 use rocketmq_protocol::protocol::heartbeat::message_model::MessageModel;
 use rocketmq_protocol::protocol::heartbeat::producer_data::ProducerData;
 use rocketmq_protocol::protocol::namespace_util::NamespaceUtil;
+use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 use rocketmq_protocol::protocol::route::route_data_view::BrokerData;
 use rocketmq_protocol::protocol::route::topic_route_data::TopicRouteData;
 use rocketmq_protocol::protocol::route_facade::BrokerDataExt;
@@ -199,6 +201,7 @@ pub struct MQClientInstance {
     telemetry_handle: TelemetryHandle,
     client_metrics: ClientMetrics,
     request_future_holder: Arc<RequestFutureHolder>,
+    remoting_command_factory: RemotingCommandFactory,
     pub(crate) client_config: Arc<ClientConfig>,
     nameserver_discovery_config: Option<NameServerDiscoveryConfig>,
     nameserver_discovery_supervisor: Mutex<Option<Arc<NameServerDiscoverySupervisor>>>,
@@ -296,6 +299,33 @@ impl MQClientInstance {
         telemetry_handle: TelemetryHandle,
         request_future_holder: Arc<RequestFutureHolder>,
     ) -> Arc<MQClientInstance> {
+        Self::new_arc_with_remoting_command_factory(
+            client_config,
+            application_remoting_command_factory(),
+            instance_generation,
+            client_id,
+            rpc_hook,
+            service_context,
+            telemetry_handle,
+            request_future_holder,
+        )
+    }
+
+    /// Creates a client instance with explicitly owned remoting wire defaults.
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "the compatibility constructor keeps the existing lifecycle dependencies explicit"
+    )]
+    pub(crate) fn new_arc_with_remoting_command_factory(
+        client_config: ClientConfig,
+        remoting_command_factory: RemotingCommandFactory,
+        instance_generation: u64,
+        client_id: impl Into<CheetahString>,
+        rpc_hook: Option<Arc<dyn RPCHook>>,
+        service_context: ChildServiceContext,
+        telemetry_handle: TelemetryHandle,
+        request_future_holder: Arc<RequestFutureHolder>,
+    ) -> Arc<MQClientInstance> {
         let resource_budget = crate::runtime::build_client_resource_budget(
             &crate::runtime::ClientRuntimeConfig::default(),
             &service_context.process_budget(),
@@ -304,6 +334,7 @@ impl MQClientInstance {
         let client_metrics = ClientMetrics::from_handle(&telemetry_handle);
         Self::new_arc_with_resource_budget(
             client_config,
+            remoting_command_factory,
             instance_generation,
             client_id,
             rpc_hook,
@@ -317,6 +348,7 @@ impl MQClientInstance {
 
     pub(crate) fn new_arc_with_resource_budget(
         client_config: ClientConfig,
+        remoting_command_factory: RemotingCommandFactory,
         instance_generation: u64,
         client_id: impl Into<CheetahString>,
         rpc_hook: Option<Arc<dyn RPCHook>>,
@@ -329,6 +361,7 @@ impl MQClientInstance {
         Self::new_arc_with_resource_budget_and_discovery(
             client_config,
             None,
+            remoting_command_factory,
             instance_generation,
             client_id,
             rpc_hook,
@@ -343,6 +376,7 @@ impl MQClientInstance {
     pub(crate) fn new_arc_with_resource_budget_and_discovery(
         client_config: ClientConfig,
         nameserver_discovery_config: Option<NameServerDiscoveryConfig>,
+        remoting_command_factory: RemotingCommandFactory,
         _instance_generation: u64,
         client_id: impl Into<CheetahString>,
         rpc_hook: Option<Arc<dyn RPCHook>>,
@@ -395,6 +429,7 @@ impl MQClientInstance {
             telemetry_handle,
             client_metrics,
             request_future_holder,
+            remoting_command_factory,
             client_config: shared_config,
             nameserver_discovery_config,
             nameserver_discovery_supervisor: Mutex::new(None),
@@ -454,6 +489,7 @@ impl MQClientInstance {
             Some(tx),
             service_context.component("remoting"),
             instance.telemetry_handle.clone(),
+            remoting_command_factory,
         ));
 
         if let Some(namesrv_addr) = client_config.get_namesrv_addr().as_deref() {
@@ -479,6 +515,10 @@ impl MQClientInstance {
 
     pub fn service_context(&self) -> &ChildServiceContext {
         &self.service_context
+    }
+
+    pub(crate) fn remoting_command_factory(&self) -> RemotingCommandFactory {
+        self.remoting_command_factory
     }
 
     pub(crate) fn resource_budget(&self) -> ResourceBudget {

--- a/rocketmq-client/src/implementation/client_remoting_processor.rs
+++ b/rocketmq-client/src/implementation/client_remoting_processor.rs
@@ -40,6 +40,7 @@ use rocketmq_protocol::protocol::header::reply_message_request_header::ReplyMess
 use rocketmq_protocol::protocol::header::reset_offset_request_header::ResetOffsetRequestHeader;
 use rocketmq_protocol::protocol::namespace_util::NamespaceUtil;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 use rocketmq_protocol::protocol::RemotingSerializable;
 use rocketmq_runtime::common::time_utils::current_millis;
 use rocketmq_transport::api::v1::Channel;
@@ -57,6 +58,7 @@ use crate::producer::request_future_holder::RequestFutureHolder;
 pub struct ClientRemotingProcessor {
     client_instance: Weak<MQClientInstance>,
     request_future_holder: Arc<RequestFutureHolder>,
+    remoting_command_factory: RemotingCommandFactory,
 }
 
 impl ClientRemotingProcessor {
@@ -64,6 +66,7 @@ impl ClientRemotingProcessor {
         Self {
             client_instance: Arc::downgrade(client_instance),
             request_future_holder: client_instance.request_future_holder(),
+            remoting_command_factory: client_instance.remoting_command_factory(),
         }
     }
 
@@ -159,7 +162,10 @@ impl ClientRemotingProcessor {
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         let receive_time = current_millis();
-        let response = RemotingCommand::create_java_default_error_response_command().set_opaque(request.opaque());
+        let response = self
+            .remoting_command_factory
+            .create_java_default_error_response_command()
+            .set_opaque(request.opaque());
         let request_header = match request.decode_command_custom_header::<ReplyMessageRequestHeader>() {
             Ok(header) => header,
             Err(error) => {
@@ -241,7 +247,9 @@ impl ClientRemotingProcessor {
         debug!("Receive reply message: {:?}", msg);
         self.process_reply_message(msg).await;
         Ok(Some(
-            RemotingCommand::create_success_response_command().set_opaque(request.opaque()),
+            self.remoting_command_factory
+                .create_success_response_command()
+                .set_opaque(request.opaque()),
         ))
     }
 
@@ -348,7 +356,10 @@ impl ClientRemotingProcessor {
         &mut self,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let response = RemotingCommand::create_java_default_error_response_command().set_opaque(request.opaque());
+        let response = self
+            .remoting_command_factory
+            .create_java_default_error_response_command()
+            .set_opaque(request.opaque());
         let request_header = match request.decode_command_custom_header::<GetConsumerStatusRequestHeader>() {
             Ok(header) => header,
             Err(error) => {
@@ -368,7 +379,8 @@ impl ClientRemotingProcessor {
                 let mut body = GetConsumerStatusBody::new();
                 body.message_queue_table = message_queue_table;
                 Ok(Some(
-                    RemotingCommand::create_success_response_command()
+                    self.remoting_command_factory
+                        .create_success_response_command()
                         .set_opaque(request.opaque())
                         .set_body(body.encode()),
                 ))
@@ -380,7 +392,8 @@ impl ClientRemotingProcessor {
                     request_header.group
                 );
                 Ok(Some(
-                    RemotingCommand::create_success_response_command()
+                    self.remoting_command_factory
+                        .create_success_response_command()
                         .set_opaque(request.opaque())
                         .set_body(GetConsumerStatusBody::new().encode()),
                 ))
@@ -392,7 +405,10 @@ impl ClientRemotingProcessor {
         &mut self,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let response = RemotingCommand::create_java_default_error_response_command().set_opaque(request.opaque());
+        let response = self
+            .remoting_command_factory
+            .create_java_default_error_response_command()
+            .set_opaque(request.opaque());
         let request_header = match request.decode_command_custom_header::<GetConsumerRunningInfoRequestHeader>() {
             Ok(header) => header,
             Err(error) => {
@@ -414,7 +430,8 @@ impl ClientRemotingProcessor {
                 }
                 let body = consumer_running_info.encode_java_compatible()?;
                 Ok(Some(
-                    RemotingCommand::create_success_response_command()
+                    self.remoting_command_factory
+                        .create_success_response_command()
                         .set_opaque(request.opaque())
                         .set_body(body),
                 ))
@@ -493,7 +510,10 @@ impl ClientRemotingProcessor {
         _ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let response = RemotingCommand::create_java_default_error_response_command().set_opaque(request.opaque());
+        let response = self
+            .remoting_command_factory
+            .create_java_default_error_response_command()
+            .set_opaque(request.opaque());
         let request_header = match request.decode_command_custom_header::<ConsumeMessageDirectlyResultRequestHeader>() {
             Ok(header) => header,
             Err(error) => {
@@ -539,7 +559,8 @@ impl ClientRemotingProcessor {
         if let Some(result) = result {
             match result.encode() {
                 Ok(body) => Ok(Some(
-                    RemotingCommand::create_success_response_command()
+                    self.remoting_command_factory
+                        .create_success_response_command()
                         .set_opaque(request.opaque())
                         .set_body(body),
                 )),
@@ -574,6 +595,9 @@ mod tests {
 
     use bytes::Bytes;
     use rocketmq_model::common::message::message_queue::MessageQueue;
+    use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandDefaults;
+    use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
+    use rocketmq_protocol::protocol::SerializeType;
     use rocketmq_transport::test_support::LocalRequestHarness;
 
     use super::*;
@@ -597,6 +621,24 @@ mod tests {
         let runtime = crate::runtime::test_client_runtime("client-remoting-processor-instance");
         MQClientInstance::new_arc(
             client_config,
+            0,
+            client_id,
+            None,
+            runtime.component("instance"),
+            runtime.telemetry_handle().clone(),
+            runtime.pool().request_future_holder(),
+        )
+    }
+
+    fn test_client_instance_with_factory(
+        client_config: ClientConfig,
+        client_id: impl Into<CheetahString>,
+        remoting_command_factory: RemotingCommandFactory,
+    ) -> Arc<MQClientInstance> {
+        let runtime = crate::runtime::test_client_runtime("client-remoting-processor-factory-instance");
+        MQClientInstance::new_arc_with_remoting_command_factory(
+            client_config,
+            remoting_command_factory,
             0,
             client_id,
             None,
@@ -985,6 +1027,26 @@ mod tests {
         assert!(response
             .remark()
             .is_some_and(|remark| remark.contains("decode reply message request header failed")));
+    }
+
+    #[tokio::test]
+    async fn callback_response_uses_owning_factory_defaults() {
+        let factory = RemotingCommandFactory::new(RemotingCommandDefaults::new(947, SerializeType::ROCKETMQ));
+        let client_instance = test_client_instance_with_factory(ClientConfig::default(), "reply-factory-test", factory);
+        let mut processor = ClientRemotingProcessor::new(&client_instance);
+        let harness = LocalRequestHarness::new(test_task_group())
+            .await
+            .expect("local remoting harness should start");
+        let mut request = RemotingCommand::create_remoting_command(RequestCode::PushReplyMessageToClient);
+
+        let response = processor
+            .process_request(harness.channel(), harness.context(), &mut request)
+            .await
+            .expect("malformed reply callback should not fail")
+            .expect("malformed reply callback should return an error response");
+
+        assert_eq!(response.version(), 947);
+        assert_eq!(response.serialize_type(), SerializeType::ROCKETMQ);
     }
 
     #[tokio::test]

--- a/rocketmq-client/src/implementation/mq_client_api_impl.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl.rs
@@ -282,6 +282,7 @@ use rocketmq_protocol::protocol::heartbeat::message_model::MessageModel;
 use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
 use rocketmq_protocol::protocol::namespace_util::NamespaceUtil;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 use rocketmq_protocol::protocol::route::topic_route_data::TopicRouteData;
 use rocketmq_protocol::protocol::static_topic::topic_config_and_queue_mapping::TopicConfigAndQueueMapping;
 #[cfg(feature = "admin-mutation")]
@@ -395,6 +396,7 @@ pub struct MQClientAPIImpl {
     top_addressing: RwLock<Arc<dyn TopAddressing>>,
     name_srv_addr: RwLock<Option<String>>,
     client_config: Arc<ClientConfig>,
+    command_factory: RemotingCommandFactory,
     background_tasks: TaskTracker,
     background_shutdown: CancellationToken,
 }

--- a/rocketmq-client/src/implementation/mq_client_api_impl/admin.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl/admin.rs
@@ -43,7 +43,7 @@ impl MQClientAPIImpl {
         timeout_millis: u64,
     ) -> RocketMQResult<Option<CheetahString>> {
         let request_header = GetKVConfigRequestHeader::new(namespace, key);
-        let request = RemotingCommand::create_request_command(RequestCode::GetKvConfig, request_header);
+        let request = self.create_request_command(RequestCode::GetKvConfig, request_header);
 
         let name_server_address_list = self.remoting_client.get_name_server_address_list();
         let mut err_response = None;
@@ -91,7 +91,7 @@ impl MQClientAPIImpl {
         timeout_millis: u64,
     ) -> RocketMQResult<()> {
         let request_header = DeleteKVConfigRequestHeader::new(namespace, key);
-        let request = RemotingCommand::create_request_command(RequestCode::DeleteKvConfig, request_header);
+        let request = self.create_request_command(RequestCode::DeleteKvConfig, request_header);
 
         let name_server_address_list = self.remoting_client.get_name_server_address_list();
         let mut err_response = None;
@@ -131,7 +131,7 @@ impl MQClientAPIImpl {
         timeout_millis: u64,
     ) -> RocketMQResult<rocketmq_protocol::protocol::body::kv_table::KVTable> {
         let request_header = GetKVListByNamespaceRequestHeader::new(namespace);
-        let request = RemotingCommand::create_request_command(RequestCode::GetKvlistByNamespace, request_header);
+        let request = self.create_request_command(RequestCode::GetKvlistByNamespace, request_header);
 
         let response = self
             .remoting_client
@@ -166,7 +166,7 @@ impl MQClientAPIImpl {
         timeout_millis: u64,
     ) -> RocketMQResult<()> {
         let request_header = PutKVConfigRequestHeader::new(namespace, key, value);
-        let request = RemotingCommand::create_request_command(RequestCode::PutKvConfig, request_header);
+        let request = self.create_request_command(RequestCode::PutKvConfig, request_header);
 
         let name_server_address_list = self.remoting_client.get_name_server_address_list();
         let mut err_response = None;
@@ -214,7 +214,7 @@ impl MQClientAPIImpl {
             .clone()
             .ok_or_else(|| mq_client_err!(-1, "username is required".to_string()))?;
         request_header.set_username(username);
-        let mut request = RemotingCommand::create_request_command(RequestCode::AuthCreateUser, request_header);
+        let mut request = self.create_request_command(RequestCode::AuthCreateUser, request_header);
         request = request.set_body(user_info.encode()?);
 
         let response = self
@@ -250,7 +250,7 @@ impl MQClientAPIImpl {
             .clone()
             .ok_or_else(|| mq_client_err!(-1, "username is required".to_string()))?;
         request_header.set_username(username);
-        let mut request = RemotingCommand::create_request_command(RequestCode::AuthUpdateUser, request_header);
+        let mut request = self.create_request_command(RequestCode::AuthUpdateUser, request_header);
         request = request.set_body(user_info.encode()?);
 
         let response = self
@@ -285,7 +285,8 @@ impl MQClientAPIImpl {
             .clone()
             .ok_or_else(|| mq_client_err!(-1, "ACL subject is required".to_string()))?;
         let request_header = CreateAclRequestHeader { subject };
-        let request = RemotingCommand::create_request_command(RequestCode::AuthCreateAcl, request_header)
+        let request = self
+            .create_request_command(RequestCode::AuthCreateAcl, request_header)
             .set_body(acl_info.encode()?);
 
         let response = self
@@ -314,7 +315,8 @@ impl MQClientAPIImpl {
             .clone()
             .ok_or_else(|| mq_client_err!(-1, "ACL subject is required".to_string()))?;
         let request_header = UpdateAclRequestHeader { subject };
-        let request = RemotingCommand::create_request_command(RequestCode::AuthUpdateAcl, request_header)
+        let request = self
+            .create_request_command(RequestCode::AuthUpdateAcl, request_header)
             .set_body(acl_info.encode()?);
 
         let response = self
@@ -338,7 +340,7 @@ impl MQClientAPIImpl {
         plain_access_config: &PlainAccessConfig,
         timeout_millis: u64,
     ) -> RocketMQResult<()> {
-        let request = create_and_update_plain_access_config_request(plain_access_config)?;
+        let request = create_and_update_plain_access_config_request(&self.command_factory, plain_access_config)?;
 
         let response = self
             .remoting_client
@@ -361,7 +363,7 @@ impl MQClientAPIImpl {
         access_key: CheetahString,
         timeout_millis: u64,
     ) -> RocketMQResult<()> {
-        let request = delete_plain_access_config_request(&access_key);
+        let request = delete_plain_access_config_request(&self.command_factory, &access_key);
 
         let response = self
             .remoting_client
@@ -385,8 +387,7 @@ impl MQClientAPIImpl {
         timeout_millis: u64,
     ) -> RocketMQResult<()> {
         let request_header = UpdateGlobalWhiteAddrsConfigRequestHeader { global_white_addrs };
-        let request =
-            RemotingCommand::create_request_command(RequestCode::UpdateGlobalWhiteAddrsConfig, request_header);
+        let request = self.create_request_command(RequestCode::UpdateGlobalWhiteAddrsConfig, request_header);
 
         let response = self
             .remoting_client
@@ -407,7 +408,7 @@ impl MQClientAPIImpl {
         broker_address: CheetahString,
         timeout_millis: u64,
     ) -> RocketMQResult<ClusterAclVersionInfo> {
-        let request = RemotingCommand::create_remoting_command(RequestCode::GetBrokerClusterAclInfo);
+        let request = self.create_remoting_command(RequestCode::GetBrokerClusterAclInfo);
 
         let response = self
             .remoting_client
@@ -433,7 +434,7 @@ impl MQClientAPIImpl {
     ) -> RocketMQResult<()> {
         let resource_option = if resource.is_empty() { None } else { Some(resource) };
         let request_header = DeleteAclRequestHeader::new(subject, resource_option);
-        let request = RemotingCommand::create_request_command(RequestCode::AuthDeleteAcl, request_header);
+        let request = self.create_request_command(RequestCode::AuthDeleteAcl, request_header);
 
         let response = self
             .remoting_client
@@ -460,7 +461,7 @@ impl MQClientAPIImpl {
             subject_filter,
             resource_filter,
         };
-        let request = RemotingCommand::create_request_command(RequestCode::AuthListAcl, request_header);
+        let request = self.create_request_command(RequestCode::AuthListAcl, request_header);
 
         let response = self
             .remoting_client
@@ -488,7 +489,7 @@ impl MQClientAPIImpl {
         subject: CheetahString,
         timeout_millis: u64,
     ) -> RocketMQResult<AclInfo> {
-        let request = get_acl_request(subject);
+        let request = get_acl_request(&self.command_factory, subject);
         let response = self
             .remoting_client
             .invoke_request(Some(&broker_address), request, timeout_millis)
@@ -517,7 +518,7 @@ impl MQClientAPIImpl {
         let request_header = GetUserRequestHeader {
             username: username.clone(),
         };
-        let request = RemotingCommand::create_request_command(RequestCode::AuthGetUser, request_header);
+        let request = self.create_request_command(RequestCode::AuthGetUser, request_header);
 
         let response = self
             .remoting_client
@@ -548,7 +549,7 @@ impl MQClientAPIImpl {
         timeout_millis: u64,
     ) -> RocketMQResult<Vec<UserInfo>> {
         let request_header = ListUsersRequestHeader { filter };
-        let request = RemotingCommand::create_request_command(RequestCode::AuthListUsers, request_header);
+        let request = self.create_request_command(RequestCode::AuthListUsers, request_header);
 
         let response = self
             .remoting_client
@@ -588,7 +589,7 @@ impl MQClientAPIImpl {
     ) -> RocketMQResult<()> {
         let mut request_header = DeleteUserRequestHeader::default();
         request_header.set_username(username);
-        let request = RemotingCommand::create_request_command(RequestCode::AuthDeleteUser, request_header);
+        let request = self.create_request_command(RequestCode::AuthDeleteUser, request_header);
 
         let response = self
             .remoting_client
@@ -634,7 +635,7 @@ impl MQClientAPIImpl {
             return Ok(());
         }
         let empty_header = EmptyHeader {};
-        let mut request = RemotingCommand::create_request_command(RequestCode::UpdateNamesrvConfig, empty_header);
+        let mut request = self.create_request_command(RequestCode::UpdateNamesrvConfig, empty_header);
 
         request = request.set_body(body.to_string());
         let mut err_response = None;
@@ -666,7 +667,7 @@ impl MQClientAPIImpl {
         timeout_millis: u64,
     ) -> RocketMQResult<i32> {
         let request_header = AddWritePermOfBrokerRequestHeader::new(broker_name);
-        let request = RemotingCommand::create_request_command(RequestCode::AddWritePermOfBroker, request_header);
+        let request = self.create_request_command(RequestCode::AddWritePermOfBroker, request_header);
 
         let response = self
             .remoting_client
@@ -690,7 +691,7 @@ impl MQClientAPIImpl {
         timeout_millis: u64,
     ) -> RocketMQResult<i32> {
         let request_header = WipeWritePermOfBrokerRequestHeader::new(broker_name);
-        let request = RemotingCommand::create_request_command(RequestCode::WipeWritePermOfBroker, request_header);
+        let request = self.create_request_command(RequestCode::WipeWritePermOfBroker, request_header);
 
         let response = self
             .remoting_client
@@ -707,7 +708,7 @@ impl MQClientAPIImpl {
     }
 
     pub(crate) async fn get_broker_cluster_info(&self, timeout_millis: u64) -> RocketMQResult<ClusterInfo> {
-        let request = RemotingCommand::create_request_command(RequestCode::GetBrokerClusterInfo, EmptyHeader {});
+        let request = self.create_request_command(RequestCode::GetBrokerClusterInfo, EmptyHeader {});
         let response = self
             .remoting_client
             .invoke_request(None, request, timeout_millis)
@@ -728,7 +729,7 @@ impl MQClientAPIImpl {
         addr: &CheetahString,
         timeout_millis: u64,
     ) -> RocketMQResult<rocketmq_protocol::protocol::body::kv_table::KVTable> {
-        let request = RemotingCommand::create_request_command(RequestCode::GetBrokerRuntimeInfo, EmptyHeader {});
+        let request = self.create_request_command(RequestCode::GetBrokerRuntimeInfo, EmptyHeader {});
         let response = self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
@@ -764,7 +765,7 @@ impl MQClientAPIImpl {
         broker_name: &CheetahString,
     ) -> RocketMQResult<Option<BrokerMemberGroup>> {
         let request_header = GetBrokerMemberGroupRequestHeader::new(cluster_name.clone(), broker_name.clone());
-        let request = RemotingCommand::create_request_command(RequestCode::GetBrokerMemberGroup, request_header);
+        let request = self.create_request_command(RequestCode::GetBrokerMemberGroup, request_header);
         let mut response = self.remoting_client.invoke_request(None, request, 3000).await?;
         if ResponseCode::from(response.code()) == ResponseCode::Success {
             if let Some(body) = response.take_body() {
@@ -792,7 +793,7 @@ impl MQClientAPIImpl {
             )),
             ..Default::default()
         };
-        let request = RemotingCommand::create_request_command(RequestCode::GetRouteinfoByTopic, request_header);
+        let request = self.create_request_command(RequestCode::GetRouteinfoByTopic, request_header);
         let mut response = self.remoting_client.invoke_request(None, request, 3000).await?;
         if ResponseCode::from(response.code()) == ResponseCode::Success {
             if let Some(body) = response.take_body() {
@@ -812,7 +813,7 @@ impl MQClientAPIImpl {
         addr: &CheetahString,
         timeout_millis: u64,
     ) -> RocketMQResult<GetBrokerLiteInfoResponseBody> {
-        let request = RemotingCommand::create_request_command(RequestCode::GetBrokerLiteInfo, EmptyHeader {});
+        let request = self.create_request_command(RequestCode::GetBrokerLiteInfo, EmptyHeader {});
         let response = self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
@@ -840,7 +841,7 @@ impl MQClientAPIImpl {
             check_store_time,
             rpc: None,
         };
-        let request = RemotingCommand::create_request_command(RequestCode::CheckRocksdbCqWriteProgress, request_header);
+        let request = self.create_request_command(RequestCode::CheckRocksdbCqWriteProgress, request_header);
         let response = self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
@@ -881,7 +882,7 @@ impl MQClientAPIImpl {
             },
             topic_request_header: None,
         };
-        let request = RemotingCommand::create_request_command(RequestCode::QueryConsumeQueue, request_header);
+        let request = self.create_request_command(RequestCode::QueryConsumeQueue, request_header);
         let response = self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
@@ -917,7 +918,7 @@ impl MQClientAPIImpl {
             top_k,
             rpc: None,
         };
-        let request = RemotingCommand::create_request_command(RequestCode::GetLiteGroupInfo, request_header);
+        let request = self.create_request_command(RequestCode::GetLiteGroupInfo, request_header);
         let response = self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
@@ -947,7 +948,7 @@ impl MQClientAPIImpl {
             client_id: Some(client_id),
             max_count: 1000,
         };
-        let request = RemotingCommand::create_request_command(RequestCode::GetLiteClientInfo, request_header);
+        let request = self.create_request_command(RequestCode::GetLiteClientInfo, request_header);
         let response = self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
@@ -975,7 +976,7 @@ impl MQClientAPIImpl {
             group,
             client_id: if client_id.is_empty() { None } else { Some(client_id) },
         };
-        let request = RemotingCommand::create_request_command(RequestCode::TriggerLiteDispatch, request_header);
+        let request = self.create_request_command(RequestCode::TriggerLiteDispatch, request_header);
         let response = self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
@@ -996,7 +997,7 @@ impl MQClientAPIImpl {
         lite_subscription_dto: LiteSubscriptionDTO,
         timeout_millis: u64,
     ) -> RocketMQResult<()> {
-        let request = lite_subscription_ctl_request(lite_subscription_dto)?;
+        let request = lite_subscription_ctl_request(&self.command_factory, lite_subscription_dto)?;
         let response = self
             .remoting_client
             .invoke_request(Some(broker_addr), request, timeout_millis)
@@ -1034,7 +1035,7 @@ impl MQClientAPIImpl {
             parent_topic: parent_topic.clone(),
             lite_topic: lite_topic.clone(),
         };
-        let request = RemotingCommand::create_request_command(RequestCode::GetLiteTopicInfo, request_header);
+        let request = self.create_request_command(RequestCode::GetLiteTopicInfo, request_header);
         let response = self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
@@ -1056,7 +1057,7 @@ impl MQClientAPIImpl {
         timeout_millis: u64,
     ) -> RocketMQResult<GetParentTopicInfoResponseBody> {
         let request_header = GetParentTopicInfoRequestHeader { topic, rpc: None };
-        let request = RemotingCommand::create_request_command(RequestCode::GetParentTopicInfo, request_header);
+        let request = self.create_request_command(RequestCode::GetParentTopicInfo, request_header);
         let response = self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
@@ -1086,7 +1087,7 @@ impl MQClientAPIImpl {
             rpc_request_header: None,
         };
 
-        let request = RemotingCommand::create_request_command(RequestCode::DeleteSubscriptionGroup, request_header);
+        let request = self.create_request_command(RequestCode::DeleteSubscriptionGroup, request_header);
 
         let response = self
             .remoting_client
@@ -1113,7 +1114,7 @@ impl MQClientAPIImpl {
             master_flush_offset: Some(master_flush_offset),
         };
 
-        let request = RemotingCommand::create_request_command(RequestCode::ResetMasterFlushOffset, request_header);
+        let request = self.create_request_command(RequestCode::ResetMasterFlushOffset, request_header);
 
         let response = self
             .remoting_client
@@ -1135,7 +1136,7 @@ impl MQClientAPIImpl {
         request_code: RequestCode,
         timeout_millis: u64,
     ) -> RocketMQResult<TopicList> {
-        let request = RemotingCommand::create_request_command(request_code, EmptyHeader {});
+        let request = self.create_request_command(request_code, EmptyHeader {});
         let response = self
             .remoting_client
             .invoke_request(None, request, timeout_millis)
@@ -1210,7 +1211,7 @@ impl MQClientAPIImpl {
         timeout_millis: u64,
     ) -> RocketMQResult<rocketmq_protocol::protocol::body::topic::topic_list::TopicList> {
         let request_header = GetTopicsByClusterRequestHeader::new(cluster);
-        let request = RemotingCommand::create_request_command(RequestCode::GetTopicsByCluster, request_header);
+        let request = self.create_request_command(RequestCode::GetTopicsByCluster, request_header);
         let response = self
             .remoting_client
             .invoke_request(None, request, timeout_millis)
@@ -1244,8 +1245,7 @@ impl MQClientAPIImpl {
         addr: &CheetahString,
         timeout_millis: u64,
     ) -> RocketMQResult<rocketmq_protocol::protocol::body::topic::topic_list::TopicList> {
-        let request =
-            RemotingCommand::create_request_command(RequestCode::GetSystemTopicListFromBroker, EmptyHeader {});
+        let request = self.create_request_command(RequestCode::GetSystemTopicListFromBroker, EmptyHeader {});
         let broker_addr = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr.as_str());
         let response = self
             .remoting_client
@@ -1268,7 +1268,7 @@ impl MQClientAPIImpl {
         request_header: rocketmq_protocol::protocol::header::get_consume_stats_request_header::GetConsumeStatsRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<rocketmq_protocol::protocol::admin::consume_stats::ConsumeStats> {
-        let request = RemotingCommand::create_request_command(RequestCode::GetConsumeStats, request_header);
+        let request = self.create_request_command(RequestCode::GetConsumeStats, request_header);
         let response = self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
@@ -1290,7 +1290,7 @@ impl MQClientAPIImpl {
         request_header: QueryConsumeTimeSpanRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<Vec<rocketmq_protocol::protocol::body::queue_time_span::QueueTimeSpan>> {
-        let request = RemotingCommand::create_request_command(RequestCode::QueryConsumeTimeSpan, request_header);
+        let request = self.create_request_command(RequestCode::QueryConsumeTimeSpan, request_header);
         let broker_addr = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr.as_str());
         let response = self
             .remoting_client
@@ -1314,7 +1314,7 @@ impl MQClientAPIImpl {
         request_header: GetTopicStatsInfoRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<rocketmq_protocol::protocol::admin::topic_stats_table::TopicStatsTable> {
-        let request = RemotingCommand::create_request_command(RequestCode::GetTopicStatsInfo, request_header);
+        let request = self.create_request_command(RequestCode::GetTopicStatsInfo, request_header);
         let broker_addr = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr.as_str());
         let response = self
             .remoting_client
@@ -1337,7 +1337,7 @@ impl MQClientAPIImpl {
         request_header: GetTopicConfigRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<TopicConfigAndQueueMapping> {
-        let request = RemotingCommand::create_request_command(RequestCode::GetTopicConfig, request_header);
+        let request = self.create_request_command(RequestCode::GetTopicConfig, request_header);
         let broker_addr = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr.as_str());
         let response = self
             .remoting_client
@@ -1394,7 +1394,8 @@ impl MQClientAPIImpl {
             force: Some(force),
             topic_request_header: None,
         };
-        let request = RemotingCommand::create_request_command(RequestCode::UpdateAndCreateStaticTopic, request_header)
+        let request = self
+            .create_request_command(RequestCode::UpdateAndCreateStaticTopic, request_header)
             .set_body(mapping_detail.encode()?);
         let broker_addr = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr.as_str());
         let response = self
@@ -1419,7 +1420,7 @@ impl MQClientAPIImpl {
         request_header: rocketmq_protocol::protocol::header::query_topic_consume_by_who_request_header::QueryTopicConsumeByWhoRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<rocketmq_protocol::protocol::body::group_list::GroupList> {
-        let request = RemotingCommand::create_request_command(RequestCode::QueryTopicConsumeByWho, request_header);
+        let request = self.create_request_command(RequestCode::QueryTopicConsumeByWho, request_header);
         let broker_addr = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr.as_str());
         let response = self
             .remoting_client
@@ -1442,7 +1443,7 @@ impl MQClientAPIImpl {
         request_header: QueryTopicsByConsumerRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<rocketmq_protocol::protocol::body::topic::topic_list::TopicList> {
-        let request = RemotingCommand::create_request_command(RequestCode::QueryTopicsByConsumer, request_header);
+        let request = self.create_request_command(RequestCode::QueryTopicsByConsumer, request_header);
         let broker_addr = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr.as_str());
         let response = self
             .remoting_client
@@ -1465,7 +1466,7 @@ impl MQClientAPIImpl {
         request_header: QuerySubscriptionByConsumerRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<SubscriptionData> {
-        let request = RemotingCommand::create_request_command(RequestCode::QuerySubscriptionByConsumer, request_header);
+        let request = self.create_request_command(RequestCode::QuerySubscriptionByConsumer, request_header);
         let broker_addr = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr.as_str());
         let response = self
             .remoting_client
@@ -1494,7 +1495,7 @@ impl MQClientAPIImpl {
         request_code: RequestCode,
         timeout_millis: u64,
     ) -> RocketMQResult<bool> {
-        let request = RemotingCommand::create_request_command(request_code, EmptyHeader {});
+        let request = self.create_request_command(request_code, EmptyHeader {});
         let broker_addr = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr.as_str());
         let response = self
             .remoting_client
@@ -1563,7 +1564,7 @@ impl MQClientAPIImpl {
         topic_config_list: Vec<TopicConfig>,
         timeout_millis: u64,
     ) -> RocketMQResult<()> {
-        let request = create_topic_list_request(topic_config_list)?;
+        let request = create_topic_list_request(&self.command_factory, topic_config_list)?;
         let broker_addr = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, address.as_str());
         let response = self
             .remoting_client
@@ -1584,7 +1585,7 @@ impl MQClientAPIImpl {
         request_header: CreateTopicRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<()> {
-        let request = RemotingCommand::create_request_command(RequestCode::UpdateAndCreateTopic, request_header);
+        let request = self.create_request_command(RequestCode::UpdateAndCreateTopic, request_header);
         let broker_addr = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr.as_str());
         let response = self
             .remoting_client
@@ -1606,7 +1607,7 @@ impl MQClientAPIImpl {
         configs: Vec<SubscriptionGroupConfig>,
         timeout_millis: u64,
     ) -> RocketMQResult<()> {
-        let request = create_subscription_group_list_request(configs)?;
+        let request = create_subscription_group_list_request(&self.command_factory, configs)?;
         let broker_addr = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, address.as_str());
         let response = self
             .remoting_client
@@ -1629,7 +1630,7 @@ impl MQClientAPIImpl {
         request_header: DeleteTopicRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<()> {
-        let request = RemotingCommand::create_request_command(RequestCode::DeleteTopicInBroker, request_header);
+        let request = self.create_request_command(RequestCode::DeleteTopicInBroker, request_header);
         let broker_addr = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr.as_str());
         let response = self
             .remoting_client
@@ -1667,7 +1668,7 @@ impl MQClientAPIImpl {
         request_header: DeleteTopicFromNamesrvRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<()> {
-        let request = RemotingCommand::create_request_command(RequestCode::DeleteTopicInNamesrv, request_header);
+        let request = self.create_request_command(RequestCode::DeleteTopicInNamesrv, request_header);
         let response = self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
@@ -1688,7 +1689,7 @@ impl MQClientAPIImpl {
         request_header: ResetOffsetRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<HashMap<MessageQueue, i64>> {
-        let request = RemotingCommand::create_request_command(RequestCode::InvokeBrokerToResetOffset, request_header);
+        let request = self.create_request_command(RequestCode::InvokeBrokerToResetOffset, request_header);
         let broker_addr = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr.as_str());
         let response = self
             .remoting_client
@@ -1711,7 +1712,7 @@ impl MQClientAPIImpl {
         filter_groups: Option<Vec<CheetahString>>,
         timeout_millis: u64,
     ) -> RocketMQResult<HashMap<i32, i64>> {
-        let request = query_correction_offset_request(topic, group, filter_groups);
+        let request = query_correction_offset_request(&self.command_factory, topic, group, filter_groups);
         let broker_addr = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr.as_str());
         let response = self
             .remoting_client
@@ -1734,7 +1735,7 @@ impl MQClientAPIImpl {
         request_header: rocketmq_protocol::protocol::header::view_broker_stats_data_request_header::ViewBrokerStatsDataRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<rocketmq_protocol::protocol::subscription::broker_stats_data::BrokerStatsData> {
-        let request = RemotingCommand::create_request_command(RequestCode::ViewBrokerStatsData, request_header);
+        let request = self.create_request_command(RequestCode::ViewBrokerStatsData, request_header);
         let response = self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
@@ -1758,7 +1759,7 @@ impl MQClientAPIImpl {
         request_header: rocketmq_protocol::protocol::header::get_consume_stats_in_broker_header::GetConsumeStatsInBrokerHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<rocketmq_protocol::protocol::admin::consume_stats_list::ConsumeStatsList> {
-        let request = RemotingCommand::create_request_command(RequestCode::GetBrokerConsumeStats, request_header);
+        let request = self.create_request_command(RequestCode::GetBrokerConsumeStats, request_header);
         let broker_addr = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr.as_str());
         let response = self
             .remoting_client
@@ -1795,7 +1796,7 @@ impl MQClientAPIImpl {
             offline: is_offline,
             rpc_request_header: None,
         };
-        let request = RemotingCommand::create_request_command(RequestCode::CloneGroupOffset, request_header);
+        let request = self.create_request_command(RequestCode::CloneGroupOffset, request_header);
         let broker_addr = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr.as_str());
         let response = self
             .remoting_client
@@ -1821,7 +1822,7 @@ impl MQClientAPIImpl {
         addr: &CheetahString,
         timeout_millis: u64,
     ) -> RocketMQResult<ProxyDrainStateResponseBody> {
-        let request = RemotingCommand::create_remoting_command(RequestCode::GetProxyDrainState);
+        let request = self.create_remoting_command(RequestCode::GetProxyDrainState);
         let response = self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
@@ -1869,7 +1870,7 @@ impl MQClientAPIImpl {
             operation_id: operation_id.to_string(),
         }
         .encode()?;
-        let request = RemotingCommand::new_request(request_code, body);
+        let request = self.create_request(request_code, body);
         let response = self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
@@ -1895,8 +1896,9 @@ impl MQClientAPIImpl {
             return Ok(());
         }
 
-        let request =
-            RemotingCommand::create_remoting_command(RequestCode::UpdateBrokerConfig).set_body(body.to_string());
+        let request = self
+            .create_remoting_command(RequestCode::UpdateBrokerConfig)
+            .set_body(body.to_string());
         let broker_addr = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr.as_str());
         let response = self
             .remoting_client
@@ -1922,7 +1924,7 @@ impl MQClientAPIImpl {
         let request_header = AddBrokerRequestHeader {
             config_path: Some(broker_config_path),
         };
-        let request = RemotingCommand::create_request_command(RequestCode::AddBroker, request_header);
+        let request = self.create_request_command(RequestCode::AddBroker, request_header);
         let response = self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
@@ -1951,7 +1953,7 @@ impl MQClientAPIImpl {
             broker_cluster_name: cluster_name,
             broker_id,
         };
-        let request = RemotingCommand::create_request_command(RequestCode::RemoveBroker, request_header);
+        let request = self.create_request_command(RequestCode::RemoveBroker, request_header);
         let response = self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
@@ -1973,7 +1975,7 @@ impl MQClientAPIImpl {
         request_header: NotifyMinBrokerIdChangeRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<()> {
-        let request = RemotingCommand::create_request_command(RequestCode::NotifyMinBrokerIdChange, request_header);
+        let request = self.create_request_command(RequestCode::NotifyMinBrokerIdChange, request_header);
         self.remoting_client
             .invoke_request_oneway(broker_addr, request, timeout_millis)
             .await
@@ -1999,7 +2001,7 @@ impl MQClientAPIImpl {
         let request_header = ExportRocksdbConfigToJsonRequestHeader {
             config_type: CheetahString::from(config_type),
         };
-        let request = RemotingCommand::create_request_command(RequestCode::ExportRocksdbConfigToJson, request_header);
+        let request = self.create_request_command(RequestCode::ExportRocksdbConfigToJson, request_header);
         let response = self
             .remoting_client
             .invoke_request(Some(&broker_addr), request, timeout_millis)
@@ -2030,7 +2032,7 @@ impl MQClientAPIImpl {
         broker_addr: CheetahString,
         timeout_millis: u64,
     ) -> RocketMQResult<CheetahString> {
-        let request = get_all_consumer_offset_request();
+        let request = get_all_consumer_offset_request(&self.command_factory);
         let response = self
             .remoting_client
             .invoke_request(Some(&broker_addr), request, timeout_millis)
@@ -2065,7 +2067,7 @@ impl MQClientAPIImpl {
         }
 
         // Create request command
-        let request = RemotingCommand::create_remoting_command(RequestCode::GetNamesrvConfig);
+        let request = self.create_remoting_command(RequestCode::GetNamesrvConfig);
         let timeout_millis = duration_millis_to_u64("getNameServerConfig", timeout_millis)?;
         let mut config_map = HashMap::with_capacity(4);
         // Iterate through each name server
@@ -2107,7 +2109,7 @@ impl MQClientAPIImpl {
     }
 
     pub async fn probe_name_server(&self, name_server: &CheetahString, timeout_millis: Duration) -> RocketMQResult<()> {
-        let request = RemotingCommand::create_request_command(
+        let request = self.create_request_command(
             RequestCode::GetNamesrvConfig,
             GetNamesrvConfigRequestHeader::for_probe(),
         );
@@ -2131,7 +2133,7 @@ impl MQClientAPIImpl {
         controller_address: CheetahString,
         timeout_millis: u64,
     ) -> RocketMQResult<GetMetaDataResponseHeader> {
-        let request = RemotingCommand::create_remoting_command(RequestCode::ControllerGetMetadataInfo);
+        let request = self.create_remoting_command(RequestCode::ControllerGetMetadataInfo);
         let response = self
             .remoting_client
             .invoke_request(Some(&controller_address), request, timeout_millis)
@@ -2165,7 +2167,7 @@ impl MQClientAPIImpl {
         let controller_meta_data = self.get_controller_metadata(controller_address, timeout_millis).await?;
         let leader_address = controller_leader_address(controller_meta_data)?;
 
-        let request = RemotingCommand::create_remoting_command(RequestCode::ControllerGetSyncStateData);
+        let request = self.create_remoting_command(RequestCode::ControllerGetSyncStateData);
         let body = serde_json::to_vec(&brokers)
             .map_err(|e| mq_client_err!(format!("Failed to serialize broker names: {}", e)))?;
         let request = request.set_body(body);
@@ -2196,7 +2198,7 @@ impl MQClientAPIImpl {
         broker_addr: CheetahString,
         timeout_millis: u64,
     ) -> RocketMQResult<EpochEntryCache> {
-        let request = RemotingCommand::create_remoting_command(RequestCode::GetBrokerEpochCache);
+        let request = self.create_remoting_command(RequestCode::GetBrokerEpochCache);
         let response = self
             .remoting_client
             .invoke_request(Some(&broker_addr), request, timeout_millis)
@@ -2226,7 +2228,7 @@ impl MQClientAPIImpl {
         broker_addr: CheetahString,
         timeout_millis: u64,
     ) -> RocketMQResult<HARuntimeInfo> {
-        let request = RemotingCommand::create_remoting_command(RequestCode::GetBrokerHaStatus);
+        let request = self.create_remoting_command(RequestCode::GetBrokerHaStatus);
         let response = self
             .remoting_client
             .invoke_request(Some(&broker_addr), request, timeout_millis)
@@ -2254,7 +2256,7 @@ impl MQClientAPIImpl {
         request_header: UpdateGroupForbiddenRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<GroupForbidden> {
-        let request = RemotingCommand::create_request_command(RequestCode::UpdateAndGetGroupForbidden, request_header);
+        let request = self.create_request_command(RequestCode::UpdateAndGetGroupForbidden, request_header);
         let broker_addr_vip = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, broker_addr.as_str());
         let response = self
             .remoting_client
@@ -2284,7 +2286,7 @@ impl MQClientAPIImpl {
         controller_address: CheetahString,
         timeout_millis: u64,
     ) -> RocketMQResult<HashMap<CheetahString, CheetahString>> {
-        let request = RemotingCommand::create_remoting_command(RequestCode::GetControllerConfig);
+        let request = self.create_remoting_command(RequestCode::GetControllerConfig);
         let response = self
             .remoting_client
             .invoke_request(Some(&controller_address), request, timeout_millis)
@@ -2316,8 +2318,9 @@ impl MQClientAPIImpl {
             return Ok(());
         }
 
-        let request =
-            RemotingCommand::create_remoting_command(RequestCode::UpdateControllerConfig).set_body(body.to_string());
+        let request = self
+            .create_remoting_command(RequestCode::UpdateControllerConfig)
+            .set_body(body.to_string());
         let mut err_response = None;
         for controller_addr in controllers {
             let response = self
@@ -2365,7 +2368,7 @@ impl MQClientAPIImpl {
             designate_elect,
             rocketmq_runtime::common::time_utils::current_millis(),
         );
-        let request = RemotingCommand::create_request_command(RequestCode::ControllerElectMaster, request_header);
+        let request = self.create_request_command(RequestCode::ControllerElectMaster, request_header);
         let response = self
             .remoting_client
             .invoke_request(Some(&leader_address), request, timeout_millis)
@@ -2415,7 +2418,7 @@ impl MQClientAPIImpl {
             clean_living_broker,
             ..Default::default()
         };
-        let request = RemotingCommand::create_request_command(RequestCode::CleanBrokerData, request_header);
+        let request = self.create_request_command(RequestCode::CleanBrokerData, request_header);
         let response = self
             .remoting_client
             .invoke_request(Some(&leader_address), request, timeout_millis)
@@ -2442,7 +2445,7 @@ impl MQClientAPIImpl {
             return Ok(());
         }
 
-        let request = RemotingCommand::create_remoting_command(RequestCode::UpdateColdDataFlowCtrConfig);
+        let request = self.create_remoting_command(RequestCode::UpdateColdDataFlowCtrConfig);
         let request = request.set_body(body.to_string());
         let broker_addr =
             mix_all::broker_vip_channel(self.client_config.is_vip_channel_enabled(), broker_addr.as_str());
@@ -2471,7 +2474,8 @@ impl MQClientAPIImpl {
             return Ok(());
         }
 
-        let request = RemotingCommand::create_request_command(RequestCode::RemoveColdDataFlowCtrConfig, EmptyHeader {})
+        let request = self
+            .create_request_command(RequestCode::RemoveColdDataFlowCtrConfig, EmptyHeader {})
             .set_body(consumer_group.to_string());
         let broker_addr_vip =
             mix_all::broker_vip_channel(self.client_config.is_vip_channel_enabled(), broker_addr.as_str());
@@ -2495,7 +2499,7 @@ impl MQClientAPIImpl {
         broker_addr: CheetahString,
         timeout_millis: u64,
     ) -> RocketMQResult<CheetahString> {
-        let request = RemotingCommand::create_request_command(RequestCode::GetColdDataFlowCtrInfo, EmptyHeader {});
+        let request = self.create_request_command(RequestCode::GetColdDataFlowCtrInfo, EmptyHeader {});
         let response = self
             .remoting_client
             .invoke_request(Some(&broker_addr), request, timeout_millis)
@@ -2522,7 +2526,7 @@ impl MQClientAPIImpl {
         mode: CheetahString,
         timeout_millis: u64,
     ) -> RocketMQResult<CheetahString> {
-        let mut request = RemotingCommand::create_request_command(RequestCode::SetCommitlogReadMode, EmptyHeader {});
+        let mut request = self.create_request_command(RequestCode::SetCommitlogReadMode, EmptyHeader {});
         request.ensure_ext_fields_initialized();
         request.add_ext_field(file_readahead_mode::READ_AHEAD_MODE, mode);
         let response = self
@@ -2542,7 +2546,7 @@ impl MQClientAPIImpl {
 
     #[cfg(feature = "admin-mutation")]
     pub async fn export_pop_record(&self, broker_addr: CheetahString, timeout_millis: u64) -> RocketMQResult<()> {
-        let request = RemotingCommand::create_request_command(RequestCode::PopRollback, EmptyHeader {});
+        let request = self.create_request_command(RequestCode::PopRollback, EmptyHeader {});
         let response = self
             .remoting_client
             .invoke_request(Some(&broker_addr), request, timeout_millis)
@@ -2564,7 +2568,7 @@ impl MQClientAPIImpl {
         addr: &CheetahString,
         timeout_millis: u64,
     ) -> RocketMQResult<rocketmq_protocol::protocol::body::topic_info_wrapper::TopicConfigSerializeWrapper> {
-        let request = RemotingCommand::create_request_command(RequestCode::GetAllTopicConfig, EmptyHeader {});
+        let request = self.create_request_command(RequestCode::GetAllTopicConfig, EmptyHeader {});
         let response = self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
@@ -2587,8 +2591,7 @@ impl MQClientAPIImpl {
         addr: &CheetahString,
         timeout_millis: u64,
     ) -> RocketMQResult<rocketmq_protocol::protocol::body::subscription_group_wrapper::SubscriptionGroupWrapper> {
-        let request =
-            RemotingCommand::create_request_command(RequestCode::GetAllSubscriptionGroupConfig, EmptyHeader {});
+        let request = self.create_request_command(RequestCode::GetAllSubscriptionGroupConfig, EmptyHeader {});
         let mut response = self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
@@ -2621,7 +2624,7 @@ impl MQClientAPIImpl {
         timeout_millis: u64,
     ) -> RocketMQResult<rocketmq_protocol::protocol::subscription::subscription_group_config::SubscriptionGroupConfig>
     {
-        let request = RemotingCommand::create_request_command(
+        let request = self.create_request_command(
             RequestCode::GetSubscriptionGroupConfig,
             rocketmq_protocol::protocol::header::get_subscription_group_config_request_header::GetSubscriptionGroupConfigRequestHeader {
                 group,
@@ -2652,9 +2655,9 @@ impl MQClientAPIImpl {
         config: &rocketmq_protocol::protocol::subscription::subscription_group_config::SubscriptionGroupConfig,
         timeout_millis: u64,
     ) -> RocketMQResult<()> {
-        let request =
-            RemotingCommand::create_request_command(RequestCode::UpdateAndCreateSubscriptionGroup, EmptyHeader {})
-                .set_body(config.encode()?);
+        let request = self
+            .create_request_command(RequestCode::UpdateAndCreateSubscriptionGroup, EmptyHeader {})
+            .set_body(config.encode()?);
         let broker_addr = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr.as_str());
         let response = self
             .remoting_client
@@ -2684,7 +2687,7 @@ impl MQClientAPIImpl {
             jstack_enable: jstack,
             rpc_request_header: None,
         };
-        let request = RemotingCommand::create_request_command(RequestCode::GetConsumerRunningInfo, request_header);
+        let request = self.create_request_command(RequestCode::GetConsumerRunningInfo, request_header);
         let broker_addr = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr.as_str());
         let mut response = self
             .remoting_client
@@ -2719,7 +2722,8 @@ impl MQClientAPIImpl {
     ) -> RocketMQResult<rocketmq_protocol::protocol::body::consume_message_directly_result::ConsumeMessageDirectlyResult>
     {
         let body = MessageDecoder::encode(message, false)?;
-        let request = RemotingCommand::create_request_command(RequestCode::ConsumeMessageDirectly, request_header)
+        let request = self
+            .create_request_command(RequestCode::ConsumeMessageDirectly, request_header)
             .set_body(body.to_vec());
         let mut response = self
             .remoting_client
@@ -2751,7 +2755,7 @@ impl MQClientAPIImpl {
         request_header: ViewMessageRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<MessageExt> {
-        let request = RemotingCommand::create_request_command(RequestCode::ViewMessageById, request_header);
+        let request = self.create_request_command(RequestCode::ViewMessageById, request_header);
         let response = self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
@@ -2792,7 +2796,7 @@ impl MQClientAPIImpl {
             topic,
             msg_id: Some(msg_id),
         };
-        let request = RemotingCommand::create_request_command(RequestCode::ResumeCheckHalfMessage, request_header);
+        let request = self.create_request_command(RequestCode::ResumeCheckHalfMessage, request_header);
         let broker_addr = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr.as_str());
         let response = self
             .remoting_client
@@ -2818,7 +2822,7 @@ impl MQClientAPIImpl {
         engine_type: CheetahString,
         timeout_millis: u64,
     ) -> RocketMQResult<()> {
-        let mut request = RemotingCommand::create_request_command(RequestCode::SwitchTimerEngine, EmptyHeader {});
+        let mut request = self.create_request_command(RequestCode::SwitchTimerEngine, EmptyHeader {});
         request.ensure_ext_fields_initialized();
         request.add_ext_field(MessageConst::TIMER_ENGINE_TYPE, engine_type);
         let response = self
@@ -3054,6 +3058,7 @@ pub(super) fn create_topic_request_header_like_java(
 }
 
 pub(super) fn query_correction_offset_request(
+    command_factory: &RemotingCommandFactory,
     topic: CheetahString,
     group: CheetahString,
     filter_groups: Option<Vec<CheetahString>>,
@@ -3073,7 +3078,7 @@ pub(super) fn query_correction_offset_request(
         topic,
         topic_request_header: None,
     };
-    RemotingCommand::create_request_command(RequestCode::QueryCorrectionOffset, request_header)
+    command_factory.create_request_command(RequestCode::QueryCorrectionOffset, request_header)
 }
 
 pub(super) fn split_lite_dispatch_value(value: &str) -> Vec<&str> {
@@ -3228,7 +3233,7 @@ impl MqClientAdminInner for MQClientAPIImpl {
     ) -> RocketMQResult<Vec<MessageExt>> {
         let topic = request_header.topic.clone();
         let key = request_header.key.clone();
-        let mut request = RemotingCommand::create_request_command(RequestCode::QueryMessage, request_header);
+        let mut request = self.create_request_command(RequestCode::QueryMessage, request_header);
         request.ensure_ext_fields_initialized();
         request.add_ext_field(
             mix_all::UNIQUE_MSG_QUERY_FLAG,
@@ -3260,7 +3265,7 @@ impl MqClientAdminInner for MQClientAPIImpl {
         request_header: GetTopicStatsInfoRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<TopicStatsTable> {
-        let request = RemotingCommand::create_request_command(RequestCode::GetTopicStatsInfo, request_header);
+        let request = self.create_request_command(RequestCode::GetTopicStatsInfo, request_header);
         let response = self.invoke_admin_request(address, request, timeout_millis).await?;
         if ResponseCode::from(response.code()) == ResponseCode::Success {
             if let Some(body) = response.get_body() {
@@ -3279,7 +3284,7 @@ impl MqClientAdminInner for MQClientAPIImpl {
         request_header: QueryConsumeTimeSpanRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<Vec<QueueTimeSpan>> {
-        let request = RemotingCommand::create_request_command(RequestCode::QueryConsumeTimeSpan, request_header);
+        let request = self.create_request_command(RequestCode::QueryConsumeTimeSpan, request_header);
         let response = self.invoke_admin_request(address, request, timeout_millis).await?;
         if ResponseCode::from(response.code()) == ResponseCode::Success {
             if let Some(body) = response.get_body() {
@@ -3300,7 +3305,7 @@ impl MqClientAdminInner for MQClientAPIImpl {
         request_header: CreateTopicRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<()> {
-        let request = RemotingCommand::create_request_command(RequestCode::UpdateAndCreateTopic, request_header);
+        let request = self.create_request_command(RequestCode::UpdateAndCreateTopic, request_header);
         let response = self.invoke_admin_request(address, request, timeout_millis).await?;
         if ResponseCode::from(response.code()) == ResponseCode::Success {
             return Ok(());
@@ -3318,9 +3323,9 @@ impl MqClientAdminInner for MQClientAPIImpl {
         config: SubscriptionGroupConfig,
         timeout_millis: u64,
     ) -> RocketMQResult<()> {
-        let request =
-            RemotingCommand::create_request_command(RequestCode::UpdateAndCreateSubscriptionGroup, EmptyHeader {})
-                .set_body(config.encode()?);
+        let request = self
+            .create_request_command(RequestCode::UpdateAndCreateSubscriptionGroup, EmptyHeader {})
+            .set_body(config.encode()?);
         let response = self.invoke_admin_request(address, request, timeout_millis).await?;
         if ResponseCode::from(response.code()) == ResponseCode::Success {
             return Ok(());
@@ -3338,7 +3343,7 @@ impl MqClientAdminInner for MQClientAPIImpl {
         request_header: DeleteTopicRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<()> {
-        let request = RemotingCommand::create_request_command(RequestCode::DeleteTopicInBroker, request_header);
+        let request = self.create_request_command(RequestCode::DeleteTopicInBroker, request_header);
         let response = self.invoke_admin_request(address, request, timeout_millis).await?;
         if ResponseCode::from(response.code()) == ResponseCode::Success {
             return Ok(());
@@ -3356,7 +3361,7 @@ impl MqClientAdminInner for MQClientAPIImpl {
         request_header: DeleteTopicFromNamesrvRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<()> {
-        let request = RemotingCommand::create_request_command(RequestCode::DeleteTopicInNamesrv, request_header);
+        let request = self.create_request_command(RequestCode::DeleteTopicInNamesrv, request_header);
         let response = self.invoke_admin_request(address, request, timeout_millis).await?;
         if ResponseCode::from(response.code()) == ResponseCode::Success {
             return Ok(());
@@ -3374,7 +3379,7 @@ impl MqClientAdminInner for MQClientAPIImpl {
         request_header: DeleteKVConfigRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<()> {
-        let request = RemotingCommand::create_request_command(RequestCode::DeleteKvConfig, request_header);
+        let request = self.create_request_command(RequestCode::DeleteKvConfig, request_header);
         let response = self.invoke_admin_request(address, request, timeout_millis).await?;
         if ResponseCode::from(response.code()) == ResponseCode::Success {
             return Ok(());
@@ -3392,7 +3397,7 @@ impl MqClientAdminInner for MQClientAPIImpl {
         request_header: DeleteSubscriptionGroupRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<()> {
-        let request = RemotingCommand::create_request_command(RequestCode::DeleteSubscriptionGroup, request_header);
+        let request = self.create_request_command(RequestCode::DeleteSubscriptionGroup, request_header);
         let response = self.invoke_admin_request(address, request, timeout_millis).await?;
         if ResponseCode::from(response.code()) == ResponseCode::Success {
             return Ok(());
@@ -3410,7 +3415,7 @@ impl MqClientAdminInner for MQClientAPIImpl {
         request_header: ResetOffsetRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<HashMap<MessageQueue, i64>> {
-        let request = RemotingCommand::create_request_command(RequestCode::InvokeBrokerToResetOffset, request_header);
+        let request = self.create_request_command(RequestCode::InvokeBrokerToResetOffset, request_header);
         let response = self.invoke_admin_request(address, request, timeout_millis).await?;
         reset_offset_table_from_response(&response)
     }
@@ -3421,7 +3426,7 @@ impl MqClientAdminInner for MQClientAPIImpl {
         request_header: ViewMessageRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<MessageExt> {
-        let request = RemotingCommand::create_request_command(RequestCode::ViewMessageById, request_header);
+        let request = self.create_request_command(RequestCode::ViewMessageById, request_header);
         let response = self.invoke_admin_request(address, request, timeout_millis).await?;
         match ResponseCode::from(response.code()) {
             ResponseCode::Success => {
@@ -3441,7 +3446,7 @@ impl MqClientAdminInner for MQClientAPIImpl {
     }
 
     async fn get_broker_cluster_info(&self, address: &str, timeout_millis: u64) -> RocketMQResult<ClusterInfo> {
-        let request = RemotingCommand::create_request_command(RequestCode::GetBrokerClusterInfo, EmptyHeader {});
+        let request = self.create_request_command(RequestCode::GetBrokerClusterInfo, EmptyHeader {});
         let response = self.invoke_admin_request(address, request, timeout_millis).await?;
         if ResponseCode::from(response.code()) == ResponseCode::Success {
             if let Some(body) = response.get_body() {
@@ -3460,7 +3465,7 @@ impl MqClientAdminInner for MQClientAPIImpl {
         request_header: GetConsumerConnectionListRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<ConsumerConnection> {
-        let request = RemotingCommand::create_request_command(RequestCode::GetConsumerConnectionList, request_header);
+        let request = self.create_request_command(RequestCode::GetConsumerConnectionList, request_header);
         let response = self.invoke_admin_request(address, request, timeout_millis).await?;
         if ResponseCode::from(response.code()) == ResponseCode::Success {
             if let Some(body) = response.get_body() {
@@ -3479,7 +3484,7 @@ impl MqClientAdminInner for MQClientAPIImpl {
         request_header: QueryTopicsByConsumerRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<TopicList> {
-        let request = RemotingCommand::create_request_command(RequestCode::QueryTopicsByConsumer, request_header);
+        let request = self.create_request_command(RequestCode::QueryTopicsByConsumer, request_header);
         let response = self.invoke_admin_request(address, request, timeout_millis).await?;
         if ResponseCode::from(response.code()) == ResponseCode::Success {
             if let Some(body) = response.get_body() {
@@ -3498,7 +3503,7 @@ impl MqClientAdminInner for MQClientAPIImpl {
         request_header: QuerySubscriptionByConsumerRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<SubscriptionData> {
-        let request = RemotingCommand::create_request_command(RequestCode::QuerySubscriptionByConsumer, request_header);
+        let request = self.create_request_command(RequestCode::QuerySubscriptionByConsumer, request_header);
         let response = self.invoke_admin_request(address, request, timeout_millis).await?;
         if ResponseCode::from(response.code()) == ResponseCode::Success {
             let body = response
@@ -3521,7 +3526,7 @@ impl MqClientAdminInner for MQClientAPIImpl {
         request_header: GetConsumeStatsRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<ConsumeStats> {
-        let request = RemotingCommand::create_request_command(RequestCode::GetConsumeStats, request_header);
+        let request = self.create_request_command(RequestCode::GetConsumeStats, request_header);
         let response = self.invoke_admin_request(address, request, timeout_millis).await?;
         if ResponseCode::from(response.code()) == ResponseCode::Success {
             if let Some(body) = response.get_body() {
@@ -3540,7 +3545,7 @@ impl MqClientAdminInner for MQClientAPIImpl {
         request_header: QueryTopicConsumeByWhoRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<GroupList> {
-        let request = RemotingCommand::create_request_command(RequestCode::QueryTopicConsumeByWho, request_header);
+        let request = self.create_request_command(RequestCode::QueryTopicConsumeByWho, request_header);
         let response = self.invoke_admin_request(address, request, timeout_millis).await?;
         if ResponseCode::from(response.code()) == ResponseCode::Success {
             if let Some(body) = response.get_body() {
@@ -3559,7 +3564,7 @@ impl MqClientAdminInner for MQClientAPIImpl {
         request_header: GetConsumerRunningInfoRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<ConsumerRunningInfo> {
-        let request = RemotingCommand::create_request_command(RequestCode::GetConsumerRunningInfo, request_header);
+        let request = self.create_request_command(RequestCode::GetConsumerRunningInfo, request_header);
         let mut response = self.invoke_admin_request(address, request, timeout_millis).await?;
         match ResponseCode::from(response.code()) {
             ResponseCode::Success => {
@@ -3582,7 +3587,7 @@ impl MqClientAdminInner for MQClientAPIImpl {
         request_header: ConsumeMessageDirectlyResultRequestHeader,
         timeout_millis: u64,
     ) -> RocketMQResult<ConsumeMessageDirectlyResult> {
-        let request = RemotingCommand::create_request_command(RequestCode::ConsumeMessageDirectly, request_header);
+        let request = self.create_request_command(RequestCode::ConsumeMessageDirectly, request_header);
         let mut response = self.invoke_admin_request(address, request, timeout_millis).await?;
         match ResponseCode::from(response.code()) {
             ResponseCode::Success => {

--- a/rocketmq-client/src/implementation/mq_client_api_impl/admin/versioned_config.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl/admin/versioned_config.rs
@@ -227,7 +227,7 @@ impl MQClientAPIImpl {
         topic: CheetahString,
         timeout_millis: u64,
     ) -> RocketMQResult<TopicConfigVersioned> {
-        let request = RemotingCommand::create_request_command(
+        let request = self.create_request_command(
             RequestCode::GetTopicConfig,
             GetTopicConfigRequestHeader {
                 topic,
@@ -274,11 +274,12 @@ impl MQClientAPIImpl {
             ));
         }
 
-        let request = RemotingCommand::create_request_command(
-            RequestCode::UpdateBrokerConfigCas,
-            UpdateBrokerConfigRequestHeader { expected_generation },
-        )
-        .set_body(body.to_string());
+        let request = self
+            .create_request_command(
+                RequestCode::UpdateBrokerConfigCas,
+                UpdateBrokerConfigRequestHeader { expected_generation },
+            )
+            .set_body(body.to_string());
         let broker_addr = mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr.as_str());
         let response = self
             .remoting_client
@@ -370,7 +371,7 @@ impl MQClientAPIImpl {
                     .map_err(|_| RocketMQError::illegal_argument("writeQueueNums exceeds Java int range"))
             })
             .transpose()?;
-        let request = RemotingCommand::create_request_command(
+        let request = self.create_request_command(
             RequestCode::UpdateTopicConfigCas,
             UpdateTopicConfigCasRequestHeader {
                 topic,
@@ -438,7 +439,7 @@ impl MQClientAPIImpl {
                     .map_err(|_| RocketMQError::illegal_argument("consumeTimeoutMinutes exceeds Java int range"))
             })
             .transpose()?;
-        let request = RemotingCommand::create_request_command(
+        let request = self.create_request_command(
             RequestCode::UpdateSubscriptionGroupConfigCas,
             UpdateSubscriptionGroupConfigCasRequestHeader {
                 group,
@@ -461,7 +462,7 @@ impl MQClientAPIImpl {
         addr: &CheetahString,
         timeout_millis: u64,
     ) -> RocketMQResult<BrokerConfigSnapshot> {
-        let request = RemotingCommand::create_remoting_command(RequestCode::GetBrokerConfig);
+        let request = self.create_remoting_command(RequestCode::GetBrokerConfig);
         let response = self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
@@ -483,7 +484,7 @@ impl MQClientAPIImpl {
         group: CheetahString,
         timeout_millis: u64,
     ) -> RocketMQResult<SubscriptionGroupConfigVersioned> {
-        let request = RemotingCommand::create_request_command(
+        let request = self.create_request_command(
             RequestCode::GetSubscriptionGroupConfig,
             rocketmq_protocol::protocol::header::get_subscription_group_config_request_header::GetSubscriptionGroupConfigRequestHeader {
                 group,

--- a/rocketmq-client/src/implementation/mq_client_api_impl/consumer.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl/consumer.rs
@@ -128,7 +128,7 @@ impl MQClientAPIImpl {
         request_header: NotificationRequestHeader,
         timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<NotifyResult> {
-        let request = notification_request(request_header);
+        let request = notification_request(&self.command_factory, request_header);
         let response = self
             .remoting_client
             .invoke_request(Some(broker_addr), request, timeout_millis)
@@ -154,7 +154,7 @@ impl MQClientAPIImpl {
             consumer_group: CheetahString::from_slice(consumer_group),
             rpc: None,
         };
-        let request = RemotingCommand::create_request_command(RequestCode::GetConsumerListByGroup, request_header);
+        let request = self.create_request_command(RequestCode::GetConsumerListByGroup, request_header);
         let response = self
             .remoting_client
             .invoke_request(
@@ -201,7 +201,7 @@ impl MQClientAPIImpl {
             consumer_group,
             rpc_request_header: None,
         };
-        let request = RemotingCommand::create_request_command(RequestCode::GetConsumerConnectionList, request_header);
+        let request = self.create_request_command(RequestCode::GetConsumerConnectionList, request_header);
         let response = self
             .remoting_client
             .invoke_request(
@@ -241,7 +241,7 @@ impl MQClientAPIImpl {
             producer_group,
             rpc_request_header: None,
         };
-        let request = RemotingCommand::create_request_command(RequestCode::GetProducerConnectionList, request_header);
+        let request = self.create_request_command(RequestCode::GetProducerConnectionList, request_header);
         let response = self
             .remoting_client
             .invoke_request(
@@ -289,8 +289,7 @@ impl MQClientAPIImpl {
             },
             topic_request_header: None,
         };
-        let request =
-            RemotingCommand::create_request_command(RequestCode::InvokeBrokerToGetConsumerStatus, request_header);
+        let request = self.create_request_command(RequestCode::InvokeBrokerToGetConsumerStatus, request_header);
         let response = self
             .remoting_client
             .invoke_request(
@@ -323,7 +322,7 @@ impl MQClientAPIImpl {
         addr: &str,
         timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<ProducerTableInfo> {
-        let request = RemotingCommand::create_request_command(RequestCode::GetAllProducerInfo, EmptyHeader {});
+        let request = self.create_request_command(RequestCode::GetAllProducerInfo, EmptyHeader {});
         let response = self
             .remoting_client
             .invoke_request(
@@ -359,7 +358,7 @@ impl MQClientAPIImpl {
         request_header: UpdateConsumerOffsetRequestHeader,
         timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<()> {
-        let request = RemotingCommand::create_request_command(RequestCode::UpdateConsumerOffset, request_header);
+        let request = self.create_request_command(RequestCode::UpdateConsumerOffset, request_header);
         self.remoting_client
             .invoke_request_oneway(
                 mix_all::broker_vip_channel(self.client_config.vip_channel_enabled, addr).as_ref(),
@@ -385,7 +384,7 @@ impl MQClientAPIImpl {
         request_header: UpdateConsumerOffsetRequestHeader,
         timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<()> {
-        let request = RemotingCommand::create_request_command(RequestCode::UpdateConsumerOffset, request_header);
+        let request = self.create_request_command(RequestCode::UpdateConsumerOffset, request_header);
         let response = self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
@@ -416,7 +415,7 @@ impl MQClientAPIImpl {
         request_header: QueryConsumerOffsetRequestHeader,
         timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<i64> {
-        let request = RemotingCommand::create_request_command(RequestCode::QueryConsumerOffset, request_header);
+        let request = self.create_request_command(RequestCode::QueryConsumerOffset, request_header);
         let response = self
             .remoting_client
             .invoke_request(
@@ -468,7 +467,7 @@ impl MQClientAPIImpl {
         unique_key_flag: bool,
         timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<Option<(QueryMessageResponseHeader, Option<bytes::Bytes>)>> {
-        let mut request = RemotingCommand::create_request_command(RequestCode::QueryMessage, request_header);
+        let mut request = this.create_request_command(RequestCode::QueryMessage, request_header);
         if unique_key_flag {
             request.ensure_ext_fields_initialized();
             request.add_ext_field(mix_all::UNIQUE_MSG_QUERY_FLAG, "true");
@@ -508,9 +507,9 @@ impl MQClientAPIImpl {
         PCB: PullCallback + 'static,
     {
         let request = if PullSysFlag::has_lite_pull_flag(request_header.sys_flag as u32) {
-            RemotingCommand::create_request_command(RequestCode::LitePullMessage, request_header)
+            this.create_request_command(RequestCode::LitePullMessage, request_header)
         } else {
-            RemotingCommand::create_request_command(RequestCode::PullMessage, request_header)
+            this.create_request_command(RequestCode::PullMessage, request_header)
         };
         match communication_mode {
             CommunicationMode::Sync => {
@@ -640,7 +639,7 @@ impl MQClientAPIImpl {
             max_consume_retry_times,
         );
 
-        let request_command = RemotingCommand::create_request_command(RequestCode::ConsumerSendMsgBack, header);
+        let request_command = self.create_request_command(RequestCode::ConsumerSendMsgBack, header);
         let response = self
             .remoting_client
             .invoke_request(
@@ -693,7 +692,7 @@ impl MQClientAPIImpl {
         request_header: ConsumerSendMsgBackRequestHeader,
         timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
-        let request = RemotingCommand::create_request_command(RequestCode::ConsumerSendMsgBack, request_header);
+        let request = self.create_request_command(RequestCode::ConsumerSendMsgBack, request_header);
         self.remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
             .await
@@ -713,7 +712,7 @@ impl MQClientAPIImpl {
             consumer_group,
             rpc_request_header: None,
         };
-        let request = RemotingCommand::create_request_command(RequestCode::UnregisterClient, request_header);
+        let request = self.create_request_command(RequestCode::UnregisterClient, request_header);
         let response = self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
@@ -737,7 +736,7 @@ impl MQClientAPIImpl {
         oneway: bool,
     ) -> rocketmq_error::RocketMQResult<()> {
         let mut request =
-            RemotingCommand::create_request_command(RequestCode::UnlockBatchMq, UnlockBatchMqRequestHeader::default());
+            self.create_request_command(RequestCode::UnlockBatchMq, UnlockBatchMqRequestHeader::default());
         request.set_body_mut_ref(request_body.encode()?);
         if oneway {
             self.remoting_client
@@ -782,8 +781,7 @@ impl MQClientAPIImpl {
         request_body: LockBatchRequestBody,
         timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<HashSet<MessageQueue>> {
-        let mut request =
-            RemotingCommand::create_request_command(RequestCode::LockBatchMq, LockBatchMqRequestHeader::default());
+        let mut request = self.create_request_command(RequestCode::LockBatchMq, LockBatchMqRequestHeader::default());
         request.set_body_mut_ref(request_body.encode()?);
         let response = self
             .remoting_client
@@ -847,7 +845,7 @@ impl MQClientAPIImpl {
             }),
         };
 
-        let request = RemotingCommand::create_request_command(RequestCode::GetMaxOffset, request_header);
+        let request = self.create_request_command(RequestCode::GetMaxOffset, request_header);
 
         let response = self
             .remoting_client
@@ -889,7 +887,7 @@ impl MQClientAPIImpl {
             }),
         };
 
-        let request = RemotingCommand::create_request_command(RequestCode::GetMinOffset, request_header);
+        let request = self.create_request_command(RequestCode::GetMinOffset, request_header);
 
         let response = self
             .remoting_client
@@ -931,7 +929,7 @@ impl MQClientAPIImpl {
             }),
         };
 
-        let request = RemotingCommand::create_request_command(RequestCode::GetEarliestMsgStoreTime, request_header);
+        let request = self.create_request_command(RequestCode::GetEarliestMsgStoreTime, request_header);
 
         let response = self
             .remoting_client
@@ -998,7 +996,7 @@ impl MQClientAPIImpl {
                 lo: None,
             }),
         };
-        let request = RemotingCommand::create_request_command(RequestCode::SearchOffsetByTimestamp, request_header);
+        let request = self.create_request_command(RequestCode::SearchOffsetByTimestamp, request_header);
         let response = self
             .remoting_client
             .invoke_request(
@@ -1048,8 +1046,9 @@ impl MQClientAPIImpl {
             mode,
             pop_share_queue_num,
         };
-        let request =
-            RemotingCommand::create_remoting_command(RequestCode::SetMessageRequestMode).set_body(body.encode()?);
+        let request = self
+            .create_remoting_command(RequestCode::SetMessageRequestMode)
+            .set_body(body.encode()?);
         let response = self
             .remoting_client
             .invoke_request(
@@ -1087,7 +1086,7 @@ impl MQClientAPIImpl {
             strategy_name,
             message_model,
         };
-        let request = RemotingCommand::new_request(RequestCode::QueryAssignment, request_body.encode()?);
+        let request = self.create_request(RequestCode::QueryAssignment, request_body.encode()?);
         let response = self
             .remoting_client
             .invoke_request(
@@ -1129,7 +1128,7 @@ impl MQClientAPIImpl {
         let offset = request_header.offset;
         let topic = request_header.topic.clone();
         let queue_id = request_header.queue_id;
-        let request = RemotingCommand::create_request_command(RequestCode::ChangeMessageInvisibleTime, request_header);
+        let request = self.create_request_command(RequestCode::ChangeMessageInvisibleTime, request_header);
         match self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
@@ -1189,7 +1188,7 @@ impl MQClientAPIImpl {
         let addr = addr.clone();
         let topic = request_header.topic.clone();
         let order = request_header.order.unwrap_or_default();
-        let request = RemotingCommand::create_request_command(RequestCode::PopMessage, request_header);
+        let request = self.create_request_command(RequestCode::PopMessage, request_header);
         let request_task = async move {
             let response = self
                 .remoting_client
@@ -1218,7 +1217,7 @@ impl MQClientAPIImpl {
         let broker_name = broker_name.clone();
         let addr = addr.clone();
         let bind_topic = request_header.topic.clone();
-        let request = RemotingCommand::create_request_command(RequestCode::PopLiteMessage, request_header);
+        let request = self.create_request_command(RequestCode::PopLiteMessage, request_header);
         let request_task = async move {
             let response = self
                 .remoting_client
@@ -1667,11 +1666,11 @@ impl MQClientAPIImpl {
         timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<AckResult> {
         let request = if let Some(header) = request_header {
-            RemotingCommand::create_request_command(RequestCode::AckMessage, header)
+            self.create_request_command(RequestCode::AckMessage, header)
         } else {
             let body =
                 request_body.ok_or_else(|| mq_client_err!("BatchAckMessage request body is required".to_string()))?;
-            RemotingCommand::new_request(RequestCode::BatchAckMessage, body.encode()?)
+            self.create_request(RequestCode::BatchAckMessage, body.encode()?)
         };
         let response = self
             .remoting_client

--- a/rocketmq-client/src/implementation/mq_client_api_impl/producer.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl/producer.rs
@@ -69,9 +69,9 @@ impl MQClientAPIImpl {
             if *SEND_SMART_MSG {
                 let request_header_v2 =
                     SendMessageRequestHeaderV2::create_send_message_request_header_v2(&request_header);
-                RemotingCommand::create_request_command(RequestCode::SendReplyMessageV2, request_header_v2)
+                self.create_request_command(RequestCode::SendReplyMessageV2, request_header_v2)
             } else {
-                RemotingCommand::create_request_command(RequestCode::SendReplyMessage, request_header)
+                self.create_request_command(RequestCode::SendReplyMessage, request_header)
             }
         } else {
             let is_batch_message = msg.as_any().downcast_ref::<MessageBatch>().is_some();
@@ -83,9 +83,9 @@ impl MQClientAPIImpl {
                 } else {
                     RequestCode::SendMessageV2
                 };
-                RemotingCommand::create_request_command(request_code, request_header_v2)
+                self.create_request_command(request_code, request_header_v2)
             } else {
-                RemotingCommand::create_request_command(RequestCode::SendMessage, request_header)
+                self.create_request_command(RequestCode::SendMessage, request_header)
             }
         };
 
@@ -756,7 +756,7 @@ impl MQClientAPIImpl {
         heartbeat_data: &HeartbeatData,
         timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<(i32, Option<RemotingCommand>)> {
-        let request = heartbeat_request(heartbeat_data, self.client_config.language)?;
+        let request = heartbeat_request(&self.command_factory, heartbeat_data, self.client_config.language)?;
         let response = self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
@@ -788,7 +788,7 @@ impl MQClientAPIImpl {
         heartbeat_data: &HeartbeatData,
         timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<()> {
-        let request = heartbeat_request(heartbeat_data, self.client_config.language)?;
+        let request = heartbeat_request(&self.command_factory, heartbeat_data, self.client_config.language)?;
         self.remoting_client
             .invoke_request_oneway(addr, request, timeout_millis)
             .await
@@ -800,7 +800,7 @@ impl MQClientAPIImpl {
         heartbeat_data: &HeartbeatData,
         timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<bool> {
-        let request = heartbeat_request(heartbeat_data, self.client_config.language)?;
+        let request = heartbeat_request(&self.command_factory, heartbeat_data, self.client_config.language)?;
         let response = self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
@@ -814,7 +814,7 @@ impl MQClientAPIImpl {
         heartbeat_data: &HeartbeatData,
         timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<HeartbeatV2Result> {
-        let request = heartbeat_request(heartbeat_data, self.client_config.language)?;
+        let request = heartbeat_request(&self.command_factory, heartbeat_data, self.client_config.language)?;
         let response = self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)
@@ -837,7 +837,7 @@ impl MQClientAPIImpl {
         subscription_data: &SubscriptionData,
         timeout_millis: u64,
     ) -> RocketMQResult<()> {
-        let mut request = RemotingCommand::create_remoting_command(RequestCode::CheckClientConfig);
+        let mut request = self.create_remoting_command(RequestCode::CheckClientConfig);
         let body = CheckClientRequestBody::new(
             client_id.to_string(),
             consumer_group.to_string(),
@@ -867,7 +867,7 @@ impl MQClientAPIImpl {
         request_header: RecallMessageRequestHeader,
         timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<String> {
-        let request = RemotingCommand::create_request_command(RequestCode::RecallMessage, request_header);
+        let request = self.create_request_command(RequestCode::RecallMessage, request_header);
 
         let response = self
             .remoting_client
@@ -903,7 +903,7 @@ impl MQClientAPIImpl {
     where
         F: FnOnce(rocketmq_error::RocketMQResult<RemotingCommand>) + Send,
     {
-        let request = RemotingCommand::create_request_command(RequestCode::RecallMessage, request_header);
+        let request = self.create_request_command(RequestCode::RecallMessage, request_header);
         let response = self
             .remoting_client
             .invoke_request(Some(addr), request, timeout_millis)

--- a/rocketmq-client/src/implementation/mq_client_api_impl/request_builder.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl/request_builder.rs
@@ -13,75 +13,109 @@
 // limitations under the License.
 
 use super::*;
+use rocketmq_protocol::protocol::command_custom_header::CommandCustomHeader;
+
+impl MQClientAPIImpl {
+    #[inline]
+    pub(super) fn create_remoting_command(&self, code: impl Into<i32>) -> RemotingCommand {
+        self.command_factory.create_remoting_command(code)
+    }
+
+    #[inline]
+    pub(super) fn create_request(&self, code: impl Into<i32>, body: impl Into<bytes::Bytes>) -> RemotingCommand {
+        self.command_factory.create_request(code, body)
+    }
+
+    #[inline]
+    pub(super) fn create_request_command<T>(&self, code: impl Into<i32>, header: T) -> RemotingCommand
+    where
+        T: CommandCustomHeader + Send + Sync + 'static,
+    {
+        self.command_factory.create_request_command(code, header)
+    }
+}
 
 #[cfg(feature = "admin-mutation")]
 pub(super) fn lite_subscription_ctl_request(
+    command_factory: &RemotingCommandFactory,
     lite_subscription_dto: LiteSubscriptionDTO,
 ) -> RocketMQResult<RemotingCommand> {
     let mut request_body = LiteSubscriptionCtlRequestBody::new();
     request_body.set_subscription_set(vec![lite_subscription_dto]);
-    let mut request = RemotingCommand::create_request_command(RequestCode::LiteSubscriptionCtl, EmptyHeader {});
+    let mut request = command_factory.create_request_command(RequestCode::LiteSubscriptionCtl, EmptyHeader {});
     request.set_body_mut_ref(request_body.encode()?);
     Ok(request)
 }
 
-pub(super) fn notification_request(request_header: NotificationRequestHeader) -> RemotingCommand {
-    RemotingCommand::create_request_command(RequestCode::Notification, request_header)
+pub(super) fn notification_request(
+    command_factory: &RemotingCommandFactory,
+    request_header: NotificationRequestHeader,
+) -> RemotingCommand {
+    command_factory.create_request_command(RequestCode::Notification, request_header)
 }
 
 #[cfg(feature = "admin-mutation")]
 pub(super) fn create_and_update_plain_access_config_request(
+    command_factory: &RemotingCommandFactory,
     plain_access_config: &PlainAccessConfig,
 ) -> RocketMQResult<RemotingCommand> {
-    let mut request = RemotingCommand::create_request_command(RequestCode::UpdateAndCreateAclConfig, EmptyHeader {});
+    let mut request = command_factory.create_request_command(RequestCode::UpdateAndCreateAclConfig, EmptyHeader {});
     request.set_body_mut_ref(plain_access_config.encode()?);
     Ok(request)
 }
 
-pub(super) fn get_acl_request(subject: CheetahString) -> RemotingCommand {
-    RemotingCommand::create_request_command(RequestCode::AuthGetAcl, GetAclRequestHeader { subject })
+pub(super) fn get_acl_request(command_factory: &RemotingCommandFactory, subject: CheetahString) -> RemotingCommand {
+    command_factory.create_request_command(RequestCode::AuthGetAcl, GetAclRequestHeader { subject })
 }
 
 #[cfg(feature = "admin-mutation")]
-pub(super) fn delete_plain_access_config_request(access_key: &CheetahString) -> RemotingCommand {
-    RemotingCommand::create_request_command(RequestCode::DeleteAclConfig, EmptyHeader {})
+pub(super) fn delete_plain_access_config_request(
+    command_factory: &RemotingCommandFactory,
+    access_key: &CheetahString,
+) -> RemotingCommand {
+    command_factory
+        .create_request_command(RequestCode::DeleteAclConfig, EmptyHeader {})
         .set_body(access_key.as_str().as_bytes().to_vec())
 }
 
 pub(super) fn heartbeat_request(
+    command_factory: &RemotingCommandFactory,
     heartbeat_data: &HeartbeatData,
     language: LanguageCode,
 ) -> RocketMQResult<RemotingCommand> {
-    Ok(
-        RemotingCommand::create_request_command(RequestCode::HeartBeat, HeartbeatRequestHeader::default())
-            .set_language(language)
-            .set_body(heartbeat_data.encode()?),
-    )
+    Ok(command_factory
+        .create_request_command(RequestCode::HeartBeat, HeartbeatRequestHeader::default())
+        .set_language(language)
+        .set_body(heartbeat_data.encode()?))
 }
 
-pub(super) fn get_all_consumer_offset_request() -> RemotingCommand {
-    RemotingCommand::create_remoting_command(RequestCode::GetAllConsumerOffset)
+pub(super) fn get_all_consumer_offset_request(command_factory: &RemotingCommandFactory) -> RemotingCommand {
+    command_factory.create_remoting_command(RequestCode::GetAllConsumerOffset)
 }
 
 #[cfg(feature = "admin-mutation")]
-pub(super) fn create_topic_list_request(topic_config_list: Vec<TopicConfig>) -> RocketMQResult<RemotingCommand> {
+pub(super) fn create_topic_list_request(
+    command_factory: &RemotingCommandFactory,
+    topic_config_list: Vec<TopicConfig>,
+) -> RocketMQResult<RemotingCommand> {
     let body = CreateTopicListRequestBody { topic_config_list };
-    Ok(RemotingCommand::create_request_command(
-        RequestCode::UpdateAndCreateTopicList,
-        CreateTopicListRequestHeader::default(),
-    )
-    .set_body(body.encode()?))
+    Ok(command_factory
+        .create_request_command(
+            RequestCode::UpdateAndCreateTopicList,
+            CreateTopicListRequestHeader::default(),
+        )
+        .set_body(body.encode()?))
 }
 
 #[cfg(feature = "admin-mutation")]
 pub(super) fn create_subscription_group_list_request(
+    command_factory: &RemotingCommandFactory,
     configs: Vec<SubscriptionGroupConfig>,
 ) -> RocketMQResult<RemotingCommand> {
     let body = SubscriptionGroupList {
         group_config_list: configs,
     };
-    Ok(
-        RemotingCommand::create_request_command(RequestCode::UpdateAndCreateSubscriptionGroupList, EmptyHeader {})
-            .set_body(body.encode()?),
-    )
+    Ok(command_factory
+        .create_request_command(RequestCode::UpdateAndCreateSubscriptionGroupList, EmptyHeader {})
+        .set_body(body.encode()?))
 }

--- a/rocketmq-client/src/implementation/mq_client_api_impl/route.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl/route.rs
@@ -73,7 +73,7 @@ impl MQClientAPIImpl {
             accept_standard_json_only: None,
             topic_request_header: None,
         };
-        let request = RemotingCommand::create_request_command(RequestCode::GetRouteinfoByTopic, request_header);
+        let request = self.create_request_command(RequestCode::GetRouteinfoByTopic, request_header);
         let response = self.remoting_client.invoke_request(None, request, timeout_millis).await;
         match response {
             Ok(mut result) => {

--- a/rocketmq-client/src/implementation/mq_client_api_impl/transaction.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl/transaction.rs
@@ -47,8 +47,9 @@ impl MQClientAPIImpl {
         remark: CheetahString,
         timeout_millis: u64,
     ) -> rocketmq_error::RocketMQResult<()> {
-        let request =
-            RemotingCommand::create_request_command(RequestCode::EndTransaction, request_header).set_remark(remark);
+        let request = self
+            .create_request_command(RequestCode::EndTransaction, request_header)
+            .set_remark(remark);
 
         self.remoting_client
             .invoke_request_oneway(addr, request, timeout_millis)

--- a/rocketmq-client/src/implementation/mq_client_api_impl/transport.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl/transport.rs
@@ -28,6 +28,7 @@ impl MQClientAPIImpl {
         tx: Option<tokio::sync::broadcast::Sender<ConnectionNetEvent>>,
         service_context: ChildServiceContext,
         telemetry_handle: rocketmq_observability::TelemetryHandle,
+        command_factory: RemotingCommandFactory,
     ) -> Self {
         let mut remoting_config = (*tokio_client_config).clone();
         remoting_config.tls = client_config.tls_config.clone();
@@ -63,6 +64,7 @@ impl MQClientAPIImpl {
             //client_remoting_processor,
             name_srv_addr: RwLock::new(None),
             client_config,
+            command_factory,
             background_tasks: TaskTracker::new(),
             background_shutdown: CancellationToken::new(),
         }
@@ -90,6 +92,10 @@ impl MQClientAPIImpl {
 
     pub fn get_remoting_client(&self) -> Arc<RemotingClient<ClientRemotingProcessor>> {
         self.remoting_client.clone()
+    }
+
+    pub(crate) fn remoting_command_factory(&self) -> RemotingCommandFactory {
+        self.command_factory
     }
 
     #[inline]

--- a/rocketmq-client/src/implementation/mq_client_manager.rs
+++ b/rocketmq-client/src/implementation/mq_client_manager.rs
@@ -22,7 +22,8 @@ use dashmap::DashMap;
 use parking_lot::RwLock;
 use rocketmq_observability::metrics::client::ClientMetrics;
 use rocketmq_observability::TelemetryHandle;
-use rocketmq_protocol::protocol::remoting_command_facade::initialize_remoting_defaults;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandDefaults;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 use rocketmq_runtime::ChildServiceContext;
 use rocketmq_runtime::ResourceBudget;
 use rocketmq_runtime::ShutdownDeadline;
@@ -51,6 +52,7 @@ struct ClientPoolIdentity {
     vip_channel_enabled: bool,
     api_timeout_millis: u64,
     rpc_hook_identity: Option<usize>,
+    remoting_command_defaults: RemotingCommandDefaults,
 }
 
 impl ClientPoolIdentity {
@@ -58,6 +60,7 @@ impl ClientPoolIdentity {
         client_config: &ClientConfig,
         discovery: Option<&NameServerDiscoveryConfig>,
         rpc_hook: Option<&Arc<dyn RPCHook>>,
+        remoting_command_factory: RemotingCommandFactory,
     ) -> Self {
         Self {
             namesrv_addr: client_config.namesrv_addr.clone(),
@@ -66,6 +69,7 @@ impl ClientPoolIdentity {
             vip_channel_enabled: client_config.vip_channel_enabled,
             api_timeout_millis: client_config.mq_client_api_timeout,
             rpc_hook_identity: rpc_hook.map(|hook| Arc::as_ptr(hook).cast::<()>() as usize),
+            remoting_command_defaults: remoting_command_factory.defaults(),
         }
     }
 }
@@ -86,6 +90,7 @@ struct ClientPoolInner {
     factory_table: Arc<ClientInstanceHashMap>,
     accumulator_table: Arc<AccumulatorHashMap>,
     request_future_holder: Arc<RequestFutureHolder>,
+    remoting_command_factory: RemotingCommandFactory,
     next_generation: AtomicU64,
     closed: AtomicBool,
     admission: RwLock<()>,
@@ -118,6 +123,7 @@ impl ClientPool {
         resource_budget: ResourceBudget,
         telemetry_handle: TelemetryHandle,
         client_metrics: ClientMetrics,
+        remoting_command_factory: RemotingCommandFactory,
     ) -> Self {
         let request_future_holder = Arc::new(RequestFutureHolder::new(service_context.component("request-futures")));
         Self {
@@ -129,6 +135,7 @@ impl ClientPool {
                 factory_table: Arc::new(DashMap::with_capacity(128)),
                 accumulator_table: Arc::new(DashMap::with_capacity(128)),
                 request_future_holder,
+                remoting_command_factory,
                 next_generation: AtomicU64::new(0),
                 closed: AtomicBool::new(false),
                 admission: RwLock::new(()),
@@ -157,20 +164,19 @@ impl ClientPool {
         options: ClientOptions,
         rpc_hook: Option<Arc<dyn RPCHook>>,
     ) -> rocketmq_error::RocketMQResult<PooledClient> {
-        initialize_remoting_defaults(rocketmq_model::version::CURRENT_VERSION as i32).map_err(|error| {
-            rocketmq_error::RocketMQError::ConfigParseFailed {
-                key: "remoting.command.defaults",
-                reason: error.to_string(),
-            }
-        })?;
-
         let _admission = self.inner.admission.read();
         if self.inner.closed.load(Ordering::Acquire) {
             return Err(mq_client_err!("ClientRuntime is shutting down"));
         }
-        let (client_config, discovery) = options.into_normalized_parts()?;
+        let (client_config, discovery, command_factory_override) = options.into_normalized_parts()?;
+        let remoting_command_factory = command_factory_override.unwrap_or(self.inner.remoting_command_factory);
         let client_id = CheetahString::from_string(client_config.build_mq_client_id());
-        let identity = ClientPoolIdentity::new(&client_config, discovery.as_ref(), rpc_hook.as_ref());
+        let identity = ClientPoolIdentity::new(
+            &client_config,
+            discovery.as_ref(),
+            rpc_hook.as_ref(),
+            remoting_command_factory,
+        );
 
         let mut entry = self.inner.factory_table.entry(client_id.clone()).or_insert_with(|| {
             let generation = self.inner.next_generation.fetch_add(1, Ordering::AcqRel) + 1;
@@ -182,6 +188,7 @@ impl ClientPool {
             let instance = MQClientInstance::new_arc_with_resource_budget_and_discovery(
                 client_config,
                 discovery,
+                remoting_command_factory,
                 generation,
                 client_id.clone(),
                 rpc_hook,
@@ -303,6 +310,7 @@ impl ClientPool {
 mod tests {
     use cheetah_string::CheetahString;
     use rocketmq_error::RocketMQError;
+    use rocketmq_protocol::protocol::SerializeType;
 
     use super::*;
 
@@ -356,5 +364,33 @@ mod tests {
             ..Default::default()
         };
         assert!(runtime.pool().get_or_create(different_config, None).is_err());
+    }
+
+    #[test]
+    fn remoting_defaults_participate_in_pool_identity() {
+        let runtime = crate::runtime::test_client_runtime("remoting-defaults-pool-identity-test");
+        let mut config = ClientConfig::default();
+        config.set_instance_name("remoting-defaults-owner".into());
+        let json = RemotingCommandFactory::new(RemotingCommandDefaults::new(501, SerializeType::JSON));
+        let binary = RemotingCommandFactory::new(RemotingCommandDefaults::new(502, SerializeType::ROCKETMQ));
+
+        runtime
+            .pool()
+            .get_or_create_with_options(
+                ClientOptions::legacy(config.clone()).with_remoting_command_factory(json),
+                None,
+            )
+            .expect("first command owner");
+        let error = match runtime.pool().get_or_create_with_options(
+            ClientOptions::legacy(config).with_remoting_command_factory(binary),
+            None,
+        ) {
+            Ok(_) => panic!("different remoting defaults must not share one client-id owner"),
+            Err(error) => error,
+        };
+
+        assert!(error
+            .to_string()
+            .contains("ClientPool configuration conflicts with an existing client-id owner"));
     }
 }

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl/send.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl/send.rs
@@ -173,6 +173,7 @@ impl DefaultMQProducerImpl {
                             broker_addr.as_str(),
                         );
                         let mq_client_api = client_instance.get_mq_client_api_impl()?;
+                        let command_factory = mq_client_api.remoting_command_factory();
                         let send_config = runtime.send_config.clone();
                         let namespace = runtime.client_config.namespace.clone();
                         let retained_bytes = Self::message_body_len_for_backpressure(&msg).saturating_add(4 * 1024);
@@ -184,6 +185,7 @@ impl DefaultMQProducerImpl {
                                 &mq,
                                 &broker_name,
                                 &send_config,
+                                command_factory,
                                 namespace.as_deref(),
                             )?;
                             Ok(OnewayEnvelope {
@@ -1848,6 +1850,7 @@ pub(super) fn build_oneway_request_internal<T>(
     mq: &MessageQueue,
     broker_name: &CheetahString,
     send_config: &ProducerSendConfigSnapshot,
+    command_factory: rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory,
     _namespace: Option<&str>,
 ) -> rocketmq_error::RocketMQResult<RemotingCommand>
 where
@@ -1855,7 +1858,6 @@ where
 {
     use rocketmq_protocol::code::request_code::RequestCode;
     use rocketmq_protocol::protocol::header::message_operation_header::send_message_request_header::SendMessageRequestHeader;
-    use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 
     // Set message ID
     MessageClientIDSetter::set_uniq_id(msg);
@@ -1885,7 +1887,7 @@ where
     };
 
     // Build command
-    let mut request = RemotingCommand::create_request_command(RequestCode::SendMessage, request_header);
+    let mut request = command_factory.create_request_command(RequestCode::SendMessage, request_header);
 
     // Set body (zero-copy: Bytes is reference-counted)
     if let Some(body) = msg.get_body() {

--- a/rocketmq-client/src/runtime.rs
+++ b/rocketmq-client/src/runtime.rs
@@ -26,6 +26,8 @@ use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 pub use rocketmq_observability::metrics::client::ClientMetrics;
 pub use rocketmq_observability::TelemetryHandle;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
+use rocketmq_protocol::protocol::remoting_command_facade::initialize_remoting_command_factory;
 use rocketmq_runtime::BudgetCapacity;
 use rocketmq_runtime::BudgetLimit;
 use rocketmq_runtime::ChildServiceContext;
@@ -91,6 +93,30 @@ impl ClientRuntime {
         config: ClientRuntimeConfig,
         telemetry_handle: TelemetryHandle,
     ) -> RocketMQResult<Arc<Self>> {
+        let remoting_command_factory =
+            initialize_remoting_command_factory(rocketmq_model::version::CURRENT_VERSION as i32).map_err(|error| {
+                rocketmq_error::RocketMQError::ConfigParseFailed {
+                    key: "remoting.command.defaults",
+                    reason: error.to_string(),
+                }
+            })?;
+        Self::try_new_with_remoting_command_factory(service_context, config, telemetry_handle, remoting_command_factory)
+    }
+
+    /// Creates a client runtime with explicit immutable remoting wire defaults.
+    ///
+    /// This entry point does not read process configuration and permits
+    /// independent embedded client runtimes to use different wire defaults.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the configured client resource budget is invalid.
+    pub fn try_new_with_remoting_command_factory(
+        service_context: ChildServiceContext,
+        config: ClientRuntimeConfig,
+        telemetry_handle: TelemetryHandle,
+        remoting_command_factory: RemotingCommandFactory,
+    ) -> RocketMQResult<Arc<Self>> {
         let resource_budget = build_client_resource_budget(&config, &service_context.process_budget())?;
         let client_metrics = ClientMetrics::from_handle(&telemetry_handle);
         let pool = ClientPool::new(
@@ -98,6 +124,7 @@ impl ClientRuntime {
             resource_budget.clone(),
             telemetry_handle.clone(),
             client_metrics.clone(),
+            remoting_command_factory,
         );
         Ok(Arc::new(Self {
             service_context,
@@ -637,7 +664,64 @@ pub(crate) fn spawn_delayed_client_action_with_context<F>(
 mod tests {
     use std::sync::atomic::AtomicUsize;
 
+    use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandDefaults;
+    use rocketmq_protocol::protocol::SerializeType;
+
     use super::*;
+
+    #[test]
+    fn client_runtimes_keep_independent_remoting_command_factories() {
+        let json_factory = RemotingCommandFactory::new(RemotingCommandDefaults::new(301, SerializeType::JSON));
+        let binary_factory = RemotingCommandFactory::new(RemotingCommandDefaults::new(302, SerializeType::ROCKETMQ));
+        let json_runtime = ClientRuntime::try_new_with_remoting_command_factory(
+            TEST_RUNTIME_OWNER.root_context().component("client-json-command-owner"),
+            ClientRuntimeConfig::default(),
+            TelemetryHandle::noop(),
+            json_factory,
+        )
+        .expect("JSON client runtime");
+        let binary_runtime = ClientRuntime::try_new_with_remoting_command_factory(
+            TEST_RUNTIME_OWNER
+                .root_context()
+                .component("client-binary-command-owner"),
+            ClientRuntimeConfig::default(),
+            TelemetryHandle::noop(),
+            binary_factory,
+        )
+        .expect("ROCKETMQ client runtime");
+        let mut json_config = crate::base::client_config::ClientConfig::default();
+        json_config.set_instance_name("client-json-command-owner".into());
+        let mut binary_config = crate::base::client_config::ClientConfig::default();
+        binary_config.set_instance_name("client-binary-command-owner".into());
+
+        let json_client = json_runtime
+            .pool()
+            .get_or_create(json_config, None)
+            .expect("JSON client owner");
+        let binary_client = binary_runtime
+            .pool()
+            .get_or_create(binary_config, None)
+            .expect("ROCKETMQ client owner");
+
+        assert_eq!(json_client.instance().remoting_command_factory(), json_factory);
+        assert_eq!(binary_client.instance().remoting_command_factory(), binary_factory);
+        assert_eq!(
+            json_client
+                .instance()
+                .get_mq_client_api_impl()
+                .expect("JSON API owner")
+                .remoting_command_factory(),
+            json_factory
+        );
+        assert_eq!(
+            binary_client
+                .instance()
+                .get_mq_client_api_impl()
+                .expect("ROCKETMQ API owner")
+                .remoting_command_factory(),
+            binary_factory
+        );
+    }
 
     #[test]
     fn sibling_component_budgets_share_the_client_runtime_parent_limit() {

--- a/rocketmq-client/tests/implementation/mq_client_api_impl/unit.rs
+++ b/rocketmq-client/tests/implementation/mq_client_api_impl/unit.rs
@@ -38,7 +38,10 @@ use std::sync::atomic::Ordering as AtomicOrdering;
 use rocketmq_model::common::lite::LiteSubscriptionAction;
 use rocketmq_protocol::protocol::command_custom_header::CommandCustomHeader;
 use rocketmq_protocol::protocol::command_custom_header::FromMap;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandDefaults;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 use rocketmq_protocol::protocol::route::route_data_view::BrokerData;
+use rocketmq_protocol::protocol::SerializeType;
 
 use super::*;
 
@@ -413,8 +416,11 @@ fn create_topic_request_header_rejects_values_outside_java_int_range() {
 #[cfg(feature = "admin-mutation")]
 #[test]
 fn create_topic_list_request_matches_java_request_code_and_body() {
-    let request = create_topic_list_request(vec![TopicConfig::new("TopicA"), TopicConfig::new("TopicB")])
-        .expect("topic list request should encode");
+    let request = create_topic_list_request(
+        &test_remoting_command_factory(),
+        vec![TopicConfig::new("TopicA"), TopicConfig::new("TopicB")],
+    )
+    .expect("topic list request should encode");
 
     assert_eq!(request.code(), RequestCode::UpdateAndCreateTopicList as i32);
     let body = request.body().expect("topic list request body should be set");
@@ -428,10 +434,13 @@ fn create_topic_list_request_matches_java_request_code_and_body() {
 #[cfg(feature = "admin-mutation")]
 #[test]
 fn create_subscription_group_list_request_matches_java_request_code_and_body() {
-    let request = create_subscription_group_list_request(vec![
-        SubscriptionGroupConfig::new(CheetahString::from_static_str("GroupA")),
-        SubscriptionGroupConfig::new(CheetahString::from_static_str("GroupB")),
-    ])
+    let request = create_subscription_group_list_request(
+        &test_remoting_command_factory(),
+        vec![
+            SubscriptionGroupConfig::new(CheetahString::from_static_str("GroupA")),
+            SubscriptionGroupConfig::new(CheetahString::from_static_str("GroupB")),
+        ],
+    )
     .expect("subscription group list request should encode");
 
     assert_eq!(request.code(), RequestCode::UpdateAndCreateSubscriptionGroupList as i32);
@@ -448,6 +457,7 @@ fn create_subscription_group_list_request_matches_java_request_code_and_body() {
 #[test]
 fn query_correction_offset_request_joins_filter_groups_like_java() {
     let request = query_correction_offset_request(
+        &test_remoting_command_factory(),
         CheetahString::from_static_str("TopicA"),
         CheetahString::from_static_str("CompareGroup"),
         Some(vec![
@@ -837,8 +847,8 @@ fn lite_subscription_ctl_request_matches_java_single_dto_body() {
         .with_topic(CheetahString::from_static_str("topic-a"))
         .with_version(42);
 
-    let request =
-        lite_subscription_ctl_request(lite_subscription_dto.clone()).expect("lite subscription request should encode");
+    let request = lite_subscription_ctl_request(&test_remoting_command_factory(), lite_subscription_dto.clone())
+        .expect("lite subscription request should encode");
 
     assert_eq!(request.code(), RequestCode::LiteSubscriptionCtl as i32);
     let body = request.body().expect("request body should be set");
@@ -848,20 +858,23 @@ fn lite_subscription_ctl_request_matches_java_single_dto_body() {
 
 #[test]
 fn notification_request_matches_java_header_fields() {
-    let mut request = notification_request(NotificationRequestHeader {
-        consumer_group: CheetahString::from_static_str("group-a"),
-        topic: CheetahString::from_static_str("topic-a"),
-        queue_id: -1,
-        poll_time: 3_000,
-        born_time: 10,
-        order: true,
-        attempt_id: Some(CheetahString::from_static_str("attempt-a")),
-        exp_type: Some(CheetahString::from_static_str("TAG")),
-        exp: Some(CheetahString::from_static_str("tag-a")),
-        is_lite_consumer: false,
-        client_id: None,
-        topic_request_header: None,
-    });
+    let mut request = notification_request(
+        &test_remoting_command_factory(),
+        NotificationRequestHeader {
+            consumer_group: CheetahString::from_static_str("group-a"),
+            topic: CheetahString::from_static_str("topic-a"),
+            queue_id: -1,
+            poll_time: 3_000,
+            born_time: 10,
+            order: true,
+            attempt_id: Some(CheetahString::from_static_str("attempt-a")),
+            exp_type: Some(CheetahString::from_static_str("TAG")),
+            exp: Some(CheetahString::from_static_str("tag-a")),
+            is_lite_consumer: false,
+            client_id: None,
+            topic_request_header: None,
+        },
+    );
 
     assert_eq!(request.code(), RequestCode::Notification as i32);
     request.make_custom_header_to_net();
@@ -883,6 +896,35 @@ fn notification_request_matches_java_header_fields() {
     assert_eq!(ext_fields.get("exp").map(|value| value.as_str()), Some("tag-a"));
 }
 
+fn test_remoting_command_factory() -> RemotingCommandFactory {
+    RemotingCommandFactory::new(RemotingCommandDefaults::default())
+}
+
+#[test]
+fn notification_request_uses_owning_factory_defaults() {
+    let factory = RemotingCommandFactory::new(RemotingCommandDefaults::new(731, SerializeType::ROCKETMQ));
+    let request = notification_request(
+        &factory,
+        NotificationRequestHeader {
+            consumer_group: CheetahString::from_static_str("group-owner"),
+            topic: CheetahString::from_static_str("topic-owner"),
+            queue_id: 1,
+            poll_time: 3_000,
+            born_time: 10,
+            order: false,
+            attempt_id: None,
+            exp_type: None,
+            exp: None,
+            is_lite_consumer: false,
+            client_id: None,
+            topic_request_header: None,
+        },
+    );
+
+    assert_eq!(request.version(), 731);
+    assert_eq!(request.serialize_type(), SerializeType::ROCKETMQ);
+}
+
 #[cfg(feature = "admin-mutation")]
 #[test]
 fn create_and_update_plain_access_config_request_matches_java_legacy_acl_body() {
@@ -897,8 +939,8 @@ fn create_and_update_plain_access_config_request_matches_java_legacy_acl_body() 
         group_perms: vec![CheetahString::from_static_str("GroupA=SUB")],
     };
 
-    let request =
-        create_and_update_plain_access_config_request(&config).expect("plain access config request should encode");
+    let request = create_and_update_plain_access_config_request(&test_remoting_command_factory(), &config)
+        .expect("plain access config request should encode");
 
     assert_eq!(request.code(), RequestCode::UpdateAndCreateAclConfig as i32);
     let body = std::str::from_utf8(request.body().expect("request body should be set").as_ref())
@@ -912,7 +954,8 @@ fn create_and_update_plain_access_config_request_matches_java_legacy_acl_body() 
 #[cfg(feature = "admin-mutation")]
 #[test]
 fn delete_plain_access_config_request_matches_java_legacy_acl_body() {
-    let request = delete_plain_access_config_request(&CheetahString::from_static_str("AK"));
+    let request =
+        delete_plain_access_config_request(&test_remoting_command_factory(), &CheetahString::from_static_str("AK"));
 
     assert_eq!(request.code(), RequestCode::DeleteAclConfig as i32);
     assert_eq!(request.body().expect("request body should be set").as_ref(), b"AK");
@@ -920,7 +963,10 @@ fn delete_plain_access_config_request_matches_java_legacy_acl_body() {
 
 #[test]
 fn get_acl_request_matches_java_auth_get_acl_header() {
-    let request = get_acl_request(CheetahString::from_static_str("User:alice"));
+    let request = get_acl_request(
+        &test_remoting_command_factory(),
+        CheetahString::from_static_str("User:alice"),
+    );
 
     assert_eq!(request.code(), RequestCode::AuthGetAcl as i32);
     let header = request
@@ -933,7 +979,8 @@ fn get_acl_request_matches_java_auth_get_acl_header() {
 fn heartbeat_request_matches_java_register_client_request() {
     let heartbeat_data = HeartbeatData::default();
 
-    let request = heartbeat_request(&heartbeat_data, LanguageCode::RUST).expect("heartbeat request should encode body");
+    let request = heartbeat_request(&test_remoting_command_factory(), &heartbeat_data, LanguageCode::RUST)
+        .expect("heartbeat request should encode body");
 
     assert_eq!(request.code(), RequestCode::HeartBeat as i32);
     assert!(request.body().is_some());
@@ -941,7 +988,7 @@ fn heartbeat_request_matches_java_register_client_request() {
 
 #[test]
 fn get_all_consumer_offset_request_uses_java_request_code() {
-    let request = get_all_consumer_offset_request();
+    let request = get_all_consumer_offset_request(&test_remoting_command_factory());
 
     assert_eq!(request.code(), RequestCode::GetAllConsumerOffset as i32);
 }

--- a/rocketmq-client/tests/remoting_defaults_startup.rs
+++ b/rocketmq-client/tests/remoting_defaults_startup.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rocketmq_client_rust::ClientConfig;
+#![recursion_limit = "256"]
+
 use rocketmq_client_rust::ClientRuntime;
 use rocketmq_client_rust::ClientRuntimeConfig;
 use rocketmq_client_rust::TelemetryHandle;
@@ -22,7 +23,7 @@ use rocketmq_runtime::RuntimeConfig;
 use rocketmq_runtime::RuntimeOwner;
 
 #[test]
-fn client_pool_rejects_invalid_remoting_serialization_before_admission() {
+fn client_runtime_rejects_invalid_remoting_serialization_before_pool_admission() {
     // SAFETY: this integration-test binary contains one test, so no concurrent thread can read or
     // mutate this process environment key while the assertion runs.
     unsafe {
@@ -34,15 +35,12 @@ fn client_pool_rejects_invalid_remoting_serialization_before_admission() {
         ..Default::default()
     })
     .expect("test runtime owner should start");
-    let runtime = ClientRuntime::try_new(
+    let error = match ClientRuntime::try_new(
         owner.root_context().component("client"),
         ClientRuntimeConfig::default(),
         TelemetryHandle::noop(),
-    )
-    .expect("client runtime should be valid");
-
-    let error = match runtime.pool().get_or_create(ClientConfig::default(), None) {
-        Ok(_) => panic!("invalid remoting serialization must reject client admission"),
+    ) {
+        Ok(_) => panic!("invalid remoting serialization must reject client runtime construction"),
         Err(error) => error,
     };
     assert!(matches!(
@@ -52,8 +50,6 @@ fn client_pool_rejects_invalid_remoting_serialization_before_admission() {
             ..
         }
     ));
-    assert_eq!(runtime.pool().instance_count(), 0);
-
     owner
         .shutdown_runtime_blocking()
         .expect("test runtime should shut down cleanly");

--- a/rocketmq-protocol/src/protocol/remoting_command_compat.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command_compat.rs
@@ -167,7 +167,7 @@ fn read_environment_value(key: &'static str) -> Result<Option<String>, InvalidRe
 ///
 /// Returns [`RemotingDefaultsError`] when configuration is invalid or a
 /// different process default was initialized earlier.
-pub fn initialize_remoting_defaults(version: i32) -> Result<(), RemotingDefaultsError> {
+pub fn initialize_remoting_command_factory(version: i32) -> Result<RemotingCommandFactory, RemotingDefaultsError> {
     let property_value = read_environment_value(SERIALIZE_TYPE_PROPERTY)?;
     let environment_value = if property_value.is_none() {
         read_environment_value(SERIALIZE_TYPE_ENV)?
@@ -175,7 +175,24 @@ pub fn initialize_remoting_defaults(version: i32) -> Result<(), RemotingDefaults
         None
     };
     let serialize_type = resolve_remoting_serialize_type(property_value.as_deref(), environment_value.as_deref())?;
-    initialize_remoting_command_defaults(RemotingCommandDefaults::new(version, serialize_type))?;
+    let defaults = RemotingCommandDefaults::new(version, serialize_type);
+    initialize_remoting_command_defaults(defaults)?;
+    Ok(RemotingCommandFactory::new(defaults))
+}
+
+/// Initializes the immutable defaults used by all business command factories.
+///
+/// This compatibility entry point discards the resolved factory. New
+/// application owners should retain the value returned by
+/// [`initialize_remoting_command_factory`] and inject it into command
+/// producers.
+///
+/// # Errors
+///
+/// Returns [`RemotingDefaultsError`] when configuration is invalid or a
+/// different process default was initialized earlier.
+pub fn initialize_remoting_defaults(version: i32) -> Result<(), RemotingDefaultsError> {
+    initialize_remoting_command_factory(version)?;
     Ok(())
 }
 

--- a/rocketmq-protocol/src/protocol/remoting_command_defaults.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command_defaults.rs
@@ -238,7 +238,12 @@ pub(crate) fn application_remoting_command_defaults() -> RemotingCommandDefaults
     *APPLICATION_DEFAULTS.get_or_init(RemotingCommandDefaults::default)
 }
 
-pub(crate) fn application_remoting_command_factory() -> RemotingCommandFactory {
+/// Returns the immutable compatibility factory selected by the application.
+///
+/// Instance owners should capture this value once at their composition
+/// boundary and pass it to request/response producers. The returned factory
+/// does not read environment variables.
+pub fn application_remoting_command_factory() -> RemotingCommandFactory {
     RemotingCommandFactory::new(application_remoting_command_defaults())
 }
 

--- a/rocketmq-protocol/tests/remoting_command_defaults.rs
+++ b/rocketmq-protocol/tests/remoting_command_defaults.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use rocketmq_protocol::protocol::header::get_min_offset_request_header::GetMinOffsetRequestHeader;
-use rocketmq_protocol::protocol::remoting_command_facade::initialize_remoting_defaults;
+use rocketmq_protocol::protocol::remoting_command_facade::initialize_remoting_command_factory;
 use rocketmq_protocol::protocol::SerializeType;
 use rocketmq_protocol::RemotingCommand;
 
@@ -26,9 +26,12 @@ fn environment_defaults_are_resolved_before_command_construction() {
         std::env::set_var("rocketmq.serialize.type", "ROCKETMQ");
     }
 
-    initialize_remoting_defaults(4242).expect("valid process defaults should initialize");
+    let factory = initialize_remoting_command_factory(4242).expect("valid process defaults should initialize");
     let command = RemotingCommand::create_request_command(31, GetMinOffsetRequestHeader::default());
+    let owned_command = factory.create_request_command(31, GetMinOffsetRequestHeader::default());
 
     assert_eq!(command.version(), 4242);
     assert_eq!(command.serialize_type(), SerializeType::ROCKETMQ);
+    assert_eq!(owned_command.version(), 4242);
+    assert_eq!(owned_command.serialize_type(), SerializeType::ROCKETMQ);
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9326

### Brief Description

Resolve remoting command defaults once at `ClientRuntime` construction and inject the resulting immutable `RemotingCommandFactory` through `ClientPool`, `MQClientInstance`, `MQClientAPIImpl`, and `ClientRemotingProcessor`.

Client request builders and callback responses now use their owning factory. Explicit factories can isolate embedded client runtimes by version and serialization type, and factory defaults participate in pooled-client identity. The compatibility constructor still captures application defaults, while invalid process configuration now fails at runtime construction before pool admission.

Regression coverage verifies independent JSON and ROCKETMQ owners, outbound request defaults, callback response defaults, pool identity, and startup fail-fast behavior. Request codes, flags, bodies, headers, opaque values, and wire encodings are otherwise unchanged.

### How Did You Test This Change?

- `cargo test -p rocketmq-protocol --test remoting_command_defaults`
- `cargo test -p rocketmq-protocol protocol::remoting_command::tests --lib`
- `cargo test -p rocketmq-protocol --test remoting_wire_golden`
- `cargo test -p rocketmq-protocol --test request_header_java_compatibility`
- `cargo test -p rocketmq-transport --features test-support --test protocol_compatibility`
- `cargo test -p rocketmq-client-rust --lib --all-features` (1,063 passed)
- `cargo test -p rocketmq-client-rust --test remoting_defaults_startup --all-features`
- `cargo test -p rocketmq-client-rust --all-features -- --skip capability_files_stay_within_the_reviewed_split_limits --skip every_client_cargo_target_declares_a_recursion_limit` (passed; the unfiltered checks report two pre-existing `origin/main` boundary violations in `consumer.rs`/`producer/lifecycle.rs` and a missing recursion-limit declaration in `nameserver_dns_discovery.rs`)
- `cargo clippy -p rocketmq-protocol -p rocketmq-client-rust --no-deps --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- Per-package `cargo fmt -p <package> -- --check` for all 28 root workspace packages (the aggregate `cargo fmt --all -- --check` hits Windows OS error 206)
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` in `fuzz/`
- `cargo fmt -p rocketmq-example -- --check` and `cargo clippy --all-targets -- -D warnings` in `rocketmq-example/`
- SRE workspace format, check, Clippy, doc, source-layout, and dependency-boundary gates; `RUST_MIN_STACK=16777216 cargo test --locked --workspace --all-features` passed (the default Windows test stack overflows in two existing connector tests)
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`

`check-error-hygiene.ps1` reports the same two pre-existing findings on this branch and `origin/main`: source stringification in `rocketmq-store-local` and sensitive `Debug` derivation in the dashboard backend.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring remoting command protocol versions and serialization formats.
  - Added a runtime option for supplying custom remoting command settings.
  - Command settings now consistently apply across messaging, administration, routing, transactions, and callbacks.

- **Bug Fixes**
  - Prevented clients with conflicting remoting defaults from sharing the same client identity.
  - Invalid serialization settings are now rejected during runtime initialization with clearer configuration errors.

- **Tests**
  - Added coverage for custom protocol versions, serialization formats, and isolated runtime configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->