### PR TITLE
[ISSUE #9479]🐛Restore locked PKCS#8 dependency graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,18 +15,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
  "crypto-common 0.2.2",
- "inout 0.2.2",
-]
-
-[[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher 0.4.4",
- "cpufeatures 0.2.17",
+ "inout",
 ]
 
 [[package]]
@@ -35,7 +24,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
- "cipher 0.5.2",
+ "cipher",
  "cpubits",
  "cpufeatures 0.3.0",
 ]
@@ -47,8 +36,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
 dependencies = [
  "aead",
- "aes 0.9.2",
- "cipher 0.5.2",
+ "aes",
+ "cipher",
  "ctr",
  "ghash",
  "subtle",
@@ -452,11 +441,11 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -522,11 +511,11 @@ dependencies = [
 
 [[package]]
 name = "cbc"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -660,23 +649,13 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common 0.1.7",
- "inout 0.1.4",
-]
-
-[[package]]
-name = "cipher"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
  "block-buffer 0.12.1",
  "crypto-common 0.2.2",
- "inout 0.2.2",
+ "inout",
 ]
 
 [[package]]
@@ -823,12 +802,6 @@ dependencies = [
  "unicode-width",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-oid"
@@ -1118,7 +1091,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
 dependencies = [
- "cipher 0.5.2",
+ "cipher",
 ]
 
 [[package]]
@@ -1228,11 +1201,11 @@ checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "der"
-version = "0.7.10"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
- "const-oid 0.9.6",
+ "const-oid",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1331,7 +1304,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
- "subtle",
 ]
 
 [[package]]
@@ -1341,7 +1313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid 0.10.2",
+ "const-oid",
  "crypto-common 0.2.2",
  "ctutils",
 ]
@@ -1986,15 +1958,6 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "hmac"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
@@ -2298,20 +2261,11 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "block-padding",
- "generic-array",
-]
-
-[[package]]
-name = "inout"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
+ "block-padding",
  "hybrid-array",
 ]
 
@@ -3273,12 +3227,12 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pbkdf2"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
- "digest 0.10.7",
- "hmac 0.12.1",
+ "digest 0.11.3",
+ "hmac",
 ]
 
 [[package]]
@@ -3299,9 +3253,9 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.7.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -3463,28 +3417,32 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs5"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+checksum = "63d440a804ec8d6fafbb6b84471e013286658d373248927692ab3366686220ca"
 dependencies = [
- "aes 0.8.4",
+ "aes",
+ "aes-gcm",
  "cbc",
  "der",
+ "getrandom 0.4.3",
  "pbkdf2",
+ "rand_core 0.10.1",
  "scrypt",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "spki",
 ]
 
 [[package]]
 name = "pkcs8"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
  "der",
+ "getrandom 0.4.3",
  "pkcs5",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "spki",
 ]
 
@@ -3904,9 +3862,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
 
 [[package]]
 name = "rand_core"
@@ -4276,7 +4231,7 @@ dependencies = [
  "chrono",
  "criterion",
  "hex",
- "hmac 0.13.0",
+ "hmac",
  "ipnetwork",
  "md-5",
  "moka",
@@ -4619,7 +4574,7 @@ dependencies = [
  "flate2",
  "futures",
  "hex",
- "hmac 0.13.0",
+ "hmac",
  "parking_lot",
  "prost-types",
  "rcgen",
@@ -5121,11 +5076,12 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "salsa20"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
 dependencies = [
- "cipher 0.4.4",
+ "cfg-if",
+ "cipher",
 ]
 
 [[package]]
@@ -5160,13 +5116,14 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrypt"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+checksum = "d87af57419b594aa23fa95f09f0e06d80d84ba01c26148c43844cad6ff4485f0"
 dependencies = [
+ "cfg-if",
  "pbkdf2",
  "salsa20",
- "sha2 0.10.9",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -5461,9 +5418,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
  "der",

--- a/rocketmq-client/tests/transport_security_profiles.rs
+++ b/rocketmq-client/tests/transport_security_profiles.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use pkcs8::LineEnding;
-use pkcs8::PrivateKeyInfo;
+use pkcs8::PrivateKeyInfoRef;
 use rocketmq_client_rust::ClientConfig;
 use rocketmq_transport::api::v1::PrivateKeyLoader;
 use rocketmq_transport::api::v1::RequestDeadline;
@@ -32,9 +32,9 @@ fn encrypted_pkcs8_profile_is_secret_safe() {
     let rcgen::CertifiedKey { signing_key, .. } =
         rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).expect("generate key");
     let key_der = signing_key.serialize_der();
-    let key_info = PrivateKeyInfo::try_from(key_der.as_slice()).expect("parse key");
+    let key_info = PrivateKeyInfoRef::try_from(key_der.as_slice()).expect("parse key");
     let encrypted = key_info
-        .encrypt(pkcs8::rand_core::OsRng, "transport-password")
+        .encrypt("transport-password")
         .expect("encrypt key")
         .to_pem("ENCRYPTED PRIVATE KEY", LineEnding::LF)
         .expect("encode PEM");

--- a/rocketmq-transport/src/tls.rs
+++ b/rocketmq-transport/src/tls.rs
@@ -870,7 +870,7 @@ impl PrivateKeyLoader {
     ) -> RocketMQResult<tokio_rustls::rustls::pki_types::PrivateKeyDer<'static>> {
         use std::io::Cursor;
 
-        use pkcs8::EncryptedPrivateKeyInfo;
+        use pkcs8::EncryptedPrivateKeyInfoRef;
         use zeroize::Zeroizing;
 
         let path = path.as_ref();
@@ -899,7 +899,7 @@ impl PrivateKeyLoader {
                 .map_err(|_| config_error(key, safe_path.as_ref(), "encrypted private key PEM is not UTF-8"))?;
             let (_, encrypted_document) = pkcs8::SecretDocument::from_pem(pem_text)
                 .map_err(|_| config_error(key, safe_path.as_ref(), "invalid encrypted PKCS#8 PEM"))?;
-            let encrypted = EncryptedPrivateKeyInfo::try_from(encrypted_document.as_bytes())
+            let encrypted = EncryptedPrivateKeyInfoRef::try_from(encrypted_document.as_bytes())
                 .map_err(|_| config_error(key, safe_path.as_ref(), "invalid encrypted PKCS#8 payload"))?;
             let decrypted = encrypted.decrypt(password.as_slice()).map_err(|_| {
                 config_error(

--- a/rocketmq-transport/tests/tls_encrypted_key.rs
+++ b/rocketmq-transport/tests/tls_encrypted_key.rs
@@ -17,7 +17,7 @@
 use std::fs;
 
 use pkcs8::LineEnding;
-use pkcs8::PrivateKeyInfo;
+use pkcs8::PrivateKeyInfoRef;
 use rocketmq_transport::api::v1::PrivateKeyLoader;
 
 #[test]
@@ -25,10 +25,10 @@ fn encrypted_pkcs8_key_requires_the_correct_password_without_leaking_it() {
     let rcgen::CertifiedKey { signing_key, .. } =
         rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).expect("generate key");
     let key_der = signing_key.serialize_der();
-    let key_info = PrivateKeyInfo::try_from(key_der.as_slice()).expect("parse key");
+    let key_info = PrivateKeyInfoRef::try_from(key_der.as_slice()).expect("parse key");
     let password = "correct horse battery staple";
     let encrypted = key_info
-        .encrypt(pkcs8::rand_core::OsRng, password)
+        .encrypt(password)
         .expect("encrypt key")
         .to_pem("ENCRYPTED PRIVATE KEY", LineEnding::LF)
         .expect("encode PEM");


### PR DESCRIPTION
## Summary

- refresh the workspace lockfile for the already-declared PKCS#8 0.11 dependency graph
- migrate encrypted private-key parsing and test fixtures to the 0.11 borrowed DER APIs
- preserve password validation and secret-safe diagnostics

Closes #9479

## Validation

- `cargo metadata --locked --no-deps --format-version 1`
- `cargo check --locked -p rocketmq-transport --features tls`
- `cargo test --locked -p rocketmq-transport --features tls --test tls_encrypted_key`
- `cargo test --locked -p rocketmq-client-rust --test transport_security_profiles encrypted_pkcs8_profile_is_secret_safe`
- `cargo clippy --locked -p rocketmq-transport --features tls --all-targets -- -D warnings`
- `cargo clippy --locked --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo clippy --all-targets -- -D warnings` from `rocketmq-example`
- `cargo fmt -p rocketmq-transport -p rocketmq-client-rust -- --check`
- `git diff --check`

`cargo fmt --all -- --check` and the standalone example equivalent remain blocked on Windows by OS error 206 (path length); the affected packages pass focused format checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility when handling encrypted PKCS#8 private keys in TLS connections.
  - Preserved existing decryption behavior, password validation, and error reporting.
- **Tests**
  - Updated encrypted-key coverage to use the current PKCS#8 encryption and parsing interfaces.
  - Confirmed existing TLS security assertions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->