### PR TITLE
[ISSUE #9463]✨Persist and expose transaction metrics

### DIFF
--- a/rocketmq-broker/Cargo.toml
+++ b/rocketmq-broker/Cargo.toml
@@ -185,3 +185,7 @@ required-features = ["test-support"]
 [[test]]
 name = "lite_ordered_suspend"
 required-features = ["test-support"]
+
+[[test]]
+name = "transaction_metrics_persistence"
+required-features = ["test-support"]

--- a/rocketmq-broker/src/broker_runtime/data_plane.rs
+++ b/rocketmq-broker/src/broker_runtime/data_plane.rs
@@ -13,6 +13,12 @@
 // limitations under the License.
 
 use super::*;
+#[cfg(feature = "local_file_store")]
+use crate::broker_path_config_helper::get_transaction_metrics_path;
+#[cfg(feature = "local_file_store")]
+use crate::transaction::transaction_metrics::TransactionMetrics;
+#[cfg(feature = "otel-metrics")]
+use crate::transaction::transactional_message_service::TransactionalMessageService;
 use rocketmq_store::BrokerReadStore;
 use rocketmq_store::BrokerStorePort;
 pub(super) struct BrokerDataPlane {
@@ -251,11 +257,34 @@ impl BrokerRuntime {
                     topic_registration,
                     escape_bridge: Arc::downgrade(&self.composition.data_plane.escape_bridge_owner),
                 });
-                let service = match DefaultTransactionalMessageService::try_new_with_resource_budget(
+                let Some(service_context) = self.composition.state.broker_service_context() else {
+                    error!("Transaction metrics require an injected broker service context");
+                    return false;
+                };
+                let metrics_path = get_transaction_metrics_path(
+                    self.composition.state.message_store_config().store_path_root_dir.as_str(),
+                );
+                let transaction_metrics = match service_context
+                    .metadata_io()
+                    .spawn_io("broker.transaction-metrics.recover", move || TransactionMetrics::open(metrics_path))
+                    .await
+                {
+                    Ok(Ok(metrics)) => metrics,
+                    Ok(Err(error)) => {
+                        error!(%error, "Failed to recover transaction metrics");
+                        return false;
+                    }
+                    Err(error) => {
+                        error!(%error, "Failed to schedule transaction metrics recovery");
+                        return false;
+                    }
+                };
+                let service = match DefaultTransactionalMessageService::try_new_with_resource_budget_and_metrics(
                     bridge,
                     self.composition.state.broker_config_arc(),
                     self.composition.state.message_store_config().file_reserved_time as i64,
                     self.composition.state.resource_budget(),
+                    transaction_metrics,
                 ) {
                     Ok(service) => Arc::new(service),
                     Err(error) => {
@@ -266,6 +295,21 @@ impl BrokerRuntime {
                 let weak_service = Arc::downgrade(&service);
                 if let Err(error) = service.set_transactional_op_batch_service_start(weak_service).await {
                     error!("Failed to start transactional op batch service: {error}");
+                }
+                if let Err(error) = service.start_transaction_metrics_flush(
+                    service_context.component("broker.transaction-metrics"),
+                ) {
+                    error!("Failed to start transaction metrics flush service: {error}");
+                    return false;
+                }
+                #[cfg(feature = "otel-metrics")]
+                if let Some(metrics_manager) = self.composition.state.broker_metrics_manager.clone() {
+                    let transaction_service = Arc::clone(&service);
+                    metrics_manager.register_transaction_pending_observable(move || {
+                        transaction_service
+                            .get_transaction_metrics()
+                            .snapshot()
+                    });
                 }
                 self.composition.state.transactional_message_service = Some(service);
             }

--- a/rocketmq-broker/src/lib.rs
+++ b/rocketmq-broker/src/lib.rs
@@ -37,6 +37,7 @@ pub mod send_message_constants;
 #[doc(hidden)]
 pub mod test_support {
     use std::collections::HashSet;
+    use std::path::Path;
 
     use cheetah_string::CheetahString;
     use rocketmq_model::common::lite::to_lmq_name;
@@ -45,10 +46,44 @@ pub mod test_support {
     use crate::lite::memory_consumer_order_info_manager::LiteOrderVisibilityUpdate;
     use crate::lite::memory_consumer_order_info_manager::MemoryConsumerOrderInfoManager;
     use crate::subscription::lite_subscription_registry::LiteSubscriptionRegistry;
+    use crate::transaction::transaction_metrics::TransactionMetrics;
 
     pub use crate::processor::notification_processor::{
         run_notification_filter_probe, NotificationFilterProbe, NotificationFilterProbeMessage,
     };
+
+    #[derive(Debug)]
+    pub struct TransactionMetricsProbe {
+        metrics: TransactionMetrics,
+    }
+
+    impl TransactionMetricsProbe {
+        pub fn open(path: &Path) -> Result<Self, String> {
+            TransactionMetrics::open(path)
+                .map(|metrics| Self { metrics })
+                .map_err(|error| error.to_string())
+        }
+
+        pub fn add_and_get(&self, topic: &str, delta: i64) -> i64 {
+            self.metrics.add_and_get(topic, delta)
+        }
+
+        pub fn count(&self, topic: &str) -> i64 {
+            self.metrics.count(topic)
+        }
+
+        pub fn snapshot(&self) -> Vec<(String, i64)> {
+            self.metrics.snapshot()
+        }
+
+        pub fn persist(&self) -> Result<(), String> {
+            self.metrics.persist().map_err(|error| error.to_string())
+        }
+
+        pub fn recovered_from_backup(&self) -> bool {
+            self.metrics.recovered_from_backup()
+        }
+    }
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct LiteWildcardProbe {

--- a/rocketmq-broker/src/processor/end_transaction_processor.rs
+++ b/rocketmq-broker/src/processor/end_transaction_processor.rs
@@ -372,11 +372,9 @@ where
                             metrics.record_transaction_finish_latency(&topic, commit_latency_secs);
                         }
 
-                        // TODO: Update transaction metrics (half messages count -1) when
-                        // TransactionMetrics is fully implemented
-                        // self.transactional_message_service
-                        //     .get_transaction_metrics()
-                        //     .add_and_get(&topic, -1);
+                        self.transactional_message_service
+                            .get_transaction_metrics()
+                            .add_and_get(topic.as_str(), -1);
                     }
                     return Ok(Some(send_result));
                 }
@@ -424,11 +422,9 @@ where
                             metrics.inc_rollback_messages(&real_topic, 1);
                         }
 
-                        // TODO: Update transaction metrics (half messages count -1) when
-                        // TransactionMetrics is fully implemented
-                        // self.transactional_message_service
-                        //     .get_transaction_metrics()
-                        //     .add_and_get(&real_topic, -1);
+                        self.transactional_message_service
+                            .get_transaction_metrics()
+                            .add_and_get(real_topic.as_str(), -1);
                     }
                 }
                 return Ok(Some(res));

--- a/rocketmq-broker/src/transaction/queue/default_transactional_message_service.rs
+++ b/rocketmq-broker/src/transaction/queue/default_transactional_message_service.rs
@@ -37,12 +37,16 @@ use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::common::message::message_decoder as MessageDecoder;
 use rocketmq_protocol::protocol::header::end_transaction_request_header::EndTransactionRequestHeader;
 use rocketmq_runtime::common::time_utils::current_millis;
+use rocketmq_runtime::BlockingExecutor;
 use rocketmq_runtime::BudgetLimit;
+use rocketmq_runtime::ChildServiceContext;
 use rocketmq_runtime::FullPolicy;
 use rocketmq_runtime::ProcessMemoryLimit;
 use rocketmq_runtime::RateLimit;
 use rocketmq_runtime::ResourceBudget;
 use rocketmq_runtime::ResourceBudgetTree;
+use rocketmq_runtime::ScheduledTaskConfig;
+use rocketmq_runtime::ScheduledTaskGroup;
 use rocketmq_store::BrokerMasterAddressStore;
 use rocketmq_store::BrokerWriteStore;
 use rocketmq_store::PutMessageResult;
@@ -56,6 +60,7 @@ use tracing::error;
 use tracing::info;
 use tracing::warn;
 
+use crate::broker_path_config_helper::get_transaction_metrics_path;
 use crate::transaction::operation_result::OperationResult;
 use crate::transaction::queue::get_result::GetResult;
 use crate::transaction::queue::message_queue_op_context::MessageQueueOpContext;
@@ -102,6 +107,8 @@ pub struct DefaultTransactionalMessageService<MS: BrokerWriteStore + BrokerMaste
     transactional_op_batch_service: OnceLock<TransactionalOpBatchService<MS>>,
     op_queue_map: Arc<RwLock<HashMap<MessageQueue, MessageQueue>>>,
     transaction_metrics: TransactionMetrics,
+    transaction_metrics_flush_tasks: OnceLock<ScheduledTaskGroup>,
+    transaction_metrics_blocking: OnceLock<BlockingExecutor>,
     operation_queue_budget: ResourceBudget,
 }
 
@@ -172,6 +179,24 @@ where
         file_reserved_time_hours: i64,
         parent_budget: &ResourceBudget,
     ) -> RocketMQResult<Self> {
+        let transaction_metrics =
+            TransactionMetrics::open(get_transaction_metrics_path(broker_config.store_path_root_dir.as_str()))?;
+        Self::try_new_with_resource_budget_and_metrics(
+            transactional_message_bridge,
+            broker_config,
+            file_reserved_time_hours,
+            parent_budget,
+            transaction_metrics,
+        )
+    }
+
+    pub(crate) fn try_new_with_resource_budget_and_metrics(
+        transactional_message_bridge: TransactionalMessageBridge<MS>,
+        broker_config: Arc<BrokerConfig>,
+        file_reserved_time_hours: i64,
+        parent_budget: &ResourceBudget,
+        transaction_metrics: TransactionMetrics,
+    ) -> RocketMQResult<Self> {
         let queue_count = 20_000.min(parent_budget.limit().capacity.count);
         let queue_bytes = (parent_budget.limit().capacity.bytes / 16).max(1);
         let queue_rate = u64::try_from(queue_count).unwrap_or(u64::MAX).max(1);
@@ -194,9 +219,47 @@ where
             delete_context: Arc::new(Mutex::new(HashMap::new())),
             transactional_op_batch_service: OnceLock::new(),
             op_queue_map: Arc::new(Default::default()),
-            transaction_metrics: TransactionMetrics,
+            transaction_metrics,
+            transaction_metrics_flush_tasks: OnceLock::new(),
+            transaction_metrics_blocking: OnceLock::new(),
             operation_queue_budget,
         })
+    }
+
+    pub(crate) fn start_transaction_metrics_flush(&self, service_context: ChildServiceContext) -> RocketMQResult<()> {
+        const FLUSH_INTERVAL: Duration = Duration::from_secs(10);
+
+        let blocking = service_context.metadata_io().clone();
+        let _ = self.transaction_metrics_blocking.set(blocking.clone());
+        let scheduled_tasks = service_context.scheduled_tasks("transaction-metrics-flush");
+        let metrics = self.transaction_metrics.clone();
+        scheduled_tasks
+            .schedule_fixed_rate_no_overlap(
+                ScheduledTaskConfig::fixed_rate_no_overlap("broker.transaction-metrics.flush", FLUSH_INTERVAL),
+                move || {
+                    let blocking = blocking.clone();
+                    let metrics = metrics.clone();
+                    async move {
+                        match blocking
+                            .spawn_io("broker.transaction-metrics.persist", move || metrics.persist_if_dirty())
+                            .await
+                        {
+                            Ok(Ok(_)) => {}
+                            Ok(Err(error)) => error!(%error, "Failed to persist transaction metrics"),
+                            Err(error) => error!(%error, "Failed to schedule transaction metrics persistence"),
+                        }
+                    }
+                },
+            )
+            .map_err(|error| RocketMQError::IO(std::io::Error::other(error)))?;
+        self.transaction_metrics_flush_tasks
+            .set(scheduled_tasks)
+            .map_err(|_| RocketMQError::ConfigInvalidValue {
+                key: "transactionMetrics.flushService",
+                value: "duplicate".into(),
+                reason: "transaction metrics flush service already started".into(),
+            })?;
+        Ok(())
     }
 
     pub async fn set_transactional_op_batch_service_start(
@@ -357,6 +420,11 @@ where
         };
 
         if put_message_result.put_message_status() == PutMessageStatus::PutOk {
+            if let Some(real_topic) =
+                msg_ext.user_property(&CheetahString::from_static_str(MessageConst::PROPERTY_REAL_TOPIC))
+            {
+                self.transaction_metrics.add_and_get(real_topic.as_str(), -1);
+            }
             info!(
                 "Put checked-too-many-time half message to TRANS_CHECK_MAXTIME_TOPIC OK. Restored in queueOffset={}, \
                  commitLogOffset={}, real topic={:?}",
@@ -1114,11 +1182,20 @@ where
     MS: BrokerWriteStore + BrokerMasterAddressStore + Send + Sync + 'static,
 {
     async fn prepare_message(&self, message_inner: MessageExtBrokerInner) -> PutMessageResult {
-        self.transactional_message_bridge.put_half_message(message_inner).await
+        let real_topic = message_inner
+            .property(&CheetahString::from_static_str(MessageConst::PROPERTY_REAL_TOPIC))
+            .unwrap_or_else(|| message_inner.topic().clone());
+        let result = self.transactional_message_bridge.put_half_message(message_inner).await;
+        if result.put_message_status() == PutMessageStatus::PutOk
+            && result.append_message_result().is_some_and(|append| append.is_ok())
+        {
+            self.transaction_metrics.add_and_get(real_topic.as_str(), 1);
+        }
+        result
     }
 
     async fn async_prepare_message(&self, message_inner: MessageExtBrokerInner) -> PutMessageResult {
-        self.transactional_message_bridge.put_half_message(message_inner).await
+        self.prepare_message(message_inner).await
     }
 
     async fn delete_prepare_message(&self, message_ext: &MessageExt) -> bool {
@@ -1218,6 +1295,27 @@ where
     async fn close(&self) {
         if let Some(batch_service) = self.transactional_op_batch_service.get() {
             batch_service.shutdown().await
+        }
+        if let Some(flush_tasks) = self.transaction_metrics_flush_tasks.get() {
+            let report = flush_tasks.shutdown(Duration::from_secs(5)).await;
+            if !report.is_healthy() {
+                warn!(report = %report.to_json(), "Transaction metrics flush shutdown was unhealthy");
+            }
+        }
+        let metrics = self.transaction_metrics.clone();
+        let persist_result = if let Some(blocking) = self.transaction_metrics_blocking.get() {
+            blocking
+                .spawn_io("broker.transaction-metrics.shutdown-persist", move || {
+                    metrics.persist_if_dirty()
+                })
+                .await
+                .map_err(|error| RocketMQError::IO(std::io::Error::other(error)))
+                .and_then(|result| result)
+        } else {
+            metrics.persist_if_dirty()
+        };
+        if let Err(error) = persist_result {
+            error!(%error, "Failed to persist transaction metrics during shutdown");
         }
     }
 

--- a/rocketmq-broker/src/transaction/transaction_metrics.rs
+++ b/rocketmq-broker/src/transaction/transaction_metrics.rs
@@ -12,4 +12,212 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) struct TransactionMetrics;
+use std::collections::BTreeMap;
+use std::fs;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use parking_lot::RwLock;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_runtime::common::time_utils::current_millis;
+use serde::Deserialize;
+use serde::Serialize;
+
+const CHECKPOINT_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TopicMetric {
+    count: i64,
+    timestamp: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TransactionMetricsCheckpoint {
+    version: u32,
+    generation: u64,
+    topics: BTreeMap<String, TopicMetric>,
+}
+
+#[derive(Debug)]
+struct TransactionMetricsInner {
+    checkpoint_path: PathBuf,
+    topics: RwLock<BTreeMap<String, TopicMetric>>,
+    generation: AtomicU64,
+    revision: AtomicU64,
+    dirty: AtomicBool,
+    recovered_from_backup: AtomicBool,
+    persist_lock: Mutex<()>,
+}
+
+/// Java-compatible per-topic count of prepared transaction messages that have
+/// not yet reached a terminal state.
+#[derive(Debug, Clone)]
+pub(crate) struct TransactionMetrics {
+    inner: Arc<TransactionMetricsInner>,
+}
+
+impl TransactionMetrics {
+    pub(crate) fn open(checkpoint_path: impl Into<PathBuf>) -> RocketMQResult<Self> {
+        let checkpoint_path = checkpoint_path.into();
+        let backup_path = backup_path(&checkpoint_path);
+        let (checkpoint, recovered_from_backup) = match read_checkpoint(&checkpoint_path) {
+            Ok(Some(checkpoint)) => (checkpoint, false),
+            Ok(None) => match read_checkpoint(&backup_path)? {
+                Some(checkpoint) => (checkpoint, true),
+                None => empty_checkpoint(),
+            },
+            Err(primary_error) => match read_checkpoint(&backup_path) {
+                Ok(Some(checkpoint)) => (checkpoint, true),
+                _ => return Err(primary_error),
+            },
+        };
+
+        Ok(Self {
+            inner: Arc::new(TransactionMetricsInner {
+                checkpoint_path,
+                topics: RwLock::new(checkpoint.topics),
+                generation: AtomicU64::new(checkpoint.generation),
+                revision: AtomicU64::new(0),
+                dirty: AtomicBool::new(false),
+                recovered_from_backup: AtomicBool::new(recovered_from_backup),
+                persist_lock: Mutex::new(()),
+            }),
+        })
+    }
+
+    pub(crate) fn add_and_get(&self, topic: &str, delta: i64) -> i64 {
+        let mut topics = self.inner.topics.write();
+        let metric = topics.entry(topic.to_owned()).or_insert_with(|| TopicMetric {
+            count: 0,
+            timestamp: current_millis(),
+        });
+        metric.count = metric.count.wrapping_add(delta);
+        metric.timestamp = current_millis();
+        let count = metric.count;
+        drop(topics);
+        self.inner.revision.fetch_add(1, Ordering::AcqRel);
+        self.inner.dirty.store(true, Ordering::Release);
+        count
+    }
+
+    pub(crate) fn count(&self, topic: &str) -> i64 {
+        self.inner.topics.read().get(topic).map_or(0, |metric| metric.count)
+    }
+
+    pub(crate) fn snapshot(&self) -> Vec<(String, i64)> {
+        self.inner
+            .topics
+            .read()
+            .iter()
+            .map(|(topic, metric)| (topic.clone(), metric.count))
+            .collect()
+    }
+
+    pub(crate) fn persist_if_dirty(&self) -> RocketMQResult<bool> {
+        if !self.inner.dirty.load(Ordering::Acquire) {
+            return Ok(false);
+        }
+        self.persist()?;
+        Ok(true)
+    }
+
+    pub(crate) fn persist(&self) -> RocketMQResult<()> {
+        let _guard = self.inner.persist_lock.lock();
+        let snapshot_revision = self.inner.revision.load(Ordering::Acquire);
+        let generation = self.inner.generation.load(Ordering::Acquire).saturating_add(1);
+        let checkpoint = TransactionMetricsCheckpoint {
+            version: CHECKPOINT_VERSION,
+            generation,
+            topics: self.inner.topics.read().clone(),
+        };
+        let body = serde_json::to_vec(&checkpoint)?;
+        write_checkpoint(&self.inner.checkpoint_path, &body)?;
+        self.inner.generation.store(generation, Ordering::Release);
+        if self.inner.revision.load(Ordering::Acquire) == snapshot_revision {
+            self.inner.dirty.store(false, Ordering::Release);
+        }
+        Ok(())
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub(crate) fn recovered_from_backup(&self) -> bool {
+        self.inner.recovered_from_backup.load(Ordering::Acquire)
+    }
+}
+
+fn empty_checkpoint() -> (TransactionMetricsCheckpoint, bool) {
+    (
+        TransactionMetricsCheckpoint {
+            version: CHECKPOINT_VERSION,
+            generation: 0,
+            topics: BTreeMap::new(),
+        },
+        false,
+    )
+}
+
+fn read_checkpoint(path: &Path) -> RocketMQResult<Option<TransactionMetricsCheckpoint>> {
+    let body = match fs::read(path) {
+        Ok(body) => body,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    let checkpoint: TransactionMetricsCheckpoint = serde_json::from_slice(&body)?;
+    if checkpoint.version != CHECKPOINT_VERSION {
+        return Err(RocketMQError::ConfigInvalidValue {
+            key: "transactionMetrics.version",
+            value: checkpoint.version.to_string(),
+            reason: format!(
+                "unsupported transaction metrics checkpoint version {}",
+                checkpoint.version
+            ),
+        });
+    }
+    Ok(Some(checkpoint))
+}
+
+fn write_checkpoint(path: &Path, body: &[u8]) -> RocketMQResult<()> {
+    let parent = path.parent().ok_or_else(|| RocketMQError::ConfigInvalidValue {
+        key: "transactionMetrics.path",
+        value: path.display().to_string(),
+        reason: "checkpoint path must have a parent directory".into(),
+    })?;
+    fs::create_dir_all(parent)?;
+    let temporary_path = temporary_path(path);
+    let backup_path = backup_path(path);
+    let mut temporary = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&temporary_path)?;
+    temporary.write_all(body)?;
+    temporary.sync_all()?;
+    drop(temporary);
+
+    if path.exists() {
+        if backup_path.exists() {
+            fs::remove_file(&backup_path)?;
+        }
+        fs::rename(path, &backup_path)?;
+    }
+    fs::rename(&temporary_path, path)?;
+    Ok(())
+}
+
+fn backup_path(path: &Path) -> PathBuf {
+    PathBuf::from(format!("{}.bak", path.display()))
+}
+
+fn temporary_path(path: &Path) -> PathBuf {
+    PathBuf::from(format!("{}.tmp", path.display()))
+}

--- a/rocketmq-broker/tests/transaction_metrics_persistence.rs
+++ b/rocketmq-broker/tests/transaction_metrics_persistence.rs
@@ -1,0 +1,63 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs;
+
+use rocketmq_broker::test_support::TransactionMetricsProbe;
+
+#[test]
+fn persists_and_recovers_pending_counts_per_topic() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let checkpoint = directory.path().join("transactionMetrics");
+    let metrics = TransactionMetricsProbe::open(&checkpoint).expect("new metrics store");
+
+    assert_eq!(metrics.add_and_get("orders", 2), 2);
+    assert_eq!(metrics.add_and_get("payments", 1), 1);
+    assert_eq!(metrics.add_and_get("orders", -1), 1);
+    metrics.persist().expect("persist transaction metrics");
+
+    let recovered = TransactionMetricsProbe::open(&checkpoint).expect("recover transaction metrics");
+    assert_eq!(recovered.count("orders"), 1);
+    assert_eq!(recovered.count("payments"), 1);
+    assert_eq!(recovered.snapshot(), vec![("orders".into(), 1), ("payments".into(), 1)]);
+}
+
+#[test]
+fn falls_back_to_the_previous_complete_generation() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let checkpoint = directory.path().join("transactionMetrics");
+    let metrics = TransactionMetricsProbe::open(&checkpoint).expect("new metrics store");
+
+    metrics.add_and_get("orders", 1);
+    metrics.persist().expect("first checkpoint");
+    metrics.add_and_get("orders", 1);
+    metrics.persist().expect("second checkpoint");
+    fs::write(&checkpoint, b"{truncated").expect("corrupt current generation");
+
+    let recovered = TransactionMetricsProbe::open(&checkpoint).expect("recover backup generation");
+    assert_eq!(recovered.count("orders"), 1);
+    assert!(recovered.recovered_from_backup());
+}
+
+#[test]
+fn rejects_an_unknown_checkpoint_version_without_mutating_it() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let checkpoint = directory.path().join("transactionMetrics");
+    let body = br#"{"version":99,"generation":7,"topics":{}}"#;
+    fs::write(&checkpoint, body).expect("write unsupported checkpoint");
+
+    let error = TransactionMetricsProbe::open(&checkpoint).expect_err("unknown version must fail closed");
+    assert!(error.contains("unsupported transaction metrics checkpoint version 99"));
+    assert_eq!(fs::read(&checkpoint).expect("checkpoint remains readable"), body);
+}

--- a/rocketmq-observability/src/metrics.rs
+++ b/rocketmq-observability/src/metrics.rs
@@ -44,6 +44,8 @@ pub mod runtime;
 pub mod store;
 pub mod tiered_store;
 pub mod timer;
+#[cfg(feature = "otel-metrics")]
+pub(crate) mod transaction;
 
 #[cfg(all(test, feature = "otel-metrics"))]
 #[path = "metrics/tests/component_metric_isolation.rs"]

--- a/rocketmq-observability/src/metrics/broker_manager.rs
+++ b/rocketmq-observability/src/metrics/broker_manager.rs
@@ -51,6 +51,7 @@ use crate::metrics::owner_instruments::Counter;
 use crate::metrics::owner_instruments::Histogram;
 use crate::metrics::owner_instruments::KeyValue;
 use crate::metrics::owner_instruments::Meter;
+use crate::metrics::transaction::TransactionPendingSample;
 use crate::MetricLabelPolicy;
 use crate::MetricsExporter;
 use crate::SamplingGate;
@@ -770,6 +771,43 @@ impl BrokerMetricsManager {
             .build();
     }
 
+    /// Registers the Java-compatible per-topic pending transaction gauge.
+    pub fn register_transaction_pending_observable<F>(&self, pending_snapshot_fn: F)
+    where
+        F: Fn() -> Vec<(String, i64)> + Send + Sync + 'static,
+    {
+        if !self.is_recording_active() {
+            return;
+        }
+
+        let telemetry = self.telemetry.clone();
+        let attributes_supplier = self.attributes_supplier.clone();
+        #[cfg(feature = "otel-metrics")]
+        let label_policy = self.label_policy.clone();
+        let _pending_transactions = self
+            .meter
+            .i64_observable_gauge(BrokerMetricsConstant::GAUGE_HALF_MESSAGES)
+            .with_description("Pending transaction messages per topic")
+            .with_callback(move |observer| {
+                if !telemetry_allows_recording(telemetry.as_ref()) {
+                    return;
+                }
+                for (topic, count) in pending_snapshot_fn() {
+                    let sample = TransactionPendingSample::new(topic, count);
+                    let mut attrs = attributes_supplier.get();
+                    #[cfg(feature = "otel-metrics")]
+                    let topic_label =
+                        guarded_bounded_label(&label_policy, BrokerMetricsConstant::LABEL_TOPIC, &sample.topic)
+                            .key_value;
+                    #[cfg(not(feature = "otel-metrics"))]
+                    let topic_label = KeyValue::new(BrokerMetricsConstant::LABEL_TOPIC, sample.topic);
+                    attrs.push(topic_label);
+                    observer.observe(sample.count, &attrs);
+                }
+            })
+            .build();
+    }
+
     #[cfg(feature = "otel-metrics")]
     pub fn register_consumer_lag_observable_gauge<F>(&self, consumer_lag_snapshot_fn: F)
     where
@@ -1411,6 +1449,18 @@ mod tests {
                 ..AuthMetricsSnapshot::default()
             })
         });
+    }
+
+    #[test]
+    #[cfg(feature = "otel-metrics")]
+    fn transaction_pending_observable_accepts_topic_snapshots() {
+        let meter_provider = SdkMeterProvider::builder().build();
+        let manager = BrokerMetricsManager::new(
+            meter_provider.meter("transaction-pending-observable"),
+            Arc::new(NoopAttributesSupplier),
+        );
+
+        manager.register_transaction_pending_observable(|| vec![("orders".to_owned(), 3)]);
     }
 
     #[test]

--- a/rocketmq-observability/src/metrics/transaction.rs
+++ b/rocketmq-observability/src/metrics/transaction.rs
@@ -1,0 +1,41 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TransactionPendingSample {
+    pub topic: String,
+    pub count: i64,
+}
+
+impl TransactionPendingSample {
+    pub(crate) fn new(topic: impl Into<String>, count: i64) -> Self {
+        Self {
+            topic: topic.into(),
+            count,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TransactionPendingSample;
+
+    #[test]
+    fn transaction_pending_sample_keeps_java_pending_semantics() {
+        let sample = TransactionPendingSample::new("orders", 7);
+
+        assert_eq!(sample.topic, "orders");
+        assert_eq!(sample.count, 7);
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9463

### Brief Description

- Implement a versioned per-topic pending transaction checkpoint with atomic replacement and backup recovery.
- Update the Java-compatible pending count only after successful prepare, commit, rollback, and discard transitions.
- Recover and periodically flush metrics through broker-owned blocking/runtime services, and expose the real pending count as an OpenTelemetry gauge.
- Add persistence, recovery, unsupported-version, and observable registration coverage.

### How Did You Test This Change?

- `cargo test -p rocketmq-broker --features test-support --test transaction_metrics_persistence`
- `cargo test -p rocketmq-broker transaction`
- `cargo test -p rocketmq-observability --features otel-metrics transaction`
- `cargo clippy -p rocketmq-broker -p rocketmq-observability --no-deps --all-targets --all-features -- -D warnings`
- `cargo fmt -p rocketmq-broker -p rocketmq-observability -- --check`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `git diff --check`

The required fuzz `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` remains blocked by the pre-existing stale `fuzz/Cargo.lock`; the same failure reproduces on unchanged `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transaction metrics are now tracked by topic and persisted across broker restarts.
  * Metrics recover automatically from a backup when the primary checkpoint is unavailable or corrupted.
  * OpenTelemetry can report pending transactional messages by topic.
  * Transaction metrics are updated as messages are prepared, committed, rolled back, or discarded.

* **Bug Fixes**
  * Improved transaction startup and shutdown handling, including error reporting and final metric flushing.

* **Tests**
  * Added coverage for persistence, backup recovery, and unsupported checkpoint versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->