### PR TITLE
[ISSUE #9443]✨Redesign Monitor and ACL governance workspaces

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/AclPage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/AclPage.test.tsx
@@ -1,0 +1,567 @@
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { StrictMode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+import { aclApi } from '../api/acl_api';
+import { brokerApi } from '../api/broker_api';
+import { renderAtRoute } from '../test/render';
+import AclPage from './AclPage';
+
+vi.mock('../api/acl_api', () => ({
+  aclApi: {
+    listUsers: vi.fn(),
+    listPolicies: vi.fn(),
+    createUser: vi.fn(),
+    updateUser: vi.fn(),
+    deleteUser: vi.fn(),
+    createPolicy: vi.fn(),
+    updatePolicy: vi.fn(),
+    deletePolicy: vi.fn()
+  }
+}));
+
+vi.mock('../api/broker_api', () => ({
+  brokerApi: { list: vi.fn() }
+}));
+
+describe('AclPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(brokerApi.list).mockResolvedValue({
+      items: [{
+        clusterName: 'Cluster-A', brokerName: 'broker-a', brokerId: 0,
+        address: '10.0.0.1:10911', role: 'MASTER', version: '5.3.0', produceTps: 0, consumeTps: 0
+      }],
+      total: 1
+    });
+    vi.mocked(aclApi.listUsers).mockResolvedValue([]);
+    vi.mocked(aclApi.listPolicies).mockResolvedValue([]);
+  });
+
+  it('does not load ACL records until the operator confirms a valid broker scope', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<AclPage />, '/acl');
+
+    const confirm = await screen.findByRole('button', { name: 'Confirm' });
+    expect(aclApi.listUsers).not.toHaveBeenCalled();
+    expect(aclApi.listPolicies).not.toHaveBeenCalled();
+
+    await user.click(confirm);
+    await waitFor(() => expect(aclApi.listUsers).toHaveBeenCalledWith({
+      clusterName: 'Cluster-A', brokerName: 'broker-a'
+    }));
+    expect(aclApi.listPolicies).toHaveBeenCalledWith({ clusterName: 'Cluster-A', brokerName: 'broker-a' });
+  });
+
+  it('finishes broker discovery when React Strict Mode probes the mount lifecycle', async () => {
+    render(
+      <StrictMode>
+        <MemoryRouter initialEntries={['/acl']} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+          <AclPage />
+        </MemoryRouter>
+      </StrictMode>
+    );
+
+    expect(await screen.findByRole('button', { name: 'Confirm' })).toBeEnabled();
+    expect(screen.queryByRole('status', { name: 'Loading ACL scope' })).not.toBeInTheDocument();
+  });
+
+  it('renders a scoped load error beside the table and retries the confirmed scope', async () => {
+    const user = userEvent.setup();
+    vi.mocked(aclApi.listUsers)
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce([]);
+    renderAtRoute(<AclPage />, '/acl');
+
+    await user.click(await screen.findByRole('button', { name: 'Confirm' }));
+    expect(await screen.findByText('Unable to load ACL users and policies for the confirmed scope.')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => expect(aclApi.listUsers).toHaveBeenCalledTimes(2));
+    expect(screen.queryByText('Unable to load ACL users and policies for the confirmed scope.')).not.toBeInTheDocument();
+  });
+
+  it('clears stale scope A records before a deferred scope B load can make them actionable', async () => {
+    const user = userEvent.setup();
+    let resolveBUsers: (value: never[]) => void = () => undefined;
+    let resolveBPolicies: (value: never[]) => void = () => undefined;
+    vi.mocked(brokerApi.list).mockResolvedValue({
+      items: [
+        { clusterName: 'Cluster-A', brokerName: 'broker-a', brokerId: 0, address: '10.0.0.1:10911', role: 'MASTER', version: '5.3.0', produceTps: 0, consumeTps: 0 },
+        { clusterName: 'Cluster-B', brokerName: 'broker-b', brokerId: 0, address: '10.0.0.2:10911', role: 'MASTER', version: '5.3.0', produceTps: 0, consumeTps: 0 }
+      ], total: 2
+    });
+    vi.mocked(aclApi.listUsers).mockImplementation((query) => query?.brokerName === 'broker-a'
+      ? Promise.resolve([{ brokerName: 'broker-a', brokerAddr: '10.0.0.1:10911', username: 'scope-a-user', password: 'scope-a-secret' }])
+      : new Promise((resolve) => { resolveBUsers = resolve; }));
+    vi.mocked(aclApi.listPolicies).mockImplementation((query) => query?.brokerName === 'broker-a'
+      ? Promise.resolve([])
+      : new Promise((resolve) => { resolveBPolicies = resolve; }));
+    renderAtRoute(<AclPage />, '/acl');
+
+    await user.click(await screen.findByRole('button', { name: 'Confirm' }));
+    expect(await screen.findByText('scope-a-user')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Select ACL cluster' }));
+    await user.click(screen.getByRole('option', { name: 'Cluster-B' }));
+    await user.click(screen.getByRole('button', { name: 'Select ACL broker' }));
+    await user.click(screen.getByRole('option', { name: 'broker-b' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    expect(screen.queryByText('scope-a-user')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Modify ACL/ })).not.toBeInTheDocument();
+    expect(aclApi.deleteUser).not.toHaveBeenCalled();
+    await act(async () => { resolveBUsers([]); resolveBPolicies([]); });
+  });
+
+  it('invalidates confirmed rows as soon as the operator changes the draft scope', async () => {
+    const user = userEvent.setup();
+    vi.mocked(brokerApi.list).mockResolvedValue({
+      items: [
+        { clusterName: 'Cluster-A', brokerName: 'broker-a', brokerId: 0, address: '10.0.0.1:10911', role: 'MASTER', version: '5.3.0', produceTps: 0, consumeTps: 0 },
+        { clusterName: 'Cluster-B', brokerName: 'broker-b', brokerId: 0, address: '10.0.0.2:10911', role: 'MASTER', version: '5.3.0', produceTps: 0, consumeTps: 0 }
+      ],
+      total: 2
+    });
+    vi.mocked(aclApi.listUsers).mockResolvedValue([
+      { brokerName: 'broker-a', brokerAddr: '10.0.0.1:10911', username: 'scope-a-user', password: 'secret' }
+    ]);
+    renderAtRoute(<AclPage />, '/acl');
+
+    await user.click(await screen.findByRole('button', { name: 'Confirm' }));
+    expect(await screen.findByText('scope-a-user')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Select ACL cluster' }));
+    await user.click(screen.getByRole('option', { name: 'Cluster-B' }));
+
+    expect(screen.queryByText('scope-a-user')).not.toBeInTheDocument();
+    expect(screen.getByText('No confirmed scope')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add User' })).toBeDisabled();
+  });
+
+  it('locks duplicate delete submissions until the in-flight mutation settles', async () => {
+    const user = userEvent.setup();
+    let resolveDelete: () => void = () => undefined;
+    vi.mocked(aclApi.listUsers).mockResolvedValue([{ brokerName: 'broker-a', brokerAddr: '10.0.0.1:10911', username: 'locked-user', password: 'secret' }]);
+    vi.mocked(aclApi.deleteUser).mockReturnValue(new Promise((resolve) => { resolveDelete = () => resolve({ message: 'deleted', targetCount: 1 }); }));
+    renderAtRoute(<AclPage />, '/acl');
+    await user.click(await screen.findByRole('button', { name: 'Confirm' }));
+    await screen.findByText('locked-user');
+    await user.click(screen.getByRole('button', { name: 'Delete ACL user locked-user' }));
+    const confirmation = screen.getByRole('alertdialog');
+    const confirmDelete = within(confirmation).getByRole('button', { name: 'Delete' });
+    act(() => { fireEvent.click(confirmDelete); fireEvent.click(confirmDelete); });
+    await waitFor(() => expect(aclApi.deleteUser).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole('button', { name: 'Modify ACL user locked-user' })).toBeDisabled();
+    await act(async () => { resolveDelete(); });
+  });
+
+  it('clears stale delete feedback when changing tabs or opening a new dialog', async () => {
+    const user = userEvent.setup();
+    vi.mocked(aclApi.listUsers).mockResolvedValue([{
+      brokerName: 'broker-a', brokerAddr: '10.0.0.1:10911', username: 'error-user', password: 'secret'
+    }]);
+    vi.mocked(aclApi.deleteUser).mockRejectedValue(new Error('failed'));
+    renderAtRoute(<AclPage />, '/acl');
+    await user.click(await screen.findByRole('button', { name: 'Confirm' }));
+    await screen.findByText('error-user');
+
+    await user.click(screen.getByRole('button', { name: 'Delete ACL user error-user' }));
+    await user.click(within(screen.getByRole('alertdialog')).getByRole('button', { name: 'Delete' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Unable to delete the ACL user.');
+    await user.click(screen.getByRole('tab', { name: 'ACL Policies' }));
+    await user.click(screen.getByRole('tab', { name: 'ACL Users' }));
+    expect(screen.queryByText('Unable to delete the ACL user.')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Delete ACL user error-user' }));
+    await user.click(within(screen.getByRole('alertdialog')).getByRole('button', { name: 'Delete' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Unable to delete the ACL user.');
+    await user.click(screen.getByRole('button', { name: 'Add User' }));
+    expect(screen.queryByText('Unable to delete the ACL user.')).not.toBeInTheDocument();
+  });
+
+  it('clears delete feedback when the draft scope changes', async () => {
+    const user = userEvent.setup();
+    vi.mocked(brokerApi.list).mockResolvedValue({
+      items: [
+        { clusterName: 'Cluster-A', brokerName: 'broker-a', brokerId: 0, address: '10.0.0.1:10911', role: 'MASTER', version: '5.3.0', produceTps: 0, consumeTps: 0 },
+        { clusterName: 'Cluster-B', brokerName: 'broker-b', brokerId: 0, address: '10.0.0.2:10911', role: 'MASTER', version: '5.3.0', produceTps: 0, consumeTps: 0 }
+      ], total: 2
+    });
+    vi.mocked(aclApi.listUsers).mockResolvedValue([{
+      brokerName: 'broker-a', brokerAddr: '10.0.0.1:10911', username: 'scope-error-user', password: 'secret'
+    }]);
+    vi.mocked(aclApi.deleteUser).mockRejectedValue(new Error('failed'));
+    renderAtRoute(<AclPage />, '/acl');
+    await user.click(await screen.findByRole('button', { name: 'Confirm' }));
+    await screen.findByText('scope-error-user');
+    await user.click(screen.getByRole('button', { name: 'Delete ACL user scope-error-user' }));
+    await user.click(within(screen.getByRole('alertdialog')).getByRole('button', { name: 'Delete' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Unable to delete the ACL user.');
+
+    await user.click(screen.getByRole('button', { name: 'Select ACL cluster' }));
+    await user.click(screen.getByRole('option', { name: 'Cluster-B' }));
+    expect(screen.queryByText('Unable to delete the ACL user.')).not.toBeInTheDocument();
+  });
+
+  it('clears failed delete feedback when a subsequent delete succeeds', async () => {
+    const user = userEvent.setup();
+    vi.mocked(aclApi.listUsers).mockResolvedValue([{
+      brokerName: 'broker-a', brokerAddr: '10.0.0.1:10911', username: 'retry-delete-user', password: 'secret'
+    }]);
+    vi.mocked(aclApi.deleteUser)
+      .mockRejectedValueOnce(new Error('failed'))
+      .mockResolvedValueOnce({ message: 'deleted', targetCount: 1 });
+    renderAtRoute(<AclPage />, '/acl');
+    await user.click(await screen.findByRole('button', { name: 'Confirm' }));
+    await screen.findByText('retry-delete-user');
+    await user.click(screen.getByRole('button', { name: 'Delete ACL user retry-delete-user' }));
+    await user.click(within(screen.getByRole('alertdialog')).getByRole('button', { name: 'Delete' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Unable to delete the ACL user.');
+
+    await user.click(screen.getByRole('button', { name: 'Delete ACL user retry-delete-user' }));
+    await user.click(within(screen.getByRole('alertdialog')).getByRole('button', { name: 'Delete' }));
+    expect(await screen.findByText('ACL user deleted.')).toBeInTheDocument();
+    expect(screen.queryByText('Unable to delete the ACL user.')).not.toBeInTheDocument();
+  });
+
+  it('clears stale policy delete feedback when opening a policy dialog', async () => {
+    const user = userEvent.setup();
+    vi.mocked(aclApi.listPolicies).mockResolvedValue([{
+      brokerName: 'broker-a', brokerAddr: '10.0.0.1:10911', subject: 'User:policy-error', policyType: 'Custom',
+      entries: [{ resource: 'Topic:Orders', actions: ['Pub'], sourceIps: [], decision: 'Allow' }]
+    }]);
+    vi.mocked(aclApi.deletePolicy).mockRejectedValue(new Error('failed'));
+    renderAtRoute(<AclPage />, '/acl');
+    await user.click(await screen.findByRole('button', { name: 'Confirm' }));
+    await user.click(screen.getByRole('tab', { name: 'ACL Policies' }));
+    await user.click(await screen.findByRole('button', { name: 'Delete ACL policy User:policy-error on Topic:Orders' }));
+    await user.click(within(screen.getByRole('alertdialog')).getByRole('button', { name: 'Delete' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Unable to delete the ACL policy.');
+
+    await user.click(screen.getByRole('button', { name: 'Add ACL Policy' }));
+    expect(screen.queryByText('Unable to delete the ACL policy.')).not.toBeInTheDocument();
+  });
+
+  it('masks passwords by default, resets reveal state after tab changes, and does not expose passwords in failures', async () => {
+    const user = userEvent.setup();
+    vi.mocked(aclApi.listUsers).mockResolvedValue([{ brokerName: 'broker-a', brokerAddr: '10.0.0.1:10911', username: 'secret-user', password: 'do-not-leak' }]);
+    renderAtRoute(<AclPage />, '/acl');
+    await user.click(await screen.findByRole('button', { name: 'Confirm' }));
+    await screen.findByText('secret-user');
+    expect(screen.queryByText('do-not-leak')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Reveal passwords' }));
+    expect(screen.getByText('do-not-leak')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Hide passwords' }));
+    expect(screen.queryByText('do-not-leak')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Reveal passwords' }));
+    await user.click(screen.getByRole('tab', { name: 'ACL Policies' }));
+    await user.click(screen.getByRole('tab', { name: 'ACL Users' }));
+    expect(screen.queryByText('do-not-leak')).not.toBeInTheDocument();
+  });
+
+  it('does not advertise password reveal when list responses omit password values', async () => {
+    const user = userEvent.setup();
+    vi.mocked(aclApi.listUsers).mockResolvedValue([
+      { brokerName: 'broker-a', brokerAddr: '10.0.0.1:10911', username: 'production-user' }
+    ]);
+    renderAtRoute(<AclPage />, '/acl');
+
+    await user.click(await screen.findByRole('button', { name: 'Confirm' }));
+    const row = (await screen.findByText('production-user')).closest('tr');
+    expect(within(row!).getByText('Unavailable')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Reveal passwords' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Hide passwords' })).not.toBeInTheDocument();
+  });
+
+  it('keeps create input and the safe save error inside the user dialog so the operator can retry', async () => {
+    const user = userEvent.setup();
+    vi.mocked(aclApi.createUser)
+      .mockRejectedValueOnce(new Error('super-secret-password'))
+      .mockResolvedValueOnce({ message: 'created', targetCount: 1 });
+    renderAtRoute(<AclPage />, '/acl');
+    await user.click(await screen.findByRole('button', { name: 'Confirm' }));
+    await user.click(screen.getByRole('button', { name: 'Add User' }));
+    const dialog = screen.getByRole('dialog', { name: 'Add User' });
+    await user.type(within(dialog).getByLabelText('* Username'), 'new-user');
+    await user.type(within(dialog).getByLabelText('* Password'), 'super-secret-password');
+    await user.click(within(dialog).getByRole('button', { name: 'Confirm' }));
+    const error = await within(dialog).findByRole('alert');
+    expect(error).toHaveTextContent('Unable to save the ACL user. Verify the request and try again.');
+    expect(error).not.toHaveTextContent('super-secret-password');
+    expect(within(dialog).getByLabelText('* Username')).toHaveValue('new-user');
+    expect(within(dialog).getByLabelText('* Password')).toHaveValue('super-secret-password');
+
+    await user.click(within(dialog).getByRole('button', { name: 'Retry' }));
+    await waitFor(() => expect(aclApi.createUser).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText('ACL user created.')).toBeInTheDocument();
+    expect(screen.queryByRole('dialog', { name: 'Add User' })).not.toBeInTheDocument();
+  });
+
+  it('keeps a failed policy edit open with its values and retries the same update', async () => {
+    const user = userEvent.setup();
+    vi.mocked(aclApi.listPolicies).mockResolvedValue([{
+      brokerName: 'broker-a', brokerAddr: '10.0.0.1:10911', subject: 'User:payments', policyType: 'Custom',
+      entries: [{ resource: 'Topic:Orders', actions: ['Pub'], sourceIps: ['10.0.0.1'], decision: 'Allow' }]
+    }]);
+    vi.mocked(aclApi.updatePolicy)
+      .mockRejectedValueOnce(new Error('failed'))
+      .mockResolvedValueOnce({ message: 'updated', targetCount: 1 });
+    renderAtRoute(<AclPage />, '/acl');
+    await user.click(await screen.findByRole('button', { name: 'Confirm' }));
+    await user.click(await screen.findByRole('tab', { name: 'ACL Policies' }));
+    await user.click(await screen.findByRole('button', { name: 'Modify ACL policy User:payments on Topic:Orders' }));
+
+    const dialog = screen.getByRole('dialog', { name: 'Edit ACL Permission' });
+    expect(within(dialog).getByPlaceholderText('Topic:TopicTest1111, Group:please_rename_unique_group_name')).toHaveValue('Topic:Orders');
+    await user.click(within(dialog).getByRole('button', { name: 'Confirm' }));
+    expect(await within(dialog).findByRole('alert')).toHaveTextContent('Unable to save the ACL policy. Verify the request and try again.');
+    expect(within(dialog).getByPlaceholderText('Topic:TopicTest1111, Group:please_rename_unique_group_name')).toHaveValue('Topic:Orders');
+
+    await user.click(within(dialog).getByRole('button', { name: 'Retry' }));
+    await waitFor(() => expect(aclApi.updatePolicy).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText('ACL policy updated.')).toBeInTheDocument();
+  });
+
+  it('replaces only the selected policy entry when editing a subject with multiple entries', async () => {
+    const user = userEvent.setup();
+    vi.mocked(aclApi.listPolicies).mockResolvedValue([{
+      brokerName: 'broker-a', brokerAddr: '10.0.0.1:10911', subject: 'User:payments', policyType: 'Custom',
+      entries: [
+        { resource: 'Topic:Orders', actions: ['Pub'], sourceIps: ['10.0.0.1'], decision: 'Allow' },
+        { resource: 'Group:billing', actions: ['Sub'], sourceIps: ['10.0.0.2'], decision: 'Deny' }
+      ]
+    }]);
+    vi.mocked(aclApi.updatePolicy).mockResolvedValue({ message: 'updated', targetCount: 1 });
+    renderAtRoute(<AclPage />, '/acl');
+    await user.click(await screen.findByRole('button', { name: 'Confirm' }));
+    await user.click(await screen.findByRole('tab', { name: 'ACL Policies' }));
+    const ordersRow = (await screen.findByText('Topic:Orders')).closest('tr');
+    expect(ordersRow).not.toBeNull();
+    await user.click(within(ordersRow!).getByRole('button', { name: 'Modify ACL policy User:payments on Topic:Orders' }));
+    const dialog = screen.getByRole('dialog', { name: 'Edit ACL Permission' });
+    await user.click(within(dialog).getByRole('button', { name: 'Sub' }));
+    await user.click(within(dialog).getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => expect(aclApi.updatePolicy).toHaveBeenCalledWith('User:payments', {
+      brokerName: 'broker-a',
+      clusterName: 'Cluster-A',
+      subject: 'User:payments',
+      policies: [{
+        policyType: 'Custom',
+        entries: [
+          { resource: ['Topic:Orders'], actions: ['Pub', 'Sub'], sourceIps: ['10.0.0.1'], decision: 'Allow' },
+          { resource: ['Group:billing'], actions: ['Sub'], sourceIps: ['10.0.0.2'], decision: 'Deny' }
+        ]
+      }]
+    }));
+  });
+
+  it('ignores a create completion after its dialog is closed', async () => {
+    const user = userEvent.setup();
+    let resolveCreate: () => void = () => undefined;
+    vi.mocked(aclApi.createUser).mockReturnValue(new Promise((resolve) => {
+      resolveCreate = () => resolve({ message: 'created', targetCount: 1 });
+    }));
+    renderAtRoute(<AclPage />, '/acl');
+    await user.click(await screen.findByRole('button', { name: 'Confirm' }));
+    await waitFor(() => expect(aclApi.listUsers).toHaveBeenCalledTimes(1));
+    await user.click(screen.getByRole('button', { name: 'Add User' }));
+    const dialog = screen.getByRole('dialog', { name: 'Add User' });
+    await user.type(within(dialog).getByLabelText('* Username'), 'late-user');
+    await user.type(within(dialog).getByLabelText('* Password'), 'late-secret');
+    await user.click(within(dialog).getByRole('button', { name: 'Confirm' }));
+    await user.click(within(dialog).getByTitle('Close'));
+
+    await act(async () => { resolveCreate(); });
+    expect(screen.queryByText('ACL user created.')).not.toBeInTheDocument();
+    expect(aclApi.listUsers).toHaveBeenCalledTimes(1);
+  });
+
+  it('isolates the policies tab from a save that completes after the tab transition', async () => {
+    const user = userEvent.setup();
+    let resolveCreate: () => void = () => undefined;
+    vi.mocked(aclApi.createUser).mockReturnValue(new Promise((resolve) => {
+      resolveCreate = () => resolve({ message: 'created', targetCount: 1 });
+    }));
+    renderAtRoute(<AclPage />, '/acl');
+    await user.click(await screen.findByRole('button', { name: 'Confirm' }));
+    await waitFor(() => expect(aclApi.listUsers).toHaveBeenCalledTimes(1));
+    const policiesTab = screen.getByRole('tab', { name: 'ACL Policies' });
+    await user.click(screen.getByRole('button', { name: 'Add User' }));
+    const dialog = screen.getByRole('dialog', { name: 'Add User' });
+    await user.type(within(dialog).getByLabelText('* Username'), 'late-tab-user');
+    await user.type(within(dialog).getByLabelText('* Password'), 'late-secret');
+    await user.click(within(dialog).getByRole('button', { name: 'Confirm' }));
+    fireEvent.mouseDown(policiesTab, { button: 0, ctrlKey: false });
+    expect(policiesTab).toHaveAttribute('aria-selected', 'true');
+    expect(screen.queryByRole('dialog', { name: 'Add User' })).not.toBeInTheDocument();
+
+    await act(async () => { resolveCreate(); });
+    expect(screen.queryByText('ACL user created.')).not.toBeInTheDocument();
+    expect(policiesTab).toHaveAttribute('aria-selected', 'true');
+    expect(screen.queryByRole('dialog', { name: 'Add User' })).not.toBeInTheDocument();
+    expect(aclApi.listUsers).toHaveBeenCalledTimes(1);
+    expect(aclApi.listPolicies).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidates an in-flight delete completion when the draft scope changes', async () => {
+    const user = userEvent.setup();
+    let resolveDelete: () => void = () => undefined;
+    vi.mocked(brokerApi.list).mockResolvedValue({
+      items: [
+        { clusterName: 'Cluster-A', brokerName: 'broker-a', brokerId: 0, address: '10.0.0.1:10911', role: 'MASTER', version: '5.3.0', produceTps: 0, consumeTps: 0 },
+        { clusterName: 'Cluster-B', brokerName: 'broker-b', brokerId: 0, address: '10.0.0.2:10911', role: 'MASTER', version: '5.3.0', produceTps: 0, consumeTps: 0 }
+      ], total: 2
+    });
+    vi.mocked(aclApi.listUsers).mockResolvedValue([{
+      brokerName: 'broker-a', brokerAddr: '10.0.0.1:10911', username: 'deferred-delete-user', password: 'secret'
+    }]);
+    vi.mocked(aclApi.deleteUser).mockReturnValue(new Promise((resolve) => {
+      resolveDelete = () => resolve({ message: 'deleted', targetCount: 1 });
+    }));
+    renderAtRoute(<AclPage />, '/acl');
+    await user.click(await screen.findByRole('button', { name: 'Confirm' }));
+    await screen.findByText('deferred-delete-user');
+    await user.click(screen.getByRole('button', { name: 'Delete ACL user deferred-delete-user' }));
+    await user.click(within(screen.getByRole('alertdialog')).getByRole('button', { name: 'Delete' }));
+    await waitFor(() => expect(aclApi.deleteUser).toHaveBeenCalledTimes(1));
+    const clusterSelect = screen.getByRole('button', { name: 'Select ACL cluster' });
+    expect(clusterSelect).toBeEnabled();
+    await user.click(clusterSelect);
+    await user.click(screen.getByRole('option', { name: 'Cluster-B' }));
+
+    await act(async () => { resolveDelete(); });
+    expect(screen.queryByText('ACL user deleted.')).not.toBeInTheDocument();
+    expect(screen.getByText('No confirmed scope')).toBeInTheDocument();
+    expect(aclApi.listUsers).toHaveBeenCalledTimes(1);
+  });
+
+  it('guards duplicate create and edit submissions while each mutation is in flight', async () => {
+    const user = userEvent.setup();
+    let resolveCreate: () => void = () => undefined;
+    let resolveEdit: () => void = () => undefined;
+    vi.mocked(aclApi.listPolicies).mockResolvedValue([{
+      brokerName: 'broker-a', brokerAddr: '10.0.0.1:10911', subject: 'User:duplicate-edit', policyType: 'Custom',
+      entries: [{ resource: 'Topic:Orders', actions: ['Pub'], sourceIps: [], decision: 'Allow' }]
+    }]);
+    vi.mocked(aclApi.createUser).mockReturnValue(new Promise((resolve) => {
+      resolveCreate = () => resolve({ message: 'created', targetCount: 1 });
+    }));
+    vi.mocked(aclApi.updatePolicy).mockReturnValue(new Promise((resolve) => {
+      resolveEdit = () => resolve({ message: 'updated', targetCount: 1 });
+    }));
+    renderAtRoute(<AclPage />, '/acl');
+    await user.click(await screen.findByRole('button', { name: 'Confirm' }));
+    await user.click(screen.getByRole('button', { name: 'Add User' }));
+    const userDialog = screen.getByRole('dialog', { name: 'Add User' });
+    await user.type(within(userDialog).getByLabelText('* Username'), 'one-create');
+    await user.type(within(userDialog).getByLabelText('* Password'), 'secret');
+    const createButton = within(userDialog).getByRole('button', { name: 'Confirm' });
+    act(() => { fireEvent.click(createButton); fireEvent.click(createButton); });
+    await waitFor(() => expect(aclApi.createUser).toHaveBeenCalledTimes(1));
+    await act(async () => { resolveCreate(); });
+
+    await user.click(screen.getByRole('tab', { name: 'ACL Policies' }));
+    const policyRow = (await screen.findByText('Topic:Orders')).closest('tr');
+    await user.click(within(policyRow!).getByRole('button', { name: 'Modify ACL policy User:duplicate-edit on Topic:Orders' }));
+    const policyDialog = screen.getByRole('dialog', { name: 'Edit ACL Permission' });
+    const editButton = within(policyDialog).getByRole('button', { name: 'Confirm' });
+    act(() => { fireEvent.click(editButton); fireEvent.click(editButton); });
+    await waitFor(() => expect(aclApi.updatePolicy).toHaveBeenCalledTimes(1));
+    await act(async () => { resolveEdit(); });
+  });
+
+  it('keeps independent search queries and filters for the users and policies tabs', async () => {
+    const user = userEvent.setup();
+    vi.mocked(aclApi.listUsers).mockResolvedValue(Array.from({ length: 11 }, (_, index) => ({
+      brokerName: 'broker-a', brokerAddr: '10.0.0.1:10911', username: `user-${index + 1}`, password: 'secret'
+    })));
+    vi.mocked(aclApi.listPolicies).mockResolvedValue([
+      {
+        brokerName: 'broker-a', brokerAddr: '10.0.0.1:10911', subject: 'User:invoice-reader', policyType: 'Custom',
+        entries: [{ resource: 'Topic:Invoices', actions: ['Sub'], sourceIps: [], decision: 'Allow' }]
+      },
+      {
+        brokerName: 'broker-a', brokerAddr: '10.0.0.1:10911', subject: 'User:orders-reader', policyType: 'Custom',
+        entries: [{ resource: 'Topic:Orders', actions: ['Sub'], sourceIps: [], decision: 'Allow' }]
+      }
+    ]);
+    renderAtRoute(<AclPage />, '/acl');
+    await user.click(await screen.findByRole('button', { name: 'Confirm' }));
+    expect(await screen.findByText('user-10')).toBeInTheDocument();
+    expect(screen.queryByText('user-11')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Next page' }));
+    expect(await screen.findByText('user-11')).toBeInTheDocument();
+    await user.type(screen.getByPlaceholderText('Search users'), 'user-2');
+    expect(await screen.findByText('user-2')).toBeInTheDocument();
+    expect(screen.getByLabelText('Page 1 of 1')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', { name: 'ACL Policies' }));
+    const policySearch = screen.getByRole('textbox', { name: 'Search ACL policies' });
+    expect(policySearch).toHaveValue('');
+    expect(await screen.findByText('User:invoice-reader')).toBeInTheDocument();
+    expect(screen.getByText('User:orders-reader')).toBeInTheDocument();
+    await user.type(policySearch, 'Invoices');
+    expect(screen.getByText('User:invoice-reader')).toBeInTheDocument();
+    expect(screen.queryByText('User:orders-reader')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', { name: 'ACL Users' }));
+    expect(screen.getByRole('textbox', { name: 'Search ACL users' })).toHaveValue('user-2');
+    expect(screen.getByText('user-2')).toBeInTheDocument();
+    expect(screen.queryByText('user-1')).not.toBeInTheDocument();
+  });
+
+  it('exposes persistent search labels and pressed state for policy action toggles', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<AclPage />, '/acl');
+    await user.click(await screen.findByRole('button', { name: 'Confirm' }));
+    expect(screen.getByRole('textbox', { name: 'Search ACL users' })).toBeInTheDocument();
+    await user.click(screen.getByRole('tab', { name: 'ACL Policies' }));
+    expect(screen.getByRole('textbox', { name: 'Search ACL policies' })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Add ACL Policy' }));
+    const dialog = screen.getByRole('dialog', { name: 'Add ACL Permission' });
+    expect(within(dialog).getByRole('button', { name: 'Pub' })).toHaveAttribute('aria-pressed', 'true');
+    expect(within(dialog).getByRole('button', { name: 'Create' })).toHaveAttribute('aria-pressed', 'false');
+    await user.click(within(dialog).getByRole('button', { name: 'Create' }));
+    expect(within(dialog).getByRole('button', { name: 'Create' })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('summarizes only records returned for the confirmed scope', async () => {
+    const user = userEvent.setup();
+    vi.mocked(aclApi.listUsers).mockResolvedValue([
+      { brokerName: 'broker-a', brokerAddr: '10.0.0.1:10911', username: 'enabled-user', userStatus: 'enable' },
+      { brokerName: 'broker-a', brokerAddr: '10.0.0.1:10911', username: 'disabled-user', userStatus: 'disable' }
+    ]);
+    vi.mocked(aclApi.listPolicies).mockResolvedValue([{
+      brokerName: 'broker-a', brokerAddr: '10.0.0.1:10911', subject: 'User:summary', policyType: 'Custom',
+      entries: [
+        { resource: 'Topic:A', actions: ['Pub'], sourceIps: [], decision: 'Allow' },
+        { resource: 'Topic:B', actions: ['Sub'], sourceIps: [], decision: 'Allow' }
+      ]
+    }]);
+    renderAtRoute(<AclPage />, '/acl');
+
+    await user.click(await screen.findByRole('button', { name: 'Confirm' }));
+    const summary = await screen.findByRole('region', { name: 'Confirmed ACL scope summary' });
+    expect(within(summary).getByText('1', { selector: 'strong' })).toBeInTheDocument();
+    expect(within(summary).getByText('Users')).toBeInTheDocument();
+    expect(within(summary).getByText('Enabled')).toBeInTheDocument();
+    expect(within(summary).getByText('Policy rules')).toBeInTheDocument();
+    expect(within(summary).getAllByText('2', { selector: 'strong' })).toHaveLength(2);
+  });
+
+  it('returns password values to a masked state after the ACL page remounts', async () => {
+    const user = userEvent.setup();
+    vi.mocked(aclApi.listUsers).mockResolvedValue([{ brokerName: 'broker-a', brokerAddr: '10.0.0.1:10911', username: 'remount-user', password: 'remount-secret' }]);
+    const rendered = renderAtRoute(<AclPage />, '/acl');
+    await user.click(await screen.findByRole('button', { name: 'Confirm' }));
+    await screen.findByText('remount-user');
+    await user.click(screen.getByRole('button', { name: 'Reveal passwords' }));
+    expect(screen.getByText('remount-secret')).toBeInTheDocument();
+    rendered.unmount();
+    renderAtRoute(<AclPage />, '/acl');
+    await user.click(await screen.findByRole('button', { name: 'Confirm' }));
+    await screen.findByText('remount-user');
+    expect(screen.queryByText('remount-secret')).not.toBeInTheDocument();
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/AclPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/AclPage.tsx
@@ -1,977 +1,341 @@
-import * as Dialog from '@radix-ui/react-dialog';
-import {
-  CheckCircle2,
-  Edit3,
-  Eye,
-  EyeOff,
-  FileKey2,
-  KeyRound,
-  Plus,
-  RefreshCw,
-  Search,
-  ShieldCheck,
-  Trash2,
-  UserPlus,
-  X
-} from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
-import type { ReactNode } from 'react';
+import { Eye, EyeOff, FileKey2, Plus, RefreshCw, Search, UserCheck, UserPlus, Users } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { aclApi } from '../api/acl_api';
 import { brokerApi } from '../api/broker_api';
-import ConfirmDialog from '../components/ConfirmDialog';
-import EmptyState from '../components/EmptyState';
 import ErrorState from '../components/ErrorState';
 import LoadingState from '../components/LoadingState';
 import PageHeader from '../components/PageHeader';
-import SelectMenu, { type SelectMenuOption } from '../components/SelectMenu';
-import StatusBadge from '../components/StatusBadge';
-import type { AclMutationResult, AclPolicyRequest, AclPolicyView, AclQueryParams, AclUserUpsertRequest, AclUserView } from '../types/acl';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/Tabs';
+import type { AclPolicyRequest, AclPolicyView, AclUserUpsertRequest, AclUserView } from '../types/acl';
 import type { BrokerInfo } from '../types/broker';
+import AclPoliciesTable from './acl/AclPoliciesTable';
+import AclPolicyDialog from './acl/AclPolicyDialog';
+import AclScopePicker from './acl/AclScopePicker';
+import AclUserDialog from './acl/AclUserDialog';
+import AclUsersTable from './acl/AclUsersTable';
+import { createAclScopeQuery, filterAclPolicyRows, filterAclUsers, flattenAclPolicies, type AclPolicyRow, type AclScope } from './acl/acl-model';
 
-type AclTab = 'users' | 'permissions';
-type NoticeTone = 'success' | 'warning' | 'danger';
-type UserDialogState = { mode: 'create' } | { mode: 'edit'; user: AclUserView };
-type PolicyDialogState = { mode: 'create' } | { mode: 'edit'; policy: AclPolicyTableRow };
-
-interface AclPolicyTableRow {
-  key: string;
-  brokerName: string;
-  brokerAddr: string;
-  subject: string;
-  policyType: string;
-  resource: string;
-  actions: string[];
-  sourceIps: string[];
-  decision: string;
-}
-
+type AclTab = 'users' | 'policies';
+type Notice = { tone: 'success' | 'warning'; message: string };
+const emptyScope: AclScope = { clusterName: '', brokerName: '' };
 const pageSize = 10;
-const actionOptions = ['All', 'Pub', 'Sub', 'Create', 'Update', 'Delete', 'Get', 'List'];
 
 export default function AclPage() {
   const [brokers, setBrokers] = useState<BrokerInfo[]>([]);
-  const [selectedCluster, setSelectedCluster] = useState('');
-  const [selectedBroker, setSelectedBroker] = useState('');
-  const [confirmedCluster, setConfirmedCluster] = useState('');
-  const [confirmedBroker, setConfirmedBroker] = useState('');
-  const [activeTab, setActiveTab] = useState<AclTab>('users');
-  const [search, setSearch] = useState('');
+  const [draftScope, setDraftScope] = useState<AclScope>(emptyScope);
+  const [confirmedScope, setConfirmedScope] = useState<AclScope | null>(null);
   const [users, setUsers] = useState<AclUserView[]>([]);
   const [policies, setPolicies] = useState<AclPolicyView[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [activeTab, setActiveTab] = useState<AclTab>('users');
+  const [usersSearch, setUsersSearch] = useState('');
+  const [policiesSearch, setPoliciesSearch] = useState('');
+  const [loadingScope, setLoadingScope] = useState(true);
+  const [loadingRecords, setLoadingRecords] = useState(false);
   const [mutating, setMutating] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [notice, setNotice] = useState<{ tone: NoticeTone; message: string } | null>(null);
-  const [userDialog, setUserDialog] = useState<UserDialogState | null>(null);
-  const [policyDialog, setPolicyDialog] = useState<PolicyDialogState | null>(null);
+  const [showPasswords, setShowPasswords] = useState(false);
   const [usersPage, setUsersPage] = useState(1);
   const [policiesPage, setPoliciesPage] = useState(1);
-  const [showPasswords, setShowPasswords] = useState(false);
+  const [scopeError, setScopeError] = useState<string | null>(null);
+  const [recordsError, setRecordsError] = useState<string | null>(null);
+  const [userSaveError, setUserSaveError] = useState<string | null>(null);
+  const [policySaveError, setPolicySaveError] = useState<string | null>(null);
+  const [userDeleteError, setUserDeleteError] = useState<string | null>(null);
+  const [policyDeleteError, setPolicyDeleteError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<Notice | null>(null);
+  const [userDialog, setUserDialog] = useState<AclUserView | null | undefined>(undefined);
+  const [policyDialog, setPolicyDialog] = useState<AclPolicyRow | null | undefined>(undefined);
+  const requestGeneration = useRef(0);
+  const interactionGeneration = useRef(0);
+  const mutationInFlight = useRef(false);
+  const mounted = useRef(true);
 
-  const clusters = useMemo(() => Array.from(new Set(brokers.map((broker) => broker.clusterName))).filter(Boolean).sort(), [brokers]);
-  const clusterOptions = useMemo<SelectMenuOption[]>(
-    () => clusters.map((cluster) => ({ value: cluster, label: cluster })),
-    [clusters]
-  );
-  const brokerOptions = useMemo<SelectMenuOption[]>(() => {
-    const scoped = selectedCluster ? brokers.filter((broker) => broker.clusterName === selectedCluster) : brokers;
-    return scoped
-      .map((broker) => ({ value: broker.brokerName, label: broker.brokerName }))
-      .filter((option, index, list) => list.findIndex((item) => item.value === option.value) === index)
-      .sort((left, right) => left.label.localeCompare(right.label));
-  }, [brokers, selectedCluster]);
+  useEffect(() => {
+    mounted.current = true;
+    return () => { mounted.current = false; };
+  }, []);
+  useEffect(() => {
+    void brokerApi.list()
+      .then((response) => {
+        if (!mounted.current) return;
+        setBrokers(response.items);
+        const firstBroker = response.items[0];
+        if (firstBroker) setDraftScope({ clusterName: firstBroker.clusterName, brokerName: firstBroker.brokerName });
+        else setNotice({ tone: 'warning', message: 'No broker is available for ACL management.' });
+      })
+      .catch(() => { if (mounted.current) setScopeError('Unable to load available ACL broker scopes.'); })
+      .finally(() => { if (mounted.current) setLoadingScope(false); });
+  }, []);
 
-  const selectedScope = useMemo(() => {
-    const broker = brokers.find((item) => item.brokerName === confirmedBroker);
-    return {
-      cluster: confirmedCluster || 'No cluster selected',
-      broker: confirmedBroker || 'No broker selected',
-      address: broker?.address ?? '-'
-    };
-  }, [brokers, confirmedBroker, confirmedCluster]);
-
-  const policyRows = useMemo(() => flattenPolicies(policies), [policies]);
-  const normalizedSearch = search.trim().toLowerCase();
-  const visibleUsers = useMemo(
-    () => filterRows(users, normalizedSearch),
-    [normalizedSearch, users]
-  );
-  const visiblePolicies = useMemo(
-    () => filterRows(policyRows, normalizedSearch),
-    [normalizedSearch, policyRows]
-  );
-  const visibleUserPage = pageRows(visibleUsers, usersPage);
-  const visiblePolicyPage = pageRows(visiblePolicies, policiesPage);
-  const userPageCount = pageCount(visibleUsers.length);
-  const policyPageCount = pageCount(visiblePolicies.length);
-
-  const loadAclData = (scope: { clusterName?: string; brokerName?: string } = {}) => {
-    const clusterName = scope.clusterName ?? confirmedCluster;
-    const brokerName = scope.brokerName ?? confirmedBroker;
-    const query: AclQueryParams = {
-      clusterName,
-      brokerName,
-      filter: search,
-      searchParam: search
-    };
-
-    setLoading(true);
-    setError(null);
-    Promise.all([aclApi.listUsers(query), aclApi.listPolicies(query)])
-      .then(([nextUsers, nextPolicies]) => {
+  const loadAclRecords = useCallback(async (scope: AclScope) => {
+    const query = createAclScopeQuery(scope, brokers);
+    if (!query) return;
+    const request = ++requestGeneration.current;
+    setLoadingRecords(true);
+    setRecordsError(null);
+    try {
+      const [nextUsers, nextPolicies] = await Promise.all([aclApi.listUsers(query), aclApi.listPolicies(query)]);
+      if (mounted.current && request === requestGeneration.current) {
         setUsers(nextUsers);
         setPolicies(nextPolicies);
         setUsersPage(1);
         setPoliciesPage(1);
-        setNotice({
-          tone: 'success',
-          message: `ACL query completed. ${nextUsers.length} user(s), ${flattenPolicies(nextPolicies).length} permission row(s).`
-        });
-      })
-      .catch((requestError: Error) => {
+      }
+    } catch {
+      if (mounted.current && request === requestGeneration.current) {
         setUsers([]);
         setPolicies([]);
-        setError(requestError.message);
-      })
-      .finally(() => setLoading(false));
+        setRecordsError('Unable to load ACL users and policies for the confirmed scope.');
+      }
+    } finally {
+      if (mounted.current && request === requestGeneration.current) setLoadingRecords(false);
+    }
+  }, [brokers]);
+
+  const confirmScope = (scope: AclScope) => {
+    if (!createAclScopeQuery(scope, brokers)) return;
+    interactionGeneration.current += 1;
+    setUsers([]);
+    setPolicies([]);
+    setUsersPage(1);
+    setPoliciesPage(1);
+    setUserDialog(undefined);
+    setPolicyDialog(undefined);
+    setShowPasswords(false);
+    setConfirmedScope(scope);
+    setNotice(null);
+    setRecordsError(null);
+    setUserSaveError(null);
+    setPolicySaveError(null);
+    setUserDeleteError(null);
+    setPolicyDeleteError(null);
+    void loadAclRecords(scope);
+  };
+  const refresh = () => { if (confirmedScope) void loadAclRecords(confirmedScope); };
+
+  const changeDraftScope = (scope: AclScope) => {
+    setDraftScope(scope);
+    if (!confirmedScope || (scope.clusterName === confirmedScope.clusterName && scope.brokerName === confirmedScope.brokerName)) return;
+    interactionGeneration.current += 1;
+    requestGeneration.current += 1;
+    setConfirmedScope(null);
+    setUsers([]);
+    setPolicies([]);
+    setUsersPage(1);
+    setPoliciesPage(1);
+    setLoadingRecords(false);
+    setShowPasswords(false);
+    setUserDialog(undefined);
+    setPolicyDialog(undefined);
+    setNotice(null);
+    setRecordsError(null);
+    setUserSaveError(null);
+    setPolicySaveError(null);
+    setUserDeleteError(null);
+    setPolicyDeleteError(null);
   };
 
-  useEffect(() => {
-    let disposed = false;
-    setLoading(true);
-    brokerApi
-      .list()
-      .then((data) => {
-        if (disposed) return;
-        const nextBrokers = data.items;
-        const firstBroker = nextBrokers[0];
-        setBrokers(nextBrokers);
-        if (!firstBroker) {
-          setNotice({ tone: 'warning', message: 'No broker is available for ACL management.' });
-          setLoading(false);
-          return;
-        }
-        setSelectedCluster(firstBroker.clusterName);
-        setSelectedBroker(firstBroker.brokerName);
-        setConfirmedCluster(firstBroker.clusterName);
-        setConfirmedBroker(firstBroker.brokerName);
-        loadAclData({ clusterName: firstBroker.clusterName, brokerName: firstBroker.brokerName });
-      })
-      .catch((requestError: Error) => {
-        if (!disposed) {
-          setError(requestError.message);
-          setLoading(false);
-        }
-      });
+  const changeTab = (tab: AclTab) => {
+    if (tab === activeTab) return;
+    interactionGeneration.current += 1;
+    setActiveTab(tab);
+    setShowPasswords(false);
+    setUserDialog(undefined);
+    setPolicyDialog(undefined);
+    setNotice(null);
+    setUserSaveError(null);
+    setPolicySaveError(null);
+    setUserDeleteError(null);
+    setPolicyDeleteError(null);
+  };
 
-    return () => {
-      disposed = true;
-    };
-  }, []);
+  const openUserDialog = (user: AclUserView | null) => {
+    interactionGeneration.current += 1;
+    setUserSaveError(null);
+    setUserDeleteError(null);
+    setPolicyDeleteError(null);
+    setUserDialog(user);
+  };
+  const closeUserDialog = () => {
+    interactionGeneration.current += 1;
+    setUserSaveError(null);
+    setUserDialog(undefined);
+  };
+  const openPolicyDialog = (policy: AclPolicyRow | null) => {
+    interactionGeneration.current += 1;
+    setPolicySaveError(null);
+    setUserDeleteError(null);
+    setPolicyDeleteError(null);
+    setPolicyDialog(policy);
+  };
+  const closePolicyDialog = () => {
+    interactionGeneration.current += 1;
+    setPolicySaveError(null);
+    setPolicyDialog(undefined);
+  };
+
+  const saveUser = async (request: AclUserUpsertRequest, username?: string) => {
+    if (mutationInFlight.current) return;
+    const scope = confirmedScope;
+    if (!createAclScopeQuery(scope, brokers)) return;
+    const interaction = interactionGeneration.current;
+    mutationInFlight.current = true;
+    setMutating(true);
+    setUserSaveError(null);
+    try {
+      if (username) await aclApi.updateUser(username, request);
+      else await aclApi.createUser(request);
+      if (!mounted.current || interaction !== interactionGeneration.current || !scope) return;
+      setUserDeleteError(null);
+      setPolicyDeleteError(null);
+      setUserDialog(undefined);
+      setNotice({ tone: 'success', message: username ? 'ACL user updated.' : 'ACL user created.' });
+      void loadAclRecords(scope);
+    } catch {
+      if (mounted.current && interaction === interactionGeneration.current) {
+        setUserSaveError('Unable to save the ACL user. Verify the request and try again.');
+      }
+    } finally {
+      mutationInFlight.current = false;
+      if (mounted.current) setMutating(false);
+    }
+  };
+  const deleteUser = async (username: string) => {
+    if (mutationInFlight.current) return;
+    const query = confirmedScope && createAclScopeQuery(confirmedScope, brokers);
+    if (!query) return;
+    const scope = confirmedScope;
+    const interaction = interactionGeneration.current;
+    mutationInFlight.current = true;
+    setMutating(true);
+    setUserDeleteError(null);
+    try {
+      await aclApi.deleteUser(username, query);
+      if (!mounted.current || interaction !== interactionGeneration.current || !scope) return;
+      setUserDeleteError(null);
+      setPolicyDeleteError(null);
+      setNotice({ tone: 'success', message: 'ACL user deleted.' });
+      void loadAclRecords(scope);
+    } catch {
+      if (mounted.current && interaction === interactionGeneration.current) setUserDeleteError('Unable to delete the ACL user.');
+    } finally {
+      mutationInFlight.current = false;
+      if (mounted.current) setMutating(false);
+    }
+  };
+  const savePolicy = async (request: AclPolicyRequest, subject?: string) => {
+    if (mutationInFlight.current) return;
+    const scope = confirmedScope;
+    if (!createAclScopeQuery(scope, brokers)) return;
+    const interaction = interactionGeneration.current;
+    mutationInFlight.current = true;
+    setMutating(true);
+    setPolicySaveError(null);
+    try {
+      if (subject) await aclApi.updatePolicy(subject, request);
+      else await aclApi.createPolicy(request);
+      if (!mounted.current || interaction !== interactionGeneration.current || !scope) return;
+      setUserDeleteError(null);
+      setPolicyDeleteError(null);
+      setPolicyDialog(undefined);
+      setNotice({ tone: 'success', message: subject ? 'ACL policy updated.' : 'ACL policy created.' });
+      void loadAclRecords(scope);
+    } catch {
+      if (mounted.current && interaction === interactionGeneration.current) {
+        setPolicySaveError('Unable to save the ACL policy. Verify the request and try again.');
+      }
+    } finally {
+      mutationInFlight.current = false;
+      if (mounted.current) setMutating(false);
+    }
+  };
+  const deletePolicy = async (policy: AclPolicyRow) => {
+    if (mutationInFlight.current) return;
+    const query = confirmedScope && createAclScopeQuery(confirmedScope, brokers);
+    if (!query) return;
+    const scope = confirmedScope;
+    const interaction = interactionGeneration.current;
+    mutationInFlight.current = true;
+    setMutating(true);
+    setPolicyDeleteError(null);
+    try {
+      await aclApi.deletePolicy(policy.subject, { ...query, resource: policy.resource });
+      if (!mounted.current || interaction !== interactionGeneration.current || !scope) return;
+      setUserDeleteError(null);
+      setPolicyDeleteError(null);
+      setNotice({ tone: 'success', message: 'ACL policy deleted.' });
+      void loadAclRecords(scope);
+    } catch {
+      if (mounted.current && interaction === interactionGeneration.current) setPolicyDeleteError('Unable to delete the ACL policy.');
+    } finally {
+      mutationInFlight.current = false;
+      if (mounted.current) setMutating(false);
+    }
+  };
+
+  const visibleUsers = useMemo(() => filterAclUsers(users, usersSearch), [users, usersSearch]);
+  const policyRows = useMemo(() => flattenAclPolicies(policies), [policies]);
+  const enabledUsers = useMemo(() => users.filter((user) => {
+    const status = (user.userStatus || 'enable').toLowerCase();
+    return status !== 'disable' && !status.includes('disabled');
+  }).length, [users]);
+  const visiblePolicies = useMemo(() => filterAclPolicyRows(policyRows, policiesSearch), [policyRows, policiesSearch]);
+  const pagedUsers = useMemo(() => visibleUsers.slice((usersPage - 1) * pageSize, usersPage * pageSize), [usersPage, visibleUsers]);
+  const pagedPolicies = useMemo(() => visiblePolicies.slice((policiesPage - 1) * pageSize, policiesPage * pageSize), [policiesPage, visiblePolicies]);
+  const scopeReady = Boolean(confirmedScope && createAclScopeQuery(confirmedScope, brokers));
+  const hasRevealablePasswords = users.some((user) => Boolean(user.password?.length));
 
   useEffect(() => {
     setUsersPage(1);
+  }, [usersSearch]);
+  useEffect(() => {
     setPoliciesPage(1);
-  }, [search, activeTab]);
-
-  const confirmScope = () => {
-    setConfirmedCluster(selectedCluster);
-    setConfirmedBroker(selectedBroker);
-    loadAclData({ clusterName: selectedCluster, brokerName: selectedBroker });
-  };
-
-  const saveUser = (payload: AclUserUpsertRequest, mode: UserDialogState['mode'], username?: string) => {
-    setMutating(true);
-    setError(null);
-    const request = mode === 'edit' && username ? aclApi.updateUser(username, payload) : aclApi.createUser(payload);
-    request
-      .then((result) => {
-        setUserDialog(null);
-        setNotice({ tone: 'success', message: mutationMessage(result) });
-        loadAclData();
-      })
-      .catch((requestError: Error) => setError(requestError.message))
-      .finally(() => setMutating(false));
-  };
-
-  const deleteUser = (username: string) => {
-    setMutating(true);
-    setError(null);
-    aclApi
-      .deleteUser(username, scopeQuery(confirmedCluster, confirmedBroker))
-      .then((result) => {
-        setNotice({ tone: 'success', message: mutationMessage(result) });
-        loadAclData();
-      })
-      .catch((requestError: Error) => setError(requestError.message))
-      .finally(() => setMutating(false));
-  };
-
-  const savePolicy = (payload: AclPolicyRequest, mode: PolicyDialogState['mode'], subject?: string) => {
-    setMutating(true);
-    setError(null);
-    const request = mode === 'edit' && subject ? aclApi.updatePolicy(subject, payload) : aclApi.createPolicy(payload);
-    request
-      .then((result) => {
-        setPolicyDialog(null);
-        setNotice({ tone: 'success', message: mutationMessage(result) });
-        loadAclData();
-      })
-      .catch((requestError: Error) => setError(requestError.message))
-      .finally(() => setMutating(false));
-  };
-
-  const deletePolicy = (row: AclPolicyTableRow) => {
-    setMutating(true);
-    setError(null);
-    aclApi
-      .deletePolicy(row.subject, { ...scopeQuery(confirmedCluster, confirmedBroker), resource: row.resource })
-      .then((result) => {
-        setNotice({ tone: 'success', message: mutationMessage(result) });
-        loadAclData();
-      })
-      .catch((requestError: Error) => setError(requestError.message))
-      .finally(() => setMutating(false));
-  };
-
-  if (loading && brokers.length === 0) {
-    return <LoadingState label="Loading ACL scope" />;
-  }
-
-  if (error && brokers.length === 0) {
-    return <ErrorState message={error} onRetry={() => loadAclData()} />;
-  }
+  }, [policiesSearch]);
+  if (loadingScope) return <LoadingState label="Loading ACL scope" />;
+  if (scopeError && brokers.length === 0) return <ErrorState message={scopeError} onRetry={() => window.location.reload()} />;
 
   return (
     <>
-      <PageHeader
-        title="ACL Management"
-        description="Java-compatible ACL users and permissions scoped by cluster and broker."
-        actions={
-          <>
-            <button type="button" className="button button-secondary" onClick={() => loadAclData()} disabled={loading || mutating}>
-              <RefreshCw size={15} aria-hidden="true" /> Refresh
-            </button>
-          </>
-        }
-      />
-
+      <PageHeader title="ACL Management" description="Java-compatible ACL users and permissions scoped by cluster and broker." actions={
+        <button type="button" className="button button-secondary" onClick={refresh} disabled={!scopeReady || loadingRecords || mutating}><RefreshCw size={15} aria-hidden="true" /> Refresh</button>
+      } />
       {notice ? <div className={`notice notice-${notice.tone}`}>{notice.message}</div> : null}
-      {error ? <div className="notice notice-danger">{error}</div> : null}
-
-      <section className="acl-selector-panel">
-        <div className="acl-selector-grid">
-          <label className="acl-field">
-            <span>
-              <strong>*</strong> Cluster
-            </span>
-            <SelectMenu value={selectedCluster} options={clusterOptions} onChange={setSelectedCluster} ariaLabel="Select ACL cluster" className="acl-select-menu" />
-          </label>
-          <label className="acl-field">
-            <span>
-              <strong>*</strong> Broker
-            </span>
-            <SelectMenu value={selectedBroker} options={brokerOptions} onChange={setSelectedBroker} ariaLabel="Select ACL broker" className="acl-select-menu" />
-          </label>
-          <button type="button" className="button acl-confirm-button" onClick={confirmScope} disabled={!selectedCluster || !selectedBroker || loading || mutating}>
-            <CheckCircle2 size={15} aria-hidden="true" /> Confirm
-          </button>
-        </div>
-        <div className="acl-scope-card">
-          <ShieldCheck size={18} aria-hidden="true" />
-          <div>
-            <span>Active broker scope</span>
-            <strong>{selectedScope.broker}</strong>
-            <small>
-              {selectedScope.cluster} / {selectedScope.address}
-            </small>
-          </div>
-        </div>
-      </section>
-
-      <section className="acl-stat-grid">
-        <AclStatCard icon={<UserPlus size={18} aria-hidden="true" />} label="ACL users" value={users.length} hint="broker-side user credentials" />
-        <AclStatCard icon={<FileKey2 size={18} aria-hidden="true" />} label="Permission rows" value={policyRows.length} hint="flattened Java policy entries" />
-        <AclStatCard icon={<KeyRound size={18} aria-hidden="true" />} label="Broker targets" value={confirmedBroker ? 1 : 0} hint="selected ACL write target" />
-      </section>
-
-      <section className="acl-workspace">
-        <div className="acl-tabs">
-          <button type="button" className={activeTab === 'users' ? 'active' : ''} onClick={() => setActiveTab('users')}>
-            <UserPlus size={15} aria-hidden="true" /> ACL Users
-          </button>
-          <button type="button" className={activeTab === 'permissions' ? 'active' : ''} onClick={() => setActiveTab('permissions')}>
-            <FileKey2 size={15} aria-hidden="true" /> ACL Permissions
-          </button>
-        </div>
-
-        <div className="acl-table-panel">
-          <div className="acl-table-header">
-            <div>
-              <h2>{activeTab === 'users' ? 'ACL Users' : 'ACL Permissions'}</h2>
-              <p>
-                {activeTab === 'users'
-                  ? 'Username, masked password, user type, status, and Java-style update/delete operations.'
-                  : 'Subject policy entries flattened to resource rows, matching the Java ACL table.'}
-              </p>
-            </div>
-            <div className="acl-table-actions">
-              <label className="acl-search-box">
-                <Search size={15} aria-hidden="true" />
-                <input
-                  value={search}
-                  placeholder={activeTab === 'users' ? 'Search users' : 'Search subject, resource, action, source IP'}
-                  onChange={(event) => setSearch(event.target.value)}
-                />
-              </label>
-              {activeTab === 'users' ? (
-                <>
-                  <button type="button" className="button button-secondary" onClick={() => setShowPasswords((value) => !value)}>
-                    {showPasswords ? <EyeOff size={15} aria-hidden="true" /> : <Eye size={15} aria-hidden="true" />}
-                    {showPasswords ? 'Hide' : 'View'}
-                  </button>
-                  <button type="button" className="button" onClick={() => setUserDialog({ mode: 'create' })}>
-                    <Plus size={15} aria-hidden="true" /> Add User
-                  </button>
-                </>
-              ) : (
-                <button type="button" className="button" onClick={() => setPolicyDialog({ mode: 'create' })}>
-                  <Plus size={15} aria-hidden="true" /> Add ACL Permission
-                </button>
-              )}
-            </div>
-          </div>
-
-          {activeTab === 'users' ? (
-            <AclUsersTable
-              rows={visibleUserPage}
-              total={visibleUsers.length}
-              page={Math.min(usersPage, userPageCount)}
-              pageCount={userPageCount}
-              showPasswords={showPasswords}
-              loading={loading}
-              onPageChange={setUsersPage}
-              onEdit={(user) => setUserDialog({ mode: 'edit', user })}
-              onDelete={deleteUser}
-            />
-          ) : (
-            <AclPoliciesTable
-              rows={visiblePolicyPage}
-              total={visiblePolicies.length}
-              page={Math.min(policiesPage, policyPageCount)}
-              pageCount={policyPageCount}
-              loading={loading}
-              onPageChange={setPoliciesPage}
-              onEdit={(policy) => setPolicyDialog({ mode: 'edit', policy })}
-              onDelete={deletePolicy}
-            />
-          )}
-        </div>
-      </section>
-
-      <UserAclDialog
-        state={userDialog}
-        clusterName={confirmedCluster}
-        brokerName={confirmedBroker}
-        saving={mutating}
-        onClose={() => setUserDialog(null)}
-        onSubmit={saveUser}
-      />
-      <PolicyAclDialog
-        state={policyDialog}
-        clusterName={confirmedCluster}
-        brokerName={confirmedBroker}
-        saving={mutating}
-        onClose={() => setPolicyDialog(null)}
-        onSubmit={savePolicy}
-      />
+      <AclScopePicker brokers={brokers} draftScope={draftScope} confirmedScope={confirmedScope} disabled={loadingRecords} onDraftScopeChange={changeDraftScope} onConfirm={confirmScope} />
+      {scopeReady && !loadingRecords && !recordsError ? (
+        <section className="acl-stat-grid" aria-label="Confirmed ACL scope summary">
+          <article className="acl-stat-card"><div><span>Users</span><strong>{users.length}</strong><small>Accounts in this broker scope</small></div><span className="acl-stat-icon"><Users size={19} aria-hidden="true" /></span></article>
+          <article className="acl-stat-card"><div><span>Enabled</span><strong>{enabledUsers}</strong><small>Users currently enabled</small></div><span className="acl-stat-icon"><UserCheck size={19} aria-hidden="true" /></span></article>
+          <article className="acl-stat-card"><div><span>Policy rules</span><strong>{policyRows.length}</strong><small>Flattened resource permissions</small></div><span className="acl-stat-icon"><FileKey2 size={19} aria-hidden="true" /></span></article>
+        </section>
+      ) : null}
+      <Tabs value={activeTab} onValueChange={(value) => changeTab(value as AclTab)} className="acl-workspace">
+        <TabsList className="acl-tabs" aria-label="ACL records">
+          <TabsTrigger value="users"><UserPlus size={15} aria-hidden="true" /> ACL Users</TabsTrigger>
+          <TabsTrigger value="policies"><FileKey2 size={15} aria-hidden="true" /> ACL Policies</TabsTrigger>
+        </TabsList>
+        <TabsContent value="users" className="acl-table-panel">
+          <AclTableHeader title="ACL Users" description="Username, masked password, user type, status, and Java-style update/delete operations." search={usersSearch} onSearchChange={setUsersSearch} searchLabel="Search ACL users" placeholder="Search users" actions={<>
+            {hasRevealablePasswords ? <button type="button" className="button button-secondary" aria-label={showPasswords ? 'Hide passwords' : 'Reveal passwords'} aria-pressed={showPasswords} onClick={() => setShowPasswords((value) => !value)} disabled={!scopeReady}>{showPasswords ? <EyeOff size={15} aria-hidden="true" /> : <Eye size={15} aria-hidden="true" />}{showPasswords ? 'Hide' : 'Reveal'}</button> : null}
+            <button type="button" className="button" disabled={!scopeReady || mutating} onClick={() => openUserDialog(null)}><Plus size={15} aria-hidden="true" /> Add User</button>
+          </>} />
+          {userDeleteError ? <div className="acl-action-error" role="alert">{userDeleteError}</div> : null}
+          {scopeReady ? <AclUsersTable rows={pagedUsers} total={visibleUsers.length} page={usersPage} pageSize={pageSize} loading={loadingRecords} error={recordsError} onRetry={refresh} showPasswords={showPasswords} disabled={mutating} onPageChange={setUsersPage} onEdit={openUserDialog} onDelete={(username) => void deleteUser(username)} /> : <AclScopeEmptyState />}
+        </TabsContent>
+        <TabsContent value="policies" className="acl-table-panel">
+          <AclTableHeader title="ACL Policies" description="Subject policy entries flattened to resource rows, matching the Java ACL table." search={policiesSearch} onSearchChange={setPoliciesSearch} searchLabel="Search ACL policies" placeholder="Search subject, resource, action, source IP" actions={<button type="button" className="button" disabled={!scopeReady || mutating} onClick={() => openPolicyDialog(null)}><Plus size={15} aria-hidden="true" /> Add ACL Policy</button>} />
+          {policyDeleteError ? <div className="acl-action-error" role="alert">{policyDeleteError}</div> : null}
+          {scopeReady ? <AclPoliciesTable rows={pagedPolicies} total={visiblePolicies.length} page={policiesPage} pageSize={pageSize} loading={loadingRecords} error={recordsError} onRetry={refresh} disabled={mutating} onPageChange={setPoliciesPage} onEdit={openPolicyDialog} onDelete={(policy) => void deletePolicy(policy)} /> : <AclScopeEmptyState />}
+        </TabsContent>
+      </Tabs>
+      {confirmedScope ? <AclUserDialog open={userDialog !== undefined} user={userDialog} scope={confirmedScope} saving={mutating} error={userSaveError} onOpenChange={(open) => !open && closeUserDialog()} onSubmit={(request, username) => void saveUser(request, username)} /> : null}
+      {confirmedScope ? <AclPolicyDialog open={policyDialog !== undefined} policy={policyDialog} scope={confirmedScope} saving={mutating} error={policySaveError} onOpenChange={(open) => !open && closePolicyDialog()} onSubmit={(request, subject) => void savePolicy(request, subject)} /> : null}
     </>
   );
 }
 
-function AclUsersTable({
-  rows,
-  total,
-  page,
-  pageCount,
-  showPasswords,
-  loading,
-  onPageChange,
-  onEdit,
-  onDelete
-}: {
-  rows: AclUserView[];
-  total: number;
-  page: number;
-  pageCount: number;
-  showPasswords: boolean;
-  loading: boolean;
-  onPageChange: (page: number) => void;
-  onEdit: (user: AclUserView) => void;
-  onDelete: (username: string) => void;
-}) {
-  return (
-    <>
-      <div className="acl-table-scroll">
-        <table className="acl-table acl-users-table">
-          <thead>
-            <tr>
-              <th>Username</th>
-              <th>Password</th>
-              <th>User Type</th>
-              <th>User Status</th>
-              <th>Broker</th>
-              <th>Operation</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((row) => (
-              <tr key={`${row.brokerAddr}:${row.username}`}>
-                <td>
-                  <div className="acl-primary-cell">
-                    <code>{row.username}</code>
-                    <span>access key</span>
-                  </div>
-                </td>
-                <td>
-                  <code>{showPasswords ? row.password || '-' : maskPassword(row.password)}</code>
-                </td>
-                <td>
-                  <StatusBadge status={normalizeUserType(row.userType)} tone={userTypeTone(row.userType)} />
-                </td>
-                <td>
-                  <StatusBadge status={normalizeUserStatus(row.userStatus)} tone={userStatusTone(row.userStatus)} />
-                </td>
-                <td>
-                  <div className="acl-primary-cell">
-                    <span>{row.brokerName || '-'}</span>
-                    <code>{row.brokerAddr || '-'}</code>
-                  </div>
-                </td>
-                <td>
-                  <div className="acl-operation-row">
-                    <button type="button" className="button button-secondary acl-action-button" onClick={() => onEdit(row)}>
-                      <Edit3 size={14} aria-hidden="true" /> Modify
-                    </button>
-                    <ConfirmDialog
-                      title="Delete ACL user"
-                      description={`Delete ACL user ${row.username} from the selected broker target?`}
-                      confirmLabel="Delete"
-                      onConfirm={() => onDelete(row.username)}
-                    >
-                      <button type="button" className="button button-danger acl-action-button">
-                        <Trash2 size={14} aria-hidden="true" /> Delete
-                      </button>
-                    </ConfirmDialog>
-                  </div>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-      {!loading && rows.length === 0 ? <EmptyState title="No ACL users" /> : null}
-      <AclTableFooter total={total} page={page} pageCount={pageCount} onPageChange={onPageChange} />
-    </>
-  );
+function AclTableHeader({ title, description, search, onSearchChange, searchLabel, placeholder, actions }: { title: string; description: string; search: string; onSearchChange: (value: string) => void; searchLabel: string; placeholder: string; actions: ReactNode }) {
+  return <div className="acl-table-header"><div><h2>{title}</h2><p>{description}</p></div><div className="acl-table-actions"><label className="acl-search-box"><span className="sr-only">{searchLabel}</span><Search size={15} aria-hidden="true" /><input value={search} placeholder={placeholder} onChange={(event) => onSearchChange(event.target.value)} /></label>{actions}</div></div>;
 }
 
-function AclPoliciesTable({
-  rows,
-  total,
-  page,
-  pageCount,
-  loading,
-  onPageChange,
-  onEdit,
-  onDelete
-}: {
-  rows: AclPolicyTableRow[];
-  total: number;
-  page: number;
-  pageCount: number;
-  loading: boolean;
-  onPageChange: (page: number) => void;
-  onEdit: (policy: AclPolicyTableRow) => void;
-  onDelete: (policy: AclPolicyTableRow) => void;
-}) {
-  return (
-    <>
-      <div className="acl-table-scroll">
-        <table className="acl-table acl-policy-table">
-          <thead>
-            <tr>
-              <th>Username/Subject</th>
-              <th>Policy Type</th>
-              <th>Resource Name</th>
-              <th>Operation Type</th>
-              <th>Source IP</th>
-              <th>Decision</th>
-              <th>Operation</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((row) => (
-              <tr key={row.key}>
-                <td>
-                  <div className="acl-primary-cell">
-                    <code>{row.subject}</code>
-                    <span>{row.brokerName || row.brokerAddr}</span>
-                  </div>
-                </td>
-                <td>
-                  <StatusBadge status={row.policyType || 'Custom'} />
-                </td>
-                <td>
-                  <code>{row.resource}</code>
-                </td>
-                <td>
-                  <div className="acl-chip-row">
-                    {row.actions.length > 0 ? row.actions.map((action) => <span key={action}>{action}</span>) : <span>None</span>}
-                  </div>
-                </td>
-                <td>
-                  <code>{row.sourceIps.join(', ') || '-'}</code>
-                </td>
-                <td>
-                  <StatusBadge status={row.decision || '-'} tone={row.decision === 'Deny' ? 'danger' : 'success'} />
-                </td>
-                <td>
-                  <div className="acl-operation-row">
-                    <button type="button" className="button button-secondary acl-action-button" onClick={() => onEdit(row)}>
-                      <Edit3 size={14} aria-hidden="true" /> Modify
-                    </button>
-                    <ConfirmDialog
-                      title="Delete ACL permission"
-                      description={`Delete ACL permission for ${row.subject} on resource ${row.resource}?`}
-                      confirmLabel="Delete"
-                      onConfirm={() => onDelete(row)}
-                    >
-                      <button type="button" className="button button-danger acl-action-button">
-                        <Trash2 size={14} aria-hidden="true" /> Delete
-                      </button>
-                    </ConfirmDialog>
-                  </div>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-      {!loading && rows.length === 0 ? <EmptyState title="No ACL permissions" /> : null}
-      <AclTableFooter total={total} page={page} pageCount={pageCount} onPageChange={onPageChange} />
-    </>
-  );
-}
-
-function UserAclDialog({
-  state,
-  clusterName,
-  brokerName,
-  saving,
-  onClose,
-  onSubmit
-}: {
-  state: UserDialogState | null;
-  clusterName: string;
-  brokerName: string;
-  saving: boolean;
-  onClose: () => void;
-  onSubmit: (payload: AclUserUpsertRequest, mode: UserDialogState['mode'], username?: string) => void;
-}) {
-  const editingUser = state?.mode === 'edit' ? state.user : null;
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
-  const [userType, setUserType] = useState('Normal');
-  const [userStatus, setUserStatus] = useState('enable');
-
-  useEffect(() => {
-    setUsername(editingUser?.username ?? '');
-    setPassword(editingUser?.password ?? '');
-    setUserType(normalizeUserType(editingUser?.userType));
-    setUserStatus(normalizeUserStatusValue(editingUser?.userStatus));
-  }, [editingUser, state]);
-
-  const canSubmit = username.trim() && password.trim() && userType.trim() && userStatus.trim();
-  const mode = state?.mode ?? 'create';
-
-  return (
-    <Dialog.Root open={state !== null} onOpenChange={(open) => !open && onClose()}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="dialog-overlay" />
-        <Dialog.Content className="dialog-content acl-dialog">
-          <div className="drawer-header">
-            <div>
-              <Dialog.Title>{editingUser ? 'Edit User' : 'Add User'}</Dialog.Title>
-              <Dialog.Description className="dialog-description">
-                Java ACL user request: username, password, userType, and userStatus on the selected broker.
-              </Dialog.Description>
-            </div>
-            <Dialog.Close className="icon-button" title="Close">
-              <X size={15} aria-hidden="true" />
-            </Dialog.Close>
-          </div>
-          <div className="acl-dialog-form">
-            <label className="acl-field">
-              <span>
-                <strong>*</strong> Username
-              </span>
-              <input value={username} disabled={mode === 'edit'} onChange={(event) => setUsername(event.target.value)} />
-            </label>
-            <label className="acl-field">
-              <span>
-                <strong>*</strong> Password
-              </span>
-              <input type="password" value={password} onChange={(event) => setPassword(event.target.value)} />
-            </label>
-            <div className="acl-dialog-grid">
-              <label className="acl-field">
-                <span>
-                  <strong>*</strong> User Type
-                </span>
-                <SelectMenu
-                  value={userType}
-                  options={[
-                    { value: 'Super', label: 'Super' },
-                    { value: 'Normal', label: 'Normal' }
-                  ]}
-                  onChange={setUserType}
-                  ariaLabel="Select ACL user type"
-                  className="acl-select-menu"
-                />
-              </label>
-              <label className="acl-field">
-                <span>
-                  <strong>*</strong> User Status
-                </span>
-                <SelectMenu
-                  value={userStatus}
-                  options={[
-                    { value: 'enable', label: 'enable' },
-                    { value: 'disable', label: 'disable' }
-                  ]}
-                  onChange={setUserStatus}
-                  ariaLabel="Select ACL user status"
-                  className="acl-select-menu"
-                />
-              </label>
-            </div>
-          </div>
-          <div className="dialog-actions">
-            <Dialog.Close className="button button-secondary">Cancel</Dialog.Close>
-            <button
-              type="button"
-              className="button"
-              disabled={!canSubmit || saving}
-              onClick={() =>
-                onSubmit(
-                  {
-                    brokerName,
-                    clusterName,
-                    username,
-                    password,
-                    userType,
-                    userStatus
-                  },
-                  mode,
-                  editingUser?.username
-                )
-              }
-            >
-              {saving ? 'Saving...' : 'Confirm'}
-            </button>
-          </div>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
-  );
-}
-
-function PolicyAclDialog({
-  state,
-  clusterName,
-  brokerName,
-  saving,
-  onClose,
-  onSubmit
-}: {
-  state: PolicyDialogState | null;
-  clusterName: string;
-  brokerName: string;
-  saving: boolean;
-  onClose: () => void;
-  onSubmit: (payload: AclPolicyRequest, mode: PolicyDialogState['mode'], subject?: string) => void;
-}) {
-  const editingPolicy = state?.mode === 'edit' ? state.policy : null;
-  const [subject, setSubject] = useState('');
-  const [policyType, setPolicyType] = useState('Custom');
-  const [resource, setResource] = useState('');
-  const [actions, setActions] = useState<string[]>(['Pub', 'Sub']);
-  const [sourceIps, setSourceIps] = useState('');
-  const [decision, setDecision] = useState('Allow');
-
-  useEffect(() => {
-    setSubject(editingPolicy?.subject ?? '');
-    setPolicyType(editingPolicy?.policyType || 'Custom');
-    setResource(editingPolicy?.resource ?? '');
-    setActions(editingPolicy?.actions?.length ? editingPolicy.actions : ['Pub', 'Sub']);
-    setSourceIps(editingPolicy?.sourceIps?.join(', ') ?? '');
-    setDecision(editingPolicy?.decision || 'Allow');
-  }, [editingPolicy, state]);
-
-  const mode = state?.mode ?? 'create';
-  const resources = splitCsv(resource);
-  const ipValues = splitCsv(sourceIps);
-  const canSubmit = subject.trim() && policyType.trim() && resources.length > 0 && actions.length > 0 && decision.trim();
-
-  const toggleAction = (action: string) => {
-    setActions((value) => (value.includes(action) ? value.filter((item) => item !== action) : [...value, action]));
-  };
-
-  return (
-    <Dialog.Root open={state !== null} onOpenChange={(open) => !open && onClose()}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="dialog-overlay" />
-        <Dialog.Content className="dialog-content acl-dialog acl-policy-dialog">
-          <div className="drawer-header">
-            <div>
-              <Dialog.Title>{editingPolicy ? 'Edit ACL Permission' : 'Add ACL Permission'}</Dialog.Title>
-              <Dialog.Description className="dialog-description">
-                Java ACL policy request: subject, policyType, resource, actions, sourceIps, and decision.
-              </Dialog.Description>
-            </div>
-            <Dialog.Close className="icon-button" title="Close">
-              <X size={15} aria-hidden="true" />
-            </Dialog.Close>
-          </div>
-          <div className="acl-dialog-form">
-            <label className="acl-field">
-              <span>
-                <strong>*</strong> Subject
-              </span>
-              <input value={subject} disabled={mode === 'edit'} placeholder="User:rocketmq_app" onChange={(event) => setSubject(event.target.value)} />
-            </label>
-            <div className="acl-dialog-grid">
-              <label className="acl-field">
-                <span>
-                  <strong>*</strong> Policy Type
-                </span>
-                <SelectMenu
-                  value={policyType}
-                  options={[
-                    { value: 'Custom', label: 'Custom' },
-                    { value: 'Default', label: 'Default' }
-                  ]}
-                  onChange={setPolicyType}
-                  ariaLabel="Select ACL policy type"
-                  className="acl-select-menu"
-                />
-              </label>
-              <label className="acl-field">
-                <span>
-                  <strong>*</strong> Decision
-                </span>
-                <SelectMenu
-                  value={decision}
-                  options={[
-                    { value: 'Allow', label: 'Allow' },
-                    { value: 'Deny', label: 'Deny' }
-                  ]}
-                  onChange={setDecision}
-                  ariaLabel="Select ACL decision"
-                  className="acl-select-menu"
-                />
-              </label>
-            </div>
-            <label className="acl-field">
-              <span>
-                <strong>*</strong> Resource
-              </span>
-              <input
-                value={resource}
-                disabled={mode === 'edit'}
-                placeholder="Topic:TopicTest1111, Group:please_rename_unique_group_name"
-                onChange={(event) => setResource(event.target.value)}
-              />
-              <small>Multiple resources are comma-separated, matching Java ResourceInput behavior.</small>
-            </label>
-            <div className="acl-field">
-              <span>Operation Type</span>
-              <div className="acl-action-toggle-grid">
-                {actionOptions.map((action) => (
-                  <button
-                    type="button"
-                    className={actions.includes(action) ? 'active' : ''}
-                    key={action}
-                    onClick={() => toggleAction(action)}
-                  >
-                    {action}
-                  </button>
-                ))}
-              </div>
-            </div>
-            <label className="acl-field">
-              <span>Source IP</span>
-              <input value={sourceIps} placeholder="127.0.0.1, 192.168.1.1" onChange={(event) => setSourceIps(event.target.value)} />
-              <small>Leave empty to use broker defaults. IPv4, IPv6, and CIDR values can be typed as tags in Java.</small>
-            </label>
-          </div>
-          <div className="dialog-actions">
-            <Dialog.Close className="button button-secondary">Cancel</Dialog.Close>
-            <button
-              type="button"
-              className="button"
-              disabled={!canSubmit || saving}
-              onClick={() =>
-                onSubmit(
-                  {
-                    brokerName,
-                    clusterName,
-                    subject,
-                    policies: [
-                      {
-                        policyType,
-                        entries: [
-                          {
-                            resource: resources,
-                            actions,
-                            sourceIps: ipValues,
-                            decision
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  mode,
-                  editingPolicy?.subject
-                )
-              }
-            >
-              {saving ? 'Saving...' : 'Confirm'}
-            </button>
-          </div>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
-  );
-}
-
-function AclStatCard({ icon, label, value, hint }: { icon: ReactNode; label: string; value: number; hint: string }) {
-  return (
-    <div className="acl-stat-card">
-      <div>
-        <span>{label}</span>
-        <strong>{value}</strong>
-        <small>{hint}</small>
-      </div>
-      <div className="acl-stat-icon">{icon}</div>
-    </div>
-  );
-}
-
-function AclTableFooter({
-  total,
-  page,
-  pageCount,
-  onPageChange
-}: {
-  total: number;
-  page: number;
-  pageCount: number;
-  onPageChange: (page: number) => void;
-}) {
-  return (
-    <div className="acl-table-footer">
-      <span>
-        {total} rows / page {page} of {pageCount}
-      </span>
-      <div className="pagination">
-        <button type="button" className="button button-secondary" disabled={page <= 1} onClick={() => onPageChange(page - 1)}>
-          Previous
-        </button>
-        <button type="button" className="button button-secondary" disabled={page >= pageCount} onClick={() => onPageChange(page + 1)}>
-          Next
-        </button>
-      </div>
-    </div>
-  );
-}
-
-function flattenPolicies(policies: AclPolicyView[]): AclPolicyTableRow[] {
-  return policies.flatMap((policy, policyIndex) =>
-    policy.entries.flatMap((entry, entryIndex) => {
-      const resource = entry.resource || '*';
-      return {
-        key: `${policy.brokerAddr}:${policy.subject ?? ''}:${policy.policyType ?? ''}:${resource}:${policyIndex}:${entryIndex}`,
-        brokerName: policy.brokerName,
-        brokerAddr: policy.brokerAddr,
-        subject: policy.subject ?? '-',
-        policyType: policy.policyType ?? 'Custom',
-        resource,
-        actions: entry.actions ?? [],
-        sourceIps: entry.sourceIps ?? [],
-        decision: entry.decision ?? 'Allow'
-      };
-    })
-  );
-}
-
-function pageRows<T>(rows: T[], page: number) {
-  return rows.slice((Math.max(1, page) - 1) * pageSize, Math.max(1, page) * pageSize);
-}
-
-function pageCount(total: number) {
-  return Math.max(1, Math.ceil(total / pageSize));
-}
-
-function filterRows<T>(rows: T[], query: string) {
-  if (!query) {
-    return rows;
-  }
-  return rows.filter((row) => JSON.stringify(row).toLowerCase().includes(query));
-}
-
-function scopeQuery(clusterName: string, brokerName: string): AclQueryParams {
-  return { clusterName, brokerName };
-}
-
-function splitCsv(value: string) {
-  return value
-    .split(',')
-    .map((item) => item.trim())
-    .filter(Boolean);
-}
-
-function mutationMessage(result: AclMutationResult) {
-  return `${result.message || 'ACL mutation completed.'} Target count: ${result.targetCount}.`;
-}
-
-function maskPassword(value?: string) {
-  if (!value) {
-    return '********';
-  }
-  return '*'.repeat(Math.max(8, Math.min(16, value.length)));
-}
-
-function normalizeUserType(value?: string) {
-  const normalized = (value || 'Normal').toLowerCase();
-  return normalized === 'super' ? 'Super' : normalized === 'normal' ? 'Normal' : value || 'Normal';
-}
-
-function normalizeUserStatus(value?: string) {
-  const normalized = normalizeUserStatusValue(value);
-  return normalized === 'enable' ? 'enable' : 'disable';
-}
-
-function normalizeUserStatusValue(value?: string) {
-  const normalized = (value || 'enable').toLowerCase();
-  return normalized.includes('disabled') || normalized === 'disable' ? 'disable' : 'enable';
-}
-
-function userTypeTone(value?: string) {
-  return normalizeUserType(value) === 'Super' ? 'warning' : 'neutral';
-}
-
-function userStatusTone(value?: string) {
-  return normalizeUserStatus(value) === 'enable' ? 'success' : 'danger';
+function AclScopeEmptyState() {
+  return <div className="empty-state"><h2>Confirm an ACL scope</h2><p>Select and confirm a valid cluster and broker before loading ACL users or policies.</p></div>;
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/MonitorPage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/MonitorPage.test.tsx
@@ -1,0 +1,192 @@
+import { act, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { StrictMode } from 'react';
+import { vi } from 'vitest';
+import { monitorApi } from '../api/monitor_api';
+import { renderAtRoute } from '../test/render';
+import MonitorPage from './MonitorPage';
+
+vi.mock('../api/monitor_api', () => ({
+  monitorApi: {
+    listConsumerMonitors: vi.fn(),
+    saveConsumerMonitor: vi.fn(),
+    deleteConsumerMonitor: vi.fn()
+  }
+}));
+
+describe('MonitorPage', () => {
+  const rules = [
+    { consumerGroup: 'order-service', minCount: 4, maxDiffTotal: 1200 },
+    { consumerGroup: 'payment-worker', minCount: 2, maxDiffTotal: 800 }
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(monitorApi.listConsumerMonitors).mockResolvedValue(rules);
+    vi.mocked(monitorApi.saveConsumerMonitor).mockResolvedValue({ message: 'saved', item: rules[0] });
+    vi.mocked(monitorApi.deleteConsumerMonitor).mockResolvedValue({ message: 'deleted', item: null });
+  });
+
+  it('renders API-backed rule metrics and a persisted rule list', async () => {
+    renderAtRoute(<MonitorPage />, '/monitor');
+
+    expect(screen.getByRole('status', { name: 'Loading monitor rules' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Monitor' })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Rules: 2' })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Min Count range: 2–4' })).toBeInTheDocument();
+    expect(screen.getByRole('row', { name: /order-service 4 1200/ })).toBeInTheDocument();
+    expect(screen.queryByText(/active alerts|event history|firing/i)).not.toBeInTheDocument();
+  });
+
+  it('loads initial monitor rules under React StrictMode', async () => {
+    renderAtRoute(<StrictMode><MonitorPage /></StrictMode>, '/monitor');
+
+    expect(await screen.findByRole('row', { name: /order-service 4 1200/ })).toBeInTheDocument();
+    expect(screen.queryByRole('status', { name: 'Loading monitor rules' })).not.toBeInTheDocument();
+  });
+
+  it('shows retryable list errors and an empty persisted-rule state', async () => {
+    const user = userEvent.setup();
+    vi.mocked(monitorApi.listConsumerMonitors)
+      .mockRejectedValueOnce(new Error('monitor list unavailable'))
+      .mockResolvedValueOnce([]);
+    renderAtRoute(<MonitorPage />, '/monitor');
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('monitor list unavailable');
+    await user.click(screen.getByRole('button', { name: 'Retry monitor rules' }));
+
+    expect(await screen.findByText('No monitor rules')).toBeInTheDocument();
+    expect(monitorApi.listConsumerMonitors).toHaveBeenCalledTimes(2);
+  });
+
+  it('creates and edits a persisted rule then refreshes the list', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<MonitorPage />, '/monitor');
+    await screen.findByRole('heading', { name: 'Monitor' });
+
+    await user.click(screen.getByRole('button', { name: 'Create rule' }));
+    const createDialog = screen.getByRole('dialog', { name: 'Create rule' });
+    await user.type(within(createDialog).getByRole('textbox', { name: 'Group' }), 'inventory-worker');
+    await user.clear(within(createDialog).getByRole('spinbutton', { name: 'Min Count' }));
+    await user.type(within(createDialog).getByRole('spinbutton', { name: 'Min Count' }), '5');
+    await user.clear(within(createDialog).getByRole('spinbutton', { name: 'Max Diff Total' }));
+    await user.type(within(createDialog).getByRole('spinbutton', { name: 'Max Diff Total' }), '3000');
+    await user.click(within(createDialog).getByRole('button', { name: 'Save rule' }));
+
+    await waitFor(() => expect(monitorApi.saveConsumerMonitor).toHaveBeenCalledWith({
+      consumerGroup: 'inventory-worker', minCount: 5, maxDiffTotal: 3000
+    }));
+    expect(monitorApi.listConsumerMonitors).toHaveBeenCalledTimes(2);
+
+    await user.click(screen.getByRole('button', { name: 'Edit rule for order-service' }));
+    const editDialog = screen.getByRole('dialog', { name: 'Edit rule' });
+    const maxDiffTotal = within(editDialog).getByRole('spinbutton', { name: 'Max Diff Total' });
+    await user.clear(maxDiffTotal);
+    await user.type(maxDiffTotal, '1500');
+    await user.click(within(editDialog).getByRole('button', { name: 'Save rule' }));
+
+    await waitFor(() => expect(monitorApi.saveConsumerMonitor).toHaveBeenLastCalledWith({
+      consumerGroup: 'order-service', minCount: 4, maxDiffTotal: 1500
+    }));
+  });
+
+  it('treats a refresh failure after a successful save as a list retry without resubmitting the rule', async () => {
+    const user = userEvent.setup();
+    vi.mocked(monitorApi.listConsumerMonitors)
+      .mockResolvedValueOnce(rules)
+      .mockRejectedValueOnce(new Error('refresh unavailable'))
+      .mockResolvedValueOnce(rules);
+    renderAtRoute(<MonitorPage />, '/monitor');
+    await screen.findByRole('heading', { name: 'Monitor' });
+
+    await user.click(screen.getByRole('button', { name: 'Create rule' }));
+    const dialog = screen.getByRole('dialog', { name: 'Create rule' });
+    await user.type(within(dialog).getByRole('textbox', { name: 'Group' }), 'inventory-worker');
+    await user.click(within(dialog).getByRole('button', { name: 'Save rule' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('refresh unavailable');
+    expect(screen.queryByRole('dialog', { name: 'Create rule' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry monitor rules' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Retry save' })).not.toBeInTheDocument();
+    expect(monitorApi.saveConsumerMonitor).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', { name: 'Retry monitor rules' }));
+    await waitFor(() => expect(monitorApi.listConsumerMonitors).toHaveBeenCalledTimes(3));
+    expect(monitorApi.saveConsumerMonitor).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes a successfully saved rule dialog before its background refresh settles', async () => {
+    const user = userEvent.setup();
+    let resolveRefresh: (value: typeof rules) => void = () => undefined;
+    vi.mocked(monitorApi.listConsumerMonitors)
+      .mockResolvedValueOnce(rules)
+      .mockReturnValueOnce(new Promise((resolve) => { resolveRefresh = resolve; }));
+    renderAtRoute(<MonitorPage />, '/monitor');
+    await screen.findByRole('heading', { name: 'Monitor' });
+
+    await user.click(screen.getByRole('button', { name: 'Create rule' }));
+    const dialog = screen.getByRole('dialog', { name: 'Create rule' });
+    await user.type(within(dialog).getByRole('textbox', { name: 'Group' }), 'inventory-worker');
+    await user.click(within(dialog).getByRole('button', { name: 'Save rule' }));
+
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Create rule' })).not.toBeInTheDocument());
+    await act(async () => { resolveRefresh(rules); });
+  });
+
+  it('requires confirmation naming the group before deleting and refreshes after confirmation', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<MonitorPage />, '/monitor');
+    await screen.findByRole('heading', { name: 'Monitor' });
+
+    await user.click(screen.getByRole('button', { name: 'Delete rule for order-service' }));
+    let confirmation = screen.getByRole('alertdialog', { name: 'Delete rule?' });
+    expect(within(confirmation).getByText(/order-service/)).toBeInTheDocument();
+    await user.click(within(confirmation).getByRole('button', { name: 'Cancel' }));
+    expect(monitorApi.deleteConsumerMonitor).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: 'Delete rule for order-service' }));
+    confirmation = screen.getByRole('alertdialog', { name: 'Delete rule?' });
+    await user.click(within(confirmation).getByRole('button', { name: 'Delete rule' }));
+
+    await waitFor(() => expect(monitorApi.deleteConsumerMonitor).toHaveBeenCalledWith('order-service'));
+    expect(monitorApi.listConsumerMonitors).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats a refresh failure after a successful delete as a list retry without repeating deletion', async () => {
+    const user = userEvent.setup();
+    vi.mocked(monitorApi.listConsumerMonitors)
+      .mockResolvedValueOnce(rules)
+      .mockRejectedValueOnce(new Error('refresh unavailable'))
+      .mockResolvedValueOnce(rules);
+    renderAtRoute(<MonitorPage />, '/monitor');
+    await screen.findByRole('heading', { name: 'Monitor' });
+
+    await user.click(screen.getByRole('button', { name: 'Delete rule for order-service' }));
+    await user.click(within(screen.getByRole('alertdialog', { name: 'Delete rule?' })).getByRole('button', { name: 'Delete rule' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('refresh unavailable');
+    expect(screen.getByRole('button', { name: 'Retry monitor rules' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Retry delete' })).not.toBeInTheDocument();
+    expect(monitorApi.deleteConsumerMonitor).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', { name: 'Retry monitor rules' }));
+    await waitFor(() => expect(monitorApi.listConsumerMonitors).toHaveBeenCalledTimes(3));
+    expect(monitorApi.deleteConsumerMonitor).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a stale list response after a refresh request supersedes it', async () => {
+    const user = userEvent.setup();
+    let resolveInitial: (value: typeof rules) => void = () => undefined;
+    let resolveRefresh: (value: typeof rules) => void = () => undefined;
+    vi.mocked(monitorApi.listConsumerMonitors)
+      .mockReturnValueOnce(new Promise((resolve) => { resolveInitial = resolve; }))
+      .mockReturnValueOnce(new Promise((resolve) => { resolveRefresh = resolve; }));
+    renderAtRoute(<MonitorPage />, '/monitor');
+
+    await user.click(screen.getByRole('button', { name: 'Refresh' }));
+    resolveRefresh([{ consumerGroup: 'new-rule', minCount: 9, maxDiffTotal: 999 }]);
+    expect(await screen.findByRole('row', { name: /new-rule 9 999/ })).toBeInTheDocument();
+    resolveInitial(rules);
+    await waitFor(() => expect(screen.queryByRole('row', { name: /order-service 4 1200/ })).not.toBeInTheDocument());
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/MonitorPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/MonitorPage.tsx
@@ -1,130 +1,164 @@
-import { Plus, Trash2 } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { Pencil, Plus, Trash2 } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { monitorApi } from '../api/monitor_api';
-import ConfirmDialog from '../components/ConfirmDialog';
 import DataTable, { type DataTableColumn } from '../components/DataTable';
 import ErrorState from '../components/ErrorState';
 import LoadingState from '../components/LoadingState';
+import MetricCard from '../components/MetricCard';
 import PageHeader from '../components/PageHeader';
-import type { ConsumerMonitorView } from '../types/monitor';
+import RefreshButton from '../components/RefreshButton';
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogTitle } from '../components/ui/AlertDialog';
+import { Button } from '../components/ui/Button';
+import type { ConsumerMonitorUpsertRequest, ConsumerMonitorView } from '../types/monitor';
+import MonitorDialog from './monitor/MonitorDialog';
+import { getConsumerMonitorMetrics } from './monitor/monitor-model';
 
-const columns = (onDelete: (consumerGroup: string) => void): DataTableColumn<ConsumerMonitorView>[] => [
-  { header: 'Consumer Group', render: (row) => <code>{row.consumerGroup}</code> },
-  { header: 'Minimum Count', render: (row) => row.minCount },
-  { header: 'Max Diff Total', render: (row) => row.maxDiffTotal },
-  {
-    header: 'Actions',
-    render: (row) => (
-      <ConfirmDialog
-        title="Delete monitor rule"
-        description={`Delete monitor rule for ${row.consumerGroup}?`}
-        confirmLabel="Delete"
-        onConfirm={() => onDelete(row.consumerGroup)}
-      >
-        <button type="button" className="icon-button" title="Delete monitor rule">
-          <Trash2 size={15} aria-hidden="true" />
-        </button>
-      </ConfirmDialog>
-    )
-  }
-];
+interface MutationError {
+  message: string;
+  retry: () => void;
+  retryLabel: string;
+}
 
 export default function MonitorPage() {
   const [rows, setRows] = useState<ConsumerMonitorView[]>([]);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [consumerGroup, setConsumerGroup] = useState('');
-  const [minCount, setMinCount] = useState('1');
-  const [maxDiffTotal, setMaxDiffTotal] = useState('1000');
-
-  const load = () => {
-    setLoading(true);
-    setError(null);
-    monitorApi
-      .listConsumerMonitors()
-      .then(setRows)
-      .catch((requestError: Error) => setError(requestError.message))
-      .finally(() => setLoading(false));
-  };
+  const [listError, setListError] = useState<string | null>(null);
+  const [mutationError, setMutationError] = useState<MutationError | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [selectedRule, setSelectedRule] = useState<ConsumerMonitorView | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<ConsumerMonitorView | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const listRequest = useRef(0);
+  const mounted = useRef(true);
 
   useEffect(() => {
-    load();
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+      listRequest.current += 1;
+    };
   }, []);
 
-  const save = () => {
-    setError(null);
-    monitorApi
-      .saveConsumerMonitor({
-        consumerGroup,
-        minCount: Number(minCount),
-        maxDiffTotal: Number(maxDiffTotal)
-      })
-      .then(() => {
-        setConsumerGroup('');
-        load();
-      })
-      .catch((requestError: Error) => setError(requestError.message));
+  const load = useCallback(async () => {
+    const request = ++listRequest.current;
+    setLoading(true);
+    setListError(null);
+    try {
+      const nextRows = await monitorApi.listConsumerMonitors();
+      if (mounted.current && request === listRequest.current) setRows(nextRows);
+    } catch (error) {
+      if (mounted.current && request === listRequest.current) {
+        setListError(error instanceof Error ? error.message : 'Unable to load monitor rules.');
+      }
+    } finally {
+      if (mounted.current && request === listRequest.current) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const saveRule = async (request: ConsumerMonitorUpsertRequest) => {
+    await monitorApi.saveConsumerMonitor(request);
+    void load();
   };
 
-  const remove = (group: string) => {
-    setError(null);
-    monitorApi
-      .deleteConsumerMonitor(group)
-      .then(load)
-      .catch((requestError: Error) => setError(requestError.message));
+  const deleteRule = async (rule: ConsumerMonitorView) => {
+    setDeleting(true);
+    setMutationError(null);
+    try {
+      await monitorApi.deleteConsumerMonitor(rule.consumerGroup);
+      if (!mounted.current) return;
+      setDeleteTarget(null);
+      void load();
+    } catch (error) {
+      if (mounted.current) {
+        setDeleteTarget(null);
+        setMutationError({
+          message: error instanceof Error ? error.message : 'Unable to delete the monitor rule.',
+          retry: () => { void deleteRule(rule); },
+          retryLabel: 'Retry delete'
+        });
+      }
+    } finally {
+      if (mounted.current) setDeleting(false);
+    }
   };
 
-  if (loading) {
-    return <LoadingState label="Loading monitor rules" />;
-  }
-
-  if (error) {
-    return <ErrorState message={error} onRetry={load} />;
-  }
+  const metrics = useMemo(() => getConsumerMonitorMetrics(rows), [rows]);
+  const columns = useMemo<DataTableColumn<ConsumerMonitorView>[]>(() => [
+    { header: 'Group', render: (row) => <code>{row.consumerGroup}</code> },
+    { header: 'Min Count', render: (row) => row.minCount },
+    { header: 'Max Diff Total', render: (row) => row.maxDiffTotal },
+    {
+      header: 'Actions',
+      render: (row) => (
+        <div className="action-row">
+          <Button type="button" variant="ghost" size="icon" aria-label={`Edit rule for ${row.consumerGroup}`} onClick={() => {
+            setSelectedRule(row);
+            setDialogOpen(true);
+          }}>
+            <Pencil size={15} aria-hidden="true" />
+          </Button>
+          <Button type="button" variant="ghost" size="icon" aria-label={`Delete rule for ${row.consumerGroup}`} onClick={() => setDeleteTarget(row)}>
+            <Trash2 size={15} aria-hidden="true" />
+          </Button>
+        </div>
+      )
+    }
+  ], []);
 
   return (
     <>
       <PageHeader
-        title="Monitors"
-        description="Consumer accumulation thresholds and alert rules."
-        actions={
+        title="Monitor"
+        description="Persisted consumer-group threshold rules."
+        actions={(
           <div className="action-row">
-            <input
-              className="inline-input"
-              value={consumerGroup}
-              placeholder="Consumer group"
-              onChange={(event) => setConsumerGroup(event.target.value)}
-            />
-            <input
-              className="inline-input"
-              type="number"
-              min={0}
-              value={minCount}
-              placeholder="minCount"
-              onChange={(event) => setMinCount(event.target.value)}
-            />
-            <input
-              className="inline-input"
-              type="number"
-              min={0}
-              value={maxDiffTotal}
-              placeholder="maxDiffTotal"
-              onChange={(event) => setMaxDiffTotal(event.target.value)}
-            />
-            <button type="button" className="button" onClick={save}>
-              <Plus size={15} aria-hidden="true" /> Save
-            </button>
+            <Button type="button" onClick={() => {
+              setSelectedRule(null);
+              setDialogOpen(true);
+            }}>
+              <Plus size={15} aria-hidden="true" /> Create rule
+            </Button>
+            <RefreshButton onRefresh={() => void load()} />
           </div>
-        }
+        )}
       />
-      <DataTable
-        rows={rows}
-        columns={columns(remove)}
-        getRowId={(row) => row.consumerGroup}
-        searchPlaceholder="Search monitor rules"
-        emptyTitle="No monitor rules"
-        onRefresh={load}
-      />
+
+      <div className="metric-grid entity-metrics">
+        <MetricCard label="Rules" value={metrics.ruleCount} detail="Persisted configurations" />
+        <MetricCard label="Min Count range" value={metrics.minCountRange} detail="Across persisted rules" />
+        <MetricCard label="Max Diff Total range" value={metrics.maxDiffTotalRange} detail="Across persisted rules" />
+      </div>
+
+      {mutationError ? <ErrorState message={mutationError.message} onRetry={mutationError.retry} retryLabel={mutationError.retryLabel} /> : null}
+      {loading ? <LoadingState label="Loading monitor rules" /> : null}
+      {!loading && listError ? <ErrorState message={listError} onRetry={() => void load()} retryLabel="Retry monitor rules" /> : null}
+      {!loading && !listError ? (
+        <DataTable rows={rows} columns={columns} getRowId={(row) => row.consumerGroup} searchPlaceholder="Filter monitor rules" emptyTitle="No monitor rules" />
+      ) : null}
+
+      <MonitorDialog open={dialogOpen} rule={selectedRule} onOpenChange={setDialogOpen} onSubmit={saveRule} />
+
+      <AlertDialog open={Boolean(deleteTarget)} onOpenChange={(open) => {
+        if (!open && !deleting) setDeleteTarget(null);
+      }}>
+        <AlertDialogContent>
+          <AlertDialogTitle>Delete rule?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Delete the persisted threshold rule for {deleteTarget?.consumerGroup ?? 'this group'}? This does not delete consumer data.
+          </AlertDialogDescription>
+          <div className="ui-alert-dialog-actions">
+            <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction disabled={deleting} onClick={(event) => {
+              event.preventDefault();
+              if (deleteTarget) void deleteRule(deleteTarget);
+            }}>
+              {deleting ? 'Deleting' : 'Delete rule'}
+            </AlertDialogAction>
+          </div>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/AclPoliciesTable.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/AclPoliciesTable.test.tsx
@@ -1,0 +1,66 @@
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { renderAtRoute } from '../../test/render';
+import AclPoliciesTable from './AclPoliciesTable';
+
+const rows = Array.from({ length: 11 }, (_, index) => ({
+  key: `policy-${index + 1}`, entryIndex: 0, subjectEntries: [{ resource: `Topic:${index + 1}`, actions: ['Pub'], sourceIps: [], decision: 'Allow' }], brokerName: 'broker-a', brokerAddr: '10.0.0.1:10911', subject: `User:${index + 1}`,
+  policyType: 'Custom', resource: `Topic:${index + 1}`, actions: ['Pub'], sourceIps: [], decision: 'Allow'
+}));
+
+describe('AclPoliciesTable', () => {
+  it('uses the shared loading state rather than retaining policy rows', () => {
+    renderAtRoute(<AclPoliciesTable rows={rows} total={rows.length} page={1} pageSize={10} loading disabled={false} onPageChange={vi.fn()} onEdit={vi.fn()} onDelete={vi.fn()} />, '/acl');
+    expect(screen.getByRole('status', { name: 'Loading acl policies' })).toBeInTheDocument();
+    expect(screen.queryByText('User:1')).not.toBeInTheDocument();
+  });
+
+  it('receives page-sized policy rows and renders shared pagination', () => {
+    renderAtRoute(<AclPoliciesTable rows={rows.slice(0, 10)} total={rows.length} page={1} pageSize={10} loading={false} disabled={false} onPageChange={vi.fn()} onEdit={vi.fn()} onDelete={vi.fn()} />, '/acl');
+    expect(screen.getByText('User:10')).toBeInTheDocument();
+    expect(screen.queryByText('User:11')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Next page' })).toBeInTheDocument();
+  });
+
+  it('gives row actions subject and resource-specific accessible names', () => {
+    renderAtRoute(<AclPoliciesTable rows={[rows[0]]} total={1} page={1} pageSize={10} loading={false} disabled={false} onPageChange={vi.fn()} onEdit={vi.fn()} onDelete={vi.fn()} />, '/acl');
+    expect(screen.getByRole('button', { name: 'Modify ACL policy User:1 on Topic:1' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete ACL policy User:1 on Topic:1' })).toBeInTheDocument();
+  });
+
+  it('allows deletion only for Custom rows when policy targets are otherwise identical', async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn();
+    const defaultRow = { ...rows[0], key: 'default-policy', policyType: 'Default' };
+    const customRow = { ...rows[0], key: 'custom-policy' };
+    renderAtRoute(<AclPoliciesTable rows={[defaultRow, customRow]} total={2} page={1} pageSize={10} loading={false} disabled={false} onPageChange={vi.fn()} onEdit={vi.fn()} onDelete={onDelete} />, '/acl');
+
+    const defaultDelete = screen.getByRole('button', { name: 'Delete ACL policy User:1 on Topic:1 unavailable: only Custom policies can be deleted' });
+    expect(defaultDelete).toBeDisabled();
+    expect(defaultDelete).toHaveAttribute('title', 'Only Custom ACL policies can be deleted.');
+    await user.click(defaultDelete);
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+    expect(onDelete).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: 'Delete ACL policy User:1 on Topic:1' }));
+    const confirmation = screen.getByRole('alertdialog');
+    expect(confirmation).toHaveTextContent('User:1');
+    expect(confirmation).toHaveTextContent('Topic:1');
+    await user.click(within(confirmation).getByRole('button', { name: 'Delete' }));
+    expect(onDelete).toHaveBeenCalledOnce();
+    expect(onDelete).toHaveBeenCalledWith(customRow);
+  });
+
+  it('names the policy subject in destructive confirmation before deleting', async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn();
+    renderAtRoute(<AclPoliciesTable rows={[rows[0]]} total={1} page={1} pageSize={10} loading={false} disabled={false} onPageChange={vi.fn()} onEdit={vi.fn()} onDelete={onDelete} />, '/acl');
+
+    await user.click(screen.getByRole('button', { name: 'Delete ACL policy User:1 on Topic:1' }));
+    const confirmation = screen.getByRole('alertdialog');
+    expect(confirmation).toHaveTextContent('User:1');
+    await user.click(within(confirmation).getByRole('button', { name: 'Delete' }));
+    expect(onDelete).toHaveBeenCalledWith(rows[0]);
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/AclPoliciesTable.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/AclPoliciesTable.tsx
@@ -1,0 +1,46 @@
+import { Edit3, Trash2 } from 'lucide-react';
+import { useMemo } from 'react';
+import AppDataTable, { type AppDataTableColumn } from '../../components/AppDataTable';
+import ConfirmDialog from '../../components/ConfirmDialog';
+import StatusBadge from '../../components/StatusBadge';
+import type { AclPolicyRow } from './acl-model';
+
+export interface AclPoliciesTableProps {
+  rows: AclPolicyRow[];
+  total: number;
+  page: number;
+  pageSize: number;
+  loading: boolean;
+  error?: string | null;
+  onRetry?: () => void;
+  disabled: boolean;
+  onPageChange: (page: number) => void;
+  onEdit: (policy: AclPolicyRow) => void;
+  onDelete: (policy: AclPolicyRow) => void;
+}
+
+export default function AclPoliciesTable({ rows, total, page, pageSize, loading, error, onRetry, disabled, onPageChange, onEdit, onDelete }: AclPoliciesTableProps) {
+  const columns = useMemo<AppDataTableColumn<AclPolicyRow>[]>(() => [
+    { id: 'subject', header: 'Username/Subject', cell: (row) => <div className="acl-primary-cell"><code>{row.subject}</code><span>{row.brokerName || row.brokerAddr}</span></div> },
+    { id: 'type', header: 'Policy Type', cell: (row) => <StatusBadge status={row.policyType} /> },
+    { id: 'resource', header: 'Resource Name', cell: (row) => <code>{row.resource}</code> },
+    { id: 'actions', header: 'Operation Type', cell: (row) => <div className="acl-chip-row">{row.actions.length ? row.actions.map((action) => <span key={action}>{action}</span>) : <span>None</span>}</div> },
+    { id: 'sources', header: 'Source IP', cell: (row) => <code>{row.sourceIps.join(', ') || '-'}</code> },
+    { id: 'decision', header: 'Decision', cell: (row) => <StatusBadge status={row.decision} tone={row.decision === 'Deny' ? 'danger' : 'success'} /> },
+    { id: 'actions-menu', header: 'Operation', cell: (row) => {
+      const target = `${row.subject} on ${row.resource}`;
+      return <div className="acl-operation-row">
+        <button type="button" className="button button-secondary acl-action-button" aria-label={`Modify ACL policy ${target}`} disabled={disabled} onClick={() => onEdit(row)}><Edit3 size={14} aria-hidden="true" /> Modify</button>
+        {row.policyType === 'Custom' ? (
+          <ConfirmDialog title="Delete ACL permission" description={`Delete ACL permission for ${row.subject} on resource ${row.resource}?`} confirmLabel="Delete" onConfirm={() => onDelete(row)}>
+            <button type="button" className="button button-danger acl-action-button" aria-label={`Delete ACL policy ${target}`} disabled={disabled}><Trash2 size={14} aria-hidden="true" /> Delete</button>
+          </ConfirmDialog>
+        ) : (
+          <button type="button" className="button button-danger acl-action-button" aria-label={`Delete ACL policy ${target} unavailable: only Custom policies can be deleted`} title="Only Custom ACL policies can be deleted." disabled><Trash2 size={14} aria-hidden="true" /> Delete</button>
+        )}
+      </div>;
+    } }
+  ], [disabled, onDelete, onEdit]);
+
+  return <AppDataTable ariaLabel="ACL policies" rows={rows} columns={columns} getRowId={(row) => row.key} page={page} pageSize={pageSize} total={total} onPageChange={onPageChange} loading={loading} error={error} onRetry={onRetry} retryLabel="Retry" emptyTitle="No ACL permissions" />;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/AclPolicyDialog.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/AclPolicyDialog.tsx
@@ -1,0 +1,106 @@
+import * as Dialog from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import SelectMenu from '../../components/SelectMenu';
+import { buildAclPolicyRequest, type AclPolicyDraft, type AclPolicyRow, type AclScope } from './acl-model';
+import type { AclPolicyRequest } from '../../types/acl';
+
+export interface AclPolicyDialogProps {
+  open: boolean;
+  policy?: AclPolicyRow | null;
+  scope: AclScope;
+  saving: boolean;
+  error?: string | null;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (request: AclPolicyRequest, subject?: string) => void;
+}
+
+const actionOptions = ['All', 'Pub', 'Sub', 'Create', 'Update', 'Delete', 'Get', 'List'];
+const emptyDraft: AclPolicyDraft = { subject: '', policyType: 'Custom', resources: '', actions: ['Pub', 'Sub'], sourceIps: '', decision: 'Allow' };
+
+export default function AclPolicyDialog({ open, policy, scope, saving, error, onOpenChange, onSubmit }: AclPolicyDialogProps) {
+  const [draft, setDraft] = useState<AclPolicyDraft>(emptyDraft);
+  const [validationErrors, setValidationErrors] = useState<Partial<Record<keyof AclPolicyDraft, string>>>({});
+
+  useEffect(() => {
+    if (!open) return;
+    setDraft(policy ? {
+      subject: policy.subject,
+      policyType: policy.policyType,
+      resources: policy.resource,
+      actions: [...policy.actions],
+      sourceIps: policy.sourceIps.join(', '),
+      decision: policy.decision
+    } : emptyDraft);
+    setValidationErrors({});
+  }, [open, policy]);
+
+  const editing = Boolean(policy);
+  const updateDraft = <K extends keyof AclPolicyDraft>(field: K, value: AclPolicyDraft[K]) => {
+    setDraft((current) => ({ ...current, [field]: value }));
+    setValidationErrors((current) => ({ ...current, [field]: undefined }));
+  };
+  const toggleAction = (action: string) => updateDraft('actions', draft.actions.includes(action)
+    ? draft.actions.filter((item) => item !== action)
+    : [...draft.actions, action]);
+  const submit = () => {
+    const parsed = buildAclPolicyRequest(scope, draft, policy);
+    if (!parsed.ok) {
+      setValidationErrors(parsed.errors);
+      return;
+    }
+    onSubmit(parsed.value, policy?.subject);
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="dialog-overlay" />
+        <Dialog.Content className="dialog-content acl-dialog acl-policy-dialog">
+          <div className="drawer-header">
+            <div>
+              <Dialog.Title>{editing ? 'Edit ACL Permission' : 'Add ACL Permission'}</Dialog.Title>
+              <Dialog.Description className="dialog-description">Create or update an ACL policy on the confirmed broker.</Dialog.Description>
+            </div>
+            <Dialog.Close className="icon-button" title="Close"><X size={15} aria-hidden="true" /></Dialog.Close>
+          </div>
+          <div className="acl-dialog-form">
+            <label className="acl-field">
+              <span><strong>*</strong> Subject</span>
+              <input value={draft.subject} disabled={editing} placeholder="User:rocketmq_app" onChange={(event) => updateDraft('subject', event.target.value)} />
+              {validationErrors.subject ? <small className="inline-validation">{validationErrors.subject}</small> : null}
+            </label>
+            <div className="acl-dialog-grid">
+              <label className="acl-field">
+                <span><strong>*</strong> Policy Type</span>
+                <SelectMenu value={draft.policyType} options={[{ value: 'Custom', label: 'Custom' }, { value: 'Default', label: 'Default' }]} onChange={(value) => updateDraft('policyType', value)} ariaLabel="Select ACL policy type" className="acl-select-menu" />
+              </label>
+              <label className="acl-field">
+                <span><strong>*</strong> Decision</span>
+                <SelectMenu value={draft.decision} options={[{ value: 'Allow', label: 'Allow' }, { value: 'Deny', label: 'Deny' }]} onChange={(value) => updateDraft('decision', value)} ariaLabel="Select ACL decision" className="acl-select-menu" />
+              </label>
+            </div>
+            <label className="acl-field">
+              <span><strong>*</strong> Resource</span>
+              <input value={draft.resources} disabled={editing} placeholder="Topic:TopicTest1111, Group:please_rename_unique_group_name" onChange={(event) => updateDraft('resources', event.target.value)} />
+              {validationErrors.resources ? <small className="inline-validation">{validationErrors.resources}</small> : <small>Multiple resources are comma-separated.</small>}
+            </label>
+            <div className="acl-field">
+              <span>Operation Type</span>
+              <div className="acl-action-toggle-grid">
+                {actionOptions.map((action) => <button type="button" className={draft.actions.includes(action) ? 'active' : ''} key={action} aria-pressed={draft.actions.includes(action)} onClick={() => toggleAction(action)}>{action}</button>)}
+              </div>
+              {validationErrors.actions ? <small className="inline-validation">{validationErrors.actions}</small> : null}
+            </div>
+            <label className="acl-field"><span>Source IP</span><input value={draft.sourceIps} placeholder="127.0.0.1, 192.168.1.1" onChange={(event) => updateDraft('sourceIps', event.target.value)} /></label>
+          </div>
+          <div className="dialog-actions">
+            {error ? <div className="acl-dialog-error" role="alert">{error}</div> : null}
+            <Dialog.Close className="button button-secondary" disabled={saving}>Cancel</Dialog.Close>
+            <button type="button" className="button" disabled={saving} onClick={submit}>{saving ? 'Saving...' : error ? 'Retry' : 'Confirm'}</button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/AclScopePicker.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/AclScopePicker.tsx
@@ -1,0 +1,73 @@
+import { CheckCircle2, ShieldCheck } from 'lucide-react';
+import SelectMenu from '../../components/SelectMenu';
+import type { BrokerInfo } from '../../types/broker';
+import { createAclScopeQuery, deriveAclScopeOptions, type AclScope } from './acl-model';
+
+export interface AclScopePickerProps {
+  brokers: BrokerInfo[];
+  draftScope: AclScope;
+  confirmedScope: AclScope | null;
+  disabled?: boolean;
+  onDraftScopeChange: (scope: AclScope) => void;
+  onConfirm: (scope: AclScope) => void;
+}
+
+export default function AclScopePicker({
+  brokers,
+  draftScope,
+  confirmedScope,
+  disabled = false,
+  onDraftScopeChange,
+  onConfirm
+}: AclScopePickerProps) {
+  const options = deriveAclScopeOptions(brokers, draftScope.clusterName);
+  const confirmedBroker = confirmedScope
+    ? brokers.find((broker) => broker.clusterName === confirmedScope.clusterName && broker.brokerName === confirmedScope.brokerName)
+    : undefined;
+  const canConfirm = createAclScopeQuery(draftScope, brokers) !== null;
+
+  return (
+    <section className="acl-selector-panel" aria-label="ACL scope">
+      <div className="acl-selector-grid">
+        <label className="acl-field">
+          <span><strong>*</strong> Cluster</span>
+          <SelectMenu
+            value={draftScope.clusterName}
+            options={options.clusters}
+            onChange={(clusterName) => onDraftScopeChange({ clusterName, brokerName: '' })}
+            ariaLabel="Select ACL cluster"
+            className="acl-select-menu"
+          />
+        </label>
+        <label className="acl-field">
+          <span><strong>*</strong> Broker</span>
+          <SelectMenu
+            value={draftScope.brokerName}
+            options={options.brokers}
+            onChange={(brokerName) => onDraftScopeChange({ ...draftScope, brokerName })}
+            ariaLabel="Select ACL broker"
+            className="acl-select-menu"
+          />
+        </label>
+        <button
+          type="button"
+          className="button acl-confirm-button"
+          disabled={disabled || !canConfirm}
+          onClick={() => onConfirm(draftScope)}
+        >
+          <CheckCircle2 size={15} aria-hidden="true" /> Confirm
+        </button>
+      </div>
+      <div className="acl-scope-card">
+        <ShieldCheck size={18} aria-hidden="true" />
+        <div>
+          <span>Active broker scope</span>
+          <strong>{confirmedScope?.brokerName ?? 'No confirmed scope'}</strong>
+          <small>
+            {confirmedScope ? `${confirmedScope.clusterName} / ${confirmedBroker?.address ?? '-'}` : 'Confirm a cluster and broker before loading ACL data.'}
+          </small>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/AclUserDialog.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/AclUserDialog.tsx
@@ -1,0 +1,81 @@
+import * as Dialog from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import SelectMenu from '../../components/SelectMenu';
+import type { AclUserUpsertRequest, AclUserView } from '../../types/acl';
+import type { AclScope } from './acl-model';
+
+export interface AclUserDialogProps {
+  open: boolean;
+  user?: AclUserView | null;
+  scope: AclScope;
+  saving: boolean;
+  error?: string | null;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (request: AclUserUpsertRequest, username?: string) => void;
+}
+
+export default function AclUserDialog({ open, user, scope, saving, error, onOpenChange, onSubmit }: AclUserDialogProps) {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [userType, setUserType] = useState('Normal');
+  const [userStatus, setUserStatus] = useState('enable');
+
+  useEffect(() => {
+    if (!open) return;
+    setUsername(user?.username ?? '');
+    setPassword(user?.password ?? '');
+    setUserType(normalizeUserType(user?.userType));
+    setUserStatus(normalizeUserStatus(user?.userStatus));
+  }, [open, user]);
+
+  const editing = Boolean(user);
+  const canSubmit = Boolean(username.trim() && password.trim() && userType && userStatus);
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="dialog-overlay" />
+        <Dialog.Content className="dialog-content acl-dialog">
+          <div className="drawer-header">
+            <div>
+              <Dialog.Title>{editing ? 'Edit User' : 'Add User'}</Dialog.Title>
+              <Dialog.Description className="dialog-description">Create or update an ACL user on the confirmed broker.</Dialog.Description>
+            </div>
+            <Dialog.Close className="icon-button" title="Close"><X size={15} aria-hidden="true" /></Dialog.Close>
+          </div>
+          <div className="acl-dialog-form">
+            <label className="acl-field"><span><strong>*</strong> Username</span><input value={username} disabled={editing} onChange={(event) => setUsername(event.target.value)} /></label>
+            <label className="acl-field"><span><strong>*</strong> Password</span><input type="password" value={password} onChange={(event) => setPassword(event.target.value)} /></label>
+            <div className="acl-dialog-grid">
+              <label className="acl-field">
+                <span><strong>*</strong> User Type</span>
+                <SelectMenu value={userType} options={[{ value: 'Super', label: 'Super' }, { value: 'Normal', label: 'Normal' }]} onChange={setUserType} ariaLabel="Select ACL user type" className="acl-select-menu" />
+              </label>
+              <label className="acl-field">
+                <span><strong>*</strong> User Status</span>
+                <SelectMenu value={userStatus} options={[{ value: 'enable', label: 'enable' }, { value: 'disable', label: 'disable' }]} onChange={setUserStatus} ariaLabel="Select ACL user status" className="acl-select-menu" />
+              </label>
+            </div>
+          </div>
+          <div className="dialog-actions">
+            {error ? <div className="acl-dialog-error" role="alert">{error}</div> : null}
+            <Dialog.Close className="button button-secondary" disabled={saving}>Cancel</Dialog.Close>
+            <button type="button" className="button" disabled={!canSubmit || saving} onClick={() => onSubmit({
+              clusterName: scope.clusterName, brokerName: scope.brokerName, username, password, userType, userStatus
+            }, user?.username)}>{saving ? 'Saving...' : error ? 'Retry' : 'Confirm'}</button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+function normalizeUserType(value?: string) {
+  return (value || 'Normal').toLowerCase() === 'super' ? 'Super' : 'Normal';
+}
+
+function normalizeUserStatus(value?: string) {
+  const normalized = (value || 'enable').toLowerCase();
+  return normalized.includes('disabled') || normalized === 'disable' ? 'disable' : 'enable';
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/AclUsersTable.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/AclUsersTable.test.tsx
@@ -1,0 +1,68 @@
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { renderAtRoute } from '../../test/render';
+import AclUsersTable from './AclUsersTable';
+
+const rows = Array.from({ length: 11 }, (_, index) => ({
+  brokerName: 'broker-a', brokerAddr: '10.0.0.1:10911', username: `user-${index + 1}`, password: `secret-${index + 1}`
+}));
+
+describe('AclUsersTable', () => {
+  it('renders a shared loading state instead of stale rows', () => {
+    renderAtRoute(<AclUsersTable rows={rows} total={rows.length} page={1} pageSize={10} loading showPasswords={false} disabled={false} onPageChange={vi.fn()} onEdit={vi.fn()} onDelete={vi.fn()} />, '/acl');
+    expect(screen.getByRole('status', { name: 'Loading acl users' })).toBeInTheDocument();
+    expect(screen.queryByText('user-1')).not.toBeInTheDocument();
+  });
+
+  it('renders one page at a time and exposes pagination controls', () => {
+    renderAtRoute(<AclUsersTable rows={rows.slice(0, 10)} total={rows.length} page={1} pageSize={10} loading={false} showPasswords={false} disabled={false} onPageChange={vi.fn()} onEdit={vi.fn()} onDelete={vi.fn()} />, '/acl');
+    expect(screen.getByText('user-10')).toBeInTheDocument();
+    expect(screen.queryByText('user-11')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Next page' })).toBeInTheDocument();
+  });
+
+  it('preserves an unknown API user type instead of rewriting it as Normal', () => {
+    renderAtRoute(<AclUsersTable rows={[{ ...rows[0], userType: 'CustomOperator' }]} total={1} page={1} pageSize={10} loading={false} showPasswords={false} disabled={false} onPageChange={vi.fn()} onEdit={vi.fn()} onDelete={vi.fn()} />, '/acl');
+    expect(screen.getByRole('status', { name: 'CustomOperator' })).toBeInTheDocument();
+  });
+
+  it('uses a fixed password mask that does not reveal secret length', () => {
+    renderAtRoute(<AclUsersTable rows={[
+      { ...rows[0], username: 'short-secret', password: 'x' },
+      { ...rows[1], username: 'long-secret', password: 'a-very-long-secret-value' }
+    ]} total={2} page={1} pageSize={10} loading={false} showPasswords={false} disabled={false} onPageChange={vi.fn()} onEdit={vi.fn()} onDelete={vi.fn()} />, '/acl');
+
+    const shortRow = screen.getByText('short-secret').closest('tr');
+    const longRow = screen.getByText('long-secret').closest('tr');
+    expect(within(shortRow!).getByText('************')).toBeInTheDocument();
+    expect(within(longRow!).getByText('************')).toBeInTheDocument();
+  });
+
+  it('keeps omitted backend passwords unavailable even when reveal state is requested', () => {
+    const { rerender } = renderAtRoute(<AclUsersTable rows={[{ ...rows[0], password: undefined }]} total={1} page={1} pageSize={10} loading={false} showPasswords={false} disabled={false} onPageChange={vi.fn()} onEdit={vi.fn()} onDelete={vi.fn()} />, '/acl');
+    expect(screen.getByText('Unavailable')).toBeInTheDocument();
+
+    rerender(<AclUsersTable rows={[{ ...rows[0], password: undefined }]} total={1} page={1} pageSize={10} loading={false} showPasswords disabled={false} onPageChange={vi.fn()} onEdit={vi.fn()} onDelete={vi.fn()} />);
+    expect(screen.getByText('Unavailable')).toBeInTheDocument();
+    expect(screen.queryByText('************')).not.toBeInTheDocument();
+  });
+
+  it('gives row actions target-specific accessible names', () => {
+    renderAtRoute(<AclUsersTable rows={[rows[0]]} total={1} page={1} pageSize={10} loading={false} showPasswords={false} disabled={false} onPageChange={vi.fn()} onEdit={vi.fn()} onDelete={vi.fn()} />, '/acl');
+    expect(screen.getByRole('button', { name: 'Modify ACL user user-1' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete ACL user user-1' })).toBeInTheDocument();
+  });
+
+  it('names the user in destructive confirmation and honors cancellation', async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn();
+    renderAtRoute(<AclUsersTable rows={[rows[0]]} total={1} page={1} pageSize={10} loading={false} showPasswords={false} disabled={false} onPageChange={vi.fn()} onEdit={vi.fn()} onDelete={onDelete} />, '/acl');
+
+    await user.click(screen.getByRole('button', { name: 'Delete ACL user user-1' }));
+    const confirmation = screen.getByRole('alertdialog');
+    expect(confirmation).toHaveTextContent('user-1');
+    await user.click(within(confirmation).getByRole('button', { name: 'Cancel' }));
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/AclUsersTable.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/AclUsersTable.tsx
@@ -1,0 +1,50 @@
+import { Edit3, Trash2 } from 'lucide-react';
+import { useMemo } from 'react';
+import AppDataTable, { type AppDataTableColumn } from '../../components/AppDataTable';
+import ConfirmDialog from '../../components/ConfirmDialog';
+import StatusBadge from '../../components/StatusBadge';
+import type { AclUserView } from '../../types/acl';
+
+export interface AclUsersTableProps {
+  rows: AclUserView[];
+  total: number;
+  page: number;
+  pageSize: number;
+  loading: boolean;
+  error?: string | null;
+  onRetry?: () => void;
+  showPasswords: boolean;
+  disabled: boolean;
+  onPageChange: (page: number) => void;
+  onEdit: (user: AclUserView) => void;
+  onDelete: (username: string) => void;
+}
+
+export default function AclUsersTable({ rows, total, page, pageSize, loading, error, onRetry, showPasswords, disabled, onPageChange, onEdit, onDelete }: AclUsersTableProps) {
+  const columns = useMemo<AppDataTableColumn<AclUserView>[]>(() => [
+    { id: 'username', header: 'Username', cell: (row) => <div className="acl-primary-cell"><code>{row.username}</code><span>access key</span></div> },
+    { id: 'password', header: 'Password', cell: (row) => <code>{row.password ? (showPasswords ? row.password : maskPassword()) : 'Unavailable'}</code> },
+    { id: 'type', header: 'User Type', cell: (row) => <StatusBadge status={normalizeUserType(row.userType)} tone={normalizeUserType(row.userType) === 'Super' ? 'warning' : 'neutral'} /> },
+    { id: 'status', header: 'User Status', cell: (row) => <StatusBadge status={normalizeUserStatus(row.userStatus)} tone={normalizeUserStatus(row.userStatus) === 'enable' ? 'success' : 'danger'} /> },
+    { id: 'broker', header: 'Broker', cell: (row) => <div className="acl-primary-cell"><span>{row.brokerName || '-'}</span><code>{row.brokerAddr || '-'}</code></div> },
+    {
+      id: 'actions', header: 'Operation', cell: (row) => <div className="acl-operation-row">
+        <button type="button" className="button button-secondary acl-action-button" aria-label={`Modify ACL user ${row.username}`} disabled={disabled} onClick={() => onEdit(row)}><Edit3 size={14} aria-hidden="true" /> Modify</button>
+        <ConfirmDialog title="Delete ACL user" description={`Delete ACL user ${row.username} from the selected broker target?`} confirmLabel="Delete" onConfirm={() => onDelete(row.username)}>
+          <button type="button" className="button button-danger acl-action-button" aria-label={`Delete ACL user ${row.username}`} disabled={disabled}><Trash2 size={14} aria-hidden="true" /> Delete</button>
+        </ConfirmDialog>
+      </div>
+    }
+  ], [disabled, onDelete, onEdit, showPasswords]);
+
+  return <AppDataTable ariaLabel="ACL users" rows={rows} columns={columns} getRowId={(row) => `${row.brokerAddr}:${row.username}`} page={page} pageSize={pageSize} total={total} onPageChange={onPageChange} loading={loading} error={error} onRetry={onRetry} retryLabel="Retry" emptyTitle="No ACL users" />;
+}
+
+function maskPassword() { return '************'; }
+function normalizeUserType(value?: string) {
+  const normalized = (value || 'Normal').toLowerCase();
+  if (normalized === 'super') return 'Super';
+  if (normalized === 'normal') return 'Normal';
+  return value || 'Normal';
+}
+function normalizeUserStatus(value?: string) { const normalized = (value || 'enable').toLowerCase(); return normalized.includes('disabled') || normalized === 'disable' ? 'disable' : 'enable'; }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/acl-model.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/acl-model.test.ts
@@ -1,0 +1,140 @@
+import type { AclPolicyView, AclUserView } from '../../types/acl';
+import type { BrokerInfo } from '../../types/broker';
+import {
+  buildAclPolicyRequest,
+  createAclScopeQuery,
+  deriveAclScopeOptions,
+  filterAclPolicyRows,
+  filterAclUsers,
+  flattenAclPolicies
+} from './acl-model';
+
+const brokers: BrokerInfo[] = [
+  { clusterName: 'Cluster-B', brokerName: 'broker-b', brokerId: 0, address: '10.0.0.2:10911', role: 'MASTER', version: '5.3.0', produceTps: 0, consumeTps: 0 },
+  { clusterName: 'Cluster-A', brokerName: 'broker-a', brokerId: 0, address: '10.0.0.1:10911', role: 'MASTER', version: '5.3.0', produceTps: 0, consumeTps: 0 },
+  { clusterName: 'Cluster-A', brokerName: 'broker-a', brokerId: 1, address: '10.0.0.3:10911', role: 'SLAVE', version: '5.3.0', produceTps: 0, consumeTps: 0 }
+];
+
+describe('ACL scope model', () => {
+  it('derives sorted unique cluster and broker options for the selected cluster', () => {
+    expect(deriveAclScopeOptions(brokers, 'Cluster-A')).toEqual({
+      clusters: [
+        { value: 'Cluster-A', label: 'Cluster-A' },
+        { value: 'Cluster-B', label: 'Cluster-B' }
+      ],
+      brokers: [{ value: 'broker-a', label: 'broker-a' }]
+    });
+  });
+
+  it('only creates list query parameters for a confirmed coherent broker scope', () => {
+    expect(createAclScopeQuery({ clusterName: 'Cluster-A', brokerName: 'broker-a' }, brokers)).toEqual({
+      clusterName: 'Cluster-A',
+      brokerName: 'broker-a'
+    });
+    expect(createAclScopeQuery({ clusterName: 'Cluster-A', brokerName: 'broker-b' }, brokers)).toBeNull();
+    expect(createAclScopeQuery(null, brokers)).toBeNull();
+  });
+});
+
+describe('ACL filters', () => {
+  const users: AclUserView[] = [
+    { brokerName: 'broker-a', brokerAddr: '10.0.0.1:10911', username: 'rocketmq-admin', userType: 'Super', userStatus: 'enable' },
+    { brokerName: 'broker-b', brokerAddr: '10.0.0.2:10911', username: 'reader', userType: 'Normal', userStatus: 'disable' }
+  ];
+  const policies: AclPolicyView[] = [
+    {
+      brokerName: 'broker-a',
+      brokerAddr: '10.0.0.1:10911',
+      subject: 'User:rocketmq-admin',
+      policyType: 'Custom',
+      entries: [{ resource: 'Topic:Orders', actions: ['Pub'], sourceIps: ['10.0.0.0/24'], decision: 'Allow' }]
+    },
+    {
+      brokerName: 'broker-b',
+      brokerAddr: '10.0.0.2:10911',
+      subject: 'User:reader',
+      policyType: 'Custom',
+      entries: [{ resource: 'Topic:Payments', actions: ['Sub'], sourceIps: ['192.168.1.1'], decision: 'Deny' }]
+    }
+  ];
+
+  it('filters users without mutating the API array', () => {
+    const snapshot = structuredClone(users);
+    expect(filterAclUsers(users, 'admin')).toEqual([users[0]]);
+    expect(users).toEqual(snapshot);
+  });
+
+  it('flattens and filters policy rows without mutating API records or row arrays', () => {
+    const snapshot = structuredClone(policies);
+    const rows = flattenAclPolicies(policies);
+    const rowSnapshot = structuredClone(rows);
+    expect(filterAclPolicyRows(rows, '192.168.1.1')).toEqual([rows[1]]);
+    expect(policies).toEqual(snapshot);
+    expect(rows).toEqual(rowSnapshot);
+    expect(rows[0].actions).not.toBe(policies[0].entries[0].actions);
+    expect(rows[0].sourceIps).not.toBe(policies[0].entries[0].sourceIps);
+  });
+});
+
+describe('ACL policy draft parsing', () => {
+  it('maps comma-separated resource and source IP values to the current policy request DTO', () => {
+    expect(buildAclPolicyRequest(
+      { clusterName: 'Cluster-A', brokerName: 'broker-a' },
+      {
+        subject: ' User:rocketmq-admin ',
+        policyType: 'Custom',
+        resources: ' Topic:Orders, Group:billing ',
+        actions: ['Pub', 'Sub'],
+        sourceIps: ' 10.0.0.1, 2001:db8::1 ',
+        decision: 'Allow'
+      }
+    )).toEqual({
+      ok: true,
+      value: {
+        clusterName: 'Cluster-A',
+        brokerName: 'broker-a',
+        subject: 'User:rocketmq-admin',
+        policies: [{
+          policyType: 'Custom',
+          entries: [{
+            resource: ['Topic:Orders', 'Group:billing'],
+            actions: ['Pub', 'Sub'],
+            sourceIps: ['10.0.0.1', '2001:db8::1'],
+            decision: 'Allow'
+          }]
+        }]
+      }
+    });
+  });
+
+  it('retains sibling entries when building an update for one flattened policy row', () => {
+    const [selectedRow] = flattenAclPolicies([{
+      brokerName: 'broker-a', brokerAddr: '10.0.0.1:10911', subject: 'User:payments', policyType: 'Custom',
+      entries: [
+        { resource: 'Topic:Orders', actions: ['Pub'], sourceIps: ['10.0.0.1'], decision: 'Allow' },
+        { resource: 'Group:billing', actions: ['Sub'], sourceIps: ['10.0.0.2'], decision: 'Deny' }
+      ]
+    }]);
+
+    expect(buildAclPolicyRequest(
+      { clusterName: 'Cluster-A', brokerName: 'broker-a' },
+      {
+        subject: 'User:payments', policyType: 'Custom', resources: 'Topic:Orders', actions: ['Pub', 'Sub'],
+        sourceIps: '10.0.0.1', decision: 'Allow'
+      },
+      selectedRow
+    )).toEqual({
+      ok: true,
+      value: {
+        clusterName: 'Cluster-A', brokerName: 'broker-a', subject: 'User:payments',
+        policies: [{
+          policyType: 'Custom',
+          entries: [
+            { resource: ['Topic:Orders'], actions: ['Pub', 'Sub'], sourceIps: ['10.0.0.1'], decision: 'Allow' },
+            { resource: ['Group:billing'], actions: ['Sub'], sourceIps: ['10.0.0.2'], decision: 'Deny' }
+          ]
+        }]
+      }
+    });
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/acl-model.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/acl-model.ts
@@ -1,0 +1,180 @@
+import type { AclPolicyEntryView, AclPolicyRequest, AclPolicyView, AclQueryParams, AclUserView } from '../../types/acl';
+import type { BrokerInfo } from '../../types/broker';
+import type { SelectMenuOption } from '../../components/SelectMenu';
+
+export interface AclScope {
+  clusterName: string;
+  brokerName: string;
+}
+
+export interface AclScopeOptions {
+  clusters: SelectMenuOption[];
+  brokers: SelectMenuOption[];
+}
+
+export interface AclPolicyDraft {
+  subject: string;
+  policyType: string;
+  resources: string;
+  actions: string[];
+  sourceIps: string;
+  decision: string;
+}
+
+export interface AclPolicyRow {
+  key: string;
+  entryIndex: number;
+  subjectEntries: AclPolicyEntryView[];
+  brokerName: string;
+  brokerAddr: string;
+  subject: string;
+  policyType: string;
+  resource: string;
+  actions: string[];
+  sourceIps: string[];
+  decision: string;
+}
+
+export type AclPolicyDraftResult =
+  | { ok: true; value: AclPolicyRequest }
+  | { ok: false; errors: Partial<Record<keyof AclPolicyDraft, string>> };
+
+export function deriveAclScopeOptions(brokers: BrokerInfo[], clusterName: string): AclScopeOptions {
+  const clusters = uniqueSorted(brokers.map((broker) => broker.clusterName))
+    .map((value) => ({ value, label: value }));
+  const scopedBrokers = brokers.filter((broker) => broker.clusterName === clusterName);
+  const brokersOptions = uniqueSorted(scopedBrokers.map((broker) => broker.brokerName))
+    .map((value) => ({ value, label: value }));
+
+  return { clusters, brokers: brokersOptions };
+}
+
+export function createAclScopeQuery(scope: AclScope | null, brokers: BrokerInfo[]): AclQueryParams | null {
+  if (!scope || !scope.clusterName || !scope.brokerName) return null;
+
+  const matchesBroker = brokers.some((broker) =>
+    broker.clusterName === scope.clusterName && broker.brokerName === scope.brokerName
+  );
+
+  return matchesBroker ? { clusterName: scope.clusterName, brokerName: scope.brokerName } : null;
+}
+
+export function filterAclUsers(users: AclUserView[], query: string): AclUserView[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return [...users];
+
+  return users.filter((user) => matchesQuery([
+    user.username,
+    user.brokerName,
+    user.brokerAddr,
+    user.userType,
+    user.userStatus
+  ], normalizedQuery));
+}
+
+export function filterAclPolicies(policies: AclPolicyView[], query: string): AclPolicyView[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return [...policies];
+
+  return policies.filter((policy) => matchesQuery([
+    policy.subject,
+    policy.policyType,
+    policy.brokerName,
+    policy.brokerAddr,
+    ...policy.entries.flatMap((entry) => [
+      entry.resource,
+      entry.decision,
+      ...entry.actions,
+      ...entry.sourceIps
+    ])
+  ], normalizedQuery));
+}
+
+export function flattenAclPolicies(policies: AclPolicyView[]): AclPolicyRow[] {
+  return policies.flatMap((policy, policyIndex) => policy.entries.map((entry, entryIndex) => ({
+    key: `${policy.brokerAddr}:${policy.subject ?? ''}:${policy.policyType ?? ''}:${entry.resource ?? '*'}:${policyIndex}:${entryIndex}`,
+    entryIndex,
+    subjectEntries: policy.entries.map((subjectEntry) => ({
+      resource: subjectEntry.resource,
+      actions: [...subjectEntry.actions],
+      sourceIps: [...subjectEntry.sourceIps],
+      decision: subjectEntry.decision
+    })),
+    brokerName: policy.brokerName,
+    brokerAddr: policy.brokerAddr,
+    subject: policy.subject ?? '-',
+    policyType: policy.policyType ?? 'Custom',
+    resource: entry.resource ?? '*',
+    actions: [...entry.actions],
+    sourceIps: [...entry.sourceIps],
+    decision: entry.decision ?? 'Allow'
+  })));
+}
+
+export function filterAclPolicyRows(rows: AclPolicyRow[], query: string): AclPolicyRow[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return [...rows];
+
+  return rows.filter((row) => matchesQuery([
+    row.subject,
+    row.policyType,
+    row.brokerName,
+    row.brokerAddr,
+    row.resource,
+    row.decision,
+    ...row.actions,
+    ...row.sourceIps
+  ], normalizedQuery));
+}
+
+export function buildAclPolicyRequest(scope: AclScope, draft: AclPolicyDraft, selectedPolicy?: AclPolicyRow | null): AclPolicyDraftResult {
+  const subject = draft.subject.trim();
+  const policyType = draft.policyType.trim();
+  const resource = parseCommaSeparatedValues(draft.resources);
+  const actions = draft.actions.map((action) => action.trim()).filter(Boolean);
+  const sourceIps = parseCommaSeparatedValues(draft.sourceIps);
+  const decision = draft.decision.trim();
+  const errors: Partial<Record<keyof AclPolicyDraft, string>> = {};
+
+  if (!subject) errors.subject = 'Subject is required.';
+  if (!policyType) errors.policyType = 'Policy type is required.';
+  if (resource.length === 0) errors.resources = 'At least one resource is required.';
+  if (actions.length === 0) errors.actions = 'At least one action is required.';
+  if (!decision) errors.decision = 'Decision is required.';
+
+  if (Object.keys(errors).length > 0) return { ok: false, errors };
+
+  const editedEntry = { resource, actions, sourceIps, decision };
+  const entries = selectedPolicy
+    ? selectedPolicy.subjectEntries.map((entry, entryIndex) => entryIndex === selectedPolicy.entryIndex
+      ? editedEntry
+      : {
+          resource: parseCommaSeparatedValues(entry.resource ?? '*'),
+          actions: [...entry.actions],
+          sourceIps: [...entry.sourceIps],
+          decision: entry.decision ?? 'Allow'
+        })
+    : [editedEntry];
+
+  return {
+    ok: true,
+    value: {
+      brokerName: scope.brokerName,
+      clusterName: scope.clusterName,
+      subject,
+      policies: [{ policyType, entries }]
+    }
+  };
+}
+
+export function parseCommaSeparatedValues(value: string): string[] {
+  return value.split(',').map((item) => item.trim()).filter(Boolean);
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return Array.from(new Set(values.filter(Boolean))).sort((left, right) => left.localeCompare(right));
+}
+
+function matchesQuery(values: Array<string | undefined>, normalizedQuery: string): boolean {
+  return values.some((value) => value?.toLowerCase().includes(normalizedQuery));
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/monitor/MonitorDialog.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/monitor/MonitorDialog.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import MonitorDialog from './MonitorDialog';
+
+describe('MonitorDialog', () => {
+  it('validates threshold values and preserves the draft when a save fails', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockRejectedValue(new Error('monitor service unavailable'));
+    render(<MonitorDialog open onOpenChange={vi.fn()} onSubmit={onSubmit} />);
+
+    await user.type(screen.getByRole('textbox', { name: 'Group' }), 'order-service');
+    const minCount = screen.getByRole('spinbutton', { name: 'Min Count' });
+    await user.clear(minCount);
+    await user.type(minCount, '-1');
+    await user.click(screen.getByRole('button', { name: 'Save rule' }));
+
+    expect(screen.getByRole('status')).toHaveTextContent('Min Count must be a non-negative integer.');
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    await user.clear(minCount);
+    await user.type(minCount, '4');
+    await user.click(screen.getByRole('button', { name: 'Save rule' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('monitor service unavailable');
+    expect(screen.getByRole('textbox', { name: 'Group' })).toHaveValue('order-service');
+    expect(screen.getByRole('spinbutton', { name: 'Min Count' })).toHaveValue(4);
+    expect(screen.getByRole('button', { name: 'Retry save' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Retry save' }));
+    await waitFor(() => expect(onSubmit).toHaveBeenLastCalledWith({
+      consumerGroup: 'order-service',
+      minCount: 4,
+      maxDiffTotal: 1000
+    }));
+  });
+
+  it('ignores a stale save completion after the selected rule changes', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    let resolveSave: () => void = () => undefined;
+    const onSubmit = vi.fn().mockReturnValue(new Promise<void>((resolve) => { resolveSave = resolve; }));
+    const { rerender } = render(
+      <MonitorDialog
+        open
+        rule={{ consumerGroup: 'order-service', minCount: 4, maxDiffTotal: 1200 }}
+        onOpenChange={onOpenChange}
+        onSubmit={onSubmit}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Save rule' }));
+    rerender(
+      <MonitorDialog
+        open
+        rule={{ consumerGroup: 'payment-worker', minCount: 2, maxDiffTotal: 800 }}
+        onOpenChange={onOpenChange}
+        onSubmit={onSubmit}
+      />
+    );
+    resolveSave();
+
+    await waitFor(() => expect(screen.getByRole('textbox', { name: 'Group' })).toHaveValue('payment-worker'));
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/monitor/MonitorDialog.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/monitor/MonitorDialog.tsx
@@ -1,0 +1,142 @@
+import { Save } from 'lucide-react';
+import { useEffect, useId, useRef, useState } from 'react';
+import { Button } from '../../components/ui/Button';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../../components/ui/Dialog';
+import { Input } from '../../components/ui/Input';
+import { Label } from '../../components/ui/Label';
+import type { ConsumerMonitorUpsertRequest, ConsumerMonitorView } from '../../types/monitor';
+import { parseConsumerMonitorDraft, type ConsumerMonitorDraft } from './monitor-model';
+
+interface MonitorDialogProps {
+  open: boolean;
+  rule?: ConsumerMonitorView | null;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (request: ConsumerMonitorUpsertRequest) => Promise<void>;
+}
+
+const emptyDraft: ConsumerMonitorDraft = {
+  consumerGroup: '',
+  minCount: '1',
+  maxDiffTotal: '1000'
+};
+
+export default function MonitorDialog({ open, rule, onOpenChange, onSubmit }: MonitorDialogProps) {
+  const [draft, setDraft] = useState<ConsumerMonitorDraft>(emptyDraft);
+  const [validationErrors, setValidationErrors] = useState<Partial<Record<keyof ConsumerMonitorDraft, string>>>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const formId = useId();
+  const requestGeneration = useRef(0);
+  const ruleKey = rule?.consumerGroup;
+
+  useEffect(() => {
+    requestGeneration.current += 1;
+    if (!open) return;
+    setDraft(rule ? {
+      consumerGroup: rule.consumerGroup,
+      minCount: String(rule.minCount),
+      maxDiffTotal: String(rule.maxDiffTotal)
+    } : emptyDraft);
+    setValidationErrors({});
+    setSubmitError(null);
+    setSubmitting(false);
+  }, [open, ruleKey]);
+
+  const submit = async () => {
+    const parsed = parseConsumerMonitorDraft(draft);
+    if (!parsed.ok) {
+      setValidationErrors(parsed.errors);
+      return;
+    }
+
+    const generation = requestGeneration.current;
+    setValidationErrors({});
+    setSubmitError(null);
+    setSubmitting(true);
+    try {
+      await onSubmit(parsed.value);
+      if (generation === requestGeneration.current) onOpenChange(false);
+    } catch (error) {
+      if (generation === requestGeneration.current) {
+        setSubmitError(error instanceof Error ? error.message : 'Unable to save the monitor rule.');
+      }
+    } finally {
+      if (generation === requestGeneration.current) setSubmitting(false);
+    }
+  };
+
+  const updateDraft = (field: keyof ConsumerMonitorDraft, value: string) => {
+    setDraft((current) => ({ ...current, [field]: value }));
+    setValidationErrors((current) => ({ ...current, [field]: undefined }));
+    setSubmitError(null);
+  };
+
+  const editing = Boolean(rule);
+  const title = editing ? 'Edit rule' : 'Create rule';
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="entity-mutation-dialog">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>
+            Persist a consumer-group threshold configuration. This workspace does not represent live alerts.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="form-grid monitor-form-grid">
+          <div className="field field-wide">
+            <Label htmlFor={`${formId}-group`}>Group</Label>
+            <Input
+              id={`${formId}-group`}
+              value={draft.consumerGroup}
+              disabled={editing}
+              onChange={(event) => updateDraft('consumerGroup', event.target.value)}
+            />
+            {validationErrors.consumerGroup ? <div className="inline-validation" role="status">{validationErrors.consumerGroup}</div> : null}
+          </div>
+          <div className="field">
+            <Label htmlFor={`${formId}-min-count`}>Min Count</Label>
+            <Input
+              id={`${formId}-min-count`}
+              type="number"
+              min="0"
+              step="1"
+              value={draft.minCount}
+              onChange={(event) => updateDraft('minCount', event.target.value)}
+            />
+            {validationErrors.minCount ? <div className="inline-validation" role="status">{validationErrors.minCount}</div> : null}
+          </div>
+          <div className="field">
+            <Label htmlFor={`${formId}-max-diff-total`}>Max Diff Total</Label>
+            <Input
+              id={`${formId}-max-diff-total`}
+              type="number"
+              min="0"
+              step="1"
+              value={draft.maxDiffTotal}
+              onChange={(event) => updateDraft('maxDiffTotal', event.target.value)}
+            />
+            {validationErrors.maxDiffTotal ? <div className="inline-validation" role="status">{validationErrors.maxDiffTotal}</div> : null}
+          </div>
+        </div>
+
+        {submitError ? (
+          <div className="inline-validation" role="alert">
+            <span>{submitError}</span>
+            <Button type="button" variant="secondary" size="sm" onClick={() => void submit()} disabled={submitting}>
+              Retry save
+            </Button>
+          </div>
+        ) : null}
+
+        <DialogFooter>
+          <Button type="button" variant="secondary" onClick={() => onOpenChange(false)} disabled={submitting}>Cancel</Button>
+          <Button type="button" onClick={() => void submit()} disabled={submitting}>
+            <Save size={15} aria-hidden="true" /> {submitting ? 'Saving' : 'Save rule'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/monitor/monitor-model.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/monitor/monitor-model.test.ts
@@ -1,0 +1,31 @@
+import { parseConsumerMonitorDraft } from './monitor-model';
+
+describe('parseConsumerMonitorDraft', () => {
+  it.each([
+    ['-1', '1000'],
+    ['1.5', '1000'],
+    ['1', '-1000'],
+    ['1', '1000.5']
+  ])('rejects negative and non-integer threshold values (%s, %s)', (minCount, maxDiffTotal) => {
+    expect(parseConsumerMonitorDraft({
+      consumerGroup: 'order-service',
+      minCount,
+      maxDiffTotal
+    }).ok).toBe(false);
+  });
+
+  it('maps a valid draft to the persisted monitor request DTO', () => {
+    expect(parseConsumerMonitorDraft({
+      consumerGroup: ' order-service ',
+      minCount: '7',
+      maxDiffTotal: '2400'
+    })).toEqual({
+      ok: true,
+      value: {
+        consumerGroup: 'order-service',
+        minCount: 7,
+        maxDiffTotal: 2400
+      }
+    });
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/monitor/monitor-model.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/monitor/monitor-model.ts
@@ -1,0 +1,56 @@
+import type { ConsumerMonitorUpsertRequest, ConsumerMonitorView } from '../../types/monitor';
+
+export interface ConsumerMonitorDraft {
+  consumerGroup: string;
+  minCount: string;
+  maxDiffTotal: string;
+}
+
+export type ConsumerMonitorDraftResult =
+  | { ok: true; value: ConsumerMonitorUpsertRequest }
+  | { ok: false; errors: Partial<Record<keyof ConsumerMonitorDraft, string>> };
+
+export interface ConsumerMonitorMetrics {
+  ruleCount: number;
+  minCountRange: string;
+  maxDiffTotalRange: string;
+}
+
+export function parseConsumerMonitorDraft(draft: ConsumerMonitorDraft): ConsumerMonitorDraftResult {
+  const errors: Partial<Record<keyof ConsumerMonitorDraft, string>> = {};
+  const consumerGroup = draft.consumerGroup.trim();
+  const minCount = parseNonNegativeInteger(draft.minCount);
+  const maxDiffTotal = parseNonNegativeInteger(draft.maxDiffTotal);
+
+  if (!consumerGroup) errors.consumerGroup = 'Group is required.';
+  if (minCount === null) errors.minCount = 'Min Count must be a non-negative integer.';
+  if (maxDiffTotal === null) errors.maxDiffTotal = 'Max Diff Total must be a non-negative integer.';
+
+  if (Object.keys(errors).length > 0) return { ok: false, errors };
+
+  return {
+    ok: true,
+    value: { consumerGroup, minCount: minCount!, maxDiffTotal: maxDiffTotal! }
+  };
+}
+
+export function getConsumerMonitorMetrics(rows: ConsumerMonitorView[]): ConsumerMonitorMetrics {
+  return {
+    ruleCount: rows.length,
+    minCountRange: getRange(rows.map((row) => row.minCount)),
+    maxDiffTotalRange: getRange(rows.map((row) => row.maxDiffTotal))
+  };
+}
+
+function parseNonNegativeInteger(value: string) {
+  if (!/^\d+$/.test(value.trim())) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function getRange(values: number[]) {
+  if (values.length === 0) return '—';
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  return min === max ? String(min) : `${min}–${max}`;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/globals.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/globals.css
@@ -1164,10 +1164,8 @@ td code,
   padding: 14px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  background:
-    linear-gradient(135deg, color-mix(in srgb, var(--primary) 7%, transparent), transparent 54%),
-    var(--surface);
-  box-shadow: var(--shadow);
+  background: var(--surface);
+  box-shadow: none;
 }
 
 .acl-selector-grid {
@@ -1282,7 +1280,10 @@ td code,
 .acl-stat-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 14px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
 }
 
 .acl-stat-card {
@@ -1292,12 +1293,12 @@ td code,
   justify-content: space-between;
   gap: 12px;
   padding: 15px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background:
-    linear-gradient(135deg, color-mix(in srgb, var(--primary) 7%, transparent), transparent 56%),
-    var(--surface);
-  box-shadow: var(--shadow);
+  border-right: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.acl-stat-card:last-child {
+  border-right: 0;
 }
 
 .acl-stat-card > div:first-child {
@@ -1337,14 +1338,13 @@ td code,
 }
 
 .acl-tabs {
-  width: fit-content;
-  display: inline-grid;
-  grid-template-columns: repeat(2, minmax(150px, 1fr));
-  gap: 6px;
-  padding: 4px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface);
+  width: 100%;
+  display: flex;
+  gap: 24px;
+  padding: 0;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
 }
 
 .acl-tabs button {
@@ -1353,18 +1353,19 @@ td code,
   align-items: center;
   justify-content: center;
   gap: 8px;
-  border: 1px solid transparent;
-  border-radius: calc(var(--radius) - 2px);
+  border: 0;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
   background: transparent;
   color: var(--muted);
   font-weight: 700;
 }
 
-.acl-tabs button.active {
+.acl-tabs button[data-state='active'] {
   color: var(--text);
-  border-color: color-mix(in srgb, var(--primary) 38%, var(--border));
-  background: color-mix(in srgb, var(--primary) 14%, var(--surface-2));
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--primary) 16%, transparent);
+  border-bottom-color: var(--primary);
+  background: transparent;
+  box-shadow: none;
 }
 
 .acl-table-panel {
@@ -1372,7 +1373,7 @@ td code,
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--surface);
-  box-shadow: var(--shadow);
+  box-shadow: none;
 }
 
 .acl-table-header {
@@ -1382,9 +1383,7 @@ td code,
   gap: 16px;
   padding: 15px;
   border-bottom: 1px solid var(--border);
-  background:
-    linear-gradient(135deg, color-mix(in srgb, var(--primary) 7%, transparent), transparent 48%),
-    color-mix(in srgb, var(--surface-2) 78%, var(--surface));
+  background: color-mix(in srgb, var(--surface-2) 78%, var(--surface));
 }
 
 .acl-table-header h2 {
@@ -1536,6 +1535,26 @@ td code,
   min-height: 30px;
   padding: 0 9px;
   font-size: 12px;
+}
+
+.acl-action-error,
+.acl-dialog-error {
+  border: 1px solid color-mix(in srgb, var(--danger) 45%, var(--border));
+  border-radius: var(--radius-sm);
+  padding: 9px 11px;
+  color: var(--danger);
+  background: color-mix(in srgb, var(--danger) 8%, var(--surface));
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.acl-action-error {
+  margin: 10px 14px 0;
+}
+
+.acl-dialog-error {
+  flex: 1 1 240px;
+  margin-right: auto;
 }
 
 .acl-table-footer {
@@ -3765,6 +3784,15 @@ a:hover {
     grid-template-columns: 1fr;
   }
 
+  .acl-stat-card {
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .acl-stat-card:last-child {
+    border-bottom: 0;
+  }
+
   .page-header,
   .table-footer,
   .acl-table-header,
@@ -3775,7 +3803,6 @@ a:hover {
 
   .cluster-filter,
   .cluster-filter select,
-  .acl-tabs,
   .acl-search-box,
   .acl-table-actions {
     width: 100%;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9443

### Brief Description

- Redesign the Monitor page as a truthful persisted consumer-threshold workspace with validated create, edit, refresh, and named delete flows.
- Rebuild ACL Management around an explicitly confirmed cluster and broker scope, separate Users and Policies workspaces, backend-realistic password handling, and fail-closed policy deletion.
- Add focused model, dialog, table, race-condition, Strict Mode, accessibility, and page interaction regression coverage while preserving the existing API DTOs.

### How Did You Test This Change?

- `npm ci` - completed successfully.
- `npm test -- --run --maxWorkers=2` - passed 34 test files and 185 tests.
- `npm run build` - passed TypeScript compilation and the Vite production build.
- `git diff --check origin/main..HEAD` - passed with no whitespace errors.
- Exercised Monitor and ACL scope, forms, masking, tabs, and destructive confirmations in the in-app browser; compared both pages with the selected references at 1487 x 1058.
