### PR TITLE
[ISSUE #9421]✨Unify Proxy Remoting routing across backends

### DIFF
--- a/rocketmq-client/src/lib.rs
+++ b/rocketmq-client/src/lib.rs
@@ -181,6 +181,20 @@ mod cluster_session {
             self.inner.start().await
         }
 
+        /// Invokes one canonical Remoting command on a Broker selected by a managed caller.
+        pub async fn invoke_remoting(
+            &self,
+            broker_addr: &CheetahString,
+            request: RemotingCommand,
+            timeout_millis: u64,
+        ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
+            let _operation = self.operation().await;
+            self.inner
+                .get_mq_client_api_impl()?
+                .invoke(broker_addr, request, timeout_millis)
+                .await
+        }
+
         /// Returns low-cardinality NameServer discovery state without endpoint identities.
         pub async fn nameserver_discovery_status(&self) -> Option<crate::NameServerDiscoveryStatus> {
             let _operation = self.operation().await;

--- a/rocketmq-proxy-cluster/src/cluster.rs
+++ b/rocketmq-proxy-cluster/src/cluster.rs
@@ -73,6 +73,7 @@ use rocketmq_protocol::protocol::header::pull_message_request_header::PullMessag
 use rocketmq_protocol::protocol::header::query_consumer_offset_request_header::QueryConsumerOffsetRequestHeader;
 use rocketmq_protocol::protocol::header::update_consumer_offset_header::UpdateConsumerOffsetRequestHeader;
 use rocketmq_protocol::protocol::heartbeat::message_model::MessageModel;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::route::topic_route_data::TopicRouteData;
 use rocketmq_protocol::protocol::route_facade::BrokerDataExt;
 use rocketmq_protocol::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
@@ -238,6 +239,17 @@ trait ClusterClientIo: Send + Sync {
     async fn start(&self) -> Result<(), RocketMQError>;
 
     async fn shutdown(&self);
+
+    async fn invoke_remoting(
+        &self,
+        _broker_addr: &CheetahString,
+        _request: RemotingCommand,
+        _timeout_millis: u64,
+    ) -> Result<RemotingCommand, RocketMQError> {
+        Err(RocketMQError::IllegalArgument(
+            "raw Remoting invocation is unavailable for this Client adapter".to_owned(),
+        ))
+    }
 
     async fn sync_lite_subscription(
         &self,
@@ -466,6 +478,15 @@ impl ClusterClientIo for ClientInstanceHandle {
 
     async fn shutdown(&self) {
         self.shutdown_owned().await;
+    }
+
+    async fn invoke_remoting(
+        &self,
+        broker_addr: &CheetahString,
+        request: RemotingCommand,
+        timeout_millis: u64,
+    ) -> Result<RemotingCommand, RocketMQError> {
+        ClientInstanceHandle::invoke_remoting(self, broker_addr, request, timeout_millis).await
     }
 
     async fn sync_lite_subscription(
@@ -882,6 +903,17 @@ impl RocketmqClusterClient {
 
     pub(crate) async fn unlock_batch_mq(&self, request: UnlockBatchRequestBody) -> ProxyResult<()> {
         self.executor.unlock_batch_mq(request).await
+    }
+
+    pub(crate) async fn forward_remoting(
+        &self,
+        broker_name: String,
+        request: RemotingCommand,
+        timeout_millis: u64,
+    ) -> ProxyResult<RemotingCommand> {
+        self.executor
+            .forward_remoting(broker_name, request, timeout_millis)
+            .await
     }
 }
 
@@ -1407,7 +1439,36 @@ async fn handle_cluster_command(config: &ClusterConfig, state: &mut ClusterWorke
         ClusterCommand::UnlockBatchMq { request, reply } => {
             let _ = reply.send(unlock_batch_mq_inner(config, state, request).await);
         }
+        ClusterCommand::ForwardRemoting {
+            broker_name,
+            request,
+            timeout_millis,
+            reply,
+        } => {
+            let _ = reply.send(forward_remoting_inner(config, state, broker_name, request, timeout_millis).await);
+        }
     }
+}
+
+async fn forward_remoting_inner(
+    config: &ClusterConfig,
+    state: &mut ClusterWorkerState,
+    broker_name: String,
+    request: RemotingCommand,
+    timeout_millis: u64,
+) -> ProxyResult<RemotingCommand> {
+    let client = state.client(config).await?;
+    let broker_name = CheetahString::from(broker_name);
+    let broker_addr = client
+        .find_subscribe_broker_addr(&broker_name, MASTER_ID, true)
+        .await
+        .ok_or_else(|| RocketMQError::BrokerNotFound {
+            name: broker_name.to_string(),
+        })?;
+    client
+        .invoke_remoting(&broker_addr, request, timeout_millis.max(1))
+        .await
+        .map_err(ProxyError::from)
 }
 
 async fn cluster_readiness_inner(config: &ClusterConfig, state: &mut ClusterWorkerState) -> ProxyResult<()> {

--- a/rocketmq-proxy-cluster/src/cluster_admission.rs
+++ b/rocketmq-proxy-cluster/src/cluster_admission.rs
@@ -25,6 +25,7 @@ use std::time::Instant;
 
 use cheetah_string::CheetahString;
 use rocketmq_model::common::message::message_queue::MessageQueue;
+use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_proxy_core::MessageQueueTarget;
 use rocketmq_proxy_core::ProxyError;
 use rocketmq_proxy_core::ProxyResult;
@@ -521,6 +522,9 @@ impl ClusterCommand {
             | Self::GetOffset { .. }
             | Self::QueryOffset { .. } => ClusterCommandClass::Control,
             Self::ReceiveMessage { .. } | Self::PullMessage { .. } => ClusterCommandClass::LongPoll,
+            Self::ForwardRemoting { request, .. } if RequestCode::from(request.code()) == RequestCode::PopMessage => {
+                ClusterCommandClass::LongPoll
+            }
             _ => ClusterCommandClass::ShortData,
         }
     }
@@ -622,6 +626,9 @@ impl ClusterCommand {
                     request.client_id.as_ref().map(ToString::to_string).unwrap_or_default(),
                 ],
             ),
+            Self::ForwardRemoting {
+                broker_name, request, ..
+            } => ClusterOrderingKey::new("remoting", [broker_name.clone(), request.code().to_string()]),
         }
     }
 
@@ -637,6 +644,7 @@ impl ClusterCommand {
             | Self::GetOffset { deadline, .. }
             | Self::QueryOffset { deadline, .. }
             | Self::EndTransaction { deadline, .. } => *deadline,
+            Self::ForwardRemoting { timeout_millis, .. } => Some(Duration::from_millis(*timeout_millis)),
             Self::ReadinessCheck { .. }
             | Self::SyncLiteSubscription { .. }
             | Self::QueryRoute { .. }
@@ -666,6 +674,12 @@ impl ClusterCommand {
             | Self::QueryOffset { deadline, .. }
             | Self::EndTransaction { deadline, .. } => {
                 *deadline = deadline.map(|value| value.saturating_sub(waited));
+            }
+            Self::ForwardRemoting { timeout_millis, .. } => {
+                *timeout_millis = Duration::from_millis(*timeout_millis)
+                    .saturating_sub(waited)
+                    .as_millis()
+                    .clamp(0, u128::from(u64::MAX)) as u64;
             }
             Self::ReadinessCheck { .. }
             | Self::SyncLiteSubscription { .. }
@@ -815,6 +829,15 @@ impl ClusterCommand {
                 request.client_id.as_ref(),
                 &request.mq_set,
             ),
+            Self::ForwardRemoting {
+                broker_name, request, ..
+            } => {
+                broker_name.len()
+                    + request.body().map_or(0, |body| body.len())
+                    + request.ext_fields().map_or(0, |fields| {
+                        fields.iter().map(|(key, value)| key.len() + value.len()).sum()
+                    })
+            }
         };
         size_of::<Self>().saturating_add(dynamic)
     }
@@ -882,6 +905,9 @@ impl ClusterCommand {
                 let _ = reply.send(Err(error));
             }
             Self::UnlockBatchMq { reply, .. } => {
+                let _ = reply.send(Err(error));
+            }
+            Self::ForwardRemoting { reply, .. } => {
                 let _ = reply.send(Err(error));
             }
         }

--- a/rocketmq-proxy-cluster/src/cluster_execution.rs
+++ b/rocketmq-proxy-cluster/src/cluster_execution.rs
@@ -27,6 +27,7 @@ use rocketmq_protocol::protocol::body::request::lock_batch_request_body::LockBat
 use rocketmq_protocol::protocol::body::response::lock_batch_response_body::LockBatchResponseBody;
 use rocketmq_protocol::protocol::body::unlock_batch_request_body::UnlockBatchRequestBody;
 use rocketmq_protocol::protocol::body::user_info::UserInfo;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::route::topic_route_data::TopicRouteData;
 use rocketmq_proxy_core::AckMessageRequest;
 use rocketmq_proxy_core::AckMessageResultEntry;
@@ -193,6 +194,12 @@ pub(super) enum ClusterCommand {
     UnlockBatchMq {
         request: UnlockBatchRequestBody,
         reply: oneshot::Sender<ProxyResult<()>>,
+    },
+    ForwardRemoting {
+        broker_name: String,
+        request: RemotingCommand,
+        timeout_millis: u64,
+        reply: oneshot::Sender<ProxyResult<RemotingCommand>>,
     },
 }
 
@@ -570,6 +577,21 @@ impl ClusterTaskExecutor {
     pub(super) async fn unlock_batch_mq(&self, request: UnlockBatchRequestBody) -> ProxyResult<()> {
         self.execute(|reply| ClusterCommand::UnlockBatchMq { request, reply })
             .await
+    }
+
+    pub(super) async fn forward_remoting(
+        &self,
+        broker_name: String,
+        request: RemotingCommand,
+        timeout_millis: u64,
+    ) -> ProxyResult<RemotingCommand> {
+        self.execute(|reply| ClusterCommand::ForwardRemoting {
+            broker_name,
+            request,
+            timeout_millis,
+            reply,
+        })
+        .await
     }
 
     async fn execute<T>(

--- a/rocketmq-proxy-cluster/src/remoting.rs
+++ b/rocketmq-proxy-cluster/src/remoting.rs
@@ -13,11 +13,13 @@
 // limitations under the License.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::body::request::lock_batch_request_body::LockBatchRequestBody;
 use rocketmq_protocol::protocol::body::unlock_batch_request_body::UnlockBatchRequestBody;
+use rocketmq_protocol::protocol::header::pop_message_request_header::PopMessageRequestHeader;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::RemotingDeserializable;
 use rocketmq_protocol::protocol::RemotingSerializable;
@@ -60,8 +62,52 @@ impl ProxyRemotingBackend for ClusterRemotingBackend {
                     self.client.unlock_batch_mq(request_body).await?;
                     Ok(RemotingCommand::create_response_command_with_code(ResponseCode::Success).set_opaque(opaque))
                 }
+                RequestCode::ConsumerSendMsgBack
+                | RequestCode::EndTransaction
+                | RequestCode::RecallMessage
+                | RequestCode::PopMessage
+                | RequestCode::AckMessage
+                | RequestCode::ChangeMessageInvisibleTime => {
+                    let Some(broker_name) = broker_name(&request) else {
+                        return Ok(RemotingCommand::create_response_command_with_code(
+                            ResponseCode::VersionNotSupported,
+                        )
+                        .set_remark("Request doesn't have field bname")
+                        .set_opaque(opaque));
+                    };
+                    let timeout_millis = forward_timeout_millis(&request);
+                    self.client.forward_remoting(broker_name, request, timeout_millis).await
+                }
                 _ => Err(ProxyError::not_implemented("cluster remoting backend request")),
             }
         })
+    }
+}
+
+fn broker_name(request: &RemotingCommand) -> Option<String> {
+    request.ext_fields().and_then(|fields| {
+        fields
+            .iter()
+            .find(|(key, _)| key.as_str() == "bname")
+            .map(|(_, value)| value.to_string())
+            .filter(|value| !value.trim().is_empty())
+    })
+}
+
+fn forward_timeout_millis(request: &RemotingCommand) -> u64 {
+    if RequestCode::from(request.code()) == RequestCode::PopMessage {
+        return request
+            .decode_command_custom_header::<PopMessageRequestHeader>()
+            .map(|header| {
+                header
+                    .poll_time
+                    .saturating_add(Duration::from_secs(10).as_millis() as u64)
+            })
+            .unwrap_or(13_000);
+    }
+    if RequestCode::from(request.code()) == RequestCode::RecallMessage {
+        2_000
+    } else {
+        3_000
     }
 }

--- a/rocketmq-proxy-core/src/ingress/remoting.rs
+++ b/rocketmq-proxy-core/src/ingress/remoting.rs
@@ -57,6 +57,7 @@ pub enum RemotingIngressRoute {
     Heartbeat,
     UnregisterClient,
     GetConsumerListByGroup,
+    GetConsumerConnectionList,
     NotifyConsumerIdsChanged,
     NotifyUnsubscribeLite,
     LockBatchMessageQueue,
@@ -75,8 +76,198 @@ pub enum RemotingIngressRoute {
     GetProxyDrainState,
     BeginProxyDrain,
     CancelProxyDrain,
+    ForwardBackend,
     AuthAdminUnsupported,
     Unsupported,
+}
+
+/// Execution ownership selected for a Remoting request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemotingRouteClass {
+    /// The Proxy decodes the request and invokes a backend-neutral service.
+    Translate,
+    /// The Proxy preserves the command and forwards it to exactly one Broker backend.
+    ForwardBackend,
+    /// The request is outside the supported Proxy surface.
+    Unsupported,
+}
+
+/// One immutable entry in the Java-compatible Proxy Remoting policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RemotingRoutePolicy {
+    request_code: RequestCode,
+    java_request_name: &'static str,
+    route: RemotingIngressRoute,
+}
+
+impl RemotingRoutePolicy {
+    const fn new(request_code: RequestCode, java_request_name: &'static str, route: RemotingIngressRoute) -> Self {
+        Self {
+            request_code,
+            java_request_name,
+            route,
+        }
+    }
+
+    /// Returns the numeric wire request code.
+    pub const fn request_code(self) -> i32 {
+        self.request_code.to_i32()
+    }
+
+    /// Returns the Java `RequestCode` constant name used by the generated inventory.
+    pub const fn java_request_name(self) -> &'static str {
+        self.java_request_name
+    }
+
+    /// Returns the selected ingress operation.
+    pub const fn route(self) -> RemotingIngressRoute {
+        self.route
+    }
+
+    /// Returns who owns execution for this route.
+    pub const fn route_class(self) -> RemotingRouteClass {
+        match self.route {
+            RemotingIngressRoute::ForwardBackend
+            | RemotingIngressRoute::LockBatchMessageQueue
+            | RemotingIngressRoute::UnlockBatchMessageQueue => RemotingRouteClass::ForwardBackend,
+            RemotingIngressRoute::AuthAdminUnsupported | RemotingIngressRoute::Unsupported => {
+                RemotingRouteClass::Unsupported
+            }
+            _ => RemotingRouteClass::Translate,
+        }
+    }
+}
+
+const JAVA_PROXY_ACTIVE_ROUTE_POLICIES: &[RemotingRoutePolicy] = &[
+    RemotingRoutePolicy::new(
+        RequestCode::SendMessage,
+        "SEND_MESSAGE",
+        RemotingIngressRoute::SendMessage,
+    ),
+    RemotingRoutePolicy::new(
+        RequestCode::SendMessageV2,
+        "SEND_MESSAGE_V2",
+        RemotingIngressRoute::SendMessage,
+    ),
+    RemotingRoutePolicy::new(
+        RequestCode::SendBatchMessage,
+        "SEND_BATCH_MESSAGE",
+        RemotingIngressRoute::SendMessage,
+    ),
+    RemotingRoutePolicy::new(
+        RequestCode::ConsumerSendMsgBack,
+        "CONSUMER_SEND_MSG_BACK",
+        RemotingIngressRoute::ForwardBackend,
+    ),
+    RemotingRoutePolicy::new(
+        RequestCode::EndTransaction,
+        "END_TRANSACTION",
+        RemotingIngressRoute::ForwardBackend,
+    ),
+    RemotingRoutePolicy::new(
+        RequestCode::RecallMessage,
+        "RECALL_MESSAGE",
+        RemotingIngressRoute::ForwardBackend,
+    ),
+    RemotingRoutePolicy::new(RequestCode::HeartBeat, "HEART_BEAT", RemotingIngressRoute::Heartbeat),
+    RemotingRoutePolicy::new(
+        RequestCode::UnregisterClient,
+        "UNREGISTER_CLIENT",
+        RemotingIngressRoute::UnregisterClient,
+    ),
+    RemotingRoutePolicy::new(
+        RequestCode::CheckClientConfig,
+        "CHECK_CLIENT_CONFIG",
+        RemotingIngressRoute::CheckClientConfig,
+    ),
+    RemotingRoutePolicy::new(
+        RequestCode::PullMessage,
+        "PULL_MESSAGE",
+        RemotingIngressRoute::PullMessage,
+    ),
+    RemotingRoutePolicy::new(
+        RequestCode::LitePullMessage,
+        "LITE_PULL_MESSAGE",
+        RemotingIngressRoute::PullMessage,
+    ),
+    RemotingRoutePolicy::new(
+        RequestCode::PopMessage,
+        "POP_MESSAGE",
+        RemotingIngressRoute::ForwardBackend,
+    ),
+    RemotingRoutePolicy::new(
+        RequestCode::UpdateConsumerOffset,
+        "UPDATE_CONSUMER_OFFSET",
+        RemotingIngressRoute::UpdateConsumerOffset,
+    ),
+    RemotingRoutePolicy::new(
+        RequestCode::AckMessage,
+        "ACK_MESSAGE",
+        RemotingIngressRoute::ForwardBackend,
+    ),
+    RemotingRoutePolicy::new(
+        RequestCode::ChangeMessageInvisibleTime,
+        "CHANGE_MESSAGE_INVISIBLETIME",
+        RemotingIngressRoute::ForwardBackend,
+    ),
+    RemotingRoutePolicy::new(
+        RequestCode::GetConsumerConnectionList,
+        "GET_CONSUMER_CONNECTION_LIST",
+        RemotingIngressRoute::GetConsumerConnectionList,
+    ),
+    RemotingRoutePolicy::new(
+        RequestCode::GetConsumerListByGroup,
+        "GET_CONSUMER_LIST_BY_GROUP",
+        RemotingIngressRoute::GetConsumerListByGroup,
+    ),
+    RemotingRoutePolicy::new(
+        RequestCode::GetMaxOffset,
+        "GET_MAX_OFFSET",
+        RemotingIngressRoute::GetMaxOffset,
+    ),
+    RemotingRoutePolicy::new(
+        RequestCode::GetMinOffset,
+        "GET_MIN_OFFSET",
+        RemotingIngressRoute::GetMinOffset,
+    ),
+    RemotingRoutePolicy::new(
+        RequestCode::QueryConsumerOffset,
+        "QUERY_CONSUMER_OFFSET",
+        RemotingIngressRoute::QueryConsumerOffset,
+    ),
+    RemotingRoutePolicy::new(
+        RequestCode::SearchOffsetByTimestamp,
+        "SEARCH_OFFSET_BY_TIMESTAMP",
+        RemotingIngressRoute::SearchOffsetByTimestamp,
+    ),
+    RemotingRoutePolicy::new(
+        RequestCode::LockBatchMq,
+        "LOCK_BATCH_MQ",
+        RemotingIngressRoute::LockBatchMessageQueue,
+    ),
+    RemotingRoutePolicy::new(
+        RequestCode::UnlockBatchMq,
+        "UNLOCK_BATCH_MQ",
+        RemotingIngressRoute::UnlockBatchMessageQueue,
+    ),
+    RemotingRoutePolicy::new(
+        RequestCode::GetRouteinfoByTopic,
+        "GET_ROUTEINFO_BY_TOPIC",
+        RemotingIngressRoute::QueryRoute,
+    ),
+];
+
+/// Returns the complete active Java 5.5 Proxy route policy.
+pub const fn java_proxy_active_route_policies() -> &'static [RemotingRoutePolicy] {
+    JAVA_PROXY_ACTIVE_ROUTE_POLICIES
+}
+
+/// Returns the active Java policy for `code`, if the code belongs to that surface.
+pub fn remoting_route_policy(code: i32) -> Option<RemotingRoutePolicy> {
+    JAVA_PROXY_ACTIVE_ROUTE_POLICIES
+        .iter()
+        .copied()
+        .find(|policy| policy.request_code() == code)
 }
 
 impl RemotingIngressRoute {
@@ -91,6 +282,7 @@ impl RemotingIngressRoute {
             RequestCode::HeartBeat => "RemotingHeartBeat",
             RequestCode::UnregisterClient => "RemotingUnregisterClient",
             RequestCode::GetConsumerListByGroup => "RemotingGetConsumerListByGroup",
+            RequestCode::GetConsumerConnectionList => "RemotingGetConsumerConnectionList",
             RequestCode::NotifyConsumerIdsChanged => "RemotingNotifyConsumerIdsChanged",
             RequestCode::NotifyUnsubscribeLite => "RemotingNotifyUnsubscribeLite",
             RequestCode::LockBatchMq => "RemotingLockBatchMq",
@@ -110,6 +302,12 @@ impl RemotingIngressRoute {
             RequestCode::GetProxyDrainState => "RemotingGetProxyDrainState",
             RequestCode::BeginProxyDrain => "RemotingBeginProxyDrain",
             RequestCode::CancelProxyDrain => "RemotingCancelProxyDrain",
+            RequestCode::ConsumerSendMsgBack => "RemotingConsumerSendMsgBack",
+            RequestCode::EndTransaction => "RemotingEndTransaction",
+            RequestCode::RecallMessage => "RemotingRecallMessage",
+            RequestCode::PopMessage => "RemotingPopMessage",
+            RequestCode::AckMessage => "RemotingAckMessage",
+            RequestCode::ChangeMessageInvisibleTime => "RemotingChangeMessageInvisibleTime",
             _ => "RemotingRequest",
         }
     }
@@ -131,26 +329,13 @@ impl RemotingIngressDispatcher {
 
 /// Classifies a wire request code without decoding facade-owned headers.
 pub fn classify_remoting_request(code: i32) -> RemotingIngressRoute {
+    if let Some(policy) = remoting_route_policy(code) {
+        return policy.route();
+    }
     match RequestCode::from(code) {
-        RequestCode::GetRouteinfoByTopic => RemotingIngressRoute::QueryRoute,
         RequestCode::QueryAssignment => RemotingIngressRoute::QueryAssignment,
-        RequestCode::SendMessage | RequestCode::SendMessageV2 | RequestCode::SendBatchMessage => {
-            RemotingIngressRoute::SendMessage
-        }
-        RequestCode::HeartBeat => RemotingIngressRoute::Heartbeat,
-        RequestCode::UnregisterClient => RemotingIngressRoute::UnregisterClient,
-        RequestCode::GetConsumerListByGroup => RemotingIngressRoute::GetConsumerListByGroup,
         RequestCode::NotifyConsumerIdsChanged => RemotingIngressRoute::NotifyConsumerIdsChanged,
         RequestCode::NotifyUnsubscribeLite => RemotingIngressRoute::NotifyUnsubscribeLite,
-        RequestCode::LockBatchMq => RemotingIngressRoute::LockBatchMessageQueue,
-        RequestCode::UnlockBatchMq => RemotingIngressRoute::UnlockBatchMessageQueue,
-        RequestCode::CheckClientConfig => RemotingIngressRoute::CheckClientConfig,
-        RequestCode::PullMessage | RequestCode::LitePullMessage => RemotingIngressRoute::PullMessage,
-        RequestCode::UpdateConsumerOffset => RemotingIngressRoute::UpdateConsumerOffset,
-        RequestCode::QueryConsumerOffset => RemotingIngressRoute::QueryConsumerOffset,
-        RequestCode::GetMaxOffset => RemotingIngressRoute::GetMaxOffset,
-        RequestCode::GetMinOffset => RemotingIngressRoute::GetMinOffset,
-        RequestCode::SearchOffsetByTimestamp => RemotingIngressRoute::SearchOffsetByTimestamp,
         RequestCode::GetBrokerLiteInfo => RemotingIngressRoute::GetBrokerLiteInfo,
         RequestCode::GetParentTopicInfo => RemotingIngressRoute::GetParentTopicInfo,
         RequestCode::GetLiteTopicInfo => RemotingIngressRoute::GetLiteTopicInfo,

--- a/rocketmq-proxy-core/src/session.rs
+++ b/rocketmq-proxy-core/src/session.rs
@@ -500,6 +500,18 @@ impl<C> ClientSessionRegistry<C> {
         client_ids
     }
 
+    /// Returns stable snapshots for clients currently registered in a consumer group.
+    pub fn consumer_sessions(&self, consumer_group: &str) -> Vec<ClientSession> {
+        let mut sessions = self
+            .sessions
+            .iter()
+            .filter(|entry| entry.consumer_groups.contains(consumer_group))
+            .map(|entry| entry.clone())
+            .collect::<Vec<_>>();
+        sessions.sort_unstable_by(|left, right| left.client_id.cmp(&right.client_id));
+        sessions
+    }
+
     fn upsert_client_identity<P>(
         &self,
         client_id: &str,

--- a/rocketmq-proxy/src/remoting.rs
+++ b/rocketmq-proxy/src/remoting.rs
@@ -34,6 +34,8 @@ use rocketmq_model::utils::serde_json_utils::SerdeJsonUtils;
 use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::common::message::message_decoder as MessageDecoder;
+use rocketmq_protocol::protocol::body::connection::Connection;
+use rocketmq_protocol::protocol::body::consumer_connection::ConsumerConnection;
 use rocketmq_protocol::protocol::body::get_broker_lite_info_response_body::GetBrokerLiteInfoResponseBody;
 use rocketmq_protocol::protocol::body::get_consumer_list_by_group_response_body::GetConsumerListByGroupResponseBody;
 use rocketmq_protocol::protocol::body::get_lite_group_info_response_body::GetLiteGroupInfoResponseBody;
@@ -47,6 +49,7 @@ use rocketmq_protocol::protocol::body::query_assignment_request_body::QueryAssig
 use rocketmq_protocol::protocol::body::query_assignment_response_body::QueryAssignmentResponseBody;
 use rocketmq_protocol::protocol::command_custom_header::CommandCustomHeader;
 use rocketmq_protocol::protocol::header::client_request_header::GetRouteInfoRequestHeader;
+use rocketmq_protocol::protocol::header::get_consumer_connection_list_request_header::GetConsumerConnectionListRequestHeader;
 use rocketmq_protocol::protocol::header::get_consumer_listby_group_request_header::GetConsumerListByGroupRequestHeader;
 use rocketmq_protocol::protocol::header::get_lite_group_info_request_header::GetLiteGroupInfoRequestHeader;
 use rocketmq_protocol::protocol::header::get_lite_topic_info_request_header::GetLiteTopicInfoRequestHeader;
@@ -75,6 +78,7 @@ use rocketmq_protocol::protocol::heartbeat::heartbeat_data::HeartbeatData;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
 use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
+use rocketmq_protocol::protocol::LanguageCode;
 use rocketmq_protocol::protocol::RemotingSerializable;
 use rocketmq_proxy_core::identity::ResourceIdentity;
 pub use rocketmq_proxy_core::remoting::ProxyRemotingBackend;
@@ -643,6 +647,7 @@ where
             RemotingIngressRoute::Heartbeat => self.dispatch_heartbeat(context, request).await,
             RemotingIngressRoute::UnregisterClient => self.dispatch_unregister_client(request).await,
             RemotingIngressRoute::GetConsumerListByGroup => self.dispatch_get_consumer_list_by_group(request).await,
+            RemotingIngressRoute::GetConsumerConnectionList => self.dispatch_get_consumer_connection_list(request),
             RemotingIngressRoute::NotifyConsumerIdsChanged => self.dispatch_notify_consumer_ids_changed(request).await,
             RemotingIngressRoute::NotifyUnsubscribeLite => self.dispatch_notify_unsubscribe_lite(request).await,
             RemotingIngressRoute::LockBatchMessageQueue => self.dispatch_lock_batch_mq(request).await,
@@ -661,6 +666,7 @@ where
             RemotingIngressRoute::GetProxyDrainState => self.dispatch_get_proxy_drain_state(request),
             RemotingIngressRoute::BeginProxyDrain => self.dispatch_begin_proxy_drain(request),
             RemotingIngressRoute::CancelProxyDrain => self.dispatch_cancel_proxy_drain(request),
+            RemotingIngressRoute::ForwardBackend => self.dispatch_forward_backend(request).await,
             RemotingIngressRoute::AuthAdminUnsupported => unsupported_response(
                 &self.command_factory,
                 request.opaque(),
@@ -677,6 +683,71 @@ where
                     "proxy remoting ingress does not support request code {}",
                     request.code()
                 ),
+            ),
+        }
+    }
+
+    async fn dispatch_forward_backend(&self, request: &RemotingCommand) -> RemotingCommand {
+        self.dispatch_via_backend(request).await.unwrap_or_else(|| {
+            unsupported_response(
+                &self.command_factory,
+                request.opaque(),
+                format!(
+                    "proxy remoting backend is unavailable for request code {}",
+                    request.code()
+                ),
+            )
+        })
+    }
+
+    fn dispatch_get_consumer_connection_list(&self, request: &RemotingCommand) -> RemotingCommand {
+        let header = match request.decode_command_custom_header::<GetConsumerConnectionListRequestHeader>() {
+            Ok(header) => header,
+            Err(error) => {
+                return decode_error_response(
+                    &self.command_factory,
+                    request.opaque(),
+                    "decode getConsumerConnectionList header",
+                    error,
+                );
+            }
+        };
+        let sessions = self.sessions.consumer_sessions(header.consumer_group.as_str());
+        if sessions.is_empty() {
+            return response_with_code(
+                &self.command_factory,
+                request.opaque(),
+                ResponseCode::ConsumerNotOnline,
+                format!("the consumer group[{}] not online", header.consumer_group),
+            );
+        }
+
+        let mut body = ConsumerConnection::new();
+        for session in sessions {
+            let mut connection = Connection::new();
+            connection.set_client_id(CheetahString::from(session.client_id));
+            connection.set_client_addr(CheetahString::from(session.remote_addr.unwrap_or_default()));
+            connection.set_language(remoting_language(session.language.as_deref()));
+            connection.set_version(
+                session
+                    .client_version
+                    .as_deref()
+                    .and_then(|version| version.parse::<i32>().ok())
+                    .unwrap_or_default(),
+            );
+            body.insert_connection(connection);
+        }
+        match body.encode() {
+            Ok(encoded) => self
+                .command_factory
+                .create_response_command_with_code(ResponseCode::Success)
+                .set_body(encoded)
+                .set_opaque(request.opaque()),
+            Err(error) => transport_error_response(
+                &self.command_factory,
+                request.opaque(),
+                "encode getConsumerConnectionList response",
+                error,
             ),
         }
     }
@@ -1787,6 +1858,24 @@ fn build_lite_group_meta(
         .collect()
 }
 
+fn remoting_language(language: Option<&str>) -> LanguageCode {
+    match language.map(str::to_ascii_uppercase).as_deref() {
+        Some("JAVA") => LanguageCode::JAVA,
+        Some("CPP") => LanguageCode::CPP,
+        Some("DOTNET") => LanguageCode::DOTNET,
+        Some("PYTHON") => LanguageCode::PYTHON,
+        Some("DELPHI") => LanguageCode::DELPHI,
+        Some("ERLANG") => LanguageCode::ERLANG,
+        Some("RUBY") => LanguageCode::RUBY,
+        Some("HTTP") => LanguageCode::HTTP,
+        Some("GO") => LanguageCode::GO,
+        Some("PHP") => LanguageCode::PHP,
+        Some("RUST") => LanguageCode::RUST,
+        Some("NODE_JS") => LanguageCode::NODE_JS,
+        _ => LanguageCode::OTHER,
+    }
+}
+
 fn unique_lite_topics(subscriptions: &[crate::session::LiteSubscriptionSnapshot]) -> HashSet<String> {
     subscriptions
         .iter()
@@ -2123,6 +2212,7 @@ mod tests {
     use rocketmq_protocol::code::request_code::RequestCode;
     use rocketmq_protocol::code::response_code::ResponseCode;
     use rocketmq_protocol::common::message::message_decoder as MessageDecoder;
+    use rocketmq_protocol::protocol::body::consumer_connection::ConsumerConnection;
     use rocketmq_protocol::protocol::body::proxy_drain::ProxyDrainOperationRequestBody;
     use rocketmq_protocol::protocol::body::proxy_drain::ProxyDrainStateResponseBody;
     use rocketmq_protocol::protocol::body::proxy_drain::PROXY_DRAIN_SCHEMA_VERSION;
@@ -2131,6 +2221,7 @@ mod tests {
     use rocketmq_protocol::protocol::body::request::lock_batch_request_body::LockBatchRequestBody;
     use rocketmq_protocol::protocol::body::unlock_batch_request_body::UnlockBatchRequestBody;
     use rocketmq_protocol::protocol::header::client_request_header::GetRouteInfoRequestHeader;
+    use rocketmq_protocol::protocol::header::get_consumer_connection_list_request_header::GetConsumerConnectionListRequestHeader;
     use rocketmq_protocol::protocol::header::get_consumer_listby_group_request_header::GetConsumerListByGroupRequestHeader;
     use rocketmq_protocol::protocol::header::get_lite_group_info_request_header::GetLiteGroupInfoRequestHeader;
     use rocketmq_protocol::protocol::header::get_lite_topic_info_request_header::GetLiteTopicInfoRequestHeader;
@@ -2285,16 +2376,13 @@ mod tests {
 
     #[derive(Default)]
     struct TestRemotingBackend {
-        seen_codes: Mutex<Vec<i32>>,
+        seen_requests: Mutex<Vec<RemotingCommand>>,
     }
 
     impl ProxyRemotingBackend for TestRemotingBackend {
         fn process(&self, request: RemotingCommand) -> rocketmq_proxy_core::ProxyServiceFuture<'_, RemotingCommand> {
             Box::pin(async move {
-                self.seen_codes
-                    .lock()
-                    .expect("backend mutex poisoned")
-                    .push(request.code());
+                self.seen_requests.lock().expect("backend mutex poisoned").push(request);
                 Ok(RemotingCommand::create_response_command_with_code(
                     ResponseCode::Success,
                 ))
@@ -2769,6 +2857,34 @@ mod tests {
         )
         .expect("consumer list body should decode");
         assert_eq!(decoded.consumer_id_list, vec![CheetahString::from("client-a")]);
+
+        let mut connection_request = RemotingCommand::create_request_command(
+            RequestCode::GetConsumerConnectionList,
+            GetConsumerConnectionListRequestHeader {
+                consumer_group: CheetahString::from("GroupA"),
+                rpc_request_header: None,
+            },
+        );
+        connection_request.make_custom_header_to_net();
+        let connection_response = dispatcher.dispatch(&test_context(), &connection_request).await;
+        assert_eq!(ResponseCode::from(connection_response.code()), ResponseCode::Success);
+        let connections = ConsumerConnection::decode(
+            connection_response
+                .body()
+                .expect("consumer connection body should exist")
+                .as_ref(),
+        )
+        .expect("consumer connection body should decode");
+        assert_eq!(connections.get_connection_set().len(), 1);
+        assert_eq!(
+            connections
+                .get_connection_set()
+                .iter()
+                .next()
+                .expect("consumer connection should exist")
+                .get_client_id(),
+            "client-a"
+        );
     }
 
     #[tokio::test]
@@ -3273,9 +3389,85 @@ mod tests {
         assert_eq!(ResponseCode::from(unlock_response.code()), ResponseCode::Success);
 
         assert_eq!(
-            *backend.seen_codes.lock().expect("backend mutex poisoned"),
+            backend
+                .seen_requests
+                .lock()
+                .expect("backend mutex poisoned")
+                .iter()
+                .map(RemotingCommand::code)
+                .collect::<Vec<_>>(),
             vec![RequestCode::LockBatchMq.to_i32(), RequestCode::UnlockBatchMq.to_i32()]
         );
+    }
+
+    #[tokio::test]
+    async fn dispatch_forward_routes_preserve_the_command_and_call_backend_once() {
+        let backend = Arc::new(TestRemotingBackend::default());
+        let dispatcher = ProxyRemotingDispatcher::new(
+            Arc::new(ProxyConfig {
+                mode: ProxyMode::Local,
+                ..ProxyConfig::default()
+            }),
+            Arc::new(DefaultMessagingProcessor::new(Arc::new(
+                LocalServiceManager::with_services(
+                    Arc::new(StaticRouteService::default()),
+                    Arc::new(StaticMetadataService::default()),
+                    Arc::new(DefaultAssignmentService),
+                    Arc::new(TestMessageService),
+                    Arc::new(TestConsumerService),
+                    Arc::new(DefaultTransactionService),
+                ),
+            ))),
+            ClientSessionRegistry::default(),
+            Some(backend.clone()),
+        );
+        let codes = [
+            RequestCode::ConsumerSendMsgBack,
+            RequestCode::EndTransaction,
+            RequestCode::RecallMessage,
+            RequestCode::PopMessage,
+            RequestCode::AckMessage,
+            RequestCode::ChangeMessageInvisibleTime,
+        ];
+
+        for (index, code) in codes.into_iter().enumerate() {
+            let opaque = 700 + index as i32;
+            let request = RemotingCommand::create_remoting_command(code)
+                .set_opaque(opaque)
+                .set_version(501)
+                .set_serialize_type(SerializeType::ROCKETMQ)
+                .set_body(Bytes::from_static(b"forward-body"))
+                .set_ext_fields(HashMap::from([
+                    (
+                        CheetahString::from_static_str("bname"),
+                        CheetahString::from_static_str("broker-a"),
+                    ),
+                    (
+                        CheetahString::from_static_str("custom"),
+                        CheetahString::from_static_str("preserved"),
+                    ),
+                ]));
+            let response = dispatcher.dispatch(&test_context(), &request).await;
+            assert_eq!(ResponseCode::from(response.code()), ResponseCode::Success);
+            assert_eq!(response.opaque(), opaque);
+        }
+
+        let seen = backend.seen_requests.lock().expect("backend mutex poisoned");
+        assert_eq!(seen.len(), codes.len());
+        for (index, request) in seen.iter().enumerate() {
+            assert_eq!(request.code(), codes[index].to_i32());
+            assert_eq!(request.opaque(), 700 + index as i32);
+            assert_eq!(request.version(), 501);
+            assert_eq!(request.serialize_type(), SerializeType::ROCKETMQ);
+            assert_eq!(request.body().map(Bytes::as_ref), Some(b"forward-body".as_slice()));
+            assert_eq!(
+                request
+                    .ext_fields()
+                    .and_then(|fields| fields.get("custom"))
+                    .map(CheetahString::as_str),
+                Some("preserved")
+            );
+        }
     }
 
     #[tokio::test]

--- a/rocketmq-proxy/tests/remoting_route_matrix.rs
+++ b/rocketmq-proxy/tests/remoting_route_matrix.rs
@@ -1,0 +1,59 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeSet;
+
+use rocketmq_proxy_core::remoting::java_proxy_active_route_policies;
+use rocketmq_proxy_core::remoting::RemotingRouteClass;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct JavaInventory {
+    proxy_routes: Vec<JavaProxyRoute>,
+}
+
+#[derive(Deserialize)]
+struct JavaProxyRoute {
+    request_code: String,
+    classification: String,
+}
+
+#[test]
+fn every_generated_java_proxy_route_has_one_supported_policy() {
+    let inventory: JavaInventory = serde_json::from_str(include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../scripts/fixtures/java-5.5-core-inventory.json"
+    )))
+    .expect("Java 5.5 inventory fixture should decode");
+    let expected = inventory
+        .proxy_routes
+        .into_iter()
+        .filter(|route| route.classification == "active")
+        .map(|route| route.request_code)
+        .collect::<BTreeSet<_>>();
+    let policies = java_proxy_active_route_policies();
+    let actual = policies
+        .iter()
+        .map(|policy| policy.java_request_name().to_owned())
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(actual, expected);
+    assert_eq!(actual.len(), policies.len(), "active request codes must be unique");
+    assert!(
+        policies
+            .iter()
+            .all(|policy| policy.route_class() != RemotingRouteClass::Unsupported),
+        "Java-active routes must never fall through to Unsupported"
+    );
+}

--- a/scripts/v1-capability-manifest.json
+++ b/scripts/v1-capability-manifest.json
@@ -74,7 +74,7 @@
       "rust_surfaces": ["rocketmq-broker/src/processor/pop_message_processor.rs", "rocketmq-client/src/consumer/default_lite_pull_consumer.rs"],
       "profiles": ["lite-wildcard", "ordered-pop"],
       "compatibility_mode": "behavior",
-      "implementation_status": "partial",
+      "implementation_status": "implemented",
       "evidence_status": "none",
       "test_ids": ["F04-LITE-WILDCARD-ORDERED-SUSPEND"],
       "commands": ["cargo test -p rocketmq-broker --test lite_wildcard_group"],


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

- Fixes #9421

### Brief Description

Adds one immutable Proxy Remoting route policy derived from the generated Java 5.5 active inventory. Active Java routes now translate locally or forward exactly once through the selected backend, while unknown requests remain fail-closed. The cluster backend preserves the original RemotingCommand fields and the Proxy can return consumer connection snapshots from its session registry.

### How Did You Test This Change?

- `cargo test -p rocketmq-proxy --test remoting_route_matrix`
- `cargo test -p rocketmq-proxy-core ingress::remoting`
- `cargo test -p rocketmq-proxy dispatch_forward_routes_preserve_the_command_and_call_backend_once`
- `cargo test -p rocketmq-proxy dispatch_heartbeat_and_get_consumer_list_tracks_membership`
- `cargo check -p rocketmq-proxy --all-features`
- affected package Clippy with all targets and all features
- workspace Clippy with all targets and all features
- `cargo clippy --all-targets -- -D warnings` in `rocketmq-example`
- `python -m unittest scripts.tests.test_m08_proxy_feature_closure`
- `python scripts/v1_capability_guard.py --phase 0`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for forwarding raw broker requests through the proxy cluster.
  - Added consumer connection listing, including client connection details by consumer group.
  - Added routing support for additional remoting request types.

- **Bug Fixes**
  - Improved handling of unavailable brokers and backends with clear error responses.
  - Added request validation and timeout handling for forwarded operations.

- **Tests**
  - Added route compatibility coverage and validation for forwarded command preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->