### PR TITLE
[ISSUE #9515]✨Build reproducible three-platform core release archives

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,75 @@
+name: Core release candidate preparation
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_manifest:
+        description: Candidate manifest path in the prepared workspace
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      candidate_manifest:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: core-release-candidate-${{ github.run_id }}-${{ github.run_attempt }}
+  cancel-in-progress: false
+
+jobs:
+  prepare-common:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/upload-artifact@v7
+        with:
+          name: core-release-candidate-input
+          path: ${{ inputs.candidate_manifest }}
+          if-no-files-found: error
+          retention-days: 14
+
+  build-target:
+    needs: prepare-common
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - runner: windows-latest
+            target: x86_64-pc-windows-msvc
+          - runner: macos-latest
+            target: x86_64-apple-darwin
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Validate local-only candidate contract
+        shell: pwsh
+        run: |
+          python distribution/build_release_binaries.py --help
+          python distribution/build_release_archive.py --help
+          python distribution/verify_release_archive.py --help
+      - uses: actions/upload-artifact@v7
+        with:
+          name: core-release-${{ matrix.target }}-${{ github.run_attempt }}
+          path: target/v1-release
+          if-no-files-found: warn
+          retention-days: 14
+
+  aggregate:
+    needs: build-target
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v7
+        with:
+          pattern: core-release-*-${{ github.run_attempt }}
+          path: target/v1-release/downloads
+      - name: Validate aggregation tools
+        run: |
+          python distribution/merge_candidate_partials.py --help
+          python distribution/transfer_candidate.py --help

--- a/distribution/build_common_release_inputs.py
+++ b/distribution/build_common_release_inputs.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import shutil
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT / "distribution") not in sys.path:
+    sys.path.insert(0, str(ROOT / "distribution"))
+
+from release_archive_common import ArchiveError, file_inventory, load_candidate, write_json
+from release_state import resolve_existing_file, resolve_within
+
+
+SOURCES = {
+    "LICENSE-APACHE": ROOT / "LICENSE-APACHE",
+    "NOTICE": ROOT / "NOTICE",
+    "README.md": ROOT / "README.md",
+    "release-identity.json": ROOT / "distribution" / "release-identity.json",
+    "core-release-scope.json": ROOT / "scripts" / "core-release-scope.json",
+    "release-layout.json": ROOT / "distribution" / "release-layout.json",
+}
+
+
+def build_inputs(candidate_manifest: Path, output: Path) -> Path:
+    _manifest, candidate, root = load_candidate(candidate_manifest)
+    output = resolve_within(root, output, "common inputs output")
+    if output.exists():
+        raise ArchiveError(f"common inputs output already exists: {output}")
+    notes = resolve_existing_file(
+        root / "common-input-source" / "RELEASE_NOTES.md", "candidate release notes"
+    )
+    output.mkdir(parents=True)
+    for name, source in SOURCES.items():
+        shutil.copyfile(resolve_existing_file(source, name), output / name)
+    shutil.copyfile(notes, output / "RELEASE_NOTES.md")
+    inventory = file_inventory(output)
+    manifest = {
+        "schema_version": 1,
+        "candidate_id": candidate["candidate_id"],
+        "version": candidate["version"],
+        "run_id": candidate["run_id"],
+        "attempt": candidate["attempt"],
+        "files": inventory,
+        "remote_publication": "not-executed",
+    }
+    write_json(output / "COMMON_RELEASE_INPUTS.json", manifest)
+    return output
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate-manifest", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        output = build_inputs(args.candidate_manifest, args.output)
+        print(f"COMMON_RELEASE_INPUTS_OK output={output}")
+        return 0
+    except (ArchiveError, OSError) as error:
+        print(f"COMMON_RELEASE_INPUTS_FAILED detail={error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/distribution/build_release_archive.py
+++ b/distribution/build_release_archive.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import shutil
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT / "distribution") not in sys.path:
+    sys.path.insert(0, str(ROOT / "distribution"))
+
+from release_archive_common import (
+    ArchiveError,
+    add_unique_record,
+    artifact_id,
+    candidate_relative,
+    draft_partial_path,
+    file_inventory,
+    load_candidate,
+    load_layout,
+    read_policy_json,
+    save_draft,
+    target_layout,
+    write_json,
+)
+
+
+def build_archive(candidate_manifest: Path, target: str) -> tuple[Path, Path]:
+    _manifest, candidate, root = load_candidate(candidate_manifest)
+    layout = load_layout()
+    target_spec = target_layout(layout, target)
+    package_name = f"rocketmq-rust-{candidate['version']}"
+    staging = root / "staging" / target / package_name
+    required = [
+        *(staging / name for name in layout["common_files"]),
+        *(staging / "conf" / f"{service}.toml" for service in layout["configs"]),
+        staging / "sbom" / "components.cdx.json",
+        staging / "scripts" / "rocketmq-service.ps1",
+        staging / "scripts" / "rocketmq-service.sh",
+    ]
+    missing = [str(path) for path in required if not path.is_file()]
+    if missing:
+        raise ArchiveError("archive staging is incomplete: " + ", ".join(missing))
+    output_root = root / "archives"
+    output_root.mkdir(parents=True, exist_ok=True)
+    base = output_root / f"{package_name}-{target}"
+    if target_spec["archive_format"] == "zip":
+        archive = Path(shutil.make_archive(str(base), "zip", root_dir=staging.parent, base_dir=package_name))
+    else:
+        archive = Path(
+            shutil.make_archive(str(base), "gztar", root_dir=staging.parent, base_dir=package_name)
+        )
+    manifest_path = output_root / f"{package_name}-{target}.manifest.json"
+    binary_records = [
+        entry
+        for entry in read_policy_json(
+            draft_partial_path(root, target), "candidate partial draft"
+        )["artifacts"]
+        if entry.get("kind") == "binary"
+    ]
+    value = {
+        "schema_version": 1,
+        "candidate_id": candidate["candidate_id"],
+        "version": candidate["version"],
+        "run_id": candidate["run_id"],
+        "attempt": candidate["attempt"],
+        "target": target,
+        "artifact_id": artifact_id(candidate, target, "archive"),
+        "archive": candidate_relative(root, archive, "release archive"),
+        "files": file_inventory(staging),
+        "binaries": binary_records,
+        "remote_publication": "not-executed",
+    }
+    write_json(manifest_path, value)
+    partial = read_policy_json(draft_partial_path(root, target), "candidate partial draft")
+    add_unique_record(
+        partial,
+        "artifacts",
+        {
+            "id": "archive",
+            "kind": "release-archive",
+            "artifact_id": value["artifact_id"],
+            "path": value["archive"],
+        },
+    )
+    add_unique_record(
+        partial,
+        "artifacts",
+        {
+            "id": "archive-manifest",
+            "kind": "archive-manifest",
+            "path": candidate_relative(root, manifest_path, "archive manifest"),
+        },
+    )
+    save_draft(root, target, partial)
+    return archive, manifest_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate-manifest", type=Path, required=True)
+    parser.add_argument("--target", required=True)
+    args = parser.parse_args(argv)
+    try:
+        archive, manifest = build_archive(args.candidate_manifest, args.target)
+        print(f"RELEASE_ARCHIVE_OK target={args.target} archive={archive} manifest={manifest}")
+        return 0
+    except (ArchiveError, OSError, KeyError) as error:
+        print(f"RELEASE_ARCHIVE_FAILED detail={error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/distribution/build_release_binaries.py
+++ b/distribution/build_release_binaries.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+import argparse
+from contextlib import contextmanager
+import os
+from pathlib import Path
+import sys
+from typing import Any, Iterator
+
+
+ROOT = Path(__file__).resolve().parents[1]
+for module_root in (ROOT / "distribution", ROOT / "scripts"):
+    if str(module_root) not in sys.path:
+        sys.path.insert(0, str(module_root))
+
+import capture_candidate_execution_context
+import release_candidate_command
+from release_archive_common import (
+    ArchiveError,
+    add_unique_record,
+    artifact_id,
+    candidate_relative,
+    load_candidate,
+    load_layout,
+    load_or_create_draft,
+    save_draft,
+    target_layout,
+)
+
+
+def build_command(
+    candidate_root: Path,
+    target: str,
+    binary: dict[str, Any],
+) -> list[str]:
+    command = [
+        "cargo",
+        "build",
+        "--locked",
+        "--release",
+        "--target",
+        target,
+        "--target-dir",
+        str(candidate_root / "cargo-target" / target),
+        "--package",
+        binary["package"],
+        "--bin",
+        binary["binary"],
+    ]
+    features = binary.get("requested_features", [])
+    if features:
+        command.extend(["--features", ",".join(features)])
+    return command
+
+
+@contextmanager
+def _build_environment(values: dict[str, str]) -> Iterator[None]:
+    previous = {name: os.environ.get(name) for name in values}
+    os.environ.update(values)
+    try:
+        yield
+    finally:
+        for name, value in previous.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+def build_binaries(candidate_manifest: Path, target: str) -> Path:
+    manifest, candidate, root = load_candidate(candidate_manifest)
+    layout = load_layout()
+    target_spec = target_layout(layout, target)
+    draft = load_or_create_draft(root, candidate, target)
+    context = capture_candidate_execution_context.capture_context(
+        manifest,
+        draft["worker_id"],
+        root / "contexts" / target,
+    )
+    add_unique_record(
+        draft,
+        "execution_contexts",
+        {
+            "id": f"context-{target}",
+            "path": candidate_relative(root, context, "execution context"),
+        },
+    )
+    suffix = target_spec["executable_suffix"]
+    for binary in layout["binaries"]:
+        component = binary["id"]
+        route_id = f"R05-build-{component}-{target}"
+        command = build_command(root, target, binary)
+        environment = {
+            "ROCKETMQ_RELEASE_ARTIFACT_ID": artifact_id(candidate, target, component),
+            "ROCKETMQ_RELEASE_REQUESTED_FEATURES": ",".join(binary["requested_features"]),
+            "ROCKETMQ_RELEASE_EFFECTIVE_FEATURES": ",".join(binary["effective_features"]),
+        }
+        with _build_environment(environment):
+            exit_code = release_candidate_command.run_command(
+                manifest,
+                route_id=route_id,
+                worker_id=draft["worker_id"],
+                context_path=context,
+                event_root=root / "events" / target,
+                command=command,
+            )
+        if exit_code != 0:
+            raise ArchiveError(f"release binary build failed: {component}")
+        built = root / "cargo-target" / target / "release" / f"{binary['binary']}{suffix}"
+        if not built.is_file():
+            raise ArchiveError(f"release binary output is missing: {built}")
+        add_unique_record(
+            draft,
+            "artifacts",
+            {
+                "id": f"binary-{component}",
+                "kind": "binary",
+                "component": component,
+                "artifact_id": environment["ROCKETMQ_RELEASE_ARTIFACT_ID"],
+                "path": candidate_relative(root, built, "release binary"),
+                "requested_features": binary["requested_features"],
+                "effective_features": binary["effective_features"],
+                "required_dependencies": binary.get("required_dependencies", []),
+                "command": command,
+                "exit_code": exit_code,
+            },
+        )
+        add_unique_record(
+            draft,
+            "events",
+            {
+                "id": f"event-{component}",
+                "started": candidate_relative(
+                    root, root / "events" / target / f"{route_id}.started.json", "started event"
+                ),
+                "completed": candidate_relative(
+                    root,
+                    root / "events" / target / f"{route_id}.completed.json",
+                    "completed event",
+                ),
+            },
+        )
+    save_draft(root, target, draft)
+    return root / "partials" / f"CANDIDATE_PARTIAL.{target}.draft.json"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate-manifest", type=Path, required=True)
+    parser.add_argument("--target", required=True)
+    args = parser.parse_args(argv)
+    try:
+        output = build_binaries(args.candidate_manifest, args.target)
+        print(f"RELEASE_BINARY_BUILD_OK target={args.target} partial={output}")
+        return 0
+    except (ArchiveError, OSError) as error:
+        print(f"RELEASE_BINARY_BUILD_FAILED detail={error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/distribution/candidate-partial.schema.json
+++ b/distribution/candidate-partial.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RocketMQ Rust target candidate partial",
+  "type": "object",
+  "required": ["schema_version", "candidate_id", "version", "run_id", "attempt", "target", "worker_id", "sealed", "artifacts", "events", "execution_contexts"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "candidate_id": {"type": "string", "minLength": 1},
+    "version": {"type": "string", "minLength": 1},
+    "run_id": {"type": "string", "minLength": 1},
+    "attempt": {"type": "integer", "minimum": 1},
+    "target": {"type": "string", "minLength": 1},
+    "worker_id": {"type": "string", "minLength": 1},
+    "sealed": {"type": "boolean"},
+    "artifacts": {"type": "array"},
+    "events": {"type": "array"},
+    "execution_contexts": {"type": "array"}
+  },
+  "additionalProperties": false
+}

--- a/distribution/candidate-transfer.schema.json
+++ b/distribution/candidate-transfer.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RocketMQ Rust candidate transfer bundle",
+  "type": "object",
+  "required": ["schema_version", "bundle_kind", "candidate_id", "version", "run_id", "attempt", "files"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "bundle_kind": {"enum": ["build-source", "build-control", "target", "artifacts"]},
+    "candidate_id": {"type": "string"},
+    "version": {"type": "string"},
+    "run_id": {"type": "string"},
+    "attempt": {"type": "integer", "minimum": 1},
+    "files": {"type": "array"}
+  },
+  "additionalProperties": false
+}

--- a/distribution/common-release-input.schema.json
+++ b/distribution/common-release-input.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RocketMQ Rust common release inputs",
+  "type": "object",
+  "required": ["schema_version", "candidate_id", "version", "run_id", "attempt", "files", "remote_publication"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "candidate_id": {"type": "string"},
+    "version": {"type": "string"},
+    "run_id": {"type": "string"},
+    "attempt": {"type": "integer", "minimum": 1},
+    "files": {"type": "array"},
+    "remote_publication": {"const": "not-executed"}
+  },
+  "additionalProperties": false
+}

--- a/distribution/config/controller/controller.toml
+++ b/distribution/config/controller/controller.toml
@@ -1,0 +1,17 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+rocketmqHome = "./work/controller"
+configStorePath = "./work/controller/controller.properties"
+controllerType = "Raft"
+nodeId = 1
+listenAddr = "127.0.0.1:9878"
+electionTimeoutMs = 1000
+heartbeatIntervalMs = 300
+storagePath = "./work/controller/storage"
+storageBackend = "RocksDB"
+metricsExporterType = "disable"
+
+[[raftPeers]]
+id = 1
+addr = "127.0.0.1:9878"

--- a/distribution/config/proxy/proxy.toml
+++ b/distribution/config/proxy/proxy.toml
@@ -1,0 +1,17 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+mode = "cluster"
+
+[grpc]
+listenAddr = "127.0.0.1:8081"
+
+[grpc.tls]
+enabled = false
+
+[remoting]
+enabled = false
+listenAddr = "127.0.0.1:8080"
+
+[cluster]
+namesrvAddr = "127.0.0.1:9876"

--- a/distribution/generate_component_sbom.py
+++ b/distribution/generate_component_sbom.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT / "distribution") not in sys.path:
+    sys.path.insert(0, str(ROOT / "distribution"))
+
+from release_archive_common import (
+    ArchiveError,
+    add_unique_record,
+    candidate_relative,
+    draft_partial_path,
+    file_inventory,
+    load_candidate,
+    load_layout,
+    read_policy_json,
+    save_draft,
+    target_layout,
+)
+
+
+def _metadata() -> dict[str, Any]:
+    completed = subprocess.run(
+        ["cargo", "metadata", "--locked", "--format-version", "1", "--no-deps"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise ArchiveError(f"cargo metadata failed: {completed.stderr.strip()}")
+    return json.loads(completed.stdout)
+
+
+def generate_sbom(candidate_manifest: Path, target: str, toolchain: Path) -> Path:
+    _manifest, candidate, root = load_candidate(candidate_manifest)
+    layout = load_layout()
+    target_layout(layout, target)
+    policy = read_policy_json(toolchain, "SBOM toolchain")
+    staging = root / "staging" / target / f"rocketmq-rust-{candidate['version']}"
+    if not staging.is_dir():
+        raise ArchiveError(f"archive staging is missing: {staging}")
+    metadata = _metadata()
+    packages = {package["name"]: package for package in metadata["packages"]}
+    components = []
+    for binary in layout["binaries"]:
+        package = packages.get(binary["package"])
+        if package is None:
+            raise ArchiveError(f"SBOM package is absent from Cargo metadata: {binary['package']}")
+        components.append(
+            {
+                "type": "application" if binary["kind"] == "service" else "library",
+                "name": binary["binary"],
+                "version": package["version"],
+                "properties": [
+                    {"name": "rocketmq:package", "value": binary["package"]},
+                    {"name": "rocketmq:target", "value": target},
+                    {
+                        "name": "rocketmq:effective-features",
+                        "value": ",".join(binary["effective_features"]),
+                    },
+                ],
+            }
+        )
+    value = {
+        "bomFormat": policy["format"],
+        "specVersion": policy["spec_version"],
+        "version": 1,
+        "metadata": {
+            "component": {
+                "type": "application",
+                "name": "rocketmq-rust-community-distribution",
+                "version": candidate["version"],
+            },
+            "properties": [
+                {"name": "rocketmq:candidate-id", "value": candidate["candidate_id"]},
+                {"name": "rocketmq:staging-file-count", "value": str(len(file_inventory(staging)))},
+            ],
+        },
+        "components": components,
+    }
+    output = staging / "sbom" / "components.cdx.json"
+    if output.exists():
+        raise ArchiveError(f"component SBOM already exists: {output}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8", newline="\n")
+    partial = read_policy_json(draft_partial_path(root, target), "candidate partial draft")
+    add_unique_record(
+        partial,
+        "artifacts",
+        {
+            "id": "component-sbom",
+            "kind": "component-sbom",
+            "path": candidate_relative(root, output, "component SBOM"),
+        },
+    )
+    save_draft(root, target, partial)
+    return output
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate-manifest", type=Path, required=True)
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--toolchain", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        output = generate_sbom(args.candidate_manifest, args.target, args.toolchain)
+        print(f"COMPONENT_SBOM_OK target={args.target} output={output}")
+        return 0
+    except (ArchiveError, OSError, json.JSONDecodeError, KeyError) as error:
+        print(f"COMPONENT_SBOM_FAILED detail={error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/distribution/merge_candidate_partials.py
+++ b/distribution/merge_candidate_partials.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import shutil
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT / "distribution") not in sys.path:
+    sys.path.insert(0, str(ROOT / "distribution"))
+
+from release_archive_common import (
+    ArchiveError,
+    load_candidate,
+    load_layout,
+    require_relative_path,
+    resolve_candidate_path,
+    write_json,
+)
+from release_state import read_json
+
+
+def _bundle_root(partial_path: Path) -> Path:
+    for parent in partial_path.parents:
+        if (parent / "CANDIDATE_TRANSFER.json").is_file():
+            return parent
+    if partial_path.parent.name == "partials":
+        return partial_path.parent.parent
+    raise ArchiveError(f"cannot locate target bundle root for partial: {partial_path}")
+
+
+def _copy_entry(source_root: Path, candidate_root: Path, relative: str) -> None:
+    posix = require_relative_path(relative, "merged bundle path")
+    source = source_root.joinpath(*posix.parts)
+    destination = resolve_candidate_path(candidate_root, relative, "merged candidate path")
+    if not source.exists() or source.is_symlink():
+        raise ArchiveError(f"target bundle entry is missing or unsafe: {relative}")
+    sources = [path for path in source.rglob("*") if path.is_file()] if source.is_dir() else [source]
+    for path in sources:
+        if path.is_symlink():
+            raise ArchiveError(f"target bundle entry is a link: {path}")
+        suffix = path.relative_to(source)
+        output = destination / suffix if source.is_dir() else destination
+        if output.exists():
+            if not output.is_file() or output.read_bytes() != path.read_bytes():
+                raise ArchiveError(f"target bundle would overwrite a different file: {relative}")
+            continue
+        output.parent.mkdir(parents=True, exist_ok=True)
+        temporary = output.with_name(f".{output.name}.merge.tmp")
+        if temporary.exists():
+            raise ArchiveError(f"stale merge temporary file exists: {temporary}")
+        shutil.copyfile(path, temporary)
+        os.replace(temporary, output)
+
+
+def merge_partials(candidate_manifest: Path, download_root: Path, targets: list[str]) -> Path:
+    _manifest, candidate, root = load_candidate(candidate_manifest)
+    layout = load_layout()
+    download_root = download_root.resolve()
+    partials: list[dict] = []
+    for target in targets:
+        matches = list(download_root.rglob(f"CANDIDATE_PARTIAL.{target}.json"))
+        if len(matches) != 1:
+            raise ArchiveError(f"expected one sealed partial for {target}, found {len(matches)}")
+        partial_path = matches[0]
+        partial = read_json(partial_path)
+        identity = (
+            partial.get("candidate_id"),
+            partial.get("version"),
+            partial.get("run_id"),
+            partial.get("attempt"),
+            partial.get("target"),
+            partial.get("sealed"),
+        )
+        expected = (
+            candidate["candidate_id"],
+            candidate["version"],
+            candidate["run_id"],
+            candidate["attempt"],
+            target,
+            True,
+        )
+        if identity != expected:
+            raise ArchiveError(f"sealed partial identity mismatch: {target}")
+        if partial.get("worker_id") != f"release-{target}":
+            raise ArchiveError(f"sealed partial worker mismatch: {target}")
+        identifiers = {
+            entry.get("id") for entry in partial.get("artifacts", []) if isinstance(entry, dict)
+        }
+        required = {f"binary-{entry['id']}" for entry in layout["binaries"]}
+        required.update({"archive", "archive-manifest", "common-inputs", "component-sbom", "host-smoke"})
+        if not required.issubset(identifiers):
+            raise ArchiveError(f"sealed partial artifact denominator is incomplete: {target}")
+        if not partial.get("events") or not partial.get("execution_contexts"):
+            raise ArchiveError(f"sealed partial evidence denominator is incomplete: {target}")
+        source_root = _bundle_root(partial_path)
+        for artifact in partial.get("artifacts", []):
+            _copy_entry(source_root, root, artifact.get("path"))
+        for event in partial.get("events", []):
+            _copy_entry(source_root, root, event.get("started"))
+            _copy_entry(source_root, root, event.get("completed"))
+            completed = source_root.joinpath(
+                *require_relative_path(event.get("completed"), "completed event").parts
+            )
+            if read_json(completed).get("exit_code") != 0:
+                raise ArchiveError(f"sealed partial contains a failed event: {event.get('id')}")
+        for context in partial.get("execution_contexts", []):
+            _copy_entry(source_root, root, context.get("path"))
+            context_path = source_root.joinpath(
+                *require_relative_path(context.get("path"), "execution context").parts
+            )
+            if read_json(context_path).get("worker_id") != partial["worker_id"]:
+                raise ArchiveError(f"sealed partial context worker mismatch: {context.get('id')}")
+        partials.append(partial)
+    artifact_ids: set[str] = set()
+    artifacts: list[dict] = []
+    event_ids: set[str] = set()
+    context_ids: set[str] = set()
+    for partial in partials:
+        for artifact in partial["artifacts"]:
+            identifier = f"{partial['target']}:{artifact['id']}"
+            if identifier in artifact_ids:
+                raise ArchiveError(f"merged artifact identifier is duplicated: {identifier}")
+            artifact_ids.add(identifier)
+            require_relative_path(artifact["path"], "merged artifact path")
+            artifacts.append({"target": partial["target"], **artifact})
+        for event in partial["events"]:
+            identifier = f"{partial['target']}:{event['id']}"
+            if identifier in event_ids:
+                raise ArchiveError(f"merged event identifier is duplicated: {identifier}")
+            event_ids.add(identifier)
+        for context in partial["execution_contexts"]:
+            identifier = f"{partial['target']}:{context['id']}"
+            if identifier in context_ids:
+                raise ArchiveError(f"merged context identifier is duplicated: {identifier}")
+            context_ids.add(identifier)
+    value = {
+        "schema_version": 1,
+        "candidate_id": candidate["candidate_id"],
+        "version": candidate["version"],
+        "run_id": candidate["run_id"],
+        "attempt": candidate["attempt"],
+        "targets": targets,
+        "artifacts": artifacts,
+        "remote_publication": "not-executed",
+    }
+    output = root / "ARTIFACT_INDEX.json"
+    if output.exists():
+        raise ArchiveError(f"candidate artifact index already exists: {output}")
+    write_json(output, value)
+    return output
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate-manifest", type=Path, required=True)
+    parser.add_argument("--download-root", type=Path, required=True)
+    parser.add_argument("--require-targets", required=True)
+    args = parser.parse_args(argv)
+    try:
+        targets = [value for value in args.require_targets.split(",") if value]
+        if len(targets) != len(set(targets)):
+            raise ArchiveError("required target list is empty or duplicated")
+        output = merge_partials(args.candidate_manifest, args.download_root, targets)
+        print(f"CANDIDATE_PARTIAL_MERGE_OK targets={len(targets)} output={output}")
+        return 0
+    except (ArchiveError, OSError) as error:
+        print(f"CANDIDATE_PARTIAL_MERGE_FAILED detail={error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/distribution/prepare_release_archive_staging.py
+++ b/distribution/prepare_release_archive_staging.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import shutil
+import stat
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT / "distribution") not in sys.path:
+    sys.path.insert(0, str(ROOT / "distribution"))
+
+from release_archive_common import (
+    ArchiveError,
+    add_unique_record,
+    candidate_relative,
+    draft_partial_path,
+    file_inventory,
+    load_candidate,
+    load_layout,
+    read_policy_json,
+    resolve_candidate_path,
+    save_draft,
+    target_layout,
+)
+from release_state import read_json, resolve_existing_file, resolve_within
+
+
+def _copy_archive_config(service: str, source: Path, destination: Path) -> None:
+    value = source.read_text(encoding="utf-8")
+    replacements = {
+        "${user.home}/rocketmq": "./work/namesrv/rocketmq",
+        "${user.home}/namesrv": "./work/namesrv",
+        "/opt/data/rocketmq/store": "./work/broker/store",
+    }
+    for old, new in replacements.items():
+        value = value.replace(old, new)
+    if "${user.home}" in value or "/opt/data" in value:
+        raise ArchiveError(f"{service} config retains a development-machine path")
+    destination.write_text(value, encoding="utf-8", newline="\n")
+
+
+def prepare_staging(candidate_manifest: Path, target: str, common_inputs: Path) -> Path:
+    _manifest, candidate, root = load_candidate(candidate_manifest)
+    layout = load_layout()
+    target_spec = target_layout(layout, target)
+    partial = read_policy_json(draft_partial_path(root, target), "candidate partial draft")
+    common_inputs = resolve_within(root, common_inputs, "common release inputs")
+    common_manifest = read_json(common_inputs / "COMMON_RELEASE_INPUTS.json")
+    actual_inventory = [
+        entry for entry in file_inventory(common_inputs) if entry["path"] != "COMMON_RELEASE_INPUTS.json"
+    ]
+    if actual_inventory != common_manifest["files"]:
+        raise ArchiveError("common release inputs changed after their manifest was written")
+    package_root = root / "staging" / target / f"rocketmq-rust-{candidate['version']}"
+    if package_root.exists():
+        raise ArchiveError(f"archive staging already exists: {package_root}")
+    for directory in layout["archive_directories"]:
+        (package_root / directory).mkdir(parents=True, exist_ok=True)
+    for name in layout["common_files"]:
+        shutil.copyfile(resolve_existing_file(common_inputs / name, name), package_root / name)
+    suffix = target_spec["executable_suffix"]
+    binary_records = {
+        entry["component"]: entry
+        for entry in partial["artifacts"]
+        if entry.get("kind") == "binary"
+    }
+    for binary in layout["binaries"]:
+        record = binary_records.get(binary["id"])
+        if record is None:
+            raise ArchiveError(f"candidate partial has no binary: {binary['id']}")
+        source = resolve_candidate_path(root, record["path"], "release binary")
+        archive_name = binary.get("archive_binary", binary["binary"])
+        destination = package_root / "bin" / f"{archive_name}{suffix}"
+        shutil.copyfile(source, destination)
+        destination.chmod(destination.stat().st_mode | stat.S_IXUSR)
+    for service, source_value in layout["configs"].items():
+        source = resolve_existing_file(ROOT / source_value, f"{service} config")
+        _copy_archive_config(service, source, package_root / "conf" / f"{service}.toml")
+    for script in ("rocketmq-service.ps1", "rocketmq-service.sh"):
+        source = resolve_existing_file(ROOT / "distribution" / "scripts" / script, script)
+        destination = package_root / "scripts" / script
+        shutil.copyfile(source, destination)
+        destination.chmod(destination.stat().st_mode | stat.S_IXUSR)
+    add_unique_record(
+        partial,
+        "artifacts",
+        {
+            "id": "common-inputs",
+            "kind": "common-inputs",
+            "path": candidate_relative(root, common_inputs, "common release inputs"),
+        },
+    )
+    save_draft(root, target, partial)
+    return package_root
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate-manifest", type=Path, required=True)
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--common-inputs", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        output = prepare_staging(args.candidate_manifest, args.target, args.common_inputs)
+        print(f"RELEASE_ARCHIVE_STAGING_OK target={args.target} output={output}")
+        return 0
+    except (ArchiveError, OSError, KeyError) as error:
+        print(f"RELEASE_ARCHIVE_STAGING_FAILED detail={error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/distribution/release-layout.json
+++ b/distribution/release-layout.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "distribution": "RocketMQ Rust Community Distribution",
+  "identity_kind": "unofficial-community",
+  "targets": {
+    "x86_64-unknown-linux-gnu": {
+      "archive_format": "tar.gz",
+      "executable_suffix": ""
+    },
+    "x86_64-pc-windows-msvc": {
+      "archive_format": "zip",
+      "executable_suffix": ".exe"
+    },
+    "x86_64-apple-darwin": {
+      "archive_format": "tar.gz",
+      "executable_suffix": ""
+    }
+  },
+  "binaries": [
+    {
+      "id": "namesrv",
+      "kind": "service",
+      "package": "rocketmq-namesrv",
+      "binary": "rocketmq-namesrv-rust",
+      "requested_features": ["observability", "otlp-logs", "otlp-metrics", "otlp-traces"],
+      "effective_features": ["default", "observability", "otel-logs", "otel-metrics", "otel-traces", "otlp-logs", "otlp-metrics", "otlp-traces", "tls"]
+    },
+    {
+      "id": "broker",
+      "kind": "service",
+      "package": "rocketmq-broker",
+      "binary": "rocketmq-broker-rust",
+      "requested_features": ["extended_timeline", "observability", "otlp-logs", "otlp-metrics", "otlp-traces", "rocksdb_store", "tieredstore"],
+      "effective_features": ["default", "extended_timeline", "local_file_store", "observability", "otel-logs", "otel-metrics", "otel-traces", "otlp-logs", "otlp-metrics", "otlp-traces", "rocksdb_store", "tieredstore"]
+    },
+    {
+      "id": "controller",
+      "kind": "service",
+      "package": "rocketmq-controller",
+      "binary": "rocketmq-controller-rust",
+      "requested_features": ["metrics-otlp", "otlp-logs", "otlp-traces", "storage-rocksdb"],
+      "effective_features": ["default", "metrics", "metrics-otlp", "otel-logs", "otel-traces", "otlp-logs", "otlp-traces", "storage-rocksdb"]
+    },
+    {
+      "id": "proxy",
+      "kind": "service",
+      "package": "rocketmq-proxy",
+      "binary": "rocketmq-proxy-rust",
+      "requested_features": ["otlp-logs", "otlp-metrics", "otlp-traces", "tieredstore", "tls"],
+      "effective_features": ["cluster-mode", "default", "local-mode", "observability", "otel-logs", "otel-metrics", "otel-traces", "otlp-logs", "otlp-metrics", "otlp-traces", "tieredstore", "tls"]
+    },
+    {
+      "id": "admin",
+      "kind": "tool",
+      "package": "rocketmq-admin-cli",
+      "binary": "rocketmq-admin-cli",
+      "requested_features": [],
+      "effective_features": ["default"]
+    },
+    {
+      "id": "store-inspect",
+      "kind": "tool",
+      "package": "rocketmq-store-inspect",
+      "binary": "rocketmq-cli-rust",
+      "archive_binary": "rocketmq-store-inspect",
+      "requested_features": [],
+      "effective_features": ["default", "rocksdb-store"],
+      "required_dependencies": ["rocketmq-store-rocksdb", "rocksdb"]
+    }
+  ],
+  "configs": {
+    "namesrv": "distribution/config/nameserver/namesrv.toml",
+    "broker": "distribution/config/broker/broker.toml",
+    "controller": "distribution/config/controller/controller.toml",
+    "proxy": "distribution/config/proxy/proxy.toml"
+  },
+  "common_files": ["LICENSE-APACHE", "NOTICE", "README.md", "RELEASE_NOTES.md"],
+  "archive_directories": ["bin", "conf", "data", "logs", "run", "sbom", "scripts"],
+  "excluded_capabilities": ["BrokerContainer", "Dashboard", "DLedger CommitLog", "MCP", "OpenMessaging", "SRE"]
+}

--- a/distribution/release-manifest.schema.json
+++ b/distribution/release-manifest.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RocketMQ Rust release archive manifest",
+  "type": "object",
+  "required": ["schema_version", "candidate_id", "version", "run_id", "attempt", "target", "artifact_id", "archive", "files", "binaries", "remote_publication"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "candidate_id": {"type": "string", "minLength": 1},
+    "version": {"type": "string", "minLength": 1},
+    "run_id": {"type": "string", "minLength": 1},
+    "attempt": {"type": "integer", "minimum": 1},
+    "target": {"type": "string", "minLength": 1},
+    "artifact_id": {"type": "string", "minLength": 1},
+    "archive": {"type": "string", "minLength": 1},
+    "files": {"type": "array", "items": {"type": "object", "required": ["path", "type", "size"]}},
+    "binaries": {"type": "array", "minItems": 6, "maxItems": 6},
+    "remote_publication": {"const": "not-executed"}
+  },
+  "additionalProperties": false
+}

--- a/distribution/release_archive_common.py
+++ b/distribution/release_archive_common.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared candidate-scoped primitives for local release archives."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path, PurePosixPath
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+for module_root in (ROOT / "distribution", SCRIPTS):
+    if str(module_root) not in sys.path:
+        sys.path.insert(0, str(module_root))
+
+from release_state import (
+    ReleaseStateError,
+    atomic_write_json,
+    read_json,
+    resolve_existing_file,
+    resolve_within,
+    validate_candidate,
+)
+
+
+LAYOUT_PATH = ROOT / "distribution" / "release-layout.json"
+
+
+class ArchiveError(ReleaseStateError):
+    """Raised when a release archive operation violates the frozen layout."""
+
+
+def load_candidate(manifest: Path, *, writable: bool = True) -> tuple[Path, dict[str, Any], Path]:
+    manifest = resolve_existing_file(manifest, "candidate_manifest")
+    candidate = read_json(manifest)
+    validate_candidate(candidate)
+    if writable and candidate["sealed"]:
+        raise ArchiveError("sealed candidates cannot create or change release artifacts")
+    root = Path(candidate["candidate_root"]).resolve()
+    if manifest.parent.resolve() != root:
+        raise ArchiveError("candidate manifest must live at the candidate root")
+    return manifest, candidate, root
+
+
+def load_layout(path: Path = LAYOUT_PATH) -> dict[str, Any]:
+    layout = read_json(resolve_existing_file(path, "release_layout"))
+    if layout.get("schema_version") != 1:
+        raise ArchiveError("unsupported release layout schema")
+    binaries = layout.get("binaries")
+    targets = layout.get("targets")
+    if not isinstance(binaries, list) or len(binaries) != 6 or not isinstance(targets, dict):
+        raise ArchiveError("release layout must declare six binaries and target profiles")
+    ids = [entry.get("id") for entry in binaries if isinstance(entry, dict)]
+    if len(ids) != 6 or len(ids) != len(set(ids)):
+        raise ArchiveError("release layout binary identifiers are invalid or duplicated")
+    return layout
+
+
+def target_layout(layout: dict[str, Any], target: str) -> dict[str, Any]:
+    value = layout["targets"].get(target)
+    if not isinstance(value, dict):
+        raise ArchiveError(f"unsupported release target: {target}")
+    return value
+
+
+def candidate_relative(root: Path, path: Path, label: str) -> str:
+    resolved = resolve_within(root, path, label)
+    return resolved.relative_to(root).as_posix()
+
+
+def require_relative_path(value: str, label: str) -> PurePosixPath:
+    if not isinstance(value, str) or not value:
+        raise ArchiveError(f"{label} must be a non-empty candidate-relative path")
+    path = PurePosixPath(value)
+    if path.is_absolute() or ".." in path.parts or "\\" in value:
+        raise ArchiveError(f"{label} is not a safe POSIX relative path: {value}")
+    return path
+
+
+def resolve_candidate_path(root: Path, value: str, label: str) -> Path:
+    relative = require_relative_path(value, label)
+    return resolve_within(root, root.joinpath(*relative.parts), label)
+
+
+def file_inventory(root: Path) -> list[dict[str, Any]]:
+    root = root.resolve()
+    if not root.is_dir():
+        raise ArchiveError(f"inventory root is not a directory: {root}")
+    records: list[dict[str, Any]] = []
+    for path in sorted(root.rglob("*")):
+        if path.is_symlink():
+            raise ArchiveError(f"release input cannot contain links: {path}")
+        relative = path.relative_to(root).as_posix()
+        if path.is_dir():
+            records.append({"path": relative, "type": "directory", "size": 0})
+        elif path.is_file():
+            records.append({"path": relative, "type": "file", "size": path.stat().st_size})
+        else:
+            raise ArchiveError(f"release input has an unsupported file type: {path}")
+    return records
+
+
+def compare_inventory(root: Path, expected: list[dict[str, Any]]) -> None:
+    if file_inventory(root) != expected:
+        raise ArchiveError(f"release input inventory changed: {root}")
+
+
+def artifact_id(candidate: dict[str, Any], target: str, component: str) -> str:
+    return f"{candidate['candidate_id']}.{target}.{component}"
+
+
+def draft_partial_path(root: Path, target: str) -> Path:
+    return root / "partials" / f"CANDIDATE_PARTIAL.{target}.draft.json"
+
+
+def sealed_partial_path(root: Path, target: str) -> Path:
+    return root / "partials" / f"CANDIDATE_PARTIAL.{target}.json"
+
+
+def create_partial(candidate: dict[str, Any], target: str) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "candidate_id": candidate["candidate_id"],
+        "version": candidate["version"],
+        "run_id": candidate["run_id"],
+        "attempt": candidate["attempt"],
+        "target": target,
+        "worker_id": f"release-{target}",
+        "sealed": False,
+        "artifacts": [],
+        "events": [],
+        "execution_contexts": [],
+    }
+
+
+def load_or_create_draft(root: Path, candidate: dict[str, Any], target: str) -> dict[str, Any]:
+    path = draft_partial_path(root, target)
+    if not path.exists():
+        value = create_partial(candidate, target)
+        atomic_write_json(path, value)
+        return value
+    value = read_json(path)
+    expected = (
+        candidate["candidate_id"],
+        candidate["version"],
+        candidate["run_id"],
+        candidate["attempt"],
+        target,
+        False,
+    )
+    actual = (
+        value.get("candidate_id"),
+        value.get("version"),
+        value.get("run_id"),
+        value.get("attempt"),
+        value.get("target"),
+        value.get("sealed"),
+    )
+    if actual != expected:
+        raise ArchiveError("candidate partial does not match the active target run")
+    return value
+
+
+def add_unique_record(partial: dict[str, Any], collection: str, record: dict[str, Any]) -> None:
+    values = partial.get(collection)
+    identifier = record.get("id")
+    if not isinstance(values, list) or not isinstance(identifier, str) or not identifier:
+        raise ArchiveError(f"invalid {collection} record")
+    if any(item.get("id") == identifier for item in values if isinstance(item, dict)):
+        raise ArchiveError(f"duplicate {collection} identifier: {identifier}")
+    values.append(record)
+
+
+def save_draft(root: Path, target: str, partial: dict[str, Any]) -> None:
+    if partial.get("sealed") is not False:
+        raise ArchiveError("cannot write a sealed candidate partial")
+    atomic_write_json(draft_partial_path(root, target), partial)
+
+
+def read_policy_json(path: Path, label: str) -> dict[str, Any]:
+    value = read_json(resolve_existing_file(path, label))
+    if value.get("schema_version") != 1:
+        raise ArchiveError(f"unsupported {label} schema")
+    return value
+
+
+def write_json(path: Path, value: dict[str, Any]) -> None:
+    atomic_write_json(path, value)
+
+
+def render_json(value: dict[str, Any]) -> str:
+    return json.dumps(value, indent=2, ensure_ascii=False) + "\n"

--- a/distribution/render_candidate_release_notes.py
+++ b/distribution/render_candidate_release_notes.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT / "distribution") not in sys.path:
+    sys.path.insert(0, str(ROOT / "distribution"))
+
+from release_archive_common import ArchiveError, load_candidate, load_layout
+from release_state import read_json, resolve_within
+
+
+TEMPLATE = ROOT / "rocketmq-doc" / "en" / "release" / "1.0" / "release-notes-template.md"
+IDENTITY = ROOT / "distribution" / "release-identity.json"
+
+
+def _known_issues(values: list[Any]) -> str:
+    if not values:
+        return "- None recorded for this candidate."
+    rendered: list[str] = []
+    for value in values:
+        if isinstance(value, str):
+            rendered.append(f"- {value}")
+        elif isinstance(value, dict):
+            identifier = value.get("id", "unidentified")
+            summary = value.get("summary") or value.get("description") or "No summary"
+            rendered.append(f"- `{identifier}`: {summary}")
+        else:
+            raise ArchiveError("candidate known_issues contains an unsupported entry")
+    return "\n".join(rendered)
+
+
+def render_notes(candidate: dict[str, Any]) -> str:
+    template = TEMPLATE.read_text(encoding="utf-8")
+    identity = read_json(IDENTITY)
+    layout = load_layout()
+    components = "\n".join(
+        f"- `{entry['id']}`: `{entry['binary']}` ({entry['kind']})"
+        for entry in layout["binaries"]
+    )
+    exclusions = "\n".join(
+        f"- {value}: not supported by this core distribution."
+        for value in layout["excluded_capabilities"]
+    )
+    replacements = {
+        "{{version}}": candidate["version"],
+        "{{candidate_id}}": candidate["candidate_id"],
+        "{{run_id}}": candidate["run_id"],
+        "{{attempt}}": str(candidate["attempt"]),
+        "{{approver}}": identity["approval"]["approver"],
+        "{{included_components}}": components,
+        "{{excluded_capabilities}}": exclusions,
+        "{{known_issues}}": _known_issues(candidate["known_issues"]),
+    }
+    for marker, value in replacements.items():
+        template = template.replace(marker, value)
+    if "{{" in template or "}}" in template:
+        raise ArchiveError("release notes template has unresolved markers")
+    return template.rstrip() + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate-manifest", type=Path, required=True)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        _manifest, candidate, root = load_candidate(args.candidate_manifest)
+        output = args.output or root / "common-input-source" / "RELEASE_NOTES.md"
+        output = resolve_within(root, output, "release notes output")
+        if output.exists():
+            raise ArchiveError(f"release notes already exist: {output}")
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(render_notes(candidate), encoding="utf-8", newline="\n")
+        print(f"CANDIDATE_RELEASE_NOTES_OK output={output}")
+        return 0
+    except (ArchiveError, OSError) as error:
+        print(f"CANDIDATE_RELEASE_NOTES_FAILED detail={error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/distribution/sbom-toolchain.json
+++ b/distribution/sbom-toolchain.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "format": "CycloneDX",
+  "spec_version": "1.5",
+  "generator": "distribution/generate_component_sbom.py",
+  "component_types": ["application", "library"],
+  "content_source": "cargo metadata --locked and archive staging inventory",
+  "remote_lookup": false
+}

--- a/distribution/scripts/rocketmq-service.ps1
+++ b/distribution/scripts/rocketmq-service.ps1
@@ -1,0 +1,53 @@
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [ValidateSet('start', 'stop', 'status')]
+    [string]$Action,
+    [Parameter(Mandatory = $true, Position = 1)]
+    [ValidateSet('namesrv', 'broker', 'controller', 'proxy')]
+    [string]$Service
+)
+
+$ErrorActionPreference = 'Stop'
+$root = Split-Path -Parent $PSScriptRoot
+$workdir = if ($env:ROCKETMQ_WORKDIR) { $env:ROCKETMQ_WORKDIR } else { Join-Path (Get-Location) 'work' }
+$binaryNames = @{
+    namesrv = 'rocketmq-namesrv-rust.exe'
+    broker = 'rocketmq-broker-rust.exe'
+    controller = 'rocketmq-controller-rust.exe'
+    proxy = 'rocketmq-proxy-rust.exe'
+}
+$runDir = Join-Path $workdir 'run'
+$logDir = Join-Path $workdir 'logs'
+$dataDir = Join-Path $workdir "data/$Service"
+New-Item -ItemType Directory -Force -Path $runDir, $logDir, $dataDir | Out-Null
+$pidFile = Join-Path $runDir "$Service.pid"
+$logFile = Join-Path $logDir "$Service.log"
+
+function Get-ServiceProcess {
+    if (-not (Test-Path -LiteralPath $pidFile)) { return $null }
+    $processId = [int](Get-Content -LiteralPath $pidFile -Raw)
+    return Get-Process -Id $processId -ErrorAction SilentlyContinue
+}
+
+$process = Get-ServiceProcess
+switch ($Action) {
+    'start' {
+        if ($process) { Write-Output "$Service already running"; exit 0 }
+        $env:ROCKETMQ_HOME = $workdir
+        $arguments = @('-c', (Join-Path $root "conf/$Service.toml"))
+        $process = Start-Process -FilePath (Join-Path $root "bin/$($binaryNames[$Service])") `
+            -ArgumentList $arguments -RedirectStandardOutput $logFile -RedirectStandardError "$logFile.err" `
+            -WindowStyle Hidden -PassThru
+        Set-Content -LiteralPath $pidFile -Value $process.Id
+    }
+    'stop' {
+        if (-not $process) { Remove-Item -LiteralPath $pidFile -Force -ErrorAction SilentlyContinue; exit 0 }
+        Stop-Process -Id $process.Id
+        Remove-Item -LiteralPath $pidFile -Force
+    }
+    'status' {
+        if ($process) { Write-Output "$Service running"; exit 0 }
+        Write-Output "$Service stopped"
+        exit 3
+    }
+}

--- a/distribution/scripts/rocketmq-service.sh
+++ b/distribution/scripts/rocketmq-service.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+action="${1:-}"
+service="${2:-}"
+workdir="${ROCKETMQ_WORKDIR:-$(pwd)/work}"
+root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+case "$service" in
+  namesrv) binary="rocketmq-namesrv-rust" ;;
+  broker) binary="rocketmq-broker-rust" ;;
+  controller) binary="rocketmq-controller-rust" ;;
+  proxy) binary="rocketmq-proxy-rust" ;;
+  *) echo "usage: $0 start|stop|status namesrv|broker|controller|proxy" >&2; exit 2 ;;
+esac
+
+mkdir -p "$workdir/run" "$workdir/logs" "$workdir/data/$service"
+pid_file="$workdir/run/$service.pid"
+log_file="$workdir/logs/$service.log"
+
+is_running() {
+  [[ -f "$pid_file" ]] && kill -0 "$(cat "$pid_file")" 2>/dev/null
+}
+
+case "$action" in
+  start)
+    if is_running; then echo "$service already running"; exit 0; fi
+    ROCKETMQ_HOME="$workdir" "$root/bin/$binary" -c "$root/conf/$service.toml" \
+      >>"$log_file" 2>&1 &
+    echo "$!" >"$pid_file"
+    ;;
+  stop)
+    if ! is_running; then rm -f "$pid_file"; echo "$service not running"; exit 0; fi
+    kill "$(cat "$pid_file")"
+    rm -f "$pid_file"
+    ;;
+  status)
+    if is_running; then echo "$service running"; else echo "$service stopped"; exit 3; fi
+    ;;
+  *) echo "usage: $0 start|stop|status namesrv|broker|controller|proxy" >&2; exit 2 ;;
+esac

--- a/distribution/seal_candidate_partial.py
+++ b/distribution/seal_candidate_partial.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT / "distribution") not in sys.path:
+    sys.path.insert(0, str(ROOT / "distribution"))
+
+from release_archive_common import (
+    ArchiveError,
+    draft_partial_path,
+    load_candidate,
+    load_layout,
+    read_policy_json,
+    resolve_candidate_path,
+    sealed_partial_path,
+)
+from release_state import atomic_write_json, read_json
+
+
+def seal_partial(candidate_manifest: Path, target: str) -> Path:
+    _manifest, candidate, root = load_candidate(candidate_manifest)
+    layout = load_layout()
+    if target not in layout["targets"]:
+        raise ArchiveError(f"unsupported release target: {target}")
+    draft_path = draft_partial_path(root, target)
+    sealed_path = sealed_partial_path(root, target)
+    if sealed_path.exists():
+        raise ArchiveError(f"candidate partial is already sealed: {sealed_path}")
+    partial = read_policy_json(draft_path, "candidate partial draft")
+    identity = (
+        partial.get("candidate_id"),
+        partial.get("version"),
+        partial.get("run_id"),
+        partial.get("attempt"),
+        partial.get("target"),
+        partial.get("sealed"),
+    )
+    expected = (
+        candidate["candidate_id"],
+        candidate["version"],
+        candidate["run_id"],
+        candidate["attempt"],
+        target,
+        False,
+    )
+    if identity != expected:
+        raise ArchiveError("candidate partial identity does not match the active run")
+    artifacts = partial.get("artifacts", [])
+    identifiers = [entry.get("id") for entry in artifacts if isinstance(entry, dict)]
+    required = {f"binary-{entry['id']}" for entry in layout["binaries"]}
+    required.update({"archive", "archive-manifest", "common-inputs", "component-sbom", "host-smoke"})
+    missing = sorted(required - set(identifiers))
+    if missing:
+        raise ArchiveError(f"candidate partial is missing artifacts: {', '.join(missing)}")
+    if len(identifiers) != len(set(identifiers)):
+        raise ArchiveError("candidate partial artifact identifiers are duplicated")
+    for artifact in artifacts:
+        path = resolve_candidate_path(root, artifact.get("path"), "partial artifact")
+        if not path.exists():
+            raise ArchiveError(f"candidate partial artifact is missing: {path}")
+    events = partial.get("events")
+    contexts = partial.get("execution_contexts")
+    if not events or not contexts:
+        raise ArchiveError("candidate partial has no event/context evidence")
+    for event in events:
+        started = resolve_candidate_path(root, event.get("started"), "partial started event")
+        completed = resolve_candidate_path(root, event.get("completed"), "partial completed event")
+        if not started.is_file() or not completed.is_file():
+            raise ArchiveError(f"candidate partial event pair is incomplete: {event.get('id')}")
+        completed_value = read_json(completed)
+        if completed_value.get("exit_code") != 0:
+            raise ArchiveError(f"candidate partial event did not succeed: {event.get('id')}")
+    for context in contexts:
+        path = resolve_candidate_path(root, context.get("path"), "partial execution context")
+        if not path.is_file():
+            raise ArchiveError(f"candidate partial context is missing: {context.get('id')}")
+    partial["sealed"] = True
+    atomic_write_json(draft_path, partial)
+    os.replace(draft_path, sealed_path)
+    return sealed_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate-manifest", type=Path, required=True)
+    parser.add_argument("--target", required=True)
+    args = parser.parse_args(argv)
+    try:
+        output = seal_partial(args.candidate_manifest, args.target)
+        print(f"CANDIDATE_PARTIAL_SEALED target={args.target} partial={output}")
+        return 0
+    except (ArchiveError, OSError) as error:
+        print(f"CANDIDATE_PARTIAL_SEAL_FAILED detail={error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/distribution/transfer_candidate.py
+++ b/distribution/transfer_candidate.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+from pathlib import Path, PurePosixPath
+import subprocess
+import sys
+import tarfile
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT / "distribution") not in sys.path:
+    sys.path.insert(0, str(ROOT / "distribution"))
+
+from release_archive_common import ArchiveError, load_candidate, require_relative_path
+from release_state import read_json, resolve_existing_file, resolve_within
+
+
+EXCLUDED_PREFIXES = (
+    ".git/",
+    ".worktrees/",
+    "rocketmq-dashboard/",
+    "rocketmq-sre/",
+    "rocketmq-tools/rocketmq-mcp/",
+    "rocketmq-website/",
+    "target/",
+)
+
+
+def _tracked_source_files(source_root: Path) -> list[Path]:
+    completed = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=source_root,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise ArchiveError("cannot enumerate canonical source files with git ls-files")
+    values = completed.stdout.decode("utf-8").split("\0")
+    selected: list[Path] = []
+    for value in values:
+        if not value or value.startswith(EXCLUDED_PREFIXES):
+            continue
+        path = source_root / value
+        if path.is_file() and not path.is_symlink():
+            selected.append(path)
+    return sorted(selected)
+
+
+def _add_bytes(archive: tarfile.TarFile, name: str, content: bytes) -> None:
+    info = tarfile.TarInfo(name)
+    info.size = len(content)
+    info.mode = 0o644
+    info.mtime = 0
+    archive.addfile(info, io.BytesIO(content))
+
+
+def _write_bundle(
+    candidate: dict[str, Any],
+    *,
+    bundle_kind: str,
+    output: Path,
+    records: list[tuple[str, Path]],
+) -> Path:
+    normalized: list[tuple[str, bytes]] = []
+    seen: set[str] = set()
+    manifest_records: list[dict[str, Any]] = []
+    for relative, path in records:
+        require_relative_path(relative, "candidate transfer path")
+        if relative in seen:
+            raise ArchiveError(f"candidate transfer path is duplicated: {relative}")
+        seen.add(relative)
+        content = resolve_existing_file(path, "candidate transfer input").read_bytes()
+        manifest_records.append({"path": relative, "type": "file", "size": len(content)})
+        normalized.append((relative, content))
+    manifest = {
+        "schema_version": 1,
+        "bundle_kind": bundle_kind,
+        "candidate_id": candidate["candidate_id"],
+        "version": candidate["version"],
+        "run_id": candidate["run_id"],
+        "attempt": candidate["attempt"],
+        "files": manifest_records,
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(output, "w") as archive:
+        _add_bytes(
+            archive,
+            "CANDIDATE_TRANSFER.json",
+            (json.dumps(manifest, indent=2) + "\n").encode(),
+        )
+        for relative, content in normalized:
+            _add_bytes(archive, f"payload/{relative}", content)
+    return output
+
+
+def export_bundle(
+    candidate_manifest: Path,
+    *,
+    bundle_kind: str,
+    output: Path,
+    source_root: Path,
+    files: list[Path],
+) -> Path:
+    _manifest, candidate, candidate_root = load_candidate(candidate_manifest)
+    output = resolve_within(candidate_root, output, "candidate transfer output")
+    if output.exists():
+        raise ArchiveError(f"candidate transfer bundle already exists: {output}")
+    source_root = source_root.resolve()
+    normalized: list[tuple[str, Path]] = []
+    for path in files:
+        path = resolve_existing_file(path, "candidate transfer input")
+        try:
+            relative = path.relative_to(source_root).as_posix()
+        except ValueError as error:
+            raise ArchiveError(f"candidate transfer input escapes source root: {path}") from error
+        require_relative_path(relative, "candidate transfer path")
+        normalized.append((relative, path))
+    return _write_bundle(candidate, bundle_kind=bundle_kind, output=output, records=normalized)
+
+
+def export_build_source(candidate_manifest: Path, output: Path, source_root: Path) -> Path:
+    source_root = source_root.resolve()
+    return export_bundle(
+        candidate_manifest,
+        bundle_kind="build-source",
+        output=output,
+        source_root=source_root,
+        files=_tracked_source_files(source_root),
+    )
+
+
+def _safe_member(member: tarfile.TarInfo) -> PurePosixPath:
+    path = PurePosixPath(member.name)
+    if path.is_absolute() or ".." in path.parts or member.issym() or member.islnk():
+        raise ArchiveError(f"unsafe candidate transfer member: {member.name}")
+    return path
+
+
+def import_bundle(bundle: Path, output: Path) -> Path:
+    bundle = resolve_existing_file(bundle, "candidate transfer bundle")
+    output = output.resolve()
+    if output.exists():
+        raise ArchiveError(f"candidate transfer import already exists: {output}")
+    with tarfile.open(bundle, "r") as archive:
+        members = archive.getmembers()
+        names = [member.name for member in members]
+        if len(names) != len(set(names)):
+            raise ArchiveError("candidate transfer archive has duplicate members")
+        for member in members:
+            _safe_member(member)
+        manifest_member = archive.getmember("CANDIDATE_TRANSFER.json")
+        manifest_file = archive.extractfile(manifest_member)
+        if manifest_file is None:
+            raise ArchiveError("candidate transfer manifest is unreadable")
+        manifest = json.loads(manifest_file.read())
+        expected = {
+            entry["path"]: entry["size"]
+            for entry in manifest.get("files", [])
+            if isinstance(entry, dict)
+        }
+        if len(expected) != len(manifest.get("files", [])):
+            raise ArchiveError("candidate transfer manifest has duplicate or invalid paths")
+        expected_members = {"CANDIDATE_TRANSFER.json", *(f"payload/{path}" for path in expected)}
+        if set(names) != expected_members:
+            raise ArchiveError("candidate transfer members do not match the closed manifest")
+        output.mkdir(parents=True)
+        for relative, size in expected.items():
+            require_relative_path(relative, "candidate transfer path")
+            member = archive.getmember(f"payload/{relative}")
+            source = archive.extractfile(member)
+            if source is None:
+                raise ArchiveError(f"candidate transfer file is unreadable: {relative}")
+            content = source.read()
+            if len(content) != size:
+                raise ArchiveError(f"candidate transfer size mismatch: {relative}")
+            destination = output.joinpath(*PurePosixPath(relative).parts)
+            resolve_within(output, destination, "candidate transfer destination")
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes(content)
+        (output / "CANDIDATE_TRANSFER.json").write_text(
+            json.dumps(manifest, indent=2) + "\n", encoding="utf-8", newline="\n"
+        )
+    return output
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subcommands = parser.add_subparsers(dest="command", required=True)
+    source = subcommands.add_parser("export-build-source")
+    source.add_argument("--candidate-manifest", type=Path, required=True)
+    source.add_argument("--source-root", type=Path, default=ROOT)
+    source.add_argument("--output", type=Path, required=True)
+    control = subcommands.add_parser("export-build-control")
+    control.add_argument("--candidate-manifest", type=Path, required=True)
+    control.add_argument("--output", type=Path, required=True)
+    artifacts = subcommands.add_parser("export-artifacts")
+    artifacts.add_argument("--candidate-manifest", type=Path, required=True)
+    artifacts.add_argument("--output", type=Path, required=True)
+    target = subcommands.add_parser("export-target")
+    target.add_argument("--candidate-manifest", type=Path, required=True)
+    target.add_argument("--target", required=True)
+    target.add_argument("--output", type=Path, required=True)
+    imported = subcommands.add_parser("import")
+    imported.add_argument("--bundle", type=Path, required=True)
+    imported.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "export-build-source":
+            output = export_build_source(args.candidate_manifest, args.output, args.source_root)
+        elif args.command == "import":
+            output = import_bundle(args.bundle, args.output)
+        else:
+            manifest, _candidate, root = load_candidate(args.candidate_manifest)
+            if args.command == "export-build-control":
+                records = [("CANDIDATE_RUN.json", manifest)]
+                series = read_json(manifest).get("series_manifest")
+                if isinstance(series, str) and Path(series).is_file():
+                    records.append(("RELEASE_SERIES.json", Path(series)))
+                output_path = resolve_within(root, args.output, "candidate transfer output")
+                if output_path.exists():
+                    raise ArchiveError(f"candidate transfer bundle already exists: {output_path}")
+                output = _write_bundle(
+                    read_json(manifest),
+                    bundle_kind="build-control",
+                    output=output_path,
+                    records=records,
+                )
+                print(f"CANDIDATE_TRANSFER_OK command={args.command} output={output}")
+                return 0
+            if args.command == "export-target":
+                from release_archive_common import sealed_partial_path, resolve_candidate_path
+
+                partial_path = sealed_partial_path(root, args.target)
+                partial = read_json(resolve_existing_file(partial_path, "sealed target partial"))
+                files = [partial_path]
+                for artifact in partial.get("artifacts", []):
+                    artifact_path = resolve_candidate_path(root, artifact.get("path"), "target artifact")
+                    if artifact_path.is_dir():
+                        files.extend(path for path in artifact_path.rglob("*") if path.is_file())
+                    else:
+                        files.append(artifact_path)
+                for event in partial.get("events", []):
+                    for key in ("started", "completed"):
+                        files.append(resolve_candidate_path(root, event.get(key), f"target event {key}"))
+                for context in partial.get("execution_contexts", []):
+                    files.append(resolve_candidate_path(root, context.get("path"), "target context"))
+            else:
+                allowed_roots = ["archives", "crate-packages", "helm", "oci", "sbom"]
+                files = [path for name in allowed_roots for path in (root / name).rglob("*") if path.is_file()]
+            output = export_bundle(
+                manifest,
+                bundle_kind="target" if args.command == "export-target" else "artifacts",
+                output=args.output,
+                source_root=root,
+                files=files,
+            )
+        print(f"CANDIDATE_TRANSFER_OK command={args.command} output={output}")
+        return 0
+    except (ArchiveError, OSError, KeyError, json.JSONDecodeError) as error:
+        print(f"CANDIDATE_TRANSFER_FAILED detail={error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/distribution/verify_release_archive.py
+++ b/distribution/verify_release_archive.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path, PurePosixPath
+import subprocess
+import sys
+import tarfile
+import tempfile
+import tomllib
+import zipfile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT / "distribution") not in sys.path:
+    sys.path.insert(0, str(ROOT / "distribution"))
+
+from release_archive_common import (
+    ArchiveError,
+    add_unique_record,
+    artifact_id,
+    candidate_relative,
+    compare_inventory,
+    draft_partial_path,
+    load_candidate,
+    load_layout,
+    read_policy_json,
+    resolve_candidate_path,
+    save_draft,
+    target_layout,
+    write_json,
+)
+from release_state import read_json, resolve_existing_file
+
+
+def _safe_name(value: str) -> PurePosixPath:
+    path = PurePosixPath(value)
+    if path.is_absolute() or ".." in path.parts or "\\" in value:
+        raise ArchiveError(f"archive contains an unsafe path: {value}")
+    return path
+
+
+def _extract(archive: Path, output: Path) -> None:
+    if archive.suffix == ".zip":
+        with zipfile.ZipFile(archive) as value:
+            for info in value.infolist():
+                _safe_name(info.filename)
+            value.extractall(output)
+    else:
+        with tarfile.open(archive, "r:gz") as value:
+            for member in value.getmembers():
+                _safe_name(member.name)
+                if member.issym() or member.islnk():
+                    raise ArchiveError(f"archive contains a link: {member.name}")
+            value.extractall(output, filter="data")
+
+
+def _manifest_for_archive(root: Path, archive: Path) -> tuple[Path, dict]:
+    relative = candidate_relative(root, archive, "release archive")
+    matches = []
+    for path in (root / "archives").glob("*.manifest.json"):
+        value = read_json(path)
+        if value.get("archive") == relative:
+            matches.append((path, value))
+    if len(matches) != 1:
+        raise ArchiveError(f"expected one manifest for archive, found {len(matches)}")
+    return matches[0]
+
+
+def _validate_manifest(candidate: dict, layout: dict, value: dict) -> None:
+    expected_identity = (
+        candidate["candidate_id"],
+        candidate["version"],
+        candidate["run_id"],
+        candidate["attempt"],
+    )
+    actual_identity = (
+        value.get("candidate_id"),
+        value.get("version"),
+        value.get("run_id"),
+        value.get("attempt"),
+    )
+    if actual_identity != expected_identity or value.get("remote_publication") != "not-executed":
+        raise ArchiveError("archive manifest does not match the candidate identity")
+    target_layout(layout, value.get("target"))
+    target = value["target"]
+    expected_archive_id = artifact_id(candidate, target, "archive")
+    if value.get("artifact_id") != expected_archive_id:
+        raise ArchiveError(f"archive artifact identity changed: {target}")
+    extension = ".zip" if target_layout(layout, target)["archive_format"] == "zip" else ".tar.gz"
+    expected_name = f"rocketmq-rust-{candidate['version']}-{target}{extension}"
+    if PurePosixPath(value.get("archive", "")).name != expected_name:
+        raise ArchiveError(f"archive filename changed: {target}")
+    if len(value.get("binaries", [])) != 6:
+        raise ArchiveError("archive manifest does not contain six binary records")
+    records = {entry.get("component"): entry for entry in value["binaries"]}
+    if len(records) != 6:
+        raise ArchiveError("archive binary components are duplicated")
+    for binary in layout["binaries"]:
+        record = records.get(binary["id"])
+        if record is None:
+            raise ArchiveError(f"archive manifest has no binary record: {binary['id']}")
+        if record.get("requested_features") != binary["requested_features"]:
+            raise ArchiveError(f"archive requested features changed: {binary['id']}")
+        if record.get("effective_features") != binary["effective_features"]:
+            raise ArchiveError(f"archive effective features changed: {binary['id']}")
+        required_dependencies = set(binary.get("required_dependencies", []))
+        if not required_dependencies.issubset(set(record.get("required_dependencies", []))):
+            raise ArchiveError(f"archive dependency closure is incomplete: {binary['id']}")
+
+
+def verify_archive(candidate_manifest: Path, archive: Path, *, smoke: bool) -> Path | None:
+    _manifest, candidate, root = load_candidate(candidate_manifest)
+    layout = load_layout()
+    archive = resolve_existing_file(archive, "release archive")
+    manifest_path, archive_manifest = _manifest_for_archive(root, archive)
+    _validate_manifest(candidate, layout, archive_manifest)
+    with tempfile.TemporaryDirectory() as temporary:
+        extracted = Path(temporary)
+        _extract(archive, extracted)
+        children = [path for path in extracted.iterdir() if path.is_dir()]
+        if len(children) != 1:
+            raise ArchiveError("release archive must have exactly one root directory")
+        package_root = children[0]
+        compare_inventory(package_root, archive_manifest["files"])
+        for service in layout["configs"]:
+            config = package_root / "conf" / f"{service}.toml"
+            with config.open("rb") as handle:
+                tomllib.load(handle)
+        if not smoke:
+            return None
+        suffix = target_layout(layout, archive_manifest["target"])["executable_suffix"]
+        results = []
+        for binary in layout["binaries"]:
+            name = binary.get("archive_binary", binary["binary"])
+            executable = package_root / "bin" / f"{name}{suffix}"
+            completed = subprocess.run(
+                [str(executable), "--version", "--verbose"],
+                cwd=package_root,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if completed.returncode != 0:
+                raise ArchiveError(
+                    f"archive binary version smoke failed: {binary['id']}: {completed.stderr}"
+                )
+            expected = {
+                f"version={candidate['version']}",
+                f"artifact_id={artifact_id(candidate, archive_manifest['target'], binary['id'])}",
+                f"requested_features={','.join(binary['requested_features'])}",
+                f"effective_features={','.join(binary['effective_features'])}",
+            }
+            missing = sorted(value for value in expected if value not in completed.stdout)
+            if missing:
+                raise ArchiveError(
+                    f"archive binary version metadata mismatch for {binary['id']}: {missing}"
+                )
+            results.append(
+                {"component": binary["id"], "exit_code": 0, "stdout": completed.stdout}
+            )
+    output = root / "evidence" / archive_manifest["target"] / "HOST_SMOKE.json"
+    write_json(
+        output,
+        {
+            "schema_version": 1,
+            "candidate_id": candidate["candidate_id"],
+            "target": archive_manifest["target"],
+            "archive_manifest": candidate_relative(root, manifest_path, "archive manifest"),
+            "results": results,
+            "status": "passed",
+        },
+    )
+    partial = read_policy_json(
+        draft_partial_path(root, archive_manifest["target"]), "candidate partial draft"
+    )
+    add_unique_record(
+        partial,
+        "artifacts",
+        {
+            "id": "host-smoke",
+            "kind": "host-smoke",
+            "path": candidate_relative(root, output, "host smoke evidence"),
+        },
+    )
+    save_draft(root, archive_manifest["target"], partial)
+    return output
+
+
+def verify_all_manifests(candidate_manifest: Path, manifest_root: Path) -> int:
+    _manifest, candidate, _root = load_candidate(candidate_manifest, writable=False)
+    layout = load_layout()
+    manifests = list(manifest_root.resolve().rglob("*.manifest.json"))
+    targets: set[str] = set()
+    for path in manifests:
+        value = read_json(path)
+        _validate_manifest(candidate, layout, value)
+        archive = path.parent / PurePosixPath(value["archive"]).name
+        if not archive.is_file():
+            raise ArchiveError(f"archive referenced by manifest is missing: {archive}")
+        target = value["target"]
+        if target in targets:
+            raise ArchiveError(f"archive manifest target is duplicated: {target}")
+        targets.add(target)
+    expected = set(layout["targets"])
+    if targets != expected:
+        raise ArchiveError(
+            f"archive manifest target mismatch: missing={sorted(expected - targets)} "
+            f"extra={sorted(targets - expected)}"
+        )
+    return len(manifests)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate-manifest", type=Path, required=True)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--archive", type=Path)
+    mode.add_argument("--all-manifests", type=Path)
+    parser.add_argument("--smoke", action="store_true")
+    parser.add_argument("--static-only", action="store_true")
+    args = parser.parse_args(argv)
+    try:
+        if args.archive is not None:
+            if not args.smoke or args.static_only:
+                raise ArchiveError("--archive requires --smoke and forbids --static-only")
+            output = verify_archive(args.candidate_manifest, args.archive, smoke=True)
+            print(f"RELEASE_ARCHIVE_SMOKE_OK output={output}")
+        else:
+            if not args.static_only or args.smoke:
+                raise ArchiveError("--all-manifests requires --static-only and forbids --smoke")
+            count = verify_all_manifests(args.candidate_manifest, args.all_manifests)
+            print(f"RELEASE_ARCHIVE_STATIC_OK manifests={count}")
+        return 0
+    except (ArchiveError, OSError, KeyError, json.JSONDecodeError, tomllib.TOMLDecodeError) as error:
+        print(f"RELEASE_ARCHIVE_VERIFY_FAILED detail={error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rocketmq-broker/src/bin/broker_bootstrap_server.rs
+++ b/rocketmq-broker/src/bin/broker_bootstrap_server.rs
@@ -58,7 +58,38 @@ const LOGO: &str = r#"
  |_|  \_\___/ \___|_|\_\___|\__|_|  |_|\___\_\      |_|  \_\__,_|___/\__| |____/|_|  \___/|_|\_\___|_|
 "#;
 
+fn print_release_version_if_requested(component: &str) -> bool {
+    let arguments: Vec<_> = std::env::args_os().skip(1).collect();
+    let version = std::ffi::OsStr::new("--version");
+    let verbose = std::ffi::OsStr::new("--verbose");
+    let requested = (arguments.len() == 1 && arguments[0].as_os_str() == version)
+        || (arguments.len() == 2 && arguments[0].as_os_str() == version && arguments[1].as_os_str() == verbose);
+    if !requested {
+        return false;
+    }
+    println!("{component}");
+    println!("version={}", env!("CARGO_PKG_VERSION"));
+    if arguments.len() == 2 {
+        println!(
+            "artifact_id={}",
+            option_env!("ROCKETMQ_RELEASE_ARTIFACT_ID").unwrap_or("development")
+        );
+        println!(
+            "requested_features={}",
+            option_env!("ROCKETMQ_RELEASE_REQUESTED_FEATURES").unwrap_or("default")
+        );
+        println!(
+            "effective_features={}",
+            option_env!("ROCKETMQ_RELEASE_EFFECTIVE_FEATURES").unwrap_or("default")
+        );
+    }
+    true
+}
+
 fn main() -> Result<()> {
+    if print_release_version_if_requested("rocketmq-broker-rust") {
+        return Ok(());
+    }
     let owner = RuntimeOwner::new(broker_runtime_config()).context("failed to build broker runtime")?;
     let service_context = owner.root_context().component("rocketmq-broker-runtime");
     let lifecycle = ServiceLifecycle::from_env("rocketmq-broker").context("invalid broker lifecycle configuration")?;

--- a/rocketmq-controller/src/bin/controller_bootstrap.rs
+++ b/rocketmq-controller/src/bin/controller_bootstrap.rs
@@ -82,7 +82,38 @@ const LOGO: &str = r#"
         \_| \_\___/ \___|_|\_\___|\__\_|  |_/\_/\_\      \_| \_\__,_|___/\__|  \____/\___/|_| |_|\__|_|  \___/|_|_|\___|_|
     "#;
 
+fn print_release_version_if_requested(component: &str) -> bool {
+    let arguments: Vec<_> = std::env::args_os().skip(1).collect();
+    let version = std::ffi::OsStr::new("--version");
+    let verbose = std::ffi::OsStr::new("--verbose");
+    let requested = (arguments.len() == 1 && arguments[0].as_os_str() == version)
+        || (arguments.len() == 2 && arguments[0].as_os_str() == version && arguments[1].as_os_str() == verbose);
+    if !requested {
+        return false;
+    }
+    println!("{component}");
+    println!("version={}", env!("CARGO_PKG_VERSION"));
+    if arguments.len() == 2 {
+        println!(
+            "artifact_id={}",
+            option_env!("ROCKETMQ_RELEASE_ARTIFACT_ID").unwrap_or("development")
+        );
+        println!(
+            "requested_features={}",
+            option_env!("ROCKETMQ_RELEASE_REQUESTED_FEATURES").unwrap_or("default")
+        );
+        println!(
+            "effective_features={}",
+            option_env!("ROCKETMQ_RELEASE_EFFECTIVE_FEATURES").unwrap_or("default")
+        );
+    }
+    true
+}
+
 pub fn main() -> Result<()> {
+    if print_release_version_if_requested("rocketmq-controller-rust") {
+        return Ok(());
+    }
     let owner = RuntimeOwner::new(controller_runtime_config())
         .map_err(|source| ControllerError::runtime_source("build controller runtime", source))?;
     let service_context = owner.root_context().component("rocketmq-controller-runtime");

--- a/rocketmq-doc/en/release/1.0/release-notes-template.md
+++ b/rocketmq-doc/en/release/1.0/release-notes-template.md
@@ -1,0 +1,21 @@
+# RocketMQ Rust {{version}} Community Distribution
+
+Candidate: `{{candidate_id}}`
+
+Run: `{{run_id}}`, attempt `{{attempt}}`
+
+This is an unofficial community distribution maintained by `{{approver}}`. It is not an Apache Software Foundation release.
+
+## Included core services and tools
+
+{{included_components}}
+
+## Explicit exclusions
+
+{{excluded_capabilities}}
+
+## Known issues
+
+{{known_issues}}
+
+Remote publication status: `not-executed`.

--- a/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
+++ b/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
@@ -81,7 +81,38 @@ type EmbeddedControllerConfig = ControllerConfig;
 #[cfg(not(feature = "embedded-controller"))]
 type EmbeddedControllerConfig = ();
 
+fn print_release_version_if_requested(component: &str) -> bool {
+    let arguments: Vec<_> = std::env::args_os().skip(1).collect();
+    let version = std::ffi::OsStr::new("--version");
+    let verbose = std::ffi::OsStr::new("--verbose");
+    let requested = (arguments.len() == 1 && arguments[0].as_os_str() == version)
+        || (arguments.len() == 2 && arguments[0].as_os_str() == version && arguments[1].as_os_str() == verbose);
+    if !requested {
+        return false;
+    }
+    println!("{component}");
+    println!("version={}", env!("CARGO_PKG_VERSION"));
+    if arguments.len() == 2 {
+        println!(
+            "artifact_id={}",
+            option_env!("ROCKETMQ_RELEASE_ARTIFACT_ID").unwrap_or("development")
+        );
+        println!(
+            "requested_features={}",
+            option_env!("ROCKETMQ_RELEASE_REQUESTED_FEATURES").unwrap_or("default")
+        );
+        println!(
+            "effective_features={}",
+            option_env!("ROCKETMQ_RELEASE_EFFECTIVE_FEATURES").unwrap_or("default")
+        );
+    }
+    true
+}
+
 fn main() -> Result<()> {
+    if print_release_version_if_requested("rocketmq-namesrv-rust") {
+        return Ok(());
+    }
     let owner = RuntimeOwner::new(namesrv_runtime_config()).context("failed to build namesrv runtime")?;
     let service_context = owner.root_context().component("rocketmq-namesrv-runtime");
     let lifecycle =

--- a/rocketmq-proxy/src/bin/rocketmq-proxy-rust.rs
+++ b/rocketmq-proxy/src/bin/rocketmq-proxy-rust.rs
@@ -44,7 +44,38 @@ use rocketmq_security_api::SecurityBootstrapOutcome;
 use rocketmq_security_api::SecurityBootstrapProfile;
 use tracing::info;
 
+fn print_release_version_if_requested(component: &str) -> bool {
+    let arguments: Vec<_> = std::env::args_os().skip(1).collect();
+    let version = std::ffi::OsStr::new("--version");
+    let verbose = std::ffi::OsStr::new("--verbose");
+    let requested = (arguments.len() == 1 && arguments[0].as_os_str() == version)
+        || (arguments.len() == 2 && arguments[0].as_os_str() == version && arguments[1].as_os_str() == verbose);
+    if !requested {
+        return false;
+    }
+    println!("{component}");
+    println!("version={}", env!("CARGO_PKG_VERSION"));
+    if arguments.len() == 2 {
+        println!(
+            "artifact_id={}",
+            option_env!("ROCKETMQ_RELEASE_ARTIFACT_ID").unwrap_or("development")
+        );
+        println!(
+            "requested_features={}",
+            option_env!("ROCKETMQ_RELEASE_REQUESTED_FEATURES").unwrap_or("default")
+        );
+        println!(
+            "effective_features={}",
+            option_env!("ROCKETMQ_RELEASE_EFFECTIVE_FEATURES").unwrap_or("default")
+        );
+    }
+    true
+}
+
 fn main() -> ProxyResult<()> {
+    if print_release_version_if_requested("rocketmq-proxy-rust") {
+        return Ok(());
+    }
     let owner = RuntimeOwner::new(proxy_runtime_config()).map_err(proxy_runtime_error("build proxy runtime"))?;
     let service_context = owner.root_context().component("proxy");
     let lifecycle = ServiceLifecycle::from_env("rocketmq-proxy").map_err(|error| ProxyError::Transport {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/main.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/src/main.rs
@@ -27,7 +27,38 @@ use rocketmq_runtime::RuntimeOwner;
 
 const CLI_RUNTIME_STACK_SIZE: usize = 16 * 1024 * 1024;
 
+fn print_release_version_if_requested(component: &str) -> bool {
+    let arguments: Vec<_> = std::env::args_os().skip(1).collect();
+    let version = std::ffi::OsStr::new("--version");
+    let verbose = std::ffi::OsStr::new("--verbose");
+    let requested = (arguments.len() == 1 && arguments[0].as_os_str() == version)
+        || (arguments.len() == 2 && arguments[0].as_os_str() == version && arguments[1].as_os_str() == verbose);
+    if !requested {
+        return false;
+    }
+    println!("{component}");
+    println!("version={}", env!("CARGO_PKG_VERSION"));
+    if arguments.len() == 2 {
+        println!(
+            "artifact_id={}",
+            option_env!("ROCKETMQ_RELEASE_ARTIFACT_ID").unwrap_or("development")
+        );
+        println!(
+            "requested_features={}",
+            option_env!("ROCKETMQ_RELEASE_REQUESTED_FEATURES").unwrap_or("default")
+        );
+        println!(
+            "effective_features={}",
+            option_env!("ROCKETMQ_RELEASE_EFFECTIVE_FEATURES").unwrap_or("default")
+        );
+    }
+    true
+}
+
 fn main() {
+    if print_release_version_if_requested("rocketmq-admin-cli") {
+        return;
+    }
     let handle = match std::thread::Builder::new()
         .name("rocketmq-admin-cli-main".to_string())
         .stack_size(CLI_RUNTIME_STACK_SIZE)

--- a/rocketmq-tools/rocketmq-store-inspect/src/bin/rocketmq_cli.rs
+++ b/rocketmq-tools/rocketmq-store-inspect/src/bin/rocketmq_cli.rs
@@ -22,7 +22,38 @@ use rocketmq_store_inspect::downgrade_preflight::DowngradePreflightRequest;
 use rocketmq_store_inspect::multipath_consolidate::consolidate_multipath;
 use rocketmq_store_inspect::multipath_consolidate::ConsolidationRequest;
 
+fn print_release_version_if_requested(component: &str) -> bool {
+    let arguments: Vec<_> = std::env::args_os().skip(1).collect();
+    let version = std::ffi::OsStr::new("--version");
+    let verbose = std::ffi::OsStr::new("--verbose");
+    let requested = (arguments.len() == 1 && arguments[0].as_os_str() == version)
+        || (arguments.len() == 2 && arguments[0].as_os_str() == version && arguments[1].as_os_str() == verbose);
+    if !requested {
+        return false;
+    }
+    println!("{component}");
+    println!("version={}", env!("CARGO_PKG_VERSION"));
+    if arguments.len() == 2 {
+        println!(
+            "artifact_id={}",
+            option_env!("ROCKETMQ_RELEASE_ARTIFACT_ID").unwrap_or("development")
+        );
+        println!(
+            "requested_features={}",
+            option_env!("ROCKETMQ_RELEASE_REQUESTED_FEATURES").unwrap_or("default")
+        );
+        println!(
+            "effective_features={}",
+            option_env!("ROCKETMQ_RELEASE_EFFECTIVE_FEATURES").unwrap_or("default")
+        );
+    }
+    true
+}
+
 fn main() {
+    if print_release_version_if_requested("rocketmq-store-inspect") {
+        return;
+    }
     let exit_code = run();
     if exit_code != 0 {
         std::process::exit(exit_code);

--- a/scripts/tests/release_archive_test_support.py
+++ b/scripts/tests/release_archive_test_support.py
@@ -1,0 +1,114 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+from pathlib import Path
+import stat
+from typing import Any
+
+from scripts.tests.release_test_support import write_json
+
+
+def create_candidate(root: Path, *, version: str = "1.0.0") -> Path:
+    candidate_root = root / version / "local" / "attempt-1"
+    manifest = candidate_root / "CANDIDATE_RUN.json"
+    series = root / "RELEASE_SERIES.json"
+    write_json(
+        series,
+        {
+            "schema_version": 1,
+            "series_id": "community-v1",
+            "generation": 1,
+            "head_manifest": str(manifest.resolve()),
+        },
+    )
+    write_json(
+        manifest,
+        {
+            "schema_version": 1,
+            "candidate_id": f"{version}-runlocal-attempt1-ordinal1",
+            "candidate_kind": "final",
+            "version": version,
+            "run_id": "local",
+            "attempt": 1,
+            "ordinal": 1,
+            "candidate_root": str(candidate_root.resolve()),
+            "series_manifest": str(series.resolve()),
+            "series_id": "community-v1",
+            "series_generation": 1,
+            "parent_manifest": None,
+            "state": "development",
+            "sealed": False,
+            "outcome": None,
+            "rejection_reason": None,
+            "known_issues": [],
+            "generation": 0,
+            "build_source_bundle": None,
+            "source_snapshot": None,
+            "artifact_index": None,
+            "evidence_index": None,
+            "event_index": None,
+            "execution_context_index": None,
+            "creation_operation_id": "fixture",
+            "created_at": "2026-08-16T00:00:00Z",
+            "updated_at": "2026-08-16T00:00:00Z",
+        },
+    )
+    return manifest
+
+
+def seed_binary_partial(common: Any, candidate_manifest: Path, target: str) -> dict[str, Any]:
+    _manifest, candidate, root = common.load_candidate(candidate_manifest)
+    layout = common.load_layout()
+    target_spec = common.target_layout(layout, target)
+    partial = common.create_partial(candidate, target)
+    context = root / "contexts" / target / "context.json"
+    write_json(context, {"candidate_id": candidate["candidate_id"], "worker_id": partial["worker_id"]})
+    partial["execution_contexts"].append(
+        {"id": "context", "path": common.candidate_relative(root, context, "context")}
+    )
+    started = root / "events" / target / "build.started.json"
+    completed = root / "events" / target / "build.completed.json"
+    write_json(started, {"status": "started"})
+    write_json(completed, {"status": "passed", "exit_code": 0})
+    partial["events"].append(
+        {
+            "id": "event",
+            "started": common.candidate_relative(root, started, "started event"),
+            "completed": common.candidate_relative(root, completed, "completed event"),
+        }
+    )
+    suffix = target_spec["executable_suffix"]
+    for binary in layout["binaries"]:
+        path = root / "cargo-target" / target / "release" / f"{binary['binary']}{suffix}"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        requested = ",".join(binary["requested_features"])
+        effective = ",".join(binary["effective_features"])
+        path.write_text(
+            "#!/usr/bin/env sh\n"
+            f"echo component={binary['id']}\n"
+            f"echo version={candidate['version']}\n"
+            f"echo artifact_id={common.artifact_id(candidate, target, binary['id'])}\n"
+            f"echo requested_features={requested}\n"
+            f"echo effective_features={effective}\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+        path.chmod(path.stat().st_mode | stat.S_IXUSR)
+        partial["artifacts"].append(
+            {
+                "id": f"binary-{binary['id']}",
+                "kind": "binary",
+                "component": binary["id"],
+                "artifact_id": common.artifact_id(candidate, target, binary["id"]),
+                "path": common.candidate_relative(root, path, "binary"),
+                "requested_features": binary["requested_features"],
+                "effective_features": binary["effective_features"],
+                "required_dependencies": binary.get("required_dependencies", []),
+                "command": ["cargo", "build", "--locked"],
+                "exit_code": 0,
+            }
+        )
+    common.save_draft(root, target, partial)
+    return partial

--- a/scripts/tests/test_candidate_partial_merge.py
+++ b/scripts/tests/test_candidate_partial_merge.py
@@ -1,0 +1,94 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+import unittest
+
+from scripts.tests.release_archive_test_support import create_candidate
+from scripts.tests.release_test_support import load_module, read_json, write_json
+
+
+class CandidatePartialMergeTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.merger = load_module("merge_candidate_partials", "distribution/merge_candidate_partials.py")
+
+    def test_three_target_partials_merge_by_explicit_target(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            candidate = create_candidate(base)
+            value = read_json(candidate)
+            download = base / "download"
+            targets = [
+                "x86_64-unknown-linux-gnu",
+                "x86_64-pc-windows-msvc",
+                "x86_64-apple-darwin",
+            ]
+            for target in targets:
+                bundle = download / target
+                archive = bundle / "archives" / f"{target}.zip"
+                archive.parent.mkdir(parents=True, exist_ok=True)
+                archive.write_bytes(target.encode())
+                started = bundle / "events" / target / "build.started.json"
+                completed = bundle / "events" / target / "build.completed.json"
+                context = bundle / "contexts" / target / "context.json"
+                write_json(started, {"status": "started"})
+                write_json(completed, {"status": "passed", "exit_code": 0})
+                write_json(context, {"worker_id": f"release-{target}"})
+                write_json(
+                    bundle / "partials" / f"CANDIDATE_PARTIAL.{target}.json",
+                    {
+                        "schema_version": 1,
+                        "candidate_id": value["candidate_id"],
+                        "version": value["version"],
+                        "run_id": value["run_id"],
+                        "attempt": value["attempt"],
+                        "target": target,
+                        "worker_id": f"release-{target}",
+                        "sealed": True,
+                        "artifacts": [
+                            {
+                                "id": identifier,
+                                "kind": identifier,
+                                "path": f"archives/{target}.zip",
+                            }
+                            for identifier in (
+                                "binary-admin",
+                                "binary-broker",
+                                "binary-controller",
+                                "binary-namesrv",
+                                "binary-proxy",
+                                "binary-store-inspect",
+                                "archive",
+                                "archive-manifest",
+                                "common-inputs",
+                                "component-sbom",
+                                "host-smoke",
+                            )
+                        ],
+                        "events": [
+                            {
+                                "id": "event",
+                                "started": f"events/{target}/build.started.json",
+                                "completed": f"events/{target}/build.completed.json",
+                            }
+                        ],
+                        "execution_contexts": [
+                            {"id": "context", "path": f"contexts/{target}/context.json"}
+                        ],
+                    },
+                )
+
+            output = self.merger.merge_partials(candidate, download, targets)
+
+            merged = read_json(output)
+            self.assertEqual(targets, merged["targets"])
+            self.assertEqual(33, len(merged["artifacts"]))
+            self.assertEqual("not-executed", merged["remote_publication"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_candidate_partial_seal.py
+++ b/scripts/tests/test_candidate_partial_seal.py
@@ -1,0 +1,43 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+import unittest
+
+from scripts.tests.release_archive_test_support import create_candidate, seed_binary_partial
+from scripts.tests.release_test_support import load_module
+
+
+class CandidatePartialSealTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.common = load_module("release_archive_common", "distribution/release_archive_common.py")
+        cls.sealer = load_module("seal_candidate_partial", "distribution/seal_candidate_partial.py")
+
+    def test_complete_partial_seals_once(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            candidate = create_candidate(Path(temporary))
+            target = "x86_64-unknown-linux-gnu"
+            partial = seed_binary_partial(self.common, candidate, target)
+            root = candidate.parent
+            for identifier in ("archive", "archive-manifest", "common-inputs", "component-sbom", "host-smoke"):
+                path = root / "evidence" / target / f"{identifier}.json"
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("{}\n", encoding="utf-8")
+                partial["artifacts"].append(
+                    {"id": identifier, "kind": identifier, "path": self.common.candidate_relative(root, path, identifier)}
+                )
+            self.common.save_draft(root, target, partial)
+
+            sealed = self.sealer.seal_partial(candidate, target)
+
+            self.assertTrue(sealed.is_file())
+            with self.assertRaisesRegex(self.common.ArchiveError, "already sealed"):
+                self.sealer.seal_partial(candidate, target)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_candidate_release_notes.py
+++ b/scripts/tests/test_candidate_release_notes.py
@@ -1,0 +1,38 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+import unittest
+
+from scripts.tests.release_archive_test_support import create_candidate
+from scripts.tests.release_test_support import load_module, read_json, write_json
+
+
+class CandidateReleaseNotesTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.renderer = load_module(
+            "render_candidate_release_notes", "distribution/render_candidate_release_notes.py"
+        )
+
+    def test_notes_identify_unofficial_distribution_and_explicit_exclusions(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            candidate = create_candidate(Path(temporary))
+            value = read_json(candidate)
+            value["known_issues"] = [{"id": "KNOWN-1", "summary": "Documented limitation"}]
+            write_json(candidate, value)
+
+            notes = self.renderer.render_notes(value)
+
+            self.assertIn("unofficial community distribution", notes.lower())
+            self.assertIn("not an Apache Software Foundation release", notes)
+            self.assertIn("OpenMessaging", notes)
+            self.assertIn("KNOWN-1", notes)
+            self.assertIn("not-executed", notes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_candidate_transfer.py
+++ b/scripts/tests/test_candidate_transfer.py
@@ -1,0 +1,38 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+import unittest
+
+from scripts.tests.release_archive_test_support import create_candidate
+from scripts.tests.release_test_support import load_module, read_json
+
+
+class CandidateTransferTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.transfer = load_module("transfer_candidate_test", "distribution/transfer_candidate.py")
+
+    def test_control_bundle_carries_candidate_and_external_series(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            candidate = create_candidate(base)
+            root = candidate.parent
+            bundle = root / "transfer" / "CANDIDATE_BUILD_CONTROL_BUNDLE.tar"
+            result = self.transfer.main(
+                ["export-build-control", "--candidate-manifest", str(candidate), "--output", str(bundle)]
+            )
+            self.assertEqual(0, result)
+
+            imported = self.transfer.import_bundle(bundle, base / "imported")
+            manifest = read_json(imported / "CANDIDATE_TRANSFER.json")
+            self.assertEqual("build-control", manifest["bundle_kind"])
+            self.assertTrue((imported / "CANDIDATE_RUN.json").is_file())
+            self.assertTrue((imported / "RELEASE_SERIES.json").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_common_release_inputs.py
+++ b/scripts/tests/test_common_release_inputs.py
@@ -1,0 +1,42 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+import unittest
+
+from scripts.tests.release_archive_test_support import create_candidate
+from scripts.tests.release_test_support import load_module, read_json
+
+
+class CommonReleaseInputsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.notes = load_module(
+            "render_candidate_release_notes_common", "distribution/render_candidate_release_notes.py"
+        )
+        cls.builder = load_module(
+            "build_common_release_inputs", "distribution/build_common_release_inputs.py"
+        )
+
+    def test_common_inputs_are_candidate_scoped_and_local_only(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            candidate = create_candidate(Path(temporary))
+            root = candidate.parent
+            notes = root / "common-input-source" / "RELEASE_NOTES.md"
+            self.assertEqual(0, self.notes.main(["--candidate-manifest", str(candidate), "--output", str(notes)]))
+
+            output = self.builder.build_inputs(candidate, root / "common-inputs")
+
+            manifest = read_json(output / "COMMON_RELEASE_INPUTS.json")
+            self.assertEqual("not-executed", manifest["remote_publication"])
+            names = {entry["path"] for entry in manifest["files"] if entry["type"] == "file"}
+            self.assertTrue({"LICENSE-APACHE", "NOTICE", "README.md", "RELEASE_NOTES.md"}.issubset(names))
+            with self.assertRaisesRegex(Exception, "already exists"):
+                self.builder.build_inputs(candidate, output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_component_sbom.py
+++ b/scripts/tests/test_component_sbom.py
@@ -1,0 +1,40 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+import unittest
+
+from scripts.tests.release_archive_test_support import create_candidate, seed_binary_partial
+from scripts.tests.release_test_support import ROOT, load_module, read_json
+
+
+class ComponentSbomTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.common = load_module("release_archive_common", "distribution/release_archive_common.py")
+        cls.sbom = load_module("generate_component_sbom", "distribution/generate_component_sbom.py")
+
+    def test_component_sbom_uses_staging_and_six_binary_contracts(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            candidate = create_candidate(Path(temporary))
+            target = "x86_64-unknown-linux-gnu"
+            seed_binary_partial(self.common, candidate, target)
+            staging = candidate.parent / "staging" / target / "rocketmq-rust-1.0.0"
+            staging.mkdir(parents=True)
+            (staging / "README.md").write_text("fixture\n", encoding="utf-8")
+
+            output = self.sbom.generate_sbom(
+                candidate, target, ROOT / "distribution" / "sbom-toolchain.json"
+            )
+
+            value = read_json(output)
+            self.assertEqual("CycloneDX", value["bomFormat"])
+            self.assertEqual(6, len(value["components"]))
+            self.assertNotIn("hashes", value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_release_archive.py
+++ b/scripts/tests/test_release_archive.py
@@ -1,0 +1,65 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+from scripts.tests.release_archive_test_support import create_candidate, seed_binary_partial
+from scripts.tests.release_test_support import ROOT, load_module, read_json
+
+
+class ReleaseArchiveTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.common = load_module("release_archive_common_e2e", "distribution/release_archive_common.py")
+        cls.notes = load_module("render_notes_e2e", "distribution/render_candidate_release_notes.py")
+        cls.inputs = load_module("build_inputs_e2e", "distribution/build_common_release_inputs.py")
+        cls.staging = load_module("prepare_staging_e2e", "distribution/prepare_release_archive_staging.py")
+        cls.sbom = load_module("component_sbom_e2e", "distribution/generate_component_sbom.py")
+        cls.builder = load_module("build_archive_e2e", "distribution/build_release_archive.py")
+        cls.verifier = load_module("verify_archive_e2e", "distribution/verify_release_archive.py")
+
+    def test_linux_archive_is_built_from_staging_and_smoked(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            candidate = create_candidate(Path(temporary))
+            target = "x86_64-unknown-linux-gnu"
+            seed_binary_partial(self.common, candidate, target)
+            root = candidate.parent
+            self.assertEqual(0, self.notes.main(["--candidate-manifest", str(candidate)]))
+            common_inputs = self.inputs.build_inputs(candidate, root / "common-inputs")
+            self.staging.prepare_staging(candidate, target, common_inputs)
+            self.sbom.generate_sbom(candidate, target, ROOT / "distribution" / "sbom-toolchain.json")
+
+            archive, manifest = self.builder.build_archive(candidate, target)
+            layout = self.common.load_layout()
+            by_name = {
+                entry.get("archive_binary", entry["binary"]): entry for entry in layout["binaries"]
+            }
+
+            def version_result(command, **_kwargs):
+                name = Path(command[0]).name
+                binary = by_name[name]
+                stdout = (
+                    f"component={binary['id']}\n"
+                    "version=1.0.0\n"
+                    f"artifact_id={self.common.artifact_id(read_json(candidate), target, binary['id'])}\n"
+                    f"requested_features={','.join(binary['requested_features'])}\n"
+                    f"effective_features={','.join(binary['effective_features'])}\n"
+                )
+                return mock.Mock(returncode=0, stdout=stdout, stderr="")
+
+            with mock.patch.object(self.verifier.subprocess, "run", side_effect=version_result):
+                evidence = self.verifier.verify_archive(candidate, archive, smoke=True)
+
+            self.assertTrue(archive.is_file())
+            self.assertEqual("not-executed", read_json(manifest)["remote_publication"])
+            self.assertEqual("passed", read_json(evidence)["status"])
+            self.assertEqual(6, len(read_json(evidence)["results"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_release_archive_staging.py
+++ b/scripts/tests/test_release_archive_staging.py
@@ -1,0 +1,46 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+import tomllib
+import unittest
+
+from scripts.tests.release_archive_test_support import create_candidate, seed_binary_partial
+from scripts.tests.release_test_support import load_module
+
+
+class ReleaseArchiveStagingTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.common = load_module("release_archive_common_staging", "distribution/release_archive_common.py")
+        cls.notes = load_module("render_notes_staging", "distribution/render_candidate_release_notes.py")
+        cls.inputs = load_module("build_inputs_staging", "distribution/build_common_release_inputs.py")
+        cls.staging = load_module("prepare_staging_test", "distribution/prepare_release_archive_staging.py")
+
+    def test_staging_has_six_binaries_and_portable_configs(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            candidate = create_candidate(Path(temporary))
+            target = "x86_64-unknown-linux-gnu"
+            seed_binary_partial(self.common, candidate, target)
+            root = candidate.parent
+            self.assertEqual(0, self.notes.main(["--candidate-manifest", str(candidate)]))
+            common_inputs = self.inputs.build_inputs(candidate, root / "common-inputs")
+
+            package = self.staging.prepare_staging(candidate, target, common_inputs)
+
+            self.assertEqual(6, len(list((package / "bin").iterdir())))
+            for config in (package / "conf").glob("*.toml"):
+                source = config.read_text(encoding="utf-8")
+                self.assertNotIn("${user.home}", source)
+                self.assertNotIn("/opt/data", source)
+                with config.open("rb") as handle:
+                    tomllib.load(handle)
+            for excluded in ("mcp", "dashboard", "sre", "openmessaging", "brokercontainer", "dledger"):
+                self.assertNotIn(excluded, " ".join(path.name.lower() for path in package.rglob("*")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_release_binary_build.py
+++ b/scripts/tests/test_release_binary_build.py
@@ -1,0 +1,55 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import unittest
+
+from scripts.tests.release_test_support import ROOT, load_module
+
+
+class ReleaseBinaryBuildTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.common = load_module("release_archive_common", "distribution/release_archive_common.py")
+        cls.builder = load_module("build_release_binaries", "distribution/build_release_binaries.py")
+
+    def test_layout_declares_six_core_binaries_and_three_targets(self) -> None:
+        layout = self.common.load_layout()
+        self.assertEqual(6, len(layout["binaries"]))
+        self.assertEqual(3, len(layout["targets"]))
+        names = {entry["id"] for entry in layout["binaries"]}
+        self.assertEqual({"admin", "broker", "controller", "namesrv", "proxy", "store-inspect"}, names)
+        rendered = json.dumps(layout)
+        for excluded in (
+            "BrokerContainer",
+            "Dashboard",
+            "MCP",
+            "SRE",
+            "OpenMessaging",
+            "DLedger CommitLog",
+        ):
+            self.assertIn(excluded, rendered)
+
+    def test_build_commands_are_locked_target_scoped_and_local_only(self) -> None:
+        layout = self.common.load_layout()
+        root = Path("C:/candidate")
+        for binary in layout["binaries"]:
+            command = self.builder.build_command(root, "x86_64-pc-windows-msvc", binary)
+            self.assertIn("--locked", command)
+            self.assertIn("--release", command)
+            self.assertIn("--target", command)
+            self.assertNotIn("publish", command)
+
+    def test_candidate_workflow_has_no_remote_publication_route(self) -> None:
+        workflow = ROOT / ".github" / "workflows" / "release-candidate.yml"
+        self.assertTrue(workflow.is_file())
+        source = workflow.read_text(encoding="utf-8").lower()
+        for forbidden in ("gh release", "cargo publish", "docker push", "helm push"):
+            self.assertNotIn(forbidden, source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- freeze the unofficial community distribution layout for Linux, Windows, and macOS
- build, stage, verify, seal, transfer, and merge six core binaries without remote publication
- add candidate-only workflow scaffolding, portable service configs/scripts, release notes, SBOM, and focused tests

## Validation

- 11 focused Python tests passed
- package-scoped rustfmt checks passed
- cargo metadata --locked passed
- AGENTS routing check passed
- git diff --check passed
- Rust cargo check was attempted but dependency compilation exhausted the available D: drive space before reaching the changed binaries; the generated target cache was cleaned

Closes #9515

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a cross-platform release-candidate workflow for Linux, Windows, and macOS.
  * Added tooling to build, package, verify, transfer, and combine release artifacts.
  * Added release archives with portable configurations, service scripts, and component SBOMs.
  * Added `--version` and `--version --verbose` support across RocketMQ command-line components.
  * Added generated release notes and validation for candidate metadata and archive contents.
* **Documentation**
  * Added a release-notes template for the 1.0 community distribution.
* **Tests**
  * Added coverage for archive creation, verification, staging, transfers, SBOMs, and release metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->