### PR TITLE
[ISSUE #9367]♻️Eliminate redundant body length refcount churn

### DIFF
--- a/rocketmq-doc/en/performance/remoting-command/opt-05.md
+++ b/rocketmq-doc/en/performance/remoting-command/opt-05.md
@@ -1,0 +1,36 @@
+# OPT-05: explicit body length during frame assembly
+
+## Change and invariant
+
+`EncodedFrame::from_command` previously took the body, cloned its `Bytes` handle back into the command, encoded the header so it could rediscover the body length, and finally dropped the clone. The new path takes the body once, reads `body.len()`, and passes that value to one crate-private header encoder.
+
+The existing public encoder still derives the length from its in-memory body and delegates to the same implementation. External-body frame heads pass their validated length through the same entry point. If a command still contains an in-memory body whose length differs from the explicit value, encoding fails and restores the destination to its original bytes.
+
+## Byte and error contract
+
+A table-driven test covers JSON and ROCKETMQ with body lengths 0, 1, 128 B, 4 KiB, 64 KiB, 1 MiB, and 4 MiB. For every case, prefix plus header plus external body is byte-for-byte equal to the complete `EncodedFrame`. Existing checked-in golden and deterministic round-trip tests remain unchanged. The mismatch test starts with a non-empty destination and proves failure is atomic.
+
+## Short same-session A/B
+
+Candidate and baseline ran consecutively on the same machine with a 1 second warmup, 1 second measurement, and 10 samples. The candidate ran first and the baseline second, so this is a directional time-boxed A/B rather than the formal interleaved profile.
+
+| Format | Body | Baseline median | Candidate median | Delta |
+|---|---:|---:|---:|---:|
+| JSON | 0 | 1.318 us | 1.157 us | -12.2% |
+| JSON | 128 B | 1.337 us | 1.127 us | -15.7% |
+| JSON | 4 KiB | 1.289 us | 1.090 us | -15.5% |
+| JSON | 64 KiB | 1.282 us | 1.119 us | -12.7% |
+| JSON | 1 MiB | 1.597 us | 1.257 us | -21.3% |
+| JSON | 4 MiB | 1.921 us | 1.842 us | -4.1% |
+| ROCKETMQ | 0 | 802.41 ns | 798.24 ns | -0.5% |
+| ROCKETMQ | 128 B | 856.93 ns | 803.36 ns | -6.3% |
+| ROCKETMQ | 4 KiB | 866.26 ns | 778.81 ns | -10.1% |
+| ROCKETMQ | 64 KiB | 891.26 ns | 821.17 ns | -7.9% |
+| ROCKETMQ | 1 MiB | 1.313 us | 1.019 us | -22.4% |
+| ROCKETMQ | 4 MiB | 1.709 us | 1.389 us | -18.8% |
+
+Every measured point improved and no small-body point exceeded the 2% regression budget. The exact percentages are diagnostic, but the consistent direction plus removal of a provable refcount round trip supports retaining the change.
+
+## Scope, risk, and rollback
+
+Only protocol-internal header assembly and `EncodedFrame` ownership change; transport callers keep the same APIs. The main risks are inconsistent announced lengths and a difference between contiguous and segmented output. Explicit mismatch rejection, byte-equality coverage, wire golden tests, and transport codec/segmented tests address those risks. Revert both protocol files together if any frame byte or length policy changes.

--- a/rocketmq-protocol/src/protocol/encoded_frame.rs
+++ b/rocketmq-protocol/src/protocol/encoded_frame.rs
@@ -58,17 +58,8 @@ impl EncodedFrame {
     /// length field.
     pub fn from_command(mut command: RemotingCommand) -> RocketMQResult<Self> {
         let body = command.take_body().unwrap_or_default();
-        command.set_body_mut_ref(body.clone());
-        let (prefix, header) = encode_header_segments(&mut command)?;
-        let total_len = checked_payload_len(header.len(), body.len())?;
-        let announced_total = i32::from_be_bytes([prefix[0], prefix[1], prefix[2], prefix[3]]);
-        if announced_total != total_len {
-            return Err(SerializationError::encode_failed(
-                "remoting-command",
-                "fast header encoder produced inconsistent wire lengths",
-            )
-            .into());
-        }
+        let (prefix, header) = encode_header_segments(&mut command, body.len())?;
+        validate_announced_payload_len(&prefix, header.len(), body.len())?;
         Ok(Self { prefix, header, body })
     }
 
@@ -123,9 +114,8 @@ impl EncodedFrameHead {
             )
             .into());
         }
-        let (mut prefix, header) = encode_header_segments(&mut command)?;
-        let total_len = checked_payload_len(header.len(), body_len)?;
-        prefix[..4].copy_from_slice(&total_len.to_be_bytes());
+        let (prefix, header) = encode_header_segments(&mut command, body_len)?;
+        validate_announced_payload_len(&prefix, header.len(), body_len)?;
         Ok(Self {
             prefix,
             header,
@@ -155,9 +145,12 @@ impl EncodedFrameHead {
     }
 }
 
-fn encode_header_segments(command: &mut RemotingCommand) -> RocketMQResult<([u8; FRAME_PREFIX_BYTES], Bytes)> {
+fn encode_header_segments(
+    command: &mut RemotingCommand,
+    body_len: usize,
+) -> RocketMQResult<([u8; FRAME_PREFIX_BYTES], Bytes)> {
     let mut encoded_header = BytesMut::new();
-    command.try_fast_header_encode(&mut encoded_header)?;
+    command.try_fast_header_encode_with_body_length(&mut encoded_header, body_len)?;
     if encoded_header.len() < FRAME_PREFIX_BYTES {
         return Err(SerializationError::encode_failed(
             "remoting-command",
@@ -202,6 +195,23 @@ fn checked_payload_len(header_len: usize, body_len: usize) -> RocketMQResult<i32
         )
         .into()
     })
+}
+
+fn validate_announced_payload_len(
+    prefix: &[u8; FRAME_PREFIX_BYTES],
+    header_len: usize,
+    body_len: usize,
+) -> RocketMQResult<()> {
+    let expected = checked_payload_len(header_len, body_len)?;
+    let announced = i32::from_be_bytes([prefix[0], prefix[1], prefix[2], prefix[3]]);
+    if announced != expected {
+        return Err(SerializationError::encode_failed(
+            "remoting-command",
+            "fast header encoder produced inconsistent wire lengths",
+        )
+        .into());
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -313,6 +323,45 @@ mod tests {
 
         assert_eq!(reconstructed.freeze(), complete);
         assert_eq!(head.body_len(), body.len());
+    }
+
+    #[test]
+    fn frame_head_and_complete_frame_match_for_all_body_sizes_and_protocols() {
+        for serialize_type in [SerializeType::JSON, SerializeType::ROCKETMQ] {
+            for body_len in [0, 1, 128, 4 * 1024, 64 * 1024, 1024 * 1024, 4 * 1024 * 1024] {
+                let body = Bytes::from(vec![0x5a; body_len]);
+                let command = RemotingCommand::create_remoting_command(108)
+                    .set_opaque(92)
+                    .set_serialize_type(serialize_type)
+                    .set_remark("body-length-matrix");
+                let head = EncodedFrameHead::from_command_and_body_len(command.clone(), body_len).unwrap();
+                let complete = EncodedFrame::from_command(command.set_body(body.clone()))
+                    .unwrap()
+                    .into_bytes();
+                let [prefix, header] = head.segments();
+                let mut reconstructed = BytesMut::with_capacity(head.encoded_len());
+                reconstructed.put_slice(prefix);
+                reconstructed.put_slice(header);
+                reconstructed.put_slice(&body);
+
+                assert_eq!(
+                    reconstructed.freeze(),
+                    complete,
+                    "{serialize_type:?} body_len={body_len}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn explicit_body_length_rejects_an_in_memory_body_mismatch_atomically() {
+        let mut command = RemotingCommand::create_remoting_command(109).set_body(Bytes::from_static(b"body"));
+        let mut destination = BytesMut::from(&b"existing"[..]);
+
+        assert!(command
+            .try_fast_header_encode_with_body_length(&mut destination, 3)
+            .is_err());
+        assert_eq!(destination.as_ref(), b"existing");
     }
 
     #[test]

--- a/rocketmq-protocol/src/protocol/remoting_command.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command.rs
@@ -680,8 +680,25 @@ impl RemotingCommand {
     /// Returns the custom-header validation or direct-binary encoding failure.
     #[inline]
     pub fn try_fast_header_encode(&mut self, dst: &mut BytesMut) -> rocketmq_error::RocketMQResult<()> {
+        let body_length = self.body.as_ref().map_or(0, Bytes::len);
+        self.try_fast_header_encode_with_body_length(dst, body_length)
+    }
+
+    #[inline]
+    pub(crate) fn try_fast_header_encode_with_body_length(
+        &mut self,
+        dst: &mut BytesMut,
+        body_length: usize,
+    ) -> rocketmq_error::RocketMQResult<()> {
         let checkpoint = dst.len();
-        let result = self.try_fast_header_encode_inner(dst);
+        let result = match self.body.as_ref() {
+            Some(body) if body.len() != body_length => Err(rocketmq_error::SerializationError::encode_failed(
+                "remoting-command",
+                "explicit body length does not match the in-memory body",
+            )
+            .into()),
+            _ => self.try_fast_header_encode_inner(dst, body_length),
+        };
         if result.is_err() {
             dst.truncate(checkpoint);
         }
@@ -689,30 +706,33 @@ impl RemotingCommand {
     }
 
     #[inline]
-    fn try_fast_header_encode_inner(&mut self, dst: &mut BytesMut) -> rocketmq_error::RocketMQResult<()> {
+    fn try_fast_header_encode_inner(
+        &mut self,
+        dst: &mut BytesMut,
+        body_length: usize,
+    ) -> rocketmq_error::RocketMQResult<()> {
         match self.serialize_type {
-            SerializeType::JSON => self.fast_encode_json(dst),
-            SerializeType::ROCKETMQ => self.fast_encode_rocketmq(dst),
+            SerializeType::JSON => self.fast_encode_json(dst, body_length),
+            SerializeType::ROCKETMQ => self.fast_encode_rocketmq(dst, body_length),
         }
     }
 
     /// Optimized JSON encoding with pre-calculated capacity and zero-copy optimizations
     #[inline]
-    fn fast_encode_json(&mut self, dst: &mut BytesMut) -> rocketmq_error::RocketMQResult<()> {
+    fn fast_encode_json(&mut self, dst: &mut BytesMut, body_length: usize) -> rocketmq_error::RocketMQResult<()> {
         let direct_fields = !self.custom_header_to_net
             && self.ext_fields.is_absent()
             && self
                 .command_custom_header_ref()
                 .is_some_and(CommandCustomHeader::supports_direct_json_fields);
         if direct_fields {
-            return self.fast_encode_json_direct(dst);
+            return self.fast_encode_json_direct(dst, body_length);
         }
 
         self.try_make_custom_header_to_net()
             .map_err(|error| rocketmq_error::RocketMQError::request_header_error(error.to_string()))?;
 
         let estimated_header_size = self.estimate_json_header_size();
-        let body_length = self.body.as_ref().map_or(0, |b| b.len());
         let begin_index = dst.len();
 
         dst.reserve(8 + estimated_header_size);
@@ -738,14 +758,13 @@ impl RemotingCommand {
     }
 
     #[inline]
-    fn fast_encode_json_direct(&self, dst: &mut BytesMut) -> rocketmq_error::RocketMQResult<()> {
+    fn fast_encode_json_direct(&self, dst: &mut BytesMut, body_length: usize) -> rocketmq_error::RocketMQResult<()> {
         let header = self.command_custom_header_ref().ok_or_else(|| {
             rocketmq_error::SerializationError::encode_failed(
                 "remoting-command",
                 "direct JSON header capability was selected without a custom header",
             )
         })?;
-        let body_length = self.body.as_ref().map_or(0, |body| body.len());
         let begin_index = dst.len();
 
         // Avoid a full preflight walk over every typed field. A single 1 KiB
@@ -787,7 +806,7 @@ impl RemotingCommand {
 
     /// Optimized ROCKETMQ binary encoding with minimal allocations
     #[inline]
-    fn fast_encode_rocketmq(&mut self, dst: &mut BytesMut) -> rocketmq_error::RocketMQResult<()> {
+    fn fast_encode_rocketmq(&mut self, dst: &mut BytesMut, body_length: usize) -> rocketmq_error::RocketMQResult<()> {
         let begin_index = dst.len();
         dst.reserve(8 + RocketMQSerializable::INITIAL_ENCODE_CAPACITY);
         dst.put_i64(0); // Placeholder for total_length + serialize_type
@@ -804,7 +823,6 @@ impl RemotingCommand {
             None => RocketMQSerializable::try_rocketmq_protocol_encode_with_capability(self, dst, capability),
         }
         .map_err(|error| rocketmq_error::RocketMQError::request_header_error(error.to_string()))?;
-        let body_length = self.body.as_ref().map_or(0, |b| b.len());
         let (total_length, serialize_type) =
             Self::checked_frame_lengths(header_size, body_length, SerializeType::ROCKETMQ)?;
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9367

### Brief Description

Remove the redundant `Bytes` clone-and-restore cycle from complete frame assembly by passing the already-known body length through the crate-private header encoder. Complete and segmented frames now share the same length-aware header path, preserve atomic error behavior, and validate that announced wire lengths remain consistent.

Add JSON and ROCKETMQ byte-equivalence coverage across empty through 4 MiB bodies, an explicit mismatch regression test, and a time-boxed same-session performance report.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-protocol -p rocketmq-transport -- --check`
- `cargo test --locked -p rocketmq-protocol --lib protocol::encoded_frame::tests` (11 passed)
- `cargo test --locked -p rocketmq-protocol --test remoting_wire_golden` (2 passed)
- `cargo test --locked -p rocketmq-transport --lib encode_handles_` (2 passed)
- `cargo test --locked -p rocketmq-transport --features test-support --test connection_lifecycle raw_and_segmented_output_obey_the_owner_frame_limits_atomically` (1 passed)
- `cargo test --locked -p rocketmq-transport --features test-support --test connection_lifecycle direct_tls_segmented_output_obeys_the_owner_frame_limits` (1 passed)
- `cargo test --locked -p rocketmq-transport --features test-support --test connection_lifecycle batch_and_file_region_output_reject_over_limit_bodies_before_writing` (1 passed)
- `cargo clippy --locked -p rocketmq-protocol -p rocketmq-transport --no-deps --all-targets --all-features -- -D warnings`
- `git diff --check`
