### PR TITLE
[ISSUE #9347]♻️Enforce symmetric remoting frame limits across endpoints

### DIFF
--- a/rocketmq-broker/src/processor/default_pull_message_result_handler.rs
+++ b/rocketmq-broker/src/processor/default_pull_message_result_handler.rs
@@ -250,15 +250,21 @@ impl<MS: BrokerReadStore> PullMessageResultHandler for DefaultPullMessageResultH
                         return None;
                     }
 
-                    if let Some(header_bytes) =
+                    let Some(header_bytes) =
                         response.encode_header_with_body_length(get_message_result.buffer_total_size() as usize)
-                    {
-                        let _ = channel.send_bytes(header_bytes).await;
-                    }
+                    else {
+                        warn!("Failed to encode pull response header");
+                        return None;
+                    };
+                    let mut frame_segments = Vec::with_capacity(get_message_result.message_mapped_list().len() + 1);
+                    frame_segments.push(header_bytes);
                     for select_result in get_message_result.message_mapped_list_mut() {
                         if let Some(message) = select_result.take() {
-                            let _ = channel.send_bytes(message).await;
+                            frame_segments.push(message);
                         }
+                    }
+                    if let Err(error) = channel.send_frame_segments(frame_segments).await {
+                        warn!(%error, "Failed to send segmented pull response");
                     }
 
                     None

--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -767,16 +767,24 @@ where
                     Ok(Some(final_response))
                 } else {
                     //zero copy transfer
-                    if let Some(header_bytes) =
-                        final_response.encode_header_with_body_length(get_message_result.buffer_total_size() as usize)
-                    {
-                        channel.send_bytes(header_bytes).await?;
-                    }
+                    let header_bytes = final_response
+                        .encode_header_with_body_length(get_message_result.buffer_total_size() as usize)
+                        .ok_or_else(|| {
+                            rocketmq_error::RocketMQError::Serialization(
+                                rocketmq_error::SerializationError::encode_failed(
+                                    "remoting-command",
+                                    "failed to encode POP response header",
+                                ),
+                            )
+                        })?;
+                    let mut frame_segments = Vec::with_capacity(get_message_result.message_mapped_list().len() + 1);
+                    frame_segments.push(header_bytes);
                     for select_result in get_message_result.message_mapped_list_mut() {
                         if let Some(message) = select_result.take() {
-                            channel.send_bytes(message).await?;
+                            frame_segments.push(message);
                         }
                     }
+                    channel.send_frame_segments(frame_segments).await?;
 
                     Ok(None)
                 }

--- a/rocketmq-protocol/src/protocol/remoting_command.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command.rs
@@ -837,9 +837,27 @@ impl RemotingCommand {
         size
     }
 
-    /// Optimized decode with enhanced boundary checks and reduced allocations
+    /// Decodes one command with the historical 16 MiB announced-payload ceiling.
+    ///
+    /// Transport owners with an explicit total-wire limit should use
+    /// [`Self::decode_with_max_frame_bytes`] so inbound and outbound policy stays symmetric.
     #[inline]
     pub fn decode(src: &mut BytesMut) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        Self::decode_with_max_frame_bytes(src, 16 * 1024 * 1024 + 4)
+    }
+
+    /// Decodes one command bounded by a caller-owned complete wire-frame limit.
+    ///
+    /// `max_frame_bytes` includes the four-byte announced-length prefix.
+    ///
+    /// # Errors
+    ///
+    /// Returns a serialization error for a negative, overflowing, oversized, or malformed frame.
+    #[inline]
+    pub fn decode_with_max_frame_bytes(
+        src: &mut BytesMut,
+        max_frame_bytes: usize,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
         const FRAME_HEADER_SIZE: usize = 4;
         const SERIALIZE_TYPE_SIZE: usize = 4;
         const MIN_PAYLOAD_SIZE: usize = SERIALIZE_TYPE_SIZE; // Minimum: just serialize_type field
@@ -852,20 +870,30 @@ impl RemotingCommand {
         }
 
         // Read total size without advancing the buffer (peek)
-        let total_size = i32::from_be_bytes([src[0], src[1], src[2], src[3]]) as usize;
+        let announced_size = i32::from_be_bytes([src[0], src[1], src[2], src[3]]);
+        let total_size = usize::try_from(announced_size).map_err(|_| {
+            rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
+                format: "remoting_command",
+                message: format!("Invalid negative frame size {announced_size}"),
+            })
+        })?;
+        let full_frame_size = total_size.checked_add(FRAME_HEADER_SIZE).ok_or_else(|| {
+            rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
+                format: "remoting_command",
+                message: format!("Frame size {total_size} overflows the wire envelope"),
+            })
+        })?;
 
-        // Validate total_size to prevent overflow attacks (check max first)
-        if total_size > 16 * 1024 * 1024 {
+        if full_frame_size > max_frame_bytes {
             return Err(rocketmq_error::RocketMQError::Serialization(
                 rocketmq_error::SerializationError::DecodeFailed {
                     format: "remoting_command",
-                    message: format!("Frame size {total_size} exceeds maximum allowed (16MB)"),
+                    message: format!("Wire frame size {full_frame_size} exceeds configured limit {max_frame_bytes}"),
                 },
             ));
         }
 
         // Wait for complete frame
-        let full_frame_size = total_size + FRAME_HEADER_SIZE;
         if available < full_frame_size {
             return Ok(None);
         }

--- a/rocketmq-transport/src/client.rs
+++ b/rocketmq-transport/src/client.rs
@@ -282,6 +282,7 @@ pub struct OneShotTransportClient {
     next_opaque: AtomicI32,
     security: Arc<TransportSecurity>,
     telemetry: TransportTelemetry,
+    frame_limits: FrameLimits,
 }
 
 impl OneShotTransportClient {
@@ -325,6 +326,7 @@ impl OneShotTransportClient {
             next_opaque: AtomicI32::new(1),
             security,
             telemetry: TransportTelemetry::noop(),
+            frame_limits: FrameLimits::default(),
         })
     }
 
@@ -348,6 +350,13 @@ impl OneShotTransportClient {
     pub fn with_telemetry(mut self, telemetry: TransportTelemetry) -> Self {
         self.telemetry = telemetry;
         self
+    }
+
+    /// Binds every plaintext/TLS connection opened by this client to one frame profile.
+    pub fn try_with_frame_limits(mut self, frame_limits: FrameLimits) -> RocketMQResult<Self> {
+        frame_limits.validate()?;
+        self.frame_limits = frame_limits;
+        Ok(self)
     }
 
     pub fn pending_usage(&self) -> PendingRequestUsage {
@@ -379,7 +388,7 @@ impl OneShotTransportClient {
         let connected = connect_with_config_and_telemetry(
             &address.to_string(),
             tls_config,
-            FrameLimits::default(),
+            self.frame_limits,
             deadline,
             self.telemetry.clone(),
         )

--- a/rocketmq-transport/src/clients/client.rs
+++ b/rocketmq-transport/src/clients/client.rs
@@ -197,6 +197,7 @@ fn connect<PR>(
     _notify: broadcast::Receiver<()>,
     _send_notify: broadcast::Receiver<()>,
     tls_config: TlsConfig,
+    frame_limits: FrameLimits,
     task_group: TaskGroup,
     operation: OperationContext,
     process_budget: ResourceBudget,
@@ -213,7 +214,7 @@ where
                 crate::client::connect_with_config_and_telemetry(
                     address.as_str(),
                     &tls_config,
-                    FrameLimits::legacy_compatibility(),
+                    frame_limits,
                     deadline,
                     telemetry,
                 )
@@ -223,7 +224,7 @@ where
                 crate::client::connect_target_with_config_options_and_telemetry(
                     &target,
                     &tls_config,
-                    FrameLimits::legacy_compatibility(),
+                    frame_limits,
                     crate::config::SocketOptions::default(),
                     deadline,
                     telemetry,
@@ -310,6 +311,7 @@ where
             cmd_handler,
             tx,
             tls_config,
+            FrameLimits::java_compatibility(),
             deadline,
             telemetry,
         )
@@ -322,6 +324,7 @@ where
         cmd_handler: Arc<RemotingGeneralHandler<PR>>,
         tx: Option<&tokio::sync::broadcast::Sender<ConnectionNetEvent>>,
         tls_config: TlsConfig,
+        frame_limits: FrameLimits,
         deadline: RequestDeadline,
         telemetry: TransportTelemetry,
     ) -> RocketMQResult<TransportSession<PR>> {
@@ -331,6 +334,7 @@ where
             cmd_handler,
             tx,
             tls_config,
+            frame_limits,
             task_group,
             operation,
             context.process_budget(),
@@ -347,6 +351,7 @@ where
         cmd_handler: Arc<RemotingGeneralHandler<PR>>,
         tx: Option<&tokio::sync::broadcast::Sender<ConnectionNetEvent>>,
         tls_config: TlsConfig,
+        frame_limits: FrameLimits,
         task_group: TaskGroup,
         operation: OperationContext,
         process_budget: ResourceBudget,
@@ -368,6 +373,7 @@ where
             receiver,
             send_receiver,
             tls_config,
+            frame_limits,
             task_group,
             operation,
             process_budget,

--- a/rocketmq-transport/src/clients/rocketmq_tokio_client.rs
+++ b/rocketmq-transport/src/clients/rocketmq_tokio_client.rs
@@ -58,6 +58,7 @@ use crate::clients::reconnect::CircuitAdmission;
 use crate::clients::reconnect::CircuitBreaker;
 use crate::clients::reconnect::CircuitState;
 use crate::clients::TransportSession;
+use crate::codec::remoting_command_codec::FrameLimits;
 use crate::deadline::RequestDeadline;
 use crate::error_helpers::remote_error;
 use crate::remoting::inner::RemotingGeneralHandler;
@@ -219,6 +220,7 @@ pub struct TransportClient<PR = DefaultRequestProcessor> {
     transport_security: Option<Arc<TransportSecurity>>,
 
     telemetry: TransportTelemetry,
+    frame_limits: FrameLimits,
 }
 
 /// Builds a persistent endpoint client without exposing positional optional capabilities.
@@ -229,6 +231,7 @@ pub struct TransportClientBuilder<PR> {
     connection_events: Option<tokio::sync::broadcast::Sender<ConnectionNetEvent>>,
     transport_security: Option<Arc<TransportSecurity>>,
     telemetry: TransportTelemetry,
+    frame_limits: FrameLimits,
 }
 
 impl<PR> TransportClientBuilder<PR>
@@ -250,6 +253,13 @@ where
         self
     }
 
+    /// Applies one validated frame profile to every connection created by this client.
+    pub fn frame_limits(mut self, frame_limits: FrameLimits) -> RocketMQResult<Self> {
+        frame_limits.validate()?;
+        self.frame_limits = frame_limits;
+        Ok(self)
+    }
+
     pub fn build(self) -> RocketMQResult<TransportClient<PR>> {
         let mut client = TransportClient::build_inner(
             self.config,
@@ -257,6 +267,7 @@ where
             self.connection_events,
             self.service_context,
             self.telemetry,
+            self.frame_limits,
         )?;
         if let Some(transport_security) = self.transport_security {
             client = client.with_transport_security(transport_security);
@@ -330,6 +341,12 @@ where
     pub fn telemetry(mut self, telemetry: TransportTelemetry) -> Self {
         self.transport = self.transport.telemetry(telemetry);
         self
+    }
+
+    /// Applies one validated frame profile to every connection created by this client.
+    pub fn frame_limits(mut self, frame_limits: FrameLimits) -> RocketMQResult<Self> {
+        self.transport = self.transport.frame_limits(frame_limits)?;
+        Ok(self)
     }
 
     pub fn build(self) -> RocketMQResult<RemotingClient<PR>> {
@@ -488,6 +505,7 @@ impl<PR> Clone for TransportClient<PR> {
             tx: self.tx.clone(),
             transport_security: self.transport_security.clone(),
             telemetry: self.telemetry.clone(),
+            frame_limits: self.frame_limits,
         }
     }
 }
@@ -507,6 +525,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
             connection_events: None,
             transport_security: None,
             telemetry: TransportTelemetry::noop(),
+            frame_limits: FrameLimits::java_compatibility(),
         }
     }
 
@@ -527,7 +546,9 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
         tx: Option<tokio::sync::broadcast::Sender<ConnectionNetEvent>>,
         service_context: ChildServiceContext,
         telemetry: TransportTelemetry,
+        frame_limits: FrameLimits,
     ) -> RocketMQResult<Self> {
+        frame_limits.validate()?;
         let process_budget = service_context.process_budget();
         let handler = RemotingGeneralHandler::new_with_telemetry(
             processor,
@@ -560,6 +581,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
             tx,
             transport_security: None,
             telemetry,
+            frame_limits,
         })
     }
 
@@ -1083,6 +1105,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
             None => SessionConnectTarget::Legacy(addr.to_string()),
         };
         let tls_config = self.tokio_client_config.tls.clone();
+        let frame_limits = self.frame_limits;
 
         let transport_security = self.transport_security.clone();
         let connect_result = TransportSession::connect_target_with_service_context_until_and_telemetry(
@@ -1091,6 +1114,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
             self.cmd_handler.clone(),
             self.tx.as_ref(),
             tls_config,
+            frame_limits,
             deadline,
             self.telemetry.clone(),
         )

--- a/rocketmq-transport/src/codec/remoting_command_codec.rs
+++ b/rocketmq-transport/src/codec/remoting_command_codec.rs
@@ -12,7 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use bytes::Bytes;
 use bytes::BytesMut;
+use rocketmq_error::SerializationError;
+use serde::de::Error as _;
+use serde::Deserialize;
+use serde::Serialize;
 use tokio_util::codec::Decoder;
 use tokio_util::codec::Encoder;
 
@@ -59,12 +64,26 @@ pub struct RemotingCommandCodec {
     limits: FrameLimits,
 }
 
-/// Allocation limits applied before a complete frame is handed to protocol decoding.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+/// Symmetric wire limits owned by one remoting endpoint.
+///
+/// `max_frame_bytes` is the complete wire size, including the four-byte length prefix. This
+/// matches Netty's `LengthFieldBasedFrameDecoder` accounting used by RocketMQ Java.
+///
+/// | Endpoint owner | Profile |
+/// | --- | --- |
+/// | RocketMQ-compatible client/server | [`Self::java_compatibility`] |
+/// | Hardened internal connection | [`Self::default`] |
+/// | Tests and benchmarks | An explicit profile owned by the fixture |
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct FrameLimits {
+    /// Complete frame bytes on the wire, including the four-byte length prefix.
     pub max_frame_bytes: usize,
+    /// Serialized command header bytes, excluding the eight-byte wire prefix and marker.
     pub max_header_bytes: usize,
+    /// Command body bytes following the serialized header.
     pub max_body_bytes: usize,
+    /// Initial decoder buffer allocation; growth remains bounded by the limits above.
     pub initial_read_bytes: usize,
 }
 
@@ -82,8 +101,130 @@ impl Default for FrameLimits {
 }
 
 impl FrameLimits {
-    /// Compatibility envelope selected explicitly by the Remoting owner.
-    pub const fn legacy_compatibility() -> Self {
+    const MIN_FRAME_BYTES: usize = 8;
+    const MAX_HEADER_BYTES: usize = 0x00ff_ffff;
+    const MAX_INITIAL_READ_BYTES: usize = 1024 * 1024;
+    const MAX_PROTOCOL_FRAME_BYTES: usize = i32::MAX as usize + 4;
+
+    /// Builds and validates one endpoint profile.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed argument error when the wire envelope cannot represent the profile or the
+    /// initial allocation is outside the safe frame-owned range.
+    pub fn try_new(
+        max_frame_bytes: usize,
+        max_header_bytes: usize,
+        max_body_bytes: usize,
+        initial_read_bytes: usize,
+    ) -> rocketmq_error::RocketMQResult<Self> {
+        let limits = Self {
+            max_frame_bytes,
+            max_header_bytes,
+            max_body_bytes,
+            initial_read_bytes,
+        };
+        limits.validate()?;
+        Ok(limits)
+    }
+
+    /// Validates that this profile is representable and safe to allocate.
+    ///
+    /// Public fields remain available for source compatibility; every codec and connection entry
+    /// point calls this method before using a caller-constructed value.
+    pub fn validate(self) -> rocketmq_error::RocketMQResult<()> {
+        if !(Self::MIN_FRAME_BYTES..=Self::MAX_PROTOCOL_FRAME_BYTES).contains(&self.max_frame_bytes) {
+            return Err(rocketmq_error::RocketMQError::illegal_argument(format!(
+                "max frame bytes must be between {} and {}",
+                Self::MIN_FRAME_BYTES,
+                Self::MAX_PROTOCOL_FRAME_BYTES
+            )));
+        }
+        if self.max_header_bytes > Self::MAX_HEADER_BYTES {
+            return Err(rocketmq_error::RocketMQError::illegal_argument(format!(
+                "max header bytes {} exceeds the 24-bit protocol ceiling {}",
+                self.max_header_bytes,
+                Self::MAX_HEADER_BYTES
+            )));
+        }
+        if !(Self::MIN_FRAME_BYTES..=Self::MAX_INITIAL_READ_BYTES).contains(&self.initial_read_bytes)
+            || self.initial_read_bytes > self.max_frame_bytes
+        {
+            return Err(rocketmq_error::RocketMQError::illegal_argument(format!(
+                "initial read bytes must be between {} and {} and no larger than max frame bytes",
+                Self::MIN_FRAME_BYTES,
+                Self::MAX_INITIAL_READ_BYTES
+            )));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn safe_initial_read_bytes(self) -> usize {
+        self.initial_read_bytes
+            .clamp(Self::MIN_FRAME_BYTES, Self::MAX_INITIAL_READ_BYTES)
+            .min(self.max_frame_bytes.max(Self::MIN_FRAME_BYTES))
+    }
+
+    pub(crate) fn validate_raw_payload(self, payload_len: usize) -> rocketmq_error::RocketMQResult<()> {
+        self.validate()?;
+        if payload_len > self.max_frame_bytes {
+            return Err(encoding_limit_error("raw payload", payload_len, self.max_frame_bytes));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn validate_frame_segments(self, segments: &[Bytes]) -> rocketmq_error::RocketMQResult<usize> {
+        self.validate()?;
+        let frame_len = segments.iter().try_fold(0_usize, |total, segment| {
+            total
+                .checked_add(segment.len())
+                .ok_or_else(|| encoding_limit_error("frame", usize::MAX, self.max_frame_bytes))
+        })?;
+        if frame_len < Self::MIN_FRAME_BYTES {
+            return Err(encoding_limit_error("frame", frame_len, Self::MIN_FRAME_BYTES));
+        }
+
+        let mut envelope = [0_u8; Self::MIN_FRAME_BYTES];
+        let mut copied = 0;
+        for segment in segments {
+            let count = (envelope.len() - copied).min(segment.len());
+            envelope[copied..copied + count].copy_from_slice(&segment[..count]);
+            copied += count;
+            if copied == envelope.len() {
+                break;
+            }
+        }
+        let announced = i32::from_be_bytes(envelope[..4].try_into().expect("four-byte prefix"));
+        let announced = usize::try_from(announced)
+            .map_err(|_| encoding_limit_error("announced frame", usize::MAX, self.max_frame_bytes))?;
+        let announced_wire_len = announced
+            .checked_add(4)
+            .ok_or_else(|| encoding_limit_error("announced frame", usize::MAX, self.max_frame_bytes))?;
+        if announced_wire_len != frame_len {
+            return Err(SerializationError::encode_failed(
+                "remoting-command",
+                format!("announced wire length {announced_wire_len} does not match segmented frame length {frame_len}"),
+            )
+            .into());
+        }
+
+        let header_marker = u32::from_be_bytes(envelope[4..].try_into().expect("four-byte header marker"));
+        let header_len = (header_marker & 0x00ff_ffff) as usize;
+        let body_len = frame_len
+            .checked_sub(Self::MIN_FRAME_BYTES)
+            .and_then(|payload| payload.checked_sub(header_len))
+            .ok_or_else(|| {
+                SerializationError::encode_failed(
+                    "remoting-command",
+                    format!("header length {header_len} exceeds segmented frame payload"),
+                )
+            })?;
+        self.validate_encoded_lengths(frame_len, header_len, body_len)?;
+        Ok(frame_len)
+    }
+
+    /// RocketMQ Java's externally compatible Netty frame envelope.
+    pub const fn java_compatibility() -> Self {
         Self {
             max_frame_bytes: 16 * 1024 * 1024,
             max_header_bytes: 4 * 1024 * 1024,
@@ -91,6 +232,143 @@ impl FrameLimits {
             initial_read_bytes: 8 * 1024,
         }
     }
+
+    /// Compatibility alias for endpoints that have not adopted the semantic profile name yet.
+    pub const fn legacy_compatibility() -> Self {
+        Self::java_compatibility()
+    }
+
+    pub(crate) fn encode_command(
+        self,
+        command: RemotingCommand,
+    ) -> Result<EncodedFrame, rocketmq_error::RocketMQError> {
+        self.validate()?;
+        self.validate_command_lower_bounds(&command)?;
+        let frame = EncodedFrame::from_command(command)?;
+        self.validate_encoded_frame(&frame)?;
+        Ok(frame)
+    }
+
+    pub(crate) fn encode_file_frame_head(
+        self,
+        command: RemotingCommand,
+        body_len: usize,
+    ) -> Result<rocketmq_protocol::protocol::encoded_frame::EncodedFrameHead, rocketmq_error::RocketMQError> {
+        self.validate()?;
+        self.validate_command_and_body_lower_bounds(&command, body_len)?;
+        let head =
+            rocketmq_protocol::protocol::encoded_frame::EncodedFrameHead::from_command_and_body_len(command, body_len)?;
+        let [_, header] = head.segments();
+        self.validate_encoded_lengths(head.encoded_len(), header.len(), body_len)?;
+        Ok(head)
+    }
+
+    fn validate_command_lower_bounds(&self, command: &RemotingCommand) -> Result<(), rocketmq_error::RocketMQError> {
+        self.validate_command_and_body_lower_bounds(command, command.body().map_or(0, bytes::Bytes::len))
+    }
+
+    fn validate_command_and_body_lower_bounds(
+        &self,
+        command: &RemotingCommand,
+        body_len: usize,
+    ) -> Result<(), rocketmq_error::RocketMQError> {
+        if body_len > self.max_body_bytes {
+            return Err(encoding_limit_error("body", body_len, self.max_body_bytes));
+        }
+        let materialized_header_bytes =
+            command
+                .remark()
+                .map_or(0, |remark| remark.len())
+                .saturating_add(command.ext_fields().map_or(0, |fields| {
+                    fields
+                        .iter()
+                        .map(|(key, value)| key.len().saturating_add(value.len()))
+                        .fold(0_usize, usize::saturating_add)
+                }));
+        if materialized_header_bytes > self.max_header_bytes {
+            return Err(encoding_limit_error(
+                "materialized header fields",
+                materialized_header_bytes,
+                self.max_header_bytes,
+            ));
+        }
+        let known_wire_bytes = 8_usize
+            .checked_add(materialized_header_bytes)
+            .and_then(|bytes| bytes.checked_add(body_len))
+            .ok_or_else(|| encoding_limit_error("frame", usize::MAX, self.max_frame_bytes))?;
+        if known_wire_bytes > self.max_frame_bytes {
+            return Err(encoding_limit_error("frame", known_wire_bytes, self.max_frame_bytes));
+        }
+        Ok(())
+    }
+
+    fn validate_encoded_frame(&self, frame: &EncodedFrame) -> Result<(), rocketmq_error::RocketMQError> {
+        let [_, header, body] = frame.segments();
+        self.validate_encoded_lengths(frame.encoded_len(), header.len(), body.len())
+    }
+
+    fn validate_encoded_lengths(
+        &self,
+        frame_len: usize,
+        header_len: usize,
+        body_len: usize,
+    ) -> Result<(), rocketmq_error::RocketMQError> {
+        if header_len > self.max_header_bytes {
+            return Err(encoding_limit_error("header", header_len, self.max_header_bytes));
+        }
+        if body_len > self.max_body_bytes {
+            return Err(encoding_limit_error("body", body_len, self.max_body_bytes));
+        }
+        if frame_len > self.max_frame_bytes {
+            return Err(encoding_limit_error("frame", frame_len, self.max_frame_bytes));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields, default)]
+struct DeserializedFrameLimits {
+    max_frame_bytes: usize,
+    max_header_bytes: usize,
+    max_body_bytes: usize,
+    initial_read_bytes: usize,
+}
+
+impl Default for DeserializedFrameLimits {
+    fn default() -> Self {
+        let limits = FrameLimits::default();
+        Self {
+            max_frame_bytes: limits.max_frame_bytes,
+            max_header_bytes: limits.max_header_bytes,
+            max_body_bytes: limits.max_body_bytes,
+            initial_read_bytes: limits.initial_read_bytes,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for FrameLimits {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let limits = DeserializedFrameLimits::deserialize(deserializer)?;
+        Self::try_new(
+            limits.max_frame_bytes,
+            limits.max_header_bytes,
+            limits.max_body_bytes,
+            limits.initial_read_bytes,
+        )
+        .map_err(D::Error::custom)
+    }
+}
+
+fn encoding_limit_error(component: &str, actual: usize, limit: usize) -> rocketmq_error::RocketMQError {
+    SerializationError::encode_failed(
+        "remoting-command",
+        format!("encoded {component} is {actual} bytes, exceeding configured limit {limit}"),
+    )
+    .into()
 }
 
 impl Default for RemotingCommandCodec {
@@ -112,6 +390,7 @@ impl RemotingCommandCodec {
         &mut self,
         src: &mut BytesMut,
     ) -> Result<Option<DecodedCommand>, rocketmq_error::RocketMQError> {
+        self.limits.validate()?;
         self.validate_announced_frame(src)?;
         let retained_frame_bytes = if src.len() >= 4 {
             let total = i32::from_be_bytes(src[..4].try_into().expect("four bytes checked"));
@@ -119,11 +398,15 @@ impl RemotingCommandCodec {
         } else {
             None
         };
-        Ok(RemotingCommand::decode(src)?.map(|command| DecodedCommand {
-            command,
-            retained_frame_bytes: retained_frame_bytes.unwrap_or_default(),
-            partial_frame_permit: None,
-        }))
+        Ok(
+            RemotingCommand::decode_with_max_frame_bytes(src, self.limits.max_frame_bytes)?.map(|command| {
+                DecodedCommand {
+                    command,
+                    retained_frame_bytes: retained_frame_bytes.unwrap_or_default(),
+                    partial_frame_permit: None,
+                }
+            }),
+        )
     }
 }
 
@@ -169,9 +452,13 @@ impl RemotingCommandCodec {
             return Ok(());
         }
         let total = i32::from_be_bytes(src[..4].try_into().expect("four bytes checked"));
-        if total > 0 && total as usize > self.limits.max_frame_bytes {
+        let total_wire_bytes = (total > 0)
+            .then(|| (total as usize).checked_add(4))
+            .flatten()
+            .unwrap_or(usize::MAX);
+        if total > 0 && total_wire_bytes > self.limits.max_frame_bytes {
             return Err(crate::error_helpers::decoding_error(
-                total.max(0) as usize,
+                total_wire_bytes,
                 self.limits.max_frame_bytes,
             ));
         }
@@ -223,7 +510,7 @@ impl Encoder<RemotingCommand> for RemotingCommandCodec {
     ///
     /// This function will return an error if the encoding process fails.
     fn encode(&mut self, item: RemotingCommand, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        EncodedFrame::from_command(item)?.copy_to(dst);
+        self.limits.encode_command(item)?.copy_to(dst);
         Ok(())
     }
 }

--- a/rocketmq-transport/src/connection.rs
+++ b/rocketmq-transport/src/connection.rs
@@ -51,8 +51,6 @@ use crate::write_strategy::OutboundPayload;
 use crate::write_strategy::QueuedWrite;
 use crate::write_strategy::QueuedWriteProgress;
 use crate::writer_runtime::WriterLanes;
-use rocketmq_protocol::protocol::encoded_frame::EncodedFrame;
-use rocketmq_protocol::protocol::encoded_frame::EncodedFrameHead;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_runtime::BlockingExecutor;
 use rocketmq_runtime::ResourcePermit;
@@ -414,6 +412,9 @@ pub struct Connection {
     /// Direct socket writer or a capability to the canonical session writer actor.
     outbound: ConnectionWriter,
 
+    /// One endpoint-owned profile shared by inbound decoding and every outbound command path.
+    limits: FrameLimits,
+
     // === State Management (Tokio Watch Channel) ===
     /// Broadcast channel for connection state changes
     ///
@@ -534,7 +535,7 @@ impl Connection {
     where
         S: ConnectionTransport + 'static,
     {
-        let max_plaintext_frame_bytes = limits.max_frame_bytes.saturating_add(4);
+        let max_plaintext_frame_bytes = limits.max_frame_bytes;
         Self::new_with_stream_limits_and_write_mode(
             stream,
             limits,
@@ -572,16 +573,17 @@ impl Connection {
         let inbound = FramedRead::with_capacity(
             read_half,
             RemotingCommandCodec::with_limits(limits),
-            limits.initial_read_bytes.max(4),
+            limits.safe_initial_read_bytes(),
         );
         let outbound = FrameWriter::new(write_half, write_mode)
-            .unwrap_or_else(|_| unreachable!("connection frame limits always produce a non-zero writer bound"));
+            .expect("constructing a frame writer does not perform fallible I/O");
         // Initialize watch channel with Healthy state
         let (state_tx, state_rx) = watch::channel(ConnectionState::Healthy);
 
         Self {
             inbound: Some(inbound),
             outbound: ConnectionWriter::Direct(outbound),
+            limits,
             state_tx,
             state_rx,
             connection_id: CheetahString::from_string(Uuid::new_v4().to_string()),
@@ -617,6 +619,7 @@ impl Connection {
         state_tx: watch::Sender<ConnectionState>,
         state_rx: watch::Receiver<ConnectionState>,
         connection_id: ConnectionId,
+        limits: FrameLimits,
         response_class: Option<AdmissionClass>,
         lifecycle: Arc<SessionLifecycle>,
         telemetry: TransportTelemetry,
@@ -630,6 +633,7 @@ impl Connection {
                 response_class,
                 lifecycle,
             }),
+            limits,
             state_tx,
             state_rx,
             connection_id,
@@ -657,6 +661,12 @@ impl Connection {
             .unwrap_or_else(|| unreachable!("session runtime requires an owned transport reader"))
             .map_decoder(|decoder| SessionCommandDecoder::new(decoder, admission));
         (writer, reader)
+    }
+
+    /// Returns the immutable frame policy shared by this connection's reader and writer.
+    #[inline]
+    pub const fn frame_limits(&self) -> FrameLimits {
+        self.limits
     }
 
     pub(crate) fn telemetry(&self) -> TransportTelemetry {
@@ -891,7 +901,7 @@ impl Connection {
         let class = self
             .response_class()
             .unwrap_or_else(|| AdmissionClass::for_request_code(command.code()));
-        let frame = EncodedFrame::from_command(command)?;
+        let frame = self.limits.encode_command(command)?;
         self.send_payload(
             OutboundPayload::Frame(frame),
             class,
@@ -922,7 +932,7 @@ impl Connection {
         let class = self
             .response_class()
             .unwrap_or_else(|| AdmissionClass::for_request_code(command.code()));
-        let frame = EncodedFrame::from_command(command)?;
+        let frame = self.limits.encode_command(command)?;
         deadline.ensure_before_send(target.clone())?;
 
         self.send_payload(OutboundPayload::Frame(frame), class, None, Some(deadline), target)
@@ -986,7 +996,7 @@ impl Connection {
         let body_len = usize::try_from(body.len()).map_err(|_| {
             rocketmq_error::RocketMQError::illegal_argument("file region sequence length exceeds this platform's usize")
         })?;
-        let head = EncodedFrameHead::from_command_and_body_len(command_without_body, body_len)?;
+        let head = self.limits.encode_file_frame_head(command_without_body, body_len)?;
         if let Some(deadline) = deadline {
             deadline.ensure_before_send(target.clone())?;
         }
@@ -1013,7 +1023,7 @@ impl Connection {
         let class = self
             .response_class()
             .unwrap_or_else(|| AdmissionClass::for_request_code(command.code()));
-        let frame = EncodedFrame::from_command(command)?;
+        let frame = self.limits.encode_command(command)?;
         deadline.ensure_before_send(target.clone())?;
 
         self.send_payload(
@@ -1050,8 +1060,8 @@ impl Connection {
             .response_class()
             .unwrap_or_else(|| AdmissionClass::for_request_code(command.code()));
         let owned = command.clone();
+        let frame = self.limits.encode_command(owned)?;
         let _ = command.take_body();
-        let frame = EncodedFrame::from_command(owned)?;
         self.send_payload(
             OutboundPayload::Frame(frame),
             class,
@@ -1088,9 +1098,10 @@ impl Connection {
         if commands.is_empty() {
             return Ok(());
         }
+        let limits = self.limits;
         let frames = commands
             .into_iter()
-            .map(EncodedFrame::from_command)
+            .map(|command| limits.encode_command(command))
             .collect::<rocketmq_error::RocketMQResult<Vec<_>>>()?;
         let payload = OutboundPayload::batch(frames)?;
         self.send_payload(
@@ -1103,10 +1114,10 @@ impl Connection {
         .await
     }
 
-    /// Sends raw `Bytes` directly to the peer (zero-copy).
+    /// Sends one complete pre-encoded remoting frame directly to the peer (zero-copy).
     ///
-    /// Bypasses command encoding and sends pre-serialized bytes directly.
-    /// Use for forwarding or when bytes are already encoded.
+    /// Bypasses command encoding but validates the serialized prefix, header, body, and complete
+    /// wire length against the connection-owned profile before writing.
     /// **Automatically marks connection as Degraded on I/O errors.**
     ///
     /// # Arguments
@@ -1123,6 +1134,7 @@ impl Connection {
     /// This is the most efficient send method as it avoids intermediate buffering
     /// and serialization overhead.
     pub async fn send_bytes(&mut self, bytes: Bytes) -> rocketmq_error::RocketMQResult<()> {
+        self.limits.validate_frame_segments(std::slice::from_ref(&bytes))?;
         self.send_payload(
             OutboundPayload::Contiguous(bytes),
             AdmissionClass::Data,
@@ -1156,9 +1168,32 @@ impl Connection {
     /// ```
     pub async fn send_slice(&mut self, slice: &'static [u8]) -> rocketmq_error::RocketMQResult<()> {
         let bytes = Bytes::from_static(slice);
+        self.limits.validate_raw_payload(bytes.len())?;
         self.send_payload(
             OutboundPayload::Contiguous(bytes),
             AdmissionClass::Control,
+            None,
+            None,
+            "transport-session-writer".to_string(),
+        )
+        .await
+    }
+
+    /// Sends one already encoded frame as immutable ordered segments.
+    ///
+    /// The complete sequence is validated against the connection-owned frame, header, and body
+    /// limits before it enters the writer queue, preserving zero-copy plaintext output without
+    /// allowing multipart writes to bypass the endpoint policy.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed serialization error before socket progress when the prefix, aggregate
+    /// length, header length, body length, or endpoint profile is invalid.
+    pub async fn send_frame_segments(&mut self, segments: Vec<Bytes>) -> rocketmq_error::RocketMQResult<()> {
+        let encoded_len = self.limits.validate_frame_segments(&segments)?;
+        self.send_payload(
+            OutboundPayload::FrameSegments { segments, encoded_len },
+            AdmissionClass::Data,
             None,
             None,
             "transport-session-writer".to_string(),

--- a/rocketmq-transport/src/dispatch/response_sink.rs
+++ b/rocketmq-transport/src/dispatch/response_sink.rs
@@ -79,7 +79,7 @@ impl LocalResponseSink {
             return Err(ResponseSinkError::AlreadyCompleted);
         }
         state.encoded.extend_from_slice(&bytes);
-        let decoded = RemotingCommandCodec::with_limits(FrameLimits::legacy_compatibility())
+        let decoded = RemotingCommandCodec::with_limits(FrameLimits::java_compatibility())
             .decode(&mut state.encoded)
             .map_err(|error| ResponseSinkError::Decode(error.to_string()))?;
         let Some(command) = decoded else {
@@ -157,6 +157,23 @@ impl ResponseSink {
                 .await
                 .map_err(|error| ResponseSinkError::Transport(error.to_string())),
             Self::Local(sink) => sink.send_bytes(bytes),
+        }
+    }
+
+    /// Delivers one pre-encoded response as a validated immutable segment sequence.
+    pub async fn send_frame_segments(&self, segments: Vec<Bytes>) -> Result<(), ResponseSinkError> {
+        match self {
+            Self::Network(session) => session
+                .connection()
+                .send_frame_segments(segments)
+                .await
+                .map_err(|error| ResponseSinkError::Transport(error.to_string())),
+            Self::Local(sink) => {
+                for segment in segments {
+                    sink.send_bytes(segment)?;
+                }
+                Ok(())
+            }
         }
     }
 }

--- a/rocketmq-transport/src/net/channel.rs
+++ b/rocketmq-transport/src/net/channel.rs
@@ -281,6 +281,11 @@ impl Channel {
         self.inner.send_bytes(bytes).await
     }
 
+    /// Sends one pre-encoded frame as an atomically validated immutable segment sequence.
+    pub async fn send_frame_segments(&self, segments: Vec<Bytes>) -> rocketmq_error::RocketMQResult<()> {
+        self.inner.send_frame_segments(segments).await
+    }
+
     /// Sends a request and waits for its correlated response.
     pub async fn send_wait_response(
         &self,
@@ -856,6 +861,17 @@ impl ChannelInner {
         match &self.connection {
             ChannelIo::Network(connection) => connection.lock().await.send_bytes(bytes).await,
             ChannelIo::Local(response) => response.send_bytes(bytes).await.map_err(response_sink_error),
+        }
+    }
+
+    /// Sends one pre-encoded frame without allowing multipart output to bypass endpoint limits.
+    pub async fn send_frame_segments(&self, segments: Vec<Bytes>) -> rocketmq_error::RocketMQResult<()> {
+        match &self.connection {
+            ChannelIo::Network(connection) => connection.lock().await.send_frame_segments(segments).await,
+            ChannelIo::Local(response) => response
+                .send_frame_segments(segments)
+                .await
+                .map_err(response_sink_error),
         }
     }
 

--- a/rocketmq-transport/src/remoting_server/rocketmq_tokio_server.rs
+++ b/rocketmq-transport/src/remoting_server/rocketmq_tokio_server.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 
+use crate::codec::remoting_command_codec::FrameLimits;
 use crate::config::ServerConfig;
 use crate::dispatch::AuthorizedCommandDispatcher;
 use crate::file_region::FileTransferMode;
@@ -347,6 +348,7 @@ struct ConnectionListener<RP> {
 
     file_region_blocking: BlockingExecutor,
     file_transfer_mode: FileTransferMode,
+    frame_limits: FrameLimits,
 
     transport_principal: Option<Principal>,
     command_interceptor: Arc<dyn SessionCommandInterceptor>,
@@ -429,6 +431,7 @@ impl<RP: RequestProcessor + Sync + 'static + Clone> ConnectionListener<RP> {
         )
         .with_authorized_dispatch(self.dispatcher.boundary(), self.transport_principal.clone())
         .with_file_region_io(self.file_region_blocking.clone(), self.file_transfer_mode)
+        .try_with_frame_limits(self.frame_limits)?
         .with_telemetry(self.telemetry.clone());
         transport
             .run(Arc::new(InterceptingConnectionHandler {
@@ -647,6 +650,7 @@ pub struct TransportServer<RP> {
     authorized_dispatcher: Option<Arc<AuthorizedCommandDispatcher<RP>>>,
     telemetry: TransportTelemetry,
     lifecycle_event_config: LifecycleEventConfig,
+    frame_limits: FrameLimits,
     #[cfg(all(test, not(doctest)))]
     test_request_hook: Option<TestRequestHook>,
     _phantom_data: std::marker::PhantomData<RP>,
@@ -664,6 +668,7 @@ impl<RP> TransportServer<RP> {
             authorized_dispatcher: None,
             telemetry: TransportTelemetry::noop(),
             lifecycle_event_config: LifecycleEventConfig::default(),
+            frame_limits: FrameLimits::java_compatibility(),
             #[cfg(all(test, not(doctest)))]
             test_request_hook: None,
             _phantom_data: std::marker::PhantomData,
@@ -691,6 +696,13 @@ impl<RP> TransportServer<RP> {
     pub fn with_telemetry(mut self, telemetry: TransportTelemetry) -> Self {
         self.telemetry = telemetry;
         self
+    }
+
+    /// Applies one validated frame profile to every accepted connection.
+    pub fn try_with_frame_limits(mut self, frame_limits: FrameLimits) -> RocketMQResult<Self> {
+        frame_limits.validate()?;
+        self.frame_limits = frame_limits;
+        Ok(self)
     }
 
     pub fn register_rpc_hook(&mut self, hook: Arc<dyn RPCHook>) {
@@ -802,6 +814,7 @@ impl<RP: RequestProcessor + Sync + 'static + Clone> TransportServer<RP> {
                 task_group: remoting_context.task_group().clone(),
                 file_region_blocking: remoting_context.storage_io().clone(),
                 file_transfer_mode: self.config.file_transfer_mode,
+                frame_limits: self.frame_limits,
                 process_budget: self.service_context.process_budget(),
                 transport_security: self.transport_security.clone(),
                 transport_principal: self.transport_principal.clone(),
@@ -935,6 +948,7 @@ impl<RP: RequestProcessor + Sync + 'static + Clone> TransportServer<RP> {
                 task_group,
                 file_region_blocking: remoting_context.storage_io().clone(),
                 file_transfer_mode: self.config.file_transfer_mode,
+                frame_limits: self.frame_limits,
                 process_budget: self.service_context.process_budget(),
                 transport_security: self.transport_security.clone(),
                 transport_principal: self.transport_principal.clone(),
@@ -1041,6 +1055,7 @@ async fn run_with_report_with_service_context_and_telemetry<RP: RequestProcessor
             task_group: remoting_context.task_group().clone(),
             file_region_blocking: remoting_context.storage_io().clone(),
             file_transfer_mode: FileTransferMode::Auto,
+            frame_limits: FrameLimits::java_compatibility(),
             process_budget: service_context.process_budget(),
             transport_security: None,
             transport_principal: None,
@@ -1058,6 +1073,7 @@ struct RemotingServerRunCapabilities {
     task_group: TaskGroup,
     file_region_blocking: BlockingExecutor,
     file_transfer_mode: FileTransferMode,
+    frame_limits: FrameLimits,
     process_budget: rocketmq_runtime::ResourceBudget,
     transport_security: Option<Arc<TransportSecurity>>,
     transport_principal: Option<Principal>,
@@ -1082,6 +1098,7 @@ async fn run_with_tls_config_report<RP: RequestProcessor + Sync + 'static + Clon
         task_group,
         file_region_blocking,
         file_transfer_mode,
+        frame_limits,
         process_budget,
         transport_security,
         transport_principal,
@@ -1145,6 +1162,7 @@ async fn run_with_tls_config_report<RP: RequestProcessor + Sync + 'static + Clon
         task_group: task_group.clone(),
         file_region_blocking,
         file_transfer_mode,
+        frame_limits,
         transport_principal,
         command_interceptor,
         telemetry,
@@ -2244,6 +2262,7 @@ mod tests {
                 task_group: service.component("remoting-server").task_group().clone(),
                 file_region_blocking: service.storage_io().clone(),
                 file_transfer_mode: FileTransferMode::Auto,
+                frame_limits: FrameLimits::default(),
                 process_budget: service.process_budget(),
                 transport_security: None,
                 transport_principal: None,

--- a/rocketmq-transport/src/server.rs
+++ b/rocketmq-transport/src/server.rs
@@ -48,6 +48,7 @@ use crate::admission::AdmissionController;
 use crate::admission::AdmissionResource;
 use crate::admission::AdmissionScope;
 use crate::admission::AdmissionScopeHandle;
+use crate::codec::remoting_command_codec::FrameLimits;
 use crate::config::SocketOptions;
 use crate::config::TlsConfig;
 use crate::config::TlsMode;
@@ -124,6 +125,7 @@ struct SessionSendHandle {
     local_addr: SocketAddr,
     remote_addr: SocketAddr,
     connection_id: ConnectionId,
+    frame_limits: FrameLimits,
     writer: WriterLanes,
     writer_diagnostics: Arc<SessionWriterDiagnostics>,
     admission: AdmissionScopeHandle,
@@ -165,6 +167,7 @@ impl SessionHandle {
             self.send.state_tx.clone(),
             self.send.state_rx.clone(),
             self.send.connection_id.clone(),
+            self.send.frame_limits,
             self.response_class,
             self.send.lifecycle.clone(),
             self.send.telemetry.clone(),
@@ -334,6 +337,7 @@ async fn negotiate_transport_connection(
     scope: AdmissionScope,
     stream: tokio::net::TcpStream,
     remote_addr: SocketAddr,
+    frame_limits: FrameLimits,
     timeouts: NegotiationTimeouts,
 ) -> Option<NegotiatedConnection> {
     // Protocol detection waits under the connection idle budget. Once TLS is identified, the
@@ -353,7 +357,8 @@ async fn negotiate_transport_connection(
             AdmissionClass::Data,
         )
         .ok()?;
-    let negotiation = tls.negotiate_detected_connection(stream, remote_addr, is_tls_handshake);
+    let negotiation =
+        tls.negotiate_detected_connection_with_limits(stream, remote_addr, is_tls_handshake, frame_limits);
 
     if is_tls_handshake {
         tokio::time::timeout(timeouts.tls_handshake, negotiation)
@@ -379,6 +384,7 @@ pub struct TransportListener {
     socket_options: SocketOptions,
     file_region_blocking: Option<BlockingExecutor>,
     file_transfer_mode: FileTransferMode,
+    frame_limits: FrameLimits,
 }
 
 impl TransportListener {
@@ -406,6 +412,7 @@ impl TransportListener {
             socket_options: SocketOptions::default(),
             file_region_blocking: None,
             file_transfer_mode: FileTransferMode::Auto,
+            frame_limits: FrameLimits::default(),
         }
     }
 
@@ -424,6 +431,13 @@ impl TransportListener {
     pub fn with_io_policy(mut self, io_policy: SessionIoPolicy) -> Self {
         self.io_policy = io_policy;
         self
+    }
+
+    /// Applies one symmetric frame profile to plaintext/TLS readers and writers.
+    pub fn try_with_frame_limits(mut self, frame_limits: FrameLimits) -> RocketMQResult<Self> {
+        frame_limits.validate()?;
+        self.frame_limits = frame_limits;
+        Ok(self)
     }
 
     #[allow(dead_code, reason = "custom security is used by the feature-gated session harness")]
@@ -519,6 +533,7 @@ impl TransportListener {
             let telemetry = self.telemetry.clone();
             let file_region_blocking = self.file_region_blocking.clone();
             let file_transfer_mode = self.file_transfer_mode;
+            let frame_limits = self.frame_limits;
             let spawn_group = session_group.clone();
             if spawn_group
                 .spawn_service("rocketmq.transport.session", async move {
@@ -532,6 +547,7 @@ impl TransportListener {
                             scope,
                             stream,
                             remote_addr,
+                            frame_limits,
                             NegotiationTimeouts {
                                 protocol_detection: io_policy.idle_timeout,
                                 tls_handshake: handshake_timeout,
@@ -586,6 +602,7 @@ async fn run_framed_session<H>(
     H: ConnectionHandler,
 {
     let connection_id = connection.connection_id().clone();
+    let frame_limits = connection.frame_limits();
     let telemetry = connection.telemetry();
     let admission = dispatch.admission_controller();
     let admission_scope = match admission.prepare_scope(scope) {
@@ -633,6 +650,7 @@ async fn run_framed_session<H>(
             local_addr,
             remote_addr,
             connection_id,
+            frame_limits,
             writer: writer.clone(),
             writer_diagnostics,
             admission: admission_scope,
@@ -831,6 +849,7 @@ pub struct SessionTransportServer {
     active_sessions: AtomicUsize,
     principal: Option<Principal>,
     telemetry: TransportTelemetry,
+    frame_limits: FrameLimits,
 }
 
 #[allow(dead_code, reason = "owned by the feature-gated low-level session server")]
@@ -914,13 +933,26 @@ impl SessionTransportServer {
         processor: Arc<dyn SessionProcessor>,
         admission: Arc<AdmissionController>,
     ) -> RocketMQResult<Arc<Self>> {
-        Self::bind_with_security(
+        Self::bind_with_frame_limits(service_context, config, FrameLimits::default(), processor, admission).await
+    }
+
+    pub async fn bind_with_frame_limits(
+        service_context: ChildServiceContext,
+        config: SessionTransportServerConfig,
+        frame_limits: FrameLimits,
+        processor: Arc<dyn SessionProcessor>,
+        admission: Arc<AdmissionController>,
+    ) -> RocketMQResult<Arc<Self>> {
+        frame_limits.validate()?;
+        Self::bind_with_capabilities(
             service_context,
             config,
             processor,
             admission,
             Arc::new(TransportSecurity::development_insecure_loopback(None, None)),
             None,
+            TransportTelemetry::noop(),
+            frame_limits,
         )
         .await
     }
@@ -975,7 +1007,32 @@ impl SessionTransportServer {
         principal: Option<Principal>,
         telemetry: TransportTelemetry,
     ) -> RocketMQResult<Arc<Self>> {
+        Self::bind_with_capabilities(
+            service_context,
+            config,
+            processor,
+            admission,
+            security,
+            principal,
+            telemetry,
+            FrameLimits::default(),
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn bind_with_capabilities(
+        service_context: ChildServiceContext,
+        config: SessionTransportServerConfig,
+        processor: Arc<dyn SessionProcessor>,
+        admission: Arc<AdmissionController>,
+        security: Arc<TransportSecurity>,
+        principal: Option<Principal>,
+        telemetry: TransportTelemetry,
+        frame_limits: FrameLimits,
+    ) -> RocketMQResult<Arc<Self>> {
         config.io_policy.validate()?;
+        frame_limits.validate()?;
         let listener = tokio::net::TcpListener::bind(config.bind_address).await?;
         let local_addr = listener.local_addr()?;
         let tls = TlsServerRuntime::initialize_with_service_context(config.tls.clone(), &service_context).await?;
@@ -992,6 +1049,7 @@ impl SessionTransportServer {
             active_sessions: AtomicUsize::new(0),
             principal,
             telemetry,
+            frame_limits,
         }))
     }
 
@@ -1087,6 +1145,7 @@ impl SessionTransportServer {
                 scope,
                 stream,
                 remote_addr,
+                self.frame_limits,
                 NegotiationTimeouts {
                     protocol_detection: self.config.io_policy.idle_timeout,
                     tls_handshake: self.config.handshake_timeout,

--- a/rocketmq-transport/src/tls.rs
+++ b/rocketmq-transport/src/tls.rs
@@ -46,6 +46,7 @@ use tokio_rustls::rustls::pki_types::pem::PemObject;
 use tracing::debug;
 use tracing::warn;
 
+use crate::codec::remoting_command_codec::FrameLimits;
 use crate::connection::Connection;
 
 const TLS_HANDSHAKE_MAGIC_CODE: u8 = 0x16;
@@ -228,8 +229,19 @@ impl TlsServerRuntime {
         stream: TcpStream,
         remote_addr: SocketAddr,
     ) -> Option<NegotiatedConnection> {
+        self.negotiate_connection_with_limits(stream, remote_addr, FrameLimits::default())
+            .await
+    }
+
+    /// Negotiates a connection whose plaintext/TLS codec shares one explicit frame profile.
+    pub async fn negotiate_connection_with_limits(
+        &self,
+        stream: TcpStream,
+        remote_addr: SocketAddr,
+        frame_limits: FrameLimits,
+    ) -> Option<NegotiatedConnection> {
         let is_tls_handshake = self.detect_tls_handshake(&stream, remote_addr).await?;
-        self.negotiate_detected_connection(stream, remote_addr, is_tls_handshake)
+        self.negotiate_detected_connection_with_limits(stream, remote_addr, is_tls_handshake, frame_limits)
             .await
     }
 
@@ -243,12 +255,17 @@ impl TlsServerRuntime {
         }
     }
 
-    pub(crate) async fn negotiate_detected_connection(
+    pub(crate) async fn negotiate_detected_connection_with_limits(
         &self,
         stream: TcpStream,
         remote_addr: SocketAddr,
         is_tls_handshake: bool,
+        frame_limits: FrameLimits,
     ) -> Option<NegotiatedConnection> {
+        if let Err(error) = frame_limits.validate() {
+            warn!(%error, %remote_addr, "rejected invalid remoting frame profile");
+            return None;
+        }
         match self.mode {
             TlsMode::Disabled => {
                 if is_tls_handshake {
@@ -256,14 +273,14 @@ impl TlsServerRuntime {
                     None
                 } else {
                     Some(NegotiatedConnection {
-                        connection: Connection::new(stream),
+                        connection: Connection::new_with_limits(stream, frame_limits),
                         negotiated_tls: false,
                     })
                 }
             }
             TlsMode::Permissive => {
                 if is_tls_handshake {
-                    self.accept_tls(stream, remote_addr)
+                    self.accept_tls(stream, remote_addr, frame_limits)
                         .await
                         .map(|connection| NegotiatedConnection {
                             connection,
@@ -271,14 +288,14 @@ impl TlsServerRuntime {
                         })
                 } else {
                     Some(NegotiatedConnection {
-                        connection: Connection::new(stream),
+                        connection: Connection::new_with_limits(stream, frame_limits),
                         negotiated_tls: false,
                     })
                 }
             }
             TlsMode::Enforcing => {
                 if is_tls_handshake {
-                    self.accept_tls(stream, remote_addr)
+                    self.accept_tls(stream, remote_addr, frame_limits)
                         .await
                         .map(|connection| NegotiatedConnection {
                             connection,
@@ -294,6 +311,18 @@ impl TlsServerRuntime {
 
     pub async fn into_connection(&self, stream: TcpStream, remote_addr: SocketAddr) -> Option<Connection> {
         self.negotiate_connection(stream, remote_addr)
+            .await
+            .map(NegotiatedConnection::into_connection)
+    }
+
+    /// Negotiates and returns a connection with one explicit symmetric frame profile.
+    pub async fn into_connection_with_limits(
+        &self,
+        stream: TcpStream,
+        remote_addr: SocketAddr,
+        frame_limits: FrameLimits,
+    ) -> Option<Connection> {
+        self.negotiate_connection_with_limits(stream, remote_addr, frame_limits)
             .await
             .map(NegotiatedConnection::into_connection)
     }
@@ -372,10 +401,15 @@ impl TlsServerRuntime {
     }
 
     #[cfg(feature = "tls")]
-    async fn accept_tls(&self, stream: TcpStream, remote_addr: SocketAddr) -> Option<Connection> {
+    async fn accept_tls(
+        &self,
+        stream: TcpStream,
+        remote_addr: SocketAddr,
+        frame_limits: FrameLimits,
+    ) -> Option<Connection> {
         self.accept_stream(stream, remote_addr)
             .await
-            .map(Connection::new_with_tls_stream)
+            .map(|stream| Connection::new_with_tls_stream_and_limits(stream, frame_limits))
     }
 
     /// Performs a server-side TLS handshake with the atomically published acceptor generation.
@@ -403,7 +437,12 @@ impl TlsServerRuntime {
     }
 
     #[cfg(not(feature = "tls"))]
-    async fn accept_tls(&self, _stream: TcpStream, remote_addr: SocketAddr) -> Option<Connection> {
+    async fn accept_tls(
+        &self,
+        _stream: TcpStream,
+        remote_addr: SocketAddr,
+        _frame_limits: FrameLimits,
+    ) -> Option<Connection> {
         warn!("client {remote_addr} attempted TLS but rocketmq-transport was compiled without TLS support");
         None
     }

--- a/rocketmq-transport/src/write_strategy.rs
+++ b/rocketmq-transport/src/write_strategy.rs
@@ -116,6 +116,10 @@ pub(crate) enum OutboundPayload {
         frames: Vec<EncodedFrame>,
         encoded_len: usize,
     },
+    FrameSegments {
+        segments: Vec<Bytes>,
+        encoded_len: usize,
+    },
     Contiguous(Bytes),
 }
 
@@ -134,6 +138,7 @@ impl OutboundPayload {
             Self::Frame(frame) => frame.encoded_len(),
             Self::FileFrame { head, .. } => head.encoded_len(),
             Self::Batch { encoded_len, .. } => *encoded_len,
+            Self::FrameSegments { encoded_len, .. } => *encoded_len,
             Self::Contiguous(bytes) => bytes.len(),
         }
     }
@@ -220,24 +225,8 @@ where
     ///
     /// # Errors
     ///
-    /// Returns `InvalidInput` when the TLS coalescing bound is zero.
+    /// This constructor performs no I/O.
     pub fn new(io: W, mode: FrameWriteMode) -> io::Result<Self> {
-        if matches!(
-            mode,
-            FrameWriteMode::TlsCoalesced {
-                max_plaintext_frame_bytes: 0
-            } | FrameWriteMode::TlsVectored {
-                max_plaintext_frame_bytes: 0
-            } | FrameWriteMode::TlsAuto {
-                max_plaintext_frame_bytes: 0,
-                ..
-            }
-        ) {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "TLS writing requires a non-zero frame-byte bound",
-            ));
-        }
         Ok(Self {
             io,
             mode,
@@ -688,6 +677,13 @@ fn validate_tls_payloads(payloads: &[&OutboundPayload], max_plaintext_frame_byte
                     validate_tls_frame(frame, max_plaintext_frame_bytes)?;
                 }
             }
+            OutboundPayload::FrameSegments { encoded_len, .. } if *encoded_len > max_plaintext_frame_bytes => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "segmented frame exceeds TLS plaintext bound",
+                ));
+            }
+            OutboundPayload::FrameSegments { .. } => {}
             OutboundPayload::Contiguous(bytes) if bytes.len() > max_plaintext_frame_bytes => {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
@@ -730,6 +726,10 @@ fn payload_segments<'a>(payloads: &'a [&'a OutboundPayload]) -> io::Result<Vec<&
                     segments.extend(frame.segments());
                 }
             }
+            OutboundPayload::FrameSegments {
+                segments: frame_segments,
+                ..
+            } => segments.extend(frame_segments.iter().map(Bytes::as_ref)),
             OutboundPayload::Contiguous(bytes) => segments.push(bytes.as_ref()),
         }
     }
@@ -757,6 +757,13 @@ where
                 write_contiguous(io, buffer.as_ref()).await?;
             }
             Ok(())
+        }
+        OutboundPayload::FrameSegments { segments, .. } => {
+            buffer.clear();
+            for segment in segments {
+                buffer.extend_from_slice(segment);
+            }
+            write_contiguous(io, buffer.as_ref()).await
         }
         OutboundPayload::Contiguous(bytes) => write_contiguous(io, bytes).await,
     }

--- a/rocketmq-transport/tests/client_server_lifecycle.rs
+++ b/rocketmq-transport/tests/client_server_lifecycle.rs
@@ -21,11 +21,13 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
+use bytes::Bytes;
 use cheetah_string::CheetahString;
 use rocketmq_error::RocketMQResult;
 use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::EncodedFrame;
 use rocketmq_runtime::RuntimeContext;
 use rocketmq_runtime::ShutdownDeadline;
 use rocketmq_security_api::AuthenticatedRequestContext;
@@ -42,12 +44,11 @@ use rocketmq_transport::api::v1::AdmissionController;
 use rocketmq_transport::api::v1::AdmissionLimits;
 use rocketmq_transport::api::v1::AdmissionResource;
 use rocketmq_transport::api::v1::AdmissionScope;
+use rocketmq_transport::api::v1::FrameLimits;
 use rocketmq_transport::api::v1::OneShotTransportClient;
 use rocketmq_transport::api::v1::RequestDeadline;
 use rocketmq_transport::api::v1::ResourceLimit;
-#[cfg(feature = "tls")]
 use rocketmq_transport::api::v1::TlsClientConfig;
-#[cfg(feature = "tls")]
 use rocketmq_transport::api::v1::TlsConfig;
 use rocketmq_transport::api::v1::TlsMode;
 use rocketmq_transport::api::v1::TlsServerRuntime;
@@ -169,6 +170,42 @@ impl RequestPolicy for RecordPeerTls {
 
 struct SessionEchoHandler {
     calls: AtomicUsize,
+}
+
+struct SegmentedResponseHandler {
+    rejected: Arc<AtomicUsize>,
+}
+
+impl ConnectionHandler for SegmentedResponseHandler {
+    fn connected(&self, _session: SessionHandle) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async {})
+    }
+
+    fn command(
+        &self,
+        session: SessionHandle,
+        command: RemotingCommand,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async move {
+            let body_len = if command.code() == RequestCode::HeartBeat.to_i32() {
+                32
+            } else {
+                33
+            };
+            let wire = EncodedFrame::from_command(
+                RemotingCommand::create_response_command_with_code(ResponseCode::Success)
+                    .set_opaque(command.opaque())
+                    .set_body(vec![7_u8; body_len]),
+            )
+            .unwrap()
+            .into_bytes();
+            let header_end = 8 + (u32::from_be_bytes(wire[4..8].try_into().unwrap()) & 0x00ff_ffff) as usize;
+            let segments = vec![wire.slice(..header_end), wire.slice(header_end..)];
+            if session.connection().send_frame_segments(segments).await.is_err() {
+                self.rejected.fetch_add(1, Ordering::SeqCst);
+            }
+        })
+    }
 }
 
 impl ConnectionHandler for SessionEchoHandler {
@@ -492,15 +529,168 @@ async fn transport_security_signs_outbound_and_fails_closed_without_a_principal(
 }
 
 #[tokio::test]
+async fn plaintext_server_and_client_enforce_their_owned_frame_profile() {
+    let runtime = RuntimeContext::from_current("transport-frame-profile-test");
+    let frame_limits = FrameLimits {
+        max_frame_bytes: 1024,
+        max_header_bytes: 512,
+        max_body_bytes: 32,
+        initial_read_bytes: 8,
+    };
+    let server_config = SessionTransportServerConfig::loopback();
+    let server = SessionTransportServer::bind_with_frame_limits(
+        runtime.service_context("transport-server"),
+        server_config,
+        frame_limits,
+        Arc::new(EchoProcessor),
+        Arc::new(AdmissionController::new(AdmissionLimits::default())),
+    )
+    .await
+    .unwrap();
+    let address = server.local_addr();
+    server.start().unwrap();
+
+    let bounded = OneShotTransportClient::new(
+        runtime.service_context("bounded-client"),
+        Arc::new(AdmissionController::new(AdmissionLimits::default())),
+    )
+    .try_with_frame_limits(frame_limits)
+    .unwrap();
+    let response = bounded
+        .invoke(
+            address,
+            RemotingCommand::create_remoting_command(RequestCode::HeartBeat).set_body(vec![7_u8; 32]),
+            RequestDeadline::after(Duration::from_secs(1)),
+        )
+        .await
+        .expect("exact endpoint body limit");
+    assert_eq!(response.body().map(bytes::Bytes::len), Some(32));
+
+    let permissive = OneShotTransportClient::new(
+        runtime.service_context("permissive-client"),
+        Arc::new(AdmissionController::new(AdmissionLimits::default())),
+    )
+    .try_with_frame_limits(FrameLimits::java_compatibility())
+    .unwrap();
+    assert!(permissive
+        .invoke(
+            address,
+            RemotingCommand::create_remoting_command(RequestCode::HeartBeat).set_body(vec![7_u8; 33]),
+            RequestDeadline::after(Duration::from_secs(1)),
+        )
+        .await
+        .is_err());
+
+    let _ = server
+        .shutdown_until(ShutdownDeadline::after(Duration::from_secs(1)))
+        .await;
+    let _ = runtime.shutdown_tasks(Duration::from_secs(1)).await;
+}
+
+async fn queued_segmented_response_obeys_owner_limits(tls_enabled: bool) {
+    let runtime = RuntimeContext::from_current("transport-segmented-frame-profile-test");
+    let service = runtime.service_context("transport-listener");
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let frame_limits = FrameLimits {
+        max_frame_bytes: 1024,
+        max_header_bytes: 512,
+        max_body_bytes: 32,
+        initial_read_bytes: 8,
+    };
+    let mut server_tls = TlsConfig::default();
+    let mut client_tls = TlsConfig::default();
+    if tls_enabled {
+        server_tls.test_mode_enable = true;
+        server_tls.server.mode = TlsMode::Permissive;
+        client_tls.enable = true;
+        client_tls.test_mode_enable = true;
+        client_tls.client = TlsClientConfig {
+            auth_server: false,
+            ..TlsClientConfig::default()
+        };
+    } else {
+        server_tls.server.mode = TlsMode::Disabled;
+    }
+    let transport = TransportListener::new(
+        listener,
+        service.task_group().clone(),
+        TlsServerRuntime::initialize_with_service_context(server_tls, &service)
+            .await
+            .unwrap(),
+        Arc::new(AdmissionController::new(AdmissionLimits::default())),
+        Duration::from_secs(1),
+    )
+    .try_with_frame_limits(frame_limits)
+    .unwrap();
+    let rejected = Arc::new(AtomicUsize::new(0));
+    let handler = Arc::new(SegmentedResponseHandler {
+        rejected: rejected.clone(),
+    });
+    service
+        .spawn_service("segmented-listener", async move {
+            let _ = transport.run(handler).await;
+        })
+        .unwrap();
+
+    let client = OneShotTransportClient::new(
+        runtime.service_context("transport-client"),
+        Arc::new(AdmissionController::new(AdmissionLimits::default())),
+    )
+    .try_with_frame_limits(FrameLimits::java_compatibility())
+    .unwrap();
+    let exact = client
+        .invoke_with_config(
+            address,
+            RemotingCommand::create_remoting_command(RequestCode::HeartBeat),
+            &client_tls,
+            RequestDeadline::after(Duration::from_secs(2)),
+        )
+        .await
+        .expect("exact segmented response");
+    assert_eq!(exact.body().map(Bytes::len), Some(32));
+
+    assert!(client
+        .invoke_with_config(
+            address,
+            RemotingCommand::create_remoting_command(RequestCode::SendMessage),
+            &client_tls,
+            RequestDeadline::after(Duration::from_millis(100)),
+        )
+        .await
+        .is_err());
+    assert_eq!(rejected.load(Ordering::SeqCst), 1);
+    let _ = runtime.shutdown_tasks(Duration::from_secs(1)).await;
+}
+
+#[tokio::test]
+async fn queued_plaintext_segmented_responses_enforce_the_complete_frame_profile() {
+    queued_segmented_response_obeys_owner_limits(false).await;
+}
+
+#[tokio::test]
+#[cfg(feature = "tls")]
+async fn queued_tls_segmented_responses_enforce_the_complete_frame_profile() {
+    queued_segmented_response_obeys_owner_limits(true).await;
+}
+
+#[tokio::test]
 #[cfg(feature = "tls")]
 async fn tls_client_invocation_releases_pending_and_server_ownership() {
     let runtime = RuntimeContext::from_current("transport-tls-client-convergence-test");
+    let frame_limits = FrameLimits {
+        max_frame_bytes: 4096,
+        max_header_bytes: 2048,
+        max_body_bytes: 1024,
+        initial_read_bytes: 8,
+    };
     let mut server_config = SessionTransportServerConfig::loopback();
     server_config.tls.test_mode_enable = true;
     server_config.tls.server.mode = TlsMode::Permissive;
-    let server = SessionTransportServer::bind(
+    let server = SessionTransportServer::bind_with_frame_limits(
         runtime.service_context("transport-server"),
         server_config,
+        frame_limits,
         Arc::new(EchoProcessor),
         Arc::new(AdmissionController::new(AdmissionLimits::default())),
     )
@@ -514,7 +704,9 @@ async fn tls_client_invocation_releases_pending_and_server_ownership() {
     let client = OneShotTransportClient::new(
         runtime.service_context("transport-client"),
         Arc::new(AdmissionController::new(AdmissionLimits::default())),
-    );
+    )
+    .try_with_frame_limits(frame_limits)
+    .unwrap();
     let client_tls = TlsConfig {
         enable: true,
         test_mode_enable: true,
@@ -548,6 +740,22 @@ async fn tls_client_invocation_releases_pending_and_server_ownership() {
     .expect("server session and processor tasks should converge");
     assert_eq!(server.owned_component_group_count(), baseline_components);
     assert!(transport_io_snapshot().encoded_bytes_written > io_before.encoded_bytes_written);
+
+    let permissive_client = OneShotTransportClient::new(
+        runtime.service_context("permissive-tls-client"),
+        Arc::new(AdmissionController::new(AdmissionLimits::default())),
+    )
+    .try_with_frame_limits(FrameLimits::java_compatibility())
+    .unwrap();
+    assert!(permissive_client
+        .invoke_with_config(
+            address,
+            RemotingCommand::create_remoting_command(RequestCode::HeartBeat).set_body(vec![7_u8; 1025]),
+            &client_tls,
+            RequestDeadline::after(Duration::from_secs(2)),
+        )
+        .await
+        .is_err());
 
     let _ = server
         .shutdown_until(ShutdownDeadline::after(Duration::from_secs(1)))

--- a/rocketmq-transport/tests/codec_bounds.rs
+++ b/rocketmq-transport/tests/codec_bounds.rs
@@ -21,6 +21,28 @@ use rocketmq_transport::test_support::RemotingCommandCodec;
 use tokio_util::codec::Decoder;
 use tokio_util::codec::Encoder;
 
+fn announced_frame(total_wire_bytes: usize, header_bytes: usize) -> BytesMut {
+    let announced_bytes = total_wire_bytes - 4;
+    let mut frame = BytesMut::with_capacity(8);
+    frame.extend_from_slice(&(announced_bytes as i32).to_be_bytes());
+    frame.extend_from_slice(&(header_bytes as u32).to_be_bytes());
+    frame
+}
+
+fn command_with_encoded_header_bytes(target_header_bytes: usize) -> RemotingCommand {
+    let empty = RemotingCommand::create_remoting_command(105)
+        .set_opaque(1)
+        .set_remark("");
+    let mut codec = RemotingCommandCodec::with_limits(FrameLimits::java_compatibility());
+    let mut wire = BytesMut::new();
+    codec.encode(empty, &mut wire).unwrap();
+    let empty_header_bytes = (u32::from_be_bytes(wire[4..8].try_into().unwrap()) & 0x00ff_ffff) as usize;
+    assert!(target_header_bytes >= empty_header_bytes);
+    RemotingCommand::create_remoting_command(105)
+        .set_opaque(1)
+        .set_remark("x".repeat(target_header_bytes - empty_header_bytes))
+}
+
 #[test]
 fn fragmented_frame_waits_and_then_decodes_without_eager_megabyte_allocation() {
     let mut codec = RemotingCommandCodec::with_limits(FrameLimits {
@@ -57,14 +79,114 @@ fn oversized_frame_is_rejected_before_body_allocation() {
 #[test]
 fn legacy_large_body_acceptance_requires_an_explicit_owner_profile() {
     let canonical = FrameLimits::default();
+    let java = FrameLimits::java_compatibility();
     let legacy = FrameLimits::legacy_compatibility();
 
     assert_eq!(canonical.max_frame_bytes, 16 * 1024 * 1024);
     assert_eq!(canonical.max_header_bytes, 1024 * 1024);
     assert_eq!(canonical.max_body_bytes, 4 * 1024 * 1024);
-    assert_eq!(legacy.max_frame_bytes, 16 * 1024 * 1024);
-    assert_eq!(legacy.max_body_bytes, 16 * 1024 * 1024);
+    assert_eq!(java.max_frame_bytes, 16 * 1024 * 1024);
+    assert_eq!(java.max_header_bytes, 4 * 1024 * 1024);
+    assert_eq!(java.max_body_bytes, 16 * 1024 * 1024);
+    assert_eq!(legacy, java);
     assert_eq!(canonical.initial_read_bytes, 8 * 1024);
+}
+
+#[test]
+fn encode_and_decode_apply_the_same_total_wire_byte_limit() {
+    let command = RemotingCommand::create_remoting_command(105).set_body(vec![7_u8; 64]);
+    let mut unrestricted = RemotingCommandCodec::with_limits(FrameLimits::java_compatibility());
+    let mut wire = BytesMut::new();
+    unrestricted.encode(command.clone(), &mut wire).unwrap();
+    let exact_wire_bytes = wire.len();
+
+    let exact_limits = FrameLimits {
+        max_frame_bytes: exact_wire_bytes,
+        max_header_bytes: exact_wire_bytes,
+        max_body_bytes: 64,
+        initial_read_bytes: 8,
+    };
+    let mut exact_codec = RemotingCommandCodec::with_limits(exact_limits);
+    let mut exact_encoded = BytesMut::new();
+    exact_codec.encode(command.clone(), &mut exact_encoded).unwrap();
+    assert!(exact_codec.decode(&mut exact_encoded).unwrap().is_some());
+
+    let below_limits = FrameLimits {
+        max_frame_bytes: exact_wire_bytes - 1,
+        ..exact_limits
+    };
+    let mut below_encoder = RemotingCommandCodec::with_limits(below_limits);
+    let mut destination = BytesMut::from(&b"existing"[..]);
+    let original = destination.clone();
+    assert!(below_encoder.encode(command, &mut destination).is_err());
+    assert_eq!(destination, original, "failed encoding must be atomic");
+
+    let mut below_decoder = RemotingCommandCodec::with_limits(below_limits);
+    assert!(below_decoder.decode(&mut wire).is_err());
+}
+
+#[test]
+fn encoder_rejects_body_over_limit_without_mutating_destination() {
+    let limits = FrameLimits {
+        max_frame_bytes: 1024,
+        max_header_bytes: 512,
+        max_body_bytes: 16,
+        initial_read_bytes: 8,
+    };
+    let command = RemotingCommand::create_remoting_command(105).set_body(vec![0_u8; 17]);
+    let mut codec = RemotingCommandCodec::with_limits(limits);
+    let mut destination = BytesMut::from(&b"existing"[..]);
+    let original = destination.clone();
+
+    assert!(codec.encode(command, &mut destination).is_err());
+    assert_eq!(destination, original, "failed encoding must not append a partial frame");
+}
+
+#[test]
+fn canonical_encoder_accepts_exact_header_limit_and_rejects_one_byte_over() {
+    let limits = FrameLimits::default();
+    let mut codec = RemotingCommandCodec::with_limits(limits);
+    let mut exact = BytesMut::new();
+    codec
+        .encode(command_with_encoded_header_bytes(limits.max_header_bytes), &mut exact)
+        .unwrap();
+    let encoded_header_bytes = (u32::from_be_bytes(exact[4..8].try_into().unwrap()) & 0x00ff_ffff) as usize;
+    assert_eq!(encoded_header_bytes, limits.max_header_bytes);
+    assert!(codec.decode(&mut exact).unwrap().is_some());
+
+    let mut destination = BytesMut::from(&b"existing"[..]);
+    let original = destination.clone();
+    assert!(codec
+        .encode(
+            command_with_encoded_header_bytes(limits.max_header_bytes + 1),
+            &mut destination,
+        )
+        .is_err());
+    assert_eq!(destination, original);
+}
+
+#[test]
+fn canonical_encoder_accepts_exact_body_limit_and_rejects_one_byte_over() {
+    let limits = FrameLimits::default();
+    let mut codec = RemotingCommandCodec::with_limits(limits);
+    let mut exact = BytesMut::new();
+    codec
+        .encode(
+            RemotingCommand::create_remoting_command(105).set_body(vec![0_u8; limits.max_body_bytes]),
+            &mut exact,
+        )
+        .unwrap();
+    assert!(codec.decode(&mut exact).unwrap().is_some());
+
+    let mut destination = BytesMut::from(&b"existing"[..]);
+    let original = destination.clone();
+    assert!(codec
+        .encode(
+            RemotingCommand::create_remoting_command(105).set_body(vec![0_u8; limits.max_body_bytes + 1]),
+            &mut destination,
+        )
+        .is_err());
+    assert_eq!(destination, original);
 }
 
 #[test]
@@ -92,4 +214,170 @@ fn canonical_limits_reject_announced_body_over_limit_before_allocation() {
 
     assert!(codec.decode(&mut announced).is_err());
     assert!(announced.capacity() < 1024);
+}
+
+#[test]
+fn canonical_header_boundary_is_checked_from_the_eight_byte_announcement() {
+    let limits = FrameLimits::default();
+    for header_bytes in [limits.max_header_bytes - 1, limits.max_header_bytes] {
+        let mut announced = announced_frame(8 + header_bytes, header_bytes);
+        let capacity = announced.capacity();
+        let mut codec = RemotingCommandCodec::with_limits(limits);
+        assert!(codec.decode(&mut announced).unwrap().is_none());
+        assert_eq!(announced.capacity(), capacity);
+    }
+
+    let header_bytes = limits.max_header_bytes + 1;
+    let mut announced = announced_frame(8 + header_bytes, header_bytes);
+    let capacity = announced.capacity();
+    let mut codec = RemotingCommandCodec::with_limits(limits);
+    assert!(codec.decode(&mut announced).is_err());
+    assert_eq!(announced.capacity(), capacity);
+}
+
+#[test]
+fn canonical_body_boundary_is_checked_from_the_eight_byte_announcement() {
+    let limits = FrameLimits::default();
+    for body_bytes in [limits.max_body_bytes - 1, limits.max_body_bytes] {
+        let mut announced = announced_frame(8 + body_bytes, 0);
+        let capacity = announced.capacity();
+        let mut codec = RemotingCommandCodec::with_limits(limits);
+        assert!(codec.decode(&mut announced).unwrap().is_none());
+        assert_eq!(announced.capacity(), capacity);
+    }
+
+    let body_bytes = limits.max_body_bytes + 1;
+    let mut announced = announced_frame(8 + body_bytes, 0);
+    let capacity = announced.capacity();
+    let mut codec = RemotingCommandCodec::with_limits(limits);
+    assert!(codec.decode(&mut announced).is_err());
+    assert_eq!(announced.capacity(), capacity);
+}
+
+#[test]
+fn total_wire_boundary_counts_the_length_prefix() {
+    let limits = FrameLimits {
+        max_frame_bytes: 1024,
+        max_header_bytes: 512,
+        max_body_bytes: 1024,
+        initial_read_bytes: 8,
+    };
+    for total_wire_bytes in [limits.max_frame_bytes - 1, limits.max_frame_bytes] {
+        let mut announced = announced_frame(total_wire_bytes, 0);
+        let mut codec = RemotingCommandCodec::with_limits(limits);
+        assert!(codec.decode(&mut announced).unwrap().is_none());
+    }
+
+    let mut over = announced_frame(limits.max_frame_bytes + 1, 0);
+    let capacity = over.capacity();
+    let mut codec = RemotingCommandCodec::with_limits(limits);
+    assert!(codec.decode(&mut over).is_err());
+    assert_eq!(over.capacity(), capacity);
+}
+
+#[test]
+fn full_24_bit_header_marker_obeys_the_explicit_endpoint_profile() {
+    let max_header_bytes = 0x00ff_ffff;
+    let limits = FrameLimits {
+        max_frame_bytes: max_header_bytes + 8,
+        max_header_bytes,
+        max_body_bytes: 0,
+        initial_read_bytes: 8,
+    };
+    let mut codec = RemotingCommandCodec::with_limits(limits);
+    let mut exact = BytesMut::new();
+    codec
+        .encode(command_with_encoded_header_bytes(max_header_bytes), &mut exact)
+        .unwrap();
+    assert_eq!(exact.len(), limits.max_frame_bytes);
+    assert!(codec.decode(&mut exact).unwrap().is_some());
+
+    let mut below = BytesMut::new();
+    codec
+        .encode(command_with_encoded_header_bytes(max_header_bytes - 1), &mut below)
+        .unwrap();
+    assert_eq!(below.len(), limits.max_frame_bytes - 1);
+    assert!(codec.decode(&mut below).unwrap().is_some());
+
+    let over = FrameLimits {
+        max_header_bytes: max_header_bytes + 1,
+        max_frame_bytes: limits.max_frame_bytes + 1,
+        ..limits
+    };
+    assert!(over.validate().is_err());
+}
+
+#[test]
+fn invalid_frame_limit_profiles_fail_before_encoding_or_deserialization() {
+    assert!(FrameLimits::try_new(7, 1, 1, 7).is_err());
+    assert!(FrameLimits::try_new(1024, 0x0100_0000, 0, 8).is_err());
+    assert!(FrameLimits::try_new(1024, 512, 512, 1025).is_err());
+    assert!(serde_json::from_str::<FrameLimits>(
+        r#"{"maxFrameBytes":1024,"maxHeaderBytes":512,"maxBodyBytes":512,"initialReadBytes":1025}"#,
+    )
+    .is_err());
+
+    let invalid = FrameLimits {
+        max_frame_bytes: 0,
+        max_header_bytes: 0,
+        max_body_bytes: 0,
+        initial_read_bytes: usize::MAX,
+    };
+    let mut codec = RemotingCommandCodec::with_limits(invalid);
+    let mut destination = BytesMut::from(&b"unchanged"[..]);
+    let original = destination.clone();
+    assert!(codec
+        .encode(RemotingCommand::create_remoting_command(105), &mut destination)
+        .is_err());
+    assert_eq!(destination, original);
+}
+
+#[test]
+fn encoder_preserves_the_protocol_24_bit_header_ceiling() {
+    let limits = FrameLimits {
+        max_frame_bytes: 64 * 1024 * 1024,
+        max_header_bytes: 32 * 1024 * 1024,
+        max_body_bytes: 0,
+        initial_read_bytes: 8,
+    };
+    let command = RemotingCommand::create_remoting_command(105).set_remark("x".repeat(0x0100_0000));
+    let mut codec = RemotingCommandCodec::with_limits(limits);
+    let mut destination = BytesMut::new();
+
+    assert!(codec.encode(command, &mut destination).is_err());
+    assert!(destination.is_empty());
+}
+
+#[test]
+fn consecutive_frames_decode_without_consuming_the_next_prefix() {
+    let mut codec = RemotingCommandCodec::with_limits(FrameLimits::default());
+    let mut wire = BytesMut::new();
+    codec
+        .encode(RemotingCommand::create_remoting_command(105).set_opaque(1), &mut wire)
+        .unwrap();
+    codec
+        .encode(RemotingCommand::create_remoting_command(106).set_opaque(2), &mut wire)
+        .unwrap();
+
+    let first = codec.decode(&mut wire).unwrap().unwrap();
+    let second = codec.decode(&mut wire).unwrap().unwrap();
+    assert_eq!((first.code(), first.opaque()), (105, 1));
+    assert_eq!((second.code(), second.opaque()), (106, 2));
+    assert!(wire.is_empty());
+}
+
+#[test]
+fn negative_and_forged_announcements_fail_without_buffer_growth() {
+    let limits = FrameLimits::default();
+    let cases = [
+        BytesMut::from(&[0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0][..]),
+        BytesMut::from(&[0, 0, 0, 4, 0, 0, 0, 1][..]),
+    ];
+
+    for mut announced in cases {
+        let capacity = announced.capacity();
+        let mut codec = RemotingCommandCodec::with_limits(limits);
+        assert!(codec.decode(&mut announced).is_err());
+        assert_eq!(announced.capacity(), capacity);
+    }
 }

--- a/rocketmq-transport/tests/connection_lifecycle.rs
+++ b/rocketmq-transport/tests/connection_lifecycle.rs
@@ -14,10 +14,20 @@
 
 #![cfg(feature = "test-support")]
 
+use std::io::Write;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use bytes::BytesMut;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_transport::api::v1::ConnectionState;
+use rocketmq_transport::api::v1::FileRegion;
 use rocketmq_transport::api::v1::FrameLimits;
+use rocketmq_transport::api::v1::RequestDeadline;
 use rocketmq_transport::test_support::Connection;
+use tokio::io::AsyncReadExt;
+use tokio_util::codec::Encoder;
 
 #[tokio::test]
 async fn loopback_connection_preserves_wire_identity_and_half_close_state() {
@@ -63,4 +73,161 @@ async fn owner_injected_legacy_limits_accept_a_large_fragmented_frame() {
         .expect("valid legacy frame");
     assert_eq!(command.body().unwrap().len(), 5 * 1024 * 1024);
     server.await.unwrap();
+}
+
+#[tokio::test]
+async fn outbound_connection_rejects_frames_that_exceed_its_inbound_limits() {
+    let limits = FrameLimits {
+        max_frame_bytes: 1024,
+        max_header_bytes: 512,
+        max_body_bytes: 16,
+        initial_read_bytes: 8,
+    };
+    let (stream, mut peer) = tokio::io::duplex(4096);
+    let mut connection = Connection::new_with_plaintext_stream_and_limits(stream, limits);
+
+    let result = connection
+        .send_command(RemotingCommand::create_remoting_command(105).set_body(vec![0_u8; 17]))
+        .await;
+
+    assert!(result.is_err());
+    let mut byte = [0_u8; 1];
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(20), peer.read(&mut byte))
+            .await
+            .is_err()
+    );
+}
+
+#[tokio::test]
+async fn raw_and_segmented_output_obey_the_owner_frame_limits_atomically() {
+    let limits = FrameLimits {
+        max_frame_bytes: 256,
+        max_header_bytes: 192,
+        max_body_bytes: 32,
+        initial_read_bytes: 8,
+    };
+    let (stream, mut peer) = tokio::io::duplex(1024);
+    let mut connection = Connection::new_with_plaintext_stream_and_limits(stream, limits);
+
+    assert!(connection.send_bytes(Bytes::from(vec![0_u8; 129])).await.is_err());
+    let mut wire = BytesMut::new();
+    rocketmq_transport::test_support::RemotingCommandCodec::with_limits(limits)
+        .encode(
+            RemotingCommand::create_remoting_command(105).set_body(vec![7_u8; 33]),
+            &mut wire,
+        )
+        .expect_err("fixture is over the body limit");
+
+    let unrestricted = FrameLimits {
+        max_frame_bytes: 1024,
+        max_header_bytes: 512,
+        max_body_bytes: 512,
+        initial_read_bytes: 8,
+    };
+    rocketmq_transport::test_support::RemotingCommandCodec::with_limits(unrestricted)
+        .encode(
+            RemotingCommand::create_remoting_command(105).set_body(vec![7_u8; 33]),
+            &mut wire,
+        )
+        .unwrap();
+    let body_offset = 8 + (u32::from_be_bytes(wire[4..8].try_into().unwrap()) & 0x00ff_ffff) as usize;
+    let body = wire.split_off(body_offset).freeze();
+    let head = wire.freeze();
+    assert!(connection.send_frame_segments(vec![head, body]).await.is_err());
+
+    let mut byte = [0_u8; 1];
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(20), peer.read(&mut byte))
+            .await
+            .is_err()
+    );
+
+    let mut exact_wire = BytesMut::new();
+    rocketmq_transport::test_support::RemotingCommandCodec::with_limits(unrestricted)
+        .encode(
+            RemotingCommand::create_remoting_command(105).set_body(vec![7_u8; 32]),
+            &mut exact_wire,
+        )
+        .unwrap();
+    let expected_len = exact_wire.len();
+    let body_offset = 8 + (u32::from_be_bytes(exact_wire[4..8].try_into().unwrap()) & 0x00ff_ffff) as usize;
+    let body = exact_wire.split_off(body_offset).freeze();
+    connection
+        .send_frame_segments(vec![exact_wire.freeze(), body])
+        .await
+        .unwrap();
+    let mut received = vec![0_u8; expected_len];
+    peer.read_exact(&mut received).await.unwrap();
+}
+
+#[tokio::test]
+async fn direct_tls_segmented_output_obeys_the_owner_frame_limits() {
+    let limits = FrameLimits {
+        max_frame_bytes: 256,
+        max_header_bytes: 192,
+        max_body_bytes: 32,
+        initial_read_bytes: 8,
+    };
+    let unrestricted = FrameLimits {
+        max_frame_bytes: 1024,
+        max_header_bytes: 512,
+        max_body_bytes: 512,
+        initial_read_bytes: 8,
+    };
+    let (stream, mut peer) = tokio::io::duplex(1024);
+    let mut connection = Connection::new_with_tls_stream_and_limits(stream, limits);
+    let mut wire = BytesMut::new();
+    rocketmq_transport::test_support::RemotingCommandCodec::with_limits(unrestricted)
+        .encode(
+            RemotingCommand::create_remoting_command(105).set_body(vec![7_u8; 33]),
+            &mut wire,
+        )
+        .unwrap();
+    let body_offset = 8 + (u32::from_be_bytes(wire[4..8].try_into().unwrap()) & 0x00ff_ffff) as usize;
+    let body = wire.split_off(body_offset).freeze();
+    assert!(connection.send_frame_segments(vec![wire.freeze(), body]).await.is_err());
+
+    let mut byte = [0_u8; 1];
+    assert!(tokio::time::timeout(Duration::from_millis(20), peer.read(&mut byte))
+        .await
+        .is_err());
+}
+
+#[tokio::test]
+async fn batch_and_file_region_output_reject_over_limit_bodies_before_writing() {
+    let limits = FrameLimits {
+        max_frame_bytes: 256,
+        max_header_bytes: 192,
+        max_body_bytes: 32,
+        initial_read_bytes: 8,
+    };
+    let (stream, mut peer) = tokio::io::duplex(1024);
+    let mut connection = Connection::new_with_plaintext_stream_and_limits(stream, limits);
+
+    assert!(connection
+        .send_batch(vec![
+            RemotingCommand::create_remoting_command(105),
+            RemotingCommand::create_remoting_command(106).set_body(vec![0_u8; 33]),
+        ])
+        .await
+        .is_err());
+
+    let mut file = tempfile::tempfile().unwrap();
+    file.write_all(&[7_u8; 33]).unwrap();
+    file.flush().unwrap();
+    let region = FileRegion::try_new(Arc::new(file), 0, 33).unwrap();
+    assert!(connection
+        .send_file_region_command(
+            RemotingCommand::create_remoting_command(107),
+            region,
+            RequestDeadline::after(Duration::from_secs(1)),
+        )
+        .await
+        .is_err());
+
+    let mut byte = [0_u8; 1];
+    assert!(tokio::time::timeout(Duration::from_millis(20), peer.read(&mut byte))
+        .await
+        .is_err());
 }

--- a/rocketmq-transport/tests/fixtures/java_netty_frame_limit_boundaries.json
+++ b/rocketmq-transport/tests/fixtures/java_netty_frame_limit_boundaries.json
@@ -1,0 +1,14 @@
+{
+  "decoder": "org.apache.rocketmq.remoting.netty.NettyDecoder",
+  "sourceRevision": "e3458616d",
+  "maxFrameLength": 16777216,
+  "lengthFieldOffset": 0,
+  "lengthFieldLength": 4,
+  "lengthAdjustment": 0,
+  "initialBytesToStrip": 4,
+  "cases": [
+    { "totalWireBytes": 16777215, "accepted": true },
+    { "totalWireBytes": 16777216, "accepted": true },
+    { "totalWireBytes": 16777217, "accepted": false }
+  ]
+}

--- a/rocketmq-transport/tests/java_frame_limit_compatibility.rs
+++ b/rocketmq-transport/tests/java_frame_limit_compatibility.rs
@@ -1,0 +1,87 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(feature = "test-support")]
+
+use bytes::BytesMut;
+use rocketmq_protocol::protocol::encoded_frame::EncodedFrame;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_transport::api::v1::FrameLimits;
+use rocketmq_transport::test_support::RemotingCommandCodec;
+use tokio_util::codec::Decoder;
+use tokio_util::codec::Encoder;
+
+const JAVA_FRAME_MAX_LENGTH: usize = 16 * 1024 * 1024;
+
+fn java_netty_boundary_fixture() -> serde_json::Value {
+    serde_json::from_str(include_str!("fixtures/java_netty_frame_limit_boundaries.json"))
+        .expect("valid Java Netty boundary fixture")
+}
+
+fn command_with_total_wire_bytes(total_wire_bytes: usize) -> RemotingCommand {
+    let command = RemotingCommand::create_remoting_command(105);
+    let header_only = EncodedFrame::from_command(command.clone()).unwrap().encoded_len();
+    command.set_body(vec![0_u8; total_wire_bytes - header_only])
+}
+
+// RocketMQ Java NettyDecoder configures LengthFieldBasedFrameDecoder with offset=0,
+// length=4, adjustment=0, strip=4. Netty adds the four-byte length-field end offset before
+// comparing maxFrameLength, so the configured 16 MiB is the complete wire frame, not the
+// announced payload after the prefix.
+#[test]
+fn java_netty_frame_max_length_includes_the_four_byte_prefix() {
+    let fixture = java_netty_boundary_fixture();
+    assert_eq!(fixture["decoder"], "org.apache.rocketmq.remoting.netty.NettyDecoder");
+    assert_eq!(fixture["maxFrameLength"], JAVA_FRAME_MAX_LENGTH);
+    assert_eq!(fixture["lengthFieldOffset"], 0);
+    assert_eq!(fixture["lengthFieldLength"], 4);
+    assert_eq!(fixture["lengthAdjustment"], 0);
+    assert_eq!(fixture["initialBytesToStrip"], 4);
+    assert_eq!(fixture["cases"][0]["totalWireBytes"], JAVA_FRAME_MAX_LENGTH - 1);
+    assert_eq!(fixture["cases"][0]["accepted"], true);
+    assert_eq!(fixture["cases"][1]["totalWireBytes"], JAVA_FRAME_MAX_LENGTH);
+    assert_eq!(fixture["cases"][1]["accepted"], true);
+    assert_eq!(fixture["cases"][2]["totalWireBytes"], JAVA_FRAME_MAX_LENGTH + 1);
+    assert_eq!(fixture["cases"][2]["accepted"], false);
+
+    let limits = FrameLimits::java_compatibility();
+    assert_eq!(limits.max_frame_bytes, JAVA_FRAME_MAX_LENGTH);
+
+    let exact = command_with_total_wire_bytes(JAVA_FRAME_MAX_LENGTH);
+    let mut codec = RemotingCommandCodec::with_limits(limits);
+    let mut exact_wire = BytesMut::new();
+    codec.encode(exact, &mut exact_wire).unwrap();
+    assert_eq!(exact_wire.len(), JAVA_FRAME_MAX_LENGTH);
+    assert!(codec.decode(&mut exact_wire).unwrap().is_some());
+
+    let over = command_with_total_wire_bytes(JAVA_FRAME_MAX_LENGTH + 1);
+    let mut destination = BytesMut::new();
+    assert!(codec.encode(over, &mut destination).is_err());
+    assert!(destination.is_empty());
+}
+
+#[test]
+fn oversized_java_announcement_is_rejected_with_an_eight_byte_allocation_bound() {
+    let limits = FrameLimits::java_compatibility();
+    let announced_after_prefix = limits.max_frame_bytes - 4 + 1;
+    let mut announced = BytesMut::with_capacity(8);
+    announced.extend_from_slice(&(announced_after_prefix as i32).to_be_bytes());
+    announced.extend_from_slice(&0_u32.to_be_bytes());
+    let capacity_before = announced.capacity();
+    let mut codec = RemotingCommandCodec::with_limits(limits);
+
+    assert!(codec.decode(&mut announced).is_err());
+    assert_eq!(capacity_before, 8);
+    assert_eq!(announced.capacity(), capacity_before);
+}

--- a/rocketmq-transport/tests/public_api_contract.rs
+++ b/rocketmq-transport/tests/public_api_contract.rs
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 use rocketmq_transport::api::v1::AdmissionLimits;
+use rocketmq_transport::api::v1::FileTransferMode;
 use rocketmq_transport::api::v1::FrameLimits;
 use rocketmq_transport::api::v1::OneShotTransportClient;
 use rocketmq_transport::api::v1::ServerConfig;
+use rocketmq_transport::api::v1::TransportClientConfig;
 
 #[test]
 fn transport_consumers_use_only_versioned_capabilities_and_dtos() {
@@ -68,5 +70,16 @@ fn transport_consumers_use_only_versioned_capabilities_and_dtos() {
     let _ = AdmissionLimits::default();
     let _ = FrameLimits::default();
     let _ = ServerConfig::default();
+    let _ = ServerConfig {
+        listen_port: 10911,
+        bind_address: "127.0.0.1".to_owned(),
+        tls_config: Default::default(),
+        file_transfer_mode: FileTransferMode::Auto,
+    };
+    let _ = TransportClientConfig {
+        connect: Default::default(),
+        maintenance: Default::default(),
+        tls: Default::default(),
+    };
     let _: Option<OneShotTransportClient> = None;
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9347

### Brief Description

Define validated Java-compatible and hardened remoting frame profiles with total wire-byte semantics, then propagate one owner-selected profile through client and server plaintext/TLS connections, decoders, and all outbound command paths.

Parameterize protocol decoding so custom profiles remain symmetric above the historical 16 MiB envelope. Validate configuration and serialized frame segments before allocation or socket progress, preserve public configuration struct-literal compatibility, and migrate Broker zero-copy pull/POP responses to one bounded segmented-frame write.

Add exact header, body, total-frame, 24-bit header, malformed announcement, raw multipart, batch, file-region, direct/queued plaintext, and TLS coverage. The checked-in Java Netty boundary fixture records an `EmbeddedChannel` probe against RocketMQ revision `e3458616d`: total wire sizes 16 MiB - 1 and 16 MiB are accepted, while 16 MiB + 1 is rejected.

### How Did You Test This Change?

- `cargo test -p rocketmq-transport --test codec_bounds --features test-support` (17 passed)
- `cargo test -p rocketmq-transport --test partial_frame_admission --features test-support` (1 passed)
- `cargo test -p rocketmq-transport --test connection_lifecycle --features test-support` (6 passed)
- `cargo test -p rocketmq-transport --test client_server_lifecycle --all-features` (13 passed)
- `cargo test -p rocketmq-transport --test java_frame_limit_compatibility --features test-support` (2 passed)
- `cargo test -p rocketmq-transport --all-features` (passed)
- `cargo test -p rocketmq-protocol --test remoting_wire_golden` (2 passed)
- `cargo test -p rocketmq-protocol --lib remoting_command` (50 passed)
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` (passed)
- Per-package `cargo fmt -p <package> -- --check` for all 28 workspace packages (passed; workspace-wide invocation exceeds the Windows command-line limit)
- `cargo check --locked --all-targets` in `fuzz/` (passed)
- `cargo clippy --all-targets --all-features -- -D warnings` in `rocketmq-example/` (passed)
- Full `rocketmq-tools/rocketmq-mcp` validation profile (passed: boundary guard, default/all-feature tests, Clippy, and Rustdoc)
- `cargo doc -p rocketmq-protocol -p rocketmq-transport --all-features --no-deps` (passed)
- `scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` (passed)
- `scripts/check-error-hygiene.ps1` (passed)
- Java `NettyDecoder` direct boundary probe via `EmbeddedChannel` (passed: 16 MiB - 1 accepted, 16 MiB accepted, 16 MiB + 1 rejected)

The existing Broker test `processor::send_message_processor::capability::tests::extended_timer_capability_is_published_from_one_policy_generation` still fails with `left: 0, right: 1`; the same unrelated baseline failure was present before this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable frame-size limits for clients, servers, connections, and TLS/plaintext transport.
  * Added Java-compatible and legacy compatibility profiles with validation.
  * Added support for sending segmented response frames efficiently.
  * Added configurable maximum frame decoding limits.

* **Bug Fixes**
  * Improved handling and reporting of oversized, malformed, or unsuccessfully encoded frames.
  * Prevented invalid frames from being sent or causing unnecessary buffer growth.

* **Tests**
  * Expanded coverage for frame boundaries, segmented responses, TLS, lifecycle behavior, and Java compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->