### PR TITLE
[ISSUE #9337]📝Remove Star History chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **docs:** Remove the Star History chart from `README.md` ([#9337](https://github.com/mxsm/rocketmq-rust/issues/9337))
 - **test(store):** Remove obsolete phase3_integration_tests.rs integration test file ([#6649](https://github.com/mxsm/rocketmq-rust/issues/6649))
 - **refactor(broker):** Update ProducerManager to use ProducerGroupName type alias for producer group mapping ([#6638](https://github.com/mxsm/rocketmq-rust/issues/6638))
 - **test(store):** Remove obsolete io_uring_integration_tests.rs integration test file ([#6620](https://github.com/mxsm/rocketmq-rust/issues/6620))
-

--- a/README.md
+++ b/README.md
@@ -350,10 +350,6 @@ Thanks to all our contributors! 🙏
   <img src="https://contrib.rocks/image?repo=mxsm/rocketmq-rust&anon=1" />
 </a>
 
-### Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=mxsm/rocketmq-rust&type=Date)](https://star-history.com/#mxsm/rocketmq-rust&Date)
-
 ## 📄 License
 
 RocketMQ-Rust is licensed under the **Apache License 2.0**.
@@ -375,4 +371,3 @@ See [LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2
 [codecov-image]: https://codecov.io/gh/mxsm/rocketmq-rust/branch/main/graph/badge.svg
 
 [codecov-url]: https://codecov.io/gh/mxsm/rocketmq-rust
-


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9337

### Brief Description

Removes the external Star History chart from `README.md` as requested and records the documentation removal under the changelog's Unreleased section.

### How Did You Test This Change?

- `git diff --check origin/main...HEAD` - passed
- `rg "Star History|star-history\\.com" README.md` - returned no matches
- Cargo validation was not run because this is a Markdown-only change that does not affect generated Rust, build configuration, executable examples, or documented Rust commands.

Implementation and validation were prepared with OpenAI Codex assistance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the Star History chart and related link from the README.
  * Updated the unreleased changelog to record the removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->