### PR TITLE
[ISSUE #9392] Fix broken star history chart in README

### DIFF
--- a/README-zh_cn.md
+++ b/README-zh_cn.md
@@ -321,7 +321,7 @@ RocketMQ-Rust 利用 Rust 的零成本抽象和高效的异步运行时，以较
 
 ### Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=mxsm/rocketmq-rust&type=Date)](https://star-history.com/#mxsm/rocketmq-rust&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=mxsm/rocketmq-rust&type=Date)](https://star-history.dera.page/#mxsm/rocketmq-rust&Date)
 
 ## 📄 许可证
 


### PR DESCRIPTION
The star history chart in the Chinese README is currently broken because the previous provider is affected by GitHub stargazer API restrictions.

This change points the chart to a provider that works without an API token, so the star history renders correctly again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fix #9392

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History chart link and image source to the new hosting endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->