### PR TITLE
[ISSUE #9453]✨Set default listen port for NameServer to 9876 and add corresponding test

### DIFF
--- a/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
+++ b/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
@@ -39,6 +39,7 @@ use rocketmq_model::utils::env_utils::EnvUtils;
 use rocketmq_model::version::CURRENT_VERSION;
 use rocketmq_namesrv::bootstrap::Builder;
 use rocketmq_namesrv::config::is_tls_config_key;
+use rocketmq_namesrv::config::DEFAULT_NAMESRV_LISTEN_PORT;
 use rocketmq_namesrv::parse_command_and_config_file;
 use rocketmq_namesrv::security::NameServerTransportPolicy;
 use rocketmq_namesrv::NamesrvConfig;
@@ -489,7 +490,10 @@ fn parse_and_merge_config(
         namesrv_config.kv_config_path = kv_path.to_string_lossy().to_string();
     }
 
-    let mut server_config = ServerConfig::default();
+    let mut server_config = ServerConfig {
+        listen_port: DEFAULT_NAMESRV_LISTEN_PORT,
+        ..ServerConfig::default()
+    };
     let mut tokio_client_config = TransportClientConfig::default();
     if let Some(config_file) = args.config_file.clone() {
         let config = Config::builder()

--- a/rocketmq-namesrv/src/config.rs
+++ b/rocketmq-namesrv/src/config.rs
@@ -27,6 +27,7 @@ use serde::Deserialize;
 use serde_json::Value;
 
 pub const REMOVED_ROUTE_MANAGER_CONFIG_KEY: &str = "useRouteInfoManagerV2";
+pub const DEFAULT_NAMESRV_LISTEN_PORT: u32 = 9876;
 const REMOVED_ROUTE_MANAGER_CONFIG_FIELD: &str = "use_route_info_manager_v2";
 
 const MAX_THREAD_COUNT: i32 = 4096;

--- a/rocketmq-namesrv/tests/namesrv_bootstrap_config.rs
+++ b/rocketmq-namesrv/tests/namesrv_bootstrap_config.rs
@@ -1,0 +1,50 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::process::Command;
+
+#[test]
+fn namesrv_without_listen_port_override_reports_9876() {
+    let root = tempfile::tempdir().expect("create isolated NameServer config root");
+    let config_path = root.path().join("namesrv.toml");
+    let rocketmq_home = root.path().to_string_lossy().replace('\\', "/");
+    let config_store_path = root
+        .path()
+        .join("namesrv.properties")
+        .to_string_lossy()
+        .replace('\\', "/");
+    std::fs::write(
+        &config_path,
+        format!("rocketmqHome = \"{rocketmq_home}\"\nconfigStorePath = \"{config_store_path}\"\n"),
+    )
+    .expect("write isolated NameServer config");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rocketmq-namesrv-rust"))
+        .arg("--configFile")
+        .arg(&config_path)
+        .arg("--printConfigItem")
+        .output()
+        .expect("run NameServer config inspection");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "NameServer config inspection failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.lines().any(|line| line.trim() == "listenPort = 9876"),
+        "NameServer should default to port 9876\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #9453

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * NameServer now defaults to port `9876` when no listening port is configured.
  * Configuration inspection accurately reports the default listening port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->