### PR TITLE
[ISSUE #9341]♻️Inject remoting command factories into Controller owners

### DIFF
--- a/rocketmq-controller/src/bin/controller_bootstrap.rs
+++ b/rocketmq-controller/src/bin/controller_bootstrap.rs
@@ -328,9 +328,14 @@ async fn run_controller(
     // Create controller manager
     info!("Creating Controller Manager...");
     let security = build_controller_security(&config, &service_context).await?;
-    let controller_manager =
-        ControllerManager::new_with_security(config, service_context.clone(), telemetry_handle.clone(), security)
-            .await?;
+    let controller_manager = ControllerManager::new_with_security_and_remoting_command_factory(
+        config,
+        service_context.clone(),
+        telemetry_handle.clone(),
+        security,
+        rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory(),
+    )
+    .await?;
     let controller_manager = Arc::new(controller_manager);
     // Initialize controller
     info!("Initializing Controller...");

--- a/rocketmq-controller/src/controller/broker_role_notifier.rs
+++ b/rocketmq-controller/src/controller/broker_role_notifier.rs
@@ -20,6 +20,7 @@ use cheetah_string::CheetahString;
 use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::protocol::header::notify_broker_role_change_request_header::NotifyBrokerRoleChangedRequestHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 use rocketmq_store_api::HaContractError;
 use rocketmq_store_api::MasterEpoch;
 use rocketmq_store_api::SyncStateSetEpoch;
@@ -96,14 +97,15 @@ impl NotifyTask {
         }
     }
 
-    fn build_request(&self) -> RemotingCommand {
+    fn build_request(&self, command_factory: &RemotingCommandFactory) -> RemotingCommand {
         let request_header = NotifyBrokerRoleChangedRequestHeader {
             master_address: self.master_address.clone(),
             master_epoch: Some(self.state.authority.master_epoch().get()),
             sync_state_set_epoch: Some(self.state.sync_state_set_epoch.get()),
             master_broker_id: Some(self.state.authority.broker_id() as u64),
         };
-        RemotingCommand::create_request_command(RequestCode::NotifyBrokerRoleChanged, request_header)
+        command_factory
+            .create_request_command(RequestCode::NotifyBrokerRoleChanged, request_header)
             .set_body(self.sync_state_set.clone())
     }
 

--- a/rocketmq-controller/src/controller/broker_role_notifier/actor.rs
+++ b/rocketmq-controller/src/controller/broker_role_notifier/actor.rs
@@ -20,6 +20,7 @@ use std::time::Instant;
 
 use parking_lot::Mutex;
 use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 use rocketmq_runtime::TaskGroup;
 use rocketmq_runtime::TaskKind;
 use rocketmq_transport::api::v1::TransportClient;
@@ -332,6 +333,7 @@ impl Mailbox {
 #[derive(Clone)]
 pub(crate) struct BrokerRoleNotifier {
     client: Arc<TransportClient>,
+    command_factory: RemotingCommandFactory,
     sender: mpsc::Sender<NotifyKey>,
     receiver: Arc<Mutex<Option<mpsc::Receiver<NotifyKey>>>>,
     mailbox: Arc<Mutex<Mailbox>>,
@@ -339,10 +341,15 @@ pub(crate) struct BrokerRoleNotifier {
 }
 
 impl BrokerRoleNotifier {
-    pub(crate) fn new(client: Arc<TransportClient>, retry_base_delay: Duration) -> Self {
+    pub(crate) fn new(
+        client: Arc<TransportClient>,
+        retry_base_delay: Duration,
+        command_factory: RemotingCommandFactory,
+    ) -> Self {
         let (sender, receiver) = mpsc::channel(DEFAULT_MAILBOX_CAPACITY);
         Self {
             client,
+            command_factory,
             sender,
             receiver: Arc::new(Mutex::new(Some(receiver))),
             mailbox: Arc::new(Mutex::new(Mailbox::new(DEFAULT_MAILBOX_CAPACITY))),
@@ -401,7 +408,11 @@ impl BrokerRoleNotifier {
         let started_at = Instant::now();
         let result = self
             .client
-            .invoke_request(Some(&task.broker_addr), task.build_request(), NOTIFY_TIMEOUT_MILLIS)
+            .invoke_request(
+                Some(&task.broker_addr),
+                task.build_request(&self.command_factory),
+                NOTIFY_TIMEOUT_MILLIS,
+            )
             .await;
         let success = matches!(&result, Ok(response) if response.code() == ResponseCode::Success as i32);
         let should_retry = self.mailbox.lock().finish(&task, success, started_at.elapsed());

--- a/rocketmq-controller/src/controller/broker_role_notifier/tests.rs
+++ b/rocketmq-controller/src/controller/broker_role_notifier/tests.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use rocketmq_protocol::protocol::remoting_command_defaults::{RemotingCommandDefaults, RemotingCommandFactory};
+use rocketmq_protocol::protocol::SerializeType;
 use rocketmq_store_api::MasterEpoch;
 use rocketmq_store_api::SyncStateSetEpoch;
 use tokio::sync::mpsc;
@@ -38,6 +40,16 @@ fn state(master_epoch: i32, sync_state_set_epoch: i32) -> NotifyState {
         Some("127.0.0.1:10911".to_string()),
     )
     .expect("valid notify state")
+}
+
+#[test]
+fn notify_request_uses_the_owning_command_factory() {
+    let factory = RemotingCommandFactory::new(RemotingCommandDefaults::new(666, SerializeType::ROCKETMQ));
+
+    let request = NotifyTask::new_for_test(key(1), state(1, 1)).build_request(&factory);
+
+    assert_eq!(request.version(), 666);
+    assert_eq!(request.serialize_type(), SerializeType::ROCKETMQ);
 }
 
 #[test]

--- a/rocketmq-controller/src/controller/controller_manager.rs
+++ b/rocketmq-controller/src/controller/controller_manager.rs
@@ -51,6 +51,8 @@ use rocketmq_protocol::protocol::header::controller::get_replica_info_request_he
 use rocketmq_protocol::protocol::header::controller::get_replica_info_response_header::GetReplicaInfoResponseHeader;
 use rocketmq_protocol::protocol::header::elect_master_response_header::ElectMasterResponseHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 use rocketmq_protocol::protocol::RemotingDeserializable;
 use rocketmq_protocol::protocol::RemotingSerializable;
 use rocketmq_runtime::common::time_utils::current_millis;
@@ -306,6 +308,9 @@ pub struct ControllerManager {
     /// Configuration
     config: ControllerConfigHandle,
 
+    /// Immutable wire defaults shared by all command producers owned by this Controller.
+    command_factory: RemotingCommandFactory,
+
     /// Raft controller for consensus and leader election.
     /// Lifecycle mutation is synchronized inside the controller.
     raft_controller: Arc<RaftController>,
@@ -365,7 +370,35 @@ impl ControllerManager {
         service_context: ChildServiceContext,
         telemetry_handle: TelemetryHandle,
     ) -> Result<Self> {
-        Self::new_with_security(config, service_context, telemetry_handle, None).await
+        Self::new_with_remoting_command_factory(
+            config,
+            service_context,
+            telemetry_handle,
+            application_remoting_command_factory(),
+        )
+        .await
+    }
+
+    /// Creates a Controller manager with explicitly injected remoting defaults.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ControllerError`] when configuration validation or component
+    /// initialization fails.
+    pub async fn new_with_remoting_command_factory(
+        config: ControllerConfig,
+        service_context: ChildServiceContext,
+        telemetry_handle: TelemetryHandle,
+        command_factory: RemotingCommandFactory,
+    ) -> Result<Self> {
+        Self::new_with_security_and_remoting_command_factory(
+            config,
+            service_context,
+            telemetry_handle,
+            None,
+            command_factory,
+        )
+        .await
     }
 
     /// Creates a Controller manager with an explicitly injected security boundary.
@@ -383,6 +416,29 @@ impl ControllerManager {
         service_context: ChildServiceContext,
         telemetry_handle: TelemetryHandle,
         security: Option<ControllerSecurity>,
+    ) -> Result<Self> {
+        Self::new_with_security_and_remoting_command_factory(
+            config,
+            service_context,
+            telemetry_handle,
+            security,
+            application_remoting_command_factory(),
+        )
+        .await
+    }
+
+    /// Creates a Controller manager with explicit security and wire-default owners.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ControllerError`] when configuration is invalid, an enabled
+    /// security capability is missing, or component initialization fails.
+    pub async fn new_with_security_and_remoting_command_factory(
+        config: ControllerConfig,
+        service_context: ChildServiceContext,
+        telemetry_handle: TelemetryHandle,
+        security: Option<ControllerSecurity>,
+        command_factory: RemotingCommandFactory,
     ) -> Result<Self> {
         config.validate().map_err(ControllerError::ConfigError)?;
         let security_enabled =
@@ -428,12 +484,15 @@ impl ControllerManager {
         // Initialize Raft controller for leader election.
         // The controller and request processor must share the same heartbeat manager so that
         // liveness-aware paths observe the broker heartbeats recorded by RPC handlers.
-        let raft_arc = Arc::new(RaftController::new_open_raft_with_heartbeat_and_metrics(
-            config.reader(),
-            heartbeat_manager.clone(),
-            service_context.component("controller.openraft"),
-            metrics_manager.clone(),
-        ));
+        let raft_arc = Arc::new(
+            RaftController::new_open_raft_with_heartbeat_metrics_and_remoting_command_factory(
+                config.reader(),
+                heartbeat_manager.clone(),
+                service_context.component("controller.openraft"),
+                metrics_manager.clone(),
+                command_factory,
+            ),
+        );
 
         // Initialize remoting server for inbound requests
         let listen_port = config.snapshot().listen_addr.port() as u32;
@@ -466,13 +525,18 @@ impl ControllerManager {
             .map_err(|error| ControllerError::runtime_error(format!("Failed to build remoting client: {error}")))?,
         );
         let notify_retry_base_delay = Duration::from_millis(config.snapshot().heartbeat_interval_ms.max(100));
-        let broker_role_notifier = BrokerRoleNotifier::new(remoting_client.transport_client(), notify_retry_base_delay);
+        let broker_role_notifier = BrokerRoleNotifier::new(
+            remoting_client.transport_client(),
+            notify_retry_base_delay,
+            command_factory,
+        );
         info!("Remoting client created");
 
         info!("Controller manager created successfully");
 
         Ok(Self {
             config,
+            command_factory,
             raft_controller: raft_arc,
             heartbeat_manager,
             remoting_server: Mutex::new(remoting_server),
@@ -973,6 +1037,11 @@ impl ControllerManager {
         self.config.snapshot()
     }
 
+    /// Returns the immutable command factory owned by this Controller instance.
+    pub fn remoting_command_factory(&self) -> RemotingCommandFactory {
+        self.command_factory
+    }
+
     /// Returns the security boundary injected by the composition root.
     pub fn security(&self) -> Option<&ControllerSecurity> {
         self.security.as_ref()
@@ -1273,6 +1342,8 @@ mod tests {
     use rocketmq_protocol::protocol::header::controller::register_broker_to_controller_request_header::RegisterBrokerToControllerRequestHeader;
     use rocketmq_protocol::protocol::header::namesrv::broker_request::BrokerHeartbeatRequestHeader;
     use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+    use rocketmq_protocol::protocol::remoting_command_defaults::{RemotingCommandDefaults, RemotingCommandFactory};
+    use rocketmq_protocol::protocol::SerializeType;
     use rocketmq_transport::api::v1::Channel;
     use rocketmq_transport::api::v1::ConnectionHandlerContextWrapper;
     use rocketmq_transport::api::v1::RequestProcessor;
@@ -1329,6 +1400,80 @@ mod tests {
 
     fn test_service_context() -> ChildServiceContext {
         rocketmq_runtime::RuntimeContext::from_current("controller-manager-test").service_context("controller-manager")
+    }
+
+    #[tokio::test]
+    async fn manager_retains_its_injected_remoting_command_factory() {
+        let factory = RemotingCommandFactory::new(RemotingCommandDefaults::new(667, SerializeType::ROCKETMQ));
+        let config = ControllerConfig::default().with_node_info(1, reserve_controller_addresses().0);
+
+        let manager = ControllerManager::new_with_security_and_remoting_command_factory(
+            config,
+            test_service_context(),
+            test_telemetry_handle(),
+            None,
+            factory,
+        )
+        .await
+        .expect("create manager with explicit command factory");
+
+        assert_eq!(manager.remoting_command_factory(), factory);
+        let response = manager
+            .controller()
+            .get_controller_metadata()
+            .await
+            .expect("query unstarted Controller")
+            .expect("unstarted Controller response");
+        assert_eq!(response.version(), 667);
+        assert_eq!(response.serialize_type(), SerializeType::ROCKETMQ);
+    }
+
+    #[tokio::test]
+    async fn request_processor_uses_its_manager_command_factory() {
+        let binary_factory = RemotingCommandFactory::new(RemotingCommandDefaults::new(668, SerializeType::ROCKETMQ));
+        let json_factory = RemotingCommandFactory::new(RemotingCommandDefaults::new(669, SerializeType::JSON));
+        let binary_manager = Arc::new(
+            ControllerManager::new_with_remoting_command_factory(
+                ControllerConfig::default().with_node_info(1, reserve_controller_addresses().0),
+                test_service_context(),
+                test_telemetry_handle(),
+                binary_factory,
+            )
+            .await
+            .expect("create binary manager"),
+        );
+        let json_manager = Arc::new(
+            ControllerManager::new_with_remoting_command_factory(
+                ControllerConfig::default().with_node_info(2, reserve_controller_addresses().0),
+                test_service_context(),
+                test_telemetry_handle(),
+                json_factory,
+            )
+            .await
+            .expect("create JSON manager"),
+        );
+
+        async fn unsupported_response(manager: Arc<ControllerManager>) -> RemotingCommand {
+            let mut processor = ControllerRequestProcessor::new(manager);
+            let channel = create_test_channel().await;
+            let ctx = Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+            let mut request = RemotingCommand::create_remoting_command(-12345);
+            processor
+                .process_request(channel, ctx, &mut request)
+                .await
+                .expect("unsupported request dispatch")
+                .expect("unsupported request response")
+        }
+
+        let binary = unsupported_response(binary_manager).await;
+        let json = unsupported_response(json_manager).await;
+
+        assert_eq!(binary.code(), ResponseCode::RequestCodeNotSupported as i32);
+        assert_eq!(binary.version(), 668);
+        assert_eq!(binary.serialize_type(), SerializeType::ROCKETMQ);
+        assert_eq!(json.code(), ResponseCode::RequestCodeNotSupported as i32);
+        assert_eq!(json.version(), 669);
+        assert_eq!(json.serialize_type(), SerializeType::JSON);
     }
 
     #[tokio::test]

--- a/rocketmq-controller/src/controller/open_raft_controller.rs
+++ b/rocketmq-controller/src/controller/open_raft_controller.rs
@@ -84,6 +84,8 @@ use rocketmq_protocol::protocol::header::controller::register_broker_to_controll
 use rocketmq_protocol::protocol::header::get_meta_data_response_header::GetMetaDataResponseHeader;
 use rocketmq_protocol::protocol::header::namesrv::broker_request::BrokerHeartbeatRequestHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 use rocketmq_protocol::protocol::CommandCustomHeader;
 use rocketmq_protocol::protocol::RemotingDeserializable;
 use rocketmq_runtime::common::time_utils::current_millis;
@@ -137,6 +139,7 @@ struct OpenRaftLifecycle {
 /// 3. Waits for gRPC server task to complete (with 10s timeout)
 pub struct OpenRaftController {
     config: ControllerConfigReader,
+    command_factory: RemotingCommandFactory,
     /// Serializes startup and shutdown transitions.
     lifecycle_lock: AsyncMutex<()>,
     /// Raft node and gRPC shutdown handle owned by the lifecycle transition.
@@ -155,11 +158,25 @@ pub struct OpenRaftController {
 
 impl OpenRaftController {
     pub fn new(config: ControllerConfigReader, service_context: ChildServiceContext) -> Self {
+        Self::new_with_remoting_command_factory(config, service_context, application_remoting_command_factory())
+    }
+
+    /// Creates a Controller with explicit immutable remoting defaults.
+    pub fn new_with_remoting_command_factory(
+        config: ControllerConfigReader,
+        service_context: ChildServiceContext,
+        command_factory: RemotingCommandFactory,
+    ) -> Self {
         let heartbeat_manager = Arc::new(DefaultBrokerHeartbeatManager::new(
             config.clone(),
             service_context.task_group().clone(),
         ));
-        Self::new_with_heartbeat(config, heartbeat_manager, service_context)
+        Self::new_with_heartbeat_and_remoting_command_factory(
+            config,
+            heartbeat_manager,
+            service_context,
+            command_factory,
+        )
     }
 
     pub fn new_with_heartbeat(
@@ -167,9 +184,31 @@ impl OpenRaftController {
         heartbeat_manager: Arc<DefaultBrokerHeartbeatManager>,
         service_context: ChildServiceContext,
     ) -> Self {
+        Self::new_with_heartbeat_and_remoting_command_factory(
+            config,
+            heartbeat_manager,
+            service_context,
+            application_remoting_command_factory(),
+        )
+    }
+
+    /// Creates a Controller that shares the supplied heartbeat manager and
+    /// uses explicit immutable remoting defaults.
+    pub fn new_with_heartbeat_and_remoting_command_factory(
+        config: ControllerConfigReader,
+        heartbeat_manager: Arc<DefaultBrokerHeartbeatManager>,
+        service_context: ChildServiceContext,
+        command_factory: RemotingCommandFactory,
+    ) -> Self {
         let metrics_manager =
             ControllerMetricsManager::new(config.clone(), &rocketmq_observability::TelemetryHandle::noop());
-        Self::new_with_heartbeat_and_metrics(config, heartbeat_manager, service_context, metrics_manager)
+        Self::new_with_heartbeat_metrics_and_remoting_command_factory(
+            config,
+            heartbeat_manager,
+            service_context,
+            metrics_manager,
+            command_factory,
+        )
     }
 
     pub(crate) fn new_with_heartbeat_and_metrics(
@@ -178,8 +217,25 @@ impl OpenRaftController {
         service_context: ChildServiceContext,
         metrics_manager: Arc<ControllerMetricsManager>,
     ) -> Self {
+        Self::new_with_heartbeat_metrics_and_remoting_command_factory(
+            config,
+            heartbeat_manager,
+            service_context,
+            metrics_manager,
+            application_remoting_command_factory(),
+        )
+    }
+
+    pub(crate) fn new_with_heartbeat_metrics_and_remoting_command_factory(
+        config: ControllerConfigReader,
+        heartbeat_manager: Arc<DefaultBrokerHeartbeatManager>,
+        service_context: ChildServiceContext,
+        metrics_manager: Arc<ControllerMetricsManager>,
+        command_factory: RemotingCommandFactory,
+    ) -> Self {
         Self {
             config,
+            command_factory,
             lifecycle_lock: AsyncMutex::new(()),
             lifecycle: Mutex::new(OpenRaftLifecycle::default()),
             task_group: Arc::new(Mutex::new(None)),
@@ -320,14 +376,14 @@ impl OpenRaftController {
     }
 
     fn not_leader_response(&self) -> Option<RemotingCommand> {
-        Some(RemotingCommand::create_response_command_with_code_remark(
+        Some(self.command_factory.create_response_command_with_code_remark(
             ResponseCode::ControllerNotLeader,
             "The controller is not in leader state",
         ))
     }
 
     fn not_started_response(&self) -> Option<RemotingCommand> {
-        Some(RemotingCommand::create_response_command_with_code_remark(
+        Some(self.command_factory.create_response_command_with_code_remark(
             ResponseCode::SystemError,
             "The controller raft node is not started",
         ))
@@ -339,8 +395,10 @@ impl OpenRaftController {
     {
         let (_events, header, body, response_code, remark) = result.into_parts();
         let mut response = match header {
-            Some(header) => RemotingCommand::create_response_command_with_code_and_header(response_code, header),
-            None => RemotingCommand::create_response_command_with_code(response_code),
+            Some(header) => self
+                .command_factory
+                .create_response_command_with_code_and_header(response_code, header),
+            None => self.command_factory.create_response_command_with_code(response_code),
         };
         if let Some(remark) = remark {
             response = response.set_remark(remark);
@@ -353,7 +411,7 @@ impl OpenRaftController {
 
     fn command_from_result_without_header(&self, result: EventControllerResult<()>) -> RemotingCommand {
         let (_events, _header, body, response_code, remark) = result.into_parts();
-        let mut response = RemotingCommand::create_response_command_with_code(response_code);
+        let mut response = self.command_factory.create_response_command_with_code(response_code);
         if let Some(remark) = remark {
             response = response.set_remark(remark);
         }
@@ -411,7 +469,9 @@ impl OpenRaftController {
         };
 
         let response = node.client_write(request).await?;
-        Ok(Some(response.data.into_remoting_command()))
+        Ok(Some(
+            response.data.into_remoting_command_with_factory(&self.command_factory),
+        ))
     }
 
     async fn write_internal_request(&self, request: ControllerRequest) -> RocketMQResult<Option<ControllerResponse>> {
@@ -432,14 +492,14 @@ impl OpenRaftController {
         request: &BrokerHeartbeatRequestHeader,
     ) -> RocketMQResult<Option<RemotingCommand>> {
         let Some(broker_id) = request.broker_id else {
-            return Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+            return Ok(Some(self.command_factory.create_response_command_with_code_remark(
                 ResponseCode::ControllerInvalidRequest,
                 "Heart beat with empty brokerId",
             )));
         };
 
         if broker_id < 0 {
-            return Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+            return Ok(Some(self.command_factory.create_response_command_with_code_remark(
                 ResponseCode::ControllerInvalidRequest,
                 "Heart beat with invalid brokerId",
             )));
@@ -480,8 +540,8 @@ impl OpenRaftController {
             })
             .await?
         {
-            Some(response) => Ok(Some(response.into_remoting_command())),
-            None => Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+            Some(response) => Ok(Some(response.into_remoting_command_with_factory(&self.command_factory))),
+            None => Ok(Some(self.command_factory.create_response_command_with_code_remark(
                 ResponseCode::Success,
                 "Heart beat success",
             ))),
@@ -1087,7 +1147,9 @@ impl Controller for OpenRaftController {
             }
         }
 
-        let mut command = RemotingCommand::create_success_response_command_with_header(register_header.clone());
+        let mut command = self
+            .command_factory
+            .create_success_response_command_with_header(register_header.clone());
         if let Some(body) = replica_info.body().cloned() {
             if let Ok(sync_state_set) = SyncStateSet::decode(body.as_ref()) {
                 register_header.sync_state_set_epoch = Some(sync_state_set.get_sync_state_set_epoch());
@@ -1113,7 +1175,7 @@ impl Controller for OpenRaftController {
 
     async fn apply_broker_id(&self, request: &ApplyBrokerIdRequestHeader) -> RocketMQResult<Option<RemotingCommand>> {
         if request.applied_broker_id < 0 {
-            return Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+            return Ok(Some(self.command_factory.create_response_command_with_code_remark(
                 ResponseCode::ControllerBrokerIdInvalid,
                 format!(
                     "Invalid broker ID: {}. Broker ID must be non-negative.",
@@ -1272,9 +1334,10 @@ impl Controller for OpenRaftController {
                 applied_log_index,
             }
         };
-        Ok(Some(RemotingCommand::create_success_response_command_with_header(
-            controller_metadata_info,
-        )))
+        Ok(Some(
+            self.command_factory
+                .create_success_response_command_with_header(controller_metadata_info),
+        ))
     }
 
     async fn get_sync_state_data(&self, broker_names: &[CheetahString]) -> RocketMQResult<Option<RemotingCommand>> {

--- a/rocketmq-controller/src/controller/raft_controller.rs
+++ b/rocketmq-controller/src/controller/raft_controller.rs
@@ -35,6 +35,8 @@ use rocketmq_protocol::protocol::header::controller::get_replica_info_request_he
 use rocketmq_protocol::protocol::header::controller::register_broker_to_controller_request_header::RegisterBrokerToControllerRequestHeader;
 use rocketmq_protocol::protocol::header::namesrv::broker_request::BrokerHeartbeatRequestHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 use rocketmq_runtime::ChildServiceContext;
 use rocketmq_security_api::MaintenanceAuthorizationGrant;
 use tracing::info;
@@ -65,8 +67,25 @@ pub struct RaftController {
 impl RaftController {
     /// Create a new OpenRaft-based controller
     pub fn new_open_raft(config: ControllerConfigReader, service_context: ChildServiceContext) -> Self {
+        Self::new_open_raft_with_remoting_command_factory(
+            config,
+            service_context,
+            application_remoting_command_factory(),
+        )
+    }
+
+    /// Creates an OpenRaft Controller with explicit immutable remoting defaults.
+    pub fn new_open_raft_with_remoting_command_factory(
+        config: ControllerConfigReader,
+        service_context: ChildServiceContext,
+        command_factory: RemotingCommandFactory,
+    ) -> Self {
         Self {
-            inner: Arc::new(OpenRaftController::new(config, service_context)),
+            inner: Arc::new(OpenRaftController::new_with_remoting_command_factory(
+                config,
+                service_context,
+                command_factory,
+            )),
         }
     }
 
@@ -76,11 +95,28 @@ impl RaftController {
         heartbeat_manager: Arc<DefaultBrokerHeartbeatManager>,
         service_context: ChildServiceContext,
     ) -> Self {
+        Self::new_open_raft_with_heartbeat_and_remoting_command_factory(
+            config,
+            heartbeat_manager,
+            service_context,
+            application_remoting_command_factory(),
+        )
+    }
+
+    /// Creates an OpenRaft Controller that shares the supplied heartbeat
+    /// manager and uses explicit immutable remoting defaults.
+    pub fn new_open_raft_with_heartbeat_and_remoting_command_factory(
+        config: ControllerConfigReader,
+        heartbeat_manager: Arc<DefaultBrokerHeartbeatManager>,
+        service_context: ChildServiceContext,
+        command_factory: RemotingCommandFactory,
+    ) -> Self {
         Self {
-            inner: Arc::new(OpenRaftController::new_with_heartbeat(
+            inner: Arc::new(OpenRaftController::new_with_heartbeat_and_remoting_command_factory(
                 config,
                 heartbeat_manager,
                 service_context,
+                command_factory,
             )),
         }
     }
@@ -91,13 +127,32 @@ impl RaftController {
         service_context: ChildServiceContext,
         metrics_manager: Arc<ControllerMetricsManager>,
     ) -> Self {
+        Self::new_open_raft_with_heartbeat_metrics_and_remoting_command_factory(
+            config,
+            heartbeat_manager,
+            service_context,
+            metrics_manager,
+            application_remoting_command_factory(),
+        )
+    }
+
+    pub(crate) fn new_open_raft_with_heartbeat_metrics_and_remoting_command_factory(
+        config: ControllerConfigReader,
+        heartbeat_manager: Arc<DefaultBrokerHeartbeatManager>,
+        service_context: ChildServiceContext,
+        metrics_manager: Arc<ControllerMetricsManager>,
+        command_factory: RemotingCommandFactory,
+    ) -> Self {
         Self {
-            inner: Arc::new(OpenRaftController::new_with_heartbeat_and_metrics(
-                config,
-                heartbeat_manager,
-                service_context,
-                metrics_manager,
-            )),
+            inner: Arc::new(
+                OpenRaftController::new_with_heartbeat_metrics_and_remoting_command_factory(
+                    config,
+                    heartbeat_manager,
+                    service_context,
+                    metrics_manager,
+                    command_factory,
+                ),
+            ),
         }
     }
 

--- a/rocketmq-controller/src/processor.rs
+++ b/rocketmq-controller/src/processor.rs
@@ -21,6 +21,8 @@ use crate::processor::controller_request_processor::ControllerRequestProcessor;
 use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 use rocketmq_transport::api::v1::Channel;
 use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use rocketmq_transport::api::v1::RejectRequestResponse;
@@ -57,15 +59,22 @@ impl rocketmq_transport::api::v1::RequestProcessor for ControllerRequestProcesso
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct ControllerServerRequestProcessor {
     default_request_processor: Option<ControllerRequestProcessorWrapper>,
+    command_factory: RemotingCommandFactory,
 }
 
 impl ControllerServerRequestProcessor {
     pub fn new() -> Self {
+        Self::new_with_remoting_command_factory(application_remoting_command_factory())
+    }
+
+    /// Creates the server processor with explicit immutable remoting defaults.
+    pub fn new_with_remoting_command_factory(command_factory: RemotingCommandFactory) -> Self {
         Self {
             default_request_processor: None,
+            command_factory,
         }
     }
 
@@ -83,7 +92,7 @@ impl rocketmq_transport::api::v1::RequestProcessor for ControllerServerRequestPr
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         match self.default_request_processor.as_mut() {
             None => {
-                let response_command = RemotingCommand::create_response_command_with_code_remark(
+                let response_command = self.command_factory.create_response_command_with_code_remark(
                     ResponseCode::SystemError,
                     format!("The request code {} is not supported.", request.code_ref()),
                 );
@@ -93,5 +102,61 @@ impl rocketmq_transport::api::v1::RequestProcessor for ControllerServerRequestPr
                 rocketmq_transport::api::v1::RequestProcessor::process_request(processor, channel, ctx, request).await
             }
         }
+    }
+}
+
+impl Default for ControllerServerRequestProcessor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::SocketAddr;
+
+    use rocketmq_protocol::protocol::remoting_command_defaults::{RemotingCommandDefaults, RemotingCommandFactory};
+    use rocketmq_protocol::protocol::SerializeType;
+    use rocketmq_runtime::RuntimeContext;
+    use rocketmq_transport::api::v1::ConnectionHandlerContextWrapper;
+    use rocketmq_transport::api::v1::RequestProcessor;
+    use rocketmq_transport::test_support::Connection;
+
+    use super::*;
+
+    async fn test_channel() -> Channel {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local listener");
+        let local_addr = listener.local_addr().expect("local listener address");
+        let stream = std::net::TcpStream::connect(local_addr).expect("connect local listener");
+        stream.set_nonblocking(true).expect("set nonblocking");
+        drop(listener);
+        let connection = Connection::new(tokio::net::TcpStream::from_std(stream).expect("convert stream"));
+        let task_group = RuntimeContext::from_current("controller-server-processor-test")
+            .service_context("processor")
+            .task_group()
+            .clone();
+        rocketmq_transport::test_support::TestChannelBuilder::new(connection, task_group)
+            .addresses(local_addr, SocketAddr::from(([127, 0, 0, 1], 0)))
+            .build()
+            .expect("build channel")
+    }
+
+    #[tokio::test]
+    async fn unsupported_response_uses_the_injected_command_factory() {
+        let factory = RemotingCommandFactory::new(RemotingCommandDefaults::new(670, SerializeType::ROCKETMQ));
+        let mut processor = ControllerServerRequestProcessor::new_with_remoting_command_factory(factory);
+        let channel = test_channel().await;
+        let ctx = Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let mut request = factory.create_remoting_command(-44).set_opaque(91);
+
+        let response = processor
+            .process_request(channel, ctx, &mut request)
+            .await
+            .expect("unsupported request dispatch")
+            .expect("unsupported request response");
+
+        assert_eq!(response.version(), 670);
+        assert_eq!(response.serialize_type(), SerializeType::ROCKETMQ);
+        assert_eq!(response.opaque(), 91);
     }
 }

--- a/rocketmq-controller/src/processor/controller_request_processor.rs
+++ b/rocketmq-controller/src/processor/controller_request_processor.rs
@@ -80,6 +80,7 @@ use rocketmq_protocol::protocol::header::controller::register_broker_to_controll
 use rocketmq_protocol::protocol::header::maintenance_request_header::MaintenanceRequestHeader;
 use rocketmq_protocol::protocol::header::namesrv::broker_request::BrokerHeartbeatRequestHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 use rocketmq_protocol::protocol::RemotingDeserializable;
 use rocketmq_security_api::MaintenanceAuthorizationContext;
 use rocketmq_security_api::MaintenanceAuthorizationGrant;
@@ -106,6 +107,9 @@ pub struct ControllerRequestProcessor {
     /// Reference to the controller manager
     controller_manager: Weak<ControllerManager>,
 
+    /// Immutable wire defaults captured from the owning Controller manager.
+    command_factory: RemotingCommandFactory,
+
     /// Reference to the heartbeat manager
     heartbeat_manager: Arc<DefaultBrokerHeartbeatManager>,
 
@@ -130,9 +134,11 @@ impl ControllerRequestProcessor {
     pub fn new(controller_manager: Arc<ControllerManager>) -> Self {
         let heartbeat_manager = controller_manager.heartbeat_manager().clone();
         let config_blacklist = Arc::new(Self::init_config_blacklist(&controller_manager));
+        let command_factory = controller_manager.remoting_command_factory();
 
         Self {
             controller_manager: Arc::downgrade(&controller_manager),
+            command_factory,
             heartbeat_manager,
             config_blacklist,
         }
@@ -218,7 +224,7 @@ impl ControllerRequestProcessor {
             RequestCode::MaintenanceRestoreVerify => self.handle_restore_verify(channel, ctx, request).await,
             _ => {
                 let error_msg = format!("request type {} not supported", request.code());
-                Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+                Ok(Some(self.command_factory.create_response_command_with_code_remark(
                     ResponseCode::RequestCodeNotSupported,
                     error_msg,
                 )))
@@ -310,7 +316,9 @@ impl ControllerRequestProcessor {
         };
         let body = serde_json::to_vec(&response)
             .map_err(|error| RocketMQError::internal("encode maintenance capabilities", error))?;
-        Ok(Some(RemotingCommand::create_success_response_command().set_body(body)))
+        Ok(Some(
+            self.command_factory.create_success_response_command().set_body(body),
+        ))
     }
 
     async fn handle_create_release_snapshot(
@@ -332,7 +340,9 @@ impl ControllerRequestProcessor {
             .await?;
         let body = serde_json::to_vec(&snapshot.manifest)
             .map_err(|error| RocketMQError::internal("encode Controller release snapshot manifest", error))?;
-        Ok(Some(RemotingCommand::create_success_response_command().set_body(body)))
+        Ok(Some(
+            self.command_factory.create_success_response_command().set_body(body),
+        ))
     }
 
     async fn handle_verify_release_snapshot(
@@ -349,7 +359,9 @@ impl ControllerRequestProcessor {
             .await?;
         let body = serde_json::to_vec(&manifest)
             .map_err(|error| RocketMQError::internal("encode verified Controller snapshot manifest", error))?;
-        Ok(Some(RemotingCommand::create_success_response_command().set_body(body)))
+        Ok(Some(
+            self.command_factory.create_success_response_command().set_body(body),
+        ))
     }
 
     async fn handle_restore_verify(
@@ -367,7 +379,9 @@ impl ControllerRequestProcessor {
             .await?;
         let body = serde_json::to_vec(&verification)
             .map_err(|error| RocketMQError::internal("encode Controller restore-verification proof", error))?;
-        Ok(Some(RemotingCommand::create_success_response_command().set_body(body)))
+        Ok(Some(
+            self.command_factory.create_success_response_command().set_body(body),
+        ))
     }
 
     /// Handle ALTER_SYNC_STATE_SET request
@@ -582,7 +596,7 @@ impl ControllerRequestProcessor {
                 .record_broker_heartbeat(&request_header)
                 .await
         } else {
-            Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+            Ok(Some(self.command_factory.create_response_command_with_code_remark(
                 ResponseCode::ControllerInvalidRequest,
                 "Heart beat with empty brokerId",
             )))
@@ -615,7 +629,7 @@ impl ControllerRequestProcessor {
                 return controller_manager.controller().get_sync_state_data(&broker_names).await;
             }
         }
-        Ok(Some(RemotingCommand::create_success_response_command()))
+        Ok(Some(self.command_factory.create_success_response_command()))
     }
 
     /// Handle UPDATE_CONTROLLER_CONFIG request
@@ -656,7 +670,7 @@ impl ControllerRequestProcessor {
         }
         // Validate against blacklist
         if self.validate_blacklist_config_exist(&properties) {
-            return Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+            return Ok(Some(self.command_factory.create_response_command_with_code_remark(
                 ResponseCode::NoPermission,
                 "Cannot update blacklisted configuration".to_string(),
             )));
@@ -667,7 +681,7 @@ impl ControllerRequestProcessor {
         controller_manager.update_config(properties).await?;
 
         // Return success
-        Ok(Some(RemotingCommand::create_success_response_command()))
+        Ok(Some(self.command_factory.create_success_response_command()))
     }
     // Helper function to parse properties
     async fn parse_properties_from_string(body: &[u8]) -> RocketMQResult<HashMap<String, String>> {
@@ -709,7 +723,10 @@ impl ControllerRequestProcessor {
         let controller_config = self.controller_manager()?.controller_config();
         let config_string = controller_config.to_properties_string();
 
-        let response = RemotingCommand::create_success_response_command().set_body(config_string.into_bytes());
+        let response = self
+            .command_factory
+            .create_success_response_command()
+            .set_body(config_string.into_bytes());
         Ok(Some(response))
     }
 
@@ -740,7 +757,7 @@ impl ControllerRequestProcessor {
             })?;
 
         if request_header.broker_name.is_empty() {
-            return Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+            return Ok(Some(self.command_factory.create_response_command_with_code_remark(
                 ResponseCode::ControllerInvalidRequest,
                 "broker_name cannot be empty",
             )));
@@ -785,7 +802,7 @@ impl ControllerRequestProcessor {
         // Validate cluster_name
         if request_header.cluster_name.is_empty() {
             warn!("GetNextBrokerId request rejected: cluster_name is empty");
-            return Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+            return Ok(Some(self.command_factory.create_response_command_with_code_remark(
                 ResponseCode::ControllerInvalidRequest,
                 "cluster_name cannot be empty".to_string(),
             )));
@@ -794,7 +811,7 @@ impl ControllerRequestProcessor {
         // Validate broker_name
         if request_header.broker_name.is_empty() {
             warn!("GetNextBrokerId request rejected: broker_name is empty");
-            return Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+            return Ok(Some(self.command_factory.create_response_command_with_code_remark(
                 ResponseCode::ControllerInvalidRequest,
                 "broker_name cannot be empty".to_string(),
             )));
@@ -885,7 +902,7 @@ impl ControllerRequestProcessor {
         // Validate cluster_name is not empty
         if request_header.cluster_name.is_empty() {
             warn!("ApplyBrokerId request rejected: cluster_name is empty");
-            return Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+            return Ok(Some(self.command_factory.create_response_command_with_code_remark(
                 ResponseCode::ControllerInvalidRequest,
                 "cluster_name cannot be empty".to_string(),
             )));
@@ -894,7 +911,7 @@ impl ControllerRequestProcessor {
         // Validate broker_name is not empty
         if request_header.broker_name.is_empty() {
             warn!("ApplyBrokerId request rejected: broker_name is empty");
-            return Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+            return Ok(Some(self.command_factory.create_response_command_with_code_remark(
                 ResponseCode::ControllerInvalidRequest,
                 "broker_name cannot be empty".to_string(),
             )));
@@ -906,7 +923,7 @@ impl ControllerRequestProcessor {
                 "ApplyBrokerId request rejected: invalid broker_id={} for broker={}",
                 request_header.applied_broker_id, request_header.broker_name
             );
-            return Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+            return Ok(Some(self.command_factory.create_response_command_with_code_remark(
                 ResponseCode::ControllerBrokerIdInvalid,
                 format!(
                     "Invalid broker ID: {}. Broker ID must be non-negative.",
@@ -984,7 +1001,7 @@ impl ControllerRequestProcessor {
         let broker_address = request_header.broker_address.clone().unwrap_or_default();
 
         if broker_name.is_empty() || cluster_name.is_empty() || broker_address.is_empty() {
-            return Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+            return Ok(Some(self.command_factory.create_response_command_with_code_remark(
                 ResponseCode::ControllerInvalidRequest,
                 "cluster_name, broker_name and broker_address cannot be empty",
             )));
@@ -1079,7 +1096,7 @@ impl ControllerRequestProcessor {
                 if let Some(name) = request_name {
                     self.record_request_metrics(name, RequestHandleStatus::Timeout, latency_us);
                 }
-                Ok(Some(RemotingCommand::create_response_command_with_code_remark(
+                Ok(Some(self.command_factory.create_response_command_with_code_remark(
                     ResponseCode::SystemError,
                     "Controller request timed out",
                 )))

--- a/rocketmq-controller/src/typ.rs
+++ b/rocketmq-controller/src/typ.rs
@@ -28,6 +28,8 @@ use rocketmq_protocol::protocol::header::controller::apply_broker_id_response_he
 use rocketmq_protocol::protocol::header::controller::register_broker_to_controller_response_header::RegisterBrokerToControllerResponseHeader;
 use rocketmq_protocol::protocol::header::elect_master_response_header::ElectMasterResponseHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 
 /// Node ID type - represents a unique identifier for a controller node.
 pub type NodeId = u64;
@@ -241,20 +243,26 @@ impl ControllerResponse {
     }
 
     pub fn into_remoting_command(self) -> RemotingCommand {
+        self.into_remoting_command_with_factory(&application_remoting_command_factory())
+    }
+
+    /// Converts this replicated response with the immutable defaults owned by a
+    /// specific Controller instance.
+    pub fn into_remoting_command_with_factory(self, command_factory: &RemotingCommandFactory) -> RemotingCommand {
         let mut command = match self.header {
             Some(ControllerResponseHeader::ApplyBrokerId(header)) => {
-                RemotingCommand::create_response_command_with_code_and_header(self.response_code, header)
+                command_factory.create_response_command_with_code_and_header(self.response_code, header)
             }
             Some(ControllerResponseHeader::RegisterBroker(header)) => {
-                RemotingCommand::create_response_command_with_code_and_header(self.response_code, header)
+                command_factory.create_response_command_with_code_and_header(self.response_code, header)
             }
             Some(ControllerResponseHeader::AlterSyncStateSet(header)) => {
-                RemotingCommand::create_response_command_with_code_and_header(self.response_code, header)
+                command_factory.create_response_command_with_code_and_header(self.response_code, header)
             }
             Some(ControllerResponseHeader::ElectMaster(header)) => {
-                RemotingCommand::create_response_command_with_code_and_header(self.response_code, header)
+                command_factory.create_response_command_with_code_and_header(self.response_code, header)
             }
-            None => RemotingCommand::create_response_command_with_code(self.response_code),
+            None => command_factory.create_response_command_with_code(self.response_code),
         };
         if let Some(remark) = self.remark {
             command = command.set_remark(remark);
@@ -269,6 +277,8 @@ impl ControllerResponse {
 #[cfg(test)]
 mod tests {
     use cheetah_string::CheetahString;
+    use rocketmq_protocol::protocol::remoting_command_defaults::{RemotingCommandDefaults, RemotingCommandFactory};
+    use rocketmq_protocol::protocol::SerializeType;
 
     use super::*;
 
@@ -307,6 +317,20 @@ mod tests {
             .expect("controller response header");
         assert_eq!(header.cluster_name.as_deref(), Some("cluster-a"));
         assert_eq!(header.broker_name.as_deref(), Some("broker-a"));
+    }
+
+    #[test]
+    fn controller_response_uses_the_owning_command_factory() {
+        let json_factory = RemotingCommandFactory::new(RemotingCommandDefaults::new(664, SerializeType::JSON));
+        let binary_factory = RemotingCommandFactory::new(RemotingCommandDefaults::new(665, SerializeType::ROCKETMQ));
+
+        let json = ControllerResponse::success().into_remoting_command_with_factory(&json_factory);
+        let binary = ControllerResponse::success().into_remoting_command_with_factory(&binary_factory);
+
+        assert_eq!(json.version(), 664);
+        assert_eq!(json.serialize_type(), SerializeType::JSON);
+        assert_eq!(binary.version(), 665);
+        assert_eq!(binary.serialize_type(), SerializeType::ROCKETMQ);
     }
 }
 

--- a/rocketmq-controller/tests/remoting_command_factory_owner_audit.rs
+++ b/rocketmq-controller/tests/remoting_command_factory_owner_audit.rs
@@ -1,0 +1,83 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const RUNTIME_OWNER_SOURCES: &[(&str, &str, bool)] = &[
+    (
+        "controller_manager.rs",
+        include_str!("../src/controller/controller_manager.rs"),
+        true,
+    ),
+    (
+        "open_raft_controller.rs",
+        include_str!("../src/controller/open_raft_controller.rs"),
+        true,
+    ),
+    (
+        "raft_controller.rs",
+        include_str!("../src/controller/raft_controller.rs"),
+        true,
+    ),
+    ("processor.rs", include_str!("../src/processor.rs"), false),
+    (
+        "controller_request_processor.rs",
+        include_str!("../src/processor/controller_request_processor.rs"),
+        true,
+    ),
+    (
+        "broker_role_notifier.rs",
+        include_str!("../src/controller/broker_role_notifier.rs"),
+        false,
+    ),
+    (
+        "broker_role_notifier/actor.rs",
+        include_str!("../src/controller/broker_role_notifier/actor.rs"),
+        false,
+    ),
+];
+
+const STATIC_COMMAND_CONSTRUCTORS: &[&str] = &[
+    "RemotingCommand::create_remoting_command(",
+    "RemotingCommand::create_request(",
+    "RemotingCommand::create_request_command(",
+    "RemotingCommand::create_response_command",
+    "RemotingCommand::create_success_response_command",
+    "RemotingCommand::create_java_default_error_response_command",
+];
+
+#[test]
+fn controller_runtime_owners_do_not_bypass_their_command_factory() {
+    let mut bypasses = Vec::new();
+
+    for (path, source, has_inline_test_module) in RUNTIME_OWNER_SOURCES {
+        let production = if *has_inline_test_module {
+            source.split("mod tests {").next().unwrap_or(source)
+        } else {
+            source
+        };
+        for (line_index, line) in production.lines().enumerate() {
+            if STATIC_COMMAND_CONSTRUCTORS
+                .iter()
+                .any(|constructor| line.contains(constructor))
+            {
+                bypasses.push(format!("{path}:{}: {}", line_index + 1, line.trim()));
+            }
+        }
+    }
+
+    assert!(
+        bypasses.is_empty(),
+        "Controller runtime owners must construct commands through their injected factory:\n{}",
+        bypasses.join("\n")
+    );
+}

--- a/rocketmq-namesrv/src/bootstrap.rs
+++ b/rocketmq-namesrv/src/bootstrap.rs
@@ -533,10 +533,11 @@ impl NameServerRuntime {
                 .expect("NameServerRuntime always has an injected ChildServiceContext")
                 .component("namesrv.embedded-controller");
             let controller_manager = Arc::new(
-                ControllerManager::new(
+                ControllerManager::new_with_remoting_command_factory(
                     (*controller_config).clone(),
                     controller_context,
                     self.inner.telemetry.clone(),
+                    self.inner.remoting_command_factory(),
                 )
                 .await?,
             );
@@ -1887,6 +1888,8 @@ mod tests {
 
     use cheetah_string::CheetahString;
     #[cfg(feature = "embedded-controller")]
+    use rocketmq_controller::Controller;
+    #[cfg(feature = "embedded-controller")]
     use rocketmq_controller::ControllerConfig;
     use rocketmq_error::ErrorKind;
     use rocketmq_model::common::config::TopicConfig;
@@ -1927,11 +1930,15 @@ mod tests {
     use rocketmq_protocol::protocol::header::namesrv::topic_operation_header::GetTopicsByClusterRequestHeader;
     use rocketmq_protocol::protocol::header::namesrv::topic_operation_header::RegisterTopicRequestHeader;
     use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+    #[cfg(feature = "embedded-controller")]
+    use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandDefaults;
     use rocketmq_protocol::protocol::route::route_data_view::QueueData;
     use rocketmq_protocol::protocol::route::topic_route_data::TopicRouteData;
     use rocketmq_protocol::protocol::DataVersion;
     use rocketmq_protocol::protocol::RemotingDeserializable;
     use rocketmq_protocol::protocol::RemotingSerializable;
+    #[cfg(feature = "embedded-controller")]
+    use rocketmq_protocol::protocol::SerializeType;
     use rocketmq_runtime::RuntimeContext;
     use rocketmq_transport::api::v1::ConnectionState;
     use rocketmq_transport::api::v1::RPCHook;
@@ -4169,12 +4176,14 @@ mod tests {
     #[cfg(feature = "embedded-controller")]
     #[tokio::test]
     async fn enable_controller_in_namesrv_lifecycle_matches_namesrv_runtime() {
+        let command_factory = RemotingCommandFactory::new(RemotingCommandDefaults::new(671, SerializeType::ROCKETMQ));
         let (namesrv_config, _namesrv_root) = isolated_namesrv_config(NamesrvConfig {
             enable_controller_in_namesrv: true,
             ..NamesrvConfig::default()
         });
         let (controller_config, _controller_root) = embedded_controller_config();
         let mut bootstrap = Builder::new(test_service_context(), TelemetryHandle::noop())
+            .set_remoting_command_factory(command_factory)
             .set_name_server_config(namesrv_config)
             .set_server_config(namesrv_server_config())
             .set_controller_config(controller_config)
@@ -4196,6 +4205,17 @@ mod tests {
             .expect("embedded controller should be initialized");
         assert!(controller_manager.is_initialized());
         assert!(!controller_manager.is_running());
+        assert_eq!(controller_manager.remoting_command_factory(), command_factory);
+        let response = controller_manager
+            .controller()
+            .get_controller_metadata()
+            .await
+            .expect("query unstarted embedded Controller")
+            .expect("unstarted embedded Controller response");
+        assert_eq!(
+            (response.version(), response.serialize_type()),
+            (671, SerializeType::ROCKETMQ)
+        );
 
         let mut runtime = bootstrap.name_server_runtime;
         let start_handle = tokio::spawn(async move { runtime.start().await });


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9341

### Brief Description

- Capture one immutable `RemotingCommandFactory` at each Controller composition boundary.
- Propagate the factory through ControllerManager, Raft/OpenRaft responses, inbound processors, unsupported-request responses, and broker-role notification requests.
- Preserve existing constructors as compatibility wrappers while adding explicit injection entry points.
- Pass the NameServer-owned factory into its embedded Controller.
- Add owner-isolation, outbound-request, embedded-owner, and source-audit regression coverage.

### How Did You Test This Change?

- `cargo test -p rocketmq-controller --lib` (174 passed, 3 ignored)
- `cargo test -p rocketmq-controller --tests -- --skip test_five_node_cluster` (passed)
- `cargo test -p rocketmq-controller --all-features --lib` (175 passed, 3 ignored)
- `cargo test -p rocketmq-controller --all-features --test remoting_command_factory_owner_audit` (passed)
- `cargo test -p rocketmq-namesrv --all-features --lib -- --skip config::tests::test_namesrv_config` (257 passed)
- `cargo test -p rocketmq-namesrv --features embedded-controller enable_controller_in_namesrv_lifecycle_matches_namesrv_runtime --lib` (passed)
- `cargo clippy -p rocketmq-controller --all-targets --all-features -- -D warnings` (passed)
- `cargo clippy -p rocketmq-namesrv --all-targets --all-features -- -D warnings` (passed)
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` (passed)
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/` (passed)
- `cargo fmt -p rocketmq-controller -- --check` and `cargo fmt -p rocketmq-namesrv -- --check` (passed)
- `scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` (passed)
- `scripts/check-error-hygiene.ps1` (passed)
- `cargo doc -p rocketmq-controller -p rocketmq-namesrv --all-features --no-deps` (passed with two pre-existing NameServer invalid-HTML-tag warnings)
- `git diff --check` (passed)

The aggregate `cargo fmt --all -- --check` command remains unavailable on Windows because it exits with OS error 206; both changed packages pass their package-scoped format checks. `test_five_node_cluster` fails because a learner has not reached the committed-log frontier; the same command reproduces the failure on the unmodified `main` branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable remoting protocol versions and serialization types for Controller requests, responses, and broker notifications.
  * Embedded Controllers now inherit the NameServer’s configured remoting settings.
  * Added construction options for explicitly selecting remoting command defaults.

* **Tests**
  * Added coverage verifying custom protocol settings are preserved across Controller operations and embedded initialization.
  * Added safeguards ensuring runtime responses use the configured command factory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->