### PR TITLE
[ISSUE #9373]♻️Keep command formatting lazy and redacted

### DIFF
--- a/rocketmq-doc/en/performance/remoting-command/opt-11.md
+++ b/rocketmq-doc/en/performance/remoting-command/opt-11.md
@@ -1,0 +1,27 @@
+# OPT-11: lazy extension fields and redacted formatting
+
+## Change
+
+`RemotingCommand` formatting no longer calls `ExtensionFields::as_map()`. It emits only the representation, field count, and whether a raw field set already has a materialized compatibility map. JSON and ROCKETMQ raw values therefore stay cold and extension-field values are not written to logs.
+
+When a raw field set was explicitly read before mutation, the mutable transition now takes its cached `Arc<HeaderMap>`. A uniquely owned cache reuses the map allocation with `Arc::try_unwrap`; a shared cache clones once to preserve isolation. A cold field set still materializes directly from its validated raw representation.
+
+## Contract and evidence
+
+The focused regression test decodes both raw formats, formats each command, and proves:
+
+- the output reports `JsonRaw` or `RocketMqRaw`, count, and cold cache state;
+- neither secret test value appears in the output;
+- formatting leaves both compatibility maps unmaterialized.
+
+The existing raw read, clone, mutation, typed-header collision, canonical encoding, and materialization tests continue to pass. They cover the isolation boundary used by the cached-map transition.
+
+## Performance decision
+
+**ACCEPT.** Display-only changes from one complete raw-map materialization to zero. The read-then-mutate path removes the second raw scan and can reuse the existing map allocation when it is unique. Shared clones retain copy-on-write isolation and pay at most one map clone at mutation.
+
+No time-only A/B was needed: the optimized work is directly countable, and the time-boxed qualification prioritizes the allocation/materialization invariant. The representation and wire bytes are unchanged.
+
+## Rollback
+
+Revert the extension-field summary and cached-map take together if formatting compatibility requires full field values. Prefer a separate explicit diagnostic API for full values rather than restoring them to the default `Display` implementation.

--- a/rocketmq-protocol/src/protocol/header_codec/field_source.rs
+++ b/rocketmq-protocol/src/protocol/header_codec/field_source.rs
@@ -80,6 +80,10 @@ impl BinaryHeaderFields {
         Ok(Self { payload, entry_count })
     }
 
+    pub(crate) const fn len(&self) -> usize {
+        self.entry_count
+    }
+
     /// Materializes the compatibility map. The payload has already been
     /// validated, so iteration uses its immutable representation invariant.
     pub(crate) fn materialize(&self) -> HeaderMap {

--- a/rocketmq-protocol/src/protocol/header_codec/json_field_source.rs
+++ b/rocketmq-protocol/src/protocol/header_codec/json_field_source.rs
@@ -53,6 +53,10 @@ enum JsonFieldEncoding {
 }
 
 impl JsonHeaderFields {
+    pub(crate) const fn len(&self) -> usize {
+        self.entry_count
+    }
+
     pub(crate) fn from_length_prefixed(payload: Vec<u8>, entry_count: usize) -> Self {
         Self {
             payload: Bytes::from(payload),

--- a/rocketmq-protocol/src/protocol/remoting_command.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command.rs
@@ -196,7 +196,7 @@ impl fmt::Display for RemotingCommand {
             self.opaque,
             self.flag,
             self.remark.as_ref().unwrap_or(&CheetahString::default()),
-            self.ext_fields.as_map(),
+            self.ext_fields,
             self.serialize_type
         )
     }
@@ -2025,6 +2025,35 @@ mod tests {
         assert_eq!(json["extFields"]["unicode"], "火箭");
         assert!(cloned.ext_fields.is_json_raw());
         assert!(cloned.ext_fields.has_materialized_map());
+    }
+
+    #[test]
+    fn display_summarizes_raw_extension_fields_without_materializing_or_exposing_values() {
+        let mut json_header = json_header_with_ext_fields(r#"{"token":"json-secret"}"#);
+        let json_length = json_header.len();
+        let json = RemotingCommand::header_decode(&mut json_header, json_length, SerializeType::JSON)
+            .unwrap()
+            .unwrap();
+
+        let mut rocketmq_source = RemotingCommand::create_remoting_command(1)
+            .set_serialize_type(SerializeType::ROCKETMQ)
+            .set_ext_fields(HashMap::from([(
+                CheetahString::from_static_str("token"),
+                CheetahString::from_static_str("rocketmq-secret"),
+            )]));
+        let mut encoded = BytesMut::new();
+        rocketmq_source.try_fast_header_encode(&mut encoded).unwrap();
+        let rocketmq = RemotingCommand::decode(&mut encoded).unwrap().unwrap();
+
+        let json_display = json.to_string();
+        let rocketmq_display = rocketmq.to_string();
+
+        assert!(json_display.contains("JsonRaw(count=1, materialized=false)"));
+        assert!(rocketmq_display.contains("RocketMqRaw(count=1, materialized=false)"));
+        assert!(!json_display.contains("json-secret"));
+        assert!(!rocketmq_display.contains("rocketmq-secret"));
+        assert!(!json.ext_fields.has_materialized_map());
+        assert!(!rocketmq.ext_fields.has_materialized_map());
     }
 
     #[test]

--- a/rocketmq-protocol/src/protocol/remoting_command/extension_fields.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command/extension_fields.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
 use std::sync::Arc;
 use std::sync::OnceLock;
 
@@ -33,6 +34,27 @@ pub(super) enum ExtensionFields {
         fields: JsonHeaderFields,
         materialized: OnceLock<Arc<HeaderMap>>,
     },
+}
+
+impl fmt::Debug for ExtensionFields {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Absent => formatter.write_str("Absent"),
+            Self::Materialized(fields) => write!(formatter, "Materialized(count={})", fields.len()),
+            Self::RocketMqRaw { fields, materialized } => write!(
+                formatter,
+                "RocketMqRaw(count={}, materialized={})",
+                fields.len(),
+                materialized.get().is_some()
+            ),
+            Self::JsonRaw { fields, materialized } => write!(
+                formatter,
+                "JsonRaw(count={}, materialized={})",
+                fields.len(),
+                materialized.get().is_some()
+            ),
+        }
+    }
 }
 
 impl ExtensionFields {
@@ -77,13 +99,19 @@ impl ExtensionFields {
         match self {
             Self::Absent => None,
             Self::Materialized(fields) => Some(fields),
-            Self::RocketMqRaw { fields, .. } => {
-                let fields = fields.materialize();
+            Self::RocketMqRaw { fields, materialized } => {
+                let fields = materialized.take().map_or_else(
+                    || fields.materialize(),
+                    |cached| Arc::try_unwrap(cached).unwrap_or_else(|shared| (*shared).clone()),
+                );
                 *self = Self::Materialized(fields);
                 self.as_map_mut()
             }
-            Self::JsonRaw { fields, .. } => {
-                let fields = fields.materialize();
+            Self::JsonRaw { fields, materialized } => {
+                let fields = materialized.take().map_or_else(
+                    || fields.materialize(),
+                    |cached| Arc::try_unwrap(cached).unwrap_or_else(|shared| (*shared).clone()),
+                );
                 *self = Self::Materialized(fields);
                 self.as_map_mut()
             }
@@ -97,13 +125,19 @@ impl ExtensionFields {
                 *self = Self::Materialized(HeaderMap::new());
                 self.get_or_insert_map()
             }
-            Self::RocketMqRaw { fields, .. } => {
-                let fields = fields.materialize();
+            Self::RocketMqRaw { fields, materialized } => {
+                let fields = materialized.take().map_or_else(
+                    || fields.materialize(),
+                    |cached| Arc::try_unwrap(cached).unwrap_or_else(|shared| (*shared).clone()),
+                );
                 *self = Self::Materialized(fields);
                 self.get_or_insert_map()
             }
-            Self::JsonRaw { fields, .. } => {
-                let fields = fields.materialize();
+            Self::JsonRaw { fields, materialized } => {
+                let fields = materialized.take().map_or_else(
+                    || fields.materialize(),
+                    |cached| Arc::try_unwrap(cached).unwrap_or_else(|shared| (*shared).clone()),
+                );
                 *self = Self::Materialized(fields);
                 self.get_or_insert_map()
             }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9373

### Brief Description

Keep decoded extension fields lazy during command formatting and redact their values from the default display output. Formatting now reports only the representation, field count, and cache state for absent, materialized, JSON raw, and ROCKETMQ raw fields.

Reuse a uniquely owned cached compatibility map during a read-then-mutate transition; shared caches clone once to retain isolation. Add JSON and ROCKETMQ regression coverage proving display neither materializes the map nor exposes field values.

### How Did You Test This Change?

- RED: the new display regression failed because formatting materialized and printed the field map.
- `cargo test --locked -p rocketmq-protocol --lib display_summarizes_raw_extension_fields_without_materializing_or_exposing_values` (1 passed)
- `cargo test --locked -p rocketmq-protocol --lib protocol::remoting_command::tests` (37 passed)
- `cargo fmt -p rocketmq-protocol -- --check`
- `cargo clippy --locked -p rocketmq-protocol --no-deps --all-targets --all-features -- -D warnings`
- `git diff --check`
