### PR TITLE
[ISSUE #9361]♻️Avoid outbound request IDs during binary wire decode

### DIFF
--- a/rocketmq-doc/en/performance/remoting-command/opt-01.md
+++ b/rocketmq-doc/en/performance/remoting-command/opt-01.md
@@ -1,0 +1,34 @@
+# OPT-01: binary wire construction without outbound request IDs
+
+## Problem and invariant
+
+ROCKETMQ binary decode previously called `RemotingCommand::default()`, which generated an outbound request ID, before replacing every wire field including `opaque`. Inbound decode must preserve the wire value and must not advance the outbound correlation-ID sequence. JSON decode already assembles its wire representation directly and is unchanged.
+
+The implementation adds a crate-private `from_binary_wire_parts` constructor. It receives every fixed wire field plus the lazy binary extension-field view, fixes the serialization type to `ROCKETMQ`, and initializes transient state without consulting defaults or the request-ID atomic. No public API or wire format changes.
+
+## Test evidence
+
+The test-only counter is thread-local, so unrelated parallel tests cannot perturb the observation. The focused test failed on the old decode path with `left: 1, right: 0`; it passes after routing binary decode through the wire constructor. The same test uses non-default code, language, version, opaque, flag, remark, empty raw extension fields, and serialization type.
+
+Existing golden, deterministic round-trip, malformed-input, and protocol library tests protect body attachment, field values, lazy extension fields, and rejection behavior. Encoding is not modified, so the checked-in golden frame remains byte-for-byte identical.
+
+## Diagnostic performance curve
+
+The benchmark adds the requested 0/8/32/128 extension-field by 1/8/16/32-thread decode matrix. To avoid another long formal replay, the recorded candidate curve uses a diagnostic 1 second warmup, 1 second measurement, and 10 samples. Values are millions of decoded commands per second:
+
+| Extension fields | 1 thread | 8 threads | 16 threads | 32 threads |
+|---:|---:|---:|---:|---:|
+| 0 | 6.50 | 20.14 | 22.86 | 25.08 |
+| 8 | 4.04 | 13.05 | 15.77 | 16.61 |
+| 32 | 2.14 | 7.43 | 9.02 | 10.34 |
+| 128 | 0.77 | 2.86 | 3.61 | 3.98 |
+
+The candidate single-thread ext-32/body-0 diagnostic measured 612.66 ns. The earlier formal baseline measured 509.48 ns in a different session, while an independent unchanged small-header replay in that later session drifted by +18.5%. These values therefore do not establish a performance gain or regression. A future release claim requires an interleaved same-session A/B; this PR makes no performance claim.
+
+## Decision
+
+Retain the change as a correctness and maintenance improvement: inbound decode no longer has an outbound side effect, all wire initialization is explicit in one constructor, two now-unused mutation helpers are removed, and the public surface stays unchanged. The diagnostic curve shows that the new path scales across the requested concurrency dimensions, but is not used as an acceptance claim.
+
+## Scope, risk, and rollback
+
+Changed production scope is limited to `remoting_command.rs` and `rocketmq_serializable.rs`; the benchmark and this report are supporting evidence. The main risk is omitting a decoded field or transient invariant. Whole-field assertions plus existing golden/malformed coverage address that risk. Revert the constructor and decode call together if any wire or malformed-input behavior differs.

--- a/rocketmq-protocol/benches/remoting_command_hot_paths.rs
+++ b/rocketmq-protocol/benches/remoting_command_hot_paths.rs
@@ -53,6 +53,7 @@ use sysinfo::System as ProcessSystem;
 static ALLOCATOR: CountingAllocator<SystemAllocator> = CountingAllocator::new(SystemAllocator);
 
 const CONSTRUCTS_PER_ROUND: usize = 512;
+const DECODES_PER_ROUND: usize = 512;
 const BODY_SIZES: [usize; 6] = [0, 128, 4 * 1024, 64 * 1024, 1024 * 1024, 4 * 1024 * 1024];
 const EXT_FIELD_COUNTS: [usize; 7] = [0, 1, 8, 16, 32, 128, 256];
 
@@ -176,6 +177,61 @@ impl ConstructContentionHarness {
     fn run(&self) {
         self.start.wait();
         self.finish.wait();
+    }
+}
+
+struct DecodeContentionHarness {
+    start: Arc<Barrier>,
+    finish: Arc<Barrier>,
+    stop: Arc<AtomicBool>,
+    workers: Vec<JoinHandle<()>>,
+}
+
+impl DecodeContentionHarness {
+    fn new(worker_count: usize, ext_fields: usize) -> Self {
+        let frame = encoded(command(SerializeType::ROCKETMQ, ext_fields, None, 0));
+        let start = Arc::new(Barrier::new(worker_count + 1));
+        let finish = Arc::new(Barrier::new(worker_count + 1));
+        let stop = Arc::new(AtomicBool::new(false));
+        let workers = (0..worker_count)
+            .map(|_| {
+                let frame = frame.clone();
+                let start = Arc::clone(&start);
+                let finish = Arc::clone(&finish);
+                let stop = Arc::clone(&stop);
+                std::thread::spawn(move || loop {
+                    start.wait();
+                    if stop.load(Ordering::Acquire) {
+                        break;
+                    }
+                    for _ in 0..DECODES_PER_ROUND {
+                        black_box(decode_complete(&frame));
+                    }
+                    finish.wait();
+                })
+            })
+            .collect();
+        Self {
+            start,
+            finish,
+            stop,
+            workers,
+        }
+    }
+
+    fn run(&self) {
+        self.start.wait();
+        self.finish.wait();
+    }
+}
+
+impl Drop for DecodeContentionHarness {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Release);
+        self.start.wait();
+        for worker in self.workers.drain(..) {
+            worker.join().expect("decode contention worker must stop");
+        }
     }
 }
 
@@ -475,6 +531,20 @@ fn benchmark_decode_and_round_trip(c: &mut Criterion) {
         }
     }
     decode.finish();
+
+    let mut contention = c.benchmark_group("remoting_command/decode_contention");
+    for ext_fields in [0, 8, 32, 128] {
+        for thread_count in [1, 8, 16, 32] {
+            let harness = DecodeContentionHarness::new(thread_count, ext_fields);
+            contention.throughput(Throughput::Elements((thread_count * DECODES_PER_ROUND) as u64));
+            contention.bench_with_input(
+                BenchmarkId::new(format!("ext-{ext_fields}"), format!("threads-{thread_count}")),
+                &harness,
+                |benchmark, harness| benchmark.iter(|| harness.run()),
+            );
+        }
+    }
+    contention.finish();
 
     let mut typed_decode = c.benchmark_group("remoting_command/typed_decode");
     for (serialize_type, protocol) in protocols() {

--- a/rocketmq-protocol/src/protocol/remoting_command.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command.rs
@@ -51,6 +51,16 @@ pub const REMOTING_VERSION_KEY: &str = "rocketmq.remoting.version";
 
 static REQUEST_ID: std::sync::LazyLock<Arc<AtomicI32>> = std::sync::LazyLock::new(|| Arc::new(AtomicI32::new(0)));
 
+#[cfg(test)]
+std::thread_local! {
+    static REQUEST_ID_GENERATIONS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn request_id_generation_count() -> usize {
+    REQUEST_ID_GENERATIONS.get()
+}
+
 #[inline]
 fn write_json_i32(out: &mut BytesMut, value: i32) {
     let mut buffer = itoa::Buffer::new();
@@ -192,6 +202,8 @@ impl RemotingCommand {
     /// The protocol crate deliberately does not read process environment or configuration files.
     /// Legacy facades resolve those sources and pass the resulting wire values here.
     pub fn with_resolved_defaults(version: i32, serialize_type: SerializeType) -> Self {
+        #[cfg(test)]
+        REQUEST_ID_GENERATIONS.set(REQUEST_ID_GENERATIONS.get() + 1);
         let opaque = REQUEST_ID.fetch_add(1, Ordering::AcqRel);
         RemotingCommand {
             code: 0,
@@ -206,6 +218,31 @@ impl RemotingCommand {
             command_custom_header: None,
             custom_header_to_net: false,
             serialize_type,
+        }
+    }
+
+    pub(crate) fn from_binary_wire_parts(
+        code: i32,
+        language: LanguageCode,
+        version: i32,
+        opaque: i32,
+        flag: i32,
+        remark: Option<CheetahString>,
+        ext_fields: BinaryHeaderFields,
+    ) -> Self {
+        Self {
+            code,
+            language,
+            version,
+            opaque,
+            flag,
+            remark,
+            ext_fields: ExtensionFields::from_rocketmq_raw(ext_fields),
+            body: None,
+            suspended: false,
+            command_custom_header: None,
+            custom_header_to_net: false,
+            serialize_type: SerializeType::ROCKETMQ,
         }
     }
 }
@@ -378,11 +415,6 @@ impl RemotingCommand {
         self
     }
 
-    #[inline]
-    pub(crate) fn set_language_ref(&mut self, language: LanguageCode) {
-        self.language = language;
-    }
-
     pub fn set_version_ref(&mut self, version: i32) {
         self.version = version;
     }
@@ -407,11 +439,6 @@ impl RemotingCommand {
     pub fn set_flag(mut self, flag: i32) -> Self {
         self.flag = flag;
         self
-    }
-
-    #[inline]
-    pub(crate) fn set_flag_ref(&mut self, flag: i32) {
-        self.flag = flag;
     }
 
     #[inline]
@@ -445,14 +472,9 @@ impl RemotingCommand {
 
     #[cfg(test)]
     fn set_binary_ext_fields(mut self, ext_fields: BinaryHeaderFields) -> Self {
-        self.set_binary_ext_fields_ref(ext_fields);
-        self
-    }
-
-    #[inline]
-    pub(crate) fn set_binary_ext_fields_ref(&mut self, ext_fields: BinaryHeaderFields) {
         self.ext_fields = ExtensionFields::from_rocketmq_raw(ext_fields);
         self.custom_header_to_net = false;
+        self
     }
 
     #[inline]

--- a/rocketmq-protocol/src/protocol/rocketmq_serializable.rs
+++ b/rocketmq-protocol/src/protocol/rocketmq_serializable.rs
@@ -409,12 +409,11 @@ impl RocketMQSerializable {
             return Err(decoding_error(FIXED_HEADER_LEN, header.len()));
         }
 
-        let mut cmd = RemotingCommand::default();
-        cmd.set_code_ref(i16::from_be_bytes([header[0], header[1]]));
-        cmd.set_language_ref(LanguageCode::from(header[2]));
-        cmd.set_version_ref(i16::from_be_bytes([header[3], header[4]]) as i32);
-        cmd.set_opaque_mut(i32::from_be_bytes([header[5], header[6], header[7], header[8]]));
-        cmd.set_flag_ref(i32::from_be_bytes([header[9], header[10], header[11], header[12]]));
+        let code = i16::from_be_bytes([header[0], header[1]]) as i32;
+        let language = LanguageCode::from(header[2]);
+        let version = i16::from_be_bytes([header[3], header[4]]) as i32;
+        let opaque = i32::from_be_bytes([header[5], header[6], header[7], header[8]]);
+        let flag = i32::from_be_bytes([header[9], header[10], header[11], header[12]]);
 
         let mut cursor = FIXED_HEADER_LEN;
         if header.len() - cursor < LENGTH_FIELD_LEN {
@@ -466,10 +465,10 @@ impl RocketMQSerializable {
             return Err(trailing_header_error(header.len() - cursor));
         }
 
-        let ext = BinaryHeaderFields::new(payload)?;
-        cmd.set_remark_option_mut(remark);
-        cmd.set_binary_ext_fields_ref(ext);
-        Ok(cmd)
+        let ext_fields = BinaryHeaderFields::new(payload)?;
+        Ok(RemotingCommand::from_binary_wire_parts(
+            code, language, version, opaque, flag, remark, ext_fields,
+        ))
     }
 
     /// Optimized map deserialization with capacity hint and better error handling
@@ -730,5 +729,34 @@ mod tests {
         assert_eq!(command.flag(), 1);
         assert_eq!(command.remark().map(CheetahString::as_str), Some("remark"));
         assert_eq!(command.ext_fields().unwrap().get("key").unwrap(), "value");
+    }
+
+    #[test]
+    fn binary_decode_does_not_generate_an_outbound_request_id() {
+        let mut buf = BytesMut::new();
+        buf.put_i16(105);
+        buf.put_u8(LanguageCode::JAVA.get_code());
+        buf.put_i16(321);
+        buf.put_i32(0x0102_0304);
+        buf.put_i32(3);
+        RocketMQSerializable::write_str(&mut buf, false, "wire");
+        buf.put_i32(0);
+        let before = crate::protocol::remoting_command::request_id_generation_count();
+
+        let command = RocketMQSerializable::rocket_mq_protocol_decode_bytes(buf.freeze()).unwrap();
+
+        assert_eq!(
+            crate::protocol::remoting_command::request_id_generation_count(),
+            before,
+            "binary decode must not consume an outbound correlation ID"
+        );
+        assert_eq!(command.code(), 105);
+        assert_eq!(command.language(), LanguageCode::JAVA);
+        assert_eq!(command.version(), 321);
+        assert_eq!(command.opaque(), 0x0102_0304);
+        assert_eq!(command.flag(), 3);
+        assert_eq!(command.remark().map(CheetahString::as_str), Some("wire"));
+        assert!(command.ext_fields().is_some_and(HashMap::is_empty));
+        assert_eq!(command.get_serialize_type(), crate::protocol::SerializeType::ROCKETMQ);
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9361

### Brief Description

Routes ROCKETMQ binary header decoding through a crate-private wire constructor that initializes every decoded field and transient invariant without generating an outbound request ID. This removes an unrelated atomic side effect from inbound decode while preserving the public API, lazy binary extension fields, JSON behavior, and wire bytes.

The change includes a thread-local test probe, non-default wire-field assertions, a 0/8/32/128 extension-field by 1/8/16/32-thread decode benchmark, and an OPT-01 decision report. The short benchmark curve is diagnostic only; this PR makes no performance claim and retains the implementation for correctness and simpler ownership semantics.

### How Did You Test This Change?

- RED: `cargo test -p rocketmq-protocol --lib protocol::rocketmq_serializable::tests::binary_decode_does_not_generate_an_outbound_request_id -- --exact --nocapture` failed with request-ID generation count `1` versus `0` on the old decode path.
- GREEN: the same focused test passed after using the wire constructor.
- `cargo test --locked -p rocketmq-protocol --lib protocol::rocketmq_serializable::tests`: passed, 21 tests.
- `cargo test --locked -p rocketmq-protocol --test remoting_wire_golden`: passed, 2 tests.
- `cargo fmt -p rocketmq-protocol -- --check`: passed.
- `cargo clippy --locked -p rocketmq-protocol --no-deps --all-targets --all-features -- -D warnings`: passed.
- Diagnostic decode matrix with 1 second warmup, 1 second measurement, and 10 samples: completed all 16 field-count/concurrency cases; results are recorded in `rocketmq-doc/en/performance/remoting-command/opt-01.md`.
- `git diff --check`: passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved binary command decoding to preserve inbound wire fields accurately.
  * Prevented decoding from generating new outbound request IDs.
  * Preserved remarks, empty extension fields, and serialization type during decoding.

* **Tests**
  * Added regression coverage for decoding correctness.
  * Added benchmarks for decoding performance under varying extension-field and thread counts.

* **Documentation**
  * Documented the decoding optimization, performance results, limitations, risks, and rollback guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->