### PR TITLE
[ISSUE #9363]♻️Simplify remoting request ID storage

### DIFF
--- a/rocketmq-doc/en/performance/remoting-command/opt-02a.md
+++ b/rocketmq-doc/en/performance/remoting-command/opt-02a.md
@@ -1,0 +1,30 @@
+# OPT-02A: direct static request ID storage
+
+## Change
+
+The process-wide outbound request ID sequence no longer uses `LazyLock<Arc<AtomicI32>>`. It is a direct `static AtomicI32`, and all three allocation entry points delegate to one private `next_request_id` helper. This change intentionally retains `Ordering::AcqRel`; any ordering change is evaluated separately.
+
+## Semantics and happens-before audit
+
+The generated value is copied into `RemotingCommand::opaque` and used as a correlation key on the remoting wire. Searches of protocol production code show one atomic declaration, one atomic fetch in `next_request_id_from`, and three callers of `next_request_id`. No consumer performs an acquire load from the request-ID atomic, derives object visibility from its ordering, or treats the old `Arc` identity as state. Removing the lazy and shared-pointer wrappers therefore changes ownership and indirection only.
+
+Tests use an isolated local atomic rather than mutating the process-global sequence. Eight threads generate 8,192 values with no duplicates and the exact 0 through 8,191 range. A boundary test proves the existing signed wrap from `i32::MAX` to `i32::MIN` remains unchanged. A source contract prevents reintroducing lazy/shared storage.
+
+## Diagnostic construction curve
+
+The candidate curve used a 1 second warmup, 1 second measurement, and 10 samples. The baseline column is the earlier formal 10-process baseline, so the directional delta is not a same-session acceptance result.
+
+| Threads | Formal baseline M commands/s | Candidate diagnostic M commands/s | Directional delta |
+|---:|---:|---:|---:|
+| 1 | 31.49 | 38.16 | +21.2% |
+| 2 | 37.05 | 56.87 | +53.5% |
+| 4 | 34.17 | 57.85 | +69.3% |
+| 8 | 29.76 | 42.97 | +44.4% |
+| 16 | 28.98 | 38.29 | +32.1% |
+| 32 | 29.05 | 37.40 | +28.7% |
+
+The direction is consistent across every concurrency point, but session and profile differences prevent attributing the percentages to the storage change. The implementation is retained because it removes unnecessary lifetime machinery, preserves all semantics, and has no negative directional signal. This report makes no release-level performance claim.
+
+## Risk and rollback
+
+The risk is accidental divergence between request-ID entry points or wrap behavior. The shared helper and tests cover both. Revert the static declaration, helper, and tests together if any correlation behavior changes. Do not combine this result with a future memory-ordering result when reporting performance.

--- a/rocketmq-protocol/src/protocol/remoting_command.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command.rs
@@ -49,7 +49,7 @@ pub const SERIALIZE_TYPE_PROPERTY: &str = "rocketmq.serialize.type";
 pub const SERIALIZE_TYPE_ENV: &str = "ROCKETMQ_SERIALIZE_TYPE";
 pub const REMOTING_VERSION_KEY: &str = "rocketmq.remoting.version";
 
-static REQUEST_ID: std::sync::LazyLock<Arc<AtomicI32>> = std::sync::LazyLock::new(|| Arc::new(AtomicI32::new(0)));
+static REQUEST_ID: AtomicI32 = AtomicI32::new(0);
 
 #[cfg(test)]
 std::thread_local! {
@@ -59,6 +59,18 @@ std::thread_local! {
 #[cfg(test)]
 pub(crate) fn request_id_generation_count() -> usize {
     REQUEST_ID_GENERATIONS.get()
+}
+
+#[inline]
+fn next_request_id_from(counter: &AtomicI32) -> i32 {
+    counter.fetch_add(1, Ordering::AcqRel)
+}
+
+#[inline]
+fn next_request_id() -> i32 {
+    #[cfg(test)]
+    REQUEST_ID_GENERATIONS.set(REQUEST_ID_GENERATIONS.get() + 1);
+    next_request_id_from(&REQUEST_ID)
 }
 
 #[inline]
@@ -202,9 +214,7 @@ impl RemotingCommand {
     /// The protocol crate deliberately does not read process environment or configuration files.
     /// Legacy facades resolve those sources and pass the resulting wire values here.
     pub fn with_resolved_defaults(version: i32, serialize_type: SerializeType) -> Self {
-        #[cfg(test)]
-        REQUEST_ID_GENERATIONS.set(REQUEST_ID_GENERATIONS.get() + 1);
-        let opaque = REQUEST_ID.fetch_add(1, Ordering::AcqRel);
+        let opaque = next_request_id();
         RemotingCommand {
             code: 0,
             language: LanguageCode::RUST, // Replace with your actual enum variant
@@ -286,7 +296,7 @@ impl RemotingCommand {
     }
 
     pub fn get_and_add() -> i32 {
-        REQUEST_ID.fetch_add(1, Ordering::AcqRel)
+        next_request_id()
     }
 
     pub fn create_response_command_with_code(code: impl Into<i32>) -> Self {
@@ -1367,7 +1377,7 @@ impl RemotingCommand {
     }
 
     pub fn create_new_request_id() -> i32 {
-        REQUEST_ID.fetch_add(1, Ordering::AcqRel)
+        next_request_id()
     }
 
     #[inline]
@@ -1470,6 +1480,8 @@ impl AsMut<RemotingCommand> for RemotingCommand {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::*;
 
     fn json_header_with_ext_fields(ext_fields: &str) -> BytesMut {
@@ -1479,6 +1491,50 @@ mod tests {
             )
             .as_bytes(),
         )
+    }
+
+    #[test]
+    fn request_id_sequence_is_unique_under_contention() {
+        const THREADS: usize = 8;
+        const IDS_PER_THREAD: usize = 1_024;
+        let counter = Arc::new(AtomicI32::new(0));
+        let handles = (0..THREADS)
+            .map(|_| {
+                let counter = Arc::clone(&counter);
+                std::thread::spawn(move || {
+                    (0..IDS_PER_THREAD)
+                        .map(|_| next_request_id_from(&counter))
+                        .collect::<Vec<_>>()
+                })
+            })
+            .collect::<Vec<_>>();
+        let ids = handles
+            .into_iter()
+            .flat_map(|handle| handle.join().expect("request ID worker must finish"))
+            .collect::<HashSet<_>>();
+
+        assert_eq!(ids.len(), THREADS * IDS_PER_THREAD);
+        assert_eq!(ids.iter().copied().min(), Some(0));
+        assert_eq!(ids.iter().copied().max(), Some((THREADS * IDS_PER_THREAD - 1) as i32));
+    }
+
+    #[test]
+    fn request_id_sequence_preserves_signed_wrap_behavior() {
+        let counter = AtomicI32::new(i32::MAX);
+
+        assert_eq!(next_request_id_from(&counter), i32::MAX);
+        assert_eq!(next_request_id_from(&counter), i32::MIN);
+    }
+
+    #[test]
+    fn request_id_storage_is_a_direct_static_atomic() {
+        let source = include_str!("remoting_command.rs");
+        let declaration = source
+            .lines()
+            .find(|line| line.starts_with("static REQUEST_ID:"))
+            .expect("request ID declaration");
+
+        assert_eq!(declaration, "static REQUEST_ID: AtomicI32 = AtomicI32::new(0);");
     }
 
     #[derive(Debug, Default, PartialEq, Eq)]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9363

### Brief Description

Replaces the process-wide request ID `LazyLock<Arc<AtomicI32>>` with a direct static atomic while preserving `Ordering::AcqRel`. All outbound ID allocation entry points now delegate to one private helper.

The change adds deterministic local-atomic tests for concurrent uniqueness and signed wrap behavior, a source contract for the storage shape, a happens-before audit, and an OPT-02A diagnostic construction curve. Memory ordering is intentionally unchanged and no ordering-related benefit is attributed to this PR.

### How Did You Test This Change?

- RED: request-ID sequence tests initially failed to compile because the shared helper did not exist; they passed after all entry points used it.
- RED: `request_id_storage_is_a_direct_static_atomic` failed with the previous `LazyLock<Arc<AtomicI32>>` declaration; it passed after the storage change.
- `cargo test --locked -p rocketmq-protocol --lib request_id_`: passed, 3 tests.
- `cargo test --locked -p rocketmq-protocol --lib protocol::rocketmq_serializable::tests::binary_decode_does_not_generate_an_outbound_request_id -- --exact`: passed, 1 test.
- `cargo fmt -p rocketmq-protocol -- --check`: passed.
- `cargo clippy --locked -p rocketmq-protocol --no-deps --all-targets --all-features -- -D warnings`: passed.
- Diagnostic 1/2/4/8/16/32-thread construction curve with 1 second warmup, 1 second measurement, and 10 samples: completed; results and limitations are recorded in `rocketmq-doc/en/performance/remoting-command/opt-02a.md`.
- `git diff --check`: passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved request ID generation with more direct, centralized allocation.
  * Added safeguards and validation for concurrent ID generation and integer wraparound.
* **Documentation**
  * Added technical documentation covering the change, performance benchmark results, limitations, and rollback guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->