### PR TITLE
[ISSUE #9339]♻️Inject remoting command factories into NameServer owners

### DIFF
--- a/rocketmq-namesrv/src/bootstrap.rs
+++ b/rocketmq-namesrv/src/bootstrap.rs
@@ -43,6 +43,8 @@ use rocketmq_error::UnifiedServiceError;
 use rocketmq_observability::metrics::namesrv::NameServerMetrics;
 use rocketmq_observability::TelemetryHandle;
 use rocketmq_protocol::code::request_code::RequestCode;
+use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 use rocketmq_runtime::wait_for_signal;
 use rocketmq_runtime::ChildServiceContext;
 use rocketmq_runtime::MetadataDeadline;
@@ -123,6 +125,7 @@ pub struct Builder {
     cluster_test_route_lookup: Option<Arc<dyn ClusterTestRouteLookup>>,
     transport_security: Option<Arc<TransportSecurity>>,
     transport_principal: Option<Principal>,
+    command_factory: RemotingCommandFactory,
     telemetry: TelemetryHandle,
     service_context: ChildServiceContext,
 }
@@ -1020,6 +1023,7 @@ impl NameServerRuntime {
         let mut name_server_request_processor = NameServerRequestProcessor::new_with_in_flight_tracker(
             self.inner.in_flight_request_tracker(),
             self.inner.namesrv_metrics(),
+            self.inner.remoting_command_factory(),
         )
         .with_runtime_handle(runtime_handle)
         .with_workload_admission(Arc::clone(&self.inner.workload_admission))
@@ -1067,6 +1071,7 @@ impl Builder {
             cluster_test_route_lookup: None,
             transport_security: None,
             transport_principal: None,
+            command_factory: application_remoting_command_factory(),
             telemetry,
             service_context,
         }
@@ -1075,6 +1080,13 @@ impl Builder {
     #[inline]
     pub fn set_name_server_config(mut self, name_server_config: NamesrvConfig) -> Self {
         self.name_server_config = Some(name_server_config);
+        self
+    }
+
+    /// Overrides the remoting command defaults owned by this NameServer instance.
+    #[inline]
+    pub fn set_remoting_command_factory(mut self, command_factory: RemotingCommandFactory) -> Self {
+        self.command_factory = command_factory;
         self
     }
 
@@ -1167,6 +1179,7 @@ impl Builder {
                     service_context.component("namesrv.cluster-test-route-lookup"),
                     transport_telemetry.clone(),
                     &name_server_config,
+                    self.command_factory,
                 )) as Arc<dyn ClusterTestRouteLookup>)
             })
         } else {
@@ -1272,6 +1285,7 @@ impl Builder {
                 transport_telemetry,
                 transport_security,
                 transport_principal,
+                command_factory: self.command_factory,
             }
         });
 
@@ -1316,6 +1330,7 @@ pub(crate) struct NameServerRuntimeInner {
     transport_telemetry: TransportTelemetry,
     transport_security: Option<Arc<TransportSecurity>>,
     transport_principal: Option<Principal>,
+    command_factory: RemotingCommandFactory,
     cluster_test_route_lookup: Option<Arc<dyn ClusterTestRouteLookup>>,
     service_context: Option<ChildServiceContext>,
     task_group: OnceLock<TaskGroup>,
@@ -1396,6 +1411,10 @@ impl NameServerRuntimeHandle {
         self.runtime().namesrv_metrics()
     }
 
+    pub(crate) fn remoting_command_factory(&self) -> RemotingCommandFactory {
+        self.runtime().remoting_command_factory()
+    }
+
     pub(crate) fn cluster_test_route_lookup(&self) -> Option<Arc<dyn ClusterTestRouteLookup>> {
         self.runtime().cluster_test_route_lookup()
     }
@@ -1448,6 +1467,10 @@ impl NameServerRuntimeInner {
 
     pub(crate) fn namesrv_metrics(&self) -> NameServerMetrics {
         self.namesrv_metrics.clone()
+    }
+
+    pub(crate) fn remoting_command_factory(&self) -> RemotingCommandFactory {
+        self.command_factory
     }
 
     pub(crate) fn route_response_cache(&self) -> Arc<RouteResponseCache> {
@@ -4275,6 +4298,124 @@ mod tests {
         assert_eq!(
             properties.get("tls.client.authServer").map(|value| value.as_str()),
             Some("true")
+        );
+    }
+
+    #[tokio::test]
+    async fn default_processor_response_keeps_builder_factory_defaults() {
+        let factory = rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory::new(
+            rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandDefaults::new(
+                656,
+                rocketmq_protocol::protocol::SerializeType::ROCKETMQ,
+            ),
+        );
+        let bootstrap = Builder::new(test_service_context(), TelemetryHandle::noop())
+            .set_remoting_command_factory(factory)
+            .build();
+        let harness = LocalRequestHarness::new(test_task_group("namesrv-factory-local-harness"))
+            .await
+            .expect("local harness should start");
+        let mut request = RemotingCommand::create_remoting_command(RequestCode::GetNamesrvConfig);
+
+        let response = process_with_default_processor(&bootstrap, &harness, &mut request).await;
+
+        assert_eq!(response.version(), 656);
+        assert_eq!(
+            response.serialize_type(),
+            rocketmq_protocol::protocol::SerializeType::ROCKETMQ
+        );
+    }
+
+    #[tokio::test]
+    async fn client_processor_response_keeps_builder_factory_defaults() {
+        let factory = rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory::new(
+            rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandDefaults::new(
+                660,
+                rocketmq_protocol::protocol::SerializeType::ROCKETMQ,
+            ),
+        );
+        let bootstrap = Builder::new(test_service_context(), TelemetryHandle::noop())
+            .set_remoting_command_factory(factory)
+            .build();
+        let harness = LocalRequestHarness::new(test_task_group("namesrv-client-factory-local-harness"))
+            .await
+            .expect("local harness should start");
+        let mut request = RemotingCommand::create_request_command(
+            RequestCode::GetRouteinfoByTopic,
+            GetRouteInfoRequestHeader::new(CheetahString::from("missing-factory-topic"), Some(true)),
+        );
+        request.make_custom_header_to_net();
+
+        let response = process_with_client_processor(&bootstrap, &harness, &mut request).await;
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::TopicNotExist);
+        assert_eq!(response.version(), 660);
+        assert_eq!(
+            response.serialize_type(),
+            rocketmq_protocol::protocol::SerializeType::ROCKETMQ
+        );
+    }
+
+    #[tokio::test]
+    async fn request_processor_response_keeps_builder_factory_defaults() {
+        let factory = rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory::new(
+            rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandDefaults::new(
+                661,
+                rocketmq_protocol::protocol::SerializeType::ROCKETMQ,
+            ),
+        );
+        let bootstrap = Builder::new(test_service_context(), TelemetryHandle::noop())
+            .set_remoting_command_factory(factory)
+            .build();
+        let harness = LocalRequestHarness::new(test_task_group("namesrv-wrapper-factory-local-harness"))
+            .await
+            .expect("local harness should start");
+        let mut request = RemotingCommand::create_remoting_command(999_999);
+
+        let response = process_with_name_server_processor(&bootstrap, &harness, &mut request).await;
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::NoPermission);
+        assert_eq!(response.version(), 661);
+        assert_eq!(
+            response.serialize_type(),
+            rocketmq_protocol::protocol::SerializeType::ROCKETMQ
+        );
+    }
+
+    #[tokio::test]
+    async fn independent_nameserver_owners_keep_distinct_factory_defaults() {
+        use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandDefaults;
+        use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
+        use rocketmq_protocol::protocol::SerializeType;
+
+        let json_owner = Builder::new(test_service_context(), TelemetryHandle::noop())
+            .set_remoting_command_factory(RemotingCommandFactory::new(RemotingCommandDefaults::new(
+                662,
+                SerializeType::JSON,
+            )))
+            .build();
+        let rocketmq_owner = Builder::new(test_service_context(), TelemetryHandle::noop())
+            .set_remoting_command_factory(RemotingCommandFactory::new(RemotingCommandDefaults::new(
+                663,
+                SerializeType::ROCKETMQ,
+            )))
+            .build();
+        let harness = LocalRequestHarness::new(test_task_group("namesrv-owner-isolation-local-harness"))
+            .await
+            .expect("local harness should start");
+        let mut json_request = RemotingCommand::create_remoting_command(RequestCode::GetNamesrvConfig);
+        let mut rocketmq_request = RemotingCommand::create_remoting_command(RequestCode::GetNamesrvConfig);
+
+        let json_response = process_with_default_processor(&json_owner, &harness, &mut json_request).await;
+        let rocketmq_response = process_with_default_processor(&rocketmq_owner, &harness, &mut rocketmq_request).await;
+
+        assert_eq!(
+            (json_response.version(), json_response.serialize_type()),
+            (662, SerializeType::JSON)
+        );
+        assert_eq!(
+            (rocketmq_response.version(), rocketmq_response.serialize_type()),
+            (663, SerializeType::ROCKETMQ)
         );
     }
 

--- a/rocketmq-namesrv/src/processor.rs
+++ b/rocketmq-namesrv/src/processor.rs
@@ -25,8 +25,8 @@ use rocketmq_observability::metrics::namesrv::NameServerSecurityEvent;
 use rocketmq_observability::metrics::namesrv::NameServerWorkloadClass;
 use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
-use rocketmq_transport::api::v1::command_from_error_with_remark_and_opaque;
-use rocketmq_transport::api::v1::request_code_not_supported_with_opaque;
+use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 use rocketmq_transport::api::v1::Channel;
 use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use rocketmq_transport::api::v1::RejectRequestResponse;
@@ -41,6 +41,7 @@ pub(crate) use self::cluster_test_request_processor::TransportClusterTestRouteLo
 use crate::bootstrap::InFlightRequestTracker;
 use crate::bootstrap::NameServerRuntimeHandle;
 use crate::processor::default_request_processor::DefaultRequestProcessor;
+use crate::processor::response_factory::NameServerResponseFactoryExt;
 use crate::processor::workload_admission::NameServerWorkloadAdmission;
 use crate::processor::workload_admission::WorkloadAdmissionClass;
 use crate::security::classify_namesrv_request;
@@ -48,6 +49,7 @@ use crate::security::classify_namesrv_request;
 pub(crate) mod client_request_processor;
 mod cluster_test_request_processor;
 pub mod default_request_processor;
+mod response_factory;
 #[doc(hidden)]
 pub mod workload_admission;
 
@@ -97,7 +99,7 @@ impl RequestProcessor for NameServerRequestProcessorWrapper {
 
 pub(crate) type RequestCodeType = i32;
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct NameServerRequestProcessor {
     processor_table: Arc<HashMap<RequestCodeType, NameServerRequestProcessorWrapper>>,
     default_request_processor: Option<NameServerRequestProcessorWrapper>,
@@ -106,6 +108,13 @@ pub struct NameServerRequestProcessor {
     runtime_handle: Option<NameServerRuntimeHandle>,
     workload_admission: Option<Arc<NameServerWorkloadAdmission>>,
     metrics: NameServerMetrics,
+    command_factory: RemotingCommandFactory,
+}
+
+impl Default for NameServerRequestProcessor {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl NameServerRequestProcessor {
@@ -118,17 +127,24 @@ impl NameServerRequestProcessor {
             runtime_handle: None,
             workload_admission: None,
             metrics: NameServerMetrics::noop(),
+            command_factory: application_remoting_command_factory(),
         }
     }
 
     pub(crate) fn new_with_in_flight_tracker(
         in_flight_requests: Arc<InFlightRequestTracker>,
         metrics: NameServerMetrics,
+        command_factory: RemotingCommandFactory,
     ) -> Self {
         Self {
+            processor_table: Arc::new(HashMap::new()),
+            default_request_processor: None,
             in_flight_requests: Some(in_flight_requests),
+            auth_runtime: None,
+            runtime_handle: None,
+            workload_admission: None,
             metrics,
-            ..Self::new()
+            command_factory,
         }
     }
 
@@ -174,7 +190,7 @@ impl RequestProcessor for NameServerRequestProcessor {
             None => {
                 let error = RocketMQError::authentication_failed("request code is not authorized by NameServer");
                 self.metrics.record_security_event(NameServerSecurityEvent::AuthDenied);
-                return Ok(Some(command_from_error_with_remark_and_opaque(
+                return Ok(Some(self.command_factory.command_from_error_with_remark_and_opaque(
                     &error,
                     "NameServer request is not authorized",
                     request.opaque(),
@@ -199,7 +215,7 @@ impl RequestProcessor for NameServerRequestProcessor {
                     request_started.elapsed(),
                     0,
                 );
-                return Ok(Some(command_from_error_with_remark_and_opaque(
+                return Ok(Some(self.command_factory.command_from_error_with_remark_and_opaque(
                     &error,
                     error.to_string(),
                     request.opaque(),
@@ -255,7 +271,8 @@ impl RequestProcessor for NameServerRequestProcessor {
                                 rocketmq_observability::metrics::namesrv::NameServerRouteErrorKind::Rejected,
                             );
                         }
-                        let response = workload_admission_rejection_response(rejection, request.opaque());
+                        let response =
+                            workload_admission_rejection_response(&self.command_factory, rejection, request.opaque());
                         let response_bytes = response.body().map_or(0, bytes::Bytes::len);
                         self.metrics.record_request(
                             metric_class,
@@ -274,7 +291,9 @@ impl RequestProcessor for NameServerRequestProcessor {
         let response = match self.processor_table.get(request.code_ref()).cloned() {
             None => match self.default_request_processor.clone() {
                 None => {
-                    let response = request_code_not_supported_with_opaque(request.code(), request.opaque());
+                    let response = self
+                        .command_factory
+                        .request_code_not_supported_with_opaque(request.code(), request.opaque());
                     Ok(Some(response))
                 }
                 Some(mut processor) => RequestProcessor::process_request(&mut processor, channel, ctx, request).await,
@@ -369,10 +388,12 @@ fn metric_workload_class(class: WorkloadAdmissionClass) -> NameServerWorkloadCla
 }
 
 fn workload_admission_rejection_response(
+    command_factory: &RemotingCommandFactory,
     rejection: workload_admission::WorkloadAdmissionRejection,
     opaque: i32,
 ) -> RemotingCommand {
-    RemotingCommand::create_response_command_with_code(rocketmq_protocol::code::response_code::ResponseCode::SystemBusy)
+    command_factory
+        .create_response_command_with_code(rocketmq_protocol::code::response_code::ResponseCode::SystemBusy)
         .set_remark(format!(
             "NameServer workload admission rejected request: {}",
             rejection.as_str()
@@ -405,11 +426,25 @@ mod tests {
 
     #[test]
     fn admission_rejection_is_stable_system_busy_and_preserves_opaque() {
-        let response =
-            workload_admission_rejection_response(workload_admission::WorkloadAdmissionRejection::QueueFull, 9191);
+        let factory = rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory::new(
+            rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandDefaults::new(
+                655,
+                rocketmq_protocol::protocol::SerializeType::ROCKETMQ,
+            ),
+        );
+        let response = workload_admission_rejection_response(
+            &factory,
+            workload_admission::WorkloadAdmissionRejection::QueueFull,
+            9191,
+        );
 
         assert_eq!(response.code(), ResponseCode::SystemBusy as i32);
         assert_eq!(response.opaque(), 9191);
+        assert_eq!(response.version(), 655);
+        assert_eq!(
+            response.serialize_type(),
+            rocketmq_protocol::protocol::SerializeType::ROCKETMQ
+        );
         assert_eq!(
             response.remark().map(cheetah_string::CheetahString::as_str),
             Some("NameServer workload admission rejected request: queue-full")

--- a/rocketmq-namesrv/src/processor/client_request_processor.rs
+++ b/rocketmq-namesrv/src/processor/client_request_processor.rs
@@ -26,10 +26,10 @@ use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::header::client_request_header::GetRouteInfoRequestHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 use rocketmq_protocol::protocol::route::topic_route_data::TopicRouteData;
 use rocketmq_protocol::protocol::RemotingSerializable;
 use rocketmq_runtime::common::time_utils;
-use rocketmq_transport::api::v1::command_from_error_with_remark;
 use rocketmq_transport::api::v1::Channel;
 use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use rocketmq_transport::api::v1::RequestProcessor;
@@ -37,6 +37,7 @@ use tracing::debug;
 use tracing::warn;
 
 use crate::bootstrap::NameServerRuntimeHandle;
+use crate::processor::response_factory::NameServerResponseFactoryExt;
 use crate::processor::NAMESPACE_ORDER_TOPIC_CONFIG;
 use crate::route::response_cache::JsonEncoding;
 use crate::route::response_cache::RouteCacheKey;
@@ -56,6 +57,7 @@ thread_local! {
 /// Client request processor for handling route info queries
 pub struct ClientRequestProcessor {
     name_server_runtime_inner: NameServerRuntimeHandle,
+    command_factory: RemotingCommandFactory,
     need_check_namesrv_ready: AtomicBool,
     startup_time_millis: u64,
 }
@@ -90,10 +92,12 @@ impl ClientRequestProcessor {
     }
 
     pub(crate) fn new(name_server_runtime_inner: NameServerRuntimeHandle) -> Self {
+        let command_factory = name_server_runtime_inner.remoting_command_factory();
         Self {
             need_check_namesrv_ready: AtomicBool::new(true),
             startup_time_millis: time_utils::current_millis(),
             name_server_runtime_inner,
+            command_factory,
         }
     }
 
@@ -124,7 +128,10 @@ impl ClientRequestProcessor {
                 warn!("name server not ready. request code {}", request.code());
                 let error = rocketmq_error::RocketMQError::not_initialized("name server not ready");
                 route_span.record("result", "not_ready");
-                return Ok(Some(command_from_error_with_remark(&error, "name server not ready")));
+                return Ok(Some(
+                    self.command_factory
+                        .command_from_error_with_remark(&error, "name server not ready"),
+                ));
             }
         }
 
@@ -141,13 +148,13 @@ impl ClientRequestProcessor {
             ) => {
                 route_span.record("result", "not_found");
                 return Ok(Some(
-                    RemotingCommand::create_response_command_with_code(ResponseCode::TopicNotExist).set_remark(
-                        format!(
+                    self.command_factory
+                        .create_response_command_with_code(ResponseCode::TopicNotExist)
+                        .set_remark(format!(
                             "No topic route info in name server for the topic: {}{}",
                             request_header.topic,
                             FAQUrl::suggest_todo(FAQUrl::APPLY_TOPIC_URL)
-                        ),
-                    ),
+                        )),
                 ));
             }
             Err(error) => {
@@ -260,7 +267,9 @@ impl ClientRequestProcessor {
         metrics.record_route_response_bytes(content.len());
         route_span.record("result", "success");
         Ok(Some(
-            RemotingCommand::create_response_command_with_code(ResponseCode::Success).set_body(content),
+            self.command_factory
+                .create_response_command_with_code(ResponseCode::Success)
+                .set_body(content),
         ))
     }
 }

--- a/rocketmq-namesrv/src/processor/cluster_test_request_processor.rs
+++ b/rocketmq-namesrv/src/processor/cluster_test_request_processor.rs
@@ -18,6 +18,7 @@ use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::header::client_request_header::GetRouteInfoRequestHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 use rocketmq_transport::api::v1::Channel;
 use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use rocketmq_transport::api::v1::RequestProcessor;
@@ -41,12 +42,15 @@ pub(crate) use route_lookup::TransportClusterTestRouteLookup;
 
 pub struct ClusterTestRequestProcessor {
     name_server_runtime_inner: NameServerRuntimeHandle,
+    command_factory: RemotingCommandFactory,
 }
 
 impl ClusterTestRequestProcessor {
     pub(crate) fn new(name_server_runtime_inner: NameServerRuntimeHandle) -> Self {
+        let command_factory = name_server_runtime_inner.remoting_command_factory();
         Self {
             name_server_runtime_inner,
+            command_factory,
         }
     }
 
@@ -114,16 +118,20 @@ impl ClusterTestRequestProcessor {
                 typed_zone_filtered,
             )?;
             return Ok(Some(
-                RemotingCommand::create_response_command_with_code(ResponseCode::Success).set_body(content),
+                self.command_factory
+                    .create_response_command_with_code(ResponseCode::Success)
+                    .set_body(content),
             ));
         }
 
         Ok(Some(
-            RemotingCommand::create_response_command_with_code(ResponseCode::TopicNotExist).set_remark(format!(
-                "No topic route info in name server for the topic: {}{}",
-                request_header.topic,
-                FAQUrl::suggest_todo(FAQUrl::APPLY_TOPIC_URL)
-            )),
+            self.command_factory
+                .create_response_command_with_code(ResponseCode::TopicNotExist)
+                .set_remark(format!(
+                    "No topic route info in name server for the topic: {}{}",
+                    request_header.topic,
+                    FAQUrl::suggest_todo(FAQUrl::APPLY_TOPIC_URL)
+                )),
         ))
     }
 
@@ -221,11 +229,18 @@ mod tests {
         });
 
         let runtime = rocketmq_runtime::RuntimeContext::from_current("namesrv-cluster-test-processor");
+        let command_factory = rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory::new(
+            rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandDefaults::new(
+                657,
+                rocketmq_protocol::protocol::SerializeType::ROCKETMQ,
+            ),
+        );
         let bootstrap = Builder::new(
             runtime.service_context("namesrv"),
             rocketmq_observability::TelemetryHandle::noop(),
         )
         .set_name_server_config(namesrv_config)
+        .set_remoting_command_factory(command_factory)
         .set_cluster_test_route_lookup(mock_lookup)
         .build();
 
@@ -252,6 +267,11 @@ mod tests {
             .expect("processor should always return a response");
 
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+        assert_eq!(response.version(), 657);
+        assert_eq!(
+            response.serialize_type(),
+            rocketmq_protocol::protocol::SerializeType::ROCKETMQ
+        );
         let body = response.body().expect("cluster test response should include a body");
         let route_data = TopicRouteData::decode(body).expect("route body should decode");
         assert_eq!(

--- a/rocketmq-namesrv/src/processor/cluster_test_request_processor/route_lookup.rs
+++ b/rocketmq-namesrv/src/processor/cluster_test_request_processor/route_lookup.rs
@@ -28,6 +28,9 @@ use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::header::client_request_header::GetRouteInfoRequestHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+#[cfg(test)]
+use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 use rocketmq_protocol::protocol::route::topic_route_data::TopicRouteData;
 use rocketmq_runtime::ChildServiceContext;
 use rocketmq_runtime::ShutdownDeadline;
@@ -113,6 +116,7 @@ pub(crate) struct TransportClusterTestRouteLookup {
     endpoint_resolution: tokio::sync::Mutex<()>,
     lookup_cache: ClusterTestLookupCache,
     request_timeout: Duration,
+    command_factory: RemotingCommandFactory,
 }
 
 #[derive(Default)]
@@ -127,6 +131,7 @@ impl TransportClusterTestRouteLookup {
         service_context: ChildServiceContext,
         telemetry: TransportTelemetry,
         namesrv_config: &NamesrvConfig,
+        command_factory: RemotingCommandFactory,
     ) -> Self {
         Self::with_resolver_and_cache(
             service_context,
@@ -134,6 +139,7 @@ impl TransportClusterTestRouteLookup {
             ROUTE_LOOKUP_TIMEOUT,
             telemetry,
             LookupCacheConfig::from_namesrv_config(namesrv_config),
+            command_factory,
         )
     }
 
@@ -150,6 +156,7 @@ impl TransportClusterTestRouteLookup {
             request_timeout,
             telemetry,
             LookupCacheConfig::default(),
+            application_remoting_command_factory(),
         )
     }
 
@@ -159,6 +166,7 @@ impl TransportClusterTestRouteLookup {
         request_timeout: Duration,
         telemetry: TransportTelemetry,
         cache_config: LookupCacheConfig,
+        command_factory: RemotingCommandFactory,
     ) -> Self {
         let task_group = service_context.task_group().clone();
         let transport = OneShotTransportClient::new(
@@ -174,6 +182,7 @@ impl TransportClusterTestRouteLookup {
             endpoint_resolution: tokio::sync::Mutex::new(()),
             lookup_cache: ClusterTestLookupCache::new(cache_config),
             request_timeout,
+            command_factory,
         }
     }
 
@@ -206,7 +215,11 @@ impl TransportClusterTestRouteLookup {
                 return Err(route_lookup_timeout(deadline));
             }
 
-            match self.transport.invoke(endpoint, route_request(topic), deadline).await {
+            match self
+                .transport
+                .invoke(endpoint, route_request(&self.command_factory, topic), deadline)
+                .await
+            {
                 Ok(response) => return decode_route_response(response),
                 Err(error) => last_error = Some(error),
             }
@@ -286,8 +299,8 @@ impl ClusterTestRouteLookup for TransportClusterTestRouteLookup {
     }
 }
 
-fn route_request(topic: &CheetahString) -> RemotingCommand {
-    let mut request = RemotingCommand::create_request_command(
+fn route_request(command_factory: &RemotingCommandFactory, topic: &CheetahString) -> RemotingCommand {
+    let mut request = command_factory.create_request_command(
         RequestCode::GetRouteinfoByTopic,
         GetRouteInfoRequestHeader::new(topic.clone(), None),
     );
@@ -380,6 +393,24 @@ mod tests {
     use tokio::sync::Notify;
 
     use super::*;
+
+    #[test]
+    fn route_request_keeps_lookup_factory_defaults() {
+        let factory = rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory::new(
+            rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandDefaults::new(
+                658,
+                rocketmq_protocol::protocol::SerializeType::ROCKETMQ,
+            ),
+        );
+
+        let request = route_request(&factory, &CheetahString::from("factory-topic"));
+
+        assert_eq!(request.version(), 658);
+        assert_eq!(
+            request.serialize_type(),
+            rocketmq_protocol::protocol::SerializeType::ROCKETMQ
+        );
+    }
 
     struct FixedEndpointResolver {
         endpoints: Vec<SocketAddr>,

--- a/rocketmq-namesrv/src/processor/default_request_processor.rs
+++ b/rocketmq-namesrv/src/processor/default_request_processor.rs
@@ -49,16 +49,12 @@ use rocketmq_protocol::protocol::header::namesrv::topic_operation_header::Delete
 use rocketmq_protocol::protocol::header::namesrv::topic_operation_header::GetTopicsByClusterRequestHeader;
 use rocketmq_protocol::protocol::header::namesrv::topic_operation_header::RegisterTopicRequestHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 use rocketmq_protocol::protocol::route::topic_route_data::TopicRouteData;
 use rocketmq_protocol::protocol::DataVersion;
 use rocketmq_protocol::protocol::RemotingDeserializable;
 use rocketmq_protocol::protocol::RemotingSerializable;
 use rocketmq_runtime::MetadataDeadline;
-use rocketmq_transport::api::v1::internal_error;
-use rocketmq_transport::api::v1::invalid_parameter_with_remark;
-use rocketmq_transport::api::v1::no_permission_with_remark;
-use rocketmq_transport::api::v1::query_not_found_with_remark;
-use rocketmq_transport::api::v1::request_code_not_supported_with_remark;
 use rocketmq_transport::api::v1::Channel;
 use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use rocketmq_transport::api::v1::RequestProcessor;
@@ -66,11 +62,13 @@ use tracing::debug;
 use tracing::warn;
 
 use crate::bootstrap::NameServerRuntimeHandle;
+use crate::processor::response_factory::NameServerResponseFactoryExt;
 use crate::processor::NAMESPACE_ORDER_TOPIC_CONFIG;
 use crate::NamesrvConfig;
 
 pub struct DefaultRequestProcessor {
     name_server_runtime_inner: NameServerRuntimeHandle,
+    command_factory: RemotingCommandFactory,
 }
 
 impl RequestProcessor for DefaultRequestProcessor {
@@ -134,7 +132,7 @@ impl DefaultRequestProcessor {
             RequestCode::GetHasUnitSubUnunitTopicList => self.get_has_unit_sub_un_unit_topic_list(request),
             RequestCode::UpdateNamesrvConfig => self.update_config(request).await,
             RequestCode::GetNamesrvConfig => self.get_config(request),
-            _ => Ok(request_code_not_supported_with_remark(
+            _ => Ok(self.command_factory.request_code_not_supported_with_remark(
                 request.code(),
                 format!(" request type {} not supported", request.code()),
             )),
@@ -149,7 +147,9 @@ impl DefaultRequestProcessor {
         let request_header = request.decode_command_custom_header::<PutKVConfigRequestHeader>()?;
         //check namespace and key, need?
         if request_header.namespace.is_empty() || request_header.key.is_empty() {
-            return Ok(invalid_parameter_with_remark("namespace or key is empty"));
+            return Ok(self
+                .command_factory
+                .invalid_parameter_with_remark("namespace or key is empty"));
         }
 
         self.name_server_runtime_inner
@@ -161,7 +161,7 @@ impl DefaultRequestProcessor {
                 MetadataDeadline::after(Duration::from_secs(5)),
             )
             .await?;
-        Ok(RemotingCommand::create_success_response_command())
+        Ok(self.command_factory.create_success_response_command())
     }
 
     fn get_kv_config(&self, request: &mut RemotingCommand) -> rocketmq_error::RocketMQResult<RemotingCommand> {
@@ -173,11 +173,11 @@ impl DefaultRequestProcessor {
             .get_kvconfig(&request_header.namespace, &request_header.key);
 
         if value.is_some() {
-            return Ok(RemotingCommand::create_success_response_command_with_header(
-                GetKVConfigResponseHeader::new(value),
-            ));
+            return Ok(self
+                .command_factory
+                .create_success_response_command_with_header(GetKVConfigResponseHeader::new(value)));
         }
-        Ok(query_not_found_with_remark(format!(
+        Ok(self.command_factory.query_not_found_with_remark(format!(
             "No config item, Namespace: {} Key: {}",
             request_header.namespace, request_header.key
         )))
@@ -194,7 +194,7 @@ impl DefaultRequestProcessor {
                 MetadataDeadline::after(Duration::from_secs(5)),
             )
             .await?;
-        Ok(RemotingCommand::create_success_response_command())
+        Ok(self.command_factory.create_success_response_command())
     }
 
     fn query_broker_topic_config(
@@ -226,8 +226,9 @@ impl DefaultRequestProcessor {
             );
 
         // Build response with changed flag
-        let mut command =
-            RemotingCommand::create_success_response_command_with_header(QueryDataVersionResponseHeader::new(changed));
+        let mut command = self
+            .command_factory
+            .create_success_response_command_with_header(QueryDataVersionResponseHeader::new(changed));
 
         // Query and attach broker topic config if available
         if let Some(topic_config) = self
@@ -251,8 +252,10 @@ impl DefaultRequestProcessor {
 #[allow(clippy::new_without_default)]
 impl DefaultRequestProcessor {
     pub(crate) fn new(name_server_runtime_inner: NameServerRuntimeHandle) -> Self {
+        let command_factory = name_server_runtime_inner.remoting_command_factory();
         Self {
             name_server_runtime_inner,
+            command_factory,
         }
     }
 }
@@ -264,10 +267,10 @@ impl DefaultRequestProcessor {
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         let request_header = request.decode_command_custom_header::<RegisterBrokerRequestHeader>()?;
         if !check_sum_crc32(request, &request_header) {
-            return Ok(invalid_parameter_with_remark("crc32 not match"));
+            return Ok(self.command_factory.invalid_parameter_with_remark("crc32 not match"));
         }
 
-        let mut response_command = RemotingCommand::create_success_response_command();
+        let mut response_command = self.command_factory.create_success_response_command();
         let broker_version = RocketMqVersion::try_from(request.version() as u32)?;
         let decode_started = Instant::now();
         let wire_bytes = request.body().map_or(0, bytes::Bytes::len);
@@ -349,9 +352,11 @@ impl DefaultRequestProcessor {
             .submit_unregister_broker_request(request_header)
         {
             warn!("Couldn't submit the unregister broker request to handler");
-            return Ok(internal_error("could not submit unregister broker request to handler"));
+            return Ok(self
+                .command_factory
+                .internal_error("could not submit unregister broker request to handler"));
         }
-        Ok(RemotingCommand::create_success_response_command())
+        Ok(self.command_factory.create_success_response_command())
     }
 }
 
@@ -364,7 +369,7 @@ impl DefaultRequestProcessor {
         self.name_server_runtime_inner
             .route_info_manager()
             .update_broker_info_update_timestamp(request_header.cluster_name, request_header.broker_addr);
-        Ok(RemotingCommand::create_success_response_command())
+        Ok(self.command_factory.create_success_response_command())
     }
 
     fn get_broker_member_group(
@@ -379,7 +384,7 @@ impl DefaultRequestProcessor {
             .get_broker_member_group(request_header.cluster_name, request_header.broker_name);
         let response_body = GetBrokerMemberGroupResponseBody { broker_member_group };
         let body = response_body.encode()?;
-        Ok(RemotingCommand::create_success_response_command().set_body(body))
+        Ok(self.command_factory.create_success_response_command().set_body(body))
     }
 
     fn get_broker_cluster_info(
@@ -391,7 +396,10 @@ impl DefaultRequestProcessor {
             .route_info_manager()
             .get_all_cluster_info()
             .encode()?;
-        Ok(RemotingCommand::create_response_command_with_code(RemotingSysResponseCode::Success).set_body(vec))
+        Ok(self
+            .command_factory
+            .create_response_command_with_code(RemotingSysResponseCode::Success)
+            .set_body(vec))
     }
 
     fn wipe_write_perm_of_broker(
@@ -403,9 +411,9 @@ impl DefaultRequestProcessor {
             .name_server_runtime_inner
             .route_info_manager()
             .wipe_write_perm_of_broker_by_lock(request_header.broker_name.to_string());
-        Ok(RemotingCommand::create_success_response_command_with_header(
-            WipeWritePermOfBrokerResponseHeader::new(wipe_topic_cnt),
-        ))
+        Ok(self
+            .command_factory
+            .create_success_response_command_with_header(WipeWritePermOfBrokerResponseHeader::new(wipe_topic_cnt)))
     }
 
     fn add_write_perm_of_broker(
@@ -417,9 +425,9 @@ impl DefaultRequestProcessor {
             .name_server_runtime_inner
             .route_info_manager()
             .add_write_perm_of_broker_by_lock(request_header.broker_name.to_string());
-        Ok(RemotingCommand::create_success_response_command_with_header(
-            AddWritePermOfBrokerResponseHeader::new(add_topic_cnt),
-        ))
+        Ok(self
+            .command_factory
+            .create_success_response_command_with_header(AddWritePermOfBrokerResponseHeader::new(add_topic_cnt)))
     }
 
     fn get_all_topic_list_from_nameserver(
@@ -436,9 +444,9 @@ impl DefaultRequestProcessor {
                 broker_addr: None,
             };
             let body = topics.encode()?;
-            return Ok(RemotingCommand::create_success_response_command().set_body(body));
+            return Ok(self.command_factory.create_success_response_command().set_body(body));
         }
-        Ok(internal_error("disable"))
+        Ok(self.command_factory.internal_error("disable"))
     }
 
     fn delete_topic_in_name_srv(
@@ -449,7 +457,7 @@ impl DefaultRequestProcessor {
         self.name_server_runtime_inner
             .route_info_manager()
             .delete_topic(request_header.topic, request_header.cluster_name);
-        Ok(RemotingCommand::create_success_response_command())
+        Ok(self.command_factory.create_success_response_command())
     }
 
     fn register_topic_to_name_srv(
@@ -470,7 +478,7 @@ impl DefaultRequestProcessor {
                     .register_topic(request_header.topic, topic_route_data.queue_datas)
             }
         }
-        Ok(RemotingCommand::create_success_response_command())
+        Ok(self.command_factory.create_success_response_command())
     }
 
     fn get_kv_list_by_namespace(
@@ -483,9 +491,9 @@ impl DefaultRequestProcessor {
             .kvconfig_manager()
             .get_kv_list_by_namespace(&request_header.namespace);
         if let Some(value) = value {
-            return Ok(RemotingCommand::create_success_response_command().set_body(value));
+            return Ok(self.command_factory.create_success_response_command().set_body(value));
         }
-        Ok(query_not_found_with_remark(format!(
+        Ok(self.command_factory.query_not_found_with_remark(format!(
             "No config item, Namespace: {}",
             request_header.namespace.as_str()
         )))
@@ -493,7 +501,7 @@ impl DefaultRequestProcessor {
 
     fn get_topics_by_cluster(&self, request: &mut RemotingCommand) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         if !self.name_server_runtime_inner.name_server_config().enable_topic_list {
-            return Ok(internal_error("disable"));
+            return Ok(self.command_factory.internal_error("disable"));
         }
 
         let request_header = request.decode_command_custom_header::<GetTopicsByClusterRequestHeader>()?;
@@ -505,7 +513,7 @@ impl DefaultRequestProcessor {
             broker_addr: None,
         };
         let body = topics_by_cluster.encode()?;
-        Ok(RemotingCommand::create_success_response_command().set_body(body))
+        Ok(self.command_factory.create_success_response_command().set_body(body))
     }
 
     fn get_system_topic_list_from_ns(
@@ -517,16 +525,16 @@ impl DefaultRequestProcessor {
             .route_info_manager()
             .get_system_topic_list();
         let body = topic_list.encode()?;
-        Ok(RemotingCommand::create_success_response_command().set_body(body))
+        Ok(self.command_factory.create_success_response_command().set_body(body))
     }
 
     fn get_unit_topic_list(&self, _request: &mut RemotingCommand) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         if self.name_server_runtime_inner.name_server_config().enable_topic_list {
             let topic_list = self.name_server_runtime_inner.route_info_manager().get_unit_topics();
             let body = topic_list.encode()?;
-            return Ok(RemotingCommand::create_success_response_command().set_body(body));
+            return Ok(self.command_factory.create_success_response_command().set_body(body));
         }
-        Ok(internal_error("disable"))
+        Ok(self.command_factory.internal_error("disable"))
     }
 
     fn get_has_unit_sub_topic_list(
@@ -539,9 +547,9 @@ impl DefaultRequestProcessor {
                 .route_info_manager()
                 .get_has_unit_sub_topic_list();
             let body = topic_list.encode()?;
-            return Ok(RemotingCommand::create_success_response_command().set_body(body));
+            return Ok(self.command_factory.create_success_response_command().set_body(body));
         }
-        Ok(internal_error("disable"))
+        Ok(self.command_factory.internal_error("disable"))
     }
 
     fn get_has_unit_sub_un_unit_topic_list(
@@ -553,9 +561,12 @@ impl DefaultRequestProcessor {
                 .name_server_runtime_inner
                 .route_info_manager()
                 .get_has_unit_sub_ununit_topic_list();
-            return Ok(RemotingCommand::create_success_response_command().set_body(topic_list.encode()?));
+            return Ok(self
+                .command_factory
+                .create_success_response_command()
+                .set_body(topic_list.encode()?));
         }
-        Ok(internal_error("disable"))
+        Ok(self.command_factory.internal_error("disable"))
     }
 
     async fn update_config(&self, request: &mut RemotingCommand) -> rocketmq_error::RocketMQResult<RemotingCommand> {
@@ -564,29 +575,35 @@ impl DefaultRequestProcessor {
             let body_str = match str::from_utf8(body) {
                 Ok(s) => s,
                 Err(e) => {
-                    return Ok(invalid_parameter_with_remark(format!(
-                        "UnsupportedEncodingException {e:?}"
-                    )));
+                    return Ok(self
+                        .command_factory
+                        .invalid_parameter_with_remark(format!("UnsupportedEncodingException {e:?}")));
                 }
             };
 
             let properties = match string_to_properties(body_str) {
                 Some(props) => props,
                 None => {
-                    return Ok(invalid_parameter_with_remark("string_to_properties error"));
+                    return Ok(self
+                        .command_factory
+                        .invalid_parameter_with_remark("string_to_properties error"));
                 }
             };
             if validate_blacklist_config_exist(
                 &properties,
                 &build_effective_config_blacklist(&self.name_server_runtime_inner.name_server_config()),
             ) {
-                return Ok(no_permission_with_remark("Cannot update config in blacklist."));
+                return Ok(self
+                    .command_factory
+                    .no_permission_with_remark("Cannot update config in blacklist."));
             }
 
             apply_outcome = Some(self.name_server_runtime_inner.update_runtime_config(properties).await?);
         }
 
-        let mut response = RemotingCommand::create_response_command_with_code(RemotingSysResponseCode::Success);
+        let mut response = self
+            .command_factory
+            .create_response_command_with_code(RemotingSysResponseCode::Success);
         response.ensure_ext_fields_initialized();
         if let Some(outcome) = apply_outcome {
             response.add_ext_field("desiredGeneration", outcome.desired_generation.to_string());
@@ -610,12 +627,14 @@ impl DefaultRequestProcessor {
 
     fn get_config(&self, request: &mut RemotingCommand) -> rocketmq_error::RocketMQResult<RemotingCommand> {
         if is_probe_only_namesrv_config_request(request) {
-            return Ok(create_namesrv_config_success_response(None));
+            return Ok(create_namesrv_config_success_response(&self.command_factory, None));
         }
 
         let result = match self.name_server_runtime_inner.get_all_configs_format_string() {
-            Ok(content) => create_namesrv_config_success_response(Some(content.into_bytes())),
-            Err(e) => internal_error(format!("UnsupportedEncodingException {e}")),
+            Ok(content) => create_namesrv_config_success_response(&self.command_factory, Some(content.into_bytes())),
+            Err(e) => self
+                .command_factory
+                .internal_error(format!("UnsupportedEncodingException {e}")),
         };
         Ok(result)
     }
@@ -738,11 +757,12 @@ fn is_probe_only_namesrv_config_request(request: &RemotingCommand) -> bool {
         })
 }
 
-fn create_namesrv_config_success_response(body: Option<Vec<u8>>) -> RemotingCommand {
-    let response = RemotingCommand::create_response_command_with_code_remark(
-        RemotingSysResponseCode::Success,
-        CheetahString::empty(),
-    );
+fn create_namesrv_config_success_response(
+    command_factory: &RemotingCommandFactory,
+    body: Option<Vec<u8>>,
+) -> RemotingCommand {
+    let response = command_factory
+        .create_response_command_with_code_remark(RemotingSysResponseCode::Success, CheetahString::empty());
 
     match body {
         Some(body) => response.set_body(body),
@@ -961,7 +981,10 @@ mod tests {
         let request = RemotingCommand::create_remoting_command(RequestCode::GetNamesrvConfig);
         assert!(!is_probe_only_namesrv_config_request(&request));
 
-        let response = create_namesrv_config_success_response(Some(b"name=value".to_vec()));
+        let response = create_namesrv_config_success_response(
+            &rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory(),
+            Some(b"name=value".to_vec()),
+        );
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
         assert_eq!(
             response.body().map(|body| body.as_ref().to_vec()),
@@ -979,7 +1002,10 @@ mod tests {
 
         assert!(is_probe_only_namesrv_config_request(&request));
 
-        let response = create_namesrv_config_success_response(None);
+        let response = create_namesrv_config_success_response(
+            &rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory(),
+            None,
+        );
         assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
         assert!(response.body().is_none());
     }

--- a/rocketmq-namesrv/src/processor/response_factory.rs
+++ b/rocketmq-namesrv/src/processor/response_factory.rs
@@ -1,0 +1,95 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_error::ProtocolError;
+use rocketmq_error::RocketMQError;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
+
+pub(crate) trait NameServerResponseFactoryExt {
+    fn command_from_error_with_remark(&self, error: &RocketMQError, remark: impl Into<String>) -> RemotingCommand;
+
+    fn command_from_error_with_remark_and_opaque(
+        &self,
+        error: &RocketMQError,
+        remark: impl Into<String>,
+        opaque: i32,
+    ) -> RemotingCommand;
+
+    fn request_code_not_supported_with_remark(&self, request_code: i32, remark: impl Into<String>) -> RemotingCommand;
+
+    fn request_code_not_supported_with_opaque(&self, request_code: i32, opaque: i32) -> RemotingCommand;
+
+    fn invalid_parameter_with_remark(&self, remark: impl Into<String>) -> RemotingCommand;
+
+    fn no_permission_with_remark(&self, remark: impl Into<String>) -> RemotingCommand;
+
+    fn query_not_found_with_remark(&self, remark: impl Into<String>) -> RemotingCommand;
+
+    fn internal_error(&self, remark: impl Into<String>) -> RemotingCommand;
+}
+
+impl NameServerResponseFactoryExt for RemotingCommandFactory {
+    fn command_from_error_with_remark(&self, error: &RocketMQError, remark: impl Into<String>) -> RemotingCommand {
+        self.create_response_command_from_error_with_remark(error, remark.into())
+    }
+
+    fn command_from_error_with_remark_and_opaque(
+        &self,
+        error: &RocketMQError,
+        remark: impl Into<String>,
+        opaque: i32,
+    ) -> RemotingCommand {
+        self.command_from_error_with_remark(error, remark).set_opaque(opaque)
+    }
+
+    fn request_code_not_supported_with_remark(&self, request_code: i32, remark: impl Into<String>) -> RemotingCommand {
+        let error = RocketMQError::Protocol(ProtocolError::invalid_command(request_code));
+        self.command_from_error_with_remark(&error, remark)
+    }
+
+    fn request_code_not_supported_with_opaque(&self, request_code: i32, opaque: i32) -> RemotingCommand {
+        self.request_code_not_supported_with_remark(
+            request_code,
+            format!("The request code {request_code} is not supported."),
+        )
+        .set_opaque(opaque)
+    }
+
+    fn invalid_parameter_with_remark(&self, remark: impl Into<String>) -> RemotingCommand {
+        let remark = remark.into();
+        let error = RocketMQError::illegal_argument(remark.clone());
+        self.command_from_error_with_remark(&error, remark)
+    }
+
+    fn no_permission_with_remark(&self, remark: impl Into<String>) -> RemotingCommand {
+        let remark = remark.into();
+        let error = RocketMQError::BrokerPermissionDenied {
+            operation: remark.clone(),
+        };
+        self.command_from_error_with_remark(&error, remark)
+    }
+
+    fn query_not_found_with_remark(&self, remark: impl Into<String>) -> RemotingCommand {
+        let remark = remark.into();
+        let error = RocketMQError::query_not_found(remark.clone());
+        self.command_from_error_with_remark(&error, remark)
+    }
+
+    fn internal_error(&self, remark: impl Into<String>) -> RemotingCommand {
+        let remark = remark.into();
+        let error = RocketMQError::invariant_violated("legacy remoting handler returned an internal response");
+        self.command_from_error_with_remark(&error, remark)
+    }
+}

--- a/rocketmq-namesrv/src/route/route_info_manager.rs
+++ b/rocketmq-namesrv/src/route/route_info_manager.rs
@@ -34,6 +34,7 @@ use rocketmq_protocol::protocol::header::namesrv::broker_request::UnRegisterBrok
 use rocketmq_protocol::protocol::header::namesrv::brokerid_change_request_header::NotifyMinBrokerIdChangeRequestHeader;
 use rocketmq_protocol::protocol::namesrv::RegisterBrokerResult;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 use rocketmq_protocol::protocol::route::route_data_view::BrokerData;
 use rocketmq_protocol::protocol::route::route_data_view::QueueData;
 use rocketmq_protocol::protocol::route::topic_route_data::TopicRouteData;
@@ -971,7 +972,10 @@ impl RouteInfoManager {
         );
 
         // Create remoting command
-        let request = RemotingCommand::create_request_command(RequestCode::NotifyMinBrokerIdChange, request_header);
+        let request = build_min_broker_id_change_request(
+            &self.name_server_runtime_inner.remoting_command_factory(),
+            request_header,
+        );
         let notification_version = self.min_broker_notify_sequence.fetch_add(1, Ordering::Relaxed) + 1;
         self.min_broker_notify_versions
             .insert(broker_name.clone(), notification_version);
@@ -2027,6 +2031,13 @@ impl RouteInfoManager {
     }
 }
 
+fn build_min_broker_id_change_request(
+    command_factory: &RemotingCommandFactory,
+    request_header: NotifyMinBrokerIdChangeRequestHeader,
+) -> RemotingCommand {
+    command_factory.create_request_command(RequestCode::NotifyMinBrokerIdChange, request_header)
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Barrier;
@@ -2042,6 +2053,25 @@ mod tests {
 
     use super::*;
     use crate::bootstrap::Builder;
+
+    #[test]
+    fn min_broker_notification_request_keeps_factory_defaults() {
+        let factory = rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory::new(
+            rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandDefaults::new(
+                659,
+                rocketmq_protocol::protocol::SerializeType::ROCKETMQ,
+            ),
+        );
+        let header = NotifyMinBrokerIdChangeRequestHeader::new(Some(0), None, None, None, None);
+
+        let request = build_min_broker_id_change_request(&factory, header);
+
+        assert_eq!(request.version(), 659);
+        assert_eq!(
+            request.serialize_type(),
+            rocketmq_protocol::protocol::SerializeType::ROCKETMQ
+        );
+    }
 
     fn test_route_manager() -> (crate::bootstrap::NameServerBootstrap, Arc<RouteInfoManager>) {
         test_route_manager_with_config(crate::NamesrvConfig::default())

--- a/rocketmq-protocol/src/protocol/remoting_command_defaults.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command_defaults.rs
@@ -19,6 +19,7 @@ use std::sync::OnceLock;
 
 use bytes::Bytes;
 use cheetah_string::CheetahString;
+use rocketmq_error::RocketMQError;
 
 use crate::code::response_code::RemotingSysResponseCode;
 use crate::protocol::command_custom_header::CommandCustomHeader;
@@ -137,6 +138,22 @@ impl RemotingCommandFactory {
             .mark_response_type()
     }
 
+    /// Creates a response from the central typed-error remoting mapping.
+    pub fn create_response_command_from_error(&self, error: &RocketMQError) -> RemotingCommand {
+        let view = error.boundary_view();
+        self.create_response_command_with_code_remark(view.remoting().code.as_i32(), view.message())
+    }
+
+    /// Creates a mapped typed-error response with an explicit wire remark.
+    pub fn create_response_command_from_error_with_remark(
+        &self,
+        error: &RocketMQError,
+        remark: impl Into<CheetahString>,
+    ) -> RemotingCommand {
+        let view = error.boundary_view();
+        self.create_response_command_with_code_remark(view.remoting().code.as_i32(), remark)
+    }
+
     /// Creates an explicitly successful response.
     pub fn create_success_response_command(&self) -> RemotingCommand {
         self.create_response_command_with_code(RemotingSysResponseCode::Success)
@@ -249,6 +266,8 @@ pub fn application_remoting_command_factory() -> RemotingCommandFactory {
 
 #[cfg(test)]
 mod tests {
+    use rocketmq_error::RocketMQError;
+
     use super::*;
 
     #[test]
@@ -266,5 +285,22 @@ mod tests {
                 requested: second,
             })
         );
+    }
+
+    #[test]
+    fn typed_error_response_keeps_factory_defaults() {
+        let factory = RemotingCommandFactory::new(RemotingCommandDefaults::new(654, SerializeType::ROCKETMQ));
+        let error = RocketMQError::illegal_argument("invalid nameserver request");
+
+        let response = factory.create_response_command_from_error_with_remark(&error, "invalid route request");
+
+        assert_eq!(response.version(), 654);
+        assert_eq!(response.serialize_type(), SerializeType::ROCKETMQ);
+        assert_eq!(response.code(), error.boundary_view().remoting().code.as_i32());
+        assert_eq!(
+            response.remark().map(CheetahString::as_str),
+            Some("invalid route request")
+        );
+        assert!(response.is_response_type());
     }
 }

--- a/rocketmq-transport/src/error_response.rs
+++ b/rocketmq-transport/src/error_response.rs
@@ -16,11 +16,11 @@ use rocketmq_error::ProtocolError;
 use rocketmq_error::RocketMQError;
 
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
 
 /// Convert a typed RocketMQ error into a remoting response command.
 pub fn command_from_error(error: &RocketMQError) -> RemotingCommand {
-    let view = error.boundary_view();
-    RemotingCommand::create_response_command_with_code_remark(view.remoting().code.as_i32(), view.message())
+    application_remoting_command_factory().create_response_command_from_error(error)
 }
 
 /// Convert a typed RocketMQ error into a remoting response command and preserve
@@ -32,8 +32,7 @@ pub fn command_from_error_with_opaque(error: &RocketMQError, opaque: i32) -> Rem
 /// Convert a typed RocketMQ error into a remoting response command with an
 /// explicit wire remark.
 pub fn command_from_error_with_remark(error: &RocketMQError, remark: impl Into<String>) -> RemotingCommand {
-    let view = error.boundary_view();
-    RemotingCommand::create_response_command_with_code_remark(view.remoting().code.as_i32(), remark.into())
+    application_remoting_command_factory().create_response_command_from_error_with_remark(error, remark.into())
 }
 
 /// Apply a typed RocketMQ error mapping to an existing remoting response.


### PR DESCRIPTION
﻿### Which Issue(s) This PR Fixes(Closes)

- Fixes #9339

### Brief Description

- adds owner-scoped typed-error response construction to `RemotingCommandFactory`
- retains one immutable command factory in each NameServer runtime and injects it into request processors
- routes cluster-test lookups and broker notifications through the owning factory
- preserves transport error helpers as application-default compatibility wrappers
- adds JSON/ROCKETMQ owner-isolation and outbound request regression coverage

Compatibility is preserved for request and response codes, remarks, bodies, headers, opaque values, flags, and typed error mappings. `Builder::new` remains backward compatible by capturing the application factory once, while embedded owners can select independent remoting versions and serialization types. All direct production static command constructions and global transport error-helper bypasses are removed from the migrated NameServer paths.

### How Did You Test This Change?

- `cargo test -p rocketmq-protocol --lib` (1483 passed)
- `cargo test -p rocketmq-transport --lib` (193 passed)
- `cargo test -p rocketmq-namesrv --lib -- --skip config::tests::test_namesrv_config` (255 passed)
- `cargo test -p rocketmq-namesrv --all-features --lib -- --skip config::tests::test_namesrv_config` (257 passed)
- `cargo clippy -p rocketmq-namesrv --all-targets --all-features -- -D warnings`
- `cargo clippy -p rocketmq-protocol -p rocketmq-transport --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- all 28 root workspace packages passed package-scoped `cargo fmt -p <package> -- --check`
- fixed-nightly fuzz build passed
- standalone example Clippy passed
- RocketMQ MCP read-only boundary, default/all-feature tests, streamable HTTP Clippy, and rustdoc passed
- protocol/transport rustdoc, error hygiene, wire golden, and Java header compatibility checks passed

Aggregate `cargo fmt --all -- --check` reaches Windows OS error 206; package-scoped checks passed for all 28 workspace packages. `config::tests::test_namesrv_config` fails unchanged on `main` because its `allow_insecure_public_listener` assertion disagrees with the current default; all other NameServer default and all-feature tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable response settings for each NameServer, including response version and serialization format.
  * Added support for customizing how NameServer requests and responses are created.
  * Added consistent error responses with mapped error codes and optional remarks.

* **Bug Fixes**
  * Ensured custom response settings are preserved across routing, errors, unsupported requests, and readiness checks.
  * Prevented response configuration from leaking between independent NameServer instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->