### PR TITLE
[ISSUE #9461]✨Complete compaction semantics and mapped file construction

### DIFF
--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use crate::config::broker_config::BrokerConfig;
+use crate::send_message_constants::has_valid_compaction_key;
 use cheetah_string::CheetahString;
 use rand::RngExt;
 use rocketmq_error::RocketMQError;
@@ -1975,12 +1976,6 @@ fn message_body_limit_violation(request: &RemotingCommand, configured_max_messag
 
 fn broker_send_permission_denied(broker_permission: u32) -> bool {
     !PermName::is_writeable(broker_permission)
-}
-
-fn has_valid_compaction_key(properties: &HashMap<CheetahString, CheetahString>) -> bool {
-    properties
-        .get(MessageConst::PROPERTY_KEYS)
-        .is_some_and(|value| !value.trim().is_empty())
 }
 
 fn apply_topic_delivery_properties(

--- a/rocketmq-broker/src/send_message_constants.rs
+++ b/rocketmq-broker/src/send_message_constants.rs
@@ -33,6 +33,21 @@
 //! }
 //! ```
 
+use std::collections::HashMap;
+
+use cheetah_string::CheetahString;
+use rocketmq_model::common::message::MessageConst;
+
+/// Returns whether a compaction message has the Java-compatible raw `KEYS` identity.
+///
+/// Accepted keys are preserved byte-for-byte by the Store. This validation only rejects a
+/// missing, empty, or whitespace-only value; it deliberately does not trim or split the key.
+pub fn has_valid_compaction_key(properties: &HashMap<CheetahString, CheetahString>) -> bool {
+    properties
+        .get(MessageConst::PROPERTY_KEYS)
+        .is_some_and(|value| !value.is_empty() && !value.chars().all(char::is_whitespace))
+}
+
 /// Message-related limit constants
 ///
 /// These constants define the maximum sizes for various message components.

--- a/rocketmq-broker/tests/compaction_topic_contract.rs
+++ b/rocketmq-broker/tests/compaction_topic_contract.rs
@@ -1,0 +1,58 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use cheetah_string::CheetahString;
+use rocketmq_broker::send_message_constants::has_valid_compaction_key;
+use rocketmq_model::common::message::MessageConst;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct Contract {
+    key_cases: Vec<KeyCase>,
+}
+
+#[derive(Deserialize)]
+struct KeyCase {
+    name: String,
+    raw_key: String,
+    accepted: bool,
+    canonical_key: Option<String>,
+}
+
+#[test]
+fn compaction_topic_key_admission_matches_the_java_55_fixture() {
+    let contract: Contract =
+        serde_json::from_str(include_str!("../../scripts/fixtures/java-5.5-compaction-contract.json"))
+            .expect("valid Java 5.5 compaction fixture");
+
+    for case in contract.key_cases {
+        let properties = HashMap::from([(
+            CheetahString::from_static_str(MessageConst::PROPERTY_KEYS),
+            CheetahString::from_string(case.raw_key.clone()),
+        )]);
+        assert_eq!(has_valid_compaction_key(&properties), case.accepted, "{}", case.name);
+        if case.accepted {
+            assert_eq!(case.canonical_key.as_deref(), Some(case.raw_key.as_str()));
+        } else {
+            assert!(case.canonical_key.is_none());
+        }
+    }
+}
+
+#[test]
+fn missing_compaction_key_is_rejected_before_store_projection() {
+    assert!(!has_valid_compaction_key(&HashMap::new()));
+}

--- a/rocketmq-store/src/base/dispatch_request.rs
+++ b/rocketmq-store/src/base/dispatch_request.rs
@@ -24,6 +24,8 @@ pub struct DispatchRequest {
     pub queue_id: i32,
     pub commit_log_offset: i64,
     pub msg_size: i32,
+    /// Decoded message body length. `-1` means that the parser did not expose it.
+    pub body_size: i32,
     pub tags_code: i64,
     pub store_timestamp: i64,
     pub consume_queue_offset: i64,
@@ -48,6 +50,7 @@ impl Default for DispatchRequest {
             queue_id: 0,
             commit_log_offset: 0,
             msg_size: 0,
+            body_size: -1,
             tags_code: 0,
             store_timestamp: 0,
             consume_queue_offset: 0,
@@ -71,7 +74,7 @@ impl Display for DispatchRequest {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "DispatchRequest {{ topic: {}, queue_id: {}, commit_log_offset: {}, msg_size: {}, tags_code: {}, \
+            "DispatchRequest {{ topic: {}, queue_id: {}, commit_log_offset: {}, msg_size: {}, body_size: {}, tags_code: {}, \
              store_timestamp: {}, consume_queue_offset: {}, keys: {}, success: {}, uniq_key: {:?}, sys_flag: {}, \
              prepared_transaction_offset: {}, properties_map: {:?}, bit_map: {:?}, buffer_size: {}, msg_base_offset: \
              {}, batch_size: {}, next_reput_from_offset: {}, offset_id: {:?} }}",
@@ -79,6 +82,7 @@ impl Display for DispatchRequest {
             self.queue_id,
             self.commit_log_offset,
             self.msg_size,
+            self.body_size,
             self.tags_code,
             self.store_timestamp,
             self.consume_queue_offset,

--- a/rocketmq-store/src/index/index_service.rs
+++ b/rocketmq-store/src/index/index_service.rs
@@ -774,6 +774,7 @@ mod tests {
             queue_id: 0,
             commit_log_offset: 1000,
             msg_size: 100,
+            body_size: 0,
             tags_code: 0,
             store_timestamp: 1000000000000,
             consume_queue_offset: 0,

--- a/rocketmq-store/src/kv/compaction_generation.rs
+++ b/rocketmq-store/src/kv/compaction_generation.rs
@@ -39,13 +39,15 @@ use std::os::windows::ffi::OsStrExt;
 const CURRENT_MAGIC: u32 = 0x4343_5547;
 const GENERATION_MAGIC: u32 = 0x4347_454E;
 const RECORDS_MAGIC: u32 = 0x4347_5253;
-const FORMAT_VERSION: u16 = 1;
+const LEGACY_FORMAT_VERSION: u16 = 1;
+const FORMAT_VERSION: u16 = 2;
 const CURRENT_SIZE: usize = 40;
 const GENERATION_METADATA_SIZE: usize = 64;
 const RECORDS_HEADER_SIZE: usize = 16;
 const RECORD_HEADER_SIZE: usize = 40;
 const NO_GENERATION: u64 = u64::MAX;
 const NO_KEY: u16 = u16::MAX;
+const RECORD_FLAG_TOMBSTONE: u32 = 1;
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub(crate) struct CompactionQueueKey {
@@ -76,6 +78,7 @@ pub(crate) struct CompactionRecord {
     pub(crate) key: Option<CheetahString>,
     pub(crate) source_physical_offset: i64,
     pub(crate) source_size: i32,
+    pub(crate) tombstone: bool,
     pub(crate) payload: CompactionPayload,
 }
 
@@ -391,7 +394,8 @@ fn encode_records(queues: &CompactionQueues, path: &Path) -> Result<Vec<u8>, Roc
                 ));
             };
             if record.source_physical_offset < 0
-                || record.source_size <= 0
+                || record.source_size < 0
+                || (!record.tombstone && record.source_size == 0)
                 || payload.len() != record.source_size as usize
             {
                 return Err(RocketMQError::storage_write_failed(
@@ -406,7 +410,7 @@ fn encode_records(queues: &CompactionQueues, path: &Path) -> Result<Vec<u8>, Roc
             bytes.put_i32(record.batch_num);
             bytes.put_i64(record.source_physical_offset);
             bytes.put_i32(record.source_size);
-            bytes.put_u32(0);
+            bytes.put_u32(u32::from(record.tombstone) * RECORD_FLAG_TOMBSTONE);
             bytes.put_u32(0);
             bytes.put_slice(topic);
             if let Some(key) = key_bytes {
@@ -423,7 +427,11 @@ fn decode_records(bytes: &[u8], path: &Path, generation: u64) -> Result<Compacti
         return Err(corrupted(path));
     }
     let mut cursor = Bytes::copy_from_slice(bytes);
-    if cursor.get_u32() != RECORDS_MAGIC || cursor.get_u16() != FORMAT_VERSION {
+    if cursor.get_u32() != RECORDS_MAGIC {
+        return Err(corrupted(path));
+    }
+    let format_version = cursor.get_u16();
+    if !is_supported_version(format_version) {
         return Err(corrupted(path));
     }
     let _reserved = cursor.get_u16();
@@ -441,10 +449,21 @@ fn decode_records(bytes: &[u8], path: &Path, generation: u64) -> Result<Compacti
         let batch_num = cursor.get_i32();
         let physical_offset = cursor.get_i64();
         let size = cursor.get_i32();
+        let flags = cursor.get_u32();
         let _reserved = cursor.get_u32();
-        let _reserved = cursor.get_u32();
+        if (format_version == LEGACY_FORMAT_VERSION && flags != 0)
+            || (format_version == FORMAT_VERSION && flags & !RECORD_FLAG_TOMBSTONE != 0)
+        {
+            return Err(corrupted(path));
+        }
+        let tombstone = format_version == FORMAT_VERSION && flags & RECORD_FLAG_TOMBSTONE != 0;
         let variable_size = topic_len.saturating_add(key_len).saturating_add(size.max(0) as usize);
-        if queue_offset < 0 || batch_num <= 0 || physical_offset < 0 || size <= 0 || cursor.remaining() < variable_size
+        if queue_offset < 0
+            || batch_num <= 0
+            || physical_offset < 0
+            || size < 0
+            || (!tombstone && size == 0)
+            || cursor.remaining() < variable_size
         {
             return Err(corrupted(path));
         }
@@ -472,6 +491,7 @@ fn decode_records(bytes: &[u8], path: &Path, generation: u64) -> Result<Compacti
             key: key.map(CheetahString::from_string),
             source_physical_offset: physical_offset,
             source_size: size,
+            tombstone,
             payload: CompactionPayload::Generation {
                 generation,
                 position: payload_position,
@@ -528,7 +548,7 @@ fn decode_generation_metadata(bytes: &[u8], path: &Path) -> Result<GenerationMet
         return Err(corrupted(path));
     }
     let mut cursor = Bytes::copy_from_slice(bytes);
-    if cursor.get_u32() != GENERATION_MAGIC || cursor.get_u16() != FORMAT_VERSION {
+    if cursor.get_u32() != GENERATION_MAGIC || !is_supported_version(cursor.get_u16()) {
         return Err(corrupted(path));
     }
     let _reserved = cursor.get_u16();
@@ -578,7 +598,7 @@ fn decode_current(bytes: &[u8], path: &Path) -> Result<CurrentPointer, RocketMQE
         return Err(corrupted(path));
     }
     let mut cursor = Bytes::copy_from_slice(bytes);
-    if cursor.get_u32() != CURRENT_MAGIC || cursor.get_u16() != FORMAT_VERSION {
+    if cursor.get_u32() != CURRENT_MAGIC || !is_supported_version(cursor.get_u16()) {
         return Err(corrupted(path));
     }
     let _reserved = cursor.get_u16();
@@ -596,6 +616,10 @@ fn decode_current(bytes: &[u8], path: &Path) -> Result<CurrentPointer, RocketMQE
         previous,
         next_generation,
     })
+}
+
+fn is_supported_version(version: u16) -> bool {
+    matches!(version, LEGACY_FORMAT_VERSION | FORMAT_VERSION)
 }
 
 fn parse_generation_id(path: &Path) -> Option<u64> {
@@ -776,6 +800,47 @@ mod tests {
         assert_eq!(
             decode_generation_metadata(&encoded, Path::new("GENERATION")).unwrap(),
             metadata
+        );
+    }
+
+    #[test]
+    fn version_two_reader_accepts_legacy_version_one_metadata_and_records() {
+        let pointer = CurrentPointer {
+            current: 7,
+            previous: Some(6),
+            next_generation: 8,
+        };
+        let mut legacy_current = encode_current(pointer);
+        legacy_current[4..6].copy_from_slice(&LEGACY_FORMAT_VERSION.to_be_bytes());
+        let checksum = crc32(&legacy_current[..32]);
+        legacy_current[32..36].copy_from_slice(&checksum.to_be_bytes());
+        assert_eq!(decode_current(&legacy_current, Path::new("CURRENT")).unwrap(), pointer);
+
+        let mut queues = CompactionQueues::new();
+        queues.insert(
+            CompactionQueueKey {
+                topic: CheetahString::from_static_str("legacy-topic"),
+                queue_id: 0,
+            },
+            BTreeMap::from([(
+                3,
+                CompactionRecord {
+                    queue_offset: 3,
+                    batch_num: 1,
+                    key: Some(CheetahString::from_static_str("legacy-key")),
+                    source_physical_offset: 10,
+                    source_size: 4,
+                    tombstone: false,
+                    payload: CompactionPayload::Inline(Bytes::from_static(b"data")),
+                },
+            )]),
+        );
+        let mut legacy_records = encode_records(&queues, Path::new("records")).unwrap();
+        legacy_records[4..6].copy_from_slice(&LEGACY_FORMAT_VERSION.to_be_bytes());
+        let decoded = decode_records(&legacy_records, Path::new("records"), 7).unwrap();
+        assert_eq!(
+            decoded.values().next().unwrap().values().next().unwrap().queue_offset,
+            3
         );
     }
 }

--- a/rocketmq-store/src/kv/compaction_service.rs
+++ b/rocketmq-store/src/kv/compaction_service.rs
@@ -15,6 +15,9 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use cheetah_string::CheetahString;
+use dashmap::DashMap;
+use rocketmq_model::common::config::TopicConfig;
 use rocketmq_runtime::ScheduledTaskConfig;
 use rocketmq_runtime::ScheduledTaskGroup;
 use rocketmq_runtime::ScheduledTaskSnapshot;
@@ -34,6 +37,7 @@ pub struct CompactionService {
     worker_group: Option<rocketmq_runtime::TaskGroup>,
     scheduled_tasks: Option<ScheduledTaskGroup>,
     loaded: bool,
+    topic_config_table: Option<Arc<DashMap<CheetahString, Arc<TopicConfig>>>>,
 }
 
 impl CompactionService {
@@ -50,7 +54,16 @@ impl CompactionService {
             worker_group: None,
             scheduled_tasks: None,
             loaded: false,
+            topic_config_table: None,
         }
+    }
+
+    pub(crate) fn with_topic_config_table(
+        mut self,
+        topic_config_table: Arc<DashMap<CheetahString, Arc<TopicConfig>>>,
+    ) -> Self {
+        self.topic_config_table = Some(topic_config_table);
+        self
     }
 
     pub async fn load(&mut self, exit_ok: bool, required_wal_position: i64) -> bool {
@@ -74,6 +87,7 @@ impl CompactionService {
 
         self.shutdown_token = CancellationToken::new();
         let compaction_store = self.compaction_store.clone();
+        let topic_config_table = self.topic_config_table.clone();
         let schedule_interval = self.schedule_interval;
         let worker_group = crate::runtime::task_group(&self.runtime_scope, "rocketmq-store.kv.compaction");
         let scheduled_tasks = ScheduledTaskGroup::new(worker_group.clone());
@@ -82,7 +96,11 @@ impl CompactionService {
 
         if let Err(error) = scheduled_tasks.schedule_fixed_rate_no_overlap(config, move || {
             let compaction_store = compaction_store.clone();
+            let topic_config_table = topic_config_table.clone();
             async move {
+                if let Some(topic_config_table) = topic_config_table {
+                    compaction_store.reconcile_topic_policies(&topic_config_table);
+                }
                 match compaction_store.compact_once().await {
                     Ok(removed) if removed > 0 => {
                         info!("compaction service removed {} obsolete messages", removed);

--- a/rocketmq-store/src/kv/compaction_store.rs
+++ b/rocketmq-store/src/kv/compaction_store.rs
@@ -14,6 +14,7 @@
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -21,6 +22,9 @@ use bytes::Bytes;
 use cheetah_string::CheetahString;
 use parking_lot::RwLock;
 use rocketmq_error::RocketMQError;
+use rocketmq_model::common::attribute::cleanup_policy::CleanupPolicy;
+use rocketmq_model::common::config::TopicConfig;
+use rocketmq_model::utils::cleanup_policy_utils::get_delete_policy_arc_mut;
 
 use crate::base::dispatch_request::DispatchRequest;
 use crate::base::get_message_result::GetMessageResult;
@@ -75,6 +79,8 @@ struct CompactionState {
     delta: CompactionQueues,
     next_generation: u64,
     read_state: CompactionReadState,
+    corrupted: bool,
+    inactive_topics: HashSet<CheetahString>,
 }
 
 pub struct CompactionStore {
@@ -103,6 +109,8 @@ impl Default for CompactionStore {
                     generation: 0,
                     durable_watermark: 0,
                 },
+                corrupted: false,
+                inactive_topics: HashSet::new(),
             }),
             payload_resolver: RwLock::new(None),
             generation_lock: tokio::sync::Mutex::new(()),
@@ -202,6 +210,8 @@ impl CompactionStore {
                 durable_watermark,
                 required_wal_position: durable_watermark,
             };
+            state.corrupted = false;
+            state.inactive_topics.clear();
         }
         compaction_generation::cleanup_orphans(
             runtime_scope,
@@ -254,20 +264,51 @@ impl CompactionStore {
             .max(commit_log_min_offset)
     }
 
+    pub(crate) fn reconcile_topic_policies(
+        &self,
+        topic_config_table: &dashmap::DashMap<CheetahString, Arc<TopicConfig>>,
+    ) {
+        let mut state = self.state.write();
+        let topics = state
+            .current
+            .queues
+            .keys()
+            .chain(state.delta.keys())
+            .map(|key| key.topic.clone())
+            .collect::<HashSet<_>>();
+        for topic in topics {
+            let is_compaction = topic_config_table
+                .get(&topic)
+                .is_some_and(|config| get_delete_policy_arc_mut(Some(config.value())) == CleanupPolicy::COMPACTION);
+            if !is_compaction {
+                state.inactive_topics.insert(topic);
+            }
+        }
+    }
+
+    pub(crate) fn deactivate_topics(&self, topics: &[CheetahString]) {
+        self.state.write().inactive_topics.extend(topics.iter().cloned());
+    }
+
     pub fn put_message(&self, topic: &CheetahString, queue_id: i32, queue_offset: i64, batch_num: i32, payload: Bytes) {
         self.put_message_with_key(topic, queue_id, queue_offset, batch_num, None, payload);
     }
 
     pub(crate) fn put_dispatch_message(&self, dispatch_request: &DispatchRequest) {
-        let key = (!dispatch_request.keys.is_empty()).then(|| dispatch_request.keys.clone());
+        let key = canonical_key(Some(dispatch_request.keys.clone()));
+        let Some(key) = key else {
+            tracing::warn!(topic = %dispatch_request.topic, "compaction projection rejected a message without a non-blank key");
+            return;
+        };
         self.put_reference(
             &dispatch_request.topic,
             dispatch_request.queue_id,
             dispatch_request.consume_queue_offset,
             dispatch_request.batch_size as i32,
-            key,
+            Some(key),
             dispatch_request.commit_log_offset,
             dispatch_request.msg_size,
+            dispatch_request.body_size == 0,
         );
     }
 
@@ -280,19 +321,24 @@ impl CompactionStore {
         message_key: Option<CheetahString>,
         payload: Bytes,
     ) {
-        if queue_offset < 0 || payload.is_empty() {
+        let Some(message_key) = canonical_key(message_key) else {
+            return;
+        };
+        if queue_offset < 0 {
             return;
         }
         let source_size = payload.len() as i32;
+        let tombstone = payload.is_empty();
         self.insert_record(
             topic,
             queue_id,
             CompactionRecord {
                 queue_offset,
                 batch_num: batch_num.max(1),
-                key: message_key,
+                key: Some(message_key),
                 source_physical_offset: queue_offset,
                 source_size,
+                tombstone,
                 payload: CompactionPayload::Inline(payload),
             },
         );
@@ -307,6 +353,7 @@ impl CompactionStore {
         message_key: Option<CheetahString>,
         physical_offset: i64,
         size: i32,
+        tombstone: bool,
     ) {
         if queue_offset < 0 || physical_offset < 0 || size <= 0 {
             return;
@@ -320,6 +367,7 @@ impl CompactionStore {
                 key: message_key,
                 source_physical_offset: physical_offset,
                 source_size: size,
+                tombstone,
                 payload: CompactionPayload::CommitLog,
             },
         );
@@ -327,9 +375,37 @@ impl CompactionStore {
 
     fn insert_record(&self, topic: &CheetahString, queue_id: i32, record: CompactionRecord) {
         let mut state = self.state.write();
+        if state.inactive_topics.remove(topic) {
+            let mut queues = state.current.queues.clone();
+            queues.retain(|key, _| key.topic != *topic);
+            state.current = Arc::new(CompactionGeneration {
+                metadata: state.current.metadata,
+                queues,
+            });
+            state.delta.retain(|key, _| key.topic != *topic);
+        }
+        let queue_key = CompactionQueueKey::new(topic, queue_id);
+        let existing = state
+            .delta
+            .get(&queue_key)
+            .and_then(|queue| queue.get(&record.queue_offset))
+            .or_else(|| {
+                state
+                    .current
+                    .queues
+                    .get(&queue_key)
+                    .and_then(|queue| queue.get(&record.queue_offset))
+            });
+        if let Some(existing) = existing {
+            if !same_record_identity(existing, &record) {
+                state.corrupted = true;
+                tracing::error!(topic = %topic, queue_id, queue_offset = record.queue_offset, "conflicting compaction replay detected");
+            }
+            return;
+        }
         state
             .delta
-            .entry(CompactionQueueKey::new(topic, queue_id))
+            .entry(queue_key)
             .or_default()
             .insert(record.queue_offset, record);
     }
@@ -364,16 +440,23 @@ impl CompactionStore {
     pub async fn compact_once(&self) -> Result<usize, RocketMQError> {
         let _generation_guard = self.generation_lock.lock().await;
         self.cleanup_retired().await?;
-        let (base_generation, delta_snapshot, merged, generation, before) = {
+        let (base_generation, delta_snapshot, inactive_snapshot, merged, generation, before) = {
             let state = self.state.read();
-            if state.delta.is_empty() {
+            if state.corrupted {
+                return Err(RocketMQError::StorageCorrupted {
+                    path: self.root_display(),
+                });
+            }
+            if state.delta.is_empty() && state.inactive_topics.is_empty() {
                 return Ok(0);
             }
-            let source = merged_queues(&state.current.queues, &state.delta);
+            let mut source = merged_queues(&state.current.queues, &state.delta);
             let before = merged_count(&source);
+            source.retain(|key, _| !state.inactive_topics.contains(&key.topic));
             (
                 state.current.metadata.generation,
                 state.delta.clone(),
+                state.inactive_topics.clone(),
                 compact_queues(source),
                 state.next_generation,
                 before,
@@ -432,6 +515,7 @@ impl CompactionStore {
                 queues: published_queues,
             });
             remove_snapshot_from_delta(&mut state.delta, &delta_snapshot);
+            state.inactive_topics.retain(|topic| !inactive_snapshot.contains(topic));
             state.next_generation = generation.saturating_add(1);
             state.read_state = match state.read_state {
                 CompactionReadState::Ready { durable_watermark, .. } => CompactionReadState::Ready {
@@ -488,6 +572,10 @@ impl CompactionStore {
         let mut materialized = queues.clone();
         for queue in materialized.values_mut() {
             for record in queue.values_mut() {
+                if record.tombstone && record.source_size == 0 {
+                    record.payload = CompactionPayload::Inline(Bytes::new());
+                    continue;
+                }
                 let Some(payload) = self.resolve_payload(record).await? else {
                     return Err(RocketMQError::storage_read_failed(
                         self.root_display(),
@@ -543,7 +631,7 @@ impl CompactionStore {
         max_msg_nums: i32,
         max_total_msg_size: i32,
     ) -> Option<GetMessageResult> {
-        let (current_lease, delta, read_state) = {
+        let (current_lease, delta, read_state, corrupted, inactive) = {
             let state = self.state.read();
             (
                 state.current.clone(),
@@ -553,22 +641,32 @@ impl CompactionStore {
                     .cloned()
                     .unwrap_or_default(),
                 state.read_state.clone(),
+                state.corrupted,
+                state.inactive_topics.contains(topic),
             )
         };
-        if matches!(read_state, CompactionReadState::Recovering { .. }) {
+        if corrupted || matches!(read_state, CompactionReadState::Recovering { .. }) {
             // Preserve the stable Java-compatible public enum while making the internal state explicit.
             return Some(status_result(GetMessageStatus::MessageWasRemoving, offset, 0, 0));
+        }
+        if inactive {
+            return Some(status_result(GetMessageStatus::NoMatchedLogicQueue, 0, 0, 0));
         }
 
         let key = CompactionQueueKey::new(topic, queue_id);
         let mut queue = current_lease.queues.get(&key).cloned().unwrap_or_default();
         queue.extend(delta);
-        let queue = compact_queue(queue);
+        let compacted_queue = compact_queue(queue);
+        let queue = compacted_queue
+            .iter()
+            .filter(|(_, record)| !record.tombstone)
+            .map(|(offset, record)| (*offset, record.clone()))
+            .collect::<BTreeMap<_, _>>();
         if queue.is_empty() {
             return Some(status_result(GetMessageStatus::NoMatchedLogicQueue, 0, 0, 0));
         }
         let min_offset = *queue.keys().next().unwrap_or(&0);
-        let max_offset = queue
+        let max_offset = compacted_queue
             .values()
             .map(|message| message.queue_offset + i64::from(message.batch_num))
             .max()
@@ -671,7 +769,7 @@ impl CompactionStore {
         if result.message_count() == 0 {
             return Some(status_result(
                 GetMessageStatus::NoMatchedMessage,
-                offset,
+                max_offset,
                 min_offset,
                 max_offset,
             ));
@@ -723,12 +821,18 @@ impl CompactionStore {
 
     pub fn message_count(&self, topic: &CheetahString, queue_id: i32) -> usize {
         let state = self.state.read();
+        if state.inactive_topics.contains(topic) {
+            return 0;
+        }
         let key = CompactionQueueKey::new(topic, queue_id);
         let mut queue = state.current.queues.get(&key).cloned().unwrap_or_default();
         if let Some(delta) = state.delta.get(&key) {
             queue.extend(delta.clone());
         }
-        compact_queue(queue).len()
+        if state.corrupted {
+            return 0;
+        }
+        visible_queue(queue).len()
     }
 
     pub(crate) fn current_generation_id(&self) -> u64 {
@@ -813,25 +917,34 @@ fn compact_queues(mut queues: CompactionQueues) -> CompactionQueues {
 }
 
 fn compact_queue(mut queue: BTreeMap<i64, CompactionRecord>) -> BTreeMap<i64, CompactionRecord> {
-    let mut latest = HashMap::<CheetahString, (i64, i64)>::new();
+    let mut latest = HashMap::<CheetahString, i64>::new();
     for (&queue_offset, record) in &queue {
         let Some(key) = record.key.as_ref() else {
             continue;
         };
-        let candidate = (record.physical_offset(), queue_offset);
         latest
             .entry(key.clone())
-            .and_modify(|current| *current = (*current).max(candidate))
-            .or_insert(candidate);
+            .and_modify(|current| *current = (*current).max(queue_offset))
+            .or_insert(queue_offset);
     }
     queue.retain(|queue_offset, record| {
-        record.key.as_ref().is_none_or(|key| {
-            latest
-                .get(key)
-                .is_some_and(|latest| *latest == (record.physical_offset(), *queue_offset))
-        })
+        record
+            .key
+            .as_ref()
+            .is_some_and(|key| latest.get(key).is_some_and(|latest| latest == queue_offset))
     });
     queue
+}
+
+fn visible_queue(queue: BTreeMap<i64, CompactionRecord>) -> BTreeMap<i64, CompactionRecord> {
+    compact_queue(queue)
+        .into_iter()
+        .filter(|(_, record)| !record.tombstone)
+        .collect()
+}
+
+fn canonical_key(key: Option<CheetahString>) -> Option<CheetahString> {
+    key.filter(|key| !key.is_empty() && !key.chars().all(char::is_whitespace))
 }
 
 fn merged_count(queues: &CompactionQueues) -> usize {
@@ -855,8 +968,15 @@ fn same_record_identity(left: &CompactionRecord, right: &CompactionRecord) -> bo
     left.queue_offset == right.queue_offset
         && left.batch_num == right.batch_num
         && left.key == right.key
+        && left.tombstone == right.tombstone
         && left.physical_offset() == right.physical_offset()
         && left.end_physical_offset() == right.end_physical_offset()
+        && match (&left.payload, &right.payload) {
+            (CompactionPayload::Inline(left), CompactionPayload::Inline(right)) => left == right,
+            // A durable generation record and its CommitLog replay intentionally use different payload owners.
+            // Their exact physical range and metadata above are the stable replay identity.
+            _ => true,
+        }
 }
 
 fn metadata_for_memory(generation: u64, queues: &CompactionQueues) -> GenerationMetadata {
@@ -915,6 +1035,7 @@ mod tests {
     use bytes::Bytes;
     use cheetah_string::CheetahString;
     use parking_lot::RwLock;
+    use serde::Deserialize;
 
     use super::CompactionReadState;
     use super::CompactionStore;
@@ -924,6 +1045,71 @@ mod tests {
 
     fn durable_store(root: PathBuf) -> CompactionStore {
         CompactionStore::with_root(root, crate::runtime::test_scope("compaction-store-test"))
+    }
+
+    #[derive(Deserialize)]
+    struct JavaCompactionContract {
+        records: Vec<JavaCompactionRecord>,
+        replay: JavaReplayContract,
+        retention: JavaRetentionContract,
+    }
+
+    #[derive(Deserialize)]
+    struct JavaCompactionRecord {
+        queue_offset: i64,
+        raw_key: String,
+        body: String,
+        tombstone: bool,
+    }
+
+    #[derive(Deserialize)]
+    struct JavaReplayContract {
+        identical_same_offset: String,
+        conflicting_same_offset: String,
+        winner: String,
+    }
+
+    #[derive(Deserialize)]
+    struct JavaRetentionContract {
+        retain_tombstone_until_atomic_generation_covers_older_records: bool,
+        restart_must_not_resurrect_deleted_value: bool,
+    }
+
+    #[tokio::test]
+    async fn java_55_fixture_drives_batch_tombstone_replay_and_retention_contracts() {
+        let fixture: JavaCompactionContract = serde_json::from_str(include_str!(
+            "../../../scripts/fixtures/java-5.5-compaction-contract.json"
+        ))
+        .expect("valid Java 5.5 compaction fixture");
+        let store = CompactionStore::new();
+        let topic = CheetahString::from_static_str("java-fixture-topic");
+        let group = CheetahString::from_static_str("java-fixture-group");
+
+        for record in fixture.records {
+            assert_eq!(record.tombstone, record.body.is_empty());
+            store.put_message_with_key(
+                &topic,
+                0,
+                record.queue_offset,
+                1,
+                Some(CheetahString::from_string(record.raw_key)),
+                Bytes::from(record.body),
+            );
+        }
+
+        assert_eq!(store.message_count(&topic, 0), 1);
+        let result = store.get_message(&group, &topic, 0, 11, 1, 1024).await.unwrap();
+        assert_eq!(result.status(), Some(GetMessageStatus::Found));
+        assert_eq!(result.next_begin_offset(), 12);
+        assert_eq!(fixture.replay.identical_same_offset, "idempotent");
+        assert_eq!(fixture.replay.conflicting_same_offset, "fail-closed");
+        assert_eq!(fixture.replay.winner, "maximum-queue-offset");
+        assert!(
+            fixture
+                .retention
+                .retain_tombstone_until_atomic_generation_covers_older_records
+        );
+        assert!(fixture.retention.restart_must_not_resurrect_deleted_value);
     }
 
     #[tokio::test]
@@ -944,7 +1130,14 @@ mod tests {
         let store = CompactionStore::new();
         let topic = CheetahString::from_static_str("compaction-topic");
         let group = CheetahString::from_static_str("compaction-group");
-        store.put_message(&topic, 0, 7, 1, Bytes::from_static(b"compacted-message"));
+        store.put_message_with_key(
+            &topic,
+            0,
+            7,
+            1,
+            Some(CheetahString::from_static_str("key")),
+            Bytes::from_static(b"compacted-message"),
+        );
         let result = store
             .get_message(&group, &topic, 0, 7, 32, 1024)
             .await
@@ -978,6 +1171,143 @@ mod tests {
             latest_result.message_mapped_list()[0].get_bytes_ref().unwrap(),
             &Bytes::from_static(b"latest-message")
         );
+    }
+
+    #[tokio::test]
+    async fn latest_queue_offset_wins_even_when_physical_offsets_are_not_monotonic() {
+        let store = CompactionStore::new();
+        let topic = CheetahString::from_static_str("compaction-order-topic");
+        let group = CheetahString::from_static_str("compaction-order-group");
+        let key = CheetahString::from_static_str("same-key");
+        let payloads = Arc::new(RwLock::new(HashMap::from([
+            (100_i64, Bytes::from_static(b"old")),
+            (50_i64, Bytes::from_static(b"new")),
+        ])));
+        install_resolver(&store, payloads);
+
+        store.put_reference(&topic, 0, 10, 1, Some(key.clone()), 100, 3, false);
+        store.put_reference(&topic, 0, 11, 1, Some(key), 50, 3, false);
+
+        let result = store.get_message(&group, &topic, 0, 11, 1, 1024).await.unwrap();
+        assert_eq!(result.status(), Some(GetMessageStatus::Found));
+        assert_eq!(
+            result.message_mapped_list()[0].get_bytes_ref().unwrap().as_ref(),
+            b"new"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_body_tombstone_survives_generation_restart_without_resurrection() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("compaction-tombstone");
+        let topic = CheetahString::from_static_str("compaction-tombstone-topic");
+        let group = CheetahString::from_static_str("compaction-tombstone-group");
+        let key = CheetahString::from_static_str("deleted-key");
+
+        let store = durable_store(root.clone());
+        store.load().await.unwrap();
+        store.finish_recovery(0);
+        store.put_message_with_key(&topic, 0, 0, 1, Some(key.clone()), Bytes::from_static(b"value"));
+        store.compact_once().await.unwrap();
+        store.put_message_with_key(&topic, 0, 1, 1, Some(key), Bytes::new());
+        assert_eq!(store.message_count(&topic, 0), 0);
+        store.compact_once().await.unwrap();
+        drop(store);
+
+        let restarted = durable_store(root);
+        restarted.load().await.unwrap();
+        restarted.finish_recovery(1);
+        assert_eq!(restarted.message_count(&topic, 0), 0);
+        let result = restarted.get_message(&group, &topic, 0, 0, 1, 1024).await.unwrap();
+        assert_eq!(result.status(), Some(GetMessageStatus::NoMatchedLogicQueue));
+    }
+
+    #[tokio::test]
+    async fn same_offset_replay_is_idempotent_but_conflicting_replay_fails_closed() {
+        let store = CompactionStore::new();
+        let topic = CheetahString::from_static_str("compaction-replay-topic");
+        let group = CheetahString::from_static_str("compaction-replay-group");
+        let key = CheetahString::from_static_str("key");
+
+        store.put_message_with_key(&topic, 0, 4, 1, Some(key.clone()), Bytes::from_static(b"same"));
+        store.put_message_with_key(&topic, 0, 4, 1, Some(key.clone()), Bytes::from_static(b"same"));
+        assert_eq!(store.message_count(&topic, 0), 1);
+
+        store.put_message_with_key(&topic, 0, 4, 1, Some(key), Bytes::from_static(b"different"));
+        assert_eq!(store.message_count(&topic, 0), 0);
+        let result = store.get_message(&group, &topic, 0, 4, 1, 1024).await.unwrap();
+        assert_eq!(result.status(), Some(GetMessageStatus::MessageWasRemoving));
+        assert!(store.compact_once().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn raw_multi_token_key_is_compacted_as_one_key_without_splitting() {
+        let store = CompactionStore::new();
+        let topic = CheetahString::from_static_str("compaction-raw-key-topic");
+        let group = CheetahString::from_static_str("compaction-raw-key-group");
+        let key = CheetahString::from_static_str("a b");
+
+        store.put_message_with_key(&topic, 0, 0, 1, Some(key.clone()), Bytes::from_static(b"old"));
+        store.put_message_with_key(&topic, 0, 1, 1, Some(key), Bytes::from_static(b"new"));
+        assert_eq!(store.message_count(&topic, 0), 1);
+        let result = store.get_message(&group, &topic, 0, 1, 1, 1024).await.unwrap();
+        assert_eq!(
+            result.message_mapped_list()[0].get_bytes_ref().unwrap().as_ref(),
+            b"new"
+        );
+    }
+
+    #[tokio::test]
+    async fn tombstone_only_tail_advances_the_logical_read_frontier() {
+        let store = CompactionStore::new();
+        let topic = CheetahString::from_static_str("compaction-tombstone-frontier-topic");
+        let group = CheetahString::from_static_str("compaction-tombstone-frontier-group");
+
+        store.put_message_with_key(
+            &topic,
+            0,
+            0,
+            1,
+            Some(CheetahString::from_static_str("visible")),
+            Bytes::from_static(b"value"),
+        );
+        store.put_message_with_key(
+            &topic,
+            0,
+            2,
+            1,
+            Some(CheetahString::from_static_str("deleted")),
+            Bytes::new(),
+        );
+
+        let result = store.get_message(&group, &topic, 0, 1, 1, 1024).await.unwrap();
+        assert_eq!(result.status(), Some(GetMessageStatus::NoMatchedMessage));
+        assert_eq!(result.next_begin_offset(), 3);
+        assert_eq!(result.max_offset(), 3);
+    }
+
+    #[tokio::test]
+    async fn missing_or_blank_keys_never_create_compaction_projection_state() {
+        let store = CompactionStore::new();
+        let topic = CheetahString::from_static_str("compaction-key-contract-topic");
+        let group = CheetahString::from_static_str("compaction-key-contract-group");
+
+        store.put_message_with_key(&topic, 0, 0, 1, None, Bytes::from_static(b"missing"));
+        store.put_message_with_key(
+            &topic,
+            0,
+            1,
+            1,
+            Some(CheetahString::from_static_str("   \t")),
+            Bytes::from_static(b"blank"),
+        );
+
+        assert_eq!(store.message_count(&topic, 0), 0);
+        let result = store
+            .get_message(&group, &topic, 0, 0, 32, 1024)
+            .await
+            .expect("compaction status");
+        assert_eq!(result.status(), Some(GetMessageStatus::NoMatchedLogicQueue));
     }
 
     #[tokio::test]
@@ -1021,10 +1351,10 @@ mod tests {
         install_resolver(&store, payloads.clone());
         store.load().await.unwrap();
         store.finish_recovery(0);
-        store.put_reference(&topic, 0, 0, 1, Some(key.clone()), 10, 3);
+        store.put_reference(&topic, 0, 0, 1, Some(key.clone()), 10, 3, false);
         store.compact_once().await.unwrap();
         assert_eq!(store.durable_dispatch_offset(0), 13);
-        store.put_reference(&topic, 0, 1, 1, Some(key.clone()), 20, 3);
+        store.put_reference(&topic, 0, 1, 1, Some(key.clone()), 20, 3, false);
         store.compact_once().await.unwrap();
         assert_eq!(store.current_generation_id(), 2);
         drop(store);
@@ -1048,7 +1378,7 @@ mod tests {
             Some(GetMessageStatus::MessageWasRemoving)
         );
 
-        restarted.put_reference(&topic, 0, 1, 1, Some(key), 20, 3);
+        restarted.put_reference(&topic, 0, 1, 1, Some(key), 20, 3, false);
         restarted.finish_recovery(23);
         assert_eq!(
             restarted
@@ -1072,7 +1402,16 @@ mod tests {
         install_resolver(&store, payloads.clone());
         store.load().await.unwrap();
         store.finish_recovery(0);
-        store.put_reference(&topic, 0, 0, 1, None, 10, 4);
+        store.put_reference(
+            &topic,
+            0,
+            0,
+            1,
+            Some(CheetahString::from_static_str("key")),
+            10,
+            4,
+            false,
+        );
         store.compact_once().await.unwrap();
         payloads.write().clear();
 
@@ -1110,9 +1449,9 @@ mod tests {
         install_resolver(&store, payloads.clone());
         store.load().await.unwrap();
         store.finish_recovery(0);
-        store.put_reference(&topic, 0, 0, 1, Some(key.clone()), 10, 3);
+        store.put_reference(&topic, 0, 0, 1, Some(key.clone()), 10, 3, false);
         store.compact_once().await.unwrap();
-        store.put_reference(&topic, 0, 1, 1, Some(key.clone()), 20, 3);
+        store.put_reference(&topic, 0, 1, 1, Some(key.clone()), 20, 3, false);
         store.set_fault(stage);
         assert!(store.compact_once().await.is_err());
         let expected_generation = if matches!(stage, FaultStage::Cleanup) { 2 } else { 1 };
@@ -1126,7 +1465,7 @@ mod tests {
         let recovering = restarted.get_message(&group, &topic, 0, 0, 32, 1024).await.unwrap();
         assert_eq!(recovering.status(), Some(GetMessageStatus::MessageWasRemoving));
 
-        restarted.put_reference(&topic, 0, 1, 1, Some(key), 20, 3);
+        restarted.put_reference(&topic, 0, 1, 1, Some(key), 20, 3, false);
         restarted.finish_recovery(23);
         let result = restarted.get_message(&group, &topic, 0, 0, 32, 1024).await.unwrap();
         assert_eq!(result.status(), Some(GetMessageStatus::OffsetTooSmall));
@@ -1154,12 +1493,13 @@ mod tests {
         );
         store.load().await.unwrap();
         store.finish_recovery(0);
-        store.put_reference(&topic, 0, 0, 1, None, 10, 3);
+        let key = CheetahString::from_static_str("lease-key");
+        store.put_reference(&topic, 0, 0, 1, Some(key.clone()), 10, 3, false);
         store.compact_once().await.unwrap();
         let generation_one_lease = store.current_lease();
-        store.put_reference(&topic, 0, 1, 1, None, 20, 3);
+        store.put_reference(&topic, 0, 1, 1, Some(key.clone()), 20, 3, false);
         store.compact_once().await.unwrap();
-        store.put_reference(&topic, 0, 2, 1, None, 30, 5);
+        store.put_reference(&topic, 0, 2, 1, Some(key), 30, 5, false);
         store.compact_once().await.unwrap();
         assert!(compaction_generation::generation_path(&root, 1).exists());
         drop(generation_one_lease);

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -2746,6 +2746,7 @@ pub fn check_message_and_return_size(
         queue_id: record.queue_id,
         commit_log_offset: record.physical_offset,
         msg_size: total_size,
+        body_size: body_len,
         tags_code,
         store_timestamp: record.store_timestamp,
         consume_queue_offset: record.queue_offset,

--- a/rocketmq-store/src/log_file/mapped_file/builder.rs
+++ b/rocketmq-store/src/log_file/mapped_file/builder.rs
@@ -14,6 +14,8 @@
 
 use std::path::Path;
 
+use cheetah_string::CheetahString;
+
 use super::default_mapped_file_impl::DefaultMappedFile;
 use super::FlushStrategy;
 use super::MappedFileError;
@@ -32,10 +34,10 @@ use super::MappedFileResult;
 ///
 /// # Optional Parameters
 ///
-/// - Flush strategy (default: `FlushStrategy::Async`)
-/// - Transient store pool usage (default: disabled)
-/// - Metrics collection (default: enabled)
-/// - Warmup on creation (default: disabled)
+/// - Flush strategy (only `FlushStrategy::Async` is currently supported)
+/// - Transient store pool usage (must remain disabled)
+/// - Metrics collection (must remain enabled)
+/// - Warmup on creation (must remain disabled)
 ///
 /// # Examples
 ///
@@ -47,13 +49,7 @@ use super::MappedFileResult;
 ///     .size_mb(1024)  // 1 GB file
 ///     .build()?;
 ///
-/// // Advanced configuration
-/// let file = MappedFileBuilder::new("data/commitlog/00000000000000000000")
-///     .size(1024 * 1024 * 1024)
-///     .flush_strategy(FlushStrategy::periodic(Duration::from_millis(500)))
-///     .enable_transient_store_pool()
-///     .warmup(true)
-///     .build()?;
+/// Unsupported options return a configuration error before the file is created.
 /// ```
 #[derive(Debug, Clone)]
 pub struct MappedFileBuilder {
@@ -145,7 +141,7 @@ impl MappedFileBuilder {
     ///     .size_mb(1024);  // 1 GB
     /// ```
     pub fn size_mb(self, mb: u64) -> Self {
-        self.size(mb * 1024 * 1024)
+        self.size(mb.saturating_mul(1024 * 1024))
     }
 
     /// Sets the file size in gigabytes.
@@ -165,7 +161,7 @@ impl MappedFileBuilder {
     ///     .size_gb(1);  // 1 GB
     /// ```
     pub fn size_gb(self, gb: u64) -> Self {
-        self.size(gb * 1024 * 1024 * 1024)
+        self.size(gb.saturating_mul(1024 * 1024 * 1024))
     }
 
     /// Sets the flush strategy.
@@ -292,13 +288,11 @@ impl MappedFileBuilder {
     ///
     /// `Ok(())` if configuration is valid, `Err` otherwise
     fn validate(&self) -> MappedFileResult<()> {
-        if self.file_size.is_none() {
+        let Some(size) = self.file_size else {
             return Err(MappedFileError::Configuration(
                 "file size must be specified".to_string(),
             ));
-        }
-
-        let size = self.file_size.unwrap();
+        };
         if size == 0 {
             return Err(MappedFileError::Configuration(
                 "file size must be greater than zero".to_string(),
@@ -312,6 +306,46 @@ impl MappedFileBuilder {
                 "file size {} exceeds maximum {} bytes",
                 size, MAX_FILE_SIZE
             )));
+        }
+
+        if self.flush_strategy != FlushStrategy::Async {
+            return Err(MappedFileError::Configuration(
+                "mapped file builder only supports the async flush strategy".to_string(),
+            ));
+        }
+        if self.use_transient_store_pool {
+            return Err(MappedFileError::Configuration(
+                "mapped file builder does not support transient store pool allocation".to_string(),
+            ));
+        }
+        if !self.enable_metrics {
+            return Err(MappedFileError::Configuration(
+                "mapped file builder does not support disabling mapped-file metrics".to_string(),
+            ));
+        }
+        if self.warmup {
+            return Err(MappedFileError::Configuration(
+                "mapped file builder does not support eager mapped-file warmup".to_string(),
+            ));
+        }
+
+        let file_name = Path::new(&self.file_path)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| MappedFileError::Configuration("mapped file name is missing".to_string()))?;
+        let parsed_offset = file_name.parse::<u64>().map_err(|_| {
+            MappedFileError::Configuration(format!(
+                "mapped file name must be a numeric starting offset: {file_name}"
+            ))
+        })?;
+        match self.file_from_offset {
+            Some(configured_offset) if configured_offset != parsed_offset => {
+                return Err(MappedFileError::Configuration(format!(
+                    "configured starting offset does not match mapped file name: configured={configured_offset}, \
+                     parsed={parsed_offset}"
+                )));
+            }
+            _ => {}
         }
 
         Ok(())
@@ -340,14 +374,11 @@ impl MappedFileBuilder {
     ///     .build()?;
     /// ```
     pub fn build(self) -> MappedFileResult<DefaultMappedFile> {
-        // Validate configuration
         self.validate()?;
-
-        // This will be implemented once DefaultMappedFile refactoring is complete
-        // For now, return a configuration error as a placeholder
-        Err(MappedFileError::Configuration(
-            "Builder implementation pending DefaultMappedFile refactoring".to_string(),
-        ))
+        let file_size = self
+            .file_size
+            .ok_or_else(|| MappedFileError::Configuration("file size must be specified".to_string()))?;
+        DefaultMappedFile::try_new(CheetahString::from_string(self.file_path), file_size).map_err(MappedFileError::from)
     }
 
     /// Returns the configured file size in bytes.

--- a/rocketmq-store/src/message_store/local_file_message_store/composition.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/composition.rs
@@ -279,6 +279,7 @@ impl LocalFileMessageStore {
                 compaction_store.clone(),
                 message_store_config.compaction_schedule_internal,
             )
+            .with_topic_config_table(topic_config_table.clone())
         });
         Ok(Self {
             runtime_scope: runtime_scope.clone(),

--- a/rocketmq-store/src/message_store/local_file_message_store/dispatch.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/dispatch.rs
@@ -139,6 +139,7 @@ impl LocalFileMessageStore {
             if !removed {
                 continue;
             }
+            self.compaction_store.deactivate_topics(std::slice::from_ref(topic));
             info!("DeleteTopic: Topic has been destroyed, topic={}", topic);
             delete_count += 1;
         }

--- a/rocketmq-store/tests/compaction_lifecycle_tests.rs
+++ b/rocketmq-store/tests/compaction_lifecycle_tests.rs
@@ -1,0 +1,195 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use bytes::Bytes;
+use cheetah_string::CheetahString;
+use dashmap::DashMap;
+use rocketmq_model::common::attribute::cleanup_policy::CleanupPolicy;
+use rocketmq_model::common::attribute::Attribute;
+use rocketmq_model::common::config::TopicConfig;
+use rocketmq_model::common::message::message_ext_broker_inner::MessageExtBrokerInner;
+use rocketmq_model::common::message::MessageConst;
+use rocketmq_model::common::message::MessageTrait;
+use rocketmq_model::TopicAttributes::TopicAttributes;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use rocketmq_store::BrokerReadStore;
+use rocketmq_store::BrokerStorePort;
+use rocketmq_store::BrokerWriteStore;
+use rocketmq_store::FlushDiskType;
+use rocketmq_store::GetMessageStatus;
+use rocketmq_store::LocalFileMessageStore;
+use rocketmq_store::MessageStoreConfig;
+use rocketmq_store::PutMessageStatus;
+use rocketmq_store::StoreRuntimeConfig;
+
+fn service_context() -> rocketmq_runtime::ChildServiceContext {
+    static OWNER: OnceLock<RuntimeOwner> = OnceLock::new();
+    OWNER
+        .get_or_init(|| {
+            RuntimeOwner::new(RuntimeConfig::server_default("compaction-lifecycle-tests"))
+                .expect("compaction lifecycle runtime")
+        })
+        .root_context()
+        .component("compaction-store")
+}
+
+fn compaction_topic(name: &str) -> TopicConfig {
+    let mut config = TopicConfig::new(name);
+    config.attributes.insert(
+        TopicAttributes::cleanup_policy_attribute().name().clone(),
+        CleanupPolicy::COMPACTION.to_string().into(),
+    );
+    config
+}
+
+fn delete_topic(name: &str) -> TopicConfig {
+    TopicConfig::new(name)
+}
+
+fn message(topic: &CheetahString, key: Option<&str>, body: &'static [u8]) -> MessageExtBrokerInner {
+    let mut message = MessageExtBrokerInner::default();
+    message.set_topic(topic.clone());
+    message.message_ext_inner.set_queue_id(0);
+    message.set_body(Bytes::from_static(body));
+    if let Some(key) = key {
+        message.put_property(
+            CheetahString::from_static_str(MessageConst::PROPERTY_KEYS),
+            CheetahString::from_string(key.to_owned()),
+        );
+    }
+    message
+}
+
+fn new_store(root: &std::path::Path, topics: Arc<DashMap<CheetahString, Arc<TopicConfig>>>) -> LocalFileMessageStore {
+    let config = MessageStoreConfig {
+        store_path_root_dir: root.to_string_lossy().to_string().into(),
+        enable_compaction: true,
+        compaction_schedule_internal: 1,
+        flush_disk_type: FlushDiskType::AsyncFlush,
+        mapped_file_size_commit_log: 1024 * 1024,
+        mapped_file_size_consume_queue: 20 * 1024,
+        ha_listen_port: 0,
+        timer_wheel_enable: false,
+        ..MessageStoreConfig::default()
+    };
+    let mut store = LocalFileMessageStore::new(
+        Arc::new(config),
+        Arc::new(StoreRuntimeConfig::default()),
+        topics,
+        None,
+        false,
+        service_context(),
+    );
+    store
+        .wire_owned_root_dependencies()
+        .expect("wire compaction test store dependencies");
+    store
+}
+
+async fn start(store: &mut LocalFileMessageStore) {
+    store.init().await.expect("initialize compaction test store");
+    assert!(store.load().await, "load compaction test store");
+    store.start().await.expect("start compaction test store");
+}
+
+async fn wait_for_status(
+    store: &LocalFileMessageStore,
+    group: &CheetahString,
+    topic: &CheetahString,
+    offset: i64,
+    expected: GetMessageStatus,
+) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    loop {
+        if store
+            .get_message(group, topic, 0, offset, 32, None)
+            .await
+            .is_some_and(|result| result.status() == Some(expected))
+        {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for {expected:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test]
+async fn tombstone_is_durable_and_cleanup_policy_selects_exactly_one_read_path() {
+    let temp = tempfile::tempdir().expect("compaction temp directory");
+    let topic = CheetahString::from_static_str("CompactionLifecycleTopic");
+    let group = CheetahString::from_static_str("CompactionLifecycleGroup");
+    let topics = Arc::new(DashMap::new());
+    topics.insert(topic.clone(), Arc::new(compaction_topic(topic.as_str())));
+
+    let mut store = new_store(temp.path(), topics.clone());
+    start(&mut store).await;
+    for body in [b"old".as_slice(), b"new".as_slice()] {
+        let result = store.put_message(message(&topic, Some("a b"), body)).await;
+        assert_eq!(result.put_message_status(), PutMessageStatus::PutOk);
+    }
+    wait_for_status(&store, &group, &topic, 1, GetMessageStatus::Found).await;
+
+    topics.insert(topic.clone(), Arc::new(delete_topic(topic.as_str())));
+    wait_for_status(&store, &group, &topic, 0, GetMessageStatus::Found).await;
+    topics.insert(topic.clone(), Arc::new(compaction_topic(topic.as_str())));
+
+    let tombstone = store.put_message(message(&topic, Some("a b"), b"")).await;
+    assert_eq!(tombstone.put_message_status(), PutMessageStatus::PutOk);
+    wait_for_status(&store, &group, &topic, 0, GetMessageStatus::NoMatchedLogicQueue).await;
+    let current = temp.path().join("compaction").join("CURRENT");
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    while !current.exists() {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "compaction generation was not published"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    store.shutdown().await;
+    drop(store);
+
+    let mut restarted = new_store(temp.path(), topics);
+    start(&mut restarted).await;
+    wait_for_status(&restarted, &group, &topic, 0, GetMessageStatus::NoMatchedLogicQueue).await;
+    restarted.shutdown().await;
+}
+
+#[tokio::test]
+async fn missing_key_keeps_main_commit_log_ack_but_has_no_compaction_projection() {
+    let temp = tempfile::tempdir().expect("compaction temp directory");
+    let topic = CheetahString::from_static_str("CompactionMissingKeyTopic");
+    let group = CheetahString::from_static_str("CompactionMissingKeyGroup");
+    let topics = Arc::new(DashMap::new());
+    topics.insert(topic.clone(), Arc::new(compaction_topic(topic.as_str())));
+    let mut store = new_store(temp.path(), topics);
+    start(&mut store).await;
+
+    let result = store.put_message(message(&topic, None, b"main-log-value")).await;
+    assert_eq!(result.put_message_status(), PutMessageStatus::PutOk);
+    wait_for_status(&store, &group, &topic, 0, GetMessageStatus::NoMatchedLogicQueue).await;
+    assert!(
+        store.get_max_phy_offset() > 0,
+        "main CommitLog append must remain acknowledged"
+    );
+    store.shutdown().await;
+}

--- a/rocketmq-store/tests/mapped_file_builder_tests.rs
+++ b/rocketmq-store/tests/mapped_file_builder_tests.rs
@@ -1,0 +1,137 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_store::FlushStrategy;
+use rocketmq_store::MappedFile;
+use rocketmq_store::MappedFileBuilder;
+use rocketmq_store::MappedFileError;
+use tempfile::TempDir;
+
+#[test]
+fn builder_creates_a_writable_mapped_file_with_the_declared_offset() {
+    let temp_dir = TempDir::new().expect("temporary mapped-file directory");
+    let path = temp_dir.path().join("00000000000000000042");
+
+    let mapped_file = MappedFileBuilder::new(&path)
+        .size(4096)
+        .file_from_offset(42)
+        .build()
+        .expect("build mapped file");
+
+    assert_eq!(mapped_file.get_file_size(), 4096);
+    assert_eq!(mapped_file.get_file_from_offset(), 42);
+    assert!(mapped_file.append_message_bytes(b"builder-contract"));
+    assert_eq!(
+        mapped_file.get_bytes_readable_checked(0, 16).as_deref(),
+        Some(&b"builder-contract"[..])
+    );
+    assert!(mapped_file.destroy(0));
+    assert!(!path.exists());
+}
+
+#[test]
+fn builder_rejects_offset_mismatch_before_creating_the_file() {
+    let temp_dir = TempDir::new().expect("temporary mapped-file directory");
+    let path = temp_dir.path().join("00000000000000000042");
+
+    let result = MappedFileBuilder::new(&path).size(4096).file_from_offset(43).build();
+    if let Ok(mapped_file) = &result {
+        mapped_file.destroy(0);
+    }
+
+    assert!(matches!(result, Err(MappedFileError::Configuration(_))));
+    assert!(!path.exists());
+}
+
+#[test]
+fn builder_rejects_invalid_sizes_and_file_names_before_creation() {
+    let temp_dir = TempDir::new().expect("temporary mapped-file directory");
+    let missing_size = temp_dir.path().join("00000000000000000001");
+    let zero_size = temp_dir.path().join("00000000000000000002");
+    let too_large = temp_dir.path().join("00000000000000000003");
+    let invalid_name = temp_dir.path().join("not-an-offset");
+    let cases = [
+        (missing_size.clone(), MappedFileBuilder::new(&missing_size)),
+        (zero_size.clone(), MappedFileBuilder::new(&zero_size).size(0)),
+        (
+            too_large.clone(),
+            MappedFileBuilder::new(&too_large).size(16 * 1024 * 1024 * 1024 + 1),
+        ),
+        (invalid_name.clone(), MappedFileBuilder::new(&invalid_name).size(4096)),
+    ];
+
+    for (path, builder) in cases {
+        assert!(matches!(builder.build(), Err(MappedFileError::Configuration(_))));
+        assert!(!path.exists());
+    }
+}
+
+#[test]
+fn builder_rejects_unsupported_options_without_filesystem_side_effects() {
+    let temp_dir = TempDir::new().expect("temporary mapped-file directory");
+    let sync_path = temp_dir.path().join("00000000000000000001");
+    let metrics_path = temp_dir.path().join("00000000000000000002");
+    let warmup_path = temp_dir.path().join("00000000000000000003");
+    let transient_path = temp_dir.path().join("00000000000000000004");
+    let cases = [
+        (
+            sync_path.clone(),
+            MappedFileBuilder::new(&sync_path)
+                .size(4096)
+                .flush_strategy(FlushStrategy::Sync),
+        ),
+        (
+            metrics_path.clone(),
+            MappedFileBuilder::new(&metrics_path).size(4096).disable_metrics(),
+        ),
+        (
+            warmup_path.clone(),
+            MappedFileBuilder::new(&warmup_path).size(4096).warmup(true),
+        ),
+        (
+            transient_path.clone(),
+            MappedFileBuilder::new(&transient_path)
+                .size(4096)
+                .enable_transient_store_pool(),
+        ),
+    ];
+
+    for (path, builder) in cases {
+        let result = builder.build();
+        if let Ok(mapped_file) = &result {
+            mapped_file.destroy(0);
+        }
+        assert!(matches!(result, Err(MappedFileError::Configuration(_))));
+        assert!(!path.exists());
+    }
+    assert_eq!(
+        std::fs::read_dir(temp_dir.path())
+            .expect("read temporary directory")
+            .count(),
+        0
+    );
+}
+
+#[test]
+fn builder_preserves_parent_path_io_failures() {
+    let temp_dir = TempDir::new().expect("temporary mapped-file directory");
+    let parent = temp_dir.path().join("not-a-directory");
+    std::fs::write(&parent, b"occupied").expect("create regular parent path");
+    let path = parent.join("00000000000000000000");
+
+    let result = MappedFileBuilder::new(&path).size(4096).build();
+
+    assert!(matches!(result, Err(MappedFileError::Io(_))));
+    assert!(!path.exists());
+}

--- a/rocketmq-store/tests/message_store/local_file_message_store/unit.rs
+++ b/rocketmq-store/tests/message_store/local_file_message_store/unit.rs
@@ -2069,12 +2069,12 @@ async fn compaction_topic_dispatches_and_reads_from_compaction_store() {
     store.init().await.expect("init compaction-enabled store");
     assert!(store.load().await, "load compaction-enabled store");
 
-    let put_result = store
-        .put_message(build_test_message(
-            &topic,
-            Bytes::from_static(b"compaction-fallback-body"),
-        ))
-        .await;
+    let mut message = build_test_message(&topic, Bytes::from_static(b"compaction-fallback-body"));
+    message.put_property(
+        CheetahString::from_static_str(MessageConst::PROPERTY_KEYS),
+        CheetahString::from_static_str("compaction-key"),
+    );
+    let put_result = store.put_message(message).await;
     assert_eq!(put_result.put_message_status(), PutMessageStatus::PutOk);
     store.reput_once().await;
 

--- a/scripts/fixtures/java-5.5-compaction-contract.json
+++ b/scripts/fixtures/java-5.5-compaction-contract.json
@@ -1,0 +1,22 @@
+{
+  "source": "Apache RocketMQ 5.5 Java compaction behavior",
+  "key_cases": [
+    { "name": "raw compound key", "raw_key": "a b", "accepted": true, "canonical_key": "a b" },
+    { "name": "empty key", "raw_key": "", "accepted": false, "canonical_key": null },
+    { "name": "blank key", "raw_key": " \t", "accepted": false, "canonical_key": null }
+  ],
+  "records": [
+    { "name": "batch child one", "queue_offset": 10, "raw_key": "batch-a", "body": "one", "tombstone": false },
+    { "name": "batch child two", "queue_offset": 11, "raw_key": "batch-b", "body": "two", "tombstone": false },
+    { "name": "empty body deletes", "queue_offset": 12, "raw_key": "batch-a", "body": "", "tombstone": true }
+  ],
+  "replay": {
+    "identical_same_offset": "idempotent",
+    "conflicting_same_offset": "fail-closed",
+    "winner": "maximum-queue-offset"
+  },
+  "retention": {
+    "retain_tombstone_until_atomic_generation_covers_older_records": true,
+    "restart_must_not_resurrect_deleted_value": true
+  }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9461

### Brief Description

Complete the existing Rust compaction store contract instead of introducing a second implementation. The change preserves raw message keys, rejects missing or blank projection keys, uses the greatest logical queue offset as the winner, persists empty-body tombstones in a versioned generation, fails closed on conflicting same-offset replay, advances read frontiers across tombstone-only tails, and reconciles compaction state with topic cleanup-policy changes and deletion.

The public `MappedFileBuilder` now validates all configuration before filesystem side effects and constructs a real `DefaultMappedFile`. Unsupported flush, metrics, warmup, and transient-pool combinations return typed configuration errors. A Java 5.5 behavior fixture and focused Store/Broker lifecycle tests cover key admission, generation compatibility, restart safety, and builder behavior.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-store -p rocketmq-broker -- --check`
- `cargo test -p rocketmq-store compaction_store`
- `cargo test -p rocketmq-store --test compaction_lifecycle_tests`
- `cargo test -p rocketmq-store --test mapped_file_builder_tests`
- `cargo test -p rocketmq-broker --test compaction_topic_contract`
- `cargo clippy -p rocketmq-store -p rocketmq-broker --no-deps --all-targets -- -D warnings`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `git diff --check`

The required fuzz command with `--locked` remains blocked by the pre-existing stale `fuzz/Cargo.lock`; the identical command fails on an unchanged local `main` before compiling this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compaction now supports tombstones, inactive topics, key normalization, replay conflict handling, and durable state across restarts.
  * Topic policy changes are reconciled during scheduled compaction, including cleanup of stale projections.
  * Mapped file creation now supports validated writable-file configurations and safer size handling.
* **Compatibility**
  * Added support for the latest compaction metadata format while retaining compatibility with legacy data.
* **Bug Fixes**
  * Messages without valid compaction keys are excluded from compaction projections while remaining acknowledged normally.
  * Message body sizes are now tracked accurately during storage processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->