### PR TITLE
[ISSUE #9504]✨Freeze the core 1.0 public API contract

### DIFF
--- a/.github/workflows/rocketmq-rust-ci.yaml
+++ b/.github/workflows/rocketmq-rust-ci.yaml
@@ -183,8 +183,8 @@ jobs:
       - name: Check shared-mutation baseline
         run: python scripts/arc_mut_guard.py
 
-      - name: Check stable nightly surface baseline
-        run: python scripts/stable_surface_guard.py --scope core-release
+      - name: Check stable nightly and public API target
+        run: python scripts/stable_surface_guard.py --scope core-release --mode target
 
   architecture-contracts:
     name: Architecture Contracts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2978,22 +2978,22 @@ dependencies = [
 
 [[package]]
 name = "openraft-macros"
-version = "0.10.0-alpha.34"
+version = "0.10.0-alpha.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5c57259539e016f70d05ea7e264573cc5ddabd651a127a13374e47b165b7664"
+checksum = "2ec23cd291c763fb17d8dabf7cc4eacaefd45d02e52a4df88ce50c702f030689"
 dependencies = [
  "chrono",
  "proc-macro2",
  "quote",
  "semver",
- "syn 3.0.3",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "openraft-rt"
-version = "0.10.0-alpha.34"
+version = "0.10.0-alpha.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02379ddf29c426905a6e91c5df522003ee2a9a9811b3b8be01e90ab1106ecef6"
+checksum = "a31c2d12e376df204612bb2016d652ea2d48b8edeaa04263facbe2fc7a11e3ef"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -3004,9 +3004,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-rt-tokio"
-version = "0.10.0-alpha.34"
+version = "0.10.0-alpha.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfeb8c656d8b0e01319aafc70f77b3b312cac56d07adf157d80b49677cc2fcec"
+checksum = "6d8c01f2a456a864282bc4eaf76f1f78ab040d80416fd30fd15b8ab88faa337a"
 dependencies = [
  "futures-util",
  "openraft-rt",
@@ -4361,6 +4361,9 @@ dependencies = [
  "futures",
  "hex",
  "openraft",
+ "openraft-macros",
+ "openraft-rt",
+ "openraft-rt-tokio",
  "parking_lot",
  "prost",
  "protoc-bin-vendored",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1588,6 +1588,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "ipnetwork"
@@ -2862,6 +2865,9 @@ dependencies = [
  "futures",
  "hex",
  "openraft",
+ "openraft-macros",
+ "openraft-rt",
+ "openraft-rt-tokio",
  "parking_lot",
  "prost",
  "protoc-bin-vendored",
@@ -3146,6 +3152,7 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "futures-util",
+ "ipnet",
  "local-ip-address",
  "num_cpus",
  "parking_lot",

--- a/rocketmq-controller/Cargo.toml
+++ b/rocketmq-controller/Cargo.toml
@@ -46,6 +46,11 @@ openraft = { version = "=0.10.0-alpha.21", default-features = false, features = 
   "serde",
   "tokio-rt",
 ] }
+# OpenRaft prereleases use caret constraints internally. Keep the companion
+# crates on the same alpha so Cargo cannot resolve a newer, incompatible ABI.
+openraft-macros   = "=0.10.0-alpha.21"
+openraft-rt       = "=0.10.0-alpha.21"
+openraft-rt-tokio = "=0.10.0-alpha.21"
 
 # gRPC networking
 tonic       = { version = "0.14.6", features = ["transport", "codegen"] }

--- a/rocketmq-doc/en/architecture-public-api-compatibility.md
+++ b/rocketmq-doc/en/architecture-public-api-compatibility.md
@@ -6,18 +6,19 @@ paths removed by the architecture migration.
 
 ## Public API snapshot
 
-- Scope: every current workspace library target (`library_targets=27`);
-  the standalone `rocketmq-mcp` project is validated by its own locked matrix
-- Feature profile: default
+- Scope: every core-release library target (`library_targets=26`); excluded
+  Dashboard, MCP, and SRE projects are not part of this denominator
+- Structural profiles: `profiles=50` (26 workspace defaults plus the 24 frozen
+  public-feature matrix entries)
 - Snapshot comparison: `differences=0`
 - Canonical target path counts:
 
   | Package | Previous | Current | Reviewed cause |
   |---|---:|---:|---|
-  | `rocketmq-client-rust` | 280 | 285 | scoped Admin/LitePull/Producer/Session and Proxy Cluster capabilities |
+  | `rocketmq-client-rust` | 280 | 313 | scoped Admin/LitePull/Classic Pull/Producer/Session and Proxy Cluster capabilities |
   | `rocketmq-runtime` | 351 | 374 | bounded operation/resource and versioned runtime diagnostics capabilities |
-  | `rocketmq-transport` | 194 | 212 | authorized dispatch and request/response sink capabilities |
-  | `rocketmq-store` | 254 | 263 | cumulative Store capability work; benchmark helpers are absent from the default feature surface |
+  | `rocketmq-transport` | 194 | 204 | authorized dispatch and request/response sink capabilities |
+  | `rocketmq-store` | 254 | 276 | cumulative Store capability work, including the functional mapped-file builder |
 
 - Accepted source-level cleanup relative to the previous compatibility surface:
   - additive groups: 4
@@ -37,9 +38,8 @@ paths removed by the architecture migration.
 
 Previously approved source cleanups remain in force: `ClientRuntime::new` was
 removed and callers use fallible `ClientRuntime::try_new`; `ClusterConfig` owns mandatory bounded-execution
-fields without changing Serde backward reads; Dashboard admin operations use
-concurrent `&self` receivers; and `MappedBuffer::read_zero_copy` was replaced
-by the accurately named `MappedBuffer::read_copy`.
+fields without changing Serde backward reads; and `MappedBuffer::read_zero_copy`
+was replaced by the accurately named `MappedBuffer::read_copy`.
 
 The package count is derived from `cargo metadata`; the guard rejects a
 baseline that is missing a current library target or retains a removed one.
@@ -86,8 +86,8 @@ is the compatibility classification authority for this change; it does not
 waive protocol, wire, persisted-layout, or implemented-behavior compatibility.
 The same authority explicitly approved the `ClusterConfig` source-shape change:
 the obsolete fixed-lane execution contract is not retained.
-It also approved the Dashboard receiver cleanup and typed blocking-profile
-additions; neither changes RocketMQ wire, storage, or recovery contracts.
+It also approved typed blocking-profile additions; they do not change RocketMQ
+wire, storage, or recovery contracts.
 The same source-compatibility decision applies to the mapped-buffer read
 cleanup: old internal names are not retained when they misstate allocation and
 ownership.

--- a/rocketmq-doc/en/release/1.0/api-migration.md
+++ b/rocketmq-doc/en/release/1.0/api-migration.md
@@ -1,0 +1,195 @@
+# RocketMQ Rust 1.0 API migration
+
+RocketMQ Rust 1.0 freezes the core-release Rust API at the first complete
+`1.0.0-rc.1` candidate. The freeze is structural: every public item is recorded
+by package, supported feature profile, canonical item path, kind, visibility,
+signature, and feature condition. It does not use a commit, file, or artifact
+digest as a compatibility decision.
+
+This guide covers the core release only. Dashboard, MCP, SRE, OpenMessaging,
+BrokerContainer, and DLedger CommitLog are not part of the 1.0 compatibility
+surface.
+
+## Compatibility policy
+
+The 0.9-to-1.0 transition has four explicit classifications:
+
+| Classification | Meaning |
+|---|---|
+| `compatible-addition` | A typed capability was added without removing a supported wire, storage, or source contract. |
+| `approved-break` | A misleading or unsafe pre-1.0 entry point was removed with repository-owner approval and a documented replacement. |
+| `renamed-wrapper` | The operation remains available under a name that accurately describes its behavior. |
+| `removed-placeholder` | A public placeholder or production test probe was replaced by a working capability or moved behind `test-support`. |
+
+After the freeze, additions remain compatible. Removing an item, changing its
+signature or trait bounds, changing a supported feature profile, or changing a
+documented default is rejected unless the baseline contains a matching,
+reviewed post-freeze approval.
+
+## Direct source migrations
+
+### Fallible client runtime construction
+
+`ClientRuntime::new` was removed because runtime startup can fail. Propagate the
+typed error from `try_new` instead of relying on a panic-compatible constructor.
+
+```rust,ignore
+// Before 1.0
+let runtime = ClientRuntime::new(config);
+
+// 1.0: preserve the existing service context, runtime config, and telemetry.
+let runtime = ClientRuntime::try_new(service_context, config, telemetry_handle)?;
+```
+
+Applications own the runtime and pass an `Arc<ClientRuntime>` to producers and
+consumers. Client APIs do not create hidden Tokio runtimes.
+
+### Mapped buffer reads
+
+The former `MappedBuffer::read_zero_copy` name was inaccurate because the
+returned bytes were owned copies. Use `read_copy`; the ownership and allocation
+behavior are unchanged.
+
+```rust,ignore
+// Before 1.0
+let bytes = mapped.read_zero_copy(position..position + length)?;
+
+// 1.0
+let bytes = mapped.read_copy(position..position + length)?;
+```
+
+### Narrow client capabilities
+
+The placeholder `MQClientAPIExt` and implementation aliases are not part of the
+1.0 surface. Depend on the narrow capability needed by the caller:
+
+| Old dependency | 1.0 capability |
+|---|---|
+| generic producer operations | `ProducerClient` |
+| pull, POP, ACK, and consumer operations | `ConsumerClient` |
+| route lookup and refresh | `RouteClient` |
+| administrative RPC operations | `AdminClient` |
+| transaction end/check operations | `TransactionClient` |
+
+Repository integration probes that were once exported from production roots
+are available only through the explicit `test-support` feature. Application
+code must not depend on those probes.
+
+## Frozen 1.0 entry points
+
+### MappedFileBuilder
+
+`MappedFileBuilder` is a working, fallible builder rather than a pending public
+placeholder. A path and size are required. Supported defaults create a mapped
+file; invalid sizes, unsupported flush/transient/warmup combinations, and I/O
+failures return `MappedFileError`.
+
+```rust,ignore
+use rocketmq_store::MappedFileBuilder;
+
+let mapped_file = MappedFileBuilder::new("data/commitlog/00000000000000000000")
+    .size_mb(1024)
+    .build()?;
+```
+
+Do not unwrap builder failures in a Broker startup path. Surface the typed
+configuration or I/O error before the service starts accepting traffic.
+
+### Classic Pull compatibility facade
+
+`DefaultMQPullConsumer` remains functional for applications that need explicit
+queue and offset control. New Rust-native applications should normally use
+`DefaultLitePullConsumer`; migrations from Java Classic Pull may use the stable
+facade.
+
+```rust,ignore
+let consumer = DefaultMQPullConsumer::builder(client_runtime.clone())
+    .consumer_group("manual-pull-group")
+    .name_server_addr("127.0.0.1:9876")
+    .build()?;
+
+consumer.start().await?;
+let result = consumer.pull(&queue, "TagA || TagB", offset, 32).await?;
+consumer
+    .update_consume_offset(&queue, result.next_begin_offset() as i64)
+    .await?;
+consumer.shutdown().await?;
+```
+
+The facade supports synchronous and asynchronous pull, TAG/SQL92 selectors,
+block-if-not-found deadlines, queue discovery, offset persistence, queue
+listeners, and scheduled pull callbacks. It uses an injected runtime and never
+advertises the LitePull stream request type. Detached compatibility
+constructors remain source-compatible but fail closed for operations that need
+a runtime.
+
+For overload-style calls, use `PullOptions` so timeout, count, size, offset, and
+long-poll invariants are validated before a request is sent.
+
+### Proxy gRPC Settings
+
+Proxy settings are resolved through one immutable `ServerSettingsPolicy`
+generation per telemetry request. Server-owned values override client claims;
+client identity and subscription expressions remain client-owned.
+
+The 1.0 fallback values are:
+
+| Setting | Default |
+|---|---:|
+| maximum message body | 4 MiB |
+| validate message type | `true` |
+| consumer retry attempts | 17 |
+| receive batch size | 32 |
+| long-poll timeout | 20 seconds |
+| FIFO | `false` |
+| Lite subscription quota | 2000 |
+| maximum Lite topic-name length | 64 |
+
+Producer retry policy is built from `SettingsConfig`; consumer group policy is
+resolved from the authoritative backend. If the policy cannot be resolved, the
+request fails closed rather than silently reverting to unrelated constants.
+
+Custom embedders may provide a `SettingsPolicyProvider`, but the provider must
+return a complete immutable policy for the request lifetime.
+
+## Feature-profile compatibility
+
+The default API of every core library is recorded separately. The 24 public
+feature profiles in `m09_compatibility_matrix.py` are also recorded separately,
+including no-default, selected-feature, combined-feature, and all-feature
+profiles for Protocol, Transport, Store, Admin, and Proxy.
+
+Notable 1.0 defaults include:
+
+- `rocketmq-client-rust`: `admin-full`;
+- `rocketmq-transport`: `tls,socks`;
+- `rocketmq-store`: `local_file_store,fast-load`;
+- `rocketmq-controller`: `storage-rocksdb`;
+- `rocketmq-proxy`: `cluster-mode,local-mode`.
+
+Use `--no-default-features` only when the application also selects one of the
+frozen supported profiles. An arbitrary Cargo feature power set is not an
+implicit compatibility promise.
+
+## Checking an application migration
+
+Before adopting a release candidate:
+
+1. replace the direct source migrations above;
+2. select a frozen feature profile;
+3. run the application's normal tests against `1.0.0-rc.N`;
+4. exercise startup and shutdown so runtime ownership is verified;
+5. exercise send, pull/POP, query, and Admin paths used by the application;
+6. treat any new compiler error or default-behavior difference as a release
+   candidate compatibility finding.
+
+The repository verifies its own frozen surface with:
+
+```powershell
+python scripts/public_api_snapshot.py --scope core-release --check scripts/public-api-snapshot-baseline.json --identity structural
+python scripts/stable_surface_guard.py --scope core-release --mode target
+```
+
+The snapshot command reports additions separately from breaking changes. A
+post-freeze break is accepted only when its exact package, profile, item path,
+and change kind match a non-empty approval record.

--- a/scripts/architecture-dependency-baseline.json
+++ b/scripts/architecture-dependency-baseline.json
@@ -1406,6 +1406,27 @@
       "package": "rocketmq-controller"
     },
     {
+      "dependency": "openraft-macros",
+      "features": [],
+      "kind": "normal",
+      "optional": false,
+      "package": "rocketmq-controller"
+    },
+    {
+      "dependency": "openraft-rt",
+      "features": [],
+      "kind": "normal",
+      "optional": false,
+      "package": "rocketmq-controller"
+    },
+    {
+      "dependency": "openraft-rt-tokio",
+      "features": [],
+      "kind": "normal",
+      "optional": false,
+      "package": "rocketmq-controller"
+    },
+    {
       "dependency": "parking_lot",
       "features": [],
       "kind": "normal",

--- a/scripts/architecture-release-plan.json
+++ b/scripts/architecture-release-plan.json
@@ -58,7 +58,7 @@
     },
     {
       "id": "stable-surface",
-      "command": "python scripts/stable_surface_guard.py --scope core-release",
+      "command": "python scripts/stable_surface_guard.py --scope core-release --mode target",
       "result": "stable_surface"
     },
     {

--- a/scripts/architecture_release_guard.py
+++ b/scripts/architecture_release_guard.py
@@ -429,7 +429,7 @@ def validate_semantic_routes(plan: dict[str, Any], findings: list[Finding]) -> N
         },
         {
             "id": "stable-surface",
-            "command": "python scripts/stable_surface_guard.py --scope core-release",
+            "command": "python scripts/stable_surface_guard.py --scope core-release --mode target",
             "result": "stable_surface",
         },
         {

--- a/scripts/core_release_static_guard.py
+++ b/scripts/core_release_static_guard.py
@@ -61,7 +61,10 @@ def required_routes() -> tuple[StaticRoute, ...]:
         ),
         StaticRoute("architecture-debt", (python, "scripts/architecture_debt_guard.py", "--check", *scope)),
         StaticRoute("module-maintainability", (python, "scripts/module_maintainability_guard.py", *scope)),
-        StaticRoute("stable-surface", (python, "scripts/stable_surface_guard.py", *scope)),
+        StaticRoute(
+            "stable-surface",
+            (python, "scripts/stable_surface_guard.py", *scope, "--mode", "target"),
+        ),
         StaticRoute(
             "architecture-release",
             (python, "scripts/architecture_release_guard.py", *scope, "--mode", "structural"),

--- a/scripts/public-api-freeze-policy.json
+++ b/scripts/public-api-freeze-policy.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": 1,
+  "freeze": {
+    "version": "1.0.0-rc.1",
+    "breaking_change_policy": "approval-required-after-freeze"
+  },
+  "compatibility_decisions": [
+    {
+      "id": "API-0.9-001",
+      "classification": "compatible-addition",
+      "applies_to": "0.9-to-1.0",
+      "reason": "The 1.0 core capabilities add typed, fallible APIs without removing an already supported wire or persisted contract."
+    },
+    {
+      "id": "API-0.9-002",
+      "classification": "approved-break",
+      "applies_to": "0.9-to-1.0",
+      "old_item_path": "rocketmq_runtime::ClientRuntime::new",
+      "replacement": "rocketmq_runtime::ClientRuntime::try_new",
+      "reason": "Runtime construction is fallible and must not hide initialization failure behind a panic-compatible constructor.",
+      "approved_by": "repository-owner",
+      "approved_on": "2026-07-29"
+    },
+    {
+      "id": "API-0.9-003",
+      "classification": "renamed-wrapper",
+      "applies_to": "0.9-to-1.0",
+      "old_item_path": "rocketmq_store::MappedBuffer::read_zero_copy",
+      "replacement": "rocketmq_store::MappedBuffer::read_copy",
+      "reason": "The old name claimed zero-copy behavior that the implementation never provided; the replacement states the ownership cost accurately.",
+      "approved_by": "repository-owner",
+      "approved_on": "2026-07-29"
+    },
+    {
+      "id": "API-0.9-004",
+      "classification": "removed-placeholder",
+      "applies_to": "0.9-to-1.0",
+      "old_item_path": "rocketmq_client_rust::MQClientAPIExt",
+      "replacement": "rocketmq_client_rust::{AdminClient,ConsumerClient,ProducerClient,RouteClient,TransactionClient}",
+      "reason": "The exported placeholder and production probe facades were replaced by narrow capabilities; test-only probes moved behind the explicit test-support feature.",
+      "approved_by": "repository-owner",
+      "approved_on": "2026-07-29"
+    }
+  ],
+  "frozen_contracts": [
+    {
+      "capability_id": "F-13",
+      "profile_id": "rocketmq-store:default",
+      "package": "rocketmq-store",
+      "item_paths": [
+        "rocketmq_store::log_file::mapped_file::builder::MappedFileBuilder"
+      ],
+      "behavior": "MappedFileBuilder creates a usable mapped file for supported defaults and returns a typed configuration or I/O error for unsupported or invalid inputs.",
+      "evidence": [
+        "cargo test -p rocketmq-store --test public_api_contract"
+      ]
+    },
+    {
+      "capability_id": "F-15",
+      "profile_id": "rocketmq-proxy-core:default",
+      "package": "rocketmq-proxy-core",
+      "item_paths": [
+        "rocketmq_proxy_core::settings::ServerSettingsPolicy",
+        "rocketmq_proxy_core::settings::SettingsConfig",
+        "rocketmq_proxy_core::settings::SettingsPolicyProvider",
+        "rocketmq_proxy_core::settings::SettingsPolicyValues"
+      ],
+      "behavior": "One immutable server policy generation overrides server-owned gRPC settings while preserving client identity and subscription expressions.",
+      "defaults": {
+        "max_body_size": 4194304,
+        "validate_message_type": true,
+        "retry_max_attempts": 17,
+        "receive_batch_size": 32,
+        "long_polling_timeout_seconds": 20,
+        "fifo": false,
+        "lite_subscription_quota": 2000,
+        "max_lite_topic_size": 64
+      },
+      "evidence": [
+        "cargo test -p rocketmq-proxy-core --test effective_settings"
+      ]
+    },
+    {
+      "capability_id": "F-18",
+      "profile_id": "rocketmq-client-rust:default",
+      "package": "rocketmq-client-rust",
+      "item_paths": [
+        "rocketmq_client_rust::consumer::consumer_impl::default_mq_pull_consumer_impl::DefaultMQPullConsumerImpl",
+        "rocketmq_client_rust::consumer::default_mq_pull_consumer::ClassicPullCallback",
+        "rocketmq_client_rust::consumer::default_mq_pull_consumer::DefaultMQPullConsumer",
+        "rocketmq_client_rust::consumer::default_mq_pull_consumer::PullOptions",
+        "rocketmq_client_rust::consumer::default_mq_pull_consumer_builder::DefaultMQPullConsumerBuilder"
+      ],
+      "behavior": "The deprecated Classic Pull facade remains functional on the shared runtime, supports synchronous and asynchronous pull, queue discovery, offset persistence, listeners, and scheduled callbacks without advertising LitePull stream semantics.",
+      "evidence": [
+        "cargo test -p rocketmq-client-rust --test classic_pull_equivalence"
+      ]
+    }
+  ]
+}

--- a/scripts/public_api_snapshot.py
+++ b/scripts/public_api_snapshot.py
@@ -12,31 +12,70 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Generate and verify the default-feature public API snapshot from rustdoc JSON."""
+"""Generate and verify the core-release structural public API freeze."""
 
 from __future__ import annotations
 
 import argparse
 import json
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import core_release_scope
+import m09_compatibility_matrix
 
 
 ROOT = Path(__file__).resolve().parents[1]
 PUBLIC_API_INTENT = ROOT / "scripts" / "public-api-intent.json"
-SCHEMA_VERSION = 2
+DEFAULT_FREEZE_POLICY = ROOT / "scripts" / "public-api-freeze-policy.json"
+SCHEMA_VERSION = 3
+IDENTITY = "structural"
 LIB_KINDS = {"lib", "rlib", "proc-macro"}
 RUSTDOC_TOOLCHAIN = "nightly-2026-07-05"
+STRUCTURAL_ITEM_FIELDS = (
+    "package",
+    "module",
+    "item_path",
+    "kind",
+    "visibility",
+    "signature",
+    "feature",
+)
+PROFILE_SPEC_FIELDS = (
+    "package",
+    "target",
+    "default_features",
+    "all_features",
+    "features",
+    "declared_default_features",
+    "source",
+    "matrix_ids",
+)
+COMPATIBILITY_CLASSIFICATIONS = {
+    "compatible-addition",
+    "approved-break",
+    "renamed-wrapper",
+    "removed-placeholder",
+}
+BREAKING_CLASSIFICATIONS = {
+    "approved-break",
+    "renamed-wrapper",
+    "removed-placeholder",
+}
+REQUIRED_FROZEN_CAPABILITIES = {"F-13", "F-15", "F-18"}
+VOLATILE_RUSTDOC_KEYS = frozenset(
+    {"id", "fields", "impls", "implementations", "items", "variants"}
+)
+FEATURE_RE = re.compile(r"feature\s*=\s*\"([^\"]+)\"")
 
 
 class SnapshotError(RuntimeError):
-    pass
+    """A public API input, build, or freeze contract is invalid."""
 
 
 def run(command: list[str]) -> str:
@@ -56,10 +95,21 @@ def run(command: list[str]) -> str:
     return result.stdout.strip()
 
 
-def workspace_library_targets(*, scope: str = "core-release") -> list[tuple[str, str]]:
-    metadata = json.loads(
+def workspace_metadata() -> dict[str, Any]:
+    value = json.loads(
         run(["cargo", "metadata", "--format-version", "1", "--no-deps", "--locked"])
     )
+    if not isinstance(value, dict):
+        raise SnapshotError("cargo metadata must return an object")
+    return value
+
+
+def workspace_library_targets(
+    *,
+    scope: str = "core-release",
+    metadata: dict[str, Any] | None = None,
+) -> list[tuple[str, str]]:
+    metadata = metadata or workspace_metadata()
     members = set(metadata["workspace_members"])
     scope_document = core_release_scope.load_scope()
     core_names = {entry["name"] for entry in core_release_scope.core_packages(scope_document)}
@@ -81,6 +131,107 @@ def workspace_library_targets(*, scope: str = "core-release") -> list[tuple[str,
     return sorted(targets)
 
 
+def workspace_package_features(metadata: dict[str, Any]) -> dict[str, dict[str, list[str]]]:
+    members = set(metadata["workspace_members"])
+    result: dict[str, dict[str, list[str]]] = {}
+    for package in metadata["packages"]:
+        if package["id"] not in members:
+            continue
+        raw_features = package.get("features", {})
+        if not isinstance(raw_features, dict):
+            raise SnapshotError(f"{package['name']} features must be an object")
+        result[package["name"]] = {
+            name: sorted(values)
+            for name, values in raw_features.items()
+            if isinstance(name, str) and isinstance(values, list)
+        }
+    return result
+
+
+def _matrix_profile(
+    entry: Any,
+    target_by_package: dict[str, str],
+    package_features: dict[str, dict[str, list[str]]],
+) -> dict[str, Any]:
+    command = list(entry.command)
+    package_flag = "-p" if "-p" in command else "--package" if "--package" in command else None
+    if package_flag is None:
+        raise SnapshotError(f"feature matrix entry {entry.id} has no package selector")
+    try:
+        package = command[command.index(package_flag) + 1]
+    except IndexError as error:
+        raise SnapshotError(f"feature matrix entry {entry.id} has an empty package selector") from error
+    if package not in target_by_package:
+        raise SnapshotError(f"feature matrix entry {entry.id} targets non-core library {package}")
+
+    features: list[str] = []
+    if "--features" in command:
+        try:
+            raw_features = command[command.index("--features") + 1]
+        except IndexError as error:
+            raise SnapshotError(f"feature matrix entry {entry.id} has an empty --features") from error
+        features = sorted({feature.strip() for feature in raw_features.split(",") if feature.strip()})
+    declared = package_features.get(package, {})
+    unknown = sorted(set(features) - set(declared))
+    if unknown:
+        raise SnapshotError(
+            f"feature matrix entry {entry.id} uses undeclared {package} features: {', '.join(unknown)}"
+        )
+    all_features = "--all-features" in command
+    if all_features and features:
+        raise SnapshotError(f"feature matrix entry {entry.id} mixes --all-features and --features")
+    return {
+        "id": entry.id,
+        "package": package,
+        "target": target_by_package[package],
+        "default_features": "--no-default-features" not in command,
+        "all_features": all_features,
+        "features": features,
+        "declared_default_features": sorted(declared.get("default", [])),
+        "source": "m09-public-feature-matrix",
+        "matrix_ids": [entry.id],
+    }
+
+
+def derive_feature_profiles(
+    targets: list[tuple[str, str]],
+    package_features: dict[str, dict[str, list[str]]],
+    matrix_entries: Iterable[Any] = m09_compatibility_matrix.MATRIX,
+) -> list[dict[str, Any]]:
+    """Return each library default plus every frozen M09 public feature profile."""
+
+    target_by_package = dict(targets)
+    profiles: dict[str, dict[str, Any]] = {}
+    for package, target in targets:
+        profile_id = f"{package}:default"
+        profiles[profile_id] = {
+            "id": profile_id,
+            "package": package,
+            "target": target,
+            "default_features": True,
+            "all_features": False,
+            "features": [],
+            "declared_default_features": sorted(package_features.get(package, {}).get("default", [])),
+            "source": "workspace-default",
+            "matrix_ids": [],
+        }
+
+    for entry in matrix_entries:
+        if entry.group != "feature":
+            continue
+        if entry.id in profiles:
+            raise SnapshotError(f"duplicate public API profile id: {entry.id}")
+        profiles[entry.id] = _matrix_profile(entry, target_by_package, package_features)
+    return sorted(
+        profiles.values(),
+        key=lambda profile: (
+            profile["package"],
+            profile["source"] != "workspace-default",
+            profile["id"],
+        ),
+    )
+
+
 def toolchain() -> dict[str, str]:
     return {
         "rustc": run(["rustc", f"+{RUSTDOC_TOOLCHAIN}", "--version"]),
@@ -89,111 +240,264 @@ def toolchain() -> dict[str, str]:
     }
 
 
-VOLATILE_RUSTDOC_KEYS = frozenset({"id", "fields", "impls", "items", "variants"})
-FEATURE_RE = re.compile(r"feature\s*=\s*\"([^\"]+)\"")
+def _item_by_id(index: dict[str, Any], item_id: Any) -> dict[str, Any] | None:
+    item = index.get(str(item_id))
+    return item if isinstance(item, dict) else None
 
 
-def _semantic_value(value: Any) -> Any:
+def _semantic_value(value: Any, index: dict[str, Any]) -> Any:
     if isinstance(value, dict):
-        return {
-            key: _semantic_value(item)
-            for key, item in sorted(value.items())
-            if key not in VOLATILE_RUSTDOC_KEYS
-        }
+        result: dict[str, Any] = {}
+        for key, item in sorted(value.items()):
+            if key in VOLATILE_RUSTDOC_KEYS:
+                continue
+            if (
+                key == "tuple"
+                and isinstance(item, list)
+                and item
+                and all(_item_by_id(index, item_id) is not None for item_id in item)
+            ):
+                result["tuple_arity"] = len(item)
+                continue
+            result[key] = _semantic_value(item, index)
+        return result
     if isinstance(value, list):
-        return [_semantic_value(item) for item in value]
+        return [_semantic_value(item, index) for item in value]
     return value
+
+
+def _item_kind_and_value(item: dict[str, Any]) -> tuple[str, Any]:
+    inner = item.get("inner")
+    if not isinstance(inner, dict) or len(inner) != 1:
+        return "unknown", inner
+    return next(iter(inner.items()))
+
+
+def _item_feature(item: dict[str, Any], fallback: str = "default") -> str:
+    attributes = item.get("attrs", [])
+    features = sorted(
+        {
+            feature
+            for attribute in attributes
+            if isinstance(attribute, str)
+            for feature in FEATURE_RE.findall(attribute)
+        }
+    )
+    return ",".join(features) if features else fallback
+
+
+def _reference_list(value: Any) -> list[Any]:
+    return list(value) if isinstance(value, list) else []
+
+
+def _struct_field_ids(value: Any) -> list[Any]:
+    if not isinstance(value, dict):
+        return []
+    kind = value.get("kind")
+    if not isinstance(kind, dict):
+        return []
+    plain = kind.get("plain")
+    if isinstance(plain, dict):
+        return _reference_list(plain.get("fields"))
+    tuple_fields = kind.get("tuple")
+    if isinstance(tuple_fields, list):
+        return [item_id for item_id in tuple_fields if item_id is not None]
+    return []
+
+
+def _variant_field_ids(value: Any) -> list[Any]:
+    if not isinstance(value, dict):
+        return []
+    kind = value.get("kind")
+    if not isinstance(kind, dict):
+        return []
+    tuple_fields = kind.get("tuple")
+    if isinstance(tuple_fields, list):
+        return [item_id for item_id in tuple_fields if item_id is not None]
+    struct_fields = kind.get("struct")
+    if isinstance(struct_fields, dict):
+        return _reference_list(struct_fields.get("fields"))
+    return []
+
+
+def _direct_associated_ids(kind: str, value: Any) -> list[Any]:
+    if kind == "struct":
+        return _struct_field_ids(value)
+    if kind == "union" and isinstance(value, dict):
+        return _reference_list(value.get("fields"))
+    if kind == "enum" and isinstance(value, dict):
+        return _reference_list(value.get("variants"))
+    if kind == "variant":
+        return _variant_field_ids(value)
+    if kind == "trait" and isinstance(value, dict):
+        return _reference_list(value.get("items"))
+    return []
+
+
+def _inherent_associated_ids(kind: str, value: Any, index: dict[str, Any]) -> list[Any]:
+    if kind not in {"struct", "enum", "union", "type_alias"} or not isinstance(value, dict):
+        return []
+    associated: list[Any] = []
+    for impl_id in _reference_list(value.get("impls")):
+        impl_item = _item_by_id(index, impl_id)
+        if impl_item is None:
+            continue
+        impl_kind, impl_value = _item_kind_and_value(impl_item)
+        if impl_kind != "impl" or not isinstance(impl_value, dict):
+            continue
+        if impl_value.get("trait") is not None or impl_value.get("is_synthetic"):
+            continue
+        associated.extend(_reference_list(impl_value.get("items")))
+    return associated
+
+
+def _is_public_associated(parent_kind: str, item: dict[str, Any]) -> bool:
+    visibility = item.get("visibility", "default")
+    if parent_kind in {"enum", "variant", "trait"}:
+        return visibility in {"public", "default"}
+    return visibility == "public"
+
+
+def _record(
+    package: str,
+    item_path: str,
+    item: dict[str, Any],
+    index: dict[str, Any],
+    *,
+    fallback_feature: str = "default",
+) -> dict[str, str]:
+    kind, kind_value = _item_kind_and_value(item)
+    visibility = item.get("visibility", "public")
+    if not isinstance(visibility, str):
+        visibility = json.dumps(visibility, sort_keys=True, separators=(",", ":"))
+    return {
+        "package": package,
+        "module": item_path.rsplit("::", 1)[0] if "::" in item_path else "",
+        "item_path": item_path,
+        "kind": kind,
+        "visibility": visibility,
+        "signature": json.dumps(
+            _semantic_value(kind_value, index),
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+        "feature": _item_feature(item, fallback_feature),
+    }
 
 
 def semantic_public_items(package: str, document: dict[str, Any]) -> list[dict[str, str]]:
     """Build stable, readable API records from rustdoc's public path table."""
 
     index = document.get("index", {})
-    records: list[dict[str, str]] = []
+    path_by_id = {
+        str(item_id): "::".join(path_record["path"])
+        for item_id, path_record in document.get("paths", {}).items()
+        if path_record.get("crate_id") == 0
+        and isinstance(path_record.get("path"), list)
+        and path_record["path"]
+        and all(isinstance(part, str) for part in path_record["path"])
+    }
+    records: dict[str, dict[str, str]] = {}
+
+    def add_associated(parent_id: Any, parent_path: str, parent_feature: str) -> None:
+        parent = _item_by_id(index, parent_id)
+        if parent is None:
+            return
+        parent_kind, parent_value = _item_kind_and_value(parent)
+        direct_ids = _direct_associated_ids(parent_kind, parent_value)
+        inherent_ids = _inherent_associated_ids(parent_kind, parent_value, index)
+        for position, child_id in enumerate((*direct_ids, *inherent_ids)):
+            child = _item_by_id(index, child_id)
+            if child is None:
+                continue
+            relationship_kind = parent_kind if position < len(direct_ids) else "impl"
+            if not _is_public_associated(relationship_kind, child):
+                continue
+            name = child.get("name")
+            if not isinstance(name, str) or not name:
+                name = str(position)
+            child_path = path_by_id.get(str(child_id), f"{parent_path}::{name}")
+            records[child_path] = _record(
+                package,
+                child_path,
+                child,
+                index,
+                fallback_feature=parent_feature,
+            )
+            child_kind, _ = _item_kind_and_value(child)
+            if child_kind == "variant":
+                add_associated(child_id, child_path, _item_feature(child, parent_feature))
+
     for item_id, path_record in document.get("paths", {}).items():
         if path_record.get("crate_id") != 0:
             continue
         path = path_record.get("path")
         if not isinstance(path, list) or not path or any(not isinstance(part, str) for part in path):
             raise SnapshotError(f"invalid public path for {package}: {path!r}")
-        item = index.get(item_id, {})
-        kind = str(path_record.get("kind") or next(iter(item.get("inner", {})), "unknown"))
-        visibility = item.get("visibility", "public")
-        if not isinstance(visibility, str):
-            visibility = json.dumps(visibility, sort_keys=True, separators=(",", ":"))
-        attributes = item.get("attrs", [])
-        features = sorted(
-            {
-                feature
-                for attribute in attributes
-                if isinstance(attribute, str)
-                for feature in FEATURE_RE.findall(attribute)
-            }
-        )
-        inner = item.get("inner", {})
-        kind_value = inner.get(kind, inner) if isinstance(inner, dict) else inner
-        signature = json.dumps(
-            _semantic_value(kind_value),
-            sort_keys=True,
-            separators=(",", ":"),
-        )
-        records.append(
-            {
-                "package": package,
-                "module": "::".join(path[:-1]),
-                "item_path": "::".join(path),
-                "kind": kind,
-                "visibility": visibility,
-                "signature": signature,
-                "feature": ",".join(features) if features else "default",
-            }
-        )
+        item = _item_by_id(index, item_id)
+        if item is None:
+            continue
+        item_path = "::".join(path)
+        feature = _item_feature(item)
+        records[item_path] = _record(package, item_path, item, index)
+        add_associated(item_id, item_path, feature)
     return sorted(
-        records,
-        key=lambda item: tuple(
-            item[field]
-            for field in (
-                "package",
-                "module",
-                "item_path",
-                "kind",
-                "visibility",
-                "signature",
-                "feature",
-            )
-        ),
+        records.values(),
+        key=lambda item: tuple(item[field] for field in STRUCTURAL_ITEM_FIELDS),
     )
 
 
-def snapshot_package(package: str, target: str, *, refresh: bool = True) -> dict[str, Any]:
+def _profile_cache_path(profile_id: str) -> Path:
+    safe_name = re.sub(r"[^A-Za-z0-9_.-]+", "_", profile_id)
+    return ROOT / "target" / "public-api-snapshot" / f"{safe_name}.json"
+
+
+def _rustdoc_command(profile: dict[str, Any]) -> list[str]:
+    command = [
+        "cargo",
+        f"+{RUSTDOC_TOOLCHAIN}",
+        "rustdoc",
+        "--locked",
+        "-p",
+        profile["package"],
+        "--lib",
+    ]
+    if profile["all_features"]:
+        command.append("--all-features")
+    else:
+        if not profile["default_features"]:
+            command.append("--no-default-features")
+        if profile["features"]:
+            command.extend(("--features", ",".join(profile["features"])))
+    command.extend(("--", "-Z", "unstable-options", "--output-format", "json"))
+    return command
+
+
+def snapshot_profile(profile: dict[str, Any], *, refresh: bool = True) -> dict[str, Any]:
+    cache_path = _profile_cache_path(profile["id"])
     if refresh:
-        run(
-            [
-                "cargo",
-                f"+{RUSTDOC_TOOLCHAIN}",
-                "rustdoc",
-                "-p",
-                package,
-                "--lib",
-                "--",
-                "-Z",
-                "unstable-options",
-                "--output-format",
-                "json",
-            ]
-        )
-    rustdoc_json = ROOT / "target" / "doc" / f"{target}.json"
-    if not rustdoc_json.is_file():
-        raise SnapshotError(f"rustdoc JSON was not produced for {package}: {rustdoc_json}")
-    document = json.loads(rustdoc_json.read_text(encoding="utf-8"))
-    return {
-        "target": target,
-        "crate_version": document.get("crate_version"),
-        "public_api": semantic_public_items(package, document),
-    }
+        run(_rustdoc_command(profile))
+        rustdoc_json = ROOT / "target" / "doc" / f"{profile['target']}.json"
+        if not rustdoc_json.is_file():
+            raise SnapshotError(
+                f"rustdoc JSON was not produced for {profile['id']}: {rustdoc_json}"
+            )
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(rustdoc_json, cache_path)
+    if not cache_path.is_file():
+        raise SnapshotError(f"cached rustdoc JSON is missing for {profile['id']}: {cache_path}")
+    document = json.loads(cache_path.read_text(encoding="utf-8"))
+    result = {field: profile[field] for field in PROFILE_SPEC_FIELDS}
+    result.update(
+        {
+            "crate_version": document.get("crate_version"),
+            "public_api": semantic_public_items(profile["package"], document),
+        }
+    )
+    return result
 
 
-def validate_existing_artifacts(targets: list[tuple[str, str]]) -> None:
+def validate_existing_artifacts(profiles: list[dict[str, Any]]) -> None:
     dirty_api_inputs = run(
         [
             "git",
@@ -210,31 +514,65 @@ def validate_existing_artifacts(targets: list[tuple[str, str]]) -> None:
         raise SnapshotError(
             "--from-existing cannot verify dirty Rust/API inputs; refresh after committing or stashing them"
         )
-
     commit_timestamp = int(run(["git", "show", "-s", "--format=%ct", "HEAD"]))
-    missing = []
-    stale = []
-    for package, target in targets:
-        rustdoc_json = ROOT / "target" / "doc" / f"{target}.json"
-        if not rustdoc_json.is_file():
-            missing.append(package)
-        elif rustdoc_json.stat().st_mtime < commit_timestamp:
-            stale.append(package)
+    missing: list[str] = []
+    stale: list[str] = []
+    for profile in profiles:
+        cache_path = _profile_cache_path(profile["id"])
+        if not cache_path.is_file():
+            missing.append(profile["id"])
+        elif cache_path.stat().st_mtime < commit_timestamp:
+            stale.append(profile["id"])
     if missing or stale:
         raise SnapshotError(
-            "--from-existing requires artifacts refreshed after HEAD; "
+            "--from-existing requires profile artifacts refreshed after HEAD; "
             f"missing={','.join(missing) or '-'} stale={','.join(stale) or '-'}"
         )
 
 
-def generate_snapshot(*, refresh: bool = True, scope: str = "core-release") -> dict[str, Any]:
-    targets = workspace_library_targets(scope=scope)
+def load_freeze_policy(path: Path = DEFAULT_FREEZE_POLICY) -> dict[str, Any]:
+    try:
+        policy = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise SnapshotError(f"cannot read public API freeze policy {path}: {error}") from error
+    if not isinstance(policy, dict) or policy.get("schema_version") != 1:
+        raise SnapshotError("public API freeze policy schema_version must be 1")
+    return policy
+
+
+def generate_snapshot(
+    *,
+    refresh: bool = True,
+    scope: str = "core-release",
+    freeze_policy_path: Path = DEFAULT_FREEZE_POLICY,
+) -> dict[str, Any]:
+    metadata = workspace_metadata()
+    targets = workspace_library_targets(scope=scope, metadata=metadata)
+    profiles = derive_feature_profiles(
+        targets,
+        workspace_package_features(metadata),
+        m09_compatibility_matrix.MATRIX,
+    )
     if not refresh:
-        validate_existing_artifacts(targets)
-    packages = {}
-    for index, (package, target) in enumerate(targets, start=1):
-        print(f"PUBLIC_API_SNAPSHOT_PACKAGE {index}/{len(targets)} {package}", flush=True)
-        packages[package] = snapshot_package(package, target, refresh=refresh)
+        validate_existing_artifacts(profiles)
+    profile_snapshots: dict[str, dict[str, Any]] = {}
+    for index, profile in enumerate(profiles, start=1):
+        print(
+            f"PUBLIC_API_SNAPSHOT_PROFILE {index}/{len(profiles)} {profile['id']}",
+            flush=True,
+        )
+        profile_snapshots[profile["id"]] = snapshot_profile(profile, refresh=refresh)
+
+    packages: dict[str, dict[str, Any]] = {}
+    for package, target in targets:
+        packages[package] = {
+            "target": target,
+            "profile_ids": sorted(
+                profile_id
+                for profile_id, profile in profile_snapshots.items()
+                if profile["package"] == package
+            ),
+        }
     intent = json.loads(PUBLIC_API_INTENT.read_text(encoding="utf-8"))
     intent_counts = {
         package: {
@@ -242,70 +580,385 @@ def generate_snapshot(*, refresh: bool = True, scope: str = "core-release") -> d
             for category in ("stable", "experimental", "compat")
         }
         for package, spec in intent["crates"].items()
+        if package in packages
     }
+    freeze_policy = load_freeze_policy(freeze_policy_path)
     return {
         "schema_version": SCHEMA_VERSION,
+        "identity": IDENTITY,
         "scope": scope,
-        "feature_profile": "default",
+        "freeze": freeze_policy["freeze"],
         "toolchain": toolchain(),
         "packages": packages,
+        "profiles": profile_snapshots,
         "public_api_intent": intent_counts,
+        "compatibility_decisions": freeze_policy["compatibility_decisions"],
+        "frozen_contracts": freeze_policy["frozen_contracts"],
     }
+
+
+def _require_non_empty_string(value: Any, label: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise SnapshotError(f"{label} must be non-empty")
+
+
+def _validate_decisions(value: Any) -> None:
+    if not isinstance(value, list):
+        raise SnapshotError("compatibility_decisions must be a list")
+    ids: set[str] = set()
+    for index, decision in enumerate(value):
+        if not isinstance(decision, dict):
+            raise SnapshotError(f"compatibility_decisions[{index}] must be an object")
+        for field in ("id", "classification", "applies_to", "reason"):
+            _require_non_empty_string(decision.get(field), f"compatibility_decisions[{index}].{field}")
+        decision_id = decision["id"]
+        if decision_id in ids:
+            raise SnapshotError(f"duplicate compatibility decision: {decision_id}")
+        ids.add(decision_id)
+        classification = decision["classification"]
+        if classification not in COMPATIBILITY_CLASSIFICATIONS:
+            raise SnapshotError(
+                f"compatibility_decisions[{index}].classification is invalid: {classification}"
+            )
+        if classification in BREAKING_CLASSIFICATIONS:
+            _require_non_empty_string(
+                decision.get("approved_by"),
+                f"compatibility_decisions[{index}].approved_by",
+            )
+            _require_non_empty_string(
+                decision.get("approved_on"),
+                f"compatibility_decisions[{index}].approved_on",
+            )
+        if decision["applies_to"] == "post-freeze":
+            for field in ("profile_id", "package", "item_path", "change", "replacement"):
+                _require_non_empty_string(
+                    decision.get(field),
+                    f"compatibility_decisions[{index}].{field}",
+                )
+
+
+def _validate_profiles(baseline: dict[str, Any]) -> None:
+    packages = baseline.get("packages")
+    profiles = baseline.get("profiles")
+    if not isinstance(packages, dict) or not packages:
+        raise SnapshotError("packages must be a non-empty object")
+    if not isinstance(profiles, dict) or not profiles:
+        raise SnapshotError("profiles must be a non-empty object")
+    referenced: set[str] = set()
+    for package, package_record in packages.items():
+        if not isinstance(package_record, dict):
+            raise SnapshotError(f"packages.{package} must be an object")
+        _require_non_empty_string(package_record.get("target"), f"packages.{package}.target")
+        profile_ids = package_record.get("profile_ids")
+        if not isinstance(profile_ids, list) or not profile_ids:
+            raise SnapshotError(f"packages.{package}.profile_ids must be non-empty")
+        if f"{package}:default" not in profile_ids:
+            raise SnapshotError(f"packages.{package} is missing its default profile")
+        for profile_id in profile_ids:
+            _require_non_empty_string(profile_id, f"packages.{package}.profile_ids entry")
+            if profile_id in referenced:
+                raise SnapshotError(f"profile is referenced more than once: {profile_id}")
+            referenced.add(profile_id)
+            profile = profiles.get(profile_id)
+            if not isinstance(profile, dict):
+                raise SnapshotError(f"missing profile record: {profile_id}")
+            if profile.get("package") != package:
+                raise SnapshotError(f"profile {profile_id} package does not match {package}")
+            for field in PROFILE_SPEC_FIELDS:
+                if field not in profile:
+                    raise SnapshotError(f"profile {profile_id} missing {field}")
+            api = profile.get("public_api")
+            if not isinstance(api, list) or not api:
+                raise SnapshotError(f"profile {profile_id} public_api must be non-empty")
+            item_paths: set[str] = set()
+            for item_index, item in enumerate(api):
+                if not isinstance(item, dict) or set(item) != set(STRUCTURAL_ITEM_FIELDS):
+                    raise SnapshotError(
+                        f"profile {profile_id} public_api[{item_index}] must contain the structural fields"
+                    )
+                for field in STRUCTURAL_ITEM_FIELDS:
+                    if not isinstance(item[field], str):
+                        raise SnapshotError(
+                            f"profile {profile_id} public_api[{item_index}].{field} must be a string"
+                        )
+                if item["package"] != package:
+                    raise SnapshotError(f"profile {profile_id} contains another package's item")
+                if item["item_path"] in item_paths:
+                    raise SnapshotError(
+                        f"profile {profile_id} has duplicate item path: {item['item_path']}"
+                    )
+                item_paths.add(item["item_path"])
+    if referenced != set(profiles):
+        extras = sorted(set(profiles) - referenced)
+        raise SnapshotError(f"unreferenced profiles: {', '.join(extras)}")
+
+
+def _validate_frozen_contracts(baseline: dict[str, Any]) -> None:
+    contracts = baseline.get("frozen_contracts")
+    if not isinstance(contracts, list):
+        raise SnapshotError("frozen_contracts must be a list")
+    capabilities = [contract.get("capability_id") for contract in contracts if isinstance(contract, dict)]
+    if set(capabilities) != REQUIRED_FROZEN_CAPABILITIES or len(capabilities) != len(REQUIRED_FROZEN_CAPABILITIES):
+        raise SnapshotError("frozen_contracts must contain exactly F-13, F-15, and F-18")
+    profiles = baseline["profiles"]
+    for index, contract in enumerate(contracts):
+        for field in ("capability_id", "profile_id", "package", "behavior"):
+            _require_non_empty_string(contract.get(field), f"frozen_contracts[{index}].{field}")
+        evidence = contract.get("evidence")
+        if not isinstance(evidence, list) or not evidence:
+            raise SnapshotError(f"frozen_contracts[{index}].evidence must be non-empty")
+        profile = profiles.get(contract["profile_id"])
+        if not isinstance(profile, dict) or profile.get("package") != contract["package"]:
+            raise SnapshotError(f"frozen_contracts[{index}] references an invalid profile")
+        item_paths = contract.get("item_paths")
+        if not isinstance(item_paths, list) or not item_paths:
+            raise SnapshotError(f"frozen_contracts[{index}].item_paths must be non-empty")
+        available = {item["item_path"] for item in profile["public_api"]}
+        missing = sorted(set(item_paths) - available)
+        if missing:
+            raise SnapshotError(
+                f"frozen_contracts[{index}] item paths are absent from {contract['profile_id']}: {', '.join(missing)}"
+            )
+
+
+def validate_baseline_contract(baseline: dict[str, Any]) -> None:
+    if baseline.get("schema_version") != SCHEMA_VERSION:
+        raise SnapshotError(f"baseline schema_version must be {SCHEMA_VERSION}")
+    if baseline.get("identity") != IDENTITY:
+        raise SnapshotError(f"baseline identity must be {IDENTITY}")
+    if baseline.get("scope") != "core-release":
+        raise SnapshotError("baseline scope must be core-release")
+    freeze = baseline.get("freeze")
+    if not isinstance(freeze, dict):
+        raise SnapshotError("freeze must be an object")
+    if freeze.get("version") != "1.0.0-rc.1":
+        raise SnapshotError("freeze.version must be 1.0.0-rc.1")
+    if freeze.get("breaking_change_policy") != "approval-required-after-freeze":
+        raise SnapshotError("freeze.breaking_change_policy must require approval after freeze")
+    _validate_profiles(baseline)
+    _validate_decisions(baseline.get("compatibility_decisions"))
+    _validate_frozen_contracts(baseline)
+
+
+def _approval_for(
+    baseline: dict[str, Any],
+    *,
+    profile_id: str,
+    package: str,
+    item_path: str,
+    change: str,
+) -> dict[str, Any] | None:
+    for decision in baseline.get("compatibility_decisions", []):
+        if (
+            decision.get("applies_to") == "post-freeze"
+            and decision.get("profile_id") == profile_id
+            and decision.get("package") == package
+            and decision.get("item_path") == item_path
+            and decision.get("change") in {change, "any"}
+            and decision.get("classification") == "approved-break"
+            and isinstance(decision.get("approved_by"), str)
+            and decision["approved_by"].strip()
+        ):
+            return decision
+    return None
+
+
+def _breaking_difference(
+    baseline: dict[str, Any],
+    difference: dict[str, Any],
+    *,
+    profile_id: str = "",
+    package: str = "",
+    item_path: str = "",
+    change: str,
+) -> dict[str, Any]:
+    approval = _approval_for(
+        baseline,
+        profile_id=profile_id,
+        package=package,
+        item_path=item_path,
+        change=change,
+    )
+    difference.update(
+        {
+            "classification": "approved-break" if approval else "breaking",
+            "allowed": approval is not None,
+        }
+    )
+    if approval:
+        difference["decision_id"] = approval["id"]
+    return difference
+
+
+def _profile_items(profile: dict[str, Any]) -> dict[str, dict[str, str]]:
+    return {item["item_path"]: item for item in profile.get("public_api", [])}
 
 
 def compare_snapshots(baseline: dict[str, Any], candidate: dict[str, Any]) -> list[dict[str, Any]]:
     differences: list[dict[str, Any]] = []
-    if baseline.get("schema_version") != SCHEMA_VERSION:
-        differences.append({"kind": "schema", "expected": SCHEMA_VERSION, "actual": baseline.get("schema_version")})
-    if baseline.get("feature_profile") != candidate.get("feature_profile"):
-        differences.append(
-            {
-                "kind": "feature-profile",
-                "expected": baseline.get("feature_profile"),
-                "actual": candidate.get("feature_profile"),
-            }
-        )
-    if baseline.get("toolchain") != candidate.get("toolchain"):
-        differences.append(
-            {"kind": "toolchain", "expected": baseline.get("toolchain"), "actual": candidate.get("toolchain")}
-        )
+    for field, expected in (
+        ("schema_version", SCHEMA_VERSION),
+        ("identity", IDENTITY),
+        ("scope", "core-release"),
+    ):
+        if baseline.get(field) != expected:
+            differences.append(
+                {
+                    "kind": field,
+                    "expected": expected,
+                    "actual": baseline.get(field),
+                    "classification": "breaking",
+                    "allowed": False,
+                }
+            )
+        elif candidate.get(field) != baseline.get(field):
+            differences.append(
+                {
+                    "kind": field,
+                    "expected": baseline.get(field),
+                    "actual": candidate.get(field),
+                    "classification": "breaking",
+                    "allowed": False,
+                }
+            )
+    for field in ("freeze", "compatibility_decisions", "frozen_contracts"):
+        if baseline.get(field) != candidate.get(field):
+            differences.append(
+                {
+                    "kind": f"{field}-changed",
+                    "classification": "breaking",
+                    "allowed": False,
+                }
+            )
 
     baseline_packages = baseline.get("packages", {})
     candidate_packages = candidate.get("packages", {})
-    for package in sorted(set(baseline_packages) | set(candidate_packages)):
-        before = baseline_packages.get(package)
-        after = candidate_packages.get(package)
+    removed_packages = set(baseline_packages) - set(candidate_packages)
+    added_packages = set(candidate_packages) - set(baseline_packages)
+    for package in sorted(removed_packages):
+        differences.append(
+            _breaking_difference(
+                baseline,
+                {"kind": "package-removed", "package": package},
+                package=package,
+                change="package-removed",
+            )
+        )
+    for package in sorted(added_packages):
+        differences.append(
+            {
+                "kind": "package-added",
+                "package": package,
+                "classification": "compatible-addition",
+                "allowed": True,
+            }
+        )
+
+    baseline_profiles = baseline.get("profiles", {})
+    candidate_profiles = candidate.get("profiles", {})
+    for profile_id in sorted(set(baseline_profiles) | set(candidate_profiles)):
+        before = baseline_profiles.get(profile_id)
+        after = candidate_profiles.get(profile_id)
         if before is None:
-            differences.append({"kind": "package-added", "package": package, "classification": "unclassified"})
-        elif after is None:
-            differences.append({"kind": "package-removed", "package": package, "classification": "breaking"})
-        else:
-            before_items = {
-                tuple(item[field] for field in ("package", "module", "item_path", "kind", "visibility", "signature", "feature"))
-                for item in before.get("public_api", [])
-            }
-            after_items = {
-                tuple(item[field] for field in ("package", "module", "item_path", "kind", "visibility", "signature", "feature"))
-                for item in after.get("public_api", [])
-            }
-            for identity in sorted(before_items - after_items):
-                differences.append(
+            differences.append(
+                {
+                    "kind": "profile-added",
+                    "profile_id": profile_id,
+                    "classification": "compatible-addition",
+                    "allowed": True,
+                }
+            )
+            continue
+        if after is None:
+            if before.get("package") in removed_packages:
+                continue
+            differences.append(
+                _breaking_difference(
+                    baseline,
+                    {
+                        "kind": "profile-removed",
+                        "profile_id": profile_id,
+                        "package": before.get("package"),
+                    },
+                    profile_id=profile_id,
+                    package=str(before.get("package", "")),
+                    change="profile-removed",
+                )
+            )
+            continue
+        spec_changes = [field for field in PROFILE_SPEC_FIELDS if before.get(field) != after.get(field)]
+        if spec_changes:
+            differences.append(
+                _breaking_difference(
+                    baseline,
+                    {
+                        "kind": "profile-changed",
+                        "profile_id": profile_id,
+                        "package": before.get("package"),
+                        "changed_fields": spec_changes,
+                    },
+                    profile_id=profile_id,
+                    package=str(before.get("package", "")),
+                    change="profile-spec",
+                )
+            )
+        before_items = _profile_items(before)
+        after_items = _profile_items(after)
+        package = str(before.get("package", ""))
+        for item_path in sorted(set(before_items) - set(after_items)):
+            differences.append(
+                _breaking_difference(
+                    baseline,
                     {
                         "kind": "item-removed",
+                        "profile_id": profile_id,
                         "package": package,
-                        "classification": "breaking",
-                        "item": dict(zip(("package", "module", "item_path", "kind", "visibility", "signature", "feature"), identity, strict=True)),
-                    }
+                        "item": before_items[item_path],
+                    },
+                    profile_id=profile_id,
+                    package=package,
+                    item_path=item_path,
+                    change="removed",
                 )
-            for identity in sorted(after_items - before_items):
-                differences.append(
+            )
+        for item_path in sorted(set(after_items) - set(before_items)):
+            differences.append(
+                {
+                    "kind": "item-added",
+                    "profile_id": profile_id,
+                    "package": package,
+                    "item": after_items[item_path],
+                    "classification": "compatible-addition",
+                    "allowed": True,
+                }
+            )
+        for item_path in sorted(set(before_items) & set(after_items)):
+            changed_fields = [
+                field
+                for field in STRUCTURAL_ITEM_FIELDS
+                if before_items[item_path][field] != after_items[item_path][field]
+            ]
+            if not changed_fields:
+                continue
+            change = changed_fields[0] if len(changed_fields) == 1 else "structural"
+            differences.append(
+                _breaking_difference(
+                    baseline,
                     {
-                        "kind": "item-added",
+                        "kind": "item-changed",
+                        "profile_id": profile_id,
                         "package": package,
-                        "classification": "additive",
-                        "item": dict(zip(("package", "module", "item_path", "kind", "visibility", "signature", "feature"), identity, strict=True)),
-                    }
+                        "item_path": item_path,
+                        "changed_fields": changed_fields,
+                        "before": before_items[item_path],
+                        "after": after_items[item_path],
+                    },
+                    profile_id=profile_id,
+                    package=package,
+                    item_path=item_path,
+                    change=change,
                 )
+            )
     return differences
 
 
@@ -324,15 +977,13 @@ def parse_args() -> argparse.Namespace:
     mode.add_argument("--write-baseline", type=Path)
     mode.add_argument("--check", type=Path)
     parser.add_argument("--output", type=Path)
-    parser.add_argument(
-        "--scope",
-        choices=("core-release",),
-        default="core-release",
-    )
+    parser.add_argument("--scope", choices=("core-release",), default="core-release")
+    parser.add_argument("--identity", choices=(IDENTITY,), default=IDENTITY)
+    parser.add_argument("--freeze-policy", type=Path, default=DEFAULT_FREEZE_POLICY)
     parser.add_argument(
         "--from-existing",
         action="store_true",
-        help="assemble the snapshot from rustdoc JSON already refreshed for this source commit",
+        help="assemble from per-profile rustdoc JSON cached after the current HEAD",
     )
     return parser.parse_args()
 
@@ -340,30 +991,45 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     try:
-        candidate = generate_snapshot(refresh=not args.from_existing, scope=args.scope)
+        baseline: dict[str, Any] | None = None
+        if args.check:
+            baseline = json.loads(args.check.read_text(encoding="utf-8"))
+            validate_baseline_contract(baseline)
+        candidate = generate_snapshot(
+            refresh=not args.from_existing,
+            scope=args.scope,
+            freeze_policy_path=args.freeze_policy.resolve(),
+        )
+        validate_baseline_contract(candidate)
         if args.write_baseline:
             write_json(args.write_baseline, candidate)
             print(
                 f"PUBLIC_API_BASELINE_WRITTEN packages={len(candidate['packages'])} "
-                f"path={args.write_baseline.as_posix()}"
+                f"profiles={len(candidate['profiles'])} path={args.write_baseline.as_posix()}"
             )
             return 0
 
-        baseline = json.loads(args.check.read_text(encoding="utf-8"))
+        assert baseline is not None
         differences = compare_snapshots(baseline, candidate)
+        incompatible = [difference for difference in differences if not difference.get("allowed", False)]
         report = {
             "schema_version": SCHEMA_VERSION,
+            "identity": args.identity,
             "scope": args.scope,
             "packages": len(candidate["packages"]),
+            "profiles": len(candidate["profiles"]),
             "differences": differences,
-            "status": "compatible" if not differences else "review-required",
+            "status": "compatible" if not incompatible else "review-required",
         }
         if args.output:
             write_json(args.output, report)
-        if differences:
+        if incompatible:
             print(json.dumps(report, indent=2, sort_keys=True))
             return 1
-        print(f"PUBLIC_API_SNAPSHOT_OK packages={len(candidate['packages'])} differences=0")
+        print(
+            f"PUBLIC_API_SNAPSHOT_OK packages={len(candidate['packages'])} "
+            f"profiles={len(candidate['profiles'])} differences={len(differences)}"
+        )
         return 0
     except (OSError, json.JSONDecodeError, SnapshotError) as error:
         print(f"PUBLIC_API_SNAPSHOT_FAILED {error}", file=sys.stderr)

--- a/scripts/stable_surface_guard.py
+++ b/scripts/stable_surface_guard.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Freeze the remaining Rust nightly feature surface until stable closeout."""
+"""Freeze nightly debt and the core-release structural public API contract."""
 
 from __future__ import annotations
 
@@ -27,10 +27,12 @@ from pathlib import Path
 from typing import Any
 
 import core_release_scope
+import public_api_snapshot
 
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_POLICY = ROOT / "scripts" / "stable-surface-policy.json"
+DEFAULT_API_BASELINE = ROOT / "scripts" / "public-api-snapshot-baseline.json"
 FEATURE_ATTRIBUTE_RE = re.compile(r"#!\s*\[\s*feature\s*\((?P<body>.*?)\)\s*\]", re.DOTALL)
 FEATURE_START_RE = re.compile(r"#!\s*\[\s*feature\b")
 FEATURE_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
@@ -133,7 +135,14 @@ def scan_features(root: Path, *, scope: str = "all") -> set[NightlyFeature]:
     return findings
 
 
-def validate(root: Path, policy_path: Path, mode: str, *, scope: str = "all") -> str:
+def validate(
+    root: Path,
+    policy_path: Path,
+    mode: str,
+    *,
+    scope: str = "all",
+    api_baseline: Path | None = None,
+) -> str:
     if not root.is_dir():
         raise InputError(f"root does not exist: {root}")
     policy = load_policy(policy_path)
@@ -158,13 +167,25 @@ def validate(root: Path, policy_path: Path, mode: str, *, scope: str = "all") ->
     if mode == "target" and actual:
         rendered = ", ".join(entry.render() for entry in sorted(actual))
         raise InputError(f"stable target still has nightly features: {rendered}")
-    return f"STABLE_SURFACE_GUARD_OK mode={mode} features={len(actual)} scope={scope}"
+    api_status = "not-requested"
+    if api_baseline is not None:
+        try:
+            baseline = json.loads(api_baseline.read_text(encoding="utf-8"))
+            public_api_snapshot.validate_baseline_contract(baseline)
+        except (OSError, json.JSONDecodeError, public_api_snapshot.SnapshotError) as error:
+            raise InputError(f"invalid public API freeze: {error}") from error
+        api_status = "verified"
+    return (
+        f"STABLE_SURFACE_GUARD_OK mode={mode} features={len(actual)} "
+        f"scope={scope} api_freeze={api_status}"
+    )
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", type=Path, default=ROOT)
     parser.add_argument("--policy", type=Path, default=DEFAULT_POLICY)
+    parser.add_argument("--api-baseline", type=Path)
     parser.add_argument("--mode", choices=("baseline", "target"), default="baseline")
     parser.add_argument(
         "--scope",
@@ -176,12 +197,16 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
+    api_baseline = args.api_baseline
+    if api_baseline is None and args.mode == "target" and args.scope == "core-release":
+        api_baseline = DEFAULT_API_BASELINE
     try:
         message = validate(
             args.root.resolve(),
             args.policy.resolve(),
             args.mode,
             scope=args.scope,
+            api_baseline=api_baseline.resolve() if api_baseline is not None else None,
         )
     except InputError as error:
         print(f"STABLE_SURFACE_GUARD_ERROR: {error}", file=sys.stderr)

--- a/scripts/tests/test_core_release_static_guard.py
+++ b/scripts/tests/test_core_release_static_guard.py
@@ -47,9 +47,10 @@ class CoreReleaseStaticGuardTests(unittest.TestCase):
             self.assertIn("core-release", command)
         self.assertEqual("structural", commands["architecture-dependency"][commands["architecture-dependency"].index("--mode") + 1])
         self.assertEqual("semantic", commands["architecture-documentation"][commands["architecture-documentation"].index("--mode") + 1])
+        self.assertEqual("target", commands["stable-surface"][commands["stable-surface"].index("--mode") + 1])
         self.assertEqual("structural", commands["architecture-release"][commands["architecture-release"].index("--mode") + 1])
         serialized = " ".join(argument for command in commands.values() for argument in command).lower()
-        for forbidden in ("sha256", "fingerprint", "--mode baseline", "--mode transition", "--mode target"):
+        for forbidden in ("sha256", "fingerprint", "--mode baseline", "--mode transition"):
             self.assertNotIn(forbidden, serialized)
 
     def test_run_routes_records_every_result_and_returns_failure(self) -> None:

--- a/scripts/tests/test_m09_public_api_compatibility.py
+++ b/scripts/tests/test_m09_public_api_compatibility.py
@@ -24,14 +24,6 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 BASELINE = ROOT / "scripts" / "public-api-snapshot-baseline.json"
-EVIDENCE = (
-    ROOT
-    / "rocketmq-doc"
-    / "en"
-    / "architecture-public-api-compatibility.md"
-)
-
-
 def load_module(name: str, relative: str):
     spec = importlib.util.spec_from_file_location(name, ROOT / relative)
     if spec is None or spec.loader is None:
@@ -55,35 +47,86 @@ class PublicApiCompatibilityTests(unittest.TestCase):
         baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
         targets = PUBLIC_API.workspace_library_targets()
 
-        self.assertEqual(1, baseline["schema_version"])
-        self.assertEqual("default", baseline["feature_profile"])
+        self.assertEqual(3, baseline["schema_version"])
+        self.assertEqual("structural", baseline["identity"])
+        self.assertEqual("core-release", baseline["scope"])
         self.assertGreater(len(targets), 0)
         self.assertEqual({package for package, _ in targets}, set(baseline["packages"]))
-        self.assertEqual(40, len(baseline["source_commit"]))
-        for package in baseline["packages"].values():
-            self.assertGreater(package["public_path_count"], 0)
-            self.assertEqual(64, len(package["public_path_sha256"]))
-            self.assertEqual(64, len(package["rustdoc_json_sha256"]))
+        def keys(value):
+            if isinstance(value, dict):
+                for key, item in value.items():
+                    yield key.lower()
+                    yield from keys(item)
+            elif isinstance(value, list):
+                for item in value:
+                    yield from keys(item)
+
+        baseline_keys = set(keys(baseline))
+        self.assertFalse(any("sha" in key for key in baseline_keys))
+        self.assertFalse(any("digest" in key for key in baseline_keys))
+        self.assertFalse(any("fingerprint" in key for key in baseline_keys))
+        for package_name, package in baseline["packages"].items():
+            self.assertIn(f"{package_name}:default", package["profile_ids"])
+            for profile_id in package["profile_ids"]:
+                profile = baseline["profiles"][profile_id]
+                self.assertEqual(package_name, profile["package"])
+                self.assertGreater(len(profile["public_api"]), 0)
+                for item in profile["public_api"]:
+                    self.assertEqual(
+                        {"package", "module", "item_path", "kind", "visibility", "signature", "feature"},
+                        set(item),
+                    )
+
+        expected_matrix_profiles = {entry.id for entry in MATRIX.MATRIX if entry.group == "feature"}
+        actual_matrix_profiles = {
+            matrix_id
+            for profile in baseline["profiles"].values()
+            for matrix_id in profile["matrix_ids"]
+        }
+        self.assertEqual(expected_matrix_profiles, actual_matrix_profiles)
 
     def test_snapshot_diff_requires_classification_and_marks_removal_breaking(self) -> None:
-        package = {
+        item = {
+            "package": "demo",
+            "module": "demo",
+            "item_path": "demo::Api",
+            "kind": "struct",
+            "visibility": "public",
+            "signature": "{}",
+            "feature": "default",
+        }
+        profile = {
+            "package": "demo",
             "target": "demo",
+            "default_features": True,
+            "all_features": False,
+            "features": [],
+            "declared_default_features": [],
+            "source": "workspace-default",
+            "matrix_ids": [],
             "crate_version": "1.0.0",
-            "public_path_count": 1,
-            "public_path_sha256": "a",
-            "rustdoc_json_sha256": "b",
+            "public_api": [item],
         }
         baseline = {
-            "schema_version": 1,
-            "feature_profile": "default",
+            "schema_version": 3,
+            "identity": "structural",
+            "scope": "core-release",
+            "freeze": {
+                "version": "1.0.0-rc.1",
+                "breaking_change_policy": "approval-required-after-freeze",
+            },
             "toolchain": {"rustc": "same"},
-            "packages": {"demo": package},
+            "packages": {"demo": {"target": "demo", "profile_ids": ["demo:default"]}},
+            "profiles": {"demo:default": profile},
+            "compatibility_decisions": [],
+            "frozen_contracts": [],
         }
 
         self.assertEqual([], PUBLIC_API.compare_snapshots(baseline, baseline))
-        changed = {**baseline, "packages": {"demo": {**package, "public_path_count": 2}}}
-        self.assertEqual("unclassified", PUBLIC_API.compare_snapshots(baseline, changed)[0]["classification"])
-        removed = {**baseline, "packages": {}}
+        changed = json.loads(json.dumps(baseline))
+        changed["profiles"]["demo:default"]["public_api"][0]["signature"] = "changed"
+        self.assertEqual("breaking", PUBLIC_API.compare_snapshots(baseline, changed)[0]["classification"])
+        removed = {**baseline, "packages": {}, "profiles": {}}
         self.assertEqual("breaking", PUBLIC_API.compare_snapshots(baseline, removed)[0]["classification"])
 
     def test_current_feature_boundaries_are_exact(self) -> None:
@@ -93,7 +136,7 @@ class PublicApiCompatibilityTests(unittest.TestCase):
         proxy = manifest("rocketmq-proxy")["features"]
 
         self.assertEqual([], protocol["default"])
-        self.assertEqual(["tls"], transport["default"])
+        self.assertEqual(["tls", "socks"], transport["default"])
         self.assertEqual([], admin["default"])
         self.assertEqual(["cluster-mode", "local-mode"], proxy["default"])
         self.assertEqual(
@@ -108,6 +151,7 @@ class PublicApiCompatibilityTests(unittest.TestCase):
                 "otlp-traces",
                 "otlp-logs",
                 "tieredstore",
+                "tls",
             },
             set(proxy),
         )
@@ -177,32 +221,21 @@ class PublicApiCompatibilityTests(unittest.TestCase):
         self.assertIn("<java-root>", route.command)
         self.assertNotIn("D:\\", route.command)
 
-    def test_evidence_records_current_snapshot_and_approved_breaking_cleanup(self) -> None:
-        evidence = EVIDENCE.read_text(encoding="utf-8")
+    def test_freeze_contracts_and_migration_decisions_are_machine_readable(self) -> None:
+        baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
 
-        targets = PUBLIC_API.workspace_library_targets()
-
-        self.assertIn(f"library_targets={len(targets)}", evidence)
-        self.assertIn("differences=0", evidence)
-        self.assertIn("40/40", evidence)
-        self.assertIn("feature=24/24", evidence)
-        self.assertIn("wire=6/6", evidence)
-        self.assertIn("storage=10/10", evidence)
-        self.assertIn("additive groups: 4", evidence)
-        self.assertIn("deprecated: 0", evidence)
-        self.assertIn("breaking groups: 4", evidence)
-        self.assertIn("scoped Client capabilities", evidence)
-        self.assertIn("versioned Runtime diagnostics", evidence)
-        self.assertIn("authorized Transport dispatch capabilities", evidence)
-        self.assertIn("non-default `test-support`", evidence)
-        self.assertIn("Client compatibility facade", evidence)
-        self.assertIn("Store `bench_support`", evidence)
-        self.assertIn("ClientRuntime::new", evidence)
-        self.assertIn("ClusterConfig", evidence)
-        self.assertIn("Dashboard admin operations", evidence)
-        self.assertIn("MappedBuffer::read_zero_copy", evidence)
-        self.assertIn("MappedBuffer::read_copy", evidence)
-        self.assertIn("repository owner explicitly approved", evidence)
+        self.assertEqual(
+            {"F-13", "F-15", "F-18"},
+            {contract["capability_id"] for contract in baseline["frozen_contracts"]},
+        )
+        self.assertEqual(
+            {"compatible-addition", "approved-break", "renamed-wrapper", "removed-placeholder"},
+            {decision["classification"] for decision in baseline["compatibility_decisions"]},
+        )
+        for decision in baseline["compatibility_decisions"]:
+            if decision["classification"] != "compatible-addition":
+                self.assertTrue(decision["approved_by"])
+                self.assertTrue(decision["approved_on"])
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_public_api_snapshot.py
+++ b/scripts/tests/test_public_api_snapshot.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import copy
 import json
+from types import SimpleNamespace
 import unittest
 
 from scripts import public_api_snapshot as snapshot
@@ -40,15 +41,90 @@ def rustdoc_fixture(item_id: str = "17") -> dict[str, object]:
                 "attrs": ["#[cfg(feature = \"message-view\")]"],
                 "inner": {
                     "struct": {
-                        "kind": "plain",
+                        "kind": {
+                            "plain": {
+                                "fields": ["41", "42"],
+                                "has_stripped_fields": False,
+                            }
+                        },
                         "generics": {"params": [], "where_predicates": []},
-                        "fields": ["41", "42"],
                         "impls": ["99"],
                     }
                 },
             }
         },
     }
+
+
+def rustdoc_associated_fixture(
+    *,
+    root_id: str = "17",
+    field_id: str = "41",
+    impl_id: str = "99",
+    method_id: str = "77",
+    field_type: str = "u64",
+) -> dict[str, object]:
+    document = rustdoc_fixture(root_id)
+    root = document["index"][root_id]
+    root["inner"]["struct"]["kind"]["plain"]["fields"] = [field_id]
+    root["inner"]["struct"]["impls"] = [impl_id]
+    document["index"].update(
+        {
+            field_id: {
+                "id": field_id,
+                "crate_id": 0,
+                "name": "value",
+                "visibility": "public",
+                "attrs": [],
+                "inner": {"struct_field": {"primitive": field_type}},
+            },
+            impl_id: {
+                "id": impl_id,
+                "crate_id": 0,
+                "name": None,
+                "visibility": "default",
+                "attrs": [],
+                "inner": {
+                    "impl": {
+                        "is_unsafe": False,
+                        "generics": {"params": [], "where_predicates": []},
+                        "provided_trait_methods": [],
+                        "trait": None,
+                        "for": {"resolved_path": {"path": "MessageView", "id": root_id}},
+                        "items": [method_id],
+                        "is_negative": False,
+                        "is_synthetic": False,
+                        "blanket_impl": None,
+                    }
+                },
+            },
+            method_id: {
+                "id": method_id,
+                "crate_id": 0,
+                "name": "build",
+                "visibility": "public",
+                "attrs": [],
+                "inner": {
+                    "function": {
+                        "sig": {
+                            "inputs": [],
+                            "output": {"resolved_path": {"path": "MessageView", "id": root_id}},
+                            "is_c_variadic": False,
+                        },
+                        "generics": {"params": [], "where_predicates": []},
+                        "header": {
+                            "is_const": False,
+                            "is_unsafe": False,
+                            "is_async": False,
+                            "abi": "Rust",
+                        },
+                        "has_body": True,
+                    }
+                },
+            },
+        }
+    )
+    return document
 
 
 class PublicApiSnapshotTests(unittest.TestCase):
@@ -77,35 +153,235 @@ class PublicApiSnapshotTests(unittest.TestCase):
         self.assertNotIn("fingerprint", json.dumps(record).lower())
 
     def test_rustdoc_internal_ids_do_not_change_semantic_snapshot(self) -> None:
-        first = snapshot.semantic_public_items("rocketmq-model", rustdoc_fixture("17"))
-        second_document = rustdoc_fixture("200")
-        second_document["index"]["200"]["inner"]["struct"]["fields"] = ["501", "502"]
-        second_document["index"]["200"]["inner"]["struct"]["impls"] = ["777"]
-        second = snapshot.semantic_public_items("rocketmq-model", second_document)
+        first = snapshot.semantic_public_items("rocketmq-model", rustdoc_associated_fixture())
+        second = snapshot.semantic_public_items(
+            "rocketmq-model",
+            rustdoc_associated_fixture(
+                root_id="200",
+                field_id="501",
+                impl_id="777",
+                method_id="888",
+            ),
+        )
 
         self.assertEqual(first, second)
 
+    def test_public_fields_and_inherent_methods_are_structural_records(self) -> None:
+        records = snapshot.semantic_public_items("rocketmq-model", rustdoc_associated_fixture())
+
+        self.assertEqual(
+            [
+                "rocketmq_model::message::MessageView",
+                "rocketmq_model::message::MessageView::build",
+                "rocketmq_model::message::MessageView::value",
+            ],
+            [record["item_path"] for record in records],
+        )
+        by_path = {record["item_path"]: record for record in records}
+        self.assertIn('"primitive":"u64"', by_path["rocketmq_model::message::MessageView::value"]["signature"])
+        self.assertNotIn('"implementations"', by_path["rocketmq_model::message::MessageView"]["signature"])
+
+    def test_public_field_type_change_is_a_breaking_signature_change(self) -> None:
+        baseline = self.structural_snapshot(rustdoc_associated_fixture())
+        candidate = self.structural_snapshot(rustdoc_associated_fixture(field_type="u32"))
+
+        differences = snapshot.compare_snapshots(baseline, candidate)
+
+        self.assertEqual(1, len(differences))
+        self.assertEqual("item-changed", differences[0]["kind"])
+        self.assertEqual(
+            "rocketmq_model::message::MessageView::value",
+            differences[0]["item_path"],
+        )
+        self.assertEqual(["signature"], differences[0]["changed_fields"])
+        self.assertFalse(differences[0]["allowed"])
+
     def test_removed_semantic_item_is_reported_as_breaking(self) -> None:
-        baseline = {
-            "schema_version": 2,
-            "feature_profile": "default",
-            "toolchain": {"rustc": "x", "rustdoc": "x", "cargo": "x"},
-            "packages": {
-                "rocketmq-model": {
-                    "target": "rocketmq_model",
-                    "crate_version": "1.0.0",
-                    "public_api": snapshot.semantic_public_items("rocketmq-model", rustdoc_fixture()),
-                }
-            },
-            "public_api_intent": {},
-        }
+        baseline = self.structural_snapshot()
         candidate = copy.deepcopy(baseline)
-        candidate["packages"]["rocketmq-model"]["public_api"] = []
+        candidate["profiles"]["rocketmq-model:default"]["public_api"] = []
 
         differences = snapshot.compare_snapshots(baseline, candidate)
 
         self.assertEqual("item-removed", differences[0]["kind"])
         self.assertEqual("breaking", differences[0]["classification"])
+        self.assertFalse(differences[0]["allowed"])
+
+    def test_signature_change_is_one_breaking_change_not_remove_plus_add(self) -> None:
+        baseline = self.structural_snapshot()
+        candidate = copy.deepcopy(baseline)
+        candidate["profiles"]["rocketmq-model:default"]["public_api"][0]["signature"] = "changed"
+
+        differences = snapshot.compare_snapshots(baseline, candidate)
+
+        self.assertEqual(1, len(differences))
+        self.assertEqual("item-changed", differences[0]["kind"])
+        self.assertEqual(["signature"], differences[0]["changed_fields"])
+        self.assertEqual("breaking", differences[0]["classification"])
+        self.assertFalse(differences[0]["allowed"])
+
+    def test_post_freeze_approval_allows_only_the_matching_break(self) -> None:
+        baseline = self.structural_snapshot()
+        baseline["compatibility_decisions"] = [
+            {
+                "id": "API-POST-001",
+                "classification": "approved-break",
+                "applies_to": "post-freeze",
+                "profile_id": "rocketmq-model:default",
+                "package": "rocketmq-model",
+                "item_path": "rocketmq_model::message::MessageView",
+                "change": "signature",
+                "replacement": "rocketmq_model::message::MessageViewV2",
+                "reason": "The replacement preserves the supported behavior.",
+                "approved_by": "release-approver",
+                "approved_on": "2026-08-16",
+            }
+        ]
+        candidate = copy.deepcopy(baseline)
+        candidate["profiles"]["rocketmq-model:default"]["public_api"][0]["signature"] = "changed"
+
+        differences = snapshot.compare_snapshots(baseline, candidate)
+
+        self.assertEqual(1, len(differences))
+        self.assertEqual("approved-break", differences[0]["classification"])
+        self.assertEqual("API-POST-001", differences[0]["decision_id"])
+        self.assertTrue(differences[0]["allowed"])
+
+    def test_addition_is_compatible_without_an_approval(self) -> None:
+        baseline = self.structural_snapshot()
+        candidate = copy.deepcopy(baseline)
+        added = copy.deepcopy(candidate["profiles"]["rocketmq-model:default"]["public_api"][0])
+        added["item_path"] = "rocketmq_model::message::NewMessageView"
+        candidate["profiles"]["rocketmq-model:default"]["public_api"].append(added)
+
+        differences = snapshot.compare_snapshots(baseline, candidate)
+
+        self.assertEqual(1, len(differences))
+        self.assertEqual("compatible-addition", differences[0]["classification"])
+        self.assertTrue(differences[0]["allowed"])
+
+    def test_feature_profiles_include_defaults_and_each_frozen_matrix_entry(self) -> None:
+        targets = [("demo", "demo")]
+        package_features = {
+            "demo": {
+                "default": ["tls"],
+                "tls": ["dep:tls"],
+                "trace": ["dep:trace"],
+            }
+        }
+        matrix = (
+            SimpleNamespace(
+                id="demo-no-default",
+                group="feature",
+                command=("cargo", "check", "-p", "demo", "--no-default-features"),
+            ),
+            SimpleNamespace(
+                id="demo-trace",
+                group="feature",
+                command=(
+                    "cargo",
+                    "check",
+                    "-p",
+                    "demo",
+                    "--no-default-features",
+                    "--features",
+                    "trace",
+                ),
+            ),
+            SimpleNamespace(
+                id="demo-all",
+                group="feature",
+                command=("cargo", "check", "-p", "demo", "--all-features"),
+            ),
+            SimpleNamespace(
+                id="ignored-wire",
+                group="wire",
+                command=("cargo", "test", "-p", "demo"),
+            ),
+        )
+
+        profiles = snapshot.derive_feature_profiles(targets, package_features, matrix)
+
+        self.assertEqual(
+            ["demo:default", "demo-all", "demo-no-default", "demo-trace"],
+            [profile["id"] for profile in profiles],
+        )
+        self.assertEqual(
+            {
+                "id": "demo:default",
+                "package": "demo",
+                "target": "demo",
+                "default_features": True,
+                "all_features": False,
+                "features": [],
+                "declared_default_features": ["tls"],
+                "source": "workspace-default",
+                "matrix_ids": [],
+            },
+            profiles[0],
+        )
+        self.assertEqual(["trace"], profiles[3]["features"])
+        self.assertFalse(profiles[3]["default_features"])
+        self.assertTrue(profiles[1]["all_features"])
+
+    def test_rustdoc_profile_command_uses_only_supported_cargo_rustdoc_flags(self) -> None:
+        profile = {
+            "id": "demo-trace",
+            "package": "demo",
+            "target": "demo",
+            "default_features": False,
+            "all_features": False,
+            "features": ["trace"],
+        }
+
+        command = snapshot._rustdoc_command(profile)
+
+        self.assertIn("--locked", command)
+        self.assertNotIn("--no-deps", command)
+        self.assertEqual(
+            ["--no-default-features", "--features", "trace"],
+            command[command.index("--lib") + 1 : command.index("--")],
+        )
+
+    @staticmethod
+    def structural_snapshot(document: dict[str, object] | None = None) -> dict[str, object]:
+        public_api = snapshot.semantic_public_items(
+            "rocketmq-model",
+            document or rustdoc_fixture(),
+        )
+        return {
+            "schema_version": 3,
+            "identity": "structural",
+            "scope": "core-release",
+            "freeze": {
+                "version": "1.0.0-rc.1",
+                "breaking_change_policy": "approval-required-after-freeze",
+            },
+            "toolchain": {"rustc": "x", "rustdoc": "x", "cargo": "x"},
+            "packages": {
+                "rocketmq-model": {
+                    "target": "rocketmq_model",
+                    "profile_ids": ["rocketmq-model:default"],
+                }
+            },
+            "profiles": {
+                "rocketmq-model:default": {
+                    "package": "rocketmq-model",
+                    "target": "rocketmq_model",
+                    "default_features": True,
+                    "all_features": False,
+                    "features": [],
+                    "declared_default_features": [],
+                    "source": "workspace-default",
+                    "matrix_ids": [],
+                    "crate_version": "1.0.0",
+                    "public_api": public_api,
+                }
+            },
+            "public_api_intent": {},
+            "compatibility_decisions": [],
+            "frozen_contracts": [],
+        }
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_stable_surface_guard.py
+++ b/scripts/tests/test_stable_surface_guard.py
@@ -63,17 +63,28 @@ class StableSurfaceGuardTests(unittest.TestCase):
         )
 
     def run_guard(self, mode: str = "baseline") -> subprocess.CompletedProcess[str]:
+        return self.run_guard_with_api(mode=mode)
+
+    def run_guard_with_api(
+        self,
+        *,
+        mode: str = "baseline",
+        api_baseline: Path | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        command = [
+            sys.executable,
+            str(GUARD),
+            "--root",
+            str(self.root),
+            "--policy",
+            str(self.policy),
+            "--mode",
+            mode,
+        ]
+        if api_baseline is not None:
+            command.extend(("--api-baseline", str(api_baseline)))
         return subprocess.run(
-            [
-                sys.executable,
-                str(GUARD),
-                "--root",
-                str(self.root),
-                "--policy",
-                str(self.policy),
-                "--mode",
-                mode,
-            ],
+            command,
             check=False,
             capture_output=True,
             text=True,
@@ -111,6 +122,105 @@ class StableSurfaceGuardTests(unittest.TestCase):
         result = self.run_guard("target")
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("mode=target features=0", result.stdout)
+
+    def test_target_mode_rejects_an_unapproved_api_break_decision(self) -> None:
+        self.source.write_text("pub fn value() {}\n", encoding="utf-8")
+        self.write_policy([])
+        baseline = self.root / "api-baseline.json"
+        value = self.api_freeze_fixture()
+        value["compatibility_decisions"].append(
+            {
+                "id": "API-001",
+                "classification": "approved-break",
+                "applies_to": "post-freeze",
+                "profile_id": "rocketmq-store:default",
+                "package": "rocketmq-store",
+                "item_path": "rocketmq_store::MappedFileBuilder",
+                "change": "signature",
+                "replacement": "rocketmq_store::MappedFileBuilder",
+                "reason": "Test fixture.",
+                "approved_by": "",
+                "approved_on": "2026-08-16",
+            }
+        )
+        baseline.write_text(json.dumps(value), encoding="utf-8")
+
+        result = self.run_guard_with_api(mode="target", api_baseline=baseline)
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("approved_by must be non-empty", result.stderr)
+
+    def test_target_mode_accepts_a_complete_api_freeze_contract(self) -> None:
+        self.source.write_text("pub fn value() {}\n", encoding="utf-8")
+        self.write_policy([])
+        baseline = self.root / "api-baseline.json"
+        baseline.write_text(json.dumps(self.api_freeze_fixture()), encoding="utf-8")
+
+        result = self.run_guard_with_api(mode="target", api_baseline=baseline)
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("api_freeze=verified", result.stdout)
+
+    @staticmethod
+    def api_freeze_fixture() -> dict[str, object]:
+        profiles = {}
+        packages = {}
+        contracts = []
+        anchors = {
+            "F-13": ("rocketmq-store", "rocketmq_store::MappedFileBuilder"),
+            "F-18": ("rocketmq-client-rust", "rocketmq_client_rust::DefaultMQPullConsumer"),
+            "F-15": ("rocketmq-proxy-core", "rocketmq_proxy_core::SettingsPolicyValues"),
+        }
+        for capability_id, (package, item_path) in anchors.items():
+            profile_id = f"{package}:default"
+            profiles[profile_id] = {
+                "package": package,
+                "target": package.replace("-", "_"),
+                "default_features": True,
+                "all_features": False,
+                "features": [],
+                "declared_default_features": [],
+                "source": "workspace-default",
+                "matrix_ids": [],
+                "crate_version": "1.0.0",
+                "public_api": [
+                    {
+                        "package": package,
+                        "module": item_path.rsplit("::", 1)[0],
+                        "item_path": item_path,
+                        "kind": "struct",
+                        "visibility": "public",
+                        "signature": "{}",
+                        "feature": "default",
+                    }
+                ],
+            }
+            packages[package] = {"target": package.replace("-", "_"), "profile_ids": [profile_id]}
+            contracts.append(
+                {
+                    "capability_id": capability_id,
+                    "profile_id": profile_id,
+                    "package": package,
+                    "item_paths": [item_path],
+                    "behavior": "Frozen test behavior.",
+                    "evidence": ["fixture-test"],
+                }
+            )
+        return {
+            "schema_version": 3,
+            "identity": "structural",
+            "scope": "core-release",
+            "freeze": {
+                "version": "1.0.0-rc.1",
+                "breaking_change_policy": "approval-required-after-freeze",
+            },
+            "toolchain": {"rustc": "x", "rustdoc": "x", "cargo": "x"},
+            "packages": packages,
+            "profiles": profiles,
+            "public_api_intent": {},
+            "compatibility_decisions": [],
+            "frozen_contracts": contracts,
+        }
 
 
 class RepositoryStableSurfaceContracts(unittest.TestCase):


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9504

### Brief Description

- Replace digest/count public API evidence with a structural core-release freeze across 26 libraries and 50 supported feature profiles.
- Record public fields, enum variants, trait items, inherent methods, signatures, approvals, and the frozen F-13, F-15, and F-18 contracts; add 0.9-to-1.0 migration guidance.
- Make target API validation a required core static and CI route, and pin the OpenRaft prerelease companion crates consistently, including the standalone fuzz lock metadata.

### How Did You Test This Change?

- `python scripts/public_api_snapshot.py --scope core-release --check scripts/public-api-snapshot-baseline.json --identity structural`: passed (`packages=26 profiles=50 differences=0`).
- Focused Python regression suite: passed (96 tests).
- `python scripts/stable_surface_guard.py --scope core-release --mode target`: passed.
- `python scripts/core_release_static_guard.py`: 9 of 10 routes passed; the maintainability route remains red because PR #9505 increased the Admin topic public surface and module size. The affected source files are unchanged by this PR.
- Controller storage-file library Clippy: passed.
- Controller storage-file library tests: passed (178 passed, 3 ignored).
- Standalone fuzz `cargo +nightly-2026-07-05 check --locked --all-targets --all-features`: passed.
- `scripts/check-agents-routing.ps1`: passed.
- `cargo metadata --locked --no-deps --format-version 1`: passed.
- `git diff --check`: passed.
- `cargo fmt -p rocketmq-controller -- --check`: passed. Workspace-wide formatting remains blocked on Windows by the pre-existing OS error 206 path-length failure.
- Controller all-target Clippy remains blocked by the pre-existing unused `TopicConfig` import in the client crate; the targeted controller library Clippy passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive RocketMQ Rust 1.0 API migration guide covering compatibility rules, runtime usage, client capabilities, mapped files, proxy settings, and migration verification.
  * Documented the 1.0 release API freeze policy, supported contracts, behavioral guarantees, and approval requirements.
  * Updated public API compatibility records and release guidance.

* **Quality Improvements**
  * Strengthened automated checks for API compatibility, feature profiles, structural changes, and approved breaking changes.
  * Improved release validation reporting for public API freeze status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->