### PR TITLE
[ISSUE #9350]♻️Add bounded GO_AWAY reconnection retries

### DIFF
--- a/rocketmq-doc/en/remoting-go-away-retry-policy.md
+++ b/rocketmq-doc/en/remoting-go-away-retry-policy.md
@@ -1,0 +1,47 @@
+# Remoting GO_AWAY Retry Policy
+
+`GO_AWAY` tells a response-aware client that the current peer-bound session
+must not accept another request. `TransportClient` can perform one bounded
+retry on a replacement session when its owner installs an explicit
+`GoAwayPolicy`.
+
+## Compatibility default
+
+The policy is disabled by default. A disabled client returns `GO_AWAY` to its
+caller exactly as it did before retry support was added. Enabling the policy
+still does not retry every request: owners must provide a request-code
+allowlist. Side-effecting operations should remain outside that allowlist
+unless their application-level idempotency contract makes a duplicate attempt
+safe. One-way requests never enter the response retry path.
+
+## Attempt and deadline contract
+
+A logical invocation has at most two wire attempts: the initial request and
+one replacement-connection retry. Both attempts use the same immutable
+`RequestDeadline`; reconnecting does not create a fresh timeout budget. A
+second `GO_AWAY` is returned as a typed unexpected-response error. Failure to
+reconnect, write, or receive within the remaining budget is returned directly.
+
+The retry preserves the logical command's code, language, version, flags,
+remark, serialization type, typed header, extension fields, and body. It uses
+a newly allocated opaque so a late frame from the retired session cannot
+complete the replacement session's pending future. Connection-bound signing
+runs for each physical attempt, while business RPC hooks run once before the
+logical invocation and once after its final successful response. The existing
+failure contract does not run the after hook when the retry fails.
+
+## Session ownership
+
+After the first `GO_AWAY`, the producing session stops accepting new requests.
+The endpoint registry uses compare-and-remove against an exact client-local session token,
+so it cannot evict a replacement installed by concurrent work. The retired
+session drains through the client's existing lifecycle-owned worker task group;
+no detached runtime task is created. Its bounded drain window comes from the
+pending table's maximum request age, not from the triggering request's shorter
+deadline, so older in-flight requests keep their own budgets. Pending entries
+remain scoped to their physical connection owner and are released on success,
+timeout, retirement, or shutdown.
+
+Transport telemetry emits low-cardinality `go_away` lifecycle outcomes:
+`received`, `retry_success`, and `retry_failed`. It does not record bodies,
+extension-field contents, credentials, or channel-sensitive data.

--- a/rocketmq-transport/src/base/pending_request_table.rs
+++ b/rocketmq-transport/src/base/pending_request_table.rs
@@ -439,6 +439,10 @@ impl PendingRequestTable {
         }
     }
 
+    pub(crate) fn max_request_age(&self) -> Duration {
+        self.inner.max_request_age
+    }
+
     /// Returns the age of the oldest pending request for low-cardinality diagnostics.
     pub fn oldest_age(&self, now: Instant) -> Option<Duration> {
         self.inner.entries.iter().map(|entry| entry.age(now)).max()

--- a/rocketmq-transport/src/clients/client.rs
+++ b/rocketmq-transport/src/clients/client.rs
@@ -79,6 +79,7 @@ pub(crate) struct TransportSession<PR> {
     peer: PeerInfo,
     last_used_millis: Arc<AtomicU64>,
     accepting_requests: Arc<AtomicBool>,
+    registry_token: Arc<()>,
     _processor: PhantomData<fn() -> PR>,
 }
 
@@ -392,6 +393,7 @@ where
             peer: PeerInfo::new(remote_address, negotiated_tls),
             last_used_millis: Arc::new(AtomicU64::new(current_millis())),
             accepting_requests: Arc::new(AtomicBool::new(true)),
+            registry_token: Arc::new(()),
             _processor: PhantomData,
         })
     }
@@ -641,6 +643,14 @@ where
 
     pub fn remote_address(&self) -> SocketAddr {
         self.channel.remote_address()
+    }
+
+    pub(crate) fn is_same_registry_session(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.registry_token, &other.registry_token)
+    }
+
+    pub(crate) fn max_pending_request_age(&self) -> Duration {
+        self.pending_requests.max_request_age()
     }
 
     pub(crate) fn idle_for_at(&self, now_millis: u64) -> Duration {

--- a/rocketmq-transport/src/clients/rocketmq_tokio_client.rs
+++ b/rocketmq-transport/src/clients/rocketmq_tokio_client.rs
@@ -29,6 +29,7 @@ use parking_lot::RwLock;
 use rocketmq_error::NetworkError;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
+use rocketmq_error::RpcClientError;
 use rocketmq_runtime::common::time_utils::current_millis;
 use rocketmq_runtime::ChildServiceContext;
 use rocketmq_runtime::ResourcePermit;
@@ -65,15 +66,18 @@ use crate::remoting::inner::RemotingGeneralHandler;
 use crate::request_processor::default_request_processor::DefaultRequestProcessor;
 #[cfg(test)]
 use crate::runtime::config::client_config::ConnectConfig;
+use crate::runtime::config::client_config::GoAwayPolicy;
 #[cfg(test)]
 use crate::runtime::config::client_config::MaintenanceConfig;
 use crate::runtime::config::client_config::TransportClientConfig;
 use crate::runtime::processor::RequestProcessor;
 use crate::runtime::RPCHook;
 use crate::security::TransportSecurity;
+use crate::telemetry::TransportGoAwayOutcome;
 use crate::telemetry::TransportNameServerFailoverReason;
 use crate::telemetry::TransportTelemetry;
 use crate::tls::TlsConfig;
+use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 
 /// High-performance async RocketMQ client with persistent endpoint sessions and auto-reconnection.
@@ -221,6 +225,7 @@ pub struct TransportClient<PR = DefaultRequestProcessor> {
 
     telemetry: TransportTelemetry,
     frame_limits: FrameLimits,
+    go_away_policy: GoAwayPolicy,
 }
 
 /// Builds a persistent endpoint client without exposing positional optional capabilities.
@@ -232,6 +237,7 @@ pub struct TransportClientBuilder<PR> {
     transport_security: Option<Arc<TransportSecurity>>,
     telemetry: TransportTelemetry,
     frame_limits: FrameLimits,
+    go_away_policy: GoAwayPolicy,
 }
 
 impl<PR> TransportClientBuilder<PR>
@@ -260,6 +266,13 @@ where
         Ok(self)
     }
 
+    /// Applies an explicit allowlist for one bounded `GO_AWAY` reconnect retry.
+    #[must_use]
+    pub fn go_away_policy(mut self, policy: GoAwayPolicy) -> Self {
+        self.go_away_policy = policy;
+        self
+    }
+
     pub fn build(self) -> RocketMQResult<TransportClient<PR>> {
         let mut client = TransportClient::build_inner(
             self.config,
@@ -268,6 +281,7 @@ where
             self.service_context,
             self.telemetry,
             self.frame_limits,
+            self.go_away_policy,
         )?;
         if let Some(transport_security) = self.transport_security {
             client = client.with_transport_security(transport_security);
@@ -347,6 +361,13 @@ where
     pub fn frame_limits(mut self, frame_limits: FrameLimits) -> RocketMQResult<Self> {
         self.transport = self.transport.frame_limits(frame_limits)?;
         Ok(self)
+    }
+
+    /// Applies an explicit allowlist for one bounded `GO_AWAY` reconnect retry.
+    #[must_use]
+    pub fn go_away_policy(mut self, policy: GoAwayPolicy) -> Self {
+        self.transport = self.transport.go_away_policy(policy);
+        self
     }
 
     pub fn build(self) -> RocketMQResult<RemotingClient<PR>> {
@@ -506,6 +527,7 @@ impl<PR> Clone for TransportClient<PR> {
             transport_security: self.transport_security.clone(),
             telemetry: self.telemetry.clone(),
             frame_limits: self.frame_limits,
+            go_away_policy: self.go_away_policy.clone(),
         }
     }
 }
@@ -526,6 +548,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
             transport_security: None,
             telemetry: TransportTelemetry::noop(),
             frame_limits: FrameLimits::java_compatibility(),
+            go_away_policy: GoAwayPolicy::default(),
         }
     }
 
@@ -547,6 +570,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
         service_context: ChildServiceContext,
         telemetry: TransportTelemetry,
         frame_limits: FrameLimits,
+        go_away_policy: GoAwayPolicy,
     ) -> RocketMQResult<Self> {
         frame_limits.validate()?;
         let process_budget = service_context.process_budget();
@@ -582,6 +606,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
             transport_security: None,
             telemetry,
             frame_limits,
+            go_away_policy,
         })
     }
 
@@ -1434,6 +1459,46 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
 }
 
 impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
+    const MAX_GO_AWAY_ATTEMPTS: usize = 2;
+
+    fn session_cache_identity(
+        &self,
+        requested_addr: Option<&CheetahString>,
+        session: &TransportSession<PR>,
+    ) -> CheetahString {
+        requested_addr
+            .cloned()
+            .or_else(|| {
+                self.connection_tables
+                    .iter()
+                    .find(|entry| entry.value().is_same_registry_session(session))
+                    .map(|entry| entry.key().clone())
+            })
+            .or_else(|| self.namesrv_addr_choosed.read().clone())
+            .unwrap_or_else(|| CheetahString::from_string(session.remote_address().to_string()))
+    }
+
+    fn remove_cached_session_if_matches(&self, identity: &CheetahString, expected: &TransportSession<PR>) -> bool {
+        self.connection_tables
+            .remove_if(identity, |_, current| current.is_same_registry_session(expected))
+            .is_some()
+    }
+
+    fn start_go_away_drain(&self, identity: CheetahString, session: TransportSession<PR>) {
+        session.begin_drain();
+        let drain_timeout = session.max_pending_request_age();
+        let task_name = format!("rocketmq.transport.go-away-drain.{identity}");
+        let spawned = self.spawn_worker_task(task_name, async move {
+            let report = session.drain_and_close(drain_timeout).await;
+            if !report.is_healthy() {
+                warn!(report = %report.to_json(), "GO_AWAY session drain was unhealthy");
+            }
+        });
+        if spawned.is_none() {
+            warn!(%identity, "GO_AWAY session drain could not be scheduled because the client is shutting down");
+        }
+    }
+
     fn record_nameserver_outcome(&self, addr: Option<&CheetahString>, latency: Duration, success: bool) {
         let Some(addr) = addr else {
             return;
@@ -1653,9 +1718,6 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
         let target = addr.map_or_else(|| "<nameserver>".to_string(), ToString::to_string);
         deadline.ensure_before_send(target.clone())?;
 
-        // Determine target address (for metrics recording)
-        let target_addr = addr.cloned().or_else(|| self.namesrv_addr_choosed.read().clone());
-
         let mut client = self.get_and_create_client_until(addr, deadline).await?.ok_or_else(|| {
             if target == "<nameserver>" {
                 let configured_list = self.name_server_identity_list();
@@ -1673,9 +1735,8 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
                 error!("Failed to get client for {}", target);
             }
 
-            // Record connection error
             if nameserver_request {
-                if let Some(ref addr) = target_addr {
+                if let Some(addr) = self.namesrv_addr_choosed.read().as_ref() {
                     self.latency_tracker.record_error(addr);
                 }
             }
@@ -1688,34 +1749,25 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
         }
 
         let mut request = request;
-        let remote_address = client.remote_address();
-        let nameserver_metric_addr = nameserver_request.then(|| {
-            self.namesrv_addr_choosed
-                .read()
-                .clone()
-                .unwrap_or_else(|| CheetahString::from_string(remote_address.to_string()))
-        });
-        deadline.ensure_before_send(remote_address.to_string())?;
+        let initial_remote_address = client.remote_address();
+        let initial_identity = self.session_cache_identity(addr, &client);
+        let nameserver_metric_addr = nameserver_request.then(|| initial_identity.clone());
+        deadline.ensure_before_send(initial_remote_address.to_string())?;
         let hooks = self.cmd_handler.hook_snapshot();
         let request_for_after = if let Some(hooks) = hooks {
             request.make_custom_header_to_net();
             self.cmd_handler.do_before_rpc_hooks_with_snapshot(
                 Some(hooks.as_ref()),
-                remote_address,
+                initial_remote_address,
                 Some(&mut request),
             )?;
-            deadline.ensure_before_send(remote_address.to_string())?;
+            deadline.ensure_before_send(initial_remote_address.to_string())?;
             Some((request.clone(), hooks))
         } else {
             None
         };
-
-        let send_result = client.send_read(request, deadline).await;
-
-        let latency = start.elapsed();
-
-        match send_result {
-            Ok(mut response) => {
+        let apply_final_hooks =
+            |mut response: RemotingCommand, remote_address: std::net::SocketAddr| -> RocketMQResult<RemotingCommand> {
                 if let Some((request, hooks)) = request_for_after.as_ref() {
                     self.cmd_handler.do_after_rpc_hooks_with_snapshot(
                         Some(hooks.as_ref()),
@@ -1723,46 +1775,127 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
                         request,
                         Some(&mut response),
                     )?;
-                    if deadline.is_expired() {
-                        return Err(RocketMQError::network_response_timeout(
-                            remote_address.to_string(),
-                            timeout_millis,
-                        ));
-                    }
                 }
+                if deadline.is_expired() {
+                    return Err(RocketMQError::network_response_timeout(
+                        remote_address.to_string(),
+                        timeout_millis,
+                    ));
+                }
+                Ok(response)
+            };
+        let retry_allowed = self.go_away_policy.allows_request(request.code()) && !request.is_oneway_rpc();
+        let retry_request = request.clone();
+        let mut attempted_retry = false;
 
-                self.record_nameserver_outcome(nameserver_metric_addr.as_ref(), latency, true);
-                if let Some(ref addr) = target_addr {
+        for attempt in 0..Self::MAX_GO_AWAY_ATTEMPTS {
+            let remote_address = client.remote_address();
+            let identity = self.session_cache_identity(addr, &client);
+            let mut attempt_request = retry_request.clone();
+            if attempt > 0 {
+                attempt_request.set_opaque_mut(RemotingCommand::get_and_add());
+            }
+
+            match client.send_read(attempt_request, deadline).await {
+                Ok(response) if response.code() == ResponseCode::GoAway.to_i32() => {
+                    self.telemetry.record_go_away(TransportGoAwayOutcome::Received);
+                    if !retry_allowed {
+                        let response = apply_final_hooks(response, remote_address)?;
+                        let latency = start.elapsed();
+                        self.record_nameserver_outcome(nameserver_metric_addr.as_ref(), latency, true);
+                        debug!(
+                            remote_addr = %identity,
+                            elapsed_ms = latency.as_millis() as u64,
+                            "request completed with GO_AWAY retry disabled"
+                        );
+                        return Ok(response);
+                    }
+                    self.remove_cached_session_if_matches(&identity, &client);
+                    self.start_go_away_drain(identity.clone(), client);
+
+                    if attempt + 1 == Self::MAX_GO_AWAY_ATTEMPTS {
+                        self.telemetry.record_go_away(TransportGoAwayOutcome::RetryFailed);
+                        self.record_nameserver_outcome(nameserver_metric_addr.as_ref(), start.elapsed(), false);
+                        return Err(RpcClientError::unexpected_response_code(
+                            response.code(),
+                            "GO_AWAY after replacement-connection retry",
+                        )
+                        .into());
+                    }
+
+                    attempted_retry = true;
+                    if let Err(error) = deadline.ensure_before_send(identity.to_string()) {
+                        self.telemetry.record_go_away(TransportGoAwayOutcome::RetryFailed);
+                        self.record_nameserver_outcome(nameserver_metric_addr.as_ref(), start.elapsed(), false);
+                        return Err(error);
+                    }
+                    let replacement = match self.get_and_create_client_until(addr, deadline).await {
+                        Ok(Some(replacement)) => Ok(replacement),
+                        Ok(None) => Err(RocketMQError::network_connection_failed(
+                            identity.to_string(),
+                            "GO_AWAY replacement connection unavailable",
+                        )),
+                        Err(error) => Err(error),
+                    };
+                    client = match replacement {
+                        Ok(replacement) => replacement,
+                        Err(error) => {
+                            self.telemetry.record_go_away(TransportGoAwayOutcome::RetryFailed);
+                            self.record_nameserver_outcome(nameserver_metric_addr.as_ref(), start.elapsed(), false);
+                            return Err(error);
+                        }
+                    };
+                }
+                Ok(response) => {
+                    let response = match apply_final_hooks(response, remote_address) {
+                        Ok(response) => response,
+                        Err(error) => {
+                            if attempted_retry {
+                                self.telemetry.record_go_away(TransportGoAwayOutcome::RetryFailed);
+                            }
+                            self.record_nameserver_outcome(nameserver_metric_addr.as_ref(), start.elapsed(), false);
+                            return Err(error);
+                        }
+                    };
+                    if attempted_retry {
+                        self.telemetry.record_go_away(TransportGoAwayOutcome::RetrySuccess);
+                    }
+                    let latency = start.elapsed();
+                    self.record_nameserver_outcome(nameserver_metric_addr.as_ref(), latency, true);
                     debug!(
-                        remote_addr = %addr,
+                        remote_addr = %identity,
                         elapsed_ms = latency.as_millis() as u64,
                         "request completed"
                     );
+                    return Ok(response);
                 }
-                Ok(response)
-            }
-            Err(err) => {
-                if matches!(
-                    err,
-                    RocketMQError::Network(NetworkError::WriteTimeout { .. } | NetworkError::ResponseTimeout { .. })
-                ) {
-                    client.retire_after_timeout().await;
-                    if let Some(ref addr) = target_addr {
-                        self.connection_tables.remove(addr);
+                Err(error) => {
+                    if matches!(
+                        error,
+                        RocketMQError::Network(
+                            NetworkError::WriteTimeout { .. } | NetworkError::ResponseTimeout { .. }
+                        )
+                    ) {
+                        client.retire_after_timeout().await;
+                        self.remove_cached_session_if_matches(&identity, &client);
                     }
-                }
-                self.record_nameserver_outcome(nameserver_metric_addr.as_ref(), latency, false);
-                if let Some(ref addr) = target_addr {
+                    if attempted_retry {
+                        self.telemetry.record_go_away(TransportGoAwayOutcome::RetryFailed);
+                    }
+                    let latency = start.elapsed();
+                    self.record_nameserver_outcome(nameserver_metric_addr.as_ref(), latency, false);
                     warn!(
-                        remote_addr = %addr,
+                        remote_addr = %identity,
                         elapsed_ms = latency.as_millis() as u64,
-                        error = ?err,
+                        error = ?error,
                         "request failed"
                     );
+                    return Err(error);
                 }
-                Err(err)
             }
         }
+
+        unreachable!("GO_AWAY attempt loop has a fixed non-zero bound")
     }
 
     pub async fn invoke_request_oneway_with_deadline(
@@ -2194,6 +2327,54 @@ mod tests {
 
         server.await.expect("server task");
         client.shutdown();
+    }
+
+    #[tokio::test]
+    async fn registry_token_distinguishes_replacements_and_same_port_nameserver_identities() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
+        let addr = listener.local_addr().expect("listener addr");
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (first, _) = listener.accept().await.expect("accept first client");
+            let (second, _) = listener.accept().await.expect("accept replacement client");
+            let _connections = (first, second);
+            let _ = release_rx.await;
+        });
+
+        let client = TransportClient::build_for_test(
+            Arc::new(TransportClientConfig::default()),
+            DefaultRequestProcessor,
+            test_service_context("remoting-client-registry-token-test"),
+        );
+        let target = CheetahString::from_string(addr.to_string());
+        let first = client
+            .create_client(&target, Duration::from_secs(1))
+            .await
+            .expect("first client");
+        client.connection_tables.remove(&target);
+        let replacement = client
+            .create_client(&target, Duration::from_secs(1))
+            .await
+            .expect("replacement client");
+        client.connection_tables.remove(&target);
+
+        let first_identity = CheetahString::from_static_str("nameserver-a:9876");
+        let replacement_identity = CheetahString::from_static_str("nameserver-b:9876");
+        client.connection_tables.insert(first_identity.clone(), first.clone());
+        client
+            .connection_tables
+            .insert(replacement_identity.clone(), replacement.clone());
+
+        assert_eq!(client.session_cache_identity(None, &first), first_identity);
+        assert_eq!(client.session_cache_identity(None, &replacement), replacement_identity);
+        assert!(!client.remove_cached_session_if_matches(&replacement_identity, &first));
+        assert!(client.connection_tables.contains_key(&replacement_identity));
+        assert!(client.remove_cached_session_if_matches(&first_identity, &first));
+        assert!(client.connection_tables.contains_key(&replacement_identity));
+
+        client.shutdown();
+        let _ = release_tx.send(());
+        server.await.expect("server task");
     }
 
     #[tokio::test]

--- a/rocketmq-transport/src/public_api.rs
+++ b/rocketmq-transport/src/public_api.rs
@@ -96,6 +96,7 @@ pub use crate::rpc::rpc_request_header::RpcRequestHeader;
 pub use crate::rpc::rpc_response::RpcResponse;
 pub use crate::rpc::topic_request_header::TopicRequestHeader;
 pub use crate::runtime::config::client_config::ConnectConfig;
+pub use crate::runtime::config::client_config::GoAwayPolicy;
 pub use crate::runtime::config::client_config::MaintenanceConfig;
 pub use crate::runtime::config::client_config::TransportClientConfig;
 pub use crate::runtime::connection_handler_context::ConnectionHandlerContext;

--- a/rocketmq-transport/src/runtime/config/client_config.rs
+++ b/rocketmq-transport/src/runtime/config/client_config.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::env;
+use std::sync::Arc;
 use std::time::Duration;
 
 use crate::config::TlsConfig;
@@ -50,6 +51,62 @@ impl Default for MaintenanceConfig {
     }
 }
 
+/// Controls whether a response-aware request may reconnect after `GO_AWAY`.
+///
+/// The retryable request codes are an explicit allowlist. This keeps the
+/// default behavior unchanged and prevents side-effecting requests from being
+/// repeated unless their owner deliberately opts them in.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GoAwayPolicy {
+    enabled: bool,
+    retryable_request_codes: Arc<[i32]>,
+}
+
+impl GoAwayPolicy {
+    /// Preserves the historical single-attempt behavior.
+    #[must_use]
+    pub fn disabled() -> Self {
+        Self {
+            enabled: false,
+            retryable_request_codes: Arc::from([]),
+        }
+    }
+
+    /// Enables one replacement-connection retry for the supplied request codes.
+    #[must_use]
+    pub fn enabled_for_request_codes(request_codes: impl IntoIterator<Item = i32>) -> Self {
+        let mut request_codes = request_codes.into_iter().collect::<Vec<_>>();
+        request_codes.sort_unstable();
+        request_codes.dedup();
+        Self {
+            enabled: true,
+            retryable_request_codes: request_codes.into(),
+        }
+    }
+
+    /// Returns whether response-aware retries are enabled.
+    #[must_use]
+    pub const fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Returns the sorted, duplicate-free request-code allowlist.
+    #[must_use]
+    pub fn retryable_request_codes(&self) -> &[i32] {
+        &self.retryable_request_codes
+    }
+
+    pub(crate) fn allows_request(&self, request_code: i32) -> bool {
+        self.enabled && self.retryable_request_codes.binary_search(&request_code).is_ok()
+    }
+}
+
+impl Default for GoAwayPolicy {
+    fn default() -> Self {
+        Self::disabled()
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct TransportClientConfig {
     pub connect: ConnectConfig,
@@ -67,5 +124,18 @@ mod tests {
 
         assert!(!config.connect.timeout.is_zero());
         assert_eq!(config.maintenance.idle_scan_interval, Some(Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn go_away_policy_is_disabled_and_deduplicates_explicit_codes() {
+        let disabled = GoAwayPolicy::default();
+        assert!(!disabled.is_enabled());
+        assert!(!disabled.allows_request(105));
+
+        let enabled = GoAwayPolicy::enabled_for_request_codes([105, 10, 105]);
+        assert!(enabled.is_enabled());
+        assert_eq!(enabled.retryable_request_codes(), &[10, 105]);
+        assert!(enabled.allows_request(105));
+        assert!(!enabled.allows_request(106));
     }
 }

--- a/rocketmq-transport/src/telemetry.rs
+++ b/rocketmq-transport/src/telemetry.rs
@@ -142,6 +142,11 @@ impl TransportTelemetry {
     }
 
     #[inline]
+    pub(crate) fn record_go_away(&self, outcome: TransportGoAwayOutcome) {
+        self.record_lifecycle_event("go_away", outcome.as_str());
+    }
+
+    #[inline]
     pub(crate) fn request_guard(
         &self,
         request_code: i32,
@@ -174,6 +179,23 @@ pub(crate) enum TransportNameServerFailoverReason {
     Unhealthy,
     CircuitOpen,
     Draining,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum TransportGoAwayOutcome {
+    Received,
+    RetrySuccess,
+    RetryFailed,
+}
+
+impl TransportGoAwayOutcome {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Received => "received",
+            Self::RetrySuccess => "retry_success",
+            Self::RetryFailed => "retry_failed",
+        }
+    }
 }
 
 pub(crate) struct TransportRequestMetricsGuard {
@@ -224,6 +246,7 @@ impl TransportRequestMetricsGuard {
 
 #[cfg(test)]
 mod tests {
+    use super::TransportGoAwayOutcome;
     use super::TransportNameServerFailoverReason;
     use super::TransportTelemetry;
 
@@ -236,6 +259,7 @@ mod tests {
         telemetry.record_lifecycle_event("connected", "queued");
         telemetry.record_lifecycle_listener_latency(std::time::Duration::from_millis(1), "connected");
         telemetry.record_nameserver_failover(TransportNameServerFailoverReason::ConnectFailure);
+        telemetry.record_go_away(TransportGoAwayOutcome::Received);
         assert!(telemetry.request_span(10, 1).is_disabled());
         let mut guard = telemetry.request_guard(10, 64, false);
         guard.complete_response(0);

--- a/rocketmq-transport/tests/go_away_reconnect.rs
+++ b/rocketmq-transport/tests/go_away_reconnect.rs
@@ -1,0 +1,832 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(feature = "test-support")]
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use cheetah_string::CheetahString;
+use rocketmq_error::RocketMQResult;
+use rocketmq_protocol::code::request_code::RequestCode;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::command_custom_header::CommandCustomHeader;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::LanguageCode;
+use rocketmq_protocol::protocol::SerializeType;
+use rocketmq_runtime::RuntimeContext;
+use rocketmq_security_api::OutboundSigner;
+use rocketmq_security_api::Secret;
+use rocketmq_security_api::SecurityRequestView;
+use rocketmq_security_api::Signature;
+use rocketmq_security_api::SigningError;
+use rocketmq_transport::api::v1::AdmissionController;
+use rocketmq_transport::api::v1::AdmissionLimits;
+use rocketmq_transport::api::v1::DefaultRequestProcessor;
+use rocketmq_transport::api::v1::GoAwayPolicy;
+use rocketmq_transport::api::v1::RPCHook;
+use rocketmq_transport::api::v1::RequestDeadline;
+use rocketmq_transport::api::v1::TlsClientConfig;
+use rocketmq_transport::api::v1::TlsConfig;
+use rocketmq_transport::api::v1::TlsMode;
+use rocketmq_transport::api::v1::TlsServerRuntime;
+use rocketmq_transport::api::v1::TransportClient;
+use rocketmq_transport::api::v1::TransportClientConfig;
+use rocketmq_transport::api::v1::TransportSecurity;
+use rocketmq_transport::test_support::ConnectionHandler;
+use rocketmq_transport::test_support::SessionHandle;
+use rocketmq_transport::test_support::TransportListener;
+
+#[derive(Clone, Copy)]
+struct Reply {
+    code: i32,
+    delay: Duration,
+    body: &'static [u8],
+    late_success: Option<(usize, &'static [u8])>,
+}
+
+impl Reply {
+    const fn immediate(code: i32, body: &'static [u8]) -> Self {
+        Self {
+            code,
+            delay: Duration::ZERO,
+            body,
+            late_success: None,
+        }
+    }
+
+    const fn delayed(code: i32, delay: Duration, body: &'static [u8]) -> Self {
+        Self {
+            code,
+            delay,
+            body,
+            late_success: None,
+        }
+    }
+
+    const fn with_late_success_after_calls(mut self, expected_calls: usize, body: &'static [u8]) -> Self {
+        self.late_success = Some((expected_calls, body));
+        self
+    }
+}
+
+struct ScriptedHandler {
+    replies: Vec<Reply>,
+    calls: AtomicUsize,
+    completed: AtomicUsize,
+    observed: Mutex<Vec<(u64, RemotingCommand)>>,
+    changed: tokio::sync::Notify,
+    completion_changed: tokio::sync::Notify,
+    first_entered: Option<Arc<tokio::sync::Notify>>,
+    first_release: Option<Arc<tokio::sync::Notify>>,
+}
+
+impl ScriptedHandler {
+    fn new(replies: Vec<Reply>) -> Self {
+        Self {
+            replies,
+            calls: AtomicUsize::new(0),
+            completed: AtomicUsize::new(0),
+            observed: Mutex::new(Vec::new()),
+            changed: tokio::sync::Notify::new(),
+            completion_changed: tokio::sync::Notify::new(),
+            first_entered: None,
+            first_release: None,
+        }
+    }
+
+    fn gated_first(
+        replies: Vec<Reply>,
+        first_entered: Arc<tokio::sync::Notify>,
+        first_release: Arc<tokio::sync::Notify>,
+    ) -> Self {
+        Self {
+            replies,
+            calls: AtomicUsize::new(0),
+            completed: AtomicUsize::new(0),
+            observed: Mutex::new(Vec::new()),
+            changed: tokio::sync::Notify::new(),
+            completion_changed: tokio::sync::Notify::new(),
+            first_entered: Some(first_entered),
+            first_release: Some(first_release),
+        }
+    }
+
+    async fn wait_for_calls(&self, expected: usize) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let changed = self.changed.notified();
+                tokio::pin!(changed);
+                changed.as_mut().enable();
+                if self.calls.load(Ordering::SeqCst) >= expected {
+                    return;
+                }
+                changed.await;
+            }
+        })
+        .await
+        .expect("scripted server did not receive the expected requests");
+    }
+
+    async fn wait_for_completions(&self, expected: usize) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let changed = self.completion_changed.notified();
+                tokio::pin!(changed);
+                changed.as_mut().enable();
+                if self.completed.load(Ordering::SeqCst) >= expected {
+                    return;
+                }
+                changed.await;
+            }
+        })
+        .await
+        .expect("scripted server did not complete the expected responses");
+    }
+
+    fn observations(&self) -> Vec<(u64, RemotingCommand)> {
+        self.observed.lock().expect("observation lock").clone()
+    }
+}
+
+impl ConnectionHandler for ScriptedHandler {
+    fn connected(&self, _session: SessionHandle) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async {})
+    }
+
+    fn command(
+        &self,
+        session: SessionHandle,
+        command: RemotingCommand,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async move {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst);
+            self.observed
+                .lock()
+                .expect("observation lock")
+                .push((session.session_id(), command.clone()));
+            self.changed.notify_waiters();
+            if call == 0 {
+                if let Some(first_entered) = &self.first_entered {
+                    first_entered.notify_one();
+                }
+                if let Some(first_release) = &self.first_release {
+                    first_release.notified().await;
+                }
+            }
+            let reply = self
+                .replies
+                .get(call)
+                .copied()
+                .unwrap_or_else(|| Reply::immediate(ResponseCode::SystemError.to_i32(), b"unexpected"));
+            if !reply.delay.is_zero() {
+                tokio::time::sleep(reply.delay).await;
+            }
+            let mut connection = session.connection();
+            let _ = connection
+                .send_command(
+                    RemotingCommand::create_response_command_with_code(reply.code)
+                        .set_opaque(command.opaque())
+                        .set_body(reply.body),
+                )
+                .await;
+            if let Some((expected_calls, late_body)) = reply.late_success {
+                self.wait_for_calls(expected_calls).await;
+                let _ = connection
+                    .send_command(
+                        RemotingCommand::create_response_command_with_code(ResponseCode::Success)
+                            .set_opaque(command.opaque())
+                            .set_body(late_body),
+                    )
+                    .await;
+            }
+            self.completed.fetch_add(1, Ordering::SeqCst);
+            self.completion_changed.notify_waiters();
+        })
+    }
+}
+
+#[derive(Default)]
+struct CountingHook {
+    before: AtomicUsize,
+    after: AtomicUsize,
+}
+
+struct RetryHeader;
+
+impl CommandCustomHeader for RetryHeader {
+    fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
+        Some(HashMap::from([(
+            CheetahString::from_static_str("typedRetryHeader"),
+            CheetahString::from_static_str("preserved"),
+        )]))
+    }
+}
+
+impl RPCHook for CountingHook {
+    fn do_before_request(&self, _remote_addr: SocketAddr, request: &mut RemotingCommand) -> RocketMQResult<()> {
+        self.before.fetch_add(1, Ordering::SeqCst);
+        request.ensure_ext_fields_initialized();
+        request.add_ext_field("hooked", "true");
+        Ok(())
+    }
+
+    fn do_after_response(
+        &self,
+        _remote_addr: SocketAddr,
+        _request: &RemotingCommand,
+        response: &mut RemotingCommand,
+    ) -> RocketMQResult<()> {
+        self.after.fetch_add(1, Ordering::SeqCst);
+        response.ensure_ext_fields_initialized();
+        response.add_ext_field("afterHook", "true");
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct CountingSigner {
+    calls: AtomicUsize,
+}
+
+impl OutboundSigner for CountingSigner {
+    fn sign(&self, _request: SecurityRequestView<'_>) -> Result<Signature, SigningError> {
+        let call = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
+        Ok(Signature::new(vec![(
+            CheetahString::from_static_str("connectionSignature"),
+            Secret::new(CheetahString::from_string(call.to_string())),
+        )]))
+    }
+}
+
+async fn start_server<H>(runtime: &RuntimeContext, name: &'static str, handler: Arc<H>, tls_enabled: bool) -> SocketAddr
+where
+    H: ConnectionHandler,
+{
+    let service = runtime.service_context(name);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind scripted server");
+    let address = listener.local_addr().expect("scripted server address");
+    let mut tls = TlsConfig::default();
+    if tls_enabled {
+        tls.test_mode_enable = true;
+        tls.server.mode = TlsMode::Permissive;
+    } else {
+        tls.server.mode = TlsMode::Disabled;
+    }
+    let transport = TransportListener::new(
+        listener,
+        service.task_group().clone(),
+        TlsServerRuntime::initialize_with_service_context(tls, &service)
+            .await
+            .expect("initialize scripted server TLS"),
+        Arc::new(AdmissionController::new(AdmissionLimits::default())),
+        Duration::from_secs(1),
+    );
+    service
+        .spawn_service("go-away-scripted-listener", async move {
+            let _ = transport.run(handler).await;
+        })
+        .expect("spawn scripted listener");
+    address
+}
+
+async fn start_client(
+    runtime: &RuntimeContext,
+    name: &'static str,
+    policy: Option<GoAwayPolicy>,
+    tls_enabled: bool,
+) -> Arc<TransportClient> {
+    start_client_with_security(runtime, name, policy, tls_enabled, None).await
+}
+
+async fn start_client_with_security(
+    runtime: &RuntimeContext,
+    name: &'static str,
+    policy: Option<GoAwayPolicy>,
+    tls_enabled: bool,
+    transport_security: Option<Arc<TransportSecurity>>,
+) -> Arc<TransportClient> {
+    let mut tls = TlsConfig::default();
+    if tls_enabled {
+        tls.enable = true;
+        tls.test_mode_enable = true;
+        tls.client = TlsClientConfig {
+            auth_server: false,
+            ..TlsClientConfig::default()
+        };
+    }
+    let config = Arc::new(TransportClientConfig {
+        tls,
+        ..TransportClientConfig::default()
+    });
+    let mut builder = TransportClient::builder(config, DefaultRequestProcessor, runtime.service_context(name));
+    if let Some(policy) = policy {
+        builder = builder.go_away_policy(policy);
+    }
+    if let Some(transport_security) = transport_security {
+        builder = builder.transport_security(transport_security);
+    }
+    let client = Arc::new(builder.build().expect("build persistent client"));
+    client.start().await.expect("start persistent client");
+    client
+}
+
+fn retry_safe_reads() -> GoAwayPolicy {
+    GoAwayPolicy::enabled_for_request_codes([RequestCode::GetBrokerClusterInfo.to_i32()])
+}
+
+async fn shutdown(runtime: RuntimeContext, clients: &[Arc<TransportClient>]) {
+    for client in clients {
+        client.shutdown();
+    }
+    let report = runtime.shutdown_tasks(Duration::from_secs(2)).await;
+    report.assert_no_task_leak().expect("GO_AWAY lifecycle tasks");
+}
+
+#[tokio::test]
+async fn go_away_retries_once_on_a_replacement_connection() {
+    let runtime = RuntimeContext::from_current("go-away-replacement-test");
+    let handler = Arc::new(ScriptedHandler::new(vec![
+        Reply::immediate(ResponseCode::GoAway.to_i32(), b"retire")
+            .with_late_success_after_calls(2, b"late-old-session"),
+        Reply::immediate(ResponseCode::Success.to_i32(), b"replacement"),
+    ]));
+    let address = start_server(&runtime, "go-away-replacement-server", handler.clone(), false).await;
+    let signer = Arc::new(CountingSigner::default());
+    let client = start_client_with_security(
+        &runtime,
+        "go-away-replacement-client",
+        Some(retry_safe_reads()),
+        false,
+        Some(Arc::new(TransportSecurity::development_insecure_loopback(
+            None,
+            Some(signer.clone()),
+        ))),
+    )
+    .await;
+    let hook = Arc::new(CountingHook::default());
+    client.register_rpc_hook(hook.clone());
+    let target = CheetahString::from_string(address.to_string());
+    let mut request = RemotingCommand::create_request_command(RequestCode::GetBrokerClusterInfo, RetryHeader)
+        .set_body("payload")
+        .set_language(LanguageCode::GO)
+        .set_version(412)
+        .set_remark("logical-request")
+        .set_serialize_type(SerializeType::ROCKETMQ);
+    request.ensure_ext_fields_initialized();
+    request.add_ext_field("original", "value");
+
+    let response = client
+        .invoke_request_with_deadline(Some(&target), request, RequestDeadline::after(Duration::from_secs(2)))
+        .await
+        .expect("GO_AWAY retry should succeed");
+
+    assert_eq!(response.code(), ResponseCode::Success.to_i32());
+    assert_eq!(response.body().map(|body| body.as_ref()), Some(b"replacement".as_ref()));
+    assert_eq!(
+        response
+            .ext_fields()
+            .and_then(|fields| fields.get("afterHook"))
+            .map(CheetahString::as_str),
+        Some("true")
+    );
+    let observed = handler.observations();
+    assert_eq!(observed.len(), 2);
+    assert_ne!(observed[0].0, observed[1].0, "retry must use a replacement session");
+    assert_ne!(observed[0].1.opaque(), observed[1].1.opaque());
+    assert_eq!(observed[0].1.code(), observed[1].1.code());
+    assert_eq!(observed[0].1.language(), observed[1].1.language());
+    assert_eq!(observed[0].1.version(), observed[1].1.version());
+    assert_eq!(observed[0].1.serialize_type(), observed[1].1.serialize_type());
+    assert_eq!(observed[0].1.flag(), observed[1].1.flag());
+    assert_eq!(observed[0].1.body(), observed[1].1.body());
+    assert_eq!(observed[0].1.remark(), observed[1].1.remark());
+    for (_, request) in &observed {
+        assert_eq!(
+            request
+                .ext_fields()
+                .and_then(|fields| fields.get("original"))
+                .map(CheetahString::as_str),
+            Some("value")
+        );
+        assert_eq!(
+            request
+                .ext_fields()
+                .and_then(|fields| fields.get("hooked"))
+                .map(CheetahString::as_str),
+            Some("true")
+        );
+        assert_eq!(
+            request
+                .ext_fields()
+                .and_then(|fields| fields.get("typedRetryHeader"))
+                .map(CheetahString::as_str),
+            Some("preserved")
+        );
+    }
+    assert_eq!(hook.before.load(Ordering::SeqCst), 1);
+    assert_eq!(hook.after.load(Ordering::SeqCst), 1);
+    assert_eq!(signer.calls.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        observed[0]
+            .1
+            .ext_fields()
+            .and_then(|fields| fields.get("connectionSignature"))
+            .map(CheetahString::as_str),
+        Some("1")
+    );
+    assert_eq!(
+        observed[1]
+            .1
+            .ext_fields()
+            .and_then(|fields| fields.get("connectionSignature"))
+            .map(CheetahString::as_str),
+        Some("2")
+    );
+    assert_eq!(client.snapshot().pending.count, 0);
+    assert_eq!(client.snapshot().connection_count, 1);
+
+    shutdown(runtime, &[client]).await;
+}
+
+#[tokio::test]
+async fn nameserver_routing_retires_the_actual_selected_endpoint() {
+    let runtime = RuntimeContext::from_current("go-away-nameserver-routing-test");
+    let handler = Arc::new(ScriptedHandler::new(vec![
+        Reply::immediate(ResponseCode::GoAway.to_i32(), b"retire"),
+        Reply::immediate(ResponseCode::Success.to_i32(), b"replacement"),
+    ]));
+    let address = start_server(&runtime, "go-away-nameserver-routing-server", handler.clone(), false).await;
+    let client = start_client(
+        &runtime,
+        "go-away-nameserver-routing-client",
+        Some(retry_safe_reads()),
+        false,
+    )
+    .await;
+    let identity = CheetahString::from_string(address.to_string());
+    client.update_name_server_address_list(vec![identity]).await;
+
+    let response = client
+        .invoke_request_with_deadline(
+            None,
+            RemotingCommand::create_remoting_command(RequestCode::GetBrokerClusterInfo),
+            RequestDeadline::after(Duration::from_secs(2)),
+        )
+        .await
+        .expect("NameServer GO_AWAY retry");
+
+    assert_eq!(response.code(), ResponseCode::Success.to_i32());
+    let observed = handler.observations();
+    assert_eq!(observed.len(), 2);
+    assert_ne!(observed[0].0, observed[1].0);
+    assert_eq!(client.snapshot().connection_count, 1);
+    assert_eq!(client.snapshot().pending.count, 0);
+
+    shutdown(runtime, &[client]).await;
+}
+
+#[tokio::test]
+async fn a_second_go_away_fails_without_an_unbounded_retry() {
+    let runtime = RuntimeContext::from_current("go-away-bound-test");
+    let handler = Arc::new(ScriptedHandler::new(vec![
+        Reply::immediate(ResponseCode::GoAway.to_i32(), b"first"),
+        Reply::immediate(ResponseCode::GoAway.to_i32(), b"second"),
+    ]));
+    let address = start_server(&runtime, "go-away-bound-server", handler.clone(), false).await;
+    let client = start_client(&runtime, "go-away-bound-client", Some(retry_safe_reads()), false).await;
+    let hook = Arc::new(CountingHook::default());
+    client.register_rpc_hook(hook.clone());
+    let target = CheetahString::from_string(address.to_string());
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(2),
+        client.invoke_request_with_deadline(
+            Some(&target),
+            RemotingCommand::create_remoting_command(RequestCode::GetBrokerClusterInfo),
+            RequestDeadline::after(Duration::from_secs(1)),
+        ),
+    )
+    .await
+    .expect("bounded retry must complete");
+    let error = match result {
+        Ok(_) => panic!("second GO_AWAY must be an error"),
+        Err(error) => error,
+    };
+
+    assert!(error.to_string().contains("GO_AWAY"), "{error}");
+    assert_eq!(handler.calls.load(Ordering::SeqCst), 2);
+    assert_eq!(hook.before.load(Ordering::SeqCst), 1);
+    assert_eq!(hook.after.load(Ordering::SeqCst), 0);
+    assert_eq!(client.snapshot().pending.count, 0);
+    assert_eq!(client.snapshot().connection_count, 0);
+
+    shutdown(runtime, &[client]).await;
+}
+
+#[tokio::test]
+async fn disabled_and_non_allowlisted_requests_preserve_single_attempt_behavior() {
+    let runtime = RuntimeContext::from_current("go-away-policy-test");
+    let handler = Arc::new(ScriptedHandler::new(vec![
+        Reply::immediate(ResponseCode::GoAway.to_i32(), b"disabled"),
+        Reply::immediate(ResponseCode::GoAway.to_i32(), b"side-effect"),
+    ]));
+    let address = start_server(&runtime, "go-away-policy-server", handler.clone(), false).await;
+    let target = CheetahString::from_string(address.to_string());
+    let disabled = start_client(&runtime, "go-away-disabled-client", None, false).await;
+    let allowlisted = start_client(&runtime, "go-away-allowlisted-client", Some(retry_safe_reads()), false).await;
+
+    let disabled_response = disabled
+        .invoke_request(
+            Some(&target),
+            RemotingCommand::create_remoting_command(RequestCode::GetBrokerClusterInfo),
+            1_000,
+        )
+        .await
+        .expect("disabled policy preserves the response");
+    let side_effect_response = allowlisted
+        .invoke_request(
+            Some(&target),
+            RemotingCommand::create_remoting_command(RequestCode::SendMessage),
+            1_000,
+        )
+        .await
+        .expect("non-allowlisted request preserves the response");
+
+    assert_eq!(disabled_response.code(), ResponseCode::GoAway.to_i32());
+    assert_eq!(side_effect_response.code(), ResponseCode::GoAway.to_i32());
+    assert_eq!(handler.calls.load(Ordering::SeqCst), 2);
+
+    shutdown(runtime, &[disabled, allowlisted]).await;
+}
+
+#[tokio::test]
+async fn retry_uses_only_the_original_deadline_budget() {
+    let runtime = RuntimeContext::from_current("go-away-deadline-test");
+    let handler = Arc::new(ScriptedHandler::new(vec![
+        Reply::delayed(ResponseCode::GoAway.to_i32(), Duration::from_millis(100), b"retire"),
+        Reply::delayed(ResponseCode::Success.to_i32(), Duration::from_millis(150), b"too-late"),
+    ]));
+    let address = start_server(&runtime, "go-away-deadline-server", handler.clone(), false).await;
+    let client = start_client(&runtime, "go-away-deadline-client", Some(retry_safe_reads()), false).await;
+    let target = CheetahString::from_string(address.to_string());
+
+    let result = tokio::time::timeout(
+        Duration::from_millis(220),
+        client.invoke_request_with_deadline(
+            Some(&target),
+            RemotingCommand::create_remoting_command(RequestCode::GetBrokerClusterInfo),
+            RequestDeadline::after(Duration::from_millis(180)),
+        ),
+    )
+    .await;
+
+    assert!(matches!(result, Ok(Err(_))), "the immutable request deadline must win");
+    handler.wait_for_calls(2).await;
+    assert_eq!(client.snapshot().pending.count, 0);
+
+    shutdown(runtime, &[client]).await;
+}
+
+#[tokio::test]
+async fn an_exhausted_deadline_never_writes_a_second_attempt() {
+    let runtime = RuntimeContext::from_current("go-away-exhausted-deadline-test");
+    let handler = Arc::new(ScriptedHandler::new(vec![Reply::delayed(
+        ResponseCode::GoAway.to_i32(),
+        Duration::from_millis(80),
+        b"too-late",
+    )]));
+    let address = start_server(&runtime, "go-away-exhausted-deadline-server", handler.clone(), false).await;
+    let client = start_client(
+        &runtime,
+        "go-away-exhausted-deadline-client",
+        Some(retry_safe_reads()),
+        false,
+    )
+    .await;
+    let target = CheetahString::from_string(address.to_string());
+
+    let result = client
+        .invoke_request_with_deadline(
+            Some(&target),
+            RemotingCommand::create_remoting_command(RequestCode::GetBrokerClusterInfo),
+            RequestDeadline::after(Duration::from_millis(30)),
+        )
+        .await;
+
+    assert!(result.is_err());
+    handler.wait_for_completions(1).await;
+    assert_eq!(handler.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(client.snapshot().pending.count, 0);
+
+    shutdown(runtime, &[client]).await;
+}
+
+#[tokio::test]
+async fn retiring_the_old_session_does_not_remove_a_concurrent_replacement() {
+    let runtime = RuntimeContext::from_current("go-away-cache-race-test");
+    let first_entered = Arc::new(tokio::sync::Notify::new());
+    let first_release = Arc::new(tokio::sync::Notify::new());
+    let handler = Arc::new(ScriptedHandler::gated_first(
+        vec![
+            Reply::immediate(ResponseCode::GoAway.to_i32(), b"retire"),
+            Reply::immediate(ResponseCode::Success.to_i32(), b"concurrent"),
+            Reply::immediate(ResponseCode::Success.to_i32(), b"replacement"),
+        ],
+        first_entered.clone(),
+        first_release.clone(),
+    ));
+    let address = start_server(&runtime, "go-away-cache-race-server", handler.clone(), false).await;
+    let client = start_client(&runtime, "go-away-cache-race-client", Some(retry_safe_reads()), false).await;
+    let target = CheetahString::from_string(address.to_string());
+
+    let primary_client = client.clone();
+    let primary_target = target.clone();
+    let primary = tokio::spawn(async move {
+        primary_client
+            .invoke_request_with_deadline(
+                Some(&primary_target),
+                RemotingCommand::create_remoting_command(RequestCode::GetBrokerClusterInfo),
+                RequestDeadline::after(Duration::from_secs(2)),
+            )
+            .await
+    });
+    tokio::time::timeout(Duration::from_secs(1), first_entered.notified())
+        .await
+        .expect("first request should reach the old session");
+
+    let concurrent_client = client.clone();
+    let concurrent_target = target.clone();
+    let concurrent = tokio::spawn(async move {
+        concurrent_client
+            .invoke_request_with_deadline(
+                Some(&concurrent_target),
+                RemotingCommand::create_remoting_command(RequestCode::GetBrokerClusterInfo),
+                RequestDeadline::after(Duration::from_secs(2)),
+            )
+            .await
+    });
+    handler.wait_for_calls(2).await;
+    first_release.notify_one();
+
+    let primary_response = primary.await.expect("primary task").expect("primary response");
+    let concurrent_response = concurrent.await.expect("concurrent task").expect("concurrent response");
+    assert_eq!(primary_response.code(), ResponseCode::Success.to_i32());
+    assert_eq!(concurrent_response.code(), ResponseCode::Success.to_i32());
+    let observed = handler.observations();
+    assert_eq!(observed.len(), 3);
+    assert_eq!(
+        observed[0].0, observed[1].0,
+        "concurrent work started on the old session"
+    );
+    assert_ne!(observed[0].0, observed[2].0, "retry must install a replacement session");
+    assert_eq!(client.snapshot().pending.count, 0);
+    assert_eq!(client.snapshot().connection_count, 1);
+
+    shutdown(runtime, &[client]).await;
+}
+
+#[tokio::test]
+async fn a_short_go_away_request_does_not_truncate_an_older_pending_deadline() {
+    let runtime = RuntimeContext::from_current("go-away-independent-drain-deadline-test");
+    let handler = Arc::new(ScriptedHandler::new(vec![
+        Reply::delayed(
+            ResponseCode::Success.to_i32(),
+            Duration::from_millis(700),
+            b"older-long-request",
+        ),
+        Reply::immediate(ResponseCode::GoAway.to_i32(), b"retire"),
+        Reply::immediate(ResponseCode::Success.to_i32(), b"replacement"),
+    ]));
+    let address = start_server(
+        &runtime,
+        "go-away-independent-drain-deadline-server",
+        handler.clone(),
+        false,
+    )
+    .await;
+    let client = start_client(
+        &runtime,
+        "go-away-independent-drain-deadline-client",
+        Some(retry_safe_reads()),
+        false,
+    )
+    .await;
+    let target = CheetahString::from_string(address.to_string());
+
+    let older_client = client.clone();
+    let older_target = target.clone();
+    let older = tokio::spawn(async move {
+        older_client
+            .invoke_request_with_deadline(
+                Some(&older_target),
+                RemotingCommand::create_remoting_command(RequestCode::GetBrokerClusterInfo),
+                RequestDeadline::after(Duration::from_secs(2)),
+            )
+            .await
+    });
+    handler.wait_for_calls(1).await;
+
+    let short_response = client
+        .invoke_request_with_deadline(
+            Some(&target),
+            RemotingCommand::create_remoting_command(RequestCode::GetBrokerClusterInfo),
+            RequestDeadline::after(Duration::from_millis(500)),
+        )
+        .await
+        .expect("short request should reconnect within its own budget");
+    let older_response = older
+        .await
+        .expect("older request task")
+        .expect("older request keeps its longer deadline while the old session drains");
+
+    assert_eq!(
+        short_response.body().map(|body| body.as_ref()),
+        Some(b"replacement".as_ref())
+    );
+    assert_eq!(
+        older_response.body().map(|body| body.as_ref()),
+        Some(b"older-long-request".as_ref())
+    );
+    assert_eq!(client.snapshot().pending.count, 0);
+    assert_eq!(client.snapshot().connection_count, 1);
+
+    shutdown(runtime, &[client]).await;
+}
+
+#[tokio::test]
+async fn oneway_requests_do_not_enter_the_response_retry_policy() {
+    let runtime = RuntimeContext::from_current("go-away-oneway-test");
+    let handler = Arc::new(ScriptedHandler::new(vec![Reply::immediate(
+        ResponseCode::GoAway.to_i32(),
+        b"ignored",
+    )]));
+    let address = start_server(&runtime, "go-away-oneway-server", handler.clone(), false).await;
+    let client = start_client(&runtime, "go-away-oneway-client", Some(retry_safe_reads()), false).await;
+    let target = CheetahString::from_string(address.to_string());
+
+    client
+        .invoke_request_oneway_with_deadline(
+            &target,
+            RemotingCommand::create_remoting_command(RequestCode::GetBrokerClusterInfo),
+            RequestDeadline::after(Duration::from_secs(1)),
+        )
+        .await
+        .expect("oneway write");
+    handler.wait_for_calls(1).await;
+    tokio::task::yield_now().await;
+    assert_eq!(handler.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(client.snapshot().pending.count, 0);
+
+    shutdown(runtime, &[client]).await;
+}
+
+#[tokio::test]
+#[cfg(feature = "tls")]
+async fn tls_go_away_retry_uses_a_replacement_connection() {
+    let runtime = RuntimeContext::from_current("go-away-tls-test");
+    let handler = Arc::new(ScriptedHandler::new(vec![
+        Reply::immediate(ResponseCode::GoAway.to_i32(), b"retire"),
+        Reply::immediate(ResponseCode::Success.to_i32(), b"replacement"),
+    ]));
+    let address = start_server(&runtime, "go-away-tls-server", handler.clone(), true).await;
+    let client = start_client(&runtime, "go-away-tls-client", Some(retry_safe_reads()), true).await;
+    let target = CheetahString::from_string(address.to_string());
+
+    let response = client
+        .invoke_request_with_deadline(
+            Some(&target),
+            RemotingCommand::create_remoting_command(RequestCode::GetBrokerClusterInfo),
+            RequestDeadline::after(Duration::from_secs(2)),
+        )
+        .await
+        .expect("TLS GO_AWAY retry");
+
+    assert_eq!(response.code(), ResponseCode::Success.to_i32());
+    let observed = handler.observations();
+    assert_eq!(observed.len(), 2);
+    assert_ne!(observed[0].0, observed[1].0);
+    assert_eq!(client.snapshot().pending.count, 0);
+
+    shutdown(runtime, &[client]).await;
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9350

### Brief Description

Adds an opt-in, request-code allowlisted `GoAwayPolicy` to the remoting client. Eligible requests make at most one retry on a replacement connection while sharing the original absolute deadline, preserving command fields, assigning a fresh opaque, and running logical business hooks once while transport signing runs per physical attempt.

Connection retirement now uses an exact client-local session token, compare-removes only the matching cached session, and drains existing pending requests under their configured maximum age. This also handles the actual selected NameServer endpoint and records bounded-cardinality GO_AWAY outcomes.

Adds plaintext, TLS, NameServer, deadline, late-response, hook, signing, side-effect, replacement-race, and pending-request regression coverage together with the retry policy documentation.

### How Did You Test This Change?

- `cargo test -p rocketmq-transport --all-features`
- `cargo clippy -p rocketmq-transport --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo doc -p rocketmq-transport --all-features --no-deps`
- `powershell -File scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `powershell -File scripts/check-error-hygiene.ps1`
- `cargo clippy --all-targets -- -D warnings` from `rocketmq-example`
- All mandatory locked checks, tests, Clippy, documentation, and the read-only boundary audit from `rocketmq-tools/rocketmq-mcp`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional, configurable `GO_AWAY` retry policy for eligible requests.
  - Supports one bounded retry using a replacement connection while preserving request metadata, deadlines, hooks, and security behavior.
  - Added safeguards for session replacement, pending-request cleanup, one-way requests, TLS, and NameServer routing.
  - Added telemetry for received, successful, and failed retry outcomes.

- **Documentation**
  - Documented policy configuration, eligibility rules, retry behavior, lifecycle handling, errors, and observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->