### PR TITLE
[ISSUE #9478]✅Certify Controller HA multipath recovery

### DIFF
--- a/rocketmq-broker/src/broker/broker_control_plane/bootstrap.rs
+++ b/rocketmq-broker/src/broker/broker_control_plane/bootstrap.rs
@@ -23,6 +23,7 @@ use std::time::Instant;
 use cheetah_string::CheetahString;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
+use rocketmq_protocol::protocol::header::namesrv::broker_request::BrokerHeartbeatRequestHeader;
 use rocketmq_runtime::MetadataDeadline;
 use rocketmq_store::BrokerReplicationStore;
 use tracing::error;
@@ -666,12 +667,22 @@ impl<MS: BrokerReplicationStore> BrokerControllerRuntime<MS> {
         let broker_election_priority = broker_config.broker_election_priority;
         let broker_id = heartbeat_state.broker_id;
         let epoch = heartbeat_state.epoch;
-        let (max_offset, confirm_offset) = self.store.controller_heartbeat_offsets();
+        let (max_offset, confirm_offset, store_ready) = self.store.controller_heartbeat_state();
+        let heartbeat_header = BrokerHeartbeatRequestHeader {
+            cluster_name,
+            broker_addr: self.broker_addr.clone(),
+            broker_name,
+            broker_id: Some(broker_id),
+            epoch,
+            max_offset,
+            confirm_offset,
+            store_ready,
+            heartbeat_timeout_mills: Some(controller_heartbeat_timeout_millis),
+            election_priority: Some(broker_election_priority),
+        };
 
         let futures = controller_targets.into_iter().map(|controller_address| {
-            let cluster_name = cluster_name.clone();
-            let broker_addr = self.broker_addr.clone();
-            let broker_name = broker_name.clone();
+            let heartbeat_header = heartbeat_header.clone();
             async move {
                 if self.shutdown.load(Ordering::Acquire) {
                     return None;
@@ -680,19 +691,7 @@ impl<MS: BrokerReplicationStore> BrokerControllerRuntime<MS> {
                 let sent_at = Instant::now();
                 let result = self
                     .broker_outer_api
-                    .send_heartbeat_to_controller(
-                        controller_address,
-                        cluster_name,
-                        broker_addr,
-                        broker_name,
-                        broker_id,
-                        send_heartbeat_timeout_millis,
-                        epoch,
-                        max_offset,
-                        confirm_offset,
-                        Some(controller_heartbeat_timeout_millis),
-                        Some(broker_election_priority),
-                    )
+                    .send_heartbeat_to_controller(controller_address, send_heartbeat_timeout_millis, heartbeat_header)
                     .await;
                 Some((target, sent_at, result))
             }
@@ -730,23 +729,26 @@ impl<MS: BrokerReplicationStore> BrokerControllerRuntime<MS> {
                 )
             })?;
         let broker_config = self.config.broker_snapshot();
-        let (max_offset, confirm_offset) = self.store.controller_heartbeat_offsets();
+        let (max_offset, confirm_offset, store_ready) = self.store.controller_heartbeat_state();
 
         let sent_at = Instant::now();
         let grant = self
             .broker_outer_api
             .send_heartbeat_to_controller_sync(
                 controller_leader,
-                broker_config.broker_identity.broker_cluster_name.clone(),
-                self.broker_addr.clone(),
-                broker_config.broker_identity.broker_name.clone(),
-                heartbeat_state.broker_id,
                 broker_config.send_heartbeat_timeout_millis,
-                heartbeat_state.epoch,
-                max_offset,
-                confirm_offset,
-                Some(broker_config.controller_heartbeat_timeout_mills),
-                Some(broker_config.broker_election_priority),
+                BrokerHeartbeatRequestHeader {
+                    cluster_name: broker_config.broker_identity.broker_cluster_name.clone(),
+                    broker_addr: self.broker_addr.clone(),
+                    broker_name: broker_config.broker_identity.broker_name.clone(),
+                    broker_id: Some(heartbeat_state.broker_id),
+                    epoch: heartbeat_state.epoch,
+                    max_offset,
+                    confirm_offset,
+                    store_ready,
+                    heartbeat_timeout_mills: Some(broker_config.controller_heartbeat_timeout_mills),
+                    election_priority: Some(broker_config.broker_election_priority),
+                },
             )
             .await?;
         let lease_required = self

--- a/rocketmq-broker/src/failover/escape_bridge_capability.rs
+++ b/rocketmq-broker/src/failover/escape_bridge_capability.rs
@@ -288,10 +288,16 @@ impl<MS: BrokerReadStore> EscapeBridgeStoreCapability<MS> {
         self.with_store(|store| (store.get_max_phy_offset(), store.get_flushed_where()))
     }
 
-    pub(crate) fn controller_heartbeat_offsets(&self) -> (Option<i64>, Option<i64>) {
-        self.with_store(|store| (store.get_max_phy_offset(), store.get_confirm_offset()))
-            .map(|(max_offset, confirm_offset)| (Some(max_offset), Some(confirm_offset)))
-            .unwrap_or((None, None))
+    pub(crate) fn controller_heartbeat_state(&self) -> (Option<i64>, Option<i64>, Option<bool>) {
+        self.with_store(|store| {
+            (
+                store.get_max_phy_offset(),
+                store.get_confirm_offset(),
+                store.put_message_preflight().is_store_ready_for_promotion(),
+            )
+        })
+        .map(|(max_offset, confirm_offset, store_ready)| (Some(max_offset), Some(confirm_offset), Some(store_ready)))
+        .unwrap_or((None, None, None))
     }
 
     pub(crate) fn set_alive_replica_num_in_group(&self, alive_replica_num: i32) -> Result<(), MessageStoreUnavailable>
@@ -654,7 +660,7 @@ mod tests {
     fn controller_observations_fail_closed_before_store_binding() {
         let store = EscapeBridgeStoreCapability::<StorePorts>::default();
 
-        assert_eq!(store.controller_heartbeat_offsets(), (None, None));
+        assert_eq!(store.controller_heartbeat_state(), (None, None, None));
         assert!(store.set_alive_replica_num_in_group(1).is_err());
     }
 }

--- a/rocketmq-broker/src/out_api/broker_outer_api.rs
+++ b/rocketmq-broker/src/out_api/broker_outer_api.rs
@@ -453,6 +453,7 @@ impl BrokerOuterAPI {
             epoch: None,
             max_offset: None,
             confirm_offset: None,
+            store_ready: None,
             heartbeat_timeout_mills: None,
             election_priority: None,
         };
@@ -1293,31 +1294,12 @@ impl BrokerOuterAPI {
     pub async fn send_heartbeat_to_controller(
         &self,
         controller_address: CheetahString,
-        cluster_name: CheetahString,
-        broker_addr: CheetahString,
-        broker_name: CheetahString,
-        broker_id: i64,
         timeout_millis: u64,
-        epoch: Option<i32>,
-        max_offset: Option<i64>,
-        confirm_offset: Option<i64>,
-        heartbeat_timeout_millis: Option<i64>,
-        election_priority: Option<i32>,
+        request_header: BrokerHeartbeatRequestHeader,
     ) -> rocketmq_error::RocketMQResult<Option<ControllerWriteLeaseGrant>> {
         if controller_address.is_empty() {
             return Ok(None);
         }
-        let request_header = BrokerHeartbeatRequestHeader {
-            cluster_name,
-            broker_addr,
-            broker_name,
-            broker_id: Some(broker_id),
-            epoch,
-            max_offset,
-            confirm_offset,
-            heartbeat_timeout_mills: heartbeat_timeout_millis,
-            election_priority,
-        };
         let request = self
             .command_factory
             .create_request_command(RequestCode::BrokerHeartbeat, request_header);
@@ -1343,28 +1325,9 @@ impl BrokerOuterAPI {
     pub async fn send_heartbeat_to_controller_sync(
         &self,
         controller_address: &CheetahString,
-        cluster_name: CheetahString,
-        broker_addr: CheetahString,
-        broker_name: CheetahString,
-        broker_id: i64,
         timeout_millis: u64,
-        epoch: Option<i32>,
-        max_offset: Option<i64>,
-        confirm_offset: Option<i64>,
-        heartbeat_timeout_millis: Option<i64>,
-        election_priority: Option<i32>,
+        request_header: BrokerHeartbeatRequestHeader,
     ) -> rocketmq_error::RocketMQResult<Option<ControllerWriteLeaseGrant>> {
-        let request_header = BrokerHeartbeatRequestHeader {
-            cluster_name,
-            broker_addr,
-            broker_name,
-            broker_id: Some(broker_id),
-            epoch,
-            max_offset,
-            confirm_offset,
-            heartbeat_timeout_mills: heartbeat_timeout_millis,
-            election_priority,
-        };
         let request = self
             .command_factory
             .create_request_command(RequestCode::BrokerHeartbeat, request_header);

--- a/rocketmq-broker/tests/controller_mode_multipath_recovery.rs
+++ b/rocketmq-broker/tests/controller_mode_multipath_recovery.rs
@@ -1,0 +1,71 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Controller-side promotion contract for a recovered multipath Broker store.
+
+use rocketmq_controller::ApplyBrokerIdEvent;
+use rocketmq_controller::BrokerLiveInfoSnapshot;
+use rocketmq_controller::ControllerConfig;
+use rocketmq_controller::ControllerConfigReader;
+use rocketmq_controller::ElectMasterEvent;
+use rocketmq_controller::ReplicasInfoManager;
+
+fn heartbeat(store_ready: bool) -> BrokerLiveInfoSnapshot {
+    BrokerLiveInfoSnapshot {
+        cluster_name: "multipath-cluster".to_owned(),
+        broker_name: "broker-a".to_owned(),
+        broker_addr: "127.0.0.1:10911".to_owned(),
+        broker_id: 0,
+        last_update_timestamp: 1_000,
+        heartbeat_timeout_millis: 30_000,
+        epoch: 1,
+        max_offset: 64,
+        confirm_offset: 48,
+        election_priority: Some(1),
+        store_ready,
+    }
+}
+
+#[test]
+fn controller_excludes_an_unrecovered_store_from_promotion_and_leases() {
+    let manager = ReplicasInfoManager::new(ControllerConfigReader::new(ControllerConfig::new_node(
+        1,
+        "127.0.0.1:9876".parse().unwrap(),
+    )));
+    manager
+        .try_apply_event(&ApplyBrokerIdEvent::new(
+            "multipath-cluster",
+            "broker-a",
+            "127.0.0.1:10911",
+            0,
+            "check-0",
+        ))
+        .unwrap();
+    manager
+        .try_apply_event(&ElectMasterEvent::with_new_master("broker-a", 0))
+        .unwrap();
+
+    let unready = heartbeat(false);
+    manager.on_broker_heartbeat(unready.identity(), unready.clone());
+    assert!(manager.is_broker_active_at("multipath-cluster", "broker-a", 0, 1_001));
+    assert!(!manager.is_broker_promotion_ready_at("multipath-cluster", "broker-a", 0, 1_001));
+    assert!(manager.check_not_active_broker(1_001).is_empty());
+    assert!(manager.grant_write_lease(&unready.identity(), &unready, true).is_none());
+
+    let ready = heartbeat(true);
+    manager.on_broker_heartbeat(ready.identity(), ready.clone());
+    assert!(manager.is_broker_active_at("multipath-cluster", "broker-a", 0, 1_001));
+    assert!(manager.is_broker_promotion_ready_at("multipath-cluster", "broker-a", 0, 1_001));
+    assert!(manager.grant_write_lease(&ready.identity(), &ready, true).is_some());
+}

--- a/rocketmq-controller/benches/controller_bench.rs
+++ b/rocketmq-controller/benches/controller_bench.rs
@@ -43,6 +43,7 @@ fn heartbeat_fixture() -> (BrokerIdentityInfoSnapshot, BrokerLiveInfoSnapshot) {
             max_offset: 100,
             confirm_offset: 100,
             election_priority: Some(1),
+            store_ready: true,
         },
     )
 }

--- a/rocketmq-controller/src/controller/controller_manager.rs
+++ b/rocketmq-controller/src/controller/controller_manager.rs
@@ -1783,6 +1783,7 @@ mod tests {
                 epoch: Some(1),
                 max_offset: Some(100),
                 confirm_offset: Some(80),
+                store_ready: Some(true),
                 heartbeat_timeout_mills: Some(60_000),
                 election_priority: Some(1),
             };
@@ -1854,6 +1855,7 @@ mod tests {
             epoch: Some(1),
             max_offset: Some(100),
             confirm_offset: Some(80),
+            store_ready: Some(true),
             heartbeat_timeout_mills: Some(60_000),
             election_priority: Some(1),
         };
@@ -1967,6 +1969,7 @@ mod tests {
                 epoch: Some(1),
                 max_offset: Some(100),
                 confirm_offset: Some(80),
+                store_ready: Some(true),
                 heartbeat_timeout_mills: Some(60_000),
                 election_priority: Some(1),
             };

--- a/rocketmq-controller/src/controller/open_raft_controller.rs
+++ b/rocketmq-controller/src/controller/open_raft_controller.rs
@@ -551,6 +551,7 @@ impl OpenRaftController {
             max_offset: request.max_offset.unwrap_or(-1),
             confirm_offset: request.confirm_offset.unwrap_or(-1),
             election_priority: request.election_priority.or(Some(i32::MAX)),
+            store_ready: request.store_ready.unwrap_or(false),
         };
         let lease_grant_allowed = self.current_leader_term().is_some_and(|leader_term| {
             let authority = self.node().and_then(|node| {
@@ -1169,8 +1170,12 @@ impl Controller for OpenRaftController {
 
         if let Some(replica_header) = replica_info.response() {
             if let Some(master_broker_id) = replica_header.master_broker_id {
-                if replicas_info_manager.is_broker_active(cluster_name.as_str(), broker_name.as_str(), master_broker_id)
-                {
+                if replicas_info_manager.is_broker_promotion_ready_at(
+                    cluster_name.as_str(),
+                    broker_name.as_str(),
+                    master_broker_id,
+                    rocketmq_runtime::common::time_utils::current_millis(),
+                ) {
                     register_header.master_broker_id = Some(master_broker_id);
                     register_header.master_address =
                         replica_header.master_address.clone().map(CheetahString::from_string);

--- a/rocketmq-controller/src/manager/replicas_info_manager.rs
+++ b/rocketmq-controller/src/manager/replicas_info_manager.rs
@@ -168,7 +168,7 @@ impl ReplicasInfoManager {
         broker_live_info: &BrokerLiveInfoSnapshot,
         lease_grant_allowed: bool,
     ) -> Option<ControllerWriteLeaseGrant> {
-        if !lease_grant_allowed {
+        if !lease_grant_allowed || !broker_live_info.store_ready {
             return None;
         }
         let broker_id = broker_identity.broker_id?;
@@ -960,6 +960,7 @@ impl ReplicasInfoManager {
             prev.last_update_timestamp = broker_live_info.last_update_timestamp;
             prev.heartbeat_timeout_millis = broker_live_info.heartbeat_timeout_millis;
             prev.election_priority = broker_live_info.election_priority;
+            prev.store_ready = broker_live_info.store_ready;
 
             if broker_live_info.epoch > prev.epoch
                 || (broker_live_info.epoch == prev.epoch && broker_live_info.max_offset > prev.max_offset)
@@ -1053,6 +1054,23 @@ impl ReplicasInfoManager {
         self.broker_live_table
             .get(&identity)
             .is_some_and(|live_info| live_info.is_active_at(check_time_millis))
+    }
+
+    pub fn is_broker_promotion_ready_at(
+        &self,
+        cluster_name: &str,
+        broker_name: &str,
+        broker_id: i64,
+        check_time_millis: u64,
+    ) -> bool {
+        if broker_id < 0 {
+            return false;
+        }
+
+        let identity = BrokerIdentityInfoSnapshot::new(cluster_name, broker_name, Some(broker_id as u64));
+        self.broker_live_table
+            .get(&identity)
+            .is_some_and(|live_info| live_info.is_promotion_ready_at(check_time_millis))
     }
 
     pub fn is_broker_active(&self, cluster_name: &str, broker_name: &str, broker_id: i64) -> bool {
@@ -1351,7 +1369,9 @@ fn compare_live_info(left: &BrokerLiveInfoSnapshot, right: &BrokerLiveInfoSnapsh
 
 impl BrokerValidPredicate for ReplicasInfoManager {
     fn check(&self, cluster_name: &str, broker_name: &str, broker_id: Option<i64>) -> bool {
-        broker_id.is_some_and(|broker_id| self.is_broker_active(cluster_name, broker_name, broker_id))
+        broker_id.is_some_and(|broker_id| {
+            self.is_broker_promotion_ready_at(cluster_name, broker_name, broker_id, current_millis())
+        })
     }
 }
 
@@ -1367,7 +1387,9 @@ impl ReplicasInfoManager {
         let valid_brokers: HashSet<i64> = brokers
             .iter()
             .copied()
-            .filter(|broker_id| self.is_broker_active(cluster_name, broker_name, *broker_id))
+            .filter(|broker_id| {
+                self.is_broker_promotion_ready_at(cluster_name, broker_name, *broker_id, current_millis())
+            })
             .collect();
 
         if valid_brokers.is_empty() {
@@ -1473,6 +1495,7 @@ mod tests {
                 max_offset: 100,
                 confirm_offset: 90,
                 election_priority: None,
+                store_ready: true,
             };
             manager.on_broker_heartbeat(live_info.identity(), live_info);
         }
@@ -1510,6 +1533,7 @@ mod tests {
             max_offset: 100,
             confirm_offset: 90,
             election_priority: None,
+            store_ready: true,
         };
 
         let first = heartbeat(0, 1, 100);

--- a/rocketmq-controller/src/openraft/state_machine.rs
+++ b/rocketmq-controller/src/openraft/state_machine.rs
@@ -726,6 +726,7 @@ mod tests {
                 max_offset: 100,
                 confirm_offset: 80,
                 election_priority: Some(1),
+                store_ready: true,
             },
             lease_grant_allowed: false,
         }

--- a/rocketmq-controller/src/typ.rs
+++ b/rocketmq-controller/src/typ.rs
@@ -100,6 +100,8 @@ pub struct BrokerLiveInfoSnapshot {
     pub max_offset: i64,
     pub confirm_offset: i64,
     pub election_priority: Option<i32>,
+    #[serde(default)]
+    pub store_ready: bool,
 }
 
 impl BrokerLiveInfoSnapshot {
@@ -107,10 +109,16 @@ impl BrokerLiveInfoSnapshot {
         BrokerIdentityInfoSnapshot::new(&self.cluster_name, &self.broker_name, Some(self.broker_id))
     }
 
+    /// Returns whether this heartbeat remains within its liveness timeout.
     pub fn is_active_at(&self, timestamp_millis: u64) -> bool {
         self.last_update_timestamp
             .checked_add(self.heartbeat_timeout_millis)
             .is_some_and(|expires_at| expires_at >= timestamp_millis)
+    }
+
+    /// Returns whether the live Broker has also reported a recovered, writable Store.
+    pub fn is_promotion_ready_at(&self, timestamp_millis: u64) -> bool {
+        self.store_ready && self.is_active_at(timestamp_millis)
     }
 }
 
@@ -283,6 +291,26 @@ mod tests {
     use rocketmq_protocol::protocol::SerializeType;
 
     use super::*;
+
+    #[test]
+    fn legacy_heartbeat_snapshot_requires_fresh_store_readiness_before_promotion() {
+        let encoded = r#"{
+            "cluster_name":"cluster-a",
+            "broker_name":"broker-a",
+            "broker_addr":"127.0.0.1:10911",
+            "broker_id":0,
+            "last_update_timestamp":1000,
+            "heartbeat_timeout_millis":30000,
+            "epoch":1,
+            "max_offset":64,
+            "confirm_offset":48,
+            "election_priority":1
+        }"#;
+        let heartbeat: BrokerLiveInfoSnapshot = serde_json::from_str(encoded).expect("legacy heartbeat snapshot");
+
+        assert!(heartbeat.is_active_at(1_001));
+        assert!(!heartbeat.is_promotion_ready_at(1_001));
+    }
 
     #[test]
     fn controller_response_preserves_success_contract() {

--- a/rocketmq-controller/tests/controller_request_processor_contract_test.rs
+++ b/rocketmq-controller/tests/controller_request_processor_contract_test.rs
@@ -181,6 +181,7 @@ impl ProcessorHarness {
             epoch: Some(1),
             max_offset: Some(100),
             confirm_offset: Some(80),
+            store_ready: Some(true),
             heartbeat_timeout_mills: Some(3_000),
             election_priority: Some(1),
         };
@@ -449,7 +450,7 @@ async fn controller_request_contract_broker_heartbeat() {
     assert_eq!(response.code(), ResponseCode::Success as i32);
     assert_eq!(
         response.remark().map(|remark| remark.as_str()),
-        Some("Heart beat success")
+        Some("Heartbeat committed; no write lease for this authority")
     );
     wait_until(
         Duration::from_secs(5),
@@ -477,6 +478,7 @@ async fn controller_request_contract_broker_heartbeat_rejects_missing_timeout_he
         epoch: Some(1),
         max_offset: Some(100),
         confirm_offset: Some(80),
+        store_ready: Some(true),
         heartbeat_timeout_mills: None,
         election_priority: Some(1),
     };

--- a/rocketmq-controller/tests/multi_node_cluster_test.rs
+++ b/rocketmq-controller/tests/multi_node_cluster_test.rs
@@ -181,6 +181,7 @@ fn broker_heartbeat_request(
             max_offset: 100,
             confirm_offset: 80,
             election_priority: Some(1),
+            store_ready: true,
         },
         lease_grant_allowed: false,
     }

--- a/rocketmq-controller/tests/openraft_integration_test.rs
+++ b/rocketmq-controller/tests/openraft_integration_test.rs
@@ -83,6 +83,7 @@ fn broker_heartbeat_request(
             max_offset: 100,
             confirm_offset: 80,
             election_priority: Some(1),
+            store_ready: true,
         },
         lease_grant_allowed: false,
     }

--- a/rocketmq-controller/tests/snapshot_test.rs
+++ b/rocketmq-controller/tests/snapshot_test.rs
@@ -74,6 +74,7 @@ fn broker_heartbeat_request(
             max_offset: 100,
             confirm_offset: 80,
             election_priority: Some(1),
+            store_ready: true,
         },
         lease_grant_allowed: false,
     }

--- a/rocketmq-namesrv/src/bootstrap.rs
+++ b/rocketmq-namesrv/src/bootstrap.rs
@@ -2833,6 +2833,7 @@ mod tests {
                 epoch: Some(1),
                 max_offset: Some(128),
                 confirm_offset: Some(64),
+                store_ready: None,
                 heartbeat_timeout_mills: Some(30_000),
                 election_priority: Some(1),
             },

--- a/rocketmq-protocol/src/protocol/header/namesrv/broker_request.rs
+++ b/rocketmq-protocol/src/protocol/header/namesrv/broker_request.rs
@@ -84,6 +84,8 @@ pub struct BrokerHeartbeatRequestHeader {
     pub epoch: Option<i32>,
     pub max_offset: Option<i64>,
     pub confirm_offset: Option<i64>,
+    /// Rust-native Controller extension; Java peers and NameServers ignore it.
+    pub store_ready: Option<bool>,
     pub heartbeat_timeout_mills: Option<i64>,
     pub election_priority: Option<i32>,
 }
@@ -146,6 +148,7 @@ mod tests {
             epoch: Some(1),
             max_offset: Some(100),
             confirm_offset: Some(50),
+            store_ready: Some(true),
             heartbeat_timeout_mills: Some(3000),
             election_priority: Some(1),
         };
@@ -156,6 +159,7 @@ mod tests {
         assert_eq!(header.epoch, Some(1));
         assert_eq!(header.max_offset, Some(100));
         assert_eq!(header.confirm_offset, Some(50));
+        assert_eq!(header.store_ready, Some(true));
         assert_eq!(header.heartbeat_timeout_mills, Some(3000));
         assert_eq!(header.election_priority, Some(1));
     }
@@ -170,6 +174,7 @@ mod tests {
             epoch: None,
             max_offset: None,
             confirm_offset: None,
+            store_ready: None,
             heartbeat_timeout_mills: None,
             election_priority: None,
         };
@@ -180,6 +185,7 @@ mod tests {
         assert!(header.epoch.is_none());
         assert!(header.max_offset.is_none());
         assert!(header.confirm_offset.is_none());
+        assert!(header.store_ready.is_none());
         assert!(header.heartbeat_timeout_mills.is_none());
         assert!(header.election_priority.is_none());
     }
@@ -194,6 +200,7 @@ mod tests {
             epoch: None,
             max_offset: None,
             confirm_offset: None,
+            store_ready: None,
             heartbeat_timeout_mills: None,
             election_priority: None,
         };
@@ -204,6 +211,7 @@ mod tests {
         assert!(header.epoch.is_none());
         assert!(header.max_offset.is_none());
         assert!(header.confirm_offset.is_none());
+        assert!(header.store_ready.is_none());
         assert!(header.heartbeat_timeout_mills.is_none());
         assert!(header.election_priority.is_none());
     }
@@ -219,6 +227,7 @@ mod tests {
             epoch: Some(1),
             max_offset: Some(100),
             confirm_offset: Some(50),
+            store_ready: Some(true),
             heartbeat_timeout_mills: Some(3000),
             election_priority: Some(1),
         };
@@ -229,6 +238,7 @@ mod tests {
         assert_eq!(header.epoch, Some(1));
         assert_eq!(header.max_offset, Some(100));
         assert_eq!(header.confirm_offset, Some(50));
+        assert_eq!(header.store_ready, Some(true));
         assert_eq!(header.heartbeat_timeout_mills, Some(3000));
         assert_eq!(header.election_priority, Some(1));
     }

--- a/rocketmq-store/src/base/backend_ops.rs
+++ b/rocketmq-store/src/base/backend_ops.rs
@@ -39,6 +39,7 @@ use rocketmq_runtime::common::time_utils::current_millis;
 use rocketmq_store_api::TimerRecallRequest;
 use rocketmq_store_api::TimerRecallStatus;
 use rocketmq_store_api::WriteLeaseToken;
+use rocketmq_store_local::mapped_file::queue_state::MappedFileQueueRuntimeState;
 use rocketmq_store_local::mapped_file::ManagedRetirementStage;
 
 use crate::base::allocate_mapped_file_service::AllocateMappedFileService;
@@ -109,6 +110,7 @@ pub struct PutMessagePreflight {
     running_flags: Arc<RunningFlags>,
     begin_time_in_lock: Arc<AtomicU64>,
     controller_write_lease: ControllerWriteLeaseState,
+    commit_log_queue_state: MappedFileQueueRuntimeState,
 }
 
 impl PutMessagePreflight {
@@ -117,12 +119,14 @@ impl PutMessagePreflight {
         running_flags: Arc<RunningFlags>,
         begin_time_in_lock: Arc<AtomicU64>,
         controller_write_lease: ControllerWriteLeaseState,
+        commit_log_queue_state: MappedFileQueueRuntimeState,
     ) -> Self {
         Self {
             shutdown,
             running_flags,
             begin_time_in_lock,
             controller_write_lease,
+            commit_log_queue_state,
         }
     }
 
@@ -132,6 +136,7 @@ impl PutMessagePreflight {
             Arc::new(RunningFlags::new()),
             Arc::new(AtomicU64::new(0)),
             ControllerWriteLeaseState::new(false),
+            MappedFileQueueRuntimeState::default(),
         )
     }
 
@@ -142,7 +147,12 @@ impl PutMessagePreflight {
 
     /// Returns whether the store running flags permit writes.
     pub fn is_writeable(&self) -> bool {
-        self.running_flags.is_writeable() && self.controller_write_lease.is_write_permitted()
+        self.is_store_ready_for_promotion() && self.controller_write_lease.is_write_permitted()
+    }
+
+    /// Returns whether recovery and the CommitLog inventory permit Controller promotion.
+    pub fn is_store_ready_for_promotion(&self) -> bool {
+        !self.is_shutdown() && self.running_flags.is_writeable() && !self.commit_log_queue_state.is_closing()
     }
 
     /// Returns the raw running-state flags for diagnostic logging.
@@ -937,6 +947,7 @@ mod tests {
     use rocketmq_store_api::MasterEpoch;
     use rocketmq_store_api::WriteAuthority;
     use rocketmq_store_api::WriteLeaseToken;
+    use rocketmq_store_local::mapped_file::queue_state::MappedFileQueueRuntimeState;
 
     use super::PutMessagePreflight;
     use super::StateMachineVersionView;
@@ -953,10 +964,12 @@ mod tests {
             running_flags.clone(),
             begin_time_in_lock.clone(),
             ControllerWriteLeaseState::new(false),
+            MappedFileQueueRuntimeState::default(),
         );
 
         assert!(!preflight.is_shutdown());
         assert!(preflight.is_writeable());
+        assert!(preflight.is_store_ready_for_promotion());
         assert_eq!(preflight.flag_bits(), 0);
         assert!(!preflight.is_os_page_cache_busy(10));
 
@@ -976,7 +989,8 @@ mod tests {
         let preflight = PutMessagePreflight::unavailable();
 
         assert!(preflight.is_shutdown());
-        assert!(preflight.is_writeable());
+        assert!(!preflight.is_writeable());
+        assert!(!preflight.is_store_ready_for_promotion());
         assert_eq!(preflight.flag_bits(), 0);
         assert!(!preflight.is_os_page_cache_busy(10));
     }
@@ -989,6 +1003,7 @@ mod tests {
             Arc::new(RunningFlags::new()),
             Arc::new(AtomicU64::new(0)),
             lease.clone(),
+            MappedFileQueueRuntimeState::default(),
         );
         assert!(!preflight.is_writeable());
 
@@ -997,6 +1012,24 @@ mod tests {
         assert!(lease.install(token, Duration::from_secs(1)));
         assert!(preflight.is_writeable());
         lease.fence();
+        assert!(!preflight.is_writeable());
+    }
+
+    #[test]
+    fn fenced_commit_log_queue_blocks_promotion_readiness() {
+        let queue_state = MappedFileQueueRuntimeState::default();
+        let preflight = PutMessagePreflight::new(
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(RunningFlags::new()),
+            Arc::new(AtomicU64::new(0)),
+            ControllerWriteLeaseState::new(false),
+            queue_state.clone(),
+        );
+        assert!(preflight.is_store_ready_for_promotion());
+
+        let _guard = queue_state.commit_lock().lock();
+        assert!(queue_state.begin_close());
+        assert!(!preflight.is_store_ready_for_promotion());
         assert!(!preflight.is_writeable());
     }
 

--- a/rocketmq-store/src/consume_queue/mapped_file_queue.rs
+++ b/rocketmq-store/src/consume_queue/mapped_file_queue.rs
@@ -929,6 +929,10 @@ impl MappedFileQueue {
         self.runtime_state.is_closing()
     }
 
+    pub(crate) fn runtime_state_handle(&self) -> MappedFileQueueRuntimeState {
+        self.runtime_state.clone()
+    }
+
     #[inline]
     pub fn new(
         store_path: String,
@@ -988,13 +992,18 @@ impl MappedFileQueue {
                 ),
                 Err(error) => {
                     error!(%error, "multipath CommitLog inventory failed closed");
+                    self.fence_writes();
                     return false;
                 }
             }
         } else {
             load_mapped_file_queue_path(self.storage.store_path(), self.storage.mapped_file_size())
         };
-        self.apply_load_outcome(outcome)
+        let loaded = self.apply_load_outcome(outcome);
+        if !loaded && self.is_multipath_commit_log() {
+            self.fence_writes();
+        }
+        loaded
     }
 
     /// Commit data to file system cache

--- a/rocketmq-store/src/log_file/commit_log.rs
+++ b/rocketmq-store/src/log_file/commit_log.rs
@@ -96,6 +96,7 @@ use crate::ha::ha_service::HAService;
 use crate::ha::write_lease::ControllerWriteLeaseState;
 use crate::log_file::cold_data_check_service::ColdDataCheckService;
 use crate::log_file::commit_log_path_set::CommitLogPathSet;
+use rocketmq_store_local::mapped_file::queue_state::MappedFileQueueRuntimeState;
 use rocketmq_store_local::mapped_file::ManagedLifecycleRuntime;
 use rocketmq_store_local::mapped_file::ManagedMappedFileQueueGeneration;
 // Import the optimized loader module
@@ -603,6 +604,10 @@ impl CommitLog {
 
     pub(crate) fn controller_write_lease_state(&self) -> ControllerWriteLeaseState {
         self.store_context.controller_write_lease.clone()
+    }
+
+    pub(crate) fn mapped_file_queue_runtime_state(&self) -> MappedFileQueueRuntimeState {
+        self.mapped_file_queue.runtime_state_handle()
     }
 
     #[inline]

--- a/rocketmq-store/src/message_store/local_file_message_store.rs
+++ b/rocketmq-store/src/message_store/local_file_message_store.rs
@@ -2077,6 +2077,7 @@ impl BackendOps for LocalFileMessageStore {
             self.running_flags.clone(),
             self.commit_log.begin_time_in_lock().clone(),
             self.commit_log.controller_write_lease_state(),
+            self.commit_log.mapped_file_queue_runtime_state(),
         )
     }
 

--- a/rocketmq-store/src/test_support/multipath_commit_log.rs
+++ b/rocketmq-store/src/test_support/multipath_commit_log.rs
@@ -144,6 +144,10 @@ impl MultipathCommitLogHarness {
         self.queue.is_write_fenced()
     }
 
+    pub fn is_promotion_ready(&self) -> bool {
+        !self.queue.is_write_fenced()
+    }
+
     pub fn flush(&self) -> bool {
         if self.queue.get_mapped_files().iter().any(|mapped_file| {
             self.paths

--- a/rocketmq-store/tests/commitlog_multipath_tests.rs
+++ b/rocketmq-store/tests/commitlog_multipath_tests.rs
@@ -72,11 +72,13 @@ fn f08_mp_003_restart_rebuilds_global_order_and_truncates_the_real_owner() {
     let mut restarted =
         MultipathCommitLogHarness::try_new(vec![first, second], vec![], SEGMENT_SIZE, None).expect("restart");
     assert!(restarted.load());
+    assert!(restarted.is_promotion_ready());
     assert_eq!(
         restarted.read_range(0, 32).expect("global read"),
         [[1_u8; 16], [2_u8; 16]].concat()
     );
     assert!(restarted.truncate(16));
+    assert!(restarted.is_promotion_ready());
     assert_eq!(restarted.segment_owners().len(), 2);
     assert!(restarted.read_range(16, 1).is_err());
 }
@@ -101,10 +103,28 @@ fn f08_mp_004_prewrite_failure_moves_root_but_mid_segment_failure_fences() {
 
     assert!(harness.create_segment(0, &[1; 16]).is_err());
     assert!(harness.is_write_fenced());
+    assert!(!harness.is_promotion_ready());
     let owners = harness.segment_owners();
     assert_eq!(owners.len(), 1);
     assert_eq!(owners[0].1, fs::canonicalize(second).expect("canonical second"));
     assert!(harness.create_segment(16, &[2; 16]).is_err());
+}
+
+#[test]
+fn controller_promotion_remains_blocked_after_conflicting_inventory() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let first = temp.path().join("a");
+    let second = temp.path().join("b");
+    fs::create_dir_all(&first).expect("first root");
+    fs::create_dir_all(&second).expect("second root");
+    fs::write(first.join("00000000000000000000"), [1_u8; 16]).expect("first owner");
+    fs::write(second.join("00000000000000000000"), [2_u8; 16]).expect("conflicting owner");
+
+    let mut harness =
+        MultipathCommitLogHarness::try_new(vec![first, second], vec![], SEGMENT_SIZE, None).expect("harness");
+    assert!(!harness.load());
+    assert!(harness.is_write_fenced());
+    assert!(!harness.is_promotion_ready());
 }
 
 #[test]

--- a/scripts/request-header-codec/extension-allowlist.json
+++ b/scripts/request-header-codec/extension-allowlist.json
@@ -18,6 +18,14 @@
       "expiry": "2027-08-01"
     },
     {
+      "rustTypeId": "rocketmq_protocol::protocol::header::namesrv::broker_request::BrokerHeartbeatRequestHeader",
+      "fields": ["storeReady"],
+      "owner": "rocketmq-rust maintainers",
+      "rationale": "Rust controller promotion-readiness extension; Java ignores unknown fields",
+      "compatibleSince": "1.0.0",
+      "expiry": "2028-08-01"
+    },
+    {
       "rustTypeId": "rocketmq_protocol::protocol::header::check_rocksdb_cq_write_progress_request_header::CheckRocksdbCqWriteProgressRequestHeader",
       "fields": ["ns", "nsd", "bname", "oway"],
       "owner": "rocketmq-rust maintainers",


### PR DESCRIPTION
## Summary
- fence multipath CommitLog recovery failures and expose Store promotion readiness
- propagate Store readiness through the Rust-native Controller heartbeat while keeping liveness separate from election eligibility
- deny master election and write leases until the Store has recovered, with restart, truncation, fault, and conflicting-inventory coverage

## Validation
- `cargo test --locked -p rocketmq-broker --test controller_mode_multipath_recovery`
- `cargo test --locked -p rocketmq-store --features test-support --test commitlog_multipath_tests`
- `cargo test --locked -p rocketmq-controller --lib`
- `cargo test --locked -p rocketmq-controller --test controller_request_processor_contract_test`
- `cargo test --locked -p rocketmq-protocol --test request_header_codec_v3_registry registered_typed_schemas_match_the_pinned_java_contract`
- `cargo clippy --locked --workspace --no-deps --all-targets --all-features -- -D warnings`
- affected-package `cargo fmt ... -- --check`
- `git diff --check`
- fixed-nightly fuzz compile check passed with the existing lockfile refreshed offline; the exact `--locked` route remains blocked by the pre-existing stale standalone fuzz lockfile
- root `cargo fmt --all -- --check` remains blocked on Windows by OS error 206; affected-package formatting passed

Closes #9478

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Broker heartbeats now report whether message storage is ready for promotion.
  - Controllers only promote brokers and grant write leases when storage is healthy, active, and ready.
  - Legacy heartbeat data remains compatible and is treated as not promotion-ready by default.

- **Bug Fixes**
  - Multipath storage failures and conflicting commit-log inventories now fence writes and prevent promotion.
  - Recovery and truncation scenarios more reliably preserve safe broker availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->