### PR TITLE
[ISSUE #9454]✨Preserve query message index cursors end to end

### DIFF
--- a/rocketmq-broker/src/failover/escape_bridge.rs
+++ b/rocketmq-broker/src/failover/escape_bridge.rs
@@ -233,15 +233,9 @@ impl<MS: BrokerReadStore> EscapeBridge<MS> {
 
     pub(crate) async fn query_message_from_store(
         &self,
-        topic: &CheetahString,
-        key: &CheetahString,
-        max_num: i32,
-        begin_timestamp: i64,
-        end_timestamp: i64,
+        request: &rocketmq_store::QueryMessageRequest,
     ) -> Result<Option<QueryMessageResult>, MessageStoreUnavailable> {
-        self.message_store
-            .query_message(topic, key, max_num, begin_timestamp, end_timestamp)
-            .await
+        self.message_store.query_message(request).await
     }
 
     pub(crate) fn select_message_from_store(

--- a/rocketmq-broker/src/failover/escape_bridge_capability.rs
+++ b/rocketmq-broker/src/failover/escape_bridge_capability.rs
@@ -40,6 +40,7 @@ use rocketmq_store::HAService;
 use rocketmq_store::MessageStoreConfig;
 use rocketmq_store::MessageStoreHealthCapability;
 use rocketmq_store::PutMessageResult;
+use rocketmq_store::QueryMessageRequest;
 use rocketmq_store::QueryMessageResult;
 use rocketmq_store::SelectMappedBufferResult;
 use rocketmq_store::StoreAppendReceipt;
@@ -423,16 +424,10 @@ impl<MS: BrokerReadStore> EscapeBridgeStoreCapability<MS> {
 
     pub(crate) async fn query_message(
         &self,
-        topic: &CheetahString,
-        key: &CheetahString,
-        max_num: i32,
-        begin_timestamp: i64,
-        end_timestamp: i64,
+        request: &QueryMessageRequest,
     ) -> Result<Option<QueryMessageResult>, MessageStoreUnavailable> {
         let store = self.store()?;
-        Ok(store
-            .query_message(topic, key, max_num, begin_timestamp, end_timestamp)
-            .await)
+        Ok(store.query_message_with_options(request).await)
     }
 
     pub(crate) fn select_message(

--- a/rocketmq-broker/src/processor/query_message_processor.rs
+++ b/rocketmq-broker/src/processor/query_message_processor.rs
@@ -28,6 +28,7 @@ use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
 use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 use rocketmq_store::BrokerReadStore;
+use rocketmq_store::QueryMessageRequest;
 use rocketmq_store::QueryMessageResult;
 use rocketmq_store::SelectMappedBufferResult;
 use rocketmq_store_api::StoreError;
@@ -67,27 +68,16 @@ fn query_store_unavailable() -> StoreError {
 pub trait QueryMessageStore: Send + Sync {
     fn query_message(
         &self,
-        topic: &CheetahString,
-        key: &CheetahString,
-        max_num: i32,
-        begin_timestamp: i64,
-        end_timestamp: i64,
+        request: &QueryMessageRequest,
     ) -> impl Future<Output = Result<Option<QueryMessageResult>, StoreError>> + Send;
 
     fn select_message_by_offset(&self, offset: i64) -> Result<Option<SelectMappedBufferResult>, StoreError>;
 }
 
 impl<MS: BrokerReadStore> QueryMessageStore for QueryMessageStoreCapability<MS> {
-    async fn query_message(
-        &self,
-        topic: &CheetahString,
-        key: &CheetahString,
-        max_num: i32,
-        begin_timestamp: i64,
-        end_timestamp: i64,
-    ) -> Result<Option<QueryMessageResult>, StoreError> {
+    async fn query_message(&self, request: &QueryMessageRequest) -> Result<Option<QueryMessageResult>, StoreError> {
         self.provider()?
-            .query_message_from_store(topic, key, max_num, begin_timestamp, end_timestamp)
+            .query_message_from_store(request)
             .await
             .map_err(|MessageStoreUnavailable| query_store_unavailable())
     }
@@ -120,7 +110,7 @@ fn query_index_type(request_header: &QueryMessageRequestHeader, is_unique_key: b
         .filter(|idx_type| {
             matches!(
                 *idx_type,
-                MessageConst::INDEX_UNIQUE_TYPE | MessageConst::INDEX_TAG_TYPE
+                MessageConst::INDEX_KEY_TYPE | MessageConst::INDEX_UNIQUE_TYPE | MessageConst::INDEX_TAG_TYPE
             )
         })
         .or_else(|| is_unique_key.then_some(MessageConst::INDEX_UNIQUE_TYPE))
@@ -250,6 +240,18 @@ where
         let is_unique_key = ext_fields
             .get(UNIQUE_MSG_QUERY_FLAG)
             .is_some_and(|value| value == "true");
+        if request_header.index_type.as_deref().is_some_and(|index_type| {
+            !matches!(
+                index_type,
+                MessageConst::INDEX_KEY_TYPE | MessageConst::INDEX_UNIQUE_TYPE | MessageConst::INDEX_TAG_TYPE
+            )
+        }) {
+            return Ok(Some(
+                response
+                    .set_code(ResponseCode::SystemError)
+                    .set_remark("indexType must be K, U, or T"),
+            ));
+        }
         let query_index_type = query_index_type(&request_header, is_unique_key).map(CheetahString::from_slice);
         if is_unique_key
             || query_index_type
@@ -258,20 +260,16 @@ where
         {
             request_header.max_num = self.default_query_max_num;
         }
-        let typed_query_key = query_index_type
-            .as_deref()
-            .map(|idx_type| CheetahString::from_string(format!("{}#{}", idx_type, request_header.key.as_str())));
-        let query_key = typed_query_key.as_ref().unwrap_or(&request_header.key);
-        let query_message_result = self
-            .query_store
-            .query_message(
-                request_header.topic.as_ref(),
-                query_key,
-                request_header.max_num,
-                request_header.begin_timestamp,
-                request_header.end_timestamp,
-            )
-            .await;
+        let store_request = QueryMessageRequest {
+            topic: request_header.topic.clone(),
+            key: request_header.key.clone(),
+            index_type: query_index_type,
+            max_num: request_header.max_num,
+            begin: request_header.begin_timestamp,
+            end: request_header.end_timestamp,
+            last_key: request_header.last_key.clone(),
+        };
+        let query_message_result = self.query_store.query_message(&store_request).await;
         let query_message_result = match query_message_result {
             Ok(Some(query_message_result)) => query_message_result,
             Ok(None) => {
@@ -384,10 +382,10 @@ mod tests {
     }
 
     #[test]
-    fn query_index_type_ignores_normal_key_index_type_for_store_key_compatibility() {
+    fn query_index_type_preserves_normal_key_index_type_for_rocksdb_cursor_queries() {
         assert_eq!(
             query_index_type(&header(Some(MessageConst::INDEX_KEY_TYPE)), false),
-            None
+            Some(MessageConst::INDEX_KEY_TYPE)
         );
     }
 
@@ -428,7 +426,8 @@ mod tests {
         let topic = CheetahString::from_static_str("TopicA");
         let key = CheetahString::from_static_str("KeyA");
 
-        let Err(query_error) = capability.query_message(&topic, &key, 32, 0, i64::MAX).await else {
+        let request = QueryMessageRequest::legacy(&topic, &key, 32, 0, i64::MAX);
+        let Err(query_error) = capability.query_message(&request).await else {
             panic!("closed provider must reject query");
         };
         assert_eq!(StoreErrorKind::NotStarted, query_error.kind());

--- a/rocketmq-broker/tests/test_store_injection.rs
+++ b/rocketmq-broker/tests/test_store_injection.rs
@@ -18,7 +18,6 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
-use cheetah_string::CheetahString;
 use rocketmq_broker::QueryMessageProcessor;
 use rocketmq_broker::QueryMessageStore;
 use rocketmq_store::QueryMessageResult;
@@ -33,11 +32,7 @@ struct TestStore {
 impl QueryMessageStore for TestStore {
     fn query_message(
         &self,
-        _topic: &CheetahString,
-        _key: &CheetahString,
-        _max_num: i32,
-        _begin_timestamp: i64,
-        _end_timestamp: i64,
+        _request: &rocketmq_store::QueryMessageRequest,
     ) -> impl Future<Output = Result<Option<QueryMessageResult>, StoreError>> + Send {
         self.query_count.fetch_add(1, Ordering::SeqCst);
         ready(Ok(Some(QueryMessageResult::default())))
@@ -53,10 +48,9 @@ async fn query_processor_accepts_a_test_store_without_a_backend_facade() {
     let store = TestStore::default();
     let _processor = QueryMessageProcessor::new(32, store.clone());
 
-    let topic = CheetahString::from_static_str("TestTopic");
-    let key = CheetahString::from_static_str("TestKey");
+    let request = rocketmq_store::QueryMessageRequest::legacy(&"TestTopic".into(), &"TestKey".into(), 32, 0, i64::MAX);
     let result = store
-        .query_message(&topic, &key, 32, 0, i64::MAX)
+        .query_message(&request)
         .await
         .expect("test store query should succeed");
 

--- a/rocketmq-client/src/admin/default_mq_admin_ext_impl/topic.rs
+++ b/rocketmq-client/src/admin/default_mq_admin_ext_impl/topic.rs
@@ -45,6 +45,28 @@ pub(super) fn query_consume_queue_index_to_java_long(index: u64) -> rocketmq_err
     offset_to_java_long("queryConsumeQueue", index)
 }
 
+#[allow(clippy::too_many_arguments, reason = "mirrors the Java query-message wire header")]
+pub(super) fn query_message_request_header(
+    topic: &CheetahString,
+    key: &CheetahString,
+    max_num: i32,
+    begin_timestamp: i64,
+    end_timestamp: i64,
+    key_type: &CheetahString,
+    last_key: Option<&CheetahString>,
+) -> rocketmq_protocol::protocol::header::query_message_request_header::QueryMessageRequestHeader {
+    rocketmq_protocol::protocol::header::query_message_request_header::QueryMessageRequestHeader {
+        topic: topic.clone(),
+        key: key.clone(),
+        max_num,
+        begin_timestamp,
+        end_timestamp,
+        index_type: Some(key_type.clone()),
+        last_key: last_key.cloned(),
+        topic_request_header: None,
+    }
+}
+
 pub(super) fn search_offset_timestamp_to_java_long(timestamp: u64) -> rocketmq_error::RocketMQResult<i64> {
     timestamp_to_java_long("searchOffset", timestamp)
 }
@@ -228,11 +250,21 @@ impl DefaultMQAdminExtImpl {
         max_num: i32,
         begin_timestamp: i64,
         end_timestamp: i64,
-        _key_type: CheetahString,
-        _last_key: Option<CheetahString>,
+        key_type: CheetahString,
+        last_key: Option<CheetahString>,
     ) -> rocketmq_error::RocketMQResult<crate::base::query_result::QueryResult> {
-        self.query_message_by_key_internal(cluster_name, topic, key, max_num, begin_timestamp, end_timestamp, false)
-            .await
+        self.query_message_by_key_internal(
+            cluster_name,
+            topic,
+            key,
+            max_num,
+            begin_timestamp,
+            end_timestamp,
+            key_type,
+            last_key,
+            false,
+        )
+        .await
     }
 
     pub async fn query_message_by_unique_key(
@@ -251,6 +283,8 @@ impl DefaultMQAdminExtImpl {
             max_num,
             begin_timestamp,
             end_timestamp,
+            CheetahString::from_static_str(MessageConst::INDEX_UNIQUE_TYPE),
+            None,
             true,
         )
         .await
@@ -264,6 +298,8 @@ impl DefaultMQAdminExtImpl {
         max_num: i32,
         begin_timestamp: i64,
         end_timestamp: i64,
+        key_type: CheetahString,
+        last_key: Option<CheetahString>,
         unique_key_flag: bool,
     ) -> rocketmq_error::RocketMQResult<crate::base::query_result::QueryResult> {
         let route_topic = cluster_name.unwrap_or_else(|| topic.clone());
@@ -284,21 +320,15 @@ impl DefaultMQAdminExtImpl {
                 None => continue,
             };
 
-            let request_header =
-                rocketmq_protocol::protocol::header::query_message_request_header::QueryMessageRequestHeader {
-                    topic: topic.clone(),
-                    key: key.clone(),
-                    max_num,
-                    begin_timestamp,
-                    end_timestamp,
-                    index_type: Some(CheetahString::from_static_str(if unique_key_flag {
-                        MessageConst::INDEX_UNIQUE_TYPE
-                    } else {
-                        MessageConst::INDEX_KEY_TYPE
-                    })),
-                    last_key: None,
-                    topic_request_header: None,
-                };
+            let request_header = query_message_request_header(
+                &topic,
+                &key,
+                max_num,
+                begin_timestamp,
+                end_timestamp,
+                &key_type,
+                last_key.as_ref(),
+            );
 
             match MQClientAPIImpl::query_message(&api_impl, &broker_addr, request_header, unique_key_flag, timeout)
                 .await

--- a/rocketmq-client/tests/admin/default_mq_admin_ext_impl/unit.rs
+++ b/rocketmq-client/tests/admin/default_mq_admin_ext_impl/unit.rs
@@ -43,6 +43,23 @@ use rocketmq_model::common::message::message_enum::MessageRequestMode;
 use rocketmq_model::common::message::message_ext::MessageExt;
 use rocketmq_model::common::message::message_queue::MessageQueue;
 use rocketmq_model::common::message::MessageConst;
+
+#[test]
+fn query_message_header_preserves_index_type_and_last_key() {
+    let cursor = CheetahString::from_static_str("1700000000000@TopicA@K@KeyA@UniqA@1024");
+    let header = query_message_request_header(
+        &CheetahString::from_static_str("TopicA"),
+        &CheetahString::from_static_str("KeyA"),
+        32,
+        1,
+        2,
+        &CheetahString::from_static_str(MessageConst::INDEX_KEY_TYPE),
+        Some(&cursor),
+    );
+
+    assert_eq!(header.index_type.as_deref(), Some(MessageConst::INDEX_KEY_TYPE));
+    assert_eq!(header.last_key.as_deref(), Some(cursor.as_str()));
+}
 use rocketmq_model::common::mix_all;
 use rocketmq_model::common::mix_all::DLQ_GROUP_TOPIC_PREFIX;
 use rocketmq_model::common::mix_all::RETRY_GROUP_TOPIC_PREFIX;

--- a/rocketmq-store-rocksdb/src/key.rs
+++ b/rocketmq-store-rocksdb/src/key.rs
@@ -249,6 +249,49 @@ impl IndexRocksDbKey {
         Ok(prefix)
     }
 
+    /// Converts Java's textual six-field index cursor into the persisted RocksDB key.
+    pub fn from_java_cursor(cursor: &str) -> Result<Vec<u8>, RocketMQError> {
+        let fields: Vec<&str> = cursor.split(INDEX_KEY_SPLIT).collect();
+        if fields.len() != 6 {
+            return Err(codec_error(format!(
+                "index cursor must contain six @-separated fields, got {}",
+                fields.len()
+            )));
+        }
+        let store_time_hour = fields[0]
+            .parse::<i64>()
+            .map_err(|error| codec_error(format!("invalid index cursor hour: {error}")))?;
+        if store_time_hour <= 0 || store_time_hour % MILLIS_FOR_HOUR != 0 {
+            return Err(codec_error("index cursor hour must be a positive whole-hour timestamp"));
+        }
+        let offset_py = fields[5]
+            .parse::<i64>()
+            .map_err(|error| codec_error(format!("invalid index cursor offset: {error}")))?;
+        if offset_py < 0 {
+            return Err(codec_error("index cursor offset must be non-negative"));
+        }
+
+        let middle = format!("@{}@{}@{}@{}@", fields[1], fields[2], fields[3], fields[4]);
+        let mut encoded = Vec::with_capacity(16 + middle.len());
+        encoded.extend_from_slice(&store_time_hour.to_be_bytes());
+        encoded.extend_from_slice(middle.as_bytes());
+        encoded.extend_from_slice(&offset_py.to_be_bytes());
+        Ok(encoded)
+    }
+
+    pub fn java_cursor_hour(cursor: &str) -> Result<i64, RocketMQError> {
+        let hour = cursor
+            .split(INDEX_KEY_SPLIT)
+            .next()
+            .ok_or_else(|| codec_error("index cursor is empty"))?
+            .parse::<i64>()
+            .map_err(|error| codec_error(format!("invalid index cursor hour: {error}")))?;
+        if hour <= 0 || hour % MILLIS_FOR_HOUR != 0 {
+            return Err(codec_error("index cursor hour must be a positive whole-hour timestamp"));
+        }
+        Ok(hour)
+    }
+
     fn new(
         topic: impl Into<String>,
         index_type: impl Into<String>,

--- a/rocketmq-store-rocksdb/src/message.rs
+++ b/rocketmq-store-rocksdb/src/message.rs
@@ -141,21 +141,37 @@ impl MessageRocksDbStorage {
         begin_time: i64,
         end_time: i64,
         max_num: usize,
+        last_key: Option<&str>,
     ) -> Result<Vec<i64>, RocketMQError> {
         if max_num == 0 {
             return Ok(Vec::new());
         }
         let hours = index_hours(begin_time, end_time)?;
         let mut offsets = Vec::with_capacity(max_num);
-        let mut seen_offsets = HashSet::with_capacity(max_num);
+        let last_index_hour = last_key.map(IndexRocksDbKey::java_cursor_hour).transpose()?;
         for hour in hours {
+            if last_index_hour.is_some_and(|last_hour| hour < last_hour) {
+                continue;
+            }
             let prefix = IndexRocksDbKey::query_prefix(topic, index_type, key, hour)?;
-            let items = self.store.prefix_scan(&RocksDbScanOptions {
+            let options = RocksDbScanOptions {
                 cf: RocksDbColumnFamily::Default.name().to_string(),
                 prefix,
                 limit: 0,
-            })?;
+            };
+            let cursor = if last_index_hour == Some(hour) {
+                last_key.map(IndexRocksDbKey::from_java_cursor).transpose()?
+            } else {
+                None
+            };
+            let items = match cursor.as_deref() {
+                Some(cursor) => self.store.prefix_scan_from(&options, cursor)?,
+                None => self.store.prefix_scan(&options)?,
+            };
             for item in items {
+                if cursor.as_deref().is_some_and(|cursor| item.key.as_ref() == cursor) {
+                    continue;
+                }
                 let value = IndexRocksDbValue::decode(item.value.as_ref())?;
                 if value.store_time < begin_time || value.store_time > end_time {
                     continue;
@@ -164,9 +180,6 @@ impl MessageRocksDbStorage {
                     return Err(codec_error("index key is too short to contain physical offset"));
                 }
                 let offset = decode_i64(&item.key[item.key.len() - 8..])?;
-                if !seen_offsets.insert(offset) {
-                    continue;
-                }
                 offsets.push(offset);
                 if offsets.len() >= max_num {
                     return Ok(offsets);

--- a/rocketmq-store-rocksdb/src/message_store.rs
+++ b/rocketmq-store-rocksdb/src/message_store.rs
@@ -442,16 +442,24 @@ impl RocksDbDerivedStore {
         &self,
         topic: &str,
         key: &str,
+        index_type: Option<&str>,
         max_num: usize,
         begin: i64,
         end: i64,
+        last_key: Option<&str>,
         max_query_days: usize,
     ) -> Result<(Vec<i64>, i64, i64), RocksDbMessageStoreError> {
         let (begin, end) = normalize_index_query_time_range(begin, end, max_query_days);
-        let mut offsets =
-            self.message_rocksdb_storage
-                .query_offsets_for_index(topic, INDEX_KEY_TYPE, key, begin, end, max_num)?;
-        if offsets.is_empty() {
+        let mut offsets = self.message_rocksdb_storage.query_offsets_for_index(
+            topic,
+            index_type.unwrap_or(INDEX_KEY_TYPE),
+            key,
+            begin,
+            end,
+            max_num,
+            last_key,
+        )?;
+        if index_type.is_none() && offsets.is_empty() {
             offsets = self.message_rocksdb_storage.query_offsets_for_index(
                 topic,
                 INDEX_UNIQUE_TYPE,
@@ -459,6 +467,7 @@ impl RocksDbDerivedStore {
                 begin,
                 end,
                 max_num,
+                last_key,
             )?;
         }
         offsets.sort_unstable();
@@ -602,9 +611,11 @@ impl RocksDbMessageStoreRoot {
         local: &L,
         topic: &str,
         key: &str,
+        index_type: Option<&str>,
         max_num: usize,
         begin: i64,
         end: i64,
+        last_key: Option<&str>,
         max_query_days: usize,
     ) -> Result<RocksDbIndexLookup<L::Selection>, RocksDbMessageStoreError>
     where
@@ -612,7 +623,7 @@ impl RocksDbMessageStoreRoot {
     {
         let (offsets, last_update_timestamp, last_update_physical_offset) =
             self.derived
-                .index_offsets(topic, key, max_num, begin, end, max_query_days)?;
+                .index_offsets(topic, key, index_type, max_num, begin, end, last_key, max_query_days)?;
         let mut records = Vec::with_capacity(offsets.len());
         for offset in offsets {
             if let Some(selection) = local.read_from(offset)? {

--- a/rocketmq-store-rocksdb/src/store.rs
+++ b/rocketmq-store-rocksdb/src/store.rs
@@ -251,6 +251,37 @@ impl RocksDbStore {
         result
     }
 
+    /// Scans a prefix beginning at an arbitrary seek key.
+    pub fn prefix_scan_from(
+        &self,
+        options: &RocksDbScanOptions,
+        start: &[u8],
+    ) -> Result<Vec<RocksDbScanItem>, RocketMQError> {
+        self.ensure_open()?;
+        let handle = self.cf_handle(&options.cf)?;
+        let iter = self.db.iterator_cf(
+            &handle,
+            ::rocksdb::IteratorMode::From(start, ::rocksdb::Direction::Forward),
+        );
+        let mut items = Vec::new();
+        for item in iter {
+            let (key, value) = item.map_err(|error| self.map_native_error(error, RocksDbErrorKind::Iterator))?;
+            if !key.starts_with(&options.prefix) {
+                break;
+            }
+            items.push(RocksDbScanItem {
+                key: Bytes::copy_from_slice(&key),
+                value: Bytes::copy_from_slice(&value),
+            });
+            if options.limit > 0 && items.len() >= options.limit {
+                break;
+            }
+        }
+        let result = Ok(items);
+        self.record_result(&result, RocksDbMetricsCollector::record_scan);
+        result
+    }
+
     pub async fn prefix_scan_blocking(
         &self,
         runtime_scope: &RocksDbRuntimeScope,

--- a/rocketmq-store/src/base.rs
+++ b/rocketmq-store/src/base.rs
@@ -28,6 +28,7 @@ pub mod message_encoder_pool;
 pub mod message_result;
 pub mod message_status_enum;
 pub mod put_message_context;
+pub mod query_message_request;
 pub mod query_message_result;
 pub mod select_result;
 pub mod store_checkpoint;

--- a/rocketmq-store/src/base/backend_ops.rs
+++ b/rocketmq-store/src/base/backend_ops.rs
@@ -47,6 +47,7 @@ use crate::base::flush_manager::SyncFlushRuntimeInfo;
 use crate::base::get_message_result::GetMessageResult;
 use crate::base::message_result::AppendMessageResult;
 use crate::base::message_result::PutMessageResult;
+use crate::base::query_message_request::QueryMessageRequest;
 use crate::base::query_message_result::QueryMessageResult;
 use crate::base::select_result::SelectMappedBufferResult;
 use crate::base::store_checkpoint::StoreCheckpoint;
@@ -538,6 +539,9 @@ pub trait BackendOps: Send + Sync + 'static {
         begin: i64,
         end: i64,
     ) -> Option<QueryMessageResult>;
+
+    /// Query messages while preserving the optional index type and continuation cursor.
+    async fn query_message_with_options(&self, request: &QueryMessageRequest) -> Option<QueryMessageResult>;
 
     /// Update HA master address.
     async fn update_ha_master_address(&self, new_addr: &str);

--- a/rocketmq-store/src/base/query_message_request.rs
+++ b/rocketmq-store/src/base/query_message_request.rs
@@ -1,0 +1,53 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cheetah_string::CheetahString;
+
+/// Complete query-message contract passed from the Broker to a Store backend.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryMessageRequest {
+    pub topic: CheetahString,
+    pub key: CheetahString,
+    pub index_type: Option<CheetahString>,
+    pub max_num: i32,
+    pub begin: i64,
+    pub end: i64,
+    pub last_key: Option<CheetahString>,
+}
+
+impl QueryMessageRequest {
+    pub fn legacy(topic: &CheetahString, key: &CheetahString, max_num: i32, begin: i64, end: i64) -> Self {
+        Self {
+            topic: topic.clone(),
+            key: key.clone(),
+            index_type: None,
+            max_num,
+            begin,
+            end,
+            last_key: None,
+        }
+    }
+
+    /// Returns the legacy LocalFile lookup key used before index metadata was explicit.
+    pub fn legacy_backend_key(&self) -> CheetahString {
+        match self.index_type.as_deref() {
+            Some("U" | "T") => CheetahString::from_string(format!(
+                "{}#{}",
+                self.index_type.as_deref().unwrap_or_default(),
+                self.key
+            )),
+            _ => self.key.clone(),
+        }
+    }
+}

--- a/rocketmq-store/src/capability.rs
+++ b/rocketmq-store/src/capability.rs
@@ -63,6 +63,7 @@ use crate::base::get_message_result::GetMessageResult;
 use crate::base::message_result::PutMessageResult;
 use crate::base::message_status_enum::GetMessageStatus;
 use crate::base::message_status_enum::PutMessageStatus;
+use crate::base::query_message_request::QueryMessageRequest;
 use crate::base::query_message_result::QueryMessageResult;
 use crate::base::select_result::SelectMappedBufferCacheState;
 use crate::base::select_result::SelectMappedBufferResult;
@@ -246,6 +247,13 @@ pub trait BrokerReadStore: BackendAccess {
         end: i64,
     ) -> impl Future<Output = Option<QueryMessageResult>> + Send {
         BackendOps::query_message(self.backend(), topic, key, max_num, begin, end)
+    }
+
+    fn query_message_with_options(
+        &self,
+        request: &QueryMessageRequest,
+    ) -> impl Future<Output = Option<QueryMessageResult>> + Send {
+        BackendOps::query_message_with_options(self.backend(), request)
     }
 
     fn get_max_offset_in_queue(&self, topic: &CheetahString, queue_id: i32) -> i64 {

--- a/rocketmq-store/src/message_store.rs
+++ b/rocketmq-store/src/message_store.rs
@@ -53,6 +53,7 @@ use crate::base::get_message_result::GetMessageResult;
 use crate::base::message_arriving_listener::MessageArrivingListener;
 use crate::base::message_result::AppendMessageResult;
 use crate::base::message_result::PutMessageResult;
+use crate::base::query_message_request::QueryMessageRequest;
 use crate::base::query_message_result::QueryMessageResult;
 use crate::base::select_result::SelectMappedBufferResult;
 use crate::base::store_checkpoint::StoreCheckpoint;
@@ -402,6 +403,10 @@ macro_rules! message_store_methods {
         end: i64,
     ) -> Option<QueryMessageResult> {
         delegate_store_async!(self, query_message(topic, key, max_num, begin, end))
+    }
+
+    async fn query_message_with_options(&self, request: &QueryMessageRequest) -> Option<QueryMessageResult> {
+        delegate_store_async!(self, query_message_with_options(request))
     }
 
     async fn update_ha_master_address(&self, new_addr: &str) {

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -125,6 +125,7 @@ use crate::base::message_result::AppendMessageResult;
 use crate::base::message_result::PutMessageResult;
 use crate::base::message_status_enum::GetMessageStatus;
 use crate::base::message_status_enum::PutMessageStatus;
+use crate::base::query_message_request::QueryMessageRequest;
 use crate::base::query_message_result::QueryMessageResult;
 use crate::base::select_result::SelectMappedBufferResult;
 use crate::base::store_checkpoint::StoreCheckpoint;
@@ -1859,6 +1860,12 @@ impl BackendOps for LocalFileMessageStore {
         end_timestamp: i64,
     ) -> Option<QueryMessageResult> {
         self.query_messages(topic, key, max_num, begin_timestamp, end_timestamp)
+            .await
+    }
+
+    async fn query_message_with_options(&self, request: &QueryMessageRequest) -> Option<QueryMessageResult> {
+        let key = request.legacy_backend_key();
+        self.query_messages(&request.topic, &key, request.max_num, request.begin, request.end)
             .await
     }
 

--- a/rocketmq-store/src/message_store/rocksdb_message_store.rs
+++ b/rocketmq-store/src/message_store/rocksdb_message_store.rs
@@ -56,6 +56,7 @@ use crate::base::get_message_result::GetMessageResult;
 use crate::base::message_result::AppendMessageResult;
 use crate::base::message_result::PutMessageResult;
 use crate::base::message_status_enum::GetMessageStatus;
+use crate::base::query_message_request::QueryMessageRequest;
 use crate::base::query_message_result::QueryMessageResult;
 use crate::base::select_result::SelectMappedBufferResult;
 use crate::base::store_checkpoint::StoreCheckpoint;
@@ -454,9 +455,11 @@ impl RocksDBMessageStore {
         &self,
         topic: &CheetahString,
         key: &CheetahString,
+        index_type: Option<&str>,
         max_num: i32,
         begin: i64,
         end: i64,
+        last_key: Option<&str>,
     ) -> Result<QueryMessageResult, StoreError> {
         let max_num = max_num
             .max(0)
@@ -471,9 +474,11 @@ impl RocksDBMessageStore {
                 &local_wal,
                 topic.as_str(),
                 key.as_str(),
+                index_type,
                 max_num as usize,
                 begin,
                 end,
+                last_key,
                 self.get_message_store_config().max_rocksdb_index_query_days,
             )
             .map_err(message_store_adapter_error)?;
@@ -838,7 +843,7 @@ impl BackendOps for RocksDBMessageStore {
         begin: i64,
         end: i64,
     ) -> Option<QueryMessageResult> {
-        match self.query_message_by_rocksdb_index(topic, key, max_num, begin, end) {
+        match self.query_message_by_rocksdb_index(topic, key, None, max_num, begin, end, None) {
             Ok(result) if result.buffer_total_size > 0 => Some(result),
             Ok(_) => {
                 self.local_file_store
@@ -849,6 +854,38 @@ impl BackendOps for RocksDBMessageStore {
                 warn!(topic = %topic, key = %key, error = %error, "failed to query message by RocksDB index");
                 self.local_file_store
                     .query_message(topic, key, max_num, begin, end)
+                    .await
+            }
+        }
+    }
+
+    async fn query_message_with_options(&self, request: &QueryMessageRequest) -> Option<QueryMessageResult> {
+        match self.query_message_by_rocksdb_index(
+            &request.topic,
+            &request.key,
+            request.index_type.as_deref(),
+            request.max_num,
+            request.begin,
+            request.end,
+            request.last_key.as_deref(),
+        ) {
+            Ok(result) if result.buffer_total_size > 0 => Some(result),
+            Ok(result) if request.last_key.is_some() => Some(result),
+            Ok(_) => {
+                let key = request.legacy_backend_key();
+                self.local_file_store
+                    .query_message(&request.topic, &key, request.max_num, request.begin, request.end)
+                    .await
+            }
+            Err(error) if request.last_key.is_some() => {
+                warn!(topic = %request.topic, key = %request.key, error = %error, "rejected invalid RocksDB index cursor");
+                Some(QueryMessageResult::default())
+            }
+            Err(error) => {
+                warn!(topic = %request.topic, key = %request.key, error = %error, "failed to query message by RocksDB index");
+                let key = request.legacy_backend_key();
+                self.local_file_store
+                    .query_message(&request.topic, &key, request.max_num, request.begin, request.end)
                     .await
             }
         }

--- a/rocketmq-store/src/public_api.rs
+++ b/rocketmq-store/src/public_api.rs
@@ -36,6 +36,7 @@ pub use crate::base::message_status_enum::AppendMessageStatus;
 pub use crate::base::message_status_enum::GetMessageStatus;
 pub use crate::base::message_status_enum::PutMessageStatus;
 pub use crate::base::put_message_context::PutMessageContext;
+pub use crate::base::query_message_request::QueryMessageRequest;
 pub use crate::base::query_message_result::QueryMessageResult;
 pub use crate::base::select_result::SelectMappedBufferCacheState;
 pub use crate::base::select_result::SelectMappedBufferResult;

--- a/rocketmq-store/tests/rocksdb_foundation_tests.rs
+++ b/rocketmq-store/tests/rocksdb_foundation_tests.rs
@@ -841,21 +841,59 @@ fn message_rocksdb_storage_queries_index_offsets_by_java_hour_prefix() {
 
     assert_eq!(
         storage
-            .query_offsets_for_index("TopicA", MessageConst::INDEX_KEY_TYPE, "KeyA", begin, second, 10)
+            .query_offsets_for_index("TopicA", MessageConst::INDEX_KEY_TYPE, "KeyA", begin, second, 10, None)
             .expect("index query should scan"),
-        vec![100, 200]
+        vec![100, 200, 200]
     );
     assert_eq!(
         storage
-            .query_offsets_for_index("TopicA", MessageConst::INDEX_UNIQUE_TYPE, "UniqB", begin, filtered, 10)
+            .query_offsets_for_index(
+                "TopicA",
+                MessageConst::INDEX_UNIQUE_TYPE,
+                "UniqB",
+                begin,
+                filtered,
+                10,
+                None,
+            )
             .expect("unique index query should scan"),
         vec![200]
     );
     assert_eq!(
         storage
-            .query_offsets_for_index("TopicA", MessageConst::INDEX_KEY_TYPE, "KeyA", begin, filtered, 1)
+            .query_offsets_for_index("TopicA", MessageConst::INDEX_KEY_TYPE, "KeyA", begin, filtered, 1, None)
             .expect("limited index query should scan"),
         vec![100]
+    );
+    let cursor = format!("{base_hour}@TopicA@K@KeyA@UniqA@100");
+    assert_eq!(
+        storage
+            .query_offsets_for_index(
+                "TopicA",
+                MessageConst::INDEX_KEY_TYPE,
+                "KeyA",
+                begin,
+                filtered,
+                10,
+                Some(&cursor),
+            )
+            .expect("cursor query should resume after the exact index key"),
+        vec![200, 200, 300]
+    );
+    let unique_cursor = format!("{base_hour}@TopicA@U@UniqB@200");
+    assert!(
+        storage
+            .query_offsets_for_index(
+                "TopicA",
+                MessageConst::INDEX_UNIQUE_TYPE,
+                "UniqB",
+                begin,
+                filtered,
+                10,
+                Some(&unique_cursor),
+            )
+            .is_err(),
+        "Java's five-field U index key is not a valid six-field continuation cursor"
     );
 }
 
@@ -3054,7 +3092,8 @@ fn rocksdb_message_store_dispatcher_dual_writes_commitlog_dispatch_to_rocksdb_cq
                 "KeyA",
                 1_700_000_000_000,
                 1_700_000_000_000,
-                10
+                10,
+                None,
             )
             .expect("rocksdb index query should scan"),
         vec![1024]
@@ -3068,7 +3107,8 @@ fn rocksdb_message_store_dispatcher_dual_writes_commitlog_dispatch_to_rocksdb_cq
                 "TagA",
                 1_700_000_000_000,
                 1_700_000_000_000,
-                10
+                10,
+                None,
             )
             .expect("rocksdb tag index query should scan"),
         vec![1024]

--- a/rocketmq-store/tests/rocksdb_store_semantics_tests.rs
+++ b/rocketmq-store/tests/rocksdb_store_semantics_tests.rs
@@ -300,6 +300,7 @@ async fn rocksdb_query_message_after_dispatch() {
             append_result.store_timestamp,
             append_result.store_timestamp,
             10,
+            None,
         )
         .expect("query RocksDB index directly after reput");
     assert_eq!(indexed_offsets.len(), 1, "reput must flush the RocksDB index batch");

--- a/scripts/fixtures/java-5.5-query-last-key.json
+++ b/scripts/fixtures/java-5.5-query-last-key.json
@@ -1,0 +1,12 @@
+{
+  "source": "Apache RocketMQ 5.5 MessageRocksDBStorage.queryOffsetForIndex",
+  "separator": "@",
+  "cursorFields": ["storeTimeHour", "topic", "indexType", "queryKey", "uniqueKey", "physicalOffset"],
+  "acceptedIndexTypes": ["K", "T"],
+  "uniqueIndexPersistedFieldCount": 5,
+  "matchingHourUniqueCursorResult": "QUERY_NOT_FOUND",
+  "earlierThanBegin": "ignored",
+  "laterThanEnd": "empty",
+  "exactCursor": "skip-and-resume-at-successor",
+  "deletedCursor": "seek-successor"
+}

--- a/scripts/public-api-intent.json
+++ b/scripts/public-api-intent.json
@@ -3588,6 +3588,15 @@
         },
         {
           "category": "stable",
+          "declaration": "pub use crate::base::query_message_request::QueryMessageRequest",
+          "identity": "rocketmq-store/src/public_api.rs:pub use crate::base::query_message_request::QueryMessageRequest",
+          "owner": "store",
+          "path": "rocketmq-store/src/public_api.rs",
+          "rationale": "preserves the Java query-message index type and continuation cursor across the Broker/Store boundary",
+          "removal_condition": "retain while QUERY_MESSAGE pagination remains supported"
+        },
+        {
+          "category": "stable",
           "declaration": "pub use crate::base::query_message_result::QueryMessageResult",
           "identity": "rocketmq-store/src/public_api.rs:pub use crate::base::query_message_result::QueryMessageResult",
           "owner": "store",


### PR DESCRIPTION
## Summary
- preserve QUERY_MESSAGE indexType and lastKey from Admin client through Broker and Store capabilities
- implement Java 5.5-compatible six-field RocksDB K/T cursor seek semantics without physical-offset deduplication
- keep LocalFile and Tiered fallback cursor behavior compatible while retaining legacy wrappers

## Validation
- cargo test -p rocketmq-store --features rocksdb_store --test rocksdb_foundation_tests
- cargo test -p rocketmq-store --features rocksdb_store --test rocksdb_store_semantics_tests
- cargo test -p rocketmq-broker --features rocksdb_store query_message_processor::tests --lib
- cargo test -p rocketmq-client-rust --lib query_message_header_preserves_index_type_and_last_key
- cargo test -p rocketmq-protocol query_message_request_header_tests
- focused Clippy for store-rocksdb, store, broker, and client

Closes #9454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for paginated message queries using continuation cursors.
  * Added support for configurable normal and unique-key indexes.
  * Improved query handling across supported storage backends.
  * Added validation for invalid index types and cursors.
* **Bug Fixes**
  * Queries now resume correctly after the previous result without returning duplicates.
  * Time ranges and result limits are preserved during pagination.
* **Tests**
  * Added coverage for cursor handling, index selection, and continuation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->