### PR TITLE
[ISSUE #9389]🧪Cover hook visibility and lazy field clone isolation

### DIFF
--- a/rocketmq-protocol/src/protocol/remoting_command.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command.rs
@@ -2057,6 +2057,42 @@ mod tests {
     }
 
     #[test]
+    fn populated_raw_cache_clone_mutation_preserves_the_original_for_both_protocols() {
+        let mut json_header = json_header_with_ext_fields(r#"{"original":"json"}"#);
+        let json_length = json_header.len();
+        let json = RemotingCommand::header_decode(&mut json_header, json_length, SerializeType::JSON)
+            .unwrap()
+            .unwrap();
+
+        let mut rocketmq_source = RemotingCommand::create_remoting_command(1)
+            .set_serialize_type(SerializeType::ROCKETMQ)
+            .set_ext_fields(HashMap::from([(
+                CheetahString::from_static_str("original"),
+                CheetahString::from_static_str("rocketmq"),
+            )]));
+        let mut encoded = BytesMut::new();
+        rocketmq_source.try_fast_header_encode(&mut encoded).unwrap();
+        let rocketmq = RemotingCommand::decode(&mut encoded).unwrap().unwrap();
+
+        for original in [json, rocketmq] {
+            assert!(original
+                .ext_fields()
+                .is_some_and(|fields| fields.contains_key("original")));
+            assert!(original.ext_fields.has_materialized_map());
+
+            let mut cloned = original.clone();
+            cloned.add_ext_field("cloned", "only");
+
+            assert!(original
+                .ext_fields()
+                .is_some_and(|fields| !fields.contains_key("cloned")));
+            assert!(cloned
+                .ext_fields()
+                .is_some_and(|fields| fields.get("cloned").is_some_and(|value| value == "only")));
+        }
+    }
+
+    #[test]
     fn json_decode_preserves_absent_null_and_empty_extension_fields() {
         let mut missing = BytesMut::from(
             r#"{"code":1,"language":"RUST","version":0,"opaque":7,"flag":0,"remark":null,"serializeTypeCurrentRPC":"JSON"}"#

--- a/rocketmq-transport/src/clients/rocketmq_tokio_client.rs
+++ b/rocketmq-transport/src/clients/rocketmq_tokio_client.rs
@@ -1949,6 +1949,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
 #[cfg(test)]
 mod tests {
     use std::net::SocketAddr;
+    use std::sync::atomic::AtomicBool;
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering;
     use std::sync::Arc;
@@ -1972,6 +1973,7 @@ mod tests {
     struct CountingHook {
         before_count: AtomicUsize,
         after_count: AtomicUsize,
+        after_observed_before_field: AtomicBool,
     }
 
     impl RPCHook for CountingHook {
@@ -1985,10 +1987,17 @@ mod tests {
         fn do_after_response(
             &self,
             _remote_addr: SocketAddr,
-            _request: &RemotingCommand,
+            request: &RemotingCommand,
             response: &mut RemotingCommand,
         ) -> RocketMQResult<()> {
             self.after_count.fetch_add(1, Ordering::SeqCst);
+            self.after_observed_before_field.store(
+                request
+                    .ext_fields()
+                    .and_then(|fields| fields.get("hooked"))
+                    .is_some_and(|value| value == "true"),
+                Ordering::SeqCst,
+            );
             response.ensure_ext_fields_initialized();
             response.add_ext_field("afterHook", "true");
             Ok(())
@@ -2207,6 +2216,7 @@ mod tests {
 
         assert_eq!(hook.before_count.load(Ordering::SeqCst), 1);
         assert_eq!(hook.after_count.load(Ordering::SeqCst), 1);
+        assert!(hook.after_observed_before_field.load(Ordering::SeqCst));
         assert_eq!(
             response
                 .ext_fields()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9389

### Brief Description

Add direct contract coverage for two ownership guarantees used by the remoting qualification. The outbound hook test now proves the after hook observes the request field added by the before hook. The protocol test reads and populates JSON and ROCKETMQ raw caches, clones each command, mutates the clone, and proves the original cached map remains unchanged.

Production behavior and public APIs are unchanged.

### How Did You Test This Change?

- `cargo test --locked -p rocketmq-protocol --lib populated_raw_cache_clone_mutation_preserves_the_original_for_both_protocols` (1 passed)
- `cargo test --locked -p rocketmq-transport --lib invoke_request_runs_outbound_rpc_hooks` (1 passed)
- `cargo fmt -p rocketmq-protocol -p rocketmq-transport -- --check`
- `cargo clippy --locked -p rocketmq-protocol -p rocketmq-transport --no-deps --all-targets --all-features -- -D warnings`
- `git diff --check`
