### PR TITLE
[ISSUE #9369]🧪Record custom header ownership stop decision

### DIFF
--- a/rocketmq-doc/en/performance/remoting-command/opt-03.md
+++ b/rocketmq-doc/en/performance/remoting-command/opt-03.md
@@ -1,0 +1,24 @@
+# OPT-03: direct trait-object ownership stop decision
+
+## Candidate
+
+The candidate replaced `Option<Arc<Box<dyn CommandCustomHeader>>>` with `Option<Arc<dyn CommandCustomHeader>>`. This removes one allocation and one indirection when a command owns a typed custom header, but changes the `Arc` from a thin pointer to a fat pointer inside every `RemotingCommand`.
+
+## Allocation and footprint evidence
+
+The existing allocation probe was extended with a canonical `GetRouteInfoRequestHeader` construction case. Baseline and candidate were built separately in the same worktree and process profile.
+
+| Metric | Baseline | Candidate | Result |
+|---|---:|---:|---:|
+| Typed command construction allocations | 2 | 1 | -1 allocation |
+| Typed command construction bytes | 152 B | 136 B | -16 B |
+| `size_of::<RemotingCommand>()` | 160 B | 168 B | +5.0% |
+| RSS delta for 100,000 empty commands | 16,015,360 B | 16,814,080 B | +5.0% |
+
+The clone probe includes construction of its source and reports the same allocation difference; cloning an already-created command continues to clone only the `Arc`. The candidate passed all 36 focused `remoting_command` tests before it was reverted.
+
+## Decision
+
+**STOP.** The allocation saving applies only when constructing a typed-header command, while the additional eight inline bytes apply to every command, including decoded and headerless traffic. The object and RSS increases exceed the 2% footprint budget, so latency benchmarking cannot make this candidate acceptable and was intentionally skipped under the evaluation short-circuit rule.
+
+Production ownership remains `Arc<Box<dyn CommandCustomHeader>>`. The allocation probe stays in the benchmark harness so a future representation can be compared without reconstructing this evidence. Revisit only with a representation that preserves the 160-byte command footprint or with production traffic evidence showing typed-header allocation pressure dominates the universal object cost.

--- a/rocketmq-protocol/benches/remoting_command_hot_paths.rs
+++ b/rocketmq-protocol/benches/remoting_command_hot_paths.rs
@@ -327,6 +327,16 @@ fn write_allocation_evidence() {
     };
     let mut cases = Vec::new();
     cases.push(allocation_case(
+        "construct-typed-get-route",
+        || typed_command(SerializeType::ROCKETMQ),
+        |_| (0, None),
+    ));
+    cases.push(allocation_case(
+        "clone-typed-get-route",
+        || typed_command(SerializeType::ROCKETMQ).clone(),
+        |_| (0, None),
+    ));
+    cases.push(allocation_case(
         "construct-json-ext-32-body-4096",
         || command(SerializeType::JSON, 32, None, 4096),
         |command| (command.body().map_or(0, Bytes::len), None),


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9369

### Brief Description

Record the measured stop decision for replacing `Arc<Box<dyn CommandCustomHeader>>` with `Arc<dyn CommandCustomHeader>`. The candidate removes one typed-header construction allocation and 16 allocated bytes, but increases every `RemotingCommand` from 160 to 168 bytes and raises the 100,000-object RSS probe by about 5%, exceeding the footprint budget.

Extend the allocation evidence harness with canonical typed-header construction and clone cases. The candidate production change was reverted; the report explains the tradeoff and revisit condition.

### How Did You Test This Change?

- Separate baseline and candidate `cargo bench --locked -p rocketmq-protocol --bench remoting_command_hot_paths -- __opt03_evidence_only__` runs completed and emitted allocation/footprint evidence.
- `cargo fmt -p rocketmq-protocol -- --check`
- `cargo test --locked -p rocketmq-protocol --lib protocol::remoting_command::tests` (36 passed)
- `git diff --check`
