### PR TITLE
[ISSUE #9486]✅Add Rust storage upgrade and rollback matrix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4784,9 +4784,16 @@ dependencies = [
  "bytes",
  "cheetah-string",
  "clap",
+ "config",
+ "fs2",
  "rocketmq-error",
+ "rocketmq-model",
  "rocketmq-store",
+ "rocketmq-store-rocksdb",
+ "serde",
+ "serde_json",
  "tabled",
+ "tempfile",
 ]
 
 [[package]]

--- a/rocketmq-broker/Cargo.toml
+++ b/rocketmq-broker/Cargo.toml
@@ -202,3 +202,7 @@ required-features = ["rocksdb_store", "test-support"]
 [[test]]
 name = "pop_retry_version_migration"
 required-features = ["rocksdb_store", "test-support"]
+
+[[test]]
+name              = "upgrade_rollback_matrix"
+required-features = ["rocksdb_store"]

--- a/rocketmq-broker/src/pop/rocksdb_store.rs
+++ b/rocketmq-broker/src/pop/rocksdb_store.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fs;
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -32,6 +35,7 @@ use serde::Serialize;
 
 const POP_RECORD_KEY_SEPARATOR: u8 = b'@';
 pub(crate) const POP_ROCKSDB_DIRECTORY: &str = "kvStore";
+const STORAGE_FORMAT_INVENTORY: &str = "config/storage-format-inventory.json";
 
 pub(crate) fn pop_rocksdb_path(store_path_root_dir: impl AsRef<Path>) -> PathBuf {
     store_path_root_dir.as_ref().join(POP_ROCKSDB_DIRECTORY)
@@ -198,7 +202,8 @@ impl PopConsumerRocksDbStore {
         let mut batch = RocksDbWriteBatch::with_capacity(2);
         batch.put_cf(cf, POP_CONSUMER_PROFILE_MARKER_KEY.to_vec(), marker);
         batch.put_cf(cf, key, value);
-        self.store.write_batch(&batch)
+        self.store.write_batch(&batch)?;
+        self.persist_profile_format_inventory()
     }
 
     #[cfg(any(test, feature = "test-support"))]
@@ -212,6 +217,72 @@ impl PopConsumerRocksDbStore {
 
     pub(crate) fn close(&self) {
         self.store.close();
+    }
+
+    fn persist_profile_format_inventory(&self) -> Result<(), RocketMQError> {
+        let store_root = self.config.path.parent().ok_or_else(|| {
+            codec_error(format!(
+                "POP RocksDB path has no Store root: {}",
+                self.config.path.display()
+            ))
+        })?;
+        let inventory = store_root.join(STORAGE_FORMAT_INVENTORY);
+        match fs::read(&inventory) {
+            Ok(bytes) => {
+                let value: serde_json::Value = serde_json::from_slice(&bytes)
+                    .map_err(|error| codec_error(format!("storage format inventory is invalid: {error}")))?;
+                if value
+                    .pointer("/popConsumerProfile/declared")
+                    .and_then(serde_json::Value::as_bool)
+                    == Some(true)
+                {
+                    return Ok(());
+                }
+                return Err(codec_error(
+                    "storage format inventory exists without a declared POP consumer profile",
+                ));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(codec_error(format!(
+                    "read storage format inventory {}: {error}",
+                    inventory.display()
+                )));
+            }
+        }
+
+        let parent = inventory
+            .parent()
+            .ok_or_else(|| codec_error("storage format inventory has no parent"))?;
+        fs::create_dir_all(parent).map_err(|error| {
+            codec_error(format!(
+                "create storage format inventory directory {}: {error}",
+                parent.display()
+            ))
+        })?;
+        let temporary = parent.join(format!(".storage-format-inventory.{}.tmp", std::process::id()));
+        let body = b"{\n  \"popConsumerProfile\": {\n    \"declared\": true\n  }\n}\n";
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary)
+            .map_err(|error| codec_error(format!("create {}: {error}", temporary.display())))?;
+        let write_result = (|| -> std::io::Result<()> {
+            file.write_all(body)?;
+            file.sync_all()?;
+            fs::rename(&temporary, &inventory)
+        })();
+        if let Err(error) = write_result {
+            let _ = fs::remove_file(&temporary);
+            if inventory.is_file() {
+                return self.persist_profile_format_inventory();
+            }
+            return Err(codec_error(format!(
+                "publish storage format inventory {}: {error}",
+                inventory.display()
+            )));
+        }
+        Ok(())
     }
 }
 

--- a/rocketmq-broker/tests/pop_profile_persistence.rs
+++ b/rocketmq-broker/tests/pop_profile_persistence.rs
@@ -24,6 +24,16 @@ fn profile_survives_restart_and_isolated_from_inflight_state() {
         .expect("persist profile");
     assert_eq!(profile.generation, 1);
     assert_eq!(store.inflight_record_count().expect("scan inflight"), 0);
+    let inventory: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(root.path().join("config/storage-format-inventory.json")).expect("storage format inventory"),
+    )
+    .expect("decode storage format inventory");
+    assert_eq!(
+        inventory
+            .pointer("/popConsumerProfile/declared")
+            .and_then(serde_json::Value::as_bool),
+        Some(true)
+    );
     drop(store);
 
     let reopened = PopProfileStoreProbe::open(root.path(), 16).expect("reopen profile store");

--- a/rocketmq-broker/tests/upgrade_rollback_matrix.rs
+++ b/rocketmq-broker/tests/upgrade_rollback_matrix.rs
@@ -1,0 +1,91 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[path = "../src/transaction/transaction_metrics.rs"]
+mod transaction_metrics;
+
+use rocketmq_broker::config::java_properties::JavaBrokerProperties;
+use rocketmq_model::common::pop_retry_policy::PopRetryPolicy;
+use rocketmq_store_rocksdb::profile_marker::PopConsumerProfileMarker;
+use rocketmq_store_rocksdb::profile_marker::POP_CONSUMER_PROFILE_COLUMN_FAMILY;
+use rocketmq_store_rocksdb::profile_marker::POP_CONSUMER_PROFILE_MARKER_KEY;
+use rocketmq_store_rocksdb::read_only::PopConsumerProfileState;
+use rocketmq_store_rocksdb::read_only::ReadOnlyRocksDb;
+use rocketmq_store_rocksdb::store::KeyValueStore;
+use rocketmq_store_rocksdb::RocksDbStore;
+use transaction_metrics::TransactionMetrics;
+
+#[test]
+fn pop_profile_and_transaction_checkpoint_survive_a_restart_boundary() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let store = open_profile_store(temp.path().join("kvStore"));
+    let marker = PopConsumerProfileMarker::new(3);
+    store
+        .put_cf(
+            POP_CONSUMER_PROFILE_COLUMN_FAMILY,
+            POP_CONSUMER_PROFILE_MARKER_KEY,
+            &marker.encode().expect("marker"),
+        )
+        .expect("persist profile marker");
+    store.flush().expect("flush profile marker");
+    store.close();
+    drop(store);
+
+    let reopened = ReadOnlyRocksDb::open_existing(temp.path().join("kvStore"))
+        .expect("read-only reopen")
+        .expect("profile database");
+    assert_eq!(
+        reopened.inspect_pop_consumer_profile(true).expect("inspect marker"),
+        PopConsumerProfileState::PresentValid(marker)
+    );
+    assert_eq!(PopRetryPolicy::dual_read_v2_write(0).write_version.number(), 2);
+
+    let checkpoint = temp.path().join("transactionMetrics");
+    let metrics = TransactionMetrics::open(&checkpoint).expect("transaction metrics");
+    metrics.add_and_get("UpgradeTopic", 2);
+    metrics.persist().expect("persist transaction metrics");
+    let recovered = TransactionMetrics::open(&checkpoint).expect("recover transaction metrics");
+    assert_eq!(recovered.count("UpgradeTopic"), 2);
+    assert_eq!(recovered.snapshot(), vec![("UpgradeTopic".to_owned(), 2)]);
+    assert!(!recovered.persist_if_dirty().expect("clean checkpoint"));
+    assert!(!recovered.recovered_from_backup());
+}
+
+#[test]
+fn java_properties_conversion_is_idempotent_across_restart_input() {
+    let input = include_str!("fixtures/config/java-broker.conf");
+    let first = JavaBrokerProperties::parse(input).expect("first conversion");
+    let second = JavaBrokerProperties::parse(input).expect("second conversion");
+
+    assert_eq!(
+        first.config().broker().get_properties(),
+        second.config().broker().get_properties()
+    );
+    assert_eq!(
+        first.config().store().get_properties(),
+        second.config().store().get_properties()
+    );
+}
+
+fn open_profile_store(path: std::path::PathBuf) -> RocksDbStore {
+    let mut config = rocketmq_store_rocksdb::RocksDbConfig {
+        enabled: true,
+        path,
+        ..rocketmq_store_rocksdb::RocksDbConfig::default()
+    };
+    let mut profile = rocketmq_store_rocksdb::config::RocksDbColumnFamilyConfig::consume_queue_default();
+    profile.name = POP_CONSUMER_PROFILE_COLUMN_FAMILY.to_owned();
+    config.column_families.push(profile);
+    RocksDbStore::open(config).expect("open profile store")
+}

--- a/rocketmq-doc/en/release/1.0/upgrade-and-rollback.md
+++ b/rocketmq-doc/en/release/1.0/upgrade-and-rollback.md
@@ -1,0 +1,102 @@
+# RocketMQ Rust 1.0 Upgrade and Rollback
+
+This guide covers upgrades between Rust Broker releases. It does not promise
+direct takeover of a Java Broker data directory, DLedger CommitLog support, or
+Java Controller/AutoSwitchHA wire compatibility.
+
+## Before upgrading
+
+1. Stop all writers and take a recoverable backup of the configuration and
+   Store roots.
+2. Retain the old Rust Broker binary and the 1.0 `rocketmq-cli-rust` tool.
+3. Record every writable and read-only CommitLog root. Do not remove a root that
+   still owns historical segments.
+4. Run the new Broker first with the existing Store backend and compatibility
+   modes. Enable a new owner only after its shadow/compare checks pass.
+5. Verify ordinary, retry, transaction, delay, FIFO, batch, recall, and LMQ
+   message flows before changing a persisted format owner.
+
+## Mandatory downgrade preflight
+
+Always stop the Broker and run the 1.0 preflight before starting an older Rust
+binary:
+
+```shell
+rocketmq-cli-rust downgrade-preflight \
+  --target-version 0.9.0 \
+  --config /etc/rocketmq-rust/broker.toml \
+  --output downgrade-report.json
+```
+
+Exit code `0` permits the inspected transition. Exit code `2` is a hard fence.
+Do not bypass it by invoking an older Broker directly. The tool opens RocksDB
+column families read-only and rejects missing, corrupt, or incompatible state
+that the configuration or format inventory declares as initialized.
+
+## Persisted-format boundaries
+
+### Multipath CommitLog
+
+Returning to a single-path configuration is safe only before the first segment
+is allocated outside the primary root. After that point, keep every historical
+root mounted or consolidate offline into a new directory:
+
+```shell
+rocketmq-cli-rust consolidate-multipath \
+  --source-root /data-a/commitlog \
+  --source-root /data-b/commitlog \
+  --target /data-consolidated/commitlog \
+  --mapped-file-size 1073741824 \
+  --store-root /var/lib/rocketmq-rust/store
+```
+
+The target must be new. The command holds the Store lock, rejects duplicate or
+gapped segment ownership, validates CommitLog frames, compares every copied
+byte, and leaves all source roots unchanged. Point the Broker at the target only
+after the report succeeds.
+
+### POP retry and consumer profiles
+
+Rust 1.0 uses dual-read/v2-write retry semantics and stores a versioned POP
+consumer-profile marker. A configuration rollback may select the dual reader;
+a pre-v2 binary cannot safely acknowledge v2 state. Drain POP inflight work and
+profiles before such a downgrade. Missing state is accepted only when persistent
+POP was never declared; declared-but-missing state is corruption.
+
+### Timer ownership
+
+`java_compat` is the default Rust timer mode. `extended_timeline` is a Rust-owned
+format and is unrelated to Java TimerRocksDB. Move through shadow comparison
+before formal activation. Once the extended owner marker is committed, rollback
+requires quiescing admissions, draining outstanding timers, and recording a
+clean checkpoint. An old binary must not be started against an active extended
+owner.
+
+### Compaction and Tiered metadata
+
+Compaction `CURRENT` and Tiered metadata carry explicit versions. Rust 1.0 reads
+the supported legacy generation and rejects future or corrupt versions without
+rewriting them. Retain the 1.0 reader until any v2 Compaction generation and
+Tiered v1 metadata have been migrated or retired.
+
+### Transactions, query cursors, and configuration
+
+Transaction metrics use atomic checkpoints with restart recovery. Legacy query
+requests remain valid while Java-compatible RocksDB `lastKey` cursors are
+accepted where that backend defines continuation. Java properties conversion is
+an import step: save and use the generated canonical TOML for subsequent Rust
+restarts.
+
+## Controller and HA
+
+Controller mode is Rust-native. Upgrade Controller and Broker components using
+their Rust protocol and fencing contract. Do not form a mixed Java/Rust
+Controller quorum or connect Java AutoSwitchHA peers. DefaultHA remains the
+bounded Java interoperability profile documented separately.
+
+## Recovery rule
+
+If any check reports an unknown version, corrupt marker, missing declared state,
+or incomplete consolidation, keep the Broker stopped. Restore the backup or use
+the retained 1.0 reader/tool to repair or migrate the state, then rerun the
+preflight. Never treat an inspection failure as permission to truncate data.

--- a/rocketmq-store-rocksdb/src/lib.rs
+++ b/rocketmq-store-rocksdb/src/lib.rs
@@ -27,6 +27,7 @@ pub mod message;
 pub mod message_store;
 pub mod options;
 pub mod profile_marker;
+pub mod read_only;
 pub mod release_checkpoint;
 pub mod resource_budget;
 #[doc(hidden)]

--- a/rocketmq-store-rocksdb/src/read_only.rs
+++ b/rocketmq-store-rocksdb/src/read_only.rs
@@ -1,0 +1,203 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Read-only inspection of existing RocksDB state for offline compatibility checks.
+
+use std::path::Path;
+use std::path::PathBuf;
+
+use bytes::Bytes;
+use rocketmq_error::RocketMQError;
+
+use crate::profile_marker::PopConsumerProfileMarker;
+use crate::profile_marker::POP_CONSUMER_PROFILE_COLUMN_FAMILY;
+use crate::profile_marker::POP_CONSUMER_PROFILE_MARKER_KEY;
+
+/// Classification of the persistent POP consumer-profile format.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PopConsumerProfileState {
+    /// No profile format has been declared by this legacy database.
+    LegacyAbsent,
+    /// A supported marker is present and valid.
+    PresentValid(PopConsumerProfileMarker),
+    /// The format was declared but its column family or marker is missing or corrupt.
+    DeclaredPresentInvalid { reason: String },
+}
+
+/// Read-only handle over an existing RocksDB database.
+///
+/// The handle never creates a database or column family and exposes no mutating operation.
+pub struct ReadOnlyRocksDb {
+    db: ::rocksdb::DB,
+    path: PathBuf,
+    column_families: Vec<String>,
+}
+
+impl ReadOnlyRocksDb {
+    /// Opens an existing database and all of its existing column families read-only.
+    ///
+    /// `Ok(None)` means the RocksDB `CURRENT` marker is absent. Callers must hold the
+    /// owning Store's offline lock before opening a live Broker path.
+    pub fn open_existing(path: impl AsRef<Path>) -> Result<Option<Self>, RocketMQError> {
+        let path = path.as_ref();
+        if !path.join("CURRENT").is_file() {
+            return Ok(None);
+        }
+        let options = ::rocksdb::Options::default();
+        let column_families = ::rocksdb::DB::list_cf(&options, path)
+            .map_err(|error| read_error(path, format!("list column families: {error}")))?;
+        let db = ::rocksdb::DB::open_cf_for_read_only(&options, path, &column_families, false)
+            .map_err(|error| read_error(path, format!("open existing column families read-only: {error}")))?;
+        Ok(Some(Self {
+            db,
+            path: path.to_path_buf(),
+            column_families,
+        }))
+    }
+
+    /// Returns the exact database path opened by this handle.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Returns the column-family inventory captured before opening the handle.
+    pub fn column_families(&self) -> &[String] {
+        &self.column_families
+    }
+
+    /// Reads one value from an existing column family.
+    pub fn get_cf(&self, column_family: &str, key: &[u8]) -> Result<Option<Bytes>, RocketMQError> {
+        let handle = self
+            .db
+            .cf_handle(column_family)
+            .ok_or_else(|| read_error(&self.path, format!("column family {column_family} is not present")))?;
+        self.db
+            .get_cf(&handle, key)
+            .map(|value| value.map(Bytes::from))
+            .map_err(|error| read_error(&self.path, format!("read {column_family}: {error}")))
+    }
+
+    /// Classifies the persistent POP consumer-profile marker without mutating the database.
+    pub fn inspect_pop_consumer_profile(&self, declared: bool) -> Result<PopConsumerProfileState, RocketMQError> {
+        if !self
+            .column_families
+            .iter()
+            .any(|name| name == POP_CONSUMER_PROFILE_COLUMN_FAMILY)
+        {
+            return Ok(if declared {
+                PopConsumerProfileState::DeclaredPresentInvalid {
+                    reason: "declared POP consumer profile column family is missing".to_owned(),
+                }
+            } else {
+                PopConsumerProfileState::LegacyAbsent
+            });
+        }
+
+        let Some(bytes) = self.get_cf(POP_CONSUMER_PROFILE_COLUMN_FAMILY, POP_CONSUMER_PROFILE_MARKER_KEY)? else {
+            return Ok(if declared {
+                PopConsumerProfileState::DeclaredPresentInvalid {
+                    reason: "declared POP consumer profile marker is missing".to_owned(),
+                }
+            } else {
+                PopConsumerProfileState::LegacyAbsent
+            });
+        };
+        Ok(match PopConsumerProfileMarker::decode(&bytes) {
+            Ok(marker) => PopConsumerProfileState::PresentValid(marker),
+            Err(error) => PopConsumerProfileState::DeclaredPresentInvalid {
+                reason: error.to_string(),
+            },
+        })
+    }
+}
+
+fn read_error(path: &Path, reason: String) -> RocketMQError {
+    RocketMQError::storage_read_failed(path.display().to_string(), reason)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::fs;
+
+    use crate::config::RocksDbColumnFamilyConfig;
+    use crate::config::RocksDbConfig;
+    use crate::profile_marker::PopConsumerProfileMarker;
+    use crate::profile_marker::POP_CONSUMER_PROFILE_COLUMN_FAMILY;
+    use crate::profile_marker::POP_CONSUMER_PROFILE_MARKER_KEY;
+    use crate::store::KeyValueStore;
+    use crate::store::RocksDbStore;
+
+    use super::*;
+
+    #[test]
+    fn missing_database_is_legacy_absent() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        assert!(ReadOnlyRocksDb::open_existing(temp.path().join("missing"))
+            .expect("inspection")
+            .is_none());
+    }
+
+    #[test]
+    fn profile_marker_is_read_without_changing_database_files() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut config = RocksDbConfig {
+            enabled: true,
+            path: temp.path().join("db"),
+            ..RocksDbConfig::default()
+        };
+        let mut profile = RocksDbColumnFamilyConfig::consume_queue_default();
+        profile.name = POP_CONSUMER_PROFILE_COLUMN_FAMILY.to_owned();
+        config.column_families.push(profile);
+        let store = RocksDbStore::open(config).expect("open writable fixture");
+        store
+            .put_cf(
+                POP_CONSUMER_PROFILE_COLUMN_FAMILY,
+                POP_CONSUMER_PROFILE_MARKER_KEY,
+                &PopConsumerProfileMarker::new(7).encode().expect("encode marker"),
+            )
+            .expect("write marker");
+        store.flush().expect("flush fixture");
+        store.close();
+        drop(store);
+        let before = snapshot(&temp.path().join("db"));
+
+        let read_only = ReadOnlyRocksDb::open_existing(temp.path().join("db"))
+            .expect("read-only open")
+            .expect("database exists");
+        assert_eq!(
+            read_only.inspect_pop_consumer_profile(true).expect("inspect profile"),
+            PopConsumerProfileState::PresentValid(PopConsumerProfileMarker::new(7))
+        );
+        drop(read_only);
+
+        assert_eq!(snapshot(&temp.path().join("db")), before);
+    }
+
+    fn snapshot(root: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
+        let mut output = BTreeMap::new();
+        let mut pending = vec![root.to_path_buf()];
+        while let Some(directory) = pending.pop() {
+            for entry in fs::read_dir(&directory).expect("read fixture directory") {
+                let path = entry.expect("fixture entry").path();
+                if path.is_dir() {
+                    pending.push(path);
+                } else {
+                    output.insert(path.strip_prefix(root).unwrap().to_path_buf(), fs::read(path).unwrap());
+                }
+            }
+        }
+        output
+    }
+}

--- a/rocketmq-store/Cargo.toml
+++ b/rocketmq-store/Cargo.toml
@@ -268,3 +268,14 @@ required-features = ["extended_timeline"]
 [[test]]
 name              = "timer_java_compat_to_extended_cutover_tests"
 required-features = ["extended_timeline"]
+
+[[test]]
+name = "store_upgrade_rollback"
+
+[[test]]
+name              = "store_upgrade_extended"
+required-features = ["extended_timeline", "rocksdb_store", "test-support"]
+
+[[test]]
+name              = "store_upgrade_tiered"
+required-features = ["tieredstore", "test-support"]

--- a/rocketmq-store/tests/store_upgrade_extended.rs
+++ b/rocketmq-store/tests/store_upgrade_extended.rs
@@ -1,0 +1,28 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_store::test_support::run_timer_index_migration_probe;
+
+#[test]
+fn extended_timeline_index_cutover_and_rollback_resume_from_checkpoint() {
+    let probe = run_timer_index_migration_probe();
+
+    assert!(probe.interrupted_owner_is_rocks);
+    assert!(probe.resumed_from_checkpoint);
+    assert!(probe.compared_records > 0);
+    assert!(probe.bulk_overlay_complete);
+    assert!(probe.cutover_owner_is_segmented);
+    assert!(probe.rollback_standby_received_increment);
+    assert!(probe.rollback_restored_rocks);
+}

--- a/rocketmq-store/tests/store_upgrade_rollback.rs
+++ b/rocketmq-store/tests/store_upgrade_rollback.rs
@@ -1,0 +1,86 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::Bytes;
+use cheetah_string::CheetahString;
+use rocketmq_store::decode_commit_log_record;
+use rocketmq_store::CommitLogRecordBodyMode;
+use rocketmq_store::CommitLogRecordChecksum;
+use rocketmq_store::CommitLogRecordOutcome;
+use rocketmq_store::QueryMessageRequest;
+
+struct FixtureChecksum;
+
+impl CommitLogRecordChecksum for FixtureChecksum {
+    fn checksum(&self, bytes: &[u8]) -> u32 {
+        rocketmq_model::utils::crc32_utils::crc32(bytes)
+    }
+}
+
+#[test]
+fn v0_9_local_file_fixture_remains_readable_without_rewrite() {
+    let bytes = include_bytes!("fixtures/upgrade/v0.9.0/local-file/commitlog/00000000000000000000");
+    let before = bytes.to_vec();
+    let mut position = 0usize;
+    let mut records = Vec::new();
+    while position + 4 <= bytes.len() {
+        let size = i32::from_be_bytes(bytes[position..position + 4].try_into().expect("size prefix"));
+        if size <= 0 {
+            break;
+        }
+        let size = usize::try_from(size).expect("positive size");
+        if position + size > bytes.len() {
+            break;
+        }
+        let frame = Bytes::copy_from_slice(&bytes[position..position + size]);
+        match decode_commit_log_record(&frame, CommitLogRecordBodyMode::ReadAndVerify, &FixtureChecksum)
+            .expect("decode v0.9.0 frame")
+        {
+            CommitLogRecordOutcome::Message(record) => records.push(record),
+            CommitLogRecordOutcome::Blank { .. } => break,
+        }
+        position += size;
+    }
+
+    assert_eq!(records.len(), 2);
+    assert_eq!(records[0].topic.as_ref(), b"V1UpgradeTopic");
+    assert_eq!(records[0].queue_offset, 0);
+    assert_eq!(records[1].queue_offset, 1);
+    assert_eq!(records[0].body.as_deref(), Some(b"v0.9.0-message-0".as_slice()));
+    assert_eq!(records[1].body.as_deref(), Some(b"v0.9.0-message-1".as_slice()));
+    assert_eq!(
+        bytes.as_slice(),
+        before.as_slice(),
+        "read compatibility must not rewrite the fixture"
+    );
+}
+
+#[test]
+fn legacy_and_cursor_query_requests_can_coexist() {
+    let topic = CheetahString::from_static_str("UpgradeTopic");
+    let key = CheetahString::from_static_str("order-7");
+    let legacy = QueryMessageRequest::legacy(&topic, &key, 32, 1, 2);
+    let cursor = QueryMessageRequest {
+        index_type: Some(CheetahString::from_static_str("K")),
+        last_key: Some(CheetahString::from_static_str(
+            "1700000000000@UpgradeTopic@K@order-7@uniq-7@1024",
+        )),
+        ..legacy.clone()
+    };
+
+    assert_eq!(legacy.last_key, None);
+    assert_eq!(legacy.legacy_backend_key(), key);
+    assert_eq!(cursor.index_type.as_deref(), Some("K"));
+    assert!(cursor.last_key.is_some());
+}

--- a/rocketmq-store/tests/store_upgrade_tiered.rs
+++ b/rocketmq-store/tests/store_upgrade_tiered.rs
@@ -1,0 +1,48 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs;
+use std::sync::Arc;
+
+use rocketmq_tieredstore::JsonMetadataStore;
+use rocketmq_tieredstore::TieredMetadataStore;
+use rocketmq_tieredstore::TieredStoreConfig;
+
+#[tokio::test]
+async fn tiered_v1_metadata_reopens_and_unknown_version_fails_without_rewrite() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let config = Arc::new(TieredStoreConfig {
+        store_path_root_dir: temp.path().to_path_buf(),
+        ..TieredStoreConfig::default()
+    });
+    let writer = JsonMetadataStore::new(Arc::clone(&config));
+    writer.persist().await.expect("persist v1 metadata");
+    drop(writer);
+
+    let reader = JsonMetadataStore::new(Arc::clone(&config));
+    reader.load().await.expect("read current metadata");
+    drop(reader);
+
+    let path = temp.path().join("config/tieredStoreMetadata.json");
+    let mut value: serde_json::Value = serde_json::from_slice(&fs::read(&path).expect("read metadata")).unwrap();
+    value["version"] = serde_json::json!(99);
+    let incompatible = serde_json::to_vec_pretty(&value).expect("encode future fixture");
+    fs::write(&path, &incompatible).expect("write future fixture");
+
+    JsonMetadataStore::new(config)
+        .load()
+        .await
+        .expect_err("future metadata must fail closed");
+    assert_eq!(fs::read(path).expect("metadata remains readable"), incompatible);
+}

--- a/rocketmq-tools/rocketmq-store-inspect/Cargo.toml
+++ b/rocketmq-tools/rocketmq-store-inspect/Cargo.toml
@@ -28,14 +28,23 @@ categories             = ["development-tools"]
 rust-version.workspace = true
 
 [dependencies]
-rocketmq-error  = { workspace = true }
-rocketmq-store  = { workspace = true }
+rocketmq-error         = { workspace = true }
+rocketmq-model         = { workspace = true }
+rocketmq-store         = { workspace = true }
+rocketmq-store-rocksdb = { workspace = true }
 
 
 clap           = { version = "4.6.1", features = ["derive"] }
 tabled         = "0.21.0"
 bytes          = { workspace = true }
 cheetah-string = { workspace = true }
+config         = { workspace = true }
+fs2            = "0.4"
+serde          = { workspace = true }
+serde_json     = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3.27.0"
 [[bin]]
 name = "rocketmq-cli-rust"
 path = "src/bin/rocketmq_cli.rs"

--- a/rocketmq-tools/rocketmq-store-inspect/README.md
+++ b/rocketmq-tools/rocketmq-store-inspect/README.md
@@ -4,6 +4,9 @@
 
 Provide some command-line tools to read data from RocketMQ files.
 
+The CLI also contains offline safety commands for Rust Broker upgrades. Stop the
+Broker before running either command; both commands require the Store lock.
+
 ## Getting Started
 
 ### Requirements
@@ -93,3 +96,34 @@ file size: 1073741824B
 +----------------------------------+
 ```
 
+### downgrade-preflight Command
+
+Inspect Rust-owned Store formats before starting an older Rust Broker binary:
+
+```shell
+rocketmq-cli-rust downgrade-preflight \
+  --target-version 0.9.0 \
+  --config /etc/rocketmq-rust/broker.toml \
+  --output downgrade-report.json
+```
+
+The command exits with code `2` when the downgrade is unsafe. A denied result is
+a startup fence, not a warning. Keep the 1.0 tool available until the rollback
+window has closed.
+
+### consolidate-multipath Command
+
+Consolidate a stopped Broker's multipath CommitLog into a new single root:
+
+```shell
+rocketmq-cli-rust consolidate-multipath \
+  --source-root /data-a/commitlog \
+  --source-root /data-b/commitlog \
+  --target /data-consolidated/commitlog \
+  --mapped-file-size 1073741824 \
+  --store-root /var/lib/rocketmq-rust/store
+```
+
+The destination must not exist. The tool validates segment ownership,
+continuity, frame structure, byte equality, and available space before it
+atomically publishes the destination. Source files are never modified.

--- a/rocketmq-tools/rocketmq-store-inspect/src/bin/rocketmq_cli.rs
+++ b/rocketmq-tools/rocketmq-store-inspect/src/bin/rocketmq_cli.rs
@@ -17,6 +17,10 @@ use rocketmq_error::CliErrorView;
 use rocketmq_store_inspect::command_line::Commands;
 use rocketmq_store_inspect::command_line::RootCli;
 use rocketmq_store_inspect::content_show::print_content;
+use rocketmq_store_inspect::downgrade_preflight::run_preflight;
+use rocketmq_store_inspect::downgrade_preflight::DowngradePreflightRequest;
+use rocketmq_store_inspect::multipath_consolidate::consolidate_multipath;
+use rocketmq_store_inspect::multipath_consolidate::ConsolidationRequest;
 
 fn main() {
     let exit_code = run();
@@ -35,6 +39,72 @@ fn run() -> i32 {
                 return view.exit_code().as_i32();
             }
         }
+        Commands::ConsolidateMultipath {
+            source_roots,
+            target,
+            mapped_file_size,
+            store_root,
+        } => {
+            let request =
+                ConsolidationRequest::new(source_roots, target.clone(), mapped_file_size).with_store_root(store_root);
+            match consolidate_multipath(&request) {
+                Ok(report) => {
+                    if let Err(error) = print_json(&report) {
+                        return render_error(&error);
+                    }
+                }
+                Err(error) => {
+                    return render_error(&rocketmq_error::RocketMQError::storage_write_failed(
+                        target.display().to_string(),
+                        error.to_string(),
+                    ));
+                }
+            }
+        }
+        Commands::DowngradePreflight {
+            target_version,
+            config,
+            output,
+        } => match run_preflight(&DowngradePreflightRequest::new(target_version, config)) {
+            Ok(report) => {
+                let body = match serde_json::to_string_pretty(&report) {
+                    Ok(body) => format!("{body}\n"),
+                    Err(error) => {
+                        return render_error(&rocketmq_error::RocketMQError::internal(
+                            "serialize downgrade preflight report",
+                            error,
+                        ));
+                    }
+                };
+                if let Some(path) = output {
+                    if let Err(error) = std::fs::write(&path, body) {
+                        return render_error(&rocketmq_error::RocketMQError::storage_write_failed(
+                            path.display().to_string(),
+                            error.to_string(),
+                        ));
+                    }
+                } else {
+                    print!("{body}");
+                }
+                if !report.allowed {
+                    return 2;
+                }
+            }
+            Err(error) => return render_error(&error),
+        },
     }
     0
+}
+
+fn print_json(value: &impl serde::Serialize) -> Result<(), rocketmq_error::RocketMQError> {
+    let body = serde_json::to_string_pretty(value)
+        .map_err(|error| rocketmq_error::RocketMQError::internal("serialize store inspection report", error))?;
+    println!("{body}");
+    Ok(())
+}
+
+fn render_error(error: &rocketmq_error::RocketMQError) -> i32 {
+    let view = CliErrorView::from_error(error);
+    eprintln!("{}", view.render_stderr());
+    view.exit_code().as_i32()
 }

--- a/rocketmq-tools/rocketmq-store-inspect/src/command_line.rs
+++ b/rocketmq-tools/rocketmq-store-inspect/src/command_line.rs
@@ -60,4 +60,66 @@ pub enum Commands {
         )]
         to: Option<u32>,
     },
+    #[command(
+        name = "consolidate-multipath",
+        arg_required_else_help = true,
+        about = "offline consolidation of CommitLog segments into a new single root"
+    )]
+    ConsolidateMultipath {
+        #[arg(long = "source-root", required = true)]
+        source_roots: Vec<PathBuf>,
+        #[arg(long)]
+        target: PathBuf,
+        #[arg(long)]
+        mapped_file_size: u64,
+        #[arg(long)]
+        store_root: PathBuf,
+    },
+    #[command(
+        name = "downgrade-preflight",
+        arg_required_else_help = true,
+        about = "fail-closed offline compatibility check before starting an older Broker"
+    )]
+    DowngradePreflight {
+        #[arg(long)]
+        target_version: String,
+        #[arg(long)]
+        config: PathBuf,
+        #[arg(long)]
+        output: Option<PathBuf>,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_offline_upgrade_commands() {
+        let cli = RootCli::try_parse_from([
+            "rocketmq-cli-rust",
+            "downgrade-preflight",
+            "--target-version",
+            "0.9.0",
+            "--config",
+            "broker.toml",
+        ])
+        .expect("parse preflight");
+        assert!(matches!(cli.command, Commands::DowngradePreflight { .. }));
+
+        let cli = RootCli::try_parse_from([
+            "rocketmq-cli-rust",
+            "consolidate-multipath",
+            "--source-root",
+            "a",
+            "--target",
+            "target",
+            "--mapped-file-size",
+            "1024",
+            "--store-root",
+            "store",
+        ])
+        .expect("parse consolidation");
+        assert!(matches!(cli.command, Commands::ConsolidateMultipath { .. }));
+    }
 }

--- a/rocketmq-tools/rocketmq-store-inspect/src/downgrade_preflight.rs
+++ b/rocketmq-tools/rocketmq-store-inspect/src/downgrade_preflight.rs
@@ -1,0 +1,529 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Offline compatibility checks that run before starting an older Broker binary.
+
+use std::fs;
+use std::fs::File;
+use std::fs::OpenOptions;
+use std::io;
+use std::path::Path;
+use std::path::PathBuf;
+
+use rocketmq_error::RocketMQError;
+use rocketmq_store_rocksdb::read_only::PopConsumerProfileState;
+use rocketmq_store_rocksdb::read_only::ReadOnlyRocksDb;
+use serde::Deserialize;
+use serde::Serialize;
+
+const EXTENDED_TIMER_OWNER_MARKER: &str = "config/timer-store-owner.meta";
+const EXTENDED_TIMER_OWNER_PREFIX: &str = "extended_timeline:v1:";
+const STORAGE_FORMAT_INVENTORY: &str = "config/storage-format-inventory.json";
+const COMPACTION_CURRENT_MAGIC: u32 = 0x4343_5547;
+const COMPACTION_CURRENT_SIZE: usize = 40;
+
+/// Inputs for one offline downgrade decision.
+#[derive(Debug, Clone)]
+pub struct DowngradePreflightRequest {
+    /// Target Rust release that would be started after this check.
+    pub target_version: String,
+    /// Canonical Broker TOML configuration.
+    pub config_path: PathBuf,
+}
+
+impl DowngradePreflightRequest {
+    /// Creates a request.
+    pub fn new(target_version: impl Into<String>, config_path: impl Into<PathBuf>) -> Self {
+        Self {
+            target_version: target_version.into(),
+            config_path: config_path.into(),
+        }
+    }
+}
+
+/// One stable compatibility check result.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PreflightCheck {
+    /// Stable check identifier.
+    pub id: String,
+    /// Machine-readable status.
+    pub status: String,
+    /// Human-readable evidence or reason.
+    pub detail: String,
+}
+
+/// Complete downgrade decision. A denied report is a hard listener-start fence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DowngradePreflightReport {
+    /// Requested target release.
+    pub target_version: String,
+    /// Whether the target may be started using the inspected state.
+    pub allowed: bool,
+    /// Per-format decisions.
+    pub checks: Vec<PreflightCheck>,
+    /// Required operator actions before retrying a denied downgrade.
+    pub actions: Vec<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct BrokerFile {
+    store: StoreSection,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct StoreSection {
+    store_path_root_dir: PathBuf,
+    store_path_commit_log: Option<String>,
+    read_only_commit_log_store_paths: Option<String>,
+    mapped_file_size_commit_log: u64,
+    enable_compaction: bool,
+    timer_store_mode: String,
+    timer_extended_activation_epoch: u64,
+}
+
+impl Default for StoreSection {
+    fn default() -> Self {
+        Self {
+            store_path_root_dir: PathBuf::from("store"),
+            store_path_commit_log: None,
+            read_only_commit_log_store_paths: None,
+            mapped_file_size_commit_log: 1024 * 1024 * 1024,
+            enable_compaction: false,
+            timer_store_mode: "java_compat".to_owned(),
+            timer_extended_activation_epoch: 0,
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct StorageFormatInventory {
+    pop_consumer_profile: DeclaredFormat,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct DeclaredFormat {
+    declared: bool,
+}
+
+/// Inspects every Rust-owned format relevant to a downgrade and returns a fail-closed report.
+pub fn run_preflight(request: &DowngradePreflightRequest) -> Result<DowngradePreflightReport, RocketMQError> {
+    let target_major = parse_target_major(&request.target_version)?;
+    let loaded = config::Config::builder()
+        .add_source(config::File::from(request.config_path.clone()))
+        .build()
+        .map_err(|error| read_error(&request.config_path, format!("load Broker config: {error}")))?;
+    let broker: BrokerFile = loaded
+        .try_deserialize()
+        .map_err(|error| read_error(&request.config_path, format!("decode Broker config: {error}")))?;
+    let root = canonical_existing_root(&broker.store.store_path_root_dir)?;
+    let _lock = OfflineLock::acquire(&root)?;
+    let inventory = load_inventory(&root)?;
+    let mut checks = Vec::new();
+    let mut actions = Vec::new();
+
+    check_multipath(&broker.store, target_major, &mut checks, &mut actions)?;
+    check_pop(&root, &inventory, target_major, &mut checks, &mut actions)?;
+    check_timer(&root, &broker.store, target_major, &mut checks, &mut actions)?;
+    check_compaction(&root, &broker.store, target_major, &mut checks, &mut actions)?;
+    check_tiered(&root, target_major, &mut checks, &mut actions)?;
+
+    let allowed = checks.iter().all(|check| {
+        !matches!(
+            check.status.as_str(),
+            "incompatible" | "declared-present-invalid" | "corrupt"
+        )
+    });
+    Ok(DowngradePreflightReport {
+        target_version: request.target_version.clone(),
+        allowed,
+        checks,
+        actions,
+    })
+}
+
+fn check_multipath(
+    store: &StoreSection,
+    target_major: u64,
+    checks: &mut Vec<PreflightCheck>,
+    actions: &mut Vec<String>,
+) -> Result<(), RocketMQError> {
+    let primary_default = store.store_path_root_dir.join("commitlog").display().to_string();
+    let writable = split_paths(store.store_path_commit_log.as_deref().unwrap_or(&primary_default));
+    let mut roots = writable.clone();
+    roots.extend(split_paths(
+        store.read_only_commit_log_store_paths.as_deref().unwrap_or_default(),
+    ));
+    roots.sort();
+    roots.dedup();
+    let primary = writable
+        .into_iter()
+        .next()
+        .ok_or_else(|| RocketMQError::illegal_argument("CommitLog has no primary path"))?;
+    let primary = fs::canonicalize(&primary).map_err(|error| read_error(&primary, error.to_string()))?;
+    let mut outside_primary = false;
+    let mut offsets = Vec::new();
+    for root in roots {
+        let canonical = fs::canonicalize(&root).map_err(|error| read_error(&root, error.to_string()))?;
+        for entry in fs::read_dir(&canonical).map_err(|error| read_error(&canonical, error.to_string()))? {
+            let path = entry.map_err(|error| read_error(&canonical, error.to_string()))?.path();
+            let name = path.file_name().and_then(|name| name.to_str()).unwrap_or_default();
+            if name.len() != 20 || !name.bytes().all(|byte| byte.is_ascii_digit()) || !path.is_file() {
+                return Err(read_error(&path, "unknown or non-file CommitLog entry".to_owned()));
+            }
+            offsets.push(
+                name.parse::<u64>()
+                    .map_err(|error| read_error(&path, error.to_string()))?,
+            );
+            outside_primary |= canonical != primary;
+        }
+    }
+    offsets.sort_unstable();
+    for pair in offsets.windows(2) {
+        let expected = pair[0]
+            .checked_add(store.mapped_file_size_commit_log)
+            .ok_or_else(|| RocketMQError::storage_read_failed("CommitLog", "segment offset overflow"))?;
+        if pair[1] != expected {
+            return Err(RocketMQError::storage_read_failed(
+                "CommitLog",
+                format!("non-contiguous segments: expected {expected}, found {}", pair[1]),
+            ));
+        }
+    }
+    let incompatible = target_major < 1 && outside_primary;
+    checks.push(check(
+        "multipath",
+        if incompatible { "incompatible" } else { "compatible" },
+        if outside_primary {
+            "CommitLog segments exist outside the primary root"
+        } else {
+            "all existing CommitLog segments are readable from the primary root"
+        },
+    ));
+    if incompatible {
+        actions.push("run rocketmq-cli-rust consolidate-multipath while the Broker is stopped".to_owned());
+    }
+    Ok(())
+}
+
+fn check_pop(
+    root: &Path,
+    inventory: &StorageFormatInventory,
+    target_major: u64,
+    checks: &mut Vec<PreflightCheck>,
+    actions: &mut Vec<String>,
+) -> Result<(), RocketMQError> {
+    let declared = inventory.pop_consumer_profile.declared;
+    let database = ReadOnlyRocksDb::open_existing(root.join("kvStore"))?;
+    let state = match database {
+        Some(database) => database.inspect_pop_consumer_profile(declared)?,
+        None if declared => PopConsumerProfileState::DeclaredPresentInvalid {
+            reason: "format inventory declares POP consumer profiles but kvStore is absent".to_owned(),
+        },
+        None => PopConsumerProfileState::LegacyAbsent,
+    };
+    match state {
+        PopConsumerProfileState::LegacyAbsent => checks.push(check(
+            "pop",
+            "legacy-absent",
+            "persistent POP consumer-profile state is not initialized",
+        )),
+        PopConsumerProfileState::PresentValid(marker) if target_major >= 1 => checks.push(check(
+            "pop",
+            "present-valid",
+            format!(
+                "POP profile format {} generation {}",
+                marker.format_version, marker.generation
+            ),
+        )),
+        PopConsumerProfileState::PresentValid(marker) => {
+            checks.push(check(
+                "pop",
+                "incompatible",
+                format!("target cannot read POP profile format {}", marker.format_version),
+            ));
+            actions.push("drain POP inflight/profile ownership using a 1.0 dual-reader before downgrade".to_owned());
+        }
+        PopConsumerProfileState::DeclaredPresentInvalid { reason } => {
+            checks.push(check("pop", "declared-present-invalid", reason));
+            actions.push("repair the declared POP profile database before starting any Broker".to_owned());
+        }
+    }
+    Ok(())
+}
+
+fn check_timer(
+    root: &Path,
+    store: &StoreSection,
+    target_major: u64,
+    checks: &mut Vec<PreflightCheck>,
+    actions: &mut Vec<String>,
+) -> Result<(), RocketMQError> {
+    let path = root.join(EXTENDED_TIMER_OWNER_MARKER);
+    let marker = match fs::read_to_string(&path) {
+        Ok(value) => Some(value),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+        Err(error) => return Err(read_error(&path, error.to_string())),
+    };
+    let configured_extended =
+        store.timer_store_mode == "extended_timeline" || store.timer_extended_activation_epoch > 0;
+    match marker {
+        None if configured_extended => {
+            checks.push(check(
+                "timer",
+                "declared-present-invalid",
+                "Extended Timeline is configured but its owner marker is absent",
+            ));
+            actions.push("repair the Extended Timeline owner marker before restart".to_owned());
+        }
+        None => checks.push(check("timer", "legacy-absent", "Java-compatible Timer remains owner")),
+        Some(marker) => {
+            let epoch = marker
+                .trim()
+                .strip_prefix(EXTENDED_TIMER_OWNER_PREFIX)
+                .and_then(|value| value.parse::<u64>().ok())
+                .filter(|epoch| *epoch > 0);
+            let Some(epoch) = epoch else {
+                checks.push(check("timer", "corrupt", "Extended Timeline owner marker is invalid"));
+                actions.push("repair the Extended Timeline owner marker before restart".to_owned());
+                return Ok(());
+            };
+            if target_major < 1 {
+                checks.push(check(
+                    "timer",
+                    "incompatible",
+                    format!("Extended Timeline owns timer delivery at epoch {epoch}"),
+                ));
+                actions.push(
+                    "quiesce Timer admissions, drain outstanding delivery, and produce a clean checkpoint before downgrade"
+                        .to_owned(),
+                );
+            } else {
+                checks.push(check(
+                    "timer",
+                    "present-valid",
+                    format!("Extended Timeline owner epoch {epoch}"),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn check_compaction(
+    root: &Path,
+    store: &StoreSection,
+    target_major: u64,
+    checks: &mut Vec<PreflightCheck>,
+    actions: &mut Vec<String>,
+) -> Result<(), RocketMQError> {
+    let compaction = root.join("compaction");
+    let current = compaction.join("CURRENT");
+    let bytes = match fs::read(&current) {
+        Ok(bytes) => Some(bytes),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+        Err(error) => return Err(read_error(&current, error.to_string())),
+    };
+    let generations = compaction.join("generations");
+    let generations_present = generations.is_dir()
+        && fs::read_dir(&generations)
+            .map_err(|error| read_error(&generations, error.to_string()))?
+            .next()
+            .is_some();
+    let Some(bytes) = bytes else {
+        if store.enable_compaction && generations_present {
+            checks.push(check(
+                "compaction",
+                "declared-present-invalid",
+                "Compaction generations exist but CURRENT is absent",
+            ));
+            actions.push("recover or roll back the last complete Compaction generation with the 1.0 tool".to_owned());
+        } else {
+            checks.push(check(
+                "compaction",
+                "legacy-absent",
+                "no published Compaction generation",
+            ));
+        }
+        return Ok(());
+    };
+    let Some(version) = decode_compaction_current(&bytes) else {
+        checks.push(check("compaction", "corrupt", "Compaction CURRENT is invalid"));
+        actions.push("recover the last complete Compaction generation before restart".to_owned());
+        return Ok(());
+    };
+    let status = match version {
+        1 => "present-valid",
+        2 if target_major >= 1 => "present-valid",
+        2 => "incompatible",
+        _ => "corrupt",
+    };
+    checks.push(check(
+        "compaction",
+        status,
+        format!("Compaction CURRENT format version {version}"),
+    ));
+    if matches!(status, "incompatible" | "corrupt") {
+        actions.push("recover or convert Compaction state with the 1.0 tool before downgrade".to_owned());
+    }
+    Ok(())
+}
+
+fn decode_compaction_current(bytes: &[u8]) -> Option<u16> {
+    if bytes.len() != COMPACTION_CURRENT_SIZE
+        || u32::from_be_bytes(bytes[0..4].try_into().ok()?) != COMPACTION_CURRENT_MAGIC
+        || rocketmq_model::utils::crc32_utils::crc32(&bytes[..32]) != u32::from_be_bytes(bytes[32..36].try_into().ok()?)
+    {
+        return None;
+    }
+    let version = u16::from_be_bytes(bytes[4..6].try_into().ok()?);
+    let current = u64::from_be_bytes(bytes[8..16].try_into().ok()?);
+    let previous = u64::from_be_bytes(bytes[16..24].try_into().ok()?);
+    let next = u64::from_be_bytes(bytes[24..32].try_into().ok()?);
+    if next <= current || previous == current || !matches!(version, 1 | 2) {
+        return None;
+    }
+    Some(version)
+}
+
+fn check_tiered(
+    root: &Path,
+    target_major: u64,
+    checks: &mut Vec<PreflightCheck>,
+    actions: &mut Vec<String>,
+) -> Result<(), RocketMQError> {
+    let path = root.join("config/tieredStoreMetadata.json");
+    let bytes = match fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            checks.push(check("tiered", "legacy-absent", "no Tiered metadata"));
+            return Ok(());
+        }
+        Err(error) => return Err(read_error(&path, error.to_string())),
+    };
+    let value: serde_json::Value = serde_json::from_slice(&bytes)
+        .map_err(|error| read_error(&path, format!("decode Tiered metadata: {error}")))?;
+    let format = value.get("format").and_then(serde_json::Value::as_str);
+    let version = value.get("version").and_then(serde_json::Value::as_u64);
+    let status = if format != Some("rocketmq-tiered-metadata") || version != Some(1) {
+        "corrupt"
+    } else if target_major < 1 {
+        "incompatible"
+    } else {
+        "present-valid"
+    };
+    checks.push(check(
+        "tiered",
+        status,
+        format!("Tiered metadata format={format:?} version={version:?}"),
+    ));
+    if matches!(status, "incompatible" | "corrupt") {
+        actions.push("retain the 1.0 Tiered reader or migrate metadata before downgrade".to_owned());
+    }
+    Ok(())
+}
+
+fn load_inventory(root: &Path) -> Result<StorageFormatInventory, RocketMQError> {
+    let path = root.join(STORAGE_FORMAT_INVENTORY);
+    match fs::read(&path) {
+        Ok(bytes) => serde_json::from_slice(&bytes)
+            .map_err(|error| read_error(&path, format!("decode storage format inventory: {error}"))),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(StorageFormatInventory::default()),
+        Err(error) => Err(read_error(&path, error.to_string())),
+    }
+}
+
+fn parse_target_major(version: &str) -> Result<u64, RocketMQError> {
+    let numeric = version.trim_start_matches('v');
+    numeric
+        .split('.')
+        .next()
+        .and_then(|major| major.parse().ok())
+        .ok_or_else(|| RocketMQError::illegal_argument(format!("invalid target version: {version}")))
+}
+
+fn split_paths(value: &str) -> Vec<PathBuf> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from)
+        .collect()
+}
+
+fn canonical_existing_root(path: &Path) -> Result<PathBuf, RocketMQError> {
+    let canonical = fs::canonicalize(path).map_err(|error| read_error(path, format!("open Store root: {error}")))?;
+    Ok(platform_compatible_canonical_path(canonical))
+}
+
+#[cfg(windows)]
+fn platform_compatible_canonical_path(path: PathBuf) -> PathBuf {
+    let value = path.to_string_lossy();
+    if let Some(unc) = value.strip_prefix(r"\\?\UNC\") {
+        return PathBuf::from(format!(r"\\{unc}"));
+    }
+    value.strip_prefix(r"\\?\").map_or(path.clone(), PathBuf::from)
+}
+
+#[cfg(not(windows))]
+fn platform_compatible_canonical_path(path: PathBuf) -> PathBuf {
+    path
+}
+
+fn check(id: &str, status: &str, detail: impl Into<String>) -> PreflightCheck {
+    PreflightCheck {
+        id: id.to_owned(),
+        status: status.to_owned(),
+        detail: detail.into(),
+    }
+}
+
+fn read_error(path: &Path, reason: String) -> RocketMQError {
+    RocketMQError::storage_read_failed(path.display().to_string(), reason)
+}
+
+struct OfflineLock {
+    file: File,
+}
+
+impl OfflineLock {
+    fn acquire(store_root: &Path) -> Result<Self, RocketMQError> {
+        let path = store_root.join("lock");
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)
+            .map_err(|error| read_error(&path, error.to_string()))?;
+        fs2::FileExt::try_lock_exclusive(&file).map_err(|error| {
+            RocketMQError::storage_read_failed(
+                path.display().to_string(),
+                format!("Broker must be stopped before downgrade preflight: {error}"),
+            )
+        })?;
+        Ok(Self { file })
+    }
+}
+
+impl Drop for OfflineLock {
+    fn drop(&mut self) {
+        let _ = fs2::FileExt::unlock(&self.file);
+    }
+}

--- a/rocketmq-tools/rocketmq-store-inspect/src/lib.rs
+++ b/rocketmq-tools/rocketmq-store-inspect/src/lib.rs
@@ -14,3 +14,5 @@
 
 pub mod command_line;
 pub mod content_show;
+pub mod downgrade_preflight;
+pub mod multipath_consolidate;

--- a/rocketmq-tools/rocketmq-store-inspect/src/multipath_consolidate.rs
+++ b/rocketmq-tools/rocketmq-store-inspect/src/multipath_consolidate.rs
@@ -1,0 +1,445 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Offline consolidation of a multipath CommitLog into a new single root.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::fs::File;
+use std::fs::OpenOptions;
+use std::io;
+use std::io::Read;
+use std::path::Path;
+use std::path::PathBuf;
+
+use bytes::Bytes;
+use rocketmq_store::decode_commit_log_record;
+use rocketmq_store::CommitLogRecordBodyMode;
+use rocketmq_store::CommitLogRecordChecksum;
+use rocketmq_store::CommitLogRecordOutcome;
+use serde::Serialize;
+
+/// Immutable request for one offline consolidation attempt.
+#[derive(Debug, Clone)]
+pub struct ConsolidationRequest {
+    /// Existing CommitLog roots. The source tree is never modified.
+    pub source_roots: Vec<PathBuf>,
+    /// New single-root destination. It must not already exist.
+    pub target: PathBuf,
+    /// Configured CommitLog segment size.
+    pub mapped_file_size: u64,
+    /// Store root whose `lock` file fences a running Broker.
+    pub store_root: PathBuf,
+}
+
+impl ConsolidationRequest {
+    /// Creates a request and derives the Store root from the target parent.
+    pub fn new(source_roots: Vec<PathBuf>, target: PathBuf, mapped_file_size: u64) -> Self {
+        let store_root = target.parent().unwrap_or_else(|| Path::new(".")).to_path_buf();
+        Self {
+            source_roots,
+            target,
+            mapped_file_size,
+            store_root,
+        }
+    }
+
+    /// Overrides the Store root used for the exclusive offline lock.
+    pub fn with_store_root(mut self, store_root: PathBuf) -> Self {
+        self.store_root = store_root;
+        self
+    }
+}
+
+/// Successful consolidation summary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsolidationReport {
+    /// Number of copied CommitLog segments.
+    pub segment_count: usize,
+    /// Total bytes copied and compared.
+    pub copied_bytes: u64,
+    /// Number of structurally valid message frames copied.
+    pub record_count: usize,
+}
+
+#[derive(Debug)]
+struct Segment {
+    offset: u64,
+    path: PathBuf,
+    size: u64,
+    record_count: usize,
+}
+
+/// Consolidates all source segments and atomically publishes the target directory.
+pub fn consolidate_multipath(request: &ConsolidationRequest) -> io::Result<ConsolidationReport> {
+    consolidate_multipath_with_environment(request, |path| fs2::available_space(path), |_| Ok(()))
+}
+
+/// Consolidates with a deterministic post-copy hook used by interruption tests.
+#[doc(hidden)]
+pub fn consolidate_multipath_with_hook(
+    request: &ConsolidationRequest,
+    after_copy: impl FnMut(usize) -> io::Result<()>,
+) -> io::Result<ConsolidationReport> {
+    consolidate_multipath_with_environment(request, |path| fs2::available_space(path), after_copy)
+}
+
+/// Consolidates with deterministic environment hooks used by capacity and interruption tests.
+#[doc(hidden)]
+pub fn consolidate_multipath_with_environment(
+    request: &ConsolidationRequest,
+    available_space: impl FnOnce(&Path) -> io::Result<u64>,
+    mut after_copy: impl FnMut(usize) -> io::Result<()>,
+) -> io::Result<ConsolidationReport> {
+    validate_request(request)?;
+    let _lock = OfflineLock::acquire(&request.store_root)?;
+    let segments = scan_segments(&request.source_roots, request.mapped_file_size)?;
+    let record_count = segments.iter().try_fold(0_usize, |total, segment| {
+        total
+            .checked_add(segment.record_count)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "CommitLog record count overflow"))
+    })?;
+    let copied_bytes = segments.iter().try_fold(0_u64, |total, segment| {
+        total
+            .checked_add(segment.size)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "CommitLog byte count overflow"))
+    })?;
+    let target_parent = request.target.parent().unwrap_or_else(|| Path::new("."));
+    if available_space(target_parent)? < copied_bytes {
+        return Err(io::Error::new(
+            io::ErrorKind::StorageFull,
+            "target filesystem has insufficient free space",
+        ));
+    }
+    let target_name = request
+        .target
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "target has no UTF-8 file name"))?;
+    let staging = target_parent.join(format!(".{target_name}.staging-{}", std::process::id()));
+    if staging.exists() {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("staging directory already exists: {}", staging.display()),
+        ));
+    }
+    fs::create_dir(&staging)?;
+    let mut cleanup = StagingCleanup::new(staging.clone());
+    for (index, segment) in segments.iter().enumerate() {
+        let destination = staging.join(format!("{:020}", segment.offset));
+        fs::copy(&segment.path, &destination)?;
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&destination)?
+            .sync_all()?;
+        compare_files(&segment.path, &destination)?;
+        if validate_segment_frames(&destination, segment.offset)? != segment.record_count {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "copied segment record count differs from source {}",
+                    segment.path.display()
+                ),
+            ));
+        }
+        after_copy(index + 1)?;
+    }
+    fs::rename(&staging, &request.target)?;
+    cleanup.disarm();
+    Ok(ConsolidationReport {
+        segment_count: segments.len(),
+        copied_bytes,
+        record_count,
+    })
+}
+
+struct IgnoredChecksum;
+
+impl CommitLogRecordChecksum for IgnoredChecksum {
+    fn checksum(&self, _bytes: &[u8]) -> u32 {
+        0
+    }
+}
+
+fn validate_segment_frames(path: &Path, segment_offset: u64) -> io::Result<usize> {
+    let bytes = fs::read(path)?;
+    let mut position = 0_usize;
+    let mut records = 0_usize;
+    while position < bytes.len() {
+        if bytes[position..].iter().all(|byte| *byte == 0) {
+            return Ok(records);
+        }
+        let size_prefix = bytes.get(position..position + 4).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "truncated CommitLog size prefix in {} at byte {position}",
+                    path.display()
+                ),
+            )
+        })?;
+        let declared_size = i32::from_be_bytes(size_prefix.try_into().unwrap_or_default());
+        let declared_size = usize::try_from(declared_size).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("negative CommitLog frame size in {} at byte {position}", path.display()),
+            )
+        })?;
+        let end = position
+            .checked_add(declared_size)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "CommitLog frame offset overflow"))?;
+        let frame = bytes.get(position..end).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("truncated CommitLog frame in {} at byte {position}", path.display()),
+            )
+        })?;
+        match decode_commit_log_record(
+            &Bytes::copy_from_slice(frame),
+            CommitLogRecordBodyMode::Skip,
+            &IgnoredChecksum,
+        )
+        .map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "invalid CommitLog frame in {} at byte {position}: {error:?}",
+                    path.display()
+                ),
+            )
+        })? {
+            CommitLogRecordOutcome::Message(record) => {
+                let expected_offset = segment_offset
+                    .checked_add(position as u64)
+                    .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "CommitLog physical offset overflow"))?;
+                if u64::try_from(record.physical_offset).ok() != Some(expected_offset) {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "CommitLog physical offset mismatch in {} at byte {position}: expected {expected_offset}, found {}",
+                            path.display(),
+                            record.physical_offset
+                        ),
+                    ));
+                }
+                records += 1;
+            }
+            CommitLogRecordOutcome::Blank { .. } => {
+                if bytes[end..].iter().any(|byte| *byte != 0) {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("non-zero bytes follow CommitLog blank marker in {}", path.display()),
+                    ));
+                }
+                return Ok(records);
+            }
+        }
+        position = end;
+    }
+    Ok(records)
+}
+
+fn validate_request(request: &ConsolidationRequest) -> io::Result<()> {
+    if request.source_roots.is_empty() || request.mapped_file_size == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "at least one source root and a non-zero segment size are required",
+        ));
+    }
+    if request.target.exists() {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("target already exists: {}", request.target.display()),
+        ));
+    }
+    let parent = request.target.parent().unwrap_or_else(|| Path::new("."));
+    if !parent.is_dir() || !request.store_root.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "target parent and Store root must already exist",
+        ));
+    }
+    let target_parent = fs::canonicalize(parent)?;
+    for source in &request.source_roots {
+        let source = fs::canonicalize(source)?;
+        if target_parent.starts_with(&source) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "target must not be created inside a source CommitLog root",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn scan_segments(roots: &[PathBuf], mapped_file_size: u64) -> io::Result<Vec<Segment>> {
+    let mut segments = BTreeMap::<u64, Segment>::new();
+    for root in roots {
+        let canonical_root = fs::canonicalize(root)?;
+        for entry in fs::read_dir(&canonical_root)? {
+            let path = entry?.path();
+            let metadata = fs::symlink_metadata(&path)?;
+            if !metadata.file_type().is_file() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("non-file CommitLog entry: {}", path.display()),
+                ));
+            }
+            let offset = parse_offset(&path)?;
+            if metadata.len() > mapped_file_size {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("segment {} exceeds configured size", path.display()),
+                ));
+            }
+            if let Some(existing) = segments.get(&offset) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "duplicate CommitLog owner for offset {offset}: {} and {}",
+                        existing.path.display(),
+                        path.display()
+                    ),
+                ));
+            }
+            let segment = Segment {
+                offset,
+                path: path.clone(),
+                size: metadata.len(),
+                record_count: validate_segment_frames(&path, offset)?,
+            };
+            segments.insert(offset, segment);
+        }
+    }
+    let segments = segments.into_values().collect::<Vec<_>>();
+    for (index, pair) in segments.windows(2).enumerate() {
+        if pair[0].size != mapped_file_size {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("non-tail segment {} is not full", pair[0].path.display()),
+            ));
+        }
+        let expected = pair[0]
+            .offset
+            .checked_add(mapped_file_size)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "CommitLog segment offset overflow"))?;
+        if pair[1].offset != expected {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "CommitLog is not contiguous after segment {index}: expected offset {expected}, found {}",
+                    pair[1].offset
+                ),
+            ));
+        }
+    }
+    Ok(segments)
+}
+
+fn parse_offset(path: &Path) -> io::Result<u64> {
+    let name = path.file_name().and_then(|name| name.to_str()).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("CommitLog entry has no UTF-8 name: {}", path.display()),
+        )
+    })?;
+    if name.len() != 20 || !name.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("unknown CommitLog entry: {}", path.display()),
+        ));
+    }
+    name.parse().map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid CommitLog offset {}: {error}", path.display()),
+        )
+    })
+}
+
+fn compare_files(source: &Path, destination: &Path) -> io::Result<()> {
+    let mut left = File::open(source)?;
+    let mut right = File::open(destination)?;
+    let mut left_buffer = [0_u8; 64 * 1024];
+    let mut right_buffer = [0_u8; 64 * 1024];
+    loop {
+        let left_len = left.read(&mut left_buffer)?;
+        let right_len = right.read(&mut right_buffer)?;
+        if left_len != right_len || left_buffer[..left_len] != right_buffer[..right_len] {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("copied segment differs from source {}", source.display()),
+            ));
+        }
+        if left_len == 0 {
+            return Ok(());
+        }
+    }
+}
+
+struct OfflineLock {
+    file: File,
+}
+
+impl OfflineLock {
+    fn acquire(store_root: &Path) -> io::Result<Self> {
+        let path = store_root.join("lock");
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)?;
+        fs2::FileExt::try_lock_exclusive(&file).map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::WouldBlock,
+                format!(
+                    "Broker must be stopped; Store lock {} is unavailable: {error}",
+                    path.display()
+                ),
+            )
+        })?;
+        Ok(Self { file })
+    }
+}
+
+impl Drop for OfflineLock {
+    fn drop(&mut self) {
+        let _ = fs2::FileExt::unlock(&self.file);
+    }
+}
+
+struct StagingCleanup {
+    path: Option<PathBuf>,
+}
+
+impl StagingCleanup {
+    fn new(path: PathBuf) -> Self {
+        Self { path: Some(path) }
+    }
+
+    fn disarm(&mut self) {
+        self.path = None;
+    }
+}
+
+impl Drop for StagingCleanup {
+    fn drop(&mut self) {
+        if let Some(path) = self.path.take() {
+            let _ = fs::remove_dir_all(path);
+        }
+    }
+}

--- a/rocketmq-tools/rocketmq-store-inspect/tests/downgrade_preflight.rs
+++ b/rocketmq-tools/rocketmq-store-inspect/tests/downgrade_preflight.rs
@@ -1,0 +1,324 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::fs::OpenOptions;
+use std::path::Path;
+use std::path::PathBuf;
+
+use rocketmq_store_inspect::downgrade_preflight::run_preflight;
+use rocketmq_store_inspect::downgrade_preflight::DowngradePreflightRequest;
+use rocketmq_store_rocksdb::config::RocksDbColumnFamilyConfig;
+use rocketmq_store_rocksdb::profile_marker::PopConsumerProfileMarker;
+use rocketmq_store_rocksdb::profile_marker::POP_CONSUMER_PROFILE_COLUMN_FAMILY;
+use rocketmq_store_rocksdb::profile_marker::POP_CONSUMER_PROFILE_MARKER_KEY;
+use rocketmq_store_rocksdb::store::KeyValueStore;
+use rocketmq_store_rocksdb::store::RocksDbStore;
+use rocketmq_store_rocksdb::RocksDbConfig;
+
+#[test]
+fn legacy_absent_store_is_safe_for_pre_one_zero_target() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let store = temp.path().join("store");
+    fs::create_dir_all(store.join("commitlog")).expect("commitlog");
+    let config = write_config(temp.path(), &store, false);
+
+    let report = run_preflight(&DowngradePreflightRequest::new("0.9.0", config)).expect("preflight");
+
+    assert!(report.allowed, "{report:?}");
+    assert!(report
+        .checks
+        .iter()
+        .any(|check| check.id == "pop" && check.status == "legacy-absent"));
+}
+
+#[test]
+fn extended_timer_owner_denies_pre_one_zero_target() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let store = temp.path().join("store");
+    fs::create_dir_all(store.join("commitlog")).expect("commitlog");
+    fs::create_dir_all(store.join("config")).expect("config");
+    fs::write(store.join("config/timer-store-owner.meta"), b"extended_timeline:v1:7\n").expect("owner marker");
+    let config = write_config(temp.path(), &store, false);
+
+    let report = run_preflight(&DowngradePreflightRequest::new("0.9.0", config)).expect("preflight");
+
+    assert!(!report.allowed);
+    assert!(report
+        .checks
+        .iter()
+        .any(|check| check.id == "timer" && check.status == "incompatible"));
+    assert!(report.actions.iter().any(|action| action.contains("quiesce")));
+}
+
+#[test]
+fn declared_pop_profile_without_database_fails_closed() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let store = temp.path().join("store");
+    fs::create_dir_all(store.join("commitlog")).expect("commitlog");
+    fs::create_dir_all(store.join("config")).expect("config");
+    fs::write(
+        store.join("config/storage-format-inventory.json"),
+        br#"{"popConsumerProfile":{"declared":true,"formatVersion":1}}"#,
+    )
+    .expect("format inventory");
+    let config = write_config(temp.path(), &store, false);
+
+    let report = run_preflight(&DowngradePreflightRequest::new("1.0.0", config)).expect("preflight");
+
+    assert!(!report.allowed);
+    assert!(report
+        .checks
+        .iter()
+        .any(|check| check.id == "pop" && check.status == "declared-present-invalid"));
+}
+
+#[test]
+fn multipath_segment_outside_primary_requires_consolidation() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let store = temp.path().join("store");
+    let primary = temp.path().join("commitlog-a");
+    let secondary = temp.path().join("commitlog-b");
+    fs::create_dir_all(&store).expect("store");
+    fs::create_dir_all(&primary).expect("primary");
+    fs::create_dir_all(&secondary).expect("secondary");
+    fs::write(primary.join("00000000000000000000"), [0_u8; 8]).expect("primary segment");
+    fs::write(secondary.join("00000000000000000008"), [1_u8; 8]).expect("secondary segment");
+    let config = temp.path().join("broker.toml");
+    fs::write(
+        &config,
+        format!(
+            "[store]\nstorePathRootDir = {:?}\nstorePathCommitLog = {:?}\nmappedFileSizeCommitLog = 8\n",
+            store.to_string_lossy(),
+            format!("{},{}", primary.display(), secondary.display())
+        ),
+    )
+    .expect("config");
+
+    let report = run_preflight(&DowngradePreflightRequest::new("0.9.0", config)).expect("preflight");
+
+    assert!(!report.allowed);
+    assert!(report
+        .checks
+        .iter()
+        .any(|check| check.id == "multipath" && check.status == "incompatible"));
+}
+
+#[test]
+fn legacy_database_without_profile_cf_is_absent_until_declared() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let store = temp.path().join("store");
+    fs::create_dir_all(store.join("commitlog")).expect("commitlog");
+    create_pop_database(&store.join("kvStore"), false, None);
+    let before = snapshot(&store.join("kvStore"));
+    let config = write_config(temp.path(), &store, false);
+
+    let legacy = run_preflight(&DowngradePreflightRequest::new("1.0.0", &config)).expect("legacy preflight");
+    assert!(legacy.allowed, "{legacy:?}");
+    assert!(legacy
+        .checks
+        .iter()
+        .any(|check| check.id == "pop" && check.status == "legacy-absent"));
+    assert_eq!(snapshot(&store.join("kvStore")), before);
+
+    fs::create_dir_all(store.join("config")).expect("config");
+    fs::write(
+        store.join("config/storage-format-inventory.json"),
+        br#"{"popConsumerProfile":{"declared":true}}"#,
+    )
+    .expect("inventory");
+    let declared = run_preflight(&DowngradePreflightRequest::new("1.0.0", config)).expect("declared preflight");
+    assert!(!declared.allowed);
+    assert!(declared
+        .checks
+        .iter()
+        .any(|check| check.id == "pop" && check.status == "declared-present-invalid"));
+    assert_eq!(snapshot(&store.join("kvStore")), before);
+}
+
+#[test]
+fn valid_markers_allow_current_reader_and_fence_pre_one_zero_without_mutation() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let store = temp.path().join("store");
+    fs::create_dir_all(store.join("commitlog")).expect("commitlog");
+    fs::create_dir_all(store.join("config")).expect("config");
+    create_pop_database(&store.join("kvStore"), true, Some(PopConsumerProfileMarker::new(7)));
+    fs::write(
+        store.join("config/storage-format-inventory.json"),
+        br#"{"popConsumerProfile":{"declared":true}}"#,
+    )
+    .expect("inventory");
+    fs::write(
+        store.join("config/timer-store-owner.meta"),
+        b"extended_timeline:v1:11\n",
+    )
+    .expect("timer marker");
+    fs::create_dir_all(store.join("compaction")).expect("compaction");
+    fs::write(store.join("compaction/CURRENT"), compaction_current(2)).expect("compaction current");
+    fs::write(
+        store.join("config/tieredStoreMetadata.json"),
+        br#"{"format":"rocketmq-tiered-metadata","version":1}"#,
+    )
+    .expect("tiered metadata");
+    let config = write_config(temp.path(), &store, true);
+    let before = snapshot(&store.join("kvStore"));
+
+    let current = run_preflight(&DowngradePreflightRequest::new("1.0.0", &config)).expect("current preflight");
+    assert!(current.allowed, "{current:?}");
+    for id in ["pop", "timer", "compaction", "tiered"] {
+        assert!(current
+            .checks
+            .iter()
+            .any(|check| check.id == id && check.status == "present-valid"));
+    }
+    assert_eq!(snapshot(&store.join("kvStore")), before);
+
+    let old = run_preflight(&DowngradePreflightRequest::new("0.9.0", config)).expect("old preflight");
+    assert!(!old.allowed);
+    for id in ["pop", "timer", "compaction", "tiered"] {
+        assert!(old
+            .checks
+            .iter()
+            .any(|check| check.id == id && check.status == "incompatible"));
+    }
+    assert_eq!(snapshot(&store.join("kvStore")), before);
+}
+
+#[test]
+fn incomplete_compaction_generation_and_active_store_lock_fail_closed() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let store = temp.path().join("store");
+    fs::create_dir_all(store.join("commitlog")).expect("commitlog");
+    fs::create_dir_all(store.join("compaction/generations/gen-1")).expect("half generation");
+    fs::write(store.join("compaction/generations/gen-1/GENERATION"), b"partial").expect("partial generation");
+    let config = write_config(temp.path(), &store, true);
+
+    let report = run_preflight(&DowngradePreflightRequest::new("1.0.0", &config)).expect("preflight");
+    assert!(!report.allowed);
+    assert!(report
+        .checks
+        .iter()
+        .any(|check| check.id == "compaction" && check.status == "declared-present-invalid"));
+
+    let lock = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(store.join("lock"))
+        .expect("lock file");
+    fs2::FileExt::try_lock_exclusive(&lock).expect("simulate Broker lock");
+    let error =
+        run_preflight(&DowngradePreflightRequest::new("1.0.0", config)).expect_err("active Store lock must fail");
+    assert!(error.to_string().contains("Broker must be stopped"));
+    fs2::FileExt::unlock(&lock).expect("unlock fixture");
+}
+
+#[test]
+fn legacy_compaction_current_is_accepted_but_a_bad_checksum_is_not() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let store = temp.path().join("store");
+    fs::create_dir_all(store.join("commitlog")).expect("commitlog");
+    fs::create_dir_all(store.join("compaction")).expect("compaction");
+    let current_path = store.join("compaction/CURRENT");
+    let valid = compaction_current(1);
+    fs::write(&current_path, valid).expect("legacy CURRENT");
+    let config = write_config(temp.path(), &store, true);
+
+    let legacy = run_preflight(&DowngradePreflightRequest::new("0.9.0", &config)).expect("legacy preflight");
+    assert!(legacy.allowed, "{legacy:?}");
+    assert!(legacy
+        .checks
+        .iter()
+        .any(|check| check.id == "compaction" && check.status == "present-valid"));
+
+    let mut corrupt = valid;
+    corrupt[10] ^= 1;
+    fs::write(&current_path, corrupt).expect("corrupt CURRENT");
+    let rejected = run_preflight(&DowngradePreflightRequest::new("1.0.0", config)).expect("corrupt preflight");
+    assert!(!rejected.allowed);
+    assert!(rejected
+        .checks
+        .iter()
+        .any(|check| check.id == "compaction" && check.status == "corrupt"));
+    assert_eq!(fs::read(current_path).expect("CURRENT remains unchanged"), corrupt);
+}
+
+fn write_config(root: &std::path::Path, store: &std::path::Path, compaction: bool) -> std::path::PathBuf {
+    let config = root.join("broker.toml");
+    fs::write(
+        &config,
+        format!(
+            "[store]\nstorePathRootDir = {:?}\nstorePathCommitLog = {:?}\nmappedFileSizeCommitLog = 8\nenableCompaction = {compaction}\ntimerStoreMode = \"java_compat\"\n",
+            store.to_string_lossy(),
+            store.join("commitlog").to_string_lossy()
+        ),
+    )
+    .expect("config");
+    config
+}
+
+fn create_pop_database(path: &Path, profile_cf: bool, marker: Option<PopConsumerProfileMarker>) {
+    let mut config = RocksDbConfig {
+        enabled: true,
+        path: path.to_path_buf(),
+        ..RocksDbConfig::default()
+    };
+    if profile_cf {
+        let mut profile = RocksDbColumnFamilyConfig::consume_queue_default();
+        profile.name = POP_CONSUMER_PROFILE_COLUMN_FAMILY.to_owned();
+        config.column_families.push(profile);
+    }
+    let database = RocksDbStore::open(config).expect("create RocksDB fixture");
+    if let Some(marker) = marker {
+        database
+            .put_cf(
+                POP_CONSUMER_PROFILE_COLUMN_FAMILY,
+                POP_CONSUMER_PROFILE_MARKER_KEY,
+                &marker.encode().expect("encode marker"),
+            )
+            .expect("write marker");
+    }
+    database.flush().expect("flush fixture");
+    database.close();
+}
+
+fn compaction_current(version: u16) -> [u8; 40] {
+    let mut bytes = [0_u8; 40];
+    bytes[0..4].copy_from_slice(&0x4343_5547_u32.to_be_bytes());
+    bytes[4..6].copy_from_slice(&version.to_be_bytes());
+    bytes[8..16].copy_from_slice(&7_u64.to_be_bytes());
+    bytes[16..24].copy_from_slice(&u64::MAX.to_be_bytes());
+    bytes[24..32].copy_from_slice(&8_u64.to_be_bytes());
+    let checksum = rocketmq_model::utils::crc32_utils::crc32(&bytes[..32]);
+    bytes[32..36].copy_from_slice(&checksum.to_be_bytes());
+    bytes
+}
+
+fn snapshot(root: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
+    let mut output = BTreeMap::new();
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(directory) = pending.pop() {
+        for entry in fs::read_dir(&directory).expect("read fixture directory") {
+            let path = entry.expect("fixture entry").path();
+            if path.is_dir() {
+                pending.push(path);
+            } else {
+                output.insert(path.strip_prefix(root).unwrap().to_path_buf(), fs::read(path).unwrap());
+            }
+        }
+    }
+    output
+}

--- a/rocketmq-tools/rocketmq-store-inspect/tests/multipath_consolidate.rs
+++ b/rocketmq-tools/rocketmq-store-inspect/tests/multipath_consolidate.rs
@@ -1,0 +1,163 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs;
+use std::fs::OpenOptions;
+use std::io;
+
+use rocketmq_store_inspect::multipath_consolidate::consolidate_multipath;
+use rocketmq_store_inspect::multipath_consolidate::consolidate_multipath_with_environment;
+use rocketmq_store_inspect::multipath_consolidate::consolidate_multipath_with_hook;
+use rocketmq_store_inspect::multipath_consolidate::ConsolidationRequest;
+
+const V0_9_COMMIT_LOG: &[u8] =
+    include_bytes!("../../../rocketmq-store/tests/fixtures/upgrade/v0.9.0/local-file/commitlog/00000000000000000000");
+
+#[test]
+fn consolidates_contiguous_segments_and_leaves_sources_unchanged() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root_a = temp.path().join("a");
+    let root_b = temp.path().join("b");
+    let target = temp.path().join("target");
+    fs::create_dir_all(&root_a).expect("root a");
+    fs::create_dir_all(&root_b).expect("root b");
+    let segment_size = V0_9_COMMIT_LOG.len() as u64;
+    fs::write(root_a.join("00000000000000000000"), V0_9_COMMIT_LOG).expect("segment zero");
+    fs::write(
+        root_b.join(format!("{segment_size:020}")),
+        vec![0_u8; V0_9_COMMIT_LOG.len()],
+    )
+    .expect("segment one");
+
+    let report = consolidate_multipath(&ConsolidationRequest::new(
+        vec![root_a.clone(), root_b.clone()],
+        target.clone(),
+        segment_size,
+    ))
+    .expect("consolidation succeeds");
+
+    assert_eq!(report.segment_count, 2);
+    assert_eq!(report.copied_bytes, segment_size * 2);
+    assert_eq!(report.record_count, 2);
+    assert_eq!(fs::read(target.join("00000000000000000000")).unwrap(), V0_9_COMMIT_LOG);
+    assert_eq!(
+        fs::read(target.join(format!("{segment_size:020}"))).unwrap(),
+        vec![0_u8; V0_9_COMMIT_LOG.len()]
+    );
+    assert_eq!(fs::read(root_a.join("00000000000000000000")).unwrap(), V0_9_COMMIT_LOG);
+    assert_eq!(
+        fs::read(root_b.join(format!("{segment_size:020}"))).unwrap(),
+        vec![0_u8; V0_9_COMMIT_LOG.len()]
+    );
+}
+
+#[test]
+fn rejects_duplicate_owner_and_gap_without_publishing_target() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root_a = temp.path().join("a");
+    let root_b = temp.path().join("b");
+    fs::create_dir_all(&root_a).expect("root a");
+    fs::create_dir_all(&root_b).expect("root b");
+    fs::write(root_a.join("00000000000000000000"), [0_u8; 8]).expect("segment zero");
+    fs::write(root_b.join("00000000000000000000"), [1_u8; 8]).expect("duplicate");
+    let target = temp.path().join("target-duplicate");
+    let error = consolidate_multipath(&ConsolidationRequest::new(
+        vec![root_a.clone(), root_b.clone()],
+        target.clone(),
+        8,
+    ))
+    .expect_err("duplicate owner must fail");
+    assert!(error.to_string().contains("duplicate"));
+    assert!(!target.exists());
+
+    fs::remove_file(root_b.join("00000000000000000000")).expect("remove duplicate");
+    fs::write(root_b.join("00000000000000000016"), [0_u8; 8]).expect("gapped segment");
+    let target = temp.path().join("target-gap");
+    let error = consolidate_multipath(&ConsolidationRequest::new(vec![root_a, root_b], target.clone(), 8))
+        .expect_err("gap must fail");
+    assert!(error.to_string().contains("expected offset 8"));
+    assert!(!target.exists());
+}
+
+#[test]
+fn injected_interruption_never_publishes_partial_target() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path().join("root");
+    let target = temp.path().join("target");
+    fs::create_dir_all(&root).expect("root");
+    fs::write(root.join("00000000000000000000"), [0_u8; 8]).expect("segment zero");
+    fs::write(root.join("00000000000000000008"), [0_u8; 8]).expect("segment eight");
+
+    let error = consolidate_multipath_with_hook(
+        &ConsolidationRequest::new(vec![root.clone()], target.clone(), 8),
+        |copied| {
+            if copied == 1 {
+                Err(io::Error::other("injected interruption"))
+            } else {
+                Ok(())
+            }
+        },
+    )
+    .expect_err("interruption must fail");
+
+    assert!(error.to_string().contains("injected interruption"));
+    assert!(!target.exists());
+    assert_eq!(fs::read(root.join("00000000000000000000")).unwrap(), [0_u8; 8]);
+    assert_eq!(fs::read(root.join("00000000000000000008")).unwrap(), [0_u8; 8]);
+}
+
+#[test]
+fn rejects_running_broker_lock_without_copying() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path().join("source");
+    let target = temp.path().join("target");
+    fs::create_dir_all(&root).expect("source");
+    fs::write(root.join("00000000000000000000"), [0_u8; 8]).expect("segment");
+    let lock = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(temp.path().join("lock"))
+        .expect("lock file");
+    fs2::FileExt::try_lock_exclusive(&lock).expect("simulate Broker lock");
+
+    let error = consolidate_multipath(
+        &ConsolidationRequest::new(vec![root], target.clone(), 8).with_store_root(temp.path().to_path_buf()),
+    )
+    .expect_err("active Broker lock must fail");
+
+    assert_eq!(error.kind(), io::ErrorKind::WouldBlock);
+    assert!(!target.exists());
+    fs2::FileExt::unlock(&lock).expect("unlock fixture");
+}
+
+#[test]
+fn rejects_insufficient_target_space_before_staging() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path().join("source");
+    let target = temp.path().join("target");
+    fs::create_dir_all(&root).expect("source");
+    fs::write(root.join("00000000000000000000"), [0_u8; 8]).expect("segment");
+
+    let error = consolidate_multipath_with_environment(
+        &ConsolidationRequest::new(vec![root], target.clone(), 8),
+        |_| Ok(7),
+        |_| Ok(()),
+    )
+    .expect_err("insufficient capacity must fail");
+
+    assert_eq!(error.kind(), io::ErrorKind::StorageFull);
+    assert!(!target.exists());
+}


### PR DESCRIPTION
## Summary
- add fail-closed offline downgrade preflight for multipath CommitLog, POP profiles, Timer ownership, Compaction, and Tiered metadata
- add lock-protected multipath consolidation with capacity, continuity, frame-offset, record-count, byte-equality, interruption, and atomic-publication checks
- add read-only RocksDB inspection, persisted POP format declaration, Rust upgrade fixtures, restart matrices, and operator documentation

## Compatibility boundary
- covers Rust-owned upgrade and rollback paths
- does not claim Java data-directory takeover, DLedger CommitLog, Java Controller/AutoSwitchHA wire compatibility, OpenMessaging, or BrokerContainer

## Validation
- all Task 3.7 Store, Broker, RocksDB, and store-inspect tests passed
- POP retry/profile, transaction checkpoint, Java config conversion, EscapeBridge, and Compaction regressions passed
- targeted and workspace all-feature Clippy passed with `-D warnings`
- AGENTS routing and `git diff --check` passed
- fixed nightly fuzz all-target/all-feature compile passed using an isolated temporary lock; the repository's pre-existing stale standalone lock still rejects the exact `--locked` command before compilation
- package formatting passed; root `cargo fmt --all -- --check` remains blocked on Windows by OS error 206

Closes #9486

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added offline commands to consolidate multipath CommitLogs and assess downgrade readiness.
  - Added safe, atomic consolidation with validation, locking, interruption cleanup, and detailed reports.
  - Added read-only storage inspection for POP consumer profile state.
  - Added persistence of storage-format inventory metadata.

- **Documentation**
  - Added upgrade and rollback guidance, including compatibility checks and recovery considerations.
  - Documented offline command usage, prerequisites, validation, and safety behavior.

- **Tests**
  - Expanded coverage for upgrades, rollbacks, tiered storage, persistence, metadata validation, and failure recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->