### PR TITLE
[ISSUE #9377]♻️Avoid one-field canonical sort allocation

### DIFF
--- a/rocketmq-doc/en/performance/remoting-command/opt-small-fields.md
+++ b/rocketmq-doc/en/performance/remoting-command/opt-small-fields.md
@@ -1,0 +1,17 @@
+# Small extension-field canonicalization
+
+## Change
+
+ROCKETMQ extension-field serialization now iterates maps with zero or one entry directly. Canonical ordering is unambiguous at those sizes, so allocating a temporary vector and sorting it cannot change the wire result. Maps with two or more entries retain the existing filtered vector and unstable key sort.
+
+The direct iterator still filters an empty key. Both the fallible command encoder and exact-capacity map serializer consume the same helper, so length errors, empty-value behavior, and canonical bytes remain aligned.
+
+## Decision
+
+**ACCEPT the 0/1 specialization.** It removes one temporary heap allocation from the one-field path by construction and adds no dependency or stack-resident buffer to every call. The zero-field path remains allocation-free.
+
+**STOP before `SmallVec`.** The formal profile covers 0/1/8/16/32/128/256 fields but does not show the temporary sort allocation as a dominant cost or provide production weights around the 16/17 boundary. Adding a dependency and a stack/heap threshold without that evidence would increase code and stack complexity for an unproven gain.
+
+## Validation and rollback
+
+The 21 serialization tests cover empty, one-field, empty-key/value, length, malformed input, and larger maps. The checked-in ROCKETMQ wire golden remains unchanged. Revert the iterator enum and restore the vector helper if a canonical-byte regression is found; no public API or persisted format changed.

--- a/rocketmq-protocol/src/protocol/rocketmq_serializable.rs
+++ b/rocketmq-protocol/src/protocol/rocketmq_serializable.rs
@@ -48,10 +48,29 @@ fn trailing_header_error(remaining: usize) -> rocketmq_error::RocketMQError {
     })
 }
 
-fn sorted_ext_fields(map: &HashMap<CheetahString, CheetahString>) -> Vec<(&CheetahString, &CheetahString)> {
+enum SortedExtFields<'a> {
+    Direct(std::collections::hash_map::Iter<'a, CheetahString, CheetahString>),
+    Sorted(std::vec::IntoIter<(&'a CheetahString, &'a CheetahString)>),
+}
+
+impl<'a> Iterator for SortedExtFields<'a> {
+    type Item = (&'a CheetahString, &'a CheetahString);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Direct(entries) => entries.find(|(key, _)| !key.is_empty()),
+            Self::Sorted(entries) => entries.next(),
+        }
+    }
+}
+
+fn sorted_ext_fields(map: &HashMap<CheetahString, CheetahString>) -> SortedExtFields<'_> {
+    if map.len() <= 1 {
+        return SortedExtFields::Direct(map.iter());
+    }
     let mut entries = map.iter().filter(|(key, _)| !key.is_empty()).collect::<Vec<_>>();
     entries.sort_unstable_by(|(left, _), (right, _)| left.as_str().cmp(right.as_str()));
-    entries
+    SortedExtFields::Sorted(entries.into_iter())
 }
 
 pub struct RocketMQSerializable;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9377

### Brief Description

Avoid allocating and sorting a temporary vector when a ROCKETMQ extension-field map has zero or one entry. The shared iterator keeps the existing canonical sorted path for two or more entries, preserves empty-key filtering, and is used by both fallible command encoding and exact-capacity map serialization.

Record why a `SmallVec` threshold is not justified without production-weighted evidence around the 16/17-field boundary.

### How Did You Test This Change?

- `cargo test --locked -p rocketmq-protocol --lib protocol::rocketmq_serializable::tests` (21 passed)
- `cargo test --locked -p rocketmq-protocol --test remoting_wire_golden` (2 passed)
- `cargo fmt -p rocketmq-protocol -- --check`
- `cargo clippy --locked -p rocketmq-protocol --no-deps --all-targets --all-features -- -D warnings`
- `git diff --check`
