### PR TITLE
[ISSUE #9457]✨Redesign OPS Proxy Login and harden dashboard quality

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/App.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/App.test.tsx
@@ -1,0 +1,108 @@
+import type { ReactNode } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { vi } from 'vitest';
+import App from './App';
+
+function pageModule(title: string) {
+  return {
+    default: () => <h1>{title}</h1>
+  };
+}
+
+vi.mock('./layouts/AppLayout', () => ({
+  default: ({ children }: { children: ReactNode }) => (
+    <>
+      <nav aria-label="Dashboard navigation">Dashboard navigation</nav>
+      {children}
+    </>
+  )
+}));
+
+vi.mock('./pages/AclPage', () => pageModule('ACL workspace'));
+vi.mock('./pages/BrokerDetailPage', () => pageModule('Broker detail workspace'));
+vi.mock('./pages/BrokerListPage', () => pageModule('Brokers workspace'));
+vi.mock('./pages/ConfigPage', () => pageModule('Configuration workspace'));
+vi.mock('./pages/ConsumerDetailPage', () => pageModule('Consumer detail workspace'));
+vi.mock('./pages/ConsumerListPage', () => pageModule('Consumers workspace'));
+vi.mock('./pages/DashboardPage', () => pageModule('Dashboard workspace'));
+vi.mock('./pages/DlqMessagePage', () => pageModule('DLQ messages workspace'));
+vi.mock('./pages/LoginPage', () => pageModule('Login workspace'));
+vi.mock('./pages/MessageQueryPage', () => pageModule('Messages workspace'));
+vi.mock('./pages/MessageTracePage', () => pageModule('Message trace workspace'));
+vi.mock('./pages/MonitorPage', () => pageModule('Monitors workspace'));
+vi.mock('./pages/ProducerListPage', () => pageModule('Producers workspace'));
+vi.mock('./pages/ProxyPage', () => pageModule('Proxy workspace'));
+vi.mock('./pages/TopicDetailPage', () => pageModule('Topic detail workspace'));
+vi.mock('./pages/TopicListPage', () => pageModule('Topics workspace'));
+
+function renderApp(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <App />
+    </MemoryRouter>
+  );
+}
+
+function LocationProbe() {
+  const location = useLocation();
+  return <output aria-label="Current route">{location.pathname}</output>;
+}
+
+const canonicalPages = [
+  ['/login', 'Login workspace'],
+  ['/proxy', 'Proxy workspace'],
+  ['/dashboard', 'Dashboard workspace'],
+  ['/topics', 'Topics workspace'],
+  ['/topics/Orders', 'Topic detail workspace'],
+  ['/consumers', 'Consumers workspace'],
+  ['/consumers/reporting', 'Consumer detail workspace'],
+  ['/producers', 'Producers workspace'],
+  ['/brokers', 'Brokers workspace'],
+  ['/brokers/broker-a', 'Broker detail workspace'],
+  ['/messages', 'Messages workspace'],
+  ['/messages/dlq', 'DLQ messages workspace'],
+  ['/message-trace', 'Message trace workspace'],
+  ['/acl', 'ACL workspace'],
+  ['/monitors', 'Monitors workspace'],
+  ['/config', 'Configuration workspace']
+] as const;
+
+describe('App routes', () => {
+  it('shows a named loading state while a route module resolves', async () => {
+    renderApp('/dashboard');
+
+    expect(screen.getByRole('status', { name: 'Loading dashboard workspace' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Dashboard workspace' })).toBeInTheDocument();
+  });
+
+  it.each(canonicalPages)('renders the %s canonical route', async (path, title) => {
+    renderApp(path);
+
+    expect(await screen.findByRole('heading', { name: title })).toBeInTheDocument();
+  });
+
+  it('keeps the login workspace outside dashboard navigation', async () => {
+    renderApp('/login');
+
+    expect(await screen.findByRole('heading', { name: 'Login workspace' })).toBeInTheDocument();
+    expect(screen.queryByRole('navigation', { name: 'Dashboard navigation' })).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ['/ops', '/config'],
+    ['/cluster', '/brokers'],
+    ['/dlq', '/messages/dlq'],
+    ['/', '/dashboard'],
+    ['/does-not-exist', '/dashboard']
+  ])('redirects %s to %s', async (path, destination) => {
+    render(
+      <MemoryRouter initialEntries={[path]} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <App />
+        <LocationProbe />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(screen.getByRole('status', { name: 'Current route' })).toHaveTextContent(destination));
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/App.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/App.tsx
@@ -1,55 +1,60 @@
+import { lazy, Suspense } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
+import RouteLoading from './components/RouteLoading';
 import AppLayout from './layouts/AppLayout';
-import AclPage from './pages/AclPage';
-import BrokerDetailPage from './pages/BrokerDetailPage';
-import BrokerListPage from './pages/BrokerListPage';
-import ConfigPage from './pages/ConfigPage';
-import ConsumerDetailPage from './pages/ConsumerDetailPage';
-import ConsumerListPage from './pages/ConsumerListPage';
-import DashboardPage from './pages/DashboardPage';
-import DlqMessagePage from './pages/DlqMessagePage';
-import LoginPage from './pages/LoginPage';
-import MessageQueryPage from './pages/MessageQueryPage';
-import MessageTracePage from './pages/MessageTracePage';
-import MonitorPage from './pages/MonitorPage';
-import ProducerListPage from './pages/ProducerListPage';
-import ProxyPage from './pages/ProxyPage';
-import TopicDetailPage from './pages/TopicDetailPage';
-import TopicListPage from './pages/TopicListPage';
+
+const AclPage = lazy(() => import('./pages/AclPage'));
+const BrokerDetailPage = lazy(() => import('./pages/BrokerDetailPage'));
+const BrokerListPage = lazy(() => import('./pages/BrokerListPage'));
+const ConfigPage = lazy(() => import('./pages/ConfigPage'));
+const ConsumerDetailPage = lazy(() => import('./pages/ConsumerDetailPage'));
+const ConsumerListPage = lazy(() => import('./pages/ConsumerListPage'));
+const DashboardPage = lazy(() => import('./pages/DashboardPage'));
+const DlqMessagePage = lazy(() => import('./pages/DlqMessagePage'));
+const LoginPage = lazy(() => import('./pages/LoginPage'));
+const MessageQueryPage = lazy(() => import('./pages/MessageQueryPage'));
+const MessageTracePage = lazy(() => import('./pages/MessageTracePage'));
+const MonitorPage = lazy(() => import('./pages/MonitorPage'));
+const ProducerListPage = lazy(() => import('./pages/ProducerListPage'));
+const ProxyPage = lazy(() => import('./pages/ProxyPage'));
+const TopicDetailPage = lazy(() => import('./pages/TopicDetailPage'));
+const TopicListPage = lazy(() => import('./pages/TopicListPage'));
 
 export default function App() {
   return (
-    <Routes>
-      <Route path="/login" element={<LoginPage />} />
-      <Route
-        path="/*"
-        element={
-          <AppLayout>
-            <Routes>
-              <Route path="/" element={<Navigate to="/dashboard" replace />} />
-              <Route path="/ops" element={<Navigate to="/config" replace />} />
-              <Route path="/proxy" element={<ProxyPage />} />
-              <Route path="/dashboard" element={<DashboardPage />} />
-              <Route path="/cluster" element={<Navigate to="/brokers" replace />} />
-              <Route path="/topics" element={<TopicListPage />} />
-              <Route path="/topics/:topic" element={<TopicDetailPage />} />
-              <Route path="/consumers" element={<ConsumerListPage />} />
-              <Route path="/consumers/:group" element={<ConsumerDetailPage />} />
-              <Route path="/producers" element={<ProducerListPage />} />
-              <Route path="/brokers" element={<BrokerListPage />} />
-              <Route path="/brokers/:brokerName" element={<BrokerDetailPage />} />
-              <Route path="/messages" element={<MessageQueryPage />} />
-              <Route path="/messages/dlq" element={<DlqMessagePage />} />
-              <Route path="/dlq" element={<Navigate to="/messages/dlq" replace />} />
-              <Route path="/message-trace" element={<MessageTracePage />} />
-              <Route path="/acl" element={<AclPage />} />
-              <Route path="/monitors" element={<MonitorPage />} />
-              <Route path="/config" element={<ConfigPage />} />
-              <Route path="*" element={<Navigate to="/dashboard" replace />} />
-            </Routes>
-          </AppLayout>
-        }
-      />
-    </Routes>
+    <Suspense fallback={<RouteLoading />}>
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route
+          path="/*"
+          element={
+            <AppLayout>
+              <Routes>
+                <Route path="/" element={<Navigate to="/dashboard" replace />} />
+                <Route path="/ops" element={<Navigate to="/config" replace />} />
+                <Route path="/proxy" element={<ProxyPage />} />
+                <Route path="/dashboard" element={<DashboardPage />} />
+                <Route path="/cluster" element={<Navigate to="/brokers" replace />} />
+                <Route path="/topics" element={<TopicListPage />} />
+                <Route path="/topics/:topic" element={<TopicDetailPage />} />
+                <Route path="/consumers" element={<ConsumerListPage />} />
+                <Route path="/consumers/:group" element={<ConsumerDetailPage />} />
+                <Route path="/producers" element={<ProducerListPage />} />
+                <Route path="/brokers" element={<BrokerListPage />} />
+                <Route path="/brokers/:brokerName" element={<BrokerDetailPage />} />
+                <Route path="/messages" element={<MessageQueryPage />} />
+                <Route path="/messages/dlq" element={<DlqMessagePage />} />
+                <Route path="/dlq" element={<Navigate to="/messages/dlq" replace />} />
+                <Route path="/message-trace" element={<MessageTracePage />} />
+                <Route path="/acl" element={<AclPage />} />
+                <Route path="/monitors" element={<MonitorPage />} />
+                <Route path="/config" element={<ConfigPage />} />
+                <Route path="*" element={<Navigate to="/dashboard" replace />} />
+              </Routes>
+            </AppLayout>
+          }
+        />
+      </Routes>
+    </Suspense>
   );
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/RankingTable.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/RankingTable.tsx
@@ -1,4 +1,3 @@
-import type { CSSProperties } from 'react';
 import EmptyState from './EmptyState';
 
 export interface RankingTableRow {
@@ -10,7 +9,6 @@ export interface RankingTableRow {
 interface RankingTableProps {
   rows: RankingTableRow[];
   valueLabel: string;
-  accent: string;
   emptyTitle: string;
   emptyDetail: string;
   formatValue?: (value: number) => string;
@@ -19,7 +17,6 @@ interface RankingTableProps {
 export default function RankingTable({
   rows,
   valueLabel,
-  accent,
   emptyTitle,
   emptyDetail,
   formatValue = (value) => String(Math.round(value))
@@ -31,14 +28,14 @@ export default function RankingTable({
   }
 
   return (
-    <div className="ranking-table" style={{ '--rank-accent': accent } as CSSProperties}>
+    <div className="ranking-table">
       {rows.map((row, index) => {
         const isZero = row.value <= 0;
         const width = isZero ? 0 : Math.max(4, (row.value / maxValue) * 100);
 
         return (
           <div className={isZero ? 'ranking-row ranking-row-zero' : 'ranking-row'} key={row.name}>
-            <span className={index < 3 && !isZero ? 'rank-badge rank-badge-hot' : 'rank-badge'}>{index + 1}</span>
+            <span className="rank-badge">{index + 1}</span>
             <div className="ranking-main">
               <div className="ranking-header">
                 <strong title={row.name}>{row.name}</strong>

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/RouteLoading.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/RouteLoading.css
@@ -1,0 +1,13 @@
+.route-loading {
+  display: grid;
+  min-block-size: 100dvh;
+  place-items: center;
+  padding: 1.5rem;
+  background: var(--background);
+  color: var(--foreground);
+}
+
+.route-loading p {
+  margin: 0;
+  color: var(--muted-foreground);
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/RouteLoading.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/RouteLoading.tsx
@@ -1,0 +1,9 @@
+import './RouteLoading.css';
+
+export default function RouteLoading() {
+  return (
+    <div className="route-loading" role="status" aria-live="polite" aria-label="Loading dashboard workspace">
+      <p>Loading dashboard workspace</p>
+    </div>
+  );
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/TopicMaintenanceDialog.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/TopicMaintenanceDialog.test.tsx
@@ -1,0 +1,23 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderAtRoute } from '../test/render';
+import TopicMaintenanceDialog from './TopicMaintenanceDialog';
+
+describe('TopicMaintenanceDialog', () => {
+  it('renders the API-backed consumer offset reset controls', () => {
+    renderAtRoute(
+      <TopicMaintenanceDialog
+        topic="orders"
+        open
+        onOpenChange={vi.fn()}
+        consumerGroups={[{ group: 'order-service', clientCount: 1, diffTotal: 0, consumeType: 'CONSUME_PASSIVELY', messageModel: 'CLUSTERING' }]}
+        onMutationFinished={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('heading', { name: 'Reset Consumer Offset' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Consumer groups')).toBeInTheDocument();
+    expect(screen.getByLabelText('Reset time')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Reset' })).toBeEnabled();
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/TopicMaintenanceDialog.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/TopicMaintenanceDialog.tsx
@@ -1,43 +1,22 @@
 import * as Dialog from '@radix-ui/react-dialog';
-import { FastForward, RotateCcw, Send, X } from 'lucide-react';
+import { RotateCcw, X } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { consumerApi } from '../api/consumer_api';
 import type { ConsumerGroupInfo } from '../types/consumer';
 import ConfirmDialog from './ConfirmDialog';
 import StatusBadge from './StatusBadge';
-
-export type TopicMaintenanceMode = 'send' | 'reset' | 'skip';
+import { Button } from './ui/Button';
 
 interface TopicMaintenanceDialogProps {
   topic: string | null;
-  mode: TopicMaintenanceMode;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   consumerGroups: ConsumerGroupInfo[];
   onMutationFinished: () => void;
 }
 
-const modeCopy = {
-  send: {
-    title: 'Send Message',
-    description: 'Java API /topic/sendTopicMessage.do sends a test message to the selected topic.',
-    icon: Send
-  },
-  reset: {
-    title: 'Reset Consumer Offset',
-    description: 'Reset selected consumer groups to the specified timestamp for this topic.',
-    icon: RotateCcw
-  },
-  skip: {
-    title: 'Skip Message Accumulate',
-    description: 'Java API /consumer/skipAccumulate.do moves selected consumer groups to the latest offset.',
-    icon: FastForward
-  }
-};
-
 export default function TopicMaintenanceDialog({
   topic,
-  mode,
   open,
   onOpenChange,
   consumerGroups,
@@ -46,16 +25,10 @@ export default function TopicMaintenanceDialog({
   const [selectedGroups, setSelectedGroups] = useState<string[]>([]);
   const [resetTime, setResetTime] = useState(() => toDateTimeLocal(Date.now()));
   const [force, setForce] = useState(true);
-  const [tag, setTag] = useState('');
-  const [messageKey, setMessageKey] = useState('');
-  const [messageBody, setMessageBody] = useState('');
-  const [traceEnabled, setTraceEnabled] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
-  const copy = modeCopy[mode];
-  const Icon = copy.icon;
   const sortedGroups = useMemo(() => [...consumerGroups].sort((left, right) => left.group.localeCompare(right.group)), [consumerGroups]);
 
   useEffect(() => {
@@ -63,14 +36,10 @@ export default function TopicMaintenanceDialog({
     setSelectedGroups([]);
     setResetTime(toDateTimeLocal(Date.now()));
     setForce(true);
-    setTag('');
-    setMessageKey('');
-    setMessageBody('');
-    setTraceEnabled(false);
     setError(null);
     setResult(null);
     setSubmitting(false);
-  }, [mode, open, topic]);
+  }, [open, topic]);
 
   const resetOffset = () => {
     if (!topic) return;
@@ -94,11 +63,6 @@ export default function TopicMaintenanceDialog({
       .finally(() => setSubmitting(false));
   };
 
-  const notImplementedMessage =
-    mode === 'send'
-      ? 'Rust backend does not expose /api/topics/:topic/send-message yet. Keep this Java-compatible dialog as an M2 entry point.'
-      : 'Rust backend does not expose /api/consumers/:group/skip-accumulate yet. Keep this Java-compatible dialog as an M2 entry point.';
-
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
@@ -107,100 +71,65 @@ export default function TopicMaintenanceDialog({
           <div className="drawer-header">
             <div>
               <Dialog.Title className="dialog-title">
-                <Icon size={18} aria-hidden="true" />
-                {copy.title}
+                <RotateCcw size={18} aria-hidden="true" />
+                Reset Consumer Offset
               </Dialog.Title>
-              <p className="dialog-description">{copy.description}</p>
+              <Dialog.Description asChild>
+                <p className="dialog-description">Reset selected consumer groups to the specified timestamp for this topic.</p>
+              </Dialog.Description>
               <div className="drawer-meta">
                 <StatusBadge status={topic ?? 'topic pending'} tone="success" />
-                {mode !== 'reset' ? <StatusBadge status="M2 backend API pending" tone="warning" /> : null}
               </div>
             </div>
-            <Dialog.Close className="icon-button" title="Close">
-              <X size={15} aria-hidden="true" />
+            <Dialog.Close asChild>
+              <Button type="button" variant="ghost" size="icon" title="Close" aria-label="Close">
+                <X size={15} aria-hidden="true" />
+              </Button>
             </Dialog.Close>
           </div>
 
-          {mode === 'send' ? (
-            <div className="form-grid topic-form-grid">
-              <label className="field field-wide">
-                Topic
-                <input value={topic ?? ''} disabled />
-              </label>
-              <label className="field">
-                Tag
-                <input value={tag} onChange={(event) => setTag(event.target.value)} />
-              </label>
-              <label className="field">
-                Key
-                <input value={messageKey} onChange={(event) => setMessageKey(event.target.value)} />
-              </label>
-              <label className="field field-wide">
-                Message body
-                <textarea value={messageBody} onChange={(event) => setMessageBody(event.target.value)} />
-              </label>
-              <label className="compact-check">
-                <input type="checkbox" checked={traceEnabled} onChange={(event) => setTraceEnabled(event.target.checked)} />
-                Enable message trace
-              </label>
-            </div>
-          ) : null}
-
-          {mode === 'reset' || mode === 'skip' ? (
-            <div className="form-grid topic-form-grid">
-              <label className="field field-wide">
-                Consumer groups
-                <select
-                  className="multi-select"
-                  multiple
-                  value={selectedGroups}
-                  onChange={(event) => setSelectedGroups(Array.from(event.target.selectedOptions).map((option) => option.value))}
-                >
-                  {sortedGroups.map((group) => (
-                    <option key={group.group} value={group.group}>
-                      {group.group}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              {mode === 'reset' ? (
-                <>
-                  <label className="field">
-                    Reset time
-                    <input type="datetime-local" value={resetTime} onChange={(event) => setResetTime(event.target.value)} />
-                  </label>
-                  <label className="compact-check topic-force-check">
-                    <input type="checkbox" checked={force} onChange={(event) => setForce(event.target.checked)} />
-                    Force reset
-                  </label>
-                </>
-              ) : null}
-            </div>
-          ) : null}
-
-          {mode !== 'reset' ? <div className="notice notice-danger">{notImplementedMessage}</div> : null}
+          <div className="form-grid topic-form-grid">
+            <label className="field field-wide">
+              Consumer groups
+              <select
+                className="multi-select"
+                multiple
+                value={selectedGroups}
+                onChange={(event) => setSelectedGroups(Array.from(event.target.selectedOptions).map((option) => option.value))}
+              >
+                {sortedGroups.map((group) => (
+                  <option key={group.group} value={group.group}>
+                    {group.group}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="field">
+              Reset time
+              <input type="datetime-local" value={resetTime} onChange={(event) => setResetTime(event.target.value)} />
+            </label>
+            <label className="compact-check topic-force-check">
+              <input type="checkbox" checked={force} onChange={(event) => setForce(event.target.checked)} />
+              Force reset
+            </label>
+          </div>
           {error ? <div className="notice notice-danger">{error}</div> : null}
           {result ? <div className="notice notice-success">{result}</div> : null}
 
           <div className="dialog-actions">
-            <Dialog.Close className="button button-secondary">Close</Dialog.Close>
-            {mode === 'reset' ? (
-              <ConfirmDialog
-                title="Reset consumer offset"
-                description={`Reset ${selectedGroups.length || 'selected'} consumer group(s) for ${topic}?`}
-                confirmLabel="Reset"
-                onConfirm={resetOffset}
-              >
-                <button type="button" className="button button-danger" disabled={submitting}>
-                  <RotateCcw size={15} aria-hidden="true" /> {submitting ? 'Resetting' : 'Reset'}
-                </button>
-              </ConfirmDialog>
-            ) : (
-              <button type="button" className="button button-secondary" disabled>
-                {mode === 'send' ? <Send size={15} aria-hidden="true" /> : <FastForward size={15} aria-hidden="true" />}
-                Backend pending
-              </button>
-            )}
+            <Dialog.Close asChild>
+              <Button type="button" variant="secondary">Close</Button>
+            </Dialog.Close>
+            <ConfirmDialog
+              title="Reset consumer offset"
+              description={`Reset ${selectedGroups.length || 'selected'} consumer group(s) for ${topic}?`}
+              confirmLabel="Reset"
+              onConfirm={resetOffset}
+            >
+              <Button type="button" variant="destructive" disabled={submitting}>
+                <RotateCcw size={15} aria-hidden="true" /> {submitting ? 'Resetting' : 'Reset'}
+              </Button>
+            </ConfirmDialog>
           </div>
         </Dialog.Content>
       </Dialog.Portal>

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/ui/Button.styles.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/ui/Button.styles.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import '../../styles/tokens.css';
+import '../../styles/components.css';
+import { Button } from './Button';
+
+function relativeLuminance(hex: string) {
+  const channels = hex.slice(1).match(/.{2}/g)?.map((channel) => Number.parseInt(channel, 16) / 255) ?? [];
+  const [red, green, blue] = channels.map((channel) => (
+    channel <= 0.03928 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4
+  ));
+  return (0.2126 * red) + (0.7152 * green) + (0.0722 * blue);
+}
+
+function contrastRatio(background: string, foreground: string) {
+  const [lighter, darker] = [relativeLuminance(background), relativeLuminance(foreground)].sort((left, right) => right - left);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function findStyleRule(selector: string) {
+  return Array.from(document.styleSheets)
+    .flatMap((styleSheet) => Array.from(styleSheet.cssRules))
+    .find((rule): rule is CSSStyleRule => rule instanceof CSSStyleRule && rule.selectorText === selector);
+}
+
+function resolveCustomPropertyColor(value: string) {
+  const variable = value.match(/^var\((--[^)]+)\)$/)?.[1];
+  return variable ? getComputedStyle(document.documentElement).getPropertyValue(variable).trim() : value;
+}
+
+describe('destructive button styling', () => {
+  it('uses an accessible dark-red foreground pairing at rest and on hover', () => {
+    render(<Button variant="destructive">Delete endpoint</Button>);
+
+    const foreground = getComputedStyle(document.documentElement).getPropertyValue('--foreground').trim();
+    const defaultBackground = getComputedStyle(document.documentElement).getPropertyValue('--destructive-control-default').trim();
+    const hoverBackground = getComputedStyle(document.documentElement).getPropertyValue('--destructive-control-hover').trim();
+    const styles = getComputedStyle(screen.getByRole('button', { name: 'Delete endpoint' }));
+    const destructiveRule = findStyleRule('.ui-button-destructive');
+    const destructiveHoverRule = findStyleRule('.ui-button-destructive:hover');
+    expect(findStyleRule('.ui-button-destructive')?.style.color).toBe('var(--foreground)');
+    expect(destructiveRule?.style.background).toBe('var(--destructive-control-default)');
+    expect(destructiveHoverRule?.style.background).toBe('var(--destructive-control-hover)');
+    expect(styles.color).toBe('var(--foreground)');
+    expect(foreground).toBe('#f4f7fa');
+    expect(defaultBackground).toBe('#b91c1c');
+    expect(hoverBackground).toBe('#991b1b');
+    expect(resolveCustomPropertyColor(destructiveRule?.style.background ?? '')).toBe(defaultBackground);
+    expect(resolveCustomPropertyColor(destructiveHoverRule?.style.background ?? '')).toBe(hoverBackground);
+    expect(resolveCustomPropertyColor(styles.color)).toBe(foreground);
+    expect(contrastRatio(defaultBackground, foreground)).toBeGreaterThanOrEqual(4.5);
+    expect(contrastRatio(hoverBackground, foreground)).toBeGreaterThanOrEqual(4.5);
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/AclPage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/AclPage.test.tsx
@@ -54,6 +54,16 @@ describe('AclPage', () => {
     expect(aclApi.listPolicies).toHaveBeenCalledWith({ clusterName: 'Cluster-A', brokerName: 'broker-a' });
   });
 
+  it('uses operator-facing descriptions for users and policy records', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<AclPage />, '/acl');
+
+    expect(await screen.findByText('Manage ACL users and permissions for the selected cluster and broker.')).toBeInTheDocument();
+    expect(await screen.findByText('Manage credentials, account status, and access changes for the selected broker.')).toBeInTheDocument();
+    await user.click(screen.getByRole('tab', { name: 'ACL Policies' }));
+    expect(screen.getByText('Review and manage subject permissions for resources in the selected broker.')).toBeInTheDocument();
+  });
+
   it('finishes broker discovery when React Strict Mode probes the mount lifecycle', async () => {
     render(
       <StrictMode>

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/AclPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/AclPage.tsx
@@ -5,6 +5,7 @@ import { brokerApi } from '../api/broker_api';
 import ErrorState from '../components/ErrorState';
 import LoadingState from '../components/LoadingState';
 import PageHeader from '../components/PageHeader';
+import { Button } from '../components/ui/Button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/Tabs';
 import type { AclPolicyRequest, AclPolicyView, AclUserUpsertRequest, AclUserView } from '../types/acl';
 import type { BrokerInfo } from '../types/broker';
@@ -295,8 +296,8 @@ export default function AclPage() {
 
   return (
     <>
-      <PageHeader title="ACL Management" description="Java-compatible ACL users and permissions scoped by cluster and broker." actions={
-        <button type="button" className="button button-secondary" onClick={refresh} disabled={!scopeReady || loadingRecords || mutating}><RefreshCw size={15} aria-hidden="true" /> Refresh</button>
+      <PageHeader title="ACL Management" description="Manage ACL users and permissions for the selected cluster and broker." actions={
+        <Button type="button" variant="secondary" onClick={refresh} disabled={!scopeReady || loadingRecords || mutating}><RefreshCw size={15} aria-hidden="true" /> Refresh</Button>
       } />
       {notice ? <div className={`notice notice-${notice.tone}`}>{notice.message}</div> : null}
       <AclScopePicker brokers={brokers} draftScope={draftScope} confirmedScope={confirmedScope} disabled={loadingRecords} onDraftScopeChange={changeDraftScope} onConfirm={confirmScope} />
@@ -313,15 +314,15 @@ export default function AclPage() {
           <TabsTrigger value="policies"><FileKey2 size={15} aria-hidden="true" /> ACL Policies</TabsTrigger>
         </TabsList>
         <TabsContent value="users" className="acl-table-panel">
-          <AclTableHeader title="ACL Users" description="Username, masked password, user type, status, and Java-style update/delete operations." search={usersSearch} onSearchChange={setUsersSearch} searchLabel="Search ACL users" placeholder="Search users" actions={<>
-            {hasRevealablePasswords ? <button type="button" className="button button-secondary" aria-label={showPasswords ? 'Hide passwords' : 'Reveal passwords'} aria-pressed={showPasswords} onClick={() => setShowPasswords((value) => !value)} disabled={!scopeReady}>{showPasswords ? <EyeOff size={15} aria-hidden="true" /> : <Eye size={15} aria-hidden="true" />}{showPasswords ? 'Hide' : 'Reveal'}</button> : null}
-            <button type="button" className="button" disabled={!scopeReady || mutating} onClick={() => openUserDialog(null)}><Plus size={15} aria-hidden="true" /> Add User</button>
+          <AclTableHeader title="ACL Users" description="Manage credentials, account status, and access changes for the selected broker." search={usersSearch} onSearchChange={setUsersSearch} searchLabel="Search ACL users" placeholder="Search users" actions={<>
+            {hasRevealablePasswords ? <Button type="button" variant="secondary" aria-label={showPasswords ? 'Hide passwords' : 'Reveal passwords'} aria-pressed={showPasswords} onClick={() => setShowPasswords((value) => !value)} disabled={!scopeReady}>{showPasswords ? <EyeOff size={15} aria-hidden="true" /> : <Eye size={15} aria-hidden="true" />}{showPasswords ? 'Hide' : 'Reveal'}</Button> : null}
+            <Button type="button" disabled={!scopeReady || mutating} onClick={() => openUserDialog(null)}><Plus size={15} aria-hidden="true" /> Add User</Button>
           </>} />
           {userDeleteError ? <div className="acl-action-error" role="alert">{userDeleteError}</div> : null}
           {scopeReady ? <AclUsersTable rows={pagedUsers} total={visibleUsers.length} page={usersPage} pageSize={pageSize} loading={loadingRecords} error={recordsError} onRetry={refresh} showPasswords={showPasswords} disabled={mutating} onPageChange={setUsersPage} onEdit={openUserDialog} onDelete={(username) => void deleteUser(username)} /> : <AclScopeEmptyState />}
         </TabsContent>
         <TabsContent value="policies" className="acl-table-panel">
-          <AclTableHeader title="ACL Policies" description="Subject policy entries flattened to resource rows, matching the Java ACL table." search={policiesSearch} onSearchChange={setPoliciesSearch} searchLabel="Search ACL policies" placeholder="Search subject, resource, action, source IP" actions={<button type="button" className="button" disabled={!scopeReady || mutating} onClick={() => openPolicyDialog(null)}><Plus size={15} aria-hidden="true" /> Add ACL Policy</button>} />
+          <AclTableHeader title="ACL Policies" description="Review and manage subject permissions for resources in the selected broker." search={policiesSearch} onSearchChange={setPoliciesSearch} searchLabel="Search ACL policies" placeholder="Search subject, resource, action, source IP" actions={<Button type="button" disabled={!scopeReady || mutating} onClick={() => openPolicyDialog(null)}><Plus size={15} aria-hidden="true" /> Add ACL Policy</Button>} />
           {policyDeleteError ? <div className="acl-action-error" role="alert">{policyDeleteError}</div> : null}
           {scopeReady ? <AclPoliciesTable rows={pagedPolicies} total={visiblePolicies.length} page={policiesPage} pageSize={pageSize} loading={loadingRecords} error={recordsError} onRetry={refresh} disabled={mutating} onPageChange={setPoliciesPage} onEdit={openPolicyDialog} onDelete={(policy) => void deletePolicy(policy)} /> : <AclScopeEmptyState />}
         </TabsContent>

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConfigPage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConfigPage.test.tsx
@@ -1,0 +1,204 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { configApi } from '../api/config_api';
+import { renderAtRoute } from '../test/render';
+import type { DashboardConfigView } from '../types/config';
+import ConfigPage from './ConfigPage';
+
+vi.mock('../api/config_api', () => ({
+  configApi: {
+    getConfig: vi.fn(),
+    replaceNameservers: vi.fn(),
+    addNameserver: vi.fn(),
+    setVipChannel: vi.fn(),
+    setTls: vi.fn(),
+    addProxy: vi.fn(),
+    switchProxy: vi.fn(),
+    deleteProxy: vi.fn()
+  }
+}));
+
+const initialConfig: DashboardConfigView = {
+  namesrvAddrList: ['10.0.0.10:9876', '10.0.0.11:9876'],
+  currentNamesrv: '10.0.0.10:9876',
+  useVIPChannel: false,
+  useTLS: false,
+  proxyAddrList: [],
+  currentProxyAddr: null,
+  storageBackend: 'file'
+};
+
+const mockedConfigApi = vi.mocked(configApi);
+
+function mutationResult(config = initialConfig, message = 'Configuration updated') {
+  return Promise.resolve({ config, message });
+}
+
+describe('ConfigPage', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockedConfigApi.getConfig.mockResolvedValue(initialConfig);
+    mockedConfigApi.replaceNameservers.mockImplementation((request) => mutationResult({
+      ...initialConfig,
+      namesrvAddrList: request.namesrvAddrList,
+      currentNamesrv: request.currentNamesrv
+    }, 'NameServers updated'));
+    mockedConfigApi.addNameserver.mockResolvedValue(awaitableMutation());
+    mockedConfigApi.setVipChannel.mockImplementation(({ enabled }) => mutationResult({ ...initialConfig, useVIPChannel: enabled }, 'VIP updated'));
+    mockedConfigApi.setTls.mockImplementation(({ enabled }) => mutationResult({ ...initialConfig, useTLS: enabled }, 'TLS updated'));
+  });
+
+  it('replaces NameServers with the selected current endpoint and signals successful persistence', async () => {
+    const user = userEvent.setup();
+    const onConfigUpdated = vi.fn();
+    window.addEventListener('rocketmq-config-updated', onConfigUpdated);
+
+    renderAtRoute(<ConfigPage />, '/config');
+    await screen.findByRole('heading', { name: 'OPS settings' });
+
+    await user.selectOptions(screen.getByLabelText('Current NameServer'), '10.0.0.11:9876');
+    await user.click(screen.getByRole('button', { name: 'Save NameServers' }));
+
+    await waitFor(() => expect(mockedConfigApi.replaceNameservers).toHaveBeenCalledWith({
+      namesrvAddrList: ['10.0.0.10:9876', '10.0.0.11:9876'],
+      currentNamesrv: '10.0.0.11:9876'
+    }));
+    expect(onConfigUpdated).toHaveBeenCalledTimes(1);
+    window.removeEventListener('rocketmq-config-updated', onConfigUpdated);
+  });
+
+  it('adds a NameServer with the exact normalized address and clears the input only after success', async () => {
+    const user = userEvent.setup();
+    const onConfigUpdated = vi.fn();
+    window.addEventListener('rocketmq-config-updated', onConfigUpdated);
+    mockedConfigApi.addNameserver.mockResolvedValue(awaitableMutation({
+      ...initialConfig,
+      namesrvAddrList: [...initialConfig.namesrvAddrList, '10.0.0.12:9876']
+    }, 'NameServer added'));
+
+    renderAtRoute(<ConfigPage />, '/config');
+    const input = await screen.findByLabelText('Add NameServer');
+    await user.type(input, ' 10.0.0.12:9876 ');
+    await user.click(screen.getByRole('button', { name: 'Add NameServer' }));
+
+    await waitFor(() => expect(mockedConfigApi.addNameserver).toHaveBeenCalledWith({ address: '10.0.0.12:9876' }));
+    await waitFor(() => expect(input).toHaveValue(''));
+    expect(onConfigUpdated).toHaveBeenCalledTimes(1);
+    window.removeEventListener('rocketmq-config-updated', onConfigUpdated);
+  });
+
+  it('preserves a NameServer input after an add error', async () => {
+    const user = userEvent.setup();
+    const onConfigUpdated = vi.fn();
+    window.addEventListener('rocketmq-config-updated', onConfigUpdated);
+    mockedConfigApi.addNameserver.mockRejectedValueOnce(new Error('NameServer unavailable'));
+
+    renderAtRoute(<ConfigPage />, '/config');
+    const input = await screen.findByLabelText('Add NameServer');
+    await user.type(input, '10.0.0.12:9876');
+    await user.click(screen.getByRole('button', { name: 'Add NameServer' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('NameServer unavailable');
+    expect(input).toHaveValue('10.0.0.12:9876');
+    expect(onConfigUpdated).not.toHaveBeenCalled();
+    window.removeEventListener('rocketmq-config-updated', onConfigUpdated);
+  });
+
+  it('locks rebase operations while a current NameServer selection draft is dirty', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<ConfigPage />, '/config');
+    await screen.findByRole('heading', { name: 'OPS settings' });
+
+    await user.selectOptions(screen.getByLabelText('Current NameServer'), '10.0.0.11:9876');
+
+    expect(screen.getByLabelText('Current NameServer')).toHaveValue('10.0.0.11:9876');
+    expect(screen.getByRole('button', { name: 'Reload OPS settings' })).toBeDisabled();
+    expect(screen.getByLabelText('Add NameServer')).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Add NameServer' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Remove 10.0.0.10:9876' })).toBeDisabled();
+    expect(mockedConfigApi.getConfig).toHaveBeenCalledTimes(1);
+    expect(mockedConfigApi.addNameserver).not.toHaveBeenCalled();
+    expect(mockedConfigApi.replaceNameservers).not.toHaveBeenCalled();
+  });
+
+  it('submits one add mutation when Enter is repeated while the first request is pending', async () => {
+    const user = userEvent.setup();
+    let resolveAdd: ((value: Awaited<ReturnType<typeof awaitableMutation>>) => void) | undefined;
+    mockedConfigApi.addNameserver.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveAdd = resolve;
+    }));
+    renderAtRoute(<ConfigPage />, '/config');
+    const input = await screen.findByLabelText('Add NameServer');
+    await user.type(input, '10.0.0.12:9876{enter}{enter}');
+
+    expect(mockedConfigApi.addNameserver).toHaveBeenCalledTimes(1);
+    expect(input).toBeDisabled();
+    resolveAdd?.({ config: initialConfig, message: 'NameServer added' });
+    await waitFor(() => expect(input).toHaveValue(''));
+  });
+
+  it('persists VIP and TLS toggles through their exact config APIs and signals each success', async () => {
+    const user = userEvent.setup();
+    const onConfigUpdated = vi.fn();
+    window.addEventListener('rocketmq-config-updated', onConfigUpdated);
+
+    renderAtRoute(<ConfigPage />, '/config');
+    await screen.findByRole('heading', { name: 'OPS settings' });
+    await user.click(screen.getByRole('button', { name: 'Security' }));
+    await user.click(screen.getByRole('button', { name: 'Enable VIP channel' }));
+    await user.click(screen.getByRole('button', { name: 'Enable TLS' }));
+
+    await waitFor(() => expect(mockedConfigApi.setVipChannel).toHaveBeenCalledWith({ enabled: true }));
+    await waitFor(() => expect(mockedConfigApi.setTls).toHaveBeenCalledWith({ enabled: true }));
+    expect(onConfigUpdated).toHaveBeenCalledTimes(2);
+    window.removeEventListener('rocketmq-config-updated', onConfigUpdated);
+  });
+
+  it('asks for confirmation before discarding unsaved NameServer changes to change sections', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<ConfigPage />, '/config');
+    await screen.findByRole('heading', { name: 'OPS settings' });
+
+    await user.selectOptions(screen.getByLabelText('Current NameServer'), '10.0.0.11:9876');
+    await user.click(screen.getByRole('button', { name: 'Security' }));
+
+    expect(await screen.findByRole('alertdialog')).toHaveTextContent('Discard unsaved NameServer changes?');
+    await user.click(screen.getByRole('button', { name: 'Discard changes' }));
+    expect(await screen.findByRole('heading', { name: 'Security' })).toBeInTheDocument();
+  });
+
+  it('does not remove a NameServer when its confirmation is cancelled', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<ConfigPage />, '/config');
+    await screen.findByRole('heading', { name: 'OPS settings' });
+
+    await user.click(screen.getByRole('button', { name: 'Remove 10.0.0.11:9876' }));
+    expect(await screen.findByRole('alertdialog')).toHaveTextContent('Remove NameServer 10.0.0.11:9876?');
+    await user.click(screen.getByRole('button', { name: 'Keep NameServer' }));
+
+    expect(mockedConfigApi.replaceNameservers).not.toHaveBeenCalled();
+  });
+
+  it('removes the current NameServer with the remaining endpoint as the exact current fallback', async () => {
+    const user = userEvent.setup();
+    const onConfigUpdated = vi.fn();
+    window.addEventListener('rocketmq-config-updated', onConfigUpdated);
+    renderAtRoute(<ConfigPage />, '/config');
+    await screen.findByRole('heading', { name: 'OPS settings' });
+
+    await user.click(screen.getByRole('button', { name: 'Remove 10.0.0.10:9876' }));
+    await user.click(screen.getByRole('button', { name: 'Remove NameServer' }));
+
+    await waitFor(() => expect(mockedConfigApi.replaceNameservers).toHaveBeenCalledWith({
+      namesrvAddrList: ['10.0.0.11:9876'],
+      currentNamesrv: '10.0.0.11:9876'
+    }));
+    expect(onConfigUpdated).toHaveBeenCalledTimes(1);
+    window.removeEventListener('rocketmq-config-updated', onConfigUpdated);
+  });
+});
+
+function awaitableMutation(config = initialConfig, message = 'NameServer added') {
+  return { config, message };
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConfigPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConfigPage.tsx
@@ -1,33 +1,42 @@
-import { Plus, RefreshCw, Save, Trash2 } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { AlertTriangle, Plus, RefreshCw, RotateCcw, Save, Trash2 } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { configApi } from '../api/config_api';
-import ConfirmDialog from '../components/ConfirmDialog';
-import DataTable from '../components/DataTable';
 import ErrorState from '../components/ErrorState';
 import LoadingState from '../components/LoadingState';
 import PageHeader from '../components/PageHeader';
 import StatusBadge from '../components/StatusBadge';
-import type { DashboardConfigView } from '../types/config';
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogTitle } from '../components/ui/AlertDialog';
+import { Button } from '../components/ui/Button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/Card';
+import { Input } from '../components/ui/Input';
+import { Label } from '../components/ui/Label';
+import type { ConfigMutationResult, DashboardConfigView } from '../types/config';
+import SettingsSectionNav, { type SettingsSection } from './settings/SettingsSectionNav';
+import { isNameserverDraftDirty, normalizeNameserverDraft, type NameserverDraft } from './settings/settings-model';
 
-interface AddressRow {
-  address: string;
-}
+type Notice = { tone: 'success' | 'danger' | 'warning'; message: string };
 
 export default function ConfigPage() {
   const [config, setConfig] = useState<DashboardConfigView | null>(null);
+  const [savedDraft, setSavedDraft] = useState<NameserverDraft | null>(null);
+  const [nameserverDraft, setNameserverDraft] = useState<NameserverDraft | null>(null);
+  const [newNameserver, setNewNameserver] = useState('');
+  const [activeSection, setActiveSection] = useState<SettingsSection>('connection');
+  const [requestedSection, setRequestedSection] = useState<SettingsSection | null>(null);
+  const [nameserverToRemove, setNameserverToRemove] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [operationError, setOperationError] = useState<string | null>(null);
-  const [operationMessage, setOperationMessage] = useState<string | null>(null);
-  const [nameserver, setNameserver] = useState('');
-  const [proxy, setProxy] = useState('');
+  const [notice, setNotice] = useState<Notice | null>(null);
+  const mutationInFlight = useRef(false);
 
   const load = () => {
+    if (isDirty) return;
     setLoading(true);
     setError(null);
     configApi
       .getConfig()
-      .then(setConfig)
+      .then((nextConfig) => applyConfig(nextConfig))
       .catch((requestError: Error) => setError(requestError.message))
       .finally(() => setLoading(false));
   };
@@ -36,203 +45,148 @@ export default function ConfigPage() {
     load();
   }, []);
 
-  const applyConfig = (nextConfig: DashboardConfigView, message?: string) => {
+  const isDirty = useMemo(
+    () => Boolean(nameserverDraft && savedDraft && isNameserverDraftDirty(nameserverDraft, savedDraft)),
+    [nameserverDraft, savedDraft]
+  );
+
+  function applyConfig(nextConfig: DashboardConfigView, message?: string) {
+    const nextDraft = normalizeNameserverDraft({
+      namesrvAddrList: nextConfig.namesrvAddrList,
+      currentNamesrv: nextConfig.currentNamesrv ?? null
+    });
     setConfig(nextConfig);
-    setOperationError(null);
-    setOperationMessage(message ?? 'Configuration updated');
-    window.dispatchEvent(new CustomEvent('rocketmq-config-updated'));
-  };
+    setSavedDraft(nextDraft);
+    setNameserverDraft(nextDraft);
+    if (message) setNotice({ tone: 'success', message });
+  }
 
-  const runMutation = (mutation: Promise<{ message: string; config: DashboardConfigView }>, onSuccess?: () => void) =>
-    mutation
-      .then((result) => {
-        applyConfig(result.config, result.message);
-        onSuccess?.();
-      })
-      .catch((requestError: Error) => {
-        setOperationMessage(null);
-        setOperationError(requestError.message);
-      });
+  async function runMutation(mutation: () => Promise<ConfigMutationResult>, onSuccess?: () => void) {
+    if (mutationInFlight.current) return;
 
-  if (loading) return <LoadingState label="Loading config" />;
+    mutationInFlight.current = true;
+    setPending(true);
+    setNotice(null);
+    try {
+      const result = await mutation();
+      applyConfig(result.config, result.message || 'Configuration updated.');
+      onSuccess?.();
+      window.dispatchEvent(new CustomEvent('rocketmq-config-updated'));
+    } catch (requestError) {
+      setNotice({ tone: 'danger', message: requestError instanceof Error ? requestError.message : 'Configuration update failed.' });
+    } finally {
+      mutationInFlight.current = false;
+      setPending(false);
+    }
+  }
+
+  function requestSectionChange(section: SettingsSection) {
+    if (section === activeSection) return;
+    if (isDirty) {
+      setRequestedSection(section);
+      return;
+    }
+    setActiveSection(section);
+  }
+
+  function discardChanges() {
+    if (savedDraft) setNameserverDraft(savedDraft);
+    if (requestedSection) setActiveSection(requestedSection);
+    setRequestedSection(null);
+  }
+
+  function addNameserver() {
+    if (isDirty || mutationInFlight.current) return;
+    const address = newNameserver.trim();
+    if (!address) {
+      setNotice({ tone: 'warning', message: 'NameServer address is required.' });
+      return;
+    }
+    void runMutation(() => configApi.addNameserver({ address }), () => setNewNameserver(''));
+  }
+
+  function saveNameservers() {
+    if (!nameserverDraft) return;
+    void runMutation(() => configApi.replaceNameservers(normalizeNameserverDraft(nameserverDraft)));
+  }
+
+  function removeNameserver() {
+    if (isDirty || !nameserverDraft || !nameserverToRemove) return;
+    const namesrvAddrList = nameserverDraft.namesrvAddrList.filter((address) => address !== nameserverToRemove);
+    const currentNamesrv = nameserverDraft.currentNamesrv === nameserverToRemove
+      ? namesrvAddrList[0] ?? null
+      : nameserverDraft.currentNamesrv;
+    void runMutation(() => configApi.replaceNameservers({ namesrvAddrList, currentNamesrv }), () => setNameserverToRemove(null));
+  }
+
+  if (loading) return <LoadingState label="Loading OPS settings" />;
   if (error) return <ErrorState message={error} onRetry={load} />;
-  if (!config) return null;
+  if (!config || !nameserverDraft) return null;
 
-  const namesrvRows: AddressRow[] = config.namesrvAddrList.map((address) => ({ address }));
-  const proxyRows: AddressRow[] = config.proxyAddrList.map((address) => ({ address }));
-  const switchNameserver = (address: string) =>
-    runMutation(configApi.replaceNameservers({ namesrvAddrList: config.namesrvAddrList, currentNamesrv: address }));
-  const deleteNameserver = (address: string) => {
-    const nextNameservers = config.namesrvAddrList.filter((item) => item !== address);
-    const nextCurrentNamesrv = config.currentNamesrv === address ? nextNameservers[0] ?? null : config.currentNamesrv ?? null;
-    return runMutation(configApi.replaceNameservers({ namesrvAddrList: nextNameservers, currentNamesrv: nextCurrentNamesrv }));
-  };
+  const storageBackend = String(config.storageBackend).toLowerCase();
 
   return (
     <>
       <PageHeader
-        title="Operations Config"
-        description="NameServer, VIP channel, TLS, Proxy, and persistence controls mapped to the Rust Web backend."
-        actions={
-          <>
-            <StatusBadge status={`storage ${String(config.storageBackend).toLowerCase()}`} />
-            <button type="button" className="icon-button" title="Reload config" onClick={load}>
-              <RefreshCw size={15} aria-hidden="true" />
-            </button>
-          </>
-        }
+        title="OPS settings"
+        description="Configure NameServer connectivity, transport security, and dashboard storage for this RocketMQ environment."
+        actions={<><StatusBadge status={`storage ${storageBackend}`} /><Button type="button" variant="ghost" size="icon" title="Reload OPS settings" aria-label="Reload OPS settings" onClick={load} disabled={pending || isDirty}><RefreshCw className={pending ? 'spin' : undefined} size={15} aria-hidden="true" /></Button></>}
       />
-      {operationMessage ? <div className="notice notice-success">{operationMessage}</div> : null}
-      {operationError ? <div className="notice notice-danger">{operationError}</div> : null}
-      <div className="ops-grid">
-        <section className="panel ops-main">
-          <div className="panel-heading">
-            <div>
-              <h2>NameServer Address List</h2>
-              <p>Equivalent to Java OPS NameServerAddressList, backed by <code>PUT /api/config/nameservers</code>.</p>
-            </div>
-            <StatusBadge status={config.currentNamesrv ?? 'unconfigured'} tone={config.currentNamesrv ? 'success' : 'warning'} />
-          </div>
-          <div className="action-row">
-            <input
-              className="inline-input inline-input-wide"
-              value={nameserver}
-              placeholder="127.0.0.1:9876"
-              onChange={(event) => setNameserver(event.target.value)}
-            />
-            <button
-              type="button"
-              className="button"
-              onClick={() => runMutation(configApi.addNameserver({ address: nameserver }), () => setNameserver(''))}
-            >
-              <Plus size={15} aria-hidden="true" /> Add
-            </button>
-          </div>
-        </section>
-        <section className="panel ops-side">
-          <div className="panel-heading">
-            <div>
-              <h2>Runtime Flags</h2>
-              <p>Persisted switches used by the Rust admin facade.</p>
-            </div>
-          </div>
-          <div className="flag-row">
-            <span>VIP Channel</span>
-            <button
-              type="button"
-              className={config.useVIPChannel ? 'switch-button checked' : 'switch-button'}
-              aria-pressed={config.useVIPChannel}
-              onClick={() => runMutation(configApi.setVipChannel({ enabled: !config.useVIPChannel }))}
-            >
-              <span />
-            </button>
-            <button type="button" className="button button-secondary" onClick={() => runMutation(configApi.setVipChannel({ enabled: !config.useVIPChannel }))}>
-              <Save size={15} aria-hidden="true" /> Update
-            </button>
-          </div>
-          <div className="flag-row">
-            <span>TLS</span>
-            <button
-              type="button"
-              className={config.useTLS ? 'switch-button checked' : 'switch-button'}
-              aria-pressed={config.useTLS}
-              onClick={() => runMutation(configApi.setTls({ enabled: !config.useTLS }))}
-            >
-              <span />
-            </button>
-            <button type="button" className="button button-secondary" onClick={() => runMutation(configApi.setTls({ enabled: !config.useTLS }))}>
-              <Save size={15} aria-hidden="true" /> Update
-            </button>
-          </div>
-        </section>
+      {notice ? <div className={`notice notice-${notice.tone}`} role={notice.tone === 'danger' ? 'alert' : 'status'}>{notice.message}</div> : null}
+      <div className="settings-workspace">
+        <SettingsSectionNav activeSection={activeSection} onSelect={requestSectionChange} />
+        <div className="settings-section-content">
+          {activeSection === 'connection' ? <ConnectionSection draft={nameserverDraft} newNameserver={newNameserver} dirty={isDirty} pending={pending} onDraftChange={setNameserverDraft} onNewNameserverChange={setNewNameserver} onAdd={addNameserver} onRemove={setNameserverToRemove} onSave={saveNameservers} onReset={() => setNameserverDraft(savedDraft)} /> : null}
+          {activeSection === 'security' ? <SecuritySection useVIPChannel={config.useVIPChannel} useTLS={config.useTLS} pending={pending} onToggleVip={() => void runMutation(() => configApi.setVipChannel({ enabled: !config.useVIPChannel }))} onToggleTls={() => void runMutation(() => configApi.setTls({ enabled: !config.useTLS }))} /> : null}
+          {activeSection === 'storage' ? <StorageSection storageBackend={storageBackend} /> : null}
+        </div>
       </div>
-      <DataTable
-        rows={namesrvRows}
-        columns={[
-          { header: 'NameServer', render: (row) => <code>{row.address}</code> },
-          { header: 'Current', render: (row) => (row.address === config.currentNamesrv ? <StatusBadge status="current" tone="success" /> : <StatusBadge status="standby" />) },
-          {
-            header: 'Actions',
-            render: (row) => (
-              <div className="action-row">
-                <button
-                  type="button"
-                  className="button button-secondary"
-                  disabled={row.address === config.currentNamesrv}
-                  onClick={() => switchNameserver(row.address)}
-                >
-                  Switch
-                </button>
-                <ConfirmDialog
-                  title="Delete NameServer"
-                  description={`Delete NameServer ${row.address}?`}
-                  confirmLabel="Delete"
-                  onConfirm={() => deleteNameserver(row.address)}
-                >
-                  <button type="button" className="icon-button" title="Delete NameServer">
-                    <Trash2 size={15} aria-hidden="true" />
-                  </button>
-                </ConfirmDialog>
-              </div>
-            )
-          }
-        ]}
-        getRowId={(row) => row.address}
-        emptyTitle="No NameServers"
-      />
-      <section className="panel" id="proxy">
-        <div className="panel-heading">
-          <div>
-            <h2>Proxy Endpoints</h2>
-            <p>Rust endpoints: <code>POST /api/config/proxies</code>, <code>PUT /api/config/proxies/current</code>, and delete by address.</p>
-          </div>
-          <StatusBadge status={config.currentProxyAddr ?? 'no proxy'} tone={config.currentProxyAddr ? 'success' : 'neutral'} />
-        </div>
-        <div className="action-row">
-          <input className="inline-input inline-input-wide" value={proxy} placeholder="127.0.0.1:8080" onChange={(event) => setProxy(event.target.value)} />
-          <button
-            type="button"
-            className="button"
-            onClick={() => runMutation(configApi.addProxy({ address: proxy }), () => setProxy(''))}
-          >
-            <Plus size={15} aria-hidden="true" /> Add Proxy
-          </button>
-        </div>
-      </section>
-      <DataTable
-        rows={proxyRows}
-        columns={[
-          { header: 'Proxy', render: (row) => <code>{row.address}</code> },
-          { header: 'Current', render: (row) => (row.address === config.currentProxyAddr ? <StatusBadge status="current" tone="success" /> : null) },
-          {
-            header: 'Actions',
-            render: (row) => (
-              <div className="action-row">
-                <button
-                  type="button"
-                  className="button button-secondary"
-                  disabled={row.address === config.currentProxyAddr}
-                  onClick={() => runMutation(configApi.switchProxy({ address: row.address }))}
-                >
-                  Switch
-                </button>
-                <ConfirmDialog
-                  title="Delete proxy"
-                  description={`Delete proxy ${row.address}?`}
-                  confirmLabel="Delete"
-                  onConfirm={() => runMutation(configApi.deleteProxy(row.address))}
-                >
-                  <button type="button" className="icon-button" title="Delete proxy">
-                    <Trash2 size={15} aria-hidden="true" />
-                  </button>
-                </ConfirmDialog>
-              </div>
-            )
-          }
-        ]}
-        getRowId={(row) => row.address}
-        emptyTitle="No proxies"
-      />
+      <AlertDialog open={requestedSection !== null} onOpenChange={(open) => !open && setRequestedSection(null)}>
+        <AlertDialogContent>
+          <AlertDialogTitle className="dialog-title"><AlertTriangle size={18} aria-hidden="true" />Discard unsaved NameServer changes?</AlertDialogTitle>
+          <AlertDialogDescription>Your draft NameServer selection has not been persisted. Discard it before changing settings sections?</AlertDialogDescription>
+          <div className="dialog-actions"><AlertDialogCancel>Keep editing</AlertDialogCancel><AlertDialogAction onClick={discardChanges}>Discard changes</AlertDialogAction></div>
+        </AlertDialogContent>
+      </AlertDialog>
+      <AlertDialog open={nameserverToRemove !== null} onOpenChange={(open) => !open && setNameserverToRemove(null)}>
+        <AlertDialogContent>
+          <AlertDialogTitle className="dialog-title"><AlertTriangle size={18} aria-hidden="true" />Remove NameServer {nameserverToRemove}?</AlertDialogTitle>
+          <AlertDialogDescription>This removes the endpoint from the configured NameServer list and updates the current endpoint if needed.</AlertDialogDescription>
+          <div className="dialog-actions"><AlertDialogCancel>Keep NameServer</AlertDialogCancel><AlertDialogAction onClick={removeNameserver}>Remove NameServer</AlertDialogAction></div>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
+}
+
+interface ConnectionSectionProps {
+  draft: NameserverDraft;
+  newNameserver: string;
+  dirty: boolean;
+  pending: boolean;
+  onDraftChange: (draft: NameserverDraft) => void;
+  onNewNameserverChange: (value: string) => void;
+  onAdd: () => void;
+  onRemove: (address: string) => void;
+  onSave: () => void;
+  onReset: () => void;
+}
+
+function ConnectionSection({ draft, newNameserver, dirty, pending, onDraftChange, onNewNameserverChange, onAdd, onRemove, onSave, onReset }: ConnectionSectionProps) {
+  return <Card className="settings-card"><CardHeader><div><CardTitle>Connection</CardTitle><CardDescription>Choose the NameServer endpoint that the dashboard uses for RocketMQ operations.</CardDescription></div><StatusBadge status={draft.currentNamesrv ?? 'unconfigured'} tone={draft.currentNamesrv ? 'success' : 'warning'} /></CardHeader><CardContent className="settings-card-content"><div className="settings-field-grid"><label className="settings-field"><span>Current NameServer</span><select aria-label="Current NameServer" value={draft.currentNamesrv ?? ''} onChange={(event) => onDraftChange({ ...draft, currentNamesrv: event.target.value || null })}>{draft.namesrvAddrList.length === 0 ? <option value="">No NameServers configured</option> : null}{draft.namesrvAddrList.map((address) => <option key={address} value={address}>{address}</option>)}</select></label><div className="settings-field"><span>Configured NameServers</span><div className="settings-address-list" aria-label="Configured NameServers">{draft.namesrvAddrList.length === 0 ? <span className="settings-empty-value">No endpoints configured</span> : null}{draft.namesrvAddrList.map((address) => <span className="settings-address-item" key={address}><code>{address}</code><Button type="button" variant="ghost" size="icon" aria-label={`Remove ${address}`} title={`Remove ${address}`} disabled={pending || dirty} onClick={() => onRemove(address)}><Trash2 size={14} aria-hidden="true" /></Button></span>)}</div></div></div><div className="settings-add-row"><Label htmlFor="new-nameserver">Add NameServer</Label><div><Input id="new-nameserver" value={newNameserver} placeholder="127.0.0.1:9876" disabled={pending || dirty} onChange={(event) => onNewNameserverChange(event.target.value)} onKeyDown={(event) => event.key === 'Enter' && onAdd()} /><Button type="button" onClick={onAdd} disabled={pending || dirty}><Plus size={15} aria-hidden="true" />Add NameServer</Button></div></div><div className="settings-actions"><span>{dirty ? 'Unsaved NameServer changes' : 'NameServer configuration is current'}</span><div><Button type="button" variant="outline" onClick={onReset} disabled={!dirty || pending}><RotateCcw size={15} aria-hidden="true" />Reset draft</Button><Button type="button" onClick={onSave} disabled={!dirty || pending}><Save size={15} aria-hidden="true" />Save NameServers</Button></div></div></CardContent></Card>;
+}
+
+interface SecuritySectionProps { useVIPChannel: boolean; useTLS: boolean; pending: boolean; onToggleVip: () => void; onToggleTls: () => void; }
+
+function SecuritySection({ useVIPChannel, useTLS, pending, onToggleVip, onToggleTls }: SecuritySectionProps) {
+  return <Card className="settings-card"><CardHeader><div><CardTitle>Security</CardTitle><CardDescription>Apply the available transport settings for NameServer and broker connections.</CardDescription></div></CardHeader><CardContent className="settings-card-content settings-toggle-list"><SettingToggle label="VIP channel" description="Prefer the VIP channel for client connections." enabled={useVIPChannel} pending={pending} onClick={onToggleVip} /><SettingToggle label="TLS" description="Enable TLS for dashboard connections." enabled={useTLS} pending={pending} onClick={onToggleTls} /></CardContent></Card>;
+}
+
+function SettingToggle({ label, description, enabled, pending, onClick }: { label: string; description: string; enabled: boolean; pending: boolean; onClick: () => void }) {
+  const action = `${enabled ? 'Disable' : 'Enable'} ${label}`;
+  return <div className="settings-toggle-row"><div><strong>{label}</strong><p>{description}</p></div><Button type="button" variant={enabled ? 'default' : 'outline'} onClick={onClick} disabled={pending} aria-pressed={enabled}>{action}</Button></div>;
+}
+
+function StorageSection({ storageBackend }: { storageBackend: string }) {
+  return <Card className="settings-card"><CardHeader><div><CardTitle>Storage</CardTitle><CardDescription>Persistence is reported by the connected dashboard backend and cannot be changed here.</CardDescription></div></CardHeader><CardContent className="settings-card-content"><dl className="settings-storage-detail"><div><dt>Storage backend</dt><dd><StatusBadge status={storageBackend} /></dd></div><div><dt>Configuration mode</dt><dd>Read-only</dd></div></dl></CardContent></Card>;
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/DashboardPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/DashboardPage.tsx
@@ -231,7 +231,6 @@ export default function DashboardPage() {
             <RankingTable
               rows={topicRankingRows}
               valueLabel="Messages"
-              accent="var(--primary)"
               emptyTitle="No topic ranking"
               emptyDetail="Topic metrics are not available for the current cluster."
               formatValue={formatDashboardMetric}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/LoginPage.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/LoginPage.css
@@ -1,0 +1,144 @@
+.login-shell {
+  display: grid;
+  min-height: 100vh;
+  grid-template-rows: auto 1fr auto;
+  padding: 28px;
+  background: var(--background);
+}
+
+.login-brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--foreground);
+}
+
+.login-brand-mark {
+  display: grid;
+  width: 48px;
+  height: 48px;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--chrome);
+  color: var(--primary);
+}
+
+.login-brand strong,
+.login-brand span {
+  display: block;
+}
+
+.login-brand strong {
+  font-size: 20px;
+  line-height: 1.2;
+}
+
+.login-brand span,
+.login-footer {
+  color: var(--muted-foreground);
+}
+
+.login-brand span {
+  margin-top: 2px;
+  font-size: 14px;
+}
+
+.login-content {
+  display: grid;
+  width: min(572px, 100%);
+  align-self: center;
+  justify-self: center;
+  gap: 20px;
+}
+
+.login-session-note {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 0;
+  padding: 16px 20px;
+  border: 1px solid color-mix(in srgb, var(--info) 70%, var(--border));
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--info) 8%, var(--background));
+  color: var(--foreground);
+  font-size: 16px;
+}
+
+.login-session-note svg {
+  flex: 0 0 auto;
+  color: var(--info);
+}
+
+.login-card {
+  box-shadow: var(--shadow);
+}
+
+.login-card .ui-card-header {
+  gap: 8px;
+  padding: 28px 30px 0;
+}
+
+.login-card .ui-card-title {
+  font-size: 27px;
+  line-height: 1.2;
+}
+
+.login-card .ui-card-description {
+  font-size: 16px;
+}
+
+.login-card .ui-card-content {
+  padding: 28px 30px 30px;
+}
+
+.login-form {
+  display: grid;
+  gap: 22px;
+}
+
+.login-field {
+  display: grid;
+  gap: 8px;
+}
+
+.login-field .ui-input {
+  min-height: 48px;
+  font-size: 16px;
+}
+
+.login-submit {
+  width: 100%;
+  min-height: 48px;
+  font-size: 16px;
+}
+
+.login-form .state-block {
+  margin: 0;
+}
+
+.login-footer {
+  justify-self: center;
+  margin: 20px 0 0;
+  font-size: 14px;
+}
+
+@media (max-width: 640px) {
+  .login-shell {
+    padding: 20px;
+  }
+
+  .login-content {
+    gap: 16px;
+  }
+
+  .login-card .ui-card-header,
+  .login-card .ui-card-content {
+    padding-right: 20px;
+    padding-left: 20px;
+  }
+
+  .login-card .ui-card-title {
+    font-size: 23px;
+  }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/LoginPage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/LoginPage.test.tsx
@@ -1,0 +1,146 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { authApi } from '../api/auth_api';
+import { ApiClientError } from '../api/client';
+import { renderAtRoute } from '../test/render';
+import LoginPage from './LoginPage';
+
+const navigate = vi.fn();
+
+vi.mock('../api/auth_api', () => ({
+  authApi: {
+    session: vi.fn(),
+    login: vi.fn()
+  }
+}));
+
+vi.mock('react-router-dom', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react-router-dom')>()),
+  useNavigate: () => navigate
+}));
+
+const mockedAuthApi = vi.mocked(authApi);
+
+const requiredSession = {
+  loginRequired: true,
+  authenticated: false
+};
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockedAuthApi.session.mockResolvedValue(requiredSession);
+  });
+
+  it('shows an accessible session-checking state before rendering credentials', () => {
+    mockedAuthApi.session.mockReturnValue(new Promise(() => undefined));
+
+    renderAtRoute(<LoginPage />, '/login');
+
+    expect(screen.getByRole('status', { name: 'Checking session' })).toBeInTheDocument();
+    expect(screen.queryByLabelText('Username')).not.toBeInTheDocument();
+  });
+
+  it('shows a retryable session error before rendering credentials, then shows them after retry', async () => {
+    const user = userEvent.setup();
+    mockedAuthApi.session.mockRejectedValueOnce(new Error('session unavailable')).mockResolvedValueOnce(requiredSession);
+
+    renderAtRoute(<LoginPage />, '/login');
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Unable to load auth session.');
+    expect(screen.queryByLabelText('Username')).not.toBeInTheDocument();
+    expect(screen.queryByText('Authentication is required for this dashboard.')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(await screen.findByLabelText('Username')).toBeInTheDocument();
+    expect(mockedAuthApi.session).toHaveBeenCalledTimes(2);
+  });
+
+  it('redirects with replacement when login is disabled', async () => {
+    mockedAuthApi.session.mockResolvedValue({ loginRequired: false, authenticated: false });
+
+    renderAtRoute(<LoginPage />, '/login');
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('/dashboard', { replace: true }));
+  });
+
+  it('redirects with replacement when the current session is already authenticated', async () => {
+    mockedAuthApi.session.mockResolvedValue({ loginRequired: true, authenticated: true, username: 'operator' });
+
+    renderAtRoute(<LoginPage />, '/login');
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('/dashboard', { replace: true }));
+  });
+
+  it('submits credentials and redirects with replacement after successful login', async () => {
+    const user = userEvent.setup();
+    mockedAuthApi.login.mockResolvedValue({ ...requiredSession, authenticated: true, username: 'operator' });
+
+    renderAtRoute(<LoginPage />, '/login');
+    const username = await screen.findByLabelText('Username');
+    const password = screen.getByLabelText('Password');
+    expect(username).toHaveValue('');
+    expect(password).toHaveValue('');
+
+    await user.type(username, 'operator');
+    await user.type(password, 'correct-password');
+    await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+    await waitFor(() => expect(mockedAuthApi.login).toHaveBeenCalledWith({ username: 'operator', password: 'correct-password' }));
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('/dashboard', { replace: true }));
+  });
+
+  it('reports invalid credentials without exposing the password', async () => {
+    const user = userEvent.setup();
+    mockedAuthApi.login.mockRejectedValue(new ApiClientError('AUTH_ERROR', 'Invalid username or password.'));
+
+    renderAtRoute(<LoginPage />, '/login');
+    const username = await screen.findByLabelText('Username');
+    const password = screen.getByLabelText('Password');
+    await user.type(username, 'operator');
+    await user.type(password, 'incorrect-password');
+    await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Invalid username or password.');
+    expect(screen.queryByText('incorrect-password')).not.toBeInTheDocument();
+  });
+
+  it('preserves the username, clears the password, and restores password focus after login failure', async () => {
+    const user = userEvent.setup();
+    mockedAuthApi.login.mockRejectedValue(new ApiClientError('AUTH_ERROR', 'Invalid username or password.'));
+
+    renderAtRoute(<LoginPage />, '/login');
+    const username = await screen.findByLabelText('Username');
+    const password = screen.getByLabelText('Password');
+    await user.type(username, 'operator');
+    await user.type(password, 'incorrect-password');
+    await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+    await screen.findByRole('alert');
+    expect(username).toHaveValue('operator');
+    expect(password).toHaveValue('');
+    await waitFor(() => expect(password).toHaveFocus());
+  });
+
+  it('prevents duplicate login submissions while a request is pending', async () => {
+    const user = userEvent.setup();
+    let resolveLogin: ((value: typeof requiredSession) => void) | undefined;
+    mockedAuthApi.login.mockReturnValue(new Promise((resolve) => {
+      resolveLogin = resolve;
+    }));
+
+    renderAtRoute(<LoginPage />, '/login');
+    await user.type(await screen.findByLabelText('Username'), 'operator');
+    await user.type(screen.getByLabelText('Password'), 'correct-password');
+    const submit = screen.getByRole('button', { name: 'Sign in' });
+    await user.click(submit);
+    await user.click(submit);
+
+    expect(mockedAuthApi.login).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('button', { name: 'Signing in' })).toBeDisabled();
+    resolveLogin?.(requiredSession);
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('/dashboard', { replace: true }));
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/LoginPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/LoginPage.tsx
@@ -1,44 +1,71 @@
-import { LogIn } from 'lucide-react';
-import { FormEvent, useEffect, useState } from 'react';
+import { Activity, LogIn } from 'lucide-react';
+import { FormEvent, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { authApi } from '../api/auth_api';
 import { ApiClientError } from '../api/client';
 import ErrorState from '../components/ErrorState';
 import LoadingState from '../components/LoadingState';
+import { Button } from '../components/ui/Button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/Card';
+import { Input } from '../components/ui/Input';
+import { Label } from '../components/ui/Label';
+import './LoginPage.css';
 
 export default function LoginPage() {
   const navigate = useNavigate();
-  const [username, setUsername] = useState('admin');
+  const passwordInputRef = useRef<HTMLInputElement>(null);
+  const submittingRef = useRef(false);
+  const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [checking, setChecking] = useState(true);
   const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [sessionError, setSessionError] = useState<string | null>(null);
+  const [credentialError, setCredentialError] = useState<string | null>(null);
+
+  const checkSession = async () => {
+    setChecking(true);
+    setSessionError(null);
+    try {
+      const session = await authApi.session();
+      if (!session.loginRequired || session.authenticated) {
+        navigate('/dashboard', { replace: true });
+      }
+    } catch {
+      setSessionError('Unable to load auth session.');
+    } finally {
+      setChecking(false);
+    }
+  };
 
   useEffect(() => {
-    authApi
-      .session()
-      .then((session) => {
-        if (!session.loginRequired || session.authenticated) {
-          navigate('/dashboard', { replace: true });
-        }
-      })
-      .catch(() => {
-        setError('Unable to load auth session.');
-      })
-      .finally(() => setChecking(false));
+    void checkSession();
   }, [navigate]);
 
-  const submit = (event: FormEvent<HTMLFormElement>) => {
+  useEffect(() => {
+    if (credentialError && !submitting) {
+      passwordInputRef.current?.focus();
+    }
+  }, [credentialError, submitting]);
+
+  const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    setError(null);
+    if (submittingRef.current) {
+      return;
+    }
+
+    submittingRef.current = true;
+    setCredentialError(null);
     setSubmitting(true);
-    authApi
-      .login({ username, password })
-      .then(() => navigate('/dashboard', { replace: true }))
-      .catch((err: unknown) => {
-        setError(err instanceof ApiClientError ? err.message : 'Login failed.');
-      })
-      .finally(() => setSubmitting(false));
+    try {
+      await authApi.login({ username, password });
+      navigate('/dashboard', { replace: true });
+    } catch (err) {
+      setPassword('');
+      setCredentialError(err instanceof ApiClientError ? err.message : 'Login failed.');
+    } finally {
+      submittingRef.current = false;
+      setSubmitting(false);
+    }
   };
 
   if (checking) {
@@ -49,31 +76,72 @@ export default function LoginPage() {
     );
   }
 
+  if (sessionError) {
+    return (
+      <main className="login-shell">
+        <ErrorState message={sessionError} onRetry={() => void checkSession()} />
+      </main>
+    );
+  }
+
   return (
     <main className="login-shell">
-      <form className="login-panel" onSubmit={submit}>
-        <div className="login-mark" aria-hidden="true">
-          <LogIn size={22} />
+      <div className="login-brand" aria-label="RocketMQ Operations">
+        <div className="login-brand-mark" aria-hidden="true">
+          <Activity size={22} />
         </div>
-        <h1>RocketMQ Dashboard</h1>
-        <label className="field">
-          Username
-          <input value={username} autoComplete="username" onChange={(event) => setUsername(event.target.value)} />
-        </label>
-        <label className="field">
-          Password
-          <input
-            value={password}
-            type="password"
-            autoComplete="current-password"
-            onChange={(event) => setPassword(event.target.value)}
-          />
-        </label>
-        {error ? <ErrorState message={error} /> : null}
-        <button type="submit" className="button" disabled={submitting || !username || !password}>
-          {submitting ? 'Signing in' : 'Sign in'}
-        </button>
-      </form>
+        <div>
+          <strong>RocketMQ</strong>
+          <span>Operations</span>
+        </div>
+      </div>
+
+      <div className="login-content">
+        <p className="login-session-note" role="status">
+          <LogIn size={18} aria-hidden="true" />
+          Authentication is required for this dashboard.
+        </p>
+        <Card className="login-card">
+          <CardHeader>
+            <CardTitle>Sign in to RocketMQ Operations</CardTitle>
+            <CardDescription>Use your dashboard credentials to continue.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form className="login-form" onSubmit={submit} aria-busy={submitting}>
+              <div className="login-field">
+                <Label htmlFor="login-username">Username</Label>
+                <Input
+                  id="login-username"
+                  value={username}
+                  autoComplete="username"
+                  placeholder="Enter your username"
+                  disabled={submitting}
+                  onChange={(event) => setUsername(event.target.value)}
+                />
+              </div>
+              <div className="login-field">
+                <Label htmlFor="login-password">Password</Label>
+                <Input
+                  ref={passwordInputRef}
+                  id="login-password"
+                  value={password}
+                  type="password"
+                  autoComplete="current-password"
+                  placeholder="Enter your password"
+                  disabled={submitting}
+                  onChange={(event) => setPassword(event.target.value)}
+                />
+              </div>
+              {credentialError ? <ErrorState message={credentialError} /> : null}
+              <Button type="submit" className="login-submit" loading={submitting} disabled={!username || !password}>
+                {submitting ? 'Signing in' : 'Sign in'}
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+
+      <p className="login-footer">RocketMQ Dashboard Web</p>
     </main>
   );
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ProxyPage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ProxyPage.test.tsx
@@ -1,0 +1,181 @@
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { configApi } from '../api/config_api';
+import { renderAtRoute } from '../test/render';
+import type { DashboardConfigView } from '../types/config';
+import ProxyPage from './ProxyPage';
+
+vi.mock('../api/config_api', () => ({
+  configApi: {
+    getConfig: vi.fn(),
+    addProxy: vi.fn(),
+    switchProxy: vi.fn(),
+    deleteProxy: vi.fn()
+  }
+}));
+
+const initialConfig: DashboardConfigView = {
+  namesrvAddrList: [],
+  currentNamesrv: null,
+  useVIPChannel: false,
+  useTLS: false,
+  proxyAddrList: ['proxy-a:8081', 'proxy-b:8081'],
+  currentProxyAddr: 'proxy-a:8081',
+  storageBackend: 'file'
+};
+
+const mockedConfigApi = vi.mocked(configApi);
+
+function configMutation(config: DashboardConfigView, message: string) {
+  return { config, message };
+}
+
+describe('ProxyPage', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockedConfigApi.getConfig.mockResolvedValue(initialConfig);
+    mockedConfigApi.addProxy.mockImplementation(({ address }) => Promise.resolve(configMutation({
+      ...initialConfig,
+      proxyAddrList: [...initialConfig.proxyAddrList, address]
+    }, 'Proxy endpoint added.')));
+    mockedConfigApi.switchProxy.mockImplementation(({ address }) => Promise.resolve(configMutation({
+      ...initialConfig,
+      currentProxyAddr: address
+    }, 'Current proxy updated.')));
+    mockedConfigApi.deleteProxy.mockImplementation((address) => Promise.resolve(configMutation({
+      ...initialConfig,
+      proxyAddrList: initialConfig.proxyAddrList.filter((proxyAddress) => proxyAddress !== address)
+    }, 'Proxy endpoint deleted.')));
+  });
+
+  it('adds a normalized endpoint and prevents a normalized duplicate before persistence', async () => {
+    const user = userEvent.setup();
+    const onConfigUpdated = vi.fn();
+    window.addEventListener('rocketmq-config-updated', onConfigUpdated);
+    renderAtRoute(<ProxyPage />, '/proxy');
+
+    await user.click(await screen.findByRole('button', { name: 'Add endpoint' }));
+    const dialog = screen.getByRole('dialog', { name: 'Add proxy endpoint' });
+    const input = within(dialog).getByLabelText('Proxy address');
+    await user.type(input, ' proxy-c:8081 ');
+    await user.click(within(dialog).getByRole('button', { name: 'Add proxy endpoint' }));
+
+    await waitFor(() => expect(mockedConfigApi.addProxy).toHaveBeenCalledWith({ address: 'proxy-c:8081' }));
+    expect(onConfigUpdated).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', { name: 'Add endpoint' }));
+    const duplicateDialog = screen.getByRole('dialog', { name: 'Add proxy endpoint' });
+    await user.type(within(duplicateDialog).getByLabelText('Proxy address'), ' PROXY-A:+08081 ');
+    await user.click(within(duplicateDialog).getByRole('button', { name: 'Add proxy endpoint' }));
+
+    expect(await within(duplicateDialog).findByRole('alert')).toHaveTextContent('This proxy endpoint is already configured.');
+    expect(mockedConfigApi.addProxy).toHaveBeenCalledTimes(1);
+    window.removeEventListener('rocketmq-config-updated', onConfigUpdated);
+  });
+
+  it('keeps focus on the endpoint field when a blank add is rejected', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<ProxyPage />, '/proxy');
+
+    await user.click(await screen.findByRole('button', { name: 'Add endpoint' }));
+    const dialog = screen.getByRole('dialog', { name: 'Add proxy endpoint' });
+    const input = within(dialog).getByLabelText('Proxy address');
+    await user.click(within(dialog).getByRole('button', { name: 'Add proxy endpoint' }));
+
+    expect(await within(dialog).findByRole('alert')).toHaveTextContent('Enter a proxy endpoint.');
+    expect(input).toHaveFocus();
+    expect(mockedConfigApi.addProxy).not.toHaveBeenCalled();
+  });
+
+  it('keeps focus on the endpoint field after an add request is rejected', async () => {
+    const user = userEvent.setup();
+    mockedConfigApi.addProxy.mockRejectedValueOnce(new Error('Proxy endpoint was rejected.'));
+    renderAtRoute(<ProxyPage />, '/proxy');
+
+    await user.click(await screen.findByRole('button', { name: 'Add endpoint' }));
+    const dialog = screen.getByRole('dialog', { name: 'Add proxy endpoint' });
+    const input = within(dialog).getByLabelText('Proxy address');
+    await user.type(input, 'proxy-c:8081');
+    await user.click(within(dialog).getByRole('button', { name: 'Add proxy endpoint' }));
+
+    expect(await within(dialog).findByRole('alert')).toHaveTextContent('Proxy endpoint was rejected.');
+    expect(input).toHaveFocus();
+    expect(mockedConfigApi.addProxy).toHaveBeenCalledWith({ address: 'proxy-c:8081' });
+  });
+
+  it('switches the current endpoint through the exact config API and reports the returned state', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<ProxyPage />, '/proxy');
+
+    await screen.findByText('proxy-b:8081');
+    await user.click(screen.getByRole('button', { name: 'Set current proxy proxy-b:8081' }));
+
+    await waitFor(() => expect(mockedConfigApi.switchProxy).toHaveBeenCalledWith({ address: 'proxy-b:8081' }));
+    expect(await screen.findByText('Current proxy updated.')).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: 'Current' })).toBeInTheDocument();
+  });
+
+  it('does not call the delete API when proxy deletion is cancelled', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<ProxyPage />, '/proxy');
+
+    await user.click(await screen.findByRole('button', { name: 'Delete proxy proxy-b:8081' }));
+    const confirmation = screen.getByRole('alertdialog');
+    expect(confirmation).toHaveTextContent('Delete proxy proxy-b:8081?');
+    await user.click(within(confirmation).getByRole('button', { name: 'Cancel' }));
+
+    expect(mockedConfigApi.deleteProxy).not.toHaveBeenCalled();
+  });
+
+  it('deletes the selected endpoint only after confirmation with the exact config API argument', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<ProxyPage />, '/proxy');
+
+    await user.click(await screen.findByRole('button', { name: 'Delete proxy proxy-b:8081' }));
+    const confirmation = screen.getByRole('alertdialog');
+    await user.click(within(confirmation).getByRole('button', { name: 'Delete proxy' }));
+
+    await waitFor(() => expect(mockedConfigApi.deleteProxy).toHaveBeenCalledWith('proxy-b:8081'));
+    expect(await screen.findByText('Proxy endpoint deleted.')).toBeInTheDocument();
+  });
+
+  it('uses the API response as the source of truth when deleting the current endpoint', async () => {
+    const user = userEvent.setup();
+    mockedConfigApi.getConfig.mockResolvedValue({
+      ...initialConfig,
+      proxyAddrList: ['proxy-a:8081'],
+      currentProxyAddr: 'proxy-a:8081'
+    });
+    mockedConfigApi.deleteProxy.mockResolvedValue(configMutation({
+      ...initialConfig,
+      proxyAddrList: [],
+      currentProxyAddr: null
+    }, 'Proxy endpoint deleted.'));
+    renderAtRoute(<ProxyPage />, '/proxy');
+
+    await user.click(await screen.findByRole('button', { name: 'Delete proxy proxy-a:8081' }));
+    await user.click(within(screen.getByRole('alertdialog')).getByRole('button', { name: 'Delete proxy' }));
+
+    expect(await screen.findByText('No current endpoint')).toBeInTheDocument();
+    expect(screen.queryByRole('status', { name: 'Current' })).not.toBeInTheDocument();
+  });
+
+  it('submits one add request while the first request is in flight', async () => {
+    const user = userEvent.setup();
+    let resolveAdd: ((value: ReturnType<typeof configMutation>) => void) | undefined;
+    mockedConfigApi.addProxy.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveAdd = resolve;
+    }));
+    renderAtRoute(<ProxyPage />, '/proxy');
+
+    await user.click(await screen.findByRole('button', { name: 'Add endpoint' }));
+    const dialog = screen.getByRole('dialog', { name: 'Add proxy endpoint' });
+    await user.type(within(dialog).getByLabelText('Proxy address'), 'proxy-c:8081');
+    await user.dblClick(within(dialog).getByRole('button', { name: 'Add proxy endpoint' }));
+
+    expect(mockedConfigApi.addProxy).toHaveBeenCalledTimes(1);
+    resolveAdd?.(configMutation({ ...initialConfig, proxyAddrList: [...initialConfig.proxyAddrList, 'proxy-c:8081'] }, 'Proxy endpoint added.'));
+    expect(await screen.findByText('Proxy endpoint added.')).toBeInTheDocument();
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ProxyPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ProxyPage.tsx
@@ -1,14 +1,18 @@
-import { CheckCircle2, Copy, Database, Plus, RefreshCw, Route, Server, Trash2, Zap } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { CheckCircle2, Plus, RefreshCw, Route, Trash2 } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { configApi } from '../api/config_api';
 import ConfirmDialog from '../components/ConfirmDialog';
 import EmptyState from '../components/EmptyState';
 import ErrorState from '../components/ErrorState';
 import LoadingState from '../components/LoadingState';
 import PageHeader from '../components/PageHeader';
-import SelectMenu, { type SelectMenuOption } from '../components/SelectMenu';
 import StatusBadge from '../components/StatusBadge';
+import { Button } from '../components/ui/Button';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../components/ui/Dialog';
+import { Input } from '../components/ui/Input';
+import { Label } from '../components/ui/Label';
 import type { ConfigMutationResult, DashboardConfigView } from '../types/config';
+import { getProxyEndpointLabel, isDuplicateProxyAddress, normalizeProxyAddress } from './proxy/proxy-model';
 
 type NoticeTone = 'success' | 'warning' | 'danger';
 
@@ -18,257 +22,225 @@ export default function ProxyPage() {
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<{ tone: NoticeTone; message: string } | null>(null);
+  const [addDialogOpen, setAddDialogOpen] = useState(false);
   const [proxyAddress, setProxyAddress] = useState('');
+  const [addError, setAddError] = useState<string | null>(null);
+  const mutationInFlight = useRef(false);
+  const proxyAddressInputRef = useRef<HTMLInputElement>(null);
 
-  const load = () => {
+  const load = useCallback(async () => {
     setLoading(true);
     setError(null);
-    configApi
-      .getConfig()
-      .then((data) => {
-        setConfig(data);
-        setNotice(null);
-      })
-      .catch((requestError: Error) => setError(requestError.message))
-      .finally(() => setLoading(false));
-  };
-
-  useEffect(() => {
-    load();
+    try {
+      setConfig(await configApi.getConfig());
+      setNotice(null);
+    } catch (requestError) {
+      setError(getErrorMessage(requestError));
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
-  const proxyOptions = useMemo<SelectMenuOption[]>(() => {
-    const proxies = config?.proxyAddrList ?? [];
-    if (proxies.length === 0) {
-      return [{ value: '', label: 'No proxy configured', disabled: true }];
-    }
-    return proxies.map((address) => ({ value: address, label: address }));
-  }, [config]);
+  useEffect(() => {
+    void load();
+  }, [load]);
 
-  const currentProxy = config?.currentProxyAddr ?? config?.proxyAddrList[0] ?? '';
-  const storageBackend = String(config?.storageBackend ?? 'file').toLowerCase();
+  useEffect(() => {
+    if (addDialogOpen && addError) proxyAddressInputRef.current?.focus();
+  }, [addDialogOpen, addError]);
 
   const applyMutation = (result: ConfigMutationResult) => {
     setConfig(result.config);
     setNotice({ tone: 'success', message: result.message || 'Proxy configuration updated.' });
-    if (result.config.currentProxyAddr) {
-      localStorage.setItem('proxyAddr', result.config.currentProxyAddr);
-    }
     window.dispatchEvent(new CustomEvent('rocketmq-config-updated'));
   };
 
-  const runMutation = (mutation: Promise<ConfigMutationResult>, onSuccess?: () => void) => {
+  const runMutation = async (request: () => Promise<ConfigMutationResult>, onSuccess?: () => void, onError?: (message: string) => void) => {
+    if (mutationInFlight.current) return;
+
+    mutationInFlight.current = true;
     setPending(true);
     setNotice(null);
-    mutation
-      .then((result) => {
-        applyMutation(result);
-        onSuccess?.();
-      })
-      .catch((requestError: Error) => {
-        setNotice({ tone: 'danger', message: requestError.message });
-      })
-      .finally(() => setPending(false));
+    try {
+      applyMutation(await request());
+      onSuccess?.();
+    } catch (requestError) {
+      const message = getErrorMessage(requestError);
+      setNotice({ tone: 'danger', message });
+      onError?.(message);
+    } finally {
+      mutationInFlight.current = false;
+      setPending(false);
+    }
   };
 
   const addProxy = () => {
-    const address = proxyAddress.trim();
+    const address = normalizeProxyAddress(proxyAddress);
     if (!address) {
-      setNotice({ tone: 'warning', message: 'Input proxy address required.' });
+      setAddError('Enter a proxy endpoint.');
+      proxyAddressInputRef.current?.focus();
       return;
     }
-    runMutation(configApi.addProxy({ address }), () => setProxyAddress(''));
+    if (isDuplicateProxyAddress(address, config?.proxyAddrList ?? [])) {
+      setAddError('This proxy endpoint is already configured.');
+      return;
+    }
+
+    void runMutation(
+      () => configApi.addProxy({ address }),
+      () => {
+        setProxyAddress('');
+        setAddError(null);
+        setAddDialogOpen(false);
+      },
+      (message) => {
+        setAddError(message);
+        proxyAddressInputRef.current?.focus();
+      }
+    );
   };
 
   const switchProxy = (address: string) => {
-    if (!address || address === config?.currentProxyAddr) {
-      return;
-    }
-    runMutation(configApi.switchProxy({ address }));
+    if (pending || getProxyEndpointLabel(address, config?.currentProxyAddr) === 'Current') return;
+    void runMutation(() => configApi.switchProxy({ address }));
   };
 
   const deleteProxy = (address: string) => {
-    runMutation(configApi.deleteProxy(address));
+    if (pending) return;
+    void runMutation(() => configApi.deleteProxy(address));
   };
 
-  const copyProxy = (address: string) => {
-    copyText(address);
-    setNotice({ tone: 'success', message: `Copied proxy ${address}.` });
+  const openAddDialog = () => {
+    setAddError(null);
+    setAddDialogOpen(true);
   };
 
-  if (loading) return <LoadingState label="Loading proxy configuration" />;
+  if (loading) return <LoadingState label="Loading proxy endpoints" />;
   if (error) return <ErrorState message={error} onRetry={load} />;
   if (!config) return null;
 
   const proxies = config.proxyAddrList;
+  const currentProxy = config.currentProxyAddr ?? null;
 
   return (
     <>
       <PageHeader
         title="Proxy"
-        description="ProxyServerAddressList parity with Java Dashboard, redesigned for dense RocketMQ operations."
-        actions={
+        description="Manage configured proxy endpoints and select the current endpoint."
+        actions={(
           <>
-            <StatusBadge status={currentProxy || 'no proxy'} tone={currentProxy ? 'success' : 'neutral'} />
-            <button type="button" className="icon-button" title="Reload proxy" onClick={load} disabled={pending}>
-              <RefreshCw className={pending ? 'spin' : undefined} size={15} aria-hidden="true" />
-            </button>
+            <Button type="button" variant="secondary" onClick={() => void load()} disabled={pending} aria-label="Refresh proxy endpoints">
+              <RefreshCw size={15} aria-hidden="true" /> Refresh
+            </Button>
+            <Button type="button" onClick={openAddDialog} disabled={pending}>
+              <Plus size={15} aria-hidden="true" /> Add endpoint
+            </Button>
           </>
-        }
+        )}
       />
 
-      {notice ? <div className={`notice notice-${notice.tone}`}>{notice.message}</div> : null}
+      {notice ? <div className={`notice notice-${notice.tone}`} role={notice.tone === 'danger' ? 'alert' : 'status'}>{notice.message}</div> : null}
 
-      <section className="proxy-hero-grid">
-        <div className="panel proxy-selector-panel">
-          <div className="panel-heading">
-            <div>
-              <h2>ProxyServerAddressList</h2>
-              <p>Select the active proxy endpoint used by pages that support proxy context.</p>
-            </div>
-            <StatusBadge status={`${proxies.length} endpoint${proxies.length === 1 ? '' : 's'}`} tone={proxies.length > 0 ? 'success' : 'neutral'} />
-          </div>
-          <div className="proxy-select-row">
-            <label className="proxy-field">
-              Current Proxy
-              <SelectMenu
-                value={currentProxy}
-                options={proxyOptions}
-                onChange={switchProxy}
-                ariaLabel="Select current proxy"
-                className="proxy-select-menu"
-              />
-            </label>
-            <button type="button" className="button button-secondary" onClick={load} disabled={pending}>
-              <RefreshCw className={pending ? 'spin' : undefined} size={15} aria-hidden="true" />
-              Refresh
-            </button>
-          </div>
+      <section className="proxy-summary" aria-label="Proxy endpoint summary">
+        <div className="panel proxy-summary-card">
+          <span>Total endpoints</span>
+          <strong>{proxies.length}</strong>
         </div>
-
-        <div className="panel proxy-add-panel">
-          <div className="panel-heading">
-            <div>
-              <h2>Add ProxyAddr</h2>
-              <p>Persist a new proxy endpoint to the Rust Web config store.</p>
-            </div>
-          </div>
-          <div className="proxy-add-row">
-            <label className="proxy-field">
-              ProxyAddr
-              <input
-                value={proxyAddress}
-                placeholder="127.0.0.1:8080"
-                onChange={(event) => setProxyAddress(event.target.value)}
-                onKeyDown={(event) => {
-                  if (event.key === 'Enter') {
-                    addProxy();
-                  }
-                }}
-              />
-            </label>
-            <button type="button" className="button proxy-add-button" onClick={addProxy} disabled={pending}>
-              <Plus size={15} aria-hidden="true" />
-              Add
-            </button>
-          </div>
-        </div>
-
-        <div className="panel proxy-status-panel">
-          <div className="proxy-status-icon">
-            <Zap size={20} aria-hidden="true" />
-          </div>
-          <span>Status</span>
-          <strong>{currentProxy ? 'Enabled' : 'Disabled'}</strong>
-          <small>{currentProxy || 'Add a proxy endpoint to enable proxy context.'}</small>
+        <div className="panel proxy-summary-card">
+          <span>Current endpoint</span>
+          {currentProxy ? <StatusBadge status={currentProxy} tone="success" /> : <strong className="proxy-summary-empty">No current endpoint</strong>}
         </div>
       </section>
 
-      <section className="panel proxy-endpoint-panel">
+      <section className="panel proxy-endpoint-panel" aria-labelledby="proxy-endpoints-heading">
         <div className="proxy-table-toolbar">
           <div>
-            <h2>Proxy endpoints</h2>
-            <p>Current endpoint, standby endpoints, switch action, and guarded delete.</p>
+            <h2 id="proxy-endpoints-heading">Proxy endpoints</h2>
+            <p>Select one endpoint as current or remove an endpoint that is no longer needed.</p>
           </div>
-          <StatusBadge status={`storage ${storageBackend}`} />
+          <StatusBadge status={`${proxies.length} configured`} tone={proxies.length > 0 ? 'success' : 'neutral'} />
         </div>
 
         {proxies.length > 0 ? (
-          <>
-            <div className="proxy-endpoint-table">
-              <div className="proxy-endpoint-row proxy-endpoint-head">
-                <span>Proxy address</span>
-                <span>Role</span>
-                <span>Persistence</span>
-                <span>Operation</span>
-              </div>
-              {proxies.map((address) => {
-                const isCurrent = address === config.currentProxyAddr;
-                return (
-                  <div className={isCurrent ? 'proxy-endpoint-row proxy-endpoint-current' : 'proxy-endpoint-row'} key={address}>
-                    <code>{address}</code>
-                    <StatusBadge status={isCurrent ? 'current' : 'standby'} tone={isCurrent ? 'success' : 'neutral'} />
-                    <span className="proxy-storage">
-                      <Database size={14} aria-hidden="true" />
-                      {storageBackend}
-                    </span>
-                    <div className="proxy-actions">
-                      <button type="button" className="button button-secondary" onClick={() => switchProxy(address)} disabled={pending || isCurrent}>
-                        {isCurrent ? <CheckCircle2 size={14} aria-hidden="true" /> : <Route size={14} aria-hidden="true" />}
-                        {isCurrent ? 'Current' : 'Switch'}
-                      </button>
-                      <button type="button" className="icon-button" title="Copy proxy" onClick={() => copyProxy(address)}>
-                        <Copy size={15} aria-hidden="true" />
-                      </button>
-                      <ConfirmDialog
-                        title="Delete proxy"
-                        description={`Delete proxy ${address}? This removes it from ProxyServerAddressList.`}
-                        confirmLabel="Delete"
-                        onConfirm={() => deleteProxy(address)}
-                      >
-                        <button type="button" className="icon-button icon-button-danger" title="Delete proxy" disabled={pending}>
-                          <Trash2 size={15} aria-hidden="true" />
-                        </button>
-                      </ConfirmDialog>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-            <div className="proxy-table-footer">
-              <span>{proxies.length} rows / Java compatible proxy home data</span>
-              <span>
-                <Server size={14} aria-hidden="true" />
-                {currentProxy || 'no current proxy'}
-              </span>
-            </div>
-          </>
+          <div className="proxy-table-scroll">
+            <table className="proxy-endpoint-table">
+              <thead>
+                <tr>
+                  <th scope="col">Endpoint</th>
+                  <th scope="col">Status</th>
+                  <th scope="col" className="proxy-actions-header">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {proxies.map((address) => {
+                  const label = getProxyEndpointLabel(address, currentProxy);
+                  const isCurrent = label === 'Current';
+                  return (
+                    <tr className={isCurrent ? 'proxy-endpoint-current' : undefined} key={address}>
+                      <td><code>{address}</code></td>
+                      <td><StatusBadge status={label} tone={isCurrent ? 'success' : 'neutral'} /></td>
+                      <td className="proxy-actions">
+                        <Button
+                          type="button"
+                          variant="secondary"
+                          size="sm"
+                          onClick={() => switchProxy(address)}
+                          disabled={pending || isCurrent}
+                          aria-label={isCurrent ? `Current proxy ${address}` : `Set current proxy ${address}`}
+                        >
+                          {isCurrent ? <CheckCircle2 size={14} aria-hidden="true" /> : <Route size={14} aria-hidden="true" />}
+                          {isCurrent ? 'Current' : 'Set current'}
+                        </Button>
+                        <ConfirmDialog
+                          title="Delete proxy"
+                          description={`Delete proxy ${address}? This removes the endpoint from the configured list.`}
+                          confirmLabel="Delete proxy"
+                          onConfirm={() => deleteProxy(address)}
+                        >
+                          <Button type="button" variant="destructive" size="sm" disabled={pending} aria-label={`Delete proxy ${address}`}>
+                            <Trash2 size={14} aria-hidden="true" /> Delete
+                          </Button>
+                        </ConfirmDialog>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
         ) : (
-          <EmptyState title="No proxy endpoints" detail="Add a ProxyAddr to enable proxy-aware Consumer operations." />
+          <EmptyState title="No proxy endpoints" detail="Add an endpoint to begin managing proxy configuration." />
         )}
       </section>
+
+      <Dialog open={addDialogOpen} onOpenChange={(open) => !pending && setAddDialogOpen(open)}>
+        <DialogContent aria-label="Add proxy endpoint">
+          <DialogHeader>
+            <DialogTitle>Add proxy endpoint</DialogTitle>
+            <DialogDescription>Add an endpoint to the configured proxy list.</DialogDescription>
+          </DialogHeader>
+          <form onSubmit={(event) => { event.preventDefault(); addProxy(); }}>
+            <Label className="proxy-dialog-field" htmlFor="proxy-address">Proxy address</Label>
+            <Input
+              id="proxy-address"
+              ref={proxyAddressInputRef}
+              value={proxyAddress}
+              placeholder="127.0.0.1:8080"
+              onChange={(event) => { setProxyAddress(event.target.value); setAddError(null); }}
+              disabled={pending}
+            />
+            {addError ? <div className="inline-validation" role="alert">{addError}</div> : null}
+            <DialogFooter>
+              <Button type="button" variant="secondary" onClick={() => setAddDialogOpen(false)} disabled={pending}>Cancel</Button>
+              <Button type="submit" disabled={pending}>Add proxy endpoint</Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }
 
-function copyText(value: string) {
-  if (!value) return;
-  if (navigator.clipboard?.writeText) {
-    void navigator.clipboard.writeText(value).catch(() => legacyCopyText(value));
-    return;
-  }
-  legacyCopyText(value);
-}
-
-function legacyCopyText(value: string) {
-  const textarea = document.createElement('textarea');
-  textarea.value = value;
-  textarea.setAttribute('readonly', 'true');
-  textarea.style.position = 'fixed';
-  textarea.style.left = '-9999px';
-  textarea.style.top = '0';
-  document.body.appendChild(textarea);
-  textarea.select();
-  document.execCommand('copy');
-  textarea.remove();
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : 'Unable to update proxy configuration.';
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/TopicListPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/TopicListPage.tsx
@@ -312,7 +312,6 @@ export default function TopicListPage() {
       <TopicMaintenanceDialog
         open={maintenanceTopic !== null}
         topic={maintenanceTopic}
-        mode="reset"
         consumerGroups={consumerGroups}
         onOpenChange={(open) => { if (!open) setMaintenanceTopic(null); }}
         onMutationFinished={() => void load()}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/AclPoliciesTable.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/AclPoliciesTable.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import AppDataTable, { type AppDataTableColumn } from '../../components/AppDataTable';
 import ConfirmDialog from '../../components/ConfirmDialog';
 import StatusBadge from '../../components/StatusBadge';
+import { Button } from '../../components/ui/Button';
 import type { AclPolicyRow } from './acl-model';
 
 export interface AclPoliciesTableProps {
@@ -30,13 +31,13 @@ export default function AclPoliciesTable({ rows, total, page, pageSize, loading,
     { id: 'actions-menu', header: 'Operation', cell: (row) => {
       const target = `${row.subject} on ${row.resource}`;
       return <div className="acl-operation-row">
-        <button type="button" className="button button-secondary acl-action-button" aria-label={`Modify ACL policy ${target}`} disabled={disabled} onClick={() => onEdit(row)}><Edit3 size={14} aria-hidden="true" /> Modify</button>
+        <Button type="button" variant="secondary" className="acl-action-button" aria-label={`Modify ACL policy ${target}`} disabled={disabled} onClick={() => onEdit(row)}><Edit3 size={14} aria-hidden="true" /> Modify</Button>
         {row.policyType === 'Custom' ? (
           <ConfirmDialog title="Delete ACL permission" description={`Delete ACL permission for ${row.subject} on resource ${row.resource}?`} confirmLabel="Delete" onConfirm={() => onDelete(row)}>
-            <button type="button" className="button button-danger acl-action-button" aria-label={`Delete ACL policy ${target}`} disabled={disabled}><Trash2 size={14} aria-hidden="true" /> Delete</button>
+            <Button type="button" variant="destructive" className="acl-action-button" aria-label={`Delete ACL policy ${target}`} disabled={disabled}><Trash2 size={14} aria-hidden="true" /> Delete</Button>
           </ConfirmDialog>
         ) : (
-          <button type="button" className="button button-danger acl-action-button" aria-label={`Delete ACL policy ${target} unavailable: only Custom policies can be deleted`} title="Only Custom ACL policies can be deleted." disabled><Trash2 size={14} aria-hidden="true" /> Delete</button>
+          <Button type="button" variant="destructive" className="acl-action-button" aria-label={`Delete ACL policy ${target} unavailable: only Custom policies can be deleted`} title="Only Custom ACL policies can be deleted." disabled><Trash2 size={14} aria-hidden="true" /> Delete</Button>
         )}
       </div>;
     } }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/AclPolicyDialog.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/AclPolicyDialog.tsx
@@ -2,6 +2,7 @@ import * as Dialog from '@radix-ui/react-dialog';
 import { X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import SelectMenu from '../../components/SelectMenu';
+import { Button } from '../../components/ui/Button';
 import { buildAclPolicyRequest, type AclPolicyDraft, type AclPolicyRow, type AclScope } from './acl-model';
 import type { AclPolicyRequest } from '../../types/acl';
 
@@ -62,7 +63,7 @@ export default function AclPolicyDialog({ open, policy, scope, saving, error, on
               <Dialog.Title>{editing ? 'Edit ACL Permission' : 'Add ACL Permission'}</Dialog.Title>
               <Dialog.Description className="dialog-description">Create or update an ACL policy on the confirmed broker.</Dialog.Description>
             </div>
-            <Dialog.Close className="icon-button" title="Close"><X size={15} aria-hidden="true" /></Dialog.Close>
+            <Dialog.Close asChild><Button type="button" variant="ghost" size="icon" title="Close" aria-label="Close"><X size={15} aria-hidden="true" /></Button></Dialog.Close>
           </div>
           <div className="acl-dialog-form">
             <label className="acl-field">
@@ -88,7 +89,7 @@ export default function AclPolicyDialog({ open, policy, scope, saving, error, on
             <div className="acl-field">
               <span>Operation Type</span>
               <div className="acl-action-toggle-grid">
-                {actionOptions.map((action) => <button type="button" className={draft.actions.includes(action) ? 'active' : ''} key={action} aria-pressed={draft.actions.includes(action)} onClick={() => toggleAction(action)}>{action}</button>)}
+                {actionOptions.map((action) => <Button type="button" variant="ghost" className={draft.actions.includes(action) ? 'active' : ''} key={action} aria-pressed={draft.actions.includes(action)} onClick={() => toggleAction(action)}>{action}</Button>)}
               </div>
               {validationErrors.actions ? <small className="inline-validation">{validationErrors.actions}</small> : null}
             </div>
@@ -96,8 +97,8 @@ export default function AclPolicyDialog({ open, policy, scope, saving, error, on
           </div>
           <div className="dialog-actions">
             {error ? <div className="acl-dialog-error" role="alert">{error}</div> : null}
-            <Dialog.Close className="button button-secondary" disabled={saving}>Cancel</Dialog.Close>
-            <button type="button" className="button" disabled={saving} onClick={submit}>{saving ? 'Saving...' : error ? 'Retry' : 'Confirm'}</button>
+            <Dialog.Close asChild><Button type="button" variant="secondary" disabled={saving}>Cancel</Button></Dialog.Close>
+            <Button type="button" disabled={saving} onClick={submit}>{saving ? 'Saving...' : error ? 'Retry' : 'Confirm'}</Button>
           </div>
         </Dialog.Content>
       </Dialog.Portal>

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/AclScopePicker.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/AclScopePicker.tsx
@@ -1,5 +1,6 @@
 import { CheckCircle2, ShieldCheck } from 'lucide-react';
 import SelectMenu from '../../components/SelectMenu';
+import { Button } from '../../components/ui/Button';
 import type { BrokerInfo } from '../../types/broker';
 import { createAclScopeQuery, deriveAclScopeOptions, type AclScope } from './acl-model';
 
@@ -49,14 +50,14 @@ export default function AclScopePicker({
             className="acl-select-menu"
           />
         </label>
-        <button
+        <Button
           type="button"
-          className="button acl-confirm-button"
+          className="acl-confirm-button"
           disabled={disabled || !canConfirm}
           onClick={() => onConfirm(draftScope)}
         >
           <CheckCircle2 size={15} aria-hidden="true" /> Confirm
-        </button>
+        </Button>
       </div>
       <div className="acl-scope-card">
         <ShieldCheck size={18} aria-hidden="true" />

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/AclUserDialog.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/AclUserDialog.tsx
@@ -2,6 +2,7 @@ import * as Dialog from '@radix-ui/react-dialog';
 import { X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import SelectMenu from '../../components/SelectMenu';
+import { Button } from '../../components/ui/Button';
 import type { AclUserUpsertRequest, AclUserView } from '../../types/acl';
 import type { AclScope } from './acl-model';
 
@@ -42,7 +43,7 @@ export default function AclUserDialog({ open, user, scope, saving, error, onOpen
               <Dialog.Title>{editing ? 'Edit User' : 'Add User'}</Dialog.Title>
               <Dialog.Description className="dialog-description">Create or update an ACL user on the confirmed broker.</Dialog.Description>
             </div>
-            <Dialog.Close className="icon-button" title="Close"><X size={15} aria-hidden="true" /></Dialog.Close>
+            <Dialog.Close asChild><Button type="button" variant="ghost" size="icon" title="Close" aria-label="Close"><X size={15} aria-hidden="true" /></Button></Dialog.Close>
           </div>
           <div className="acl-dialog-form">
             <label className="acl-field"><span><strong>*</strong> Username</span><input value={username} disabled={editing} onChange={(event) => setUsername(event.target.value)} /></label>
@@ -60,10 +61,10 @@ export default function AclUserDialog({ open, user, scope, saving, error, onOpen
           </div>
           <div className="dialog-actions">
             {error ? <div className="acl-dialog-error" role="alert">{error}</div> : null}
-            <Dialog.Close className="button button-secondary" disabled={saving}>Cancel</Dialog.Close>
-            <button type="button" className="button" disabled={!canSubmit || saving} onClick={() => onSubmit({
+            <Dialog.Close asChild><Button type="button" variant="secondary" disabled={saving}>Cancel</Button></Dialog.Close>
+            <Button type="button" disabled={!canSubmit || saving} onClick={() => onSubmit({
               clusterName: scope.clusterName, brokerName: scope.brokerName, username, password, userType, userStatus
-            }, user?.username)}>{saving ? 'Saving...' : error ? 'Retry' : 'Confirm'}</button>
+            }, user?.username)}>{saving ? 'Saving...' : error ? 'Retry' : 'Confirm'}</Button>
           </div>
         </Dialog.Content>
       </Dialog.Portal>

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/AclUsersTable.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/acl/AclUsersTable.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import AppDataTable, { type AppDataTableColumn } from '../../components/AppDataTable';
 import ConfirmDialog from '../../components/ConfirmDialog';
 import StatusBadge from '../../components/StatusBadge';
+import { Button } from '../../components/ui/Button';
 import type { AclUserView } from '../../types/acl';
 
 export interface AclUsersTableProps {
@@ -29,9 +30,9 @@ export default function AclUsersTable({ rows, total, page, pageSize, loading, er
     { id: 'broker', header: 'Broker', cell: (row) => <div className="acl-primary-cell"><span>{row.brokerName || '-'}</span><code>{row.brokerAddr || '-'}</code></div> },
     {
       id: 'actions', header: 'Operation', cell: (row) => <div className="acl-operation-row">
-        <button type="button" className="button button-secondary acl-action-button" aria-label={`Modify ACL user ${row.username}`} disabled={disabled} onClick={() => onEdit(row)}><Edit3 size={14} aria-hidden="true" /> Modify</button>
+        <Button type="button" variant="secondary" className="acl-action-button" aria-label={`Modify ACL user ${row.username}`} disabled={disabled} onClick={() => onEdit(row)}><Edit3 size={14} aria-hidden="true" /> Modify</Button>
         <ConfirmDialog title="Delete ACL user" description={`Delete ACL user ${row.username} from the selected broker target?`} confirmLabel="Delete" onConfirm={() => onDelete(row.username)}>
-          <button type="button" className="button button-danger acl-action-button" aria-label={`Delete ACL user ${row.username}`} disabled={disabled}><Trash2 size={14} aria-hidden="true" /> Delete</button>
+          <Button type="button" variant="destructive" className="acl-action-button" aria-label={`Delete ACL user ${row.username}`} disabled={disabled}><Trash2 size={14} aria-hidden="true" /> Delete</Button>
         </ConfirmDialog>
       </div>
     }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/proxy/proxy-model.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/proxy/proxy-model.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getProxyEndpointLabel,
+  isDuplicateProxyAddress,
+  normalizeProxyAddress
+} from './proxy-model';
+
+describe('proxy endpoint model', () => {
+  it('canonicalizes host casing and decimal ports like the backend', () => {
+    expect(normalizeProxyAddress(' PROXY-A:08081 ')).toBe('proxy-a:8081');
+    expect(normalizeProxyAddress(' PROXY-A:+08081 ')).toBe('proxy-a:8081');
+    expect(normalizeProxyAddress(' ÄPROXY-A:08081 ')).toBe('Äproxy-a:8081');
+  });
+
+  it('preserves invalid trimmed endpoint input for backend validation', () => {
+    expect(normalizeProxyAddress(' proxy-a:not-a-port ')).toBe('proxy-a:not-a-port');
+    expect(normalizeProxyAddress(' proxy-a:++8081 ')).toBe('proxy-a:++8081');
+  });
+
+  it('labels only the configured current endpoint as current', () => {
+    expect(getProxyEndpointLabel('proxy-a:8081', 'proxy-a:8081')).toBe('Current');
+    expect(getProxyEndpointLabel('proxy-b:8081', 'proxy-a:8081')).toBe('Available');
+    expect(getProxyEndpointLabel('proxy-a:8081', null)).toBe('Available');
+  });
+
+  it('prevents additions that duplicate an existing normalized endpoint', () => {
+    expect(isDuplicateProxyAddress(' PROXY-A:08081 ', ['proxy-a:8081', 'proxy-b:8081'])).toBe(true);
+    expect(isDuplicateProxyAddress(' PROXY-A:+08081 ', ['proxy-a:8081', 'proxy-b:8081'])).toBe(true);
+    expect(isDuplicateProxyAddress('proxy-c:8081', ['proxy-a:8081', 'proxy-b:8081'])).toBe(false);
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/proxy/proxy-model.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/proxy/proxy-model.ts
@@ -1,0 +1,32 @@
+export type ProxyEndpointLabel = 'Current' | 'Available';
+
+function toAsciiLowercase(value: string) {
+  return value.replace(/[A-Z]/g, (character) => character.toLowerCase());
+}
+
+export function normalizeProxyAddress(address: string) {
+  const trimmed = address.trim();
+  const separatorIndex = trimmed.lastIndexOf(':');
+  if (separatorIndex < 0) return trimmed;
+
+  const host = trimmed.slice(0, separatorIndex).trim();
+  const port = trimmed.slice(separatorIndex + 1).trim();
+  if (!host || /\s/.test(host) || !/^\+?\d+$/.test(port)) return trimmed;
+
+  const portNumber = Number(port);
+  if (!Number.isInteger(portNumber) || portNumber < 0 || portNumber > 65_535) return trimmed;
+
+  return `${toAsciiLowercase(host)}:${portNumber}`;
+}
+
+export function getProxyEndpointLabel(address: string, currentProxyAddress?: string | null): ProxyEndpointLabel {
+  return normalizeProxyAddress(address) === normalizeProxyAddress(currentProxyAddress ?? '')
+    && normalizeProxyAddress(currentProxyAddress ?? '')
+    ? 'Current'
+    : 'Available';
+}
+
+export function isDuplicateProxyAddress(address: string, proxyAddresses: string[]) {
+  const normalizedAddress = normalizeProxyAddress(address);
+  return normalizedAddress !== '' && proxyAddresses.some((proxyAddress) => normalizeProxyAddress(proxyAddress) === normalizedAddress);
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/settings/SettingsSectionNav.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/settings/SettingsSectionNav.tsx
@@ -1,0 +1,44 @@
+import { Database, Network, ShieldCheck } from 'lucide-react';
+import { Button } from '../../components/ui/Button';
+import { cn } from '../../lib/cn';
+
+export type SettingsSection = 'connection' | 'security' | 'storage';
+
+interface SettingsSectionNavProps {
+  activeSection: SettingsSection;
+  onSelect: (section: SettingsSection) => void;
+}
+
+const sections = [
+  { id: 'connection' as const, label: 'Connection', description: 'NameServers and selection', icon: Network },
+  { id: 'security' as const, label: 'Security', description: 'VIP and TLS transport', icon: ShieldCheck },
+  { id: 'storage' as const, label: 'Storage', description: 'Persistence backend', icon: Database }
+];
+
+export default function SettingsSectionNav({ activeSection, onSelect }: SettingsSectionNavProps) {
+  return (
+    <nav className="settings-section-nav" aria-label="OPS settings sections">
+      {sections.map((section) => {
+        const Icon = section.icon;
+        const isActive = activeSection === section.id;
+        return (
+          <Button
+            key={section.id}
+            type="button"
+            variant="ghost"
+            className={cn('settings-section-link', isActive && 'is-active')}
+            aria-label={section.label}
+            aria-current={isActive ? 'page' : undefined}
+            onClick={() => onSelect(section.id)}
+          >
+            <Icon size={16} aria-hidden="true" />
+            <span>
+              <strong>{section.label}</strong>
+              <small>{section.description}</small>
+            </span>
+          </Button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/settings/settings-model.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/settings/settings-model.test.ts
@@ -1,0 +1,39 @@
+import { isNameserverDraftDirty, normalizeNameserverDraft } from './settings-model';
+
+describe('normalizeNameserverDraft', () => {
+  it('trims, removes duplicate and empty addresses, and selects the first valid address when current is invalid', () => {
+    expect(normalizeNameserverDraft({
+      namesrvAddrList: [' 10.0.0.10:9876 ', '', '10.0.0.11:9876', '10.0.0.10:9876'],
+      currentNamesrv: 'missing:9876'
+    })).toEqual({
+      namesrvAddrList: ['10.0.0.10:9876', '10.0.0.11:9876'],
+      currentNamesrv: '10.0.0.10:9876'
+    });
+  });
+
+  it('retains a current NameServer after normalizing its value', () => {
+    expect(normalizeNameserverDraft({
+      namesrvAddrList: ['10.0.0.10:9876', '10.0.0.11:9876'],
+      currentNamesrv: ' 10.0.0.11:9876 '
+    }).currentNamesrv).toBe('10.0.0.11:9876');
+  });
+});
+
+describe('isNameserverDraftDirty', () => {
+  const saved = {
+    namesrvAddrList: ['10.0.0.10:9876', '10.0.0.11:9876'],
+    currentNamesrv: '10.0.0.10:9876'
+  };
+
+  it('ignores equivalent whitespace but detects a changed current selection or address list', () => {
+    expect(isNameserverDraftDirty({
+      namesrvAddrList: [' 10.0.0.10:9876 ', '10.0.0.11:9876'],
+      currentNamesrv: '10.0.0.10:9876'
+    }, saved)).toBe(false);
+    expect(isNameserverDraftDirty({ ...saved, currentNamesrv: '10.0.0.11:9876' }, saved)).toBe(true);
+    expect(isNameserverDraftDirty({
+      ...saved,
+      namesrvAddrList: ['10.0.0.10:9876']
+    }, saved)).toBe(true);
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/settings/settings-model.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/settings/settings-model.ts
@@ -1,0 +1,21 @@
+export interface NameserverDraft {
+  namesrvAddrList: string[];
+  currentNamesrv: string | null;
+}
+
+export function normalizeNameserverDraft(draft: NameserverDraft): NameserverDraft {
+  const namesrvAddrList = [...new Set(draft.namesrvAddrList.map((address) => address.trim()).filter(Boolean))];
+  const requestedCurrent = draft.currentNamesrv?.trim() ?? '';
+  const currentNamesrv = namesrvAddrList.includes(requestedCurrent) ? requestedCurrent : namesrvAddrList[0] ?? null;
+
+  return { namesrvAddrList, currentNamesrv };
+}
+
+export function isNameserverDraftDirty(draft: NameserverDraft, saved: NameserverDraft) {
+  const normalizedDraft = normalizeNameserverDraft(draft);
+  const normalizedSaved = normalizeNameserverDraft(saved);
+
+  return normalizedDraft.currentNamesrv !== normalizedSaved.currentNamesrv
+    || normalizedDraft.namesrvAddrList.length !== normalizedSaved.namesrvAddrList.length
+    || normalizedDraft.namesrvAddrList.some((address, index) => address !== normalizedSaved.namesrvAddrList[index]);
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/router/index.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/router/index.tsx
@@ -1,3 +1,29 @@
+export const canonicalRoutePatterns = [
+  '/login',
+  '/proxy',
+  '/dashboard',
+  '/topics',
+  '/topics/:topic',
+  '/consumers',
+  '/consumers/:group',
+  '/producers',
+  '/brokers',
+  '/brokers/:brokerName',
+  '/messages',
+  '/messages/dlq',
+  '/message-trace',
+  '/acl',
+  '/monitors',
+  '/config'
+] as const;
+
+export const compatibilityRedirects = {
+  '/': '/dashboard',
+  '/ops': '/config',
+  '/cluster': '/brokers',
+  '/dlq': '/messages/dlq'
+} as const;
+
 export const routes = [
   '/ops',
   '/proxy',

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/components.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/components.css
@@ -19,8 +19,8 @@
 .ui-button-ghost:hover { background: color-mix(in srgb, var(--foreground) 7%, var(--card)); }
 .ui-button-outline { background: transparent; border-color: var(--border); color: var(--foreground); }
 .ui-button-ghost { background: transparent; color: var(--muted-foreground); }
-.ui-button-destructive { background: var(--destructive); color: #fff; }
-.ui-button-destructive:hover { background: color-mix(in srgb, var(--destructive) 82%, #000); }
+.ui-button-destructive { background: var(--destructive-control-default); color: var(--foreground); }
+.ui-button-destructive:hover { background: var(--destructive-control-hover); }
 .ui-button-link { background: transparent; color: var(--primary); text-decoration: underline; text-underline-offset: 4px; }
 .ui-button-size-default { min-height: 36px; padding: 0 14px; }
 .ui-button-size-sm { min-height: 32px; padding: 0 10px; font-size: 13px; }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/globals.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/globals.css
@@ -6,8 +6,7 @@
 .dialog-actions,
 .page-header,
 .page-header-actions,
-.panel-heading,
-.flag-row {
+.panel-heading {
   display: flex;
   align-items: center;
 }
@@ -29,7 +28,6 @@
   color: var(--metric-accent);
   background: color-mix(in srgb, var(--metric-accent) 13%, var(--surface-2));
   border: 1px solid color-mix(in srgb, var(--metric-accent) 45%, var(--border));
-  box-shadow: 0 0 0 4px color-mix(in srgb, var(--metric-accent) 8%, transparent);
 }
 
 .dashboard-metrics .metric-icon::before,
@@ -51,7 +49,6 @@
   width: 18px;
   height: 2px;
   background: var(--metric-accent);
-  box-shadow: -34px -24px 0 color-mix(in srgb, var(--metric-accent) 80%, transparent);
 }
 
 .page-header p,
@@ -134,9 +131,6 @@
   position: absolute;
   inset: 0;
   border-top: 2px solid color-mix(in srgb, var(--metric-accent) 65%, transparent);
-  background:
-    linear-gradient(90deg, color-mix(in srgb, var(--metric-accent) 13%, transparent), transparent 38%),
-    linear-gradient(135deg, transparent 0 72%, color-mix(in srgb, var(--metric-accent) 9%, transparent) 72% 100%);
   z-index: -1;
 }
 
@@ -202,7 +196,7 @@
   padding: 0 12px;
   font-size: 13px;
   background: var(--primary);
-  color: #fff;
+  color: var(--primary-foreground);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -217,7 +211,7 @@
 
 .button-danger {
   background: var(--danger);
-  color: #fff;
+  color: var(--foreground);
 }
 
 .button:disabled {
@@ -494,50 +488,128 @@ td code,
   gap: 6px;
 }
 
-.ops-grid {
+.proxy-summary {
   display: grid;
-  grid-template-columns: minmax(0, 1.45fr) minmax(360px, 0.8fr);
-  gap: 14px;
-  align-items: stretch;
-}
-
-.ops-main,
-.ops-side {
-  min-height: 168px;
-}
-
-.proxy-hero-grid {
-  display: grid;
-  grid-template-columns: minmax(420px, 1.35fr) minmax(320px, 0.9fr) minmax(220px, 0.55fr);
+  grid-template-columns: minmax(180px, 0.35fr) minmax(300px, 0.65fr);
   gap: 14px;
 }
 
-.proxy-selector-panel,
-.proxy-add-panel,
-.proxy-status-panel,
+@media (max-width: 900px) {
+  .proxy-summary {
+    grid-template-columns: 1fr;
+  }
+}
+
+.proxy-summary-card,
 .proxy-endpoint-panel {
   min-width: 0;
 }
 
-.proxy-select-row,
-.proxy-add-row {
-  display: flex;
-  align-items: end;
-  gap: 10px;
-  margin-top: 18px;
+.proxy-summary-card {
+  display: grid;
+  align-content: center;
+  gap: 8px;
+  min-height: 96px;
 }
 
-.proxy-field {
-  min-width: 0;
-  display: grid;
-  flex: 1 1 auto;
-  gap: 8px;
+.proxy-summary-card > span {
   color: var(--muted);
   font-size: 12px;
   font-weight: 700;
 }
 
-.proxy-field input {
+.proxy-summary-card strong {
+  color: var(--text);
+  font-size: 24px;
+}
+
+.proxy-summary-empty {
+  color: var(--muted) !important;
+  font-size: 16px !important;
+}
+
+.proxy-endpoint-panel {
+  display: grid;
+  gap: 14px;
+}
+
+.proxy-table-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.proxy-table-toolbar h2 {
+  margin: 0;
+  font-size: 16px;
+}
+
+.proxy-table-toolbar p {
+  margin: 5px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.proxy-table-scroll {
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.proxy-endpoint-table {
+  width: 100%;
+  min-width: 680px;
+  border-collapse: collapse;
+  background: var(--surface);
+}
+
+.proxy-endpoint-table th,
+.proxy-endpoint-table td {
+  padding: 12px;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+}
+
+.proxy-endpoint-table th {
+  background: var(--surface-2);
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.proxy-endpoint-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.proxy-endpoint-table code {
+  color: var(--primary);
+  font-size: 13px;
+}
+
+.proxy-endpoint-current {
+  background: color-mix(in srgb, var(--primary) 8%, var(--surface));
+}
+
+.proxy-actions-header {
+  text-align: right !important;
+}
+
+.proxy-endpoint-table .proxy-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.proxy-dialog-field {
+  display: block;
+  margin-bottom: 8px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.proxy-dialog-field + input {
   width: 100%;
   min-height: 38px;
   padding: 0 12px;
@@ -550,332 +622,9 @@ td code,
   font-size: 13px;
 }
 
-.proxy-field input:focus {
+.proxy-dialog-field + input:focus {
   border-color: color-mix(in srgb, var(--primary) 70%, var(--border));
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary) 12%, transparent);
-}
-
-.proxy-select-menu {
-  min-width: 320px;
-}
-
-.proxy-select-menu .select-menu-trigger {
-  min-height: 38px;
-  background: var(--bg);
-  font-family: var(--font-mono);
-}
-
-.proxy-select-menu .select-menu-popover {
-  width: 100%;
-  min-width: 320px;
-}
-
-.proxy-add-button {
-  min-width: 82px;
-  min-height: 38px;
-}
-
-.proxy-status-panel {
-  display: grid;
-  align-content: start;
-  gap: 8px;
-  background:
-    linear-gradient(135deg, color-mix(in srgb, var(--primary) 12%, transparent), transparent 58%),
-    var(--surface);
-}
-
-.proxy-status-icon {
-  width: 40px;
-  height: 40px;
-  display: grid;
-  place-items: center;
-  border: 1px solid color-mix(in srgb, var(--primary) 46%, var(--border));
-  border-radius: var(--radius);
-  background: color-mix(in srgb, var(--primary) 14%, transparent);
-  color: var(--primary);
-}
-
-.proxy-status-panel span,
-.proxy-status-panel small {
-  color: var(--muted);
-}
-
-.proxy-status-panel strong {
-  color: var(--text);
-  font-size: 24px;
-}
-
-.proxy-status-panel small {
-  line-height: 1.45;
-}
-
-.proxy-endpoint-panel {
-  display: grid;
-  gap: 14px;
-}
-
-.proxy-table-toolbar,
-.proxy-table-footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.proxy-table-toolbar h2 {
-  margin: 0;
-  font-size: 16px;
-}
-
-.proxy-table-toolbar p,
-.proxy-table-footer {
-  color: var(--muted);
-  font-size: 13px;
-}
-
-.proxy-endpoint-table {
-  overflow: hidden;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: color-mix(in srgb, var(--surface-2) 45%, transparent);
-}
-
-.proxy-endpoint-row {
-  display: grid;
-  grid-template-columns: minmax(240px, 1.35fr) minmax(120px, 0.55fr) minmax(160px, 0.75fr) minmax(270px, auto);
-  align-items: center;
-  gap: 14px;
-  min-height: 52px;
-  padding: 8px 12px;
-  border-bottom: 1px solid var(--border);
-}
-
-.proxy-endpoint-row:last-child {
-  border-bottom: 0;
-}
-
-.proxy-endpoint-head {
-  min-height: 40px;
-  background: var(--surface-2);
-  color: var(--muted);
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.proxy-endpoint-current {
-  background:
-    linear-gradient(90deg, color-mix(in srgb, var(--primary) 10%, transparent), transparent 54%),
-    color-mix(in srgb, var(--surface-2) 62%, transparent);
-}
-
-.proxy-endpoint-row code {
-  min-width: 0;
-  overflow: hidden;
-  color: var(--primary);
-  text-overflow: ellipsis;
-}
-
-.proxy-endpoint-row .status-badge {
-  justify-self: start;
-}
-
-.proxy-storage,
-.proxy-table-footer span:last-child {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-}
-
-.proxy-storage {
-  color: var(--muted);
-  font-size: 13px;
-}
-
-.proxy-actions {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: 8px;
-}
-
-.flag-row {
-  min-height: 46px;
-  justify-content: space-between;
-  gap: 10px;
-  border-top: 1px solid var(--border);
-}
-
-.flag-row:first-of-type {
-  border-top: 0;
-}
-
-.flag-row > span {
-  min-width: 120px;
-  font-weight: 600;
-}
-
-.switch-button {
-  width: 52px;
-  height: 28px;
-  padding: 3px;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: var(--surface-3);
-}
-
-.switch-button span {
-  display: block;
-  width: 20px;
-  height: 20px;
-  border-radius: 999px;
-  background: var(--surface);
-  box-shadow: 0 1px 4px rgba(15, 23, 42, 0.18);
-  transition: transform 160ms ease;
-}
-
-.switch-button.checked {
-  background: var(--primary);
-  border-color: var(--primary);
-}
-
-.switch-button.checked span {
-  transform: translateX(22px);
-}
-
-.dashboard-filter,
-.dashboard-select {
-  min-height: 34px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface-2);
-  color: var(--text);
-}
-
-.dashboard-filter {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 0 10px;
-}
-
-.dashboard-filter input {
-  width: 132px;
-  min-height: 30px;
-  padding: 0;
-  border: 0;
-  outline: 0;
-  background: transparent;
-  color: var(--text);
-}
-
-.dashboard-select {
-  width: min(260px, 100%);
-  padding: 0 10px;
-}
-
-.dashboard-overview-grid,
-.dashboard-chart-grid {
-  display: grid;
-  gap: 14px;
-}
-
-.dashboard-overview-grid {
-  grid-template-columns: minmax(0, 1.55fr) minmax(360px, 0.75fr);
-}
-
-.dashboard-chart-grid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.dashboard-panel {
-  min-width: 0;
-}
-
-.dashboard-panel-table {
-  display: grid;
-  gap: 12px;
-}
-
-.dashboard-panel-table .table-shell {
-  box-shadow: none;
-}
-
-.dashboard-panel-table .table-toolbar {
-  padding: 10px;
-}
-
-.broker-overview-table-shell {
-  overflow: hidden;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: color-mix(in srgb, var(--surface-2) 45%, transparent);
-}
-
-.broker-overview-table {
-  min-width: 920px;
-}
-
-.broker-overview-table th,
-.broker-overview-table td {
-  height: 42px;
-  border-right: 1px solid var(--border);
-  font-size: 13px;
-}
-
-.broker-overview-table th:last-child,
-.broker-overview-table td:last-child {
-  border-right: 0;
-}
-
-.broker-overview-table th:nth-child(3),
-.broker-overview-table td:nth-child(3),
-.broker-overview-table th:nth-child(4),
-.broker-overview-table td:nth-child(4),
-.broker-overview-table th:nth-child(5),
-.broker-overview-table td:nth-child(5) {
-  text-align: left;
-}
-
-.broker-overview-table td:nth-child(3),
-.broker-overview-table td:nth-child(4),
-.broker-overview-table td:nth-child(5) {
-  font-family: var(--font-mono);
-  font-weight: 700;
-}
-
-.dashboard-signal-grid {
-  display: grid;
-  gap: 10px;
-}
-
-.dashboard-signal {
-  min-height: 58px;
-  display: grid;
-  grid-template-columns: 34px minmax(0, 0.8fr) minmax(0, 1.3fr);
-  align-items: center;
-  gap: 10px;
-  padding: 10px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: color-mix(in srgb, var(--surface-2) 72%, transparent);
-}
-
-.dashboard-signal svg {
-  color: var(--primary);
-}
-
-.dashboard-signal span {
-  color: var(--muted);
-  font-size: 12px;
-}
-
-.dashboard-signal strong {
-  min-width: 0;
-  overflow: hidden;
-  font-family: var(--font-mono);
-  font-size: 12px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .ranking-table {
@@ -894,9 +643,7 @@ td code,
   padding: 8px 10px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  background:
-    linear-gradient(90deg, color-mix(in srgb, var(--rank-accent) 7%, transparent), transparent 42%),
-    color-mix(in srgb, var(--surface-2) 64%, transparent);
+  background: color-mix(in srgb, var(--rank-accent) 7%, var(--surface-2));
 }
 
 .ranking-row:hover {
@@ -923,13 +670,6 @@ td code,
   font-family: var(--font-mono);
   font-size: 12px;
   font-weight: 700;
-}
-
-.rank-badge-hot {
-  color: var(--rank-accent);
-  border-color: color-mix(in srgb, var(--rank-accent) 55%, var(--border));
-  background: color-mix(in srgb, var(--rank-accent) 12%, transparent);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--rank-accent) 8%, transparent);
 }
 
 .ranking-main {
@@ -974,8 +714,7 @@ td code,
   display: block;
   height: 100%;
   border-radius: inherit;
-  background: linear-gradient(90deg, color-mix(in srgb, var(--rank-accent) 72%, #ffffff), var(--rank-accent));
-  box-shadow: 0 0 12px color-mix(in srgb, var(--rank-accent) 34%, transparent);
+  background: var(--rank-accent);
 }
 
 .ranking-value {
@@ -992,38 +731,6 @@ td code,
 
 .dashboard-trend-chart {
   margin-top: 8px;
-}
-
-.cluster-filter {
-  min-height: 34px;
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 0 10px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface-2);
-}
-
-.cluster-filter span {
-  color: var(--muted);
-  font-size: 12px;
-}
-
-.cluster-filter select {
-  min-width: 220px;
-  min-height: 30px;
-  padding: 0;
-  border: 0;
-  outline: 0;
-  background: transparent;
-  color: var(--text);
-  color-scheme: inherit;
-}
-
-.cluster-filter select option {
-  background: var(--surface-2);
-  color: var(--text);
 }
 
 .select-menu {
@@ -1642,9 +1349,7 @@ td code,
   gap: 14px;
   padding: 14px;
   border-bottom: 1px solid var(--border);
-  background:
-    linear-gradient(90deg, color-mix(in srgb, var(--primary) 7%, transparent), transparent 46%),
-    var(--surface-2);
+  background: var(--surface-2);
 }
 
 .topic-list-toolbar h2 {
@@ -1867,7 +1572,6 @@ td code,
   border-radius: var(--radius);
   background: var(--bg);
   color: var(--text);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
 }
 
 .producer-topic-select .select-menu-trigger:hover {
@@ -1899,9 +1603,7 @@ td code,
   padding: 15px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  background:
-    linear-gradient(135deg, color-mix(in srgb, var(--primary) 8%, transparent), transparent 52%),
-    var(--surface);
+  background: var(--surface);
   box-shadow: var(--shadow);
 }
 
@@ -2263,9 +1965,7 @@ td code,
   padding: 15px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  background:
-    linear-gradient(135deg, color-mix(in srgb, var(--primary) 9%, transparent), transparent 54%),
-    var(--surface);
+  background: var(--surface);
   box-shadow: var(--shadow);
 }
 
@@ -2326,9 +2026,7 @@ td code,
 
 .message-results-wide .table-toolbar {
   padding: 14px 16px;
-  background:
-    linear-gradient(90deg, color-mix(in srgb, var(--primary) 8%, transparent), transparent 44%),
-    var(--surface);
+  background: var(--surface);
 }
 
 .message-results-wide .search-box {
@@ -2618,9 +2316,7 @@ td code,
 
 .trace-topic-panel {
   justify-content: space-between;
-  background:
-    linear-gradient(90deg, color-mix(in srgb, var(--primary) 8%, transparent), transparent 46%),
-    var(--surface);
+  background: var(--surface);
 }
 
 .trace-topic-panel p {
@@ -2639,9 +2335,7 @@ td code,
   display: grid;
   align-items: stretch;
   gap: 16px;
-  background:
-    linear-gradient(90deg, color-mix(in srgb, var(--primary) 7%, transparent), transparent 54%),
-    var(--surface);
+  background: var(--surface);
 }
 
 .trace-query-head,
@@ -2702,9 +2396,7 @@ td code,
 }
 
 .trace-metric-grid .message-metric-card:nth-child(4) {
-  background:
-    linear-gradient(135deg, color-mix(in srgb, var(--warning) 10%, transparent), transparent 54%),
-    var(--surface);
+  background: var(--surface);
 }
 
 .trace-metric-grid .message-metric-card:nth-child(4) strong {
@@ -2719,9 +2411,7 @@ td code,
 
 .trace-table-toolbar {
   padding: 14px 16px;
-  background:
-    linear-gradient(90deg, color-mix(in srgb, var(--primary) 8%, transparent), transparent 44%),
-    var(--surface);
+  background: var(--surface);
 }
 
 .trace-table-toolbar h2 {
@@ -2806,10 +2496,7 @@ td code,
   overflow: hidden;
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  background:
-    linear-gradient(90deg, color-mix(in srgb, var(--border) 44%, transparent) 1px, transparent 1px) 0 0 / 96px 100%,
-    linear-gradient(180deg, color-mix(in srgb, var(--border) 38%, transparent) 1px, transparent 1px) 0 0 / 100% 48px,
-    var(--bg);
+  background: var(--bg);
 }
 
 .trace-graph-axis {
@@ -2911,9 +2598,7 @@ td code,
   padding: 16px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  background:
-    linear-gradient(90deg, color-mix(in srgb, var(--primary) 8%, transparent), transparent 52%),
-    var(--surface);
+  background: var(--surface);
   box-shadow: var(--shadow);
 }
 
@@ -2970,9 +2655,7 @@ td code,
 }
 
 .dlq-metric-grid .message-metric-card:nth-child(2) {
-  background:
-    linear-gradient(135deg, color-mix(in srgb, var(--warning) 10%, transparent), transparent 54%),
-    var(--surface);
+  background: var(--surface);
 }
 
 .dlq-results-wide .table-shell {
@@ -2981,9 +2664,7 @@ td code,
 
 .dlq-table-toolbar {
   padding: 14px 16px;
-  background:
-    linear-gradient(90deg, color-mix(in srgb, var(--primary) 8%, transparent), transparent 44%),
-    var(--surface);
+  background: var(--surface);
 }
 
 .dlq-table-toolbar h2 {
@@ -3254,9 +2935,7 @@ td code,
   padding: 15px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  background:
-    linear-gradient(135deg, color-mix(in srgb, var(--primary) 8%, transparent), transparent 52%),
-    var(--surface);
+  background: var(--surface);
   box-shadow: var(--shadow);
 }
 
@@ -3727,43 +3406,6 @@ a:hover {
   font-size: 12px;
 }
 
-.login-shell {
-  min-height: 100vh;
-  display: grid;
-  place-items: center;
-  padding: 24px;
-  background:
-    linear-gradient(135deg, color-mix(in srgb, var(--primary) 10%, transparent), transparent 36%),
-    var(--bg);
-}
-
-.login-panel {
-  width: min(420px, 100%);
-  display: grid;
-  gap: 16px;
-  padding: 24px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface);
-  box-shadow: var(--shadow);
-}
-
-.login-panel h1 {
-  margin: 0;
-  font-size: 24px;
-  letter-spacing: 0;
-}
-
-.login-mark {
-  width: 40px;
-  height: 40px;
-  display: grid;
-  place-items: center;
-  border-radius: var(--radius);
-  color: var(--primary);
-  background: color-mix(in srgb, var(--primary) 13%, transparent);
-}
-
 @keyframes spin {
   to {
     transform: rotate(360deg);
@@ -3773,10 +3415,7 @@ a:hover {
 @media (max-width: 900px) {
   .metric-grid,
   .dashboard-metrics,
-  .dashboard-overview-grid,
-  .dashboard-chart-grid,
   .form-grid,
-  .ops-grid,
   .acl-selector-panel,
   .acl-selector-grid,
   .acl-stat-grid,
@@ -3801,8 +3440,6 @@ a:hover {
     flex-direction: column;
   }
 
-  .cluster-filter,
-  .cluster-filter select,
   .acl-search-box,
   .acl-table-actions {
     width: 100%;

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/pages.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/pages.css
@@ -924,6 +924,134 @@
 }
 
 /* Message operations */
+.settings-workspace {
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.settings-section-nav {
+  display: grid;
+  gap: 6px;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--card);
+}
+
+.settings-section-link {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 9px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  padding: 10px;
+  background: transparent;
+  color: var(--muted-foreground);
+  text-align: left;
+}
+
+.settings-section-link:hover,
+.settings-section-link:focus-visible {
+  border-color: var(--border);
+  background: var(--muted-surface);
+  color: var(--foreground);
+}
+
+.settings-section-link.is-active {
+  border-color: color-mix(in srgb, var(--primary) 40%, var(--border));
+  background: color-mix(in srgb, var(--primary) 10%, var(--card));
+  color: var(--primary);
+}
+
+.settings-section-link > span {
+  display: grid;
+  gap: 2px;
+}
+
+.settings-section-link strong { font-size: 12px; }
+.settings-section-link small { color: var(--muted-foreground); font-size: 11px; }
+.settings-section-content { min-width: 0; }
+.settings-card { min-height: 310px; box-shadow: none; }
+
+.settings-card > .ui-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  border-bottom: 1px solid var(--border);
+  background: var(--muted-surface);
+}
+
+.settings-card-content { display: grid; gap: 18px; }
+.settings-field-grid { display: grid; grid-template-columns: minmax(230px, .9fr) minmax(0, 1.1fr); gap: 14px; }
+
+.settings-field,
+.settings-add-row {
+  display: grid;
+  gap: 7px;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: .035em;
+  text-transform: uppercase;
+}
+
+.settings-field select {
+  width: 100%;
+  min-height: 36px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0 30px 0 10px;
+  background: var(--background);
+  color: var(--foreground);
+  font: inherit;
+  letter-spacing: normal;
+  text-transform: none;
+}
+
+.settings-address-list { display: flex; min-height: 36px; align-items: center; gap: 6px; flex-wrap: wrap; }
+.settings-address-item { display: inline-flex; min-width: 0; align-items: center; gap: 4px; flex-wrap: wrap; }
+.settings-address-item code { min-width: 0; overflow-wrap: anywhere; }
+.settings-address-list code { border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 5px 7px; background: var(--background); color: var(--foreground); font-size: 11px; letter-spacing: normal; text-transform: none; }
+.settings-empty-value { color: var(--muted-foreground); font-size: 12px; font-weight: 400; letter-spacing: normal; text-transform: none; }
+.settings-add-row > div { display: flex; gap: 8px; }
+.settings-add-row .ui-input { flex: 1; min-width: 0; }
+.settings-actions,
+.settings-actions > div,
+.settings-toggle-row { display: flex; align-items: center; gap: 8px; }
+
+.settings-actions { justify-content: space-between; border-top: 1px solid var(--border); padding-top: 14px; color: var(--muted-foreground); font-size: 12px; }
+.settings-toggle-list { gap: 0; }
+.settings-toggle-row { justify-content: space-between; min-height: 82px; border-bottom: 1px solid var(--border); }
+.settings-toggle-row:last-child { border-bottom: 0; }
+.settings-toggle-row strong { font-size: 13px; }
+.settings-toggle-row p { margin: 4px 0 0; color: var(--muted-foreground); font-size: 12px; }
+.settings-storage-detail { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1px; margin: 0; overflow: hidden; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--border); }
+.settings-storage-detail > div { display: grid; gap: 7px; padding: 14px; background: var(--card); }
+.settings-storage-detail dt { color: var(--muted-foreground); font-size: 11px; font-weight: 600; letter-spacing: .035em; text-transform: uppercase; }
+.settings-storage-detail dd { margin: 0; color: var(--foreground); font-size: 13px; }
+
+@media (max-width: 760px) {
+  .settings-workspace { grid-template-columns: 1fr; }
+  .settings-section-nav { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .settings-section-link { justify-content: center; padding: 9px 6px; }
+  .settings-section-link small { display: none; }
+  .settings-field-grid { grid-template-columns: 1fr; }
+  .settings-add-row > div,
+  .settings-actions { align-items: stretch; flex-direction: column; }
+  .settings-add-row .ui-button,
+  .settings-actions .ui-button { width: 100%; }
+}
+
+@media (max-width: 520px) {
+  .settings-section-link { flex-direction: column; gap: 4px; }
+  .settings-section-link strong { font-size: 11px; }
+  .settings-storage-detail { grid-template-columns: 1fr; }
+}
+
 .message-ops-workspace {
   display: grid;
   gap: 14px;

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/tokens.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/tokens.css
@@ -16,6 +16,8 @@
   --success: #22c55e;
   --warning: #f59e0b;
   --destructive: #ef4444;
+  --destructive-control-default: #b91c1c;
+  --destructive-control-hover: #991b1b;
   --info: #3b82f6;
   --ring: #2dd4bf;
   --bg: var(--background);


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9457

### Brief Description

- Rebuild the OPS settings, Proxy endpoint management, and independent Login route with the shared dark dashboard primitives and the existing API contracts.
- Add route-level lazy loading with an accessible fallback while preserving canonical routes and redirects.
- Remove unsupported UI remnants, gradients, glow styling, compatibility copy, and raw page controls; complete responsive layouts for shared operational workspaces.
- Harden NameServer draft protection, mutation locking, Proxy address canonicalization, session-discovery failure handling, and destructive-control contrast.
- Add focused coverage for settings, Proxy, Login, routing, shared controls, and review regressions.

### How Did You Test This Change?

- `npm ci` (completed with the existing dependency audit advisories: 2 moderate and 2 high)
- `npm test -- --run --maxWorkers=2` (42 files, 243 tests passed)
- `npm run build` (2,441 modules transformed; no Vite chunk warning)
- `git diff --check origin/main...HEAD`
- Codex in-app browser QA across all 13 top-level routes, including side-by-side comparison with the approved references, overlay behavior, focus return, forms, filters, and destructive-action cancellation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned settings workspace with Connection, Security, and Storage sections.
  - Improved NameServer and proxy endpoint management with validation, confirmations, and duplicate prevention.
  - Added a responsive, branded login experience with retry and clearer error handling.
  - Added loading feedback during page navigation and compatibility redirects for legacy routes.
  - Simplified topic maintenance to focus on consumer offset resets.

- **Improvements**
  - Refreshed ACL controls, descriptions, button styling, and responsive layouts.
  - Updated dashboard visuals with a cleaner, less decorative interface and improved theme support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->