### PR TITLE
[ISSUE #9476]✨Harden Controller write authority with leases

### DIFF
--- a/rocketmq-broker/src/broker/broker_control_plane.rs
+++ b/rocketmq-broker/src/broker/broker_control_plane.rs
@@ -221,6 +221,10 @@ impl<MS: BrokerReplicationStore> BrokerControllerRuntime<MS> {
         sync_state_set: std::collections::HashSet<i64>,
     ) -> rocketmq_error::RocketMQResult<()> {
         let _operation_guard = self.controller.lock_operation().await;
+        // Revoke the old authority before publishing any new role metadata.
+        // Store remains fail-closed until a quorum-committed heartbeat installs
+        // a lease for the newly published authority.
+        let _ = self.store.fence_controller_writes();
         let outcome = self
             .controller
             .with_replicas_mut(|replicas_manager| {

--- a/rocketmq-broker/src/broker/broker_control_plane/bootstrap.rs
+++ b/rocketmq-broker/src/broker/broker_control_plane/bootstrap.rs
@@ -18,6 +18,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
+use std::time::Instant;
 
 use cheetah_string::CheetahString;
 use rocketmq_error::RocketMQError;
@@ -35,8 +36,26 @@ use crate::controller::replicas_manager::ControllerRegisterFollowup;
 use crate::controller::replicas_manager::ControllerReplicaInfoFollowup;
 use crate::controller::replicas_manager::ControllerReplicaSyncFollowup;
 use crate::controller::replicas_manager::ReplicasManager;
+use crate::controller::write_lease::validate_grant;
 
 impl<MS: BrokerReplicationStore> BrokerControllerRuntime<MS> {
+    async fn install_controller_write_lease(
+        &self,
+        grant: rocketmq_protocol::protocol::body::controller_write_lease::ControllerWriteLeaseGrant,
+        sent_at: Instant,
+    ) -> bool {
+        let _operation_guard = self.controller.lock_operation().await;
+        let Some(expected_authority) = self.replicas_snapshot().and_then(|manager| manager.write_authority()) else {
+            return false;
+        };
+        let Some((token, valid_for)) = validate_grant(grant, expected_authority, sent_at.elapsed()) else {
+            return false;
+        };
+        self.store
+            .install_controller_write_lease(token, valid_for)
+            .unwrap_or(false)
+    }
+
     pub(crate) async fn run_heartbeat_cycle(&self) {
         if self.shutdown.load(Ordering::Acquire) {
             return;
@@ -658,6 +677,7 @@ impl<MS: BrokerReplicationStore> BrokerControllerRuntime<MS> {
                     return None;
                 }
                 let target = controller_address.clone();
+                let sent_at = Instant::now();
                 let result = self
                     .broker_outer_api
                     .send_heartbeat_to_controller(
@@ -674,18 +694,26 @@ impl<MS: BrokerReplicationStore> BrokerControllerRuntime<MS> {
                         Some(broker_election_priority),
                     )
                     .await;
-                Some((target, result))
+                Some((target, sent_at, result))
             }
         });
+        let mut installed_lease = false;
         for outcome in futures::future::join_all(futures).await.into_iter().flatten() {
-            let (target, result) = outcome;
-            if let Err(error) = result {
-                warn!(
-                    remote_addr = %target,
-                    error_kind = ?error.kind(),
-                    "controller heartbeat failed"
-                );
+            let (target, sent_at, result) = outcome;
+            match result {
+                Ok(Some(grant)) => installed_lease |= self.install_controller_write_lease(grant, sent_at).await,
+                Ok(None) => {}
+                Err(error) => {
+                    warn!(
+                        remote_addr = %target,
+                        error_kind = ?error.kind(),
+                        "controller heartbeat failed"
+                    );
+                }
             }
+        }
+        if !installed_lease {
+            let _ = self.store.fence_controller_writes();
         }
     }
 
@@ -704,7 +732,9 @@ impl<MS: BrokerReplicationStore> BrokerControllerRuntime<MS> {
         let broker_config = self.config.broker_snapshot();
         let (max_offset, confirm_offset) = self.store.controller_heartbeat_offsets();
 
-        self.broker_outer_api
+        let sent_at = Instant::now();
+        let grant = self
+            .broker_outer_api
             .send_heartbeat_to_controller_sync(
                 controller_leader,
                 broker_config.broker_identity.broker_cluster_name.clone(),
@@ -718,7 +748,23 @@ impl<MS: BrokerReplicationStore> BrokerControllerRuntime<MS> {
                 Some(broker_config.controller_heartbeat_timeout_mills),
                 Some(broker_config.broker_election_priority),
             )
-            .await
+            .await?;
+        let lease_required = self
+            .replicas_snapshot()
+            .and_then(|manager| manager.write_authority())
+            .is_some();
+        let installed = match grant {
+            Some(grant) => self.install_controller_write_lease(grant, sent_at).await,
+            None => false,
+        };
+        if installed || !lease_required {
+            Ok(())
+        } else {
+            let _ = self.store.fence_controller_writes();
+            Err(RocketMQError::illegal_argument(
+                "controller heartbeat completed without a valid committed write lease",
+            ))
+        }
     }
 }
 

--- a/rocketmq-broker/src/controller.rs
+++ b/rocketmq-broker/src/controller.rs
@@ -13,3 +13,4 @@
 // limitations under the License.
 
 pub(crate) mod replicas_manager;
+pub(crate) mod write_lease;

--- a/rocketmq-broker/src/controller/write_lease.rs
+++ b/rocketmq-broker/src/controller/write_lease.rs
@@ -1,0 +1,77 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use rocketmq_protocol::protocol::body::controller_write_lease::ControllerWriteLeaseGrant;
+use rocketmq_store_api::MasterEpoch;
+use rocketmq_store_api::WriteAuthority;
+use rocketmq_store_api::WriteLeaseToken;
+
+pub(crate) const MAX_APPEND_ACK_MILLIS: u64 = 1_000;
+
+pub(crate) fn validate_grant(
+    grant: ControllerWriteLeaseGrant,
+    expected_authority: WriteAuthority,
+    request_elapsed: Duration,
+) -> Option<(WriteLeaseToken, Duration)> {
+    if grant.lease_duration_millis <= grant.safety_margin_millis || grant.safety_margin_millis < MAX_APPEND_ACK_MILLIS {
+        return None;
+    }
+    let master_epoch = MasterEpoch::try_from(grant.master_epoch).ok()?;
+    let authority = WriteAuthority::try_new(grant.broker_id, master_epoch).ok()?;
+    if authority != expected_authority {
+        return None;
+    }
+    let token = WriteLeaseToken::try_new(authority, grant.generation).ok()?;
+    let local_budget = Duration::from_millis(grant.lease_duration_millis - grant.safety_margin_millis);
+    let valid_for = local_budget.checked_sub(request_elapsed)?;
+    (!valid_for.is_zero()).then_some((token, valid_for))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn authority() -> WriteAuthority {
+        WriteAuthority::try_new(0, MasterEpoch::try_from(3).unwrap()).unwrap()
+    }
+
+    fn grant() -> ControllerWriteLeaseGrant {
+        ControllerWriteLeaseGrant {
+            broker_id: 0,
+            master_epoch: 3,
+            generation: 7,
+            lease_duration_millis: 10_000,
+            safety_margin_millis: 2_000,
+        }
+    }
+
+    #[test]
+    fn request_send_time_bounds_the_local_deadline() {
+        let (token, valid_for) = validate_grant(grant(), authority(), Duration::from_millis(1_500)).unwrap();
+        assert_eq!(token.generation(), 7);
+        assert_eq!(valid_for, Duration::from_millis(6_500));
+        assert!(validate_grant(grant(), authority(), Duration::from_millis(8_000)).is_none());
+    }
+
+    #[test]
+    fn wrong_authority_or_unsafe_margin_is_rejected() {
+        let other = WriteAuthority::try_new(1, MasterEpoch::try_from(3).unwrap()).unwrap();
+        assert!(validate_grant(grant(), other, Duration::ZERO).is_none());
+        let mut unsafe_grant = grant();
+        unsafe_grant.safety_margin_millis = 999;
+        assert!(validate_grant(unsafe_grant, authority(), Duration::ZERO).is_none());
+    }
+}

--- a/rocketmq-broker/src/failover/escape_bridge_capability.rs
+++ b/rocketmq-broker/src/failover/escape_bridge_capability.rs
@@ -16,6 +16,7 @@ use std::collections::HashSet;
 use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::Weak;
+use std::time::Duration;
 
 use crate::config::broker_config::BrokerConfig;
 use arc_swap::ArcSwap;
@@ -51,6 +52,7 @@ use rocketmq_store_api::StoreError;
 use rocketmq_store_api::StoreErrorKind;
 use rocketmq_store_api::StoreHealth;
 use rocketmq_store_api::StoreOperation;
+use rocketmq_store_api::WriteLeaseToken;
 
 use crate::controller::replicas_manager::BrokerReplicaRole;
 use crate::failover::escape_bridge::MessageStoreUnavailable;
@@ -362,6 +364,7 @@ impl<MS: BrokerReadStore> EscapeBridgeStoreCapability<MS> {
             Ok(store) => store,
             Err(_) => return Ok(()),
         };
+        store.fence_controller_writes();
         let Some(ha_service) = store.get_ha_service().cloned() else {
             return Ok(());
         };
@@ -400,6 +403,24 @@ impl<MS: BrokerReadStore> EscapeBridgeStoreCapability<MS> {
             )
             .map_err(|error| HAError::invalid_state(format!("timer role fencing failed: {error}")))?;
         Ok(())
+    }
+
+    pub(crate) fn install_controller_write_lease(
+        &self,
+        token: WriteLeaseToken,
+        valid_for: Duration,
+    ) -> Result<bool, MessageStoreUnavailable>
+    where
+        MS: BrokerReplicationStore,
+    {
+        self.with_store(|store| store.install_controller_write_lease(token, valid_for))
+    }
+
+    pub(crate) fn fence_controller_writes(&self) -> Result<(), MessageStoreUnavailable>
+    where
+        MS: BrokerReplicationStore,
+    {
+        self.with_store(BrokerReplicationStore::fence_controller_writes)
     }
 
     pub(crate) fn master_flushed_offset(&self) -> Result<i64, MessageStoreUnavailable> {

--- a/rocketmq-broker/src/out_api/broker_outer_api.rs
+++ b/rocketmq-broker/src/out_api/broker_outer_api.rs
@@ -42,6 +42,7 @@ use rocketmq_protocol::protocol::body::broker_body::broker_member_group::BrokerM
 use rocketmq_protocol::protocol::body::broker_body::broker_member_group::GetBrokerMemberGroupResponseBody;
 use rocketmq_protocol::protocol::body::broker_body::register_broker_body::RegisterBrokerBody;
 use rocketmq_protocol::protocol::body::consumer_offset_serialize_wrapper::ConsumerOffsetSerializeWrapper;
+use rocketmq_protocol::protocol::body::controller_write_lease::ControllerWriteLeaseGrant;
 use rocketmq_protocol::protocol::body::elect_master_response_body::ElectMasterResponseBody;
 use rocketmq_protocol::protocol::body::kv_table::KVTable;
 use rocketmq_protocol::protocol::body::message_request_mode_serialize_wrapper::MessageRequestModeSerializeWrapper;
@@ -1302,9 +1303,9 @@ impl BrokerOuterAPI {
         confirm_offset: Option<i64>,
         heartbeat_timeout_millis: Option<i64>,
         election_priority: Option<i32>,
-    ) -> rocketmq_error::RocketMQResult<()> {
+    ) -> rocketmq_error::RocketMQResult<Option<ControllerWriteLeaseGrant>> {
         if controller_address.is_empty() {
-            return Ok(());
+            return Ok(None);
         }
         let request_header = BrokerHeartbeatRequestHeader {
             cluster_name,
@@ -1320,9 +1321,23 @@ impl BrokerOuterAPI {
         let request = self
             .command_factory
             .create_request_command(RequestCode::BrokerHeartbeat, request_header);
-        self.remoting_client
-            .invoke_request_oneway(&controller_address, request, timeout_millis)
-            .await
+        let response = self
+            .remoting_client
+            .invoke_request(Some(&controller_address), request, timeout_millis)
+            .await?;
+        match ResponseCode::from(response.code()) {
+            ResponseCode::Success => response
+                .body()
+                .map(|body| serde_json::from_slice(body.as_ref()))
+                .transpose()
+                .map_err(Into::into),
+            _ => Err(RocketMQError::BrokerOperationFailed {
+                operation: "send_heartbeat_to_controller",
+                code: response.code(),
+                message: response.remark().map_or_else(String::new, ToString::to_string),
+                broker_addr: Some(controller_address.to_string()),
+            }),
+        }
     }
 
     pub async fn send_heartbeat_to_controller_sync(
@@ -1338,7 +1353,7 @@ impl BrokerOuterAPI {
         confirm_offset: Option<i64>,
         heartbeat_timeout_millis: Option<i64>,
         election_priority: Option<i32>,
-    ) -> rocketmq_error::RocketMQResult<()> {
+    ) -> rocketmq_error::RocketMQResult<Option<ControllerWriteLeaseGrant>> {
         let request_header = BrokerHeartbeatRequestHeader {
             cluster_name,
             broker_addr,
@@ -1359,7 +1374,11 @@ impl BrokerOuterAPI {
             .await?;
 
         match ResponseCode::from(response.code()) {
-            ResponseCode::Success => Ok(()),
+            ResponseCode::Success => response
+                .body()
+                .map(|body| serde_json::from_slice(body.as_ref()))
+                .transpose()
+                .map_err(Into::into),
             _ => Err(RocketMQError::BrokerOperationFailed {
                 operation: "send_heartbeat_to_controller_sync",
                 code: response.code(),

--- a/rocketmq-controller/benches/controller_bench.rs
+++ b/rocketmq-controller/benches/controller_bench.rs
@@ -60,6 +60,7 @@ fn controller_bench(criterion: &mut Criterion) {
     let request = ControllerRequest::BrokerHeartbeat {
         broker_identity: identity,
         broker_live_info: heartbeat,
+        lease_grant_allowed: false,
     };
     criterion.bench_function("controller/raft_request_json_encode", |bencher| {
         bencher.iter(|| black_box(serde_json::to_vec(black_box(&request)).expect("serialize benchmark request")));

--- a/rocketmq-controller/src/controller/open_raft_controller.rs
+++ b/rocketmq-controller/src/controller/open_raft_controller.rs
@@ -32,6 +32,7 @@ use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
+use std::time::Instant;
 
 use crate::config::ControllerConfigReader;
 use crate::controller::broker_heartbeat_manager::DEFAULT_BROKER_CHANNEL_EXPIRED_TIME;
@@ -47,6 +48,7 @@ use crate::error::Result;
 use crate::event::controller_result::ControllerResult as EventControllerResult;
 use crate::heartbeat::default_broker_heartbeat_manager::DefaultBrokerHeartbeatManager;
 use crate::helper::broker_lifecycle_listener::BrokerLifecycleListener;
+use crate::manager::write_lease_manager::WriteLeaseGrantGate;
 use crate::metrics::controller_metrics_manager::ControllerMetricsManager;
 use crate::openraft::GrpcRaftService;
 use crate::openraft::RaftNodeManager;
@@ -154,6 +156,7 @@ pub struct OpenRaftController {
     first_received_heartbeat_time: Arc<AtomicU64>,
     service_context: ChildServiceContext,
     metrics_manager: Arc<ControllerMetricsManager>,
+    write_lease_grant_gate: Mutex<WriteLeaseGrantGate>,
 }
 
 impl OpenRaftController {
@@ -247,6 +250,7 @@ impl OpenRaftController {
             first_received_heartbeat_time: Arc::new(AtomicU64::new(0)),
             service_context,
             metrics_manager,
+            write_lease_grant_gate: Mutex::new(WriteLeaseGrantGate::default()),
         }
     }
 
@@ -363,6 +367,22 @@ impl OpenRaftController {
         use openraft::async_runtime::WatchReceiver;
         let metrics = node.raft().metrics().borrow_watched().clone();
         metrics.current_leader == Some(self.config.snapshot().node_id)
+    }
+
+    fn current_leader_term(&self) -> Option<u64> {
+        let Some(node) = self.node() else {
+            self.write_lease_grant_gate.lock().observe_not_leader();
+            return None;
+        };
+
+        use openraft::async_runtime::WatchReceiver;
+        let metrics = node.raft().metrics().borrow_watched().clone();
+        if metrics.current_leader == Some(self.config.snapshot().node_id) {
+            Some(metrics.current_term)
+        } else {
+            self.write_lease_grant_gate.lock().observe_not_leader();
+            None
+        }
     }
 
     pub(crate) fn has_recovered_cluster_state(&self) -> bool {
@@ -532,11 +552,23 @@ impl OpenRaftController {
             confirm_offset: request.confirm_offset.unwrap_or(-1),
             election_priority: request.election_priority.or(Some(i32::MAX)),
         };
+        let lease_grant_allowed = self.current_leader_term().is_some_and(|leader_term| {
+            let authority = self.node().and_then(|node| {
+                node.store()
+                    .state_machine
+                    .replicas_info_manager()
+                    .current_write_authority(&request.cluster_name, &request.broker_name)
+            });
+            self.write_lease_grant_gate
+                .lock()
+                .allow(leader_term, authority, Instant::now())
+        });
 
         match self
             .write_internal_request(ControllerRequest::BrokerHeartbeat {
                 broker_identity,
                 broker_live_info,
+                lease_grant_allowed,
             })
             .await?
         {

--- a/rocketmq-controller/src/manager.rs
+++ b/rocketmq-controller/src/manager.rs
@@ -15,6 +15,7 @@
 pub(crate) mod broker_replica_info;
 pub(crate) mod replicas_info_manager;
 pub(crate) mod sync_state_info;
+pub(crate) mod write_lease_manager;
 
 // Re-export ControllerManager from controller module for backward compatibility
 pub use crate::controller::controller_manager::ControllerManager;

--- a/rocketmq-controller/src/manager/replicas_info_manager.rs
+++ b/rocketmq-controller/src/manager/replicas_info_manager.rs
@@ -47,6 +47,7 @@ use rocketmq_protocol::protocol::body::broker_body::broker_member_group::BrokerM
 use rocketmq_protocol::protocol::body::broker_replicas_info::BrokerReplicasInfo;
 use rocketmq_protocol::protocol::body::broker_replicas_info::ReplicaIdentity;
 use rocketmq_protocol::protocol::body::broker_replicas_info::ReplicasInfo;
+use rocketmq_protocol::protocol::body::controller_write_lease::ControllerWriteLeaseGrant;
 use rocketmq_protocol::protocol::body::elect_master_response_body::ElectMasterResponseBody;
 use rocketmq_protocol::protocol::body::sync_state_set_body::SyncStateSet;
 use rocketmq_protocol::protocol::header::controller::alter_sync_state_set_response_header::AlterSyncStateSetResponseHeader;
@@ -92,6 +93,15 @@ struct SerializedState {
     sync_state_set_info_table: HashMap<String, SyncStateInfo>,
     #[serde(default)]
     broker_live_table: Vec<(BrokerIdentityInfoSnapshot, BrokerLiveInfoSnapshot)>,
+    #[serde(default)]
+    write_lease_table: HashMap<String, PersistedWriteLease>,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+struct PersistedWriteLease {
+    broker_id: u64,
+    master_epoch: i32,
+    generation: u64,
 }
 
 /// The manager that manages the replicas info for all brokers.
@@ -117,6 +127,9 @@ pub struct ReplicasInfoManager {
     /// Replicated broker liveness table, equivalent to Java RaftReplicasInfoManager
     /// brokerLiveTable.
     broker_live_table: Arc<DashMap<BrokerIdentityInfoSnapshot, BrokerLiveInfoSnapshot>>,
+
+    /// Quorum-replicated generation and handover quarantine for each broker set.
+    write_lease_table: Arc<DashMap<String, PersistedWriteLease>>,
 }
 
 impl ReplicasInfoManager {
@@ -127,7 +140,81 @@ impl ReplicasInfoManager {
             replica_info_table: Arc::new(DashMap::new()),
             sync_state_set_info_table: Arc::new(DashMap::new()),
             broker_live_table: Arc::new(DashMap::new()),
+            write_lease_table: Arc::new(DashMap::new()),
         }
+    }
+
+    fn write_lease_key(cluster_name: &str, broker_name: &str) -> String {
+        format!("{cluster_name}\0{broker_name}")
+    }
+
+    pub(crate) fn current_write_authority(&self, cluster_name: &str, broker_name: &str) -> Option<(u64, i32)> {
+        let state = self.sync_state_set_info_table.get(broker_name)?;
+        if state.cluster_name() != cluster_name {
+            return None;
+        }
+        Some((state.master_broker_id()?, state.master_epoch()))
+    }
+
+    /// Grants a write lease only to the currently committed master authority.
+    ///
+    /// The method executes inside the replicated state-machine apply path. A
+    /// rejected request never advances the generation. Handover to a different
+    /// authority waits longer than the old Broker's maximum local lease lifetime,
+    /// preventing overlap without comparing Controller and Broker clocks.
+    pub fn grant_write_lease(
+        &self,
+        broker_identity: &BrokerIdentityInfoSnapshot,
+        broker_live_info: &BrokerLiveInfoSnapshot,
+        lease_grant_allowed: bool,
+    ) -> Option<ControllerWriteLeaseGrant> {
+        if !lease_grant_allowed {
+            return None;
+        }
+        let broker_id = broker_identity.broker_id?;
+        if broker_id != broker_live_info.broker_id || broker_live_info.epoch <= 0 {
+            return None;
+        }
+
+        let replica_info = self.replica_info_table.get(broker_identity.broker_name.as_str())?;
+        if replica_info.cluster_name() != broker_identity.cluster_name || !replica_info.is_broker_exist(broker_id) {
+            return None;
+        }
+        drop(replica_info);
+
+        let sync_state = self
+            .sync_state_set_info_table
+            .get(broker_identity.broker_name.as_str())?;
+        if sync_state.cluster_name() != broker_identity.cluster_name
+            || sync_state.master_broker_id() != Some(broker_id)
+            || sync_state.master_epoch() != broker_live_info.epoch
+        {
+            return None;
+        }
+        drop(sync_state);
+
+        let key = Self::write_lease_key(&broker_identity.cluster_name, &broker_identity.broker_name);
+        let mut next_generation = 1;
+        if let Some(current) = self.write_lease_table.get(&key) {
+            next_generation = current.generation.saturating_add(1);
+        }
+
+        let grant = ControllerWriteLeaseGrant {
+            broker_id: broker_id as i64,
+            master_epoch: broker_live_info.epoch,
+            generation: next_generation,
+            lease_duration_millis: ControllerWriteLeaseGrant::DEFAULT_LEASE_DURATION_MILLIS,
+            safety_margin_millis: ControllerWriteLeaseGrant::DEFAULT_SAFETY_MARGIN_MILLIS,
+        };
+        self.write_lease_table.insert(
+            key,
+            PersistedWriteLease {
+                broker_id,
+                master_epoch: broker_live_info.epoch,
+                generation: next_generation,
+            },
+        );
+        Some(grant)
     }
 
     /// Alter the sync state set for a broker
@@ -1056,6 +1143,11 @@ impl ReplicasInfoManager {
                 .iter()
                 .map(|entry| (entry.key().clone(), entry.value().clone()))
                 .collect(),
+            write_lease_table: self
+                .write_lease_table
+                .iter()
+                .map(|entry| (entry.key().clone(), entry.value().clone()))
+                .collect(),
         };
 
         serde_json::to_vec(&state).map_err(|e| ControllerError::serialization_source("serialize sync state data", e))
@@ -1069,6 +1161,7 @@ impl ReplicasInfoManager {
         self.replica_info_table.clear();
         self.sync_state_set_info_table.clear();
         self.broker_live_table.clear();
+        self.write_lease_table.clear();
 
         for (key, value) in state.replica_info_table {
             self.replica_info_table.insert(CheetahString::from_string(key), value);
@@ -1081,6 +1174,10 @@ impl ReplicasInfoManager {
 
         for (key, value) in state.broker_live_table {
             self.broker_live_table.insert(key, value);
+        }
+
+        for (key, value) in state.write_lease_table {
+            self.write_lease_table.insert(key, value);
         }
 
         Ok(())
@@ -1381,5 +1478,93 @@ mod tests {
         }
 
         assert_eq!(manager.heartbeat_age_samples_at(1_000), vec![0, 100, 250]);
+    }
+
+    #[test]
+    fn write_lease_requires_committed_master_and_quarantines_handover() {
+        let config = ControllerConfigReader::new(ControllerConfig::new_node(1, "127.0.0.1:9876".parse().unwrap()));
+        let manager = ReplicasInfoManager::new(config);
+        for broker_id in [0, 1] {
+            manager
+                .try_apply_event(&ApplyBrokerIdEvent::new(
+                    "cluster-a",
+                    "broker-a",
+                    format!("127.0.0.1:{}", 10_911 + broker_id).as_str(),
+                    broker_id,
+                    format!("code-{broker_id}").as_str(),
+                ))
+                .unwrap();
+        }
+        manager
+            .try_apply_event(&ElectMasterEvent::with_new_master("broker-a", 0))
+            .unwrap();
+
+        let heartbeat = |broker_id, epoch, timestamp| BrokerLiveInfoSnapshot {
+            cluster_name: "cluster-a".to_owned(),
+            broker_name: "broker-a".to_owned(),
+            broker_addr: format!("127.0.0.1:{}", 10_911 + broker_id),
+            broker_id,
+            last_update_timestamp: timestamp,
+            heartbeat_timeout_millis: 30_000,
+            epoch,
+            max_offset: 100,
+            confirm_offset: 90,
+            election_priority: None,
+        };
+
+        let first = heartbeat(0, 1, 100);
+        assert_eq!(
+            manager
+                .grant_write_lease(&first.identity(), &first, true)
+                .expect("current committed master should receive a lease")
+                .generation,
+            1
+        );
+        let slave = heartbeat(1, 1, 200);
+        assert!(manager.grant_write_lease(&slave.identity(), &slave, true).is_none());
+
+        manager
+            .try_apply_event(&ElectMasterEvent::with_new_master("broker-a", 1))
+            .unwrap();
+        let early_new_master = heartbeat(1, 2, 12_099);
+        assert!(manager
+            .grant_write_lease(&early_new_master.identity(), &early_new_master, false)
+            .is_none());
+        let safe_new_master = heartbeat(1, 2, 12_100);
+        assert_eq!(
+            manager
+                .grant_write_lease(&safe_new_master.identity(), &safe_new_master, true)
+                .expect("handover quarantine has elapsed")
+                .generation,
+            2
+        );
+
+        let stale_old_master = heartbeat(0, 1, 20_000);
+        assert!(manager
+            .grant_write_lease(&stale_old_master.identity(), &stale_old_master, true)
+            .is_none());
+        let renewal = heartbeat(1, 2, 20_001);
+        assert_eq!(
+            manager
+                .grant_write_lease(&renewal.identity(), &renewal, true)
+                .unwrap()
+                .generation,
+            3
+        );
+
+        let snapshot = manager.serialize().unwrap();
+        let restored = ReplicasInfoManager::new(ControllerConfigReader::new(ControllerConfig::new_node(
+            1,
+            "127.0.0.1:9876".parse().unwrap(),
+        )));
+        restored.deserialize_from(&snapshot).unwrap();
+        let post_restore = heartbeat(1, 2, 20_002);
+        assert_eq!(
+            restored
+                .grant_write_lease(&post_restore.identity(), &post_restore, true)
+                .unwrap()
+                .generation,
+            4
+        );
     }
 }

--- a/rocketmq-controller/src/manager/write_lease_manager.rs
+++ b/rocketmq-controller/src/manager/write_lease_manager.rs
@@ -1,0 +1,99 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+use std::time::Instant;
+
+use rocketmq_protocol::protocol::body::controller_write_lease::ControllerWriteLeaseGrant;
+
+const LEADER_AND_HANDOVER_WAIT: Duration = Duration::from_millis(
+    ControllerWriteLeaseGrant::DEFAULT_LEASE_DURATION_MILLIS + ControllerWriteLeaseGrant::DEFAULT_SAFETY_MARGIN_MILLIS,
+);
+
+/// Leader-local monotonic gate for the first lease of a term or authority.
+#[derive(Debug, Default)]
+pub(crate) struct WriteLeaseGrantGate {
+    leader_term: Option<u64>,
+    leader_since: Option<Instant>,
+    authority: Option<(u64, i32)>,
+    authority_since: Option<Instant>,
+}
+
+impl WriteLeaseGrantGate {
+    pub(crate) fn allow(&mut self, leader_term: u64, committed_authority: Option<(u64, i32)>, now: Instant) -> bool {
+        if self.leader_term != Some(leader_term) {
+            self.leader_term = Some(leader_term);
+            self.leader_since = Some(now);
+            self.authority = committed_authority;
+            self.authority_since = Some(now);
+            return false;
+        }
+
+        if self.authority != committed_authority {
+            self.authority = committed_authority;
+            self.authority_since = Some(now);
+            return false;
+        }
+
+        committed_authority.is_some()
+            && self
+                .leader_since
+                .is_some_and(|since| now.duration_since(since) >= LEADER_AND_HANDOVER_WAIT)
+            && self
+                .authority_since
+                .is_some_and(|since| now.duration_since(since) >= LEADER_AND_HANDOVER_WAIT)
+    }
+
+    pub(crate) fn observe_not_leader(&mut self) {
+        self.leader_term = None;
+        self.leader_since = None;
+        self.authority = None;
+        self.authority_since = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn term_and_authority_changes_each_restart_the_monotonic_wait() {
+        let start = Instant::now();
+        let mut gate = WriteLeaseGrantGate::default();
+        assert!(!gate.allow(4, Some((0, 1)), start));
+        assert!(!gate.allow(
+            4,
+            Some((0, 1)),
+            start + LEADER_AND_HANDOVER_WAIT - Duration::from_millis(1)
+        ));
+        assert!(gate.allow(4, Some((0, 1)), start + LEADER_AND_HANDOVER_WAIT));
+
+        let handover = start + LEADER_AND_HANDOVER_WAIT;
+        assert!(!gate.allow(4, Some((1, 2)), handover));
+        assert!(gate.allow(4, Some((1, 2)), handover + LEADER_AND_HANDOVER_WAIT));
+
+        let next_term = handover + LEADER_AND_HANDOVER_WAIT;
+        assert!(!gate.allow(5, Some((1, 2)), next_term));
+        assert!(gate.allow(5, Some((1, 2)), next_term + LEADER_AND_HANDOVER_WAIT));
+    }
+
+    #[test]
+    fn losing_leadership_invalidates_the_local_wait() {
+        let start = Instant::now();
+        let mut gate = WriteLeaseGrantGate::default();
+        assert!(!gate.allow(8, Some((0, 3)), start));
+        gate.observe_not_leader();
+        assert!(!gate.allow(8, Some((0, 3)), start + LEADER_AND_HANDOVER_WAIT));
+    }
+}

--- a/rocketmq-controller/src/openraft/state_machine.rs
+++ b/rocketmq-controller/src/openraft/state_machine.rs
@@ -26,6 +26,7 @@ use rocketmq_model::utils::crc32_utils::crc32;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::header::controller::get_next_broker_id_response_header::GetNextBrokerIdResponseHeader;
 use rocketmq_protocol::protocol::header::controller::get_replica_info_response_header::GetReplicaInfoResponseHeader;
+use rocketmq_protocol::protocol::RemotingSerializable;
 use tokio::sync::Mutex;
 use tokio::sync::RwLock;
 
@@ -396,13 +397,21 @@ impl StateMachine {
             ControllerRequest::BrokerHeartbeat {
                 broker_identity,
                 broker_live_info,
+                lease_grant_allowed,
             } => {
                 replicas_info_manager.on_broker_heartbeat(broker_identity.clone(), broker_live_info.clone());
+                let lease_body = replicas_info_manager
+                    .grant_write_lease(broker_identity, broker_live_info, *lease_grant_allowed)
+                    .and_then(|grant| grant.encode().ok());
                 ControllerResponse::new(
                     rocketmq_protocol::code::response_code::ResponseCode::Success.into(),
-                    Some("Heart beat success".to_string()),
+                    Some(if lease_body.is_some() {
+                        "Heartbeat committed; write lease granted".to_string()
+                    } else {
+                        "Heartbeat committed; no write lease for this authority".to_string()
+                    }),
                     None,
-                    None,
+                    lease_body,
                 )
             }
             ControllerRequest::BrokerChannelClose { broker_identity } => {
@@ -718,6 +727,7 @@ mod tests {
                 confirm_offset: 80,
                 election_priority: Some(1),
             },
+            lease_grant_allowed: false,
         }
     }
 

--- a/rocketmq-controller/src/typ.rs
+++ b/rocketmq-controller/src/typ.rs
@@ -158,6 +158,8 @@ pub enum ControllerRequest {
     BrokerHeartbeat {
         broker_identity: BrokerIdentityInfoSnapshot,
         broker_live_info: BrokerLiveInfoSnapshot,
+        #[serde(default)]
+        lease_grant_allowed: bool,
     },
     BrokerChannelClose {
         broker_identity: BrokerIdentityInfoSnapshot,

--- a/rocketmq-controller/tests/multi_node_cluster_test.rs
+++ b/rocketmq-controller/tests/multi_node_cluster_test.rs
@@ -182,6 +182,7 @@ fn broker_heartbeat_request(
             confirm_offset: 80,
             election_priority: Some(1),
         },
+        lease_grant_allowed: false,
     }
 }
 

--- a/rocketmq-controller/tests/openraft_integration_test.rs
+++ b/rocketmq-controller/tests/openraft_integration_test.rs
@@ -84,6 +84,7 @@ fn broker_heartbeat_request(
             confirm_offset: 80,
             election_priority: Some(1),
         },
+        lease_grant_allowed: false,
     }
 }
 

--- a/rocketmq-controller/tests/snapshot_test.rs
+++ b/rocketmq-controller/tests/snapshot_test.rs
@@ -75,6 +75,7 @@ fn broker_heartbeat_request(
             confirm_offset: 80,
             election_priority: Some(1),
         },
+        lease_grant_allowed: false,
     }
 }
 

--- a/rocketmq-doc/en/ha/rust-controller-mode-contract.md
+++ b/rocketmq-doc/en/ha/rust-controller-mode-contract.md
@@ -1,0 +1,52 @@
+# Rust Controller Mode Write-Authority Contract
+
+RocketMQ Rust Controller mode uses a Rust-only lease protocol between the OpenRaft Controller,
+Broker control plane, and Store. It provides the fencing and failover behavior required by the
+RocketMQ Controller feature without depending on Java Controller, JRaft, DLedger, or Java
+AutoSwitchHA wire formats.
+
+## Authority and lease
+
+- A write authority is the pair `(brokerId, masterEpoch)` committed in the Controller state machine.
+- A lease token adds a monotonically increasing `generation` for that broker set.
+- A Controller heartbeat can grant a lease only when its cluster, broker set, registered broker ID,
+  and reported epoch exactly match the committed current master.
+- Slave, learner, unknown, removed, stale-epoch, and future-epoch requests receive no lease and do
+  not advance the generation.
+- The default Controller lease duration is 10 seconds. The Broker reserves a 2-second safety margin,
+  which is greater than the one-second maximum append/ACK budget.
+
+The heartbeat is replicated through OpenRaft before the response is returned. An ordinary one-way
+heartbeat is not write authority.
+
+## Clock and handover safety
+
+The Broker records a monotonic timestamp before sending the heartbeat. Its local deadline is no
+later than `send_time + lease_duration - safety_margin`; response delay therefore consumes the
+lease instead of extending it. Controller and Broker wall clocks are never compared.
+
+When the committed master authority changes, the Controller withholds the first lease for the new
+authority until `lease_duration + safety_margin` has elapsed since the last old-authority grant.
+This quarantine prevents the old and new masters from holding overlapping valid leases.
+
+## Store fencing
+
+Role changes fence Store before the Broker publishes the new role. Store remains fenced until a
+valid lease for that exact authority is installed. CommitLog captures the token before both normal
+and batch append, then validates the same token again before returning the final result. This check
+also applies to local-ACK, asynchronous flush, `waitStoreMsgOK=false`, duplication, single-replica,
+and internal Timer write paths.
+
+An expired, explicitly fenced, mismatched, or superseded token returns `SERVICE_NOT_AVAILABLE` and
+must never produce a successful client ACK. A delayed response with an older generation cannot
+revive a fenced Broker. Broker readiness uses the same live lease state.
+
+## Failure behavior
+
+- Loss of all Controller responses causes the Broker to fence local writes.
+- A direct client still connected to the isolated old master receives a retryable unavailable
+  response once the lease is absent or expired.
+- Rejoining with a stale epoch cannot acquire authority. Existing HA epoch recovery remains
+  responsible for truncating divergent tail data before the Broker can receive a current lease.
+- Controller snapshots persist lease generation and handover timing so restart cannot reset fencing
+  state or reissue an older generation.

--- a/rocketmq-protocol/src/protocol/body.rs
+++ b/rocketmq-protocol/src/protocol/body.rs
@@ -14,6 +14,7 @@
 
 pub mod broker_body;
 pub mod consumer_running_info;
+pub mod controller_write_lease;
 pub mod create_topic_list_request_body;
 pub mod delete_subscription_group_list_request_body;
 pub mod delete_topic_list_request_body;

--- a/rocketmq-protocol/src/protocol/body/controller_write_lease.rs
+++ b/rocketmq-protocol/src/protocol/body/controller_write_lease.rs
@@ -1,0 +1,57 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::Deserialize;
+use serde::Serialize;
+
+/// Rust-native Controller response that authorizes one Broker master to write.
+///
+/// This body is intentionally not part of the Java Controller wire contract.
+/// It is returned only after the corresponding heartbeat has been committed by
+/// the Rust Controller quorum.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ControllerWriteLeaseGrant {
+    pub broker_id: i64,
+    pub master_epoch: i32,
+    pub generation: u64,
+    pub lease_duration_millis: u64,
+    pub safety_margin_millis: u64,
+}
+
+impl ControllerWriteLeaseGrant {
+    pub const DEFAULT_LEASE_DURATION_MILLIS: u64 = 10_000;
+    pub const DEFAULT_SAFETY_MARGIN_MILLIS: u64 = 2_000;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ControllerWriteLeaseGrant;
+
+    #[test]
+    fn grant_uses_stable_camel_case_wire_fields() {
+        let grant = ControllerWriteLeaseGrant {
+            broker_id: 0,
+            master_epoch: 3,
+            generation: 7,
+            lease_duration_millis: 10_000,
+            safety_margin_millis: 2_000,
+        };
+
+        let json = serde_json::to_string(&grant).expect("grant should serialize");
+        assert!(json.contains("\"brokerId\":0"));
+        assert!(json.contains("\"masterEpoch\":3"));
+        assert_eq!(serde_json::from_str::<ControllerWriteLeaseGrant>(&json).unwrap(), grant);
+    }
+}

--- a/rocketmq-store-api/src/ha_contract.rs
+++ b/rocketmq-store-api/src/ha_contract.rs
@@ -128,6 +128,41 @@ pub struct WriteAuthority {
     master_epoch: MasterEpoch,
 }
 
+/// A generation-scoped Controller write lease token.
+///
+/// The token deliberately excludes an expiry timestamp. A Broker converts the
+/// Controller-provided duration into a process-local monotonic deadline before
+/// installing it in Store.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct WriteLeaseToken {
+    authority: WriteAuthority,
+    generation: u64,
+}
+
+impl WriteLeaseToken {
+    /// Creates a token for a non-zero Controller lease generation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HaContractError::InvalidLeaseGeneration`] when `generation` is zero.
+    pub fn try_new(authority: WriteAuthority, generation: u64) -> Result<Self, HaContractError> {
+        if generation == 0 {
+            return Err(HaContractError::InvalidLeaseGeneration(generation));
+        }
+        Ok(Self { authority, generation })
+    }
+
+    /// Returns the Controller authority carried by this lease.
+    pub const fn authority(self) -> WriteAuthority {
+        self.authority
+    }
+
+    /// Returns the monotonically increasing lease generation.
+    pub const fn generation(self) -> u64 {
+        self.generation
+    }
+}
+
 impl WriteAuthority {
     /// Creates an authority for a non-negative broker identifier and positive epoch.
     ///
@@ -421,6 +456,8 @@ pub enum HaContractError {
     InvalidAckPolicy(i32),
     /// A physical offset was negative.
     InvalidOffset(i64),
+    /// A Controller write-lease generation was zero.
+    InvalidLeaseGeneration(u64),
     /// The sync-state set was empty.
     EmptySyncStateSet,
     /// The current leader was absent from the sync-state set.
@@ -446,6 +483,9 @@ impl fmt::Display for HaContractError {
             }
             Self::InvalidAckPolicy(value) => write!(formatter, "unsupported legacy ACK policy value {value}"),
             Self::InvalidOffset(value) => write!(formatter, "HA offset must be non-negative, got {value}"),
+            Self::InvalidLeaseGeneration(value) => {
+                write!(formatter, "write-lease generation must be positive, got {value}")
+            }
             Self::EmptySyncStateSet => formatter.write_str("sync-state set must not be empty"),
             Self::LeaderMissingFromSyncStateSet(value) => {
                 write!(formatter, "leader broker {value} is absent from the sync-state set")

--- a/rocketmq-store-api/src/lib.rs
+++ b/rocketmq-store-api/src/lib.rs
@@ -67,6 +67,7 @@ pub use ha_contract::ReplicationObservation;
 pub use ha_contract::SyncStateSet;
 pub use ha_contract::SyncStateSetEpoch;
 pub use ha_contract::WriteAuthority;
+pub use ha_contract::WriteLeaseToken;
 pub use progress::CursorAdvance;
 pub use progress::CursorAdvanceDisposition;
 pub use progress::CursorAdvanceError;

--- a/rocketmq-store/src/base/backend_ops.rs
+++ b/rocketmq-store/src/base/backend_ops.rs
@@ -38,6 +38,7 @@ use rocketmq_runtime::common::system_clock::SystemClock;
 use rocketmq_runtime::common::time_utils::current_millis;
 use rocketmq_store_api::TimerRecallRequest;
 use rocketmq_store_api::TimerRecallStatus;
+use rocketmq_store_api::WriteLeaseToken;
 use rocketmq_store_local::mapped_file::ManagedRetirementStage;
 
 use crate::base::allocate_mapped_file_service::AllocateMappedFileService;
@@ -58,6 +59,7 @@ use crate::consume_queue::mapped_file_queue::FlushProgress;
 use crate::filter::ArcMessageFilter;
 use crate::filter::MessageFilter;
 use crate::ha::general_ha_service::GeneralHAService;
+use crate::ha::write_lease::ControllerWriteLeaseState;
 use crate::hook::put_message_hook::BoxedPutMessageHook;
 use crate::hook::put_message_hook::PutMessageHook;
 use crate::hook::send_message_back_hook::SendMessageBackHook;
@@ -106,6 +108,7 @@ pub struct PutMessagePreflight {
     shutdown: Arc<AtomicBool>,
     running_flags: Arc<RunningFlags>,
     begin_time_in_lock: Arc<AtomicU64>,
+    controller_write_lease: ControllerWriteLeaseState,
 }
 
 impl PutMessagePreflight {
@@ -113,11 +116,13 @@ impl PutMessagePreflight {
         shutdown: Arc<AtomicBool>,
         running_flags: Arc<RunningFlags>,
         begin_time_in_lock: Arc<AtomicU64>,
+        controller_write_lease: ControllerWriteLeaseState,
     ) -> Self {
         Self {
             shutdown,
             running_flags,
             begin_time_in_lock,
+            controller_write_lease,
         }
     }
 
@@ -126,6 +131,7 @@ impl PutMessagePreflight {
             Arc::new(AtomicBool::new(true)),
             Arc::new(RunningFlags::new()),
             Arc::new(AtomicU64::new(0)),
+            ControllerWriteLeaseState::new(false),
         )
     }
 
@@ -136,7 +142,7 @@ impl PutMessagePreflight {
 
     /// Returns whether the store running flags permit writes.
     pub fn is_writeable(&self) -> bool {
-        self.running_flags.is_writeable()
+        self.running_flags.is_writeable() && self.controller_write_lease.is_write_permitted()
     }
 
     /// Returns the raw running-state flags for diagnostic logging.
@@ -802,6 +808,14 @@ pub trait BackendOps: Send + Sync + 'static {
         Ok(())
     }
 
+    /// Installs a Controller lease using a Broker-computed monotonic lifetime.
+    fn install_controller_write_lease(&self, _token: WriteLeaseToken, _valid_for: Duration) -> bool {
+        false
+    }
+
+    /// Immediately invalidates Controller-mode local write authority.
+    fn fence_controller_writes(&self) {}
+
     /// Calculate the checksum of a certain range of data.
     fn calc_delta_checksum(&self, from: i64, to: i64) -> Vec<u8>;
 
@@ -917,11 +931,16 @@ mod tests {
     use std::sync::atomic::AtomicU64;
     use std::sync::atomic::Ordering;
     use std::sync::Arc;
+    use std::time::Duration;
 
     use rocketmq_runtime::common::time_utils::current_millis;
+    use rocketmq_store_api::MasterEpoch;
+    use rocketmq_store_api::WriteAuthority;
+    use rocketmq_store_api::WriteLeaseToken;
 
     use super::PutMessagePreflight;
     use super::StateMachineVersionView;
+    use crate::ha::write_lease::ControllerWriteLeaseState;
     use crate::store::running_flags::RunningFlags;
 
     #[test]
@@ -929,7 +948,12 @@ mod tests {
         let shutdown = Arc::new(AtomicBool::new(false));
         let running_flags = Arc::new(RunningFlags::new());
         let begin_time_in_lock = Arc::new(AtomicU64::new(0));
-        let preflight = PutMessagePreflight::new(shutdown.clone(), running_flags.clone(), begin_time_in_lock.clone());
+        let preflight = PutMessagePreflight::new(
+            shutdown.clone(),
+            running_flags.clone(),
+            begin_time_in_lock.clone(),
+            ControllerWriteLeaseState::new(false),
+        );
 
         assert!(!preflight.is_shutdown());
         assert!(preflight.is_writeable());
@@ -955,6 +979,25 @@ mod tests {
         assert!(preflight.is_writeable());
         assert_eq!(preflight.flag_bits(), 0);
         assert!(!preflight.is_os_page_cache_busy(10));
+    }
+
+    #[test]
+    fn controller_preflight_requires_a_live_write_lease() {
+        let lease = ControllerWriteLeaseState::new(true);
+        let preflight = PutMessagePreflight::new(
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(RunningFlags::new()),
+            Arc::new(AtomicU64::new(0)),
+            lease.clone(),
+        );
+        assert!(!preflight.is_writeable());
+
+        let authority = WriteAuthority::try_new(0, MasterEpoch::try_from(2).unwrap()).unwrap();
+        let token = WriteLeaseToken::try_new(authority, 1).unwrap();
+        assert!(lease.install(token, Duration::from_secs(1)));
+        assert!(preflight.is_writeable());
+        lease.fence();
+        assert!(!preflight.is_writeable());
     }
 
     #[test]

--- a/rocketmq-store/src/capability.rs
+++ b/rocketmq-store/src/capability.rs
@@ -23,6 +23,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::future::Future;
 use std::sync::Arc;
+use std::time::Duration;
 
 use bytes::Bytes;
 use bytes::BytesMut;
@@ -52,6 +53,7 @@ use rocketmq_store_api::StoreHealth;
 use rocketmq_store_api::StoreHealthSnapshot as ApiStoreHealthSnapshot;
 use rocketmq_store_api::TimerRecallRequest;
 use rocketmq_store_api::TimerRecallStatus;
+use rocketmq_store_api::WriteLeaseToken;
 
 use crate::base::backend_ops::BackendOps;
 use crate::base::backend_ops::MessageStoreShutdownReport;
@@ -673,6 +675,14 @@ pub trait BrokerReplicationStore: BrokerReadWriteStore + BrokerMasterAddressStor
         external_term: u64,
     ) -> Result<(), crate::store_error::StoreError> {
         BackendOps::sync_broker_role_with_term(self.backend(), broker_role, external_term)
+    }
+
+    fn install_controller_write_lease(&self, token: WriteLeaseToken, valid_for: Duration) -> bool {
+        BackendOps::install_controller_write_lease(self.backend(), token, valid_for)
+    }
+
+    fn fence_controller_writes(&self) {
+        BackendOps::fence_controller_writes(self.backend());
     }
 
     fn get_ha_service(&self) -> Option<&GeneralHAService> {

--- a/rocketmq-store/src/ha.rs
+++ b/rocketmq-store/src/ha.rs
@@ -31,6 +31,7 @@ pub mod ha_service;
 pub mod transfer_engine;
 pub mod transfer_metrics;
 pub(crate) mod wait_notify_object;
+pub(crate) mod write_lease;
 
 pub use rocketmq_store_local::ha::error::HAConnectionError;
 

--- a/rocketmq-store/src/ha/write_lease.rs
+++ b/rocketmq-store/src/ha/write_lease.rs
@@ -1,0 +1,132 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
+
+use parking_lot::Mutex;
+use rocketmq_store_api::WriteLeaseToken;
+
+#[derive(Clone, Copy, Debug)]
+struct ActiveWriteLease {
+    token: WriteLeaseToken,
+    deadline: Instant,
+}
+
+/// Process-local monotonic projection of Controller write authority.
+#[derive(Clone, Debug)]
+pub(crate) struct ControllerWriteLeaseState {
+    required: bool,
+    active: Arc<Mutex<Option<ActiveWriteLease>>>,
+}
+
+impl ControllerWriteLeaseState {
+    pub(crate) fn new(required: bool) -> Self {
+        Self {
+            required,
+            active: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    pub(crate) fn install(&self, token: WriteLeaseToken, valid_for: Duration) -> bool {
+        let Some(deadline) = Instant::now().checked_add(valid_for) else {
+            return false;
+        };
+        if valid_for.is_zero() {
+            return false;
+        }
+
+        let mut active = self.active.lock();
+        if active
+            .as_ref()
+            .is_some_and(|current| current.token.generation() >= token.generation())
+        {
+            return false;
+        }
+        *active = Some(ActiveWriteLease { token, deadline });
+        true
+    }
+
+    pub(crate) fn fence(&self) {
+        if let Some(active) = self.active.lock().as_mut() {
+            active.deadline = Instant::now();
+        }
+    }
+
+    pub(crate) fn capture(&self) -> Result<Option<WriteLeaseToken>, ()> {
+        if !self.required {
+            return Ok(None);
+        }
+        let active = self.active.lock();
+        active
+            .as_ref()
+            .filter(|lease| Instant::now() < lease.deadline)
+            .map(|lease| Some(lease.token))
+            .ok_or(())
+    }
+
+    pub(crate) fn validate(&self, expected: Option<WriteLeaseToken>) -> bool {
+        if !self.required {
+            return expected.is_none();
+        }
+        let Some(expected) = expected else {
+            return false;
+        };
+        self.active
+            .lock()
+            .as_ref()
+            .is_some_and(|lease| lease.token == expected && Instant::now() < lease.deadline)
+    }
+
+    pub(crate) fn is_write_permitted(&self) -> bool {
+        self.capture().is_ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread;
+
+    use rocketmq_store_api::MasterEpoch;
+    use rocketmq_store_api::WriteAuthority;
+
+    use super::*;
+
+    fn token(generation: u64) -> WriteLeaseToken {
+        let authority = WriteAuthority::try_new(0, MasterEpoch::try_from(3).unwrap()).unwrap();
+        WriteLeaseToken::try_new(authority, generation).unwrap()
+    }
+
+    #[test]
+    fn expired_and_stale_leases_fail_closed() {
+        let state = ControllerWriteLeaseState::new(true);
+        assert!(state.capture().is_err());
+        assert!(state.install(token(2), Duration::from_millis(2)));
+        let captured = state.capture().unwrap();
+        thread::sleep(Duration::from_millis(4));
+        assert!(!state.validate(captured));
+        assert!(!state.install(token(1), Duration::from_secs(1)));
+        assert!(state.capture().is_err());
+    }
+
+    #[test]
+    fn explicit_fence_invalidates_current_generation() {
+        let state = ControllerWriteLeaseState::new(true);
+        assert!(state.install(token(4), Duration::from_secs(1)));
+        let captured = state.capture().unwrap();
+        state.fence();
+        assert!(!state.validate(captured));
+    }
+}

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -30,6 +30,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::time::Duration;
 use std::time::Instant;
 
 use crate::config::store_runtime_config::StoreRuntimeConfig;
@@ -59,6 +60,7 @@ use rocketmq_protocol::common::message::message_decoder::cheetah_from_utf8_lossy
 use rocketmq_protocol::common::message::message_decoder::string_to_message_properties;
 use rocketmq_runtime::common::system_clock::SystemClock;
 use rocketmq_runtime::resource_budget::QueueSnapshot;
+use rocketmq_store_api::WriteLeaseToken;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
@@ -91,6 +93,7 @@ use crate::consume_queue::mapped_file_queue::MappedFileQueueAppendHandle;
 use crate::consume_queue::mapped_file_queue::MappedFileWarmupStats;
 use crate::ha::general_ha_service::GeneralHAService;
 use crate::ha::ha_service::HAService;
+use crate::ha::write_lease::ControllerWriteLeaseState;
 use crate::log_file::cold_data_check_service::ColdDataCheckService;
 use crate::log_file::commit_log_path_set::CommitLogPathSet;
 use rocketmq_store_local::mapped_file::ManagedLifecycleRuntime;
@@ -586,7 +589,20 @@ impl CommitLog {
             enabled_append_prop_crc: self.enabled_append_prop_crc,
             append_port: self.append_runtime.port(),
             telemetry_handle: self.telemetry_handle.clone(),
+            store_context: self.store_context.clone(),
         }
+    }
+
+    pub(crate) fn install_controller_write_lease(&self, token: WriteLeaseToken, valid_for: Duration) -> bool {
+        self.store_context.controller_write_lease.install(token, valid_for)
+    }
+
+    pub(crate) fn fence_controller_writes(&self) {
+        self.store_context.controller_write_lease.fence();
+    }
+
+    pub(crate) fn controller_write_lease_state(&self) -> ControllerWriteLeaseState {
+        self.store_context.controller_write_lease.clone()
     }
 
     #[inline]
@@ -1115,6 +1131,10 @@ impl CommitLog {
 
     pub async fn put_messages(&self, mut msg_batch: MessageExtBatch) -> PutMessageResult {
         let append_span = rocketmq_observability::trace::store::append_span(&self.telemetry_handle);
+        let requested_lease = match self.store_context.controller_write_lease.capture() {
+            Ok(lease) => lease,
+            Err(()) => return PutMessageResult::new_default(PutMessageStatus::ServiceNotAvailable),
+        };
         #[cfg(any(feature = "observability", feature = "observability-traces"))]
         rocketmq_observability::trace::record_message_properties_with_handle(
             &self.telemetry_handle,
@@ -1181,12 +1201,17 @@ impl CommitLog {
             sequenced.batch.message_ext_broker_inner,
             need_ack_nums,
             need_handle_ha,
+            requested_lease,
         )
         .await
     }
 
     pub async fn put_message(&self, mut msg: MessageExtBrokerInner) -> PutMessageResult {
         let append_span = rocketmq_observability::trace::store::append_span(&self.telemetry_handle);
+        let requested_lease = match self.store_context.controller_write_lease.capture() {
+            Ok(lease) => lease,
+            Err(()) => return PutMessageResult::new_default(PutMessageStatus::ServiceNotAvailable),
+        };
         #[cfg(any(feature = "observability", feature = "observability-traces"))]
         rocketmq_observability::trace::record_message_properties_with_handle(
             &self.telemetry_handle,
@@ -1245,8 +1270,14 @@ impl CommitLog {
         if sequenced.result.put_message_status() != PutMessageStatus::PutOk {
             return sequenced.result;
         }
-        self.handle_disk_flush_and_ha(sequenced.result, sequenced.message, need_ack_nums, need_handle_ha)
-            .await
+        self.handle_disk_flush_and_ha(
+            sequenced.result,
+            sequenced.message,
+            need_ack_nums,
+            need_handle_ha,
+            requested_lease,
+        )
+        .await
     }
 
     #[inline]
@@ -1282,6 +1313,7 @@ impl CommitLog {
         msg: MessageExtBrokerInner,
         need_ack_nums: i32,
         need_handle_ha: bool,
+        requested_lease: Option<WriteLeaseToken>,
     ) -> PutMessageResult {
         let append_message_result = put_message_result.append_message_result().unwrap();
 
@@ -1315,6 +1347,10 @@ impl CommitLog {
                 }
             }
             (FlushDiskType::AsyncFlush, false) => {}
+        }
+
+        if !self.store_context.controller_write_lease.validate(requested_lease) {
+            put_message_result.set_put_message_status(PutMessageStatus::ServiceNotAvailable);
         }
 
         put_message_result
@@ -1782,6 +1818,7 @@ impl CommitLog {
         if self.broker_config.enable_controller_mode {
             if self.store_runtime_state.broker_role() != BrokerRole::Slave
                 && !self.store_context.running_flags.is_fenced()
+                && self.store_context.controller_write_lease.is_write_permitted()
             {
                 let max_phy_offset = self.get_max_offset();
                 if let Some(ha_service) = self.store_context.ha_service() {
@@ -2858,6 +2895,8 @@ mod tests {
     use rocketmq_model::utils::crc32_utils::crc32;
     use rocketmq_protocol::common::message::message_decoder::create_crc32;
     use rocketmq_runtime::common::time_utils::current_millis;
+    use rocketmq_store_api::MasterEpoch;
+    use rocketmq_store_api::WriteAuthority;
 
     #[test]
     fn put_message_lock_stats_records_totals_and_maxes() {
@@ -3003,9 +3042,40 @@ mod tests {
             .await
             .expect("append data");
         store.set_confirm_offset(1);
+        let authority = WriteAuthority::try_new(0, MasterEpoch::try_from(1).unwrap()).unwrap();
+        let token = WriteLeaseToken::try_new(authority, 1).unwrap();
+        assert!(store
+            .get_commit_log()
+            .install_controller_write_lease(token, Duration::from_secs(1)));
 
         assert_eq!(store.get_confirm_offset(), 4);
         assert_eq!(read_handle.get_confirm_offset(), 4);
+
+        let _ = std::fs::remove_dir_all(temp_root);
+    }
+
+    #[tokio::test]
+    async fn controller_mode_local_ack_path_requires_a_live_lease() {
+        let temp_root = std::env::temp_dir().join(format!("rocketmq-rust-commitlog-write-lease-{}", current_millis()));
+        let mut store = new_test_message_store(&temp_root, BrokerRole::SyncMaster, false);
+        store.init().await.expect("init message store");
+
+        let denied = store
+            .get_commit_log()
+            .put_message(append_test_message("lease-topic", b"denied"))
+            .await;
+        assert_eq!(denied.put_message_status(), PutMessageStatus::ServiceNotAvailable);
+
+        let authority = WriteAuthority::try_new(0, MasterEpoch::try_from(1).unwrap()).unwrap();
+        let token = WriteLeaseToken::try_new(authority, 1).unwrap();
+        assert!(store
+            .get_commit_log()
+            .install_controller_write_lease(token, Duration::from_secs(1)));
+        let accepted = store
+            .get_commit_log()
+            .put_message(append_test_message("lease-topic", b"accepted"))
+            .await;
+        assert_eq!(accepted.put_message_status(), PutMessageStatus::PutOk);
 
         let _ = std::fs::remove_dir_all(temp_root);
     }

--- a/rocketmq-store/src/log_file/commit_log/context.rs
+++ b/rocketmq-store/src/log_file/commit_log/context.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 
 use crate::base::store_stats_service::StoreStatsService;
 use crate::ha::general_ha_service::GeneralHAService;
+use crate::ha::write_lease::ControllerWriteLeaseState;
 use crate::store::running_flags::RunningFlags;
 use arc_swap::ArcSwapOption;
 
@@ -34,6 +35,7 @@ pub(crate) struct CommitLogStoreContext {
     pub(super) ha_service: Arc<ArcSwapOption<GeneralHAService>>,
     pub(super) max_delay_level: i32,
     pub(super) delay_level_table: Arc<BTreeMap<i32, i64>>,
+    pub(super) controller_write_lease: ControllerWriteLeaseState,
 }
 
 impl CommitLogStoreContext {
@@ -43,6 +45,7 @@ impl CommitLogStoreContext {
         store_stats_service: Arc<StoreStatsService>,
         max_delay_level: i32,
         delay_level_table: Arc<BTreeMap<i32, i64>>,
+        controller_mode: bool,
     ) -> Self {
         Self {
             running_flags,
@@ -51,6 +54,7 @@ impl CommitLogStoreContext {
             ha_service: Arc::new(ArcSwapOption::empty()),
             max_delay_level,
             delay_level_table,
+            controller_write_lease: ControllerWriteLeaseState::new(controller_mode),
         }
     }
 

--- a/rocketmq-store/src/log_file/commit_log/handles.rs
+++ b/rocketmq-store/src/log_file/commit_log/handles.rs
@@ -25,6 +25,7 @@ use tracing::Instrument;
 
 use crate::base::message_encoder_pool;
 use crate::base::message_result::PutMessageResult;
+use crate::base::message_status_enum::PutMessageStatus;
 use crate::base::select_result::SelectMappedBufferResult;
 use crate::base::store_checkpoint::StoreCheckpoint;
 use crate::config::flush_disk_type::FlushDiskType;
@@ -158,6 +159,7 @@ impl CommitLogReadHandle {
         if self.broker_config.enable_controller_mode {
             if self.store_runtime_state.broker_role() != BrokerRole::Slave
                 && !self.store_context.running_flags.is_fenced()
+                && self.store_context.controller_write_lease.is_write_permitted()
             {
                 let max_phy_offset = self.get_max_offset();
                 if let Some(ha_service) = self.store_context.ha_service() {
@@ -217,11 +219,16 @@ pub(crate) struct CommitLogInternalMessageWriteHandle {
     pub(super) enabled_append_prop_crc: bool,
     pub(super) append_port: CommitLogAppendPort,
     pub(super) telemetry_handle: rocketmq_observability::TelemetryHandle,
+    pub(super) store_context: CommitLogStoreContext,
 }
 
 impl CommitLogInternalMessageWriteHandle {
     pub(crate) async fn put_message(&self, mut msg: MessageExtBrokerInner) -> PutMessageResult {
         let append_span = rocketmq_observability::trace::store::append_span(&self.telemetry_handle);
+        let requested_lease = match self.store_context.controller_write_lease.capture() {
+            Ok(lease) => lease,
+            Err(()) => return PutMessageResult::new_default(PutMessageStatus::ServiceNotAvailable),
+        };
         msg.set_wait_store_msg_ok(false);
         #[cfg(any(feature = "observability", feature = "observability-traces"))]
         rocketmq_observability::trace::record_message_properties_with_handle(
@@ -252,11 +259,16 @@ impl CommitLogInternalMessageWriteHandle {
             Ok(prepared) => prepared,
             Err(result) => return result,
         };
-        self.append_port
+        let mut result = self
+            .append_port
             .append_message(msg, prepared, need_assign_offset)
             .instrument(append_span)
             .await
-            .result
+            .result;
+        if !self.store_context.controller_write_lease.validate(requested_lease) {
+            result.set_put_message_status(PutMessageStatus::ServiceNotAvailable);
+        }
+        result
     }
 }
 
@@ -353,7 +365,10 @@ pub(super) fn resolve_commit_log_confirm_offset(
     flushed_where: i64,
 ) -> i64 {
     if broker_config.enable_controller_mode {
-        if broker_role == BrokerRole::Slave || store_context.running_flags.is_fenced() {
+        if broker_role == BrokerRole::Slave
+            || store_context.running_flags.is_fenced()
+            || !store_context.controller_write_lease.is_write_permitted()
+        {
             return stored_confirm_offset;
         }
 

--- a/rocketmq-store/src/message_store.rs
+++ b/rocketmq-store/src/message_store.rs
@@ -27,6 +27,7 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::time::Duration;
 
 use bytes::Bytes;
 use bytes::BytesMut;
@@ -40,6 +41,7 @@ use rocketmq_protocol::protocol::body::ha_runtime_info::HARuntimeInfo;
 use rocketmq_runtime::common::system_clock::SystemClock;
 use rocketmq_store_api::TimerRecallRequest;
 use rocketmq_store_api::TimerRecallStatus;
+use rocketmq_store_api::WriteLeaseToken;
 
 use crate::base::allocate_mapped_file_service::AllocateMappedFileService;
 use crate::base::backend_ops::BackendOps;
@@ -699,6 +701,14 @@ macro_rules! message_store_methods {
 
     fn sync_broker_role_with_term(&self, broker_role: BrokerRole, external_term: u64) -> Result<(), StoreError> {
         delegate_store!(self, sync_broker_role_with_term(broker_role, external_term))
+    }
+
+    fn install_controller_write_lease(&self, token: WriteLeaseToken, valid_for: Duration) -> bool {
+        delegate_store!(self, install_controller_write_lease(token, valid_for))
+    }
+
+    fn fence_controller_writes(&self) {
+        delegate_store!(self, fence_controller_writes());
     }
 
     fn calc_delta_checksum(&self, from: i64, to: i64) -> Vec<u8> {

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -85,6 +85,7 @@ use rocketmq_store_api::checkpoint::CheckpointOffsets as ReleaseCheckpointOffset
 use rocketmq_store_api::TimerRecallRequest;
 use rocketmq_store_api::TimerRecallStatus;
 use rocketmq_store_api::TimerStoreMode;
+use rocketmq_store_api::WriteLeaseToken;
 #[cfg(feature = "extended_timeline")]
 use rocketmq_store_rocksdb::store::KeyValueStore;
 #[cfg(feature = "extended_timeline")]
@@ -2075,6 +2076,7 @@ impl BackendOps for LocalFileMessageStore {
             self.shutdown.clone(),
             self.running_flags.clone(),
             self.commit_log.begin_time_in_lock().clone(),
+            self.commit_log.controller_write_lease_state(),
         )
     }
 
@@ -2348,6 +2350,14 @@ impl BackendOps for LocalFileMessageStore {
         #[cfg(feature = "extended_timeline")]
         self.sync_extended_timeline_controller_role(previous_role, broker_role, external_term)?;
         Ok(())
+    }
+
+    fn install_controller_write_lease(&self, token: WriteLeaseToken, valid_for: Duration) -> bool {
+        self.commit_log.install_controller_write_lease(token, valid_for)
+    }
+
+    fn fence_controller_writes(&self) {
+        self.commit_log.fence_controller_writes();
     }
 
     fn calc_delta_checksum(&self, from: i64, to: i64) -> Vec<u8> {

--- a/rocketmq-store/src/message_store/local_file_message_store/composition.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store/composition.rs
@@ -274,6 +274,7 @@ impl LocalFileMessageStore {
             store_stats_service.clone(),
             max_delay_level,
             delay_level_table.clone(),
+            broker_config.enable_controller_mode,
         );
         let store_runtime_state = Arc::new(StoreRuntimeState::new(message_store_config.as_ref()));
         let mut commit_log = CommitLog::try_new(

--- a/rocketmq-store/src/message_store/rocksdb_message_store.rs
+++ b/rocketmq-store/src/message_store/rocksdb_message_store.rs
@@ -19,6 +19,7 @@ use std::fmt;
 use std::ops::Deref;
 use std::ops::DerefMut;
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::config::store_runtime_config::StoreRuntimeConfig;
 use bytes::Bytes;
@@ -36,6 +37,7 @@ use rocketmq_runtime::common::system_clock::SystemClock;
 use rocketmq_runtime::ChildServiceContext;
 use rocketmq_store_api::GetStatus as ApiGetStatus;
 use rocketmq_store_api::WalPort;
+use rocketmq_store_api::WriteLeaseToken;
 use rocketmq_store_rocksdb::message_store::RocksDbDerivedStore;
 use rocketmq_store_rocksdb::message_store::RocksDbMessageStoreError;
 use rocketmq_store_rocksdb::message_store::RocksDbMessageStoreOptions;
@@ -1203,6 +1205,14 @@ impl BackendOps for RocksDBMessageStore {
 
     fn sync_broker_role(&self, broker_role: BrokerRole) {
         self.local_file_store.sync_broker_role(broker_role);
+    }
+
+    fn install_controller_write_lease(&self, token: WriteLeaseToken, valid_for: Duration) -> bool {
+        self.local_file_store.install_controller_write_lease(token, valid_for)
+    }
+
+    fn fence_controller_writes(&self) {
+        self.local_file_store.fence_controller_writes();
     }
 
     fn calc_delta_checksum(&self, from: i64, to: i64) -> Vec<u8> {

--- a/rocketmq-store/tests/message_store/local_file_message_store/unit.rs
+++ b/rocketmq-store/tests/message_store/local_file_message_store/unit.rs
@@ -56,6 +56,9 @@ use rocketmq_model::common::running::running_stats::RunningStats;
 use rocketmq_model::common::topic::TopicValidator;
 use rocketmq_model::utils::crc32_utils::crc32;
 use rocketmq_runtime::ShutdownDeadline;
+use rocketmq_store_api::MasterEpoch;
+use rocketmq_store_api::WriteAuthority;
+use rocketmq_store_api::WriteLeaseToken;
 #[cfg(feature = "tieredstore")]
 use rocketmq_tieredstore::fetcher::TieredGetMessageStatus;
 #[cfg(feature = "tieredstore")]
@@ -3484,6 +3487,11 @@ async fn sync_broker_role_in_controller_mode_refreshes_confirm_offset_for_master
     assert_eq!(store.get_commit_log().get_confirm_offset_directly(), 0);
 
     store.sync_broker_role(BrokerRole::SyncMaster);
+    let authority = WriteAuthority::try_new(7, MasterEpoch::try_from(1).unwrap()).unwrap();
+    let token = WriteLeaseToken::try_new(authority, 1).unwrap();
+    assert!(store
+        .get_commit_log()
+        .install_controller_write_lease(token, Duration::from_secs(1)));
 
     assert_eq!(store.get_commit_log().get_confirm_offset_directly(), 4);
     assert_eq!(store.get_confirm_offset(), 4);


### PR DESCRIPTION
Closes #9476.

## Summary
- add a Rust-native, quorum-committed Controller write-lease contract
- require leader-local monotonic quarantine after leadership or authority changes
- fence Store before role publication and validate the same lease at append admission and final ACK
- cover LocalFile and RocksDB-backed Broker stores, including local-ACK and internal write paths

## Scope
This does not add Java Controller/AutoSwitch wire compatibility, DLedger CommitLog, OpenMessaging, BrokerContainer, MCP, SRE, or Dashboard behavior.

## Validation
- Controller library: 174 passed, 3 ignored
- Controller linearizability: passed
- Store HA fault smoke: 7 passed
- Broker epoch fault smoke: 2 passed
- focused Broker/Store/protocol lease tests: passed
- affected package Clippy, including rocksdb_store profiles: passed
- runtime ownership audit: passed
- fixed-nightly fuzz all-target/all-feature compile: passed after the known stale standalone lock was refreshed offline and restored
- git diff --check: passed

Known baseline: root cargo fmt --all is blocked on Windows by the repository's existing OS error 206 path-length condition; all affected packages were formatted successfully. An unrelated pre-existing rocketmq-client unused import warning remains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added controller write leases to authorize broker writes during controller-mode operation.
  * Heartbeats can now issue, renew, and validate time-limited write authority.
  * Added generation and epoch checks to prevent stale or unauthorized writes.
* **Bug Fixes**
  * Automatically fences writes when leadership, lease validity, or authority is uncertain.
  * Prevents writes from continuing during controller handovers or expired leases.
* **Documentation**
  * Documented write-authority behavior, fencing, failover handling, deadlines, and persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->