### PR TITLE
[ISSUE #9472]✨Add Java 5.5 broker properties conversion

### DIFF
--- a/rocketmq-broker/src/bin/broker_bootstrap_server.rs
+++ b/rocketmq-broker/src/bin/broker_bootstrap_server.rs
@@ -24,7 +24,9 @@ use anyhow::Result;
 use clap::Parser;
 use rocketmq_broker::build_broker_telemetry_bootstrap_config;
 use rocketmq_broker::command::Args;
+use rocketmq_broker::command::ConfigFileFormat;
 use rocketmq_broker::config::broker_config::BrokerConfig;
+use rocketmq_broker::config::java_properties::JavaBrokerProperties;
 use rocketmq_broker::config::raw::RawBrokerConfig;
 use rocketmq_broker::config::validated::ValidatedBrokerConfig;
 use rocketmq_broker::Builder;
@@ -346,11 +348,45 @@ fn verify_rocketmq_home() -> Result<()> {
 fn parse_config_file(args: &Args) -> Result<RawBrokerConfig> {
     if let Some(config_file) = args.get_config_file() {
         info!("Loading configuration from: {}", config_file.display());
-        RawBrokerConfig::load(&config_file)
-            .with_context(|| format!("Failed to parse canonical broker configuration from {:?}", config_file))
+        match resolve_config_format(args, &config_file)? {
+            ConfigFileFormat::Toml => RawBrokerConfig::load(&config_file)
+                .with_context(|| format!("Failed to parse canonical broker configuration from {:?}", config_file)),
+            ConfigFileFormat::Properties => {
+                let input = std::fs::read_to_string(&config_file)
+                    .with_context(|| format!("Failed to read Java broker properties from {:?}", config_file))?;
+                let conversion = JavaBrokerProperties::parse(&input)
+                    .with_context(|| format!("Failed to convert Java broker properties from {:?}", config_file))?;
+                let report_path = args
+                    .conversion_report
+                    .clone()
+                    .unwrap_or_else(|| config_file.with_extension("conversion.json"));
+                let report = conversion
+                    .report_json()
+                    .context("Failed to serialize Java broker properties conversion report")?;
+                std::fs::write(&report_path, report)
+                    .with_context(|| format!("Failed to write Java conversion report to {:?}", report_path))?;
+                Ok(conversion.into_config())
+            }
+        }
     } else {
         info!("Using default configuration (no config file specified)");
         Ok(RawBrokerConfig::default())
+    }
+}
+
+fn resolve_config_format(args: &Args, path: &std::path::Path) -> Result<ConfigFileFormat> {
+    if let Some(format) = args.config_format {
+        return Ok(format);
+    }
+    match path.extension().and_then(std::ffi::OsStr::to_str) {
+        Some(extension) if extension.eq_ignore_ascii_case("toml") => Ok(ConfigFileFormat::Toml),
+        Some(extension) if extension.eq_ignore_ascii_case("conf") || extension.eq_ignore_ascii_case("properties") => {
+            Ok(ConfigFileFormat::Properties)
+        }
+        _ => anyhow::bail!(
+            "configuration format is ambiguous for {}; use --config-format toml|properties",
+            path.display()
+        ),
     }
 }
 
@@ -695,6 +731,8 @@ storePathCommitLog = "{}"
 
         let args = Args {
             config_file: Some(config_file),
+            config_format: None,
+            conversion_report: None,
             print_config_item: false,
             print_important_config: false,
             namesrv_addr: None,
@@ -733,5 +771,54 @@ storePathCommitLog = "{}"
                 .map(|path| path.as_str()),
             Some(commit_log.as_str())
         );
+    }
+
+    #[test]
+    fn parse_config_file_converts_java_properties_and_writes_one_report() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let config_file = temp_dir.path().join("broker.conf");
+        let report_file = temp_dir.path().join("conversion.json");
+        std::fs::write(
+            &config_file,
+            "brokerName=converted-broker\nstoreType=DEFAULTROCKSDB\nmaxMessageSize=0\n",
+        )
+        .expect("write Java properties");
+        let args = Args {
+            config_file: Some(config_file),
+            config_format: None,
+            conversion_report: Some(report_file.clone()),
+            print_config_item: false,
+            print_important_config: false,
+            namesrv_addr: None,
+            log_filter: None,
+        };
+
+        let raw = parse_config_file(&args).expect("convert Java properties");
+        assert_eq!(raw.broker().broker_identity.broker_name, "converted-broker");
+        assert_eq!(raw.store().store_type, rocketmq_store::StoreType::RocksDB);
+        assert_eq!(raw.store().max_message_size, 0);
+        let report = std::fs::read_to_string(report_file).expect("read conversion report");
+        assert!(report.contains("brokerName"));
+        assert!(report.contains("store.storeType"));
+    }
+
+    #[test]
+    fn conversion_report_failure_prevents_configuration_startup() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let config_file = temp_dir.path().join("broker.properties");
+        let blocked_report = temp_dir.path().join("report-directory");
+        std::fs::write(&config_file, "brokerName=blocked-report\n").expect("write Java properties");
+        std::fs::create_dir(&blocked_report).expect("create blocking report directory");
+        let args = Args {
+            config_file: Some(config_file),
+            config_format: Some(ConfigFileFormat::Properties),
+            conversion_report: Some(blocked_report),
+            print_config_item: false,
+            print_important_config: false,
+            namesrv_addr: None,
+            log_filter: None,
+        };
+
+        assert!(parse_config_file(&args).is_err());
     }
 }

--- a/rocketmq-broker/src/command.rs
+++ b/rocketmq-broker/src/command.rs
@@ -18,6 +18,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 
 use clap::Parser;
+use clap::ValueEnum;
 use thiserror::Error;
 use tracing::info;
 
@@ -49,6 +50,12 @@ pub enum BrokerArgsError {
     ConfigLoadError(String),
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum ConfigFileFormat {
+    Toml,
+    Properties,
+}
+
 /// RocketMQ Broker command line arguments
 ///
 /// Supports the same command line options as the Java implementation:
@@ -74,6 +81,15 @@ pub struct Args {
     /// 2. Default configuration values
     #[arg(short = 'c', long = "configFile", value_name = "FILE")]
     pub config_file: Option<PathBuf>,
+
+    /// Explicit configuration syntax. When omitted, `.toml`, `.conf`, and
+    /// `.properties` extensions are interpreted deterministically.
+    #[arg(long = "config-format", value_enum)]
+    pub config_format: Option<ConfigFileFormat>,
+
+    /// Destination for the redacted Java-properties conversion report.
+    #[arg(long = "conversion-report", value_name = "FILE")]
+    pub conversion_report: Option<PathBuf>,
 
     /// Print all configuration items and exit
     ///
@@ -286,9 +302,26 @@ mod tests {
     }
 
     #[test]
+    fn explicit_java_properties_format_and_report_are_parsed() {
+        let args = Args::try_parse_from([
+            "rocketmq-broker-rust",
+            "--config-format",
+            "properties",
+            "--conversion-report",
+            "converted.json",
+        ])
+        .expect("configuration conversion arguments should parse");
+
+        assert_eq!(args.config_format, Some(ConfigFileFormat::Properties));
+        assert_eq!(args.conversion_report, Some(PathBuf::from("converted.json")));
+    }
+
+    #[test]
     fn test_validate_namesrv_addr_single() {
         let args = Args {
             config_file: None,
+            config_format: None,
+            conversion_report: None,
             print_config_item: false,
             print_important_config: false,
             namesrv_addr: Some("127.0.0.1:9876".to_string()),
@@ -302,6 +335,8 @@ mod tests {
     fn test_validate_namesrv_addr_multiple() {
         let args = Args {
             config_file: None,
+            config_format: None,
+            conversion_report: None,
             print_config_item: false,
             print_important_config: false,
             namesrv_addr: Some("192.168.0.1:9876;192.168.0.2:9876".to_string()),
@@ -315,6 +350,8 @@ mod tests {
     fn test_validate_namesrv_addr_invalid() {
         let args = Args {
             config_file: None,
+            config_format: None,
+            conversion_report: None,
             print_config_item: false,
             print_important_config: false,
             namesrv_addr: Some("invalid".to_string()),
@@ -328,6 +365,8 @@ mod tests {
     fn test_should_exit_after_print() {
         let args_print = Args {
             config_file: None,
+            config_format: None,
+            conversion_report: None,
             print_config_item: true,
             print_important_config: false,
             namesrv_addr: None,
@@ -337,6 +376,8 @@ mod tests {
 
         let args_important = Args {
             config_file: None,
+            config_format: None,
+            conversion_report: None,
             print_config_item: false,
             print_important_config: true,
             namesrv_addr: None,
@@ -346,6 +387,8 @@ mod tests {
 
         let args_none = Args {
             config_file: None,
+            config_format: None,
+            conversion_report: None,
             print_config_item: false,
             print_important_config: false,
             namesrv_addr: None,
@@ -358,6 +401,8 @@ mod tests {
     fn test_get_namesrv_addr_default() {
         let args = Args {
             config_file: None,
+            config_format: None,
+            conversion_report: None,
             print_config_item: false,
             print_important_config: false,
             namesrv_addr: None,
@@ -372,6 +417,8 @@ mod tests {
     fn test_get_namesrv_addr_from_args() {
         let args = Args {
             config_file: None,
+            config_format: None,
+            conversion_report: None,
             print_config_item: false,
             print_important_config: false,
             namesrv_addr: Some("192.168.1.1:9876".to_string()),
@@ -385,6 +432,8 @@ mod tests {
     fn test_is_valid_host_port() {
         let args = Args {
             config_file: None,
+            config_format: None,
+            conversion_report: None,
             print_config_item: false,
             print_important_config: false,
             namesrv_addr: None,

--- a/rocketmq-broker/src/config.rs
+++ b/rocketmq-broker/src/config.rs
@@ -15,6 +15,7 @@
 pub mod broker_config;
 pub mod config_manager;
 pub mod error;
+pub mod java_properties;
 pub mod raw;
 pub mod sections;
 pub mod transaction;

--- a/rocketmq-broker/src/config/java_properties.rs
+++ b/rocketmq-broker/src/config/java_properties.rs
@@ -1,0 +1,397 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+
+use rocketmq_store::StoreType;
+use serde::Serialize;
+use serde_json::Map;
+use serde_json::Value;
+
+use super::error::BrokerConfigError;
+use super::raw::RawBrokerConfig;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum JavaConfigEntryStatus {
+    Mapped,
+    Renamed,
+    AlternativeEquivalent,
+    NotApplicable,
+}
+
+impl JavaConfigEntryStatus {
+    pub const fn is_mapped(self) -> bool {
+        matches!(self, Self::Mapped | Self::Renamed | Self::AlternativeEquivalent)
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JavaConfigEntry {
+    original_key: String,
+    canonical_key: String,
+    owner: String,
+    status: JavaConfigEntryStatus,
+    sensitive: bool,
+    value_state: &'static str,
+}
+
+impl JavaConfigEntry {
+    pub fn original_key(&self) -> &str {
+        &self.original_key
+    }
+
+    pub fn canonical_key(&self) -> &str {
+        &self.canonical_key
+    }
+
+    pub fn owner(&self) -> &str {
+        &self.owner
+    }
+
+    pub const fn status(&self) -> JavaConfigEntryStatus {
+        self.status
+    }
+
+    pub const fn sensitive(&self) -> bool {
+        self.sensitive
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JavaConfigWarning {
+    key: String,
+    action: String,
+}
+
+impl JavaConfigWarning {
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    pub fn action(&self) -> &str {
+        &self.action
+    }
+}
+
+#[derive(Debug)]
+pub struct JavaConfigConversion {
+    config: RawBrokerConfig,
+    entries: Vec<JavaConfigEntry>,
+    warnings: Vec<JavaConfigWarning>,
+}
+
+impl JavaConfigConversion {
+    pub const fn config(&self) -> &RawBrokerConfig {
+        &self.config
+    }
+
+    pub fn entries(&self) -> &[JavaConfigEntry] {
+        &self.entries
+    }
+
+    pub fn warnings(&self) -> &[JavaConfigWarning] {
+        &self.warnings
+    }
+
+    pub fn into_config(self) -> RawBrokerConfig {
+        self.config
+    }
+
+    pub fn report_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string_pretty(&serde_json::json!({
+            "entries": self.entries,
+            "warnings": self.warnings,
+        }))
+    }
+}
+
+pub struct JavaBrokerProperties;
+
+impl JavaBrokerProperties {
+    pub fn parse(input: &str) -> Result<JavaConfigConversion, BrokerConfigError> {
+        let mut root = Map::new();
+        root.insert("broker".to_owned(), Value::Object(Map::new()));
+        root.insert("store".to_owned(), Value::Object(Map::new()));
+        let mut seen_original = HashSet::new();
+        let mut seen_canonical = HashSet::new();
+        let mut entries = Vec::new();
+        let mut warnings = Vec::new();
+
+        for (line_index, line) in input.lines().enumerate() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') || line.starts_with('!') {
+                continue;
+            }
+            let separator = line.find(['=', ':']).or_else(|| line.find(char::is_whitespace));
+            let Some(separator) = separator else {
+                return Err(invalid_property(
+                    format!("line {}", line_index + 1),
+                    "non-empty text",
+                    "key=value, key:value, or key value",
+                ));
+            };
+            let key = line[..separator].trim();
+            let value = line[separator + 1..]
+                .trim_start_matches(char::is_whitespace)
+                .strip_prefix(['=', ':'])
+                .unwrap_or(&line[separator + 1..])
+                .trim();
+            if key.is_empty() {
+                return Err(invalid_property(
+                    format!("line {}", line_index + 1),
+                    "empty key",
+                    "non-empty Java property key",
+                ));
+            }
+            if !seen_original.insert(key.to_owned()) {
+                return Err(invalid_property(key, "duplicate", "one value per Java property"));
+            }
+            if key.to_ascii_lowercase().contains("dledger") {
+                return Err(invalid_property(
+                    key,
+                    "DLedger configuration",
+                    "DLedger CommitLog is outside the Rust 1.0 scope",
+                ));
+            }
+
+            let mapping = resolve_mapping(key, value, &root)?;
+            if !seen_canonical.insert(mapping.canonical_key.clone()) {
+                return Err(invalid_property(
+                    key,
+                    "alias conflict",
+                    "one Java source for each canonical property",
+                ));
+            }
+            for path in &mapping.paths {
+                if !insert_path(&mut root, path, mapping.value.clone()) {
+                    return Err(invalid_property(
+                        key,
+                        "canonical owner conflict",
+                        "a non-conflicting broker/store/logging owner path",
+                    ));
+                }
+            }
+            if mapping.sensitive_file_reference {
+                warnings.push(JavaConfigWarning {
+                    key: key.to_owned(),
+                    action: "copy or mount the referenced file separately; its contents are not embedded".to_owned(),
+                });
+            }
+            entries.push(JavaConfigEntry {
+                original_key: key.to_owned(),
+                canonical_key: mapping.canonical_key,
+                owner: mapping.owner.to_owned(),
+                status: mapping.status,
+                sensitive: mapping.sensitive,
+                value_state: if mapping.sensitive { "configured" } else { "validated" },
+            });
+        }
+
+        let config = RawBrokerConfig::from_serde_value(Value::Object(root)).map_err(|_| {
+            invalid_property(
+                "java properties",
+                "invalid typed value",
+                "a complete Java 5.5 configuration that maps to the canonical Rust schema",
+            )
+        })?;
+        Ok(JavaConfigConversion {
+            config,
+            entries,
+            warnings,
+        })
+    }
+}
+
+struct ResolvedMapping {
+    paths: Vec<Vec<String>>,
+    canonical_key: String,
+    owner: &'static str,
+    status: JavaConfigEntryStatus,
+    value: Value,
+    sensitive: bool,
+    sensitive_file_reference: bool,
+}
+
+fn resolve_mapping(key: &str, value: &str, root: &Map<String, Value>) -> Result<ResolvedMapping, BrokerConfigError> {
+    let manual = match key {
+        "brokerName" | "brokerClusterName" | "brokerId" => Some((
+            vec!["broker", "brokerIdentity", key],
+            "broker.identity",
+            JavaConfigEntryStatus::Renamed,
+            value_candidates(value),
+        )),
+        "brokerIP1" => Some((
+            vec!["broker", "brokerIp1"],
+            "broker.network",
+            JavaConfigEntryStatus::Renamed,
+            value_candidates(value),
+        )),
+        "brokerIP2" => Some((
+            vec!["broker", "brokerIp2"],
+            "broker.network",
+            JavaConfigEntryStatus::Renamed,
+            value_candidates(value),
+        )),
+        "brokerRole" | "flushDiskType" | "maxMessageSize" => Some((
+            vec!["store", key],
+            "store",
+            JavaConfigEntryStatus::Mapped,
+            value_candidates(value),
+        )),
+        "storeType" => {
+            let store_type = StoreType::from_java_alias(value).ok_or_else(|| {
+                invalid_property(
+                    key,
+                    "unknown store type",
+                    "default or defaultRocksDB (ASCII case-insensitive)",
+                )
+            })?;
+            Some((
+                vec!["store", "storeType"],
+                "store",
+                JavaConfigEntryStatus::Renamed,
+                vec![Value::String(store_type.get_store_type().to_owned())],
+            ))
+        }
+        "storePathRootDir" => {
+            let candidate = Value::String(value.to_owned());
+            return Ok(ResolvedMapping {
+                paths: vec![
+                    vec!["broker".to_owned(), key.to_owned()],
+                    vec!["store".to_owned(), key.to_owned()],
+                ],
+                canonical_key: "broker.storePathRootDir+store.storePathRootDir".to_owned(),
+                owner: "broker+store",
+                status: JavaConfigEntryStatus::AlternativeEquivalent,
+                value: candidate,
+                sensitive: false,
+                sensitive_file_reference: false,
+            });
+        }
+        "logFilter" => Some((
+            vec!["logFilter"],
+            "logging",
+            JavaConfigEntryStatus::Mapped,
+            vec![Value::String(value.to_owned())],
+        )),
+        _ => None,
+    };
+    if let Some((path, owner, status, candidates)) = manual {
+        return select_candidate(key, path, owner, status, candidates, root);
+    }
+
+    for owner in ["broker", "store"] {
+        let path = vec![owner, key];
+        if let Ok(mapping) = select_candidate(
+            key,
+            path,
+            owner,
+            JavaConfigEntryStatus::Mapped,
+            value_candidates(value),
+            root,
+        ) {
+            return Ok(mapping);
+        }
+    }
+    Err(BrokerConfigError::UnsupportedKeys { keys: key.to_owned() })
+}
+
+fn select_candidate(
+    original_key: &str,
+    path: Vec<&str>,
+    owner: &'static str,
+    status: JavaConfigEntryStatus,
+    candidates: Vec<Value>,
+    root: &Map<String, Value>,
+) -> Result<ResolvedMapping, BrokerConfigError> {
+    for candidate in candidates {
+        let mut trial = root.clone();
+        let owned_path = path.iter().map(|part| (*part).to_owned()).collect::<Vec<_>>();
+        if !insert_path(&mut trial, &owned_path, candidate.clone()) {
+            continue;
+        }
+        if RawBrokerConfig::from_serde_value(Value::Object(trial)).is_ok() {
+            let canonical_key = owned_path.join(".");
+            let sensitive_file_reference = matches!(original_key, "authConfigPath" | "aclFile");
+            let sensitive = sensitive_file_reference
+                || original_key.to_ascii_lowercase().contains("password")
+                || original_key.to_ascii_lowercase().contains("secret");
+            return Ok(ResolvedMapping {
+                paths: vec![owned_path],
+                canonical_key,
+                owner,
+                status,
+                value: candidate,
+                sensitive,
+                sensitive_file_reference,
+            });
+        }
+    }
+    Err(invalid_property(
+        original_key,
+        "invalid typed value",
+        "the Java 5.5 property type",
+    ))
+}
+
+fn value_candidates(value: &str) -> Vec<Value> {
+    let mut candidates = vec![Value::String(value.to_owned())];
+    if value.eq_ignore_ascii_case("true") {
+        candidates.push(Value::Bool(true));
+    } else if value.eq_ignore_ascii_case("false") {
+        candidates.push(Value::Bool(false));
+    }
+    if let Ok(number) = value.parse::<i64>() {
+        candidates.push(Value::Number(number.into()));
+    }
+    if let Ok(number) = value.parse::<u64>() {
+        candidates.push(Value::Number(number.into()));
+    }
+    if let Ok(number) = value.parse::<f64>() {
+        if let Some(number) = serde_json::Number::from_f64(number) {
+            candidates.push(Value::Number(number));
+        }
+    }
+    candidates
+}
+
+fn insert_path(root: &mut Map<String, Value>, path: &[String], value: Value) -> bool {
+    let mut current = root;
+    for part in &path[..path.len().saturating_sub(1)] {
+        let entry = current.entry(part.clone()).or_insert_with(|| Value::Object(Map::new()));
+        let Some(object) = entry.as_object_mut() else {
+            return false;
+        };
+        current = object;
+    }
+    if let Some(last) = path.last() {
+        current.insert(last.clone(), value);
+    }
+    true
+}
+
+fn invalid_property(
+    key: impl Into<String>,
+    value_class: impl Into<String>,
+    expected: &'static str,
+) -> BrokerConfigError {
+    BrokerConfigError::InvalidProperty {
+        key: key.into(),
+        value: value_class.into(),
+        expected,
+    }
+}

--- a/rocketmq-broker/src/config/raw.rs
+++ b/rocketmq-broker/src/config/raw.rs
@@ -130,6 +130,10 @@ impl RawBrokerConfig {
         Ok(raw)
     }
 
+    pub(crate) fn from_serde_value(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        serde_json::from_value(value)
+    }
+
     #[must_use]
     pub fn from_parts(broker: BrokerConfig, store: MessageStoreConfig) -> Self {
         Self {

--- a/rocketmq-broker/tests/fixtures/config/java-broker.conf
+++ b/rocketmq-broker/tests/fixtures/config/java-broker.conf
@@ -1,0 +1,9 @@
+# Java 5.5-style flat broker properties
+brokerName=broker-a
+brokerClusterName=DefaultCluster
+brokerId=0
+listenPort=11911
+namesrvAddr=127.0.0.1:9876
+storeType=DeFaUlT
+maxMessageSize=0
+enablePropertyFilter=false

--- a/rocketmq-broker/tests/fixtures/config/java-rocksdb.conf
+++ b/rocketmq-broker/tests/fixtures/config/java-rocksdb.conf
@@ -1,0 +1,5 @@
+brokerName=rocksdb-broker
+storeType=defaultRocksDB
+storePathRootDir=target/java-rocksdb-store
+brokerRole=ASYNC_MASTER
+flushDiskType=ASYNC_FLUSH

--- a/rocketmq-broker/tests/java_config_conversion.rs
+++ b/rocketmq-broker/tests/java_config_conversion.rs
@@ -1,0 +1,98 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_broker::config::java_properties::JavaBrokerProperties;
+use rocketmq_store::StoreType;
+
+#[test]
+fn converts_java_broker_and_store_properties_atomically() {
+    let input = include_str!("fixtures/config/java-broker.conf");
+    let conversion = JavaBrokerProperties::parse(input).expect("Java properties should convert");
+
+    assert_eq!(conversion.config().broker().broker_identity.broker_name, "broker-a");
+    assert_eq!(conversion.config().broker().listen_port, 11911);
+    assert_eq!(conversion.config().store().store_type, StoreType::LocalFile);
+    assert_eq!(conversion.config().store().max_message_size, 0);
+    assert!(!conversion.config().broker().enable_property_filter);
+    assert_eq!(
+        conversion.entries().len(),
+        input.lines().filter(|line| line.contains('=')).count()
+    );
+    assert!(conversion.entries().iter().all(|entry| entry.status().is_mapped()));
+}
+
+#[test]
+fn java_store_type_alias_is_ascii_case_insensitive_but_canonical() {
+    for alias in ["default", "DEFAULT", "DeFaUlT"] {
+        let conversion =
+            JavaBrokerProperties::parse(&format!("storeType={alias}")).expect("default alias should convert");
+        assert_eq!(conversion.config().store().store_type, StoreType::LocalFile);
+    }
+    for alias in ["defaultRocksDB", "DEFAULTROCKSDB", "DefaultRocksDb"] {
+        let conversion =
+            JavaBrokerProperties::parse(&format!("storeType={alias}")).expect("defaultRocksDB alias should convert");
+        assert_eq!(conversion.config().store().store_type, StoreType::RocksDB);
+    }
+    assert!(JavaBrokerProperties::parse("storeType=rocksdb").is_err());
+}
+
+#[test]
+fn accepts_java_properties_whitespace_separator() {
+    let conversion = JavaBrokerProperties::parse("brokerName broker-from-java\nlistenPort : 10919")
+        .expect("Java whitespace and colon separators should convert");
+
+    assert_eq!(
+        conversion.config().broker().broker_identity.broker_name,
+        "broker-from-java"
+    );
+    assert_eq!(conversion.config().broker().listen_port, 10919);
+}
+
+#[test]
+fn converts_java_rocksdb_role_and_flush_fixture() {
+    let conversion = JavaBrokerProperties::parse(include_str!("fixtures/config/java-rocksdb.conf"))
+        .expect("Java RocksDB properties should convert");
+
+    assert_eq!(conversion.config().store().store_type, StoreType::RocksDB);
+    assert_eq!(
+        conversion.config().store().broker_role,
+        rocketmq_model::common::broker::broker_role::BrokerRole::AsyncMaster
+    );
+    assert_eq!(
+        conversion.config().store().flush_disk_type,
+        rocketmq_store::FlushDiskType::AsyncFlush
+    );
+}
+
+#[test]
+fn duplicate_unknown_and_dledger_properties_fail_closed() {
+    assert!(JavaBrokerProperties::parse("listenPort=10911\nlistenPort=10912").is_err());
+    assert!(JavaBrokerProperties::parse("notARealRocketMqProperty=true").is_err());
+    let error =
+        JavaBrokerProperties::parse("enableDLedgerCommitLog=true").expect_err("DLedger configuration must be rejected");
+    assert!(error.to_string().contains("enableDLedgerCommitLog"), "{error}");
+    assert!(error.to_string().contains("DLedger"), "{error}");
+}
+
+#[test]
+fn conversion_report_redacts_sensitive_values_and_preserves_empty_strings() {
+    let conversion = JavaBrokerProperties::parse("authConfigPath=\naclFile=/secret/plain_acl.yml")
+        .expect("auth paths should map to broker configuration");
+    assert!(conversion.config().broker().auth_config_path.is_empty());
+
+    let report = conversion.report_json().expect("conversion report should serialize");
+    assert!(!report.contains("/secret/plain_acl.yml"));
+    assert!(report.contains("configured"));
+    assert!(conversion.warnings().iter().any(|warning| warning.key() == "aclFile"));
+}

--- a/rocketmq-doc/en/migration/java-55-config-to-rust.md
+++ b/rocketmq-doc/en/migration/java-55-config-to-rust.md
@@ -1,0 +1,31 @@
+# Convert a Java 5.5 broker configuration
+
+RocketMQ Rust keeps TOML as its canonical, strict configuration format. A Java
+5.5 flat `.conf` or `.properties` file can be converted at the Broker startup
+boundary without making canonical TOML accept Java aliases.
+
+```text
+rocketmq-broker-rust \
+  --configFile conf/broker.conf \
+  --config-format properties \
+  --conversion-report target/broker-config-conversion.json
+```
+
+The explicit format wins. Without it, `.toml` selects canonical TOML and
+`.conf`/`.properties` selects Java properties; other extensions fail closed.
+
+The converter validates the complete input once and returns one atomic result:
+the canonical Broker/Store configuration, the per-key conversion entries, and
+warnings. Broker startup writes the redacted report before consuming the
+configuration. A parse, validation, or report-write failure prevents listener
+startup.
+
+Java `storeType=default` and `storeType=defaultRocksDB` are accepted with ASCII
+case-insensitive comparison and normalize to `LocalFile` and `RocksDB`.
+Canonical TOML accepts only those canonical spellings. Duplicate keys, unknown
+keys, conflicting aliases, unsupported values, and all DLedger CommitLog keys
+are rejected.
+
+Authentication and ACL path values map to the canonical `[broker]` fields. The
+report records that referenced files must be copied or mounted separately; it
+does not embed file contents or reveal sensitive values.

--- a/rocketmq-store/src/base/store_enum.rs
+++ b/rocketmq-store/src/base/store_enum.rs
@@ -33,6 +33,18 @@ impl StoreType {
             StoreType::RocksDB => "RocksDB",
         }
     }
+
+    /// Converts the Java 5.5 `storeType` aliases without weakening canonical
+    /// Rust configuration deserialization.
+    pub fn from_java_alias(value: &str) -> Option<Self> {
+        if value.eq_ignore_ascii_case("default") {
+            Some(Self::LocalFile)
+        } else if value.eq_ignore_ascii_case("defaultRocksDB") {
+            Some(Self::RocksDB)
+        } else {
+            None
+        }
+    }
 }
 
 impl Serialize for StoreType {
@@ -59,7 +71,7 @@ impl<'de> Deserialize<'de> for StoreType {
             type Value = StoreType;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("a string representing TopicFilterType")
+                formatter.write_str("`LocalFile` or `RocksDB`")
             }
 
             fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
@@ -69,7 +81,7 @@ impl<'de> Deserialize<'de> for StoreType {
                 match value {
                     "LocalFile" => Ok(StoreType::LocalFile),
                     "RocksDB" => Ok(StoreType::RocksDB),
-                    _ => Err(serde::de::Error::unknown_variant(value, &["SingleTag", "MultiTag"])),
+                    _ => Err(serde::de::Error::unknown_variant(value, &["LocalFile", "RocksDB"])),
                 }
             }
         }
@@ -109,8 +121,18 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "unknown variant `Unknown`, expected `SingleTag` or `MultiTag`")]
-    fn deserialize_panics_on_unknown_variant() {
-        let _: StoreType = serde_json::from_value(json!("Unknown")).unwrap();
+    fn deserialize_rejects_unknown_variant() {
+        let error = serde_json::from_value::<StoreType>(json!("Unknown"))
+            .expect_err("unknown canonical store type should fail");
+        assert!(error.to_string().contains("LocalFile"));
+        assert!(error.to_string().contains("RocksDB"));
+    }
+
+    #[test]
+    fn java_aliases_are_isolated_from_canonical_deserialization() {
+        assert_eq!(StoreType::from_java_alias("DeFaUlT"), Some(StoreType::LocalFile));
+        assert_eq!(StoreType::from_java_alias("DEFAULTROCKSDB"), Some(StoreType::RocksDB));
+        assert_eq!(StoreType::from_java_alias("rocksdb"), None);
+        assert!(serde_json::from_value::<StoreType>(json!("default")).is_err());
     }
 }


### PR DESCRIPTION
## Summary

- add a fail-closed Java 5.5 broker `.conf`/properties converter with deterministic Rust TOML output
- map Java `storeType` aliases case-insensitively and report converted, ignored, external-action, and rejected keys without exposing secrets
- add Broker CLI conversion flags, migration fixtures, focused tests, and an operator migration guide

## Validation

- Java converter tests: 6 passed
- Broker config contract: 20 passed
- Broker CLI tests: 9 passed
- `cargo clippy -p rocketmq-store --all-targets --all-features -- -D warnings`
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings`
- fuzz dependency graph compiled with the fixed nightly after an offline lock refresh; the checked-in standalone lock remains unchanged
- focused rustfmt and `git diff --check`

Closes #9472

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Broker startup now supports TOML and Java `.conf`/`.properties` configuration files.
  * Select the format explicitly or let it be detected from the file extension.
  * Generate a JSON conversion report at a specified or default location.
  * Java configuration supports common property separators, aliases, and RocksDB settings.

* **Bug Fixes**
  * Improved validation for duplicate, unsupported, and ambiguous configuration options.
  * Sensitive values are redacted in conversion reports.

* **Documentation**
  * Added migration guidance for converting Java 5.5 broker configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->