### PR TITLE
[ISSUE #9402]✨Add atomic release version propagation

### DIFF
--- a/scripts/check_release_version.py
+++ b/scripts/check_release_version.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Check semantic release-version alignment without publishing anything."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import re
+import sys
+import tempfile
+import tomllib
+
+import set_workspace_version as setter
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass(frozen=True, order=True)
+class VersionFinding:
+    code: str
+    path: str
+    detail: str
+
+
+def check_version(root: Path, version: str) -> list[VersionFinding]:
+    root = root.resolve()
+    findings: list[VersionFinding] = []
+    try:
+        packages, core_names = setter._read_scope(root)
+        actual = setter.workspace_version(root)
+    except setter.VersionError as error:
+        return [VersionFinding("version-input-invalid", "repository", str(error))]
+    if actual != version:
+        findings.append(VersionFinding("workspace-version-drift", "Cargo.toml", f"expected {version}, found {actual}"))
+    manifest_paths = [root / "Cargo.toml", *(root / item["path"] / "Cargo.toml" for item in packages)]
+    example = root / "rocketmq-example/Cargo.toml"
+    if example.is_file():
+        manifest_paths.append(example)
+    for path in manifest_paths:
+        try:
+            text = path.read_text(encoding="utf-8")
+            manifest = tomllib.loads(text)
+        except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as error:
+            findings.append(VersionFinding("manifest-invalid", path.relative_to(root).as_posix(), str(error)))
+            continue
+        package = manifest.get("package", {})
+        if path != root / "Cargo.toml" and isinstance(package.get("version"), str) and package["name"] in core_names:
+            if package["version"] != version:
+                findings.append(
+                    VersionFinding(
+                        "manifest-version-drift",
+                        path.relative_to(root).as_posix(),
+                        f"{package['name']} must use {version}",
+                    )
+                )
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            if "path" not in line or "version" not in line:
+                continue
+            key_match = re.match(r"\s*([A-Za-z0-9_-]+)\s*=", line)
+            package_match = re.search(r"\bpackage\s*=\s*\"([^\"]+)\"", line)
+            dependency = package_match.group(1) if package_match else key_match.group(1) if key_match else None
+            if dependency not in core_names:
+                continue
+            found = re.search(r"\bversion\s*=\s*\"([^\"]+)\"", line)
+            if found is None or found.group(1) != version:
+                findings.append(
+                    VersionFinding(
+                        "manifest-version-drift",
+                        f"{path.relative_to(root).as_posix()}:{line_number}",
+                        f"{dependency} must use {version}",
+                    )
+                )
+    for relative in setter.LOCK_PATHS:
+        path = root / relative
+        try:
+            data = tomllib.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as error:
+            findings.append(VersionFinding("lockfile-invalid", relative, str(error)))
+            continue
+        lock_names = core_names | setter.workspace_inherited_exclusions(root) if relative == "Cargo.lock" else core_names
+        for package in data.get("package", []):
+            if package.get("name") in lock_names and package.get("version") != version:
+                findings.append(
+                    VersionFinding(
+                        "lockfile-version-drift",
+                        relative,
+                        f"{package.get('name')} must use {version}, found {package.get('version')}",
+                    )
+                )
+    chart = root / "distribution/helm/rocketmq-rust-core/Chart.yaml"
+    if chart.is_file():
+        text = chart.read_text(encoding="utf-8")
+        values = dict(re.findall(r'^\s*(version|appVersion)\s*:\s*["\']?([^"\'\s]+)', text, re.MULTILINE))
+        for field in ("version", "appVersion"):
+            if values.get(field) != version:
+                findings.append(
+                    VersionFinding("chart-version-drift", chart.relative_to(root).as_posix(), f"{field} must use {version}")
+                )
+    policy = root / "docker/core-container-policy.json"
+    if policy.is_file():
+        try:
+            release_version = json.loads(policy.read_text(encoding="utf-8")).get("release_version")
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+            findings.append(VersionFinding("oci-metadata-invalid", policy.relative_to(root).as_posix(), str(error)))
+        else:
+            if release_version != version:
+                findings.append(
+                    VersionFinding(
+                        "oci-version-drift",
+                        policy.relative_to(root).as_posix(),
+                        f"release_version must use {version}",
+                    )
+                )
+    return sorted(set(findings))
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8", newline="\n")
+
+
+def _fixture(root: Path) -> None:
+    scope = {
+        "schema_version": 1,
+        "core_packages": [{"name": "core", "path": "core", "classification": "registry-publish"}],
+        "workspace_exclusions": [],
+    }
+    _write(root / "scripts/core-release-scope.json", json.dumps(scope))
+    _write(
+        root / "Cargo.toml",
+        '[workspace]\nmembers=["core"]\n[workspace.package]\nversion="1.0.0-dev"\n'
+        '[workspace.dependencies]\ncore={version="1.0.0-dev",path="core"}\n',
+    )
+    _write(root / "core/Cargo.toml", '[package]\nname="core"\nversion.workspace=true\n')
+    lock = 'version = 4\n\n[[package]]\nname = "core"\nversion = "1.0.0-dev"\n'
+    for relative in setter.LOCK_PATHS:
+        _write(root / relative, lock)
+
+
+def run_fixture_validation() -> int:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        root = Path(temp_dir)
+        _fixture(root)
+        for version in ("1.0.0-rc.1", "1.0.0-rc.2", "1.0.0"):
+            setter.apply_version(root, version)
+            if check_version(root, version):
+                return 1
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=ROOT)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--fixture", action="store_true")
+    args = parser.parse_args()
+    if args.fixture:
+        result = run_fixture_validation()
+        print(f"RELEASE_VERSION_FIXTURE_{'OK' if result == 0 else 'FAILED'} version={args.version}")
+        return result
+    findings = check_version(args.root, args.version)
+    if findings:
+        print(f"RELEASE_VERSION_CHECK_FAILED findings={len(findings)}")
+        for finding in findings:
+            print(f"RELEASE_VERSION_FINDING code={finding.code} path={finding.path} detail={finding.detail}")
+        return 1
+    print(f"RELEASE_VERSION_CHECK_OK version={args.version}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/set_workspace_version.py
+++ b/scripts/set_workspace_version.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Atomically propagate a release version through the core Cargo topology."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import re
+import sys
+import tomllib
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VERSION_PATTERN = re.compile(r"^\d+\.\d+\.\d+(?:-dev(?:\.\d+)?|-rc\.[1-9]\d*)?$")
+LOCK_PATHS = (
+    "Cargo.lock",
+    "rocketmq-example/Cargo.lock",
+    "fuzz/Cargo.lock",
+    "rocketmq-macros/tests/fixtures/renamed-consumer/Cargo.lock",
+)
+
+
+class VersionError(ValueError):
+    """Raised when the requested version transaction is invalid."""
+
+
+@dataclass(frozen=True)
+class VersionResult:
+    previous_version: str
+    version: str
+    changed_files: int
+
+
+def _read_scope(root: Path) -> tuple[list[dict[str, str]], set[str]]:
+    path = root / "scripts/core-release-scope.json"
+    try:
+        scope = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise VersionError(f"cannot read core release scope: {error}") from error
+    packages = scope.get("core_packages")
+    if not isinstance(packages, list) or not packages:
+        raise VersionError("core release scope has no packages")
+    names = {item.get("name") for item in packages}
+    if None in names or len(names) != len(packages):
+        raise VersionError("core release package names must be unique")
+    return packages, names
+
+
+def workspace_inherited_exclusions(root: Path) -> set[str]:
+    scope = json.loads((root / "scripts/core-release-scope.json").read_text(encoding="utf-8"))
+    inherited: set[str] = set()
+    for exclusion in scope.get("workspace_exclusions", []):
+        name = exclusion.get("name")
+        relative = exclusion.get("path")
+        if not isinstance(name, str) or not isinstance(relative, str):
+            continue
+        path = root / relative / "Cargo.toml"
+        if not path.is_file():
+            continue
+        data = _toml(path, path.read_text(encoding="utf-8"))
+        if data.get("package", {}).get("version", {}).get("workspace") is True:
+            inherited.add(name)
+    return inherited
+
+
+def _toml(path: Path, text: str) -> dict:
+    try:
+        return tomllib.loads(text)
+    except tomllib.TOMLDecodeError as error:
+        raise VersionError(f"invalid TOML in {path}: {error}") from error
+
+
+def workspace_version(root: Path) -> str:
+    path = root / "Cargo.toml"
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+        value = data["workspace"]["package"]["version"]
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError, KeyError, TypeError) as error:
+        raise VersionError(f"cannot read workspace package version: {error}") from error
+    if not isinstance(value, str):
+        raise VersionError("workspace package version must be a string")
+    return value
+
+
+def validate_transition(previous: str, version: str) -> None:
+    if not VERSION_PATTERN.fullmatch(version):
+        raise VersionError(f"unsupported release version: {version}")
+    if previous == version:
+        return
+    previous_rc = re.fullmatch(r"(\d+\.\d+\.\d+)-rc\.(\d+)", previous)
+    next_rc = re.fullmatch(r"(\d+\.\d+\.\d+)-rc\.(\d+)", version)
+    if next_rc:
+        if previous_rc:
+            if next_rc.group(1) != previous_rc.group(1) or int(next_rc.group(2)) != int(previous_rc.group(2)) + 1:
+                raise VersionError(f"RC sequence must advance exactly once: {previous} -> {version}")
+        elif int(next_rc.group(2)) != 1 or previous not in {next_rc.group(1), f"{next_rc.group(1)}-dev"}:
+            raise VersionError(f"the first RC must follow its development version: {previous} -> {version}")
+    elif previous_rc and version != previous_rc.group(1):
+        raise VersionError(f"an RC can only advance or promote its own base version: {previous} -> {version}")
+
+
+def _replace_workspace_version(text: str, previous: str, version: str) -> str:
+    pattern = re.compile(
+        r"(?ms)(^\[workspace\.package\]\s*$.*?^version\s*=\s*\")" + re.escape(previous) + r"(\")"
+    )
+    updated, count = pattern.subn(rf"\g<1>{version}\g<2>", text, count=1)
+    if count != 1:
+        raise VersionError("root Cargo.toml must contain exactly one workspace package version")
+    return updated
+
+
+def _replace_core_dependencies(text: str, core_names: set[str], previous: str, version: str) -> str:
+    lines = text.splitlines(keepends=True)
+    for index, line in enumerate(lines):
+        if "path" not in line or "version" not in line:
+            continue
+        key_match = re.match(r"\s*([A-Za-z0-9_-]+)\s*=", line)
+        package_match = re.search(r"\bpackage\s*=\s*\"([^\"]+)\"", line)
+        dependency = package_match.group(1) if package_match else key_match.group(1) if key_match else None
+        if dependency not in core_names:
+            continue
+        lines[index] = re.sub(
+            r"(\bversion\s*=\s*\")" + re.escape(previous) + r"(\")",
+            rf"\g<1>{version}\g<2>",
+            line,
+        )
+    return "".join(lines)
+
+
+def _replace_direct_package_version(text: str, package_name: str, previous: str, version: str) -> str:
+    data = _toml(Path(f"{package_name}/Cargo.toml"), text)
+    package = data.get("package", {})
+    if package.get("name") != package_name or package.get("version") != previous:
+        return text
+    pattern = re.compile(r"(?ms)(^\[package\]\s*$.*?^version\s*=\s*\")" + re.escape(previous) + r"(\")")
+    return pattern.sub(rf"\g<1>{version}\g<2>", text, count=1)
+
+
+def _replace_lock_versions(text: str, core_names: set[str], previous: str, version: str, path: Path) -> str:
+    data = _toml(path, text)
+    if not isinstance(data.get("package"), list):
+        raise VersionError(f"Cargo lock has no package list: {path}")
+    blocks = re.split(r"(?=^\[\[package\]\]\s*$)", text, flags=re.MULTILINE)
+    updated: list[str] = []
+    for block in blocks:
+        name_match = re.search(r'^name\s*=\s*"([^"]+)"\s*$', block, re.MULTILINE)
+        if name_match and name_match.group(1) in core_names:
+            block = re.sub(
+                r'(^version\s*=\s*")' + re.escape(previous) + r'("\s*$)',
+                rf"\g<1>{version}\g<2>",
+                block,
+                count=1,
+                flags=re.MULTILINE,
+            )
+        updated.append(block)
+    return "".join(updated)
+
+
+def plan_version_update(root: Path, version: str) -> tuple[str, dict[Path, bytes]]:
+    root = root.resolve()
+    packages, core_names = _read_scope(root)
+    previous = workspace_version(root)
+    validate_transition(previous, version)
+    manifest_paths = [root / "Cargo.toml"]
+    for package in packages:
+        manifest_paths.append(root / package["path"] / "Cargo.toml")
+    example_manifest = root / "rocketmq-example/Cargo.toml"
+    if example_manifest.is_file():
+        manifest_paths.append(example_manifest)
+    missing = [str(path.relative_to(root)) for path in manifest_paths if not path.is_file()]
+    if missing:
+        raise VersionError(f"required manifest files are missing: {', '.join(missing)}")
+
+    planned: dict[Path, bytes] = {}
+    for path in dict.fromkeys(manifest_paths):
+        original = path.read_text(encoding="utf-8")
+        updated = _replace_core_dependencies(original, core_names, previous, version)
+        if path == root / "Cargo.toml":
+            updated = _replace_workspace_version(updated, previous, version)
+        else:
+            package_name = next((item["name"] for item in packages if root / item["path"] / "Cargo.toml" == path), None)
+            if package_name:
+                updated = _replace_direct_package_version(updated, package_name, previous, version)
+        _toml(path, updated)
+        if updated != original:
+            planned[path] = updated.encode("utf-8")
+
+    inherited_exclusions = workspace_inherited_exclusions(root)
+    for relative in LOCK_PATHS:
+        path = root / relative
+        if not path.is_file():
+            raise VersionError(f"required lockfile is missing: {relative}")
+        original = path.read_text(encoding="utf-8")
+        lock_names = core_names | inherited_exclusions if relative == "Cargo.lock" else core_names
+        updated = _replace_lock_versions(original, lock_names, previous, version, path)
+        _toml(path, updated)
+        if updated != original:
+            planned[path] = updated.encode("utf-8")
+    return previous, planned
+
+
+def _atomic_replace(planned: dict[Path, bytes]) -> None:
+    originals = {path: path.read_bytes() for path in planned}
+    temporary: dict[Path, Path] = {}
+    replaced: list[Path] = []
+    try:
+        for path, content in planned.items():
+            temp = path.with_name(f".{path.name}.version-{os.getpid()}.tmp")
+            with temp.open("wb") as output:
+                output.write(content)
+                output.flush()
+                os.fsync(output.fileno())
+            temporary[path] = temp
+        for path, temp in temporary.items():
+            os.replace(temp, path)
+            replaced.append(path)
+    except OSError as error:
+        for path in reversed(replaced):
+            path.write_bytes(originals[path])
+        raise VersionError(f"version transaction failed and was rolled back: {error}") from error
+    finally:
+        for temp in temporary.values():
+            if temp.exists():
+                temp.unlink()
+
+
+def apply_version(root: Path, version: str) -> VersionResult:
+    previous, planned = plan_version_update(root, version)
+    _atomic_replace(planned)
+    return VersionResult(previous, version, len(planned))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=ROOT)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--check-only", action="store_true")
+    args = parser.parse_args()
+    try:
+        previous, planned = plan_version_update(args.root, args.version)
+        if not args.check_only:
+            _atomic_replace(planned)
+    except VersionError as error:
+        print(f"SET_WORKSPACE_VERSION_FAILED detail={error}", file=sys.stderr)
+        return 1
+    print(
+        f"SET_WORKSPACE_VERSION_OK previous={previous} version={args.version} "
+        f"changed_files={len(planned)} mode={'check' if args.check_only else 'write'}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_release_version.py
+++ b/scripts/tests/test_release_version.py
@@ -1,0 +1,184 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_module(name: str):
+    path = ROOT / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8", newline="\n")
+
+
+def create_fixture(root: Path) -> None:
+    scope = {
+        "schema_version": 1,
+        "core_packages": [
+            {"name": "rocketmq-admin-core", "path": "admin-core", "classification": "registry-publish"},
+            {"name": "rocketmq-admin-cli", "path": "admin-cli", "classification": "binary-only"},
+            {"name": "rocketmq-protocol", "path": "protocol", "classification": "registry-publish"},
+        ],
+        "workspace_exclusions": [
+            {"name": "rocketmq-dashboard-common", "path": "dashboard", "classification": "excluded-dashboard"}
+        ],
+    }
+    write(root / "scripts/core-release-scope.json", json.dumps(scope))
+    write(
+        root / "Cargo.toml",
+        '[workspace]\nmembers = ["admin-core", "admin-cli", "protocol", "dashboard"]\n\n'
+        '[workspace.package]\nversion = "1.0.0-dev"\n\n'
+        '[workspace.dependencies]\nrocketmq-admin-core = { version = "1.0.0-dev", path = "admin-core" }\n'
+        'rocketmq-protocol = { version = "1.0.0-dev", path = "protocol" }\n'
+        'rocketmq-dashboard-common = { version = "1.0.0-dev", path = "dashboard" }\n',
+    )
+    write(root / "admin-core/Cargo.toml", '[package]\nname = "rocketmq-admin-core"\nversion.workspace = true\n')
+    write(
+        root / "admin-cli/Cargo.toml",
+        '[package]\nname = "rocketmq-admin-cli"\nversion.workspace = true\n\n[dependencies]\n'
+        'rocketmq-admin-core = { version = "1.0.0-dev", path = "../admin-core" }\n',
+    )
+    write(root / "protocol/Cargo.toml", '[package]\nname = "rocketmq-protocol"\nversion.workspace = true\n')
+    write(root / "dashboard/Cargo.toml", '[package]\nname = "rocketmq-dashboard-common"\nversion.workspace = true\n')
+    write(
+        root / "rocketmq-example/Cargo.toml",
+        '[package]\nname = "example"\nversion = "0.1.0"\n\n[dependencies]\n'
+        'rocketmq-protocol = { version = "1.0.0-dev", path = "../protocol" }\n',
+    )
+    package_blocks = (
+        '[[package]]\nname = "rocketmq-admin-core"\nversion = "1.0.0-dev"\n\n'
+        '[[package]]\nname = "rocketmq-protocol"\nversion = "1.0.0-dev"\n\n'
+        '[[package]]\nname = "rocketmq-dashboard-common"\nversion = "1.0.0-dev"\n'
+    )
+    for relative in (
+        "Cargo.lock",
+        "rocketmq-example/Cargo.lock",
+        "fuzz/Cargo.lock",
+        "rocketmq-macros/tests/fixtures/renamed-consumer/Cargo.lock",
+    ):
+        write(root / relative, "version = 4\n\n" + package_blocks)
+
+
+class ReleaseVersionTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.setter = load_module("set_workspace_version")
+        cls.checker = load_module("check_release_version")
+
+    def test_three_release_transitions_update_core_manifests_and_locks(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            create_fixture(root)
+            for version in ("1.0.0-rc.1", "1.0.0-rc.2", "1.0.0"):
+                result = self.setter.apply_version(root, version)
+                self.assertGreaterEqual(result.changed_files, 6)
+                self.assertEqual([], self.checker.check_version(root, version))
+
+            for relative in (
+                "Cargo.toml",
+                "admin-cli/Cargo.toml",
+                "rocketmq-example/Cargo.toml",
+                "Cargo.lock",
+                "rocketmq-example/Cargo.lock",
+                "fuzz/Cargo.lock",
+                "rocketmq-macros/tests/fixtures/renamed-consumer/Cargo.lock",
+            ):
+                self.assertIn('1.0.0', (root / relative).read_text(encoding="utf-8"))
+                self.assertNotIn('1.0.0-rc.2', (root / relative).read_text(encoding="utf-8"))
+
+    def test_excluded_manifest_is_untouched_while_inherited_root_lock_version_stays_valid(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            create_fixture(root)
+            dashboard_before = (root / "dashboard/Cargo.toml").read_bytes()
+            self.setter.apply_version(root, "1.0.0-rc.1")
+
+            self.assertEqual(dashboard_before, (root / "dashboard/Cargo.toml").read_bytes())
+            root_lock = (root / "Cargo.lock").read_text(encoding="utf-8")
+            dashboard = root_lock.split('name = "rocketmq-dashboard-common"', 1)[1]
+            self.assertIn('version = "1.0.0-rc.1"', dashboard)
+
+    def test_invalid_version_and_rc_jump_are_rejected_before_writes(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            create_fixture(root)
+            before = (root / "Cargo.toml").read_bytes()
+
+            with self.assertRaises(self.setter.VersionError):
+                self.setter.apply_version(root, "v1.0.0")
+            with self.assertRaises(self.setter.VersionError):
+                self.setter.apply_version(root, "1.0.0-rc.2")
+            self.assertEqual(before, (root / "Cargo.toml").read_bytes())
+
+    def test_malformed_lock_aborts_the_entire_transaction(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            create_fixture(root)
+            write(root / "fuzz/Cargo.lock", "not a cargo lock")
+            before = {path: path.read_bytes() for path in root.rglob("Cargo.toml")}
+
+            with self.assertRaises(self.setter.VersionError):
+                self.setter.apply_version(root, "1.0.0-rc.1")
+            self.assertEqual(before, {path: path.read_bytes() for path in root.rglob("Cargo.toml")})
+
+    def test_checker_reports_manifest_and_lock_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            create_fixture(root)
+            self.setter.apply_version(root, "1.0.0-rc.1")
+            write(root / "admin-cli/Cargo.toml", (root / "admin-cli/Cargo.toml").read_text().replace("1.0.0-rc.1", "1.0.0"))
+
+            findings = self.checker.check_version(root, "1.0.0-rc.1")
+            self.assertTrue(any(finding.code == "manifest-version-drift" for finding in findings), findings)
+
+    def test_checker_reports_chart_and_oci_version_drift_when_present(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            create_fixture(root)
+            self.setter.apply_version(root, "1.0.0-rc.1")
+            write(root / "distribution/helm/rocketmq-rust-core/Chart.yaml", 'version: 1.0.0\nappVersion: "1.0.0"\n')
+            write(root / "docker/core-container-policy.json", '{"release_version":"1.0.0"}\n')
+
+            findings = self.checker.check_version(root, "1.0.0-rc.1")
+            codes = {finding.code for finding in findings}
+            self.assertIn("chart-version-drift", codes)
+            self.assertIn("oci-version-drift", codes)
+
+    def test_fixture_validation_does_not_modify_the_repository(self) -> None:
+        before = (ROOT / "Cargo.toml").read_bytes()
+        self.assertEqual(0, self.checker.run_fixture_validation())
+        self.assertEqual(before, (ROOT / "Cargo.toml").read_bytes())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9402

### Brief Description

Add transactional release-version propagation for core workspace manifests, direct internal path dependencies, the standalone example, and all affected lockfiles. Preserve excluded manifests while keeping workspace-inherited lock entries valid, enforce RC sequencing, detect Cargo, Helm, and OCI version drift, and provide fixture-only validation that never performs remote publication.

### How Did You Test This Change?

- `python -m unittest scripts.tests.test_release_version -v`
- `python scripts/check_release_version.py --version 1.0.0-rc.1 --fixture`
- `python scripts/check_release_version.py --version 1.0.0`
- `python scripts/set_workspace_version.py --version 1.0.0-rc.1 --check-only`
- `cargo metadata --locked --format-version 1 --no-deps`
- `cargo metadata --locked --format-version 1 --no-deps --manifest-path rocketmq-example/Cargo.toml`
- `cargo metadata --locked --format-version 1 --no-deps --manifest-path fuzz/Cargo.toml`
- `cargo check --locked --offline --manifest-path rocketmq-macros/tests/fixtures/renamed-consumer/Cargo.toml`
- `python scripts/core_release_guard.py`
- `.\scripts\check-agents-routing.ps1`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tools to validate release-version consistency across project manifests, lockfiles, charts, and policy metadata.
  * Added a utility to plan and apply workspace-wide version updates with supported format and release-transition checks.
  * Added check-only validation and rollback protection for failed updates.

* **Bug Fixes**
  * Detects version drift, invalid files, malformed versions, and unsupported release-candidate transitions.

* **Tests**
  * Added coverage for version updates, exclusions, lockfiles, validation failures, rollback behavior, and fixture checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->