### PR TITLE
[ISSUE #9406]📝Define 1.0 capability ownership and compatibility scope

### DIFF
--- a/rocketmq-doc/en/release/1.0/scope-and-compatibility.md
+++ b/rocketmq-doc/en/release/1.0/scope-and-compatibility.md
@@ -1,0 +1,56 @@
+# RocketMQ Rust 1.0 Scope and Compatibility
+
+## Release objective
+
+RocketMQ Rust 1.0 targets the user-visible core capabilities of Apache RocketMQ Java 5.5.0. Equivalent behavior does not require an identical internal implementation. A Rust-native implementation is acceptable when its externally observable behavior, durability, error handling, and operational recovery meet the same contract and have functional-system evidence.
+
+The machine-readable source of truth is `scripts/v1-capability-manifest.json`. It assigns each capability a DRI, an independent reviewer, a release approver, a target phase, a target release candidate, dependencies, implementation status, and evidence status. `scripts/v1_capability_guard.py` rejects missing or inconsistent assignments.
+
+## Supported core boundary
+
+The core denominator contains the 27 packages classified by `scripts/core-release-scope.json`. It covers the nameserver, broker, client, remoting protocol, transport, authentication, stores, Proxy, Controller, and core Admin surfaces. Repository-global findings for excluded products remain visible, but they do not alter the core capability result.
+
+The following products or implementations are explicitly outside the 1.0 denominator:
+
+- OpenMessaging;
+- BrokerContainer, including its two mqadmin commands;
+- DLedger CommitLog;
+- Java Controller internal DLedger and JRaft protocols, including request codes 1014 through 1018.
+
+Raw protocol and Admin inventories retain excluded symbols so unknown or excluded requests can fail predictably. Their presence in a raw inventory is not a claim of behavioral support.
+
+## Pure Rust Controller
+
+The supported Controller topology is a Pure Rust Controller and Rust Broker deployment. It must provide the same user-visible election, fencing, failover, recovery, and administration functions as Java 5.5. It does not promise Java Controller wire compatibility, mixed Java/Rust quorum membership, JRaft component reuse, DLedger component reuse, or Java AutoSwitchHA framing.
+
+Controller parity is therefore evaluated as a Rust-native alternative: functional-system tests must prove single-writer authority, epoch and lease fencing, committed-frontier recovery, stale-master rejection, tail truncation, and safe rejoin. Java-internal request codes remain recognizable but not applicable to the supported topology.
+
+## Rust-native Timer and POP
+
+Rust-native Timer and POP implementations may use storage layouts that differ from Java. Their compatibility obligation is semantic: delivery time, scan and recall behavior, acknowledgement and invisibility changes, retry limits, restart recovery, lag reporting, HA behavior, and failure handling must match the approved Java-visible contract.
+
+Rust-native Timer and POP alternatives do not imply support for Java TimerRocksDB directories or binary-compatible POP state. Format ownership and activation markers must be explicit. Unsupported downgrade attempts are rejected by the 1.0 preflight tool before an older reader starts.
+
+## Conditional Java data migration
+
+Conditional Java data migration is not an automatic 1.0 requirement. Rust-to-Rust upgrades, restart recovery, and rollback within documented activation boundaries are mandatory. Java-to-Rust data-directory migration or direct takeover becomes mandatory only for a product profile that explicitly declares it.
+
+When such a profile is declared, acceptance uses semantic records and upgrade/rollback behavior. It does not require Rust and Java to share the same implementation, database engine, or in-memory architecture. A profile that is not declared must not advertise direct Java data takeover.
+
+## Dependency and ownership rules
+
+Cross-domain capabilities follow their declared dependency edges. Important chains include:
+
+- query pagination: Protocol to Client to Broker to Store;
+- advanced Timer: Store to Broker to Admin to HA;
+- Proxy ingress: Protocol and Transport to Proxy policy to local and cluster backends;
+- Controller mode: Controller authority to Broker control plane to Store write admission and HA;
+- Admin parity: protocol inventory to Admin Core to CLI and TUI presentation.
+
+The DRI implements and maintains the capability. The reviewer independently evaluates the domain contract. The release approver decides whether the evidence is sufficient for the declared target. These roles must be distinct in each manifest record. Active F-01 through F-18 and G-01 through G-06 target `1.0.0-rc.1`; G-07 and G-08 are explicitly deferred.
+
+## Evidence and readiness language
+
+Short deterministic tests, compatibility inventories, focused integration tests, and bounded fault scenarios are required before the first complete release candidate. Long-running fuzzing, soak, burn-in, large-capacity, and independent security qualification are tracked separately as deferred G-07 and G-08 work.
+
+While those long-running items are deferred, the release is not production-certified. Passing the short-check matrix means that the declared functional candidate gates passed; it must not be described as proof of long-duration capacity, disaster-recovery timing, or production certification.

--- a/scripts/tests/test_v1_capability_guard.py
+++ b/scripts/tests/test_v1_capability_guard.py
@@ -89,6 +89,9 @@ print(json.dumps([finding.as_dict() for finding in findings]))
 
         self.assertEqual(expected, {item["capability_id"] for item in capabilities})
         self.assertEqual(len(test_ids), len(set(test_ids)))
+        for capability in capabilities:
+            expected = "deferred" if capability["capability_id"] in {"G-07", "G-08"} else "1.0.0-rc.1"
+            self.assertEqual(expected, capability["target_rc"])
 
     def test_missing_required_fields_are_structured_findings(self) -> None:
         manifest = self.load_manifest()
@@ -98,6 +101,7 @@ print(json.dumps([finding.as_dict() for finding in findings]))
         capability["commands"] = []
         capability["expected_results"] = []
         del capability["target_phase"]
+        del capability["target_rc"]
 
         findings = self.validate_fixture(manifest)
         codes = {item["code"] for item in findings}
@@ -108,6 +112,7 @@ print(json.dumps([finding.as_dict() for finding in findings]))
                 "commands-missing",
                 "expected-results-missing",
                 "target-phase-invalid",
+                "target-rc-invalid",
             }.issubset(codes),
             findings,
         )
@@ -173,6 +178,30 @@ print(json.dumps([finding.as_dict() for finding in findings]))
 
         findings = self.validate_fixture(manifest)
         self.assertIn("deferred-capability-not-approved", {item["code"] for item in findings})
+
+    def test_active_capability_cannot_enter_development_without_a_target_rc(self) -> None:
+        manifest = self.load_manifest()
+        capability = self.capability(manifest, "F-01")
+        capability["implementation_status"] = "partial"
+        capability["target_rc"] = "deferred"
+
+        findings = self.validate_fixture(manifest)
+        self.assertIn("active-target-rc-missing", {item["code"] for item in findings})
+
+    def test_scope_document_records_compatibility_boundaries(self) -> None:
+        path = ROOT / "rocketmq-doc/en/release/1.0/scope-and-compatibility.md"
+        self.assertTrue(path.is_file(), "1.0 scope document is missing")
+        document = path.read_text(encoding="utf-8")
+        for required in (
+            "Pure Rust Controller",
+            "Rust-native Timer and POP",
+            "Conditional Java data migration",
+            "OpenMessaging",
+            "BrokerContainer",
+            "DLedger CommitLog",
+            "not production-certified",
+        ):
+            self.assertIn(required, document)
 
     def test_phase_six_rejects_every_active_blocked_capability(self) -> None:
         findings = self.validate_fixture(self.load_manifest(), phase=6)

--- a/scripts/v1-capability-manifest.json
+++ b/scripts/v1-capability-manifest.json
@@ -19,6 +19,7 @@
       "artifacts": [],
       "ownership": { "dri": "protocol-maintainer", "reviewer": "broker-reviewer", "release_approver": "release-approver" },
       "target_phase": 1,
+      "target_rc": "1.0.0-rc.1",
       "dependencies": [],
       "completion_status": "blocked",
       "variance_class": "java-compatible"
@@ -39,6 +40,7 @@
       "artifacts": [],
       "ownership": { "dri": "broker-maintainer", "reviewer": "filter-reviewer", "release_approver": "release-approver" },
       "target_phase": 1,
+      "target_rc": "1.0.0-rc.1",
       "dependencies": [],
       "completion_status": "blocked",
       "variance_class": "java-compatible"
@@ -59,6 +61,7 @@
       "artifacts": [],
       "ownership": { "dri": "client-maintainer", "reviewer": "transport-reviewer", "release_approver": "release-approver" },
       "target_phase": 1,
+      "target_rc": "1.0.0-rc.1",
       "dependencies": [],
       "completion_status": "blocked",
       "variance_class": "java-compatible"
@@ -79,6 +82,7 @@
       "artifacts": [],
       "ownership": { "dri": "broker-maintainer", "reviewer": "client-reviewer", "release_approver": "release-approver" },
       "target_phase": 2,
+      "target_rc": "1.0.0-rc.1",
       "dependencies": ["F-03"],
       "completion_status": "blocked",
       "variance_class": "java-compatible"
@@ -99,6 +103,7 @@
       "artifacts": [],
       "ownership": { "dri": "proxy-maintainer", "reviewer": "protocol-reviewer", "release_approver": "release-approver" },
       "target_phase": 1,
+      "target_rc": "1.0.0-rc.1",
       "dependencies": [],
       "completion_status": "blocked",
       "variance_class": "java-compatible"
@@ -119,6 +124,7 @@
       "artifacts": [],
       "ownership": { "dri": "proxy-maintainer", "reviewer": "security-reviewer", "release_approver": "release-approver" },
       "target_phase": 1,
+      "target_rc": "1.0.0-rc.1",
       "dependencies": [],
       "completion_status": "blocked",
       "variance_class": "java-compatible"
@@ -139,6 +145,7 @@
       "artifacts": [],
       "ownership": { "dri": "transport-maintainer", "reviewer": "security-reviewer", "release_approver": "release-approver" },
       "target_phase": 1,
+      "target_rc": "1.0.0-rc.1",
       "dependencies": [],
       "completion_status": "blocked",
       "variance_class": "java-compatible"
@@ -159,6 +166,7 @@
       "artifacts": [],
       "ownership": { "dri": "store-maintainer", "reviewer": "ha-reviewer", "release_approver": "release-approver" },
       "target_phase": 2,
+      "target_rc": "1.0.0-rc.1",
       "dependencies": [],
       "completion_status": "blocked",
       "variance_class": "java-compatible"
@@ -179,6 +187,7 @@
       "artifacts": [],
       "ownership": { "dri": "ha-maintainer", "reviewer": "store-reviewer", "release_approver": "release-approver" },
       "target_phase": 3,
+      "target_rc": "1.0.0-rc.1",
       "dependencies": ["F-08"],
       "completion_status": "blocked",
       "variance_class": "rust-enhancement"
@@ -199,6 +208,7 @@
       "artifacts": [],
       "ownership": { "dri": "store-maintainer", "reviewer": "broker-reviewer", "release_approver": "release-approver" },
       "target_phase": 2,
+      "target_rc": "1.0.0-rc.1",
       "dependencies": ["F-09"],
       "completion_status": "blocked",
       "variance_class": "rust-enhancement"
@@ -219,6 +229,7 @@
       "artifacts": [],
       "ownership": { "dri": "broker-maintainer", "reviewer": "store-reviewer", "release_approver": "release-approver" },
       "target_phase": 2,
+      "target_rc": "1.0.0-rc.1",
       "dependencies": [],
       "completion_status": "blocked",
       "variance_class": "java-compatible"
@@ -239,6 +250,7 @@
       "artifacts": [],
       "ownership": { "dri": "broker-maintainer", "reviewer": "configuration-reviewer", "release_approver": "release-approver" },
       "target_phase": 3,
+      "target_rc": "1.0.0-rc.1",
       "dependencies": [],
       "completion_status": "blocked",
       "variance_class": "java-compatible"
@@ -259,6 +271,7 @@
       "artifacts": [],
       "ownership": { "dri": "store-maintainer", "reviewer": "api-reviewer", "release_approver": "release-approver" },
       "target_phase": 2,
+      "target_rc": "1.0.0-rc.1",
       "dependencies": ["F-08"],
       "completion_status": "blocked",
       "variance_class": "java-compatible"
@@ -279,6 +292,7 @@
       "artifacts": [],
       "ownership": { "dri": "store-maintainer", "reviewer": "broker-reviewer", "release_approver": "release-approver" },
       "target_phase": 2,
+      "target_rc": "1.0.0-rc.1",
       "dependencies": ["F-09"],
       "completion_status": "blocked",
       "variance_class": "rust-enhancement"
@@ -299,6 +313,7 @@
       "artifacts": [],
       "ownership": { "dri": "proxy-maintainer", "reviewer": "broker-reviewer", "release_approver": "release-approver" },
       "target_phase": 1,
+      "target_rc": "1.0.0-rc.1",
       "dependencies": [],
       "completion_status": "blocked",
       "variance_class": "java-compatible"
@@ -319,6 +334,7 @@
       "artifacts": [],
       "ownership": { "dri": "store-maintainer", "reviewer": "client-reviewer", "release_approver": "release-approver" },
       "target_phase": 2,
+      "target_rc": "1.0.0-rc.1",
       "dependencies": [],
       "completion_status": "blocked",
       "variance_class": "java-compatible"
@@ -339,6 +355,7 @@
       "artifacts": [],
       "ownership": { "dri": "admin-maintainer", "reviewer": "broker-reviewer", "release_approver": "release-approver" },
       "target_phase": 4,
+      "target_rc": "1.0.0-rc.1",
       "dependencies": [],
       "completion_status": "blocked",
       "variance_class": "java-compatible"
@@ -359,6 +376,7 @@
       "artifacts": [],
       "ownership": { "dri": "client-maintainer", "reviewer": "api-reviewer", "release_approver": "release-approver" },
       "target_phase": 4,
+      "target_rc": "1.0.0-rc.1",
       "dependencies": ["F-03"],
       "completion_status": "blocked",
       "variance_class": "java-compatible"
@@ -379,6 +397,7 @@
       "artifacts": [],
       "ownership": { "dri": "client-maintainer", "reviewer": "runtime-reviewer", "release_approver": "release-approver" },
       "target_phase": 1,
+      "target_rc": "1.0.0-rc.1",
       "dependencies": [],
       "completion_status": "blocked",
       "variance_class": "java-compatible"
@@ -399,6 +418,7 @@
       "artifacts": [],
       "ownership": { "dri": "broker-maintainer", "reviewer": "observability-reviewer", "release_approver": "release-approver" },
       "target_phase": 2,
+      "target_rc": "1.0.0-rc.1",
       "dependencies": [],
       "completion_status": "blocked",
       "variance_class": "java-compatible"
@@ -419,6 +439,7 @@
       "artifacts": [],
       "ownership": { "dri": "transport-maintainer", "reviewer": "protocol-reviewer", "release_approver": "release-approver" },
       "target_phase": 1,
+      "target_rc": "1.0.0-rc.1",
       "dependencies": [],
       "completion_status": "blocked",
       "variance_class": "java-compatible"
@@ -439,6 +460,7 @@
       "artifacts": [],
       "ownership": { "dri": "tieredstore-maintainer", "reviewer": "store-reviewer", "release_approver": "release-approver" },
       "target_phase": 2,
+      "target_rc": "1.0.0-rc.1",
       "dependencies": ["F-08"],
       "completion_status": "blocked",
       "variance_class": "java-compatible"
@@ -459,6 +481,7 @@
       "artifacts": [],
       "ownership": { "dri": "admin-maintainer", "reviewer": "client-reviewer", "release_approver": "release-approver" },
       "target_phase": 4,
+      "target_rc": "1.0.0-rc.1",
       "dependencies": ["F-16", "F-17"],
       "completion_status": "blocked",
       "variance_class": "java-compatible"
@@ -479,6 +502,7 @@
       "artifacts": [],
       "ownership": { "dri": "release-engineer", "reviewer": "platform-reviewer", "release_approver": "release-approver" },
       "target_phase": 5,
+      "target_rc": "1.0.0-rc.1",
       "dependencies": [],
       "completion_status": "blocked",
       "variance_class": "rust-hardening"
@@ -499,6 +523,7 @@
       "artifacts": [],
       "ownership": { "dri": "security-maintainer", "reviewer": "concurrency-reviewer", "release_approver": "release-approver" },
       "target_phase": 6,
+      "target_rc": "deferred",
       "dependencies": [],
       "completion_status": "deferred-by-scope",
       "variance_class": "rust-hardening",
@@ -520,6 +545,7 @@
       "artifacts": [],
       "ownership": { "dri": "performance-maintainer", "reviewer": "platform-reviewer", "release_approver": "release-approver" },
       "target_phase": 6,
+      "target_rc": "deferred",
       "dependencies": [],
       "completion_status": "deferred-by-scope",
       "variance_class": "rust-hardening",

--- a/scripts/v1-capability-manifest.schema.json
+++ b/scripts/v1-capability-manifest.schema.json
@@ -80,6 +80,7 @@
         "artifacts",
         "ownership",
         "target_phase",
+        "target_rc",
         "dependencies",
         "completion_status",
         "variance_class"
@@ -105,6 +106,7 @@
         },
         "ownership": { "$ref": "#/$defs/ownership" },
         "target_phase": { "type": "integer", "minimum": 0, "maximum": 6 },
+        "target_rc": { "enum": ["1.0.0-rc.1", "deferred"] },
         "dependencies": { "$ref": "#/$defs/stringArray" },
         "completion_status": {
           "enum": ["blocked", "equivalent", "alternative-equivalent", "not-applicable", "intentionally-unsupported", "deferred-by-scope"]

--- a/scripts/v1_capability_guard.py
+++ b/scripts/v1_capability_guard.py
@@ -62,6 +62,7 @@ REQUIRED_FIELDS = (
     "artifacts",
     "ownership",
     "target_phase",
+    "target_rc",
     "dependencies",
     "completion_status",
     "variance_class",
@@ -179,6 +180,13 @@ def _validate_record_shape(
     target_phase = record.get("target_phase")
     if not isinstance(target_phase, int) or isinstance(target_phase, bool) or not 0 <= target_phase <= 6:
         _finding(findings, "target-phase-invalid", path, repr(target_phase))
+    target_rc = record.get("target_rc")
+    if target_rc not in {"1.0.0-rc.1", "deferred"}:
+        _finding(findings, "target-rc-invalid", path, repr(target_rc))
+    elif completion != "deferred-by-scope" and target_rc == "deferred":
+        _finding(findings, "active-target-rc-missing", path, "active capability requires a release candidate")
+    elif completion == "deferred-by-scope" and target_rc != "deferred":
+        _finding(findings, "deferred-target-rc-invalid", path, repr(target_rc))
 
     dependencies = record.get("dependencies")
     if not isinstance(dependencies, list) or any(not isinstance(item, str) for item in dependencies):


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9406

### Brief Description

Require every 1.0 capability to declare a target release candidate or an explicit deferred target, and enforce that relationship in the capability guard. Add the public 1.0 scope document covering ownership, cross-domain dependencies, the pure Rust Controller contract, Rust-native Timer and POP alternatives, conditional Java data migration, explicit exclusions, and non-certification language for deferred long-running qualification.

### How Did You Test This Change?

- `python -m unittest scripts.tests.test_v1_capability_guard scripts.tests.test_core_release_check_routes -v`
- `python scripts/v1_capability_guard.py --phase 0`
- `python -m json.tool scripts/v1-capability-manifest.json`
- `python -m json.tool scripts/v1-capability-manifest.schema.json`
- `python scripts/core_release_guard.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the RocketMQ Rust 1.0 scope and compatibility policy, including supported capabilities, boundaries, exclusions, and release readiness requirements.

* **Release Planning**
  * Documented release-candidate targets for active capabilities and deferred targets for capabilities planned beyond the initial release.

* **Validation**
  * Enhanced capability checks to validate release targets and ensure the scope documentation includes required compatibility details.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->