### PR TITLE
[ISSUE #9379]📝Record direct codec expansion stop decision

### DIFF
--- a/rocketmq-doc/en/performance/remoting-command/opt-06.md
+++ b/rocketmq-doc/en/performance/remoting-command/opt-06.md
@@ -1,0 +1,17 @@
+# OPT-06: direct request-header codec expansion stop decision
+
+## Evidence audit
+
+The formal corpus contains 48 Java-compatible cases across 12 representative headers and both wire formats. It is suitable for per-schema correctness and cost comparison, but every schema has equal benchmark weight. It does not identify the production top request codes, the fraction of traffic still using map-based encoding, or the CPU share attributable to materialize, merge, and canonical sort.
+
+Existing direct codecs already cover several send, pull, response, and notification headers. Selecting more headers from benchmark latency alone would favor complex synthetic cases rather than verified production frequency. It would also add generated `.text`, macro output, clean build work, and a wider alias/default/collision compatibility surface.
+
+## Decision
+
+**STOP.** Do not expand the direct-codec registry without a production request-code ranking and CPU attribution showing a non-direct header is hot. No batch can meet the required selection gate, so Java fixtures, code-size measurements, and build-time A/B are intentionally not started.
+
+Reopen with a top-N table containing request share, CPU share, current allocations per operation, wire format, and existing capability. Limit each batch to at most three headers of the same risk level, keep DirectBinary separate, and preserve independent rollback per header.
+
+## Rollback
+
+No production or generated code changed. The checked-in 48-case corpus remains the compatibility control for a future evidence-backed batch.


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9379

### Brief Description

Record the stop decision for expanding generated direct request-header codecs. The formal corpus provides compatibility and per-schema cost evidence, but intentionally weights schemas equally and cannot identify production-hot non-direct headers or CPU attribution.

Define the request-share, CPU-share, allocation, code-size, and build-time evidence required before selecting a future batch of at most three independently reversible headers.

### How Did You Test This Change?

- Audited the 48-case Java-compatible header corpus, direct-codec capability coverage, and formal allocation summary.
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added OPT-06 decision documentation for expanding direct request-header codecs.
  * Defined criteria for future evaluations, including production rankings and CPU attribution.
  * Documented safeguards for future batches, including limited scope, separate handling, and per-header rollback.
  * Confirmed that no production code changed and existing compatibility coverage remains in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->