### PR TITLE
[ISSUE #9396]✨Define the core release package scope

### DIFF
--- a/scripts/architecture-release-plan.json
+++ b/scripts/architecture-release-plan.json
@@ -2,6 +2,12 @@
   "schema_version": 2,
   "milestone": "P0",
   "design_source": "rocketmq-doc/en/architecture-release-governance.md#release-topology",
+  "scope_reporting": {
+    "core_scope": "scripts/core-release-scope.json",
+    "core_command": "python scripts/architecture_release_guard.py --scope core-release",
+    "repo_global_command": "python scripts/architecture_release_guard.py --scope repo-global",
+    "release_decision_scope": "core-release"
+  },
   "release_topology": {
     "publish_order": [
       "rocketmq-error",

--- a/scripts/architecture_release_guard.py
+++ b/scripts/architecture_release_guard.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import argparse
 from dataclasses import dataclass
 from datetime import date
 import json
@@ -25,6 +26,8 @@ import sys
 import tomllib
 from pathlib import Path
 from typing import Any
+
+import core_release_scope
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -416,6 +419,19 @@ def validate_transition_contract(plan: dict[str, Any], findings: list[Finding]) 
         )
 
 
+def validate_scope_reporting(plan: dict[str, Any], findings: list[Finding]) -> None:
+    expected = {
+        "core_scope": "scripts/core-release-scope.json",
+        "core_command": "python scripts/architecture_release_guard.py --scope core-release",
+        "repo_global_command": "python scripts/architecture_release_guard.py --scope repo-global",
+        "release_decision_scope": "core-release",
+    }
+    if plan.get("scope_reporting") != expected:
+        findings.append(
+            Finding("scope-reporting-invalid", "release-plan", "core/repo-global contract drifted")
+        )
+
+
 def validate_ci(root: Path, findings: list[Finding]) -> None:
     try:
         workflow = (root / CI_PATH.relative_to(ROOT)).read_text(encoding="utf-8")
@@ -448,12 +464,38 @@ def validate(
     validate_release_topology(plan, policy, inventory, root, findings)
     validate_compatibility_windows(plan, baseline, root, findings)
     validate_transition_contract(plan, findings)
+    validate_scope_reporting(plan, findings)
     if check_ci:
         validate_ci(root, findings)
     return sorted(findings, key=Finding.render)
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--scope", choices=("core-release", "repo-global", "all"), default="all")
+    args = parser.parse_args()
+
+    if args.scope in {"core-release", "all"}:
+        try:
+            scope, scope_findings = core_release_scope.validate_repository()
+        except core_release_scope.ScopeInputError as error:
+            print(f"ARCHITECTURE_RELEASE_CORE_FAILED findings=1 detail={error}")
+            if args.scope == "core-release":
+                return 1
+            scope_findings = []
+            core_failed = True
+        else:
+            core_only = [item for item in scope_findings if item.scope == "core"]
+            core_failed = bool(core_only)
+            if core_failed:
+                print(f"ARCHITECTURE_RELEASE_CORE_FAILED findings={len(core_only)}")
+                for finding in core_only:
+                    print(finding.render())
+            else:
+                print(f"ARCHITECTURE_RELEASE_CORE_OK packages={len(core_release_scope.core_packages(scope))}")
+        if args.scope == "core-release":
+            return int(core_failed)
+
     findings: list[Finding] = []
     plan = load_json(PLAN_PATH, "release plan", findings)
     policy = load_json(POLICY_PATH, "dependency policy", findings)
@@ -462,11 +504,15 @@ def main() -> int:
         findings.extend(validate(plan, policy, baseline))
     findings = sorted(findings, key=Finding.render)
     if findings:
-        print(f"ARCHITECTURE_RELEASE_GUARD_FAILED findings={len(findings)}")
+        print(f"ARCHITECTURE_RELEASE_REPO_GLOBAL_FAILED findings={len(findings)}")
         for finding in findings:
             print(finding.render())
         return 1
-    print("ARCHITECTURE_RELEASE_GUARD_OK packages=29 standalone=7 transition_debt=tracked")
+    print("ARCHITECTURE_RELEASE_REPO_GLOBAL_OK packages=29 standalone=7 transition_debt=tracked")
+    if args.scope == "all":
+        if core_failed:
+            return 1
+        print("ARCHITECTURE_RELEASE_GUARD_OK core=27 repo_global_packages=29 standalone=7")
     return 0
 
 

--- a/scripts/core-release-scope.json
+++ b/scripts/core-release-scope.json
@@ -1,0 +1,221 @@
+{
+  "schema_version": 1,
+  "scope_name": "core-release",
+  "workspace_manifest": "Cargo.toml",
+  "metadata_command": [
+    "cargo",
+    "metadata",
+    "--no-deps",
+    "--format-version",
+    "1",
+    "--locked"
+  ],
+  "allowed_classifications": [
+    "registry-publish",
+    "internal-only",
+    "binary-only",
+    "non-publish"
+  ],
+  "core_packages": [
+    {
+      "name": "rocketmq-admin-cli",
+      "path": "rocketmq-tools/rocketmq-admin/rocketmq-admin-cli",
+      "classification": "binary-only"
+    },
+    {
+      "name": "rocketmq-admin-core",
+      "path": "rocketmq-tools/rocketmq-admin/rocketmq-admin-core",
+      "classification": "registry-publish"
+    },
+    {
+      "name": "rocketmq-admin-tui",
+      "path": "rocketmq-tools/rocketmq-admin/rocketmq-admin-tui",
+      "classification": "binary-only"
+    },
+    {
+      "name": "rocketmq-auth",
+      "path": "rocketmq-auth",
+      "classification": "registry-publish"
+    },
+    {
+      "name": "rocketmq-broker",
+      "path": "rocketmq-broker",
+      "classification": "registry-publish"
+    },
+    {
+      "name": "rocketmq-client-rust",
+      "path": "rocketmq-client",
+      "classification": "registry-publish"
+    },
+    {
+      "name": "rocketmq-controller",
+      "path": "rocketmq-controller",
+      "classification": "registry-publish"
+    },
+    {
+      "name": "rocketmq-error",
+      "path": "rocketmq-error",
+      "classification": "registry-publish"
+    },
+    {
+      "name": "rocketmq-filter",
+      "path": "rocketmq-filter",
+      "classification": "registry-publish"
+    },
+    {
+      "name": "rocketmq-macros",
+      "path": "rocketmq-macros",
+      "classification": "registry-publish"
+    },
+    {
+      "name": "rocketmq-model",
+      "path": "rocketmq-model",
+      "classification": "registry-publish"
+    },
+    {
+      "name": "rocketmq-namesrv",
+      "path": "rocketmq-namesrv",
+      "classification": "registry-publish"
+    },
+    {
+      "name": "rocketmq-observability",
+      "path": "rocketmq-observability",
+      "classification": "registry-publish"
+    },
+    {
+      "name": "rocketmq-protocol",
+      "path": "rocketmq-protocol",
+      "classification": "registry-publish"
+    },
+    {
+      "name": "rocketmq-proxy",
+      "path": "rocketmq-proxy",
+      "classification": "registry-publish"
+    },
+    {
+      "name": "rocketmq-proxy-cluster",
+      "path": "rocketmq-proxy-cluster",
+      "classification": "registry-publish"
+    },
+    {
+      "name": "rocketmq-proxy-core",
+      "path": "rocketmq-proxy-core",
+      "classification": "registry-publish"
+    },
+    {
+      "name": "rocketmq-proxy-local",
+      "path": "rocketmq-proxy-local",
+      "classification": "registry-publish"
+    },
+    {
+      "name": "rocketmq-runtime",
+      "path": "rocketmq-runtime",
+      "classification": "registry-publish"
+    },
+    {
+      "name": "rocketmq-security-api",
+      "path": "rocketmq-security-api",
+      "classification": "registry-publish"
+    },
+    {
+      "name": "rocketmq-store",
+      "path": "rocketmq-store",
+      "classification": "registry-publish"
+    },
+    {
+      "name": "rocketmq-store-api",
+      "path": "rocketmq-store-api",
+      "classification": "registry-publish"
+    },
+    {
+      "name": "rocketmq-store-inspect",
+      "path": "rocketmq-tools/rocketmq-store-inspect",
+      "classification": "binary-only"
+    },
+    {
+      "name": "rocketmq-store-local",
+      "path": "rocketmq-store-local",
+      "classification": "registry-publish"
+    },
+    {
+      "name": "rocketmq-store-rocksdb",
+      "path": "rocketmq-store-rocksdb",
+      "classification": "registry-publish"
+    },
+    {
+      "name": "rocketmq-tieredstore",
+      "path": "rocketmq-tieredstore",
+      "classification": "registry-publish"
+    },
+    {
+      "name": "rocketmq-transport",
+      "path": "rocketmq-transport",
+      "classification": "registry-publish"
+    }
+  ],
+  "workspace_exclusions": [
+    {
+      "name": "rocketmq-dashboard-common",
+      "path": "rocketmq-dashboard/rocketmq-dashboard-common",
+      "reason": "excluded-dashboard"
+    }
+  ],
+  "repository_exclusions": [
+    {
+      "name": "rocketmq-mcp",
+      "path": "rocketmq-tools/rocketmq-mcp",
+      "reason": "excluded-mcp"
+    },
+    {
+      "name": "rocketmq-sre",
+      "path": "rocketmq-sre",
+      "reason": "excluded-sre"
+    },
+    {
+      "name": "rocketmq-sre-ui",
+      "path": "rocketmq-sre/ui",
+      "reason": "excluded-sre"
+    },
+    {
+      "name": "rocketmq-sre-typescript-sdk",
+      "path": "rocketmq-sre/sdk/typescript",
+      "reason": "excluded-sre"
+    },
+    {
+      "name": "rocketmq-dashboard-gpui",
+      "path": "rocketmq-dashboard/rocketmq-dashboard-gpui",
+      "reason": "excluded-dashboard"
+    },
+    {
+      "name": "rocketmq-dashboard-tauri",
+      "path": "rocketmq-dashboard/rocketmq-dashboard-tauri",
+      "reason": "excluded-dashboard"
+    },
+    {
+      "name": "rocketmq-dashboard-tauri-backend",
+      "path": "rocketmq-dashboard/rocketmq-dashboard-tauri/src-tauri",
+      "reason": "excluded-dashboard"
+    },
+    {
+      "name": "rocketmq-dashboard-web",
+      "path": "rocketmq-dashboard/rocketmq-dashboard-web",
+      "reason": "excluded-dashboard"
+    },
+    {
+      "name": "rocketmq-dashboard-web-backend",
+      "path": "rocketmq-dashboard/rocketmq-dashboard-web/backend",
+      "reason": "excluded-dashboard"
+    },
+    {
+      "name": "rocketmq-dashboard-web-frontend",
+      "path": "rocketmq-dashboard/rocketmq-dashboard-web/frontend",
+      "reason": "excluded-dashboard"
+    }
+  ],
+  "core_services": [
+    "rocketmq-namesrv",
+    "rocketmq-broker",
+    "rocketmq-controller",
+    "rocketmq-proxy"
+  ]
+}

--- a/scripts/core_release_guard.py
+++ b/scripts/core_release_guard.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Validate the machine-readable RocketMQ core release package scope."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import core_release_scope
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--scope", choices=("core-release", "repo-global", "all"), default="core-release")
+    args = parser.parse_args()
+    try:
+        scope, findings = core_release_scope.validate_repository()
+    except core_release_scope.ScopeInputError as error:
+        print(f"CORE_RELEASE_SCOPE_INPUT_FAILED detail={error}")
+        return 1
+
+    core_findings = [item for item in findings if item.scope == "core"]
+    repo_findings = [item for item in findings if item.scope == "repo-global"]
+    if core_findings:
+        print(f"CORE_RELEASE_SCOPE_FAILED findings={len(core_findings)}")
+        for finding in core_findings:
+            print(finding.render())
+    else:
+        print(
+            "CORE_RELEASE_SCOPE_OK "
+            f"packages={len(core_release_scope.core_packages(scope))} "
+            f"workspace_exclusions={len(scope['workspace_exclusions'])}"
+        )
+    if repo_findings:
+        print(f"CORE_RELEASE_REPO_GLOBAL_FAILED findings={len(repo_findings)}")
+        for finding in repo_findings:
+            print(finding.render())
+    else:
+        print(f"CORE_RELEASE_REPO_GLOBAL_OK exclusions={len(scope['repository_exclusions'])}")
+
+    if args.scope == "core-release":
+        return int(bool(core_findings))
+    if args.scope == "repo-global":
+        return int(bool(repo_findings))
+    return int(bool(findings))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/core_release_scope.py
+++ b/scripts/core_release_scope.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Load and validate the package boundary used by core release tooling."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import json
+from pathlib import Path
+import subprocess
+from typing import Any, Iterable
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCOPE_PATH = ROOT / "scripts" / "core-release-scope.json"
+CLASSIFICATIONS = frozenset(
+    {"registry-publish", "internal-only", "binary-only", "non-publish"}
+)
+FORBIDDEN_CORE_NAMES = frozenset({"rocketmq-dashboard-common", "rocketmq-mcp", "rocketmq-sre"})
+FORBIDDEN_CORE_PATH_PARTS = frozenset({"rocketmq-dashboard", "rocketmq-sre", "rocketmq-mcp"})
+
+
+class ScopeInputError(ValueError):
+    """Raised when the scope or Cargo metadata cannot be parsed."""
+
+
+@dataclass(frozen=True, order=True)
+class ScopeFinding:
+    scope: str
+    code: str
+    path: str
+    detail: str
+
+    def as_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+    def render(self) -> str:
+        return (
+            f"CORE_SCOPE_FINDING scope={self.scope} code={self.code} "
+            f"path={self.path} detail={self.detail}"
+        )
+
+
+def load_scope(path: Path = SCOPE_PATH) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ScopeInputError(f"cannot load {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise ScopeInputError(f"{path} must contain a JSON object")
+    return value
+
+
+def core_packages(scope: dict[str, Any] | None = None) -> tuple[dict[str, Any], ...]:
+    value = (scope or load_scope()).get("core_packages")
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise ScopeInputError("core_packages must be a list of objects")
+    return tuple(value)
+
+
+def excluded_projects(scope: dict[str, Any] | None = None) -> tuple[dict[str, Any], ...]:
+    loaded = scope or load_scope()
+    values: list[dict[str, Any]] = []
+    for field in ("workspace_exclusions", "repository_exclusions"):
+        entries = loaded.get(field)
+        if not isinstance(entries, list) or any(not isinstance(item, dict) for item in entries):
+            raise ScopeInputError(f"{field} must be a list of objects")
+        values.extend(entries)
+    return tuple(values)
+
+
+def collect_metadata(root: Path = ROOT) -> dict[str, Any]:
+    completed = subprocess.run(
+        ["cargo", "metadata", "--no-deps", "--format-version", "1", "--locked"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise ScopeInputError(f"cargo metadata failed: {completed.stderr.strip()}")
+    try:
+        value = json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise ScopeInputError(f"cargo metadata returned invalid JSON: {error}") from error
+    if not isinstance(value, dict):
+        raise ScopeInputError("cargo metadata must return a JSON object")
+    return value
+
+
+def _normalized_relative_path(value: object) -> str | None:
+    if not isinstance(value, str) or not value or "\\" in value:
+        return None
+    path = Path(value)
+    if path.is_absolute() or ".." in path.parts:
+        return None
+    return path.as_posix().rstrip("/")
+
+
+def _entries(scope: dict[str, Any], field: str, findings: list[ScopeFinding]) -> list[dict[str, Any]]:
+    value = scope.get(field)
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        findings.append(ScopeFinding("core", "scope-section-invalid", "scripts/core-release-scope.json", field))
+        return []
+    return value
+
+
+def _validate_paths_and_duplicates(
+    entries: Iterable[dict[str, Any]],
+    *,
+    root: Path,
+    finding_scope: str,
+    classification_required: bool,
+    findings: list[ScopeFinding],
+) -> tuple[set[str], set[str]]:
+    names: set[str] = set()
+    paths: set[str] = set()
+    for index, entry in enumerate(entries):
+        name = entry.get("name")
+        path = _normalized_relative_path(entry.get("path"))
+        label = path or f"entry[{index}]"
+        if not isinstance(name, str) or not name or path is None:
+            findings.append(ScopeFinding(finding_scope, "scope-entry-invalid", label, f"entry={entry!r}"))
+            continue
+        if name in names or path in paths:
+            findings.append(ScopeFinding(finding_scope, "scope-package-duplicate", path, f"package={name}"))
+        names.add(name)
+        paths.add(path)
+        if not (root / path).exists():
+            findings.append(ScopeFinding(finding_scope, "scope-path-missing", path, f"package={name}"))
+        if classification_required and entry.get("classification") not in CLASSIFICATIONS:
+            findings.append(
+                ScopeFinding(
+                    finding_scope,
+                    "scope-classification-invalid",
+                    path,
+                    f"package={name} classification={entry.get('classification')!r}",
+                )
+            )
+    return names, paths
+
+
+def _workspace_packages(metadata: dict[str, Any], root: Path, findings: list[ScopeFinding]) -> dict[str, str]:
+    packages = metadata.get("packages")
+    members = metadata.get("workspace_members")
+    if not isinstance(packages, list) or not isinstance(members, list):
+        findings.append(ScopeFinding("core", "metadata-invalid", "cargo metadata", "packages/workspace_members"))
+        return {}
+    by_id = {item.get("id"): item for item in packages if isinstance(item, dict)}
+    result: dict[str, str] = {}
+    root_resolved = root.resolve()
+    for package_id in members:
+        package = by_id.get(package_id)
+        if not isinstance(package, dict):
+            findings.append(ScopeFinding("core", "metadata-member-missing", "cargo metadata", str(package_id)))
+            continue
+        name = package.get("name")
+        manifest = package.get("manifest_path")
+        if not isinstance(name, str) or not isinstance(manifest, str):
+            findings.append(ScopeFinding("core", "metadata-package-invalid", "cargo metadata", str(package_id)))
+            continue
+        try:
+            relative = Path(manifest).resolve().parent.relative_to(root_resolved).as_posix()
+        except ValueError:
+            findings.append(ScopeFinding("core", "metadata-path-outside-root", manifest, f"package={name}"))
+            continue
+        result[name] = relative
+    return result
+
+
+def validate_metadata(
+    scope: dict[str, Any],
+    metadata: dict[str, Any],
+    *,
+    root: Path = ROOT,
+) -> list[ScopeFinding]:
+    findings: list[ScopeFinding] = []
+    if scope.get("schema_version") != 1 or scope.get("scope_name") != "core-release":
+        findings.append(
+            ScopeFinding(
+                "core",
+                "scope-schema-invalid",
+                "scripts/core-release-scope.json",
+                "expected schema_version=1 scope_name=core-release",
+            )
+        )
+    declared_classifications = scope.get("allowed_classifications")
+    if (
+        not isinstance(declared_classifications, list)
+        or len(declared_classifications) != len(CLASSIFICATIONS)
+        or any(not isinstance(item, str) for item in declared_classifications)
+        or set(declared_classifications) != CLASSIFICATIONS
+    ):
+        findings.append(
+            ScopeFinding(
+                "core",
+                "scope-classifications-invalid",
+                "scripts/core-release-scope.json",
+                "classification set drifted",
+            )
+        )
+
+    core = _entries(scope, "core_packages", findings)
+    workspace_exclusions = _entries(scope, "workspace_exclusions", findings)
+    repository_exclusions = _entries(scope, "repository_exclusions", findings)
+    core_names, core_paths = _validate_paths_and_duplicates(
+        core,
+        root=root,
+        finding_scope="core",
+        classification_required=True,
+        findings=findings,
+    )
+    excluded_names, excluded_paths = _validate_paths_and_duplicates(
+        workspace_exclusions,
+        root=root,
+        finding_scope="core",
+        classification_required=False,
+        findings=findings,
+    )
+    _validate_paths_and_duplicates(
+        repository_exclusions,
+        root=root,
+        finding_scope="repo-global",
+        classification_required=False,
+        findings=findings,
+    )
+
+    if len(core) != 27:
+        findings.append(
+            ScopeFinding(
+                "core",
+                "core-package-count",
+                "scripts/core-release-scope.json",
+                f"expected=27 actual={len(core)}",
+            )
+        )
+    if core_names & excluded_names or core_paths & excluded_paths:
+        findings.append(
+            ScopeFinding(
+                "core",
+                "excluded-project-in-core",
+                "scripts/core-release-scope.json",
+                "workspace exclusion overlaps core",
+            )
+        )
+    for entry in core:
+        name = entry.get("name")
+        path = _normalized_relative_path(entry.get("path"))
+        parts = set(Path(path).parts) if path is not None else set()
+        if name in FORBIDDEN_CORE_NAMES or parts & FORBIDDEN_CORE_PATH_PARTS:
+            findings.append(
+                ScopeFinding(
+                    "core",
+                    "excluded-project-in-core",
+                    path or "core_packages",
+                    f"package={name}",
+                )
+            )
+
+    workspace = _workspace_packages(metadata, root, findings)
+    classified = core_names | excluded_names
+    for name in sorted(set(workspace) - classified):
+        findings.append(ScopeFinding("core", "workspace-package-unclassified", workspace[name], f"package={name}"))
+    for name in sorted(classified - set(workspace)):
+        findings.append(
+            ScopeFinding(
+                "core",
+                "scope-package-not-in-workspace",
+                "scripts/core-release-scope.json",
+                f"package={name}",
+            )
+        )
+    scoped_paths = {
+        entry["name"]: _normalized_relative_path(entry.get("path"))
+        for entry in (*core, *workspace_exclusions)
+        if isinstance(entry.get("name"), str)
+    }
+    for name in sorted(set(workspace) & classified):
+        if scoped_paths.get(name) != workspace[name]:
+            findings.append(
+                ScopeFinding(
+                    "core",
+                    "workspace-package-path-mismatch",
+                    workspace[name],
+                    f"package={name} scope_path={scoped_paths.get(name)!r}",
+                )
+            )
+
+    services = scope.get("core_services")
+    expected_services = {"rocketmq-namesrv", "rocketmq-broker", "rocketmq-controller", "rocketmq-proxy"}
+    if not isinstance(services, list) or set(services) != expected_services or not set(services) <= core_names:
+        findings.append(
+            ScopeFinding(
+                "core",
+                "core-services-invalid",
+                "scripts/core-release-scope.json",
+                "four core services are required",
+            )
+        )
+    return sorted(set(findings))
+
+
+def validate_repository(
+    *, root: Path = ROOT, scope_path: Path = SCOPE_PATH
+) -> tuple[dict[str, Any], list[ScopeFinding]]:
+    scope = load_scope(scope_path)
+    return scope, validate_metadata(scope, collect_metadata(root), root=root)

--- a/scripts/tests/test_core_release_scope.py
+++ b/scripts/tests/test_core_release_scope.py
@@ -1,0 +1,193 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+SCOPE_PATH = SCRIPTS / "core-release-scope.json"
+
+
+class CoreReleaseScopeTests(unittest.TestCase):
+    def load_live_scope(self) -> dict[str, object]:
+        self.assertTrue(SCOPE_PATH.is_file(), "core release scope definition is missing")
+        return json.loads(SCOPE_PATH.read_text(encoding="utf-8"))
+
+    def metadata_for(self, scope: dict[str, object], *, extra_packages: tuple[str, ...] = ()) -> dict[str, object]:
+        packages: list[dict[str, str]] = []
+        members: list[str] = []
+        entries = list(scope["core_packages"]) + list(scope["workspace_exclusions"])
+        for entry in entries:
+            name = entry["name"]
+            package_id = f"{name} 1.0.0 (path+file://fixture/{name})"
+            packages.append(
+                {
+                    "id": package_id,
+                    "name": name,
+                    "manifest_path": str(ROOT / entry["path"] / "Cargo.toml"),
+                }
+            )
+            members.append(package_id)
+        for name in extra_packages:
+            package_id = f"{name} 1.0.0 (path+file://fixture/{name})"
+            packages.append(
+                {
+                    "id": package_id,
+                    "name": name,
+                    "manifest_path": str(ROOT / name / "Cargo.toml"),
+                }
+            )
+            members.append(package_id)
+        return {"packages": packages, "workspace_members": members, "workspace_root": str(ROOT)}
+
+    def validate_fixture(
+        self,
+        scope: dict[str, object],
+        metadata: dict[str, object],
+    ) -> list[dict[str, str]]:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            scope_path = Path(temp_dir) / "scope.json"
+            metadata_path = Path(temp_dir) / "metadata.json"
+            scope_path.write_text(json.dumps(scope), encoding="utf-8")
+            metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+            code = """
+import json
+from pathlib import Path
+import core_release_scope as scope_module
+
+scope = scope_module.load_scope(Path(sys.argv[1]))
+metadata = json.loads(Path(sys.argv[2]).read_text(encoding='utf-8'))
+findings = scope_module.validate_metadata(scope, metadata, root=Path(sys.argv[3]))
+print(json.dumps([finding.as_dict() for finding in findings]))
+"""
+            completed = subprocess.run(
+                [sys.executable, "-c", "import sys\n" + code, str(scope_path), str(metadata_path), str(ROOT)],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+                env={**os.environ, "PYTHONPATH": str(SCRIPTS)},
+            )
+        self.assertEqual(0, completed.returncode, completed.stdout + completed.stderr)
+        return json.loads(completed.stdout)
+
+    def test_live_guard_matches_the_27_package_workspace_scope(self) -> None:
+        completed = subprocess.run(
+            [sys.executable, str(SCRIPTS / "core_release_guard.py")],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(0, completed.returncode, completed.stdout + completed.stderr)
+        self.assertIn("CORE_RELEASE_SCOPE_OK packages=27 workspace_exclusions=1", completed.stdout)
+
+    def test_public_helpers_expose_core_and_excluded_projects(self) -> None:
+        code = """
+import core_release_scope as scope
+loaded = scope.load_scope()
+assert len(scope.core_packages(loaded)) == 27
+assert {item['name'] for item in scope.excluded_projects(loaded)} >= {
+    'rocketmq-dashboard-common', 'rocketmq-mcp', 'rocketmq-sre'
+}
+"""
+        completed = subprocess.run(
+            [sys.executable, "-c", code],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            env={**os.environ, "PYTHONPATH": str(SCRIPTS)},
+        )
+
+        self.assertEqual(0, completed.returncode, completed.stdout + completed.stderr)
+
+    def test_unclassified_workspace_package_is_a_core_finding(self) -> None:
+        scope = self.load_live_scope()
+        findings = self.validate_fixture(scope, self.metadata_for(scope, extra_packages=("rocketmq-new",)))
+
+        self.assertIn("workspace-package-unclassified", {item["code"] for item in findings})
+
+    def test_duplicate_missing_path_and_invalid_classification_are_findings(self) -> None:
+        scope = self.load_live_scope()
+        duplicate = copy.deepcopy(scope["core_packages"][0])
+        scope["core_packages"].append(duplicate)
+        scope["core_packages"][1]["path"] = "rocketmq-does-not-exist"
+        scope["core_packages"][2]["classification"] = "implicit"
+
+        findings = self.validate_fixture(scope, self.metadata_for(self.load_live_scope()))
+        codes = {item["code"] for item in findings}
+        self.assertTrue(
+            {"scope-package-duplicate", "scope-path-missing", "scope-classification-invalid"}.issubset(codes),
+            findings,
+        )
+
+    def test_malformed_classification_inventory_is_a_structured_finding(self) -> None:
+        scope = self.load_live_scope()
+        scope["allowed_classifications"] = [{}, "internal-only", "binary-only", "non-publish"]
+
+        findings = self.validate_fixture(scope, self.metadata_for(self.load_live_scope()))
+        self.assertIn("scope-classifications-invalid", {item["code"] for item in findings})
+
+    def test_dashboard_mcp_and_sre_cannot_be_core_packages(self) -> None:
+        for forbidden_name, forbidden_path in (
+            ("rocketmq-dashboard-common", "rocketmq-dashboard/rocketmq-dashboard-common"),
+            ("rocketmq-mcp", "rocketmq-tools/rocketmq-mcp"),
+            ("rocketmq-sre", "rocketmq-sre"),
+        ):
+            with self.subTest(package=forbidden_name):
+                scope = self.load_live_scope()
+                scope["core_packages"][0] = {
+                    "name": forbidden_name,
+                    "path": forbidden_path,
+                    "classification": "registry-publish",
+                }
+                findings = self.validate_fixture(scope, self.metadata_for(self.load_live_scope()))
+                self.assertIn("excluded-project-in-core", {item["code"] for item in findings})
+
+    def test_repository_global_finding_does_not_change_core_result(self) -> None:
+        scope = self.load_live_scope()
+        scope["repository_exclusions"][0]["path"] = "missing-standalone-project"
+
+        findings = self.validate_fixture(scope, self.metadata_for(self.load_live_scope()))
+        self.assertEqual([], [item for item in findings if item["scope"] == "core"])
+        self.assertIn("scope-path-missing", {item["code"] for item in findings if item["scope"] == "repo-global"})
+
+    def test_architecture_guard_has_an_independent_core_mode(self) -> None:
+        completed = subprocess.run(
+            [sys.executable, str(SCRIPTS / "architecture_release_guard.py"), "--scope", "core-release"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(0, completed.returncode, completed.stdout + completed.stderr)
+        self.assertIn("ARCHITECTURE_RELEASE_CORE_OK packages=27", completed.stdout)
+        self.assertNotIn("ARCHITECTURE_RELEASE_REPO_GLOBAL_FAILED", completed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9396

### Brief Description

- Add a machine-readable scope for the 27 core workspace packages with explicit publication classifications.
- Keep Dashboard, MCP, SRE, and other non-core projects outside the core release boundary.
- Validate the scope against locked Cargo metadata and fail on workspace drift, invalid paths, duplicate entries, or excluded packages.
- Add independent core and repository-global modes to the architecture release guard while preserving the existing combined check.

### How Did You Test This Change?

- `python -m unittest scripts.tests.test_core_release_scope scripts.tests.test_architecture_release_guard -v`
- `python scripts/core_release_guard.py`
- `python scripts/architecture_release_guard.py --scope core-release`
- `python scripts/architecture_release_guard.py --scope repo-global`
- `cargo metadata --no-deps --format-version 1 --locked`
- `./scripts/check-agents-routing.ps1`
- `python -m compileall -q scripts/core_release_scope.py scripts/core_release_guard.py scripts/architecture_release_guard.py scripts/tests/test_core_release_scope.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for the RocketMQ core release scope and repository-wide release checks.
  * Added command options to run core-only, repository-global, or combined validation.
  * Added clear reporting of scope-specific findings and validation status.

* **Bug Fixes**
  * Improved detection of invalid, missing, duplicate, excluded, or unclassified release packages.

* **Tests**
  * Added comprehensive coverage for scope validation, command output, invalid inputs, and repository-wide findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->