### PR TITLE
[ISSUE #9413]✨Redesign Dashboard and Cluster operational workspaces

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/AppDataTable.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/AppDataTable.tsx
@@ -1,0 +1,135 @@
+import type { KeyboardEvent, ReactNode } from 'react';
+import EmptyState from './EmptyState';
+import ErrorState from './ErrorState';
+import LoadingState from './LoadingState';
+import { Button } from './ui/Button';
+
+export interface AppDataTableColumn<T> {
+  id: string;
+  header: ReactNode;
+  cell: (row: T) => ReactNode;
+  width?: string;
+  align?: 'left' | 'right' | 'center';
+}
+
+interface AppDataTableProps<T> {
+  ariaLabel: string;
+  rows: T[];
+  columns: AppDataTableColumn<T>[];
+  getRowId: (row: T) => string;
+  page: number;
+  pageSize: number;
+  total: number;
+  onPageChange: (page: number) => void;
+  onRowActivate?: (row: T, origin: HTMLElement) => void;
+  loading?: boolean;
+  error?: string | null;
+  onRetry?: () => void;
+  emptyTitle?: string;
+  emptyDetail?: string;
+}
+
+export default function AppDataTable<T>({
+  ariaLabel,
+  rows,
+  columns,
+  getRowId,
+  page,
+  pageSize,
+  total,
+  onPageChange,
+  onRowActivate,
+  loading = false,
+  error,
+  onRetry,
+  emptyTitle = 'No rows',
+  emptyDetail
+}: AppDataTableProps<T>) {
+  const pageCount = Math.max(1, Math.ceil(total / pageSize));
+  const currentPage = Math.min(Math.max(page, 1), pageCount);
+  const firstRow = total === 0 ? 0 : (currentPage - 1) * pageSize + 1;
+  const lastRow = total === 0 ? 0 : Math.min(firstRow + rows.length - 1, total);
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLTableRowElement>, row: T) => {
+    if (!onRowActivate || event.target !== event.currentTarget || (event.key !== 'Enter' && event.key !== ' ')) return;
+    event.preventDefault();
+    onRowActivate(row, event.currentTarget);
+  };
+
+  const isInteractiveTarget = (target: EventTarget | null) => (
+    target instanceof Element
+    && target.closest('a, button, input, select, textarea, [role="button"], [role="link"]') !== null
+  );
+
+  return (
+    <section className="app-data-table">
+      {loading ? <LoadingState label={`Loading ${ariaLabel.toLowerCase()}`} /> : null}
+      {!loading && error ? <ErrorState message={error} onRetry={onRetry} /> : null}
+      {!loading && !error && rows.length === 0 ? <EmptyState title={emptyTitle} detail={emptyDetail} /> : null}
+      {!loading && !error && rows.length > 0 ? (
+        <div className="app-data-table-scroll" role="region" aria-label={ariaLabel} tabIndex={0}>
+          <table>
+            <thead>
+              <tr>
+                {columns.map((column) => (
+                  <th key={column.id} scope="col" style={{ width: column.width, textAlign: column.align }}>
+                    {column.header}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr
+                  key={getRowId(row)}
+                  tabIndex={onRowActivate ? 0 : undefined}
+                  className={onRowActivate ? 'app-data-table-row-interactive' : undefined}
+                  onClick={onRowActivate ? (event) => {
+                    if (!isInteractiveTarget(event.target)) onRowActivate(row, event.currentTarget);
+                  } : undefined}
+                  onKeyDown={(event) => handleKeyDown(event, row)}
+                >
+                  {columns.map((column) => (
+                    <td key={column.id} style={{ textAlign: column.align }}>
+                      {column.cell(row)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+      {!loading && !error ? (
+        <footer className="app-data-table-footer">
+          <span>
+            {firstRow}-{lastRow} of {total}
+          </span>
+          <div className="app-data-table-pagination">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              aria-label="Previous page"
+              disabled={currentPage <= 1}
+              onClick={() => onPageChange(currentPage - 1)}
+            >
+              Previous
+            </Button>
+            <span aria-label={`Page ${currentPage} of ${pageCount}`}>{currentPage} / {pageCount}</span>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              aria-label="Next page"
+              disabled={currentPage >= pageCount}
+              onClick={() => onPageChange(currentPage + 1)}
+            >
+              Next
+            </Button>
+          </div>
+        </footer>
+      ) : null}
+    </section>
+  );
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/EntitySheet.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/EntitySheet.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode, RefObject } from 'react';
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from './ui/Sheet';
+
+interface EntitySheetProps {
+  open: boolean;
+  title: string;
+  description?: string;
+  onOpenChange: (open: boolean) => void;
+  restoreFocusRef?: RefObject<HTMLElement | null>;
+  children: ReactNode;
+}
+
+export default function EntitySheet({ open, title, description, onOpenChange, restoreFocusRef, children }: EntitySheetProps) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        className="entity-sheet"
+        onCloseAutoFocus={(event) => {
+          if (!restoreFocusRef?.current) return;
+          event.preventDefault();
+          restoreFocusRef.current.focus();
+        }}
+      >
+        <SheetHeader className="entity-sheet-header">
+          <SheetTitle>{title}</SheetTitle>
+          {description ? <SheetDescription>{description}</SheetDescription> : null}
+        </SheetHeader>
+        <div className="entity-sheet-body">{children}</div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/QueryToolbar.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/QueryToolbar.tsx
@@ -1,0 +1,48 @@
+import { RotateCcw, Search } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { Button } from './ui/Button';
+import { Input } from './ui/Input';
+
+interface QueryToolbarProps {
+  searchValue: string;
+  searchPlaceholder: string;
+  onSearchChange: (value: string) => void;
+  onReset?: () => void;
+  children?: ReactNode;
+  actions?: ReactNode;
+}
+
+export default function QueryToolbar({
+  searchValue,
+  searchPlaceholder,
+  onSearchChange,
+  onReset,
+  children,
+  actions
+}: QueryToolbarProps) {
+  return (
+    <div className="query-toolbar">
+      <label className="query-search">
+        <span className="sr-only">{searchPlaceholder}</span>
+        <Search size={16} aria-hidden="true" />
+        <Input
+          type="search"
+          value={searchValue}
+          placeholder={searchPlaceholder}
+          aria-label={searchPlaceholder}
+          onChange={(event) => onSearchChange(event.target.value)}
+        />
+      </label>
+      {children ? <div className="query-filters">{children}</div> : null}
+      <div className="query-actions">
+        {onReset ? (
+          <Button type="button" variant="ghost" size="sm" onClick={onReset} aria-label="Reset filters">
+            <RotateCcw size={14} aria-hidden="true" />
+            Reset
+          </Button>
+        ) : null}
+        {actions}
+      </div>
+    </div>
+  );
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/RefreshButton.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/RefreshButton.tsx
@@ -1,0 +1,24 @@
+import { RefreshCw } from 'lucide-react';
+import { Button } from './ui/Button';
+
+interface RefreshButtonProps {
+  refreshing?: boolean;
+  onRefresh: () => void;
+  compact?: boolean;
+}
+
+export default function RefreshButton({ refreshing = false, onRefresh, compact = false }: RefreshButtonProps) {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size={compact ? 'icon' : 'sm'}
+      loading={refreshing}
+      aria-label={refreshing ? 'Refreshing' : 'Refresh'}
+      onClick={onRefresh}
+    >
+      {!refreshing ? <RefreshCw size={15} aria-hidden="true" /> : null}
+      {!compact ? (refreshing ? 'Refreshing' : 'Refresh') : null}
+    </Button>
+  );
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/TrendAreaChart.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/TrendAreaChart.tsx
@@ -1,4 +1,4 @@
-import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import EmptyState from './EmptyState';
 
 export interface TrendAreaChartPoint {
@@ -15,8 +15,6 @@ interface TrendAreaChartProps {
 }
 
 export default function TrendAreaChart({ data, color, label, emptyTitle, emptyDetail }: TrendAreaChartProps) {
-  const gradientId = `${label.replace(/\W+/g, '-').toLowerCase()}-gradient`;
-
   if (data.length === 0) {
     return <EmptyState title={emptyTitle} detail={emptyDetail} />;
   }
@@ -24,16 +22,10 @@ export default function TrendAreaChart({ data, color, label, emptyTitle, emptyDe
   return (
     <div className="dashboard-trend-chart">
       <ResponsiveContainer width="100%" height={252}>
-        <AreaChart data={data} margin={{ top: 10, right: 12, bottom: 2, left: 0 }}>
-          <defs>
-            <linearGradient id={gradientId} x1="0" x2="0" y1="0" y2="1">
-              <stop offset="0%" stopColor={color} stopOpacity={0.3} />
-              <stop offset="100%" stopColor={color} stopOpacity={0.02} />
-            </linearGradient>
-          </defs>
+        <LineChart data={data} margin={{ top: 10, right: 12, bottom: 2, left: 12 }}>
           <CartesianGrid stroke="var(--border)" strokeDasharray="4 8" opacity={0.42} vertical={false} />
           <XAxis dataKey="time" axisLine={false} tickLine={false} minTickGap={28} tick={{ fill: 'var(--muted)', fontSize: 12 }} />
-          <YAxis axisLine={false} tickLine={false} width={44} tick={{ fill: 'var(--muted)', fontSize: 12 }} />
+          <YAxis axisLine={false} tickLine={false} width={56} tick={{ fill: 'var(--muted)', fontSize: 12 }} />
           <Tooltip
             contentStyle={{
               background: 'var(--surface)',
@@ -43,17 +35,16 @@ export default function TrendAreaChart({ data, color, label, emptyTitle, emptyDe
             }}
             labelStyle={{ color: 'var(--muted)' }}
           />
-          <Area
+          <Line
             type="monotone"
             dataKey="value"
             name={label}
             stroke={color}
             strokeWidth={2.5}
-            fill={`url(#${gradientId})`}
             dot={false}
             activeDot={{ r: 4, strokeWidth: 0 }}
           />
-        </AreaChart>
+        </LineChart>
       </ResponsiveContainer>
     </div>
   );

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/operational-workspace.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/operational-workspace.test.tsx
@@ -1,0 +1,212 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useRef, useState } from 'react';
+import { vi } from 'vitest';
+import AppDataTable, { type AppDataTableColumn } from './AppDataTable';
+import EntitySheet from './EntitySheet';
+import QueryToolbar from './QueryToolbar';
+import RefreshButton from './RefreshButton';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from './ui/Tabs';
+
+interface BrokerRow {
+  id: string;
+  name: string;
+}
+
+const columns: AppDataTableColumn<BrokerRow>[] = [
+  { id: 'broker', header: 'Broker', cell: (row) => row.name }
+];
+
+function SheetHarness() {
+  const [open, setOpen] = useState(true);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  return (
+    <>
+      <button ref={triggerRef} type="button">Inspect broker-a</button>
+      <EntitySheet open={open} title="broker-a" description="Broker details" onOpenChange={setOpen} restoreFocusRef={triggerRef}>
+        Broker content
+      </EntitySheet>
+    </>
+  );
+}
+
+function QueryHarness() {
+  const [query, setQuery] = useState('');
+  return (
+    <QueryToolbar
+      searchValue={query}
+      searchPlaceholder="Search broker or address"
+      onSearchChange={setQuery}
+      onReset={() => setQuery('')}
+    >
+      <span>Role filter</span>
+    </QueryToolbar>
+  );
+}
+
+describe('operational workspace components', () => {
+  it('controls search input and resets query state', async () => {
+    const user = userEvent.setup();
+    render(<QueryHarness />);
+
+    const search = screen.getByRole('searchbox', { name: 'Search broker or address' });
+    await user.type(search, 'broker-a');
+    expect(search).toHaveValue('broker-a');
+    expect(screen.getByText('Role filter')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Reset filters' }));
+    expect(search).toHaveValue('');
+  });
+
+  it('announces refresh progress and prevents duplicate refreshes', () => {
+    const onRefresh = vi.fn();
+    const { rerender } = render(<RefreshButton onRefresh={onRefresh} />);
+    expect(screen.getByRole('button', { name: 'Refresh' })).toBeEnabled();
+
+    rerender(<RefreshButton refreshing onRefresh={onRefresh} />);
+    expect(screen.getByRole('button', { name: 'Refreshing' })).toBeDisabled();
+  });
+
+  it('frames contextual details with an accessible title and keyboard tabs', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <EntitySheet open title="broker-a" description="Broker runtime and configuration" onOpenChange={onOpenChange}>
+        <Tabs defaultValue="overview">
+          <TabsList aria-label="Broker detail sections">
+            <TabsTrigger value="overview">Overview</TabsTrigger>
+            <TabsTrigger value="runtime">Runtime</TabsTrigger>
+          </TabsList>
+          <TabsContent value="overview">Overview content</TabsContent>
+          <TabsContent value="runtime">Runtime content</TabsContent>
+        </Tabs>
+      </EntitySheet>
+    );
+
+    expect(screen.getByRole('dialog', { name: 'broker-a' })).toBeInTheDocument();
+    expect(screen.getByText('Broker runtime and configuration')).toBeInTheDocument();
+    const overview = screen.getByRole('tab', { name: 'Overview' });
+    overview.focus();
+    await user.keyboard('{ArrowRight}');
+    expect(screen.getByRole('tab', { name: 'Runtime' })).toHaveFocus();
+    expect(screen.getByText('Runtime content')).toBeVisible();
+  });
+
+  it('restores focus to the external trigger after closing a contextual sheet', async () => {
+    const user = userEvent.setup();
+    render(<SheetHarness />);
+
+    await user.click(screen.getByRole('button', { name: 'Close details' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Inspect broker-a' })).toHaveFocus());
+  });
+
+  it('renders table states, controlled pagination, and keyboard row activation', async () => {
+    const user = userEvent.setup();
+    const onRetry = vi.fn();
+    const onPageChange = vi.fn();
+    const onRowActivate = vi.fn();
+    const { rerender } = render(
+      <AppDataTable
+        ariaLabel="Broker inventory"
+        rows={[]}
+        columns={columns}
+        getRowId={(row) => row.id}
+        page={1}
+        pageSize={1}
+        total={0}
+        onPageChange={onPageChange}
+        loading
+      />
+    );
+
+    expect(screen.getByRole('status', { name: 'Loading broker inventory' })).toBeInTheDocument();
+
+    rerender(
+      <AppDataTable
+        ariaLabel="Broker inventory"
+        rows={[]}
+        columns={columns}
+        getRowId={(row) => row.id}
+        page={1}
+        pageSize={1}
+        total={0}
+        onPageChange={onPageChange}
+        error="Broker request failed"
+        onRetry={onRetry}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <AppDataTable
+        ariaLabel="Broker inventory"
+        rows={[]}
+        columns={columns}
+        getRowId={(row) => row.id}
+        page={1}
+        pageSize={1}
+        total={0}
+        onPageChange={onPageChange}
+        emptyTitle="No brokers match"
+      />
+    );
+    expect(screen.getByText('No brokers match')).toBeInTheDocument();
+
+    rerender(
+      <AppDataTable
+        ariaLabel="Broker inventory"
+        rows={[{ id: 'b', name: 'broker-b' }]}
+        columns={columns}
+        getRowId={(row) => row.id}
+        page={2}
+        pageSize={1}
+        total={2}
+        onPageChange={onPageChange}
+        onRowActivate={onRowActivate}
+      />
+    );
+    expect(screen.getByRole('region', { name: 'Broker inventory' })).toBeInTheDocument();
+    const row = screen.getByRole('row', { name: 'broker-b' });
+    row.focus();
+    await user.keyboard('{Enter}');
+    expect(onRowActivate).toHaveBeenCalledWith({ id: 'b', name: 'broker-b' }, row);
+
+    await user.click(screen.getByRole('button', { name: 'Previous page' }));
+    expect(onPageChange).toHaveBeenCalledWith(1);
+    expect(screen.getByRole('button', { name: 'Next page' })).toBeDisabled();
+  });
+
+  it('does not activate a row when keyboard events originate from a nested control', async () => {
+    const user = userEvent.setup();
+    const onRowActivate = vi.fn();
+    const nestedAction = vi.fn();
+    const interactiveColumns: AppDataTableColumn<BrokerRow>[] = [
+      { id: 'broker', header: 'Broker', cell: (row) => row.name },
+      { id: 'action', header: 'Action', cell: () => <button type="button" onClick={nestedAction}>Open direct</button> }
+    ];
+    render(
+      <AppDataTable
+        ariaLabel="Broker inventory"
+        rows={[{ id: 'a', name: 'broker-a' }]}
+        columns={interactiveColumns}
+        getRowId={(row) => row.id}
+        page={1}
+        pageSize={10}
+        total={1}
+        onPageChange={vi.fn()}
+        onRowActivate={onRowActivate}
+      />
+    );
+
+    const nestedButton = screen.getByRole('button', { name: 'Open direct' });
+    nestedButton.focus();
+    await user.keyboard('{Enter}');
+    expect(nestedAction).toHaveBeenCalledTimes(1);
+    expect(onRowActivate).not.toHaveBeenCalled();
+
+    await user.click(screen.getByText('broker-a'));
+    const row = screen.getByRole('row', { name: /broker-a/ });
+    expect(onRowActivate).toHaveBeenCalledWith({ id: 'a', name: 'broker-a' }, row);
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/main.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/main.tsx
@@ -7,6 +7,7 @@ import './styles/base.css';
 import './styles/components.css';
 import './styles/shell.css';
 import './styles/globals.css';
+import './styles/pages.css';
 
 document.documentElement.dataset.theme = 'dark';
 

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/BrokerDetailPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/BrokerDetailPage.tsx
@@ -1,127 +1,24 @@
-import * as Dialog from '@radix-ui/react-dialog';
-import { Pencil } from 'lucide-react';
-import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
-import { brokerApi } from '../api/broker_api';
-import ConfirmDialog from '../components/ConfirmDialog';
-import ErrorState from '../components/ErrorState';
-import KeyValueTable from '../components/KeyValueTable';
-import LoadingState from '../components/LoadingState';
+import { ArrowLeft } from 'lucide-react';
+import { Link, useParams } from 'react-router-dom';
 import PageHeader from '../components/PageHeader';
-import type { BrokerConfigView, BrokerRuntimeStats } from '../types/broker';
-
-interface EntryRow {
-  key: string;
-  value: string;
-}
+import { buttonVariants } from '../components/ui/Button';
+import BrokerDetailContent from './brokers/BrokerDetailContent';
 
 export default function BrokerDetailPage() {
   const { brokerName = '' } = useParams();
-  const [runtime, setRuntime] = useState<BrokerRuntimeStats | null>(null);
-  const [config, setConfig] = useState<BrokerConfigView | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [editing, setEditing] = useState(false);
-  const [configDraft, setConfigDraft] = useState('{}');
-
-  const load = () => {
-    setLoading(true);
-    setError(null);
-    Promise.all([brokerApi.runtime(brokerName), brokerApi.config(brokerName)])
-      .then(([runtimeData, configData]) => {
-        setRuntime(runtimeData);
-        setConfig(configData);
-        setConfigDraft(JSON.stringify(configData.entries, null, 2));
-      })
-      .catch((requestError: Error) => setError(requestError.message))
-      .finally(() => setLoading(false));
-  };
-
-  useEffect(() => {
-    load();
-  }, [brokerName]);
-
-  if (loading) return <LoadingState label="Loading broker" />;
-  if (error) return <ErrorState message={error} onRetry={load} />;
-
-  const runtimeRows: EntryRow[] = Object.entries(runtime?.entries ?? {})
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([key, value]) => ({ key, value }));
-  const configRows: EntryRow[] = Object.entries(config?.entries ?? {})
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([key, value]) => ({ key, value }));
-  const saveConfig = () => {
-    let entries: Record<string, string>;
-    try {
-      const parsed = JSON.parse(configDraft) as Record<string, unknown>;
-      entries = Object.fromEntries(Object.entries(parsed).map(([key, value]) => [key, String(value)]));
-    } catch {
-      setError('Broker config must be a JSON object.');
-      return;
-    }
-    brokerApi
-      .updateConfig(brokerName, { entries })
-      .then(() => {
-        setEditing(false);
-        load();
-      })
-      .catch((requestError: Error) => setError(requestError.message));
-  };
 
   return (
-    <>
+    <div className="broker-detail-page">
       <PageHeader
         title={brokerName}
-        description="Broker runtime and configuration details."
+        description="Inspect runtime evidence and safely review broker configuration."
         actions={
-          <button type="button" className="button" onClick={() => setEditing(true)}>
-            <Pencil size={15} aria-hidden="true" /> Edit config
-          </button>
+          <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} to="/brokers">
+            <ArrowLeft size={14} aria-hidden="true" /> Back to cluster
+          </Link>
         }
       />
-      <section className="panel">
-        <div className="panel-heading">
-          <div>
-            <h2>Status</h2>
-            <p>Runtime key/value stats.</p>
-          </div>
-          <button type="button" className="button button-secondary" onClick={load}>
-            Refresh
-          </button>
-        </div>
-        <KeyValueTable rows={runtimeRows} emptyTitle="No runtime stats" />
-      </section>
-      <section className="panel">
-        <div className="panel-heading">
-          <div>
-            <h2>Config</h2>
-            <p>Broker configuration key/value entries.</p>
-          </div>
-        </div>
-        <KeyValueTable rows={configRows} emptyTitle="No broker config" />
-      </section>
-      <Dialog.Root open={editing} onOpenChange={setEditing}>
-        <Dialog.Portal>
-          <Dialog.Overlay className="dialog-overlay" />
-          <Dialog.Content className="dialog-content">
-            <Dialog.Title>Edit Broker Config</Dialog.Title>
-            <textarea className="config-editor" value={configDraft} onChange={(event) => setConfigDraft(event.target.value)} />
-            <div className="dialog-actions">
-              <Dialog.Close className="button button-secondary">Cancel</Dialog.Close>
-              <ConfirmDialog
-                title="Update broker config"
-                description={`Apply config changes to ${brokerName}?`}
-                confirmLabel="Update"
-                onConfirm={saveConfig}
-              >
-                <button type="button" className="button">
-                  Update
-                </button>
-              </ConfirmDialog>
-            </div>
-          </Dialog.Content>
-        </Dialog.Portal>
-      </Dialog.Root>
-    </>
+      <BrokerDetailContent brokerName={brokerName} />
+    </div>
   );
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/BrokerListPage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/BrokerListPage.test.tsx
@@ -1,0 +1,92 @@
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { brokerApi } from '../api/broker_api';
+import { renderAtRoute } from '../test/render';
+import type { BrokerInfo } from '../types/broker';
+import BrokerListPage from './BrokerListPage';
+
+vi.mock('../api/broker_api', () => ({
+  brokerApi: {
+    list: vi.fn(),
+    runtime: vi.fn(),
+    config: vi.fn(),
+    updateConfig: vi.fn()
+  }
+}));
+
+const brokers: BrokerInfo[] = [
+  {
+    clusterName: 'east', brokerName: 'broker-a', brokerId: 0, address: '10.0.0.1:10911', role: 'MASTER',
+    version: '5.3.2', produceTps: 120, consumeTps: 80
+  },
+  {
+    clusterName: 'east', brokerName: 'broker-b', brokerId: 1, address: '10.0.0.2:10911', role: 'SLAVE',
+    version: '5.3.2', produceTps: 0, consumeTps: 60
+  },
+  {
+    clusterName: 'west', brokerName: 'broker-c', brokerId: 0, address: '10.1.0.1:10911', role: 'MASTER',
+    version: '5.2.0', produceTps: 35.5, consumeTps: 11.1
+  }
+];
+
+describe('BrokerListPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(brokerApi.list).mockResolvedValue({ items: brokers, total: brokers.length });
+  });
+
+  it('renders cluster evidence metrics and the operational table', async () => {
+    renderAtRoute(<BrokerListPage />, '/brokers');
+
+    expect(screen.getByRole('status', { name: 'Loading brokers' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Cluster inventory' })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Clusters: 2' })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Brokers: 3' })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Roles: 2' })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Combined TPS: 306.6' })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'Broker inventory' })).toBeInTheDocument();
+  });
+
+  it('combines search, cluster, and role filters and resets them', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<BrokerListPage />, '/brokers');
+    await screen.findByText('broker-a');
+
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Cluster filter' }), 'east');
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Role filter' }), 'MASTER');
+    await user.type(screen.getByRole('searchbox', { name: 'Filter brokers' }), 'broker-a');
+    expect(screen.getByText('broker-a')).toBeInTheDocument();
+    expect(screen.queryByText('broker-b')).not.toBeInTheDocument();
+    expect(screen.queryByText('broker-c')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Reset filters' }));
+    expect(screen.getByText('broker-b')).toBeInTheDocument();
+    expect(screen.getByText('broker-c')).toBeInTheDocument();
+  });
+
+  it('opens a broker sheet from the row and preserves a direct detail link', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<BrokerListPage />, '/brokers');
+    await screen.findByText('broker-a');
+
+    const row = screen.getByText('broker-a').closest('tr');
+    expect(row).not.toBeNull();
+    expect(within(row as HTMLElement).getByRole('link', { name: 'View broker-a' })).toHaveAttribute('href', '/brokers/broker-a');
+    await user.click(within(row as HTMLElement).getByRole('button', { name: 'Inspect broker-a' }));
+
+    expect(await screen.findByRole('dialog', { name: 'broker-a' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Runtime' })).toBeInTheDocument();
+  });
+
+  it('shows a load error and retries the inventory request', async () => {
+    const user = userEvent.setup();
+    vi.mocked(brokerApi.list).mockRejectedValueOnce(new Error('inventory unavailable'));
+    renderAtRoute(<BrokerListPage />, '/brokers');
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('inventory unavailable');
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(await screen.findByText('broker-a')).toBeInTheDocument();
+    await waitFor(() => expect(brokerApi.list).toHaveBeenCalledTimes(2));
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/BrokerListPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/BrokerListPage.tsx
@@ -1,118 +1,193 @@
-import { Activity, RefreshCw, Settings } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { ExternalLink, Gauge, Layers3, RadioTower, ScanSearch, ShieldCheck } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState, type MouseEvent } from 'react';
 import { Link } from 'react-router-dom';
 import { brokerApi } from '../api/broker_api';
-import BrokerInspectorDrawer from '../components/BrokerInspectorDrawer';
-import DataTable from '../components/DataTable';
+import AppDataTable, { type AppDataTableColumn } from '../components/AppDataTable';
+import EntitySheet from '../components/EntitySheet';
 import ErrorState from '../components/ErrorState';
 import LoadingState from '../components/LoadingState';
+import MetricCard from '../components/MetricCard';
 import PageHeader from '../components/PageHeader';
-import SelectMenu from '../components/SelectMenu';
+import QueryToolbar from '../components/QueryToolbar';
+import RefreshButton from '../components/RefreshButton';
 import StatusBadge from '../components/StatusBadge';
+import { Button } from '../components/ui/Button';
 import type { BrokerInfo, BrokerListView } from '../types/broker';
+import BrokerDetailContent from './brokers/BrokerDetailContent';
 
-type BrokerDrawerTab = 'status' | 'config';
+const PAGE_SIZE = 10;
 
 export default function BrokerListPage() {
   const [data, setData] = useState<BrokerListView | null>(null);
-  const [selectedCluster, setSelectedCluster] = useState('all');
-  const [drawerBroker, setDrawerBroker] = useState<string | null>(null);
-  const [drawerTab, setDrawerTab] = useState<BrokerDrawerTab>('status');
+  const [search, setSearch] = useState('');
+  const [cluster, setCluster] = useState('all');
+  const [role, setRole] = useState('all');
+  const [page, setPage] = useState(1);
+  const [selectedBroker, setSelectedBroker] = useState<BrokerInfo | null>(null);
+  const detailTriggerRef = useRef<HTMLElement | null>(null);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const load = () => {
-    setLoading(true);
+  const load = async () => {
+    if (data) setRefreshing(true);
+    else setLoading(true);
     setError(null);
-    brokerApi
-      .list()
-      .then(setData)
-      .catch((requestError: Error) => setError(requestError.message))
-      .finally(() => setLoading(false));
+    try {
+      setData(await brokerApi.list());
+    } catch (requestError) {
+      setError(requestError instanceof Error ? requestError.message : String(requestError));
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
   };
 
   useEffect(() => {
-    load();
+    void load();
   }, []);
 
-  const clusters = useMemo(
-    () => Array.from(new Set((data?.items ?? []).map((broker) => broker.clusterName))).filter(Boolean).sort(),
-    [data]
+  const brokers = data?.items ?? [];
+  const clusters = useMemo(() => Array.from(new Set(brokers.map((broker) => broker.clusterName))).filter(Boolean).sort(), [brokers]);
+  const roles = useMemo(() => Array.from(new Set(brokers.map((broker) => broker.role))).filter(Boolean).sort(), [brokers]);
+  const combinedTps = useMemo(
+    () => Number(brokers.reduce((total, broker) => total + broker.produceTps + broker.consumeTps, 0).toFixed(2)),
+    [brokers]
   );
-  const clusterOptions = useMemo(
-    () => [{ value: 'all', label: 'All clusters' }, ...clusters.map((cluster) => ({ value: cluster, label: cluster }))],
-    [clusters]
-  );
-  const visibleRows = useMemo(
-    () =>
-      selectedCluster === 'all'
-        ? data?.items ?? []
-        : (data?.items ?? []).filter((broker) => broker.clusterName === selectedCluster),
-    [data, selectedCluster]
-  );
+  const filteredRows = useMemo(() => {
+    const normalizedSearch = search.trim().toLowerCase();
+    return brokers.filter((broker) => {
+      if (cluster !== 'all' && broker.clusterName !== cluster) return false;
+      if (role !== 'all' && broker.role !== role) return false;
+      if (!normalizedSearch) return true;
+      return `${broker.brokerName} ${broker.address} ${broker.clusterName} ${broker.version} ${broker.role}`
+        .toLowerCase()
+        .includes(normalizedSearch);
+    });
+  }, [brokers, cluster, role, search]);
 
-  const openDrawer = (broker: BrokerInfo, tab: BrokerDrawerTab) => {
-    setDrawerBroker(broker.brokerName);
-    setDrawerTab(tab);
+  const pageCount = Math.max(1, Math.ceil(filteredRows.length / PAGE_SIZE));
+  const currentPage = Math.min(page, pageCount);
+  const visibleRows = filteredRows.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
+
+  const updateFilter = (setter: (value: string) => void) => (value: string) => {
+    setter(value);
+    setPage(1);
   };
 
+  const openDetails = (broker: BrokerInfo, origin?: HTMLElement) => {
+    if (origin) detailTriggerRef.current = origin;
+    setSelectedBroker(broker);
+  };
+  const stopRowActivation = (event: MouseEvent) => event.stopPropagation();
+
+  const columns: AppDataTableColumn<BrokerInfo>[] = [
+    {
+      id: 'broker',
+      header: 'Broker',
+      width: '210px',
+      cell: (broker) => (
+        <div className="broker-name-cell">
+          <strong>{broker.brokerName}</strong>
+          <Link
+            to={`/brokers/${encodeURIComponent(broker.brokerName)}`}
+            aria-label={`View ${broker.brokerName}`}
+            onClick={stopRowActivation}
+          >
+            Full page <ExternalLink size={12} aria-hidden="true" />
+          </Link>
+        </div>
+      )
+    },
+    { id: 'cluster', header: 'Cluster', width: '150px', cell: (broker) => broker.clusterName },
+    { id: 'role', header: 'Role', width: '120px', cell: (broker) => <StatusBadge status={broker.role} tone={broker.role.toUpperCase().includes('MASTER') ? 'success' : 'info'} /> },
+    { id: 'address', header: 'Address', width: '190px', cell: (broker) => <code>{broker.address}</code> },
+    { id: 'version', header: 'Version', width: '120px', cell: (broker) => broker.version || '—' },
+    { id: 'produce', header: 'Produce TPS', width: '120px', align: 'right', cell: (broker) => broker.produceTps.toFixed(2) },
+    { id: 'consume', header: 'Consume TPS', width: '120px', align: 'right', cell: (broker) => broker.consumeTps.toFixed(2) },
+    {
+      id: 'actions',
+      header: 'Actions',
+      width: '90px',
+      align: 'right',
+      cell: (broker) => (
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          aria-label={`Inspect ${broker.brokerName}`}
+          onClick={(event) => { event.stopPropagation(); openDetails(broker, event.currentTarget); }}
+        >
+          <ScanSearch size={15} aria-hidden="true" />
+        </Button>
+      )
+    }
+  ];
+
   if (loading) return <LoadingState label="Loading brokers" />;
-  if (error) return <ErrorState message={error} onRetry={load} />;
+  if (error) return <ErrorState message={error} onRetry={() => void load()} />;
 
   return (
-    <>
+    <div className="cluster-inventory-page">
       <PageHeader
-        title="Cluster"
-        description="Broker topology, runtime status, and editable broker configuration."
-        actions={
-          <>
-            <div className="cluster-filter">
-              <span>Cluster</span>
-              <SelectMenu value={selectedCluster} options={clusterOptions} onChange={setSelectedCluster} ariaLabel="Select cluster" />
-            </div>
-            <StatusBadge status={`${visibleRows.length} brokers`} tone={visibleRows.length > 0 ? 'success' : 'neutral'} />
-            <button type="button" className="icon-button" title="Refresh brokers" onClick={load}>
-              <RefreshCw size={15} aria-hidden="true" />
-            </button>
-          </>
-        }
+        title="Cluster inventory"
+        description="Filter broker topology, compare traffic evidence, and inspect runtime or configuration without leaving the list."
+        actions={<RefreshButton refreshing={refreshing} onRefresh={() => void load()} />}
       />
-      <DataTable
-        rows={visibleRows}
-        columns={[
-          { header: 'Broker', render: (row) => <Link to={`/brokers/${encodeURIComponent(row.brokerName)}`}>{row.brokerName}</Link> },
-          { header: 'NO.', render: (row) => row.brokerId },
-          { header: 'Address', render: (row) => <code>{row.address}</code> },
-          { header: 'Version', render: (row) => row.version || '-' },
-          { header: 'Role', render: (row) => <StatusBadge status={row.role} /> },
-          { header: 'Produce Message TPS', render: (row) => row.produceTps.toFixed(2) },
-          { header: 'Consumer Message TPS', render: (row) => row.consumeTps.toFixed(2) },
-          {
-            header: 'Operation',
-            render: (row) => (
-              <div className="broker-action-buttons">
-                <button type="button" className="button button-secondary" onClick={() => openDrawer(row, 'status')}>
-                  <Activity size={15} aria-hidden="true" /> Status
-                </button>
-                <button type="button" className="button button-secondary" onClick={() => openDrawer(row, 'config')}>
-                  <Settings size={15} aria-hidden="true" /> Config
-                </button>
-              </div>
-            )
-          }
-        ]}
-        getRowId={(row) => `${row.brokerName}-${row.brokerId}-${row.address}`}
-        emptyTitle="No brokers"
-        onRefresh={load}
-      />
-      <BrokerInspectorDrawer
-        brokerName={drawerBroker}
-        initialTab={drawerTab}
-        open={drawerBroker !== null}
-        onOpenChange={(open) => {
-          if (!open) setDrawerBroker(null);
-        }}
-      />
-    </>
+
+      <div className="metric-grid cluster-metrics">
+        <MetricCard label="Clusters" value={clusters.length} detail="Unique cluster names" icon={<Layers3 size={18} />} />
+        <MetricCard label="Brokers" value={brokers.length} detail="Visible broker entries" icon={<RadioTower size={18} />} />
+        <MetricCard label="Roles" value={roles.length} detail="Distinct reported roles" icon={<ShieldCheck size={18} />} />
+        <MetricCard label="Combined TPS" value={combinedTps} detail="Produce plus consume" icon={<Gauge size={18} />} />
+      </div>
+
+      <section className="cluster-table-card">
+        <QueryToolbar
+          searchValue={search}
+          searchPlaceholder="Filter brokers"
+          onSearchChange={updateFilter(setSearch)}
+          onReset={() => { setSearch(''); setCluster('all'); setRole('all'); setPage(1); }}
+        >
+          <label className="native-filter-field">
+            <span>Cluster</span>
+            <select aria-label="Cluster filter" value={cluster} onChange={(event) => updateFilter(setCluster)(event.target.value)}>
+              <option value="all">All clusters</option>
+              {clusters.map((clusterName) => <option key={clusterName} value={clusterName}>{clusterName}</option>)}
+            </select>
+          </label>
+          <label className="native-filter-field">
+            <span>Role</span>
+            <select aria-label="Role filter" value={role} onChange={(event) => updateFilter(setRole)(event.target.value)}>
+              <option value="all">All roles</option>
+              {roles.map((roleName) => <option key={roleName} value={roleName}>{roleName}</option>)}
+            </select>
+          </label>
+        </QueryToolbar>
+        <AppDataTable
+          ariaLabel="Broker inventory"
+          rows={visibleRows}
+          columns={columns}
+          getRowId={(broker) => `${broker.brokerName}-${broker.brokerId}-${broker.address}`}
+          page={currentPage}
+          pageSize={PAGE_SIZE}
+          total={filteredRows.length}
+          onPageChange={setPage}
+          onRowActivate={openDetails}
+          emptyTitle="No brokers match"
+          emptyDetail="Adjust the search, cluster, or role filters."
+        />
+      </section>
+
+      <EntitySheet
+        open={selectedBroker !== null}
+        title={selectedBroker?.brokerName ?? 'Broker details'}
+        description={selectedBroker ? `${selectedBroker.clusterName} · ${selectedBroker.address}` : undefined}
+        restoreFocusRef={detailTriggerRef}
+        onOpenChange={(open) => { if (!open) setSelectedBroker(null); }}
+      >
+        {selectedBroker ? <BrokerDetailContent brokerName={selectedBroker.brokerName} broker={selectedBroker} /> : null}
+      </EntitySheet>
+    </div>
   );
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/DashboardPage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/DashboardPage.test.tsx
@@ -1,0 +1,158 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { brokerApi } from '../api/broker_api';
+import { dashboardApi } from '../api/dashboard_api';
+import { renderAtRoute } from '../test/render';
+import type { DashboardHistorySeries, DashboardOverview, DashboardTopicCurrent } from '../types/dashboard';
+import DashboardPage from './DashboardPage';
+
+vi.mock('../api/dashboard_api', () => ({
+  dashboardApi: {
+    overview: vi.fn(),
+    topicCurrent: vi.fn(),
+    brokerHistory: vi.fn(),
+    topicHistory: vi.fn()
+  }
+}));
+
+vi.mock('../api/broker_api', () => ({
+  brokerApi: {
+    list: vi.fn(),
+    runtime: vi.fn()
+  }
+}));
+
+const overview: DashboardOverview = {
+  currentNamesrv: '127.0.0.1:9876',
+  brokerCount: 3,
+  topicCount: 12,
+  consumerGroupCount: 5,
+  producerCount: 7,
+  messageBacklog: 1_250,
+  systemStatus: 'UP'
+};
+
+const topicCurrent: DashboardTopicCurrent = {
+  totalTopics: 2,
+  topTopics: [
+    { topic: 'orders', totalMsg: 9_000, inTps: 120, outTps: 90 },
+    { topic: 'payments', totalMsg: 4_500, inTps: 75, outTps: 64 }
+  ]
+};
+
+const brokerHistory: DashboardHistorySeries = {
+  date: '2026-08-15',
+  metric: 'brokerCount',
+  collected: true,
+  points: [{ timestamp: 1_776_220_800_000, value: 3 }]
+};
+
+const topicHistory: DashboardHistorySeries = {
+  date: '2026-08-15',
+  metric: 'topic',
+  topicName: null,
+  collected: true,
+  points: [{ timestamp: 1_776_220_800_000, value: 2 }]
+};
+
+function mockSuccessfulDashboard() {
+  vi.mocked(dashboardApi.overview).mockResolvedValue(overview);
+  vi.mocked(dashboardApi.topicCurrent).mockResolvedValue(topicCurrent);
+  vi.mocked(dashboardApi.brokerHistory).mockResolvedValue(brokerHistory);
+  vi.mocked(dashboardApi.topicHistory).mockResolvedValue(topicHistory);
+  vi.mocked(brokerApi.list).mockResolvedValue({ items: [], total: 0 });
+}
+
+describe('DashboardPage', () => {
+  beforeEach(() => {
+    mockSuccessfulDashboard();
+  });
+
+  it('renders loading then operational metrics and evidence-based advisories', async () => {
+    let resolveOverview: (value: DashboardOverview) => void = () => undefined;
+    vi.mocked(dashboardApi.overview).mockReturnValue(new Promise((resolve) => { resolveOverview = resolve; }));
+    renderAtRoute(<DashboardPage />);
+
+    expect(screen.getByRole('status', { name: 'Loading dashboard' })).toBeInTheDocument();
+    resolveOverview(overview);
+
+    expect(await screen.findByRole('heading', { name: 'Operations overview' })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Brokers: 3' })).toBeInTheDocument();
+    expect(screen.getByText('Consumer backlog requires review')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Inspect consumers' })).toHaveAttribute('href', '/consumers');
+    expect(screen.getAllByText('orders').length).toBeGreaterThan(0);
+    expect(screen.getByText(/Topic count/)).toBeInTheDocument();
+  });
+
+  it('keeps the dashboard usable when a history series is unavailable', async () => {
+    vi.mocked(dashboardApi.brokerHistory).mockRejectedValue(new Error('history offline'));
+    renderAtRoute(<DashboardPage />);
+
+    expect(await screen.findByRole('heading', { name: 'Operations overview' })).toBeInTheDocument();
+    expect(screen.getByText('Broker history unavailable')).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: 'Unavailable' })).toBeInTheDocument();
+    expect(screen.getByText('Topic activity')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('shows a primary error and retries core dashboard requests', async () => {
+    const user = userEvent.setup();
+    vi.mocked(dashboardApi.overview).mockRejectedValueOnce(new Error('overview offline')).mockResolvedValue(overview);
+    renderAtRoute(<DashboardPage />);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('overview offline');
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(await screen.findByRole('heading', { name: 'Operations overview' })).toBeInTheDocument();
+    expect(dashboardApi.overview).toHaveBeenCalledTimes(2);
+  });
+
+  it('queries selected history filters and refreshes without resetting them', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<DashboardPage />);
+    expect(await screen.findByRole('heading', { name: 'Operations overview' })).toBeInTheDocument();
+
+    const date = screen.getByLabelText('History date');
+    const topic = screen.getByRole('combobox', { name: 'Topic history filter' });
+    await user.clear(date);
+    await user.type(date, '2026-08-14');
+    await user.selectOptions(topic, 'payments');
+
+    await waitFor(() => expect(dashboardApi.topicHistory).toHaveBeenLastCalledWith({ date: '2026-08-14', topicName: 'payments' }));
+    const callsBeforeRefresh = vi.mocked(dashboardApi.overview).mock.calls.length;
+    await user.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    await waitFor(() => expect(dashboardApi.overview).toHaveBeenCalledTimes(callsBeforeRefresh + 1));
+    expect(date).toHaveValue('2026-08-14');
+    expect(topic).toHaveValue('payments');
+  });
+
+  it('keeps history loading until the latest topic filter request resolves', async () => {
+    const user = userEvent.setup();
+    let resolveOrders: (value: DashboardHistorySeries) => void = () => undefined;
+    let resolvePayments: (value: DashboardHistorySeries) => void = () => undefined;
+    vi.mocked(dashboardApi.topicHistory).mockImplementation(({ topicName }) => {
+      if (topicName === 'orders') return new Promise((resolve) => { resolveOrders = resolve; });
+      if (topicName === 'payments') return new Promise((resolve) => { resolvePayments = resolve; });
+      return Promise.resolve(topicHistory);
+    });
+    renderAtRoute(<DashboardPage />);
+    await screen.findByRole('heading', { name: 'Operations overview' });
+
+    const topic = screen.getByRole('combobox', { name: 'Topic history filter' });
+    await user.selectOptions(topic, 'orders');
+    await waitFor(() => expect(dashboardApi.topicHistory).toHaveBeenLastCalledWith(expect.objectContaining({ topicName: 'orders' })));
+    await user.selectOptions(topic, 'payments');
+    await waitFor(() => expect(dashboardApi.topicHistory).toHaveBeenLastCalledWith(expect.objectContaining({ topicName: 'payments' })));
+    expect(screen.getByRole('status', { name: 'Loading topic history' })).toBeInTheDocument();
+
+    resolveOrders({ ...topicHistory, topicName: 'orders', points: [{ timestamp: 1_776_220_800_000, value: 9_000 }] });
+    await Promise.resolve();
+    expect(screen.getByRole('status', { name: 'Loading topic history' })).toBeInTheDocument();
+
+    resolvePayments({ ...topicHistory, topicName: 'payments', points: [{ timestamp: 1_776_220_800_000, value: 4_500 }] });
+    await waitFor(() => expect(screen.queryByRole('status', { name: 'Loading topic history' })).not.toBeInTheDocument());
+    expect(topic).toHaveValue('payments');
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/DashboardPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/DashboardPage.tsx
@@ -4,14 +4,12 @@ import {
   Database,
   Layers,
   RadioTower,
-  RefreshCw,
   Send,
   Server,
-  Users,
-  Zap
+  Users
 } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
-import { brokerApi } from '../api/broker_api';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { Link } from 'react-router-dom';
 import { dashboardApi } from '../api/dashboard_api';
 import EmptyState from '../components/EmptyState';
 import ErrorState from '../components/ErrorState';
@@ -19,10 +17,13 @@ import LoadingState from '../components/LoadingState';
 import MetricCard from '../components/MetricCard';
 import PageHeader from '../components/PageHeader';
 import RankingTable from '../components/RankingTable';
+import RefreshButton from '../components/RefreshButton';
 import StatusBadge from '../components/StatusBadge';
 import TrendAreaChart from '../components/TrendAreaChart';
-import type { BrokerListView, BrokerRuntimeStats } from '../types/broker';
+import { buttonVariants } from '../components/ui/Button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/Card';
 import type { DashboardHistorySeries, DashboardOverview, DashboardTopicCurrent } from '../types/dashboard';
+import { buildDashboardAdvisories, formatDashboardMetric, sortTopTopics } from './dashboard/dashboard-model';
 
 function today() {
   const now = new Date();
@@ -31,26 +32,7 @@ function today() {
   return `${now.getFullYear()}-${month}-${day}`;
 }
 
-function formatNumber(value: number) {
-  return new Intl.NumberFormat().format(Math.round(value));
-}
-
-interface HistoryChartPoint {
-  time: string;
-  value: number;
-}
-
-type BrokerRuntimeEntries = BrokerRuntimeStats['entries'];
-
-interface BrokerOverviewRow {
-  brokerName: string;
-  address: string;
-  totalMessagesReceivedToday: number;
-  todayProduceCount: number;
-  yesterdayProduceCount: number;
-}
-
-function historyPoints(series: DashboardHistorySeries | null): HistoryChartPoint[] {
+function historyPoints(series: DashboardHistorySeries | null) {
   return (
     series?.points.map((point) => ({
       time: new Date(point.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
@@ -59,313 +41,334 @@ function historyPoints(series: DashboardHistorySeries | null): HistoryChartPoint
   );
 }
 
-function runtimeNumber(entries: BrokerRuntimeEntries | undefined, key: string) {
-  const value = entries?.[key];
-  if (value === undefined || value === null) {
-    return 0;
-  }
-  const parsed = Number.parseFloat(String(value).split(/\s+/)[0]);
-  return Number.isFinite(parsed) ? parsed : 0;
+function rejectionMessage(result: PromiseRejectedResult) {
+  return result.reason instanceof Error ? result.reason.message : String(result.reason);
 }
 
 export default function DashboardPage() {
   const [overview, setOverview] = useState<DashboardOverview | null>(null);
   const [topicCurrent, setTopicCurrent] = useState<DashboardTopicCurrent | null>(null);
-  const [brokerList, setBrokerList] = useState<BrokerListView | null>(null);
-  const [brokerRuntimeEntriesByName, setBrokerRuntimeEntriesByName] = useState<Record<string, BrokerRuntimeEntries>>({});
   const [brokerHistory, setBrokerHistory] = useState<DashboardHistorySeries | null>(null);
   const [topicHistory, setTopicHistory] = useState<DashboardHistorySeries | null>(null);
+  const [brokerHistoryError, setBrokerHistoryError] = useState<string | null>(null);
+  const [topicHistoryError, setTopicHistoryError] = useState<string | null>(null);
+  const [historyLoading, setHistoryLoading] = useState(true);
   const [historyDate, setHistoryDate] = useState(today);
   const [selectedTopic, setSelectedTopic] = useState('');
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const hasCoreData = useRef(false);
+  const latestRequest = useRef(0);
 
-  const load = () => {
-    setLoading(true);
+  const load = useCallback(async () => {
+    const requestId = ++latestRequest.current;
+    if (hasCoreData.current) setRefreshing(true);
+    else setLoading(true);
     setError(null);
-    Promise.all([
+    setHistoryLoading(true);
+    setBrokerHistory(null);
+    setTopicHistory(null);
+    setBrokerHistoryError(null);
+    setTopicHistoryError(null);
+
+    const [overviewResult, topicCurrentResult, brokerHistoryResult, topicHistoryResult] = await Promise.allSettled([
       dashboardApi.overview(),
       dashboardApi.topicCurrent(),
-      brokerApi.list(),
       dashboardApi.brokerHistory({ date: historyDate }),
       dashboardApi.topicHistory({ date: historyDate, topicName: selectedTopic || undefined })
-    ])
-      .then(async ([overviewData, topicData, brokerData, brokerHistoryData, topicHistoryData]) => {
-        const runtimeResults = await Promise.allSettled(brokerData.items.map((broker) => brokerApi.runtime(broker.brokerName)));
-        const nextRuntimeEntries = brokerData.items.reduce<Record<string, BrokerRuntimeEntries>>((entriesByName, broker, index) => {
-          const result = runtimeResults[index];
-          entriesByName[broker.brokerName] = result?.status === 'fulfilled' ? result.value.entries : {};
-          return entriesByName;
-        }, {});
+    ]);
 
-        setOverview(overviewData);
-        setTopicCurrent(topicData);
-        setBrokerList(brokerData);
-        setBrokerRuntimeEntriesByName(nextRuntimeEntries);
-        setBrokerHistory(brokerHistoryData);
-        setTopicHistory(topicHistoryData);
-        if (!selectedTopic && topicData.topTopics[0]) {
-          setSelectedTopic(topicData.topTopics[0].topic);
-        }
-      })
-      .catch((requestError: Error) => setError(requestError.message))
-      .finally(() => setLoading(false));
-  };
+    if (requestId !== latestRequest.current) return;
 
-  useEffect(() => {
-    load();
+    if (overviewResult.status === 'rejected') {
+      setError(rejectionMessage(overviewResult));
+      setHistoryLoading(false);
+      setLoading(false);
+      setRefreshing(false);
+      return;
+    }
+
+    if (topicCurrentResult.status === 'rejected') {
+      setError(rejectionMessage(topicCurrentResult));
+      setHistoryLoading(false);
+      setLoading(false);
+      setRefreshing(false);
+      return;
+    }
+
+    setOverview(overviewResult.value);
+    setTopicCurrent(topicCurrentResult.value);
+    hasCoreData.current = true;
+
+    if (brokerHistoryResult.status === 'fulfilled') {
+      setBrokerHistory(brokerHistoryResult.value);
+      setBrokerHistoryError(null);
+    } else {
+      setBrokerHistory(null);
+      setBrokerHistoryError(rejectionMessage(brokerHistoryResult));
+    }
+
+    if (topicHistoryResult.status === 'fulfilled') {
+      setTopicHistory(topicHistoryResult.value);
+      setTopicHistoryError(null);
+    } else {
+      setTopicHistory(null);
+      setTopicHistoryError(rejectionMessage(topicHistoryResult));
+    }
+
+    setHistoryLoading(false);
+    setLoading(false);
+    setRefreshing(false);
   }, [historyDate, selectedTopic]);
 
-  const brokerTopData = useMemo(
-    () =>
-      (brokerList?.items ?? [])
-        .map((broker) => ({
-          name: broker.brokerName,
-          totalTps: Number((broker.produceTps + broker.consumeTps).toFixed(2)),
-          produceTps: Number(broker.produceTps.toFixed(2)),
-          consumeTps: Number(broker.consumeTps.toFixed(2))
-        }))
-        .sort((left, right) => right.totalTps - left.totalTps)
-        .slice(0, 10),
-    [brokerList]
-  );
+  useEffect(() => {
+    void load();
+  }, [load]);
 
-  const topicTopData = useMemo(
-    () =>
-      (topicCurrent?.topTopics ?? [])
-        .map((topic) => ({
-          name: topic.topic,
-          totalMsg: topic.totalMsg,
-          inTps: Number(topic.inTps.toFixed(2)),
-          outTps: Number(topic.outTps.toFixed(2))
-        }))
-        .sort((left, right) => right.totalMsg - left.totalMsg)
-        .slice(0, 10),
-    [topicCurrent]
-  );
+  const topTopics = useMemo(() => sortTopTopics(topicCurrent?.topTopics ?? []), [topicCurrent]);
+  const advisories = useMemo(() => (overview ? buildDashboardAdvisories(overview) : []), [overview]);
 
-  if (loading) {
-    return <LoadingState label="Loading dashboard" />;
-  }
-
-  if (error) {
-    return <ErrorState message={error} onRetry={load} />;
-  }
-
-  if (!overview || !topicCurrent || !brokerList) {
-    return <EmptyState title="Dashboard unavailable" />;
-  }
+  if (loading) return <LoadingState label="Loading dashboard" />;
+  if (error) return <ErrorState message={error} onRetry={() => void load()} />;
+  if (!overview || !topicCurrent) return <EmptyState title="Dashboard unavailable" />;
 
   const brokerHistoryData = historyPoints(brokerHistory);
   const topicHistoryData = historyPoints(topicHistory);
-  const brokerOverviewRows: BrokerOverviewRow[] = brokerList.items.map((broker) => {
-    const entries = brokerRuntimeEntriesByName[broker.brokerName];
-    const todayProduceMorning = runtimeNumber(entries, 'msgPutTotalTodayMorning');
-    const yesterdayProduceMorning = runtimeNumber(entries, 'msgPutTotalYesterdayMorning');
-
-    return {
-      brokerName: broker.brokerName,
-      address: broker.address,
-      totalMessagesReceivedToday: runtimeNumber(entries, 'msgGetTotalTodayNow'),
-      todayProduceCount: todayProduceMorning,
-      yesterdayProduceCount: todayProduceMorning - yesterdayProduceMorning
-    };
-  });
-  const brokerRankingRows = brokerTopData.map((broker) => ({
-    name: broker.name,
-    value: broker.totalTps,
-    detail: `produce ${broker.produceTps} / consume ${broker.consumeTps}`
-  }));
-  const topicRankingRows = topicTopData.map((topic) => ({
-    name: topic.name,
+  const topicRankingRows = topTopics.map((topic) => ({
+    name: topic.topic,
     value: topic.totalMsg,
-    detail: `in ${topic.inTps} / out ${topic.outTps}`
+    detail: `in ${formatDashboardMetric(topic.inTps)} / out ${formatDashboardMetric(topic.outTps)} TPS`
   }));
 
   return (
-    <>
+    <div className="operations-dashboard">
       <PageHeader
-        title="Dashboard"
-        description="Broker overview, traffic top lists, and 5-minute trends from the Rust Web backend."
+        title="Operations overview"
+        description="Live RocketMQ inventory, demand signals, and collection history in one operational workspace."
         actions={
           <>
-            <label className="dashboard-filter" title="History date">
+            <label className="dashboard-date-field">
               <CalendarDays size={15} aria-hidden="true" />
-              <input type="date" value={historyDate} onChange={(event) => setHistoryDate(event.target.value)} />
+              <span className="sr-only">History date</span>
+              <input
+                aria-label="History date"
+                type="date"
+                value={historyDate}
+                onChange={(event) => {
+                  setHistoryLoading(true);
+                  setBrokerHistory(null);
+                  setTopicHistory(null);
+                  setHistoryDate(event.target.value);
+                }}
+              />
             </label>
-            <StatusBadge status={overview.systemStatus} tone={overview.systemStatus === 'UP' ? 'success' : 'warning'} />
-            <button type="button" className="icon-button" title="Refresh dashboard" onClick={load}>
-              <RefreshCw size={15} aria-hidden="true" />
-            </button>
+            <RefreshButton refreshing={refreshing} onRefresh={() => void load()} />
           </>
         }
       />
 
-      <div className="metric-grid dashboard-metrics">
-        <MetricCard label="Brokers" value={overview.brokerCount} detail="GET /api/brokers" icon={<RadioTower size={18} />} />
-        <MetricCard label="Topics" value={overview.topicCount} detail="topic-current" icon={<Database size={18} />} />
-        <MetricCard label="Consumers" value={overview.consumerGroupCount} detail="group count" icon={<Users size={18} />} />
-        <MetricCard label="Backlog" value={formatNumber(overview.messageBacklog)} detail="consumer lag" icon={<Layers size={18} />} />
-        <MetricCard label="Producers" value={overview.producerCount} detail="connections" icon={<Send size={18} />} />
+      <Card className="dashboard-health-rail" aria-label="Cluster health summary">
+        <HealthSignal
+          icon={<Activity size={16} />}
+          label="System"
+          value={overview.systemStatus}
+          tone={overview.systemStatus.toUpperCase() === 'UP' ? 'success' : 'warning'}
+        />
+        <HealthSignal icon={<RadioTower size={16} />} label="Brokers" value={String(overview.brokerCount)} tone={overview.brokerCount > 0 ? 'success' : 'danger'} />
+        <HealthSignal icon={<Layers size={16} />} label="Backlog" value={formatDashboardMetric(overview.messageBacklog)} tone={overview.messageBacklog > 0 ? 'warning' : 'success'} />
+        <HealthSignal icon={<Database size={16} />} label="Topics" value={String(overview.topicCount)} />
+        <HealthSignal icon={<Server size={16} />} label="NameServer" value={overview.currentNamesrv ?? 'Not configured'} tone={overview.currentNamesrv ? 'success' : 'danger'} />
+      </Card>
+
+      <div className="metric-grid dashboard-metrics dashboard-metrics-flat">
+        <MetricCard label="Brokers" value={overview.brokerCount} detail="Visible broker instances" icon={<RadioTower size={18} />} />
+        <MetricCard label="Topics" value={overview.topicCount} detail="Current route inventory" icon={<Database size={18} />} />
+        <MetricCard label="Consumers" value={overview.consumerGroupCount} detail="Known consumer groups" icon={<Users size={18} />} />
+        <MetricCard label="Backlog" value={formatDashboardMetric(overview.messageBacklog)} detail="Messages awaiting consumption" icon={<Layers size={18} />} />
+        <MetricCard label="Producers" value={overview.producerCount} detail="Known producer groups" icon={<Send size={18} />} />
       </div>
 
-      <div className="dashboard-overview-grid">
-        <section className="panel dashboard-panel dashboard-panel-table">
-          <div className="panel-heading">
+      <div className="dashboard-main-grid">
+        <Card className="dashboard-advisories">
+          <CardHeader>
             <div>
-              <h2>Broker Overview</h2>
-              <p>Broker address and daily message counters aligned with the Java dashboard overview.</p>
+              <CardTitle>Action center</CardTitle>
+              <CardDescription>Evidence-based checks from the current API response.</CardDescription>
             </div>
-            <StatusBadge status={`${brokerList.total} brokers`} tone={brokerList.total > 0 ? 'success' : 'neutral'} />
-          </div>
-          <BrokerOverviewTable rows={brokerOverviewRows} />
-        </section>
+            <StatusBadge status={advisories.length === 0 ? 'No active advisories' : `${advisories.length} active`} tone={advisories.length === 0 ? 'success' : 'warning'} />
+          </CardHeader>
+          <CardContent>
+            {advisories.length === 0 ? (
+              <EmptyState title="No active advisories" detail="The available dashboard signals do not require action." />
+            ) : (
+              <div className="advisory-list">
+                {advisories.map((advisory) => (
+                  <article className={`advisory-item advisory-${advisory.tone}`} key={advisory.id}>
+                    <div>
+                      <strong>{advisory.title}</strong>
+                      <p>{advisory.detail}</p>
+                    </div>
+                    <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} to={advisory.target}>
+                      {advisory.actionLabel}
+                    </Link>
+                  </article>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
 
-        <section className="panel dashboard-panel">
-          <div className="panel-heading">
+        <Card className="dashboard-ranking-card">
+          <CardHeader>
             <div>
-              <h2>Dashboard Window</h2>
-              <p>History queries use broker/topic 5-minute collector samples.</p>
-            </div>
-            <StatusBadge status={overview.currentNamesrv ?? 'No NameServer'} tone={overview.currentNamesrv ? 'success' : 'warning'} />
-          </div>
-          <div className="dashboard-signal-grid">
-            <div className="dashboard-signal">
-              <Server size={18} aria-hidden="true" />
-              <span>NameServer</span>
-              <strong>{overview.currentNamesrv ?? 'unconfigured'}</strong>
-            </div>
-            <div className="dashboard-signal">
-              <Activity size={18} aria-hidden="true" />
-              <span>History</span>
-              <strong>{brokerHistory?.collected || topicHistory?.collected ? 'collecting' : 'warming up'}</strong>
-            </div>
-            <div className="dashboard-signal">
-              <Zap size={18} aria-hidden="true" />
-              <span>Admin facade</span>
-              <strong>ready</strong>
-            </div>
-          </div>
-        </section>
-      </div>
-
-      <div className="dashboard-chart-grid">
-        <section className="panel dashboard-panel">
-          <div className="panel-heading">
-            <div>
-              <h2>Broker TOP 10</h2>
-              <p>Ranked by produce TPS + consume TPS.</p>
-            </div>
-            <StatusBadge status="Total TPS" />
-          </div>
-          <RankingTable
-            rows={brokerRankingRows}
-            valueLabel="TPS"
-            accent="var(--primary)"
-            emptyTitle="No broker traffic"
-            emptyDetail="Broker TPS is currently zero, so no TOP ranking is shown."
-            formatValue={formatNumber}
-          />
-        </section>
-
-        <section className="panel dashboard-panel">
-          <div className="panel-heading">
-            <div>
-              <h2>Broker 5min trend</h2>
-              <p>Broker count trend collected by the Rust history task.</p>
-            </div>
-            <StatusBadge status={brokerHistory?.collected ? 'collected' : 'warming up'} tone={brokerHistory?.collected ? 'success' : 'warning'} />
-          </div>
-          <TrendAreaChart
-            data={brokerHistoryData}
-            color="var(--info)"
-            label="Broker count"
-            emptyTitle="No broker trend yet"
-            emptyDetail="The collector needs at least one sample for the selected date."
-          />
-        </section>
-
-        <section className="panel dashboard-panel">
-          <div className="panel-heading">
-            <div>
-              <h2>Topic TOP 10</h2>
-              <p>Ranked by current total messages.</p>
+              <CardTitle>Top topics</CardTitle>
+              <CardDescription>Ranked by currently reported total messages.</CardDescription>
             </div>
             <StatusBadge status={`${topicCurrent.totalTopics} observed`} />
-          </div>
-          <RankingTable
-            rows={topicRankingRows}
-            valueLabel="TotalMsg"
-            accent="var(--accent)"
-            emptyTitle="No topic ranking"
-            emptyDetail="Topics with zero messages are hidden from TOP ranking."
-            formatValue={formatNumber}
-          />
-        </section>
+          </CardHeader>
+          <CardContent>
+            <RankingTable
+              rows={topicRankingRows}
+              valueLabel="Messages"
+              accent="var(--primary)"
+              emptyTitle="No topic ranking"
+              emptyDetail="Topic metrics are not available for the current cluster."
+              formatValue={formatDashboardMetric}
+            />
+          </CardContent>
+        </Card>
+      </div>
 
-        <section className="panel dashboard-panel">
-          <div className="panel-heading">
+      <div className="dashboard-history-grid">
+        <HistoryCard
+          title="Broker activity"
+          description="Collected broker count samples for the selected date."
+          series={brokerHistory}
+          error={brokerHistoryError}
+          loading={historyLoading}
+          errorTitle="Broker history unavailable"
+          data={brokerHistoryData}
+          color="var(--info)"
+          label="Broker count"
+        />
+
+        <Card className="dashboard-history-card">
+          <CardHeader>
             <div>
-              <h2>Topic 5min trend</h2>
-              <p>Select topic, then query `/api/dashboard/topics/history`.</p>
+              <CardTitle>Topic activity</CardTitle>
+              <CardDescription>
+                {selectedTopic ? 'Collected total message samples for the selected topic.' : 'Topic count collected across the cluster.'}
+              </CardDescription>
             </div>
-            <select className="dashboard-select" value={selectedTopic} onChange={(event) => setSelectedTopic(event.target.value)}>
+            <select
+              className="dashboard-topic-select"
+              aria-label="Topic history filter"
+              value={selectedTopic}
+              onChange={(event) => {
+                setHistoryLoading(true);
+                setTopicHistory(null);
+                setSelectedTopic(event.target.value);
+              }}
+            >
               <option value="">All topics</option>
-              {topicCurrent.topTopics.map((topic) => (
-                <option key={topic.topic} value={topic.topic}>
-                  {topic.topic}
-                </option>
+              {topTopics.map((topic) => (
+                <option key={topic.topic} value={topic.topic}>{topic.topic}</option>
               ))}
             </select>
-          </div>
-          <TrendAreaChart
-            data={topicHistoryData}
-            color="var(--accent)"
-            label="TotalMsg"
-            emptyTitle="No topic trend yet"
-            emptyDetail="The collector needs samples for the selected date and topic."
-          />
-        </section>
+          </CardHeader>
+          <CardContent>
+            {historyLoading ? (
+              <LoadingState label="Loading topic history" />
+            ) : topicHistoryError ? (
+              <HistoryUnavailable title="Topic history unavailable" detail={topicHistoryError} />
+            ) : topicHistory?.collected ? (
+              <TrendAreaChart
+                data={topicHistoryData}
+                color="var(--primary)"
+                label={selectedTopic ? 'Total messages' : 'Topic count'}
+                emptyTitle="No topic samples"
+                emptyDetail="No collected topic points match these filters."
+              />
+            ) : (
+              <EmptyState title="Topic history is warming up" detail="The collector has not stored a sample for these filters yet." />
+            )}
+          </CardContent>
+        </Card>
       </div>
-    </>
+    </div>
   );
 }
 
-function BrokerOverviewTable({ rows }: { rows: BrokerOverviewRow[] }) {
-  if (rows.length === 0) {
-    return <EmptyState title="No broker data" />;
-  }
+interface HealthSignalProps {
+  icon: ReactNode;
+  label: string;
+  value: string;
+  tone?: 'success' | 'warning' | 'danger';
+}
 
+function HealthSignal({ icon, label, value, tone }: HealthSignalProps) {
   return (
-    <div className="broker-overview-table-shell">
-      <div className="table-scroll">
-        <table className="broker-overview-table">
-          <thead>
-            <tr>
-              <th>Broker name</th>
-              <th>Broker address</th>
-              <th>Total messages received today</th>
-              <th>Today Produce Count</th>
-              <th>Yesterday Produce Count</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((row) => (
-              <tr key={`${row.brokerName}-${row.address}`}>
-                <td>
-                  <code>{row.brokerName}</code>
-                </td>
-                <td>
-                  <code>{row.address}</code>
-                </td>
-                <td>{formatNumber(row.totalMessagesReceivedToday)}</td>
-                <td>{formatNumber(row.todayProduceCount)}</td>
-                <td>{formatNumber(row.yesterdayProduceCount)}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+    <div className={`health-signal${tone ? ` health-${tone}` : ''}`}>
+      <span className="health-signal-icon" aria-hidden="true">{icon}</span>
+      <span>{label}</span>
+      <strong title={value}>{value}</strong>
+    </div>
+  );
+}
+
+interface HistoryCardProps {
+  title: string;
+  description: string;
+  series: DashboardHistorySeries | null;
+  error: string | null;
+  loading: boolean;
+  errorTitle: string;
+  data: Array<{ time: string; value: number }>;
+  color: string;
+  label: string;
+}
+
+function HistoryCard({ title, description, series, error, loading, errorTitle, data, color, label }: HistoryCardProps) {
+  return (
+    <Card className="dashboard-history-card">
+      <CardHeader>
+        <div>
+          <CardTitle>{title}</CardTitle>
+          <CardDescription>{description}</CardDescription>
+        </div>
+        <StatusBadge
+          status={loading ? 'Loading' : error ? 'Unavailable' : series?.collected ? 'Collected' : 'Warming up'}
+          tone={loading ? undefined : error ? 'danger' : series?.collected ? 'success' : 'warning'}
+        />
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <LoadingState label={`Loading ${title.toLowerCase()}`} />
+        ) : error ? (
+          <HistoryUnavailable title={errorTitle} detail={error} />
+        ) : series?.collected ? (
+          <TrendAreaChart
+            data={data}
+            color={color}
+            label={label}
+            emptyTitle="No samples"
+            emptyDetail="No collected points match the selected date."
+          />
+        ) : (
+          <EmptyState title={`${title} is warming up`} detail="The collector has not stored a sample for this date yet." />
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function HistoryUnavailable({ title, detail }: { title: string; detail: string }) {
+  return (
+    <div className="history-unavailable" role="status" aria-label={title} aria-live="polite">
+      <Activity size={22} aria-hidden="true" />
+      <strong>{title}</strong>
+      <span>{detail}</span>
     </div>
   );
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/brokers/BrokerDetailContent.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/brokers/BrokerDetailContent.test.tsx
@@ -1,0 +1,192 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { brokerApi } from '../../api/broker_api';
+import { renderAtRoute } from '../../test/render';
+import type { BrokerInfo } from '../../types/broker';
+import BrokerDetailContent from './BrokerDetailContent';
+
+vi.mock('../../api/broker_api', () => ({
+  brokerApi: {
+    runtime: vi.fn(),
+    config: vi.fn(),
+    updateConfig: vi.fn()
+  }
+}));
+
+const broker: BrokerInfo = {
+  clusterName: 'DefaultCluster',
+  brokerName: 'broker-a',
+  brokerId: 0,
+  address: '127.0.0.1:10911',
+  role: 'MASTER',
+  version: '5.3.2',
+  produceTps: 128.4,
+  consumeTps: 98.2
+};
+
+const brokerB: BrokerInfo = {
+  ...broker,
+  brokerName: 'broker-b',
+  address: '127.0.0.1:20911',
+  version: '5.4.0'
+};
+
+describe('BrokerDetailContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(brokerApi.runtime).mockResolvedValue({
+      brokerName: 'broker-a',
+      address: broker.address,
+      entries: { brokerVersion: '5.3.2', putTps: '128.4' }
+    });
+    vi.mocked(brokerApi.config).mockResolvedValue({
+      brokerName: 'broker-a',
+      address: broker.address,
+      entries: { sendMessageThreadPoolNums: '16' }
+    });
+    vi.mocked(brokerApi.updateConfig).mockResolvedValue({ message: 'updated' });
+  });
+
+  it('shows the broker overview without eagerly loading runtime or configuration', () => {
+    renderAtRoute(<BrokerDetailContent brokerName="broker-a" broker={broker} />, '/brokers');
+
+    expect(screen.getByText('DefaultCluster')).toBeInTheDocument();
+    expect(screen.getByText('127.0.0.1:10911')).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Produce TPS: 128.4' })).toBeInTheDocument();
+    expect(brokerApi.runtime).not.toHaveBeenCalled();
+    expect(brokerApi.config).not.toHaveBeenCalled();
+  });
+
+  it('loads runtime data once on demand and caches it for the open session', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<BrokerDetailContent brokerName="broker-a" broker={broker} />, '/brokers');
+
+    await user.click(screen.getByRole('tab', { name: 'Runtime' }));
+    expect(await screen.findByText('brokerVersion')).toBeInTheDocument();
+    await user.click(screen.getByRole('tab', { name: 'Overview' }));
+    await user.click(screen.getByRole('tab', { name: 'Runtime' }));
+
+    expect(brokerApi.runtime).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a failed lazy runtime request', async () => {
+    const user = userEvent.setup();
+    vi.mocked(brokerApi.runtime).mockRejectedValueOnce(new Error('runtime unavailable'));
+    renderAtRoute(<BrokerDetailContent brokerName="broker-a" />, '/brokers');
+
+    await user.click(screen.getByRole('tab', { name: 'Runtime' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('runtime unavailable');
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(await screen.findByText('brokerVersion')).toBeInTheDocument();
+    expect(brokerApi.runtime).toHaveBeenCalledTimes(2);
+  });
+
+  it('validates JSON objects and protects configuration updates with confirmation', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<BrokerDetailContent brokerName="broker-a" broker={broker} />, '/brokers');
+
+    await user.click(screen.getByRole('tab', { name: 'Configuration' }));
+    expect(await screen.findByText('sendMessageThreadPoolNums')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Edit configuration' }));
+
+    const editor = screen.getByRole('textbox', { name: 'Broker configuration JSON' });
+    fireEvent.change(editor, { target: { value: '[]' } });
+    await user.click(screen.getByRole('button', { name: 'Review changes' }));
+    expect(screen.getByText('Broker config must be a JSON object.')).toBeInTheDocument();
+    expect(editor).toHaveValue('[]');
+
+    fireEvent.change(editor, { target: { value: '{"threads":8}' } });
+    await user.click(screen.getByRole('button', { name: 'Review changes' }));
+    expect(screen.getByText('Broker config values must be strings.')).toBeInTheDocument();
+
+    fireEvent.change(editor, { target: { value: '{"threads":"8","enabled":"true"}' } });
+    await user.click(screen.getByRole('button', { name: 'Review changes' }));
+    expect(await screen.findByRole('alertdialog')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Apply configuration' }));
+
+    await waitFor(() => expect(brokerApi.updateConfig).toHaveBeenCalledWith('broker-a', {
+      entries: { threads: '8', enabled: 'true' }
+    }));
+  });
+
+  it('preserves the editable draft when a configuration update fails', async () => {
+    const user = userEvent.setup();
+    vi.mocked(brokerApi.updateConfig).mockRejectedValueOnce(new Error('write rejected'));
+    renderAtRoute(<BrokerDetailContent brokerName="broker-a" broker={broker} />, '/brokers');
+
+    await user.click(screen.getByRole('tab', { name: 'Configuration' }));
+    await screen.findByText('sendMessageThreadPoolNums');
+    await user.click(screen.getByRole('button', { name: 'Edit configuration' }));
+    const editor = screen.getByRole('textbox', { name: 'Broker configuration JSON' });
+    fireEvent.change(editor, { target: { value: '{"sendMessageThreadPoolNums":"24"}' } });
+    await user.click(screen.getByRole('button', { name: 'Review changes' }));
+    await user.click(await screen.findByRole('button', { name: 'Apply configuration' }));
+
+    expect(await screen.findByText('write rejected')).toBeInTheDocument();
+    expect(editor).toBeInTheDocument();
+    expect(editor).toHaveValue('{"sendMessageThreadPoolNums":"24"}');
+  });
+
+  it('ignores late runtime responses after switching brokers', async () => {
+    let resolveBrokerA: (value: Awaited<ReturnType<typeof brokerApi.runtime>>) => void = () => undefined;
+    vi.mocked(brokerApi.runtime).mockImplementation((brokerName) => {
+      if (brokerName === 'broker-a') {
+        return new Promise((resolve) => { resolveBrokerA = resolve; });
+      }
+      return Promise.resolve({
+        brokerName: 'broker-b',
+        address: brokerB.address,
+        entries: { activeBrokerMarker: 'broker-b-runtime' }
+      });
+    });
+
+    const { rerender } = render(<BrokerDetailContent brokerName="broker-a" broker={broker} initialTab="runtime" />);
+    await waitFor(() => expect(brokerApi.runtime).toHaveBeenCalledWith('broker-a'));
+
+    rerender(<BrokerDetailContent brokerName="broker-b" broker={brokerB} initialTab="runtime" />);
+    expect(await screen.findByText('broker-b-runtime')).toBeInTheDocument();
+
+    resolveBrokerA({
+      brokerName: 'broker-a',
+      address: broker.address,
+      entries: { staleBrokerMarker: 'broker-a-runtime' }
+    });
+    await waitFor(() => expect(screen.queryByText('broker-a-runtime')).not.toBeInTheDocument());
+    expect(screen.getByText('broker-b-runtime')).toBeInTheDocument();
+  });
+
+  it('clears a pending configuration confirmation when switching brokers', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<BrokerDetailContent brokerName="broker-a" broker={broker} />);
+
+    await user.click(screen.getByRole('tab', { name: 'Configuration' }));
+    await screen.findByText('sendMessageThreadPoolNums');
+    await user.click(screen.getByRole('button', { name: 'Edit configuration' }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Broker configuration JSON' }), {
+      target: { value: '{"sendMessageThreadPoolNums":"24"}' }
+    });
+    await user.click(screen.getByRole('button', { name: 'Review changes' }));
+    expect(await screen.findByRole('alertdialog')).toHaveTextContent('broker-a');
+
+    rerender(<BrokerDetailContent brokerName="broker-b" broker={brokerB} />);
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument());
+    expect(brokerApi.updateConfig).not.toHaveBeenCalled();
+  });
+
+  it('clears the previous success message when a new edit begins', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<BrokerDetailContent brokerName="broker-a" broker={broker} />, '/brokers');
+
+    await user.click(screen.getByRole('tab', { name: 'Configuration' }));
+    await screen.findByText('sendMessageThreadPoolNums');
+    await user.click(screen.getByRole('button', { name: 'Edit configuration' }));
+    await user.click(screen.getByRole('button', { name: 'Review changes' }));
+    await user.click(await screen.findByRole('button', { name: 'Apply configuration' }));
+    expect(await screen.findByText('Configuration updated.')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Edit configuration' }));
+    expect(screen.queryByText('Configuration updated.')).not.toBeInTheDocument();
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/brokers/BrokerDetailContent.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/brokers/BrokerDetailContent.tsx
@@ -1,0 +1,286 @@
+import { AlertTriangle, CheckCircle2, Pencil, Save, X } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { brokerApi } from '../../api/broker_api';
+import ErrorState from '../../components/ErrorState';
+import KeyValueTable from '../../components/KeyValueTable';
+import LoadingState from '../../components/LoadingState';
+import MetricCard from '../../components/MetricCard';
+import StatusBadge from '../../components/StatusBadge';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogTitle
+} from '../../components/ui/AlertDialog';
+import { Button } from '../../components/ui/Button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../components/ui/Tabs';
+import type { BrokerConfigView, BrokerInfo, BrokerRuntimeStats } from '../../types/broker';
+
+export type BrokerDetailTab = 'overview' | 'runtime' | 'configuration';
+
+interface BrokerDetailContentProps {
+  brokerName: string;
+  broker?: BrokerInfo;
+  initialTab?: BrokerDetailTab;
+}
+
+function toRows(entries: Record<string, string> | undefined) {
+  return Object.entries(entries ?? {})
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => ({ key, value }));
+}
+
+export default function BrokerDetailContent({ brokerName, broker, initialTab = 'overview' }: BrokerDetailContentProps) {
+  const [activeTab, setActiveTab] = useState<BrokerDetailTab>(initialTab);
+  const [runtime, setRuntime] = useState<BrokerRuntimeStats | null>(null);
+  const [runtimeLoading, setRuntimeLoading] = useState(false);
+  const [runtimeError, setRuntimeError] = useState<string | null>(null);
+  const [config, setConfig] = useState<BrokerConfigView | null>(null);
+  const [configLoading, setConfigLoading] = useState(false);
+  const [configError, setConfigError] = useState<string | null>(null);
+  const [editing, setEditing] = useState(false);
+  const [configDraft, setConfigDraft] = useState('{}');
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [pendingEntries, setPendingEntries] = useState<Record<string, string> | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const brokerNameRef = useRef(brokerName);
+  const runtimeRequestRef = useRef(0);
+  const configRequestRef = useRef(0);
+  const saveRequestRef = useRef(0);
+  brokerNameRef.current = brokerName;
+
+  useEffect(() => {
+    runtimeRequestRef.current += 1;
+    configRequestRef.current += 1;
+    saveRequestRef.current += 1;
+    setActiveTab(initialTab);
+    setRuntime(null);
+    setRuntimeLoading(false);
+    setRuntimeError(null);
+    setConfig(null);
+    setConfigLoading(false);
+    setConfigError(null);
+    setEditing(false);
+    setConfigDraft('{}');
+    setValidationError(null);
+    setPendingEntries(null);
+    setConfirmOpen(false);
+    setSaving(false);
+    setSaveMessage(null);
+    setSaveError(null);
+  }, [brokerName, initialTab]);
+
+  const loadRuntime = useCallback(async () => {
+    const requestBroker = brokerName;
+    const requestId = ++runtimeRequestRef.current;
+    setRuntimeLoading(true);
+    setRuntimeError(null);
+    try {
+      const nextRuntime = await brokerApi.runtime(requestBroker);
+      if (requestId !== runtimeRequestRef.current || brokerNameRef.current !== requestBroker) return;
+      setRuntime(nextRuntime);
+    } catch (requestError) {
+      if (requestId !== runtimeRequestRef.current || brokerNameRef.current !== requestBroker) return;
+      setRuntimeError(requestError instanceof Error ? requestError.message : String(requestError));
+    } finally {
+      if (requestId === runtimeRequestRef.current && brokerNameRef.current === requestBroker) setRuntimeLoading(false);
+    }
+  }, [brokerName]);
+
+  const loadConfig = useCallback(async () => {
+    const requestBroker = brokerName;
+    const requestId = ++configRequestRef.current;
+    setConfigLoading(true);
+    setConfigError(null);
+    try {
+      const nextConfig = await brokerApi.config(requestBroker);
+      if (requestId !== configRequestRef.current || brokerNameRef.current !== requestBroker) return;
+      setConfig(nextConfig);
+      setConfigDraft(JSON.stringify(nextConfig.entries, null, 2));
+    } catch (requestError) {
+      if (requestId !== configRequestRef.current || brokerNameRef.current !== requestBroker) return;
+      setConfigError(requestError instanceof Error ? requestError.message : String(requestError));
+    } finally {
+      if (requestId === configRequestRef.current && brokerNameRef.current === requestBroker) setConfigLoading(false);
+    }
+  }, [brokerName]);
+
+  useEffect(() => {
+    if (activeTab === 'runtime' && !runtime && !runtimeLoading && !runtimeError) void loadRuntime();
+    if (activeTab === 'configuration' && !config && !configLoading && !configError) void loadConfig();
+  }, [activeTab, config, configError, configLoading, loadConfig, loadRuntime, runtime, runtimeError, runtimeLoading]);
+
+  const runtimeRows = useMemo(() => toRows(runtime?.entries), [runtime]);
+  const configRows = useMemo(() => toRows(config?.entries), [config]);
+
+  const reviewChanges = () => {
+    setValidationError(null);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(configDraft);
+    } catch {
+      setValidationError('Broker config must be a JSON object.');
+      return;
+    }
+
+    if (parsed === null || Array.isArray(parsed) || typeof parsed !== 'object') {
+      setValidationError('Broker config must be a JSON object.');
+      return;
+    }
+
+    const parsedEntries = Object.entries(parsed);
+    if (parsedEntries.some(([, value]) => typeof value !== 'string')) {
+      setValidationError('Broker config values must be strings.');
+      return;
+    }
+
+    const entries = Object.fromEntries(parsedEntries) as Record<string, string>;
+    setPendingEntries(entries);
+    setConfirmOpen(true);
+  };
+
+  const saveConfiguration = async () => {
+    if (!pendingEntries) return;
+    const requestBroker = brokerName;
+    const requestEntries = pendingEntries;
+    const requestId = ++saveRequestRef.current;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await brokerApi.updateConfig(requestBroker, { entries: requestEntries });
+      if (requestId !== saveRequestRef.current || brokerNameRef.current !== requestBroker) return;
+      setConfig((current) => ({
+        brokerName: requestBroker,
+        address: current?.address ?? broker?.address ?? '',
+        entries: requestEntries
+      }));
+      setConfigDraft(JSON.stringify(requestEntries, null, 2));
+      setEditing(false);
+      setConfirmOpen(false);
+      setPendingEntries(null);
+      setSaveMessage('Configuration updated.');
+    } catch (requestError) {
+      if (requestId !== saveRequestRef.current || brokerNameRef.current !== requestBroker) return;
+      setSaveError(requestError instanceof Error ? requestError.message : String(requestError));
+      setConfirmOpen(false);
+    } finally {
+      if (requestId === saveRequestRef.current && brokerNameRef.current === requestBroker) setSaving(false);
+    }
+  };
+
+  return (
+    <div className="broker-detail-content">
+      <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as BrokerDetailTab)}>
+        <TabsList aria-label="Broker detail sections">
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="runtime">Runtime</TabsTrigger>
+          <TabsTrigger value="configuration">Configuration</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="overview">
+          <div className="broker-identity-grid">
+            <IdentityItem label="Broker" value={brokerName} mono />
+            <IdentityItem label="Cluster" value={broker?.clusterName ?? 'Available from cluster inventory'} />
+            <IdentityItem label="Address" value={broker?.address ?? 'Available in runtime data'} mono />
+            <IdentityItem label="Version" value={broker?.version || 'Available from cluster inventory'} />
+            <IdentityItem label="Broker ID" value={broker ? String(broker.brokerId) : '—'} />
+            <IdentityItem label="Role" value={broker?.role ?? 'Unknown'} status />
+          </div>
+          {broker ? (
+            <div className="broker-throughput-grid">
+              <MetricCard label="Produce TPS" value={broker.produceTps} detail="Current reported ingress" />
+              <MetricCard label="Consume TPS" value={broker.consumeTps} detail="Current reported egress" />
+              <MetricCard label="Combined TPS" value={Number((broker.produceTps + broker.consumeTps).toFixed(2))} detail="Produce plus consume" />
+            </div>
+          ) : null}
+        </TabsContent>
+
+        <TabsContent value="runtime">
+          <section className="broker-detail-section">
+            <div className="broker-detail-section-heading">
+              <div>
+                <h3>Runtime snapshot</h3>
+                <p>Live broker counters and process-level values.</p>
+              </div>
+              {runtime ? <Button type="button" variant="outline" size="sm" onClick={() => void loadRuntime()}>Refresh</Button> : null}
+            </div>
+            {runtimeLoading ? <LoadingState label="Loading broker runtime" /> : null}
+            {!runtimeLoading && runtimeError ? <ErrorState message={runtimeError} onRetry={() => void loadRuntime()} /> : null}
+            {!runtimeLoading && !runtimeError && runtime ? <KeyValueTable rows={runtimeRows} emptyTitle="No runtime stats" /> : null}
+          </section>
+        </TabsContent>
+
+        <TabsContent value="configuration">
+          <section className="broker-detail-section">
+            <div className="broker-detail-section-heading">
+              <div>
+                <h3>Broker configuration</h3>
+                <p>Review the active key/value configuration before applying changes.</p>
+              </div>
+              {config && !editing ? (
+                <Button type="button" variant="outline" size="sm" onClick={() => { setEditing(true); setValidationError(null); setSaveMessage(null); setSaveError(null); }}>
+                  <Pencil size={14} aria-hidden="true" /> Edit configuration
+                </Button>
+              ) : null}
+            </div>
+            {configLoading ? <LoadingState label="Loading broker configuration" /> : null}
+            {!configLoading && configError ? <ErrorState message={configError} onRetry={() => void loadConfig()} /> : null}
+            {!configLoading && !configError && config && !editing ? <KeyValueTable rows={configRows} emptyTitle="No broker configuration" /> : null}
+            {!configLoading && !configError && config && editing ? (
+              <div className="broker-config-editor">
+                <label htmlFor="broker-config-json">Broker configuration JSON</label>
+                <textarea
+                  id="broker-config-json"
+                  aria-label="Broker configuration JSON"
+                  value={configDraft}
+                  onChange={(event) => setConfigDraft(event.target.value)}
+                  spellCheck={false}
+                />
+                {validationError ? <div className="inline-validation" role="status"><AlertTriangle size={15} aria-hidden="true" />{validationError}</div> : null}
+                {saveError ? <div className="inline-validation" role="alert"><AlertTriangle size={15} aria-hidden="true" />{saveError}</div> : null}
+                <div className="broker-config-actions">
+                  <Button type="button" variant="ghost" onClick={() => { setEditing(false); setConfigDraft(JSON.stringify(config.entries, null, 2)); setValidationError(null); setSaveError(null); }}>
+                    <X size={14} aria-hidden="true" /> Cancel
+                  </Button>
+                  <Button type="button" onClick={reviewChanges}>
+                    <Save size={14} aria-hidden="true" /> Review changes
+                  </Button>
+                </div>
+              </div>
+            ) : null}
+            {saveMessage ? <div className="inline-success" role="status"><CheckCircle2 size={15} aria-hidden="true" />{saveMessage}</div> : null}
+          </section>
+        </TabsContent>
+      </Tabs>
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogTitle>Apply broker configuration?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This writes {pendingEntries ? Object.keys(pendingEntries).length : 0} configuration entries to {brokerName}.
+          </AlertDialogDescription>
+          <div className="dialog-actions">
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction disabled={saving} onClick={() => void saveConfiguration()}>
+              Apply configuration
+            </AlertDialogAction>
+          </div>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+function IdentityItem({ label, value, mono = false, status = false }: { label: string; value: string; mono?: boolean; status?: boolean }) {
+  return (
+    <div className="broker-identity-item">
+      <span>{label}</span>
+      {status ? <StatusBadge status={value} tone={value === 'Unknown' ? 'neutral' : 'info'} /> : <strong className={mono ? 'mono' : undefined}>{value}</strong>}
+    </div>
+  );
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/dashboard/dashboard-model.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/dashboard/dashboard-model.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import type { DashboardOverview, TopicCurrentMetric } from '../../types/dashboard';
+import { buildDashboardAdvisories, formatDashboardMetric, sortTopTopics } from './dashboard-model';
+
+const healthyOverview: DashboardOverview = {
+  currentNamesrv: '127.0.0.1:9876',
+  brokerCount: 3,
+  topicCount: 8,
+  consumerGroupCount: 4,
+  producerCount: 5,
+  messageBacklog: 0,
+  systemStatus: 'UP'
+};
+
+describe('dashboard model', () => {
+  it('builds actionable advisories only from overview evidence', () => {
+    expect(buildDashboardAdvisories(healthyOverview)).toEqual([]);
+
+    const advisories = buildDashboardAdvisories({
+      ...healthyOverview,
+      currentNamesrv: null,
+      brokerCount: 0,
+      messageBacklog: 14_200,
+      systemStatus: 'DEGRADED'
+    });
+
+    expect(advisories.map((advisory) => [advisory.id, advisory.target])).toEqual([
+      ['system-status', '/brokers'],
+      ['nameserver', '/config'],
+      ['brokers', '/brokers'],
+      ['backlog', '/consumers']
+    ]);
+    expect(advisories[3].detail).toContain('14,200');
+  });
+
+  it('formats compact operational metrics without hiding zero', () => {
+    expect(formatDashboardMetric(0)).toBe('0');
+    expect(formatDashboardMetric(999)).toBe('999');
+    expect(formatDashboardMetric(1_250)).toBe('1.25K');
+    expect(formatDashboardMetric(2_500_000)).toBe('2.5M');
+  });
+
+  it('sorts top topics stably without mutating API arrays', () => {
+    const topics: TopicCurrentMetric[] = [
+      { topic: 'orders', totalMsg: 20, inTps: 2, outTps: 1 },
+      { topic: 'payments', totalMsg: 40, inTps: 4, outTps: 3 },
+      { topic: 'inventory', totalMsg: 40, inTps: 1, outTps: 1 }
+    ];
+    const snapshot = structuredClone(topics);
+
+    expect(sortTopTopics(topics).map((topic) => topic.topic)).toEqual(['payments', 'inventory', 'orders']);
+    expect(topics).toEqual(snapshot);
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/dashboard/dashboard-model.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/dashboard/dashboard-model.ts
@@ -1,0 +1,79 @@
+import type { DashboardOverview, TopicCurrentMetric } from '../../types/dashboard';
+
+export interface DashboardAdvisory {
+  id: 'system-status' | 'nameserver' | 'brokers' | 'backlog';
+  title: string;
+  detail: string;
+  target: '/brokers' | '/config' | '/consumers';
+  actionLabel: string;
+  tone: 'warning' | 'destructive' | 'info';
+}
+
+export function buildDashboardAdvisories(overview: DashboardOverview): DashboardAdvisory[] {
+  const advisories: DashboardAdvisory[] = [];
+
+  if (overview.systemStatus.toUpperCase() !== 'UP') {
+    advisories.push({
+      id: 'system-status',
+      title: `System status is ${overview.systemStatus}`,
+      detail: 'Inspect the broker inventory for the current cluster state.',
+      target: '/brokers',
+      actionLabel: 'Inspect cluster',
+      tone: 'warning'
+    });
+  }
+
+  if (!overview.currentNamesrv) {
+    advisories.push({
+      id: 'nameserver',
+      title: 'NameServer is not configured',
+      detail: 'Configure a NameServer address before running admin queries.',
+      target: '/config',
+      actionLabel: 'Open OPS',
+      tone: 'destructive'
+    });
+  }
+
+  if (overview.brokerCount === 0) {
+    advisories.push({
+      id: 'brokers',
+      title: 'No brokers are visible',
+      detail: 'The current NameServer response contains no broker entries.',
+      target: '/brokers',
+      actionLabel: 'Open cluster',
+      tone: 'destructive'
+    });
+  }
+
+  if (overview.messageBacklog > 0) {
+    advisories.push({
+      id: 'backlog',
+      title: 'Consumer backlog requires review',
+      detail: `${new Intl.NumberFormat('en-US').format(Math.round(overview.messageBacklog))} messages are waiting across consumer groups.`,
+      target: '/consumers',
+      actionLabel: 'Inspect consumers',
+      tone: 'warning'
+    });
+  }
+
+  return advisories;
+}
+
+function trimCompact(value: number) {
+  return value.toFixed(2).replace(/\.0+$|(?<=\.[0-9])0$/, '');
+}
+
+export function formatDashboardMetric(value: number) {
+  const absolute = Math.abs(value);
+  if (absolute >= 1_000_000) return `${trimCompact(value / 1_000_000)}M`;
+  if (absolute >= 1_000) return `${trimCompact(value / 1_000)}K`;
+  return new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(value);
+}
+
+export function sortTopTopics(topics: TopicCurrentMetric[], limit = 10) {
+  return topics
+    .map((topic, index) => ({ topic, index }))
+    .sort((left, right) => right.topic.totalMsg - left.topic.totalMsg || left.index - right.index)
+    .slice(0, limit)
+    .map(({ topic }) => topic);
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/pages.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/pages.css
@@ -1,0 +1,590 @@
+/* Shared operational workspaces */
+.operations-dashboard,
+.cluster-inventory-page,
+.broker-detail-page {
+  display: grid;
+  gap: 16px;
+}
+
+.query-toolbar {
+  display: flex;
+  min-height: 64px;
+  align-items: end;
+  gap: 12px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--card);
+}
+
+.query-search {
+  position: relative;
+  flex: 1 1 280px;
+  min-width: 220px;
+}
+
+.query-search > svg {
+  position: absolute;
+  top: 50%;
+  left: 11px;
+  z-index: 1;
+  color: var(--muted-foreground);
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+
+.query-search .ui-input {
+  padding-left: 34px;
+  background: var(--background);
+}
+
+.query-filters,
+.query-actions {
+  display: flex;
+  align-items: end;
+  gap: 10px;
+}
+
+.query-actions {
+  margin-left: auto;
+}
+
+.native-filter-field {
+  display: grid;
+  gap: 5px;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.native-filter-field select,
+.dashboard-topic-select,
+.dashboard-date-field {
+  min-height: 36px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--background);
+  color: var(--foreground);
+}
+
+.native-filter-field select,
+.dashboard-topic-select {
+  min-width: 160px;
+  padding: 0 32px 0 10px;
+}
+
+.app-data-table {
+  min-width: 0;
+  background: var(--card);
+}
+
+.app-data-table-scroll {
+  overflow: auto;
+}
+
+.app-data-table table {
+  min-width: 1120px;
+}
+
+.app-data-table th {
+  height: 42px;
+  background: var(--chrome);
+  color: var(--muted-foreground);
+  font-size: 11px;
+  letter-spacing: 0.045em;
+  text-transform: uppercase;
+}
+
+.app-data-table td {
+  height: 52px;
+}
+
+.app-data-table-row-interactive {
+  cursor: pointer;
+}
+
+.app-data-table-row-interactive:hover td,
+.app-data-table-row-interactive:focus-visible td {
+  background: var(--muted-surface);
+}
+
+.app-data-table-row-interactive:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: -2px;
+}
+
+.app-data-table-footer {
+  display: flex;
+  min-height: 54px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 14px;
+  border-top: 1px solid var(--border);
+  color: var(--muted-foreground);
+  font-size: 12px;
+}
+
+.app-data-table-pagination {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.entity-sheet {
+  width: min(680px, 100vw) !important;
+  padding: 20px;
+  background: var(--card);
+  box-shadow: -18px 0 40px rgb(0 0 0 / 0.28);
+}
+
+.entity-sheet-header {
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.entity-sheet-body {
+  padding-top: 16px;
+}
+
+/* Dashboard */
+.dashboard-date-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0 9px;
+  color: var(--muted-foreground);
+}
+
+.dashboard-date-field input {
+  width: 126px;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--foreground);
+  font-size: 12px;
+}
+
+.dashboard-health-rail {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  overflow: hidden;
+}
+
+.health-signal {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 3px 8px;
+  padding: 12px 14px;
+  border-right: 1px solid var(--border);
+}
+
+.health-signal:last-child {
+  border-right: 0;
+}
+
+.health-signal-icon {
+  grid-row: 1 / 3;
+  display: grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--info);
+  background: var(--chrome);
+}
+
+.health-signal > span:not(.health-signal-icon) {
+  color: var(--muted-foreground);
+  font-size: 11px;
+}
+
+.health-signal strong {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--foreground);
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.health-success .health-signal-icon { color: var(--success); }
+.health-warning .health-signal-icon { color: var(--warning); }
+.health-danger .health-signal-icon { color: var(--destructive); }
+
+.dashboard-metrics-flat .metric-card,
+.cluster-metrics .metric-card {
+  box-shadow: none;
+}
+
+.dashboard-metrics-flat .metric-card::before {
+  content: none;
+  background: none;
+}
+
+.dashboard-metrics-flat .metric-icon,
+.cluster-metrics .metric-icon {
+  width: 36px;
+  height: 36px;
+  border: 1px solid var(--border);
+  color: var(--primary);
+  background: var(--chrome);
+  box-shadow: none;
+}
+
+.dashboard-metrics-flat .metric-icon::before,
+.dashboard-metrics-flat .metric-icon::after {
+  content: none;
+}
+
+.dashboard-main-grid,
+.dashboard-history-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.08fr) minmax(0, 0.92fr);
+  align-items: start;
+  gap: 16px;
+}
+
+.dashboard-main-grid .ui-card,
+.dashboard-history-grid .ui-card {
+  min-width: 0;
+}
+
+.dashboard-main-grid .ui-card-header,
+.dashboard-history-grid .ui-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.advisory-list {
+  display: grid;
+  gap: 8px;
+}
+
+.advisory-item {
+  display: flex;
+  min-height: 68px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 11px 12px;
+  border: 1px solid var(--border);
+  border-left-width: 3px;
+  border-radius: var(--radius-sm);
+  background: var(--chrome);
+}
+
+.advisory-warning { border-left-color: var(--warning); }
+.advisory-destructive { border-left-color: var(--destructive); }
+.advisory-info { border-left-color: var(--info); }
+
+.advisory-item strong {
+  display: block;
+  font-size: 13px;
+}
+
+.advisory-item p {
+  margin: 4px 0 0;
+  color: var(--muted-foreground);
+  font-size: 12px;
+}
+
+.dashboard-ranking-card .ranking-row {
+  background: var(--card);
+}
+
+.dashboard-ranking-card .ranking-row:hover {
+  background: var(--muted-surface);
+}
+
+.dashboard-ranking-card .ranking-track span {
+  background: var(--rank-accent);
+}
+
+.dashboard-history-card .ui-card-content {
+  min-height: 286px;
+}
+
+.dashboard-topic-select {
+  max-width: 200px;
+}
+
+.history-unavailable {
+  min-height: 252px;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 8px;
+  color: var(--warning);
+  text-align: center;
+}
+
+.history-unavailable span {
+  color: var(--muted-foreground);
+  font-size: 12px;
+}
+
+/* Cluster inventory */
+.cluster-metrics {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.cluster-table-card {
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--card);
+}
+
+.broker-name-cell {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+}
+
+.broker-name-cell strong {
+  overflow: hidden;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-overflow: ellipsis;
+}
+
+.broker-name-cell a {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  gap: 4px;
+  color: var(--muted-foreground);
+  font-size: 11px;
+}
+
+/* Broker detail */
+.broker-detail-content .ui-tabs-list {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.broker-detail-content .ui-tabs-trigger {
+  width: 100%;
+}
+
+.broker-identity-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--border);
+}
+
+.broker-identity-item {
+  min-width: 0;
+  display: grid;
+  gap: 6px;
+  padding: 13px;
+  background: var(--card);
+}
+
+.broker-identity-item > span:first-child {
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.broker-identity-item strong {
+  overflow: hidden;
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.broker-throughput-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.broker-throughput-grid .metric-card {
+  box-shadow: none;
+}
+
+.broker-detail-section {
+  display: grid;
+  gap: 12px;
+}
+
+.broker-detail-section-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.broker-detail-section-heading h3 {
+  margin: 0;
+  font-size: 15px;
+}
+
+.broker-detail-section-heading p {
+  margin: 4px 0 0;
+  color: var(--muted-foreground);
+  font-size: 12px;
+}
+
+.broker-config-editor {
+  display: grid;
+  gap: 9px;
+}
+
+.broker-config-editor > label {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.broker-config-editor textarea {
+  width: 100%;
+  min-height: 360px;
+  resize: vertical;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 12px;
+  background: var(--background);
+  color: var(--foreground);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.broker-config-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.inline-validation,
+.inline-success {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 9px 10px;
+  border: 1px solid;
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+}
+
+.inline-validation {
+  border-color: color-mix(in srgb, var(--destructive) 46%, var(--border));
+  color: var(--destructive);
+  background: color-mix(in srgb, var(--destructive) 8%, var(--card));
+}
+
+.inline-success {
+  border-color: color-mix(in srgb, var(--success) 42%, var(--border));
+  color: var(--success);
+  background: color-mix(in srgb, var(--success) 8%, var(--card));
+}
+
+@media (max-width: 1050px) {
+  .dashboard-health-rail {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .health-signal:nth-child(3) {
+    border-right: 0;
+  }
+
+  .health-signal:nth-child(n + 4) {
+    border-top: 1px solid var(--border);
+  }
+
+  .dashboard-main-grid,
+  .dashboard-history-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (min-width: 761px) and (max-width: 900px) {
+  .dashboard-metrics-flat {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .dashboard-metrics-flat .metric-card:last-child {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 760px) {
+  .query-toolbar,
+  .query-filters {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .query-search,
+  .native-filter-field,
+  .native-filter-field select {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .query-actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  .dashboard-health-rail {
+    grid-template-columns: 1fr;
+  }
+
+  .health-signal,
+  .health-signal:nth-child(3) {
+    border-right: 0;
+    border-top: 1px solid var(--border);
+  }
+
+  .health-signal:first-child {
+    border-top: 0;
+  }
+
+  .dashboard-main-grid .ui-card-header,
+  .dashboard-history-grid .ui-card-header,
+  .advisory-item,
+  .broker-detail-section-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .advisory-item .ui-button {
+    width: 100%;
+  }
+
+  .dashboard-topic-select {
+    width: 100%;
+    max-width: none;
+  }
+
+  .cluster-metrics,
+  .broker-throughput-grid,
+  .broker-identity-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .entity-sheet {
+    padding: 16px;
+  }
+
+  .app-data-table-footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9413

### Brief Description

- Redesign the Dashboard as a dense dark operations workspace with live inventory, evidence-based advisories, ranked topics, and collection history.
- Redesign the Cluster page around searchable broker inventory, compact filters, pagination, and contextual broker details.
- Add accessible shared query, refresh, table, and detail-sheet primitives with keyboard-safe row activation and focus restoration.
- Protect dashboard and broker detail views from stale asynchronous responses, and validate destructive broker configuration updates before confirmation.
- Replace chart gradients with a restrained single-line visualization and add responsive page-level styling.

### How Did You Test This Change?

- `npm ci`
- `npm test -- --run` (45 tests passed)
- `npm run build`
- `git diff --check`
- Compared the Dashboard and Cluster implementations with the approved references at matching desktop viewports.
- Verified responsive behavior at 768x1024 and exercised topic/date filters, broker detail tabs, configuration validation, confirmation, and focus restoration in the browser.
