### PR TITLE
[ISSUE #9473]✨Add POP retry topic migration policy

### DIFF
--- a/rocketmq-broker/Cargo.toml
+++ b/rocketmq-broker/Cargo.toml
@@ -198,3 +198,7 @@ required-features = ["rocksdb_store", "test-support"]
 [[test]]
 name = "pop_profile_runtime_flow"
 required-features = ["rocksdb_store", "test-support"]
+
+[[test]]
+name = "pop_retry_version_migration"
+required-features = ["rocksdb_store", "test-support"]

--- a/rocketmq-broker/src/broker_runtime/composition.rs
+++ b/rocketmq-broker/src/broker_runtime/composition.rs
@@ -175,6 +175,10 @@ impl<MS: BrokerStorePort> BrokerRuntimeState<MS> {
 }
 
 impl<MS: BrokerStorePort> BrokerRuntimeState<MS> {
+    pub(crate) fn pop_policy_state(&self) -> PopPolicyState {
+        self.pop_policy_state.clone()
+    }
+
     pub(super) fn build_pull_message_context(&self) -> Arc<PullMessageProcessorContext<MS>> {
         let escape_bridge = self.escape_bridge();
         Arc::new(

--- a/rocketmq-broker/src/broker_runtime/request_pipeline.rs
+++ b/rocketmq-broker/src/broker_runtime/request_pipeline.rs
@@ -257,6 +257,7 @@ impl BrokerRuntime {
         let notification_processor = NotificationProcessor::new(
             NotificationProcessorContext::new(
                 NotificationPolicy::from_config(&self.composition.state.broker_config()),
+                self.composition.state.pop_policy_state(),
                 notification_topic_config_manager,
                 notification_subscription_group_lookup,
                 notification_consumer_filter_manager,
@@ -415,6 +416,7 @@ impl BrokerRuntime {
         let peek_message_processor = Arc::new(PeekMessageProcessor::new(
             PeekMessageProcessorContext::new(
                 PeekMessagePolicy::from_config(&self.composition.state.broker_config()),
+                self.composition.state.pop_policy_state(),
                 self.composition.state.topic_config_manager_handle(),
                 self.composition.state.subscription_group_manager().config_lookup(),
                 consumer_offset_query,

--- a/rocketmq-broker/src/config/broker_config.rs
+++ b/rocketmq-broker/src/config/broker_config.rs
@@ -29,6 +29,7 @@ use rocketmq_model::common::constant::PermName;
 use rocketmq_model::common::message::message_enum::MessageRequestMode;
 use rocketmq_model::common::mix_all;
 use rocketmq_model::common::mix_all::NAMESRV_ADDR_PROPERTY;
+use rocketmq_model::common::pop_retry_policy::PopRetryMigrationState;
 use rocketmq_model::common::topic::TopicValidator;
 use rocketmq_observability::LogExporterType;
 use rocketmq_observability::MetricsExporterType;
@@ -1177,6 +1178,11 @@ pub struct BrokerConfig {
     #[serde(default = "defaults::retrieve_message_from_pop_retry_topic_v1")]
     pub retrieve_message_from_pop_retry_topic_v1: bool,
 
+    /// Explicit per-group POP retry migration target. When omitted, an existing
+    /// persisted group policy remains authoritative across restarts.
+    #[serde(default)]
+    pub pop_retry_migration_state: Option<PopRetryMigrationState>,
+
     #[serde(default = "defaults::pop_from_retry_probability")]
     pub pop_from_retry_probability: i32,
 
@@ -1592,6 +1598,7 @@ impl Default for BrokerConfig {
             enable_pop_log: false,
             enable_retry_topic_v2: false,
             retrieve_message_from_pop_retry_topic_v1: true,
+            pop_retry_migration_state: None,
             pop_from_retry_probability: 20,
             pop_from_retry_probability_for_priority: 0,
             priority_order_asc: true,

--- a/rocketmq-broker/src/lib.rs
+++ b/rocketmq-broker/src/lib.rs
@@ -43,6 +43,10 @@ pub mod test_support {
 
     use cheetah_string::CheetahString;
     use rocketmq_model::common::lite::to_lmq_name;
+    #[cfg(feature = "rocksdb_store")]
+    use rocketmq_model::common::pop_retry_policy::PopRetryPolicy;
+    #[cfg(feature = "rocksdb_store")]
+    use rocketmq_model::common::pop_retry_policy::PopRetryTopicVersion;
     use rocketmq_runtime::common::time_utils::current_millis;
 
     use crate::lite::memory_consumer_order_info_manager::LiteOrderVisibilityUpdate;
@@ -72,6 +76,7 @@ pub mod test_support {
         pub group: String,
         pub topics: Vec<String>,
         pub retry_version: i32,
+        pub retry_policy: PopRetryPolicy,
         pub generation: u64,
         pub last_seen: i64,
     }
@@ -112,6 +117,21 @@ pub mod test_support {
             retry_version: i32,
             last_seen: i64,
         ) -> Result<PopProfileSnapshotProbe, String> {
+            let retry_policy = match PopRetryTopicVersion::from_number(retry_version) {
+                Some(PopRetryTopicVersion::V1) => PopRetryPolicy::v1_only(0),
+                Some(PopRetryTopicVersion::V2) => PopRetryPolicy::dual_read_v2_write(0),
+                None => return Err("retry version must be 1 or 2".to_owned()),
+            };
+            self.upsert_policy(group, topics, retry_policy, last_seen)
+        }
+
+        pub fn upsert_policy(
+            &self,
+            group: &str,
+            topics: &[&str],
+            retry_policy: PopRetryPolicy,
+            last_seen: i64,
+        ) -> Result<PopProfileSnapshotProbe, String> {
             let subscriptions = topics
                 .iter()
                 .map(
@@ -123,12 +143,7 @@ pub mod test_support {
                 )
                 .collect();
             self.store
-                .upsert(
-                    CheetahString::from_slice(group),
-                    subscriptions,
-                    retry_version,
-                    last_seen,
-                )
+                .upsert(CheetahString::from_slice(group), subscriptions, retry_policy, last_seen)
                 .map(profile_probe)
                 .map_err(|error| error.to_string())
         }
@@ -179,6 +194,9 @@ pub mod test_support {
 
     #[cfg(feature = "rocksdb_store")]
     fn profile_probe(profile: crate::pop::profile_store::PopConsumerProfile) -> PopProfileSnapshotProbe {
+        let retry_policy = profile
+            .retry_policy
+            .expect("validated profile snapshots always contain a retry policy");
         PopProfileSnapshotProbe {
             group: profile.group.to_string(),
             topics: profile
@@ -187,6 +205,7 @@ pub mod test_support {
                 .map(|subscription| subscription.topic.to_string())
                 .collect(),
             retry_version: profile.retry_version,
+            retry_policy,
             generation: profile.generation,
             last_seen: profile.last_seen,
         }

--- a/rocketmq-broker/src/pop/profile_store.rs
+++ b/rocketmq-broker/src/pop/profile_store.rs
@@ -18,6 +18,8 @@ use std::sync::Arc;
 use cheetah_string::CheetahString;
 use parking_lot::Mutex;
 use rocketmq_error::RocketMQError;
+use rocketmq_model::common::pop_retry_policy::PopRetryPolicy;
+use rocketmq_model::common::pop_retry_policy::PopRetryTopicVersion;
 use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
 use rocketmq_store_rocksdb::profile_marker::pop_consumer_profile_key;
 use rocketmq_store_rocksdb::profile_marker::PopConsumerProfileMarker;
@@ -34,6 +36,8 @@ pub(crate) struct PopConsumerProfile {
     pub(crate) group: CheetahString,
     pub(crate) subscriptions: Vec<SubscriptionData>,
     pub(crate) retry_version: i32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) retry_policy: Option<PopRetryPolicy>,
     pub(crate) generation: u64,
     pub(crate) last_seen: i64,
     pub(crate) format_version: u32,
@@ -84,7 +88,8 @@ impl PopConsumerProfileStore {
             let record: StoredProfileRecord = serde_json::from_slice(&value)
                 .map_err(|error| codec_error(format!("profile record JSON is invalid: {error}")))?;
             match record {
-                StoredProfileRecord::Profile { profile } => {
+                StoredProfileRecord::Profile { mut profile } => {
+                    normalize_retry_policy(&mut profile)?;
                     validate_profile(&profile)?;
                     if profile.generation > generation {
                         return Err(codec_error("profile generation is newer than the format marker"));
@@ -126,7 +131,7 @@ impl PopConsumerProfileStore {
         &self,
         group: CheetahString,
         mut subscriptions: Vec<SubscriptionData>,
-        retry_version: i32,
+        retry_policy: PopRetryPolicy,
         last_seen: i64,
     ) -> Result<PopConsumerProfile, RocketMQError> {
         if group.is_empty() {
@@ -153,10 +158,12 @@ impl PopConsumerProfileStore {
             .generation
             .checked_add(1)
             .ok_or_else(|| codec_error("POP consumer profile generation overflow"))?;
+        let retry_policy = next_retry_policy(state.profiles.get(&group), retry_policy, generation)?;
         let profile = PopConsumerProfile {
             group: group.clone(),
             subscriptions,
-            retry_version,
+            retry_version: retry_policy.write_version.number(),
+            retry_policy: Some(retry_policy),
             generation,
             last_seen,
             format_version: POP_CONSUMER_PROFILE_FORMAT_VERSION,
@@ -205,6 +212,14 @@ impl PopConsumerProfileStore {
     pub(crate) fn generation(&self) -> u64 {
         self.state.lock().generation
     }
+
+    pub(crate) fn retry_policy(&self, group: &CheetahString) -> Option<PopRetryPolicy> {
+        self.state
+            .lock()
+            .profiles
+            .get(group)
+            .and_then(|profile| profile.retry_policy.clone())
+    }
 }
 
 fn validate_profile(profile: &PopConsumerProfile) -> Result<(), RocketMQError> {
@@ -228,7 +243,67 @@ fn validate_profile(profile: &PopConsumerProfile) -> Result<(), RocketMQError> {
             "persisted subscription topic must not be empty",
         ));
     }
+    let retry_policy = profile
+        .retry_policy
+        .as_ref()
+        .ok_or_else(|| codec_error("persisted POP profile is missing retry policy"))?;
+    retry_policy
+        .state()
+        .map_err(|error| codec_error(format!("invalid persisted POP retry policy: {error}")))?;
+    if retry_policy.generation != profile.generation || retry_policy.write_version.number() != profile.retry_version {
+        return Err(codec_error(
+            "persisted POP retry policy generation/version does not match the profile",
+        ));
+    }
     Ok(())
+}
+
+fn normalize_retry_policy(profile: &mut PopConsumerProfile) -> Result<(), RocketMQError> {
+    if profile.retry_policy.is_none() {
+        profile.retry_policy = Some(match PopRetryTopicVersion::from_number(profile.retry_version) {
+            Some(PopRetryTopicVersion::V1) => PopRetryPolicy::v1_only(profile.generation),
+            Some(PopRetryTopicVersion::V2) => PopRetryPolicy::dual_read_v2_write(profile.generation),
+            None => {
+                return Err(invalid_profile(
+                    "retryVersion",
+                    profile.retry_version.to_string(),
+                    "retry version must be 1 or 2",
+                ));
+            }
+        });
+    }
+    Ok(())
+}
+
+fn next_retry_policy(
+    existing: Option<&PopConsumerProfile>,
+    requested: PopRetryPolicy,
+    generation: u64,
+) -> Result<PopRetryPolicy, RocketMQError> {
+    let requested_state = requested.state().map_err(|error| {
+        invalid_profile(
+            "retryPolicy",
+            error.to_string(),
+            "a supported POP retry migration state",
+        )
+    })?;
+    let Some(existing) = existing else {
+        return Ok(PopRetryPolicy::for_state(requested_state, generation));
+    };
+    let current = existing
+        .retry_policy
+        .as_ref()
+        .ok_or_else(|| codec_error("existing POP profile is missing retry policy"))?;
+    if current.state().map_err(|error| codec_error(error.to_string()))? == requested_state {
+        return Ok(PopRetryPolicy::for_state(requested_state, generation));
+    }
+    current.transition_to(requested_state, generation).map_err(|error| {
+        invalid_profile(
+            "retryPolicy",
+            error.to_string(),
+            "the next safe POP retry migration state",
+        )
+    })
 }
 
 fn validate_format_version(format_version: u32) -> Result<(), RocketMQError> {

--- a/rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/topic_request_handler.rs
@@ -603,7 +603,7 @@ impl TopicRequestHandler {
             .which_group_by_topic(topic);
         for group in groups.iter() {
             let pop_retry_topic_v2 =
-                CheetahString::from_string(KeyBuilder::build_pop_retry_topic(topic, group.as_str(), true));
+                CheetahString::from_string(KeyBuilder::build_pop_retry_topic_v2(topic, group.as_str()));
             if broker_runtime_inner
                 .topic_config_manager()
                 .select_topic_config(pop_retry_topic_v2.as_ref())
@@ -722,7 +722,7 @@ impl TopicRequestHandler {
                 .which_group_by_topic(topic)
             {
                 for retry_topic in [
-                    CheetahString::from_string(KeyBuilder::build_pop_retry_topic(topic, group.as_str(), true)),
+                    CheetahString::from_string(KeyBuilder::build_pop_retry_topic_v2(topic, group.as_str())),
                     CheetahString::from_string(KeyBuilder::build_pop_retry_topic_v1(topic, group.as_str())),
                 ] {
                     if broker_runtime_inner

--- a/rocketmq-broker/src/processor/notification_processor.rs
+++ b/rocketmq-broker/src/processor/notification_processor.rs
@@ -24,7 +24,6 @@ use rocketmq_model::common::constant::PermName;
 use rocketmq_model::common::filter::expression_type::ExpressionType;
 #[cfg(any(test, feature = "test-support"))]
 use rocketmq_model::common::hasher::string_hasher::JavaStringHasher;
-use rocketmq_model::common::key_builder::KeyBuilder;
 use rocketmq_model::common::FAQUrl;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::filter::filter_api::FilterAPI;
@@ -55,6 +54,7 @@ use crate::long_polling::polling_header::PollingHeader;
 use crate::long_polling::polling_result::PollingResult;
 use crate::offset::manager::consumer_offset_manager::ConsumerOffsetQueryCapability;
 use crate::offset::manager::consumer_order_info_manager::ConsumerOrderInfoManager;
+use crate::processor::pop_message_processor::capability::PopPolicyState;
 use crate::processor::processor_service::pop_buffer_merge_service::PopBufferMergeService;
 use crate::subscription::manager::subscription_group_manager::SubscriptionGroupConfigLookup;
 use crate::topic::manager::topic_config_manager::TopicConfigManager;
@@ -63,8 +63,6 @@ use crate::topic::manager::topic_config_manager::TopicConfigManager;
 pub(crate) struct NotificationPolicy {
     broker_permission: u32,
     broker_ip1: CheetahString,
-    enable_retry_topic_v2: bool,
-    retrieve_message_from_pop_retry_topic_v1: bool,
     use_message_filter_for_notification: bool,
     max_message_filter_num_for_notification: i32,
 }
@@ -74,8 +72,6 @@ impl NotificationPolicy {
         Self {
             broker_permission: broker_config.broker_permission,
             broker_ip1: broker_config.broker_ip1().clone(),
-            enable_retry_topic_v2: broker_config.enable_retry_topic_v2,
-            retrieve_message_from_pop_retry_topic_v1: broker_config.retrieve_message_from_pop_retry_topic_v1,
             use_message_filter_for_notification: broker_config.use_message_filter_for_notification,
             max_message_filter_num_for_notification: broker_config.max_message_filter_num_for_notification,
         }
@@ -300,6 +296,7 @@ impl<MS: BrokerReadWriteStore> NotificationPopOffsetCapability<MS> {
 pub(crate) struct NotificationProcessorContext<MS: BrokerReadWriteStore> {
     command_factory: RemotingCommandFactory,
     policy: NotificationPolicy,
+    retry_policies: PopPolicyState,
     topic_config_manager: Arc<TopicConfigManager>,
     subscription_group_lookup: SubscriptionGroupConfigLookup,
     consumer_filter_manager: Arc<ConsumerFilterManager>,
@@ -317,6 +314,7 @@ impl<MS: BrokerReadWriteStore> NotificationProcessorContext<MS> {
     )]
     pub(crate) fn new(
         policy: NotificationPolicy,
+        retry_policies: PopPolicyState,
         topic_config_manager: Arc<TopicConfigManager>,
         subscription_group_lookup: SubscriptionGroupConfigLookup,
         consumer_filter_manager: Arc<ConsumerFilterManager>,
@@ -329,6 +327,7 @@ impl<MS: BrokerReadWriteStore> NotificationProcessorContext<MS> {
         Self {
             command_factory: application_remoting_command_factory(),
             policy,
+            retry_policies,
             topic_config_manager,
             subscription_group_lookup,
             consumer_filter_manager,
@@ -637,29 +636,19 @@ where
         let random_q: i32 = rand::rng().random_range(0..100);
         let mut has_msg = false;
         let need_retry = random_q % 5 == 0;
+        let retry_policy = self.context.retry_policies.retry_policy(&request_header.consumer_group);
 
         if need_retry {
-            let retry_topic = KeyBuilder::build_pop_retry_topic(
-                request_header.topic.as_str(),
-                request_header.consumer_group.as_str(),
-                self.context.policy.enable_retry_topic_v2,
-            )
-            .into();
-            has_msg = self
-                .has_msg_from_topic_name(&retry_topic, random_q, &request_header, None)
-                .await;
-            if !has_msg
-                && self.context.policy.enable_retry_topic_v2
-                && self.context.policy.retrieve_message_from_pop_retry_topic_v1
+            for retry_topic in
+                retry_policy.read_topics(request_header.topic.as_str(), request_header.consumer_group.as_str())
             {
-                let retry_topic_v1 = KeyBuilder::build_pop_retry_topic_v1(
-                    request_header.topic.as_str(),
-                    request_header.consumer_group.as_str(),
-                )
-                .into();
+                let retry_topic = retry_topic.into();
                 has_msg = self
-                    .has_msg_from_topic_name(&retry_topic_v1, random_q, &request_header, None)
+                    .has_msg_from_topic_name(&retry_topic, random_q, &request_header, None)
                     .await;
+                if has_msg {
+                    break;
+                }
             }
         }
         if !has_msg {
@@ -675,27 +664,16 @@ where
             }
             // if it doesn't have message, fetch retry again
             if !need_retry && !has_msg {
-                let retry_topic = KeyBuilder::build_pop_retry_topic(
-                    request_header.topic.as_str(),
-                    request_header.consumer_group.as_str(),
-                    self.context.policy.enable_retry_topic_v2,
-                )
-                .into();
-                has_msg = self
-                    .has_msg_from_topic_name(&retry_topic, random_q, &request_header, None)
-                    .await;
-                if !has_msg
-                    && self.context.policy.enable_retry_topic_v2
-                    && self.context.policy.retrieve_message_from_pop_retry_topic_v1
+                for retry_topic in
+                    retry_policy.read_topics(request_header.topic.as_str(), request_header.consumer_group.as_str())
                 {
-                    let retry_topic_v1 = KeyBuilder::build_pop_retry_topic_v1(
-                        request_header.topic.as_str(),
-                        request_header.consumer_group.as_str(),
-                    )
-                    .into();
+                    let retry_topic = retry_topic.into();
                     has_msg = self
-                        .has_msg_from_topic_name(&retry_topic_v1, random_q, &request_header, None)
+                        .has_msg_from_topic_name(&retry_topic, random_q, &request_header, None)
                         .await;
+                    if has_msg {
+                        break;
+                    }
                 }
             }
         }
@@ -782,6 +760,7 @@ mod tests {
         );
         NotificationProcessor::new(NotificationProcessorContext::new(
             policy,
+            inner.pop_policy_state(),
             topic_config_manager,
             subscription_group_lookup,
             consumer_filter_manager,
@@ -847,8 +826,6 @@ mod tests {
         let broker_config = BrokerConfig {
             broker_permission: 3,
             broker_ip1: CheetahString::from_static_str("192.0.2.11"),
-            enable_retry_topic_v2: true,
-            retrieve_message_from_pop_retry_topic_v1: true,
             use_message_filter_for_notification: false,
             max_message_filter_num_for_notification: 17,
             ..Default::default()
@@ -858,8 +835,6 @@ mod tests {
 
         assert_eq!(policy.broker_permission, 3);
         assert_eq!(policy.broker_ip1, "192.0.2.11");
-        assert!(policy.enable_retry_topic_v2);
-        assert!(policy.retrieve_message_from_pop_retry_topic_v1);
         assert!(!policy.use_message_filter_for_notification);
         assert_eq!(policy.max_message_filter_num_for_notification, 17);
     }

--- a/rocketmq-broker/src/processor/peek_message_processor.rs
+++ b/rocketmq-broker/src/processor/peek_message_processor.rs
@@ -45,6 +45,7 @@ use tracing::warn;
 use crate::failover::escape_bridge::EscapeBridge;
 use crate::failover::escape_bridge::MessageStoreUnavailable;
 use crate::offset::manager::consumer_offset_manager::ConsumerOffsetQueryCapability;
+use crate::processor::pop_message_processor::capability::PopPolicyState;
 use crate::processor::processor_service::pop_buffer_merge_service::PopBufferMergeService;
 use crate::subscription::manager::subscription_group_manager::SubscriptionGroupConfigLookup;
 use crate::topic::manager::topic_config_manager::TopicConfigManager;
@@ -55,7 +56,6 @@ pub(crate) struct PeekMessagePolicy {
     broker_ip1: CheetahString,
     revive_queue_num: u32,
     transfer_msg_by_heap: bool,
-    enable_retry_topic_v2: bool,
 }
 
 impl PeekMessagePolicy {
@@ -65,7 +65,6 @@ impl PeekMessagePolicy {
             broker_ip1: broker_config.broker_ip1().clone(),
             revive_queue_num: broker_config.revive_queue_num,
             transfer_msg_by_heap: broker_config.transfer_msg_by_heap,
-            enable_retry_topic_v2: broker_config.enable_retry_topic_v2,
         }
     }
 }
@@ -141,6 +140,7 @@ impl<MS: BrokerReadWriteStore> PeekPopOffsetCapability<MS> {
 pub(crate) struct PeekMessageProcessorContext<MS: BrokerReadWriteStore> {
     command_factory: RemotingCommandFactory,
     policy: PeekMessagePolicy,
+    retry_policies: PopPolicyState,
     topic_config_manager: Arc<TopicConfigManager>,
     subscription_group_lookup: SubscriptionGroupConfigLookup,
     consumer_offset_query: ConsumerOffsetQueryCapability<MS>,
@@ -156,6 +156,7 @@ impl<MS: BrokerReadWriteStore> PeekMessageProcessorContext<MS> {
     )]
     pub(crate) fn new(
         policy: PeekMessagePolicy,
+        retry_policies: PopPolicyState,
         topic_config_manager: Arc<TopicConfigManager>,
         subscription_group_lookup: SubscriptionGroupConfigLookup,
         consumer_offset_query: ConsumerOffsetQueryCapability<MS>,
@@ -166,6 +167,7 @@ impl<MS: BrokerReadWriteStore> PeekMessageProcessorContext<MS> {
         Self {
             command_factory: application_remoting_command_factory(),
             policy,
+            retry_policies,
             topic_config_manager,
             subscription_group_lookup,
             consumer_offset_query,
@@ -356,7 +358,7 @@ impl<MS: BrokerReadWriteStore> PeekMessageProcessor<MS> {
                 let queue_id = ((random_q + i) % topic_config.read_queue_nums) as i32;
                 rest_num = self
                     .peek_msg_from_queue(
-                        false,
+                        None,
                         &mut get_message_result,
                         &request_header,
                         queue_id,
@@ -370,7 +372,7 @@ impl<MS: BrokerReadWriteStore> PeekMessageProcessor<MS> {
         } else {
             rest_num = self
                 .peek_msg_from_queue(
-                    false,
+                    None,
                     &mut get_message_result,
                     &request_header,
                     request_header.queue_id,
@@ -479,31 +481,32 @@ impl<MS: BrokerReadWriteStore> PeekMessageProcessor<MS> {
         channel: &Channel,
         pop_time: i64,
     ) -> i64 {
-        let retry_topic = CheetahString::from_string(KeyBuilder::build_pop_retry_topic(
-            request_header.topic.as_str(),
-            request_header.consumer_group.as_str(),
-            self.context.policy.enable_retry_topic_v2,
-        ));
-
-        let retry_topic_config = self.context.topic_config_manager.select_topic_config(&retry_topic);
-
         let mut rest_num = 0i64;
 
-        if let Some(retry_config) = retry_topic_config {
-            for i in 0..retry_config.read_queue_nums {
-                let queue_id = ((random_q + i) % retry_config.read_queue_nums) as i32;
-                rest_num = self
-                    .peek_msg_from_queue(
-                        true,
-                        get_message_result,
-                        request_header,
-                        queue_id,
-                        rest_num,
-                        revive_qid,
-                        channel,
-                        pop_time,
-                    )
-                    .await;
+        let retry_policy = self.context.retry_policies.retry_policy(&request_header.consumer_group);
+        for retry_topic in
+            retry_policy.read_topics(request_header.topic.as_str(), request_header.consumer_group.as_str())
+        {
+            let retry_topic = CheetahString::from_string(retry_topic);
+            if let Some(retry_config) = self.context.topic_config_manager.select_topic_config(&retry_topic) {
+                for i in 0..retry_config.read_queue_nums {
+                    let queue_id = ((random_q + i) % retry_config.read_queue_nums) as i32;
+                    rest_num = self
+                        .peek_msg_from_queue(
+                            Some(&retry_topic),
+                            get_message_result,
+                            request_header,
+                            queue_id,
+                            rest_num,
+                            revive_qid,
+                            channel,
+                            pop_time,
+                        )
+                        .await;
+                }
+            }
+            if !get_message_result.message_mapped_list().is_empty() {
+                break;
             }
         }
 
@@ -512,7 +515,7 @@ impl<MS: BrokerReadWriteStore> PeekMessageProcessor<MS> {
 
     async fn peek_msg_from_queue(
         &self,
-        is_retry: bool,
+        retry_topic: Option<&CheetahString>,
         get_message_result: &mut GetMessageResult,
         request_header: &PeekMessageRequestHeader,
         queue_id: i32,
@@ -522,15 +525,7 @@ impl<MS: BrokerReadWriteStore> PeekMessageProcessor<MS> {
         _pop_time: i64,
     ) -> i64 {
         // Determine topic (retry or normal)
-        let topic = if is_retry {
-            CheetahString::from_string(KeyBuilder::build_pop_retry_topic(
-                request_header.topic.as_str(),
-                request_header.consumer_group.as_str(),
-                self.context.policy.enable_retry_topic_v2,
-            ))
-        } else {
-            request_header.topic.clone()
-        };
+        let topic = retry_topic.cloned().unwrap_or_else(|| request_header.topic.clone());
 
         // Get starting offset
         let offset = self
@@ -662,7 +657,6 @@ mod tests {
             broker_ip1: CheetahString::from_static_str("192.0.2.10"),
             revive_queue_num: 12,
             transfer_msg_by_heap: false,
-            enable_retry_topic_v2: true,
             ..Default::default()
         };
 
@@ -672,7 +666,6 @@ mod tests {
         assert_eq!(policy.broker_ip1, "192.0.2.10");
         assert_eq!(policy.revive_queue_num, 12);
         assert!(!policy.transfer_msg_by_heap);
-        assert!(policy.enable_retry_topic_v2);
     }
 
     #[tokio::test]

--- a/rocketmq-broker/src/processor/pop_inflight_message_counter.rs
+++ b/rocketmq-broker/src/processor/pop_inflight_message_counter.rs
@@ -471,6 +471,8 @@ mod tests {
             bit_map: 0,
             num: 0,
             re_put_times: None,
+            retry_topic_version: None,
+            retry_policy_generation: None,
         };
 
         counter.decrement_in_flight_message_num_checkpoint(&old_checkpoint);
@@ -566,6 +568,8 @@ mod tests {
             bit_map: 0,
             num: 0,
             re_put_times: None,
+            retry_topic_version: None,
+            retry_policy_generation: None,
         };
 
         counter.increment_in_flight_message_num(&topic, &group, 1, 5);

--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -42,6 +42,7 @@ use rocketmq_model::common::message::MessageConst;
 use rocketmq_model::common::message::MessageTrait;
 use rocketmq_model::common::mix_all;
 use rocketmq_model::common::pop_ack_constants::PopAckConstants;
+use rocketmq_model::common::pop_retry_policy::PopRetryPolicy;
 use rocketmq_model::common::FAQUrl;
 use rocketmq_model::topic::TopicMessageType;
 use rocketmq_protocol::code::request_code::RequestCode;
@@ -134,6 +135,9 @@ impl<MS: BrokerReadWriteStore> PopMessageProcessor<MS> {
         #[cfg(feature = "rocksdb_store")]
         if let Some(store) = &profile_store {
             for profile in store.snapshot() {
+                if let Some(retry_policy) = profile.retry_policy.clone() {
+                    context.policy.restore_retry_policy(profile.group.clone(), retry_policy);
+                }
                 context
                     .consumers
                     .restore_pop_consumer_profile(&profile.group, &profile.subscriptions);
@@ -172,6 +176,10 @@ impl<MS: BrokerReadWriteStore> PopMessageProcessor<MS> {
         }))
     }
 
+    fn retry_policy_for_group(&self, group: &CheetahString) -> PopRetryPolicy {
+        self.context.policy.retry_policy(group)
+    }
+
     pub async fn start(&self) {
         let _lifecycle = self.lifecycle.lock().await;
         PopLongPollingService::start(&self.pop_long_polling_service).await;
@@ -193,9 +201,11 @@ impl<MS: BrokerReadWriteStore> PopMessageProcessor<MS> {
                 .await
                 .map_err(crate::runtime_to_rocketmq_error)??;
             self.context.consumers.remove_compensated_consumer_profile(&group);
+            self.context.policy.remove_retry_policy(&group);
             return Ok(removed);
         }
         self.context.consumers.remove_compensated_consumer_profile(&group);
+        self.context.policy.remove_retry_policy(&group);
         Ok(false)
     }
 
@@ -314,6 +324,7 @@ where
         let opaque = request.opaque();
         let request_header = request.decode_command_custom_header::<PopMessageRequestHeader>()?;
         let policy = self.context.policy.snapshot();
+        let retry_policy = self.retry_policy_for_group(&request_header.consumer_group);
 
         if request_header.is_timeout_too_much_at(rocketmq_runtime::common::time_utils::current_millis() as i64) {
             return Ok(Some(
@@ -441,11 +452,9 @@ where
                     ));
                 }
             };
-            let retry_topic = CheetahString::from_string(KeyBuilder::build_pop_retry_topic(
-                &request_header.topic,
-                &request_header.consumer_group,
-                policy.enable_retry_topic_v2,
-            ));
+            let retry_topic = CheetahString::from_string(
+                retry_policy.write_topic(&request_header.topic, &request_header.consumer_group),
+            );
             let retry_subscription_data = match FilterAPI::build(
                 &retry_topic,
                 &CheetahString::from_static_str(SubscriptionData::SUB_ALL),
@@ -512,11 +521,9 @@ where
                     ));
                 }
             };
-            let retry_topic = CheetahString::from_string(KeyBuilder::build_pop_retry_topic(
-                &request_header.topic,
-                &request_header.consumer_group,
-                policy.enable_retry_topic_v2,
-            ));
+            let retry_topic = CheetahString::from_string(
+                retry_policy.write_topic(&request_header.topic, &request_header.consumer_group),
+            );
             let retry_subscription_data = match FilterAPI::build(
                 &retry_topic,
                 &CheetahString::from_static_str(SubscriptionData::SUB_ALL),
@@ -535,35 +542,67 @@ where
             (subscription_data, retry_subscription_data, None)
         };
 
-        let durable_subscriptions = vec![subscription_data.clone(), retry_subscription_data];
+        let mut durable_subscriptions = vec![subscription_data.clone(), retry_subscription_data];
+        for retry_topic in retry_policy.read_topics(&request_header.topic, &request_header.consumer_group) {
+            if durable_subscriptions
+                .iter()
+                .any(|subscription| subscription.topic.as_str() == retry_topic)
+            {
+                continue;
+            }
+            let fallback_subscription = FilterAPI::build(
+                &CheetahString::from_string(retry_topic),
+                &CheetahString::from_static_str(SubscriptionData::SUB_ALL),
+                request_header.exp_type.clone(),
+            )
+            .map_err(|error| rocketmq_error::RocketMQError::illegal_argument(error.to_string()))?;
+            durable_subscriptions.push(fallback_subscription);
+        }
         #[cfg(feature = "rocksdb_store")]
-        if let Some(profile_store) = &self.profile_store {
+        let retry_policy = if let Some(profile_store) = &self.profile_store {
             let profile_store = Arc::clone(profile_store);
             let group = request_header.consumer_group.clone();
             let subscriptions = durable_subscriptions.clone();
-            let retry_version = if policy.enable_retry_topic_v2 { 2 } else { 1 };
+            let requested_retry_policy = retry_policy.clone();
             let persist_result = self
                 .context
                 .metadata_io
                 .spawn_io("broker.pop-consumer-profile.upsert", move || {
-                    profile_store.upsert(group, subscriptions, retry_version, current_millis() as i64)
+                    profile_store.upsert(group, subscriptions, requested_retry_policy, current_millis() as i64)
                 })
                 .await;
-            let persist_error = match persist_result {
-                Ok(Ok(_)) => None,
-                Ok(Err(error)) => Some(error.to_string()),
-                Err(error) => Some(error.to_string()),
-            };
-            if let Some(error) = persist_error {
-                error!(%error, group = %request_header.consumer_group, "Failed to persist POP consumer profile");
-                return Ok(Some(
-                    self.context.command_factory.create_response_command_with_code_remark(
-                        ResponseCode::ServiceNotAvailable,
-                        "POP consumer profile persistence is unavailable",
-                    ),
-                ));
+            match persist_result {
+                Ok(Ok(profile)) => {
+                    let persisted_policy = profile
+                        .retry_policy
+                        .unwrap_or_else(|| policy.default_retry_policy.clone());
+                    self.context
+                        .policy
+                        .restore_retry_policy(request_header.consumer_group.clone(), persisted_policy.clone());
+                    persisted_policy
+                }
+                Ok(Err(error)) => {
+                    error!(%error, group = %request_header.consumer_group, "Failed to persist POP consumer profile");
+                    return Ok(Some(
+                        self.context.command_factory.create_response_command_with_code_remark(
+                            ResponseCode::ServiceNotAvailable,
+                            "POP consumer profile persistence is unavailable",
+                        ),
+                    ));
+                }
+                Err(error) => {
+                    error!(%error, group = %request_header.consumer_group, "Failed to persist POP consumer profile");
+                    return Ok(Some(
+                        self.context.command_factory.create_response_command_with_code_remark(
+                            ResponseCode::ServiceNotAvailable,
+                            "POP consumer profile persistence is unavailable",
+                        ),
+                    ));
+                }
             }
-        }
+        } else {
+            retry_policy
+        };
         self.context
             .consumers
             .restore_pop_consumer_profile(&request_header.consumer_group, &durable_subscriptions);
@@ -596,10 +635,6 @@ where
         };
         let need_retry = random_sample < retry_probability;
         let randomq = if use_priority_mode { 0 } else { random_sample };
-        let mut need_retry_v1 = false;
-        if policy.enable_retry_topic_v2 && policy.retrieve_message_from_pop_retry_topic_v1 {
-            need_retry_v1 = random_sample % 2 == 0;
-        }
         let mut start_offset_info = String::with_capacity(64);
         let mut msg_offset_info = String::with_capacity(64);
         let mut order_count_info = if request_header.order.is_some() {
@@ -611,53 +646,30 @@ where
 
         let mut rest_num = 0; // remaining number of messages to be fetched
         if need_retry && !request_header.order.unwrap_or(false) {
-            rest_num = if need_retry_v1 {
-                let retry_topic = CheetahString::from_string(KeyBuilder::build_pop_retry_topic_v1(
-                    &request_header.topic,
-                    &request_header.consumer_group,
-                ));
-
-                self.pop_msg_from_topic_by_name(
-                    &retry_topic,
-                    true,
-                    &mut get_message_result,
-                    &request_header,
-                    revive_qid,
-                    channel.clone(),
-                    pop_time,
-                    message_filter.clone(),
-                    &mut start_offset_info,
-                    &mut msg_offset_info,
-                    &mut order_count_info,
-                    randomq,
-                    use_priority_mode.then_some(policy.priority_order_asc),
-                    rest_num,
-                )
-                .await
-            } else {
-                let retry_topic = CheetahString::from_string(KeyBuilder::build_pop_retry_topic(
-                    &request_header.topic,
-                    &request_header.consumer_group,
-                    policy.enable_retry_topic_v2,
-                ));
-                self.pop_msg_from_topic_by_name(
-                    &retry_topic,
-                    true,
-                    &mut get_message_result,
-                    &request_header,
-                    revive_qid,
-                    channel.clone(),
-                    pop_time,
-                    message_filter.clone(),
-                    &mut start_offset_info,
-                    &mut msg_offset_info,
-                    &mut order_count_info,
-                    randomq,
-                    use_priority_mode.then_some(policy.priority_order_asc),
-                    rest_num,
-                )
-                .await
-            };
+            for retry_topic in retry_policy.read_topics(&request_header.topic, &request_header.consumer_group) {
+                let retry_topic = CheetahString::from_string(retry_topic);
+                rest_num = self
+                    .pop_msg_from_topic_by_name(
+                        &retry_topic,
+                        true,
+                        &mut get_message_result,
+                        &request_header,
+                        revive_qid,
+                        channel.clone(),
+                        pop_time,
+                        message_filter.clone(),
+                        &mut start_offset_info,
+                        &mut msg_offset_info,
+                        &mut order_count_info,
+                        randomq,
+                        use_priority_mode.then_some(policy.priority_order_asc),
+                        rest_num,
+                    )
+                    .await;
+                if !get_message_result.message_mapped_list().is_empty() {
+                    break;
+                }
+            }
         }
         //request_header.queue_id < 0 means read all queue
         rest_num = if request_header.queue_id < 0 {
@@ -703,53 +715,30 @@ where
             && get_message_result.message_mapped_list().len() < request_header.max_msg_nums as usize
             && !request_header.order.unwrap_or(false)
         {
-            rest_num = if need_retry_v1 {
-                let retry_topic = CheetahString::from_string(KeyBuilder::build_pop_retry_topic_v1(
-                    &request_header.topic,
-                    &request_header.consumer_group,
-                ));
-
-                self.pop_msg_from_topic_by_name(
-                    &retry_topic,
-                    true,
-                    &mut get_message_result,
-                    &request_header,
-                    revive_qid,
-                    channel.clone(),
-                    pop_time,
-                    message_filter.clone(),
-                    &mut start_offset_info,
-                    &mut msg_offset_info,
-                    &mut order_count_info,
-                    randomq,
-                    use_priority_mode.then_some(policy.priority_order_asc),
-                    rest_num,
-                )
-                .await
-            } else {
-                let retry_topic = CheetahString::from_string(KeyBuilder::build_pop_retry_topic(
-                    &request_header.topic,
-                    &request_header.consumer_group,
-                    policy.enable_retry_topic_v2,
-                ));
-                self.pop_msg_from_topic_by_name(
-                    &retry_topic,
-                    true,
-                    &mut get_message_result,
-                    &request_header,
-                    revive_qid,
-                    channel.clone(),
-                    pop_time,
-                    message_filter.clone(),
-                    &mut start_offset_info,
-                    &mut msg_offset_info,
-                    &mut order_count_info,
-                    randomq,
-                    use_priority_mode.then_some(policy.priority_order_asc),
-                    rest_num,
-                )
-                .await
-            };
+            for retry_topic in retry_policy.read_topics(&request_header.topic, &request_header.consumer_group) {
+                let retry_topic = CheetahString::from_string(retry_topic);
+                rest_num = self
+                    .pop_msg_from_topic_by_name(
+                        &retry_topic,
+                        true,
+                        &mut get_message_result,
+                        &request_header,
+                        revive_qid,
+                        channel.clone(),
+                        pop_time,
+                        message_filter.clone(),
+                        &mut start_offset_info,
+                        &mut msg_offset_info,
+                        &mut order_count_info,
+                        randomq,
+                        use_priority_mode.then_some(policy.priority_order_asc),
+                        rest_num,
+                    )
+                    .await;
+                if !get_message_result.message_mapped_list().is_empty() {
+                    break;
+                }
+            }
         }
         let mut final_response = self.context.command_factory.create_success_response_command();
         final_response.set_opaque_mut(opaque);
@@ -966,6 +955,7 @@ where
         order_count_info: &mut String,
     ) -> i64 {
         let policy = self.context.policy.snapshot();
+        let retry_policy = self.retry_policy_for_group(&request_header.consumer_group);
         let lock_key = CheetahString::from_string(QueueLockManager::build_lock_key(
             topic,
             &request_header.consumer_group,
@@ -1259,7 +1249,7 @@ where
                         let message_ext_list = MessageDecoder::decodes_batch(&mut bytes, true, false);
                         //maped_buffer.release();
                         for mut message_ext in message_ext_list {
-                            let ck_info = ExtraInfoUtil::build_extra_info_with_offset(
+                            let ck_info = ExtraInfoUtil::build_extra_info_with_offset_and_retry_policy(
                                 final_offset,
                                 pop_time as i64,
                                 request_header.invisible_time as i64,
@@ -1268,6 +1258,7 @@ where
                                 broker_name,
                                 message_ext.queue_id(),
                                 message_ext.queue_offset(),
+                                &retry_policy,
                             );
                             message_ext
                                 .message
@@ -1336,6 +1327,8 @@ where
         pop_time: u64,
         broker_name: &CheetahString,
     ) -> bool {
+        let retry_policy = self.retry_policy_for_group(&request_header.consumer_group);
+        let actual_retry_version = KeyBuilder::classify_pop_retry_topic(topic).unwrap_or(retry_policy.write_version);
         let mut ck = PopCheckPoint {
             start_offset: offset,
             pop_time: pop_time as i64,
@@ -1346,6 +1339,8 @@ where
             topic: topic.into(),
             cid: request_header.consumer_group.clone(),
             broker_name: Some(broker_name.clone()),
+            retry_topic_version: Some(actual_retry_version.number()),
+            retry_policy_generation: Some(retry_policy.generation),
             ..Default::default()
         };
         for msg_queue_offset in get_message_tmp_result.message_queue_offset() {
@@ -1979,6 +1974,8 @@ mod tests {
             num: 0,
             queue_offset_diff: vec![],
             re_put_times: None,
+            retry_topic_version: None,
+            retry_policy_generation: None,
         };
         let result = PopMessageProcessor::<LocalFileMessageStore>::gen_ck_unique_id(&ck);
         let expected = "test_topic@1@456@test_cid@789@test_broker@ck";

--- a/rocketmq-broker/src/processor/pop_message_processor/capability.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor/capability.rs
@@ -20,8 +20,11 @@ use std::sync::Weak;
 use crate::config::broker_config::BrokerConfig;
 use arc_swap::ArcSwap;
 use cheetah_string::CheetahString;
+use dashmap::DashMap;
 use rocketmq_model::common::broker::broker_role::BrokerRole;
 use rocketmq_model::common::config::TopicConfig;
+use rocketmq_model::common::pop_retry_policy::PopRetryMigrationState;
+use rocketmq_model::common::pop_retry_policy::PopRetryPolicy;
 use rocketmq_protocol::protocol::heartbeat::consume_type::ConsumeType;
 use rocketmq_protocol::protocol::heartbeat::message_model::MessageModel;
 use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
@@ -57,12 +60,12 @@ pub(crate) struct PopPolicy {
     pub(crate) broker_cluster_name: CheetahString,
     pub(crate) broker_permission: u32,
     pub(crate) broker_role: BrokerRole,
-    pub(crate) enable_retry_topic_v2: bool,
+    pub(crate) default_retry_policy: PopRetryPolicy,
+    pub(crate) configured_retry_state: Option<PopRetryMigrationState>,
     pub(crate) revive_queue_num: u32,
     pub(crate) pop_from_retry_probability: i32,
     pub(crate) pop_from_retry_probability_for_priority: i32,
     pub(crate) priority_order_asc: bool,
-    pub(crate) retrieve_message_from_pop_retry_topic_v1: bool,
     pub(crate) transfer_msg_by_heap: bool,
     pub(crate) enable_pop_log: bool,
     pub(crate) pop_response_return_actual_retry_topic: bool,
@@ -99,12 +102,16 @@ impl PopPolicy {
             broker_cluster_name: broker.broker_identity.broker_cluster_name.clone(),
             broker_permission: broker.broker_permission,
             broker_role: store.broker_role,
-            enable_retry_topic_v2: broker.enable_retry_topic_v2,
+            default_retry_policy: PopRetryPolicy::from_legacy_flags(
+                broker.enable_retry_topic_v2,
+                broker.retrieve_message_from_pop_retry_topic_v1,
+                0,
+            ),
+            configured_retry_state: broker.pop_retry_migration_state,
             revive_queue_num: broker.revive_queue_num,
             pop_from_retry_probability: broker.pop_from_retry_probability,
             pop_from_retry_probability_for_priority: broker.pop_from_retry_probability_for_priority,
             priority_order_asc: broker.priority_order_asc,
-            retrieve_message_from_pop_retry_topic_v1: broker.retrieve_message_from_pop_retry_topic_v1,
             transfer_msg_by_heap: broker.transfer_msg_by_heap,
             enable_pop_log: broker.enable_pop_log,
             pop_response_return_actual_retry_topic: broker.pop_response_return_actual_retry_topic,
@@ -161,6 +168,7 @@ impl PopPolicy {
 #[derive(Clone)]
 pub(crate) struct PopPolicyState {
     current: Arc<ArcSwap<PopPolicy>>,
+    group_retry_policies: Arc<DashMap<CheetahString, PopRetryPolicy>>,
 }
 
 impl PopPolicyState {
@@ -169,6 +177,7 @@ impl PopPolicyState {
             current: Arc::new(ArcSwap::from_pointee(PopPolicy::from_configs(
                 broker, store, store_host,
             ))),
+            group_retry_policies: Arc::new(DashMap::new()),
         }
     }
 
@@ -198,6 +207,29 @@ impl PopPolicyState {
             next.store_host = store_host;
             Arc::new(next)
         });
+    }
+
+    pub(crate) fn retry_policy(&self, group: &CheetahString) -> PopRetryPolicy {
+        let current = self.snapshot();
+        if let Some(state) = current.configured_retry_state {
+            let generation = self
+                .group_retry_policies
+                .get(group)
+                .map_or(0, |policy| policy.generation);
+            return PopRetryPolicy::for_state(state, generation);
+        }
+        self.group_retry_policies
+            .get(group)
+            .map(|policy| policy.value().clone())
+            .unwrap_or_else(|| current.default_retry_policy.clone())
+    }
+
+    pub(crate) fn restore_retry_policy(&self, group: CheetahString, policy: PopRetryPolicy) {
+        self.group_retry_policies.insert(group, policy);
+    }
+
+    pub(crate) fn remove_retry_policy(&self, group: &CheetahString) {
+        self.group_retry_policies.remove(group);
     }
 }
 
@@ -567,7 +599,10 @@ mod tests {
     use std::sync::Weak;
 
     use crate::config::broker_config::BrokerConfig;
+    use cheetah_string::CheetahString;
     use rocketmq_model::common::broker::broker_role::BrokerRole;
+    use rocketmq_model::common::pop_retry_policy::PopRetryMigrationState;
+    use rocketmq_model::common::pop_retry_policy::PopRetryPolicy;
     use rocketmq_store::MessageStoreConfig;
     use rocketmq_store::StorePorts;
 
@@ -592,6 +627,30 @@ mod tests {
         assert_eq!(policy.revive_interval, 321);
         assert!(!policy.timer_wheel_enable);
         assert_eq!(policy.broker_role, BrokerRole::Slave);
+    }
+
+    #[test]
+    fn persisted_group_policy_survives_restart_defaults_until_an_explicit_target_is_configured() {
+        let broker = BrokerConfig::default();
+        let store = MessageStoreConfig::default();
+        let group = CheetahString::from_static_str("group-a");
+        let state = PopPolicyState::from_configs(&broker, &store, "127.0.0.1:10911".parse().unwrap());
+        state.restore_retry_policy(group.clone(), PopRetryPolicy::dual_read_v2_write(7));
+
+        assert_eq!(
+            state.retry_policy(&group).state(),
+            Ok(PopRetryMigrationState::DualReadV2Write)
+        );
+        assert_eq!(state.retry_policy(&group).generation, 7);
+
+        let mut explicit = broker;
+        explicit.pop_retry_migration_state = Some(PopRetryMigrationState::DualReadV1Write);
+        state.update_broker_config(&explicit);
+        assert_eq!(
+            state.retry_policy(&group).state(),
+            Ok(PopRetryMigrationState::DualReadV1Write)
+        );
+        assert_eq!(state.retry_policy(&group).generation, 7);
     }
 
     #[test]

--- a/rocketmq-broker/src/processor/processor_service/pop_revive_service.rs
+++ b/rocketmq-broker/src/processor/processor_service/pop_revive_service.rs
@@ -34,6 +34,7 @@ use rocketmq_model::common::message::MessageConst;
 use rocketmq_model::common::message::MessageTrait;
 use rocketmq_model::common::mix_all;
 use rocketmq_model::common::pop_ack_constants::PopAckConstants;
+use rocketmq_model::common::pop_retry_policy::PopRetryTopicVersion;
 use rocketmq_model::common::TopicFilterType;
 use rocketmq_model::utils::data_converter::DataConverter;
 use rocketmq_model::utils::serde_json_utils::SerdeJsonUtils;
@@ -107,11 +108,18 @@ impl<MS: BrokerReadWriteStore> PopReviveService<MS> {
         // Check if topic is NOT retry topic, then build retry topic
         if !pop_check_point.topic.starts_with(mix_all::RETRY_GROUP_TOPIC_PREFIX) {
             // Normal topic -> build %RETRY% topic
-            msg_inner.set_topic(CheetahString::from_string(KeyBuilder::build_pop_retry_topic(
-                pop_check_point.topic.as_str(),
-                pop_check_point.cid.as_str(),
-                self.context.policy.snapshot().enable_retry_topic_v2,
-            )));
+            let policy = self.context.policy.snapshot();
+            let retry_version = pop_check_point
+                .retry_topic_version
+                .and_then(PopRetryTopicVersion::from_number)
+                .unwrap_or(policy.default_retry_policy.write_version);
+            msg_inner.set_topic(CheetahString::from_string(
+                KeyBuilder::build_pop_retry_topic_for_version(
+                    pop_check_point.topic.as_str(),
+                    pop_check_point.cid.as_str(),
+                    retry_version,
+                ),
+            ));
         } else {
             // Already retry topic -> keep it unchanged
             msg_inner.set_topic(pop_check_point.topic.clone());

--- a/rocketmq-broker/tests/pop_retry_version_migration.rs
+++ b/rocketmq-broker/tests/pop_retry_version_migration.rs
@@ -1,0 +1,93 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_broker::test_support::PopProfileStoreProbe;
+use rocketmq_model::common::pop_retry_policy::PopRetryMigrationState;
+use rocketmq_model::common::pop_retry_policy::PopRetryPolicy;
+use tempfile::TempDir;
+
+#[test]
+fn group_policy_survives_upgrade_write_rollback_and_restart() {
+    let root = TempDir::new().expect("temp dir");
+    let store = PopProfileStoreProbe::open(root.path(), 16).expect("open profile store");
+
+    let v1 = store
+        .upsert_policy("group-a", &["orders"], PopRetryPolicy::v1_only(0), 10)
+        .expect("persist v1-only policy");
+    let dual_v1 = store
+        .upsert_policy(
+            "group-a",
+            &["orders"],
+            v1.retry_policy
+                .transition_to(PopRetryMigrationState::DualReadV1Write, 2)
+                .expect("enter dual-read before switching writes"),
+            11,
+        )
+        .expect("persist dual-read/v1-write policy");
+    let dual_v2 = store
+        .upsert_policy(
+            "group-a",
+            &["orders"],
+            dual_v1
+                .retry_policy
+                .transition_to(PopRetryMigrationState::DualReadV2Write, 3)
+                .expect("switch writes to v2"),
+            12,
+        )
+        .expect("persist dual-read/v2-write policy");
+    let rolled_back = store
+        .upsert_policy(
+            "group-a",
+            &["orders"],
+            dual_v2
+                .retry_policy
+                .transition_to(PopRetryMigrationState::DualReadV1Write, 4)
+                .expect("roll writes back while retaining v2 reads"),
+            13,
+        )
+        .expect("persist rollback policy");
+    assert_eq!(
+        rolled_back.retry_policy.state(),
+        Ok(PopRetryMigrationState::DualReadV1Write)
+    );
+    drop(store);
+
+    let reopened = PopProfileStoreProbe::open(root.path(), 16).expect("reopen profile store");
+    let snapshot = reopened.snapshot();
+    assert_eq!(snapshot.len(), 1);
+    assert_eq!(snapshot[0].generation, 4);
+    assert_eq!(
+        snapshot[0].retry_policy.state(),
+        Ok(PopRetryMigrationState::DualReadV1Write)
+    );
+    assert_eq!(
+        snapshot[0].retry_policy.read_topics("orders", "group-a"),
+        vec!["%RETRY%group-a_orders", "%RETRY%group-a+orders"]
+    );
+}
+
+#[test]
+fn persisted_profile_rejects_a_skipped_v1_to_v2_only_transition() {
+    let root = TempDir::new().expect("temp dir");
+    let store = PopProfileStoreProbe::open(root.path(), 16).expect("open profile store");
+    store
+        .upsert_policy("group-a", &["orders"], PopRetryPolicy::v1_only(0), 10)
+        .expect("persist v1-only policy");
+
+    let error = store
+        .upsert_policy("group-a", &["orders"], PopRetryPolicy::v2_only(2), 11)
+        .expect_err("migration must not skip both dual-read states");
+    assert!(error.contains("not safe"), "{error}");
+    assert_eq!(store.generation(), 1);
+}

--- a/rocketmq-client/src/consumer.rs
+++ b/rocketmq-client/src/consumer.rs
@@ -32,6 +32,7 @@ pub mod mq_push_consumer;
 pub mod notify_result;
 pub mod pop_callback;
 pub mod pop_result;
+pub mod pop_retry_policy;
 pub mod pop_status;
 pub(crate) mod pull_callback;
 pub mod pull_result;

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_impl.rs
@@ -21,7 +21,6 @@ use std::sync::Weak;
 
 use cheetah_string::CheetahString;
 use dashmap::DashMap;
-use rocketmq_model::common::key_builder::KeyBuilder;
 use rocketmq_model::common::message::message_enum::MessageRequestMode;
 use rocketmq_model::common::message::message_queue::MessageQueue;
 use rocketmq_model::common::message::message_queue_assignment::MessageQueueAssignment;
@@ -44,6 +43,7 @@ use crate::consumer::consumer_impl::pop_request::PopRequest;
 use crate::consumer::consumer_impl::process_queue::ProcessQueue;
 use crate::consumer::consumer_impl::pull_request::PullRequest;
 use crate::consumer::consumer_impl::re_balance::Rebalance;
+use crate::consumer::pop_retry_policy::pop_retry_subscription_topics;
 use crate::factory::mq_client_instance::MQClientInstance;
 use crate::types::ConsumerGroupName;
 use crate::types::TopicName;
@@ -567,20 +567,20 @@ where
         if !topic.starts_with(mix_all::RETRY_GROUP_TOPIC_PREFIX) {
             if mq2pop_assignment.is_empty() && !mq2push_assignment.is_empty() {
                 // Assignment switched from pop-mode to push-mode; subscribe to the pop retry topic.
-                let retry_topic =
-                    CheetahString::from(KeyBuilder::build_pop_retry_topic(topic, consumer_group.as_ref(), false));
-                let subscription_data = FilterAPI::build_subscription_data(
-                    &retry_topic,
-                    &CheetahString::from_static_str(SubscriptionData::SUB_ALL),
-                );
-                if let Ok(subscription_data) = subscription_data {
-                    self.put_subscription_data(&retry_topic, subscription_data);
+                for retry_topic in pop_retry_subscription_topics(topic, consumer_group.as_ref()) {
+                    let subscription_data = FilterAPI::build_subscription_data(
+                        &retry_topic,
+                        &CheetahString::from_static_str(SubscriptionData::SUB_ALL),
+                    );
+                    if let Ok(subscription_data) = subscription_data {
+                        self.put_subscription_data(&retry_topic, subscription_data);
+                    }
                 }
             } else if !mq2pop_assignment.is_empty() && mq2push_assignment.is_empty() {
-                // Assignment switched from push-mode to pop-mode; unsubscribe from the pop retry topic.
-                let retry_topic =
-                    CheetahString::from(KeyBuilder::build_pop_retry_topic(topic, consumer_group.as_ref(), false));
-                self.remove_subscription_data(&retry_topic);
+                // Assignment switched from push-mode to pop-mode; unsubscribe from both retry versions.
+                for retry_topic in pop_retry_subscription_topics(topic, consumer_group.as_ref()) {
+                    self.remove_subscription_data(&retry_topic);
+                }
             }
         }
         let mut remove_queue_map = HashMap::with_capacity(64);

--- a/rocketmq-client/src/consumer/pop_retry_policy.rs
+++ b/rocketmq-client/src/consumer/pop_retry_policy.rs
@@ -1,0 +1,42 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cheetah_string::CheetahString;
+use rocketmq_model::common::key_builder::KeyBuilder;
+use rocketmq_model::common::pop_retry_policy::PopRetryTopicVersion;
+
+/// Returns both POP retry topics that a push-mode subscription may inherit
+/// while a Broker is inside the supported v1/v2 migration window.
+pub fn pop_retry_subscription_topics(topic: &str, consumer_group: &str) -> [CheetahString; 2] {
+    [
+        CheetahString::from_string(KeyBuilder::build_pop_retry_topic_for_version(
+            topic,
+            consumer_group,
+            PopRetryTopicVersion::V1,
+        )),
+        CheetahString::from_string(KeyBuilder::build_pop_retry_topic_for_version(
+            topic,
+            consumer_group,
+            PopRetryTopicVersion::V2,
+        )),
+    ]
+}
+
+/// Resolves an observed POP retry topic through the shared v1/v2 codec.
+pub fn resolve_pop_retry_topic<'a>(
+    retry_topic: &'a str,
+    consumer_group: &str,
+) -> Option<(PopRetryTopicVersion, &'a str)> {
+    KeyBuilder::parse_pop_retry_topic(retry_topic, consumer_group)
+}

--- a/rocketmq-client/src/lib.rs
+++ b/rocketmq-client/src/lib.rs
@@ -113,6 +113,8 @@ pub use crate::common::admin_tools_result_code_enum::AdminToolsResultCodeEnum;
 pub use crate::common::nameserver_access_config::NameserverAccessConfig;
 pub use crate::common::session_credentials::SessionCredentials;
 pub use crate::common::thread_local_index::ThreadLocalIndex;
+pub use crate::consumer::pop_retry_policy::pop_retry_subscription_topics;
+pub use crate::consumer::pop_retry_policy::resolve_pop_retry_topic;
 
 mod cluster_session {
     use std::collections::HashMap;

--- a/rocketmq-client/tests/pop_retry_policy.rs
+++ b/rocketmq-client/tests/pop_retry_policy.rs
@@ -1,0 +1,39 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_client_rust::pop_retry_subscription_topics;
+use rocketmq_client_rust::resolve_pop_retry_topic;
+use rocketmq_model::common::pop_retry_policy::PopRetryTopicVersion;
+
+#[test]
+fn push_rebalance_subscription_set_covers_both_retry_versions() {
+    let topics = pop_retry_subscription_topics("orders", "consumer-a");
+
+    assert_eq!(topics[0].as_str(), "%RETRY%consumer-a_orders");
+    assert_eq!(topics[1].as_str(), "%RETRY%consumer-a+orders");
+    assert_eq!(
+        resolve_pop_retry_topic(topics[0].as_str(), "consumer-a"),
+        Some((PopRetryTopicVersion::V1, "orders"))
+    );
+    assert_eq!(
+        resolve_pop_retry_topic(topics[1].as_str(), "consumer-a"),
+        Some((PopRetryTopicVersion::V2, "orders"))
+    );
+}
+
+#[test]
+fn retry_codec_rejects_another_groups_or_plain_retry_topic() {
+    assert_eq!(resolve_pop_retry_topic("%RETRY%consumer-b+orders", "consumer-a"), None);
+    assert_eq!(resolve_pop_retry_topic("%RETRY%consumer-a", "consumer-a"), None);
+}

--- a/rocketmq-model/src/common.rs
+++ b/rocketmq-model/src/common.rs
@@ -35,6 +35,7 @@ pub mod message;
 pub mod mix_all;
 pub mod mq_version;
 pub mod pop_ack_constants;
+pub mod pop_retry_policy;
 pub mod producer;
 
 pub mod running;

--- a/rocketmq-model/src/common/key_builder.rs
+++ b/rocketmq-model/src/common/key_builder.rs
@@ -14,6 +14,8 @@
 
 use crate::topic::RETRY_GROUP_TOPIC_PREFIX;
 
+use super::pop_retry_policy::PopRetryTopicVersion;
+
 pub const POP_ORDER_REVIVE_QUEUE: i32 = 999;
 pub const POP_RETRY_SEPARATOR_V1: char = '_';
 pub const POP_RETRY_SEPARATOR_V2: char = '+';
@@ -23,10 +25,19 @@ pub struct KeyBuilder;
 
 impl KeyBuilder {
     pub fn build_pop_retry_topic(topic: &str, cid: &str, enable_retry_v2: bool) -> String {
-        if enable_retry_v2 {
-            return KeyBuilder::build_pop_retry_topic_v2(topic, cid);
+        let version = if enable_retry_v2 {
+            PopRetryTopicVersion::V2
+        } else {
+            PopRetryTopicVersion::V1
+        };
+        Self::build_pop_retry_topic_for_version(topic, cid, version)
+    }
+
+    pub fn build_pop_retry_topic_for_version(topic: &str, cid: &str, version: PopRetryTopicVersion) -> String {
+        match version {
+            PopRetryTopicVersion::V1 => Self::build_pop_retry_topic_v1(topic, cid),
+            PopRetryTopicVersion::V2 => Self::build_pop_retry_topic_v2(topic, cid),
         }
-        KeyBuilder::build_pop_retry_topic_v1(topic, cid)
     }
 
     pub fn build_pop_retry_topic_default(topic: &str, cid: &str) -> String {
@@ -77,5 +88,29 @@ impl KeyBuilder {
 
     pub fn is_pop_retry_topic_v2(retry_topic: &str) -> bool {
         retry_topic.starts_with(RETRY_GROUP_TOPIC_PREFIX) && retry_topic.contains(POP_RETRY_SEPARATOR_V2)
+    }
+
+    pub fn classify_pop_retry_topic(retry_topic: &str) -> Option<PopRetryTopicVersion> {
+        if Self::is_pop_retry_topic_v2(retry_topic) {
+            Some(PopRetryTopicVersion::V2)
+        } else if retry_topic.starts_with(RETRY_GROUP_TOPIC_PREFIX)
+            && retry_topic[RETRY_GROUP_TOPIC_PREFIX.len()..].contains(POP_RETRY_SEPARATOR_V1)
+        {
+            Some(PopRetryTopicVersion::V1)
+        } else {
+            None
+        }
+    }
+
+    pub fn parse_pop_retry_topic<'a>(retry_topic: &'a str, cid: &str) -> Option<(PopRetryTopicVersion, &'a str)> {
+        let prefix = format!("{RETRY_GROUP_TOPIC_PREFIX}{cid}");
+        let suffix = retry_topic.strip_prefix(&prefix)?;
+        if let Some(topic) = suffix.strip_prefix(POP_RETRY_SEPARATOR_V2) {
+            (!topic.is_empty()).then_some((PopRetryTopicVersion::V2, topic))
+        } else if let Some(topic) = suffix.strip_prefix(POP_RETRY_SEPARATOR_V1) {
+            (!topic.is_empty()).then_some((PopRetryTopicVersion::V1, topic))
+        } else {
+            None
+        }
     }
 }

--- a/rocketmq-model/src/common/pop_retry_policy.rs
+++ b/rocketmq-model/src/common/pop_retry_policy.rs
@@ -1,0 +1,264 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::Deserialize;
+use serde::Serialize;
+use thiserror::Error;
+
+use super::key_builder::KeyBuilder;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PopRetryTopicVersion {
+    V1,
+    V2,
+}
+
+impl PopRetryTopicVersion {
+    pub const fn number(self) -> i32 {
+        match self {
+            Self::V1 => 1,
+            Self::V2 => 2,
+        }
+    }
+
+    pub const fn from_number(value: i32) -> Option<Self> {
+        match value {
+            1 => Some(Self::V1),
+            2 => Some(Self::V2),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PopRetryMigrationState {
+    V1Only,
+    DualReadV1Write,
+    DualReadV2Write,
+    V2Only,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PopRetryPolicy {
+    pub write_version: PopRetryTopicVersion,
+    pub read_fallback_order: Vec<PopRetryTopicVersion>,
+    pub accept_v1: bool,
+    pub accept_v2: bool,
+    pub generation: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum PopRetryPolicyError {
+    #[error("POP retry policy does not describe one of the four supported migration states")]
+    InvalidState,
+    #[error("POP retry policy transition from {from:?} to {to:?} is not safe")]
+    UnsafeTransition {
+        from: PopRetryMigrationState,
+        to: PopRetryMigrationState,
+    },
+    #[error("POP retry policy generation must advance beyond {current}, got {next}")]
+    StaleGeneration { current: u64, next: u64 },
+}
+
+impl PopRetryPolicy {
+    pub fn v1_only(generation: u64) -> Self {
+        Self::new(
+            PopRetryTopicVersion::V1,
+            vec![PopRetryTopicVersion::V1],
+            true,
+            false,
+            generation,
+        )
+    }
+
+    pub fn dual_read_v1_write(generation: u64) -> Self {
+        Self::new(
+            PopRetryTopicVersion::V1,
+            vec![PopRetryTopicVersion::V1, PopRetryTopicVersion::V2],
+            true,
+            true,
+            generation,
+        )
+    }
+
+    pub fn dual_read_v2_write(generation: u64) -> Self {
+        Self::new(
+            PopRetryTopicVersion::V2,
+            vec![PopRetryTopicVersion::V2, PopRetryTopicVersion::V1],
+            true,
+            true,
+            generation,
+        )
+    }
+
+    pub fn v2_only(generation: u64) -> Self {
+        Self::new(
+            PopRetryTopicVersion::V2,
+            vec![PopRetryTopicVersion::V2],
+            false,
+            true,
+            generation,
+        )
+    }
+
+    pub fn from_legacy_flags(enable_v2: bool, retrieve_v1: bool, generation: u64) -> Self {
+        match (enable_v2, retrieve_v1) {
+            (false, _) => Self::v1_only(generation),
+            (true, true) => Self::dual_read_v2_write(generation),
+            (true, false) => Self::v2_only(generation),
+        }
+    }
+
+    pub fn state(&self) -> Result<PopRetryMigrationState, PopRetryPolicyError> {
+        let state = match (
+            self.write_version,
+            self.read_fallback_order.as_slice(),
+            self.accept_v1,
+            self.accept_v2,
+        ) {
+            (PopRetryTopicVersion::V1, [PopRetryTopicVersion::V1], true, false) => PopRetryMigrationState::V1Only,
+            (PopRetryTopicVersion::V1, [PopRetryTopicVersion::V1, PopRetryTopicVersion::V2], true, true) => {
+                PopRetryMigrationState::DualReadV1Write
+            }
+            (PopRetryTopicVersion::V2, [PopRetryTopicVersion::V2, PopRetryTopicVersion::V1], true, true) => {
+                PopRetryMigrationState::DualReadV2Write
+            }
+            (PopRetryTopicVersion::V2, [PopRetryTopicVersion::V2], false, true) => PopRetryMigrationState::V2Only,
+            _ => return Err(PopRetryPolicyError::InvalidState),
+        };
+        Ok(state)
+    }
+
+    pub fn transition_to(&self, next: PopRetryMigrationState, generation: u64) -> Result<Self, PopRetryPolicyError> {
+        if generation <= self.generation {
+            return Err(PopRetryPolicyError::StaleGeneration {
+                current: self.generation,
+                next: generation,
+            });
+        }
+        let current = self.state()?;
+        let allowed = matches!(
+            (current, next),
+            (PopRetryMigrationState::V1Only, PopRetryMigrationState::DualReadV1Write)
+                | (
+                    PopRetryMigrationState::DualReadV1Write,
+                    PopRetryMigrationState::DualReadV2Write
+                )
+                | (PopRetryMigrationState::DualReadV2Write, PopRetryMigrationState::V2Only)
+                | (
+                    PopRetryMigrationState::DualReadV2Write,
+                    PopRetryMigrationState::DualReadV1Write
+                )
+        );
+        if !allowed {
+            return Err(PopRetryPolicyError::UnsafeTransition {
+                from: current,
+                to: next,
+            });
+        }
+        Ok(Self::for_state(next, generation))
+    }
+
+    pub fn write_topic(&self, topic: &str, consumer_group: &str) -> String {
+        KeyBuilder::build_pop_retry_topic_for_version(topic, consumer_group, self.write_version)
+    }
+
+    pub fn read_topics(&self, topic: &str, consumer_group: &str) -> Vec<String> {
+        self.read_fallback_order
+            .iter()
+            .map(|version| KeyBuilder::build_pop_retry_topic_for_version(topic, consumer_group, *version))
+            .collect()
+    }
+
+    pub const fn accepts(&self, version: PopRetryTopicVersion) -> bool {
+        match version {
+            PopRetryTopicVersion::V1 => self.accept_v1,
+            PopRetryTopicVersion::V2 => self.accept_v2,
+        }
+    }
+
+    pub fn for_state(state: PopRetryMigrationState, generation: u64) -> Self {
+        match state {
+            PopRetryMigrationState::V1Only => Self::v1_only(generation),
+            PopRetryMigrationState::DualReadV1Write => Self::dual_read_v1_write(generation),
+            PopRetryMigrationState::DualReadV2Write => Self::dual_read_v2_write(generation),
+            PopRetryMigrationState::V2Only => Self::v2_only(generation),
+        }
+    }
+
+    fn new(
+        write_version: PopRetryTopicVersion,
+        read_fallback_order: Vec<PopRetryTopicVersion>,
+        accept_v1: bool,
+        accept_v2: bool,
+        generation: u64,
+    ) -> Self {
+        Self {
+            write_version,
+            read_fallback_order,
+            accept_v1,
+            accept_v2,
+            generation,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migration_sequence_and_dual_reader_rollback_are_explicit() {
+        let v1 = PopRetryPolicy::v1_only(1);
+        let dual_v1 = v1
+            .transition_to(PopRetryMigrationState::DualReadV1Write, 2)
+            .expect("v1 should enter dual-read before switching writes");
+        let dual_v2 = dual_v1
+            .transition_to(PopRetryMigrationState::DualReadV2Write, 3)
+            .expect("dual reader should switch writes to v2");
+        let rolled_back = dual_v2
+            .transition_to(PopRetryMigrationState::DualReadV1Write, 4)
+            .expect("dual reader should roll writes back to v1");
+
+        assert_eq!(rolled_back.state(), Ok(PopRetryMigrationState::DualReadV1Write));
+        assert!(rolled_back.accepts(PopRetryTopicVersion::V2));
+        assert_eq!(rolled_back.write_version, PopRetryTopicVersion::V1);
+    }
+
+    #[test]
+    fn policy_rejects_skipped_or_stale_transitions() {
+        let v1 = PopRetryPolicy::v1_only(4);
+        assert!(matches!(
+            v1.transition_to(PopRetryMigrationState::DualReadV1Write, 4),
+            Err(PopRetryPolicyError::StaleGeneration { .. })
+        ));
+        assert!(matches!(
+            v1.transition_to(PopRetryMigrationState::DualReadV2Write, 5),
+            Err(PopRetryPolicyError::UnsafeTransition { .. })
+        ));
+    }
+
+    #[test]
+    fn dual_read_topics_follow_write_first_fallback_order() {
+        let policy = PopRetryPolicy::dual_read_v2_write(9);
+        assert_eq!(
+            policy.read_topics("orders", "consumer-a"),
+            vec!["%RETRY%consumer-a+orders", "%RETRY%consumer-a_orders"]
+        );
+        assert_eq!(policy.write_topic("orders", "consumer-a"), "%RETRY%consumer-a+orders");
+    }
+}

--- a/rocketmq-protocol/src/protocol/header/extra_info_util.rs
+++ b/rocketmq-protocol/src/protocol/header/extra_info_util.rs
@@ -21,6 +21,7 @@ use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_model::common::key_builder;
 use rocketmq_model::common::key_builder::KeyBuilder;
+use rocketmq_model::common::pop_retry_policy::PopRetryPolicy;
 
 pub struct ExtraInfoUtil;
 
@@ -34,6 +35,7 @@ pub struct AckExtraInfo<'a> {
     pub broker_name: &'a str,
     pub queue_id: i32,
     pub queue_offset: i64,
+    pub retry_generation: Option<u64>,
 }
 
 const NORMAL_TOPIC: &str = "0";
@@ -76,6 +78,14 @@ impl ExtraInfoUtil {
         let queue_offset = next("queue offset")?
             .parse::<i64>()
             .map_err(|_| illegal_argument("parse queue_offset error"))?;
+        let retry_generation = parts
+            .next()
+            .map(|value| {
+                value
+                    .parse::<u64>()
+                    .map_err(|_| illegal_argument("parse retry generation error"))
+            })
+            .transpose()?;
 
         if broker_name.trim().is_empty() {
             return Err(illegal_argument("parse POP receipt handle: broker name is blank"));
@@ -93,6 +103,7 @@ impl ExtraInfoUtil {
             broker_name,
             queue_id,
             queue_offset,
+            retry_generation,
         })
     }
 
@@ -280,6 +291,39 @@ impl ExtraInfoUtil {
             msg_queue_offset,
             sep = KEY_SEPARATOR
         )
+    }
+
+    /// Builds a receipt handle that carries the persisted POP retry policy generation.
+    ///
+    /// Existing eight-field handles remain valid. The optional ninth field is emitted only
+    /// for retry topics, while the existing retry marker continues to identify v1 or v2.
+    #[allow(clippy::too_many_arguments, reason = "preserves the established POP receipt fields")]
+    pub fn build_extra_info_with_offset_and_retry_policy(
+        ck_queue_offset: i64,
+        pop_time: i64,
+        invisible_time: i64,
+        revive_qid: i32,
+        topic: &str,
+        broker_name: &str,
+        queue_id: i32,
+        msg_queue_offset: i64,
+        retry_policy: &PopRetryPolicy,
+    ) -> String {
+        let base = Self::build_extra_info_with_offset(
+            ck_queue_offset,
+            pop_time,
+            invisible_time,
+            revive_qid,
+            topic,
+            broker_name,
+            queue_id,
+            msg_queue_offset,
+        );
+        if KeyBuilder::classify_pop_retry_topic(topic).is_some() {
+            format!("{base}{KEY_SEPARATOR}{}", retry_policy.generation)
+        } else {
+            base
+        }
     }
 
     /// Build start offset info
@@ -798,6 +842,32 @@ mod tests {
     fn build_extra_info_with_msg_queue_offset_creates_correct_string() {
         let result = ExtraInfoUtil::build_extra_info_with_offset(123, 456, 789, 10, "topic", "broker", 7, 100);
         assert_eq!(result, "123 456 789 10 0 broker 7 100");
+    }
+
+    #[test]
+    fn retry_receipt_round_trips_actual_version_and_policy_generation() {
+        let policy = PopRetryPolicy::dual_read_v2_write(17);
+        let retry_topic = policy.write_topic("topic", "consumer-a");
+        let handle = ExtraInfoUtil::build_extra_info_with_offset_and_retry_policy(
+            123,
+            456,
+            789,
+            10,
+            &retry_topic,
+            "broker",
+            7,
+            100,
+            &policy,
+        );
+
+        let parsed = ExtraInfoUtil::parse_ack_extra_info(&handle).expect("generated receipt should parse");
+        assert_eq!(parsed.retry, RETRY_TOPIC_V2);
+        assert_eq!(parsed.retry_generation, Some(17));
+        assert_eq!(
+            ExtraInfoUtil::get_real_topic_with_retry("topic", "consumer-a", parsed.retry)
+                .expect("retry marker should resolve"),
+            retry_topic
+        );
     }
 
     #[test]

--- a/rocketmq-store-local/src/pop/pop_check_point.rs
+++ b/rocketmq-store-local/src/pop/pop_check_point.rs
@@ -45,6 +45,10 @@ pub struct PopCheckPoint {
     pub broker_name: Option<CheetahString>,
     #[serde(rename = "rp")]
     pub re_put_times: Option<CheetahString>,
+    #[serde(rename = "rtv", default, skip_serializing_if = "Option::is_none")]
+    pub retry_topic_version: Option<i32>,
+    #[serde(rename = "rg", default, skip_serializing_if = "Option::is_none")]
+    pub retry_policy_generation: Option<u64>,
 }
 
 impl PopCheckPoint {
@@ -217,7 +221,8 @@ impl Display for PopCheckPoint {
         write!(
             f,
             "PopCheckPoint [start_offset={}, pop_time={}, invisible_time={}, bit_map={}, num={}, queue_id={}, \
-             topic={}, cid={}, revive_offset={}, queue_offset_diff={:?}, broker_name={}, re_put_times={}]",
+             topic={}, cid={}, revive_offset={}, queue_offset_diff={:?}, broker_name={}, re_put_times={}, \
+             retry_topic_version={:?}, retry_policy_generation={:?}]",
             self.start_offset,
             self.pop_time,
             self.invisible_time,
@@ -229,7 +234,9 @@ impl Display for PopCheckPoint {
             self.revive_offset,
             self.queue_offset_diff,
             self.broker_name.as_deref().unwrap_or("None"),
-            self.re_put_times.as_deref().unwrap_or("None")
+            self.re_put_times.as_deref().unwrap_or("None"),
+            self.retry_topic_version,
+            self.retry_policy_generation
         )
     }
 }
@@ -255,6 +262,8 @@ mod tests {
             queue_offset_diff: vec![],
             broker_name: None,
             re_put_times: None,
+            retry_topic_version: None,
+            retry_policy_generation: None,
         };
         checkpoint.add_diff(5);
         assert_eq!(checkpoint.queue_offset_diff, vec![5]);
@@ -275,6 +284,8 @@ mod tests {
             queue_offset_diff: vec![0, 1, 2, 3, 4],
             broker_name: None,
             re_put_times: None,
+            retry_topic_version: None,
+            retry_policy_generation: None,
         };
         assert_eq!(checkpoint.index_of_ack(12), 2);
     }
@@ -294,6 +305,8 @@ mod tests {
             queue_offset_diff: vec![0, 1, 2, 3, 4],
             broker_name: None,
             re_put_times: None,
+            retry_topic_version: None,
+            retry_policy_generation: None,
         };
         assert_eq!(checkpoint.index_of_ack(5), -1);
     }
@@ -313,6 +326,8 @@ mod tests {
             queue_offset_diff: vec![0, 1, 2, 3, 4],
             broker_name: None,
             re_put_times: None,
+            retry_topic_version: None,
+            retry_policy_generation: None,
         };
         assert_eq!(checkpoint.ack_offset_by_index(2), 12);
     }
@@ -332,6 +347,8 @@ mod tests {
             queue_offset_diff: vec![],
             broker_name: None,
             re_put_times: Some(CheetahString::from("5")),
+            retry_topic_version: None,
+            retry_policy_generation: None,
         };
         assert_eq!(checkpoint.parse_re_put_times(), 5);
     }
@@ -351,6 +368,8 @@ mod tests {
             queue_offset_diff: vec![],
             broker_name: None,
             re_put_times: Some(CheetahString::from("invalid")),
+            retry_topic_version: None,
+            retry_policy_generation: None,
         };
         assert_eq!(checkpoint.parse_re_put_times(), i32::MAX);
     }
@@ -370,6 +389,8 @@ mod tests {
             queue_offset_diff: vec![],
             broker_name: None,
             re_put_times: None,
+            retry_topic_version: None,
+            retry_policy_generation: None,
         };
         assert_eq!(checkpoint.parse_re_put_times(), 0);
     }
@@ -389,6 +410,8 @@ mod tests {
             queue_offset_diff: vec![],
             broker_name: None,
             re_put_times: None,
+            retry_topic_version: None,
+            retry_policy_generation: None,
         };
         let p2 = PopCheckPoint {
             start_offset: 20,
@@ -412,6 +435,8 @@ mod tests {
             queue_offset_diff: vec![],
             broker_name: None,
             re_put_times: None,
+            retry_topic_version: None,
+            retry_policy_generation: None,
         };
         let p2 = PopCheckPoint {
             start_offset: 20,
@@ -435,6 +460,8 @@ mod tests {
             queue_offset_diff: vec![],
             broker_name: None,
             re_put_times: None,
+            retry_topic_version: None,
+            retry_policy_generation: None,
         };
         let p2 = PopCheckPoint {
             start_offset: 10,
@@ -458,6 +485,8 @@ mod tests {
             queue_offset_diff: vec![1, 2, 3],
             broker_name: Some(CheetahString::from("test_broker")),
             re_put_times: Some(CheetahString::from("test_reput")),
+            retry_topic_version: None,
+            retry_policy_generation: None,
         };
         let serialized = serde_json::to_string(&p).unwrap();
         let deserialized: PopCheckPoint = serde_json::from_str(&serialized).unwrap();
@@ -498,11 +527,14 @@ mod tests {
             queue_offset_diff: vec![1, 2, 3],
             broker_name: Some(CheetahString::from("test_broker")),
             re_put_times: Some(CheetahString::from("test_reput")),
+            retry_topic_version: None,
+            retry_policy_generation: None,
         };
         let display = format!("{}", p);
         let expected = "PopCheckPoint [start_offset=10, pop_time=20, invisible_time=30, bit_map=40, num=50, \
                         queue_id=60, topic=test_topic, cid=test_cid, revive_offset=70, queue_offset_diff=[1, 2, 3], \
-                        broker_name=test_broker, re_put_times=test_reput]";
+                        broker_name=test_broker, re_put_times=test_reput, retry_topic_version=None, \
+                        retry_policy_generation=None]";
         assert_eq!(display, expected);
     }
 }


### PR DESCRIPTION
## Summary

- introduce a typed, generation-aware POP retry policy with the safe `v1-only → dual-read/v1-write → dual-read/v2-write → v2-only` sequence
- persist and restore per-group policy state, retain dual-read write rollback, and route POP, Peek, Notification, revive, cleanup, and Push rebalance through the shared topic-version contract
- carry the actual retry topic version and policy generation through receipt/checkpoint data while preserving legacy profile and receipt decoding

## Validation

- `cargo check -p rocketmq-broker`
- `cargo test -p rocketmq-model pop_retry_policy` — 3 passed
- `cargo test -p rocketmq-protocol extra_info_util` — 40 passed
- `cargo test -p rocketmq-client-rust --test pop_retry_policy` — 2 passed
- `cargo test -p rocketmq-store-local pop_check_point` — 13 passed
- Broker profile persistence/runtime/migration integration targets — 8 passed
- focused Broker policy-state test — 1 passed
- Broker RocksDB/test-support all-target Clippy passed with `-D warnings`
- model/protocol/client/store-local all-target Clippy passed with `-D warnings`
- fixed-nightly fuzz workspace compiled after an offline lock refresh; checked-in lock restored unchanged
- AGENTS routing, focused rustfmt, and `git diff --check` passed

The repository-wide `cargo fmt --all -- --check` launcher still hits the existing Windows path-length error, so changed Rust files were checked individually.

Closes #9473

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable POP retry-topic policies supporting V1, V2, dual-read, and migration states.
  * POP consumers can subscribe to and process multiple retry-topic versions with fallback behavior.
  * Retry metadata and policy generations are preserved across acknowledgements and broker restarts.
  * Added utilities for generating and resolving POP retry topics.

* **Bug Fixes**
  * Improved retry-topic deletion, message peeking, revival, and acknowledgement handling during migrations.
  * Prevented unsafe or skipped retry-policy transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->