### PR TITLE
[ISSUE #9335]🐛Preserve error sources and redact dashboard config

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/config/app_config.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/config/app_config.rs
@@ -21,7 +21,7 @@ use std::fmt;
 use std::fs;
 use std::path::PathBuf;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct AppConfig {
     pub server: ServerConfig,
     pub storage: StorageConfig,
@@ -30,6 +30,21 @@ pub struct AppConfig {
     pub dashboard_history_interval_secs: u64,
     pub initial_config: DashboardConfigView,
     pub admin_credentials: Option<AdminCredentials>,
+}
+
+impl fmt::Debug for AppConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AppConfig")
+            .field("server", &self.server)
+            .field("storage", &self.storage)
+            .field("auth", &self.auth)
+            .field("monitor_store_path", &self.monitor_store_path)
+            .field("dashboard_history_interval_secs", &self.dashboard_history_interval_secs)
+            .field("initial_config", &self.initial_config)
+            .field("admin_credentials", &self.admin_credentials.as_ref().map(|_| REDACTED))
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -283,8 +298,10 @@ impl SqliteConfigStore {
 
 #[cfg(test)]
 mod tests {
+    use super::AppConfig;
     use super::AuthConfig;
     use super::ConfigStore;
+    use super::ServerConfig;
     use super::StorageConfig;
     use super::resolve_admin_credentials;
     use crate::model::DashboardConfigView;
@@ -346,6 +363,44 @@ mod tests {
 
         assert!(debug.contains("<redacted>"));
         assert!(!debug.contains("dashboard-secret"));
+    }
+
+    #[test]
+    fn app_config_debug_redacts_all_credentials() {
+        let config = AppConfig {
+            server: ServerConfig {
+                host: "127.0.0.1".to_string(),
+                port: 8082,
+            },
+            storage: StorageConfig {
+                backend: StorageBackend::File,
+                path: "dashboard-config.json".into(),
+            },
+            auth: AuthConfig {
+                login_required: true,
+                username: "admin".to_string(),
+                password: "dashboard-secret".to_string(),
+            },
+            monitor_store_path: "monitor-config.json".into(),
+            dashboard_history_interval_secs: 60,
+            initial_config: DashboardConfigView::default(),
+            admin_credentials: Some(
+                rocketmq_admin_core::core::security::AdminCredentials::try_new(
+                    "access-value",
+                    "secret-value",
+                    Some("token-value".to_string()),
+                )
+                .expect("credentials"),
+            ),
+        };
+
+        let debug = format!("{config:?}");
+
+        assert!(debug.contains("admin_credentials: Some(\"<redacted>\")"));
+        assert!(!debug.contains("dashboard-secret"));
+        assert!(!debug.contains("access-value"));
+        assert!(!debug.contains("secret-value"));
+        assert!(!debug.contains("token-value"));
     }
 
     #[test]

--- a/rocketmq-store-local/src/mapped_file/default_mapped_file.rs
+++ b/rocketmq-store-local/src/mapped_file/default_mapped_file.rs
@@ -577,8 +577,7 @@ impl<M: MappedMemory> DefaultMappedFile<M> {
         let admission = self.acquire_owned(MappedFileOperation::Read)?;
         let is_in_cache = self.record_cache_residency_admitted(&admission, offset as i64, len);
         let owner = self.file_owner_admitted(&admission)?;
-        let range = FileRangeLease::try_from_mapped_file(owner, file_offset, len, admission)
-            .map_err(|error| MappedFileError::Custom(error.to_string()))?;
+        let range = FileRangeLease::try_from_mapped_file(owner, file_offset, len, admission)?;
         let start_offset = self
             .get_file_from_offset()
             .checked_add(file_offset)

--- a/rocketmq-store-local/src/mapped_file/mapped_file_error.rs
+++ b/rocketmq-store-local/src/mapped_file/mapped_file_error.rs
@@ -16,6 +16,8 @@ use std::io;
 
 use thiserror::Error;
 
+use crate::transfer::segment::FileRangeError;
+
 use super::MappedFileAdmissionState;
 use super::MappedFileOperation;
 
@@ -43,6 +45,10 @@ pub enum MappedFileError {
         /// The total size of the mapped file in bytes
         file_size: u64,
     },
+
+    /// A checked file range could not be constructed for the mapped file.
+    #[error("File range operation failed: {0}")]
+    FileRange(#[from] FileRangeError),
 
     /// The mapped file has reached its capacity and cannot accept more writes.
     ///
@@ -258,6 +264,18 @@ mod tests {
         let err = MappedFileError::MmapFailed(io::Error::other("out of memory"));
 
         assert!(!err.is_recoverable());
+        assert!(err.source().is_some());
+    }
+
+    #[test]
+    fn file_range_errors_preserve_the_typed_source() {
+        let err = MappedFileError::from(FileRangeError::OutOfBounds {
+            position: 1024,
+            len: 512,
+            file_len: 1280,
+        });
+
+        assert!(matches!(err, MappedFileError::FileRange(_)));
         assert!(err.source().is_some());
     }
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9335

### Brief Description

- Preserve `FileRangeError` as a typed source in `MappedFileError` instead of flattening it into a string.
- Replace the derived `AppConfig` debug representation with an explicit implementation that redacts configured admin credentials.
- Add regression tests for the mapped-file error chain and dashboard credential redaction.

### How Did You Test This Change?

- `python scripts/error_architecture_guard.py`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo test -p rocketmq-store-local file_range_errors_preserve_the_typed_source`
- `cargo test app_config_debug_redacts_all_credentials` from the Dashboard web backend
- `cargo clippy --all-targets --all-features -- -D warnings` from the Dashboard web backend
- `cargo build --all-targets --all-features` from the Dashboard web backend
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz`
- Direct `rustfmt --check` for all three changed Rust files

The aggregate `cargo fmt --all -- --check` commands remain unavailable on Windows because rustfmt receives a command line that exceeds the OS 206 path-length limit. Direct checks of every changed Rust file pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Sensitive administrative credentials, access keys, secret keys, security tokens, and passwords are now excluded from diagnostic output.

* **Bug Fixes**
  * File-range failures now retain their original error details, improving error reporting and troubleshooting.
  * Error handling is more consistent when selecting file ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->