### PR TITLE
[ISSUE #9375]📝Record encode capacity strategy stop decision

### DIFF
--- a/rocketmq-doc/en/performance/remoting-command/opt-09.md
+++ b/rocketmq-doc/en/performance/remoting-command/opt-09.md
@@ -1,0 +1,17 @@
+# OPT-09: encode capacity strategy stop decision
+
+## Evidence audit
+
+The formal allocation baseline shows that canonical JSON request-header encoding normally performs one 1,024-byte allocation. Canonical ROCKETMQ encoding normally performs one 264-byte allocation, with several larger schemas using two allocations and 792 bytes. The broader ext-field probe ends with 1,412 bytes in a 2,156-byte JSON buffer and 1,309 bytes in a 2,112-byte ROCKETMQ buffer for 32 fields.
+
+These points confirm that one global bucket cannot minimize both allocation count and retained bytes. They do not provide production traffic weights, final-length percentiles, or long remark and non-ASCII p99 tails. The formal timing corpus is intentionally uniform across schemas and field counts, so treating it as a capacity distribution would bias the decision.
+
+## Decision
+
+**STOP.** Keep the existing 1,024-byte JSON direct reserve and 256-byte ROCKETMQ initial reserve. Trying 256/384/512/1,024 buckets without a production-weighted distribution would optimize synthetic frequency and risk regressions for uncommon but large headers. An exact-size preflight scan is also rejected because it adds an O(H) traversal to every encode.
+
+Reopen only when low-cardinality telemetry or an equivalent production trace provides final length, capacity, wire format, schema, long remark, and UTF-8 percentiles. A future candidate must report latency, allocation count, allocated bytes, retained bytes, and p99 separately for JSON and ROCKETMQ.
+
+## Rollback
+
+No production code changed. The rollback is the decision itself: if representative evidence becomes available, replace this stop report with an interleaved bucket evaluation and retain the current constants as the control.


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9375

### Brief Description

Record the stop decision for changing global remoting header capacity hints. Formal allocation evidence shows materially different JSON and ROCKETMQ shapes, while the benchmark corpus has no production traffic weights or final-length percentiles. Changing buckets now would optimize synthetic frequency and risk trading allocations for retained memory.

Keep the existing capacity constants and define the production-weighted telemetry and A/B evidence required to reopen the candidate.

### How Did You Test This Change?

- Reviewed the 33-case formal allocation summary and the 251-case Rust timing summary.
- `git diff --check`
