### PR TITLE
[ISSUE #9427]✨Redesign Message DLQ and Trace operations

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/admin/common_provider.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/admin/common_provider.rs
@@ -23,6 +23,7 @@ use crate::model::ConsumerResetOffsetRequest;
 use crate::model::DashboardOverview;
 use crate::model::MessageListView;
 use crate::model::MessageResendRequest;
+use crate::model::MessageResendResult;
 use crate::model::MessageTraceView;
 use crate::model::MutationResult;
 use crate::model::ProducerConnectionView;
@@ -59,7 +60,7 @@ impl DashboardAdminProvider for DashboardAdminClient {
     type Message = MessageListView;
     type MessageTrace = MessageTraceView;
     type MessageResendRequest = MessageResendRequest;
-    type MessageResendResult = MutationResult;
+    type MessageResendResult = MessageResendResult;
 
     fn dashboard_overview(&self) -> AdminFuture<'_, Self::DashboardOverview, Self::Error> {
         Box::pin(DashboardAdminClient::dashboard_overview(self))

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/admin/dashboard_admin_client.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/admin/dashboard_admin_client.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::cmp::Reverse;
+use std::future::Future;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::AtomicUsize;
@@ -57,9 +58,11 @@ use crate::model::DashboardTopicCurrent;
 use crate::model::DlqBatchResendRequest;
 use crate::model::DlqExportView;
 use crate::model::DlqMessageQuery;
+use crate::model::DlqMessageRef;
 use crate::model::DlqMessageResendResult;
 use crate::model::MessageListView;
 use crate::model::MessageResendRequest;
+use crate::model::MessageResendResult;
 use crate::model::MessageTraceNode;
 use crate::model::MessageTraceView;
 use crate::model::MessageView;
@@ -647,7 +650,7 @@ impl DashboardAdminClient {
         &self,
         message_id: &str,
         request: MessageResendRequest,
-    ) -> Result<MutationResult, DashboardError> {
+    ) -> Result<MessageResendResult, DashboardError> {
         validate_name(message_id, "Message ID")?;
         validate_name(&request.topic, "Topic")?;
         validate_name(&request.consumer_group, "Consumer group")?;
@@ -658,9 +661,7 @@ impl DashboardAdminClient {
             client_id: request.client_id,
         };
         let result = run_admin_rpc!(self, |admin| admin.dashboard_consume_message_directly(&request))?;
-        Ok(MutationResult {
-            message: result.message,
-        })
+        Ok(map_direct_consume_result(result))
     }
 
     pub async fn query_dlq_messages(&self, query: DlqMessageQuery) -> Result<MessageListView, DashboardError> {
@@ -687,31 +688,10 @@ impl DashboardAdminClient {
                 "DLQ resend messages cannot be empty".to_string(),
             ));
         }
-        let mut results = Vec::with_capacity(request.messages.len());
-        for message in request.messages {
-            validate_name(&message.consumer_group, "Consumer group")?;
-            validate_name(&message.msg_id, "Message ID")?;
-            let topic = message
-                .topic_name
-                .filter(|topic| !topic.trim().is_empty())
-                .unwrap_or_else(|| format!("%DLQ%{}", message.consumer_group));
-            let result = self
-                .resend_message(
-                    &message.msg_id,
-                    MessageResendRequest {
-                        topic,
-                        consumer_group: message.consumer_group,
-                        client_id: message.client_id,
-                    },
-                )
-                .await?;
-            results.push(DlqMessageResendResult {
-                msg_id: message.msg_id,
-                consume_result: "REQUESTED".to_string(),
-                remark: Some(result.message),
-            });
-        }
-        Ok(results)
+        Ok(resend_dlq_batch(request.messages, |message_id, request| async move {
+            self.resend_message(&message_id, request).await
+        })
+        .await)
     }
 
     pub async fn export_dlq_messages(&self, query: DlqMessageQuery) -> Result<DlqExportView, DashboardError> {
@@ -834,6 +814,77 @@ impl DashboardAdminClient {
     }
 }
 
+async fn resend_dlq_batch<F, Fut>(messages: Vec<DlqMessageRef>, mut resend: F) -> Vec<DlqMessageResendResult>
+where
+    F: FnMut(String, MessageResendRequest) -> Fut,
+    Fut: Future<Output = Result<MessageResendResult, DashboardError>>,
+{
+    let mut results = Vec::with_capacity(messages.len());
+    for message in messages {
+        let result_id = message.msg_id.clone();
+        let outcome = match dlq_resend_request(message) {
+            Ok((message_id, request)) => resend(message_id, request).await,
+            Err(error) => Err(error),
+        };
+        match outcome {
+            Ok(result) => results.push(DlqMessageResendResult {
+                msg_id: result_id,
+                success: result.success,
+                consume_result: result.consume_result,
+                remark: result.remark,
+            }),
+            Err(error) => results.push(DlqMessageResendResult {
+                msg_id: result_id,
+                success: false,
+                consume_result: "FAILED".to_string(),
+                remark: Some(format!("{}: DLQ resend request failed", error.code())),
+            }),
+        }
+    }
+    results
+}
+
+fn map_direct_consume_result(result: core::AdminMutationResult) -> MessageResendResult {
+    const PREFIX: &str = "Direct consume returned ";
+    const REMARK_SEPARATOR: &str = ". Remark: ";
+
+    let consume_result = result
+        .message
+        .strip_prefix(PREFIX)
+        .and_then(|details| details.split_whitespace().next())
+        .unwrap_or("UNKNOWN")
+        .to_string();
+    let remark = result
+        .message
+        .split_once(REMARK_SEPARATOR)
+        .map(|(_, remark)| remark.trim().to_string())
+        .filter(|remark| !remark.is_empty());
+    MessageResendResult {
+        message: result.message,
+        success: consume_result == "CR_SUCCESS",
+        consume_result,
+        remark,
+    }
+}
+
+fn dlq_resend_request(message: DlqMessageRef) -> Result<(String, MessageResendRequest), DashboardError> {
+    validate_name(&message.consumer_group, "Consumer group")?;
+    validate_name(&message.msg_id, "Message ID")?;
+    let topic = message
+        .topic_name
+        .map(|topic| topic.trim().to_string())
+        .filter(|topic| !topic.is_empty())
+        .ok_or_else(|| DashboardError::Validation("DLQ resend requires the original topic".to_string()))?;
+    Ok((
+        message.msg_id,
+        MessageResendRequest {
+            topic,
+            consumer_group: message.consumer_group,
+            client_id: message.client_id,
+        },
+    ))
+}
+
 fn session_is_current(current: Option<&Arc<ManagedAdminSession>>, expected: &Arc<ManagedAdminSession>) -> bool {
     current.is_some_and(|candidate| Arc::ptr_eq(candidate, expected))
 }
@@ -860,14 +911,21 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
+    use rocketmq_admin_core::core::dashboard::AdminMutationResult as CoreMutationResult;
     use rocketmq_admin_core::core::dashboard::DashboardAclUser;
     use tokio::sync::Mutex;
     use tokio::sync::Notify;
 
+    use crate::model::DlqMessageRef;
+    use crate::model::MessageResendResult;
+
     use super::AdminConfigSnapshot;
     use super::AdminSessionOwner;
     use super::ManagedAdminSession;
+    use super::dlq_resend_request;
     use super::map_acl_user;
+    use super::map_direct_consume_result;
+    use super::resend_dlq_batch;
     use super::session_is_current;
 
     #[test]
@@ -882,6 +940,88 @@ mod tests {
 
         assert_eq!(mapped.username, "alice");
         assert_eq!(mapped.password, None);
+    }
+
+    #[test]
+    fn dlq_resend_request_requires_canonical_original_topic() {
+        let error = dlq_resend_request(DlqMessageRef {
+            topic_name: None,
+            consumer_group: "order-service".to_string(),
+            msg_id: "MSG-001".to_string(),
+            client_id: None,
+        })
+        .expect_err("missing original topic must fail closed");
+
+        assert!(matches!(error, crate::error::DashboardError::Validation(_)));
+
+        let (message_id, request) = dlq_resend_request(DlqMessageRef {
+            topic_name: Some("orders".to_string()),
+            consumer_group: "order-service".to_string(),
+            msg_id: "MSG-001".to_string(),
+            client_id: Some("client-a".to_string()),
+        })
+        .expect("canonical DLQ resend request");
+        assert_eq!(message_id, "MSG-001");
+        assert_eq!(request.topic, "orders");
+        assert_eq!(request.consumer_group, "order-service");
+        assert_eq!(request.client_id.as_deref(), Some("client-a"));
+    }
+
+    #[test]
+    fn direct_consume_result_classifies_non_success_outcomes() {
+        let result = map_direct_consume_result(CoreMutationResult {
+            message: "Direct consume returned CR_LATER for `MSG-001` on `orders` in consumer group `order-service`. Remark: retry later".to_string(),
+            target_count: 1,
+        });
+
+        assert!(!result.success);
+        assert_eq!(result.consume_result, "CR_LATER");
+        assert_eq!(result.remark.as_deref(), Some("retry later"));
+    }
+
+    #[tokio::test]
+    async fn resend_dlq_batch_continues_after_a_failed_message() {
+        let messages = vec![
+            DlqMessageRef {
+                topic_name: Some("orders".to_string()),
+                consumer_group: "order-service".to_string(),
+                msg_id: "MSG-001".to_string(),
+                client_id: None,
+            },
+            DlqMessageRef {
+                topic_name: Some("orders".to_string()),
+                consumer_group: "order-service".to_string(),
+                msg_id: "MSG-002".to_string(),
+                client_id: None,
+            },
+        ];
+
+        let results = resend_dlq_batch(messages, |message_id, _| async move {
+            if message_id == "MSG-001" {
+                Err(crate::error::DashboardError::Internal("broker unavailable".to_string()))
+            } else {
+                Ok(MessageResendResult {
+                    message: "Direct consume returned CR_SUCCESS".to_string(),
+                    success: true,
+                    consume_result: "CR_SUCCESS".to_string(),
+                    remark: None,
+                })
+            }
+        })
+        .await;
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].msg_id, "MSG-001");
+        assert!(!results[0].success);
+        assert_eq!(results[0].consume_result, "FAILED");
+        assert_eq!(
+            results[0].remark.as_deref(),
+            Some("INTERNAL_ERROR: DLQ resend request failed")
+        );
+        assert_eq!(results[1].msg_id, "MSG-002");
+        assert!(results[1].success);
+        assert_eq!(results[1].consume_result, "CR_SUCCESS");
+        assert_eq!(results[1].remark, None);
     }
 
     fn managed_session(generation: u64) -> Arc<ManagedAdminSession> {

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/admin/dashboard_admin_client/mapping.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/admin/dashboard_admin_client/mapping.rs
@@ -244,9 +244,7 @@ pub(super) fn map_message(message: core::DashboardMessage) -> MessageView {
         .filter(|value| !value.trim().is_empty())
         .cloned()
         .unwrap_or_else(|| store_message_id.clone());
-    properties
-        .entry("STORE_MESSAGE_ID".to_string())
-        .or_insert(store_message_id);
+    properties.insert("STORE_MESSAGE_ID".to_string(), store_message_id);
     MessageView {
         topic: message.topic,
         message_id,
@@ -315,10 +313,15 @@ pub(super) fn build_dlq_csv(messages: &[MessageView]) -> String {
 }
 
 pub(super) fn csv_escape(value: &str) -> String {
-    if value.contains([',', '"', '\n', '\r']) {
-        format!("\"{}\"", value.replace('"', "\"\""))
+    let neutralized = if matches!(value.chars().next(), Some('=' | '+' | '-' | '@' | '\t' | '\r' | '\n')) {
+        format!("'{value}")
     } else {
         value.to_string()
+    };
+    if neutralized.contains([',', '"', '\n', '\r']) {
+        format!("\"{}\"", neutralized.replace('"', "\"\""))
+    } else {
+        neutralized
     }
 }
 
@@ -383,6 +386,7 @@ mod tests {
     fn maps_owned_message_without_protocol_types() {
         let mut properties = BTreeMap::new();
         properties.insert("UNIQ_KEY".to_string(), "client-id".to_string());
+        properties.insert("STORE_MESSAGE_ID".to_string(), "producer-spoofed-id".to_string());
         let message = DashboardMessage {
             topic: "Orders".to_string(),
             message_id: "store-id".to_string(),
@@ -418,5 +422,16 @@ mod tests {
     fn escapes_csv_cells() {
         assert_eq!(csv_escape("plain"), "plain");
         assert_eq!(csv_escape("a,\"b\""), "\"a,\"\"b\"\"\"");
+    }
+
+    #[test]
+    fn neutralizes_formula_leading_csv_cells() {
+        assert_eq!(csv_escape("=1+1"), "'=1+1");
+        assert_eq!(csv_escape("+cmd"), "'+cmd");
+        assert_eq!(csv_escape("-2+3"), "'-2+3");
+        assert_eq!(csv_escape("@SUM(A1:A2)"), "'@SUM(A1:A2)");
+        assert_eq!(csv_escape("\t=1+1"), "'\t=1+1");
+        assert_eq!(csv_escape("\r=1+1"), "\"'\r=1+1\"");
+        assert_eq!(csv_escape("\n=1+1"), "\"'\n=1+1\"");
     }
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/message_api.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/message_api.rs
@@ -20,8 +20,8 @@ use crate::model::DlqMessageResendResult;
 use crate::model::MessageListView;
 use crate::model::MessageQuery;
 use crate::model::MessageResendRequest;
+use crate::model::MessageResendResult;
 use crate::model::MessageTraceView;
-use crate::model::MutationResult;
 use crate::service;
 use crate::state::AppState;
 use axum::Json;
@@ -85,7 +85,7 @@ pub async fn resend_message(
     State(state): State<AppState>,
     Path(message_id): Path<String>,
     Json(request): Json<MessageResendRequest>,
-) -> Result<Json<ApiResponse<MutationResult>>, DashboardError> {
+) -> Result<Json<ApiResponse<MessageResendResult>>, DashboardError> {
     Ok(Json(ApiResponse::success(
         service::resend_message(&state, &message_id, request).await?,
     )))

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/model/message_model.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/model/message_model.rs
@@ -68,6 +68,15 @@ pub struct MessageResendRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+pub struct MessageResendResult {
+    pub message: String,
+    pub success: bool,
+    pub consume_result: String,
+    pub remark: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct DlqMessageQuery {
     pub consumer_group: String,
     pub key: Option<String>,
@@ -99,6 +108,7 @@ pub struct DlqBatchResendRequest {
 #[serde(rename_all = "camelCase")]
 pub struct DlqMessageResendResult {
     pub msg_id: String,
+    pub success: bool,
     pub consume_result: String,
     pub remark: Option<String>,
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/message_service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/message_service.rs
@@ -19,8 +19,8 @@ use crate::model::DlqMessageResendResult;
 use crate::model::MessageListView;
 use crate::model::MessageQuery;
 use crate::model::MessageResendRequest;
+use crate::model::MessageResendResult;
 use crate::model::MessageTraceView;
-use crate::model::MutationResult;
 use crate::state::AppState;
 
 pub async fn query_messages(state: &AppState, query: MessageQuery) -> Result<MessageListView, DashboardError> {
@@ -68,7 +68,7 @@ pub async fn resend_message(
     state: &AppState,
     message_id: &str,
     request: MessageResendRequest,
-) -> Result<MutationResult, DashboardError> {
+) -> Result<MessageResendResult, DashboardError> {
     state
         .admin_facade()
         .resend_message(message_id.to_string(), request)

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/api/message_api.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/api/message_api.ts
@@ -1,6 +1,7 @@
 import { apiClient } from './client';
-import type { MessageListView, MessageQueryParams, MessageResendRequest, MessageTraceView } from '../types/message';
-import type { MutationResult } from '../types/topic';
+import type {
+  MessageListView, MessageQueryParams, MessageResendRequest, MessageResendResult, MessageTraceView
+} from '../types/message';
 
 function toQueryString(params: Record<string, string | number | undefined | null>) {
   const search = new URLSearchParams();
@@ -24,5 +25,5 @@ export const messageApi = {
       `/api/messages/${encodeURIComponent(messageId)}/trace${toQueryString({ topic, traceTopic })}`
     ),
   resend: (messageId: string, request: MessageResendRequest) =>
-    apiClient.post<MutationResult>(`/api/messages/${encodeURIComponent(messageId)}/resend`, request)
+    apiClient.post<MessageResendResult>(`/api/messages/${encodeURIComponent(messageId)}/resend`, request)
 };

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/AppDataTable.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/AppDataTable.tsx
@@ -21,6 +21,7 @@ interface AppDataTableProps<T> {
   pageSize: number;
   total: number;
   onPageChange: (page: number) => void;
+  hasNextPage?: boolean;
   onRowActivate?: (row: T, origin: HTMLElement) => void;
   loading?: boolean;
   error?: string | null;
@@ -39,6 +40,7 @@ export default function AppDataTable<T>({
   pageSize,
   total,
   onPageChange,
+  hasNextPage,
   onRowActivate,
   loading = false,
   error,
@@ -47,7 +49,12 @@ export default function AppDataTable<T>({
   emptyTitle = 'No rows',
   emptyDetail
 }: AppDataTableProps<T>) {
-  const pageCount = Math.max(1, Math.ceil(total / pageSize));
+  const countedPages = Math.max(1, Math.ceil(total / pageSize));
+  const pageCount = hasNextPage === undefined
+    ? countedPages
+    : hasNextPage
+      ? Math.max(countedPages, page + 1)
+      : Math.max(countedPages, page);
   const currentPage = Math.min(Math.max(page, 1), pageCount);
   const firstRow = total === 0 ? 0 : (currentPage - 1) * pageSize + 1;
   const lastRow = total === 0 ? 0 : Math.min(firstRow + rows.length - 1, total);
@@ -105,7 +112,7 @@ export default function AppDataTable<T>({
       {!loading && !error ? (
         <footer className="app-data-table-footer">
           <span>
-            {firstRow}-{lastRow} of {total}
+            {firstRow}-{lastRow} of {total}{hasNextPage === true ? '+' : ''}
           </span>
           <div className="app-data-table-pagination">
             <Button
@@ -124,7 +131,7 @@ export default function AppDataTable<T>({
               variant="outline"
               size="sm"
               aria-label="Next page"
-              disabled={currentPage >= pageCount}
+              disabled={hasNextPage === undefined ? currentPage >= pageCount : !hasNextPage}
               onClick={() => onPageChange(currentPage + 1)}
             >
               Next

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/operational-workspace.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/operational-workspace.test.tsx
@@ -175,6 +175,42 @@ describe('operational workspace components', () => {
     await user.click(screen.getByRole('button', { name: 'Previous page' }));
     expect(onPageChange).toHaveBeenCalledWith(1);
     expect(screen.getByRole('button', { name: 'Next page' })).toBeDisabled();
+
+    rerender(
+      <AppDataTable
+        ariaLabel="Broker inventory"
+        rows={[{ id: 'a', name: 'broker-a' }]}
+        columns={columns}
+        getRowId={(row) => row.id}
+        page={1}
+        pageSize={1}
+        total={1}
+        hasNextPage
+        onPageChange={onPageChange}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: 'Next page' }));
+    expect(onPageChange).toHaveBeenLastCalledWith(2);
+  });
+
+  it('clamps exact-total callers when the requested page exceeds the new page count', () => {
+    const columns: AppDataTableColumn<BrokerRow>[] = [
+      { id: 'broker', header: 'Broker', cell: (row) => row.name }
+    ];
+    render(
+      <AppDataTable
+        ariaLabel="Exact total rows"
+        rows={[{ id: 'a', name: 'broker-a' }]}
+        columns={columns}
+        getRowId={(row) => row.id}
+        page={5}
+        pageSize={10}
+        total={1}
+        onPageChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByLabelText('Page 1 of 1')).toBeInTheDocument();
   });
 
   it('does not activate a row when keyboard events originate from a nested control', async () => {

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/DlqMessagePage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/DlqMessagePage.test.tsx
@@ -1,0 +1,414 @@
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { StrictMode } from 'react';
+import { vi } from 'vitest';
+import { consumerApi } from '../api/consumer_api';
+import { dlqApi } from '../api/dlq_api';
+import { renderAtRoute } from '../test/render';
+import type { MessageView } from '../types/message';
+import DlqMessagePage from './DlqMessagePage';
+
+vi.mock('../api/consumer_api', () => ({ consumerApi: { list: vi.fn() } }));
+vi.mock('../api/dlq_api', () => ({ dlqApi: { list: vi.fn(), resend: vi.fn(), export: vi.fn() } }));
+
+const dlqMessage: MessageView = {
+  topic: '%DLQ%order-service', messageId: 'DLQ-001', keys: 'order:1', tags: 'TagA', bornTimestamp: 1_723_651_200_000,
+  storeTimestamp: 1_723_651_201_000, bornHost: '10.0.0.1:10911', storeHost: '10.0.0.2:10911', queueId: 1,
+  queueOffset: 42, storeSize: 128, reconsumeTimes: 16, bodyCRC: 1, sysFlag: 0, flag: 0,
+  preparedTransactionOffset: 0, body: 'SECRET-DLQ-BODY', properties: { RETRY_TOPIC: 'orders', ORIGIN_MESSAGE_ID: 'MSG-001' }
+};
+
+const firstDlqPage = Array.from({ length: 20 }, (_, index) => ({
+  ...dlqMessage,
+  messageId: index === 0 ? dlqMessage.messageId : `DLQ-${String(index + 1).padStart(3, '0')}`,
+  queueOffset: dlqMessage.queueOffset + index
+}));
+
+describe('DlqMessagePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(consumerApi.list).mockResolvedValue({
+      items: [{ group: 'order-service', consumeType: 'CONSUME_PASSIVELY', messageModel: 'MESSAGE_MODEL_CLUSTERING', clientCount: 1, diffTotal: 1 }], total: 1
+    });
+    vi.mocked(dlqApi.list)
+      .mockResolvedValueOnce({ items: firstDlqPage, total: 20 })
+      .mockResolvedValue({ items: [{ ...dlqMessage, messageId: 'DLQ-021', queueOffset: 62 }], total: 21 });
+    vi.mocked(dlqApi.resend).mockResolvedValue([{ msgId: 'MSG-001', success: true, consumeResult: 'CR_SUCCESS' }]);
+    vi.mocked(dlqApi.export).mockResolvedValue({ fileName: 'order-service-dlq.csv', rows: [dlqMessage], csv: 'messageId\nDLQ-001' });
+    Object.defineProperty(URL, 'createObjectURL', { value: vi.fn(() => 'blob:dlq'), configurable: true });
+    Object.defineProperty(URL, 'revokeObjectURL', { value: vi.fn(), configurable: true });
+  });
+
+  it('forwards server pagination exactly and resets page-local selection', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<DlqMessagePage />, '/messages/dlq');
+    await screen.findByRole('heading', { name: 'Dead-letter messages' });
+    await user.click(screen.getByRole('button', { name: 'Search DLQ messages' }));
+    await waitFor(() => expect(dlqApi.list).toHaveBeenCalledWith(expect.objectContaining({ consumerGroup: 'order-service', pageNum: 1, pageSize: 20 })));
+    await user.click(await screen.findByRole('checkbox', { name: 'Select DLQ-001' }));
+    expect(screen.getByText('1 selected')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Next page' }));
+    await waitFor(() => expect(dlqApi.list).toHaveBeenCalledWith(expect.objectContaining({ pageNum: 2, pageSize: 20 })));
+    expect(screen.getByText('0 selected')).toBeInTheDocument();
+    expect(await screen.findByText('DLQ-021')).toBeInTheDocument();
+  });
+
+  it('confirms batch resend, shows per-message outcomes, and exports the server response', async () => {
+    const user = userEvent.setup();
+    const anchorClick = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => undefined);
+    renderAtRoute(<DlqMessagePage />, '/messages/dlq');
+    await screen.findByRole('heading', { name: 'Dead-letter messages' });
+    await user.click(screen.getByRole('button', { name: 'Search DLQ messages' }));
+    await user.click(await screen.findByRole('checkbox', { name: 'Select DLQ-001' }));
+    await user.click(screen.getByRole('button', { name: 'Review selected resend' }));
+    expect(dlqApi.resend).not.toHaveBeenCalled();
+    await user.click(within(screen.getByRole('alertdialog', { name: 'Resend selected DLQ messages?' })).getByRole('button', { name: 'Confirm resend' }));
+
+    await waitFor(() => expect(dlqApi.resend).toHaveBeenCalledWith({ messages: [{
+      topicName: 'orders', consumerGroup: 'order-service', msgId: 'MSG-001', clientId: undefined
+    }] }));
+    expect(await screen.findByText('MSG-001: CR_SUCCESS')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Export current query' }));
+    await waitFor(() => expect(dlqApi.export).toHaveBeenCalledWith(expect.objectContaining({ consumerGroup: 'order-service', pageNum: 1, pageSize: 20 })));
+    expect(URL.createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+    expect(anchorClick).toHaveBeenCalled();
+    anchorClick.mockRestore();
+  });
+
+  it('clears rows and page-local selection when the consumer group changes', async () => {
+    const user = userEvent.setup();
+    vi.mocked(consumerApi.list).mockResolvedValue({
+      items: [
+        { group: 'order-service', consumeType: 'CONSUME_PASSIVELY', messageModel: 'MESSAGE_MODEL_CLUSTERING', clientCount: 1, diffTotal: 1 },
+        { group: 'payment-consumer', consumeType: 'CONSUME_PASSIVELY', messageModel: 'MESSAGE_MODEL_CLUSTERING', clientCount: 1, diffTotal: 0 }
+      ], total: 2
+    });
+    renderAtRoute(<DlqMessagePage />, '/messages/dlq');
+    await screen.findByRole('heading', { name: 'Dead-letter messages' });
+    await user.click(screen.getByRole('button', { name: 'Search DLQ messages' }));
+    await user.click(await screen.findByRole('checkbox', { name: 'Select DLQ-001' }));
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Consumer group' }), 'payment-consumer');
+    expect(screen.getByText('0 selected')).toBeInTheDocument();
+    expect(screen.queryByText('DLQ-001')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Review selected resend' })).toBeDisabled();
+  });
+
+  it('re-fetches the previous page when an optimistic next page is empty', async () => {
+    const user = userEvent.setup();
+    vi.mocked(dlqApi.list)
+      .mockReset()
+      .mockResolvedValueOnce({ items: firstDlqPage, total: 20 })
+      .mockResolvedValueOnce({ items: [], total: 20 })
+      .mockResolvedValueOnce({ items: firstDlqPage, total: 20 });
+
+    renderAtRoute(<DlqMessagePage />, '/messages/dlq');
+    await screen.findByRole('heading', { name: 'Dead-letter messages' });
+    await user.click(screen.getByRole('button', { name: 'Search DLQ messages' }));
+    await user.click(await screen.findByRole('button', { name: 'Next page' }));
+
+    await waitFor(() => expect(dlqApi.list).toHaveBeenNthCalledWith(3, expect.objectContaining({ pageNum: 1, pageSize: 20 })));
+    expect(await screen.findByText('DLQ-001')).toBeInTheDocument();
+    expect(screen.getByLabelText('Page 1 of 1')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Next page' })).toBeDisabled();
+  });
+
+  it('retries the exact page that failed to load', async () => {
+    const user = userEvent.setup();
+    vi.mocked(dlqApi.list)
+      .mockReset()
+      .mockResolvedValueOnce({ items: firstDlqPage, total: 20 })
+      .mockRejectedValueOnce(new Error('page 2 unavailable'))
+      .mockResolvedValueOnce({ items: [{ ...dlqMessage, messageId: 'DLQ-021', queueOffset: 62 }], total: 21 });
+
+    renderAtRoute(<DlqMessagePage />, '/messages/dlq');
+    await screen.findByRole('heading', { name: 'Dead-letter messages' });
+    await user.click(screen.getByRole('button', { name: 'Search DLQ messages' }));
+    await user.click(await screen.findByRole('button', { name: 'Next page' }));
+    expect(await screen.findByText('page 2 unavailable')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => expect(dlqApi.list).toHaveBeenNthCalledWith(3, expect.objectContaining({ pageNum: 2 })));
+    expect(await screen.findByText('DLQ-021')).toBeInTheDocument();
+  });
+
+  it('shows every exact-ID match as one non-paginated result set', async () => {
+    const user = userEvent.setup();
+    const duplicateMatches = Array.from({ length: 25 }, (_, index) => ({
+      ...dlqMessage,
+      queueOffset: dlqMessage.queueOffset + index
+    }));
+    vi.mocked(dlqApi.list).mockReset().mockResolvedValue({ items: duplicateMatches, total: 25 });
+
+    renderAtRoute(<DlqMessagePage />, '/messages/dlq');
+    await screen.findByRole('heading', { name: 'Dead-letter messages' });
+    await user.type(screen.getByRole('textbox', { name: 'Message ID optional' }), 'DLQ-001');
+    await user.click(screen.getByRole('button', { name: 'Search DLQ messages' }));
+
+    expect(await screen.findAllByRole('checkbox', { name: 'Select DLQ-001' })).toHaveLength(25);
+    expect(screen.getByLabelText('Page 1 of 1')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Next page' })).toBeDisabled();
+    expect(dlqApi.list).toHaveBeenLastCalledWith(expect.objectContaining({ messageId: 'DLQ-001', pageNum: 1 }));
+  });
+
+  it('ignores an in-flight response after the consumer group changes', async () => {
+    const user = userEvent.setup();
+    let resolveList!: (value: { items: MessageView[]; total: number }) => void;
+    vi.mocked(consumerApi.list).mockResolvedValue({
+      items: [
+        { group: 'order-service', consumeType: 'CONSUME_PASSIVELY', messageModel: 'MESSAGE_MODEL_CLUSTERING', clientCount: 1, diffTotal: 1 },
+        { group: 'payment-consumer', consumeType: 'CONSUME_PASSIVELY', messageModel: 'MESSAGE_MODEL_CLUSTERING', clientCount: 1, diffTotal: 0 }
+      ], total: 2
+    });
+    vi.mocked(dlqApi.list).mockReset().mockReturnValue(new Promise((resolve) => { resolveList = resolve; }));
+
+    renderAtRoute(<DlqMessagePage />, '/messages/dlq');
+    await screen.findByRole('heading', { name: 'Dead-letter messages' });
+    await user.click(screen.getByRole('button', { name: 'Search DLQ messages' }));
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Consumer group' }), 'payment-consumer');
+    resolveList({ items: [dlqMessage], total: 1 });
+
+    await waitFor(() => expect(screen.getByText('0 selected')).toBeInTheDocument());
+    expect(screen.queryByText('DLQ-001')).not.toBeInTheDocument();
+  });
+
+  it('disables resend when canonical origin metadata is missing', async () => {
+    const user = userEvent.setup();
+    const unsafeMessage = { ...dlqMessage, properties: {} };
+    vi.mocked(dlqApi.list).mockReset().mockResolvedValue({ items: [unsafeMessage], total: 1 });
+
+    renderAtRoute(<DlqMessagePage />, '/messages/dlq');
+    await screen.findByRole('heading', { name: 'Dead-letter messages' });
+    await user.click(screen.getByRole('button', { name: 'Search DLQ messages' }));
+
+    expect(await screen.findByText('Unsafe metadata')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Select DLQ-001' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Review selected resend' })).toBeDisabled();
+    expect(dlqApi.resend).not.toHaveBeenCalled();
+  });
+
+  it('renders failed resend outcomes with their safe backend remark', async () => {
+    const user = userEvent.setup();
+    vi.mocked(dlqApi.resend).mockResolvedValue([{
+      msgId: 'MSG-001', success: false, consumeResult: 'FAILED', remark: 'BACKEND: DLQ resend request failed'
+    }]);
+
+    renderAtRoute(<DlqMessagePage />, '/messages/dlq');
+    await screen.findByRole('heading', { name: 'Dead-letter messages' });
+    await user.click(screen.getByRole('button', { name: 'Search DLQ messages' }));
+    await user.click(await screen.findByRole('checkbox', { name: 'Select DLQ-001' }));
+    await user.click(screen.getByRole('button', { name: 'Review selected resend' }));
+    await user.click(within(screen.getByRole('alertdialog', { name: 'Resend selected DLQ messages?' })).getByRole('button', { name: 'Confirm resend' }));
+
+    const outcome = await screen.findByText('MSG-001: FAILED');
+    expect(outcome.closest('li')).toHaveClass('is-danger');
+    expect(screen.getByText('BACKEND: DLQ resend request failed')).toBeInTheDocument();
+  });
+
+  it('does not show a completed batch after the consumer group changes', async () => {
+    const user = userEvent.setup();
+    let resolveResend!: (value: Array<{ msgId: string; success: boolean; consumeResult: string; remark?: string }>) => void;
+    vi.mocked(consumerApi.list).mockResolvedValue({
+      items: [
+        { group: 'order-service', consumeType: 'CONSUME_PASSIVELY', messageModel: 'MESSAGE_MODEL_CLUSTERING', clientCount: 1, diffTotal: 1 },
+        { group: 'payment-consumer', consumeType: 'CONSUME_PASSIVELY', messageModel: 'MESSAGE_MODEL_CLUSTERING', clientCount: 1, diffTotal: 0 }
+      ], total: 2
+    });
+    vi.mocked(dlqApi.resend).mockReturnValueOnce(new Promise((resolve) => { resolveResend = resolve; }));
+
+    renderAtRoute(<DlqMessagePage />, '/messages/dlq');
+    await screen.findByRole('heading', { name: 'Dead-letter messages' });
+    await user.click(screen.getByRole('button', { name: 'Search DLQ messages' }));
+    await user.click(await screen.findByRole('checkbox', { name: 'Select DLQ-001' }));
+    await user.click(screen.getByRole('button', { name: 'Review selected resend' }));
+    await user.click(within(screen.getByRole('alertdialog', { name: 'Resend selected DLQ messages?' })).getByRole('button', { name: 'Confirm resend' }));
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Consumer group' }), 'payment-consumer');
+    resolveResend([{ msgId: 'MSG-001', success: true, consumeResult: 'CR_SUCCESS', remark: 'old batch completed' }]);
+
+    await waitFor(() => expect(screen.queryByText('old batch completed')).not.toBeInTheDocument());
+  });
+
+  it('keeps the destructive batch locked until an invalidated request settles', async () => {
+    const user = userEvent.setup();
+    let resolveResend!: (value: Array<{ msgId: string; success: boolean; consumeResult: string }>) => void;
+    vi.mocked(dlqApi.list).mockReset().mockResolvedValue({ items: [dlqMessage], total: 1 });
+    vi.mocked(dlqApi.resend).mockReturnValueOnce(new Promise((resolve) => { resolveResend = resolve; }));
+
+    renderAtRoute(<DlqMessagePage />, '/messages/dlq');
+    await screen.findByRole('heading', { name: 'Dead-letter messages' });
+    await user.click(screen.getByRole('button', { name: 'Search DLQ messages' }));
+    await user.click(await screen.findByRole('checkbox', { name: 'Select DLQ-001' }));
+    await user.click(screen.getByRole('button', { name: 'Review selected resend' }));
+    await user.click(within(screen.getByRole('alertdialog', { name: 'Resend selected DLQ messages?' })).getByRole('button', { name: 'Confirm resend' }));
+    await user.click(screen.getByRole('button', { name: 'Search DLQ messages' }));
+    await screen.findByRole('checkbox', { name: 'Select DLQ-001' });
+
+    expect(screen.getByRole('button', { name: 'Review selected resend' })).toBeDisabled();
+    expect(dlqApi.resend).toHaveBeenCalledTimes(1);
+    resolveResend([{ msgId: 'MSG-001', success: true, consumeResult: 'CR_SUCCESS' }]);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Review selected resend' })).toBeEnabled());
+  });
+
+  it('drops pending outcomes when the selected canonical target changes', async () => {
+    const user = userEvent.setup();
+    let resolveResend!: (value: Array<{ msgId: string; success: boolean; consumeResult: string; remark?: string }>) => void;
+    vi.mocked(dlqApi.list).mockReset().mockResolvedValue({ items: [dlqMessage], total: 1 });
+    vi.mocked(dlqApi.resend).mockReturnValueOnce(new Promise((resolve) => { resolveResend = resolve; }));
+
+    renderAtRoute(<DlqMessagePage />, '/messages/dlq');
+    await screen.findByRole('heading', { name: 'Dead-letter messages' });
+    await user.click(screen.getByRole('button', { name: 'Search DLQ messages' }));
+    const checkbox = await screen.findByRole('checkbox', { name: 'Select DLQ-001' });
+    await user.click(checkbox);
+    await user.click(screen.getByRole('button', { name: 'Review selected resend' }));
+    await user.click(within(screen.getByRole('alertdialog', { name: 'Resend selected DLQ messages?' })).getByRole('button', { name: 'Confirm resend' }));
+    await user.click(checkbox);
+    resolveResend([{ msgId: 'MSG-001', success: true, consumeResult: 'CR_SUCCESS', remark: 'old target completed' }]);
+
+    await waitFor(() => expect(screen.queryByText('old target completed')).not.toBeInTheDocument());
+  });
+
+  it('deduplicates selected envelopes that map to the same original message', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<DlqMessagePage />, '/messages/dlq');
+    await screen.findByRole('heading', { name: 'Dead-letter messages' });
+    await user.click(screen.getByRole('button', { name: 'Search DLQ messages' }));
+    await user.click(await screen.findByRole('checkbox', { name: 'Select DLQ-001' }));
+    await user.click(screen.getByRole('checkbox', { name: 'Select DLQ-002' }));
+
+    expect(screen.getByText('1 selected')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Review selected resend' }));
+    await user.click(within(screen.getByRole('alertdialog', { name: 'Resend selected DLQ messages?' })).getByRole('button', { name: 'Confirm resend' }));
+    await waitFor(() => expect(dlqApi.resend).toHaveBeenCalledWith({ messages: [{
+      topicName: 'orders', consumerGroup: 'order-service', msgId: 'MSG-001', clientId: undefined
+    }] }));
+  });
+
+  it('selects and resends only one physical row when client message identifiers collide', async () => {
+    const user = userEvent.setup();
+    const collidingRows = [
+      { ...dlqMessage, properties: { RETRY_TOPIC: 'orders', ORIGIN_MESSAGE_ID: 'MSG-001' } },
+      {
+        ...dlqMessage,
+        storeHost: '10.0.0.3:10911',
+        queueOffset: 43,
+        properties: { RETRY_TOPIC: 'payments', ORIGIN_MESSAGE_ID: 'MSG-002' }
+      }
+    ];
+    vi.mocked(dlqApi.list).mockReset().mockResolvedValue({ items: collidingRows, total: 2 });
+
+    renderAtRoute(<DlqMessagePage />, '/messages/dlq');
+    await screen.findByRole('heading', { name: 'Dead-letter messages' });
+    await user.click(screen.getByRole('button', { name: 'Search DLQ messages' }));
+    const checkboxes = await screen.findAllByRole('checkbox', { name: 'Select DLQ-001' });
+    await user.click(checkboxes[0]);
+
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).not.toBeChecked();
+    await user.click(screen.getByRole('button', { name: 'Review selected resend' }));
+    await user.click(within(screen.getByRole('alertdialog', { name: 'Resend selected DLQ messages?' })).getByRole('button', { name: 'Confirm resend' }));
+    await waitFor(() => expect(dlqApi.resend).toHaveBeenCalledWith({ messages: [{
+      topicName: 'orders', consumerGroup: 'order-service', msgId: 'MSG-001', clientId: undefined
+    }] }));
+  });
+
+  it('recovers consumer-group discovery after a retry', async () => {
+    const user = userEvent.setup();
+    vi.mocked(consumerApi.list)
+      .mockRejectedValueOnce(new Error('nameserver unavailable'))
+      .mockResolvedValueOnce({
+        items: [{ group: 'order-service', consumeType: 'CONSUME_PASSIVELY', messageModel: 'MESSAGE_MODEL_CLUSTERING', clientCount: 1, diffTotal: 1 }], total: 1
+      });
+
+    renderAtRoute(<DlqMessagePage />, '/messages/dlq');
+    expect(await screen.findByText('Consumer-group discovery failed: nameserver unavailable')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Retry consumer groups' }));
+
+    await waitFor(() => expect(consumerApi.list).toHaveBeenCalledTimes(2));
+    expect(screen.getByRole('combobox', { name: 'Consumer group' })).toHaveValue('order-service');
+    expect(screen.queryByText('Consumer-group discovery failed: nameserver unavailable')).not.toBeInTheDocument();
+  });
+
+  it('does not download an export after the query context changes', async () => {
+    const user = userEvent.setup();
+    let resolveExport!: (value: { fileName: string; rows: MessageView[]; csv: string }) => void;
+    const anchorClick = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => undefined);
+    vi.mocked(consumerApi.list).mockResolvedValue({
+      items: [
+        { group: 'order-service', consumeType: 'CONSUME_PASSIVELY', messageModel: 'MESSAGE_MODEL_CLUSTERING', clientCount: 1, diffTotal: 1 },
+        { group: 'payment-consumer', consumeType: 'CONSUME_PASSIVELY', messageModel: 'MESSAGE_MODEL_CLUSTERING', clientCount: 1, diffTotal: 0 }
+      ], total: 2
+    });
+    vi.mocked(dlqApi.export).mockReturnValueOnce(new Promise((resolve) => { resolveExport = resolve; }));
+
+    renderAtRoute(<DlqMessagePage />, '/messages/dlq');
+    await screen.findByRole('heading', { name: 'Dead-letter messages' });
+    await user.click(screen.getByRole('button', { name: 'Export current query' }));
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Consumer group' }), 'payment-consumer');
+    resolveExport({ fileName: 'old-group.csv', rows: [dlqMessage], csv: 'messageId\nDLQ-001' });
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Export current query' })).not.toBeDisabled());
+    expect(anchorClick).not.toHaveBeenCalled();
+    anchorClick.mockRestore();
+  });
+
+  it('re-enables optimistic paging when a refreshed full page may have new rows', async () => {
+    const user = userEvent.setup();
+    const secondPage = Array.from({ length: 20 }, (_, index) => ({
+      ...dlqMessage,
+      messageId: `DLQ-${String(index + 21).padStart(3, '0')}`,
+      queueOffset: dlqMessage.queueOffset + index + 20
+    }));
+    vi.mocked(dlqApi.list)
+      .mockReset()
+      .mockResolvedValueOnce({ items: firstDlqPage, total: 20 })
+      .mockResolvedValueOnce({ items: secondPage, total: 40 })
+      .mockResolvedValueOnce({ items: [], total: 40 })
+      .mockResolvedValueOnce({ items: secondPage, total: 40 })
+      .mockResolvedValueOnce({ items: secondPage, total: 40 });
+
+    renderAtRoute(<DlqMessagePage />, '/messages/dlq');
+    await screen.findByRole('heading', { name: 'Dead-letter messages' });
+    await user.click(screen.getByRole('button', { name: 'Search DLQ messages' }));
+    await user.click(await screen.findByRole('button', { name: 'Next page' }));
+    expect(await screen.findByText('DLQ-021')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Next page' }));
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Next page' })).toBeDisabled());
+    await user.click(screen.getByRole('button', { name: 'Refresh' }));
+    await waitFor(() => expect(dlqApi.list).toHaveBeenCalledTimes(5));
+    expect(screen.getByRole('button', { name: 'Next page' })).toBeEnabled();
+  });
+
+  it('keeps visible rows and offers the correct retry after an export failure', async () => {
+    const user = userEvent.setup();
+    vi.mocked(dlqApi.export).mockRejectedValueOnce(new Error('export backend unavailable'));
+
+    renderAtRoute(<DlqMessagePage />, '/messages/dlq');
+    await screen.findByRole('heading', { name: 'Dead-letter messages' });
+    await user.click(screen.getByRole('button', { name: 'Search DLQ messages' }));
+    expect(await screen.findByText('DLQ-001')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Export current query' }));
+
+    expect(await screen.findByText('export backend unavailable')).toBeInTheDocument();
+    expect(screen.getByText('DLQ-001')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry export' })).toBeInTheDocument();
+  });
+
+  it('unlocks batch resend after completion under React StrictMode', async () => {
+    const user = userEvent.setup();
+    let resolveResend!: (value: Array<{ msgId: string; success: boolean; consumeResult: string }>) => void;
+    vi.mocked(dlqApi.list).mockReset().mockResolvedValue({ items: [dlqMessage], total: 1 });
+    vi.mocked(dlqApi.resend).mockReturnValueOnce(new Promise((resolve) => { resolveResend = resolve; }));
+    renderAtRoute(<StrictMode><DlqMessagePage /></StrictMode>, '/messages/dlq');
+    await screen.findByRole('heading', { name: 'Dead-letter messages' });
+    await user.click(screen.getByRole('button', { name: 'Search DLQ messages' }));
+    await user.click(await screen.findByRole('checkbox', { name: 'Select DLQ-001' }));
+    await user.click(screen.getByRole('button', { name: 'Review selected resend' }));
+    await user.click(within(screen.getByRole('alertdialog', { name: 'Resend selected DLQ messages?' })).getByRole('button', { name: 'Confirm resend' }));
+    resolveResend([{ msgId: 'MSG-001', success: true, consumeResult: 'CR_SUCCESS' }]);
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Review selected resend' })).toBeEnabled());
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/DlqMessagePage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/DlqMessagePage.tsx
@@ -1,910 +1,373 @@
-import * as Dialog from '@radix-ui/react-dialog';
-import {
-  CheckSquare,
-  Clock3,
-  Copy,
-  DatabaseZap,
-  Download,
-  Eye,
-  FileDown,
-  Hash,
-  Inbox,
-  RefreshCw,
-  RotateCcw,
-  Search,
-  Send,
-  ShieldAlert,
-  X
-} from 'lucide-react';
-import type { ReactNode } from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { Download, RotateCcw, Search, ShieldAlert } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { consumerApi } from '../api/consumer_api';
 import { dlqApi } from '../api/dlq_api';
-import ConfirmDialog from '../components/ConfirmDialog';
-import EmptyState from '../components/EmptyState';
+import AppDataTable, { type AppDataTableColumn } from '../components/AppDataTable';
+import EntitySheet from '../components/EntitySheet';
+import MetricCard from '../components/MetricCard';
 import PageHeader from '../components/PageHeader';
-import SelectMenu, { type SelectMenuOption } from '../components/SelectMenu';
+import RefreshButton from '../components/RefreshButton';
 import StatusBadge from '../components/StatusBadge';
-import type { DlqMessageQueryParams, MessageListView, MessageView } from '../types/message';
-
-type QueryMode = 'consumer' | 'messageId';
-type NoticeTone = 'success' | 'warning' | 'danger';
-type ExportSource = 'single' | 'selected';
-
-interface ExportDialogState {
-  rows: MessageView[];
-  source: ExportSource;
-}
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription,
+  AlertDialogTitle, AlertDialogTrigger
+} from '../components/ui/AlertDialog';
+import { Button } from '../components/ui/Button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/Card';
+import { Input } from '../components/ui/Input';
+import { Label } from '../components/ui/Label';
+import type { DlqMessageQueryParams, DlqMessageResendResult, MessageView } from '../types/message';
+import {
+  dlqResendTarget, messageRowId, selectionForPage, toggleMessageSelection, uniqueDlqResendTargets
+} from './messages/dlq-selection';
+import MessageDetailContent from './messages/MessageDetailContent';
+import {
+  formatMessageTimestamp, messageKeys, messageTags, truncateIdentifier
+} from './messages/message-model';
 
 const pageSize = 20;
-const sysConsumerPrefix = 'CID_RMQ_SYS_';
-
-const queryModes: Array<{ key: QueryMode; label: string; description: string }> = [
-  {
-    key: 'consumer',
-    label: 'Consumer',
-    description: 'Scan DLQ messages for a consumer group across a store-time range.'
-  },
-  {
-    key: 'messageId',
-    label: 'Message ID',
-    description: 'Look up one DLQ message by consumer group and message ID.'
-  }
-];
 
 export default function DlqMessagePage() {
-  const [mode, setMode] = useState<QueryMode>('consumer');
+  const [groups, setGroups] = useState<string[]>([]);
   const [consumerGroup, setConsumerGroup] = useState('');
-  const [consumerGroups, setConsumerGroups] = useState<string[]>([]);
-  const [consumerLoading, setConsumerLoading] = useState(true);
   const [begin, setBegin] = useState(() => formatDateTimeInput(new Date(Date.now() - 3 * 60 * 60 * 1000)));
   const [end, setEnd] = useState(() => formatDateTimeInput(new Date()));
   const [messageId, setMessageId] = useState('');
   const [rows, setRows] = useState<MessageView[]>([]);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
-  const [tableQuery, setTableQuery] = useState('');
+  const [exhaustedAfterPage, setExhaustedAfterPage] = useState<number | null>(null);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
-  const [selectedMessage, setSelectedMessage] = useState<MessageView | null>(null);
-  const [exportDialog, setExportDialog] = useState<ExportDialogState | null>(null);
+  const [selected, setSelected] = useState<MessageView | null>(null);
   const [loading, setLoading] = useState(false);
-  const [actionLoading, setActionLoading] = useState(false);
-  const [notice, setNotice] = useState<{ tone: NoticeTone; message: string } | null>(null);
+  const [queryError, setQueryError] = useState<string | null>(null);
+  const [validation, setValidation] = useState<string | null>(null);
+  const [resending, setResending] = useState(false);
+  const [resendResults, setResendResults] = useState<DlqMessageResendResult[]>([]);
+  const [resendError, setResendError] = useState<string | null>(null);
+  const [exporting, setExporting] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
+  const [groupsLoading, setGroupsLoading] = useState(false);
+  const [groupsError, setGroupsError] = useState<string | null>(null);
+  const requestRef = useRef(0);
+  const retryPageRef = useRef(1);
+  const groupRequestRef = useRef(0);
+  const resendRequestRef = useRef(0);
+  const exportRequestRef = useRef(0);
+  const resendPendingRef = useRef(false);
+  const mountedRef = useRef(true);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
 
-  const activeMode = queryModes.find((item) => item.key === mode) ?? queryModes[0];
-
-  const consumerOptions = useMemo<SelectMenuOption[]>(() => {
-    const values = Array.from(new Set([...consumerGroups, consumerGroup].filter(Boolean))).sort((left, right) => left.localeCompare(right));
-    return values.map((value) => ({ value, label: value }));
-  }, [consumerGroup, consumerGroups]);
-
-  const selectedRows = useMemo(() => rows.filter((row) => selectedIds.has(row.messageId)), [rows, selectedIds]);
-
-  const filteredRows = useMemo(() => {
-    const normalized = tableQuery.trim().toLowerCase();
-    if (!normalized) {
-      return rows;
+  const loadGroups = useCallback(async () => {
+    const requestId = ++groupRequestRef.current;
+    setGroupsLoading(true);
+    setGroupsError(null);
+    try {
+      const data = await consumerApi.list();
+      if (groupRequestRef.current !== requestId) return;
+      const nextGroups = data.items.map((item) => item.group).filter((group) => !group.startsWith('CID_RMQ_SYS_')).sort();
+      setGroups(nextGroups);
+      setConsumerGroup((current) => current || nextGroups[0] || '');
+    } catch (requestError) {
+      if (groupRequestRef.current === requestId) {
+        setGroups([]);
+        setGroupsError(`Consumer-group discovery failed: ${requestError instanceof Error ? requestError.message : String(requestError)}`);
+      }
+    } finally {
+      if (groupRequestRef.current === requestId) setGroupsLoading(false);
     }
-    return rows.filter((row) => JSON.stringify(row).toLowerCase().includes(normalized));
-  }, [rows, tableQuery]);
-
-  const pageCount = Math.max(1, Math.ceil(Math.max(total, rows.length) / pageSize));
-  const allVisibleSelected = filteredRows.length > 0 && filteredRows.every((row) => selectedIds.has(row.messageId));
-  const querySummary =
-    mode === 'consumer'
-      ? `${formatInputDateForDisplay(begin)} - ${formatInputDateForDisplay(end)}`
-      : messageId.trim() || 'message id pending';
-
-  useEffect(() => {
-    setConsumerLoading(true);
-    consumerApi
-      .list()
-      .then((data) => {
-        const groups = data.items
-          .map((item) => item.group)
-          .filter((group) => group && !group.startsWith(sysConsumerPrefix))
-          .sort((left, right) => left.localeCompare(right));
-        setConsumerGroups(groups);
-        setConsumerGroup((current) => current || preferredConsumerGroup(groups));
-      })
-      .catch((requestError: Error) => {
-        setNotice({ tone: 'warning', message: `Consumer group list unavailable: ${requestError.message}` });
-      })
-      .finally(() => setConsumerLoading(false));
   }, []);
 
-  const submitQuery = (targetPage = 1) => {
-    const validation = validateQuery(mode, consumerGroup, messageId, begin, end);
-    if (validation) {
-      setNotice({ tone: 'warning', message: validation });
+  useEffect(() => {
+    mountedRef.current = true;
+    void loadGroups();
+    return () => {
+      mountedRef.current = false;
+      groupRequestRef.current += 1;
+      requestRef.current += 1;
+      resendRequestRef.current += 1;
+      exportRequestRef.current += 1;
+    };
+  }, [loadGroups]);
+
+  const buildQuery = (targetPage: number): DlqMessageQueryParams => ({
+    consumerGroup: consumerGroup.trim(),
+    begin: toTimestamp(begin),
+    end: toTimestamp(end),
+    messageId: messageId.trim() || undefined,
+    pageNum: targetPage,
+    pageSize
+  });
+
+  const query = async (targetPage = 1) => {
+    const issue = validateQuery(consumerGroup, begin, end);
+    if (issue) {
+      setValidation(issue);
       return;
     }
-
+    const requestPage = messageId.trim() ? 1 : targetPage;
+    retryPageRef.current = requestPage;
+    resendRequestRef.current += 1;
+    exportRequestRef.current += 1;
+    setExporting(false);
+    setResendResults([]);
+    setResendError(null);
+    setExportError(null);
+    const requestId = ++requestRef.current;
+    if (requestPage === 1) setExhaustedAfterPage(null);
     setLoading(true);
-    setNotice(null);
-    setSelectedIds(new Set());
-
-    dlqApi
-      .list(buildQuery(targetPage))
-      .then((data: MessageListView) => {
-        setRows(data.items);
-        setTotal(data.total || data.items.length);
-        setPage(targetPage);
-        setNotice({
-          tone: data.items.length > 0 ? 'success' : 'warning',
-          message:
-            data.items.length > 0
-              ? `DLQ query completed. ${data.items.length} message(s) loaded.`
-              : 'No DLQ messages matched the current query.'
-        });
-      })
-      .catch((requestError: Error) => {
+    setQueryError(null);
+    setValidation(null);
+    try {
+      const data = await dlqApi.list(buildQuery(requestPage));
+      if (requestRef.current !== requestId) return;
+      if (requestPage > 1 && data.items.length === 0) {
+        const fallbackPage = requestPage - 1;
+        const fallback = await dlqApi.list(buildQuery(fallbackPage));
+        if (requestRef.current !== requestId) return;
+        setRows(fallback.items);
+        setTotal(fallback.total);
+        setPage(fallbackPage);
+        setExhaustedAfterPage(fallbackPage);
+        setSelectedIds((current) => selectionForPage(current, fallback.items.map(messageRowId)));
+        setSelected(null);
+        setResendResults([]);
+        return;
+      }
+      setRows(data.items);
+      setTotal(data.total);
+      setPage(requestPage);
+      if (data.items.length === pageSize && requestPage === page) setExhaustedAfterPage(null);
+      setSelectedIds((current) => selectionForPage(current, data.items.map(messageRowId)));
+      setResendResults([]);
+    } catch (requestError) {
+      if (requestRef.current === requestId) {
         setRows([]);
         setTotal(0);
-        setNotice({ tone: 'danger', message: requestError.message });
-      })
-      .finally(() => setLoading(false));
-  };
-
-  const buildQuery = (targetPage = page): DlqMessageQueryParams => {
-    const base = { consumerGroup: consumerGroup.trim() };
-    if (mode === 'messageId') {
-      return {
-        ...base,
-        messageId: messageId.trim()
-      };
-    }
-    return {
-      ...base,
-      begin: toTimestamp(begin),
-      end: toTimestamp(end),
-      pageNum: targetPage,
-      pageSize
-    };
-  };
-
-  const toggleRow = (row: MessageView, checked: boolean) => {
-    setSelectedIds((current) => {
-      const next = new Set(current);
-      if (checked) {
-        next.add(row.messageId);
-      } else {
-        next.delete(row.messageId);
+        setSelectedIds(new Set());
+        setQueryError(requestError instanceof Error ? requestError.message : String(requestError));
       }
-      return next;
-    });
+    } finally {
+      if (requestRef.current === requestId) setLoading(false);
+    }
   };
 
-  const toggleVisibleRows = (checked: boolean) => {
-    setSelectedIds((current) => {
-      const next = new Set(current);
-      filteredRows.forEach((row) => {
-        if (checked) {
-          next.add(row.messageId);
-        } else {
-          next.delete(row.messageId);
-        }
-      });
-      return next;
-    });
-  };
-
-  const resetQuery = () => {
-    setMessageId('');
+  const selectedTargets = uniqueDlqResendTargets(rows, selectedIds);
+  const exactIdMode = messageId.trim().length > 0;
+  const tablePageSize = exactIdMode ? Math.max(1, total, rows.length) : pageSize;
+  const invalidateQueryResults = () => {
+    requestRef.current += 1;
+    resendRequestRef.current += 1;
+    exportRequestRef.current += 1;
+    setLoading(false);
+    setExporting(false);
     setRows([]);
     setTotal(0);
     setPage(1);
-    setTableQuery('');
+    retryPageRef.current = 1;
+    setExhaustedAfterPage(null);
     setSelectedIds(new Set());
-    setSelectedMessage(null);
-    setExportDialog(null);
-    setNotice(null);
-    setBegin(formatDateTimeInput(new Date(Date.now() - 3 * 60 * 60 * 1000)));
-    setEnd(formatDateTimeInput(new Date()));
+    setSelected(null);
+    setResendResults([]);
+    setQueryError(null);
+    setResendError(null);
+    setExportError(null);
   };
 
-  const resendRows = (targetRows: MessageView[]) => {
-    if (targetRows.length === 0) {
-      setNotice({ tone: 'warning', message: 'Select at least one DLQ message before resending.' });
-      return;
-    }
-    if (!consumerGroup.trim()) {
-      setNotice({ tone: 'warning', message: 'Consumer group is required before resending DLQ messages.' });
-      return;
-    }
+  const changeConsumerGroup = (nextGroup: string) => {
+    setConsumerGroup(nextGroup);
+    invalidateQueryResults();
+  };
 
-    setActionLoading(true);
-    setNotice(null);
-    dlqApi
-      .resend({
-        messages: targetRows.map((message) => ({
-          topicName: retryTopic(message),
-          consumerGroup: consumerGroup.trim(),
-          msgId: originMessageId(message),
+  const resendSelected = async () => {
+    if (selectedTargets.length === 0 || resendPendingRef.current) return;
+    const requestId = ++resendRequestRef.current;
+    resendPendingRef.current = true;
+    setResending(true);
+    setResendResults([]);
+    setResendError(null);
+    try {
+      const results = await dlqApi.resend({
+        messages: selectedTargets.map((target) => ({
+          topicName: target.topicName,
+          consumerGroup,
+          msgId: target.msgId,
           clientId: undefined
         }))
-      })
-      .then((results) => {
-        const failed = results.filter((item) => !isResendOk(item.consumeResult)).length;
-        setSelectedIds(new Set());
-        setNotice({
-          tone: failed === 0 ? 'success' : 'warning',
-          message:
-            failed === 0
-              ? `Resend requested for ${results.length} DLQ message(s).`
-              : `Resend completed with ${failed} failed item(s).`
-        });
-      })
-      .catch((requestError: Error) => {
-        setNotice({ tone: 'danger', message: requestError.message });
-      })
-      .finally(() => setActionLoading(false));
+      });
+      if (resendRequestRef.current === requestId) setResendResults(results);
+    } catch (requestError) {
+      if (resendRequestRef.current === requestId) {
+        setResendError(requestError instanceof Error ? requestError.message : String(requestError));
+      }
+    } finally {
+      resendPendingRef.current = false;
+      if (mountedRef.current) setResending(false);
+    }
   };
 
-  const openExportDialog = (targetRows: MessageView[], source: ExportSource) => {
-    if (targetRows.length === 0) {
-      setNotice({ tone: 'warning', message: 'Select at least one DLQ message before exporting.' });
+  const exportCurrentQuery = async () => {
+    const issue = validateQuery(consumerGroup, begin, end);
+    if (issue) {
+      setValidation(issue);
       return;
     }
-    setExportDialog({ rows: targetRows, source });
-  };
-
-  const downloadExport = () => {
-    if (!exportDialog) return;
-    const fileName =
-      exportDialog.source === 'single'
-        ? `dlq-${sanitizeFileName(exportDialog.rows[0]?.messageId ?? 'message')}.csv`
-        : `dlq-${sanitizeFileName(consumerGroup || 'selected')}-${exportDialog.rows.length}.csv`;
-    downloadTextFile(fileName, buildDlqCsv(exportDialog.rows));
-    setNotice({ tone: 'success', message: `Exported ${exportDialog.rows.length} DLQ message(s) to ${fileName}.` });
-    setExportDialog(null);
-  };
-
-  const exportCurrentQuery = () => {
-    const validation = validateQuery(mode, consumerGroup, messageId, begin, end);
-    if (validation) {
-      setNotice({ tone: 'warning', message: validation });
-      return;
+    const requestId = ++exportRequestRef.current;
+    setExporting(true);
+    setExportError(null);
+    try {
+      const view = await dlqApi.export(buildQuery(page));
+      if (exportRequestRef.current !== requestId) return;
+      const url = URL.createObjectURL(new Blob([view.csv], { type: 'text/csv;charset=utf-8' }));
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = view.fileName;
+      anchor.click();
+      URL.revokeObjectURL(url);
+    } catch (requestError) {
+      if (exportRequestRef.current === requestId) {
+        setExportError(requestError instanceof Error ? requestError.message : String(requestError));
+      }
+    } finally {
+      if (exportRequestRef.current === requestId) setExporting(false);
     }
-
-    setActionLoading(true);
-    dlqApi
-      .export(buildQuery(page))
-      .then((view) => {
-        downloadTextFile(view.fileName, view.csv);
-        setNotice({ tone: 'success', message: `Exported ${view.rows.length} DLQ message(s) from the current query.` });
-      })
-      .catch((requestError: Error) => setNotice({ tone: 'danger', message: requestError.message }))
-      .finally(() => setActionLoading(false));
   };
 
-  const copyMessageId = (value: string) => {
-    copyText(value);
-    setNotice({ tone: 'success', message: `Copied message ID ${truncateMiddle(value, 28)}.` });
-  };
+  const columns: AppDataTableColumn<MessageView>[] = [
+    {
+      id: 'select', header: <span className="sr-only">Select</span>, width: '44px', align: 'center',
+      cell: (row) => {
+        const rowId = messageRowId(row);
+        return (
+          <input
+          type="checkbox" aria-label={`Select ${row.messageId}`} checked={selectedIds.has(rowId)}
+          disabled={dlqResendTarget(row) === null}
+          title={dlqResendTarget(row) === null ? 'Missing RETRY_TOPIC or origin message ID; resend is disabled.' : undefined}
+          onChange={(event) => {
+            resendRequestRef.current += 1;
+            setResendResults([]);
+            setResendError(null);
+            setSelectedIds((current) => toggleMessageSelection(current, rowId, event.target.checked));
+          }}
+        />
+        );
+      }
+    },
+    { id: 'message-id', header: 'Message ID', width: '31%', cell: (row) => <span className="mono message-id-value" title={row.messageId}>{truncateIdentifier(row.messageId, 34)}</span> },
+    { id: 'topic', header: 'Original topic', cell: (row) => {
+      const target = dlqResendTarget(row);
+      return target ? <span className="mono">{target.topicName}</span> : <StatusBadge status="Unsafe metadata" tone="danger" />;
+    } },
+    { id: 'tags', header: 'Tags', cell: (row) => <StatusBadge status={messageTags(row)} tone={messageTags(row) === '-' ? 'neutral' : 'warning'} /> },
+    { id: 'keys', header: 'Keys', cell: (row) => <span className="mono message-muted-value">{messageKeys(row)}</span> },
+    { id: 'reconsume', header: 'Retries', align: 'right', cell: (row) => row.reconsumeTimes },
+    { id: 'stored', header: 'Stored', cell: (row) => formatMessageTimestamp(row.storeTimestamp) }
+  ];
 
   return (
-    <>
+    <div className="message-ops-workspace">
       <PageHeader
-        title="DLQMessage"
-        description="Recover dead-letter messages by consumer group or message ID, then inspect, resend, or export the matched records."
-        actions={
-          <button type="button" className="button button-secondary" onClick={() => submitQuery(page)} disabled={loading}>
-            <RefreshCw className={loading ? 'spin' : undefined} size={15} aria-hidden="true" />
-            Refresh
-          </button>
-        }
+        title="Dead-letter messages"
+        description="Inspect failed deliveries, preserve server pagination, and explicitly confirm every resend batch."
+        actions={<RefreshButton refreshing={loading} onRefresh={() => void query(page)} />}
       />
 
-      {notice ? <div className={`notice notice-${notice.tone}`}>{notice.message}</div> : null}
-
-      <section className="dlq-query-panel">
-        <div className="dlq-query-head">
-          <div className="message-mode-tabs" role="tablist" aria-label="DLQ query mode">
-            {queryModes.map((item) => (
-              <button
-                type="button"
-                role="tab"
-                aria-selected={mode === item.key}
-                className={mode === item.key ? 'active' : ''}
-                key={item.key}
-                onClick={() => {
-                  setMode(item.key);
-                  setRows([]);
-                  setTotal(0);
-                  setPage(1);
-                  setSelectedIds(new Set());
-                  setNotice(null);
-                }}
-              >
-                {item.label}
-              </button>
-            ))}
+      <Card className="message-query-card">
+        <CardHeader><div><CardTitle>Query dead-letter queue</CardTitle><CardDescription>Results are scoped to one consumer group and time window.</CardDescription></div></CardHeader>
+        <CardContent>
+          <div className="dlq-query-grid">
+            <div className="message-query-field"><Label htmlFor="dlq-group">Consumer group</Label><select id="dlq-group" value={consumerGroup} onChange={(event) => changeConsumerGroup(event.target.value)}>{groups.length === 0 ? <option value="">Select a group</option> : null}{groups.map((group) => <option key={group}>{group}</option>)}</select></div>
+            <div className="message-query-field"><Label htmlFor="dlq-begin">Begin time</Label><Input id="dlq-begin" type="datetime-local" value={begin} onChange={(event) => { setBegin(event.target.value); invalidateQueryResults(); }} /></div>
+            <div className="message-query-field"><Label htmlFor="dlq-end">End time</Label><Input id="dlq-end" type="datetime-local" value={end} onChange={(event) => { setEnd(event.target.value); invalidateQueryResults(); }} /></div>
+            <div className="message-query-field"><Label htmlFor="dlq-message-id">Message ID optional</Label><Input id="dlq-message-id" value={messageId} onChange={(event) => { setMessageId(event.target.value); invalidateQueryResults(); }} /></div>
+            <Button type="button" className="message-query-submit" loading={loading} aria-label="Search DLQ messages" onClick={() => void query(1)}><Search size={15} aria-hidden="true" /> Search DLQ messages</Button>
           </div>
-          <p>{activeMode.description}</p>
-        </div>
-
-        <div className="dlq-query-fields">
-          <label className="message-query-field">
-            <span>
-              <strong>*</strong> Consumer
-            </span>
-            {consumerOptions.length > 0 ? (
-              <SelectMenu
-                value={consumerGroup}
-                options={consumerOptions}
-                onChange={setConsumerGroup}
-                ariaLabel="Select consumer group"
-                className="dlq-consumer-select"
-              />
-            ) : (
-              <input
-                value={consumerGroup}
-                placeholder={consumerLoading ? 'Loading consumer groups' : 'Consumer group'}
-                onChange={(event) => setConsumerGroup(event.target.value)}
-              />
-            )}
-          </label>
-
-          {mode === 'consumer' ? (
-            <>
-              <label className="message-query-field message-date-field">
-                <span>Begin</span>
-                <input type="datetime-local" value={begin} onChange={(event) => setBegin(event.target.value)} />
-              </label>
-              <label className="message-query-field message-date-field">
-                <span>End</span>
-                <input type="datetime-local" value={end} onChange={(event) => setEnd(event.target.value)} />
-              </label>
-            </>
-          ) : (
-            <label className="message-query-field dlq-message-id-field">
-              <span>
-                <strong>*</strong> Message ID
-              </span>
-              <input value={messageId} placeholder="DLQ message ID" onChange={(event) => setMessageId(event.target.value)} />
-            </label>
-          )}
-
-          <button type="button" className="button dlq-action-button" onClick={() => submitQuery(1)} disabled={loading}>
-            {loading ? <RefreshCw className="spin" size={15} aria-hidden="true" /> : <Search size={15} aria-hidden="true" />}
-            Search
-          </button>
-          <button type="button" className="button button-secondary dlq-action-button" onClick={resetQuery}>
-            Reset
-          </button>
-          <ConfirmDialog
-            title="Resend selected DLQ messages"
-            description={`Resend ${selectedRows.length} selected DLQ message(s) to consumer group ${consumerGroup || '(required)'}?`}
-            confirmLabel="Resend selected"
-            onConfirm={() => resendRows(selectedRows)}
-          >
-            <button type="button" className="button button-danger dlq-action-button" disabled={selectedRows.length === 0 || actionLoading}>
-              <Send size={15} aria-hidden="true" />
-              Batch resend
-            </button>
-          </ConfirmDialog>
-          <button
-            type="button"
-            className="button button-secondary dlq-action-button"
-            disabled={selectedRows.length === 0 || actionLoading}
-            onClick={() => openExportDialog(selectedRows, 'selected')}
-          >
-            <FileDown size={15} aria-hidden="true" />
-            Batch export
-          </button>
-        </div>
-      </section>
-
-      <section className="message-metric-grid dlq-metric-grid">
-        <MessageMetric label="Rows" value={rows.length.toLocaleString()} detail={`${total.toLocaleString()} total from latest query`} icon={<DatabaseZap size={18} />} />
-        <MessageMetric label="Selected" value={selectedRows.length.toLocaleString()} detail="batch resend/export target" icon={<CheckSquare size={18} />} />
-        <MessageMetric label="Consumer" value={consumerGroup || '-'} detail="selected consumer group" icon={<Inbox size={18} />} />
-        <MessageMetric label="Condition" value={querySummary} detail="current query condition" icon={mode === 'consumer' ? <Clock3 size={18} /> : <Hash size={18} />} />
-      </section>
-
-      <section className="dlq-results-wide">
-        <div className="table-shell">
-          <div className="table-toolbar dlq-table-toolbar">
-            <div>
-              <h2>DLQ messages</h2>
-              <p>Java-compatible row operations with guarded resend and CSV export flows.</p>
+          {validation ? <div className="notice notice-warning" role="alert">{validation}</div> : null}
+          {groupsError ? (
+            <div className="notice notice-danger message-discovery-notice" role="alert">
+              <span>{groupsError}</span>
+              <Button type="button" variant="outline" size="sm" loading={groupsLoading} aria-label="Retry consumer groups" onClick={() => void loadGroups()}>Retry consumer groups</Button>
             </div>
-            <div className="dlq-table-tools">
-              <StatusBadge status={`${filteredRows.length} visible`} tone={filteredRows.length > 0 ? 'success' : 'neutral'} />
-              <button type="button" className="button button-secondary" onClick={exportCurrentQuery} disabled={actionLoading || rows.length === 0}>
-                <Download size={15} aria-hidden="true" />
-                Export query
-              </button>
-              <button type="button" className="icon-button" onClick={() => submitQuery(page)} title="Refresh table" disabled={loading}>
-                <RefreshCw className={loading ? 'spin' : undefined} size={16} aria-hidden="true" />
-              </button>
-            </div>
-          </div>
-          <div className="dlq-search-band">
-            <label className="search-box">
-              <Search size={16} aria-hidden="true" />
-              <input
-                value={tableQuery}
-                placeholder="Search message id, tag, key, retry topic, or store time"
-                onChange={(event) => setTableQuery(event.target.value)}
-              />
-            </label>
-          </div>
-          <div className="table-scroll">
-            <table>
-              <thead>
-                <tr>
-                  <th className="dlq-checkbox-column">
-                    <input
-                      aria-label="Select visible DLQ messages"
-                      className="dlq-checkbox"
-                      type="checkbox"
-                      checked={allVisibleSelected}
-                      disabled={filteredRows.length === 0}
-                      onChange={(event) => toggleVisibleRows(event.target.checked)}
-                    />
-                  </th>
-                  <th>Message ID</th>
-                  <th>Tag</th>
-                  <th>Key</th>
-                  <th>StoreTime</th>
-                  <th>Retry Topic</th>
-                  <th>Queue</th>
-                  <th>Operation</th>
-                </tr>
-              </thead>
-              <tbody>
-                {filteredRows.map((row) => (
-                  <tr key={row.messageId}>
-                    <td className="dlq-checkbox-column">
-                      <input
-                        aria-label={`Select DLQ message ${row.messageId}`}
-                        className="dlq-checkbox"
-                        type="checkbox"
-                        checked={selectedIds.has(row.messageId)}
-                        onChange={(event) => toggleRow(row, event.target.checked)}
-                      />
-                    </td>
-                    <td>
-                      <div className="message-id-cell dlq-message-id-cell">
-                        <button type="button" className="message-id-link" title={row.messageId} onClick={() => setSelectedMessage(row)}>
-                          <span>{row.messageId}</span>
-                        </button>
-                        <button type="button" className="message-copy-button" title="Copy message ID" onClick={() => copyMessageId(row.messageId)}>
-                          <Copy size={13} aria-hidden="true" /> Copy
-                        </button>
-                      </div>
-                    </td>
-                    <td>
-                      <StatusBadge status={messageTags(row)} tone={messageTags(row) !== '-' ? 'success' : 'neutral'} />
-                    </td>
-                    <td>
-                      <span className="message-muted-value">{messageKeys(row)}</span>
-                    </td>
-                    <td>{formatTimestamp(row.storeTimestamp)}</td>
-                    <td>
-                      <code className="dlq-topic-code" title={retryTopic(row)}>
-                        {retryTopic(row)}
-                      </code>
-                    </td>
-                    <td>
-                      <code className="message-queue-chip">
-                        {row.queueId} / {row.queueOffset}
-                      </code>
-                    </td>
-                    <td>
-                      <div className="message-table-actions dlq-table-actions">
-                        <button type="button" className="message-action-button" title="Message detail" onClick={() => setSelectedMessage(row)}>
-                          <Eye size={14} aria-hidden="true" /> Detail
-                        </button>
-                        <ConfirmDialog
-                          title="Resend DLQ message"
-                          description={`Resend message ${row.messageId} to consumer group ${consumerGroup || '(required)'}?`}
-                          confirmLabel="Resend"
-                          onConfirm={() => resendRows([row])}
-                        >
-                          <button type="button" className="message-action-button dlq-danger-action" title="Resend message" disabled={actionLoading}>
-                            <RotateCcw size={14} aria-hidden="true" /> Resend
-                          </button>
-                        </ConfirmDialog>
-                        <button type="button" className="message-action-button" title="Export message" onClick={() => openExportDialog([row], 'single')}>
-                          <Download size={14} aria-hidden="true" /> Export
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-          {filteredRows.length === 0 ? <EmptyState title={loading ? 'Loading DLQ messages' : 'No DLQ messages'} /> : null}
-          <div className="table-footer">
-            <span>
-              {total.toLocaleString()} rows / page {page} of {pageCount}
-            </span>
-            <div className="pagination">
-              <button type="button" className="button button-secondary" disabled={page <= 1 || loading} onClick={() => submitQuery(page - 1)}>
-                Previous
-              </button>
-              <button type="button" className="button button-secondary" disabled={page >= pageCount || loading} onClick={() => submitQuery(page + 1)}>
-                Next
-              </button>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <DlqMessageDetailDrawer
-        message={selectedMessage}
-        consumerGroup={consumerGroup}
-        actionLoading={actionLoading}
-        onClose={() => setSelectedMessage(null)}
-        onCopyMessageId={copyMessageId}
-        onResend={(message) => resendRows([message])}
-        onExport={(message) => openExportDialog([message], 'single')}
-      />
-      <ExportDialog state={exportDialog} onClose={() => setExportDialog(null)} onDownload={downloadExport} />
-    </>
-  );
-}
-
-interface MessageMetricProps {
-  label: string;
-  value: string;
-  detail: string;
-  icon: ReactNode;
-}
-
-function MessageMetric({ label, value, detail, icon }: MessageMetricProps) {
-  return (
-    <article className="message-metric-card">
-      <div>
-        <span>{label}</span>
-        <strong title={value}>{value}</strong>
-        <small>{detail}</small>
-      </div>
-      <div className="message-metric-icon">{icon}</div>
-    </article>
-  );
-}
-
-interface DlqMessageDetailDrawerProps {
-  message: MessageView | null;
-  consumerGroup: string;
-  actionLoading: boolean;
-  onClose: () => void;
-  onCopyMessageId: (value: string) => void;
-  onResend: (message: MessageView) => void;
-  onExport: (message: MessageView) => void;
-}
-
-function DlqMessageDetailDrawer({
-  message,
-  consumerGroup,
-  actionLoading,
-  onClose,
-  onCopyMessageId,
-  onResend,
-  onExport
-}: DlqMessageDetailDrawerProps) {
-  const properties = Object.entries(message?.properties ?? {});
-  const infoRows = message ? messageInfoRows(message) : [];
-
-  return (
-    <Dialog.Root open={message !== null} onOpenChange={(open) => !open && onClose()}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="dialog-overlay" />
-        <Dialog.Content className="drawer-content message-detail-drawer dlq-detail-drawer">
-          <div className="drawer-header">
-            <div>
-              <Dialog.Title>DLQ Message Detail</Dialog.Title>
-              <div className="drawer-meta">
-                <StatusBadge status={message?.topic ?? 'No topic'} tone="neutral" />
-                <StatusBadge status={messageTags(message) || 'NO_TAG'} tone={messageTags(message) ? 'success' : 'neutral'} />
-              </div>
-            </div>
-            <div className="message-detail-header-actions">
-              {message ? (
-                <>
-                  <button type="button" className="button button-secondary" onClick={() => onCopyMessageId(message.messageId)}>
-                    <Copy size={15} aria-hidden="true" />
-                    Copy ID
-                  </button>
-                  <button type="button" className="button button-secondary" onClick={() => onExport(message)}>
-                    <Download size={15} aria-hidden="true" />
-                    Export
-                  </button>
-                  <ConfirmDialog
-                    title="Resend DLQ message"
-                    description={`Resend ${message.messageId} to consumer group ${consumerGroup || '(required)'}?`}
-                    confirmLabel="Resend"
-                    onConfirm={() => onResend(message)}
-                  >
-                    <button type="button" className="button button-danger" disabled={actionLoading}>
-                      <Send size={15} aria-hidden="true" />
-                      Resend
-                    </button>
-                  </ConfirmDialog>
-                </>
-              ) : null}
-              <Dialog.Close className="icon-button" title="Close">
-                <X size={16} aria-hidden="true" />
-              </Dialog.Close>
-            </div>
-          </div>
-
-          {message ? (
-            <>
-              <section className="drawer-section">
-                <div className="message-detail-section-heading">
-                  <h3>Message info</h3>
-                  <button type="button" className="icon-button" title="Copy message id" onClick={() => onCopyMessageId(message.messageId)}>
-                    <Copy size={14} aria-hidden="true" />
-                  </button>
-                </div>
-                <div className="message-info-grid">
-                  {infoRows.map((row) => (
-                    <div className={row.wide ? 'wide' : undefined} key={row.label}>
-                      <span>{row.label}</span>
-                      <strong title={row.value}>{row.value}</strong>
-                    </div>
-                  ))}
-                </div>
-              </section>
-
-              <section className="drawer-section">
-                <div className="message-detail-section-heading">
-                  <h3>Message properties</h3>
-                  <StatusBadge status={`${properties.length} properties`} tone={properties.length > 0 ? 'success' : 'neutral'} />
-                </div>
-                {properties.length > 0 ? (
-                  <div className="message-property-table">
-                    {properties.map(([name, value]) => (
-                      <div key={name}>
-                        <span>{name}</span>
-                        <strong title={value}>{value}</strong>
-                      </div>
-                    ))}
-                  </div>
-                ) : (
-                  <EmptyState title="No message properties" />
-                )}
-              </section>
-
-              <section className="drawer-section">
-                <div className="message-detail-section-heading">
-                  <h3>Message body</h3>
-                  <button type="button" className="icon-button" title="Copy message body" onClick={() => copyText(message.body)}>
-                    <Copy size={14} aria-hidden="true" />
-                  </button>
-                </div>
-                <pre className="message-body-block">{message.body || '-'}</pre>
-              </section>
-
-              <section className="drawer-section">
-                <div className="message-detail-section-heading">
-                  <h3>Recovery</h3>
-                  <StatusBadge status={retryTopic(message)} tone="warning" />
-                </div>
-                <div className="dlq-recovery-panel">
-                  <ShieldAlert size={18} aria-hidden="true" />
-                  <div>
-                    <strong>Resend target</strong>
-                    <span>
-                      Consumer group <code>{consumerGroup || '-'}</code>, retry topic <code>{retryTopic(message)}</code>, origin message{' '}
-                      <code>{originMessageId(message)}</code>.
-                    </span>
-                  </div>
-                </div>
-              </section>
-            </>
           ) : null}
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+        </CardContent>
+      </Card>
+
+      <div className="metric-grid message-metric-grid">
+        <MetricCard label="Scanned through" value={total} detail="Rows visited by DLQ API" icon={<ShieldAlert size={18} />} />
+        <MetricCard label="Page" value={page} detail={exactIdMode ? `${rows.length} exact matches` : `${pageSize} rows per request`} icon={<Search size={18} />} />
+        <MetricCard label="Selected" value={selectedTargets.length} detail="Unique original messages" icon={<RotateCcw size={18} />} />
+        <MetricCard label="Consumer group" value={consumerGroup || '-'} detail="Current DLQ scope" />
+      </div>
+
+      <Card className="message-results-card">
+        <CardHeader>
+          <div><CardTitle>Dead-letter queue</CardTitle><CardDescription>Message bodies are available only from the detail sheet.</CardDescription></div>
+          <div className="dlq-action-bar">
+            <span>{selectedTargets.length} selected</span>
+            <Button type="button" variant="outline" loading={exporting} onClick={() => void exportCurrentQuery()}><Download size={15} aria-hidden="true" /> Export current query</Button>
+            <AlertDialog>
+              <AlertDialogTrigger asChild><Button type="button" variant="destructive" disabled={selectedTargets.length === 0 || resending}><RotateCcw size={15} aria-hidden="true" /> Review selected resend</Button></AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogTitle>Resend selected DLQ messages?</AlertDialogTitle>
+                <AlertDialogDescription>Resend {selectedTargets.length} selected message(s) to their original topics for {consumerGroup}. Results are reported per message.</AlertDialogDescription>
+                <div className="ui-alert-dialog-actions"><AlertDialogCancel>Cancel</AlertDialogCancel><AlertDialogAction onClick={() => void resendSelected()}>Confirm resend</AlertDialogAction></div>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {resendError ? <div className="notice notice-danger" role="alert">{resendError}. Review the selected batch again to retry.</div> : null}
+          {exportError ? (
+            <div className="notice notice-danger message-discovery-notice" role="alert">
+              <span>{exportError}</span>
+              <Button type="button" variant="outline" size="sm" onClick={() => void exportCurrentQuery()}>Retry export</Button>
+            </div>
+          ) : null}
+          {resendResults.length > 0 ? (
+            <ul className="dlq-resend-results" role="status">
+              {resendResults.map((result) => {
+                const failed = !result.success;
+                return (
+                  <li key={result.msgId} className={failed ? 'is-danger' : 'is-success'}>
+                    <strong>{result.msgId}: {result.consumeResult}</strong>
+                    {result.remark ? <span>{result.remark}</span> : null}
+                  </li>
+                );
+              })}
+            </ul>
+          ) : null}
+          <AppDataTable
+            ariaLabel="Dead-letter messages" rows={rows} columns={columns} getRowId={messageRowId}
+            page={page} pageSize={tablePageSize} total={total} onPageChange={(nextPage) => void query(nextPage)}
+            hasNextPage={exactIdMode ? false : rows.length === pageSize && exhaustedAfterPage !== page}
+            onRowActivate={(row, origin) => { restoreFocusRef.current = origin; setSelected(row); }}
+            loading={loading} error={queryError} onRetry={() => void query(retryPageRef.current)} emptyTitle="No dead-letter messages"
+            emptyDetail="Run a query to inspect failed deliveries."
+          />
+        </CardContent>
+      </Card>
+
+      <EntitySheet
+        open={selected !== null} title="Dead-letter message detail"
+        description={selected ? `${consumerGroup} · ${truncateIdentifier(selected.messageId, 40)}` : undefined}
+        onOpenChange={(open) => { if (!open) setSelected(null); }} restoreFocusRef={restoreFocusRef}
+      >
+        {selected ? <MessageDetailContent message={selected} /> : null}
+      </EntitySheet>
+    </div>
   );
 }
 
-interface ExportDialogProps {
-  state: ExportDialogState | null;
-  onClose: () => void;
-  onDownload: () => void;
-}
-
-function ExportDialog({ state, onClose, onDownload }: ExportDialogProps) {
-  return (
-    <Dialog.Root open={state !== null} onOpenChange={(open) => !open && onClose()}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="dialog-overlay" />
-        <Dialog.Content className="dialog-content dlq-export-dialog">
-          <Dialog.Title className="dialog-title">
-            <FileDown size={18} aria-hidden="true" />
-            Export DLQ messages
-          </Dialog.Title>
-          <Dialog.Description className="dialog-description">
-            {state?.source === 'single'
-              ? 'Export this DLQ message as CSV with Java-compatible fields.'
-              : `Export ${state?.rows.length ?? 0} selected DLQ message(s) as CSV.`}
-          </Dialog.Description>
-          <div className="dlq-export-preview">
-            <span>Rows</span>
-            <strong>{state?.rows.length ?? 0}</strong>
-          </div>
-          <div className="dialog-actions">
-            <Dialog.Close className="button button-secondary">Cancel</Dialog.Close>
-            <button type="button" className="button" onClick={onDownload}>
-              <Download size={15} aria-hidden="true" />
-              Download CSV
-            </button>
-          </div>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
-  );
-}
-
-function validateQuery(mode: QueryMode, consumerGroup: string, messageId: string, begin: string, end: string) {
-  if (!consumerGroup.trim()) {
-    return 'Consumer group is required.';
-  }
-  if (mode === 'messageId' && !messageId.trim()) {
-    return 'Message ID is required.';
-  }
-  if (mode === 'consumer') {
-    const beginTime = toTimestamp(begin);
-    const endTime = toTimestamp(end);
-    if (!beginTime || !endTime) {
-      return 'Begin and end time are required.';
-    }
-    if (endTime < beginTime) {
-      return 'End time must be later than begin time.';
-    }
-  }
+function validateQuery(consumerGroup: string, begin: string, end: string) {
+  if (!consumerGroup.trim()) return 'Consumer group is required.';
+  if (!begin || !end) return 'Begin time and end time are required.';
+  if (toTimestamp(end) <= toTimestamp(begin)) return 'End time must be after begin time.';
   return null;
 }
 
-function preferredConsumerGroup(groups: string[]) {
-  return groups.find((item) => item === 'please_rename_unique_group_name_4') ?? groups[0] ?? '';
-}
-
-function messageInfoRows(message: MessageView) {
-  return [
-    { label: 'Topic', value: message.topic, wide: true },
-    { label: 'Message ID', value: message.messageId, wide: true },
-    { label: 'Origin Message ID', value: originMessageId(message), wide: true },
-    { label: 'Retry Topic', value: retryTopic(message), wide: true },
-    { label: 'Store Message ID', value: message.properties.STORE_MESSAGE_ID || '-', wide: true },
-    { label: 'StoreHost', value: optionalMessageValue(message, 'storeHost') },
-    { label: 'BornHost', value: optionalMessageValue(message, 'bornHost') },
-    { label: 'StoreTime', value: formatTimestamp(message.storeTimestamp) },
-    { label: 'BornTime', value: formatTimestamp(message.bornTimestamp) },
-    { label: 'Queue ID', value: String(message.queueId) },
-    { label: 'Queue Offset', value: String(message.queueOffset) },
-    { label: 'ReconsumeTimes', value: optionalMessageValue(message, 'reconsumeTimes') },
-    { label: 'Tag', value: messageTags(message) },
-    { label: 'Key', value: messageKeys(message) }
-  ];
-}
-
-function optionalMessageValue(message: MessageView, key: string, fallback = '-') {
-  const value = (message as unknown as Record<string, unknown>)[key];
-  return value === undefined || value === null || value === '' ? fallback : String(value);
-}
-
-function retryTopic(message: MessageView) {
-  return message.properties.RETRY_TOPIC || message.properties.ORIGIN_TOPIC || message.topic;
-}
-
-function originMessageId(message: MessageView) {
-  return message.properties.ORIGIN_MESSAGE_ID || message.properties.UNIQ_KEY || message.messageId;
-}
-
-function messageTags(message: MessageView | null | undefined) {
-  return message?.tags || message?.properties?.TAGS || '-';
-}
-
-function messageKeys(message: MessageView | null | undefined) {
-  return message?.keys || message?.properties?.KEYS || '-';
-}
-
-function isResendOk(value: string) {
-  const normalized = value.toLowerCase();
-  return normalized.includes('success') || normalized.includes('ok') || normalized.includes('consume_success');
-}
-
-function buildDlqCsv(rows: MessageView[]) {
-  const headers = ['messageId', 'topic', 'retryTopic', 'originMessageId', 'tag', 'key', 'storeTime', 'queueId', 'queueOffset', 'body'];
-  const lines = rows.map((row) =>
-    [
-      row.messageId,
-      row.topic,
-      retryTopic(row),
-      originMessageId(row),
-      messageTags(row),
-      messageKeys(row),
-      formatTimestamp(row.storeTimestamp),
-      String(row.queueId),
-      String(row.queueOffset),
-      row.body
-    ]
-      .map(csvEscape)
-      .join(',')
-  );
-  return [headers.join(','), ...lines].join('\n');
-}
-
-function csvEscape(value: string) {
-  return `"${value.replace(/"/g, '""')}"`;
-}
-
-function downloadTextFile(fileName: string, content: string) {
-  const blob = new Blob([content], { type: 'text/csv;charset=utf-8' });
-  const url = URL.createObjectURL(blob);
-  const anchor = document.createElement('a');
-  anchor.href = url;
-  anchor.download = fileName;
-  document.body.appendChild(anchor);
-  anchor.click();
-  anchor.remove();
-  URL.revokeObjectURL(url);
-}
-
-function sanitizeFileName(value: string) {
-  return value.replace(/[^a-zA-Z0-9._-]+/g, '_').slice(0, 96) || 'dlq';
-}
+function toTimestamp(value: string) { return new Date(value).getTime(); }
 
 function formatDateTimeInput(date: Date) {
-  const year = date.getFullYear();
-  const month = pad2(date.getMonth() + 1);
-  const day = pad2(date.getDate());
-  const hour = pad2(date.getHours());
-  const minute = pad2(date.getMinutes());
-  return `${year}-${month}-${day}T${hour}:${minute}`;
-}
-
-function formatInputDateForDisplay(value: string) {
-  return value.replace('T', ' ');
-}
-
-function toTimestamp(value: string) {
-  const timestamp = new Date(value).getTime();
-  return Number.isNaN(timestamp) ? undefined : timestamp;
-}
-
-function formatTimestamp(value: number | undefined) {
-  if (!value) return '-';
-  return new Date(value).toLocaleString();
-}
-
-function truncateMiddle(value: string, maxLength: number) {
-  if (value.length <= maxLength) return value;
-  const edge = Math.floor((maxLength - 3) / 2);
-  return `${value.slice(0, edge)}...${value.slice(-edge)}`;
-}
-
-function pad2(value: number) {
-  return String(value).padStart(2, '0');
-}
-
-function copyText(value: string) {
-  if (!value) return;
-  if (navigator.clipboard?.writeText) {
-    void navigator.clipboard.writeText(value).catch(() => legacyCopyText(value));
-    return;
-  }
-  legacyCopyText(value);
-}
-
-function legacyCopyText(value: string) {
-  const textarea = document.createElement('textarea');
-  textarea.value = value;
-  textarea.setAttribute('readonly', 'true');
-  textarea.style.position = 'fixed';
-  textarea.style.left = '-9999px';
-  textarea.style.top = '0';
-  document.body.appendChild(textarea);
-  textarea.select();
-  document.execCommand('copy');
-  textarea.remove();
+  const offset = date.getTimezoneOffset();
+  return new Date(date.getTime() - offset * 60_000).toISOString().slice(0, 16);
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/MessageQueryPage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/MessageQueryPage.test.tsx
@@ -1,0 +1,255 @@
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { StrictMode } from 'react';
+import { vi } from 'vitest';
+import { messageApi } from '../api/message_api';
+import { topicApi } from '../api/topic_api';
+import { renderAtRoute } from '../test/render';
+import type { MessageView } from '../types/message';
+import MessageQueryPage from './MessageQueryPage';
+
+vi.mock('../api/message_api', () => ({
+  messageApi: { list: vi.fn(), byKey: vi.fn(), byId: vi.fn(), trace: vi.fn(), resend: vi.fn() }
+}));
+vi.mock('../api/topic_api', () => ({ topicApi: { list: vi.fn() } }));
+
+const message: MessageView = {
+  topic: 'orders', messageId: 'MSG-001', keys: 'order:1', tags: 'TagA', bornTimestamp: 1_723_651_200_000,
+  storeTimestamp: 1_723_651_201_000, bornHost: '10.0.0.1:10911', storeHost: '10.0.0.2:10911', queueId: 1,
+  queueOffset: 42, storeSize: 128, reconsumeTimes: 0, bodyCRC: 1, sysFlag: 0, flag: 0,
+  preparedTransactionOffset: 0, body: 'SECRET-BODY-CONTENT',
+  properties: { KEYS: 'order:1', TAGS: 'TagA', STORE_MESSAGE_ID: 'STORE-001' }
+};
+
+describe('MessageQueryPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(topicApi.list).mockResolvedValue({ items: [{ ...message, brokerName: 'broker-a', readQueueCount: 8, writeQueueCount: 8, perm: 6, category: 'NORMAL' }], total: 1 } as never);
+    vi.mocked(messageApi.list).mockResolvedValue({ items: [message], total: 1 });
+    vi.mocked(messageApi.byKey).mockResolvedValue({ items: [message], total: 1 });
+    vi.mocked(messageApi.byId).mockResolvedValue({ items: [message], total: 1 });
+    vi.mocked(messageApi.trace).mockResolvedValue({ messageId: message.messageId, traceTopic: 'RMQ_SYS_TRACE_TOPIC', nodes: [] });
+    vi.mocked(messageApi.resend).mockResolvedValue({
+      message: 'Direct consume returned CR_SUCCESS', success: true, consumeResult: 'CR_SUCCESS'
+    });
+  });
+
+  it('submits only the active query mode and never renders message bodies in the result table', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<MessageQueryPage />, '/messages');
+    await screen.findByRole('heading', { name: 'Message search' });
+
+    await user.click(screen.getByRole('button', { name: 'Search messages' }));
+    await waitFor(() => expect(messageApi.list).toHaveBeenCalledWith(expect.objectContaining({ topic: 'orders', begin: expect.any(Number), end: expect.any(Number) })));
+    expect(screen.queryByText('SECRET-BODY-CONTENT')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', { name: 'By message key' }));
+    await user.type(screen.getByRole('textbox', { name: 'Message key' }), 'order:1');
+    await user.click(screen.getByRole('button', { name: 'Search messages' }));
+    expect(messageApi.byKey).toHaveBeenCalledWith('orders', 'order:1');
+
+    await user.click(screen.getByRole('tab', { name: 'By message ID' }));
+    await user.type(screen.getByRole('textbox', { name: 'Message ID' }), 'MSG-001');
+    await user.click(screen.getByRole('button', { name: 'Search messages' }));
+    expect(messageApi.byId).toHaveBeenCalledWith('orders', 'MSG-001');
+    expect(await screen.findByRole('dialog', { name: 'Message detail' })).toBeInTheDocument();
+  });
+
+  it('validates time ranges and confirms the exact resend request', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<MessageQueryPage />, '/messages');
+    await screen.findByRole('heading', { name: 'Message search' });
+    const begin = screen.getByLabelText('Begin time');
+    const end = screen.getByLabelText('End time');
+    await user.clear(begin);
+    await user.type(begin, '2026-08-15T15:00');
+    await user.clear(end);
+    await user.type(end, '2026-08-15T14:00');
+    await user.click(screen.getByRole('button', { name: 'Search messages' }));
+    expect(await screen.findByText('End time must be after begin time.')).toBeInTheDocument();
+    expect(messageApi.list).not.toHaveBeenCalled();
+
+    await user.clear(begin);
+    await user.type(begin, '2026-08-15T13:00');
+    await user.click(screen.getByRole('button', { name: 'Search messages' }));
+    await user.click(await screen.findByRole('row', { name: /MSG-001/ }));
+    const dialog = await screen.findByRole('dialog', { name: 'Message detail' });
+    await user.type(within(dialog).getByRole('textbox', { name: 'Consumer group' }), 'order-service');
+    await user.type(within(dialog).getByRole('textbox', { name: 'Client ID optional' }), 'client-a');
+    await user.click(within(dialog).getByRole('button', { name: 'Review resend' }));
+    expect(messageApi.resend).not.toHaveBeenCalled();
+    expect(within(screen.getByRole('alertdialog', { name: 'Resend message?' })).getByText(/STORE-001.*orders/)).toBeInTheDocument();
+    await user.click(within(screen.getByRole('alertdialog', { name: 'Resend message?' })).getByRole('button', { name: 'Confirm resend' }));
+    await waitFor(() => expect(messageApi.resend).toHaveBeenCalledWith('STORE-001', {
+      topic: 'orders', consumerGroup: 'order-service', clientId: 'client-a'
+    }));
+  });
+
+  it('fails closed for a DLQ message without canonical origin metadata', async () => {
+    const user = userEvent.setup();
+    vi.mocked(messageApi.byId).mockResolvedValue({
+      items: [{ ...message, topic: '%DLQ%order-service', messageId: 'DLQ-001', properties: {} }], total: 1
+    });
+
+    renderAtRoute(<MessageQueryPage />, '/messages');
+    await screen.findByRole('heading', { name: 'Message search' });
+    await user.click(screen.getByRole('tab', { name: 'By message ID' }));
+    await user.type(screen.getByRole('textbox', { name: 'Message ID' }), 'DLQ-001');
+    await user.click(screen.getByRole('button', { name: 'Search messages' }));
+
+    const dialog = await screen.findByRole('dialog', { name: 'Message detail' });
+    expect(within(dialog).getByText(/Missing RETRY_TOPIC or origin message ID/)).toBeInTheDocument();
+    await user.type(within(dialog).getByRole('textbox', { name: 'Consumer group' }), 'order-service');
+    expect(within(dialog).getByRole('button', { name: 'Review resend' })).toBeDisabled();
+    expect(messageApi.resend).not.toHaveBeenCalled();
+  });
+
+  it('explains the missing physical message ID for a normal message', async () => {
+    const user = userEvent.setup();
+    const messageWithoutStoreId = { ...message, properties: { KEYS: 'order:1' } };
+    vi.mocked(messageApi.list).mockResolvedValue({ items: [messageWithoutStoreId], total: 1 });
+
+    renderAtRoute(<MessageQueryPage />, '/messages');
+    await screen.findByRole('heading', { name: 'Message search' });
+    await user.click(screen.getByRole('button', { name: 'Search messages' }));
+    await user.click(await screen.findByRole('row', { name: /MSG-001/ }));
+
+    const dialog = await screen.findByRole('dialog', { name: 'Message detail' });
+    expect(within(dialog).getByText(/Missing STORE_MESSAGE_ID/)).toBeInTheDocument();
+    expect(within(dialog).queryByText(/DLQ message/)).not.toBeInTheDocument();
+    expect(within(dialog).getByRole('button', { name: 'Review resend' })).toBeDisabled();
+  });
+
+  it('ignores a search response after an active filter changes', async () => {
+    const user = userEvent.setup();
+    let resolveList!: (value: { items: MessageView[]; total: number }) => void;
+    vi.mocked(messageApi.list).mockReturnValueOnce(new Promise((resolve) => { resolveList = resolve; }));
+
+    renderAtRoute(<MessageQueryPage />, '/messages');
+    await screen.findByRole('heading', { name: 'Message search' });
+    await user.click(screen.getByRole('button', { name: 'Search messages' }));
+    await user.clear(screen.getByLabelText('Begin time'));
+    resolveList({ items: [message], total: 1 });
+
+    await waitFor(() => expect(screen.queryByText('MSG-001')).not.toBeInTheDocument());
+  });
+
+  it('restores focus to the search action after an ID result auto-opens', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<MessageQueryPage />, '/messages');
+    await screen.findByRole('heading', { name: 'Message search' });
+    await user.click(screen.getByRole('tab', { name: 'By message ID' }));
+    await user.type(screen.getByRole('textbox', { name: 'Message ID' }), 'MSG-001');
+    const search = screen.getByRole('button', { name: 'Search messages' });
+    await user.click(search);
+    const dialog = await screen.findByRole('dialog', { name: 'Message detail' });
+    await user.click(within(dialog).getByRole('button', { name: 'Close details' }));
+
+    await waitFor(() => expect(search).toHaveFocus());
+  });
+
+  it('confirms the canonical topic and origin ID for a DLQ resend', async () => {
+    const user = userEvent.setup();
+    vi.mocked(messageApi.byId).mockResolvedValue({
+      items: [{
+        ...message, topic: '%DLQ%order-service', messageId: 'DLQ-001',
+        properties: { RETRY_TOPIC: 'orders', DLQ_ORIGIN_MESSAGE_ID: 'MSG-001' }
+      }], total: 1
+    });
+
+    renderAtRoute(<MessageQueryPage />, '/messages');
+    await screen.findByRole('heading', { name: 'Message search' });
+    await user.click(screen.getByRole('tab', { name: 'By message ID' }));
+    await user.type(screen.getByRole('textbox', { name: 'Message ID' }), 'DLQ-001');
+    await user.click(screen.getByRole('button', { name: 'Search messages' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Message detail' });
+    await user.type(within(dialog).getByRole('textbox', { name: 'Consumer group' }), 'order-service');
+    await user.click(within(dialog).getByRole('button', { name: 'Review resend' }));
+
+    expect(within(screen.getByRole('alertdialog', { name: 'Resend message?' })).getByText(/MSG-001.*orders/)).toBeInTheDocument();
+  });
+
+  it('does not show a completed resend in a newly selected message context', async () => {
+    const user = userEvent.setup();
+    let resolveResend!: (value: { message: string; success: boolean; consumeResult: string; remark?: string }) => void;
+    const secondMessage = {
+      ...message,
+      messageId: 'MSG-002',
+      keys: 'order:2',
+      queueOffset: 43,
+      properties: { ...message.properties, STORE_MESSAGE_ID: 'STORE-002' }
+    };
+    vi.mocked(messageApi.list).mockResolvedValue({ items: [message, secondMessage], total: 2 });
+    vi.mocked(messageApi.resend).mockReturnValueOnce(new Promise((resolve) => { resolveResend = resolve; }));
+
+    renderAtRoute(<MessageQueryPage />, '/messages');
+    await screen.findByRole('heading', { name: 'Message search' });
+    await user.click(screen.getByRole('button', { name: 'Search messages' }));
+    await user.click(await screen.findByRole('row', { name: /MSG-001/ }));
+    let dialog = await screen.findByRole('dialog', { name: 'Message detail' });
+    await user.type(within(dialog).getByRole('textbox', { name: 'Consumer group' }), 'order-service');
+    await user.click(within(dialog).getByRole('button', { name: 'Review resend' }));
+    await user.click(within(screen.getByRole('alertdialog', { name: 'Resend message?' })).getByRole('button', { name: 'Confirm resend' }));
+    await user.click(within(dialog).getByRole('button', { name: 'Close details' }));
+    await user.click(await screen.findByRole('row', { name: /MSG-002/ }));
+    dialog = await screen.findByRole('dialog', { name: 'Message detail' });
+    expect(within(dialog).getByRole('textbox', { name: 'Consumer group' })).toBeDisabled();
+    expect(within(dialog).getByRole('button', { name: 'Review resend' })).toBeDisabled();
+    expect(messageApi.resend).toHaveBeenCalledTimes(1);
+    resolveResend({ message: 'old resend completed', success: true, consumeResult: 'CR_SUCCESS' });
+
+    await waitFor(() => expect(within(dialog).queryByText('old resend completed')).not.toBeInTheDocument());
+    await waitFor(() => expect(within(dialog).getByRole('textbox', { name: 'Consumer group' })).toBeEnabled());
+  });
+
+  it('recovers topic discovery after a retry', async () => {
+    const user = userEvent.setup();
+    vi.mocked(topicApi.list)
+      .mockRejectedValueOnce(new Error('nameserver unavailable'))
+      .mockResolvedValueOnce({ items: [{ ...message, brokerName: 'broker-a' }], total: 1 } as never);
+
+    renderAtRoute(<MessageQueryPage />, '/messages');
+    expect(await screen.findByText('Topic discovery failed: nameserver unavailable')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Retry topics' }));
+
+    await waitFor(() => expect(topicApi.list).toHaveBeenCalledTimes(2));
+    expect(screen.getByRole('combobox', { name: 'Message topic' })).toHaveValue('orders');
+    expect(screen.queryByText('Topic discovery failed: nameserver unavailable')).not.toBeInTheDocument();
+  });
+
+  it('shows a broker CR_LATER outcome as a failed resend', async () => {
+    const user = userEvent.setup();
+    vi.mocked(messageApi.resend).mockResolvedValue({
+      message: 'Direct consume returned CR_LATER', success: false, consumeResult: 'CR_LATER', remark: 'retry later'
+    });
+
+    renderAtRoute(<MessageQueryPage />, '/messages');
+    await screen.findByRole('heading', { name: 'Message search' });
+    await user.click(screen.getByRole('button', { name: 'Search messages' }));
+    await user.click(await screen.findByRole('row', { name: /MSG-001/ }));
+    const dialog = await screen.findByRole('dialog', { name: 'Message detail' });
+    await user.type(within(dialog).getByRole('textbox', { name: 'Consumer group' }), 'order-service');
+    await user.click(within(dialog).getByRole('button', { name: 'Review resend' }));
+    await user.click(within(screen.getByRole('alertdialog', { name: 'Resend message?' })).getByRole('button', { name: 'Confirm resend' }));
+
+    const notice = await within(dialog).findByText('CR_LATER: retry later');
+    expect(notice).toHaveClass('notice-danger');
+  });
+
+  it('unlocks resend after completion under React StrictMode', async () => {
+    const user = userEvent.setup();
+    let resolveResend!: (value: { message: string; success: boolean; consumeResult: string }) => void;
+    vi.mocked(messageApi.resend).mockReturnValueOnce(new Promise((resolve) => { resolveResend = resolve; }));
+    renderAtRoute(<StrictMode><MessageQueryPage /></StrictMode>, '/messages');
+    await screen.findByRole('heading', { name: 'Message search' });
+    await user.click(screen.getByRole('button', { name: 'Search messages' }));
+    await user.click(await screen.findByRole('row', { name: /MSG-001/ }));
+    const dialog = await screen.findByRole('dialog', { name: 'Message detail' });
+    await user.type(within(dialog).getByRole('textbox', { name: 'Consumer group' }), 'order-service');
+    await user.click(within(dialog).getByRole('button', { name: 'Review resend' }));
+    await user.click(within(screen.getByRole('alertdialog', { name: 'Resend message?' })).getByRole('button', { name: 'Confirm resend' }));
+    resolveResend({ message: 'Direct consume returned CR_SUCCESS', success: true, consumeResult: 'CR_SUCCESS' });
+
+    await waitFor(() => expect(within(dialog).getByRole('button', { name: 'Review resend' })).toBeEnabled());
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/MessageQueryPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/MessageQueryPage.tsx
@@ -1,746 +1,347 @@
-import * as Dialog from '@radix-ui/react-dialog';
-import { Clock3, Copy, DatabaseZap, Eye, GitBranch, Hash, KeyRound, RefreshCw, RotateCcw, Search, Send, X } from 'lucide-react';
-import { useEffect, useMemo, useState, type FocusEvent, type MouseEvent } from 'react';
+import { Clock3, DatabaseZap, Hash, Search, Send } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { messageApi } from '../api/message_api';
 import { topicApi } from '../api/topic_api';
-import ConfirmDialog from '../components/ConfirmDialog';
-import DataTable, { type DataTableColumn } from '../components/DataTable';
-import EmptyState from '../components/EmptyState';
+import AppDataTable, { type AppDataTableColumn } from '../components/AppDataTable';
+import EntitySheet from '../components/EntitySheet';
+import MetricCard from '../components/MetricCard';
 import PageHeader from '../components/PageHeader';
-import SelectMenu, { type SelectMenuOption } from '../components/SelectMenu';
+import RefreshButton from '../components/RefreshButton';
 import StatusBadge from '../components/StatusBadge';
-import type { MessageListView, MessageTraceView, MessageView } from '../types/message';
-import type { MutationResult } from '../types/topic';
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription,
+  AlertDialogTitle, AlertDialogTrigger
+} from '../components/ui/AlertDialog';
+import { Button } from '../components/ui/Button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/Card';
+import { Input } from '../components/ui/Input';
+import { Label } from '../components/ui/Label';
+import { Tabs, TabsList, TabsTrigger } from '../components/ui/Tabs';
+import type { MessageListView, MessageView } from '../types/message';
+import MessageDetailContent from './messages/MessageDetailContent';
+import { messageResendTarget, messageRowId } from './messages/dlq-selection';
+import {
+  formatMessageSize, formatMessageTimestamp, messageKeys, messageTags, truncateIdentifier
+} from './messages/message-model';
 
-type QueryMode = 'topic' | 'key' | 'id';
-type NoticeTone = 'success' | 'warning' | 'danger';
-type BodyToast = { body: string; x: number; y: number };
-type BodyToastPoint = { clientX: number; clientY: number };
+type QueryForm =
+  | { mode: 'topic'; topic: string; begin: string; end: string }
+  | { mode: 'key'; topic: string; key: string }
+  | { mode: 'id'; topic: string; messageId: string };
 
-const queryModes: Array<{ key: QueryMode; label: string; description: string }> = [
-  {
-    key: 'topic',
-    label: 'Topic',
-    description: 'Scan messages by topic and store time range.'
-  },
-  {
-    key: 'key',
-    label: 'Message Key',
-    description: 'Query by topic and message key. Java Dashboard returns up to 64 messages.'
-  },
-  {
-    key: 'id',
-    label: 'Message ID',
-    description: 'Query by message ID and open the detail panel directly.'
-  }
-];
+const pageSize = 10;
 
 export default function MessageQueryPage() {
+  const [topics, setTopics] = useState<string[]>([]);
+  const [form, setForm] = useState<QueryForm>(() => topicForm(''));
   const [rows, setRows] = useState<MessageView[]>([]);
   const [total, setTotal] = useState(0);
-  const [topics, setTopics] = useState<string[]>([]);
-  const [mode, setMode] = useState<QueryMode>('topic');
-  const [topic, setTopic] = useState('');
-  const [begin, setBegin] = useState(() => formatDateTimeInput(new Date(Date.now() - 60 * 60 * 1000)));
-  const [end, setEnd] = useState(() => formatDateTimeInput(new Date()));
-  const [key, setKey] = useState('');
-  const [messageId, setMessageId] = useState('');
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [validation, setValidation] = useState<string | null>(null);
+  const [selected, setSelected] = useState<MessageView | null>(null);
   const [consumerGroup, setConsumerGroup] = useState('');
   const [clientId, setClientId] = useState('');
-  const [loading, setLoading] = useState(false);
-  const [topicLoading, setTopicLoading] = useState(true);
-  const [notice, setNotice] = useState<{ tone: NoticeTone; message: string } | null>(null);
-  const [selected, setSelected] = useState<MessageView | null>(null);
-  const [trace, setTrace] = useState<MessageTraceView | null>(null);
-  const [traceLoading, setTraceLoading] = useState(false);
   const [resending, setResending] = useState(false);
-  const [bodyToast, setBodyToast] = useState<BodyToast | null>(null);
+  const [resendNotice, setResendNotice] = useState<{ tone: 'success' | 'danger'; message: string } | null>(null);
+  const [topicsLoading, setTopicsLoading] = useState(false);
+  const [topicsError, setTopicsError] = useState<string | null>(null);
+  const requestRef = useRef(0);
+  const topicRequestRef = useRef(0);
+  const resendRequestRef = useRef(0);
+  const resendPendingRef = useRef(false);
+  const mountedRef = useRef(true);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
+  const searchButtonRef = useRef<HTMLButtonElement>(null);
 
-  const activeMode = queryModes.find((item) => item.key === mode) ?? queryModes[0];
-
-  const topicOptions = useMemo<SelectMenuOption[]>(() => {
-    const values = Array.from(new Set([...topics, topic].filter(Boolean))).sort((left, right) => left.localeCompare(right));
-    return values.map((value) => ({ value, label: value }));
-  }, [topic, topics]);
-
-  const querySummary = useMemo(() => {
-    if (mode === 'topic') {
-      return begin && end ? `${formatInputDateForDisplay(begin)} - ${formatInputDateForDisplay(end)}` : 'time range pending';
+  const loadTopics = useCallback(async () => {
+    const requestId = ++topicRequestRef.current;
+    setTopicsLoading(true);
+    setTopicsError(null);
+    try {
+      const data = await topicApi.list();
+      if (topicRequestRef.current !== requestId) return;
+      const nextTopics = data.items.map((item) => item.topic).sort((left, right) => left.localeCompare(right));
+      setTopics(nextTopics);
+      setForm((current) => current.topic ? current : { ...current, topic: preferredTopic(nextTopics) });
+    } catch (requestError) {
+      if (topicRequestRef.current === requestId) {
+        setTopics([]);
+        setTopicsError(`Topic discovery failed: ${requestError instanceof Error ? requestError.message : String(requestError)}`);
+      }
+    } finally {
+      if (topicRequestRef.current === requestId) setTopicsLoading(false);
     }
-    if (mode === 'key') {
-      return key.trim() || 'message key pending';
-    }
-    return messageId.trim() || 'message id pending';
-  }, [begin, end, key, messageId, mode]);
-
-  useEffect(() => {
-    setTopicLoading(true);
-    topicApi
-      .list()
-      .then((data) => {
-        const nextTopics = data.items.map((item) => item.topic).sort((left, right) => left.localeCompare(right));
-        setTopics(nextTopics);
-        setTopic((value) => value || preferredMessageTopic(nextTopics));
-      })
-      .catch((requestError: Error) => {
-        setNotice({ tone: 'warning', message: `Topic list unavailable: ${requestError.message}` });
-      })
-      .finally(() => setTopicLoading(false));
   }, []);
 
-  const submitQuery = () => {
-    const validation = validateQuery(mode, topic, key, messageId, begin, end);
-    if (validation) {
-      setNotice({ tone: 'warning', message: validation });
-      return;
-    }
+  const invalidateResend = useCallback(() => {
+    resendRequestRef.current += 1;
+    setResendNotice(null);
+  }, []);
 
-    setLoading(true);
-    setNotice(null);
-    const request =
-      mode === 'key'
-        ? messageApi.byKey(topic.trim(), key.trim())
-        : mode === 'id'
-          ? messageApi.byId(topic.trim(), messageId.trim())
-          : messageApi.list({
-              topic: topic.trim(),
-              begin: toTimestamp(begin),
-              end: toTimestamp(end)
-            });
+  useEffect(() => {
+    mountedRef.current = true;
+    void loadTopics();
+    return () => {
+      mountedRef.current = false;
+      requestRef.current += 1;
+      topicRequestRef.current += 1;
+      resendRequestRef.current += 1;
+    };
+  }, [loadTopics]);
 
-    request
-      .then((data) => {
-        applyQueryResult(data);
-        if (mode === 'id') {
-          const detail = data.items[0];
-          if (detail) {
-            setSelected(detail);
-            setTrace(null);
-          }
-        }
-      })
-      .catch((requestError: Error) => {
-        setRows([]);
-        setTotal(0);
-        setNotice({
-          tone: 'danger',
-          message: requestError.message
-        });
-      })
-      .finally(() => setLoading(false));
-  };
+  useEffect(() => {
+    invalidateResend();
+    setConsumerGroup('');
+    setClientId('');
+  }, [invalidateResend, selected?.messageId]);
 
-  const applyQueryResult = (data: MessageListView) => {
-    setRows(data.items);
-    setTotal(data.total || data.items.length);
-    setNotice({
-      tone: data.items.length > 0 ? 'success' : 'warning',
-      message: data.items.length > 0 ? `Query completed. ${data.items.length} message(s) loaded.` : 'No matched messages.'
-    });
-  };
-
-  const resetQuery = () => {
-    setKey('');
-    setMessageId('');
-    setRows([]);
-    setTotal(0);
-    setSelected(null);
-    setTrace(null);
-    setNotice(null);
-    setBegin(formatDateTimeInput(new Date(Date.now() - 60 * 60 * 1000)));
-    setEnd(formatDateTimeInput(new Date()));
-  };
-
-  const loadTrace = (message = selected) => {
-    if (!message) return;
-    setTraceLoading(true);
-    setTrace(null);
-    messageApi
-      .trace(message.messageId, message.topic)
-      .then(setTrace)
-      .catch((requestError: Error) => setNotice({ tone: 'danger', message: requestError.message }))
-      .finally(() => setTraceLoading(false));
-  };
-
-  const resendMessage = (message: MessageView) => {
-    if (!consumerGroup.trim()) {
-      setNotice({ tone: 'warning', message: 'Consumer group is required before resending a message.' });
-      return;
-    }
-
-    const targetTopic = message.topic.startsWith('%DLQ%') ? message.properties.RETRY_TOPIC || message.topic : message.topic;
-    const targetMessageId = message.topic.startsWith('%DLQ%') ? message.properties.ORIGIN_MESSAGE_ID || message.messageId : message.messageId;
-
-    setResending(true);
-    messageApi
-      .resend(targetMessageId, {
-        topic: targetTopic,
-        consumerGroup: consumerGroup.trim(),
-        clientId: clientId.trim() || undefined
-      })
-      .then((result: MutationResult) => setNotice({ tone: 'success', message: result.message || 'Message resend requested.' }))
-      .catch((requestError: Error) => setNotice({ tone: 'danger', message: requestError.message }))
-      .finally(() => setResending(false));
-  };
-
-  const copyMessageId = (messageId: string) => {
-    copyText(messageId);
-    setNotice({ tone: 'success', message: `Copied message ID ${truncateMiddle(messageId, 26)}.` });
-  };
-
-  const showBodyToast = (body: string, point: BodyToastPoint) => {
-    if (!body) {
-      setBodyToast(null);
-      return;
-    }
-    setBodyToast({ body, ...bodyToastPosition(point) });
-  };
-
-  const columns: DataTableColumn<MessageView>[] = [
+  const visibleRows = useMemo(() => rows.slice((page - 1) * pageSize, page * pageSize), [page, rows]);
+  const columns: AppDataTableColumn<MessageView>[] = [
     {
-      header: 'Message ID',
-      width: '820px',
-      render: (row) => (
-        <div className="message-id-cell">
-          <button type="button" className="message-id-link" title={row.messageId} onClick={() => openDetail(row)}>
-            <span>{row.messageId}</span>
-          </button>
-          <button type="button" className="message-copy-button" title="Copy message ID" onClick={() => copyMessageId(row.messageId)}>
-            <Copy size={13} aria-hidden="true" /> Copy
-          </button>
-        </div>
-      )
+      id: 'message-id', header: 'Message ID', width: '31%',
+      cell: (row) => <span className="mono message-id-value" title={row.messageId}>{truncateIdentifier(row.messageId, 34)}</span>
     },
-    { header: 'Tag', width: '110px', render: (row) => <StatusBadge status={messageTags(row)} tone={messageTags(row) !== '-' ? 'success' : 'neutral'} /> },
-    { header: 'Key', width: '150px', render: (row) => <span className="message-muted-value">{messageKeys(row)}</span> },
-    { header: 'StoreTime', width: '210px', render: (row) => formatTimestamp(row.storeTimestamp) },
-    {
-      header: 'Queue',
-      width: '120px',
-      render: (row) => (
-        <code className="message-queue-chip">
-          {row.queueId} / {row.queueOffset}
-        </code>
-      )
-    },
-    {
-      header: 'Body',
-      width: '260px',
-      render: (row) => <MessageBodyPreview body={row.body} onShow={showBodyToast} onHide={() => setBodyToast(null)} />
-    },
-    {
-      header: 'Operation',
-      width: '220px',
-      render: (row) => (
-        <div className="message-table-actions">
-          <button type="button" className="message-action-button" title="Message detail" onClick={() => openDetail(row)}>
-            <Eye size={14} aria-hidden="true" /> Detail
-          </button>
-          <button type="button" className="message-action-button" title="Trace message" onClick={() => openTrace(row)}>
-            <GitBranch size={14} aria-hidden="true" /> Trace
-          </button>
-        </div>
-      )
-    }
+    { id: 'tags', header: 'Tags', cell: (row) => <StatusBadge status={messageTags(row)} tone={messageTags(row) === '-' ? 'neutral' : 'success'} /> },
+    { id: 'keys', header: 'Keys', cell: (row) => <span className="mono message-muted-value">{messageKeys(row)}</span> },
+    { id: 'queue', header: 'Queue / offset', cell: (row) => <span>{row.queueId} / {row.queueOffset}</span> },
+    { id: 'size', header: 'Size', align: 'right', cell: (row) => formatMessageSize(row.storeSize) },
+    { id: 'stored', header: 'Stored', cell: (row) => formatMessageTimestamp(row.storeTimestamp) }
   ];
 
-  const openDetail = (message: MessageView) => {
-    setSelected(message);
-    setTrace(null);
+  const invalidateResults = () => {
+    requestRef.current += 1;
+    setLoading(false);
+    setRows([]);
+    setTotal(0);
+    setPage(1);
+    setValidation(null);
+    setError(null);
+    setSelected(null);
   };
 
-  const openTrace = (message: MessageView) => {
-    setSelected(message);
-    loadTrace(message);
+  const updateForm = (nextForm: QueryForm) => {
+    setForm(nextForm);
+    invalidateResults();
   };
+
+  const switchMode = (mode: string) => {
+    const topic = form.topic;
+    setForm(mode === 'key' ? { mode, topic, key: '' } : mode === 'id' ? { mode, topic, messageId: '' } : topicForm(topic));
+    invalidateResults();
+  };
+
+  const searchMessages = async () => {
+    const issue = validateForm(form);
+    if (issue) {
+      setValidation(issue);
+      return;
+    }
+    const requestId = ++requestRef.current;
+    setLoading(true);
+    setValidation(null);
+    setError(null);
+    try {
+      const data = form.mode === 'key'
+        ? await messageApi.byKey(form.topic.trim(), form.key.trim())
+        : form.mode === 'id'
+          ? await messageApi.byId(form.topic.trim(), form.messageId.trim())
+          : await messageApi.list({ topic: form.topic.trim(), begin: toTimestamp(form.begin), end: toTimestamp(form.end) });
+      if (requestRef.current !== requestId) return;
+      applyResult(data);
+      if (form.mode === 'id' && data.items[0]) {
+        restoreFocusRef.current = searchButtonRef.current;
+        setSelected(data.items[0]);
+      }
+    } catch (requestError) {
+      if (requestRef.current === requestId) {
+        setRows([]);
+        setTotal(0);
+        setError(requestError instanceof Error ? requestError.message : String(requestError));
+      }
+    } finally {
+      if (requestRef.current === requestId) setLoading(false);
+    }
+  };
+
+  const applyResult = (data: MessageListView) => {
+    setRows(data.items);
+    setTotal(data.total || data.items.length);
+    setPage(1);
+  };
+
+  const openDetail = (message: MessageView, origin: HTMLElement) => {
+    restoreFocusRef.current = origin;
+    setSelected(message);
+  };
+
+  const resend = async () => {
+    if (!selected || !consumerGroup.trim() || resendPendingRef.current) return;
+    const target = messageResendTarget(selected);
+    if (!target) {
+      setResendNotice({ tone: 'danger', message: resendUnavailableMessage(selected) });
+      return;
+    }
+    const requestId = ++resendRequestRef.current;
+    resendPendingRef.current = true;
+    setResending(true);
+    setResendNotice(null);
+    try {
+      const result = await messageApi.resend(target.messageId, {
+        topic: target.topic, consumerGroup: consumerGroup.trim(), clientId: clientId.trim() || undefined
+      });
+      if (resendRequestRef.current !== requestId) return;
+      setResendNotice({
+        tone: result.success ? 'success' : 'danger',
+        message: result.remark ? `${result.consumeResult}: ${result.remark}` : result.message
+      });
+    } catch (requestError) {
+      if (resendRequestRef.current === requestId) {
+        setResendNotice({ tone: 'danger', message: requestError instanceof Error ? requestError.message : String(requestError) });
+      }
+    } finally {
+      resendPendingRef.current = false;
+      if (mountedRef.current) setResending(false);
+    }
+  };
+
+  const selectedResendTarget = selected ? messageResendTarget(selected) : null;
+  const selectedResendError = selected && !selectedResendTarget ? resendUnavailableMessage(selected) : null;
 
   return (
-    <>
+    <div className="message-ops-workspace">
       <PageHeader
-        title="Message"
-        description="Query by topic, message key, or message ID, then inspect message body, properties, trace, and resend state."
-        actions={
-          <button type="button" className="button button-secondary" onClick={submitQuery} disabled={loading}>
-            <RefreshCw className={loading ? 'spin' : undefined} size={15} aria-hidden="true" /> Refresh
-          </button>
-        }
+        title="Message search"
+        description="Locate a message by one explicit query path, then inspect its broker-backed details in a focused sheet."
+        actions={<RefreshButton refreshing={loading} onRefresh={() => void searchMessages()} />}
       />
 
-      {notice ? <div className={`notice notice-${notice.tone}`}>{notice.message}</div> : null}
-      {bodyToast ? (
-        <div className="message-body-hover-toast" role="tooltip" style={{ left: bodyToast.x, top: bodyToast.y }}>
-          {bodyToast.body}
-        </div>
-      ) : null}
-
-      <section className="message-query-panel">
-        <div className="message-mode-row">
-          <div className="message-mode-tabs" role="tablist" aria-label="Message query mode">
-            {queryModes.map((item) => (
-              <button
-                type="button"
-                role="tab"
-                aria-selected={mode === item.key}
-                className={mode === item.key ? 'active' : ''}
-                key={item.key}
-                onClick={() => {
-                  setMode(item.key);
-                  setNotice(null);
-                  setTrace(null);
-                }}
-              >
-                {item.label}
-              </button>
-            ))}
-          </div>
-          <p>{activeMode.description}</p>
-        </div>
-
-        <div className="message-query-fields">
-          <label className="message-query-field">
-            <span>
-              <strong>*</strong> Topic
-            </span>
-            {topicOptions.length > 0 ? (
-              <SelectMenu
-                value={topic}
-                options={topicOptions}
-                onChange={setTopic}
-                ariaLabel="Select message topic"
-                className="message-topic-select"
-                searchable
-                searchPlaceholder="Search topics"
-              />
+      <Card className="message-query-card">
+        <CardHeader>
+          <div><CardTitle>Query messages</CardTitle><CardDescription>Only fields in the active mode are sent to the API.</CardDescription></div>
+          <Tabs value={form.mode} onValueChange={switchMode}>
+            <TabsList aria-label="Message query mode">
+              <TabsTrigger value="topic">By topic</TabsTrigger>
+              <TabsTrigger value="key">By message key</TabsTrigger>
+              <TabsTrigger value="id">By message ID</TabsTrigger>
+            </TabsList>
+          </Tabs>
+        </CardHeader>
+        <CardContent>
+          <div className="message-query-grid">
+            <div className="message-query-field">
+              <Label htmlFor="message-topic">Message topic</Label>
+              <select id="message-topic" value={form.topic} onChange={(event) => updateForm({ ...form, topic: event.target.value })}>
+                {topics.length === 0 ? <option value="">Select a topic</option> : null}
+                {topics.map((topic) => <option key={topic} value={topic}>{topic}</option>)}
+              </select>
+            </div>
+            {form.mode === 'topic' ? (
+              <>
+                <div className="message-query-field"><Label htmlFor="message-begin">Begin time</Label><Input id="message-begin" type="datetime-local" value={form.begin} onChange={(event) => updateForm({ ...form, begin: event.target.value })} /></div>
+                <div className="message-query-field"><Label htmlFor="message-end">End time</Label><Input id="message-end" type="datetime-local" value={form.end} onChange={(event) => updateForm({ ...form, end: event.target.value })} /></div>
+              </>
+            ) : form.mode === 'key' ? (
+              <div className="message-query-field message-query-field-wide"><Label htmlFor="message-key">Message key</Label><Input id="message-key" value={form.key} onChange={(event) => updateForm({ ...form, key: event.target.value })} /></div>
             ) : (
-              <input value={topic} placeholder={topicLoading ? 'Loading topics' : 'Topic name'} onChange={(event) => setTopic(event.target.value)} />
+              <div className="message-query-field message-query-field-wide"><Label htmlFor="message-id">Message ID</Label><Input id="message-id" value={form.messageId} onChange={(event) => updateForm({ ...form, messageId: event.target.value })} /></div>
             )}
-          </label>
-
-          {mode === 'topic' ? (
-            <>
-              <label className="message-query-field message-date-field">
-                <span>Begin</span>
-                <input type="datetime-local" value={begin} onChange={(event) => setBegin(event.target.value)} />
-              </label>
-              <label className="message-query-field message-date-field">
-                <span>End</span>
-                <input type="datetime-local" value={end} onChange={(event) => setEnd(event.target.value)} />
-              </label>
-            </>
-          ) : null}
-
-          {mode === 'key' ? (
-            <label className="message-query-field message-wide-field">
-              <span>
-                <strong>*</strong> Key
-              </span>
-              <input value={key} placeholder="Message key" onChange={(event) => setKey(event.target.value)} />
-            </label>
-          ) : null}
-
-          {mode === 'id' ? (
-            <label className="message-query-field message-wide-field">
-              <span>
-                <strong>*</strong> Message ID
-              </span>
-              <input value={messageId} placeholder="Message ID" onChange={(event) => setMessageId(event.target.value)} />
-            </label>
-          ) : null}
-
-          <button type="button" className="button message-search-button" onClick={submitQuery} disabled={loading}>
-            {loading ? <RefreshCw className="spin" size={15} aria-hidden="true" /> : <Search size={15} aria-hidden="true" />}
-            Search
-          </button>
-          <button type="button" className="button button-secondary message-search-button" onClick={resetQuery}>
-            Reset
-          </button>
-        </div>
-      </section>
-
-      <section className="message-metric-grid">
-        <MessageMetric label="Rows" value={rows.length.toLocaleString()} detail={`${total.toLocaleString()} total from latest query`} icon={<DatabaseZap size={18} />} />
-        <MessageMetric label="Mode" value={activeMode.label} detail="active query path" icon={<Search size={18} />} />
-        <MessageMetric label="Topic" value={topic || '-'} detail="selected topic" icon={<Hash size={18} />} />
-        <MessageMetric label="Condition" value={querySummary} detail="current query condition" icon={<Clock3 size={18} />} />
-      </section>
-
-      <section className="message-results-wide">
-        <DataTable
-          rows={rows}
-          columns={columns}
-          getRowId={(row) => row.messageId}
-          searchPlaceholder="Search message id, tag, key, queue, body, or store time"
-          emptyTitle={loading ? 'Loading messages' : 'No messages'}
-          onRefresh={submitQuery}
-        />
-      </section>
-
-      <MessageDetailDrawer
-        message={selected}
-        trace={trace}
-        traceLoading={traceLoading}
-        consumerGroup={consumerGroup}
-        clientId={clientId}
-        resending={resending}
-        onConsumerGroupChange={setConsumerGroup}
-        onClientIdChange={setClientId}
-        onClose={() => {
-          setSelected(null);
-          setTrace(null);
-        }}
-        onTrace={() => loadTrace()}
-        onResend={resendMessage}
-      />
-    </>
-  );
-}
-
-interface MessageMetricProps {
-  label: string;
-  value: string;
-  detail: string;
-  icon: React.ReactNode;
-}
-
-function MessageMetric({ label, value, detail, icon }: MessageMetricProps) {
-  return (
-    <article className="message-metric-card">
-      <div>
-        <span>{label}</span>
-        <strong title={value}>{value}</strong>
-        <small>{detail}</small>
-      </div>
-      <div className="message-metric-icon">{icon}</div>
-    </article>
-  );
-}
-
-interface MessageBodyPreviewProps {
-  body: string;
-  onShow: (body: string, point: BodyToastPoint) => void;
-  onHide: () => void;
-}
-
-function MessageBodyPreview({ body, onShow, onHide }: MessageBodyPreviewProps) {
-  if (!body) {
-    return <span className="message-body-preview message-body-preview-empty">-</span>;
-  }
-
-  const showFromMouse = (event: MouseEvent<HTMLElement>) => {
-    onShow(body, { clientX: event.clientX, clientY: event.clientY });
-  };
-  const showFromFocus = (event: FocusEvent<HTMLElement>) => {
-    const rect = event.currentTarget.getBoundingClientRect();
-    onShow(body, { clientX: rect.left, clientY: rect.bottom });
-  };
-
-  return (
-    <span
-      className="message-body-preview"
-      tabIndex={0}
-      onMouseEnter={showFromMouse}
-      onMouseMove={showFromMouse}
-      onMouseLeave={onHide}
-      onFocus={showFromFocus}
-      onBlur={onHide}
-    >
-      {body}
-    </span>
-  );
-}
-
-interface MessageDetailDrawerProps {
-  message: MessageView | null;
-  trace: MessageTraceView | null;
-  traceLoading: boolean;
-  consumerGroup: string;
-  clientId: string;
-  resending: boolean;
-  onConsumerGroupChange: (value: string) => void;
-  onClientIdChange: (value: string) => void;
-  onClose: () => void;
-  onTrace: () => void;
-  onResend: (message: MessageView) => void;
-}
-
-function MessageDetailDrawer({
-  message,
-  trace,
-  traceLoading,
-  consumerGroup,
-  clientId,
-  resending,
-  onConsumerGroupChange,
-  onClientIdChange,
-  onClose,
-  onTrace,
-  onResend
-}: MessageDetailDrawerProps) {
-  const properties = Object.entries(message?.properties ?? {});
-  const infoRows = message ? messageInfoRows(message) : [];
-
-  return (
-    <Dialog.Root open={message !== null} onOpenChange={(open) => !open && onClose()}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="dialog-overlay" />
-        <Dialog.Content className="drawer-content message-detail-drawer">
-          <div className="drawer-header">
-            <div>
-              <Dialog.Title>Message Detail</Dialog.Title>
-              <div className="drawer-meta">
-                <StatusBadge status={message?.topic ?? 'No topic'} tone="neutral" />
-                <StatusBadge status={messageTags(message) || 'NO_TAG'} tone={messageTags(message) ? 'success' : 'neutral'} />
-              </div>
-            </div>
-            <div className="message-detail-header-actions">
-              <button type="button" className="button button-secondary" onClick={onTrace} disabled={!message || traceLoading}>
-                <GitBranch className={traceLoading ? 'spin' : undefined} size={15} aria-hidden="true" /> Trace
-              </button>
-              {message ? (
-                <ConfirmDialog
-                  title="Resend message"
-                  description={`Resend message ${message.messageId} to consumer group ${consumerGroup || '(required)'}?`}
-                  confirmLabel="Resend"
-                  onConfirm={() => onResend(message)}
-                >
-                  <button type="button" className="button button-danger" disabled={resending}>
-                    {resending ? <RefreshCw className="spin" size={15} aria-hidden="true" /> : <Send size={15} aria-hidden="true" />}
-                    Resend
-                  </button>
-                </ConfirmDialog>
-              ) : null}
-              <Dialog.Close className="icon-button" title="Close">
-                <X size={16} aria-hidden="true" />
-              </Dialog.Close>
-            </div>
+            <Button ref={searchButtonRef} type="button" className="message-query-submit" loading={loading} aria-label="Search messages" onClick={() => void searchMessages()}>
+              <Search size={15} aria-hidden="true" /> Search messages
+            </Button>
           </div>
-
-          {message ? (
-            <>
-              <section className="drawer-section">
-                <div className="message-detail-section-heading">
-                  <h3>Message info</h3>
-                  <button type="button" className="icon-button" title="Copy message id" onClick={() => copyText(message.messageId)}>
-                    <Copy size={14} aria-hidden="true" />
-                  </button>
-                </div>
-                <div className="message-info-grid">
-                  {infoRows.map((row) => (
-                    <div className={row.wide ? 'wide' : undefined} key={row.label}>
-                      <span>{row.label}</span>
-                      <strong title={row.value}>{row.value}</strong>
-                    </div>
-                  ))}
-                </div>
-              </section>
-
-              <section className="drawer-section">
-                <div className="message-detail-section-heading">
-                  <h3>Message properties</h3>
-                  <StatusBadge status={`${properties.length} properties`} tone={properties.length > 0 ? 'success' : 'neutral'} />
-                </div>
-                {properties.length > 0 ? (
-                  <div className="message-property-table">
-                    {properties.map(([name, value]) => (
-                      <div key={name}>
-                        <span>{name}</span>
-                        <strong title={value}>{value}</strong>
-                      </div>
-                    ))}
-                  </div>
-                ) : (
-                  <EmptyState title="No message properties" />
-                )}
-              </section>
-
-              <section className="drawer-section">
-                <div className="message-detail-section-heading">
-                  <h3>Message body</h3>
-                  <button type="button" className="icon-button" title="Copy message body" onClick={() => copyText(message.body)}>
-                    <Copy size={14} aria-hidden="true" />
-                  </button>
-                </div>
-                <pre className="message-body-block">{message.body || '-'}</pre>
-              </section>
-
-              <section className="drawer-section">
-                <div className="message-detail-section-heading">
-                  <h3>Message tracking</h3>
-                  <StatusBadge status={trace ? `${trace.nodes.length} trace nodes` : 'not loaded'} tone={trace ? 'success' : 'neutral'} />
-                </div>
-                <div className="message-resend-panel">
-                  <label>
-                    Consumer group
-                    <input value={consumerGroup} placeholder="Consumer group for resend" onChange={(event) => onConsumerGroupChange(event.target.value)} />
-                  </label>
-                  <label>
-                    Client ID
-                    <input value={clientId} placeholder="Optional client id" onChange={(event) => onClientIdChange(event.target.value)} />
-                  </label>
-                </div>
-                {trace ? (
-                  <div className="message-trace-list">
-                    {trace.nodes.map((node, index) => (
-                      <div className="message-trace-node" key={`${node.nodeType}-${node.name}-${node.timestamp}-${index}`}>
-                        <KeyRound size={15} aria-hidden="true" />
-                        <div>
-                          <strong>{node.name || node.nodeType}</strong>
-                          <span>
-                            {node.status || 'UNKNOWN'} / {formatTimestamp(node.timestamp)}
-                          </span>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                ) : (
-                  <EmptyState title={traceLoading ? 'Loading trace' : 'No tracking info loaded'} />
-                )}
-              </section>
-            </>
+          {validation ? <div className="notice notice-warning" role="alert">{validation}</div> : null}
+          {topicsError ? (
+            <div className="notice notice-danger message-discovery-notice" role="alert">
+              <span>{topicsError}</span>
+              <Button type="button" variant="outline" size="sm" loading={topicsLoading} aria-label="Retry topics" onClick={() => void loadTopics()}>Retry topics</Button>
+            </div>
           ) : null}
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+        </CardContent>
+      </Card>
+
+      <div className="metric-grid message-metric-grid">
+        <MetricCard label="Returned" value={rows.length} detail={`${total} reported by API`} icon={<DatabaseZap size={18} />} />
+        <MetricCard label="Query path" value={form.mode === 'topic' ? 'Topic range' : form.mode === 'key' ? 'Message key' : 'Message ID'} detail="One active API contract" icon={<Search size={18} />} />
+        <MetricCard label="Topic" value={form.topic || '-'} detail="Current scope" icon={<Hash size={18} />} />
+        <MetricCard label="Window" value={form.mode === 'topic' ? 'Time bounded' : 'Identifier'} detail="Current condition" icon={<Clock3 size={18} />} />
+      </div>
+
+      <Card className="message-results-card">
+        <CardHeader><div><CardTitle>Query results</CardTitle><CardDescription>Activate a row to inspect the message body and properties.</CardDescription></div></CardHeader>
+        <CardContent>
+          <AppDataTable
+            ariaLabel="Message search results" rows={visibleRows} columns={columns} getRowId={messageRowId}
+            page={page} pageSize={pageSize} total={rows.length} onPageChange={setPage} onRowActivate={openDetail}
+            loading={loading} error={error} onRetry={() => void searchMessages()} emptyTitle="No messages"
+            emptyDetail="Run a query to inspect matching messages."
+          />
+        </CardContent>
+      </Card>
+
+      <EntitySheet
+        open={selected !== null} title="Message detail"
+        description={selected ? `${selected.topic} · ${truncateIdentifier(selected.messageId, 42)}` : undefined}
+        onOpenChange={(open) => { if (!open) setSelected(null); }} restoreFocusRef={restoreFocusRef}
+      >
+        {selected ? (
+          <>
+            <MessageDetailContent message={selected} />
+            <section className="message-resend-panel">
+              <div><h3>Resend message</h3><p>Submit a broker-backed resend request to one consumer group.</p></div>
+              {selectedResendError ? <div className="notice notice-danger" role="alert">{selectedResendError}</div> : null}
+              {resendNotice ? <div className={`notice notice-${resendNotice.tone}`} role="status">{resendNotice.message}</div> : null}
+              <div className="message-resend-fields">
+                <div><Label htmlFor="resend-consumer-group">Consumer group</Label><Input id="resend-consumer-group" value={consumerGroup} disabled={resending} onChange={(event) => setConsumerGroup(event.target.value)} /></div>
+                <div><Label htmlFor="resend-client-id">Client ID optional</Label><Input id="resend-client-id" value={clientId} disabled={resending} onChange={(event) => setClientId(event.target.value)} /></div>
+              </div>
+              <AlertDialog>
+                <AlertDialogTrigger asChild><Button type="button" variant="destructive" disabled={!selectedResendTarget || !consumerGroup.trim() || resending}><Send size={15} aria-hidden="true" /> Review resend</Button></AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogTitle>Resend message?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Resend original message {selectedResendTarget?.messageId} to topic {selectedResendTarget?.topic} for {consumerGroup || 'the selected consumer group'}. This operation is not reversible.
+                  </AlertDialogDescription>
+                  <div className="ui-alert-dialog-actions"><AlertDialogCancel>Cancel</AlertDialogCancel><AlertDialogAction onClick={() => void resend()}>Confirm resend</AlertDialogAction></div>
+                </AlertDialogContent>
+              </AlertDialog>
+            </section>
+          </>
+        ) : null}
+      </EntitySheet>
+    </div>
   );
 }
 
-function validateQuery(mode: QueryMode, topic: string, key: string, messageId: string, begin: string, end: string) {
-  if (!topic.trim()) {
-    return 'Topic is required.';
-  }
-  if (mode === 'key' && !key.trim()) {
-    return 'Topic and message key are required.';
-  }
-  if (mode === 'id' && !messageId.trim()) {
-    return 'Topic and message ID are required.';
-  }
-  if (mode === 'topic') {
-    const beginTime = toTimestamp(begin);
-    const endTime = toTimestamp(end);
-    if (!beginTime || !endTime) {
-      return 'Begin and end time are required.';
-    }
-    if (endTime < beginTime) {
-      return 'End time must be later than begin time.';
-    }
+function topicForm(topic: string): QueryForm {
+  return { mode: 'topic', topic, begin: formatDateTimeInput(new Date(Date.now() - 60 * 60 * 1000)), end: formatDateTimeInput(new Date()) };
+}
+
+function preferredTopic(topics: string[]) {
+  return topics.find((topic) => !topic.startsWith('%') && !topic.startsWith('RMQ_SYS')) ?? topics[0] ?? '';
+}
+
+function validateForm(form: QueryForm) {
+  if (!form.topic.trim()) return 'Message topic is required.';
+  if (form.mode === 'key' && !form.key.trim()) return 'Message key is required.';
+  if (form.mode === 'id' && !form.messageId.trim()) return 'Message ID is required.';
+  if (form.mode === 'topic') {
+    if (!form.begin || !form.end) return 'Begin time and end time are required.';
+    if (toTimestamp(form.end) <= toTimestamp(form.begin)) return 'End time must be after begin time.';
   }
   return null;
 }
 
-function preferredMessageTopic(topics: string[]) {
-  return topics.find((item) => item === 'TopicTest1111') ?? topics.find((item) => isApplicationTopic(item)) ?? topics[0] ?? '';
-}
+function toTimestamp(value: string) { return new Date(value).getTime(); }
 
-function isApplicationTopic(topic: string) {
-  return (
-    !topic.startsWith('%RETRY%') &&
-    !topic.startsWith('%DLQ%') &&
-    !topic.startsWith('RMQ_SYS') &&
-    !topic.startsWith('rmq_sys') &&
-    !topic.startsWith('SCHEDULE_TOPIC') &&
-    topic !== 'OFFSET_MOVED_EVENT' &&
-    !topic.endsWith('_REPLY_TOPIC') &&
-    !topic.includes('SYNC_BROKER_MEMBER')
-  );
-}
-
-function messageInfoRows(message: MessageView) {
-  return [
-    { label: 'Topic', value: message.topic, wide: true },
-    { label: 'Message ID', value: message.messageId, wide: true },
-    { label: 'Store Message ID', value: message.properties.STORE_MESSAGE_ID || '-', wide: true },
-    { label: 'StoreHost', value: optionalMessageValue(message, 'storeHost') },
-    { label: 'BornHost', value: optionalMessageValue(message, 'bornHost') },
-    { label: 'StoreTime', value: formatTimestamp(message.storeTimestamp) },
-    { label: 'BornTime', value: formatTimestamp(message.bornTimestamp) },
-    { label: 'Queue ID', value: String(message.queueId) },
-    { label: 'Queue Offset', value: String(message.queueOffset) },
-    { label: 'StoreSize', value: optionalMessageValue(message, 'storeSize', message.body ? `${message.body.length} chars` : '-') },
-    { label: 'ReconsumeTimes', value: optionalMessageValue(message, 'reconsumeTimes') },
-    { label: 'BodyCRC', value: optionalMessageValue(message, 'bodyCRC') },
-    { label: 'SysFlag', value: optionalMessageValue(message, 'sysFlag') },
-    { label: 'Flag', value: optionalMessageValue(message, 'flag') },
-    { label: 'PreparedTransactionOffset', value: optionalMessageValue(message, 'preparedTransactionOffset') }
-  ];
-}
-
-function optionalMessageValue(message: MessageView, key: string, fallback = '-') {
-  const value = (message as unknown as Record<string, unknown>)[key];
-  return value === undefined || value === null || value === '' ? fallback : String(value);
-}
-
-function messageTags(message: MessageView | null | undefined) {
-  return message?.tags || message?.properties?.TAGS || '-';
-}
-
-function messageKeys(message: MessageView | null | undefined) {
-  return message?.keys || message?.properties?.KEYS || '-';
+function resendUnavailableMessage(message: MessageView) {
+  return message.topic.startsWith('%DLQ%')
+    ? 'Missing RETRY_TOPIC or origin message ID. Resend is disabled for this DLQ message.'
+    : 'Missing STORE_MESSAGE_ID. Resend is disabled for this message.';
 }
 
 function formatDateTimeInput(date: Date) {
-  const year = date.getFullYear();
-  const month = pad2(date.getMonth() + 1);
-  const day = pad2(date.getDate());
-  const hour = pad2(date.getHours());
-  const minute = pad2(date.getMinutes());
-  return `${year}-${month}-${day}T${hour}:${minute}`;
-}
-
-function formatInputDateForDisplay(value: string) {
-  return value.replace('T', ' ');
-}
-
-function toTimestamp(value: string) {
-  const timestamp = new Date(value).getTime();
-  return Number.isNaN(timestamp) ? undefined : timestamp;
-}
-
-function formatTimestamp(value: number | undefined) {
-  if (!value) return '-';
-  return new Date(value).toLocaleString();
-}
-
-function truncateMiddle(value: string, maxLength: number) {
-  if (value.length <= maxLength) return value;
-  const edge = Math.floor((maxLength - 3) / 2);
-  return `${value.slice(0, edge)}...${value.slice(-edge)}`;
-}
-
-function bodyToastPosition(point: BodyToastPoint) {
-  const offset = 14;
-  const toastMaxWidth = 760;
-  const toastMaxHeight = 320;
-  const viewportPadding = 16;
-  const maxLeft = Math.max(viewportPadding, window.innerWidth - toastMaxWidth - viewportPadding);
-  const maxTop = Math.max(viewportPadding, window.innerHeight - toastMaxHeight - viewportPadding);
-  return {
-    x: Math.min(Math.max(point.clientX + offset, viewportPadding), maxLeft),
-    y: Math.min(Math.max(point.clientY + offset, viewportPadding), maxTop)
-  };
-}
-
-function pad2(value: number) {
-  return String(value).padStart(2, '0');
-}
-
-function copyText(value: string) {
-  if (!value) return;
-  if (navigator.clipboard?.writeText) {
-    void navigator.clipboard.writeText(value).catch(() => legacyCopyText(value));
-    return;
-  }
-  legacyCopyText(value);
-}
-
-function legacyCopyText(value: string) {
-  const textarea = document.createElement('textarea');
-  textarea.value = value;
-  textarea.setAttribute('readonly', 'true');
-  textarea.style.position = 'fixed';
-  textarea.style.left = '-9999px';
-  textarea.style.top = '0';
-  document.body.appendChild(textarea);
-  textarea.select();
-  document.execCommand('copy');
-  textarea.remove();
+  const offset = date.getTimezoneOffset();
+  return new Date(date.getTime() - offset * 60_000).toISOString().slice(0, 16);
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/MessageTracePage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/MessageTracePage.test.tsx
@@ -1,0 +1,146 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { messageApi } from '../api/message_api';
+import { topicApi } from '../api/topic_api';
+import { renderAtRoute } from '../test/render';
+import type { MessageView } from '../types/message';
+import type { MessageTraceView } from '../types/message';
+import MessageTracePage from './MessageTracePage';
+
+vi.mock('../api/message_api', () => ({ messageApi: { byKey: vi.fn(), byId: vi.fn(), trace: vi.fn() } }));
+vi.mock('../api/topic_api', () => ({ topicApi: { list: vi.fn() } }));
+
+const message: MessageView = {
+  topic: 'orders', messageId: 'MSG-001', keys: 'order:1', tags: 'TagA', bornTimestamp: 10, storeTimestamp: 20,
+  bornHost: 'born', storeHost: 'stored', queueId: 1, queueOffset: 2, storeSize: 128, reconsumeTimes: 0,
+  bodyCRC: 1, sysFlag: 0, flag: 0, preparedTransactionOffset: 0, body: 'secret',
+  properties: { STORE_MESSAGE_ID: 'STORE-001' }
+};
+
+describe('MessageTracePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(topicApi.list).mockResolvedValue({ items: [{ topic: 'orders', brokerName: 'broker-a', readQueueCount: 8, writeQueueCount: 8, perm: 6, category: 'NORMAL' }], total: 1 });
+    vi.mocked(messageApi.byId).mockResolvedValue({ items: [message], total: 1 });
+    vi.mocked(messageApi.byKey).mockResolvedValue({ items: [message], total: 1 });
+    vi.mocked(messageApi.trace).mockResolvedValue({
+      messageId: 'MSG-001', traceTopic: 'CUSTOM_TRACE',
+      nodes: [{ nodeType: 'PRODUCER', name: 'order-producer', status: 'SENT', timestamp: 10 }]
+    });
+  });
+
+  it('queries candidates by ID or key and forwards the selected trace topic', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<MessageTracePage />, '/message-trace');
+    await screen.findByRole('heading', { name: 'Message trace' });
+    await user.clear(screen.getByRole('textbox', { name: 'Trace topic' }));
+    await user.type(screen.getByRole('textbox', { name: 'Trace topic' }), 'CUSTOM_TRACE');
+    await user.type(screen.getByRole('textbox', { name: 'Message ID' }), 'MSG-001');
+    await user.click(screen.getByRole('button', { name: 'Find trace candidates' }));
+    expect(messageApi.byId).toHaveBeenCalledWith('orders', 'MSG-001');
+    await user.click(await screen.findByRole('row', { name: /MSG-001/ }));
+    await waitFor(() => expect(messageApi.trace).toHaveBeenCalledWith('STORE-001', 'orders', 'CUSTOM_TRACE'));
+    expect(await screen.findByText('order-producer')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', { name: 'By message key' }));
+    await user.type(screen.getByRole('textbox', { name: 'Message key' }), 'order:1');
+    await user.click(screen.getByRole('button', { name: 'Find trace candidates' }));
+    expect(messageApi.byKey).toHaveBeenCalledWith('orders', 'order:1');
+  });
+
+  it('distinguishes no candidates, zero nodes, and trace failures', async () => {
+    const user = userEvent.setup();
+    vi.mocked(messageApi.byId)
+      .mockResolvedValueOnce({ items: [], total: 0 })
+      .mockResolvedValue({ items: [message], total: 1 });
+    vi.mocked(messageApi.trace)
+      .mockResolvedValueOnce({ messageId: 'MSG-001', traceTopic: 'RMQ_SYS_TRACE_TOPIC', nodes: [] })
+      .mockRejectedValueOnce(new Error('trace backend unavailable'));
+    renderAtRoute(<MessageTracePage />, '/message-trace');
+    await screen.findByRole('heading', { name: 'Message trace' });
+    await user.type(screen.getByRole('textbox', { name: 'Message ID' }), 'MSG-001');
+    await user.click(screen.getByRole('button', { name: 'Find trace candidates' }));
+    expect(await screen.findByText('No candidate messages')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Find trace candidates' }));
+    await user.click(await screen.findByRole('row', { name: /MSG-001/ }));
+    expect(await screen.findByText('No trace nodes')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Reload trace' }));
+    expect(await screen.findByText('trace backend unavailable')).toBeInTheDocument();
+  });
+
+  it('traces the selected physical message when client identifiers collide', async () => {
+    const user = userEvent.setup();
+    const olderMessage = {
+      ...message,
+      keys: 'older-key',
+      storeTimestamp: 10,
+      storeHost: 'older-broker',
+      queueOffset: 1,
+      properties: { STORE_MESSAGE_ID: 'STORE-OLDER' }
+    };
+    vi.mocked(messageApi.byKey).mockResolvedValue({ items: [message, olderMessage], total: 2 });
+
+    renderAtRoute(<MessageTracePage />, '/message-trace');
+    await screen.findByRole('heading', { name: 'Message trace' });
+    await user.click(screen.getByRole('tab', { name: 'By message key' }));
+    await user.type(screen.getByRole('textbox', { name: 'Message key' }), 'order:1');
+    await user.click(screen.getByRole('button', { name: 'Find trace candidates' }));
+    const olderCandidate = (await screen.findByText('older-key')).closest('tr');
+    expect(olderCandidate).not.toBeNull();
+    await user.click(olderCandidate!);
+
+    await waitFor(() => expect(messageApi.trace).toHaveBeenCalledWith(
+      'STORE-OLDER', 'orders', 'RMQ_SYS_TRACE_TOPIC'
+    ));
+  });
+
+  it('ignores a trace response after a new candidate query invalidates the selection', async () => {
+    const user = userEvent.setup();
+    let resolveTrace!: (value: MessageTraceView) => void;
+    vi.mocked(messageApi.trace).mockReturnValueOnce(new Promise((resolve) => { resolveTrace = resolve; }));
+    renderAtRoute(<MessageTracePage />, '/message-trace');
+    await screen.findByRole('heading', { name: 'Message trace' });
+    await user.type(screen.getByRole('textbox', { name: 'Message ID' }), 'MSG-001');
+    await user.click(screen.getByRole('button', { name: 'Find trace candidates' }));
+    await user.click(await screen.findByRole('row', { name: /MSG-001/ }));
+    await user.click(screen.getByRole('button', { name: 'Find trace candidates' }));
+    resolveTrace({
+      messageId: 'MSG-001', traceTopic: 'RMQ_SYS_TRACE_TOPIC',
+      nodes: [{ nodeType: 'BROKER', name: 'stale-broker', status: 'STORED', timestamp: 20 }]
+    });
+    await waitFor(() => expect(screen.getByRole('group', { name: 'Trace nodes: 0' })).toBeInTheDocument());
+    expect(screen.queryByText('stale-broker')).not.toBeInTheDocument();
+  });
+
+  it('ignores a candidate response after an active query field changes', async () => {
+    const user = userEvent.setup();
+    let resolveCandidates!: (value: { items: MessageView[]; total: number }) => void;
+    vi.mocked(messageApi.byId).mockReturnValueOnce(new Promise((resolve) => { resolveCandidates = resolve; }));
+    renderAtRoute(<MessageTracePage />, '/message-trace');
+    await screen.findByRole('heading', { name: 'Message trace' });
+    const messageId = screen.getByRole('textbox', { name: 'Message ID' });
+    await user.type(messageId, 'MSG-001');
+    await user.click(screen.getByRole('button', { name: 'Find trace candidates' }));
+    await user.type(messageId, '-changed');
+    resolveCandidates({ items: [message], total: 1 });
+
+    await waitFor(() => expect(screen.queryByText('MSG-001')).not.toBeInTheDocument());
+  });
+
+  it('recovers topic discovery after a retry', async () => {
+    const user = userEvent.setup();
+    vi.mocked(topicApi.list)
+      .mockRejectedValueOnce(new Error('nameserver unavailable'))
+      .mockResolvedValueOnce({ items: [{ topic: 'orders', brokerName: 'broker-a', readQueueCount: 8, writeQueueCount: 8, perm: 6, category: 'NORMAL' }], total: 1 });
+
+    renderAtRoute(<MessageTracePage />, '/message-trace');
+    expect(await screen.findByText('Topic discovery failed: nameserver unavailable')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Retry topics' }));
+
+    await waitFor(() => expect(topicApi.list).toHaveBeenCalledTimes(2));
+    expect(screen.getByRole('combobox', { name: 'Message topic' })).toHaveValue('orders');
+    expect(screen.queryByText('Topic discovery failed: nameserver unavailable')).not.toBeInTheDocument();
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/MessageTracePage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/MessageTracePage.tsx
@@ -1,642 +1,239 @@
-import * as Dialog from '@radix-ui/react-dialog';
-import {
-  Clock3,
-  Copy,
-  DatabaseZap,
-  Eye,
-  GitBranch,
-  Hash,
-  Network,
-  RefreshCw,
-  Search,
-  X
-} from 'lucide-react';
-import type { ReactNode } from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { GitBranch, Hash, Network, Search } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { messageApi } from '../api/message_api';
 import { topicApi } from '../api/topic_api';
-import EmptyState from '../components/EmptyState';
+import AppDataTable, { type AppDataTableColumn } from '../components/AppDataTable';
+import MetricCard from '../components/MetricCard';
 import PageHeader from '../components/PageHeader';
-import SelectMenu, { type SelectMenuOption } from '../components/SelectMenu';
+import RefreshButton from '../components/RefreshButton';
 import StatusBadge from '../components/StatusBadge';
-import type { MessageListView, MessageTraceNode, MessageTraceView, MessageView } from '../types/message';
+import { Button } from '../components/ui/Button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/Card';
+import { Input } from '../components/ui/Input';
+import { Label } from '../components/ui/Label';
+import { Tabs, TabsList, TabsTrigger } from '../components/ui/Tabs';
+import type { MessageTraceView, MessageView } from '../types/message';
+import { messageRowId, messageTraceId } from './messages/dlq-selection';
+import { formatMessageTimestamp, messageKeys, messageTags, truncateIdentifier } from './messages/message-model';
+import TraceTimeline from './messages/TraceTimeline';
 
-type QueryMode = 'key' | 'id';
-type NoticeTone = 'success' | 'warning' | 'danger';
+type TraceQuery =
+  | { mode: 'id'; topic: string; messageId: string }
+  | { mode: 'key'; topic: string; messageKey: string };
 
-const traceDefaultTopic = 'RMQ_SYS_TRACE_TOPIC';
-
-const queryModes: Array<{ key: QueryMode; label: string; description: string }> = [
-  {
-    key: 'key',
-    label: 'Message Key',
-    description: 'Query by topic and message key. Only return 64 messages.'
-  },
-  {
-    key: 'id',
-    label: 'Message ID',
-    description: 'Resolve one message by topic and message ID before loading trace detail.'
-  }
-];
+const pageSize = 10;
+const defaultTraceTopic = 'RMQ_SYS_TRACE_TOPIC';
 
 export default function MessageTracePage() {
   const [topics, setTopics] = useState<string[]>([]);
-  const [topic, setTopic] = useState('');
-  const [traceTopic, setTraceTopic] = useState(traceDefaultTopic);
-  const [mode, setMode] = useState<QueryMode>('key');
-  const [messageKey, setMessageKey] = useState('');
-  const [messageId, setMessageId] = useState('');
+  const [query, setQuery] = useState<TraceQuery>({ mode: 'id', topic: '', messageId: '' });
+  const [traceTopic, setTraceTopic] = useState(defaultTraceTopic);
   const [rows, setRows] = useState<MessageView[]>([]);
-  const [total, setTotal] = useState(0);
-  const [tableQuery, setTableQuery] = useState('');
+  const [page, setPage] = useState(1);
   const [selected, setSelected] = useState<MessageView | null>(null);
   const [trace, setTrace] = useState<MessageTraceView | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [candidateLoading, setCandidateLoading] = useState(false);
+  const [candidateError, setCandidateError] = useState<string | null>(null);
   const [traceLoading, setTraceLoading] = useState(false);
-  const [notice, setNotice] = useState<{ tone: NoticeTone; message: string } | null>(null);
+  const [traceError, setTraceError] = useState<string | null>(null);
+  const [validation, setValidation] = useState<string | null>(null);
+  const [topicsLoading, setTopicsLoading] = useState(false);
+  const [topicsError, setTopicsError] = useState<string | null>(null);
+  const topicRequestRef = useRef(0);
+  const candidateRequestRef = useRef(0);
+  const traceRequestRef = useRef(0);
 
-  const activeMode = queryModes.find((item) => item.key === mode) ?? queryModes[0];
-
-  const topicOptions = useMemo<SelectMenuOption[]>(() => {
-    const values = Array.from(new Set([...topics, topic].filter(Boolean))).sort((left, right) => left.localeCompare(right));
-    return values.map((value) => ({ value, label: value }));
-  }, [topic, topics]);
-
-  const traceTopicOptions = useMemo<SelectMenuOption[]>(() => {
-    const values = Array.from(
-      new Set([
-        traceDefaultTopic,
-        traceTopic,
-        ...topics.filter((item) => !item.startsWith('%RETRY%') && !item.startsWith('%DLQ%'))
-      ].filter(Boolean))
-    ).sort((left, right) => (left === traceDefaultTopic ? -1 : right === traceDefaultTopic ? 1 : left.localeCompare(right)));
-    return values.map((value) => ({ value, label: value }));
-  }, [topics, traceTopic]);
-
-  const filteredRows = useMemo(() => {
-    const normalized = tableQuery.trim().toLowerCase();
-    if (!normalized) {
-      return rows;
+  const loadTopics = useCallback(async () => {
+    const requestId = ++topicRequestRef.current;
+    setTopicsLoading(true);
+    setTopicsError(null);
+    try {
+      const data = await topicApi.list();
+      if (topicRequestRef.current !== requestId) return;
+      const nextTopics = data.items.map((item) => item.topic).sort((left, right) => left.localeCompare(right));
+      setTopics(nextTopics);
+      setQuery((current) => current.topic ? current : { ...current, topic: preferredTopic(nextTopics) });
+    } catch (requestError) {
+      if (topicRequestRef.current === requestId) {
+        setTopics([]);
+        setTopicsError(`Topic discovery failed: ${requestError instanceof Error ? requestError.message : String(requestError)}`);
+      }
+    } finally {
+      if (topicRequestRef.current === requestId) setTopicsLoading(false);
     }
-    return rows.filter((row) => JSON.stringify(row).toLowerCase().includes(normalized));
-  }, [rows, tableQuery]);
-
-  const querySummary = mode === 'key' ? messageKey.trim() || 'message key pending' : messageId.trim() || 'message id pending';
-
-  useEffect(() => {
-    topicApi
-      .list()
-      .then((data) => {
-        const nextTopics = data.items.map((item) => item.topic).sort((left, right) => left.localeCompare(right));
-        setTopics(nextTopics);
-        setTopic((current) => current || preferredMessageTopic(nextTopics));
-        setTraceTopic((current) => current || preferredTraceTopic(nextTopics));
-      })
-      .catch((requestError: Error) => {
-        setNotice({ tone: 'warning', message: `Topic list unavailable: ${requestError.message}` });
-      });
   }, []);
 
-  const submitQuery = () => {
-    const validation = validateQuery(mode, topic, messageKey, messageId);
-    if (validation) {
-      setNotice({ tone: 'warning', message: validation });
+  useEffect(() => {
+    void loadTopics();
+    return () => { topicRequestRef.current += 1; };
+  }, [loadTopics]);
+
+  useEffect(() => () => {
+    candidateRequestRef.current += 1;
+    traceRequestRef.current += 1;
+  }, []);
+
+  const invalidateCandidates = () => {
+    candidateRequestRef.current += 1;
+    traceRequestRef.current += 1;
+    setCandidateLoading(false);
+    setRows([]);
+    setPage(1);
+    setSelected(null);
+    setTrace(null);
+    setCandidateError(null);
+    setTraceError(null);
+    setTraceLoading(false);
+    setValidation(null);
+  };
+
+  const updateQuery = (nextQuery: TraceQuery) => {
+    setQuery(nextQuery);
+    invalidateCandidates();
+  };
+
+  const switchMode = (mode: string) => {
+    setQuery(mode === 'key' ? { mode, topic: query.topic, messageKey: '' } : { mode: 'id', topic: query.topic, messageId: '' });
+    invalidateCandidates();
+  };
+
+  const findCandidates = async () => {
+    const issue = validateQuery(query, traceTopic);
+    if (issue) {
+      setValidation(issue);
       return;
     }
-
-    setLoading(true);
-    setTrace(null);
+    const requestId = ++candidateRequestRef.current;
+    traceRequestRef.current += 1;
+    setCandidateLoading(true);
+    setCandidateError(null);
+    setValidation(null);
     setSelected(null);
-    setNotice(null);
-
-    const request = mode === 'key' ? messageApi.byKey(topic.trim(), messageKey.trim()) : messageApi.byId(topic.trim(), messageId.trim());
-
-    request
-      .then((data: MessageListView) => {
-        const nextItems = normalizeTraceRows(mode, topic.trim(), data.items);
-        setRows(nextItems);
-        setTotal(data.total || data.items.length);
-        setNotice({
-          tone: nextItems.length > 0 ? 'success' : 'warning',
-          message:
-            nextItems.length > 0
-              ? `Trace query completed. ${nextItems.length} message(s) loaded.`
-              : 'No messages matched the current trace query.'
-        });
-      })
-      .catch((requestError: Error) => {
+    setTrace(null);
+    setTraceError(null);
+    setTraceLoading(false);
+    try {
+      const data = query.mode === 'id'
+        ? await messageApi.byId(query.topic.trim(), query.messageId.trim())
+        : await messageApi.byKey(query.topic.trim(), query.messageKey.trim());
+      if (candidateRequestRef.current !== requestId) return;
+      setRows(query.mode === 'id' ? data.items.slice(0, 1) : data.items.slice(0, 64));
+      setPage(1);
+    } catch (requestError) {
+      if (candidateRequestRef.current === requestId) {
         setRows([]);
-        setTotal(0);
-        setNotice({ tone: 'danger', message: requestError.message });
-      })
-      .finally(() => setLoading(false));
+        setCandidateError(requestError instanceof Error ? requestError.message : String(requestError));
+      }
+    } finally {
+      if (candidateRequestRef.current === requestId) setCandidateLoading(false);
+    }
   };
 
-  const resetQuery = () => {
-    setMessageKey('');
-    setMessageId('');
-    setRows([]);
-    setTotal(0);
-    setTableQuery('');
-    setSelected(null);
-    setTrace(null);
-    setNotice(null);
-  };
-
-  const openTrace = (message: MessageView) => {
+  const loadTrace = async (message = selected) => {
+    if (!message) return;
+    const requestId = ++traceRequestRef.current;
     setSelected(message);
     setTrace(null);
     setTraceLoading(true);
-    messageApi
-      .trace(message.messageId, message.topic, traceTopic || traceDefaultTopic)
-      .then((data) => {
-        setTrace(data);
-        setNotice({
-          tone: data.nodes.length > 0 ? 'success' : 'warning',
-          message: data.nodes.length > 0 ? `Trace detail loaded with ${data.nodes.length} node(s).` : 'Trace detail returned no nodes.'
-        });
-      })
-      .catch((requestError: Error) => {
-        setTrace(null);
-        setNotice({ tone: 'danger', message: requestError.message });
-      })
-      .finally(() => setTraceLoading(false));
+    setTraceError(null);
+    try {
+      const data = await messageApi.trace(messageTraceId(message), message.topic, traceTopic.trim());
+      if (traceRequestRef.current === requestId) setTrace(data);
+    } catch (requestError) {
+      if (traceRequestRef.current === requestId) setTraceError(requestError instanceof Error ? requestError.message : String(requestError));
+    } finally {
+      if (traceRequestRef.current === requestId) setTraceLoading(false);
+    }
   };
 
-  const copyMessageId = (value: string) => {
-    copyText(value);
-    setNotice({ tone: 'success', message: `Copied message ID ${truncateMiddle(value, 28)}.` });
-  };
+  const columns: AppDataTableColumn<MessageView>[] = [
+    { id: 'message-id', header: 'Message ID', width: '34%', cell: (row) => <span className="mono message-id-value" title={row.messageId}>{truncateIdentifier(row.messageId, 38)}</span> },
+    { id: 'topic', header: 'Topic', cell: (row) => <span className="mono">{row.topic}</span> },
+    { id: 'tags', header: 'Tags', cell: (row) => <StatusBadge status={messageTags(row)} tone={messageTags(row) === '-' ? 'neutral' : 'success'} /> },
+    { id: 'keys', header: 'Keys', cell: (row) => <span className="mono message-muted-value">{messageKeys(row)}</span> },
+    { id: 'stored', header: 'Stored', cell: (row) => formatMessageTimestamp(row.storeTimestamp) }
+  ];
+  const visibleRows = rows.slice((page - 1) * pageSize, page * pageSize);
 
   return (
-    <>
+    <div className="message-ops-workspace">
       <PageHeader
-        title="MessageTrace"
-        description="Query message trace by key or message ID, then inspect delivery and consume status in a focused detail panel."
-        actions={
-          <button type="button" className="button button-secondary" onClick={submitQuery} disabled={loading}>
-            <RefreshCw className={loading ? 'spin' : undefined} size={15} aria-hidden="true" />
-            Refresh
-          </button>
-        }
+        title="Message trace"
+        description="Find real message candidates, then render only the trace nodes returned by the backend."
+        actions={<RefreshButton refreshing={candidateLoading} onRefresh={() => void findCandidates()} />}
       />
 
-      {notice ? <div className={`notice notice-${notice.tone}`}>{notice.message}</div> : null}
-
-      <section className="trace-topic-panel">
-        <label className="message-query-field">
-          <span>
-            <strong>*</strong> TraceTopic
-          </span>
-          <SelectMenu
-            value={traceTopic}
-            options={traceTopicOptions}
-            onChange={setTraceTopic}
-            ariaLabel="Select trace topic"
-            className="trace-topic-select"
-          />
-        </label>
-        <p>Trace topic selects where the dashboard reads message trace records.</p>
-      </section>
-
-      <section className="trace-query-panel">
-        <div className="trace-query-head">
-          <div className="message-mode-tabs" role="tablist" aria-label="Message trace query mode">
-            {queryModes.map((item) => (
-              <button
-                type="button"
-                role="tab"
-                aria-selected={mode === item.key}
-                className={mode === item.key ? 'active' : ''}
-                key={item.key}
-                onClick={() => {
-                  setMode(item.key);
-                  setRows([]);
-                  setTotal(0);
-                  setSelected(null);
-                  setTrace(null);
-                  setNotice(null);
-                }}
-              >
-                {item.label}
-              </button>
-            ))}
-          </div>
-          <p>{activeMode.description}</p>
-        </div>
-
-        <div className="trace-query-fields">
-          <label className="message-query-field">
-            <span>
-              <strong>*</strong> Topic
-            </span>
-            {topicOptions.length > 0 ? (
-              <SelectMenu value={topic} options={topicOptions} onChange={setTopic} ariaLabel="Select message topic" className="trace-topic-name-select" />
+      <Card className="message-query-card">
+        <CardHeader>
+          <div><CardTitle>Find trace candidates</CardTitle><CardDescription>Select one message before loading its returned trace nodes.</CardDescription></div>
+          <Tabs value={query.mode} onValueChange={switchMode}>
+            <TabsList aria-label="Trace query mode"><TabsTrigger value="id">By message ID</TabsTrigger><TabsTrigger value="key">By message key</TabsTrigger></TabsList>
+          </Tabs>
+        </CardHeader>
+        <CardContent>
+          <div className="trace-query-grid">
+            <div className="message-query-field"><Label htmlFor="trace-topic">Trace topic</Label><Input id="trace-topic" value={traceTopic} onChange={(event) => { traceRequestRef.current += 1; setTraceTopic(event.target.value); setSelected(null); setTrace(null); setTraceError(null); setTraceLoading(false); }} /></div>
+            <div className="message-query-field"><Label htmlFor="trace-message-topic">Message topic</Label><select id="trace-message-topic" value={query.topic} onChange={(event) => updateQuery({ ...query, topic: event.target.value })}>{topics.length === 0 ? <option value="">Select a topic</option> : null}{topics.map((topic) => <option key={topic}>{topic}</option>)}</select></div>
+            {query.mode === 'id' ? (
+              <div className="message-query-field trace-identifier-field"><Label htmlFor="trace-message-id">Message ID</Label><Input id="trace-message-id" value={query.messageId} onChange={(event) => updateQuery({ ...query, messageId: event.target.value })} /></div>
             ) : (
-              <input value={topic} placeholder="Topic name" onChange={(event) => setTopic(event.target.value)} />
+              <div className="message-query-field trace-identifier-field"><Label htmlFor="trace-message-key">Message key</Label><Input id="trace-message-key" value={query.messageKey} onChange={(event) => updateQuery({ ...query, messageKey: event.target.value })} /></div>
             )}
-          </label>
-
-          {mode === 'key' ? (
-            <label className="message-query-field trace-wide-field">
-              <span>
-                <strong>*</strong> Key
-              </span>
-              <input value={messageKey} placeholder="Message key" onChange={(event) => setMessageKey(event.target.value)} />
-            </label>
-          ) : (
-            <label className="message-query-field trace-wide-field">
-              <span>
-                <strong>*</strong> Message ID
-              </span>
-              <input value={messageId} placeholder="Message ID" onChange={(event) => setMessageId(event.target.value)} />
-            </label>
-          )}
-
-          <button type="button" className="button trace-action-button" onClick={submitQuery} disabled={loading}>
-            {loading ? <RefreshCw className="spin" size={15} aria-hidden="true" /> : <Search size={15} aria-hidden="true" />}
-            Search
-          </button>
-          <button type="button" className="button button-secondary trace-action-button" onClick={resetQuery}>
-            Reset
-          </button>
-        </div>
-      </section>
-
-      <section className="message-metric-grid trace-metric-grid">
-        <TraceMetric label="Rows" value={rows.length.toLocaleString()} detail={`${total.toLocaleString()} total from latest query`} icon={<DatabaseZap size={18} />} />
-        <TraceMetric label="Trace nodes" value={(trace?.nodes.length ?? 0).toLocaleString()} detail="loaded after detail opens" icon={<GitBranch size={18} />} />
-        <TraceMetric label="Trace topic" value={traceTopic || '-'} detail="selected trace topic" icon={<Network size={18} />} />
-        <TraceMetric label="Condition" value={querySummary} detail="current query condition" icon={mode === 'key' ? <Hash size={18} /> : <Clock3 size={18} />} />
-      </section>
-
-      <section className="trace-results-wide">
-        <div className="table-shell">
-          <div className="table-toolbar trace-table-toolbar">
-            <div>
-              <h2>Trace messages</h2>
-              <p>Open Message Trace Detail for the selected message.</p>
+            <Button type="button" className="message-query-submit" loading={candidateLoading} aria-label="Find trace candidates" onClick={() => void findCandidates()}><Search size={15} aria-hidden="true" /> Find trace candidates</Button>
+          </div>
+          {topicsError ? (
+            <div className="notice notice-danger message-discovery-notice" role="alert">
+              <span>{topicsError}</span>
+              <Button type="button" variant="outline" size="sm" loading={topicsLoading} aria-label="Retry topics" onClick={() => void loadTopics()}>Retry topics</Button>
             </div>
-            <div className="trace-table-tools">
-              <StatusBadge status={`${filteredRows.length} visible`} tone={filteredRows.length > 0 ? 'success' : 'neutral'} />
-              <button type="button" className="icon-button" onClick={submitQuery} title="Refresh table" disabled={loading}>
-                <RefreshCw className={loading ? 'spin' : undefined} size={16} aria-hidden="true" />
-              </button>
-            </div>
-          </div>
-          <div className="trace-search-band">
-            <label className="search-box">
-              <Search size={16} aria-hidden="true" />
-              <input
-                value={tableQuery}
-                placeholder="Search message id, tag, key, or store time"
-                onChange={(event) => setTableQuery(event.target.value)}
-              />
-            </label>
-          </div>
-          <div className="table-scroll">
-            <table>
-              <thead>
-                <tr>
-                  <th>Message ID</th>
-                  <th>Tag</th>
-                  <th>Message Key</th>
-                  <th>StoreTime</th>
-                  <th>Trace State</th>
-                  <th>Operation</th>
-                </tr>
-              </thead>
-              <tbody>
-                {filteredRows.map((row) => (
-                  <tr key={row.messageId}>
-                    <td>
-                      <div className="message-id-cell trace-message-id-cell">
-                        <button type="button" className="message-id-link" title={row.messageId} onClick={() => openTrace(row)}>
-                          <span>{row.messageId}</span>
-                        </button>
-                        <button type="button" className="message-copy-button" title="Copy message ID" onClick={() => copyMessageId(row.messageId)}>
-                          <Copy size={13} aria-hidden="true" /> Copy
-                        </button>
-                      </div>
-                    </td>
-                    <td>
-                      <StatusBadge status={messageTags(row)} tone={messageTags(row) !== '-' ? 'success' : 'neutral'} />
-                    </td>
-                    <td>
-                      <span className="message-muted-value">{messageKeys(row)}</span>
-                    </td>
-                    <td>{formatTimestamp(row.storeTimestamp)}</td>
-                    <td>
-                      <StatusBadge status={traceStateFor(row, selected, trace, traceLoading)} tone={traceStateTone(row, selected, trace, traceLoading)} />
-                    </td>
-                    <td>
-                      <button type="button" className="message-action-button" onClick={() => openTrace(row)} disabled={traceLoading && selected?.messageId === row.messageId}>
-                        {traceLoading && selected?.messageId === row.messageId ? <RefreshCw className="spin" size={14} aria-hidden="true" /> : <Eye size={14} aria-hidden="true" />}
-                        Trace Detail
-                      </button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-          {filteredRows.length === 0 ? <EmptyState title={loading ? 'Loading trace messages' : 'No trace messages'} /> : null}
-          <div className="table-footer">
-            <span>{filteredRows.length.toLocaleString()} rows / latest query</span>
-          </div>
-        </div>
-      </section>
-
-      <MessageTraceDetailDialog
-        message={selected}
-        trace={trace}
-        traceTopic={traceTopic}
-        traceLoading={traceLoading}
-        onClose={() => {
-          setSelected(null);
-          setTrace(null);
-        }}
-        onCopyMessageId={copyMessageId}
-      />
-    </>
-  );
-}
-
-interface TraceMetricProps {
-  label: string;
-  value: string;
-  detail: string;
-  icon: ReactNode;
-}
-
-function TraceMetric({ label, value, detail, icon }: TraceMetricProps) {
-  return (
-    <article className="message-metric-card">
-      <div>
-        <span>{label}</span>
-        <strong title={value}>{value}</strong>
-        <small>{detail}</small>
-      </div>
-      <div className="message-metric-icon">{icon}</div>
-    </article>
-  );
-}
-
-interface MessageTraceDetailDialogProps {
-  message: MessageView | null;
-  trace: MessageTraceView | null;
-  traceTopic: string;
-  traceLoading: boolean;
-  onClose: () => void;
-  onCopyMessageId: (value: string) => void;
-}
-
-function MessageTraceDetailDialog({
-  message,
-  trace,
-  traceTopic,
-  traceLoading,
-  onClose,
-  onCopyMessageId
-}: MessageTraceDetailDialogProps) {
-  const nodes = trace?.nodes ?? [];
-  const groupedNodes = groupTraceNodes(nodes);
-
-  return (
-    <Dialog.Root open={message !== null} onOpenChange={(open) => !open && onClose()}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="dialog-overlay" />
-        <Dialog.Content className="drawer-content message-detail-drawer trace-detail-drawer">
-          <div className="drawer-header">
-            <div>
-              <Dialog.Title>Message Trace Detail</Dialog.Title>
-              <div className="drawer-meta">
-                <StatusBadge status={traceTopic || traceDefaultTopic} tone="neutral" />
-                <StatusBadge status={traceLoading ? 'loading trace' : `${nodes.length} nodes`} tone={nodes.length > 0 ? 'success' : 'neutral'} />
-              </div>
-            </div>
-            <div className="message-detail-header-actions">
-              {message ? (
-                <button type="button" className="button button-secondary" onClick={() => onCopyMessageId(message.messageId)}>
-                  <Copy size={15} aria-hidden="true" />
-                  Copy ID
-                </button>
-              ) : null}
-              <Dialog.Close className="icon-button" title="Close">
-                <X size={16} aria-hidden="true" />
-              </Dialog.Close>
-            </div>
-          </div>
-
-          {message ? (
-            <>
-              <section className="drawer-section">
-                <div className="message-detail-section-heading">
-                  <h3>Message trace graph</h3>
-                  <StatusBadge status={trace?.traceTopic ?? traceTopic} tone="neutral" />
-                </div>
-                <TraceGraph nodes={nodes} loading={traceLoading} />
-              </section>
-
-              <section className="drawer-section">
-                <div className="message-detail-section-heading">
-                  <h3>Send message trace</h3>
-                  <StatusBadge status={message.topic} tone="success" />
-                </div>
-                <div className="message-info-grid">
-                  {sendTraceRows(message).map((row) => (
-                    <div className={row.wide ? 'wide' : undefined} key={row.label}>
-                      <span>{row.label}</span>
-                      <strong title={row.value}>{row.value}</strong>
-                    </div>
-                  ))}
-                </div>
-              </section>
-
-              <section className="drawer-section">
-                <div className="message-detail-section-heading">
-                  <h3>Consume message trace</h3>
-                  <StatusBadge status={`${groupedNodes.length} consumer groups`} tone={groupedNodes.length > 0 ? 'success' : 'neutral'} />
-                </div>
-                {groupedNodes.length > 0 ? (
-                  <div className="trace-node-table">
-                    <div className="trace-node-row trace-node-head">
-                      <span>Consumer group</span>
-                      <span>Status</span>
-                      <span>Timestamp</span>
-                      <span>Node type</span>
-                    </div>
-                    {groupedNodes.map((node) => (
-                      <div className="trace-node-row" key={`${node.name}-${node.status}-${node.timestamp}-${node.nodeType}`}>
-                        <code>{node.name || '-'}</code>
-                        <StatusBadge status={node.status || 'UNKNOWN'} tone={traceNodeTone(node)} />
-                        <span>{formatTimestamp(node.timestamp)}</span>
-                        <span>{node.nodeType || '-'}</span>
-                      </div>
-                    ))}
-                  </div>
-                ) : (
-                  <EmptyState title={traceLoading ? 'Loading trace nodes' : 'No consumer trace nodes'} />
-                )}
-              </section>
-            </>
           ) : null}
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
-  );
-}
+          {validation ? <div className="notice notice-warning" role="alert">{validation}</div> : null}
+        </CardContent>
+      </Card>
 
-function TraceGraph({ nodes, loading }: { nodes: MessageTraceNode[]; loading: boolean }) {
-  if (loading) {
-    return <EmptyState title="Loading trace graph" />;
-  }
-  if (nodes.length === 0) {
-    return <EmptyState title="No trace graph data" />;
-  }
+      <div className="metric-grid message-metric-grid">
+        <MetricCard label="Candidates" value={rows.length} detail="Returned by message query" icon={<Search size={18} />} />
+        <MetricCard label="Trace nodes" value={trace?.nodes.length ?? 0} detail="Returned without inference" icon={<GitBranch size={18} />} />
+        <MetricCard label="Trace topic" value={traceTopic || '-'} detail="Forwarded to trace API" icon={<Network size={18} />} />
+        <MetricCard label="Query" value={query.mode === 'id' ? 'Message ID' : 'Message key'} detail="One active query path" icon={<Hash size={18} />} />
+      </div>
 
-  return (
-    <div className="trace-graph">
-      <div className="trace-graph-axis" />
-      {nodes.map((node, index) => (
-        <div
-          className={`trace-graph-node trace-graph-node-${traceNodeTone(node)}`}
-          style={{ left: `${Math.min(84, 8 + index * 18)}%`, top: `${24 + (index % 3) * 34}px` }}
-          key={`${node.name}-${node.status}-${index}`}
-        >
-          <span>{node.name || node.nodeType}</span>
-          <small>{node.status || 'UNKNOWN'}</small>
-        </div>
-      ))}
+      <div className="trace-workspace-grid">
+        <Card className="message-results-card">
+          <CardHeader><div><CardTitle>Candidate messages</CardTitle><CardDescription>Activate a row to request its trace.</CardDescription></div></CardHeader>
+          <CardContent>
+            <AppDataTable
+              ariaLabel="Trace candidate messages" rows={visibleRows} columns={columns} getRowId={messageRowId}
+              page={page} pageSize={pageSize} total={rows.length} onPageChange={setPage}
+              onRowActivate={(row) => void loadTrace(row)} loading={candidateLoading} error={candidateError}
+              onRetry={() => void findCandidates()} emptyTitle="No candidate messages"
+              emptyDetail="Run a message ID or message key query to locate candidates."
+            />
+          </CardContent>
+        </Card>
+
+        <Card className="trace-detail-card">
+          <CardHeader>
+            <div><CardTitle>Returned trace nodes</CardTitle><CardDescription>{selected ? truncateIdentifier(selected.messageId, 44) : 'Select a candidate message.'}</CardDescription></div>
+            {selected ? <Button type="button" variant="outline" size="sm" loading={traceLoading} onClick={() => void loadTrace()}>Reload trace</Button> : null}
+          </CardHeader>
+          <CardContent>
+            {selected ? <TraceTimeline nodes={trace?.nodes ?? []} loading={traceLoading} error={traceError} onRetry={() => void loadTrace()} /> : <div className="state-block"><strong>No message selected</strong><span>Choose one candidate to request its trace nodes.</span></div>}
+          </CardContent>
+        </Card>
+      </div>
     </div>
   );
 }
 
-function validateQuery(mode: QueryMode, topic: string, messageKey: string, messageId: string) {
-  if (!topic.trim()) {
-    return 'Topic is required.';
-  }
-  if (mode === 'key' && !messageKey.trim()) {
-    return 'Topic and message key are required.';
-  }
-  if (mode === 'id' && !messageId.trim()) {
-    return 'Topic and message ID are required.';
-  }
+function validateQuery(query: TraceQuery, traceTopic: string) {
+  if (!traceTopic.trim()) return 'Trace topic is required.';
+  if (!query.topic.trim()) return 'Message topic is required.';
+  if (query.mode === 'id' && !query.messageId.trim()) return 'Message ID is required.';
+  if (query.mode === 'key' && !query.messageKey.trim()) return 'Message key is required.';
   return null;
 }
 
-function preferredMessageTopic(topics: string[]) {
-  return topics.find((item) => item === 'TopicTest1111') ?? topics.find((item) => isApplicationTopic(item)) ?? topics[0] ?? '';
-}
-
-function normalizeTraceRows(mode: QueryMode, topic: string, items: MessageView[]) {
-  if (mode === 'id') {
-    const topicRows = items.filter((item) => item.topic === topic);
-    return topicRows.length > 0 ? topicRows.slice(0, 1) : items.slice(0, 1);
-  }
-  return items.slice(0, 64);
-}
-
-function preferredTraceTopic(topics: string[]) {
-  return topics.find((item) => item === traceDefaultTopic) ?? traceDefaultTopic;
-}
-
-function isApplicationTopic(topic: string) {
-  return (
-    !topic.startsWith('%RETRY%') &&
-    !topic.startsWith('%DLQ%') &&
-    !topic.startsWith('RMQ_SYS') &&
-    !topic.startsWith('rmq_sys') &&
-    !topic.startsWith('SCHEDULE_TOPIC') &&
-    topic !== 'OFFSET_MOVED_EVENT' &&
-    !topic.endsWith('_REPLY_TOPIC') &&
-    !topic.includes('SYNC_BROKER_MEMBER')
-  );
-}
-
-function sendTraceRows(message: MessageView) {
-  return [
-    { label: 'Topic', value: message.topic },
-    { label: 'Message ID', value: message.messageId, wide: true },
-    { label: 'Message Key', value: messageKeys(message) },
-    { label: 'Tag', value: messageTags(message) },
-    { label: 'StoreTime', value: formatTimestamp(message.storeTimestamp) },
-    { label: 'BornTime', value: formatTimestamp(message.bornTimestamp) },
-    { label: 'Queue ID', value: String(message.queueId) },
-    { label: 'Queue Offset', value: String(message.queueOffset) },
-    { label: 'Store Message ID', value: message.properties.STORE_MESSAGE_ID || '-', wide: true }
-  ];
-}
-
-function groupTraceNodes(nodes: MessageTraceNode[]) {
-  return [...nodes].sort((left, right) => left.name.localeCompare(right.name));
-}
-
-function traceStateFor(row: MessageView, selected: MessageView | null, trace: MessageTraceView | null, traceLoading: boolean) {
-  if (selected?.messageId !== row.messageId) {
-    return 'not loaded';
-  }
-  if (traceLoading) {
-    return 'loading';
-  }
-  return trace && trace.nodes.length > 0 ? `${trace.nodes.length} nodes` : 'no nodes';
-}
-
-function traceStateTone(row: MessageView, selected: MessageView | null, trace: MessageTraceView | null, traceLoading: boolean) {
-  if (selected?.messageId !== row.messageId || traceLoading) {
-    return 'neutral';
-  }
-  return trace && trace.nodes.length > 0 ? 'success' : 'warning';
-}
-
-function traceNodeTone(node: MessageTraceNode) {
-  const normalized = node.status.toLowerCase();
-  if (normalized.includes('consume') || normalized.includes('success') || normalized.includes('ok')) {
-    return 'success';
-  }
-  if (normalized.includes('fail') || normalized.includes('error')) {
-    return 'danger';
-  }
-  return 'warning';
-}
-
-function messageTags(message: MessageView | null | undefined) {
-  return message?.tags || message?.properties?.TAGS || '-';
-}
-
-function messageKeys(message: MessageView | null | undefined) {
-  return message?.keys || message?.properties?.KEYS || '-';
-}
-
-function formatTimestamp(value: number | undefined) {
-  if (!value) return '-';
-  return new Date(value).toLocaleString();
-}
-
-function truncateMiddle(value: string, maxLength: number) {
-  if (value.length <= maxLength) return value;
-  const edge = Math.floor((maxLength - 3) / 2);
-  return `${value.slice(0, edge)}...${value.slice(-edge)}`;
-}
-
-function copyText(value: string) {
-  if (!value) return;
-  if (navigator.clipboard?.writeText) {
-    void navigator.clipboard.writeText(value).catch(() => legacyCopyText(value));
-    return;
-  }
-  legacyCopyText(value);
-}
-
-function legacyCopyText(value: string) {
-  const textarea = document.createElement('textarea');
-  textarea.value = value;
-  textarea.setAttribute('readonly', 'true');
-  textarea.style.position = 'fixed';
-  textarea.style.left = '-9999px';
-  textarea.style.top = '0';
-  document.body.appendChild(textarea);
-  textarea.select();
-  document.execCommand('copy');
-  textarea.remove();
+function preferredTopic(topics: string[]) {
+  return topics.find((topic) => !topic.startsWith('%') && !topic.startsWith('RMQ_SYS')) ?? topics[0] ?? '';
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/messages/MessageBody.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/messages/MessageBody.tsx
@@ -1,0 +1,13 @@
+import { formatMessageBody } from './message-model';
+
+interface MessageBodyProps {
+  body: string;
+}
+
+export default function MessageBody({ body }: MessageBodyProps) {
+  return (
+    <pre className="message-body-block" aria-label="Message body">
+      {formatMessageBody(body) || 'The API returned an empty message body.'}
+    </pre>
+  );
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/messages/MessageDetailContent.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/messages/MessageDetailContent.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { messageApi } from '../../api/message_api';
+import type { MessageView } from '../../types/message';
+import MessageDetailContent from './MessageDetailContent';
+
+vi.mock('../../api/message_api', () => ({
+  messageApi: { trace: vi.fn() }
+}));
+
+const message: MessageView = {
+  topic: 'orders', messageId: 'MSG-001-LONG-IDENTIFIER', keys: 'order:1', tags: 'TagA',
+  bornTimestamp: 1_723_651_200_000, storeTimestamp: 1_723_651_201_000,
+  bornHost: '10.0.0.1:10911', storeHost: '10.0.0.2:10911', queueId: 3, queueOffset: 42,
+  storeSize: 1_536, reconsumeTimes: 2, bodyCRC: 1, sysFlag: 0, flag: 0,
+  preparedTransactionOffset: 0, body: '{"orderId":1289347}',
+  properties: { WAIT: 'true', KEYS: 'order:1', TAGS: 'TagA', STORE_MESSAGE_ID: 'STORE-001' }
+};
+
+describe('MessageDetailContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(messageApi.trace).mockResolvedValue({
+      messageId: message.messageId,
+      traceTopic: 'RMQ_SYS_TRACE_TOPIC',
+      nodes: [{ nodeType: 'BROKER', name: 'broker-a', status: 'STORED', timestamp: 1_723_651_201_000 }]
+    });
+  });
+
+  it('keeps the body in the selected detail, sorts properties, copies identifiers, and loads trace once', async () => {
+    const user = userEvent.setup();
+    const writeText = vi.spyOn(navigator.clipboard, 'writeText');
+    render(<MessageDetailContent message={message} />);
+
+    expect(screen.getByRole('group', { name: 'Body size: 1.5 KB' })).toBeInTheDocument();
+    expect(screen.queryByText('1289347')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Copy message ID' }));
+    expect(writeText).toHaveBeenCalledWith(message.messageId);
+    expect(await screen.findByText('Message ID copied.')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', { name: 'Properties' }));
+    expect(screen.getAllByRole('row').slice(1).map((row) => row.textContent)).toEqual([
+      'KEYSorder:1', 'STORE_MESSAGE_IDSTORE-001', 'TAGSTagA', 'WAITtrue'
+    ]);
+
+    await user.click(screen.getByRole('tab', { name: 'Body' }));
+    expect(screen.getByText(/"orderId": 1289347/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', { name: 'Trace' }));
+    expect(await screen.findByText('broker-a')).toBeInTheDocument();
+    await user.click(screen.getByRole('tab', { name: 'Overview' }));
+    await user.click(screen.getByRole('tab', { name: 'Trace' }));
+    await waitFor(() => expect(messageApi.trace).toHaveBeenCalledTimes(1));
+    expect(messageApi.trace).toHaveBeenCalledWith('STORE-001', message.topic, 'RMQ_SYS_TRACE_TOPIC');
+  });
+
+  it('announces clipboard failures as errors', async () => {
+    const user = userEvent.setup();
+    vi.spyOn(navigator.clipboard, 'writeText').mockRejectedValueOnce(new Error('clipboard denied'));
+    render(<MessageDetailContent message={message} />);
+
+    await user.click(screen.getByRole('button', { name: 'Copy message ID' }));
+
+    const notice = await screen.findByRole('alert');
+    expect(notice).toHaveTextContent('Unable to copy the message ID.');
+    expect(notice).toHaveClass('notice-danger');
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/messages/MessageDetailContent.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/messages/MessageDetailContent.tsx
@@ -1,0 +1,157 @@
+import { Braces, Clock3, Copy, Database, RotateCcw } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { messageApi } from '../../api/message_api';
+import MetricCard from '../../components/MetricCard';
+import { Button } from '../../components/ui/Button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../components/ui/Tabs';
+import type { MessageTraceView, MessageView } from '../../types/message';
+import MessageBody from './MessageBody';
+import { messageRowId, messageTraceId } from './dlq-selection';
+import TraceTimeline from './TraceTimeline';
+import {
+  formatMessageSize,
+  formatMessageTimestamp,
+  messageKeys,
+  messageTags,
+  sortedMessageProperties,
+  truncateIdentifier
+} from './message-model';
+
+interface MessageDetailContentProps {
+  message: MessageView;
+  traceTopic?: string;
+  initialTab?: 'overview' | 'properties' | 'body' | 'trace';
+}
+
+export default function MessageDetailContent({
+  message,
+  traceTopic = 'RMQ_SYS_TRACE_TOPIC',
+  initialTab = 'overview'
+}: MessageDetailContentProps) {
+  const [activeTab, setActiveTab] = useState(initialTab);
+  const [copyNotice, setCopyNotice] = useState<{ message: string; tone: 'success' | 'danger' } | null>(null);
+  const [trace, setTrace] = useState<MessageTraceView | null>(null);
+  const [traceLoading, setTraceLoading] = useState(false);
+  const [traceError, setTraceError] = useState<string | null>(null);
+  const [traceLoaded, setTraceLoaded] = useState(false);
+  const traceRequestRef = useRef(0);
+
+  useEffect(() => {
+    setActiveTab(initialTab);
+    setCopyNotice(null);
+    setTrace(null);
+    setTraceError(null);
+    setTraceLoaded(false);
+    setTraceLoading(false);
+    traceRequestRef.current += 1;
+  }, [initialTab, messageRowId(message), traceTopic]);
+
+  const loadTrace = async () => {
+    if (traceLoaded || traceLoading) return;
+    const requestId = ++traceRequestRef.current;
+    setTraceLoaded(true);
+    setTraceLoading(true);
+    setTraceError(null);
+    try {
+      const nextTrace = await messageApi.trace(messageTraceId(message), message.topic, traceTopic);
+      if (traceRequestRef.current === requestId) setTrace(nextTrace);
+    } catch (requestError) {
+      if (traceRequestRef.current === requestId) {
+        setTraceLoaded(false);
+        setTraceError(requestError instanceof Error ? requestError.message : String(requestError));
+      }
+    } finally {
+      if (traceRequestRef.current === requestId) setTraceLoading(false);
+    }
+  };
+
+  const changeTab = (value: string) => {
+    const nextTab = value as typeof activeTab;
+    setActiveTab(nextTab);
+    if (nextTab === 'trace') void loadTrace();
+  };
+
+  const copyMessageId = async () => {
+    try {
+      await navigator.clipboard.writeText(message.messageId);
+      setCopyNotice({ message: 'Message ID copied.', tone: 'success' });
+    } catch {
+      setCopyNotice({ message: 'Unable to copy the message ID.', tone: 'danger' });
+    }
+  };
+
+  return (
+    <div className="entity-detail-content message-detail-content">
+      {copyNotice ? (
+        <div className={`notice notice-${copyNotice.tone}`} role={copyNotice.tone === 'danger' ? 'alert' : 'status'}>
+          {copyNotice.message}
+        </div>
+      ) : null}
+      <div className="message-detail-identity">
+        <div>
+          <span>Message ID</span>
+          <strong className="mono" title={message.messageId}>{truncateIdentifier(message.messageId, 38)}</strong>
+        </div>
+        <Button type="button" variant="outline" size="sm" onClick={() => void copyMessageId()}>
+          <Copy size={14} aria-hidden="true" /> Copy message ID
+        </Button>
+      </div>
+
+      <Tabs value={activeTab} onValueChange={changeTab}>
+        <TabsList aria-label="Message detail sections">
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="properties">Properties</TabsTrigger>
+          <TabsTrigger value="body">Body</TabsTrigger>
+          <TabsTrigger value="trace">Trace</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="overview">
+          <div className="metric-grid entity-detail-metrics">
+            <MetricCard label="Body size" value={formatMessageSize(message.storeSize)} detail="Stored message bytes" icon={<Database size={18} />} />
+            <MetricCard label="Reconsume" value={message.reconsumeTimes} detail="API retry count" icon={<RotateCcw size={18} />} />
+            <MetricCard label="Queue" value={message.queueId} detail={`Offset ${message.queueOffset}`} icon={<Braces size={18} />} />
+            <MetricCard label="Stored" value={formatMessageTimestamp(message.storeTimestamp)} detail="Broker store timestamp" icon={<Clock3 size={18} />} />
+          </div>
+          <dl className="entity-description-grid">
+            <div><dt>Topic</dt><dd className="mono">{message.topic}</dd></div>
+            <div><dt>Tags</dt><dd>{messageTags(message)}</dd></div>
+            <div><dt>Keys</dt><dd className="mono">{messageKeys(message)}</dd></div>
+            <div><dt>Queue / offset</dt><dd>{message.queueId} / {message.queueOffset}</dd></div>
+            <div><dt>Born host</dt><dd className="mono">{message.bornHost || '-'}</dd></div>
+            <div><dt>Store host</dt><dd className="mono">{message.storeHost || '-'}</dd></div>
+            <div><dt>Born time</dt><dd>{formatMessageTimestamp(message.bornTimestamp)}</dd></div>
+            <div><dt>Store time</dt><dd>{formatMessageTimestamp(message.storeTimestamp)}</dd></div>
+          </dl>
+        </TabsContent>
+
+        <TabsContent value="properties">
+          {sortedMessageProperties(message).length > 0 ? (
+            <div className="message-properties-table" role="region" aria-label="Message properties">
+              <table>
+                <thead><tr><th>Key</th><th>Value</th></tr></thead>
+                <tbody>
+                  {sortedMessageProperties(message).map(([key, value]) => (
+                    <tr key={key}><td><code>{key}</code></td><td className="mono">{value}</td></tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : <div className="state-block"><strong>No message properties</strong></div>}
+        </TabsContent>
+
+        <TabsContent value="body">
+          <MessageBody body={message.body} />
+        </TabsContent>
+
+        <TabsContent value="trace">
+          <TraceTimeline
+            nodes={trace?.nodes ?? []}
+            loading={traceLoading}
+            error={traceError}
+            onRetry={() => void loadTrace()}
+          />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/messages/TraceTimeline.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/messages/TraceTimeline.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { MessageTraceNode } from '../../types/message';
+import TraceTimeline from './TraceTimeline';
+
+describe('TraceTimeline', () => {
+  it('renders only returned node fields in timestamp order without inferred edges or latency', () => {
+    const nodes: MessageTraceNode[] = [
+      { nodeType: 'CONSUMER', name: 'order-service', status: 'SUCCESS', timestamp: 30 },
+      { nodeType: 'PRODUCER', name: 'order-producer', status: 'SENT', timestamp: 10 }
+    ];
+    render(<TraceTimeline nodes={nodes} />);
+
+    expect(screen.getAllByRole('listitem').map((item) => item.textContent)).toEqual([
+      expect.stringContaining('order-producer'),
+      expect.stringContaining('order-service')
+    ]);
+    expect(screen.queryByText(/latency|duration|edge/i)).not.toBeInTheDocument();
+    expect(nodes[0].timestamp).toBe(30);
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/messages/TraceTimeline.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/messages/TraceTimeline.tsx
@@ -1,0 +1,42 @@
+import { GitBranch } from 'lucide-react';
+import EmptyState from '../../components/EmptyState';
+import ErrorState from '../../components/ErrorState';
+import LoadingState from '../../components/LoadingState';
+import StatusBadge from '../../components/StatusBadge';
+import type { MessageTraceNode } from '../../types/message';
+import { formatMessageTimestamp, sortTraceNodes, traceNodeTone } from './message-model';
+
+interface TraceTimelineProps {
+  nodes: MessageTraceNode[];
+  loading?: boolean;
+  error?: string | null;
+  onRetry?: () => void;
+}
+
+export default function TraceTimeline({ nodes, loading = false, error, onRetry }: TraceTimelineProps) {
+  if (loading) return <LoadingState label="Loading trace nodes" />;
+  if (error) return <ErrorState message={error} onRetry={onRetry} retryLabel="Reload trace" />;
+  if (nodes.length === 0) return <EmptyState title="No trace nodes" detail="The trace API returned no nodes for this message." />;
+
+  return (
+    <ol className="trace-timeline" aria-label="Returned trace nodes">
+      {sortTraceNodes(nodes).map((node, index) => (
+        <li key={`${node.timestamp}-${node.nodeType}-${node.name}-${index}`}>
+          <span className={`trace-timeline-marker trace-timeline-marker-${traceNodeTone(node)}`}>
+            <GitBranch size={14} aria-hidden="true" />
+          </span>
+          <div className="trace-timeline-card">
+            <div>
+              <strong>{node.name || 'Unnamed node'}</strong>
+              <StatusBadge status={node.status || 'UNKNOWN'} tone={traceNodeTone(node)} />
+            </div>
+            <dl>
+              <div><dt>Node type</dt><dd>{node.nodeType || '-'}</dd></div>
+              <div><dt>Timestamp</dt><dd>{formatMessageTimestamp(node.timestamp)}</dd></div>
+            </dl>
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/messages/dlq-selection.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/messages/dlq-selection.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import type { MessageView } from '../../types/message';
+import { dlqResendTarget, messageResendTarget, selectionForPage, toggleMessageSelection } from './dlq-selection';
+
+const message = (properties: Record<string, string>): MessageView => ({
+  topic: '%DLQ%order-service', messageId: 'DLQ-001', bornTimestamp: 1, storeTimestamp: 2,
+  bornHost: 'born', storeHost: 'stored', queueId: 0, queueOffset: 1, storeSize: 1,
+  reconsumeTimes: 16, bodyCRC: 1, sysFlag: 0, flag: 0, preparedTransactionOffset: 0,
+  body: 'secret', properties
+});
+
+describe('DLQ page selection', () => {
+  it('retains selections still present on the page and drops old-page identifiers', () => {
+    expect([...selectionForPage(new Set(['old-1', 'same']), ['same', 'new-1'])]).toEqual(['same']);
+  });
+
+  it('adds and removes a message without mutating the current Set', () => {
+    const current = new Set(['a']);
+    expect([...toggleMessageSelection(current, 'b', true)]).toEqual(['a', 'b']);
+    expect([...toggleMessageSelection(current, 'a', false)]).toEqual([]);
+    expect([...current]).toEqual(['a']);
+  });
+
+  it('derives canonical DLQ resend metadata and fails closed when either property is absent', () => {
+    expect(dlqResendTarget(message({ RETRY_TOPIC: 'orders', DLQ_ORIGIN_MESSAGE_ID: 'MSG-001' }))).toEqual({
+      topicName: 'orders', msgId: 'MSG-001'
+    });
+    expect(dlqResendTarget(message({ RETRY_TOPIC: 'orders' }))).toBeNull();
+    expect(dlqResendTarget(message({ ORIGIN_MESSAGE_ID: 'MSG-001' }))).toBeNull();
+    expect(messageResendTarget(message({}))).toBeNull();
+    expect(messageResendTarget({ ...message({}), topic: 'orders', messageId: 'MSG-002' })).toBeNull();
+    expect(messageResendTarget({
+      ...message({ STORE_MESSAGE_ID: 'STORE-002' }), topic: 'orders', messageId: 'MSG-002'
+    })).toEqual({
+      topic: 'orders', messageId: 'STORE-002'
+    });
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/messages/dlq-selection.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/messages/dlq-selection.ts
@@ -1,0 +1,48 @@
+import type { MessageView } from '../../types/message';
+
+export function selectionForPage(current: Set<string>, pageMessageIds: string[]) {
+  const pageIds = new Set(pageMessageIds);
+  return new Set([...current].filter((messageId) => pageIds.has(messageId)));
+}
+
+export function toggleMessageSelection(current: Set<string>, messageId: string, selected: boolean) {
+  const next = new Set(current);
+  if (selected) next.add(messageId);
+  else next.delete(messageId);
+  return next;
+}
+
+export function messageRowId(message: MessageView) {
+  const storeMessageId = message.properties.STORE_MESSAGE_ID?.trim();
+  if (storeMessageId) return JSON.stringify(['store', storeMessageId]);
+  return JSON.stringify([message.topic, message.storeHost, message.queueId, message.queueOffset]);
+}
+
+export function messageTraceId(message: MessageView) {
+  return message.properties.STORE_MESSAGE_ID?.trim() || message.messageId;
+}
+
+export function dlqResendTarget(message: MessageView) {
+  const topicName = message.properties.RETRY_TOPIC?.trim();
+  const msgId = (message.properties.ORIGIN_MESSAGE_ID || message.properties.DLQ_ORIGIN_MESSAGE_ID)?.trim();
+  return topicName && msgId ? { topicName, msgId } : null;
+}
+
+export function uniqueDlqResendTargets(messages: MessageView[], selectedIds: Set<string>) {
+  const targets = new Map<string, NonNullable<ReturnType<typeof dlqResendTarget>>>();
+  for (const message of messages) {
+    if (!selectedIds.has(messageRowId(message))) continue;
+    const target = dlqResendTarget(message);
+    if (target) targets.set(`${target.topicName}\u0000${target.msgId}`, target);
+  }
+  return [...targets.values()];
+}
+
+export function messageResendTarget(message: MessageView) {
+  if (!message.topic.startsWith('%DLQ%')) {
+    const storeMessageId = message.properties.STORE_MESSAGE_ID?.trim();
+    return storeMessageId ? { topic: message.topic, messageId: storeMessageId } : null;
+  }
+  const target = dlqResendTarget(message);
+  return target ? { topic: target.topicName, messageId: target.msgId } : null;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/messages/message-model.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/messages/message-model.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import type { MessageTraceNode, MessageView } from '../../types/message';
+import { formatMessageSize, messageKeys, messageTags, sortedMessageProperties, sortTraceNodes, traceNodeTone } from './message-model';
+
+const message: MessageView = {
+  topic: 'orders',
+  messageId: 'MSG-001',
+  keys: null,
+  tags: null,
+  bornTimestamp: 1_723_651_200_000,
+  storeTimestamp: 1_723_651_201_000,
+  bornHost: '10.0.0.1:10911',
+  storeHost: '10.0.0.2:10911',
+  queueId: 3,
+  queueOffset: 42,
+  storeSize: 1_536,
+  reconsumeTimes: 2,
+  bodyCRC: 1,
+  sysFlag: 0,
+  flag: 0,
+  preparedTransactionOffset: 0,
+  body: '{"orderId":1289347}',
+  properties: { TAGS: 'TagA', KEYS: 'order:1289347', WAIT: 'true' }
+};
+
+describe('message model', () => {
+  it('formats API-backed size, tag, key, and sorted properties', () => {
+    expect(formatMessageSize(message.storeSize)).toBe('1.5 KB');
+    expect(messageTags(message)).toBe('TagA');
+    expect(messageKeys(message)).toBe('order:1289347');
+    expect(sortedMessageProperties(message)).toEqual([
+      ['KEYS', 'order:1289347'],
+      ['TAGS', 'TagA'],
+      ['WAIT', 'true']
+    ]);
+  });
+
+  it('sorts a copied trace-node array by timestamp without mutating the response', () => {
+    const nodes: MessageTraceNode[] = [
+      { nodeType: 'CONSUMER', name: 'order-service', status: 'SUCCESS', timestamp: 30 },
+      { nodeType: 'PRODUCER', name: 'order-producer', status: 'SUCCESS', timestamp: 10 },
+      { nodeType: 'BROKER', name: 'broker-a', status: 'STORED', timestamp: 20 }
+    ];
+
+    expect(sortTraceNodes(nodes).map((node) => node.timestamp)).toEqual([10, 20, 30]);
+    expect(nodes.map((node) => node.timestamp)).toEqual([30, 10, 20]);
+    expect(traceNodeTone({ nodeType: 'CONSUMER', name: 'order-service', status: 'CONSUMED', timestamp: 30 })).toBe('success');
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/messages/message-model.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/messages/message-model.ts
@@ -1,0 +1,55 @@
+import type { MessageTraceNode, MessageView } from '../../types/message';
+
+export function messageTags(message: MessageView | null | undefined) {
+  return message?.tags || message?.properties.TAGS || '-';
+}
+
+export function messageKeys(message: MessageView | null | undefined) {
+  return message?.keys || message?.properties.KEYS || '-';
+}
+
+export function sortedMessageProperties(message: MessageView) {
+  return Object.entries(message.properties).sort(([left], [right]) => left.localeCompare(right));
+}
+
+export function formatMessageSize(bytes: number) {
+  if (!Number.isFinite(bytes) || bytes < 0) return '-';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${formatDecimal(bytes / 1024)} KB`;
+  return `${formatDecimal(bytes / (1024 * 1024))} MB`;
+}
+
+export function formatMessageTimestamp(timestamp: number) {
+  if (!Number.isFinite(timestamp) || timestamp <= 0) return '-';
+  return new Date(timestamp).toLocaleString();
+}
+
+export function formatMessageBody(body: string) {
+  if (!body) return '';
+  try {
+    return JSON.stringify(JSON.parse(body), null, 2);
+  } catch {
+    return body;
+  }
+}
+
+export function truncateIdentifier(value: string, maxLength = 30) {
+  if (value.length <= maxLength) return value;
+  const edge = Math.floor((maxLength - 3) / 2);
+  return `${value.slice(0, edge)}...${value.slice(-edge)}`;
+}
+
+export function sortTraceNodes(nodes: MessageTraceNode[]) {
+  return [...nodes].sort((left, right) => left.timestamp - right.timestamp);
+}
+
+export function traceNodeTone(node: MessageTraceNode) {
+  const value = `${node.status} ${node.nodeType}`.toLowerCase();
+  if (value.includes('fail') || value.includes('error') || value.includes('timeout')) return 'danger' as const;
+  if (value.includes('success') || value.includes('sent') || value.includes('stored') || value.includes('consumed') || value.includes('ok')) return 'success' as const;
+  return 'warning' as const;
+}
+
+function formatDecimal(value: number) {
+  return value.toFixed(1).replace(/\.0$/, '');
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/pages.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/pages.css
@@ -922,3 +922,456 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* Message operations */
+.message-ops-workspace {
+  display: grid;
+  gap: 14px;
+}
+
+.message-query-card,
+.message-results-card,
+.trace-detail-card {
+  overflow: hidden;
+  box-shadow: none;
+}
+
+.message-query-card > .ui-card-header,
+.message-results-card > .ui-card-header,
+.trace-detail-card > .ui-card-header {
+  align-items: flex-start;
+  border-bottom: 1px solid var(--border);
+  background: var(--muted-surface);
+}
+
+.message-query-card > .ui-card-content,
+.message-results-card > .ui-card-content,
+.trace-detail-card > .ui-card-content {
+  padding: 14px;
+}
+
+.message-query-grid,
+.dlq-query-grid,
+.trace-query-grid {
+  display: grid;
+  grid-template-columns: minmax(170px, 1.2fr) repeat(2, minmax(170px, 1fr)) auto;
+  align-items: end;
+  gap: 10px;
+}
+
+.dlq-query-grid {
+  grid-template-columns: minmax(180px, 1.2fr) repeat(3, minmax(160px, 1fr)) auto;
+}
+
+.trace-query-grid {
+  grid-template-columns: minmax(190px, 1fr) minmax(170px, 1fr) minmax(220px, 1.35fr) auto;
+}
+
+.message-query-field,
+.message-resend-fields > div {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.message-query-field select {
+  width: 100%;
+  height: 34px;
+  border: 1px solid var(--input);
+  border-radius: var(--radius-sm);
+  padding: 0 30px 0 10px;
+  background: var(--background);
+  color: var(--foreground);
+  font: inherit;
+}
+
+.message-query-field select:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--ring) 55%, transparent);
+  outline-offset: 1px;
+}
+
+.message-query-field-wide {
+  grid-column: span 2;
+}
+
+.message-query-submit {
+  min-width: 148px;
+  white-space: nowrap;
+}
+
+.message-query-card .notice {
+  margin-top: 10px;
+}
+
+.message-metric-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.message-metric-grid .metric-card {
+  min-width: 0;
+  box-shadow: none;
+}
+
+.message-metric-grid .metric-card strong {
+  overflow: hidden;
+  font-size: 19px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.message-results-card .app-data-table {
+  border: 0;
+}
+
+.message-results-card .app-data-table-scroll {
+  max-height: 520px;
+}
+
+.message-id-value {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  color: var(--foreground);
+  text-overflow: ellipsis;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.message-muted-value {
+  color: var(--muted-foreground);
+}
+
+.message-detail-content {
+  display: grid;
+  gap: 14px;
+  min-width: 0;
+}
+
+.message-detail-content .entity-detail-metrics {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.message-detail-content .metric-card {
+  min-width: 0;
+}
+
+.message-detail-content .metric-card strong {
+  overflow-wrap: anywhere;
+}
+
+.message-detail-identity {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 11px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--muted-surface);
+}
+
+.message-detail-identity > div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.message-detail-identity span,
+.trace-timeline dt {
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.message-detail-identity strong {
+  overflow: hidden;
+  font-size: 12px;
+  text-overflow: ellipsis;
+}
+
+.message-properties-table {
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+
+.message-properties-table table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.message-properties-table th,
+.message-properties-table td {
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  vertical-align: top;
+  word-break: break-word;
+}
+
+.message-properties-table th {
+  background: var(--muted-surface);
+  color: var(--muted-foreground);
+}
+
+.message-properties-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.message-body-block {
+  margin: 0;
+  overflow: auto;
+  max-height: 420px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 12px;
+  background: var(--background);
+  color: var(--foreground);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.message-resend-panel {
+  display: grid;
+  gap: 12px;
+  margin-top: 18px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+
+.message-resend-panel h3,
+.message-resend-panel p {
+  margin: 0;
+}
+
+.message-resend-panel h3 {
+  font-size: 14px;
+}
+
+.message-resend-panel p {
+  margin-top: 4px;
+  color: var(--muted-foreground);
+  font-size: 12px;
+}
+
+.message-resend-fields {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.dlq-action-bar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.dlq-action-bar > span {
+  color: var(--muted-foreground);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.dlq-resend-results {
+  display: flex;
+  gap: 7px;
+  margin-bottom: 10px;
+  flex-wrap: wrap;
+  list-style: none;
+  padding: 0;
+}
+
+.dlq-resend-results li {
+  display: grid;
+  gap: 3px;
+  border: 1px solid color-mix(in srgb, var(--success) 42%, var(--border));
+  border-radius: var(--radius-sm);
+  padding: 6px 8px;
+  background: color-mix(in srgb, var(--success) 7%, var(--card));
+  color: var(--success);
+  font-size: 12px;
+  font-family: var(--font-mono);
+}
+
+.dlq-resend-results li.is-danger {
+  border-color: color-mix(in srgb, var(--destructive) 45%, var(--border));
+  background: color-mix(in srgb, var(--destructive) 8%, var(--card));
+  color: var(--destructive);
+}
+
+.dlq-resend-results li span {
+  color: var(--muted-foreground);
+  font-family: var(--font-sans);
+}
+
+.message-discovery-notice {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.trace-workspace-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(340px, .75fr);
+  align-items: start;
+  gap: 14px;
+}
+
+.trace-detail-card {
+  position: sticky;
+  top: 14px;
+}
+
+.trace-workspace-grid .message-results-card .app-data-table table {
+  min-width: 680px;
+}
+
+.trace-timeline {
+  display: grid;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.trace-timeline > li {
+  position: relative;
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr);
+  gap: 9px;
+  padding-bottom: 12px;
+}
+
+.trace-timeline > li:not(:last-child)::before {
+  position: absolute;
+  top: 25px;
+  bottom: 0;
+  left: 13px;
+  width: 1px;
+  background: var(--border);
+  content: '';
+}
+
+.trace-timeline-marker {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: var(--card);
+  color: var(--muted-foreground);
+}
+
+.trace-timeline-marker-success { border-color: var(--success); color: var(--success); }
+.trace-timeline-marker-warning { border-color: var(--warning); color: var(--warning); }
+.trace-timeline-marker-danger { border-color: var(--destructive); color: var(--destructive); }
+
+.trace-timeline-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 10px;
+  background: var(--background);
+}
+
+.trace-timeline-card > div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.trace-timeline-card dl {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin: 9px 0 0;
+}
+
+.trace-timeline-card dl > div {
+  display: grid;
+  gap: 3px;
+}
+
+.trace-timeline-card dd {
+  margin: 0;
+  font-size: 12px;
+}
+
+@media (max-width: 1180px) {
+  .dlq-query-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .dlq-query-grid .message-query-submit {
+    justify-self: start;
+  }
+}
+
+@media (max-width: 960px) {
+  .message-query-grid,
+  .trace-query-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .message-query-field-wide {
+    grid-column: auto;
+  }
+
+  .trace-workspace-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .trace-detail-card {
+    position: static;
+  }
+
+  .message-metric-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .message-query-card > .ui-card-header,
+  .message-results-card > .ui-card-header,
+  .trace-detail-card > .ui-card-header {
+    flex-direction: column;
+  }
+
+  .message-query-grid,
+  .dlq-query-grid,
+  .trace-query-grid,
+  .message-resend-fields,
+  .message-metric-grid,
+  .trace-timeline-card dl {
+    grid-template-columns: 1fr;
+  }
+
+  .message-query-submit,
+  .dlq-query-grid .message-query-submit {
+    width: 100%;
+    justify-self: stretch;
+  }
+
+  .message-detail-identity,
+  .dlq-action-bar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .dlq-action-bar .ui-button {
+    width: 100%;
+  }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/types/message.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/types/message.ts
@@ -74,6 +74,14 @@ export interface DlqBatchResendRequest {
 
 export interface DlqMessageResendResult {
   msgId: string;
+  success: boolean;
+  consumeResult: string;
+  remark?: string;
+}
+
+export interface MessageResendResult {
+  message: string;
+  success: boolean;
   consumeResult: string;
   remark?: string;
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9427

### Brief Description

Redesigns the Message, DLQ Message, and Message Trace workspaces as a cohesive dark operations flow. It adds explicit query modes, reusable message details, authoritative physical-message identity, guarded resend confirmation, server-backed DLQ paging and CSV export, structured per-message outcomes, and truthful trace rendering. Backend changes preserve broker consume results, harden CSV cells against spreadsheet formulas, and keep batch processing results for every requested message.

### How Did You Test This Change?

- `npm test -- --run --maxWorkers=2` - 27 files and 128 tests passed.
- `npm run build` - production build passed; Vite reported the existing large-chunk advisory.
- `cargo clippy --all-targets --all-features -- -D warnings` - passed from `rocketmq-dashboard/rocketmq-dashboard-web/backend`.
- `cargo build --all-targets --all-features` - passed from `rocketmq-dashboard/rocketmq-dashboard-web/backend`.
- `cargo fmt --package rocketmq-dashboard-web-backend -- --check` - passed from `rocketmq-dashboard/rocketmq-dashboard-web/backend`.
- `cargo fmt --all -- --check` - could not run on Windows because rustfmt hit OS error 206 (file name or extension too long); the exact affected backend package format check passed.
- `git diff --check` - passed.
- Browser QA covered message search and detail, DLQ selection and resend confirmation, and candidate-to-trace node loading in the in-app browser.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned message query, dead-letter queue, and message trace workspaces with clearer layouts, validation, pagination, retries, and responsive views.
  - Added detailed message views with properties, formatted bodies, copy actions, and trace timelines.
  - Added message lookup by topic, key, or ID and improved trace candidate selection.
  - Added batch DLQ resend with per-message success or failure results and CSV export.
  - Added safer spreadsheet exports and clearer pagination indicators.

- **Bug Fixes**
  - Resending now continues after individual failures and reports meaningful outcomes.
  - Improved handling of stale requests, empty pages, invalid inputs, and missing metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->