### PR TITLE
[ISSUE #9482]✨Harden EscapeBridge failover routing

### DIFF
--- a/rocketmq-broker/src/broker/broker_control_plane.rs
+++ b/rocketmq-broker/src/broker/broker_control_plane.rs
@@ -225,6 +225,7 @@ impl<MS: BrokerReplicationStore> BrokerControllerRuntime<MS> {
         // Store remains fail-closed until a quorum-committed heartbeat installs
         // a lease for the newly published authority.
         let _ = self.store.fence_controller_writes();
+        self.escape_policy.fence_controller_role();
         let outcome = self
             .controller
             .with_replicas_mut(|replicas_manager| {
@@ -320,6 +321,7 @@ impl<MS: BrokerReplicationStore> BrokerControllerRuntime<MS> {
             }
         }
 
+        self.escape_policy.update_controller_role(role, outcome.master_epoch);
         self.role_state.set_isolated(false);
         if outcome.should_register_to_namesrv {
             if let Err(error) = self.registration.register().await {

--- a/rocketmq-broker/src/failover.rs
+++ b/rocketmq-broker/src/failover.rs
@@ -14,3 +14,4 @@
 
 pub mod escape_bridge;
 pub(crate) mod escape_bridge_capability;
+pub(crate) mod escape_target_resolver;

--- a/rocketmq-broker/src/failover/escape_bridge.rs
+++ b/rocketmq-broker/src/failover/escape_bridge.rs
@@ -22,10 +22,8 @@ use rocketmq_model::common::hasher::string_hasher::JavaStringHasher;
 use rocketmq_model::common::message::message_batch::MessageExtBatch;
 use rocketmq_model::common::message::message_ext::MessageExt;
 use rocketmq_model::common::message::message_ext_broker_inner::MessageExtBrokerInner;
-use rocketmq_model::common::message::message_queue::MessageQueue;
 use rocketmq_model::common::message::MessageConst;
 use rocketmq_model::common::message::MessageTrait;
-use rocketmq_model::common::mix_all;
 use rocketmq_model::result::PullStatus;
 use rocketmq_model::result::SendResult;
 use rocketmq_model::result::SendStatus;
@@ -54,7 +52,11 @@ use tracing::warn;
 
 use crate::failover::escape_bridge_capability::EscapeBridgePolicyState;
 use crate::failover::escape_bridge_capability::EscapeBridgeStoreCapability;
+use crate::failover::escape_bridge_capability::EscapeRemoteAuthority;
 use crate::failover::escape_bridge_capability::EscapeStoreReadLease;
+use crate::failover::escape_target_resolver::EscapeTargetError;
+use crate::failover::escape_target_resolver::EscapeTargetPreference;
+use crate::failover::escape_target_resolver::EscapeTargetResolver;
 use crate::out_api::broker_outer_api::BrokerOuterAPI;
 use crate::topic::manager::topic_route_info_manager::TopicRouteInfoManager;
 use crate::transaction::queue::transactional_message_util::TransactionalMessageUtil;
@@ -64,6 +66,20 @@ const DEFAULT_PULL_TIMEOUT_MILLIS: u64 = 10_000;
 
 #[derive(Debug)]
 pub(crate) struct MessageStoreUnavailable;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum EscapeDispatchError {
+    #[error(transparent)]
+    Target(#[from] EscapeTargetError),
+    #[error("the selected escape broker has no publish address")]
+    BrokerAddressUnavailable,
+    #[error("remote escape is not authorized for the current broker role")]
+    RemoteEscapeUnauthorized,
+    #[error("the controller role epoch changed before remote dispatch")]
+    StaleRoleEpoch,
+    #[error(transparent)]
+    Send(#[from] rocketmq_error::RocketMQError),
+}
 
 ///### RocketMQ's EscapeBridge for Dead Letter Queue (DLQ) Mechanism
 ///
@@ -111,6 +127,7 @@ pub(crate) struct EscapeBridge<MS> {
     message_store: EscapeBridgeStoreCapability<MS>,
     topic_route_info_manager: TopicRouteInfoManager,
     broker_outer_api: BrokerOuterAPI,
+    target_resolver: EscapeTargetResolver,
 }
 
 impl<MS: BrokerReadStore> EscapeBridge<MS> {
@@ -136,6 +153,7 @@ impl<MS: BrokerReadStore> EscapeBridge<MS> {
             message_store: EscapeBridgeStoreCapability::default(),
             topic_route_info_manager,
             broker_outer_api,
+            target_resolver: EscapeTargetResolver::default(),
         }
     }
 
@@ -424,109 +442,46 @@ where
 {
     pub async fn put_message(&self, mut message_ext: MessageExtBrokerInner) -> PutMessageResult {
         let policy = self.policy_state.snapshot();
-        if policy.broker_id == mix_all::MASTER_ID {
-            self.message_store
+        if policy.broker_role != rocketmq_model::common::broker::broker_role::BrokerRole::Slave
+            && self.message_store.is_local_writeable()
+        {
+            return self
+                .message_store
                 .put_message(message_ext)
                 .await
-                .expect("message store must be bound before broker services start")
-        } else if policy.enable_slave_acting_master && policy.enable_remote_escape {
-            message_ext.set_wait_store_msg_ok(false);
-            match self.put_message_to_remote_broker(message_ext, None).await {
-                Ok(send_result) => transform_send_result2put_result(send_result),
-                Err(e) => {
-                    error!("sendMessageInFailover to remote failed, {}", e);
-                    PutMessageResult::new(PutMessageStatus::PutToRemoteBrokerFail, None, true)
-                }
+                .unwrap_or_else(|_| PutMessageResult::new_default(PutMessageStatus::ServiceNotAvailable));
+        }
+
+        let Some(authority) = policy.remote_escape_authority() else {
+            warn!("Put message failed closed: local Store is not writable and remote escape is not authorized");
+            return PutMessageResult::new_default(PutMessageStatus::ServiceNotAvailable);
+        };
+        message_ext.set_wait_store_msg_ok(false);
+        match self
+            .dispatch_remote_message(message_ext, EscapeTargetPreference::Any, authority)
+            .await
+        {
+            Ok(send_result) => transform_send_result2put_result(Some(send_result)),
+            Err(error) => {
+                error!(%error, "send message in failover to remote failed");
+                PutMessageResult::new(PutMessageStatus::PutToRemoteBrokerFail, None, true)
             }
-        } else {
-            warn!(
-                "Put message failed, enableSlaveActingMaster={}, enableRemoteEscape={}.",
-                policy.enable_slave_acting_master, policy.enable_remote_escape
-            );
-            PutMessageResult::new_default(PutMessageStatus::ServiceNotAvailable)
         }
     }
 
-    pub async fn put_message_to_remote_broker(
+    pub(crate) async fn put_message_to_remote_broker(
         &self,
         message_ext: MessageExtBrokerInner,
-        mut broker_name_to_send: Option<CheetahString>,
-    ) -> rocketmq_error::RocketMQResult<Option<SendResult>> {
+        broker_name_to_send: Option<CheetahString>,
+    ) -> Result<SendResult, EscapeDispatchError> {
         let policy = self.policy_state.snapshot();
-        let broker_name = policy.broker_name.as_str();
-        if broker_name.is_empty() || broker_name == broker_name_to_send.as_ref().map_or("", |value| value.as_str()) {
-            // not remote broker
-            return Ok(None);
-        }
-        let is_trans_half_message = TransactionalMessageUtil::build_half_topic() == message_ext.get_topic();
-        let mut message_to_put = if is_trans_half_message {
-            TransactionalMessageUtil::build_transactional_message_from_half_message(&message_ext.message_ext_inner)
-        } else {
-            message_ext
-        };
-        let topic_publish_info = self
-            .topic_route_info_manager
-            .try_to_find_topic_publish_info(message_to_put.get_topic())
-            .await;
-        if !topic_publish_info.as_ref().is_some_and(|value| value.is_usable()) {
-            warn!(
-                "putMessageToRemoteBroker: no route info of topic {} when escaping message, msgId={}",
-                message_to_put.get_topic(),
-                message_to_put.message_ext_inner.msg_id
-            );
-            return Ok(None);
-        }
-        let topic_publish_info = topic_publish_info.unwrap();
-        let _mq_selected = if broker_name_to_send.as_ref().is_none_or(|value| !value.is_empty()) {
-            let mq = topic_publish_info
-                .select_one_queue_avoiding(broker_name_to_send.as_ref())
-                .unwrap();
-            message_to_put.message_ext_inner.queue_id = mq.queue_id();
-            broker_name_to_send = Some(mq.broker_name().clone());
-            if broker_name == mq.broker_name().as_str() {
-                warn!(
-                    "putMessageToRemoteBroker failed, remote broker not found. Topic: {}, MsgId: {}, Broker: {}",
-                    message_to_put.get_topic(),
-                    message_to_put.message_ext_inner.msg_id,
-                    mq.broker_name()
-                );
-                return Ok(None);
-            }
-            mq
-        } else {
-            MessageQueue::from_parts(
-                message_to_put.get_topic(),
-                broker_name_to_send.clone().unwrap(),
-                message_to_put.queue_id(),
-            )
-        };
-        let broker_addr_to_send = self
-            .topic_route_info_manager
-            .find_broker_address_in_publish(broker_name_to_send.as_ref());
-        if broker_addr_to_send.is_none() {
-            warn!(
-                "putMessageToRemoteBroker failed, remote broker not found. Topic: {}, MsgId:  {}, Broker: {}",
-                message_to_put.get_topic(),
-                message_to_put.message_ext_inner.msg_id,
-                broker_name_to_send.as_ref().unwrap()
-            );
-            return Ok(None);
-        }
-        let producer_group = self.get_producer_group(&message_to_put);
-        let result = self
-            .broker_outer_api
-            .send_message_to_specific_broker(
-                broker_addr_to_send.as_ref().unwrap(),
-                broker_name_to_send.as_ref().unwrap(),
-                message_to_put.message_ext_inner,
-                producer_group,
-                SEND_TIMEOUT,
-            )
-            .await?;
-        if result.send_status == SendStatus::SendOk {
-            return Ok(Some(result));
-        }
-        Ok(None)
+        let authority = policy
+            .remote_escape_authority()
+            .ok_or(EscapeDispatchError::RemoteEscapeUnauthorized)?;
+        let preference = broker_name_to_send
+            .as_ref()
+            .map_or(EscapeTargetPreference::Any, EscapeTargetPreference::Broker);
+        self.dispatch_remote_message(message_ext, preference, authority).await
     }
 
     fn get_producer_group(&self, message_ext: &MessageExtBrokerInner) -> CheetahString {
@@ -540,108 +495,123 @@ where
 
     pub async fn async_put_message(&self, mut message_ext: MessageExtBrokerInner) -> PutMessageResult {
         let policy = self.policy_state.snapshot();
-        if policy.broker_id == mix_all::MASTER_ID {
-            self.message_store
+        if policy.broker_role != rocketmq_model::common::broker::broker_role::BrokerRole::Slave
+            && self.message_store.is_local_writeable()
+        {
+            return self
+                .message_store
                 .put_message(message_ext)
                 .await
-                .expect("message store must be bound before broker services start")
-        } else if policy.enable_slave_acting_master && policy.enable_remote_escape {
-            message_ext.set_wait_store_msg_ok(false);
-            let topic_publish_info = self
-                .topic_route_info_manager
-                .try_to_find_topic_publish_info(message_ext.get_topic())
-                .await;
-            if topic_publish_info.is_none() {
-                return PutMessageResult::new_default(PutMessageStatus::ServiceNotAvailable);
+                .unwrap_or_else(|_| PutMessageResult::new_default(PutMessageStatus::ServiceNotAvailable));
+        }
+        let Some(authority) = policy.remote_escape_authority() else {
+            return PutMessageResult::new_default(PutMessageStatus::ServiceNotAvailable);
+        };
+        message_ext.set_wait_store_msg_ok(false);
+        match self
+            .dispatch_remote_message(message_ext, EscapeTargetPreference::Any, authority)
+            .await
+        {
+            Ok(result) => transform_send_result2put_result(Some(result)),
+            Err(error) => {
+                warn!(%error, "asynchronous remote escape failed closed");
+                PutMessageResult::new(PutMessageStatus::PutToRemoteBrokerFail, None, true)
             }
-            let topic_publish_info = topic_publish_info.unwrap();
-            let mq_selected = topic_publish_info.select_one_queue();
-            if mq_selected.is_none() {
-                return PutMessageResult::new_default(PutMessageStatus::ServiceNotAvailable);
-            }
-            let message_queue = mq_selected.unwrap();
-            message_ext.message_ext_inner.queue_id = message_queue.queue_id();
-            let broker_name_to_send = message_queue.broker_name();
-            let broker_addr_to_send = self
-                .topic_route_info_manager
-                .find_broker_address_in_publish(Some(broker_name_to_send));
-            let producer_group = self.get_producer_group(&message_ext);
-            let result = self
-                .broker_outer_api
-                .send_message_to_specific_broker(
-                    broker_addr_to_send.as_ref().unwrap(),
-                    broker_name_to_send,
-                    message_ext.message_ext_inner,
-                    producer_group,
-                    SEND_TIMEOUT,
-                )
-                .await;
-            transform_send_result2put_result(result.ok())
-        } else {
-            PutMessageResult::new_default(PutMessageStatus::ServiceNotAvailable)
         }
     }
 
     pub async fn put_message_to_specific_queue(&self, mut message_ext: MessageExtBrokerInner) -> PutMessageResult {
         let policy = self.policy_state.snapshot();
-        if policy.broker_id == mix_all::MASTER_ID {
-            self.message_store
+        if policy.broker_role != rocketmq_model::common::broker::broker_role::BrokerRole::Slave
+            && self.message_store.is_local_writeable()
+        {
+            return self
+                .message_store
                 .put_message(message_ext)
                 .await
-                .expect("message store must be bound before broker services start")
-        } else if policy.enable_slave_acting_master && policy.enable_remote_escape {
-            message_ext.set_wait_store_msg_ok(false);
-            let topic_publish_info = self
-                .topic_route_info_manager
-                .try_to_find_topic_publish_info(message_ext.get_topic())
-                .await;
-            if topic_publish_info.is_none() {
-                return PutMessageResult::new(PutMessageStatus::PutToRemoteBrokerFail, None, true);
-            }
-            let topic_publish_info = topic_publish_info.unwrap();
-
-            if topic_publish_info.message_queues().is_empty() {
-                return PutMessageResult::new(PutMessageStatus::PutToRemoteBrokerFail, None, true);
-            }
-            //let message_queue = mq_selected.unwrap();
-            let id = format!(
-                "{}{}",
-                message_ext.get_topic(),
-                message_ext.message_ext_inner.store_host
-            );
-            let code = JavaStringHasher::hash_str(id.as_str());
-            let index = code as usize % topic_publish_info.message_queues().len();
-            let message_queue = topic_publish_info.message_queues()[index].clone();
-            message_ext.message_ext_inner.queue_id = message_queue.queue_id();
-            let broker_name_to_send = message_queue.broker_name();
-            let broker_addr_to_send = self
-                .topic_route_info_manager
-                .find_broker_address_in_publish(Some(broker_name_to_send));
-            let producer_group = self.get_producer_group(&message_ext);
-            match self
-                .broker_outer_api
-                .send_message_to_specific_broker(
-                    broker_addr_to_send.as_ref().unwrap(),
-                    broker_name_to_send,
-                    message_ext.message_ext_inner,
-                    producer_group,
-                    SEND_TIMEOUT,
-                )
-                .await
-            {
-                Ok(result) => transform_send_result2put_result(Some(result)),
-                Err(e) => {
-                    error!("sendMessageInFailover to remote failed, {}", e);
-                    PutMessageResult::new(PutMessageStatus::PutToRemoteBrokerFail, None, true)
-                }
-            }
-        } else {
-            warn!(
-                "Put message failed, enableSlaveActingMaster={}, enableRemoteEscape={}.",
-                policy.enable_slave_acting_master, policy.enable_remote_escape
-            );
-            PutMessageResult::new_default(PutMessageStatus::ServiceNotAvailable)
+                .unwrap_or_else(|_| PutMessageResult::new_default(PutMessageStatus::ServiceNotAvailable));
         }
+        let Some(authority) = policy.remote_escape_authority() else {
+            return PutMessageResult::new_default(PutMessageStatus::ServiceNotAvailable);
+        };
+        message_ext.set_wait_store_msg_ok(false);
+        let stable_key = JavaStringHasher::hash_str(&format!(
+            "{}{}",
+            message_ext.get_topic(),
+            message_ext.message_ext_inner.store_host
+        ))
+        .unsigned_abs() as u64;
+        match self
+            .dispatch_remote_message(message_ext, EscapeTargetPreference::Stable(stable_key), authority)
+            .await
+        {
+            Ok(result) => transform_send_result2put_result(Some(result)),
+            Err(error) => {
+                error!(%error, "specific-queue remote escape failed closed");
+                PutMessageResult::new(PutMessageStatus::PutToRemoteBrokerFail, None, true)
+            }
+        }
+    }
+
+    pub async fn put_messages(&self, batch: MessageExtBatch) -> PutMessageResult {
+        let policy = self.policy_state.snapshot();
+        if policy.broker_role != rocketmq_model::common::broker::broker_role::BrokerRole::Slave
+            && self.message_store.is_local_writeable()
+        {
+            return self
+                .message_store
+                .put_messages(batch)
+                .await
+                .unwrap_or_else(|_| PutMessageResult::new_default(PutMessageStatus::ServiceNotAvailable));
+        }
+        if policy.remote_escape_authority().is_some() {
+            return PutMessageResult::new(PutMessageStatus::PutToRemoteBrokerFail, None, true);
+        }
+        PutMessageResult::new_default(PutMessageStatus::ServiceNotAvailable)
+    }
+
+    async fn dispatch_remote_message(
+        &self,
+        message_ext: MessageExtBrokerInner,
+        preference: EscapeTargetPreference<'_>,
+        authority: EscapeRemoteAuthority,
+    ) -> Result<SendResult, EscapeDispatchError> {
+        let is_trans_half_message = TransactionalMessageUtil::build_half_topic() == message_ext.get_topic();
+        let mut message_to_put = if is_trans_half_message {
+            TransactionalMessageUtil::build_transactional_message_from_half_message(&message_ext.message_ext_inner)
+        } else {
+            message_ext
+        };
+        let topic_publish_info = self
+            .topic_route_info_manager
+            .try_to_find_topic_publish_info(message_to_put.get_topic())
+            .await
+            .filter(|route| route.is_usable())
+            .ok_or(EscapeTargetError::RouteUnavailable)?;
+        let local_broker = self.policy_state.snapshot().broker_name.clone();
+        let target = self
+            .target_resolver
+            .resolve(topic_publish_info.message_queues(), &local_broker, preference)?;
+        let broker_address = self
+            .topic_route_info_manager
+            .find_broker_address_in_publish(Some(target.broker_name()))
+            .ok_or(EscapeDispatchError::BrokerAddressUnavailable)?;
+        let producer_group = self.get_producer_group(&message_to_put);
+        message_to_put.message_ext_inner.queue_id = target.queue_id();
+
+        if !self.policy_state.is_remote_escape_authority_current(authority) {
+            return Err(EscapeDispatchError::StaleRoleEpoch);
+        }
+        self.broker_outer_api
+            .send_message_to_specific_broker(
+                &broker_address,
+                target.broker_name(),
+                message_to_put.message_ext_inner,
+                producer_group,
+                SEND_TIMEOUT,
+            )
+            .await
+            .map_err(Into::into)
     }
 
     pub fn get_message_async(
@@ -667,18 +637,17 @@ where
                     .await
                     .ok()
                     .flatten();
-                if result.is_none() {
+                let Some(result) = result else {
                     warn!(
                         "getMessageResult is null, innerConsumerGroupName {}, topic {}, offset {}, queueId {}",
                         inner_consumer_group_name, topic, offset, queue_id
                     );
                     return (None, "getMessageResult is null".to_string(), false);
-                }
-                let result1 = result.unwrap();
-                let status = result1.status();
-                let mut list = decode_msg_list(result1, de_compress_body);
+                };
+                let status = result.status();
+                let mut list = decode_msg_list(result, de_compress_body);
                 if list.is_empty() {
-                    let need_retry = status.unwrap() == GetMessageStatus::OffsetFoundNull;
+                    let need_retry = status == Some(GetMessageStatus::OffsetFoundNull);
                     warn!(
                         "Can not get msg, topic {}, offset {}, queueId {}, needRetry {},",
                         topic, offset, queue_id, need_retry,
@@ -722,7 +691,9 @@ where
                 }
             }
 
-            let broker_addr = broker_addr.unwrap();
+            let Some(broker_addr) = broker_addr else {
+                return (None, "brokerAddress not found".to_string(), true);
+            };
             match broker_outer_api
                 .pull_message_from_specific_broker_async(
                     &broker_name,
@@ -738,10 +709,10 @@ where
             {
                 Ok(pull_result) => {
                     if let Some(result) = pull_result.0 {
-                        if result.pull_status() == PullStatus::Found
-                            && result.messages().is_some_and(|value| !value.is_empty())
-                        {
-                            return (Some(result.messages().unwrap()[0].clone()), "".to_string(), false);
+                        if result.pull_status() == PullStatus::Found {
+                            if let Some(message) = result.messages().and_then(|messages| messages.first()).cloned() {
+                                return (Some(message), "".to_string(), false);
+                            }
                         }
                     }
                 }
@@ -886,6 +857,8 @@ mod tests {
         };
         let result = transform_send_result2put_result(Some(send_result));
         assert_eq!(result.put_message_status(), PutMessageStatus::PutOk);
+        assert!(result.remote_put());
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/rocketmq-broker/src/failover/escape_bridge_capability.rs
+++ b/rocketmq-broker/src/failover/escape_bridge_capability.rs
@@ -26,6 +26,7 @@ use rocketmq_model::common::broker::broker_role::BrokerRole;
 use rocketmq_model::common::message::message_batch::MessageExtBatch;
 use rocketmq_model::common::message::message_ext::MessageExt;
 use rocketmq_model::common::message::message_ext_broker_inner::MessageExtBrokerInner;
+use rocketmq_model::common::mix_all::MASTER_ID;
 use rocketmq_store::store_append_receipt;
 use rocketmq_store::ArcMessageFilter;
 use rocketmq_store::BrokerAdminStore;
@@ -65,6 +66,10 @@ pub(crate) struct EscapeBridgePolicy {
     pub(crate) enable_slave_acting_master: bool,
     pub(crate) enable_remote_escape: bool,
     pub(crate) broker_role: BrokerRole,
+    enable_controller_mode: bool,
+    controller_role: Option<BrokerReplicaRole>,
+    controller_role_epoch: Option<i32>,
+    generation: u64,
 }
 
 impl EscapeBridgePolicy {
@@ -75,6 +80,10 @@ impl EscapeBridgePolicy {
             enable_slave_acting_master: broker_config.enable_slave_acting_master,
             enable_remote_escape: broker_config.enable_remote_escape,
             broker_role: message_store_config.broker_role,
+            enable_controller_mode: broker_config.enable_controller_mode,
+            controller_role: None,
+            controller_role_epoch: None,
+            generation: 0,
         }
     }
 
@@ -83,11 +92,52 @@ impl EscapeBridgePolicy {
         self.broker_id = broker_config.broker_identity.broker_id;
         self.enable_slave_acting_master = broker_config.enable_slave_acting_master;
         self.enable_remote_escape = broker_config.enable_remote_escape;
+        self.enable_controller_mode = broker_config.enable_controller_mode;
+        if !self.enable_controller_mode {
+            self.controller_role = None;
+            self.controller_role_epoch = None;
+        }
+        self.generation = self.generation.saturating_add(1);
     }
 
     fn apply_message_store_config(&mut self, message_store_config: &MessageStoreConfig) {
         self.broker_role = message_store_config.broker_role;
+        self.generation = self.generation.saturating_add(1);
     }
+
+    fn apply_controller_role(&mut self, role: Option<BrokerReplicaRole>, role_epoch: Option<i32>) {
+        self.controller_role = role;
+        self.controller_role_epoch = role_epoch;
+        self.generation = self.generation.saturating_add(1);
+    }
+
+    pub(crate) fn remote_escape_authority(&self) -> Option<EscapeRemoteAuthority> {
+        if !self.enable_slave_acting_master
+            || !self.enable_remote_escape
+            || self.broker_role != BrokerRole::Slave
+            || self.broker_id == MASTER_ID
+        {
+            return None;
+        }
+        let role_epoch = if self.enable_controller_mode {
+            if self.controller_role != Some(BrokerReplicaRole::Slave) {
+                return None;
+            }
+            Some(self.controller_role_epoch?)
+        } else {
+            None
+        };
+        Some(EscapeRemoteAuthority {
+            policy_generation: self.generation,
+            role_epoch,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct EscapeRemoteAuthority {
+    policy_generation: u64,
+    role_epoch: Option<i32>,
 }
 
 /// Atomically published failover policy generations.
@@ -124,6 +174,26 @@ impl EscapeBridgePolicyState {
             replacement.apply_message_store_config(message_store_config);
             Arc::new(replacement)
         });
+    }
+
+    pub(crate) fn update_controller_role(&self, role: BrokerReplicaRole, role_epoch: i32) {
+        self.current.rcu(|current| {
+            let mut replacement = current.as_ref().clone();
+            replacement.apply_controller_role(Some(role), Some(role_epoch));
+            Arc::new(replacement)
+        });
+    }
+
+    pub(crate) fn fence_controller_role(&self) {
+        self.current.rcu(|current| {
+            let mut replacement = current.as_ref().clone();
+            replacement.apply_controller_role(None, None);
+            Arc::new(replacement)
+        });
+    }
+
+    pub(crate) fn is_remote_escape_authority_current(&self, authority: EscapeRemoteAuthority) -> bool {
+        self.snapshot().remote_escape_authority() == Some(authority)
     }
 }
 
@@ -300,6 +370,11 @@ impl<MS: BrokerReadStore> EscapeBridgeStoreCapability<MS> {
         .unwrap_or((None, None, None))
     }
 
+    pub(crate) fn is_local_writeable(&self) -> bool {
+        self.with_store(|store| store.put_message_preflight().is_writeable())
+            .unwrap_or(false)
+    }
+
     pub(crate) fn set_alive_replica_num_in_group(&self, alive_replica_num: i32) -> Result<(), MessageStoreUnavailable>
     where
         MS: BrokerReplicationStore,
@@ -474,6 +549,13 @@ impl<MS: BrokerReadStore> EscapeBridgeStoreCapability<MS> {
         Ok(self.shared_append()?.put_message(message).await?.result)
     }
 
+    pub(crate) async fn put_messages(&self, batch: MessageExtBatch) -> Result<PutMessageResult, MessageStoreUnavailable>
+    where
+        MS: BrokerWriteStore,
+    {
+        Ok(self.shared_append()?.put_messages(batch).await?.result)
+    }
+
     pub(crate) fn set_commitlog_read_mode(
         &self,
         read_ahead_mode: rocketmq_store::CommitLogReadMode,
@@ -646,6 +728,50 @@ mod tests {
         assert_eq!(snapshot.broker_role, BrokerRole::Slave);
     }
 
+    #[test]
+    fn controller_remote_escape_authority_is_epoch_scoped_and_fail_closed() {
+        let mut broker_config = BrokerConfig::default();
+        broker_config.broker_identity.broker_id = 1;
+        broker_config.enable_controller_mode = true;
+        broker_config.enable_slave_acting_master = true;
+        broker_config.enable_remote_escape = true;
+        let store_config = MessageStoreConfig {
+            broker_role: BrokerRole::Slave,
+            ..Default::default()
+        };
+        let state = EscapeBridgePolicyState::from_configs(&broker_config, &store_config);
+
+        assert!(state.snapshot().remote_escape_authority().is_none());
+        state.update_controller_role(BrokerReplicaRole::Slave, 3);
+        let authority = state.snapshot().remote_escape_authority().expect("slave authority");
+        assert!(state.is_remote_escape_authority_current(authority));
+
+        state.fence_controller_role();
+        assert!(!state.is_remote_escape_authority_current(authority));
+        assert!(state.snapshot().remote_escape_authority().is_none());
+
+        state.update_controller_role(BrokerReplicaRole::Master, 4);
+        assert!(state.snapshot().remote_escape_authority().is_none());
+    }
+
+    #[test]
+    fn classic_remote_escape_requires_a_non_master_slave() {
+        let mut broker_config = BrokerConfig::default();
+        broker_config.broker_identity.broker_id = 1;
+        broker_config.enable_slave_acting_master = true;
+        broker_config.enable_remote_escape = true;
+        let store_config = MessageStoreConfig {
+            broker_role: BrokerRole::Slave,
+            ..Default::default()
+        };
+        let state = EscapeBridgePolicyState::from_configs(&broker_config, &store_config);
+        assert!(state.snapshot().remote_escape_authority().is_some());
+
+        broker_config.broker_identity.broker_id = 0;
+        state.update_broker_config(&broker_config);
+        assert!(state.snapshot().remote_escape_authority().is_none());
+    }
+
     #[tokio::test]
     async fn controller_role_change_is_a_noop_before_store_binding() {
         let store = EscapeBridgeStoreCapability::<StorePorts>::default();
@@ -661,6 +787,7 @@ mod tests {
         let store = EscapeBridgeStoreCapability::<StorePorts>::default();
 
         assert_eq!(store.controller_heartbeat_state(), (None, None, None));
+        assert!(!store.is_local_writeable());
         assert!(store.set_alive_replica_num_in_group(1).is_err());
     }
 }

--- a/rocketmq-broker/src/failover/escape_target_resolver.rs
+++ b/rocketmq-broker/src/failover/escape_target_resolver.rs
@@ -1,0 +1,81 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+
+use cheetah_string::CheetahString;
+use rocketmq_model::common::message::message_queue::MessageQueue;
+use thiserror::Error;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum EscapeTargetPreference<'a> {
+    Any,
+    Broker(&'a CheetahString),
+    Stable(u64),
+}
+
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+pub(crate) enum EscapeTargetError {
+    #[error("topic has no writable remote route")]
+    RouteUnavailable,
+    #[error("topic route contains only the local broker")]
+    SelfOnlyRoute,
+    #[error("the requested escape broker is the local broker")]
+    SelfTarget,
+    #[error("the requested escape broker is unavailable")]
+    RequestedBrokerUnavailable,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct EscapeTargetResolver {
+    next_queue: AtomicUsize,
+}
+
+impl EscapeTargetResolver {
+    pub(crate) fn resolve(
+        &self,
+        queues: &[MessageQueue],
+        local_broker: &CheetahString,
+        preference: EscapeTargetPreference<'_>,
+    ) -> Result<MessageQueue, EscapeTargetError> {
+        if queues.is_empty() {
+            return Err(EscapeTargetError::RouteUnavailable);
+        }
+        if matches!(preference, EscapeTargetPreference::Broker(broker) if broker == local_broker) {
+            return Err(EscapeTargetError::SelfTarget);
+        }
+
+        let remote_queues = queues
+            .iter()
+            .filter(|queue| queue.broker_name() != local_broker)
+            .collect::<Vec<_>>();
+        if remote_queues.is_empty() {
+            return Err(EscapeTargetError::SelfOnlyRoute);
+        }
+
+        let selected = match preference {
+            EscapeTargetPreference::Any => {
+                let index = self.next_queue.fetch_add(1, Ordering::Relaxed) % remote_queues.len();
+                remote_queues[index]
+            }
+            EscapeTargetPreference::Broker(broker) => remote_queues
+                .into_iter()
+                .find(|queue| queue.broker_name() == broker)
+                .ok_or(EscapeTargetError::RequestedBrokerUnavailable)?,
+            EscapeTargetPreference::Stable(key) => remote_queues[(key % remote_queues.len() as u64) as usize],
+        };
+        Ok(selected.clone())
+    }
+}

--- a/rocketmq-broker/src/topic/manager/topic_route_info_manager.rs
+++ b/rocketmq-broker/src/topic/manager/topic_route_info_manager.rs
@@ -204,24 +204,26 @@ impl TopicRouteInfoManager {
                 .broker_outer_api
                 .get_topic_route_info_from_name_server(topic, GET_TOPIC_ROUTE_TIMEOUT, true)
                 .await;
-            if let Err(e) = topic_route_data {
-                if !NamespaceUtil::is_retry_topic(topic) {
-                    if let rocketmq_error::RocketMQError::BrokerOperationFailed { code, .. } = e {
-                        if code == ResponseCode::TopicNotExist as i32 {
-                            self.clean_none_route_topic(topic);
-                            return;
+            let mut topic_route_data = match topic_route_data {
+                Ok(route) => route,
+                Err(e) => {
+                    if !NamespaceUtil::is_retry_topic(topic) {
+                        if let rocketmq_error::RocketMQError::BrokerOperationFailed { code, .. } = e {
+                            if code == ResponseCode::TopicNotExist as i32 {
+                                self.clean_none_route_topic(topic);
+                                return;
+                            }
                         }
                     }
-                }
 
-                warn!(
-                    "TopicRouteInfoManager: updateTopicRouteInfoFromNameServer, getTopicRouteInfoFromNameServer \
+                    warn!(
+                        "TopicRouteInfoManager: updateTopicRouteInfoFromNameServer, getTopicRouteInfoFromNameServer \
                      return null, Topic: {}.",
-                    topic
-                );
-                return;
-            }
-            let mut topic_route_data = topic_route_data.unwrap();
+                        topic
+                    );
+                    return;
+                }
+            };
             if is_need_update_subscribe_info {
                 self.update_subscribe_info_table(topic.clone(), &topic_route_data);
             }
@@ -308,7 +310,7 @@ impl TopicRouteInfoManager {
             .topic_publish_info_table
             .get(topic)
             .map(|entry| entry.value().clone());
-        if topic_publish_info.is_none() || !topic_publish_info.as_ref().unwrap().is_usable() {
+        if !topic_publish_info.as_ref().is_some_and(BrokerPublishRoute::is_usable) {
             self.update_topic_route_info_from_name_server_ext(topic, true, false)
                 .await;
             topic_publish_info = self

--- a/rocketmq-broker/tests/escape_bridge_failover.rs
+++ b/rocketmq-broker/tests/escape_bridge_failover.rs
@@ -1,0 +1,90 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[path = "../src/failover/escape_target_resolver.rs"]
+mod escape_target_resolver;
+
+use cheetah_string::CheetahString;
+use escape_target_resolver::EscapeTargetError;
+use escape_target_resolver::EscapeTargetPreference;
+use escape_target_resolver::EscapeTargetResolver;
+use rocketmq_model::common::message::message_queue::MessageQueue;
+
+fn queue(broker: &'static str, queue_id: i32) -> MessageQueue {
+    MessageQueue::from_parts("escape-topic", broker, queue_id)
+}
+
+#[test]
+fn missing_and_self_only_routes_fail_closed_without_panicking() {
+    let resolver = EscapeTargetResolver::default();
+    let local = CheetahString::from_static_str("broker-a");
+
+    assert_eq!(
+        resolver.resolve(&[], &local, EscapeTargetPreference::Any),
+        Err(EscapeTargetError::RouteUnavailable)
+    );
+    assert_eq!(
+        resolver.resolve(&[queue("broker-a", 0)], &local, EscapeTargetPreference::Any),
+        Err(EscapeTargetError::SelfOnlyRoute)
+    );
+}
+
+#[test]
+fn all_send_modes_share_remote_only_eligibility() {
+    let resolver = EscapeTargetResolver::default();
+    let local = CheetahString::from_static_str("broker-a");
+    let remote = CheetahString::from_static_str("broker-b");
+    let queues = [queue("broker-a", 0), queue("broker-b", 1), queue("broker-c", 2)];
+
+    let sync = resolver
+        .resolve(&queues, &local, EscapeTargetPreference::Any)
+        .expect("sync target");
+    let asynchronous = resolver
+        .resolve(&queues, &local, EscapeTargetPreference::Any)
+        .expect("async target");
+    let requested = resolver
+        .resolve(&queues, &local, EscapeTargetPreference::Broker(&remote))
+        .expect("requested target");
+    let stable = resolver
+        .resolve(&queues, &local, EscapeTargetPreference::Stable(17))
+        .expect("stable target");
+
+    for selected in [&sync, &asynchronous, &requested, &stable] {
+        assert_ne!(selected.broker_name(), &local);
+    }
+    assert_eq!(requested.broker_name(), &remote);
+    assert_eq!(
+        stable,
+        resolver
+            .resolve(&queues, &local, EscapeTargetPreference::Stable(17))
+            .expect("repeat stable target")
+    );
+}
+
+#[test]
+fn requested_local_or_missing_broker_is_rejected() {
+    let resolver = EscapeTargetResolver::default();
+    let local = CheetahString::from_static_str("broker-a");
+    let missing = CheetahString::from_static_str("broker-z");
+    let queues = [queue("broker-a", 0), queue("broker-b", 1)];
+
+    assert_eq!(
+        resolver.resolve(&queues, &local, EscapeTargetPreference::Broker(&local)),
+        Err(EscapeTargetError::SelfTarget)
+    );
+    assert_eq!(
+        resolver.resolve(&queues, &local, EscapeTargetPreference::Broker(&missing)),
+        Err(EscapeTargetError::RequestedBrokerUnavailable)
+    );
+}


### PR DESCRIPTION
## Summary
- add one remote-only target resolver for synchronous, asynchronous, requested-broker, and stable queue escape paths
- require an unwritable local Store plus a current slave-acting-master authority, and fence Controller role epochs before role changes
- remove route/network `unwrap` paths, keep refresh/send attempts bounded, preserve remote acceptance status, and fail closed for remote batch escape

## Validation
- `cargo test --locked -p rocketmq-broker --test escape_bridge_failover`
- `cargo test --locked -p rocketmq-broker --lib failover::escape_bridge_capability::tests`
- `cargo test --locked -p rocketmq-broker --lib failover::escape_bridge::tests`
- `cargo test --locked -p rocketmq-broker --lib topic_route_info_manager`
- `cargo clippy --locked --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo fmt -p rocketmq-broker -- --check`
- `git diff --check`
- `cargo +nightly-2026-07-05 check --offline --all-targets --all-features` from `fuzz/`

The exact fuzz `--locked` route remains blocked by the pre-existing stale standalone fuzz lockfile. Root `cargo fmt --all -- --check` remains blocked on Windows by OS error 206; the affected package formatting check passed.

Closes #9482

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved broker failover routing with automatic selection of eligible remote brokers.
  * Added support for requested-broker and stable queue-target selection.
  * Added batch message handling during failover.

* **Bug Fixes**
  * Prevented messages from being sent to the local broker or unavailable targets.
  * Added safeguards against stale controller state and unauthorized remote dispatch.
  * Improved handling when routes or message stores are unavailable.
  * Enhanced topic route validation and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->