### PR TITLE
[ISSUE #9511]✨Freeze the community release identity contract

### DIFF
--- a/distribution/release-identity.json
+++ b/distribution/release-identity.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": 1,
+  "revision": 1,
+  "identity_kind": "unofficial-community",
+  "distribution_name": "RocketMQ Rust Community Distribution",
+  "official_apache_release": false,
+  "project": {
+    "name": "rocketmq-rust",
+    "repository": "https://github.com/mxsm/rocketmq-rust",
+    "homepage": "https://github.com/mxsm/rocketmq-rust"
+  },
+  "crate_registry": {
+    "registry": "crates.io",
+    "owner": "mxsm",
+    "namespace": "rocketmq",
+    "package_prefix": "rocketmq-"
+  },
+  "oci": {
+    "registry": "ghcr.io",
+    "namespace": "mxsm/rocketmq-rust"
+  },
+  "helm": {
+    "chart_name": "rocketmq-rust",
+    "annotations": {
+      "rocketmqrust.com/distribution-owner": "The RocketMQ Rust Authors",
+      "rocketmqrust.com/repository": "https://github.com/mxsm/rocketmq-rust",
+      "rocketmqrust.com/official-apache-release": "false"
+    }
+  },
+  "legal": {
+    "license": "Apache-2.0",
+    "notice_owner": "The RocketMQ Rust Authors",
+    "upstream_owner": "The Apache Software Foundation",
+    "disclaimer": "Unofficial community distribution; not an official Apache Software Foundation release."
+  },
+  "approval": {
+    "approver": "mxsm",
+    "approved_revision": 1,
+    "approved_on": "2026-08-16",
+    "effective_scope": "core-release-1.0",
+    "decision_source": "release-approver-confirmed"
+  },
+  "required_consumers": [
+    "crate-package-planner",
+    "binary-archive-builder",
+    "oci-layout-builder",
+    "helm-candidate-builder",
+    "legal-sbom-provenance",
+    "public-staged-metadata"
+  ]
+}

--- a/distribution/release-identity.schema.json
+++ b/distribution/release-identity.schema.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rocketmqrust.com/schemas/release-identity.schema.json",
+  "title": "RocketMQ Rust release identity",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "revision",
+    "identity_kind",
+    "distribution_name",
+    "official_apache_release",
+    "project",
+    "crate_registry",
+    "oci",
+    "helm",
+    "legal",
+    "approval",
+    "required_consumers"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "revision": { "type": "integer", "minimum": 1 },
+    "identity_kind": {
+      "type": "string",
+      "enum": ["unofficial-community", "apache-governance"]
+    },
+    "distribution_name": { "type": "string", "minLength": 1 },
+    "official_apache_release": { "type": "boolean" },
+    "project": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "repository", "homepage"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "repository": { "type": "string", "pattern": "^https://" },
+        "homepage": { "type": "string", "pattern": "^https://" }
+      }
+    },
+    "crate_registry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["registry", "owner", "namespace", "package_prefix"],
+      "properties": {
+        "registry": { "type": "string", "minLength": 1 },
+        "owner": { "type": "string", "minLength": 1 },
+        "namespace": { "type": "string", "minLength": 1 },
+        "package_prefix": { "type": "string", "minLength": 1 }
+      }
+    },
+    "oci": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["registry", "namespace"],
+      "properties": {
+        "registry": { "type": "string", "minLength": 1 },
+        "namespace": { "type": "string", "minLength": 1 }
+      }
+    },
+    "helm": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["chart_name", "annotations"],
+      "properties": {
+        "chart_name": { "type": "string", "minLength": 1 },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "rocketmqrust.com/distribution-owner",
+            "rocketmqrust.com/repository",
+            "rocketmqrust.com/official-apache-release"
+          ],
+          "properties": {
+            "rocketmqrust.com/distribution-owner": { "type": "string", "minLength": 1 },
+            "rocketmqrust.com/repository": { "type": "string", "pattern": "^https://" },
+            "rocketmqrust.com/official-apache-release": { "enum": ["false", "true"] }
+          }
+        }
+      }
+    },
+    "legal": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["license", "notice_owner", "upstream_owner", "disclaimer"],
+      "properties": {
+        "license": { "type": "string", "minLength": 1 },
+        "notice_owner": { "type": "string", "minLength": 1 },
+        "upstream_owner": { "type": "string", "minLength": 1 },
+        "disclaimer": { "type": "string", "minLength": 1 }
+      }
+    },
+    "approval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "approver",
+        "approved_revision",
+        "approved_on",
+        "effective_scope",
+        "decision_source"
+      ],
+      "properties": {
+        "approver": { "type": "string", "minLength": 1 },
+        "approved_revision": { "type": "integer", "minimum": 1 },
+        "approved_on": { "type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$" },
+        "effective_scope": { "type": "string", "minLength": 1 },
+        "decision_source": { "const": "release-approver-confirmed" }
+      }
+    },
+    "required_consumers": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "crate-package-planner",
+          "binary-archive-builder",
+          "oci-layout-builder",
+          "helm-candidate-builder",
+          "legal-sbom-provenance",
+          "public-staged-metadata"
+        ]
+      }
+    }
+  }
+}

--- a/rocketmq-doc/en/release/1.0/release-identity.md
+++ b/rocketmq-doc/en/release/1.0/release-identity.md
@@ -1,0 +1,58 @@
+# RocketMQ Rust 1.0 release identity
+
+## Decision
+
+The 1.0 core release is prepared as the **RocketMQ Rust Community Distribution**. It is an unofficial community distribution and is not an official Apache Software Foundation release.
+
+The machine-readable decision is `distribution/release-identity.json`. Its allowed identity choices and required fields are closed by `distribution/release-identity.schema.json`.
+
+## Frozen publication surfaces
+
+The approved community identity establishes the following ownership and namespaces for local release preparation:
+
+| Surface | Frozen identity |
+|---|---|
+| Crate registry | `crates.io`, owner `mxsm`, logical namespace `rocketmq`, package prefix `rocketmq-` |
+| Source repository and homepage | `https://github.com/mxsm/rocketmq-rust` |
+| OCI candidate namespace | `ghcr.io/mxsm/rocketmq-rust` |
+| Helm chart | `rocketmq-rust`, owned by The RocketMQ Rust Authors, explicitly marked as not an official Apache release |
+| License and notice | Apache-2.0; notice owner The RocketMQ Rust Authors; upstream owner The Apache Software Foundation |
+| Approval scope | `core-release-1.0` |
+
+These values identify candidate metadata only. They do not publish crates, images, charts, Git tags, GitHub releases, or other remote artifacts.
+
+## Required consumers
+
+The identity preflight is a prerequisite for these release-preparation surfaces:
+
+- crate package planning;
+- binary archive construction;
+- OCI layout construction;
+- Helm candidate construction;
+- legal, SBOM, and provenance preparation;
+- public staged metadata preparation.
+
+Each consumer must read the frozen identity rather than infer ownership from a local login, repository URL, package name, or environment variable.
+
+## Approval and change control
+
+Revision 1 was approved by `mxsm` on 2026-08-16 for `core-release-1.0`. The approval is recorded as an explicit release-approver decision, not as an implementation-agent assumption.
+
+Changing the identity kind, an owner, namespace, repository, legal owner, annotation, or effective scope requires all of the following:
+
+1. increment `revision`;
+2. record the same value in `approval.approved_revision`;
+3. obtain a new release-approver decision and update the approval date;
+4. rerun the preflight and every affected release-preparation consumer.
+
+The guard deliberately does not use source, file, image, or artifact digests as approval evidence. Git review and the explicit revision approval are the governance boundary.
+
+## Preflight
+
+Run from the repository root:
+
+```powershell
+python scripts/release_identity_guard.py --identity distribution/release-identity.json --stage preflight
+```
+
+The preflight fails when the identity is unset, approval is incomplete or future-dated, the approved revision differs, a required namespace or consumer is missing, community metadata claims an official Apache release, repository/license/NOTICE ownership drifts, the schema is open-ended, or digest-style identity fields are introduced.

--- a/scripts/release_identity_guard.py
+++ b/scripts/release_identity_guard.py
@@ -1,0 +1,338 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+import json
+from pathlib import Path
+import re
+import tomllib
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_IDENTITY = ROOT / "distribution" / "release-identity.json"
+DEFAULT_SCHEMA = ROOT / "distribution" / "release-identity.schema.json"
+
+IDENTITY_KINDS = {"unofficial-community", "apache-governance"}
+REQUIRED_CONSUMERS = {
+    "crate-package-planner",
+    "binary-archive-builder",
+    "oci-layout-builder",
+    "helm-candidate-builder",
+    "legal-sbom-provenance",
+    "public-staged-metadata",
+}
+OBJECT_FIELDS = {
+    "root": {
+        "schema_version",
+        "revision",
+        "identity_kind",
+        "distribution_name",
+        "official_apache_release",
+        "project",
+        "crate_registry",
+        "oci",
+        "helm",
+        "legal",
+        "approval",
+        "required_consumers",
+    },
+    "project": {"name", "repository", "homepage"},
+    "crate_registry": {"registry", "owner", "namespace", "package_prefix"},
+    "oci": {"registry", "namespace"},
+    "helm": {"chart_name", "annotations"},
+    "helm.annotations": {
+        "rocketmqrust.com/distribution-owner",
+        "rocketmqrust.com/repository",
+        "rocketmqrust.com/official-apache-release",
+    },
+    "legal": {"license", "notice_owner", "upstream_owner", "disclaimer"},
+    "approval": {
+        "approver",
+        "approved_revision",
+        "approved_on",
+        "effective_scope",
+        "decision_source",
+    },
+}
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: expected a JSON object")
+    return value
+
+
+def _path_text(path: tuple[str, ...]) -> str:
+    return ".".join(path) if path else "root"
+
+
+def _is_forbidden_identity_key(key: str) -> bool:
+    if key == "$schema":
+        return False
+    normalized = key.lower().replace("-", "_")
+    tokens = normalized.split("_")
+    return any(
+        token in {"digest", "hash", "checksum", "fingerprint"} or token.startswith("sha")
+        for token in tokens
+    )
+
+
+def _find_forbidden_keys(
+    value: Any,
+    path: tuple[str, ...],
+    findings: list[str],
+) -> None:
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_text = str(key)
+            nested_path = (*path, key_text)
+            if _is_forbidden_identity_key(key_text):
+                findings.append(f"{_path_text(nested_path)}: digest/hash fields are forbidden")
+            _find_forbidden_keys(nested, nested_path, findings)
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            _find_forbidden_keys(nested, (*path, str(index)), findings)
+
+
+def _validate_schema_policy(schema: dict[str, Any]) -> list[str]:
+    findings: list[str] = []
+    _find_forbidden_keys(schema, ("schema",), findings)
+
+    def visit(value: Any, path: tuple[str, ...]) -> None:
+        if isinstance(value, dict):
+            if value.get("type") == "object" and value.get("additionalProperties") is not False:
+                findings.append(
+                    f"{_path_text(path)}.additionalProperties: object schemas must be closed"
+                )
+            for key, nested in value.items():
+                visit(nested, (*path, str(key)))
+        elif isinstance(value, list):
+            for index, nested in enumerate(value):
+                visit(nested, (*path, str(index)))
+
+    visit(schema, ("schema",))
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        findings.append("schema.properties: expected an object")
+        return findings
+    if set(properties) != OBJECT_FIELDS["root"]:
+        findings.append("schema.properties: release identity fields are not closed")
+    if set(schema.get("required", [])) != OBJECT_FIELDS["root"]:
+        findings.append("schema.required: release identity fields are not closed")
+    identity_rule = properties.get("identity_kind", {})
+    if set(identity_rule.get("enum", [])) != IDENTITY_KINDS:
+        findings.append("schema.properties.identity_kind.enum: approved choices changed")
+    consumer_rule = properties.get("required_consumers", {}).get("items", {})
+    if set(consumer_rule.get("enum", [])) != REQUIRED_CONSUMERS:
+        findings.append("schema.properties.required_consumers.items.enum: consumers changed")
+
+    nested_rules = {
+        "project": properties.get("project"),
+        "crate_registry": properties.get("crate_registry"),
+        "oci": properties.get("oci"),
+        "helm": properties.get("helm"),
+        "legal": properties.get("legal"),
+        "approval": properties.get("approval"),
+    }
+    helm_rule = nested_rules.get("helm")
+    if isinstance(helm_rule, dict):
+        nested_rules["helm.annotations"] = helm_rule.get("properties", {}).get("annotations")
+    for name, rule in nested_rules.items():
+        expected = OBJECT_FIELDS[name]
+        if not isinstance(rule, dict):
+            findings.append(f"schema.properties.{name}: expected an object schema")
+            continue
+        if set(rule.get("properties", {})) != expected or set(rule.get("required", [])) != expected:
+            findings.append(f"schema.properties.{name}: fields are not closed")
+    return findings
+
+
+def _validate_json_value(
+    value: Any,
+    rule: dict[str, Any],
+    path: tuple[str, ...],
+    findings: list[str],
+) -> None:
+    location = _path_text(path)
+    expected_type = rule.get("type")
+    matches_type = {
+        "object": isinstance(value, dict),
+        "array": isinstance(value, list),
+        "string": isinstance(value, str),
+        "integer": isinstance(value, int) and not isinstance(value, bool),
+        "boolean": isinstance(value, bool),
+    }.get(expected_type, True)
+    if not matches_type:
+        findings.append(f"{location}: expected {expected_type}")
+        return
+    if "const" in rule and value != rule["const"]:
+        findings.append(f"{location}: expected {rule['const']!r}")
+    if "enum" in rule and value not in rule["enum"]:
+        findings.append(f"{location}: unsupported value {value!r}")
+    if isinstance(value, str):
+        if len(value.strip()) < rule.get("minLength", 0):
+            findings.append(f"{location}: must not be blank")
+        pattern = rule.get("pattern")
+        if isinstance(pattern, str) and re.search(pattern, value) is None:
+            findings.append(f"{location}: does not match the required format")
+    if isinstance(value, int) and not isinstance(value, bool) and "minimum" in rule:
+        if value < rule["minimum"]:
+            findings.append(f"{location}: must be at least {rule['minimum']}")
+    if isinstance(value, dict):
+        properties = rule.get("properties", {})
+        required = set(rule.get("required", []))
+        for missing in sorted(required - set(value)):
+            findings.append(f"{location}.{missing}: required field is missing")
+        if rule.get("additionalProperties") is False:
+            for extra in sorted(set(value) - set(properties)):
+                findings.append(f"{location}.{extra}: field is not allowed")
+        for key, nested in value.items():
+            nested_rule = properties.get(key)
+            if isinstance(nested_rule, dict):
+                _validate_json_value(nested, nested_rule, (*path, str(key)), findings)
+    if isinstance(value, list):
+        if rule.get("uniqueItems") and len({json.dumps(item, sort_keys=True) for item in value}) != len(value):
+            findings.append(f"{location}: values must be unique")
+        item_rule = rule.get("items")
+        if isinstance(item_rule, dict):
+            for index, nested in enumerate(value):
+                _validate_json_value(nested, item_rule, (*path, str(index)), findings)
+
+
+def _workspace_metadata(root: Path) -> dict[str, Any]:
+    cargo = tomllib.loads((root / "Cargo.toml").read_text(encoding="utf-8"))
+    workspace_package = cargo.get("workspace", {}).get("package")
+    if not isinstance(workspace_package, dict):
+        raise ValueError("Cargo.toml: missing [workspace.package]")
+    return workspace_package
+
+
+def validate_identity(
+    identity: dict[str, Any],
+    schema: dict[str, Any],
+    *,
+    root: Path = ROOT,
+) -> list[str]:
+    findings = _validate_schema_policy(schema)
+    _find_forbidden_keys(identity, (), findings)
+    _validate_json_value(identity, schema, (), findings)
+    if findings:
+        return findings
+
+    approval = identity["approval"]
+    project = identity["project"]
+    crate_registry = identity["crate_registry"]
+    oci = identity["oci"]
+    helm = identity["helm"]
+    annotations = helm["annotations"]
+    legal = identity["legal"]
+
+    for location, value in (
+        ("approval.approver", approval["approver"]),
+        ("approval.effective_scope", approval["effective_scope"]),
+        ("crate_registry.owner", crate_registry["owner"]),
+        ("crate_registry.namespace", crate_registry["namespace"]),
+        ("oci.namespace", oci["namespace"]),
+    ):
+        if not isinstance(value, str) or not value.strip():
+            findings.append(f"{location}: must not be blank")
+
+    if approval["approved_revision"] != identity["revision"]:
+        findings.append("approval.approved_revision: must match identity revision")
+    try:
+        approved_on = date.fromisoformat(approval["approved_on"])
+        if approved_on > date.today():
+            findings.append("approval.approved_on: must not be in the future")
+    except ValueError:
+        findings.append("approval.approved_on: expected an ISO calendar date")
+    if approval["effective_scope"] != "core-release-1.0":
+        findings.append("approval.effective_scope: expected core-release-1.0")
+    if set(identity["required_consumers"]) != REQUIRED_CONSUMERS:
+        findings.append("required_consumers: must list every release-preparation consumer")
+
+    workspace = _workspace_metadata(root)
+    for field in ("repository", "homepage"):
+        if project[field] != workspace.get(field):
+            findings.append(f"project.{field}: must match Cargo workspace metadata")
+    if legal["license"] != workspace.get("license"):
+        findings.append("legal.license: must match Cargo workspace metadata")
+    notice = (root / "NOTICE").read_text(encoding="utf-8")
+    if legal["notice_owner"] not in notice:
+        findings.append("legal.notice_owner: must identify the owner recorded in NOTICE")
+
+    if annotations["rocketmqrust.com/repository"] != project["repository"]:
+        findings.append("helm.annotations.rocketmqrust.com/repository: must match project.repository")
+    if annotations["rocketmqrust.com/distribution-owner"] != legal["notice_owner"]:
+        findings.append(
+            "helm.annotations.rocketmqrust.com/distribution-owner: must match legal.notice_owner"
+        )
+
+    if identity["identity_kind"] == "unofficial-community":
+        if identity["official_apache_release"] is not False:
+            findings.append("official_apache_release: community releases must set false")
+        if annotations["rocketmqrust.com/official-apache-release"] != "false":
+            findings.append(
+                "helm.annotations.rocketmqrust.com/official-apache-release: community releases must set false"
+            )
+        if "community" not in identity["distribution_name"].lower():
+            findings.append("distribution_name: community identity must be explicit")
+        disclaimer = legal["disclaimer"].lower()
+        if "not an official apache software foundation release" not in disclaimer:
+            findings.append("legal.disclaimer: unofficial status must be explicit")
+    else:
+        if identity["official_apache_release"] is not True:
+            findings.append("official_apache_release: Apache governance releases must set true")
+        if annotations["rocketmqrust.com/official-apache-release"] != "true":
+            findings.append(
+                "helm.annotations.rocketmqrust.com/official-apache-release: Apache governance releases must set true"
+            )
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate the frozen release identity")
+    parser.add_argument("--identity", type=Path, default=DEFAULT_IDENTITY)
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    parser.add_argument("--stage", choices=("preflight",), default="preflight")
+    args = parser.parse_args()
+    try:
+        identity = read_json(args.identity)
+        schema = read_json(args.schema)
+        findings = validate_identity(identity, schema)
+    except (OSError, json.JSONDecodeError, ValueError, tomllib.TOMLDecodeError) as error:
+        print(f"RELEASE_IDENTITY_ERROR {error}")
+        return 2
+    if findings:
+        print("RELEASE_IDENTITY_FAILED")
+        for finding in findings:
+            print(f"- {finding}")
+        return 1
+    approval = identity["approval"]
+    print(
+        "RELEASE_IDENTITY_OK "
+        f"kind={identity['identity_kind']} "
+        f"approver={approval['approver']} "
+        f"scope={approval['effective_scope']} "
+        f"stage={args.stage}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_release_identity_guard.py
+++ b/scripts/tests/test_release_identity_guard.py
@@ -1,0 +1,156 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from scripts.tests.release_test_support import ROOT, read_json, write_json
+
+
+SCRIPT = ROOT / "scripts" / "release_identity_guard.py"
+IDENTITY = ROOT / "distribution" / "release-identity.json"
+SCHEMA = ROOT / "distribution" / "release-identity.schema.json"
+
+
+class ReleaseIdentityGuardTests(unittest.TestCase):
+    def run_guard(
+        self,
+        *,
+        identity: dict[str, object] | None = None,
+        schema: dict[str, object] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as temporary:
+            temporary_root = Path(temporary)
+            command = [sys.executable, str(SCRIPT)]
+            if identity is not None:
+                identity_path = temporary_root / "release-identity.json"
+                write_json(identity_path, identity)
+                command.extend(("--identity", str(identity_path)))
+            else:
+                command.extend(("--identity", str(IDENTITY)))
+            if schema is not None:
+                schema_path = temporary_root / "release-identity.schema.json"
+                write_json(schema_path, schema)
+                command.extend(("--schema", str(schema_path)))
+            command.extend(("--stage", "preflight"))
+            return subprocess.run(
+                command,
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+    def test_approved_community_identity_passes_preflight(self) -> None:
+        self.assertTrue(SCRIPT.is_file(), f"missing release identity guard: {SCRIPT}")
+        completed = self.run_guard()
+
+        self.assertEqual(0, completed.returncode, completed.stdout + completed.stderr)
+        self.assertIn("unofficial-community", completed.stdout)
+        self.assertIn("approver=mxsm", completed.stdout)
+        self.assertIn("scope=core-release-1.0", completed.stdout)
+
+    def test_preflight_rejects_unset_identity_kind(self) -> None:
+        identity = read_json(IDENTITY)
+        identity["identity_kind"] = "unset"
+
+        completed = self.run_guard(identity=identity)
+
+        self.assertEqual(1, completed.returncode)
+        self.assertIn("identity_kind", completed.stdout + completed.stderr)
+
+    def test_preflight_rejects_blank_approver(self) -> None:
+        identity = read_json(IDENTITY)
+        identity["approval"]["approver"] = "  "
+
+        completed = self.run_guard(identity=identity)
+
+        self.assertEqual(1, completed.returncode)
+        self.assertIn("approval.approver", completed.stdout + completed.stderr)
+
+    def test_preflight_rejects_future_approval_date(self) -> None:
+        identity = read_json(IDENTITY)
+        identity["approval"]["approved_on"] = "2999-01-01"
+
+        completed = self.run_guard(identity=identity)
+
+        self.assertEqual(1, completed.returncode)
+        self.assertIn("approval.approved_on", completed.stdout + completed.stderr)
+
+    def test_community_identity_cannot_claim_apache_release(self) -> None:
+        identity = read_json(IDENTITY)
+        identity["official_apache_release"] = True
+
+        completed = self.run_guard(identity=identity)
+
+        self.assertEqual(1, completed.returncode)
+        self.assertIn("official_apache_release", completed.stdout + completed.stderr)
+
+    def test_preflight_requires_publication_namespace(self) -> None:
+        identity = read_json(IDENTITY)
+        identity["oci"]["namespace"] = ""
+
+        completed = self.run_guard(identity=identity)
+
+        self.assertEqual(1, completed.returncode)
+        self.assertIn("oci.namespace", completed.stdout + completed.stderr)
+
+    def test_preflight_requires_every_release_consumer(self) -> None:
+        identity = read_json(IDENTITY)
+        identity["required_consumers"].remove("public-staged-metadata")
+
+        completed = self.run_guard(identity=identity)
+
+        self.assertEqual(1, completed.returncode)
+        self.assertIn("required_consumers", completed.stdout + completed.stderr)
+
+    def test_preflight_rejects_repository_drift(self) -> None:
+        identity = read_json(IDENTITY)
+        identity["project"]["repository"] = "https://example.invalid/rocketmq-rust"
+
+        completed = self.run_guard(identity=identity)
+
+        self.assertEqual(1, completed.returncode)
+        self.assertIn("project.repository", completed.stdout + completed.stderr)
+
+    def test_schema_cannot_authorize_digest_fields(self) -> None:
+        identity = read_json(IDENTITY)
+        schema = copy.deepcopy(read_json(SCHEMA))
+        identity["artifact_digest"] = "forbidden"
+        schema["required"].append("artifact_digest")
+        schema["properties"]["artifact_digest"] = {"type": "string"}
+
+        completed = self.run_guard(identity=identity, schema=schema)
+
+        self.assertEqual(1, completed.returncode)
+        self.assertIn("artifact_digest", completed.stdout + completed.stderr)
+
+    def test_schema_objects_must_be_closed(self) -> None:
+        schema = copy.deepcopy(read_json(SCHEMA))
+        schema["properties"]["oci"]["additionalProperties"] = True
+
+        completed = self.run_guard(schema=schema)
+
+        self.assertEqual(1, completed.returncode)
+        self.assertIn("additionalProperties", completed.stdout + completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9511

### Brief Description

Freeze the 1.0 core release identity as an unofficial RocketMQ Rust community distribution. Add a closed JSON Schema, an approved identity record, a semantic preflight guard, and release documentation covering crate, OCI, Helm, repository, and legal ownership surfaces. The guard rejects unset or incomplete approval, namespace drift, official Apache claims, open schemas, and digest-based identity fields.

This change prepares local release metadata only. It does not publish crates, images, charts, tags, or GitHub releases.

### How Did You Test This Change?

- `python -m unittest scripts.tests.test_release_identity_guard scripts.tests.test_core_release_check_routes` (17 tests passed)
- `.\scripts\check-agents-routing.ps1` (passed)
- `python scripts/release_identity_guard.py --identity distribution/release-identity.json --stage preflight` (passed)
- `python scripts/core_release_guard.py` (passed)
- `python -m py_compile scripts/release_identity_guard.py scripts/tests/test_release_identity_guard.py` (passed)
- `git diff --check` (passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added release identity metadata for the RocketMQ Rust 1.0 community distribution.
  - Added validation for project, registry, OCI, Helm, legal, approval, and consumer information.
  - Added a preflight command that reports validation results and actionable failures.

- **Documentation**
  - Documented release ownership, namespace rules, approvals, revisions, and preflight requirements.

- **Tests**
  - Added coverage for valid releases and common metadata, schema, approval, and configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->