### PR TITLE
[ISSUE #9484]✅Add bounded DefaultHA interop matrix

### DIFF
--- a/rocketmq-store/tests/ha_master_slave_transfer.rs
+++ b/rocketmq-store/tests/ha_master_slave_transfer.rs
@@ -60,6 +60,32 @@ async fn single_master_slave_transfer_round_trips_with_bytes_and_vectored_engine
     assert_eq!(vectored_result.writer.vectored_calls, 1);
 }
 
+#[test]
+fn default_ha_wire_bytes_match_java_transfer_and_report_frames() {
+    let transfer = transfer_header(4_096, 26);
+    assert_eq!(
+        transfer.as_ref(),
+        &[0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 26],
+        "Java DefaultHA uses an 8-byte offset followed by a 4-byte body length"
+    );
+    assert_eq!(
+        slave_report(4_122).as_ref(),
+        &[0, 0, 0, 0, 0, 0, 16, 26],
+        "Java DefaultHA slave reports contain exactly one big-endian offset"
+    );
+}
+
+#[test]
+fn default_ha_heartbeat_and_reconnect_offsets_are_unambiguous() {
+    let heartbeat = transfer_header(4_122, 0);
+    let decoded = SlaveFrame::decode(&heartbeat);
+    assert!(decoded.body.is_empty());
+    assert_eq!(decoded.ack_offset, 4_122);
+
+    let report = slave_report(decoded.ack_offset);
+    assert_eq!(i64::from_be_bytes(report), 4_122);
+}
+
 fn master_plans_single_slave_batch() -> TransferBatch {
     let input = TransferPlanInput {
         requested_offset: 4096,
@@ -132,6 +158,10 @@ fn transfer_header(offset: i64, body_size: usize) -> Bytes {
     header.put_i64(offset);
     header.put_i32(i32::try_from(body_size).expect("body size fits i32"));
     header.freeze()
+}
+
+fn slave_report(offset: i64) -> [u8; 8] {
+    offset.to_be_bytes()
 }
 
 struct TransferResultSnapshot {

--- a/scripts/interop/default-ha-matrix.json
+++ b/scripts/interop/default-ha-matrix.json
@@ -1,0 +1,108 @@
+{
+  "schemaVersion": 1,
+  "haMode": "DefaultHA",
+  "controllerMode": false,
+  "dledgerCommitLog": false,
+  "wireContract": {
+    "transferHeaderBytes": 12,
+    "slaveReportBytes": 8,
+    "byteOrder": "big-endian"
+  },
+  "excludedModes": [
+    "Java AutoSwitchHA",
+    "Java Controller",
+    "DLedger CommitLog"
+  ],
+  "scenarios": [
+    {
+      "id": "J2R-ASYNC-BASELINE",
+      "direction": "java-master-rust-slave",
+      "flushMode": "ASYNC_FLUSH",
+      "fault": "none",
+      "timeoutSeconds": 120,
+      "requiredAssertions": ["messageId", "queueOffset", "bodyAndProperties", "confirmOffset", "processExit"],
+      "requiredEvidence": ["masterLog", "slaveLog", "probeResult", "offsetSnapshot"]
+    },
+    {
+      "id": "J2R-SYNC-BASELINE",
+      "direction": "java-master-rust-slave",
+      "flushMode": "SYNC_FLUSH",
+      "fault": "none",
+      "timeoutSeconds": 120,
+      "requiredAssertions": ["messageId", "queueOffset", "bodyAndProperties", "confirmOffset", "processExit"],
+      "requiredEvidence": ["masterLog", "slaveLog", "probeResult", "offsetSnapshot"]
+    },
+    {
+      "id": "J2R-RECONNECT",
+      "direction": "java-master-rust-slave",
+      "flushMode": "ASYNC_FLUSH",
+      "fault": "reconnect-resume",
+      "timeoutSeconds": 120,
+      "requiredAssertions": ["messageId", "queueOffset", "bodyAndProperties", "confirmOffset", "processExit"],
+      "requiredEvidence": ["masterLog", "slaveLog", "probeResult", "offsetSnapshot"]
+    },
+    {
+      "id": "J2R-TAIL-TRUNCATE",
+      "direction": "java-master-rust-slave",
+      "flushMode": "SYNC_FLUSH",
+      "fault": "tail-truncate",
+      "timeoutSeconds": 120,
+      "requiredAssertions": ["messageId", "queueOffset", "bodyAndProperties", "confirmOffset", "processExit"],
+      "requiredEvidence": ["masterLog", "slaveLog", "probeResult", "offsetSnapshot"]
+    },
+    {
+      "id": "J2R-SLOW-REPLICA",
+      "direction": "java-master-rust-slave",
+      "flushMode": "SYNC_FLUSH",
+      "fault": "slow-replica",
+      "timeoutSeconds": 120,
+      "requiredAssertions": ["messageId", "queueOffset", "bodyAndProperties", "confirmOffset", "processExit"],
+      "requiredEvidence": ["masterLog", "slaveLog", "probeResult", "offsetSnapshot"]
+    },
+    {
+      "id": "R2J-ASYNC-BASELINE",
+      "direction": "rust-master-java-slave",
+      "flushMode": "ASYNC_FLUSH",
+      "fault": "none",
+      "timeoutSeconds": 120,
+      "requiredAssertions": ["messageId", "queueOffset", "bodyAndProperties", "confirmOffset", "processExit"],
+      "requiredEvidence": ["masterLog", "slaveLog", "probeResult", "offsetSnapshot"]
+    },
+    {
+      "id": "R2J-SYNC-BASELINE",
+      "direction": "rust-master-java-slave",
+      "flushMode": "SYNC_FLUSH",
+      "fault": "none",
+      "timeoutSeconds": 120,
+      "requiredAssertions": ["messageId", "queueOffset", "bodyAndProperties", "confirmOffset", "processExit"],
+      "requiredEvidence": ["masterLog", "slaveLog", "probeResult", "offsetSnapshot"]
+    },
+    {
+      "id": "R2J-RECONNECT",
+      "direction": "rust-master-java-slave",
+      "flushMode": "ASYNC_FLUSH",
+      "fault": "reconnect-resume",
+      "timeoutSeconds": 120,
+      "requiredAssertions": ["messageId", "queueOffset", "bodyAndProperties", "confirmOffset", "processExit"],
+      "requiredEvidence": ["masterLog", "slaveLog", "probeResult", "offsetSnapshot"]
+    },
+    {
+      "id": "R2J-TAIL-TRUNCATE",
+      "direction": "rust-master-java-slave",
+      "flushMode": "SYNC_FLUSH",
+      "fault": "tail-truncate",
+      "timeoutSeconds": 120,
+      "requiredAssertions": ["messageId", "queueOffset", "bodyAndProperties", "confirmOffset", "processExit"],
+      "requiredEvidence": ["masterLog", "slaveLog", "probeResult", "offsetSnapshot"]
+    },
+    {
+      "id": "R2J-SLOW-REPLICA",
+      "direction": "rust-master-java-slave",
+      "flushMode": "SYNC_FLUSH",
+      "fault": "slow-replica",
+      "timeoutSeconds": 120,
+      "requiredAssertions": ["messageId", "queueOffset", "bodyAndProperties", "confirmOffset", "processExit"],
+      "requiredEvidence": ["masterLog", "slaveLog", "probeResult", "offsetSnapshot"]
+    }
+  ]
+}

--- a/scripts/interop/run_default_ha_interop.ps1
+++ b/scripts/interop/run_default_ha_interop.ps1
@@ -1,0 +1,35 @@
+# Copyright 2023 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0
+
+[CmdletBinding()]
+param(
+    [ValidateSet('Both', 'JavaMasterRustSlave', 'RustMasterJavaSlave')]
+    [string]$Direction = 'Both',
+    [ValidateRange(1, 600)]
+    [int]$DurationSeconds = 90,
+    [string]$Scenario,
+    [string]$JavaRoot = 'D:\Github\Java\rocketmq',
+    [string]$RustRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path,
+    [string]$Output = (Join-Path (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path 'target\default-ha-interop'),
+    [string]$CaseDriver,
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+$runner = Join-Path $PSScriptRoot 'run_default_ha_interop.py'
+$arguments = @(
+    $runner,
+    '--direction', $Direction,
+    '--duration-seconds', $DurationSeconds,
+    '--java-root', $JavaRoot,
+    '--rust-root', $RustRoot,
+    '--output', $Output
+)
+if ($Scenario) { $arguments += @('--scenario', $Scenario) }
+if ($CaseDriver) { $arguments += @('--case-driver', $CaseDriver) }
+if ($DryRun) { $arguments += '--dry-run' }
+
+& python @arguments
+if ($LASTEXITCODE -ne 0) {
+    throw "DefaultHA interoperability runner failed with exit code $LASTEXITCODE"
+}

--- a/scripts/interop/run_default_ha_interop.py
+++ b/scripts/interop/run_default_ha_interop.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+# Copyright 2023 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+DIRECTIONS = {"java-master-rust-slave", "rust-master-java-slave"}
+FAULTS = {"none", "reconnect-resume", "tail-truncate", "slow-replica"}
+FLUSH_MODES = {"ASYNC_FLUSH", "SYNC_FLUSH"}
+
+
+def load_matrix(path: Path) -> dict[str, Any]:
+    matrix = json.loads(path.read_text(encoding="utf-8"))
+    validate_matrix(matrix)
+    return matrix
+
+
+def validate_matrix(matrix: dict[str, Any]) -> None:
+    if matrix.get("schemaVersion") != 1:
+        raise ValueError("DefaultHA matrix schemaVersion must be 1")
+    if matrix.get("haMode") != "DefaultHA":
+        raise ValueError("only the DefaultHA compatibility profile is supported")
+    if matrix.get("controllerMode") is not False or matrix.get("dledgerCommitLog") is not False:
+        raise ValueError("DefaultHA interop must exclude Controller and DLedger CommitLog")
+    wire = matrix.get("wireContract")
+    if wire != {"transferHeaderBytes": 12, "slaveReportBytes": 8, "byteOrder": "big-endian"}:
+        raise ValueError("DefaultHA wire contract must remain 12-byte transfer / 8-byte report / big-endian")
+
+    scenarios = matrix.get("scenarios")
+    if not isinstance(scenarios, list) or not scenarios:
+        raise ValueError("DefaultHA matrix must contain scenarios")
+    ids: set[str] = set()
+    observed_directions: set[str] = set()
+    for scenario in scenarios:
+        scenario_id = scenario.get("id")
+        if not isinstance(scenario_id, str) or not scenario_id or scenario_id in ids:
+            raise ValueError("scenario ids must be non-empty and unique")
+        ids.add(scenario_id)
+        direction = scenario.get("direction")
+        if direction not in DIRECTIONS:
+            raise ValueError(f"{scenario_id}: unsupported direction")
+        observed_directions.add(direction)
+        if scenario.get("flushMode") not in FLUSH_MODES:
+            raise ValueError(f"{scenario_id}: unsupported flush mode")
+        if scenario.get("fault") not in FAULTS:
+            raise ValueError(f"{scenario_id}: unsupported fault")
+        timeout = scenario.get("timeoutSeconds")
+        if not isinstance(timeout, int) or not 1 <= timeout <= 600:
+            raise ValueError(f"{scenario_id}: timeout must be between 1 and 600 seconds")
+        for field in ("requiredAssertions", "requiredEvidence"):
+            values = scenario.get(field)
+            if not isinstance(values, list) or not values or len(values) != len(set(values)):
+                raise ValueError(f"{scenario_id}: {field} must be a non-empty unique list")
+    if observed_directions != DIRECTIONS:
+        raise ValueError("DefaultHA matrix must cover both Java/Rust directions")
+
+
+def validate_scenario_result(
+    scenario: dict[str, Any], result: dict[str, Any], evidence_root: Path | None = None
+) -> None:
+    scenario_id = scenario["id"]
+    if result.get("id") != scenario_id or result.get("direction") != scenario["direction"]:
+        raise ValueError(f"{scenario_id}: result identity does not match the matrix")
+    if result.get("status") != "passed":
+        raise ValueError(f"{scenario_id}: status must be passed; skipped and partial results are failures")
+    assertions = result.get("assertions")
+    expected_assertions = set(scenario["requiredAssertions"])
+    if not isinstance(assertions, dict) or set(assertions) != expected_assertions:
+        raise ValueError(f"{scenario_id}: assertion set does not match the matrix")
+    if any(value is not True for value in assertions.values()):
+        raise ValueError(f"{scenario_id}: every assertion must pass")
+    evidence = result.get("evidence")
+    expected_evidence = set(scenario["requiredEvidence"])
+    if not isinstance(evidence, dict) or set(evidence) != expected_evidence:
+        raise ValueError(f"{scenario_id}: evidence set does not match the matrix")
+    if any(not isinstance(value, str) or not value.strip() for value in evidence.values()):
+        raise ValueError(f"{scenario_id}: evidence paths must be non-empty strings")
+    if evidence_root is not None:
+        root = evidence_root.resolve()
+        for name, value in evidence.items():
+            path = (root / value).resolve()
+            if not path.is_relative_to(root):
+                raise ValueError(f"{scenario_id}: {name} evidence escapes the output directory")
+            if not path.is_file():
+                raise ValueError(f"{scenario_id}: missing {name} evidence: {value}")
+
+
+def validate_result_set(scenarios: list[dict[str, Any]], result_directory: Path) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for scenario in scenarios:
+        path = result_directory / f"{scenario['id']}.json"
+        if not path.is_file():
+            raise ValueError(f"missing scenario result: {scenario['id']}")
+        result = json.loads(path.read_text(encoding="utf-8"))
+        validate_scenario_result(scenario, result, result_directory.parent)
+        results.append(result)
+    return results
+
+
+def selected_scenarios(matrix: dict[str, Any], direction: str, scenario_id: str | None) -> list[dict[str, Any]]:
+    direction_filter = {
+        "Both": DIRECTIONS,
+        "JavaMasterRustSlave": {"java-master-rust-slave"},
+        "RustMasterJavaSlave": {"rust-master-java-slave"},
+    }[direction]
+    selected = [item for item in matrix["scenarios"] if item["direction"] in direction_filter]
+    if scenario_id is not None:
+        selected = [item for item in selected if item["id"] == scenario_id]
+        if not selected:
+            raise ValueError(f"unknown or direction-mismatched scenario: {scenario_id}")
+    return selected
+
+
+def driver_command(driver: Path, scenario: dict[str, Any], args: argparse.Namespace, result_path: Path) -> list[str]:
+    prefix = [sys.executable, str(driver)] if driver.suffix.lower() == ".py" else [str(driver)]
+    return prefix + [
+        "--scenario",
+        scenario["id"],
+        "--duration-seconds",
+        str(args.duration_seconds),
+        "--java-root",
+        str(args.java_root),
+        "--rust-root",
+        str(args.rust_root),
+        "--result",
+        str(result_path),
+    ]
+
+
+def execute(args: argparse.Namespace) -> int:
+    matrix = load_matrix(args.matrix)
+    scenarios = selected_scenarios(matrix, args.direction, args.scenario)
+    args.output.mkdir(parents=True, exist_ok=True)
+    plan = {
+        "schemaVersion": 1,
+        "status": "planned" if args.dry_run else "running",
+        "haMode": "DefaultHA",
+        "durationSeconds": args.duration_seconds,
+        "scenarioIds": [item["id"] for item in scenarios],
+        "remotePublication": "not-executed",
+    }
+    (args.output / "plan.json").write_text(json.dumps(plan, indent=2) + "\n", encoding="utf-8")
+    if args.dry_run:
+        print(f"validated {len(scenarios)} DefaultHA scenarios; no processes executed")
+        return 0
+    if args.case_driver is None or not args.case_driver.is_file():
+        raise ValueError("--case-driver must identify an executable DefaultHA process harness")
+    if not args.java_root.is_dir() or not args.rust_root.is_dir():
+        raise ValueError("Java and Rust repository roots must exist")
+
+    result_directory = args.output / "scenarios"
+    result_directory.mkdir(parents=True, exist_ok=True)
+    try:
+        for scenario in scenarios:
+            result_path = result_directory / f"{scenario['id']}.json"
+            timeout = min(args.duration_seconds, scenario["timeoutSeconds"])
+            completed = subprocess.run(
+                driver_command(args.case_driver, scenario, args, result_path),
+                cwd=args.rust_root,
+                timeout=timeout,
+                check=False,
+            )
+            if completed.returncode != 0:
+                raise ValueError(f"{scenario['id']}: case driver exited with {completed.returncode}")
+            if not result_path.is_file():
+                raise ValueError(f"missing scenario result: {scenario['id']}")
+            validate_scenario_result(scenario, json.loads(result_path.read_text(encoding="utf-8")))
+        results = validate_result_set(scenarios, result_directory)
+    except (OSError, subprocess.TimeoutExpired, ValueError) as error:
+        failure = {**plan, "status": "failed", "error": str(error)}
+        (args.output / "run.json").write_text(json.dumps(failure, indent=2) + "\n", encoding="utf-8")
+        raise
+
+    run = {
+        **plan,
+        "status": "passed",
+        "completedAt": datetime.now(timezone.utc).isoformat(),
+        "results": results,
+    }
+    (args.output / "run.json").write_text(json.dumps(run, indent=2) + "\n", encoding="utf-8")
+    print(f"passed {len(results)} DefaultHA scenarios")
+    return 0
+
+
+def parser() -> argparse.ArgumentParser:
+    root = Path(__file__).resolve().parents[2]
+    command = argparse.ArgumentParser(description="Run bounded Java/Rust DefaultHA interoperability scenarios")
+    command.add_argument("--direction", choices=("Both", "JavaMasterRustSlave", "RustMasterJavaSlave"), default="Both")
+    command.add_argument("--duration-seconds", type=int, default=90)
+    command.add_argument("--scenario")
+    command.add_argument("--matrix", type=Path, default=Path(__file__).with_name("default-ha-matrix.json"))
+    command.add_argument("--java-root", type=Path, default=Path(r"D:\Github\Java\rocketmq"))
+    command.add_argument("--rust-root", type=Path, default=root)
+    command.add_argument("--output", type=Path, default=root / "target" / "default-ha-interop")
+    command.add_argument("--case-driver", type=Path)
+    command.add_argument("--dry-run", action="store_true")
+    return command
+
+
+def main() -> int:
+    args = parser().parse_args()
+    if not 1 <= args.duration_seconds <= 600:
+        raise ValueError("--duration-seconds must be between 1 and 600")
+    return execute(args)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError, subprocess.TimeoutExpired) as error:
+        print(f"DefaultHA interoperability failed: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/interop/run_default_ha_interop.sh
+++ b/scripts/interop/run_default_ha_interop.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Copyright 2023 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/run_default_ha_interop.py" "$@"

--- a/scripts/tests/test_default_ha_interop.py
+++ b/scripts/tests/test_default_ha_interop.py
@@ -1,0 +1,106 @@
+# Copyright 2023 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RUNNER_PATH = ROOT / "scripts" / "interop" / "run_default_ha_interop.py"
+MATRIX_PATH = ROOT / "scripts" / "interop" / "default-ha-matrix.json"
+
+
+def load_runner():
+    spec = importlib.util.spec_from_file_location("run_default_ha_interop", RUNNER_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("unable to load DefaultHA interop runner")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class DefaultHaInteropContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.runner = load_runner()
+        cls.matrix = cls.runner.load_matrix(MATRIX_PATH)
+
+    def test_matrix_covers_both_directions_and_required_faults(self) -> None:
+        scenarios = self.matrix["scenarios"]
+        directions = {scenario["direction"] for scenario in scenarios}
+        faults = {(scenario["direction"], scenario["fault"]) for scenario in scenarios}
+
+        self.assertEqual(directions, {"java-master-rust-slave", "rust-master-java-slave"})
+        for direction in directions:
+            self.assertIn((direction, "none"), faults)
+            self.assertIn((direction, "reconnect-resume"), faults)
+            self.assertIn((direction, "tail-truncate"), faults)
+            self.assertIn((direction, "slow-replica"), faults)
+
+    def test_matrix_rejects_out_of_scope_ha_modes(self) -> None:
+        mutated = json.loads(json.dumps(self.matrix))
+        mutated["haMode"] = "AutoSwitchHA"
+        with self.assertRaisesRegex(ValueError, "DefaultHA"):
+            self.runner.validate_matrix(mutated)
+
+    def test_result_requires_every_assertion_and_evidence_field(self) -> None:
+        scenario = self.matrix["scenarios"][0]
+        result = {
+            "id": scenario["id"],
+            "status": "passed",
+            "direction": scenario["direction"],
+            "assertions": {name: True for name in scenario["requiredAssertions"]},
+            "evidence": {name: f"evidence/{name}.json" for name in scenario["requiredEvidence"]},
+        }
+        self.runner.validate_scenario_result(scenario, result)
+
+        result["status"] = "skipped"
+        with self.assertRaisesRegex(ValueError, "passed"):
+            self.runner.validate_scenario_result(scenario, result)
+
+    def test_aggregate_rejects_missing_scenario_results(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(ValueError, "missing scenario result"):
+                self.runner.validate_result_set(self.matrix["scenarios"], Path(directory))
+
+    def test_aggregate_rejects_missing_or_escaping_evidence(self) -> None:
+        scenario = self.matrix["scenarios"][0]
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            scenarios = root / "scenarios"
+            scenarios.mkdir()
+            result = {
+                "id": scenario["id"],
+                "status": "passed",
+                "direction": scenario["direction"],
+                "assertions": {name: True for name in scenario["requiredAssertions"]},
+                "evidence": {name: f"evidence/{name}.json" for name in scenario["requiredEvidence"]},
+            }
+            (scenarios / f"{scenario['id']}.json").write_text(json.dumps(result), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "missing masterLog evidence"):
+                self.runner.validate_result_set([scenario], scenarios)
+
+            result["evidence"]["masterLog"] = "../outside.log"
+            (scenarios / f"{scenario['id']}.json").write_text(json.dumps(result), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "escapes the output directory"):
+                self.runner.validate_result_set([scenario], scenarios)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- define the bounded Java-master/Rust-slave and Rust-master/Java-slave DefaultHA scenario inventory
- add fail-closed PowerShell, shell, and Python orchestration entry points with explicit result/evidence contracts
- pin the Java-compatible 12-byte transfer header and 8-byte slave report encoding in Rust tests

## Scope
DefaultHA only. Java AutoSwitchHA, Java Controller, mixed Controller quorum, and DLedger CommitLog remain explicitly excluded.

## Validation
- `python -m unittest scripts.tests.test_default_ha_interop` (5 passed)
- `python -m json.tool scripts/interop/default-ha-matrix.json`
- `./scripts/interop/run_default_ha_interop.ps1 -Direction Both -DurationSeconds 90 -DryRun ...` (10 scenarios validated)
- `bash -n scripts/interop/run_default_ha_interop.sh`
- `cargo test --locked -p rocketmq-store --test ha_master_slave_transfer` (3 passed)
- `cargo fmt -p rocketmq-store -- --check`
- `cargo clippy --locked --workspace --no-deps --all-targets --all-features -- -D warnings`
- `git diff --check`

The long process-backed Java/Rust matrix is intentionally not executed in this task. A real case driver is mandatory for non-dry-run execution; missing drivers, processes, results, assertions, or evidence fail closed.

Closes #9484