### PR TITLE
[ISSUE #9459]✨Enforce cold data, slow consumer, and LMQ limits

### DIFF
--- a/rocketmq-broker/src/broker_runtime/control_plane.rs
+++ b/rocketmq-broker/src/broker_runtime/control_plane.rs
@@ -441,6 +441,11 @@ impl BrokerRuntime {
         );
 
         let protect_broker_shutdown = Arc::clone(&self.composition.state.shutdown);
+        let protect_broker_stats = self.composition.state.broker_stats_manager.clone();
+        let protect_subscription_groups = self.composition.state.subscription_group_manager().clone();
+        let protect_broker_config = self.composition.state.broker_config();
+        let protect_slow_consumers = protect_broker_config.disable_consume_if_consumer_read_slowly;
+        let consumer_fallbehind_threshold = protect_broker_config.consumer_fallbehind_threshold;
         Self::log_scheduled_task_start(
             "protect_broker",
             self.lifecycle.scheduled_task_manager.add_fixed_rate_task_async(
@@ -448,9 +453,39 @@ impl BrokerRuntime {
                 Duration::from_mins(3),
                 move |ctx| {
                     let protect_broker_shutdown = Arc::clone(&protect_broker_shutdown);
+                    let protect_broker_stats = protect_broker_stats.clone();
+                    let protect_subscription_groups = protect_subscription_groups.clone();
                     async move {
                         if ctx.is_cancelled() || protect_broker_shutdown.load(Ordering::Acquire) {
                             return Ok(());
+                        }
+                        if protect_slow_consumers {
+                            if let Some(fall_size_set) = protect_broker_stats
+                                .as_ref()
+                                .and_then(|stats| stats.get_moment_stats_item_set_fall_size())
+                            {
+                                let mut slow_groups = std::collections::HashMap::new();
+                                for entry in fall_size_set.get_stats_item_table().iter() {
+                                    let lag = entry.value().get_value().load(Ordering::Relaxed);
+                                    if lag <= consumer_fallbehind_threshold {
+                                        continue;
+                                    }
+                                    let Some(group) = entry.key().split('@').nth(2) else {
+                                        continue;
+                                    };
+                                    slow_groups
+                                        .entry(CheetahString::from(group))
+                                        .and_modify(|current: &mut i64| *current = (*current).max(lag))
+                                        .or_insert(lag);
+                                }
+                                for (group, lag) in slow_groups {
+                                    protect_subscription_groups.disable_consume_for_lag(
+                                        &group,
+                                        lag,
+                                        consumer_fallbehind_threshold,
+                                    );
+                                }
+                            }
                         }
                         Ok(())
                     }

--- a/rocketmq-broker/src/coldctr/cold_data_cg_ctr_service.rs
+++ b/rocketmq-broker/src/coldctr/cold_data_cg_ctr_service.rs
@@ -16,6 +16,7 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::atomic::AtomicI64;
 use std::sync::atomic::Ordering;
+use std::time::Duration;
 use std::time::SystemTime;
 
 use parking_lot::RwLock;
@@ -25,6 +26,14 @@ use tracing::error;
 
 const DEFAULT_CG_COLD_READ_THRESHOLD: i64 = 3 * 1024 * 1024;
 const DEFAULT_GLOBAL_COLD_READ_THRESHOLD: i64 = 100 * 1024 * 1024;
+const DEFAULT_SHORT_SUSPEND_CAPACITY: usize = 1_024;
+const DEFAULT_SHORT_SUSPEND_DURATION: Duration = Duration::from_secs(1);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ColdDataShortSuspendOutcome {
+    Suspended,
+    QueueFull,
+}
 
 struct ColdDataAccumulator {
     cold_acc: AtomicI64,
@@ -83,16 +92,40 @@ pub struct ColdDataCgCtrService {
     /// Accumulated cold data bytes per consumer group
     cg_cold_acc: RwLock<HashMap<String, ColdDataAccumulator>>,
     global_acc: AtomicI64,
+    short_suspend_slots: tokio::sync::Semaphore,
+    short_suspend_duration: Duration,
 }
 
 impl ColdDataCgCtrService {
     pub fn new(cold_data_flow_control_enable: bool) -> Self {
+        Self::with_short_suspend_limits(
+            cold_data_flow_control_enable,
+            DEFAULT_SHORT_SUSPEND_CAPACITY,
+            DEFAULT_SHORT_SUSPEND_DURATION,
+        )
+    }
+
+    pub(crate) fn with_short_suspend_limits(
+        cold_data_flow_control_enable: bool,
+        short_suspend_capacity: usize,
+        short_suspend_duration: Duration,
+    ) -> Self {
         Self {
             cold_data_flow_control_enable,
             cg_cold_read_threshold: RwLock::new(HashMap::new()),
             cg_cold_acc: RwLock::new(HashMap::new()),
             global_acc: AtomicI64::new(0),
+            short_suspend_slots: tokio::sync::Semaphore::new(short_suspend_capacity),
+            short_suspend_duration,
         }
+    }
+
+    pub(crate) async fn short_suspend_active_read(&self) -> ColdDataShortSuspendOutcome {
+        let Ok(_permit) = self.short_suspend_slots.try_acquire() else {
+            return ColdDataShortSuspendOutcome::QueueFull;
+        };
+        let _ = tokio::time::timeout(self.short_suspend_duration, std::future::pending::<()>()).await;
+        ColdDataShortSuspendOutcome::Suspended
     }
 
     /// Check if a consumer group needs cold data flow control
@@ -214,7 +247,25 @@ impl Default for ColdDataCgCtrService {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::ColdDataCgCtrService;
+    use super::ColdDataShortSuspendOutcome;
+
+    #[tokio::test]
+    async fn active_cold_read_short_suspend_is_bounded_and_queue_full_fails_fast() {
+        let service = ColdDataCgCtrService::with_short_suspend_limits(true, 1, Duration::ZERO);
+        assert_eq!(
+            service.short_suspend_active_read().await,
+            ColdDataShortSuspendOutcome::Suspended
+        );
+
+        let full = ColdDataCgCtrService::with_short_suspend_limits(true, 0, Duration::from_secs(1));
+        assert_eq!(
+            full.short_suspend_active_read().await,
+            ColdDataShortSuspendOutcome::QueueFull
+        );
+    }
 
     #[test]
     fn system_consumer_group_never_needs_cold_data_flow_control() {

--- a/rocketmq-broker/src/config/broker_config.rs
+++ b/rocketmq-broker/src/config/broker_config.rs
@@ -752,6 +752,10 @@ mod defaults {
     pub const fn broker_election_priority() -> i32 {
         i32::MAX
     }
+
+    pub const fn consumer_fallbehind_threshold() -> i64 {
+        16 * 1024 * 1024 * 1024
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -1082,6 +1086,12 @@ pub struct BrokerConfig {
 
     #[serde(default)]
     pub slave_read_enable: bool,
+
+    #[serde(default)]
+    pub disable_consume_if_consumer_read_slowly: bool,
+
+    #[serde(default = "defaults::consumer_fallbehind_threshold")]
+    pub consumer_fallbehind_threshold: i64,
 
     #[serde(default = "defaults::commercial_base_count")]
     pub commercial_base_count: i32,
@@ -1554,6 +1564,8 @@ impl Default for BrokerConfig {
             max_message_filter_num_for_notification: defaults::max_message_filter_num_for_notification(),
             use_server_side_reset_offset: true,
             slave_read_enable: false,
+            disable_consume_if_consumer_read_slowly: false,
+            consumer_fallbehind_threshold: defaults::consumer_fallbehind_threshold(),
             commercial_base_count: 1,
             reject_pull_consumer_enable: false,
             consumer_offset_update_version_step: 500,
@@ -2105,6 +2117,14 @@ impl BrokerConfig {
         );
         properties.insert("slaveReadEnable".into(), self.slave_read_enable.to_string().into());
         properties.insert(
+            "disableConsumeIfConsumerReadSlowly".into(),
+            self.disable_consume_if_consumer_read_slowly.to_string().into(),
+        );
+        properties.insert(
+            "consumerFallbehindThreshold".into(),
+            self.consumer_fallbehind_threshold.to_string().into(),
+        );
+        properties.insert(
             "commercialBaseCount".into(),
             self.commercial_base_count.to_string().into(),
         );
@@ -2339,6 +2359,28 @@ mod tests {
         assert!(!config.lite_lag_latency_metrics_enable);
         assert!(!config.lite_lag_count_metrics_enable);
         assert_eq!(config.lite_lag_latency_top_k, 50);
+    }
+
+    #[test]
+    fn default_broker_config_uses_java_slow_consumer_protection_defaults() {
+        let config = BrokerConfig::default();
+
+        assert!(!config.disable_consume_if_consumer_read_slowly);
+        assert_eq!(config.consumer_fallbehind_threshold, 16 * 1024 * 1024 * 1024);
+        assert_eq!(
+            config
+                .get_properties()
+                .get("disableConsumeIfConsumerReadSlowly")
+                .map(CheetahString::as_str),
+            Some("false")
+        );
+        assert_eq!(
+            config
+                .get_properties()
+                .get("consumerFallbehindThreshold")
+                .map(CheetahString::as_str),
+            Some("17179869184")
+        );
     }
 
     #[test]

--- a/rocketmq-broker/src/processor/end_transaction_processor.rs
+++ b/rocketmq-broker/src/processor/end_transaction_processor.rs
@@ -602,8 +602,8 @@ fn build_put_message_response(
             response.set_remark_mut("Put to remote broker failed");
         }
         PutMessageStatus::LmqConsumeQueueNumExceeded => {
-            response.set_code_mut(ResponseCode::SystemError);
-            response.set_remark_mut("UNKNOWN_ERROR DEFAULT");
+            response.set_code_mut(ResponseCode::LmqQuotaExceeded);
+            response.set_remark_mut("LMQ consume queue number exceeded");
         }
         PutMessageStatus::WheelTimerFlowControl => {
             response.set_code_mut(ResponseCode::SystemError);
@@ -863,6 +863,15 @@ mod tests {
         );
         assert_eq!(ResponseCode::from(timer_disabled.code()), ResponseCode::SystemError);
         assert!(timer_disabled.remark().is_some_and(|remark| remark.contains("false")));
+
+        let lmq_quota = build_put_message_response(
+            &application_remoting_command_factory(),
+            &policy,
+            &broker_stats_manager,
+            &topic,
+            PutMessageResult::new_default(PutMessageStatus::LmqConsumeQueueNumExceeded),
+        );
+        assert_eq!(ResponseCode::from(lmq_quota.code()), ResponseCode::LmqQuotaExceeded);
     }
 
     #[test]

--- a/rocketmq-broker/src/processor/pull_message_processor.rs
+++ b/rocketmq-broker/src/processor/pull_message_processor.rs
@@ -975,11 +975,19 @@ where
                                         ));
                                     }
                                     ConsumeType::ConsumeActively => {
-                                        return Ok(Some(
-                                            response
-                                                .set_code(ResponseCode::SystemBusy)
-                                                .set_remark("Cold-data pull suspension is not supported"),
-                                        ));
+                                        if broker_allow_suspend
+                                            && cold_data_cg_ctr_service
+                                                .short_suspend_active_read()
+                                                .await
+                                                == crate::coldctr::cold_data_cg_ctr_service::ColdDataShortSuspendOutcome::QueueFull
+                                        {
+                                            return Ok(Some(
+                                                response
+                                                    .set_code(ResponseCode::SystemBusy)
+                                                    .set_remark("Cold-data pull suspension queue is full"),
+                                            ));
+                                        }
+                                        request_header.max_msg_nums = 1;
                                     }
                                     _ => {}
                                 }

--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -796,7 +796,7 @@ fn map_put_status_to_response(status: PutMessageStatus, response: &mut RemotingC
         }
         PutMessageStatus::LmqConsumeQueueNumExceeded => {
             response
-                .set_code_mut(RemotingSysResponseCode::SystemError)
+                .set_code_mut(ResponseCode::LmqQuotaExceeded)
                 .set_remark_mut(error_messages::LMQ_QUEUE_NUM_EXCEEDED);
             false
         }
@@ -2533,7 +2533,7 @@ mod tests {
             ),
             (
                 PutMessageStatus::LmqConsumeQueueNumExceeded,
-                RemotingSysResponseCode::SystemError as i32,
+                ResponseCode::LmqQuotaExceeded as i32,
                 Some(error_messages::LMQ_QUEUE_NUM_EXCEEDED),
             ),
             (

--- a/rocketmq-broker/src/subscription/manager/subscription_group_manager.rs
+++ b/rocketmq-broker/src/subscription/manager/subscription_group_manager.rs
@@ -56,6 +56,15 @@ pub(crate) struct SubscriptionGroupConfigUpdate {
     pub(crate) data_version: DataVersion,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SlowConsumerDisableMarker {
+    pub(crate) observed_lag_bytes: i64,
+    pub(crate) threshold_bytes: i64,
+    pub(crate) reason: CheetahString,
+    pub(crate) generation: u64,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum SubscriptionGroupConfigCasError {
     GroupNotFound,
@@ -95,6 +104,8 @@ pub(crate) struct SubscriptionGroupManager {
 
     /// Forbidden table (group -> topic -> forbidden_bitmap)
     forbidden_table: Arc<DashMap<CheetahString, DashMap<CheetahString, i32>>>,
+
+    slow_consumer_markers: Arc<DashMap<CheetahString, SlowConsumerDisableMarker>>,
 
     /// Data version for tracking configuration changes
     data_version: Arc<parking_lot::RwLock<DataVersion>>,
@@ -145,6 +156,7 @@ impl SubscriptionGroupManager {
         let mut manager = Self {
             subscription_group_table: Arc::new(DashMap::new()),
             forbidden_table: Arc::new(DashMap::new()),
+            slow_consumer_markers: Arc::new(DashMap::new()),
             data_version: Arc::new(parking_lot::RwLock::new(
                 rocketmq_protocol::protocol::data_version_facade::new_data_version(),
             )),
@@ -387,6 +399,9 @@ impl SubscriptionGroupManager {
         let old = self
             .subscription_group_table
             .insert(config.group_name().clone(), Arc::new(config.clone()));
+        if config.consume_enable() {
+            self.slow_consumer_markers.remove(config.group_name());
+        }
 
         match old {
             Some(old_config) => {
@@ -694,6 +709,11 @@ impl ConfigManager for SubscriptionGroupManager {
                     (entry.key().clone(), inner)
                 })
                 .collect(),
+            slow_consumer_markers: self
+                .slow_consumer_markers
+                .iter()
+                .map(|entry| (entry.key().clone(), entry.value().clone()))
+                .collect(),
             data_version: self.data_version.read().clone(),
         };
 
@@ -724,6 +744,10 @@ impl ConfigManager for SubscriptionGroupManager {
                 topic_map.insert(topic, value);
             }
             self.forbidden_table.insert(group, topic_map);
+        }
+
+        for (group, marker) in wrapper.slow_consumer_markers {
+            self.slow_consumer_markers.insert(group, marker);
         }
 
         // Update data version
@@ -912,12 +936,53 @@ impl SubscriptionGroupManager {
         };
 
         if result.is_some() {
+            self.persist_after_mutation("disable-consume");
             info!("Disabled consume for group: {}", group_name);
         } else {
             warn!("Cannot disable consume, group not found: {}", group_name);
         }
 
         result
+    }
+
+    pub(crate) fn disable_consume_for_lag(
+        &self,
+        group_name: &CheetahString,
+        observed_lag_bytes: i64,
+        threshold_bytes: i64,
+    ) -> Option<SlowConsumerDisableMarker> {
+        let marker = {
+            let _transition = self.metadata_transition.lock();
+            let mut entry = self.subscription_group_table.get_mut(group_name)?;
+            let mut new_config = (**entry.value()).clone();
+            new_config.set_consume_enable(false);
+            *entry.value_mut() = Arc::new(new_config);
+
+            let mut data_version = self.data_version.write();
+            data_version.next_version_with(self.state_machine_version.get());
+            let generation = u64::try_from(data_version.counter()).ok()?;
+            let marker = SlowConsumerDisableMarker {
+                observed_lag_bytes,
+                threshold_bytes,
+                reason: CheetahString::from_static_str("consumer_fallbehind_threshold"),
+                generation,
+            };
+            self.slow_consumer_markers.insert(group_name.clone(), marker.clone());
+            marker
+        };
+        self.persist_after_mutation("slow-consumer-disable");
+        info!(
+            group = %group_name,
+            observed_lag_bytes,
+            threshold_bytes,
+            generation = marker.generation,
+            "Disabled slow consumer group"
+        );
+        Some(marker)
+    }
+
+    pub(crate) fn slow_consumer_marker(&self, group_name: &CheetahString) -> Option<SlowConsumerDisableMarker> {
+        self.slow_consumer_markers.get(group_name).map(|marker| marker.clone())
     }
 
     /// Enable consume capability for a specific consumer group
@@ -938,6 +1003,7 @@ impl SubscriptionGroupManager {
                 arc_config
             });
             if result.is_some() {
+                self.slow_consumer_markers.remove(group_name);
                 self.data_version
                     .write()
                     .next_version_with(self.state_machine_version.get());
@@ -946,7 +1012,7 @@ impl SubscriptionGroupManager {
         };
 
         if result.is_some() {
-            // Note: Java version does NOT persist here, only updates data version
+            self.persist_after_mutation("enable-consume");
             info!("Enabled consume for group: {}", group_name);
         } else {
             warn!("Cannot enable consume, group not found: {}", group_name);
@@ -1434,6 +1500,8 @@ pub(crate) struct SubscriptionGroupWrapperInner {
     //todo dashmap to concurrent safe
     subscription_group_table: HashMap<CheetahString, SubscriptionGroupConfig>,
     forbidden_table: HashMap<CheetahString, HashMap<CheetahString, i32>>,
+    #[serde(default)]
+    slow_consumer_markers: HashMap<CheetahString, SlowConsumerDisableMarker>,
     data_version: DataVersion,
 }
 
@@ -1585,6 +1653,48 @@ mod tests {
         assert!(config.consume_from_min_enable());
         assert_eq!(config.retry_max_times(), 16);
         assert_eq!(config.retry_queue_nums(), 1);
+    }
+
+    #[test]
+    fn slow_consumer_disable_marker_survives_serialization_and_explicit_enable_clears_it() {
+        use crate::config::broker_config::BrokerConfig;
+        use rocketmq_store::MessageStoreConfig;
+
+        let temp_dir = tempfile::TempDir::new().expect("temp dir should be created");
+        let root = CheetahString::from_string(temp_dir.path().to_string_lossy().to_string());
+        let broker_config = BrokerConfig {
+            store_path_root_dir: root.clone(),
+            ..BrokerConfig::default()
+        };
+        let message_store_config = MessageStoreConfig {
+            store_path_root_dir: root,
+            ..MessageStoreConfig::default()
+        };
+        let manager_config = SubscriptionGroupManagerConfig::from_configs(&broker_config, &message_store_config);
+        let manager = SubscriptionGroupManager::new(manager_config.clone(), StateMachineVersionView::default(), None);
+        let group = CheetahString::from_static_str("SLOW_GROUP");
+        let mut config = SubscriptionGroupConfig::new(group.clone());
+        manager.update_subscription_group_config(&mut config);
+
+        manager
+            .disable_consume_for_lag(&group, 512, 256)
+            .expect("known group must be disabled");
+        let marker = manager.slow_consumer_marker(&group).expect("slow marker");
+        assert_eq!(marker.observed_lag_bytes, 512);
+        assert_eq!(marker.threshold_bytes, 256);
+        assert_eq!(marker.reason, "consumer_fallbehind_threshold");
+        assert!(!manager.is_consume_enable(group.as_str()));
+
+        let encoded = manager.encode_pretty(false);
+        let restored = SubscriptionGroupManager::new(manager_config, StateMachineVersionView::default(), None);
+        restored.decode(&encoded);
+        assert_eq!(restored.slow_consumer_marker(&group), Some(marker));
+
+        let mut enabled = restored.get_group_config(group.as_str()).unwrap().as_ref().clone();
+        enabled.set_consume_enable(true);
+        restored.update_subscription_group_config(&mut enabled);
+        assert!(restored.is_consume_enable(group.as_str()));
+        assert!(restored.slow_consumer_marker(&group).is_none());
     }
 
     #[test]

--- a/rocketmq-model/src/common/mix_all.rs
+++ b/rocketmq-model/src/common/mix_all.rs
@@ -212,14 +212,19 @@ mod tests {
         assert!(is_sys_consumer_group_for_no_cold_read_limit("TOOLS_CONSUMER"));
         assert!(is_sys_consumer_group_for_no_cold_read_limit("SCHEDULE_CONSUMER"));
         assert!(is_sys_consumer_group_for_no_cold_read_limit("FILTERSRV_CONSUMER"));
-        assert!(!is_sys_consumer_group_for_no_cold_read_limit("MONITOR_CONSUMER"));
-        assert!(!is_sys_consumer_group_for_no_cold_read_limit("SELF_TEST_CONSUMER"));
-        assert!(!is_sys_consumer_group_for_no_cold_read_limit("ONS_HTTP_PROXY_GROUP"));
+        assert!(is_sys_consumer_group_for_no_cold_read_limit(MONITOR_CONSUMER_GROUP));
+        assert!(is_sys_consumer_group_for_no_cold_read_limit(SELF_TEST_CONSUMER_GROUP));
+        assert!(is_sys_consumer_group_for_no_cold_read_limit(ONS_HTTP_PROXY_GROUP));
         assert!(is_sys_consumer_group_for_no_cold_read_limit("CID_ONSAPI_PERMISSION"));
         assert!(is_sys_consumer_group_for_no_cold_read_limit("CID_ONSAPI_OWNER"));
         assert!(is_sys_consumer_group_for_no_cold_read_limit("CID_ONSAPI_PULL"));
         assert!(is_sys_consumer_group_for_no_cold_read_limit("CID_RMQ_SYS_TRANS"));
         assert!(is_sys_consumer_group_for_no_cold_read_limit("CID_RMQ_SYS_SOME_GROUP"));
+        assert!(!is_sys_consumer_group_for_no_cold_read_limit("MONITOR_CONSUMER"));
+        assert!(!is_sys_consumer_group_for_no_cold_read_limit("SELF_TEST_CONSUMER"));
+        assert!(!is_sys_consumer_group_for_no_cold_read_limit("ONS_HTTP_PROXY_GROUP"));
+        assert!(!is_sys_consumer_group_for_no_cold_read_limit("%RETRY%ORDINARY_GROUP"));
+        assert!(!is_sys_consumer_group_for_no_cold_read_limit("%TRANS%ORDINARY_GROUP"));
         assert!(!is_sys_consumer_group_for_no_cold_read_limit("NON_SYS_GROUP"));
     }
 

--- a/rocketmq-store-local/src/services/cold_data_check.rs
+++ b/rocketmq-store-local/src/services/cold_data_check.rs
@@ -12,13 +12,83 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use cheetah_string::CheetahString;
+use dashmap::DashMap;
+
+const MAX_RESIDENCY_OBSERVATIONS: usize = 65_536;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct MessageResidencyKey {
+    consumer_group: CheetahString,
+    topic: CheetahString,
+    queue_id: i32,
+    queue_offset: i64,
+}
+
+/// Supplies deterministic message-residency decisions to cold-data flow control.
+pub(crate) trait ColdDataResidencyProbe: Send + Sync {
+    /// Records the residency observed by the real message read path.
+    fn observe(&self, consumer_group: &str, topic: &str, queue_id: i32, queue_offset: i64, in_cache: bool);
+
+    /// Returns whether the last observed message residency was cold.
+    fn is_cold(&self, consumer_group: &str, topic: &str, queue_id: i32, queue_offset: i64) -> bool;
+}
+
+#[derive(Default)]
+struct ObservedColdDataResidencyProbe {
+    observations: DashMap<MessageResidencyKey, bool>,
+}
+
+impl ColdDataResidencyProbe for ObservedColdDataResidencyProbe {
+    fn observe(&self, consumer_group: &str, topic: &str, queue_id: i32, queue_offset: i64, in_cache: bool) {
+        if self.observations.len() >= MAX_RESIDENCY_OBSERVATIONS {
+            self.observations.clear();
+        }
+        self.observations.insert(
+            MessageResidencyKey {
+                consumer_group: consumer_group.into(),
+                topic: topic.into(),
+                queue_id,
+                queue_offset,
+            },
+            !in_cache,
+        );
+    }
+
+    fn is_cold(&self, consumer_group: &str, topic: &str, queue_id: i32, queue_offset: i64) -> bool {
+        self.observations
+            .get(&MessageResidencyKey {
+                consumer_group: consumer_group.into(),
+                topic: topic.into(),
+                queue_id,
+                queue_offset,
+            })
+            .is_some_and(|cold| *cold)
+    }
+}
 
 /// Service for checking if message data is in cold storage area
-#[derive(Default)]
-pub struct ColdDataCheckService;
+pub struct ColdDataCheckService {
+    residency_probe: Arc<dyn ColdDataResidencyProbe>,
+}
+
+impl Default for ColdDataCheckService {
+    fn default() -> Self {
+        Self {
+            residency_probe: Arc::new(ObservedColdDataResidencyProbe::default()),
+        }
+    }
+}
 
 impl ColdDataCheckService {
+    /// Creates a service backed by an injected residency probe.
+    #[cfg(test)]
+    pub(crate) fn with_probe(residency_probe: Arc<dyn ColdDataResidencyProbe>) -> Self {
+        Self { residency_probe }
+    }
+
     /// Check if the data at the given offset is in page cache
     pub fn is_data_in_page_cache(&self) -> bool {
         true
@@ -39,29 +109,74 @@ impl ColdDataCheckService {
     /// `true` if the message is in cold data area, `false` otherwise
     pub fn is_msg_in_cold_area(
         &self,
-        _consumer_group: &CheetahString,
-        _topic: &CheetahString,
-        _queue_id: i32,
-        _queue_offset: i64,
+        consumer_group: &CheetahString,
+        topic: &CheetahString,
+        queue_id: i32,
+        queue_offset: i64,
     ) -> bool {
-        // TODO: Implement actual cold data detection logic
-        // This should check if the message's physical offset is in cold storage area
-        // based on configuration like cold data threshold time or physical offset threshold
-        false
+        self.residency_probe
+            .is_cold(consumer_group.as_str(), topic.as_str(), queue_id, queue_offset)
+    }
+
+    /// Records the page-cache state observed while reading the message payload.
+    pub fn observe_message_residency(
+        &self,
+        consumer_group: &CheetahString,
+        topic: &CheetahString,
+        queue_id: i32,
+        queue_offset: i64,
+        in_cache: bool,
+    ) {
+        self.residency_probe.observe(
+            consumer_group.as_str(),
+            topic.as_str(),
+            queue_id,
+            queue_offset,
+            in_cache,
+        );
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
 
+    struct FixedResidencyProbe(bool);
+
+    impl ColdDataResidencyProbe for FixedResidencyProbe {
+        fn observe(&self, _consumer_group: &str, _topic: &str, _queue_id: i32, _queue_offset: i64, _in_cache: bool) {}
+
+        fn is_cold(&self, _consumer_group: &str, _topic: &str, _queue_id: i32, _queue_offset: i64) -> bool {
+            self.0
+        }
+    }
+
     #[test]
-    fn preserves_current_page_cache_and_cold_area_defaults() {
-        let service = ColdDataCheckService;
+    fn injected_probe_controls_residency_without_os_page_cache_dependency() {
+        let service = ColdDataCheckService::with_probe(Arc::new(FixedResidencyProbe(true)));
+        assert!(service.is_msg_in_cold_area(
+            &CheetahString::from_static_str("group"),
+            &CheetahString::from_static_str("topic"),
+            0,
+            0,
+        ));
+    }
+
+    #[test]
+    fn observed_residency_drives_cold_area_checks() {
+        let service = ColdDataCheckService::default();
         let group = CheetahString::from_static_str("group");
         let topic = CheetahString::from_static_str("topic");
 
         assert!(service.is_data_in_page_cache());
+        assert!(!service.is_msg_in_cold_area(&group, &topic, 1, 42));
+
+        service.observe_message_residency(&group, &topic, 1, 42, false);
+        assert!(service.is_msg_in_cold_area(&group, &topic, 1, 42));
+
+        service.observe_message_residency(&group, &topic, 1, 42, true);
         assert!(!service.is_msg_in_cold_area(&group, &topic, 1, 42));
     }
 }

--- a/rocketmq-store/src/config/message_store_config.rs
+++ b/rocketmq-store/src/config/message_store_config.rs
@@ -159,6 +159,10 @@ mod defaults {
         7
     }
 
+    pub fn max_lmq_consume_queue_num() -> usize {
+        20_000
+    }
+
     pub fn pop_rocksdb_block_cache_size() -> usize {
         256 * 1024 * 1024
     }
@@ -1158,7 +1162,10 @@ pub struct MessageStoreConfig {
     #[serde(default)]
     pub enable_multi_dispatch: bool,
 
-    #[serde(default)]
+    #[serde(default, alias = "enable_lmq_quota")]
+    pub enable_lmq_quota: bool,
+
+    #[serde(default = "defaults::max_lmq_consume_queue_num", alias = "max_lmq_consume_queue_num")]
     pub max_lmq_consume_queue_num: usize,
 
     #[serde(default)]
@@ -1592,7 +1599,8 @@ impl Default for MessageStoreConfig {
             enable_schedule_message_stats: false,
             enable_lmq: false,
             enable_multi_dispatch: false,
-            max_lmq_consume_queue_num: 0,
+            enable_lmq_quota: false,
+            max_lmq_consume_queue_num: defaults::max_lmq_consume_queue_num(),
             enable_schedule_async_deliver: false,
             schedule_async_deliver_max_pending_limit: 0,
             schedule_async_deliver_max_resend_num2_blocked: 0,
@@ -2345,6 +2353,7 @@ impl MessageStoreConfig {
             "enableMultiDispatch".to_string(),
             self.enable_multi_dispatch.to_string(),
         );
+        properties.insert("enableLmqQuota".to_string(), self.enable_lmq_quota.to_string());
         properties.insert(
             "maxLmqConsumeQueueNum".to_string(),
             self.max_lmq_consume_queue_num.to_string(),
@@ -3034,6 +3043,20 @@ mod tests {
         assert_eq!(config.pop_rocksdb_block_cache_size, 256 * 1024 * 1024);
         assert_eq!(config.pop_rocksdb_write_buffer_size, 32 * 1024 * 1024);
         assert!(config.use_separate_store_path_for_rocksdb_cq);
+        Ok(())
+    }
+
+    #[test]
+    fn lmq_quota_defaults_and_java_alias_preserve_explicit_zero() -> Result<(), serde_json::Error> {
+        let defaults: MessageStoreConfig = serde_json::from_str("{}")?;
+        assert!(!defaults.enable_lmq_quota);
+        assert_eq!(defaults.max_lmq_consume_queue_num, 20_000);
+
+        let enabled: MessageStoreConfig = serde_json::from_str(r#"{"enableLmqQuota":true,"maxLmqConsumeQueueNum":0}"#)?;
+        assert!(enabled.enable_lmq_quota);
+        assert_eq!(enabled.max_lmq_consume_queue_num, 0);
+        assert_eq!(enabled.get_properties()["enableLmqQuota"], "true");
+        assert_eq!(enabled.get_properties()["maxLmqConsumeQueueNum"], "0");
         Ok(())
     }
 

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -226,6 +226,7 @@ mod composition;
 mod dispatch;
 mod health;
 mod lifecycle;
+mod lmq_quota;
 mod managed_recovery;
 mod mapped_file_retirement_service;
 mod read_path;
@@ -233,6 +234,9 @@ mod recovery;
 mod reput_pipeline;
 mod root_lock;
 mod write_path;
+
+use lmq_quota::LmqQuotaController;
+use lmq_quota::LmqQuotaReservation;
 
 pub use composition::parse_delay_level;
 pub use dispatch::CommitLogDispatcherDefault;
@@ -416,6 +420,7 @@ pub(crate) struct TimerMessageWriteHandle {
     consume_queue_store: ConsumeQueueStore,
     store_stats_service: Arc<StoreStatsService>,
     reput_notify: ReputNotifyHandle,
+    lmq_quota_controller: Arc<LmqQuotaController>,
 }
 
 impl TimerMessageWriteHandle {
@@ -435,6 +440,10 @@ impl TimerMessageWriteHandle {
             }
         }
         let lmq_dispatch_queue_keys = self.prepare_lmq_dispatch(&mut msg);
+        let lmq_quota_reservation = match self.reserve_lmq_quota(&lmq_dispatch_queue_keys) {
+            Some(reservation) => reservation,
+            None => return PutMessageResult::new_default(PutMessageStatus::LmqConsumeQueueNumExceeded),
+        };
         let lmq_dispatch_message_num = Self::lmq_dispatch_message_num(&msg);
 
         if msg
@@ -474,6 +483,9 @@ impl TimerMessageWriteHandle {
                 self.consume_queue_store
                     .increase_lmq_offset(queue_key.as_str(), lmq_dispatch_message_num);
             }
+            if let Some(reservation) = lmq_quota_reservation {
+                reservation.commit();
+            }
             self.reput_notify.notify_new_message();
         }
         result
@@ -491,6 +503,7 @@ impl TimerMessageWriteHandle {
         }
 
         let mut queue_keys = Vec::new();
+        let mut unique_queue_keys = HashSet::new();
         let mut saw_queue = false;
         let mut is_all_lmq_dispatch = true;
         for queue_name in multi_dispatch_queue.split_str(MULTI_DISPATCH_QUEUE_SPLITTER) {
@@ -500,7 +513,10 @@ impl TimerMessageWriteHandle {
             }
             saw_queue = true;
             if self.message_store_config.enable_lmq && is_lmq(Some(queue_name)) {
-                queue_keys.push(format!("{queue_name}-{LMQ_QUEUE_ID}"));
+                let queue_key = format!("{queue_name}-{LMQ_QUEUE_ID}");
+                if unique_queue_keys.insert(queue_key.clone()) {
+                    queue_keys.push(queue_key);
+                }
             } else {
                 is_all_lmq_dispatch = false;
             }
@@ -533,6 +549,28 @@ impl TimerMessageWriteHandle {
         queue_keys
     }
 
+    fn reserve_lmq_quota(&self, queue_keys: &[String]) -> Option<Option<LmqQuotaReservation>> {
+        if !self.message_store_config.enable_lmq_quota
+            || !self.message_store_config.enable_lmq
+            || !self.message_store_config.enable_multi_dispatch
+            || queue_keys.is_empty()
+        {
+            return Some(None);
+        }
+        let existing_queue_keys = self
+            .consume_queue_store
+            .get_lmq_topic_names()
+            .into_iter()
+            .map(|topic| format!("{topic}-{LMQ_QUEUE_ID}"));
+        self.lmq_quota_controller
+            .reserve(
+                queue_keys,
+                existing_queue_keys,
+                self.message_store_config.max_lmq_consume_queue_num,
+            )
+            .map(Some)
+    }
+
     fn lmq_dispatch_message_num(msg: &MessageExtBrokerInner) -> i16 {
         msg.property(MessageConst::PROPERTY_INNER_NUM)
             .and_then(|message_num| message_num.parse::<i16>().ok())
@@ -558,6 +596,7 @@ pub struct LocalFileMessageStore {
     index_service: IndexService,
     allocate_mapped_file_service: Arc<AllocateMappedFileService>,
     consume_queue_store: ConsumeQueueStore,
+    lmq_quota_controller: Arc<LmqQuotaController>,
     dispatcher: CommitLogDispatcherDefault,
     #[cfg(feature = "tieredstore")]
     tiered_store: Option<Arc<TieredStoreDecorator>>,

--- a/rocketmq-store/src/message_store/local_file_message_store/composition.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/composition.rs
@@ -298,6 +298,7 @@ impl LocalFileMessageStore {
             index_service: index_service.clone(),
             allocate_mapped_file_service,
             consume_queue_store: consume_queue_store.clone(),
+            lmq_quota_controller: Arc::new(LmqQuotaController::default()),
             dispatcher,
             #[cfg(feature = "tieredstore")]
             tiered_store,
@@ -508,6 +509,7 @@ impl LocalFileMessageStore {
             consume_queue_store: self.consume_queue_store.clone(),
             store_stats_service: Arc::clone(&self.store_stats_service),
             reput_notify: self.reput_message_service.notify_handle(),
+            lmq_quota_controller: Arc::clone(&self.lmq_quota_controller),
         }
     }
 

--- a/rocketmq-store/src/message_store/local_file_message_store/dispatch.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/dispatch.rs
@@ -192,6 +192,7 @@ impl LocalFileMessageStore {
         }
 
         let mut queue_keys = Vec::new();
+        let mut unique_queue_keys = HashSet::new();
         let mut saw_queue = false;
         let mut is_all_lmq_dispatch = true;
         for queue_name in multi_dispatch_queue.split(MULTI_DISPATCH_QUEUE_SPLITTER) {
@@ -201,7 +202,10 @@ impl LocalFileMessageStore {
             }
             saw_queue = true;
             if is_lmq(Some(queue_name)) {
-                queue_keys.push(format!("{queue_name}-{LMQ_QUEUE_ID}"));
+                let queue_key = format!("{queue_name}-{LMQ_QUEUE_ID}");
+                if unique_queue_keys.insert(queue_key.clone()) {
+                    queue_keys.push(queue_key);
+                }
             } else {
                 is_all_lmq_dispatch = false;
             }
@@ -214,6 +218,28 @@ impl LocalFileMessageStore {
             self.consume_queue_store
                 .increase_lmq_offset(queue_key.as_str(), message_num);
         }
+    }
+
+    pub(super) fn reserve_lmq_quota(&self, queue_keys: &[String]) -> Option<Option<LmqQuotaReservation>> {
+        if !self.message_store_config.enable_lmq_quota
+            || !self.message_store_config.enable_lmq
+            || !self.message_store_config.enable_multi_dispatch
+            || queue_keys.is_empty()
+        {
+            return Some(None);
+        }
+        let existing_queue_keys = self
+            .consume_queue_store
+            .get_lmq_topic_names()
+            .into_iter()
+            .map(|topic| format!("{topic}-{LMQ_QUEUE_ID}"));
+        self.lmq_quota_controller
+            .reserve(
+                queue_keys,
+                existing_queue_keys,
+                self.message_store_config.max_lmq_consume_queue_num,
+            )
+            .map(Some)
     }
 
     pub(super) fn get_lmq_dispatch_message_num(&self, msg: &MessageExtBrokerInner) -> i16 {

--- a/rocketmq-store/src/message_store/local_file_message_store/lmq_quota.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/lmq_quota.rs
@@ -1,0 +1,143 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+
+#[derive(Default)]
+struct LmqQuotaState {
+    committed: HashSet<String>,
+    inflight: HashMap<String, usize>,
+}
+
+#[derive(Default)]
+pub(super) struct LmqQuotaController {
+    state: Mutex<LmqQuotaState>,
+}
+
+impl LmqQuotaController {
+    pub(super) fn reserve(
+        self: &Arc<Self>,
+        queue_keys: &[String],
+        existing_queue_keys: impl IntoIterator<Item = String>,
+        max_lmq_count: usize,
+    ) -> Option<LmqQuotaReservation> {
+        let mut state = self.state.lock();
+        state.committed.extend(existing_queue_keys);
+
+        let unique_queue_keys: HashSet<&str> = queue_keys.iter().map(String::as_str).collect();
+        let new_unique_count = unique_queue_keys
+            .iter()
+            .filter(|queue_key| !state.committed.contains(**queue_key) && !state.inflight.contains_key(**queue_key))
+            .count();
+        let occupied = state.committed.len()
+            + state
+                .inflight
+                .keys()
+                .filter(|key| !state.committed.contains(*key))
+                .count();
+        if new_unique_count > max_lmq_count.saturating_sub(occupied) {
+            return None;
+        }
+
+        let reserved = unique_queue_keys
+            .into_iter()
+            .filter(|queue_key| !state.committed.contains(*queue_key))
+            .map(str::to_owned)
+            .collect::<Vec<_>>();
+        for queue_key in &reserved {
+            *state.inflight.entry(queue_key.clone()).or_default() += 1;
+        }
+        drop(state);
+
+        Some(LmqQuotaReservation {
+            controller: Arc::clone(self),
+            queue_keys: reserved,
+            committed: false,
+        })
+    }
+
+    fn finish(&self, queue_keys: &[String], commit: bool) {
+        let mut state = self.state.lock();
+        for queue_key in queue_keys {
+            if commit {
+                state.committed.insert(queue_key.clone());
+            }
+            if let Some(count) = state.inflight.get_mut(queue_key) {
+                *count -= 1;
+                if *count == 0 {
+                    state.inflight.remove(queue_key);
+                }
+            }
+        }
+    }
+}
+
+pub(super) struct LmqQuotaReservation {
+    controller: Arc<LmqQuotaController>,
+    queue_keys: Vec<String>,
+    committed: bool,
+}
+
+impl LmqQuotaReservation {
+    pub(super) fn commit(mut self) {
+        self.controller.finish(&self.queue_keys, true);
+        self.committed = true;
+    }
+}
+
+impl Drop for LmqQuotaReservation {
+    fn drop(&mut self) {
+        if !self.committed {
+            self.controller.finish(&self.queue_keys, false);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn concurrent_unique_reservations_cannot_exceed_limit_and_drop_releases_capacity() {
+        let controller = Arc::new(LmqQuotaController::default());
+        let alpha = controller
+            .reserve(&["%LMQ%alpha-0".to_owned()], Vec::new(), 1)
+            .expect("first unique name fits");
+        assert!(controller.reserve(&["%LMQ%beta-0".to_owned()], Vec::new(), 1).is_none());
+
+        drop(alpha);
+        assert!(controller.reserve(&["%LMQ%beta-0".to_owned()], Vec::new(), 1).is_some());
+    }
+
+    #[test]
+    fn concurrent_same_name_counts_once_and_existing_name_is_allowed_at_zero_limit() {
+        let controller = Arc::new(LmqQuotaController::default());
+        let first = controller
+            .reserve(&["%LMQ%alpha-0".to_owned()], Vec::new(), 1)
+            .expect("first reservation");
+        let duplicate = controller
+            .reserve(&["%LMQ%alpha-0".to_owned()], Vec::new(), 1)
+            .expect("same inflight name does not consume another quota slot");
+        first.commit();
+        drop(duplicate);
+
+        assert!(controller
+            .reserve(&["%LMQ%alpha-0".to_owned()], vec!["%LMQ%alpha-0".to_owned()], 0,)
+            .is_some());
+    }
+}

--- a/rocketmq-store/src/message_store/local_file_message_store/read_path.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/read_path.rs
@@ -257,9 +257,17 @@ impl LocalFileMessageStore {
                                 next_phy_file_start_offset = self.commit_log.roll_next_file(offset_py);
                                 continue;
                             };
+                            let in_cache = select_result.is_in_cache();
+                            self.commit_log.get_cold_data_check_service().observe_message_residency(
+                                group,
+                                topic,
+                                queue_id,
+                                cq_unit.queue_offset,
+                                in_cache,
+                            );
                             if self.message_store_config.cold_data_flow_control_enable
                                 && !is_sys_consumer_group_for_no_cold_read_limit(group)
-                                && !select_result.is_in_cache()
+                                && !in_cache
                             {
                                 get_result_ref.set_cold_data_sum(get_result_ref.cold_data_sum() + size_py as i64);
                             }

--- a/rocketmq-store/src/message_store/local_file_message_store/write_path.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/write_path.rs
@@ -170,6 +170,10 @@ impl LocalFileMessageStore {
             }
         }
         let lmq_dispatch_queue_keys = self.prepare_lmq_dispatch(&mut msg);
+        let lmq_quota_reservation = match self.reserve_lmq_quota(&lmq_dispatch_queue_keys) {
+            Some(reservation) => reservation,
+            None => return PutMessageResult::new_default(PutMessageStatus::LmqConsumeQueueNumExceeded),
+        };
         let lmq_dispatch_message_num = self.get_lmq_dispatch_message_num(&msg);
 
         if msg
@@ -213,6 +217,9 @@ impl LocalFileMessageStore {
             if !lmq_dispatch_queue_keys.is_empty() {
                 self.update_lmq_offsets(&lmq_dispatch_queue_keys, lmq_dispatch_message_num);
             }
+            if let Some(reservation) = lmq_quota_reservation {
+                reservation.commit();
+            }
             self.reput_message_service.notify_new_message();
         }
 
@@ -231,6 +238,10 @@ impl LocalFileMessageStore {
             }
         }
         let lmq_dispatch_queue_keys = self.prepare_lmq_dispatch(&mut message_ext_batch.message_ext_broker_inner);
+        let lmq_quota_reservation = match self.reserve_lmq_quota(&lmq_dispatch_queue_keys) {
+            Some(reservation) => reservation,
+            None => return PutMessageResult::new_default(PutMessageStatus::LmqConsumeQueueNumExceeded),
+        };
         let lmq_dispatch_message_num = self.get_lmq_dispatch_message_num(&message_ext_batch.message_ext_broker_inner);
 
         let begin_time = Instant::now();
@@ -250,6 +261,9 @@ impl LocalFileMessageStore {
         if result.is_ok() {
             if !lmq_dispatch_queue_keys.is_empty() {
                 self.update_lmq_offsets(&lmq_dispatch_queue_keys, lmq_dispatch_message_num);
+            }
+            if let Some(reservation) = lmq_quota_reservation {
+                reservation.commit();
             }
             self.reput_message_service.notify_new_message();
         }

--- a/rocketmq-store/src/queue/queue_offset_operator.rs
+++ b/rocketmq-store/src/queue/queue_offset_operator.rs
@@ -91,7 +91,9 @@ impl QueueOffsetOperator {
 
     #[inline]
     pub fn get_lmq_offset(&self, topic_queue_key: &CheetahString) -> i64 {
-        *self.lmq_topic_queue_table.entry(topic_queue_key.clone()).or_insert(0)
+        self.lmq_topic_queue_table
+            .get(topic_queue_key)
+            .map_or(0, |offset| *offset)
     }
 
     #[inline]

--- a/rocketmq-store/tests/lmq_quota_tests.rs
+++ b/rocketmq-store/tests/lmq_quota_tests.rs
@@ -1,0 +1,31 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_store::MessageStoreConfig;
+
+#[test]
+fn java_lmq_quota_properties_preserve_default_and_explicit_zero() {
+    let defaults: MessageStoreConfig = serde_json::from_str("{}").expect("default config");
+    assert!(!defaults.enable_lmq_quota);
+    assert_eq!(defaults.max_lmq_consume_queue_num, 20_000);
+
+    let explicit_zero: MessageStoreConfig = serde_json::from_str(
+        r#"{"enableLmq":true,"enableMultiDispatch":true,"enableLmqQuota":true,"maxLmqConsumeQueueNum":0}"#,
+    )
+    .expect("Java property aliases");
+    assert!(explicit_zero.enable_lmq);
+    assert!(explicit_zero.enable_multi_dispatch);
+    assert!(explicit_zero.enable_lmq_quota);
+    assert_eq!(explicit_zero.max_lmq_consume_queue_num, 0);
+}

--- a/rocketmq-store/tests/message_store/local_file_message_store/unit.rs
+++ b/rocketmq-store/tests/message_store/local_file_message_store/unit.rs
@@ -4684,6 +4684,79 @@ async fn put_message_with_multi_dispatch_properties_dispatches_lmq_queues_after_
 }
 
 #[tokio::test]
+async fn lmq_quota_counts_unique_names_and_leaves_no_rejected_offset() {
+    let temp_dir = tempdir().unwrap();
+    let mut store = new_configured_test_store(
+        &temp_dir,
+        MessageStoreConfig {
+            enable_multi_dispatch: true,
+            enable_lmq: true,
+            enable_lmq_quota: true,
+            max_lmq_consume_queue_num: 1,
+            flush_disk_type: FlushDiskType::AsyncFlush,
+            ..MessageStoreConfig::default()
+        },
+    );
+
+    let mut first = MessageExtBrokerInner::default();
+    first.set_topic(CheetahString::from_static_str("lmq-quota-source"));
+    first.set_body(Bytes::from_static(b"first"));
+    first.put_property(
+        CheetahString::from_static_str(MessageConst::PROPERTY_INNER_MULTI_DISPATCH),
+        CheetahString::from_static_str("%LMQ%alpha,%LMQ%alpha"),
+    );
+    assert_eq!(
+        store.put_message(first).await.put_message_status(),
+        PutMessageStatus::PutOk
+    );
+    assert_eq!(store.consume_queue_store.get_lmq_num(), 1);
+    assert_eq!(store.consume_queue_store.get_lmq_queue_offset("%LMQ%alpha-0"), 1);
+
+    let mut rejected = MessageExtBrokerInner::default();
+    rejected.set_topic(CheetahString::from_static_str("lmq-quota-source"));
+    rejected.set_body(Bytes::from_static(b"rejected"));
+    rejected.put_property(
+        CheetahString::from_static_str(MessageConst::PROPERTY_INNER_MULTI_DISPATCH),
+        CheetahString::from_static_str("%LMQ%beta"),
+    );
+    assert_eq!(
+        store.put_message(rejected).await.put_message_status(),
+        PutMessageStatus::LmqConsumeQueueNumExceeded
+    );
+    assert_eq!(store.consume_queue_store.get_lmq_num(), 1);
+    assert!(!store.consume_queue_store.is_lmq_exist("%LMQ%beta"));
+    assert_eq!(store.consume_queue_store.get_lmq_queue_offset("%LMQ%beta-0"), 0);
+}
+
+#[tokio::test]
+async fn disabled_lmq_quota_does_not_treat_zero_as_a_limit() {
+    let temp_dir = tempdir().unwrap();
+    let mut store = new_configured_test_store(
+        &temp_dir,
+        MessageStoreConfig {
+            enable_multi_dispatch: true,
+            enable_lmq: true,
+            enable_lmq_quota: false,
+            max_lmq_consume_queue_num: 0,
+            flush_disk_type: FlushDiskType::AsyncFlush,
+            ..MessageStoreConfig::default()
+        },
+    );
+    let mut message = MessageExtBrokerInner::default();
+    message.set_topic(CheetahString::from_static_str("lmq-quota-disabled"));
+    message.set_body(Bytes::from_static(b"allowed"));
+    message.put_property(
+        CheetahString::from_static_str(MessageConst::PROPERTY_INNER_MULTI_DISPATCH),
+        CheetahString::from_static_str("%LMQ%allowed"),
+    );
+
+    assert_eq!(
+        store.put_message(message).await.put_message_status(),
+        PutMessageStatus::PutOk
+    );
+}
+
+#[tokio::test]
 async fn put_message_with_existing_multi_queue_offsets_still_updates_lmq_offsets() {
     let temp_dir = tempdir().unwrap();
     let mut store = new_configured_test_store(


### PR DESCRIPTION
Closes #9459

- enforce bounded cold-data pull throttling from observed residency
- persist slow-consumer disable markers and support explicit re-enable
- atomically enforce LMQ queue quotas across normal, batch, timer, and transaction writes
- add deterministic configuration, concurrency, persistence, and response-mapping coverage

Validation: focused tests, affected-package Clippy, runtime ownership audit, and diff hygiene.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable protection that pauses consumption for consumer groups falling significantly behind.
  - Added bounded short suspension for cold-data reads, improving handling of active cold messages.
  - Added configurable logical message queue quotas with enforcement for single and batch writes.
  - Added cold-data residency tracking to improve cache-aware read behavior.

- **Bug Fixes**
  - Quota exhaustion now returns a specific quota-exceeded response.
  - Duplicate logical queue entries are handled without inflating quota usage.
  - Missing logical queue offsets no longer create unnecessary entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->