### PR TITLE
[ISSUE #9400]✨Generate the Java 5.5 compatibility inventory

### DIFF
--- a/scripts/fixtures/java-5.5-core-inventory.json
+++ b/scripts/fixtures/java-5.5-core-inventory.json
@@ -1,0 +1,10999 @@
+{
+  "schema_version": 1,
+  "java_version": "5.5.0",
+  "inventory_semantics": {
+    "raw": "A symbol exists in the Java 5.5 source inventory; this does not claim behavioral coverage.",
+    "active": "A user-visible Java route, operation, field, or explicitly required protocol item.",
+    "excluded": "An approved product-scope exclusion retained for raw recognition only."
+  },
+  "request_codes": [
+    {
+      "symbol": "SEND_MESSAGE",
+      "value": 10,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "PULL_MESSAGE",
+      "value": 11,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "QUERY_MESSAGE",
+      "value": 12,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "QUERY_BROKER_OFFSET",
+      "value": 13,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "QUERY_CONSUMER_OFFSET",
+      "value": 14,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "UPDATE_CONSUMER_OFFSET",
+      "value": 15,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "UPDATE_AND_CREATE_TOPIC",
+      "value": 17,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "UPDATE_AND_CREATE_TOPIC_LIST",
+      "value": 18,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_ALL_TOPIC_CONFIG",
+      "value": 21,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_TOPIC_CONFIG_LIST",
+      "value": 22,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_TOPIC_NAME_LIST",
+      "value": 23,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "UPDATE_BROKER_CONFIG",
+      "value": 25,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_BROKER_CONFIG",
+      "value": 26,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "TRIGGER_DELETE_FILES",
+      "value": 27,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_BROKER_RUNTIME_INFO",
+      "value": 28,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "SEARCH_OFFSET_BY_TIMESTAMP",
+      "value": 29,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_MAX_OFFSET",
+      "value": 30,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_MIN_OFFSET",
+      "value": 31,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_EARLIEST_MSG_STORETIME",
+      "value": 32,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "VIEW_MESSAGE_BY_ID",
+      "value": 33,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "HEART_BEAT",
+      "value": 34,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "UNREGISTER_CLIENT",
+      "value": 35,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONSUMER_SEND_MSG_BACK",
+      "value": 36,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "END_TRANSACTION",
+      "value": 37,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_CONSUMER_LIST_BY_GROUP",
+      "value": 38,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CHECK_TRANSACTION_STATE",
+      "value": 39,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "NOTIFY_CONSUMER_IDS_CHANGED",
+      "value": 40,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "LOCK_BATCH_MQ",
+      "value": 41,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "UNLOCK_BATCH_MQ",
+      "value": 42,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_ALL_CONSUMER_OFFSET",
+      "value": 43,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_ALL_DELAY_OFFSET",
+      "value": 45,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CHECK_CLIENT_CONFIG",
+      "value": 46,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_CLIENT_CONFIG",
+      "value": 47,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_TIMER_CHECK_POINT",
+      "value": 60,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_TIMER_METRICS",
+      "value": 61,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "PUT_KV_CONFIG",
+      "value": 100,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_KV_CONFIG",
+      "value": 101,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "DELETE_KV_CONFIG",
+      "value": 102,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "REGISTER_BROKER",
+      "value": 103,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "UNREGISTER_BROKER",
+      "value": 104,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_ROUTEINFO_BY_TOPIC",
+      "value": 105,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_BROKER_CLUSTER_INFO",
+      "value": 106,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "UPDATE_AND_CREATE_SUBSCRIPTIONGROUP",
+      "value": 200,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "active",
+      "required_active": true
+    },
+    {
+      "symbol": "GET_ALL_SUBSCRIPTIONGROUP_CONFIG",
+      "value": 201,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_TOPIC_STATS_INFO",
+      "value": 202,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_CONSUMER_CONNECTION_LIST",
+      "value": 203,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_PRODUCER_CONNECTION_LIST",
+      "value": 204,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "WIPE_WRITE_PERM_OF_BROKER",
+      "value": 205,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_ALL_TOPIC_LIST_FROM_NAMESERVER",
+      "value": 206,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "DELETE_SUBSCRIPTIONGROUP",
+      "value": 207,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_CONSUME_STATS",
+      "value": 208,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "SUSPEND_CONSUMER",
+      "value": 209,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "RESUME_CONSUMER",
+      "value": 210,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "RESET_CONSUMER_OFFSET_IN_CONSUMER",
+      "value": 211,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "RESET_CONSUMER_OFFSET_IN_BROKER",
+      "value": 212,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "ADJUST_CONSUMER_THREAD_POOL",
+      "value": 213,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "WHO_CONSUME_THE_MESSAGE",
+      "value": 214,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "DELETE_TOPIC_IN_BROKER",
+      "value": 215,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "DELETE_TOPIC_IN_NAMESRV",
+      "value": 216,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "REGISTER_TOPIC_IN_NAMESRV",
+      "value": 217,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_KVLIST_BY_NAMESPACE",
+      "value": 219,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "RESET_CONSUMER_CLIENT_OFFSET",
+      "value": 220,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_CONSUMER_STATUS_FROM_CLIENT",
+      "value": 221,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "INVOKE_BROKER_TO_RESET_OFFSET",
+      "value": 222,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "INVOKE_BROKER_TO_GET_CONSUMER_STATUS",
+      "value": 223,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_TOPICS_BY_CLUSTER",
+      "value": 224,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "UPDATE_AND_CREATE_SUBSCRIPTIONGROUP_LIST",
+      "value": 225,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "QUERY_TOPIC_CONSUME_BY_WHO",
+      "value": 300,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "REGISTER_FILTER_SERVER",
+      "value": 301,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "REGISTER_MESSAGE_FILTER_CLASS",
+      "value": 302,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "QUERY_CONSUME_TIME_SPAN",
+      "value": 303,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_SYSTEM_TOPIC_LIST_FROM_NS",
+      "value": 304,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_SYSTEM_TOPIC_LIST_FROM_BROKER",
+      "value": 305,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CLEAN_EXPIRED_CONSUMEQUEUE",
+      "value": 306,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_CONSUMER_RUNNING_INFO",
+      "value": 307,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "QUERY_CORRECTION_OFFSET",
+      "value": 308,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONSUME_MESSAGE_DIRECTLY",
+      "value": 309,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "SEND_MESSAGE_V2",
+      "value": 310,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_UNIT_TOPIC_LIST",
+      "value": 311,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_HAS_UNIT_SUB_TOPIC_LIST",
+      "value": 312,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_HAS_UNIT_SUB_UNUNIT_TOPIC_LIST",
+      "value": 313,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CLONE_GROUP_OFFSET",
+      "value": 314,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "VIEW_BROKER_STATS_DATA",
+      "value": 315,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CLEAN_UNUSED_TOPIC",
+      "value": 316,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_BROKER_CONSUME_STATS",
+      "value": 317,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "UPDATE_NAMESRV_CONFIG",
+      "value": 318,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_NAMESRV_CONFIG",
+      "value": 319,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "SEND_BATCH_MESSAGE",
+      "value": 320,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "QUERY_CONSUME_QUEUE",
+      "value": 321,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "QUERY_DATA_VERSION",
+      "value": 322,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "RESUME_CHECK_HALF_MESSAGE",
+      "value": 323,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "SEND_REPLY_MESSAGE",
+      "value": 324,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "SEND_REPLY_MESSAGE_V2",
+      "value": 325,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "PUSH_REPLY_MESSAGE_TO_CLIENT",
+      "value": 326,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "ADD_WRITE_PERM_OF_BROKER",
+      "value": 327,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_ALL_PRODUCER_INFO",
+      "value": 328,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "DELETE_EXPIRED_COMMITLOG",
+      "value": 329,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "QUERY_TOPICS_BY_CONSUMER",
+      "value": 343,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "QUERY_SUBSCRIPTION_BY_CONSUMER",
+      "value": 345,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_TOPIC_CONFIG",
+      "value": 351,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_SUBSCRIPTIONGROUP_CONFIG",
+      "value": 352,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "UPDATE_AND_GET_GROUP_FORBIDDEN",
+      "value": 353,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CHECK_ROCKSDB_CQ_WRITE_PROGRESS",
+      "value": 354,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "EXPORT_ROCKSDB_CONFIG_TO_JSON",
+      "value": 355,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "LITE_PULL_MESSAGE",
+      "value": 361,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "RECALL_MESSAGE",
+      "value": 370,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "QUERY_ASSIGNMENT",
+      "value": 400,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "SET_MESSAGE_REQUEST_MODE",
+      "value": 401,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_ALL_MESSAGE_REQUEST_MODE",
+      "value": 402,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "UPDATE_AND_CREATE_STATIC_TOPIC",
+      "value": 513,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_BROKER_MEMBER_GROUP",
+      "value": 901,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "ADD_BROKER",
+      "value": 902,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "REMOVE_BROKER",
+      "value": 903,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "BROKER_HEARTBEAT",
+      "value": 904,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "NOTIFY_MIN_BROKER_ID_CHANGE",
+      "value": 905,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "EXCHANGE_BROKER_HA_INFO",
+      "value": 906,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_BROKER_HA_STATUS",
+      "value": 907,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "RESET_MASTER_FLUSH_OFFSET",
+      "value": 908,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONTROLLER_ALTER_SYNC_STATE_SET",
+      "value": 1001,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONTROLLER_ELECT_MASTER",
+      "value": 1002,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONTROLLER_REGISTER_BROKER",
+      "value": 1003,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONTROLLER_GET_REPLICA_INFO",
+      "value": 1004,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONTROLLER_GET_METADATA_INFO",
+      "value": 1005,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONTROLLER_GET_SYNC_STATE_DATA",
+      "value": 1006,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_BROKER_EPOCH_CACHE",
+      "value": 1007,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "NOTIFY_BROKER_ROLE_CHANGED",
+      "value": 1008,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "UPDATE_CONTROLLER_CONFIG",
+      "value": 1009,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_CONTROLLER_CONFIG",
+      "value": 1010,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CLEAN_BROKER_DATA",
+      "value": 1011,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONTROLLER_GET_NEXT_BROKER_ID",
+      "value": 1012,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONTROLLER_APPLY_BROKER_ID",
+      "value": 1013,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "BROKER_CLOSE_CHANNEL_REQUEST",
+      "value": 1014,
+      "primitive": "short",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "controller-internal-not-applicable",
+      "required_active": false
+    },
+    {
+      "symbol": "CHECK_NOT_ACTIVE_BROKER_REQUEST",
+      "value": 1015,
+      "primitive": "short",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "controller-internal-not-applicable",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_BROKER_LIVE_INFO_REQUEST",
+      "value": 1016,
+      "primitive": "short",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "controller-internal-not-applicable",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_SYNC_STATE_DATA_REQUEST",
+      "value": 1017,
+      "primitive": "short",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "controller-internal-not-applicable",
+      "required_active": false
+    },
+    {
+      "symbol": "RAFT_BROKER_HEART_BEAT_EVENT_REQUEST",
+      "value": 1018,
+      "primitive": "short",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "controller-internal-not-applicable",
+      "required_active": false
+    },
+    {
+      "symbol": "UPDATE_COLD_DATA_FLOW_CTR_CONFIG",
+      "value": 2001,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "REMOVE_COLD_DATA_FLOW_CTR_CONFIG",
+      "value": 2002,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_COLD_DATA_FLOW_CTR_INFO",
+      "value": 2003,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "SET_COMMITLOG_READ_MODE",
+      "value": 2004,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "AUTH_CREATE_USER",
+      "value": 3001,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "AUTH_UPDATE_USER",
+      "value": 3002,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "AUTH_DELETE_USER",
+      "value": 3003,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "AUTH_GET_USER",
+      "value": 3004,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "AUTH_LIST_USER",
+      "value": 3005,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "AUTH_CREATE_ACL",
+      "value": 3006,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "AUTH_UPDATE_ACL",
+      "value": 3007,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "AUTH_DELETE_ACL",
+      "value": 3008,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "AUTH_GET_ACL",
+      "value": 3009,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "AUTH_LIST_ACL",
+      "value": 3010,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "SWITCH_TIMER_ENGINE",
+      "value": 5001,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "DELETE_TOPIC_IN_BROKER_LIST",
+      "value": 5002,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "active",
+      "required_active": true
+    },
+    {
+      "symbol": "DELETE_SUBSCRIPTION_GROUP_LIST",
+      "value": 5003,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "active",
+      "required_active": true
+    },
+    {
+      "symbol": "POP_MESSAGE",
+      "value": 200050,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "ACK_MESSAGE",
+      "value": 200051,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "PEEK_MESSAGE",
+      "value": 200052,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CHANGE_MESSAGE_INVISIBLETIME",
+      "value": 200053,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "NOTIFICATION",
+      "value": 200054,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "POLLING_INFO",
+      "value": 200055,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "POP_ROLLBACK",
+      "value": 200056,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "POP_LITE_MESSAGE",
+      "value": 200070,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "LITE_SUBSCRIPTION_CTL",
+      "value": 200071,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "ACK_LITE_MESSAGE",
+      "value": 200072,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "NOTIFY_UNSUBSCRIBE_LITE",
+      "value": 200073,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_BROKER_LITE_INFO",
+      "value": 200074,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_PARENT_TOPIC_INFO",
+      "value": 200075,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_LITE_TOPIC_INFO",
+      "value": 200076,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_LITE_CLIENT_INFO",
+      "value": 200077,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GET_LITE_GROUP_INFO",
+      "value": 200078,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "TRIGGER_LITE_DISPATCH",
+      "value": 200079,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "BATCH_ACK_MESSAGE",
+      "value": 200151,
+      "primitive": "int",
+      "purpose": "Java request code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java",
+      "classification": "raw",
+      "required_active": false
+    }
+  ],
+  "response_codes": [
+    {
+      "symbol": "RPC_TIME_OUT",
+      "value": -1006,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "RPC_SEND_TO_CHANNEL_FAILED",
+      "value": -1004,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "RPC_ADDR_IS_NULL",
+      "value": -1002,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "RPC_UNKNOWN",
+      "value": -1000,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "SUCCESS",
+      "value": 0,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RemotingSysResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "SYSTEM_ERROR",
+      "value": 1,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RemotingSysResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "SYSTEM_BUSY",
+      "value": 2,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RemotingSysResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "REQUEST_CODE_NOT_SUPPORTED",
+      "value": 3,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RemotingSysResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "TRANSACTION_FAILED",
+      "value": 4,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RemotingSysResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "FLUSH_DISK_TIMEOUT",
+      "value": 10,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "SLAVE_NOT_AVAILABLE",
+      "value": 11,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "FLUSH_SLAVE_TIMEOUT",
+      "value": 12,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "MESSAGE_ILLEGAL",
+      "value": 13,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "SERVICE_NOT_AVAILABLE",
+      "value": 14,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "VERSION_NOT_SUPPORTED",
+      "value": 15,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "NO_PERMISSION",
+      "value": 16,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "TOPIC_NOT_EXIST",
+      "value": 17,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "TOPIC_EXIST_ALREADY",
+      "value": 18,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "PULL_NOT_FOUND",
+      "value": 19,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "PULL_RETRY_IMMEDIATELY",
+      "value": 20,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "PULL_OFFSET_MOVED",
+      "value": 21,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "QUERY_NOT_FOUND",
+      "value": 22,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "SUBSCRIPTION_PARSE_FAILED",
+      "value": 23,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "SUBSCRIPTION_NOT_EXIST",
+      "value": 24,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "SUBSCRIPTION_NOT_LATEST",
+      "value": 25,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "SUBSCRIPTION_GROUP_NOT_EXIST",
+      "value": 26,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "FILTER_DATA_NOT_EXIST",
+      "value": 27,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "FILTER_DATA_NOT_LATEST",
+      "value": 28,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "INVALID_PARAMETER",
+      "value": 29,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "TRANSACTION_SHOULD_COMMIT",
+      "value": 200,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "TRANSACTION_SHOULD_ROLLBACK",
+      "value": 201,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "TRANSACTION_STATE_UNKNOW",
+      "value": 202,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "TRANSACTION_STATE_GROUP_WRONG",
+      "value": 203,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "NO_BUYER_ID",
+      "value": 204,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "NOT_IN_CURRENT_UNIT",
+      "value": 205,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONSUMER_NOT_ONLINE",
+      "value": 206,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONSUME_MSG_TIMEOUT",
+      "value": 207,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "NO_MESSAGE",
+      "value": 208,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "POLLING_FULL",
+      "value": 209,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "POLLING_TIMEOUT",
+      "value": 210,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "BROKER_NOT_EXIST",
+      "value": 211,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "BROKER_DISPATCH_NOT_COMPLETE",
+      "value": 212,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "BROADCAST_CONSUMPTION",
+      "value": 213,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "FLOW_CONTROL",
+      "value": 215,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "NOT_LEADER_FOR_QUEUE",
+      "value": 501,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "ILLEGAL_OPERATION",
+      "value": 604,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "GO_AWAY",
+      "value": 1500,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONTROLLER_FENCED_MASTER_EPOCH",
+      "value": 2000,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONTROLLER_FENCED_SYNC_STATE_SET_EPOCH",
+      "value": 2001,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONTROLLER_INVALID_MASTER",
+      "value": 2002,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONTROLLER_INVALID_REPLICAS",
+      "value": 2003,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONTROLLER_MASTER_NOT_AVAILABLE",
+      "value": 2004,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONTROLLER_INVALID_REQUEST",
+      "value": 2005,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONTROLLER_BROKER_NOT_ALIVE",
+      "value": 2006,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONTROLLER_NOT_LEADER",
+      "value": 2007,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONTROLLER_BROKER_METADATA_NOT_EXIST",
+      "value": 2008,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONTROLLER_INVALID_CLEAN_BROKER_METADATA",
+      "value": 2009,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONTROLLER_BROKER_NEED_TO_BE_REGISTERED",
+      "value": 2010,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONTROLLER_MASTER_STILL_EXIST",
+      "value": 2011,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONTROLLER_ELECT_MASTER_FAILED",
+      "value": 2012,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONTROLLER_ALTER_SYNC_STATE_SET_FAILED",
+      "value": 2013,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONTROLLER_BROKER_ID_INVALID",
+      "value": 2014,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONTROLLER_JRAFT_INTERNAL_ERROR",
+      "value": 2015,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "CONTROLLER_BROKER_LIVE_INFO_NOT_EXISTS",
+      "value": 2016,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "LMQ_QUOTA_EXCEEDED",
+      "value": 2017,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "LITE_SUBSCRIPTION_QUOTA_EXCEEDED",
+      "value": 2018,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "USER_NOT_EXIST",
+      "value": 3001,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    },
+    {
+      "symbol": "POLICY_NOT_EXIST",
+      "value": 3002,
+      "primitive": "int",
+      "purpose": "Java response code",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+      "classification": "raw",
+      "required_active": false
+    }
+  ],
+  "headers": [
+    {
+      "symbol": "AckMessageRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/AckMessageRequestHeader.java",
+      "fields": [
+        "consumerGroup",
+        "extraInfo",
+        "liteTopic",
+        "offset",
+        "queueId",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "AddBrokerRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/AddBrokerRequestHeader.java",
+      "fields": [
+        "configPath"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ChangeInvisibleTimeRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/ChangeInvisibleTimeRequestHeader.java",
+      "fields": [
+        "consumerGroup",
+        "extraInfo",
+        "invisibleTime",
+        "liteTopic",
+        "offset",
+        "queueId",
+        "suspend",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ChangeInvisibleTimeResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/ChangeInvisibleTimeResponseHeader.java",
+      "fields": [
+        "invisibleTime",
+        "popTime",
+        "reviveQid"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "CheckRocksdbCqWriteProgressRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/CheckRocksdbCqWriteProgressRequestHeader.java",
+      "fields": [
+        "checkStoreTime",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "CheckTransactionStateRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/CheckTransactionStateRequestHeader.java",
+      "fields": [
+        "commitLogOffset",
+        "msgId",
+        "offsetMsgId",
+        "topic",
+        "tranStateTableOffset",
+        "transactionId"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "CheckTransactionStateResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/CheckTransactionStateResponseHeader.java",
+      "fields": [
+        "commitLogOffset",
+        "commitOrRollback",
+        "producerGroup",
+        "tranStateTableOffset"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "CloneGroupOffsetRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/CloneGroupOffsetRequestHeader.java",
+      "fields": [
+        "destGroup",
+        "offline",
+        "srcGroup",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ConsumeMessageDirectlyResultRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/ConsumeMessageDirectlyResultRequestHeader.java",
+      "fields": [
+        "brokerName",
+        "clientId",
+        "consumerGroup",
+        "groupSysFlag",
+        "msgId",
+        "topic",
+        "topicSysFlag"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ConsumerSendMsgBackRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/ConsumerSendMsgBackRequestHeader.java",
+      "fields": [
+        "delayLevel",
+        "group",
+        "maxReconsumeTimes",
+        "offset",
+        "originMsgId",
+        "originTopic",
+        "unitMode"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "CleanControllerBrokerDataRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/controller/admin/CleanControllerBrokerDataRequestHeader.java",
+      "fields": [
+        "brokerControllerIdsToClean",
+        "brokerName",
+        "clusterName",
+        "invokeTime",
+        "isCleanLivingBroker"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "AlterSyncStateSetRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/controller/AlterSyncStateSetRequestHeader.java",
+      "fields": [
+        "brokerName",
+        "invokeTime",
+        "masterBrokerId",
+        "masterEpoch"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "AlterSyncStateSetResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/controller/AlterSyncStateSetResponseHeader.java",
+      "fields": [
+        "newSyncStateSetEpoch"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ElectMasterRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/controller/ElectMasterRequestHeader.java",
+      "fields": [
+        "brokerId",
+        "brokerName",
+        "clusterName",
+        "designateElect",
+        "invokeTime"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ElectMasterResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/controller/ElectMasterResponseHeader.java",
+      "fields": [
+        "masterAddress",
+        "masterBrokerId",
+        "masterEpoch",
+        "syncStateSetEpoch"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetMetaDataResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/controller/GetMetaDataResponseHeader.java",
+      "fields": [
+        "controllerLeaderAddress",
+        "controllerLeaderId",
+        "group",
+        "isLeader",
+        "peers"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetReplicaInfoRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/controller/GetReplicaInfoRequestHeader.java",
+      "fields": [
+        "brokerName"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetReplicaInfoResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/controller/GetReplicaInfoResponseHeader.java",
+      "fields": [
+        "masterAddress",
+        "masterBrokerId",
+        "masterEpoch"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ApplyBrokerIdRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/controller/register/ApplyBrokerIdRequestHeader.java",
+      "fields": [
+        "appliedBrokerId",
+        "brokerName",
+        "clusterName",
+        "registerCheckCode"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ApplyBrokerIdResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/controller/register/ApplyBrokerIdResponseHeader.java",
+      "fields": [
+        "brokerName",
+        "clusterName"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetNextBrokerIdRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/controller/register/GetNextBrokerIdRequestHeader.java",
+      "fields": [
+        "brokerName",
+        "clusterName"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetNextBrokerIdResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/controller/register/GetNextBrokerIdResponseHeader.java",
+      "fields": [
+        "brokerName",
+        "clusterName",
+        "nextBrokerId"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "RegisterBrokerToControllerRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/controller/register/RegisterBrokerToControllerRequestHeader.java",
+      "fields": [
+        "brokerAddress",
+        "brokerId",
+        "brokerName",
+        "clusterName",
+        "invokeTime"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "RegisterBrokerToControllerResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/controller/register/RegisterBrokerToControllerResponseHeader.java",
+      "fields": [
+        "brokerName",
+        "clusterName",
+        "masterAddress",
+        "masterBrokerId",
+        "masterEpoch",
+        "syncStateSetEpoch"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "CreateAclRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/CreateAclRequestHeader.java",
+      "fields": [
+        "subject"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "CreateTopicListRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/CreateTopicListRequestHeader.java",
+      "fields": [],
+      "classification": "raw"
+    },
+    {
+      "symbol": "CreateTopicRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/CreateTopicRequestHeader.java",
+      "fields": [
+        "attributes",
+        "defaultTopic",
+        "force",
+        "order",
+        "perm",
+        "readQueueNums",
+        "topic",
+        "topicFilterType",
+        "topicSysFlag",
+        "writeQueueNums"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "CreateUserRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/CreateUserRequestHeader.java",
+      "fields": [
+        "username"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "DeleteAclRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/DeleteAclRequestHeader.java",
+      "fields": [
+        "policyType",
+        "resource",
+        "subject"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "DeleteSubscriptionGroupRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/DeleteSubscriptionGroupRequestHeader.java",
+      "fields": [
+        "cleanOffset",
+        "groupName"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "DeleteTopicRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/DeleteTopicRequestHeader.java",
+      "fields": [
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "DeleteUserRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/DeleteUserRequestHeader.java",
+      "fields": [
+        "username"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "EndTransactionRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/EndTransactionRequestHeader.java",
+      "fields": [
+        "commitLogOffset",
+        "commitOrRollback",
+        "fromTransactionCheck",
+        "msgId",
+        "producerGroup",
+        "topic",
+        "tranStateTableOffset",
+        "transactionId"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "EndTransactionResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/EndTransactionResponseHeader.java",
+      "fields": [],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ExchangeHAInfoRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/ExchangeHAInfoRequestHeader.java",
+      "fields": [
+        "masterAddress",
+        "masterFlushOffset",
+        "masterHaAddress"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ExchangeHAInfoResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/ExchangeHAInfoResponseHeader.java",
+      "fields": [
+        "masterAddress",
+        "masterFlushOffset",
+        "masterHaAddress"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ExportRocksDBConfigToJsonRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/ExportRocksDBConfigToJsonRequestHeader.java",
+      "fields": [
+        "configType",
+        "typeName"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ExtraInfoUtil",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/ExtraInfoUtil.java",
+      "fields": [],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetAclRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetAclRequestHeader.java",
+      "fields": [
+        "subject"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetAllProducerInfoRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetAllProducerInfoRequestHeader.java",
+      "fields": [],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetAllSubscriptionGroupRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetAllSubscriptionGroupRequestHeader.java",
+      "fields": [
+        "dataVersion",
+        "groupSeq",
+        "maxGroupNum"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetAllSubscriptionGroupResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetAllSubscriptionGroupResponseHeader.java",
+      "fields": [
+        "totalGroupNum"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetAllTopicConfigRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetAllTopicConfigRequestHeader.java",
+      "fields": [
+        "dataVersion",
+        "maxTopicNum",
+        "topicSeq"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetAllTopicConfigResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetAllTopicConfigResponseHeader.java",
+      "fields": [
+        "totalTopicNum"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetBrokerConfigResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetBrokerConfigResponseHeader.java",
+      "fields": [
+        "version"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetBrokerMemberGroupRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetBrokerMemberGroupRequestHeader.java",
+      "fields": [
+        "brokerName",
+        "clusterName"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetConsumerConnectionListRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetConsumerConnectionListRequestHeader.java",
+      "fields": [
+        "consumerGroup"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetConsumerListByGroupRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetConsumerListByGroupRequestHeader.java",
+      "fields": [
+        "consumerGroup"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetConsumerListByGroupResponseBody",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetConsumerListByGroupResponseBody.java",
+      "fields": [
+        "consumerIdList"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetConsumerListByGroupResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetConsumerListByGroupResponseHeader.java",
+      "fields": [],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetConsumerRunningInfoRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetConsumerRunningInfoRequestHeader.java",
+      "fields": [
+        "clientId",
+        "consumerGroup",
+        "jstackEnable"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetConsumerStatusRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetConsumerStatusRequestHeader.java",
+      "fields": [
+        "clientAddr",
+        "group",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetConsumeStatsInBrokerHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetConsumeStatsInBrokerHeader.java",
+      "fields": [
+        "isOrder"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetConsumeStatsRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetConsumeStatsRequestHeader.java",
+      "fields": [
+        "consumerGroup",
+        "topic",
+        "topicList"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetEarliestMsgStoretimeRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetEarliestMsgStoretimeRequestHeader.java",
+      "fields": [
+        "queueId",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetEarliestMsgStoretimeResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetEarliestMsgStoretimeResponseHeader.java",
+      "fields": [
+        "timestamp"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetLiteClientInfoRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetLiteClientInfoRequestHeader.java",
+      "fields": [
+        "clientId",
+        "group",
+        "maxCount",
+        "parentTopic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetLiteGroupInfoRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetLiteGroupInfoRequestHeader.java",
+      "fields": [
+        "group",
+        "liteTopic",
+        "topK"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetLiteTopicInfoRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetLiteTopicInfoRequestHeader.java",
+      "fields": [
+        "liteTopic",
+        "parentTopic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetMaxOffsetRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetMaxOffsetRequestHeader.java",
+      "fields": [
+        "committed",
+        "queueId",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetMaxOffsetResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetMaxOffsetResponseHeader.java",
+      "fields": [
+        "offset"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetMinOffsetRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetMinOffsetRequestHeader.java",
+      "fields": [
+        "queueId",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetMinOffsetResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetMinOffsetResponseHeader.java",
+      "fields": [
+        "offset"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetParentTopicInfoRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetParentTopicInfoRequestHeader.java",
+      "fields": [
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetProducerConnectionListRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetProducerConnectionListRequestHeader.java",
+      "fields": [
+        "producerGroup"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetSubscriptionGroupConfigRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetSubscriptionGroupConfigRequestHeader.java",
+      "fields": [
+        "group"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetTopicConfigRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetTopicConfigRequestHeader.java",
+      "fields": [
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetTopicsByClusterRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetTopicsByClusterRequestHeader.java",
+      "fields": [
+        "cluster"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetTopicStatsInfoRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetTopicStatsInfoRequestHeader.java",
+      "fields": [
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetUserRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/GetUserRequestHeader.java",
+      "fields": [
+        "username"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "HeartbeatRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/HeartbeatRequestHeader.java",
+      "fields": [],
+      "classification": "raw"
+    },
+    {
+      "symbol": "InitConsumerOffsetRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/InitConsumerOffsetRequestHeader.java",
+      "fields": [
+        "initMode",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ListAclsRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/ListAclsRequestHeader.java",
+      "fields": [
+        "resourceFilter",
+        "subjectFilter"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ListUsersRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/ListUsersRequestHeader.java",
+      "fields": [
+        "filter"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "LiteSubscriptionCtlRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/LiteSubscriptionCtlRequestHeader.java",
+      "fields": [],
+      "classification": "raw"
+    },
+    {
+      "symbol": "LockBatchMqRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/LockBatchMqRequestHeader.java",
+      "fields": [],
+      "classification": "raw"
+    },
+    {
+      "symbol": "AddWritePermOfBrokerRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/namesrv/AddWritePermOfBrokerRequestHeader.java",
+      "fields": [
+        "brokerName"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "AddWritePermOfBrokerResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/namesrv/AddWritePermOfBrokerResponseHeader.java",
+      "fields": [
+        "addTopicCount"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "BrokerHeartbeatRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/namesrv/BrokerHeartbeatRequestHeader.java",
+      "fields": [
+        "brokerAddr",
+        "brokerId",
+        "brokerName",
+        "clusterName",
+        "confirmOffset",
+        "electionPriority",
+        "epoch",
+        "heartbeatTimeoutMills",
+        "maxOffset"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "DeleteKVConfigRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/namesrv/DeleteKVConfigRequestHeader.java",
+      "fields": [
+        "key",
+        "namespace"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "DeleteTopicFromNamesrvRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/namesrv/DeleteTopicFromNamesrvRequestHeader.java",
+      "fields": [
+        "clusterName",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetKVConfigRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/namesrv/GetKVConfigRequestHeader.java",
+      "fields": [
+        "key",
+        "namespace"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetKVConfigResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/namesrv/GetKVConfigResponseHeader.java",
+      "fields": [
+        "value"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetKVListByNamespaceRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/namesrv/GetKVListByNamespaceRequestHeader.java",
+      "fields": [
+        "namespace"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetRouteInfoRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/namesrv/GetRouteInfoRequestHeader.java",
+      "fields": [
+        "acceptStandardJsonOnly",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "PutKVConfigRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/namesrv/PutKVConfigRequestHeader.java",
+      "fields": [
+        "key",
+        "namespace",
+        "value"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "QueryDataVersionRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/namesrv/QueryDataVersionRequestHeader.java",
+      "fields": [
+        "brokerAddr",
+        "brokerId",
+        "brokerName",
+        "clusterName"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "QueryDataVersionResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/namesrv/QueryDataVersionResponseHeader.java",
+      "fields": [
+        "changed"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "RegisterBrokerRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/namesrv/RegisterBrokerRequestHeader.java",
+      "fields": [
+        "bodyCrc32",
+        "brokerAddr",
+        "brokerId",
+        "brokerName",
+        "clusterName",
+        "compressed",
+        "enableActingMaster",
+        "haServerAddr",
+        "heartbeatTimeoutMillis"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "RegisterBrokerResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/namesrv/RegisterBrokerResponseHeader.java",
+      "fields": [
+        "haServerAddr",
+        "masterAddr"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "RegisterOrderTopicRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/namesrv/RegisterOrderTopicRequestHeader.java",
+      "fields": [
+        "orderTopicString",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "RegisterTopicRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/namesrv/RegisterTopicRequestHeader.java",
+      "fields": [
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "UnRegisterBrokerRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/namesrv/UnRegisterBrokerRequestHeader.java",
+      "fields": [
+        "brokerAddr",
+        "brokerId",
+        "brokerName",
+        "clusterName"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "WipeWritePermOfBrokerRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/namesrv/WipeWritePermOfBrokerRequestHeader.java",
+      "fields": [
+        "brokerName"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "WipeWritePermOfBrokerResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/namesrv/WipeWritePermOfBrokerResponseHeader.java",
+      "fields": [
+        "wipeTopicCount"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "NotificationRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/NotificationRequestHeader.java",
+      "fields": [
+        "attemptId",
+        "bornTime",
+        "clientId",
+        "consumerGroup",
+        "exp",
+        "expType",
+        "isLiteConsumer",
+        "order",
+        "pollTime",
+        "queueId",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "NotificationResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/NotificationResponseHeader.java",
+      "fields": [
+        "hasMsg",
+        "pollingFull"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "NotifyBrokerRoleChangedRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/NotifyBrokerRoleChangedRequestHeader.java",
+      "fields": [
+        "masterAddress",
+        "masterBrokerId",
+        "masterEpoch",
+        "syncStateSetEpoch"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "NotifyConsumerIdsChangedRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/NotifyConsumerIdsChangedRequestHeader.java",
+      "fields": [
+        "consumerGroup"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "NotifyMinBrokerIdChangeRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/NotifyMinBrokerIdChangeRequestHeader.java",
+      "fields": [
+        "brokerName",
+        "haBrokerAddr",
+        "minBrokerAddr",
+        "minBrokerId",
+        "offlineBrokerAddr"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "NotifyUnsubscribeLiteRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/NotifyUnsubscribeLiteRequestHeader.java",
+      "fields": [
+        "clientId",
+        "consumerGroup",
+        "liteTopic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "PeekMessageRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/PeekMessageRequestHeader.java",
+      "fields": [
+        "consumerGroup",
+        "maxMsgNums",
+        "queueId",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "PollingInfoRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/PollingInfoRequestHeader.java",
+      "fields": [
+        "consumerGroup",
+        "queueId",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "PollingInfoResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/PollingInfoResponseHeader.java",
+      "fields": [
+        "pollingNum"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "PopLiteMessageRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/PopLiteMessageRequestHeader.java",
+      "fields": [
+        "attemptId",
+        "bornTime",
+        "clientId",
+        "consumerGroup",
+        "invisibleTime",
+        "maxMsgNum",
+        "pollTime",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "PopLiteMessageResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/PopLiteMessageResponseHeader.java",
+      "fields": [
+        "invisibleTime",
+        "msgOffsetInfo",
+        "orderCountInfo",
+        "popTime",
+        "reviveQid",
+        "startOffsetInfo"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "PopMessageRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/PopMessageRequestHeader.java",
+      "fields": [
+        "attemptId",
+        "bornTime",
+        "consumerGroup",
+        "exp",
+        "expType",
+        "initMode",
+        "invisibleTime",
+        "maxMsgNums",
+        "order",
+        "pollTime",
+        "queueId",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "PopMessageResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/PopMessageResponseHeader.java",
+      "fields": [
+        "invisibleTime",
+        "msgOffsetInfo",
+        "orderCountInfo",
+        "popTime",
+        "restNum",
+        "reviveQid",
+        "startOffsetInfo"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "PullMessageRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/PullMessageRequestHeader.java",
+      "fields": [
+        "commitOffset",
+        "consumerGroup",
+        "expressionType",
+        "liteTopic",
+        "maxMsgBytes",
+        "maxMsgNums",
+        "proxyFrowardClientId",
+        "queueId",
+        "queueOffset",
+        "requestSource",
+        "subVersion",
+        "subscription",
+        "suspendTimeoutMillis",
+        "sysFlag",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "PullMessageResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/PullMessageResponseHeader.java",
+      "fields": [
+        "forbiddenType",
+        "groupSysFlag",
+        "maxOffset",
+        "minOffset",
+        "nextBeginOffset",
+        "offsetDelta",
+        "suggestWhichBrokerId",
+        "topicSysFlag"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "QueryConsumeQueueRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/QueryConsumeQueueRequestHeader.java",
+      "fields": [
+        "consumerGroup",
+        "count",
+        "index",
+        "queueId",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "QueryConsumerOffsetRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/QueryConsumerOffsetRequestHeader.java",
+      "fields": [
+        "consumerGroup",
+        "queueId",
+        "setZeroIfNotFound",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "QueryConsumerOffsetResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/QueryConsumerOffsetResponseHeader.java",
+      "fields": [
+        "offset"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "QueryConsumeTimeSpanRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/QueryConsumeTimeSpanRequestHeader.java",
+      "fields": [
+        "group",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "QueryCorrectionOffsetHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/QueryCorrectionOffsetHeader.java",
+      "fields": [
+        "compareGroup",
+        "filterGroups",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "QueryMessageRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/QueryMessageRequestHeader.java",
+      "fields": [
+        "beginTimestamp",
+        "endTimestamp",
+        "indexType",
+        "key",
+        "lastKey",
+        "maxNum",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "QueryMessageResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/QueryMessageResponseHeader.java",
+      "fields": [
+        "indexLastUpdatePhyoffset",
+        "indexLastUpdateTimestamp"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "QuerySubscriptionByConsumerRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/QuerySubscriptionByConsumerRequestHeader.java",
+      "fields": [
+        "group",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "QueryTopicConsumeByWhoRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/QueryTopicConsumeByWhoRequestHeader.java",
+      "fields": [
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "QueryTopicsByConsumerRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/QueryTopicsByConsumerRequestHeader.java",
+      "fields": [
+        "group"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "RecallMessageRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/RecallMessageRequestHeader.java",
+      "fields": [
+        "producerGroup",
+        "recallHandle",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "RecallMessageResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/RecallMessageResponseHeader.java",
+      "fields": [
+        "msgId"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "RemoveBrokerRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/RemoveBrokerRequestHeader.java",
+      "fields": [
+        "brokerClusterName",
+        "brokerId",
+        "brokerName"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ReplyMessageRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/ReplyMessageRequestHeader.java",
+      "fields": [
+        "bornHost",
+        "bornTimestamp",
+        "defaultTopic",
+        "defaultTopicQueueNums",
+        "flag",
+        "producerGroup",
+        "properties",
+        "queueId",
+        "reconsumeTimes",
+        "storeHost",
+        "storeTimestamp",
+        "sysFlag",
+        "topic",
+        "unitMode"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ResetMasterFlushOffsetHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/ResetMasterFlushOffsetHeader.java",
+      "fields": [
+        "masterFlushOffset"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ResetOffsetRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/ResetOffsetRequestHeader.java",
+      "fields": [
+        "group",
+        "isForce",
+        "offset",
+        "queueId",
+        "timestamp",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ResumeCheckHalfMessageRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/ResumeCheckHalfMessageRequestHeader.java",
+      "fields": [
+        "msgId",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "SearchOffsetRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/SearchOffsetRequestHeader.java",
+      "fields": [
+        "boundaryType",
+        "liteTopic",
+        "queueId",
+        "timestamp",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "SearchOffsetResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/SearchOffsetResponseHeader.java",
+      "fields": [
+        "offset"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "SendMessageRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/SendMessageRequestHeader.java",
+      "fields": [
+        "batch",
+        "bornTimestamp",
+        "defaultTopic",
+        "defaultTopicQueueNums",
+        "flag",
+        "maxReconsumeTimes",
+        "producerGroup",
+        "properties",
+        "queueId",
+        "reconsumeTimes",
+        "sysFlag",
+        "topic",
+        "unitMode"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "SendMessageRequestHeaderV2",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/SendMessageRequestHeaderV2.java",
+      "fields": [
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f",
+        "g",
+        "h",
+        "i",
+        "j",
+        "k",
+        "l",
+        "m",
+        "n"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "SendMessageResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/SendMessageResponseHeader.java",
+      "fields": [
+        "batchUniqId",
+        "msgId",
+        "queueId",
+        "queueOffset",
+        "recallHandle",
+        "transactionId"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "StatisticsMessagesRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/StatisticsMessagesRequestHeader.java",
+      "fields": [
+        "consumerGroup",
+        "fromTime",
+        "queueId",
+        "toTime",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "TriggerLiteDispatchRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/TriggerLiteDispatchRequestHeader.java",
+      "fields": [
+        "clientId",
+        "group"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "UnlockBatchMqRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/UnlockBatchMqRequestHeader.java",
+      "fields": [],
+      "classification": "raw"
+    },
+    {
+      "symbol": "UnregisterClientRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/UnregisterClientRequestHeader.java",
+      "fields": [
+        "clientID",
+        "consumerGroup",
+        "producerGroup"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "UnregisterClientResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/UnregisterClientResponseHeader.java",
+      "fields": [],
+      "classification": "raw"
+    },
+    {
+      "symbol": "UpdateAclRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/UpdateAclRequestHeader.java",
+      "fields": [
+        "subject"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "UpdateConsumerOffsetRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/UpdateConsumerOffsetRequestHeader.java",
+      "fields": [
+        "commitOffset",
+        "consumerGroup",
+        "queueId",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "UpdateConsumerOffsetResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/UpdateConsumerOffsetResponseHeader.java",
+      "fields": [],
+      "classification": "raw"
+    },
+    {
+      "symbol": "UpdateGroupForbiddenRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/UpdateGroupForbiddenRequestHeader.java",
+      "fields": [
+        "group",
+        "readable",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "UpdateUserRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/UpdateUserRequestHeader.java",
+      "fields": [
+        "username"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ViewBrokerStatsDataRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/ViewBrokerStatsDataRequestHeader.java",
+      "fields": [
+        "statsKey",
+        "statsName"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ViewMessageRequestHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/ViewMessageRequestHeader.java",
+      "fields": [
+        "offset",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ViewMessageResponseHeader",
+      "purpose": "Java remoting header",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header/ViewMessageResponseHeader.java",
+      "fields": [],
+      "classification": "raw"
+    }
+  ],
+  "bodies": [
+    {
+      "symbol": "AclInfo",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/AclInfo.java",
+      "fields": [
+        "actions",
+        "decision",
+        "entries",
+        "policies",
+        "policyType",
+        "resource",
+        "sourceIps",
+        "subject"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "BatchAck",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/BatchAck.java",
+      "fields": [
+        "bitSet",
+        "consumerGroup",
+        "invisibleTime",
+        "popTime",
+        "queueId",
+        "retry",
+        "reviveQueueId",
+        "startOffset",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "BatchAckMessageRequestBody",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/BatchAckMessageRequestBody.java",
+      "fields": [
+        "acks",
+        "brokerName"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "BrokerMemberGroup",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/BrokerMemberGroup.java",
+      "fields": [
+        "brokerName",
+        "cluster"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "BrokerReplicasInfo",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/BrokerReplicasInfo.java",
+      "fields": [
+        "alive",
+        "brokerAddress",
+        "brokerId",
+        "brokerName",
+        "inSyncReplicas",
+        "masterAddress",
+        "masterBrokerId",
+        "masterEpoch",
+        "notInSyncReplicas",
+        "syncStateSetEpoch"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "BrokerStatsData",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/BrokerStatsData.java",
+      "fields": [
+        "statsDay",
+        "statsHour",
+        "statsMinute"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "BrokerStatsItem",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/BrokerStatsItem.java",
+      "fields": [
+        "avgpt",
+        "sum",
+        "tps"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "CheckClientRequestBody",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/CheckClientRequestBody.java",
+      "fields": [
+        "clientId",
+        "group",
+        "namespace",
+        "subscriptionData"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ClusterInfo",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/ClusterInfo.java",
+      "fields": [],
+      "classification": "raw"
+    },
+    {
+      "symbol": "CMResult",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/CMResult.java",
+      "fields": [],
+      "classification": "raw"
+    },
+    {
+      "symbol": "Connection",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/Connection.java",
+      "fields": [
+        "clientAddr",
+        "clientId",
+        "language",
+        "version"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ConsumeByWho",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/ConsumeByWho.java",
+      "fields": [
+        "consumedGroup",
+        "notConsumedGroup",
+        "offset",
+        "queueId",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ConsumeMessageDirectlyResult",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/ConsumeMessageDirectlyResult.java",
+      "fields": [
+        "autoCommit",
+        "consumeResult",
+        "order",
+        "remark",
+        "spentTimeMills"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ConsumeQueueData",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/ConsumeQueueData.java",
+      "fields": [
+        "bitMap",
+        "eval",
+        "extendDataJson",
+        "msg",
+        "physicOffset",
+        "physicSize",
+        "tagsCode"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ConsumerConnection",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/ConsumerConnection.java",
+      "fields": [
+        "connectionSet",
+        "consumeFromWhere",
+        "consumeType",
+        "messageModel"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ConsumerOffsetSerializeWrapper",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/ConsumerOffsetSerializeWrapper.java",
+      "fields": [
+        "dataVersion"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ConsumerRunningInfo",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/ConsumerRunningInfo.java",
+      "fields": [
+        "jstack",
+        "mqPopTable",
+        "mqTable",
+        "properties",
+        "subscriptionSet",
+        "userConsumerInfo"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ConsumeStatsList",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/ConsumeStatsList.java",
+      "fields": [
+        "brokerAddr",
+        "totalDiff",
+        "totalInflightDiff"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ConsumeStatus",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/ConsumeStatus.java",
+      "fields": [
+        "consumeFailedMsgs",
+        "consumeFailedTPS",
+        "consumeOKTPS",
+        "consumeRT",
+        "pullRT",
+        "pullTPS"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "CreateTopicListRequestBody",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/CreateTopicListRequestBody.java",
+      "fields": [
+        "topicConfigList"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "DeleteSubscriptionGroupListRequestBody",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/DeleteSubscriptionGroupListRequestBody.java",
+      "fields": [
+        "cleanOffset",
+        "groupNameList"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "DeleteTopicListRequestBody",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/DeleteTopicListRequestBody.java",
+      "fields": [
+        "topicList"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ElectMasterResponseBody",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/ElectMasterResponseBody.java",
+      "fields": [
+        "brokerMemberGroup",
+        "syncStateSet"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "EpochEntryCache",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/EpochEntryCache.java",
+      "fields": [
+        "brokerId",
+        "brokerName",
+        "clusterName",
+        "epochList",
+        "maxOffset"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetBrokerLiteInfoResponseBody",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/GetBrokerLiteInfoResponseBody.java",
+      "fields": [
+        "cqTableSize",
+        "currentLmqNum",
+        "eventMapSize",
+        "groupMeta",
+        "liteSubscriptionCount",
+        "maxLmqNum",
+        "offsetTableSize",
+        "orderInfoCount",
+        "storeType",
+        "topicMeta"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetBrokerMemberGroupResponseBody",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/GetBrokerMemberGroupResponseBody.java",
+      "fields": [
+        "brokerMemberGroup"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetConsumerStatusBody",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/GetConsumerStatusBody.java",
+      "fields": [
+        "consumerTable",
+        "messageQueueTable"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetLiteClientInfoResponseBody",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/GetLiteClientInfoResponseBody.java",
+      "fields": [
+        "clientId",
+        "group",
+        "lastAccessTime",
+        "lastConsumeTime",
+        "liteTopicCount",
+        "liteTopicSet",
+        "parentTopic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetLiteGroupInfoResponseBody",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/GetLiteGroupInfoResponseBody.java",
+      "fields": [
+        "earliestUnconsumedTimestamp",
+        "group",
+        "lagCountTopK",
+        "lagTimestampTopK",
+        "liteTopic",
+        "liteTopicOffsetWrapper",
+        "parentTopic",
+        "totalLagCount"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetLiteTopicInfoResponseBody",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/GetLiteTopicInfoResponseBody.java",
+      "fields": [
+        "liteTopic",
+        "parentTopic",
+        "shardingToBroker",
+        "subscriber",
+        "topicOffset"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GetParentTopicInfoResponseBody",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/GetParentTopicInfoResponseBody.java",
+      "fields": [
+        "groups",
+        "liteTopicCount",
+        "lmqNum",
+        "topic",
+        "ttl"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "GroupList",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/GroupList.java",
+      "fields": [
+        "groupList"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "HARuntimeInfo",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/HARuntimeInfo.java",
+      "fields": [
+        "addr",
+        "diff",
+        "haClientRuntimeInfo",
+        "haConnectionInfo",
+        "inSync",
+        "inSyncSlaveNums",
+        "isActivated",
+        "lastReadTimestamp",
+        "lastWriteTimestamp",
+        "master",
+        "masterAddr",
+        "masterCommitLogMaxOffset",
+        "masterFlushOffset",
+        "maxOffset",
+        "slaveAckOffset",
+        "transferFromWhere",
+        "transferredByteInSecond"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "KVTable",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/KVTable.java",
+      "fields": [
+        "table"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "LiteSubscriptionCtlRequestBody",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/LiteSubscriptionCtlRequestBody.java",
+      "fields": [
+        "subscriptionSet"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "LockBatchRequestBody",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/LockBatchRequestBody.java",
+      "fields": [
+        "clientId",
+        "consumerGroup",
+        "mqSet",
+        "onlyThisBroker"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "LockBatchResponseBody",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/LockBatchResponseBody.java",
+      "fields": [
+        "lockOKMQSet"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "MessageRequestModeSerializeWrapper",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/MessageRequestModeSerializeWrapper.java",
+      "fields": [],
+      "classification": "raw"
+    },
+    {
+      "symbol": "PopProcessQueueInfo",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/PopProcessQueueInfo.java",
+      "fields": [
+        "droped",
+        "lastPopTimestamp",
+        "waitAckCount"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ProcessQueueInfo",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/ProcessQueueInfo.java",
+      "fields": [
+        "cachedMsgCount",
+        "cachedMsgMaxOffset",
+        "cachedMsgMinOffset",
+        "cachedMsgSizeInMiB",
+        "commitOffset",
+        "droped",
+        "lastConsumeTimestamp",
+        "lastLockTimestamp",
+        "lastPullTimestamp",
+        "locked",
+        "transactionMsgCount",
+        "transactionMsgMaxOffset",
+        "transactionMsgMinOffset",
+        "tryUnlockTimes"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ProducerConnection",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/ProducerConnection.java",
+      "fields": [
+        "connectionSet"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ProducerInfo",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/ProducerInfo.java",
+      "fields": [
+        "clientId",
+        "language",
+        "lastUpdateTimestamp",
+        "remoteIP",
+        "version"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ProducerTableInfo",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/ProducerTableInfo.java",
+      "fields": [
+        "data"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "QueryAssignmentRequestBody",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/QueryAssignmentRequestBody.java",
+      "fields": [
+        "clientId",
+        "consumerGroup",
+        "messageModel",
+        "strategyName",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "QueryAssignmentResponseBody",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/QueryAssignmentResponseBody.java",
+      "fields": [
+        "messageQueueAssignments"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "QueryConsumeQueueResponseBody",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/QueryConsumeQueueResponseBody.java",
+      "fields": [
+        "filterData",
+        "maxQueueIndex",
+        "minQueueIndex",
+        "queueData",
+        "subscriptionData"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "QueryConsumeTimeSpanBody",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/QueryConsumeTimeSpanBody.java",
+      "fields": [],
+      "classification": "raw"
+    },
+    {
+      "symbol": "QueryCorrectionOffsetBody",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/QueryCorrectionOffsetBody.java",
+      "fields": [
+        "correctionOffsets"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "QuerySubscriptionResponseBody",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/QuerySubscriptionResponseBody.java",
+      "fields": [
+        "group",
+        "subscriptionData",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "QueueTimeSpan",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/QueueTimeSpan.java",
+      "fields": [
+        "consumeTimeStamp",
+        "delayTime",
+        "maxTimeStamp",
+        "messageQueue",
+        "minTimeStamp"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "RegisterBrokerBody",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/RegisterBrokerBody.java",
+      "fields": [
+        "filterServerList",
+        "topicConfigSerializeWrapper"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ResetOffsetBody",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/ResetOffsetBody.java",
+      "fields": [
+        "offsetTable"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "ResetOffsetBodyForC",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/ResetOffsetBodyForC.java",
+      "fields": [
+        "offsetTable"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "RoleChangeNotifyEntry",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/RoleChangeNotifyEntry.java",
+      "fields": [
+        "brokerMemberGroup",
+        "masterAddress",
+        "masterBrokerId",
+        "masterEpoch",
+        "syncStateSet",
+        "syncStateSetEpoch"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "SetMessageRequestModeRequestBody",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/SetMessageRequestModeRequestBody.java",
+      "fields": [
+        "consumerGroup",
+        "mode",
+        "popShareQueueNum",
+        "topic"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "SubscriptionGroupList",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/SubscriptionGroupList.java",
+      "fields": [
+        "groupConfigList"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "SubscriptionGroupWrapper",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/SubscriptionGroupWrapper.java",
+      "fields": [
+        "dataVersion",
+        "forbiddenTable",
+        "subscriptionGroupTable"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "SyncStateSet",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/SyncStateSet.java",
+      "fields": [
+        "syncStateSet",
+        "syncStateSetEpoch"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "TopicConfigAndMappingSerializeWrapper",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/TopicConfigAndMappingSerializeWrapper.java",
+      "fields": [
+        "mappingDataVersion"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "TopicConfigSerializeWrapper",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/TopicConfigSerializeWrapper.java",
+      "fields": [
+        "dataVersion",
+        "topicConfigTable"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "TopicList",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/TopicList.java",
+      "fields": [
+        "brokerAddr",
+        "topicList"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "TopicQueueMappingSerializeWrapper",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/TopicQueueMappingSerializeWrapper.java",
+      "fields": [
+        "dataVersion"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "UnlockBatchRequestBody",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/UnlockBatchRequestBody.java",
+      "fields": [
+        "clientId",
+        "consumerGroup",
+        "mqSet",
+        "onlyThisBroker"
+      ],
+      "classification": "raw"
+    },
+    {
+      "symbol": "UserInfo",
+      "purpose": "Java remoting body",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/UserInfo.java",
+      "fields": [
+        "password",
+        "userStatus",
+        "userType",
+        "username"
+      ],
+      "classification": "raw"
+    }
+  ],
+  "controller_internal_payloads": [
+    {
+      "symbol": "BrokerCloseChannelRequest",
+      "purpose": "Java JRaft Controller internal payload",
+      "source": "controller/src/main/java/org/apache/rocketmq/controller/impl/task/BrokerCloseChannelRequest.java",
+      "fields": [
+        "brokerId",
+        "brokerName",
+        "clusterName"
+      ],
+      "classification": "controller-internal-not-applicable"
+    },
+    {
+      "symbol": "CheckNotActiveBrokerRequest",
+      "purpose": "Java JRaft Controller internal payload",
+      "source": "controller/src/main/java/org/apache/rocketmq/controller/impl/task/CheckNotActiveBrokerRequest.java",
+      "fields": [
+        "checkTimeMillis"
+      ],
+      "classification": "controller-internal-not-applicable"
+    },
+    {
+      "symbol": "GetBrokerLiveInfoRequest",
+      "purpose": "Java JRaft Controller internal payload",
+      "source": "controller/src/main/java/org/apache/rocketmq/controller/impl/task/GetBrokerLiveInfoRequest.java",
+      "fields": [
+        "brokerId",
+        "brokerName",
+        "clusterName"
+      ],
+      "classification": "controller-internal-not-applicable"
+    },
+    {
+      "symbol": "GetSyncStateDataRequest",
+      "purpose": "Java JRaft Controller internal payload",
+      "source": "controller/src/main/java/org/apache/rocketmq/controller/impl/task/GetSyncStateDataRequest.java",
+      "fields": [
+        "invokeTime"
+      ],
+      "classification": "controller-internal-not-applicable"
+    },
+    {
+      "symbol": "RaftBrokerHeartBeatEventRequest",
+      "purpose": "Java JRaft Controller internal payload",
+      "source": "controller/src/main/java/org/apache/rocketmq/controller/impl/task/RaftBrokerHeartBeatEventRequest.java",
+      "fields": [
+        "brokerAddr",
+        "brokerId",
+        "brokerIdIdentityInfo",
+        "brokerName",
+        "brokerNameIdentityInfo",
+        "clusterNameIdentityInfo",
+        "confirmOffset",
+        "electionPriority",
+        "epoch",
+        "heartbeatTimeoutMillis",
+        "lastUpdateTimestamp",
+        "maxOffset"
+      ],
+      "classification": "controller-internal-not-applicable"
+    }
+  ],
+  "proxy_routes": [
+    {
+      "request_code": "ACK_MESSAGE",
+      "handler": "consumerManagerActivity",
+      "executor": "updateOffsetExecutor",
+      "purpose": "Java Proxy remoting route",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java",
+      "classification": "active",
+      "required_gap": true
+    },
+    {
+      "request_code": "CHANGE_MESSAGE_INVISIBLETIME",
+      "handler": "consumerManagerActivity",
+      "executor": "updateOffsetExecutor",
+      "purpose": "Java Proxy remoting route",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java",
+      "classification": "active",
+      "required_gap": true
+    },
+    {
+      "request_code": "CHECK_CLIENT_CONFIG",
+      "handler": "clientManagerActivity",
+      "executor": "defaultExecutor",
+      "purpose": "Java Proxy remoting route",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java",
+      "classification": "active",
+      "required_gap": false
+    },
+    {
+      "request_code": "CONSUMER_SEND_MSG_BACK",
+      "handler": "sendMessageActivity",
+      "executor": "sendMessageExecutor",
+      "purpose": "Java Proxy remoting route",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java",
+      "classification": "active",
+      "required_gap": true
+    },
+    {
+      "request_code": "END_TRANSACTION",
+      "handler": "transactionActivity",
+      "executor": "sendMessageExecutor",
+      "purpose": "Java Proxy remoting route",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java",
+      "classification": "active",
+      "required_gap": true
+    },
+    {
+      "request_code": "GET_CONSUMER_CONNECTION_LIST",
+      "handler": "consumerManagerActivity",
+      "executor": "updateOffsetExecutor",
+      "purpose": "Java Proxy remoting route",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java",
+      "classification": "active",
+      "required_gap": true
+    },
+    {
+      "request_code": "GET_CONSUMER_LIST_BY_GROUP",
+      "handler": "consumerManagerActivity",
+      "executor": "defaultExecutor",
+      "purpose": "Java Proxy remoting route",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java",
+      "classification": "active",
+      "required_gap": false
+    },
+    {
+      "request_code": "GET_MAX_OFFSET",
+      "handler": "consumerManagerActivity",
+      "executor": "defaultExecutor",
+      "purpose": "Java Proxy remoting route",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java",
+      "classification": "active",
+      "required_gap": false
+    },
+    {
+      "request_code": "GET_MIN_OFFSET",
+      "handler": "consumerManagerActivity",
+      "executor": "defaultExecutor",
+      "purpose": "Java Proxy remoting route",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java",
+      "classification": "active",
+      "required_gap": false
+    },
+    {
+      "request_code": "GET_ROUTEINFO_BY_TOPIC",
+      "handler": "getTopicRouteActivity",
+      "executor": "topicRouteExecutor",
+      "purpose": "Java Proxy remoting route",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java",
+      "classification": "active",
+      "required_gap": false
+    },
+    {
+      "request_code": "HEART_BEAT",
+      "handler": "clientManagerActivity",
+      "executor": "heartbeatExecutor",
+      "purpose": "Java Proxy remoting route",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java",
+      "classification": "active",
+      "required_gap": false
+    },
+    {
+      "request_code": "LITE_PULL_MESSAGE",
+      "handler": "pullMessageActivity",
+      "executor": "pullMessageExecutor",
+      "purpose": "Java Proxy remoting route",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java",
+      "classification": "active",
+      "required_gap": false
+    },
+    {
+      "request_code": "LOCK_BATCH_MQ",
+      "handler": "consumerManagerActivity",
+      "executor": "defaultExecutor",
+      "purpose": "Java Proxy remoting route",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java",
+      "classification": "active",
+      "required_gap": false
+    },
+    {
+      "request_code": "POP_MESSAGE",
+      "handler": "pullMessageActivity",
+      "executor": "pullMessageExecutor",
+      "purpose": "Java Proxy remoting route",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java",
+      "classification": "active",
+      "required_gap": true
+    },
+    {
+      "request_code": "PULL_MESSAGE",
+      "handler": "pullMessageActivity",
+      "executor": "pullMessageExecutor",
+      "purpose": "Java Proxy remoting route",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java",
+      "classification": "active",
+      "required_gap": false
+    },
+    {
+      "request_code": "QUERY_CONSUMER_OFFSET",
+      "handler": "consumerManagerActivity",
+      "executor": "defaultExecutor",
+      "purpose": "Java Proxy remoting route",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java",
+      "classification": "active",
+      "required_gap": false
+    },
+    {
+      "request_code": "RECALL_MESSAGE",
+      "handler": "recallMessageActivity",
+      "executor": "sendMessageExecutor",
+      "purpose": "Java Proxy remoting route",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java",
+      "classification": "active",
+      "required_gap": true
+    },
+    {
+      "request_code": "SEARCH_OFFSET_BY_TIMESTAMP",
+      "handler": "consumerManagerActivity",
+      "executor": "defaultExecutor",
+      "purpose": "Java Proxy remoting route",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java",
+      "classification": "active",
+      "required_gap": false
+    },
+    {
+      "request_code": "SEND_BATCH_MESSAGE",
+      "handler": "sendMessageActivity",
+      "executor": "sendMessageExecutor",
+      "purpose": "Java Proxy remoting route",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java",
+      "classification": "active",
+      "required_gap": false
+    },
+    {
+      "request_code": "SEND_MESSAGE",
+      "handler": "sendMessageActivity",
+      "executor": "sendMessageExecutor",
+      "purpose": "Java Proxy remoting route",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java",
+      "classification": "active",
+      "required_gap": false
+    },
+    {
+      "request_code": "SEND_MESSAGE_V2",
+      "handler": "sendMessageActivity",
+      "executor": "sendMessageExecutor",
+      "purpose": "Java Proxy remoting route",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java",
+      "classification": "active",
+      "required_gap": false
+    },
+    {
+      "request_code": "UNLOCK_BATCH_MQ",
+      "handler": "consumerManagerActivity",
+      "executor": "defaultExecutor",
+      "purpose": "Java Proxy remoting route",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java",
+      "classification": "active",
+      "required_gap": false
+    },
+    {
+      "request_code": "UNREGISTER_CLIENT",
+      "handler": "clientManagerActivity",
+      "executor": "defaultExecutor",
+      "purpose": "Java Proxy remoting route",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java",
+      "classification": "active",
+      "required_gap": false
+    },
+    {
+      "request_code": "UPDATE_CONSUMER_OFFSET",
+      "handler": "consumerManagerActivity",
+      "executor": "updateOffsetExecutor",
+      "purpose": "Java Proxy remoting route",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java",
+      "classification": "active",
+      "required_gap": false
+    }
+  ],
+  "admin_operations": [
+    {
+      "symbol": "UpdateTopicSubCommand",
+      "command": "updateTopic",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/topic/UpdateTopicSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "UpdateTopicListSubCommand",
+      "command": "updateTopicList",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/topic/UpdateTopicListSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "DeleteTopicSubCommand",
+      "command": "deleteTopic",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/topic/DeleteTopicSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "UpdateSubGroupSubCommand",
+      "command": "updateSubGroup",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/consumer/UpdateSubGroupSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "UpdateSubGroupListSubCommand",
+      "command": "updateSubGroupList",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/consumer/UpdateSubGroupListSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "SetConsumeModeSubCommand",
+      "command": "setConsumeMode",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/consumer/SetConsumeModeSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "DeleteSubscriptionGroupCommand",
+      "command": "deleteSubGroup",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/consumer/DeleteSubscriptionGroupCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "UpdateBrokerConfigSubCommand",
+      "command": "updateBrokerConfig",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/broker/UpdateBrokerConfigSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "UpdateTopicPermSubCommand",
+      "command": "updateTopicPerm",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/topic/UpdateTopicPermSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "TopicRouteSubCommand",
+      "command": "topicRoute",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/topic/TopicRouteSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "TopicStatusSubCommand",
+      "command": "topicStatus",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/topic/TopicStatusSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "TopicClusterSubCommand",
+      "command": "topicClusterList",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/topic/TopicClusterSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "AddBrokerSubCommand",
+      "command": "addBroker",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/container/AddBrokerSubCommand.java",
+      "classification": "excluded-broker-container"
+    },
+    {
+      "symbol": "RemoveBrokerSubCommand",
+      "command": "removeBroker",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/container/RemoveBrokerSubCommand.java",
+      "classification": "excluded-broker-container"
+    },
+    {
+      "symbol": "ResetMasterFlushOffsetSubCommand",
+      "command": "resetMasterFlushOffset",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/broker/ResetMasterFlushOffsetSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerStatusSubCommand",
+      "command": "brokerStatus",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/broker/BrokerStatusSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "QueryMsgByIdSubCommand",
+      "command": "queryMsgById",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/message/QueryMsgByIdSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "QueryMsgByKeySubCommand",
+      "command": "queryMsgByKey",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/message/QueryMsgByKeySubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "QueryMsgByUniqueKeySubCommand",
+      "command": "queryMsgByUniqueKey",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/message/QueryMsgByUniqueKeySubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "QueryMsgByOffsetSubCommand",
+      "command": "queryMsgByOffset",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/message/QueryMsgByOffsetSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "QueryMsgTraceByIdSubCommand",
+      "command": "queryMsgTraceById",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/message/QueryMsgTraceByIdSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "PrintMessageSubCommand",
+      "command": "printMsg",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/message/PrintMessageSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "PrintMessageByQueueCommand",
+      "command": "printMsgByQueue",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/message/PrintMessageByQueueCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "SendMsgStatusCommand",
+      "command": "sendMsgStatus",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/broker/SendMsgStatusCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConsumeStatsSubCommand",
+      "command": "brokerConsumeStats",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/broker/BrokerConsumeStatsSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProducerConnectionSubCommand",
+      "command": "producerConnection",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/connection/ProducerConnectionSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ConsumerConnectionSubCommand",
+      "command": "consumerConnection",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/connection/ConsumerConnectionSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ConsumerProgressSubCommand",
+      "command": "consumerProgress",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/consumer/ConsumerProgressSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ConsumerStatusSubCommand",
+      "command": "consumerStatus",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/consumer/ConsumerStatusSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "CloneGroupOffsetCommand",
+      "command": "cloneGroupOffset",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/offset/CloneGroupOffsetCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProducerSubCommand",
+      "command": "producer",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/producer/ProducerSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClusterListSubCommand",
+      "command": "clusterList",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/cluster/ClusterListSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "TopicListSubCommand",
+      "command": "topicList",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/topic/TopicListSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "UpdateKvConfigCommand",
+      "command": "updateKvConfig",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/namesrv/UpdateKvConfigCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "DeleteKvConfigCommand",
+      "command": "deleteKvConfig",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/namesrv/DeleteKvConfigCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "WipeWritePermSubCommand",
+      "command": "wipeWritePerm",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/namesrv/WipeWritePermSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "AddWritePermSubCommand",
+      "command": "addWritePerm",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/namesrv/AddWritePermSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ResetOffsetByTimeCommand",
+      "command": "resetOffsetByTime",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/offset/ResetOffsetByTimeCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "SkipAccumulationSubCommand",
+      "command": "skipAccumulatedMessage",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/offset/SkipAccumulationSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "UpdateOrderConfCommand",
+      "command": "updateOrderConf",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/topic/UpdateOrderConfCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "CleanExpiredCQSubCommand",
+      "command": "cleanExpiredCQ",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/broker/CleanExpiredCQSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "DeleteExpiredCommitLogSubCommand",
+      "command": "deleteExpiredCommitLog",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/broker/DeleteExpiredCommitLogSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "CleanUnusedTopicCommand",
+      "command": "cleanUnusedTopic",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/broker/CleanUnusedTopicCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "StartMonitoringSubCommand",
+      "command": "startMonitoring",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/consumer/StartMonitoringSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "StatsAllSubCommand",
+      "command": "statsAll",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/stats/StatsAllSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "AllocateMQSubCommand",
+      "command": "allocateMQ",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/topic/AllocateMQSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "CheckMsgSendRTCommand",
+      "command": "checkMsgSendRT",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/message/CheckMsgSendRTCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClusterSendMsgRTCommand",
+      "command": "clusterRT",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/cluster/ClusterSendMsgRTCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "GetNamesrvConfigCommand",
+      "command": "getNamesrvConfig",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/namesrv/GetNamesrvConfigCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "UpdateNamesrvConfigCommand",
+      "command": "updateNamesrvConfig",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/namesrv/UpdateNamesrvConfigCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "GetBrokerConfigCommand",
+      "command": "getBrokerConfig",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/broker/GetBrokerConfigCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "GetConsumerConfigSubCommand",
+      "command": "getConsumerConfig",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/consumer/GetConsumerConfigSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "QueryConsumeQueueCommand",
+      "command": "queryCq",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/queue/QueryConsumeQueueCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "SendMessageCommand",
+      "command": "sendMessage",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/message/SendMessageCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ConsumeMessageCommand",
+      "command": "consumeMessage",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/message/ConsumeMessageCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "UpdateStaticTopicSubCommand",
+      "command": "updateStaticTopic",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/topic/UpdateStaticTopicSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "RemappingStaticTopicSubCommand",
+      "command": "remappingStaticTopic",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/topic/RemappingStaticTopicSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ExportMetadataCommand",
+      "command": "exportMetadata",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/export/ExportMetadataCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ExportConfigsCommand",
+      "command": "exportConfigs",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/export/ExportConfigsCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ExportMetricsCommand",
+      "command": "exportMetrics",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/export/ExportMetricsCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ExportMetadataInRocksDBCommand",
+      "command": "exportMetadataInRocksDB",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/export/ExportMetadataInRocksDBCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ExportPopRecordCommand",
+      "command": "exportPopRecord",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/export/ExportPopRecordCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "HAStatusSubCommand",
+      "command": "haStatus",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/ha/HAStatusSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "GetSyncStateSetSubCommand",
+      "command": "getSyncStateSet",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/ha/GetSyncStateSetSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "GetBrokerEpochSubCommand",
+      "command": "getBrokerEpoch",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/broker/GetBrokerEpochSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "GetControllerMetaDataSubCommand",
+      "command": "getControllerMetaData",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/controller/GetControllerMetaDataSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "GetControllerConfigSubCommand",
+      "command": "getControllerConfig",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/controller/GetControllerConfigSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "UpdateControllerConfigSubCommand",
+      "command": "updateControllerConfig",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/controller/UpdateControllerConfigSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ReElectMasterSubCommand",
+      "command": "electMaster",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/controller/ReElectMasterSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "CleanControllerBrokerMetaSubCommand",
+      "command": "cleanBrokerMetadata",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/controller/CleanControllerBrokerMetaSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "DumpCompactionLogCommand",
+      "command": "dumpCompactionLog",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/message/DumpCompactionLogCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "GetColdDataFlowCtrInfoSubCommand",
+      "command": "getColdDataFlowCtrInfo",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/broker/GetColdDataFlowCtrInfoSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "UpdateColdDataFlowCtrGroupConfigSubCommand",
+      "command": "updateColdDataFlowCtrGroupConfig",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/broker/UpdateColdDataFlowCtrGroupConfigSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "RemoveColdDataFlowCtrGroupConfigSubCommand",
+      "command": "removeColdDataFlowCtrGroupConfig",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/broker/RemoveColdDataFlowCtrGroupConfigSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "CommitLogSetReadAheadSubCommand",
+      "command": "setCommitLogReadAheadMode",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/broker/CommitLogSetReadAheadSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "CreateUserSubCommand",
+      "command": "createUser",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/auth/CreateUserSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "UpdateUserSubCommand",
+      "command": "updateUser",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/auth/UpdateUserSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "DeleteUserSubCommand",
+      "command": "deleteUser",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/auth/DeleteUserSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "GetUserSubCommand",
+      "command": "getUser",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/auth/GetUserSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ListUserSubCommand",
+      "command": "listUser",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/auth/ListUserSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "CopyUsersSubCommand",
+      "command": "copyUser",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/auth/CopyUsersSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "CreateAclSubCommand",
+      "command": "createAcl",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/auth/CreateAclSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "UpdateAclSubCommand",
+      "command": "updateAcl",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/auth/UpdateAclSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "DeleteAclSubCommand",
+      "command": "deleteAcl",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/auth/DeleteAclSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "GetAclSubCommand",
+      "command": "getAcl",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/auth/GetAclSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ListAclSubCommand",
+      "command": "listAcl",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/auth/ListAclSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "CopyAclsSubCommand",
+      "command": "copyAcl",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/auth/CopyAclsSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "RocksDBConfigToJsonCommand",
+      "command": "rocksDBConfigToJson",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/metadata/RocksDBConfigToJsonCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "CheckRocksdbCqWriteProgressCommand",
+      "command": "checkRocksdbCqWriteProgress",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/queue/CheckRocksdbCqWriteProgressCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "SwitchTimerEngineSubCommand",
+      "command": "switchTimerEngine",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/broker/SwitchTimerEngineSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "GetBrokerLiteInfoSubCommand",
+      "command": "getBrokerLiteInfo",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/lite/GetBrokerLiteInfoSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "GetParentTopicInfoSubCommand",
+      "command": "getParentTopicInfo",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/lite/GetParentTopicInfoSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "GetLiteTopicInfoSubCommand",
+      "command": "getLiteTopicInfo",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/lite/GetLiteTopicInfoSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "GetLiteClientInfoSubCommand",
+      "command": "getLiteClientInfo",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/lite/GetLiteClientInfoSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "GetLiteGroupInfoSubCommand",
+      "command": "getLiteGroupInfo",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/lite/GetLiteGroupInfoSubCommand.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "TriggerLiteDispatchSubCommand",
+      "command": "triggerLiteDispatch",
+      "purpose": "Java mqadmin operation",
+      "source": "tools/src/main/java/org/apache/rocketmq/tools/command/lite/TriggerLiteDispatchSubCommand.java",
+      "classification": "active"
+    }
+  ],
+  "config_keys": [
+    {
+      "symbol": "ClientConfig.accessChannel",
+      "key": "accessChannel",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.clientCallbackExecutorThreads",
+      "key": "clientCallbackExecutorThreads",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.clientIP",
+      "key": "clientIP",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.concurrentHeartbeatThreadPoolSize",
+      "key": "concurrentHeartbeatThreadPoolSize",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.decodeDecompressBody",
+      "key": "decodeDecompressBody",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.decodeReadBody",
+      "key": "decodeReadBody",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.detectInterval",
+      "key": "detectInterval",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.detectTimeout",
+      "key": "detectTimeout",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.enableConcurrentHeartbeat",
+      "key": "enableConcurrentHeartbeat",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.enableHeartbeatChannelEventListener",
+      "key": "enableHeartbeatChannelEventListener",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.enableStreamRequestType",
+      "key": "enableStreamRequestType",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.enableTrace",
+      "key": "enableTrace",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.heartbeatBrokerInterval",
+      "key": "heartbeatBrokerInterval",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.instanceName",
+      "key": "instanceName",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.language",
+      "key": "language",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.maxPageSizeInGetMetadata",
+      "key": "maxPageSizeInGetMetadata",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.mqClientApiTimeout",
+      "key": "mqClientApiTimeout",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.namespace",
+      "key": "namespace",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.namespaceInitialized",
+      "key": "namespaceInitialized",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.namespaceV2",
+      "key": "namespaceV2",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.namesrvAddr",
+      "key": "namesrvAddr",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.persistConsumerOffsetInterval",
+      "key": "persistConsumerOffsetInterval",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.pollNameServerInterval",
+      "key": "pollNameServerInterval",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.pullTimeDelayMillsWhenException",
+      "key": "pullTimeDelayMillsWhenException",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.sendLatencyEnable",
+      "key": "sendLatencyEnable",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.socksProxyConfig",
+      "key": "socksProxyConfig",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.startDetectorEnable",
+      "key": "startDetectorEnable",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.traceMsgBatchNum",
+      "key": "traceMsgBatchNum",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.traceTopic",
+      "key": "traceTopic",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.unitMode",
+      "key": "unitMode",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.unitName",
+      "key": "unitName",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.useHeartbeatV2",
+      "key": "useHeartbeatV2",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.useTLS",
+      "key": "useTLS",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ClientConfig.vipChannelEnabled",
+      "key": "vipChannelEnabled",
+      "purpose": "Java configuration property",
+      "source": "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.accountStatsEnable",
+      "key": "accountStatsEnable",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.accountStatsPrintZeroValues",
+      "key": "accountStatsPrintZeroValues",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.ackMessageThreadPoolNums",
+      "key": "ackMessageThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.ackThreadPoolQueueCapacity",
+      "key": "ackThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.aclEnable",
+      "key": "aclEnable",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.adminBrokerThreadPoolNums",
+      "key": "adminBrokerThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.adminBrokerThreadPoolQueueCapacity",
+      "key": "adminBrokerThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.allowRecallWhenBrokerNotWriteable",
+      "key": "allowRecallWhenBrokerNotWriteable",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.appendAckAsync",
+      "key": "appendAckAsync",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.appendCkAsync",
+      "key": "appendCkAsync",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.asyncSendEnable",
+      "key": "asyncSendEnable",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.autoCreateSubscriptionGroup",
+      "key": "autoCreateSubscriptionGroup",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.autoCreateTopicEnable",
+      "key": "autoCreateTopicEnable",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.autoDeleteUnusedStats",
+      "key": "autoDeleteUnusedStats",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.batchDeleteSubscriptionGroupMaxRate",
+      "key": "batchDeleteSubscriptionGroupMaxRate",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.batchDeleteTopicMaxRate",
+      "key": "batchDeleteTopicMaxRate",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.broadcastOffsetExpireMaxSecond",
+      "key": "broadcastOffsetExpireMaxSecond",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.broadcastOffsetExpireSecond",
+      "key": "broadcastOffsetExpireSecond",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.brokerConfigPath",
+      "key": "brokerConfigPath",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.brokerElectionPriority",
+      "key": "brokerElectionPriority",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.brokerFastFailureEnable",
+      "key": "brokerFastFailureEnable",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.brokerHeartbeatInterval",
+      "key": "brokerHeartbeatInterval",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.brokerIP1",
+      "key": "brokerIP1",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.brokerIP2",
+      "key": "brokerIP2",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.brokerNotActiveTimeoutMillis",
+      "key": "brokerNotActiveTimeoutMillis",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.brokerPermission",
+      "key": "brokerPermission",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.brokerTopicEnable",
+      "key": "brokerTopicEnable",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.cgColdReadThreshold",
+      "key": "cgColdReadThreshold",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.channelExpiredTimeout",
+      "key": "channelExpiredTimeout",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.checkSyncStateSetPeriod",
+      "key": "checkSyncStateSetPeriod",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.cleanOfflineBrokerInterval",
+      "key": "cleanOfflineBrokerInterval",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.clearRetryTopicWhenDeleteTopic",
+      "key": "clearRetryTopicWhenDeleteTopic",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.clientManageThreadPoolNums",
+      "key": "clientManageThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.clientManagerThreadPoolQueueCapacity",
+      "key": "clientManagerThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.clusterTopicEnable",
+      "key": "clusterTopicEnable",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.coldCtrStrategyEnable",
+      "key": "coldCtrStrategyEnable",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.commercialBaseCount",
+      "key": "commercialBaseCount",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.commercialSizePerMsg",
+      "key": "commercialSizePerMsg",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.compatibleWithOldNameSrv",
+      "key": "compatibleWithOldNameSrv",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.compressedRegister",
+      "key": "compressedRegister",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.configBlackList",
+      "key": "configBlackList",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.configManagerVersion",
+      "key": "configManagerVersion",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.consumerFallbehindThreshold",
+      "key": "consumerFallbehindThreshold",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.consumerManageThreadPoolNums",
+      "key": "consumerManageThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.consumerManagerThreadPoolQueueCapacity",
+      "key": "consumerManagerThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.consumerOffsetUpdateVersionStep",
+      "key": "consumerOffsetUpdateVersionStep",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.controllerAddr",
+      "key": "controllerAddr",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.controllerHeartBeatTimeoutMills",
+      "key": "controllerHeartBeatTimeoutMills",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.defaultMessageRequestMode",
+      "key": "defaultMessageRequestMode",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.defaultPopShareQueueNum",
+      "key": "defaultPopShareQueueNum",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.defaultTopicQueueNums",
+      "key": "defaultTopicQueueNums",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.delayOffsetUpdateVersionStep",
+      "key": "delayOffsetUpdateVersionStep",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.disableConsumeIfConsumerReadSlowly",
+      "key": "disableConsumeIfConsumerReadSlowly",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enableBroadcastOffsetStore",
+      "key": "enableBroadcastOffsetStore",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enableCalcFilterBitMap",
+      "key": "enableCalcFilterBitMap",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enableConnectionMetrics",
+      "key": "enableConnectionMetrics",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enableControllerMode",
+      "key": "enableControllerMode",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enableCreateSysGroup",
+      "key": "enableCreateSysGroup",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enableDetailStat",
+      "key": "enableDetailStat",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enableFastChannelEventProcess",
+      "key": "enableFastChannelEventProcess",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enableLagAndDlqMetrics",
+      "key": "enableLagAndDlqMetrics",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enableLitePopLog",
+      "key": "enableLitePopLog",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enableLmqStats",
+      "key": "enableLmqStats",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enableMessageStoreMetrics",
+      "key": "enableMessageStoreMetrics",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enableMixedMessageType",
+      "key": "enableMixedMessageType",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enableNetWorkFlowControl",
+      "key": "enableNetWorkFlowControl",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enableNotifyAfterPopOrderLockRelease",
+      "key": "enableNotifyAfterPopOrderLockRelease",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enableNotifyBeforePopCalculateLag",
+      "key": "enableNotifyBeforePopCalculateLag",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enablePopBatchAck",
+      "key": "enablePopBatchAck",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enablePopBufferMerge",
+      "key": "enablePopBufferMerge",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enablePopLog",
+      "key": "enablePopLog",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enablePopMessageThreshold",
+      "key": "enablePopMessageThreshold",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enablePopMetrics",
+      "key": "enablePopMetrics",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enablePropertyFilter",
+      "key": "enablePropertyFilter",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enableRegisterProducer",
+      "key": "enableRegisterProducer",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enableRemoteEscape",
+      "key": "enableRemoteEscape",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enableRemotingMetrics",
+      "key": "enableRemotingMetrics",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enableRequestMetrics",
+      "key": "enableRequestMetrics",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enableRetryTopicV2",
+      "key": "enableRetryTopicV2",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enableSingleTopicRegister",
+      "key": "enableSingleTopicRegister",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enableSkipLongAwaitingAck",
+      "key": "enableSkipLongAwaitingAck",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enableSlaveActingMaster",
+      "key": "enableSlaveActingMaster",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enableSplitMetadata",
+      "key": "enableSplitMetadata",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enableSplitRegistration",
+      "key": "enableSplitRegistration",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enableStatsMetrics",
+      "key": "enableStatsMetrics",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.enableTransactionMetrics",
+      "key": "enableTransactionMetrics",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.endTransactionPoolQueueCapacity",
+      "key": "endTransactionPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.endTransactionThreadPoolNums",
+      "key": "endTransactionThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.estimateAccumulation",
+      "key": "estimateAccumulation",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.expectConsumerNumUseFilter",
+      "key": "expectConsumerNumUseFilter",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.fetchControllerAddrByDnsLookup",
+      "key": "fetchControllerAddrByDnsLookup",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.fetchNameSrvAddrByDnsLookup",
+      "key": "fetchNameSrvAddrByDnsLookup",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.fetchNamesrvAddrByAddressServer",
+      "key": "fetchNamesrvAddrByAddressServer",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.fetchNamesrvAddrInterval",
+      "key": "fetchNamesrvAddrInterval",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.filterDataCleanTimeSpan",
+      "key": "filterDataCleanTimeSpan",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.filterSupportRetry",
+      "key": "filterSupportRetry",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.flushConsumerOffsetHistoryInterval",
+      "key": "flushConsumerOffsetHistoryInterval",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.flushConsumerOffsetInterval",
+      "key": "flushConsumerOffsetInterval",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.forceRegister",
+      "key": "forceRegister",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.forwardTimeout",
+      "key": "forwardTimeout",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.globalColdReadThreshold",
+      "key": "globalColdReadThreshold",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.heartbeatThreadPoolNums",
+      "key": "heartbeatThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.heartbeatThreadPoolQueueCapacity",
+      "key": "heartbeatThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.highSpeedMode",
+      "key": "highSpeedMode",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.initPopOffsetByCheckMsgInMem",
+      "key": "initPopOffsetByCheckMsgInMem",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.isolateLogEnable",
+      "key": "isolateLogEnable",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.listenPort",
+      "key": "listenPort",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.liteEventCapacityCacheTtlMs",
+      "key": "liteEventCapacityCacheTtlMs",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.liteEventCheckInterval",
+      "key": "liteEventCheckInterval",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.liteEventFullDispatchDelayTime",
+      "key": "liteEventFullDispatchDelayTime",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.liteEventFullDispatchDelayTimeForWildcardGroup",
+      "key": "liteEventFullDispatchDelayTimeForWildcardGroup",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.liteLagCountMetricsEnable",
+      "key": "liteLagCountMetricsEnable",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.liteLagLatencyCollectEnable",
+      "key": "liteLagLatencyCollectEnable",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.liteLagLatencyMetricsEnable",
+      "key": "liteLagLatencyMetricsEnable",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.liteLagLatencyTopK",
+      "key": "liteLagLatencyTopK",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.litePullMessageEnable",
+      "key": "litePullMessageEnable",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.litePullMessageThreadPoolNums",
+      "key": "litePullMessageThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.litePullThreadPoolQueueCapacity",
+      "key": "litePullThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.liteSubscriptionCheckInterval",
+      "key": "liteSubscriptionCheckInterval",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.liteSubscriptionCheckTimeoutMills",
+      "key": "liteSubscriptionCheckTimeoutMills",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.liteTtlCheckInterval",
+      "key": "liteTtlCheckInterval",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.loadBalancePollNameServerInterval",
+      "key": "loadBalancePollNameServerInterval",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.loadBalanceProcessorThreadPoolNums",
+      "key": "loadBalanceProcessorThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.loadBalanceThreadPoolQueueCapacity",
+      "key": "loadBalanceThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.lockInStrictMode",
+      "key": "lockInStrictMode",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.longPollingEnable",
+      "key": "longPollingEnable",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.maxClientEventCount",
+      "key": "maxClientEventCount",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.maxErrorRateOfBloomFilter",
+      "key": "maxErrorRateOfBloomFilter",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.maxLiteSubscriptionCount",
+      "key": "maxLiteSubscriptionCount",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.maxMessageFilterNumForNotification",
+      "key": "maxMessageFilterNumForNotification",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.maxPopPollingSize",
+      "key": "maxPopPollingSize",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.maxStatsIdleTimeInMinutes",
+      "key": "maxStatsIdleTimeInMinutes",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.messageStorePlugIn",
+      "key": "messageStorePlugIn",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.metricGrpcExporterIntervalInMills",
+      "key": "metricGrpcExporterIntervalInMills",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.metricGrpcExporterTimeOutInMills",
+      "key": "metricGrpcExporterTimeOutInMills",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.metricLoggingExporterIntervalInMills",
+      "key": "metricLoggingExporterIntervalInMills",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.metricsExportBatchMaxConcurrent",
+      "key": "metricsExportBatchMaxConcurrent",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.metricsExportBatchMaxDataPoints",
+      "key": "metricsExportBatchMaxDataPoints",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.metricsExportBatchSplitEnabled",
+      "key": "metricsExportBatchSplitEnabled",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.metricsExportOtelMemoryMode",
+      "key": "metricsExportOtelMemoryMode",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.metricsExporterType",
+      "key": "metricsExporterType",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.metricsGrpcExporterHeader",
+      "key": "metricsGrpcExporterHeader",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.metricsGrpcExporterTarget",
+      "key": "metricsGrpcExporterTarget",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.metricsInDelta",
+      "key": "metricsInDelta",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.metricsLabel",
+      "key": "metricsLabel",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.metricsOtelCardinalityLimit",
+      "key": "metricsOtelCardinalityLimit",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.metricsPromExporterHost",
+      "key": "metricsPromExporterHost",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.metricsPromExporterPort",
+      "key": "metricsPromExporterPort",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.minLiteTTl",
+      "key": "minLiteTTl",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.msgTraceTopicName",
+      "key": "msgTraceTopicName",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.namesrvAddr",
+      "key": "namesrvAddr",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.notifyConsumerIdsChangedEnable",
+      "key": "notifyConsumerIdsChangedEnable",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.persistConsumerOffsetIncrementally",
+      "key": "persistConsumerOffsetIncrementally",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.popCkMaxBufferSize",
+      "key": "popCkMaxBufferSize",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.popCkOffsetMaxQueueSize",
+      "key": "popCkOffsetMaxQueueSize",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.popCkStayBufferTime",
+      "key": "popCkStayBufferTime",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.popCkStayBufferTimeOut",
+      "key": "popCkStayBufferTimeOut",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.popConsumerFSServiceInit",
+      "key": "popConsumerFSServiceInit",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.popConsumerKVServiceEnable",
+      "key": "popConsumerKVServiceEnable",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.popConsumerKVServiceInit",
+      "key": "popConsumerKVServiceInit",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.popConsumerKVServiceLog",
+      "key": "popConsumerKVServiceLog",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.popFromRetryProbability",
+      "key": "popFromRetryProbability",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.popFromRetryProbabilityForPriority",
+      "key": "popFromRetryProbabilityForPriority",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.popInflightMessageThreshold",
+      "key": "popInflightMessageThreshold",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.popLongPollingForceNotifyInterval",
+      "key": "popLongPollingForceNotifyInterval",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.popOrderLockTimerTickMs",
+      "key": "popOrderLockTimerTickMs",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.popOrderLockTimerTicksPerWheel",
+      "key": "popOrderLockTimerTicksPerWheel",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.popPollingMapExpireTimeSeconds",
+      "key": "popPollingMapExpireTimeSeconds",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.popPollingMapSize",
+      "key": "popPollingMapSize",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.popPollingSize",
+      "key": "popPollingSize",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.popResponseReturnActualRetryTopic",
+      "key": "popResponseReturnActualRetryTopic",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.popReviveConcurrency",
+      "key": "popReviveConcurrency",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.popReviveMaxAttemptTimes",
+      "key": "popReviveMaxAttemptTimes",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.popReviveMaxReturnSizePerRead",
+      "key": "popReviveMaxReturnSizePerRead",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.popReviveSkipIfGroupAbsent",
+      "key": "popReviveSkipIfGroupAbsent",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.printChannelGroups",
+      "key": "printChannelGroups",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.printChannelGroupsMinNum",
+      "key": "printChannelGroupsMinNum",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.priorityOrderAsc",
+      "key": "priorityOrderAsc",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.processReplyMessageThreadPoolNums",
+      "key": "processReplyMessageThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.pullMessageThreadPoolNums",
+      "key": "pullMessageThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.pullThreadPoolQueueCapacity",
+      "key": "pullThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.putMessageFutureThreadPoolNums",
+      "key": "putMessageFutureThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.putThreadPoolQueueCapacity",
+      "key": "putThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.queryMessageThreadPoolNums",
+      "key": "queryMessageThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.queryThreadPoolQueueCapacity",
+      "key": "queryThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.realTimeNotifyConsumerChange",
+      "key": "realTimeNotifyConsumerChange",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.recallMessageEnable",
+      "key": "recallMessageEnable",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.recoverConcurrently",
+      "key": "recoverConcurrently",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.recoverThreadPoolNums",
+      "key": "recoverThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.regionId",
+      "key": "regionId",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.registerBrokerTimeoutMills",
+      "key": "registerBrokerTimeoutMills",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.registerNameServerPeriod",
+      "key": "registerNameServerPeriod",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.rejectPullConsumerEnable",
+      "key": "rejectPullConsumerEnable",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.rejectTransactionMessage",
+      "key": "rejectTransactionMessage",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.replyThreadPoolQueueCapacity",
+      "key": "replyThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.retrieveMessageFromPopRetryTopicV1",
+      "key": "retrieveMessageFromPopRetryTopicV1",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.reviveAckWaitMs",
+      "key": "reviveAckWaitMs",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.reviveInterval",
+      "key": "reviveInterval",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.reviveMaxSlow",
+      "key": "reviveMaxSlow",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.reviveQueueNum",
+      "key": "reviveQueueNum",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.reviveScanTime",
+      "key": "reviveScanTime",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.rocketmqHome",
+      "key": "rocketmqHome",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.sendHeartbeatTimeoutMillis",
+      "key": "sendHeartbeatTimeoutMillis",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.sendMessageThreadPoolNums",
+      "key": "sendMessageThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.sendThreadPoolQueueCapacity",
+      "key": "sendThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.serverLoadBalancerEnable",
+      "key": "serverLoadBalancerEnable",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.shortPollingTimeMills",
+      "key": "shortPollingTimeMills",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.skipPreOnline",
+      "key": "skipPreOnline",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.skipWhenCKRePutReachMaxTimes",
+      "key": "skipWhenCKRePutReachMaxTimes",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.slaveReadEnable",
+      "key": "slaveReadEnable",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.splitMetadataSize",
+      "key": "splitMetadataSize",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.splitRegistrationSize",
+      "key": "splitRegistrationSize",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.startAcceptSendRequestTimeStamp",
+      "key": "startAcceptSendRequestTimeStamp",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.storeReplyMessageEnable",
+      "key": "storeReplyMessageEnable",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.subscriptionExpiredTimeout",
+      "key": "subscriptionExpiredTimeout",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.syncBrokerMemberGroupPeriod",
+      "key": "syncBrokerMemberGroupPeriod",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.syncBrokerMetadataPeriod",
+      "key": "syncBrokerMetadataPeriod",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.syncControllerMetadataPeriod",
+      "key": "syncControllerMetadataPeriod",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.traceOn",
+      "key": "traceOn",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.traceTopicEnable",
+      "key": "traceTopicEnable",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.transactionCheckInterval",
+      "key": "transactionCheckInterval",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.transactionCheckMax",
+      "key": "transactionCheckMax",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.transactionCheckRocksdbCoreThreads",
+      "key": "transactionCheckRocksdbCoreThreads",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.transactionCheckRocksdbMaxThreads",
+      "key": "transactionCheckRocksdbMaxThreads",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.transactionCheckRocksdbQueueCapacity",
+      "key": "transactionCheckRocksdbQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.transactionMetricFlushInterval",
+      "key": "transactionMetricFlushInterval",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.transactionOpBatchInterval",
+      "key": "transactionOpBatchInterval",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.transactionOpMsgMaxSize",
+      "key": "transactionOpMsgMaxSize",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.transactionTimeOut",
+      "key": "transactionTimeOut",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.transferMsgByHeap",
+      "key": "transferMsgByHeap",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.updateNameServerAddrPeriod",
+      "key": "updateNameServerAddrPeriod",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.useMessageFilterForNotification",
+      "key": "useMessageFilterForNotification",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.usePIDColdCtrStrategy",
+      "key": "usePIDColdCtrStrategy",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.useSeparateRetryQueue",
+      "key": "useSeparateRetryQueue",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.useServerSideResetOffset",
+      "key": "useServerSideResetOffset",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.useSingleRocksDBForAllConfigs",
+      "key": "useSingleRocksDBForAllConfigs",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.useStaticSubscription",
+      "key": "useStaticSubscription",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.validateSystemTopicWhenUpdateTopic",
+      "key": "validateSystemTopicWhenUpdateTopic",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.waitTimeMillsInAckQueue",
+      "key": "waitTimeMillsInAckQueue",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.waitTimeMillsInAdminBrokerQueue",
+      "key": "waitTimeMillsInAdminBrokerQueue",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.waitTimeMillsInHeartbeatQueue",
+      "key": "waitTimeMillsInHeartbeatQueue",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.waitTimeMillsInLitePullQueue",
+      "key": "waitTimeMillsInLitePullQueue",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.waitTimeMillsInPullQueue",
+      "key": "waitTimeMillsInPullQueue",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.waitTimeMillsInSendQueue",
+      "key": "waitTimeMillsInSendQueue",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "BrokerConfig.waitTimeMillsInTransactionQueue",
+      "key": "waitTimeMillsInTransactionQueue",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.configBlackList",
+      "key": "configBlackList",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.configStorePath",
+      "key": "configStorePath",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.controllerDLegerGroup",
+      "key": "controllerDLegerGroup",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.controllerDLegerPeers",
+      "key": "controllerDLegerPeers",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.controllerDLegerSelfId",
+      "key": "controllerDLegerSelfId",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.controllerRequestThreadPoolQueueCapacity",
+      "key": "controllerRequestThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.controllerStorePath",
+      "key": "controllerStorePath",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.controllerThreadPoolNums",
+      "key": "controllerThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.controllerType",
+      "key": "controllerType",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.electMasterMaxRetryCount",
+      "key": "electMasterMaxRetryCount",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.enableElectUncleanMaster",
+      "key": "enableElectUncleanMaster",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.isProcessReadEvent",
+      "key": "isProcessReadEvent",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.jraftConfig",
+      "key": "jraftConfig",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.mappedFileSize",
+      "key": "mappedFileSize",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.metricGrpcExporterIntervalInMills",
+      "key": "metricGrpcExporterIntervalInMills",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.metricGrpcExporterTimeOutInMills",
+      "key": "metricGrpcExporterTimeOutInMills",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.metricLoggingExporterIntervalInMills",
+      "key": "metricLoggingExporterIntervalInMills",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.metricsExporterType",
+      "key": "metricsExporterType",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.metricsGrpcExporterHeader",
+      "key": "metricsGrpcExporterHeader",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.metricsGrpcExporterTarget",
+      "key": "metricsGrpcExporterTarget",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.metricsInDelta",
+      "key": "metricsInDelta",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.metricsLabel",
+      "key": "metricsLabel",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.metricsPromExporterHost",
+      "key": "metricsPromExporterHost",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.metricsPromExporterPort",
+      "key": "metricsPromExporterPort",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.notifyBrokerRoleChanged",
+      "key": "notifyBrokerRoleChanged",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.rocketmqHome",
+      "key": "rocketmqHome",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.scanInactiveMasterInterval",
+      "key": "scanInactiveMasterInterval",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ControllerConfig.scanNotActiveBrokerInterval",
+      "key": "scanNotActiveBrokerInterval",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NamesrvConfig.clientRequestThreadPoolNums",
+      "key": "clientRequestThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/namesrv/NamesrvConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NamesrvConfig.clientRequestThreadPoolQueueCapacity",
+      "key": "clientRequestThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/namesrv/NamesrvConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NamesrvConfig.clusterTest",
+      "key": "clusterTest",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/namesrv/NamesrvConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NamesrvConfig.configBlackList",
+      "key": "configBlackList",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/namesrv/NamesrvConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NamesrvConfig.configStorePath",
+      "key": "configStorePath",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/namesrv/NamesrvConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NamesrvConfig.defaultThreadPoolNums",
+      "key": "defaultThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/namesrv/NamesrvConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NamesrvConfig.defaultThreadPoolQueueCapacity",
+      "key": "defaultThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/namesrv/NamesrvConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NamesrvConfig.deleteTopicWithBrokerRegistration",
+      "key": "deleteTopicWithBrokerRegistration",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/namesrv/NamesrvConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NamesrvConfig.enableAllTopicList",
+      "key": "enableAllTopicList",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/namesrv/NamesrvConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NamesrvConfig.enableControllerInNamesrv",
+      "key": "enableControllerInNamesrv",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/namesrv/NamesrvConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NamesrvConfig.enableTopicList",
+      "key": "enableTopicList",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/namesrv/NamesrvConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NamesrvConfig.kvConfigPath",
+      "key": "kvConfigPath",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/namesrv/NamesrvConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NamesrvConfig.needWaitForService",
+      "key": "needWaitForService",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/namesrv/NamesrvConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NamesrvConfig.notifyMinBrokerIdChanged",
+      "key": "notifyMinBrokerIdChanged",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/namesrv/NamesrvConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NamesrvConfig.orderMessageEnable",
+      "key": "orderMessageEnable",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/namesrv/NamesrvConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NamesrvConfig.productEnvName",
+      "key": "productEnvName",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/namesrv/NamesrvConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NamesrvConfig.returnOrderTopicConfigToBroker",
+      "key": "returnOrderTopicConfigToBroker",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/namesrv/NamesrvConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NamesrvConfig.rocketmqHome",
+      "key": "rocketmqHome",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/namesrv/NamesrvConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NamesrvConfig.scanNotActiveBrokerInterval",
+      "key": "scanNotActiveBrokerInterval",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/namesrv/NamesrvConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NamesrvConfig.supportActingMaster",
+      "key": "supportActingMaster",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/namesrv/NamesrvConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NamesrvConfig.unRegisterBrokerQueueCapacity",
+      "key": "unRegisterBrokerQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/namesrv/NamesrvConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NamesrvConfig.waitSecondsForService",
+      "key": "waitSecondsForService",
+      "purpose": "Java configuration property",
+      "source": "common/src/main/java/org/apache/rocketmq/common/namesrv/NamesrvConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.DEFAULT_CONFIG_FILE_NAME",
+      "key": "DEFAULT_CONFIG_FILE_NAME",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.aclCacheExpiredSeconds",
+      "key": "aclCacheExpiredSeconds",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.aclCacheMaxNum",
+      "key": "aclCacheMaxNum",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.aclCacheRefreshSeconds",
+      "key": "aclCacheRefreshSeconds",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.brokerConfigPath",
+      "key": "brokerConfigPath",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.channelExpiredInSeconds",
+      "key": "channelExpiredInSeconds",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.channelExpiredTimeout",
+      "key": "channelExpiredTimeout",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.consumerProcessorThreadPoolNums",
+      "key": "consumerProcessorThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.consumerProcessorThreadPoolQueueCapacity",
+      "key": "consumerProcessorThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.contextExpiredInSeconds",
+      "key": "contextExpiredInSeconds",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.defaultInvisibleTimeMills",
+      "key": "defaultInvisibleTimeMills",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.detectInterval",
+      "key": "detectInterval",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.detectTimeout",
+      "key": "detectTimeout",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.enableAclRpcHookForClusterMode",
+      "key": "enableAclRpcHookForClusterMode",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.enableBatchAck",
+      "key": "enableBatchAck",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.enableGrpcEpoll",
+      "key": "enableGrpcEpoll",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.enableMessageBodyEmptyCheck",
+      "key": "enableMessageBodyEmptyCheck",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.enablePrintJstack",
+      "key": "enablePrintJstack",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.enableProxyAutoRenew",
+      "key": "enableProxyAutoRenew",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.enableRemotingLocalProxyGrpc",
+      "key": "enableRemotingLocalProxyGrpc",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.enableTopicMessageTypeCheck",
+      "key": "enableTopicMessageTypeCheck",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcBossLoopNum",
+      "key": "grpcBossLoopNum",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcClientConsumerLongPollingBatchSize",
+      "key": "grpcClientConsumerLongPollingBatchSize",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcClientConsumerMaxLongPollingTimeoutMillis",
+      "key": "grpcClientConsumerMaxLongPollingTimeoutMillis",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcClientConsumerMinLongPollingTimeoutMillis",
+      "key": "grpcClientConsumerMinLongPollingTimeoutMillis",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcClientIdleTimeMills",
+      "key": "grpcClientIdleTimeMills",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcClientManagerThreadPoolNums",
+      "key": "grpcClientManagerThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcClientManagerThreadQueueCapacity",
+      "key": "grpcClientManagerThreadQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcClientProducerBackoffInitialMillis",
+      "key": "grpcClientProducerBackoffInitialMillis",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcClientProducerBackoffMaxMillis",
+      "key": "grpcClientProducerBackoffMaxMillis",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcClientProducerBackoffMultiplier",
+      "key": "grpcClientProducerBackoffMultiplier",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcClientProducerMaxAttempts",
+      "key": "grpcClientProducerMaxAttempts",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcConsumerThreadPoolNums",
+      "key": "grpcConsumerThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcConsumerThreadQueueCapacity",
+      "key": "grpcConsumerThreadQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcMaxConcurrentCallsPerConnection",
+      "key": "grpcMaxConcurrentCallsPerConnection",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcMaxInboundMessageSize",
+      "key": "grpcMaxInboundMessageSize",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcProducerThreadPoolNums",
+      "key": "grpcProducerThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcProducerThreadQueueCapacity",
+      "key": "grpcProducerThreadQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcProxyRelayRequestTimeoutInSeconds",
+      "key": "grpcProxyRelayRequestTimeoutInSeconds",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcRouteThreadPoolNums",
+      "key": "grpcRouteThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcRouteThreadQueueCapacity",
+      "key": "grpcRouteThreadQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcServerPermitKeepAliveTimeMillis",
+      "key": "grpcServerPermitKeepAliveTimeMillis",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcServerPermitKeepAliveWithoutCalls",
+      "key": "grpcServerPermitKeepAliveWithoutCalls",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcServerPort",
+      "key": "grpcServerPort",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcShutdownTimeSeconds",
+      "key": "grpcShutdownTimeSeconds",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcThreadPoolNums",
+      "key": "grpcThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcThreadPoolQueueCapacity",
+      "key": "grpcThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcTransactionThreadPoolNums",
+      "key": "grpcTransactionThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcTransactionThreadQueueCapacity",
+      "key": "grpcTransactionThreadQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.grpcWorkerLoopNum",
+      "key": "grpcWorkerLoopNum",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.heartbeatSyncerThreadPoolNums",
+      "key": "heartbeatSyncerThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.heartbeatSyncerThreadPoolQueueCapacity",
+      "key": "heartbeatSyncerThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.heartbeatSyncerTopicClusterName",
+      "key": "heartbeatSyncerTopicClusterName",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.heartbeatSyncerTopicName",
+      "key": "heartbeatSyncerTopicName",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.invisibleTimeMillisWhenClear",
+      "key": "invisibleTimeMillisWhenClear",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.localProxyConnectTimeoutMs",
+      "key": "localProxyConnectTimeoutMs",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.localServeAddr",
+      "key": "localServeAddr",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.lockTimeoutMsInHandleGroup",
+      "key": "lockTimeoutMsInHandleGroup",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.log",
+      "key": "log",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.longPollingReserveTimeInMillis",
+      "key": "longPollingReserveTimeInMillis",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.maxDelayTimeMills",
+      "key": "maxDelayTimeMills",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.maxInvisibleTimeMills",
+      "key": "maxInvisibleTimeMills",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.maxLiteRenewNumPerChannel",
+      "key": "maxLiteRenewNumPerChannel",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.maxLiteTopicSize",
+      "key": "maxLiteTopicSize",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.maxMessageGroupSize",
+      "key": "maxMessageGroupSize",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.maxMessageSize",
+      "key": "maxMessageSize",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.maxRenewRetryTimes",
+      "key": "maxRenewRetryTimes",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.maxSyncLiteSubscriptionRate",
+      "key": "maxSyncLiteSubscriptionRate",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.maxTransactionRecoverySecond",
+      "key": "maxTransactionRecoverySecond",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.maxUserPropertySize",
+      "key": "maxUserPropertySize",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.messageDelayLevel",
+      "key": "messageDelayLevel",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.metadataThreadPoolNums",
+      "key": "metadataThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.metadataThreadPoolQueueCapacity",
+      "key": "metadataThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.metricCollectorAddress",
+      "key": "metricCollectorAddress",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.metricCollectorMode",
+      "key": "metricCollectorMode",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.metricGrpcExporterIntervalInMills",
+      "key": "metricGrpcExporterIntervalInMills",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.metricGrpcExporterTimeOutInMills",
+      "key": "metricGrpcExporterTimeOutInMills",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.metricLoggingExporterIntervalInMills",
+      "key": "metricLoggingExporterIntervalInMills",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.metricsExporterType",
+      "key": "metricsExporterType",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.metricsGrpcExporterHeader",
+      "key": "metricsGrpcExporterHeader",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.metricsGrpcExporterTarget",
+      "key": "metricsGrpcExporterTarget",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.metricsInDelta",
+      "key": "metricsInDelta",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.metricsLabel",
+      "key": "metricsLabel",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.metricsPromExporterHost",
+      "key": "metricsPromExporterHost",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.metricsPromExporterPort",
+      "key": "metricsPromExporterPort",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.minInvisibleTimeMillsForRecv",
+      "key": "minInvisibleTimeMillsForRecv",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.namesrvAddr",
+      "key": "namesrvAddr",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.namesrvDomain",
+      "key": "namesrvDomain",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.namesrvDomainSubgroup",
+      "key": "namesrvDomainSubgroup",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.printJstackInMillis",
+      "key": "printJstackInMillis",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.printThreadPoolStatusInMillis",
+      "key": "printThreadPoolStatusInMillis",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.producerProcessorThreadPoolNums",
+      "key": "producerProcessorThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.producerProcessorThreadPoolQueueCapacity",
+      "key": "producerProcessorThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.proxyClusterName",
+      "key": "proxyClusterName",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.proxyMode",
+      "key": "proxyMode",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.proxyName",
+      "key": "proxyName",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.regionId",
+      "key": "regionId",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.remotingAccessAddr",
+      "key": "remotingAccessAddr",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.remotingDefaultThreadPoolNums",
+      "key": "remotingDefaultThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.remotingDefaultThreadPoolQueueCapacity",
+      "key": "remotingDefaultThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.remotingHeartbeatThreadPoolNums",
+      "key": "remotingHeartbeatThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.remotingHeartbeatThreadPoolQueueCapacity",
+      "key": "remotingHeartbeatThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.remotingListenPort",
+      "key": "remotingListenPort",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.remotingPullMessageThreadPoolNums",
+      "key": "remotingPullMessageThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.remotingPullThreadPoolQueueCapacity",
+      "key": "remotingPullThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.remotingSendMessageThreadPoolNums",
+      "key": "remotingSendMessageThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.remotingSendThreadPoolQueueCapacity",
+      "key": "remotingSendThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.remotingTopicRouteThreadPoolNums",
+      "key": "remotingTopicRouteThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.remotingTopicRouteThreadPoolQueueCapacity",
+      "key": "remotingTopicRouteThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.remotingUpdateOffsetThreadPoolNums",
+      "key": "remotingUpdateOffsetThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.remotingUpdateOffsetThreadPoolQueueCapacity",
+      "key": "remotingUpdateOffsetThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.remotingWaitTimeMillsInDefaultQueue",
+      "key": "remotingWaitTimeMillsInDefaultQueue",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.remotingWaitTimeMillsInHeartbeatQueue",
+      "key": "remotingWaitTimeMillsInHeartbeatQueue",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.remotingWaitTimeMillsInPullQueue",
+      "key": "remotingWaitTimeMillsInPullQueue",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.remotingWaitTimeMillsInSendQueue",
+      "key": "remotingWaitTimeMillsInSendQueue",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.remotingWaitTimeMillsInTopicRouteQueue",
+      "key": "remotingWaitTimeMillsInTopicRouteQueue",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.remotingWaitTimeMillsInUpdateOffsetQueue",
+      "key": "remotingWaitTimeMillsInUpdateOffsetQueue",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.renewAheadTimeMillis",
+      "key": "renewAheadTimeMillis",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.renewMaxThreadPoolNums",
+      "key": "renewMaxThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.renewMaxTimeMillis",
+      "key": "renewMaxTimeMillis",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.renewSchedulePeriodMillis",
+      "key": "renewSchedulePeriodMillis",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.renewThreadPoolNums",
+      "key": "renewThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.renewThreadPoolQueueCapacity",
+      "key": "renewThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.returnHandleGroupThreadPoolNums",
+      "key": "returnHandleGroupThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.rocketMQClusterName",
+      "key": "rocketMQClusterName",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.rocketmqMQClientNum",
+      "key": "rocketmqMQClientNum",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.sendLatencyEnable",
+      "key": "sendLatencyEnable",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.startDetectorEnable",
+      "key": "startDetectorEnable",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.subscriptionGroupConfigCacheExpiredSeconds",
+      "key": "subscriptionGroupConfigCacheExpiredSeconds",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.subscriptionGroupConfigCacheMaxNum",
+      "key": "subscriptionGroupConfigCacheMaxNum",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.subscriptionGroupConfigCacheRefreshSeconds",
+      "key": "subscriptionGroupConfigCacheRefreshSeconds",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.tlsCertPath",
+      "key": "tlsCertPath",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.tlsCertWatchIntervalMs",
+      "key": "tlsCertWatchIntervalMs",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.tlsKeyPassword",
+      "key": "tlsKeyPassword",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.tlsKeyPath",
+      "key": "tlsKeyPath",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.tlsTestModeEnable",
+      "key": "tlsTestModeEnable",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.topicConfigCacheExpiredSeconds",
+      "key": "topicConfigCacheExpiredSeconds",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.topicConfigCacheMaxNum",
+      "key": "topicConfigCacheMaxNum",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.topicConfigCacheRefreshSeconds",
+      "key": "topicConfigCacheRefreshSeconds",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.topicRouteServiceCacheExpiredSeconds",
+      "key": "topicRouteServiceCacheExpiredSeconds",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.topicRouteServiceCacheMaxNum",
+      "key": "topicRouteServiceCacheMaxNum",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.topicRouteServiceCacheRefreshSeconds",
+      "key": "topicRouteServiceCacheRefreshSeconds",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.topicRouteServiceThreadPoolNums",
+      "key": "topicRouteServiceThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.topicRouteServiceThreadPoolQueueCapacity",
+      "key": "topicRouteServiceThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.traceOn",
+      "key": "traceOn",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.transactionDataExpireMillis",
+      "key": "transactionDataExpireMillis",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.transactionDataExpireScanPeriodMillis",
+      "key": "transactionDataExpireScanPeriodMillis",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.transactionDataMaxNum",
+      "key": "transactionDataMaxNum",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.transactionDataMaxWaitClearMillis",
+      "key": "transactionDataMaxWaitClearMillis",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.transactionHeartbeatBatchNum",
+      "key": "transactionHeartbeatBatchNum",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.transactionHeartbeatPeriodSecond",
+      "key": "transactionHeartbeatPeriodSecond",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.transactionHeartbeatThreadPoolNums",
+      "key": "transactionHeartbeatThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.transactionHeartbeatThreadPoolQueueCapacity",
+      "key": "transactionHeartbeatThreadPoolQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.useDelayLevel",
+      "key": "useDelayLevel",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.useEndpointPortFromRequest",
+      "key": "useEndpointPortFromRequest",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.userCacheExpiredSeconds",
+      "key": "userCacheExpiredSeconds",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.userCacheMaxNum",
+      "key": "userCacheMaxNum",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.userCacheRefreshSeconds",
+      "key": "userCacheRefreshSeconds",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "ProxyConfig.userPropertyMaxNum",
+      "key": "userPropertyMaxNum",
+      "purpose": "Java configuration property",
+      "source": "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyClientConfig.channelNotActiveInterval",
+      "key": "channelNotActiveInterval",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyClientConfig.clientAsyncSemaphoreValue",
+      "key": "clientAsyncSemaphoreValue",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyClientConfig.clientCallbackExecutorThreads",
+      "key": "clientCallbackExecutorThreads",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyClientConfig.clientChannelMaxIdleTimeSeconds",
+      "key": "clientChannelMaxIdleTimeSeconds",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyClientConfig.clientCloseSocketIfTimeout",
+      "key": "clientCloseSocketIfTimeout",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyClientConfig.clientOnewaySemaphoreValue",
+      "key": "clientOnewaySemaphoreValue",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyClientConfig.clientPooledByteBufAllocatorEnable",
+      "key": "clientPooledByteBufAllocatorEnable",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyClientConfig.clientSocketRcvBufSize",
+      "key": "clientSocketRcvBufSize",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyClientConfig.clientSocketSndBufSize",
+      "key": "clientSocketSndBufSize",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyClientConfig.clientWorkerThreads",
+      "key": "clientWorkerThreads",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyClientConfig.connectTimeoutMillis",
+      "key": "connectTimeoutMillis",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyClientConfig.disableCallbackExecutor",
+      "key": "disableCallbackExecutor",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyClientConfig.disableNettyWorkerGroup",
+      "key": "disableNettyWorkerGroup",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyClientConfig.enableReconnectForGoAway",
+      "key": "enableReconnectForGoAway",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyClientConfig.isScanAvailableNameSrv",
+      "key": "isScanAvailableNameSrv",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyClientConfig.maxReconnectIntervalTimeSeconds",
+      "key": "maxReconnectIntervalTimeSeconds",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyClientConfig.socksProxyConfig",
+      "key": "socksProxyConfig",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyClientConfig.useTLS",
+      "key": "useTLS",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyClientConfig.writeBufferHighWaterMark",
+      "key": "writeBufferHighWaterMark",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyClientConfig.writeBufferLowWaterMark",
+      "key": "writeBufferLowWaterMark",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyClientConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyServerConfig.bindAddress",
+      "key": "bindAddress",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyServerConfig.enableShutdownGracefully",
+      "key": "enableShutdownGracefully",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyServerConfig.listenPort",
+      "key": "listenPort",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyServerConfig.serverAsyncSemaphoreValue",
+      "key": "serverAsyncSemaphoreValue",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyServerConfig.serverCallbackExecutorThreads",
+      "key": "serverCallbackExecutorThreads",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyServerConfig.serverChannelMaxIdleTimeSeconds",
+      "key": "serverChannelMaxIdleTimeSeconds",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyServerConfig.serverNettyWorkerGroupEnable",
+      "key": "serverNettyWorkerGroupEnable",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyServerConfig.serverOnewaySemaphoreValue",
+      "key": "serverOnewaySemaphoreValue",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyServerConfig.serverPooledByteBufAllocatorEnable",
+      "key": "serverPooledByteBufAllocatorEnable",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyServerConfig.serverSelectorThreads",
+      "key": "serverSelectorThreads",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyServerConfig.serverSocketBacklog",
+      "key": "serverSocketBacklog",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyServerConfig.serverSocketRcvBufSize",
+      "key": "serverSocketRcvBufSize",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyServerConfig.serverSocketSndBufSize",
+      "key": "serverSocketSndBufSize",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyServerConfig.serverWorkerThreads",
+      "key": "serverWorkerThreads",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyServerConfig.shutdownWaitTimeSeconds",
+      "key": "shutdownWaitTimeSeconds",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyServerConfig.useEpollNativeSelector",
+      "key": "useEpollNativeSelector",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyServerConfig.writeBufferHighWaterMark",
+      "key": "writeBufferHighWaterMark",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "NettyServerConfig.writeBufferLowWaterMark",
+      "key": "writeBufferLowWaterMark",
+      "purpose": "Java configuration property",
+      "source": "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.accessMessageInMemoryHotRatio",
+      "key": "accessMessageInMemoryHotRatio",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.accessMessageInMemoryMaxRatio",
+      "key": "accessMessageInMemoryMaxRatio",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.allAckInSyncStateSet",
+      "key": "allAckInSyncStateSet",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.appendTopicForTimerDeleteKey",
+      "key": "appendTopicForTimerDeleteKey",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.asyncLearner",
+      "key": "asyncLearner",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.autoMessageVersionOnTopicLen",
+      "key": "autoMessageVersionOnTopicLen",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.batchDispatchRequestThreadPoolNums",
+      "key": "batchDispatchRequestThreadPoolNums",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.bitMapLengthConsumeQueueExt",
+      "key": "bitMapLengthConsumeQueueExt",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.bottomMostCompressionTypeForConsumeQueueStore",
+      "key": "bottomMostCompressionTypeForConsumeQueueStore",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.brokerRole",
+      "key": "brokerRole",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.checkCRCOnRecover",
+      "key": "checkCRCOnRecover",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.checkCommitLogOffsetOnRecover",
+      "key": "checkCommitLogOffsetOnRecover",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.cleanFileForciblyEnable",
+      "key": "cleanFileForciblyEnable",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.cleanResourceInterval",
+      "key": "cleanResourceInterval",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.cleanRocksDBDirtyCQIntervalMin",
+      "key": "cleanRocksDBDirtyCQIntervalMin",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.cleanSwapedMapInterval",
+      "key": "cleanSwapedMapInterval",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.coldDataFlowControlEnable",
+      "key": "coldDataFlowControlEnable",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.coldDataScanEnable",
+      "key": "coldDataScanEnable",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.combineAssignOffsetCQType",
+      "key": "combineAssignOffsetCQType",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.combineCQEnableCheckSelf",
+      "key": "combineCQEnableCheckSelf",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.combineCQLoadingCQTypes",
+      "key": "combineCQLoadingCQTypes",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.combineCQMaxExtraSearchCommitLogFiles",
+      "key": "combineCQMaxExtraSearchCommitLogFiles",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.combineCQPreferCQType",
+      "key": "combineCQPreferCQType",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.combineCQUseRocksdbForLmq",
+      "key": "combineCQUseRocksdbForLmq",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.commitCommitLogLeastPages",
+      "key": "commitCommitLogLeastPages",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.commitCommitLogThoroughInterval",
+      "key": "commitCommitLogThoroughInterval",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.commitIntervalCommitLog",
+      "key": "commitIntervalCommitLog",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.commitLogForceSwapMapInterval",
+      "key": "commitLogForceSwapMapInterval",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.commitLogRecoverMaxNum",
+      "key": "commitLogRecoverMaxNum",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.commitLogSwapMapInterval",
+      "key": "commitLogSwapMapInterval",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.commitLogSwapMapReserveFileNum",
+      "key": "commitLogSwapMapReserveFileNum",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.compactionCqMappedFileSize",
+      "key": "compactionCqMappedFileSize",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.compactionMappedFileSize",
+      "key": "compactionMappedFileSize",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.compactionScheduleInternal",
+      "key": "compactionScheduleInternal",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.compactionThreadNum",
+      "key": "compactionThreadNum",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.correctLogicMinOffsetForceInterval",
+      "key": "correctLogicMinOffsetForceInterval",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.correctLogicMinOffsetSleepInterval",
+      "key": "correctLogicMinOffsetSleepInterval",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.correctMinOffsetMadviseEnable",
+      "key": "correctMinOffsetMadviseEnable",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.dLegerGroup",
+      "key": "dLegerGroup",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.dLegerPeers",
+      "key": "dLegerPeers",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.dLegerSelfId",
+      "key": "dLegerSelfId",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.dataReadAheadEnable",
+      "key": "dataReadAheadEnable",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.debugLockEnable",
+      "key": "debugLockEnable",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.defaultQueryMaxNum",
+      "key": "defaultQueryMaxNum",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.deleteCommitLogFilesInterval",
+      "key": "deleteCommitLogFilesInterval",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.deleteConsumeQueueFilesInterval",
+      "key": "deleteConsumeQueueFilesInterval",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.deleteFileBatchMax",
+      "key": "deleteFileBatchMax",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.deleteWhen",
+      "key": "deleteWhen",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.destroyMapedFileIntervalForcibly",
+      "key": "destroyMapedFileIntervalForcibly",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.disappearTimeAfterStart",
+      "key": "disappearTimeAfterStart",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.diskFallRecorded",
+      "key": "diskFallRecorded",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.diskMaxUsedSpaceRatio",
+      "key": "diskMaxUsedSpaceRatio",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.diskSpaceCleanForciblyRatio",
+      "key": "diskSpaceCleanForciblyRatio",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.diskSpaceWarningLevelRatio",
+      "key": "diskSpaceWarningLevelRatio",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.dispatchCqCacheNum",
+      "key": "dispatchCqCacheNum",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.dispatchCqThreads",
+      "key": "dispatchCqThreads",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.dispatchFromSenderThread",
+      "key": "dispatchFromSenderThread",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.duplicationEnable",
+      "key": "duplicationEnable",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.enableAcceleratedRecovery",
+      "key": "enableAcceleratedRecovery",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.enableAsyncReput",
+      "key": "enableAsyncReput",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.enableAutoInSyncReplicas",
+      "key": "enableAutoInSyncReplicas",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.enableBatchPush",
+      "key": "enableBatchPush",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.enableBuildConsumeQueueConcurrently",
+      "key": "enableBuildConsumeQueueConcurrently",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.enableCleanExpiredOffset",
+      "key": "enableCleanExpiredOffset",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.enableCompaction",
+      "key": "enableCompaction",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.enableConsumeQueueExt",
+      "key": "enableConsumeQueueExt",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.enableDLegerCommitLog",
+      "key": "enableDLegerCommitLog",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.enableLmq",
+      "key": "enableLmq",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.enableLmqQuota",
+      "key": "enableLmqQuota",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.enableLogConsumeQueueRepeatedlyBuildWhenRecover",
+      "key": "enableLogConsumeQueueRepeatedlyBuildWhenRecover",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.enableMultiDispatch",
+      "key": "enableMultiDispatch",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.enableRocksDBLog",
+      "key": "enableRocksDBLog",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.enableRunningFlagsInFlush",
+      "key": "enableRunningFlagsInFlush",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.enableScheduleAsyncDeliver",
+      "key": "enableScheduleAsyncDeliver",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.enableScheduleMessageStats",
+      "key": "enableScheduleMessageStats",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.enabledAppendPropCRC",
+      "key": "enabledAppendPropCRC",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.fastFailIfNoBufferInStorePool",
+      "key": "fastFailIfNoBufferInStorePool",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.fileReservedTime",
+      "key": "fileReservedTime",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.flushCommitLogLeastPages",
+      "key": "flushCommitLogLeastPages",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.flushCommitLogThoroughInterval",
+      "key": "flushCommitLogThoroughInterval",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.flushCommitLogTimed",
+      "key": "flushCommitLogTimed",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.flushConsumeQueueLeastPages",
+      "key": "flushConsumeQueueLeastPages",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.flushConsumeQueueThoroughInterval",
+      "key": "flushConsumeQueueThoroughInterval",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.flushDelayOffsetInterval",
+      "key": "flushDelayOffsetInterval",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.flushDiskType",
+      "key": "flushDiskType",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.flushIntervalCommitLog",
+      "key": "flushIntervalCommitLog",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.flushIntervalConsumeQueue",
+      "key": "flushIntervalConsumeQueue",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.flushLeastPagesWhenWarmMapedFile",
+      "key": "flushLeastPagesWhenWarmMapedFile",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.forceVerifyPropCRC",
+      "key": "forceVerifyPropCRC",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.haFlowControlEnable",
+      "key": "haFlowControlEnable",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.haHousekeepingInterval",
+      "key": "haHousekeepingInterval",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.haListenPort",
+      "key": "haListenPort",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.haMasterAddress",
+      "key": "haMasterAddress",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.haMaxGapNotInSync",
+      "key": "haMaxGapNotInSync",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.haMaxTimeSlaveNotCatchup",
+      "key": "haMaxTimeSlaveNotCatchup",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.haSendHeartbeatInterval",
+      "key": "haSendHeartbeatInterval",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.haTransferBatchSize",
+      "key": "haTransferBatchSize",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.inSyncReplicas",
+      "key": "inSyncReplicas",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.indexFileReadEnable",
+      "key": "indexFileReadEnable",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.indexFileWriteEnable",
+      "key": "indexFileWriteEnable",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.indexRocksDBEnable",
+      "key": "indexRocksDBEnable",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.iteratorWhenUseRocksdbConsumeQueue",
+      "key": "iteratorWhenUseRocksdbConsumeQueue",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.logicQueueForceSwapMapInterval",
+      "key": "logicQueueForceSwapMapInterval",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.logicQueueSwapMapInterval",
+      "key": "logicQueueSwapMapInterval",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.logicQueueSwapMapReserveFileNum",
+      "key": "logicQueueSwapMapReserveFileNum",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.logicalDiskSpaceCleanForciblyThreshold",
+      "key": "logicalDiskSpaceCleanForciblyThreshold",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.mappedFileSizeCommitLog",
+      "key": "mappedFileSizeCommitLog",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.mappedFileSizeConsumeQueue",
+      "key": "mappedFileSizeConsumeQueue",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.mappedFileSizeConsumeQueueExt",
+      "key": "mappedFileSizeConsumeQueueExt",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.mappedFileSizeTimerLog",
+      "key": "mappedFileSizeTimerLog",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.mappedFileSwapEnable",
+      "key": "mappedFileSwapEnable",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.mapperFileSizeBatchConsumeQueue",
+      "key": "mapperFileSizeBatchConsumeQueue",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.maxAsyncPutMessageRequests",
+      "key": "maxAsyncPutMessageRequests",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.maxBatchDeleteFilesNum",
+      "key": "maxBatchDeleteFilesNum",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.maxCheckMessageReuseBufferSize",
+      "key": "maxCheckMessageReuseBufferSize",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.maxChecksumRange",
+      "key": "maxChecksumRange",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.maxConsumeQueueScan",
+      "key": "maxConsumeQueueScan",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.maxFilterMessageSize",
+      "key": "maxFilterMessageSize",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.maxHaTransferByteInSecond",
+      "key": "maxHaTransferByteInSecond",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.maxHashSlotNum",
+      "key": "maxHashSlotNum",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.maxIndexNum",
+      "key": "maxIndexNum",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.maxLmqConsumeQueueNum",
+      "key": "maxLmqConsumeQueueNum",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.maxMessageSize",
+      "key": "maxMessageSize",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.maxMsgsNumBatch",
+      "key": "maxMsgsNumBatch",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.maxOffsetMapSize",
+      "key": "maxOffsetMapSize",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.maxRecoveryCommitlogFiles",
+      "key": "maxRecoveryCommitlogFiles",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.maxRocksDBIndexQueryDays",
+      "key": "maxRocksDBIndexQueryDays",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.maxSlaveResendLength",
+      "key": "maxSlaveResendLength",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.maxTopicLength",
+      "key": "maxTopicLength",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.maxTransferBytesOnMessageInDisk",
+      "key": "maxTransferBytesOnMessageInDisk",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.maxTransferBytesOnMessageInMemory",
+      "key": "maxTransferBytesOnMessageInMemory",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.maxTransferCountOnMessageInDisk",
+      "key": "maxTransferCountOnMessageInDisk",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.maxTransferCountOnMessageInMemory",
+      "key": "maxTransferCountOnMessageInMemory",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.memTableFlushIntervalMs",
+      "key": "memTableFlushIntervalMs",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.messageDelayLevel",
+      "key": "messageDelayLevel",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.messageIndexEnable",
+      "key": "messageIndexEnable",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.messageIndexSafe",
+      "key": "messageIndexSafe",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.minInSyncReplicas",
+      "key": "minInSyncReplicas",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.offsetCheckInSlave",
+      "key": "offsetCheckInSlave",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.osPageCacheBusyTimeOutMills",
+      "key": "osPageCacheBusyTimeOutMills",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.popRocksdbBlockCacheSize",
+      "key": "popRocksdbBlockCacheSize",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.popRocksdbWriteBufferSize",
+      "key": "popRocksdbWriteBufferSize",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.preferredLeaderId",
+      "key": "preferredLeaderId",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.pullBatchMaxMessageCount",
+      "key": "pullBatchMaxMessageCount",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.putConsumeQueueDataByFileChannel",
+      "key": "putConsumeQueueDataByFileChannel",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.putMessageTimeout",
+      "key": "putMessageTimeout",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.putMsgIndexHightWater",
+      "key": "putMsgIndexHightWater",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.readOnlyCommitLogStorePaths",
+      "key": "readOnlyCommitLogStorePaths",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.readUnCommitted",
+      "key": "readUnCommitted",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.realTimePersistRocksDBConfig",
+      "key": "realTimePersistRocksDBConfig",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.recheckReputOffsetFromCq",
+      "key": "recheckReputOffsetFromCq",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.redeleteHangedFileInterval",
+      "key": "redeleteHangedFileInterval",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.replicasPerDiskPartition",
+      "key": "replicasPerDiskPartition",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.rocksdbCQDoubleWriteEnable",
+      "key": "rocksdbCQDoubleWriteEnable",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.rocksdbCQSelectiveDoubleWriteEnable",
+      "key": "rocksdbCQSelectiveDoubleWriteEnable",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.rocksdbCompressionType",
+      "key": "rocksdbCompressionType",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.rocksdbFlushWalFrequency",
+      "key": "rocksdbFlushWalFrequency",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.rocksdbMaxSizeAmplificationPercent",
+      "key": "rocksdbMaxSizeAmplificationPercent",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.rocksdbWalFileRollingThreshold",
+      "key": "rocksdbWalFileRollingThreshold",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.sampleCountThreshold",
+      "key": "sampleCountThreshold",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.sampleSteps",
+      "key": "sampleSteps",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.scheduleAsyncDeliverMaxPendingLimit",
+      "key": "scheduleAsyncDeliverMaxPendingLimit",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.scheduleAsyncDeliverMaxResendNum2Blocked",
+      "key": "scheduleAsyncDeliverMaxResendNum2Blocked",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.searchBcqByCacheEnable",
+      "key": "searchBcqByCacheEnable",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.sharedByteBufferNum",
+      "key": "sharedByteBufferNum",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.slaveTimeout",
+      "key": "slaveTimeout",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.spinLockCollisionRetreatOptimalDegree",
+      "key": "spinLockCollisionRetreatOptimalDegree",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.statRocksDBCQIntervalSec",
+      "key": "statRocksDBCQIntervalSec",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.storePathBrokerIdentity",
+      "key": "storePathBrokerIdentity",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.storePathCommitLog",
+      "key": "storePathCommitLog",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.storePathDLedgerCommitLog",
+      "key": "storePathDLedgerCommitLog",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.storePathEpochFile",
+      "key": "storePathEpochFile",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.storePathRootDir",
+      "key": "storePathRootDir",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.storeType",
+      "key": "storeType",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.syncFlushTimeout",
+      "key": "syncFlushTimeout",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.syncFromLastFile",
+      "key": "syncFromLastFile",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.syncMasterFlushOffsetWhenStartup",
+      "key": "syncMasterFlushOffsetWhenStartup",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerCheckMetricsWhen",
+      "key": "timerCheckMetricsWhen",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerColdDataCheckIntervalMs",
+      "key": "timerColdDataCheckIntervalMs",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerCongestNumEachSlot",
+      "key": "timerCongestNumEachSlot",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerEnableCheckMetrics",
+      "key": "timerEnableCheckMetrics",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerEnableDisruptor",
+      "key": "timerEnableDisruptor",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerEnableRetryUntilSuccess",
+      "key": "timerEnableRetryUntilSuccess",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerFlushIntervalMs",
+      "key": "timerFlushIntervalMs",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerGetMessageThreadNum",
+      "key": "timerGetMessageThreadNum",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerInterceptDelayLevel",
+      "key": "timerInterceptDelayLevel",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerMaxDelaySec",
+      "key": "timerMaxDelaySec",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerMetricSmallThreshold",
+      "key": "timerMetricSmallThreshold",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerPrecisionMs",
+      "key": "timerPrecisionMs",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerProgressLogIntervalMs",
+      "key": "timerProgressLogIntervalMs",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerPutMessageThreadNum",
+      "key": "timerPutMessageThreadNum",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerRecallToTimeWheelEnable",
+      "key": "timerRecallToTimeWheelEnable",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerRecallToTimelineEnable",
+      "key": "timerRecallToTimelineEnable",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerReputServiceCorePoolSize",
+      "key": "timerReputServiceCorePoolSize",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerReputServiceMaxPoolSize",
+      "key": "timerReputServiceMaxPoolSize",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerReputServiceQueueCapacity",
+      "key": "timerReputServiceQueueCapacity",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerRocksDBEnable",
+      "key": "timerRocksDBEnable",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerRocksDBPrecisionMs",
+      "key": "timerRocksDBPrecisionMs",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerRocksDBRollIntervalHours",
+      "key": "timerRocksDBRollIntervalHours",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerRocksDBRollMaxTps",
+      "key": "timerRocksDBRollMaxTps",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerRocksDBRollRangeHours",
+      "key": "timerRocksDBRollRangeHours",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerRocksDBStopScan",
+      "key": "timerRocksDBStopScan",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerRocksDBTimeExpiredMaxTps",
+      "key": "timerRocksDBTimeExpiredMaxTps",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerRollWindowSlot",
+      "key": "timerRollWindowSlot",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerSkipUnknownError",
+      "key": "timerSkipUnknownError",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerStopDequeue",
+      "key": "timerStopDequeue",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerStopEnqueue",
+      "key": "timerStopEnqueue",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerWarmEnable",
+      "key": "timerWarmEnable",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerWheelEnable",
+      "key": "timerWheelEnable",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerWheelSnapshotFlush",
+      "key": "timerWheelSnapshotFlush",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.timerWheelSnapshotIntervalMs",
+      "key": "timerWheelSnapshotIntervalMs",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.topicQueueLockNum",
+      "key": "topicQueueLockNum",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.totalReplicas",
+      "key": "totalReplicas",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.transRocksDBEnable",
+      "key": "transRocksDBEnable",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.transWriteOriginTransHalfEnable",
+      "key": "transWriteOriginTransHalfEnable",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.transientStorePoolEnable",
+      "key": "transientStorePoolEnable",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.transientStorePoolSize",
+      "key": "transientStorePoolSize",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.travelCqFileNumWhenGetMessage",
+      "key": "travelCqFileNumWhenGetMessage",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.useABSLock",
+      "key": "useABSLock",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.useReentrantLockWhenPutMessage",
+      "key": "useReentrantLockWhenPutMessage",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.useSeparateStorePathForRocksdbCQ",
+      "key": "useSeparateStorePathForRocksdbCQ",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.wakeCommitWhenPutMessage",
+      "key": "wakeCommitWhenPutMessage",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.wakeFlushWhenPutMessage",
+      "key": "wakeFlushWhenPutMessage",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.warmMapedFileEnable",
+      "key": "warmMapedFileEnable",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.writeWithoutMmap",
+      "key": "writeWithoutMmap",
+      "purpose": "Java configuration property",
+      "source": "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.brokerClusterName",
+      "key": "brokerClusterName",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.brokerName",
+      "key": "brokerName",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.commitLogRollingInterval",
+      "key": "commitLogRollingInterval",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.commitLogRollingMinimumSize",
+      "key": "commitLogRollingMinimumSize",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.messageIndexEnable",
+      "key": "messageIndexEnable",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.objectStoreAccessKey",
+      "key": "objectStoreAccessKey",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.objectStoreBucket",
+      "key": "objectStoreBucket",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.objectStoreEndpoint",
+      "key": "objectStoreEndpoint",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.objectStoreSecretKey",
+      "key": "objectStoreSecretKey",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.readAheadCacheAfterReadExpireDuration",
+      "key": "readAheadCacheAfterReadExpireDuration",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.readAheadCacheCreateExpireDuration",
+      "key": "readAheadCacheCreateExpireDuration",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.readAheadCacheEnable",
+      "key": "readAheadCacheEnable",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.readAheadCacheExpireDuration",
+      "key": "readAheadCacheExpireDuration",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.readAheadCacheSizeThresholdRate",
+      "key": "readAheadCacheSizeThresholdRate",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.readAheadMessageCountThreshold",
+      "key": "readAheadMessageCountThreshold",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.readAheadMessageSizeThreshold",
+      "key": "readAheadMessageSizeThreshold",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.recordGetMessageResult",
+      "key": "recordGetMessageResult",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.storePathRootDir",
+      "key": "storePathRootDir",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.tieredBackendServiceProvider",
+      "key": "tieredBackendServiceProvider",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.tieredMetadataServiceProvider",
+      "key": "tieredMetadataServiceProvider",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.tieredStorageLevel",
+      "key": "tieredStorageLevel",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.tieredStoreCommitLogMaxSize",
+      "key": "tieredStoreCommitLogMaxSize",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.tieredStoreConsumeQueueMaxSize",
+      "key": "tieredStoreConsumeQueueMaxSize",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.tieredStoreCrcCheckEnable",
+      "key": "tieredStoreCrcCheckEnable",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.tieredStoreDeleteFileEnable",
+      "key": "tieredStoreDeleteFileEnable",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.tieredStoreDeleteFileInterval",
+      "key": "tieredStoreDeleteFileInterval",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.tieredStoreDispatchMinFreeMemoryMaxBytes",
+      "key": "tieredStoreDispatchMinFreeMemoryMaxBytes",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.tieredStoreDispatchMinFreeMemoryRatio",
+      "key": "tieredStoreDispatchMinFreeMemoryRatio",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.tieredStoreFilePath",
+      "key": "tieredStoreFilePath",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.tieredStoreFileReservedTime",
+      "key": "tieredStoreFileReservedTime",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.tieredStoreGroupCommit",
+      "key": "tieredStoreGroupCommit",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.tieredStoreGroupCommitCount",
+      "key": "tieredStoreGroupCommitCount",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.tieredStoreGroupCommitSize",
+      "key": "tieredStoreGroupCommitSize",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.tieredStoreGroupCommitTimeout",
+      "key": "tieredStoreGroupCommitTimeout",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.tieredStoreIndexFileMaxHashSlotNum",
+      "key": "tieredStoreIndexFileMaxHashSlotNum",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.tieredStoreIndexFileMaxIndexNum",
+      "key": "tieredStoreIndexFileMaxIndexNum",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.tieredStoreMaxGroupCommitCount",
+      "key": "tieredStoreMaxGroupCommitCount",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.tieredStoreMaxPendingLimit",
+      "key": "tieredStoreMaxPendingLimit",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.value",
+      "key": "value",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    },
+    {
+      "symbol": "MessageStoreConfig.writeWithoutMmap",
+      "key": "writeWithoutMmap",
+      "purpose": "Java configuration property",
+      "source": "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+      "classification": "active"
+    }
+  ]
+}

--- a/scripts/generate_java_55_inventory.py
+++ b/scripts/generate_java_55_inventory.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate the semantic Java 5.5 compatibility inventory used by release gates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any, Iterable
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUTPUT = ROOT / "scripts" / "fixtures" / "java-5.5-core-inventory.json"
+REQUEST_CODE = "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RequestCode.java"
+RESPONSE_CODES = (
+    "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/RemotingSysResponseCode.java",
+    "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/ResponseCode.java",
+)
+HEADER_ROOT = "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/header"
+BODY_ROOT = "remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body"
+PROXY_SERVER = "proxy/src/main/java/org/apache/rocketmq/proxy/remoting/RemotingProtocolServer.java"
+ADMIN_STARTUP = "tools/src/main/java/org/apache/rocketmq/tools/command/MQAdminStartup.java"
+CONTROLLER_PAYLOADS = (
+    "controller/src/main/java/org/apache/rocketmq/controller/impl/task/BrokerCloseChannelRequest.java",
+    "controller/src/main/java/org/apache/rocketmq/controller/impl/task/CheckNotActiveBrokerRequest.java",
+    "controller/src/main/java/org/apache/rocketmq/controller/impl/task/GetBrokerLiveInfoRequest.java",
+    "controller/src/main/java/org/apache/rocketmq/controller/impl/task/GetSyncStateDataRequest.java",
+    "controller/src/main/java/org/apache/rocketmq/controller/impl/task/RaftBrokerHeartBeatEventRequest.java",
+)
+CONFIG_SOURCES = (
+    "common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java",
+    "common/src/main/java/org/apache/rocketmq/common/ControllerConfig.java",
+    "common/src/main/java/org/apache/rocketmq/common/namesrv/NamesrvConfig.java",
+    "store/src/main/java/org/apache/rocketmq/store/config/MessageStoreConfig.java",
+    "tieredstore/src/main/java/org/apache/rocketmq/tieredstore/MessageStoreConfig.java",
+    "proxy/src/main/java/org/apache/rocketmq/proxy/config/ProxyConfig.java",
+    "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyServerConfig.java",
+    "remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyClientConfig.java",
+    "client/src/main/java/org/apache/rocketmq/client/ClientConfig.java",
+)
+REQUIRED_REQUEST_CODES = frozenset(
+    {
+        "DELETE_TOPIC_IN_BROKER_LIST",
+        "DELETE_SUBSCRIPTION_GROUP_LIST",
+        "UPDATE_AND_CREATE_SUBSCRIPTIONGROUP",
+    }
+)
+REQUIRED_PROXY_GAPS = frozenset(
+    {
+        "CONSUMER_SEND_MSG_BACK",
+        "END_TRANSACTION",
+        "RECALL_MESSAGE",
+        "POP_MESSAGE",
+        "ACK_MESSAGE",
+        "CHANGE_MESSAGE_INVISIBLETIME",
+        "GET_CONSUMER_CONNECTION_LIST",
+    }
+)
+CONTAINER_COMMANDS = frozenset({"AddBrokerSubCommand", "RemoveBrokerSubCommand"})
+CONSTANT_PATTERN = re.compile(r"public\s+static\s+final\s+(int|short)\s+([A-Z0-9_]+)\s*=\s*(-?\d+)\s*;")
+TYPE_PATTERN = re.compile(r"\b(?:class|interface|enum|record)\s+([A-Za-z_$][A-Za-z0-9_$]*)")
+FIELD_PATTERN = re.compile(
+    r"^\s*(?:private|protected|public)\s+(?!static\b)(?:final\s+)?[A-Za-z0-9_$<>, ?.\[\]]+\s+"
+    r"([A-Za-z_$][A-Za-z0-9_$]*)\s*(?:=|;)",
+    re.MULTILINE,
+)
+
+
+class InventoryError(ValueError):
+    """Raised when the Java source tree cannot produce a valid inventory."""
+
+
+def _source(java_root: Path, relative: str) -> str:
+    path = java_root / relative
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as error:
+        raise InventoryError(f"cannot read required Java source {relative}: {error}") from error
+
+
+def _symbol(source: str, relative: str) -> str:
+    match = TYPE_PATTERN.search(source)
+    if match is None:
+        raise InventoryError(f"cannot identify Java type in {relative}")
+    return match.group(1)
+
+
+def _fields(source: str) -> list[str]:
+    return sorted(set(FIELD_PATTERN.findall(source)))
+
+
+def _constants(java_root: Path, sources: Iterable[str], purpose: str) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for relative in sources:
+        for primitive, symbol, value in CONSTANT_PATTERN.findall(_source(java_root, relative)):
+            numeric = int(value)
+            classification = "raw"
+            if purpose == "request" and 1014 <= numeric <= 1018:
+                classification = "controller-internal-not-applicable"
+            elif purpose == "request" and symbol in REQUIRED_REQUEST_CODES:
+                classification = "active"
+            entries.append(
+                {
+                    "symbol": symbol,
+                    "value": numeric,
+                    "primitive": primitive,
+                    "purpose": f"Java {purpose} code",
+                    "source": relative,
+                    "classification": classification,
+                    "required_active": purpose == "request" and symbol in REQUIRED_REQUEST_CODES,
+                }
+            )
+    return sorted(entries, key=lambda item: (item["value"], item["symbol"]))
+
+
+def _types(java_root: Path, relative_root: str, purpose: str) -> list[dict[str, Any]]:
+    directory = java_root / relative_root
+    if not directory.is_dir():
+        raise InventoryError(f"required Java source directory is missing: {relative_root}")
+    entries: list[dict[str, Any]] = []
+    for path in sorted(directory.rglob("*.java")):
+        relative = path.relative_to(java_root).as_posix()
+        source = _source(java_root, relative)
+        entries.append(
+            {
+                "symbol": _symbol(source, relative),
+                "purpose": purpose,
+                "source": relative,
+                "fields": _fields(source),
+                "classification": "raw",
+            }
+        )
+    return entries
+
+
+def _controller_payloads(java_root: Path) -> list[dict[str, Any]]:
+    entries = []
+    for relative in CONTROLLER_PAYLOADS:
+        source = _source(java_root, relative)
+        entries.append(
+            {
+                "symbol": _symbol(source, relative),
+                "purpose": "Java JRaft Controller internal payload",
+                "source": relative,
+                "fields": _fields(source),
+                "classification": "controller-internal-not-applicable",
+            }
+        )
+    return sorted(entries, key=lambda item: item["symbol"])
+
+
+def _proxy_routes(java_root: Path) -> list[dict[str, Any]]:
+    source = _source(java_root, PROXY_SERVER)
+    pattern = re.compile(
+        r"registerProcessor\(RequestCode\.([A-Z0-9_]+),\s*([A-Za-z0-9_.]+),\s*(?:this\.)?([A-Za-z0-9_]+)\)"
+    )
+    entries = [
+        {
+            "request_code": code,
+            "handler": handler,
+            "executor": executor,
+            "purpose": "Java Proxy remoting route",
+            "source": PROXY_SERVER,
+            "classification": "active",
+            "required_gap": code in REQUIRED_PROXY_GAPS,
+        }
+        for code, handler, executor in pattern.findall(source)
+    ]
+    return sorted(entries, key=lambda item: item["request_code"])
+
+
+def _admin_operations(java_root: Path) -> list[dict[str, Any]]:
+    source = _source(java_root, ADMIN_STARTUP)
+    symbols = re.findall(r"initCommand\(new\s+([A-Za-z0-9_]+)\(\)\);", source)
+    command_root = java_root / "tools/src/main/java/org/apache/rocketmq/tools/command"
+    by_name = {path.name: path for path in command_root.rglob("*.java")}
+    entries = []
+    for symbol in symbols:
+        path = by_name.get(f"{symbol}.java")
+        if path is None:
+            raise InventoryError(f"cannot locate Admin command source for {symbol}")
+        relative = path.relative_to(java_root).as_posix()
+        command_source = _source(java_root, relative)
+        command_match = re.search(
+            r"String\s+commandName\s*\(\s*\)\s*\{.*?return\s+\"([^\"]+)\"\s*;",
+            command_source,
+            re.DOTALL,
+        )
+        entries.append(
+            {
+                "symbol": symbol,
+                "command": command_match.group(1) if command_match else None,
+                "purpose": "Java mqadmin operation",
+                "source": relative,
+                "classification": "excluded-broker-container" if symbol in CONTAINER_COMMANDS else "active",
+            }
+        )
+    return entries
+
+
+def _config_keys(java_root: Path) -> list[dict[str, Any]]:
+    entries = []
+    for relative in CONFIG_SOURCES:
+        source = _source(java_root, relative)
+        owner = _symbol(source, relative)
+        for key in _fields(source):
+            entries.append(
+                {
+                    "symbol": f"{owner}.{key}",
+                    "key": key,
+                    "purpose": "Java configuration property",
+                    "source": relative,
+                    "classification": "active",
+                }
+            )
+    return sorted(entries, key=lambda item: (item["source"], item["key"]))
+
+
+def generate_inventory(java_root: Path) -> dict[str, Any]:
+    java_root = java_root.resolve()
+    inventory = {
+        "schema_version": 1,
+        "java_version": "5.5.0",
+        "inventory_semantics": {
+            "raw": "A symbol exists in the Java 5.5 source inventory; this does not claim behavioral coverage.",
+            "active": "A user-visible Java route, operation, field, or explicitly required protocol item.",
+            "excluded": "An approved product-scope exclusion retained for raw recognition only.",
+        },
+        "request_codes": _constants(java_root, (REQUEST_CODE,), "request"),
+        "response_codes": _constants(java_root, RESPONSE_CODES, "response"),
+        "headers": _types(java_root, HEADER_ROOT, "Java remoting header"),
+        "bodies": _types(java_root, BODY_ROOT, "Java remoting body"),
+        "controller_internal_payloads": _controller_payloads(java_root),
+        "proxy_routes": _proxy_routes(java_root),
+        "admin_operations": _admin_operations(java_root),
+        "config_keys": _config_keys(java_root),
+    }
+    findings = validate_inventory(inventory)
+    if findings:
+        raise InventoryError("; ".join(findings))
+    return inventory
+
+
+def validate_inventory(inventory: dict[str, Any]) -> list[str]:
+    findings: list[str] = []
+    expected_counts = {
+        "request_codes": 171,
+        "response_codes": 68,
+        "headers": 145,
+        "bodies": 64,
+        "controller_internal_payloads": 5,
+        "proxy_routes": 24,
+        "admin_operations": 96,
+    }
+    if inventory.get("schema_version") != 1 or inventory.get("java_version") != "5.5.0":
+        findings.append("schema/version mismatch")
+    for section, expected in expected_counts.items():
+        entries = inventory.get(section)
+        if not isinstance(entries, list) or len(entries) != expected:
+            findings.append(f"{section} count must be {expected}")
+    requests = {item.get("symbol"): item for item in inventory.get("request_codes", [])}
+    for symbol in REQUIRED_REQUEST_CODES:
+        if not requests.get(symbol, {}).get("required_active"):
+            findings.append(f"required request code missing: {symbol}")
+    internal_values = {
+        item.get("value")
+        for item in inventory.get("request_codes", [])
+        if item.get("classification") == "controller-internal-not-applicable"
+    }
+    if internal_values != set(range(1014, 1019)):
+        findings.append("Controller-internal request-code set drifted")
+    route_codes = {item.get("request_code") for item in inventory.get("proxy_routes", [])}
+    if not REQUIRED_PROXY_GAPS.issubset(route_codes):
+        findings.append("required Proxy route set is incomplete")
+    admin_exclusions = {
+        item.get("symbol")
+        for item in inventory.get("admin_operations", [])
+        if item.get("classification") != "active"
+    }
+    if admin_exclusions != CONTAINER_COMMANDS:
+        findings.append("Admin exclusion set drifted")
+    query_headers = [item for item in inventory.get("headers", []) if item.get("symbol") == "QueryMessageRequestHeader"]
+    if len(query_headers) != 1 or not {"indexType", "lastKey"}.issubset(query_headers[0].get("fields", [])):
+        findings.append("QUERY_MESSAGE indexType/lastKey fields are missing")
+    if not isinstance(inventory.get("config_keys"), list) or not inventory["config_keys"]:
+        findings.append("configuration key inventory is empty")
+    return findings
+
+
+def _render(inventory: dict[str, Any]) -> str:
+    return json.dumps(inventory, indent=2, ensure_ascii=False) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--java-root", type=Path, required=True)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    action = parser.add_mutually_exclusive_group()
+    action.add_argument("--check", action="store_true")
+    action.add_argument("--write", action="store_true")
+    args = parser.parse_args()
+    try:
+        inventory = generate_inventory(args.java_root)
+    except InventoryError as error:
+        print(f"JAVA_55_INVENTORY_INPUT_FAILED detail={error}", file=sys.stderr)
+        return 1
+    rendered = _render(inventory)
+    if args.check:
+        try:
+            existing = args.output.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as error:
+            print(f"JAVA_55_INVENTORY_CHECK_FAILED detail={error}", file=sys.stderr)
+            return 1
+        if existing != rendered:
+            print("JAVA_55_INVENTORY_CHECK_FAILED detail=generated inventory differs from fixture", file=sys.stderr)
+            return 1
+    elif args.write:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        with args.output.open("w", encoding="utf-8", newline="\n") as output:
+            output.write(rendered)
+    else:
+        print(rendered, end="")
+    print(
+        "JAVA_55_INVENTORY_OK "
+        f"requests={len(inventory['request_codes'])} responses={len(inventory['response_codes'])} "
+        f"headers={len(inventory['headers'])} bodies={len(inventory['bodies'])} "
+        f"proxy_routes={len(inventory['proxy_routes'])} admin_operations={len(inventory['admin_operations'])}",
+        file=sys.stderr if not (args.check or args.write) else sys.stdout,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/m09_compatibility_matrix.py
+++ b/scripts/m09_compatibility_matrix.py
@@ -44,6 +44,12 @@ class CapabilityRoute:
     command: str
 
 
+@dataclass(frozen=True)
+class JavaInventoryRoute:
+    id: str
+    command: str
+
+
 MATRIX = (
     MatrixEntry("protocol-no-default", "feature", ("cargo", "check", "-p", "rocketmq-protocol", "--no-default-features")),
     MatrixEntry("protocol-simd", "feature", ("cargo", "test", "-p", "rocketmq-protocol", "--features", "simd")),
@@ -237,6 +243,14 @@ def capability_routes() -> tuple[CapabilityRoute, ...]:
     return tuple(sorted(routes, key=lambda route: (route.capability_id, route.test_id)))
 
 
+def java_inventory_route() -> JavaInventoryRoute:
+    """Return the portable regeneration command for the Java 5.5 denominator."""
+    return JavaInventoryRoute(
+        "java-55-core-inventory",
+        "python scripts/generate_java_55_inventory.py --java-root <java-root> --check",
+    )
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--group", action="append", choices=("feature", "wire", "storage"))
@@ -259,6 +273,8 @@ def main() -> int:
             print(f"{entry.id}\t{entry.group}\t{' '.join(entry.command)}")
         for route in capability_routes():
             print(f"{route.capability_id}\tcapability\t{route.test_id}\t{route.command}")
+        route = java_inventory_route()
+        print(f"{route.id}\tinventory\t{route.command}")
         return 0
 
     results = []

--- a/scripts/tests/test_generate_java_55_inventory.py
+++ b/scripts/tests/test_generate_java_55_inventory.py
@@ -1,0 +1,123 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE = ROOT / "scripts" / "fixtures" / "java-5.5-core-inventory.json"
+
+
+def load_generator():
+    path = ROOT / "scripts" / "generate_java_55_inventory.py"
+    spec = importlib.util.spec_from_file_location("generate_java_55_inventory", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class Java55InventoryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.assertTrue(FIXTURE.is_file(), "Java 5.5 inventory fixture is missing")
+        self.inventory = json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+    def test_inventory_has_expected_raw_denominators(self) -> None:
+        self.assertEqual("5.5.0", self.inventory["java_version"])
+        self.assertEqual(171, len(self.inventory["request_codes"]))
+        self.assertEqual(68, len(self.inventory["response_codes"]))
+        self.assertEqual(145, len(self.inventory["headers"]))
+        self.assertEqual(64, len(self.inventory["bodies"]))
+        self.assertEqual(24, len(self.inventory["proxy_routes"]))
+        self.assertEqual(96, len(self.inventory["admin_operations"]))
+
+    def test_controller_internal_codes_and_payloads_are_not_active(self) -> None:
+        internal = {
+            item["value"]: item for item in self.inventory["request_codes"] if 1014 <= item["value"] <= 1018
+        }
+        self.assertEqual(set(range(1014, 1019)), set(internal))
+        self.assertTrue(all(item["classification"] == "controller-internal-not-applicable" for item in internal.values()))
+        self.assertEqual(5, len(self.inventory["controller_internal_payloads"]))
+        self.assertTrue(
+            all(item["classification"] == "controller-internal-not-applicable" for item in self.inventory["controller_internal_payloads"])
+        )
+
+    def test_required_active_protocol_and_proxy_items_are_explicit(self) -> None:
+        request_codes = {item["symbol"]: item for item in self.inventory["request_codes"]}
+        for symbol in (
+            "DELETE_TOPIC_IN_BROKER_LIST",
+            "DELETE_SUBSCRIPTION_GROUP_LIST",
+            "UPDATE_AND_CREATE_SUBSCRIPTIONGROUP",
+        ):
+            self.assertTrue(request_codes[symbol]["required_active"])
+
+        query_header = next(item for item in self.inventory["headers"] if item["symbol"] == "QueryMessageRequestHeader")
+        self.assertTrue({"indexType", "lastKey"}.issubset(query_header["fields"]))
+
+        required_gaps = {item["request_code"] for item in self.inventory["proxy_routes"] if item["required_gap"]}
+        self.assertEqual(
+            {
+                "CONSUMER_SEND_MSG_BACK",
+                "END_TRANSACTION",
+                "RECALL_MESSAGE",
+                "POP_MESSAGE",
+                "ACK_MESSAGE",
+                "CHANGE_MESSAGE_INVISIBLETIME",
+                "GET_CONSUMER_CONNECTION_LIST",
+            },
+            required_gaps,
+        )
+        self.assertTrue(all(item["classification"] == "active" for item in self.inventory["proxy_routes"]))
+
+    def test_broker_container_admin_operations_are_raw_but_excluded(self) -> None:
+        excluded = [item for item in self.inventory["admin_operations"] if item["classification"] != "active"]
+        self.assertEqual(
+            {"AddBrokerSubCommand", "RemoveBrokerSubCommand"},
+            {item["symbol"] for item in excluded},
+        )
+        self.assertTrue(all(item["classification"] == "excluded-broker-container" for item in excluded))
+        self.assertEqual(94, sum(item["classification"] == "active" for item in self.inventory["admin_operations"]))
+
+    def test_fixture_has_only_portable_semantic_source_data(self) -> None:
+        forbidden = {"sha", "hash", "digest", "commit", "revision"}
+
+        def walk(value: object) -> None:
+            if isinstance(value, dict):
+                self.assertTrue(forbidden.isdisjoint(key.lower() for key in value))
+                for child in value.values():
+                    walk(child)
+            elif isinstance(value, list):
+                for child in value:
+                    walk(child)
+            elif isinstance(value, str) and "/src/" in value:
+                self.assertNotIn("\\", value)
+                self.assertFalse(Path(value).is_absolute())
+
+        walk(self.inventory)
+
+    def test_generator_validation_accepts_the_checked_fixture(self) -> None:
+        generator = load_generator()
+        self.assertEqual([], generator.validate_inventory(self.inventory))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_m09_public_api_compatibility.py
+++ b/scripts/tests/test_m09_public_api_compatibility.py
@@ -169,6 +169,14 @@ class PublicApiCompatibilityTests(unittest.TestCase):
         self.assertEqual(len(routes), len({route.test_id for route in routes}))
         self.assertTrue(all(route.command for route in routes))
 
+    def test_java_inventory_route_is_listed_without_a_machine_specific_path(self) -> None:
+        self.assertTrue(hasattr(MATRIX, "java_inventory_route"), "Java inventory route is missing")
+        route = MATRIX.java_inventory_route()
+
+        self.assertEqual("java-55-core-inventory", route.id)
+        self.assertIn("<java-root>", route.command)
+        self.assertNotIn("D:\\", route.command)
+
     def test_evidence_records_current_snapshot_and_approved_breaking_cleanup(self) -> None:
         evidence = EVIDENCE.read_text(encoding="utf-8")
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9400

### Brief Description

Add a deterministic Java 5.5 source inventory generator and checked fixture covering request and response codes, remoting headers and bodies, Proxy routes, Admin operations, Controller-internal payload exclusions, and configuration keys. Keep raw symbols separate from active behavior, preserve the BrokerContainer exclusion, and expose a portable regeneration route through the M09 listing.

### How Did You Test This Change?

- `python -m unittest scripts.tests.test_generate_java_55_inventory scripts.tests.test_m09_public_api_compatibility -v`
- `python scripts/generate_java_55_inventory.py --java-root <java-root> --check`
- `python scripts/m09_compatibility_matrix.py --list`
- `python scripts/core_release_guard.py`
- `python -m compileall -q scripts/generate_java_55_inventory.py scripts/m09_compatibility_matrix.py scripts/tests/test_generate_java_55_inventory.py scripts/tests/test_m09_public_api_compatibility.py`
- `.\scripts\check-agents-routing.ps1`
- `git diff --check`
