### PR TITLE
[ISSUE #9516]🐛Prevent Windows client consumer startup stack overflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4327,6 +4327,7 @@ dependencies = [
  "rocketmq-auth",
  "rocketmq-error",
  "rocketmq-model",
+ "rocketmq-namesrv",
  "rocketmq-observability",
  "rocketmq-protocol",
  "rocketmq-runtime",

--- a/rocketmq-client/Cargo.toml
+++ b/rocketmq-client/Cargo.toml
@@ -76,6 +76,7 @@ cheetah-string = { workspace = true }
 hickory-resolver = { workspace = true, optional = true }
 
 [dev-dependencies]
+rocketmq-namesrv   = { workspace = true }
 rocketmq-transport = { workspace = true, features = ["socks", "test-support", "tls"] }
 criterion = { version = "0.8.2", features = ["async_tokio"] }
 pkcs8.workspace = true

--- a/rocketmq-client/src/consumer/consumer_impl/bounded_consume_scheduler.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/bounded_consume_scheduler.rs
@@ -196,9 +196,13 @@ where
                 }
             }
         });
-        spawn_client_task_with_context(service_context, "rocketmq-client-consume-delay-scheduler", task)
-            .map(|_| ())
-            .map_err(|error| crate::mq_client_err!(format!("failed to start consume delay scheduler: {error}")))
+        spawn_client_task_with_context(
+            service_context,
+            "rocketmq-client-consume-delay-scheduler",
+            Box::pin(task),
+        )
+        .map(|_| ())
+        .map_err(|error| crate::mq_client_err!(format!("failed to start consume delay scheduler: {error}")))
     }
 
     fn spawn_worker<H, F>(
@@ -234,7 +238,7 @@ where
                 }
             }
         });
-        spawn_client_task_with_context(service_context, "rocketmq-client-consume-worker", task)
+        spawn_client_task_with_context(service_context, "rocketmq-client-consume-worker", Box::pin(task))
             .map(|_| ())
             .map_err(|error| crate::mq_client_err!(format!("failed to start consume worker: {error}")))
     }

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_concurrently_service.rs
@@ -126,7 +126,7 @@ fn spawn_concurrent_lifecycle_task<F>(
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    match spawn_client_tracked_task_with_context(service_context, thread_name, task) {
+    match spawn_client_tracked_task_with_context(service_context, thread_name, Box::pin(task)) {
         Ok(handle) => Some(ConcurrentTaskHandle::Tracked(handle)),
         Err(error) => {
             warn!("Failed to spawn {} background task: {}", thread_name, error);

--- a/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/consume_message_orderly_service.rs
@@ -160,7 +160,7 @@ fn spawn_tracked_orderly_task<F>(
         }
     });
 
-    if let Err(error) = spawn_client_task_with_context(service_context, thread_name, tracked_task) {
+    if let Err(error) = spawn_client_task_with_context(service_context, thread_name, Box::pin(tracked_task)) {
         warn!("Failed to spawn {} background task: {}", thread_name, error);
         warn!("Failed to track {} background task", thread_name);
     }

--- a/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
@@ -188,7 +188,7 @@ fn spawn_lite_pull_task<F>(
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    let handle = spawn_client_tracked_task_with_context(service_context, thread_name, task)?;
+    let handle = spawn_client_tracked_task_with_context(service_context, thread_name, Box::pin(task))?;
     Ok(LitePullTaskHandle::Tracked { handle, cancelled })
 }
 
@@ -305,9 +305,11 @@ impl MessageQueueListener for LitePullRebalanceListener {
             }
         });
 
-        if let Err(error) =
-            spawn_client_task_with_context(&service_context, "rocketmq-client-lite-pull-rebalance-listener", task)
-        {
+        if let Err(error) = spawn_client_task_with_context(
+            &service_context,
+            "rocketmq-client-lite-pull-rebalance-listener",
+            Box::pin(task),
+        ) {
             warn!(
                 "LitePull rebalance listener ignored async assignment update because task spawn failed. error={}",
                 error

--- a/rocketmq-client/src/consumer/consumer_impl/pull_message_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/pull_message_service.rs
@@ -705,7 +705,7 @@ impl PullMessageService {
         let handle = spawn_client_tracked_task_with_context(
             &service_context,
             "rocketmq-client-pull-message-service",
-            async move {
+            Box::pin(async move {
                 info!("{} service started", "PullMessageService");
 
                 loop {
@@ -728,7 +728,7 @@ impl PullMessageService {
                 }
 
                 info!("{} service end", "PullMessageService");
-            },
+            }),
         )
         .map_err(|error| pull_message_service_startup_failed("spawn main loop", error))?;
 
@@ -742,7 +742,13 @@ impl PullMessageService {
             let handle = spawn_client_tracked_task_with_context(
                 &service_context,
                 "rocketmq-client-pull-message-service-shard",
-                run_pull_request_shard_worker(index, worker_queue, shutdown_rx, worker_instance, metrics.clone()),
+                Box::pin(run_pull_request_shard_worker(
+                    index,
+                    worker_queue,
+                    shutdown_rx,
+                    worker_instance,
+                    metrics.clone(),
+                )),
             )
             .map_err(|error| pull_message_service_startup_failed("spawn shard worker", error))?;
 
@@ -885,7 +891,11 @@ impl PullMessageService {
             .read()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .clone()?;
-        match spawn_client_task_with_context(&service_context, "rocketmq-client-pull-delayed-scheduler", tracked_task) {
+        match spawn_client_task_with_context(
+            &service_context,
+            "rocketmq-client-pull-delayed-scheduler",
+            Box::pin(tracked_task),
+        ) {
             Ok(_) => {
                 *guard = Some(queue.clone());
                 Some(queue)
@@ -1278,7 +1288,7 @@ fn spawn_scheduled_pull_message_task<F>(
         }
     });
 
-    if let Err(error) = spawn_client_task_with_context(service_context, thread_name, tracked_task) {
+    if let Err(error) = spawn_client_task_with_context(service_context, thread_name, Box::pin(tracked_task)) {
         error!("Failed to spawn {} background task: {}", thread_name, error);
     }
 }

--- a/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_service.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/re_balance/rebalance_service.rs
@@ -45,7 +45,7 @@ fn spawn_rebalance_task<F>(service_context: &ChildServiceContext, task: F) -> st
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    spawn_client_tracked_task_with_context(service_context, "rocketmq-client-rebalance-service", task)
+    spawn_client_tracked_task_with_context(service_context, "rocketmq-client-rebalance-service", Box::pin(task))
 }
 
 fn rebalance_service_startup_failed(error: impl std::fmt::Display) -> RocketMQError {

--- a/rocketmq-client/src/consumer/store/local_file_offset_store.rs
+++ b/rocketmq-client/src/consumer/store/local_file_offset_store.rs
@@ -354,14 +354,17 @@ impl LocalFileOffsetStore {
             .await;
         };
 
-        let command_handle =
-            match spawn_client_tracked_task_with_context(service_context, "rocketmq-client-local-offset-store", task) {
-                Ok(handle) => handle,
-                Err(error) => {
-                    error!("Failed to spawn LocalFileOffsetStore background task: {}", error);
-                    return PersistTaskHandle::NotStarted;
-                }
-            };
+        let command_handle = match spawn_client_tracked_task_with_context(
+            service_context,
+            "rocketmq-client-local-offset-store",
+            Box::pin(task),
+        ) {
+            Ok(handle) => handle,
+            Err(error) => {
+                error!("Failed to spawn LocalFileOffsetStore background task: {}", error);
+                return PersistTaskHandle::NotStarted;
+            }
+        };
 
         let scheduled_offset_table = offset_table;
         let scheduled_dirty_flag = dirty_flag;
@@ -1056,10 +1059,10 @@ mod tests {
         let handle = spawn_client_tracked_task_with_context(
             &crate::runtime::test_service_context("local-offset-store-timeout-test"),
             "rocketmq-client-local-offset-store-timeout-test",
-            async move {
+            Box::pin(async move {
                 let _drop_flag = DropFlag(dropped_in_task);
                 pending::<()>().await;
-            },
+            }),
         )
         .expect("timeout test command task should spawn");
         let handle = PersistTaskHandle::Tokio {

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -199,7 +199,9 @@ fn schedule_rebalance_wakeup(
         }
     });
 
-    if let Err(error) = spawn_client_task_with_context(service_context, "rocketmq-client-rebalance-delay", task) {
+    if let Err(error) =
+        spawn_client_task_with_context(service_context, "rocketmq-client-rebalance-delay", Box::pin(task))
+    {
         error!("Failed to spawn delayed rebalance wakeup task: {}", error);
     }
 }

--- a/rocketmq-client/src/factory/mq_client_instance/connection_listener.rs
+++ b/rocketmq-client/src/factory/mq_client_instance/connection_listener.rs
@@ -72,7 +72,7 @@ pub(super) fn spawn(
     match spawn_client_tracked_task_with_context(
         service_context,
         "rocketmq-client-connection-events",
-        run(rx, weak_instance, shutdown_token),
+        Box::pin(run(rx, weak_instance, shutdown_token)),
     ) {
         Ok(handle) => Some(handle),
         Err(error) => {

--- a/rocketmq-client/src/implementation/mq_client_api_factory.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_factory.rs
@@ -274,7 +274,7 @@ fn spawn_namesrv_refresh_task<F>(
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    match spawn_client_tracked_task_with_context(service_context, thread_name, task) {
+    match spawn_client_tracked_task_with_context(service_context, thread_name, Box::pin(task)) {
         Ok(handle) => Some(NamesrvRefreshTaskHandle::Tracked {
             stop_signal,
             stop_notify,

--- a/rocketmq-client/src/implementation/mq_client_api_impl/consumer.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl/consumer.rs
@@ -95,9 +95,11 @@ impl MQClientAPIImpl {
                 .await;
         });
 
-        if let Err(error) =
-            spawn_client_task_with_context(service_context, "rocketmq-client-pop-message-async", tracked_task)
-        {
+        if let Err(error) = spawn_client_task_with_context(
+            service_context,
+            "rocketmq-client-pop-message-async",
+            Box::pin(tracked_task),
+        ) {
             if let Some(mut callback) = callback
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)

--- a/rocketmq-client/src/implementation/mq_client_api_impl/producer.rs
+++ b/rocketmq-client/src/implementation/mq_client_api_impl/producer.rs
@@ -623,7 +623,7 @@ impl MQClientAPIImpl {
             }
         });
 
-        if let Err(error) = spawn_client_task_with_context(service_context, thread_name, tracked_task) {
+        if let Err(error) = spawn_client_task_with_context(service_context, thread_name, Box::pin(tracked_task)) {
             warn!("Failed to spawn {} background task: {}", thread_name, error);
         }
     }

--- a/rocketmq-client/src/producer/produce_accumulator.rs
+++ b/rocketmq-client/src/producer/produce_accumulator.rs
@@ -2006,7 +2006,7 @@ fn spawn_guard_task<F>(
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    match spawn_client_tracked_task_with_context(service_context, thread_name, task) {
+    match spawn_client_tracked_task_with_context(service_context, thread_name, Box::pin(task)) {
         Ok(handle) => Some(GuardTaskHandle::Tracked { shutdown_tx, handle }),
         Err(error) => {
             tracing::error!("Failed to spawn {} background task: {}", thread_name, error);

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl.rs
@@ -237,7 +237,7 @@ where
     drop(spawn_client_task_with_context(
         service_context,
         thread_name,
-        tracked_task,
+        Box::pin(tracked_task),
     )?);
     Ok(())
 }

--- a/rocketmq-client/src/producer/request_future_holder.rs
+++ b/rocketmq-client/src/producer/request_future_holder.rs
@@ -240,14 +240,16 @@ impl RequestFutureHolder {
 
     pub(crate) fn fail_request(self: &Arc<Self>, correlation_id: String) {
         let holder = Arc::clone(self);
-        if let Err(error) =
-            spawn_client_task_with_context(&self.service_context, "rocketmq-client-request-failure", async move {
+        if let Err(error) = spawn_client_task_with_context(
+            &self.service_context,
+            "rocketmq-client-request-failure",
+            Box::pin(async move {
                 if let Some(request) = holder.remove_request_and_get(&correlation_id).await {
                     request.set_send_request_ok(false);
                     request.execute_request_callback();
                 }
-            })
-        {
+            }),
+        ) {
             error!(%error, "failed to schedule request failure callback");
         }
     }

--- a/rocketmq-client/src/runtime.rs
+++ b/rocketmq-client/src/runtime.rs
@@ -14,6 +14,7 @@
 
 use std::future::Future;
 use std::io;
+use std::pin::Pin;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::mpsc as std_mpsc;
@@ -318,14 +319,17 @@ impl ClientRuntimeTaskHandle {
     }
 }
 
-pub(crate) fn spawn_client_task_with_context<F>(
+/// Heap-erased future submitted through the client task ownership boundary.
+///
+/// Callers allocate the concrete future before it enters the generic task-group
+/// spawn chain so large async state does not exhaust default Windows stacks.
+pub(crate) type ClientTaskFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+
+pub(crate) fn spawn_client_task_with_context(
     context: &ChildServiceContext,
     task_name: &'static str,
-    task: F,
-) -> io::Result<ClientRuntimeTaskHandle>
-where
-    F: Future<Output = ()> + Send + 'static,
-{
+    task: ClientTaskFuture,
+) -> io::Result<ClientRuntimeTaskHandle> {
     let task_group = context.task_group().clone();
     let (completion_tx, completion_rx) = std_mpsc::channel();
     let task_id = task_group
@@ -342,14 +346,11 @@ where
     })
 }
 
-pub(crate) fn spawn_background_client_task_with_context<F>(
+pub(crate) fn spawn_background_client_task_with_context(
     context: &ChildServiceContext,
     task_name: &'static str,
-    task: F,
-) -> io::Result<()>
-where
-    F: Future<Output = ()> + Send + 'static,
-{
+    task: ClientTaskFuture,
+) -> io::Result<()> {
     drop(spawn_client_task_with_context(context, task_name, task)?);
     Ok(())
 }
@@ -441,14 +442,11 @@ fn timed_out_task_report(task_name: &'static str, elapsed: Duration, aborted: bo
     report
 }
 
-pub(crate) fn spawn_client_tracked_task_with_context<F>(
+pub(crate) fn spawn_client_tracked_task_with_context(
     context: &ChildServiceContext,
     task_name: &'static str,
-    task: F,
-) -> io::Result<ClientTrackedTaskHandle>
-where
-    F: Future<Output = ()> + Send + 'static,
-{
+    task: ClientTaskFuture,
+) -> io::Result<ClientTrackedTaskHandle> {
     let task_group = context.task_group().clone();
     let (completion_tx, completion_rx) = std_mpsc::channel();
     let task_id = task_group
@@ -652,10 +650,14 @@ pub(crate) fn spawn_delayed_client_action_with_context<F>(
         return;
     }
 
-    if let Err(error) = spawn_background_client_task_with_context(context, task_name, async move {
-        tokio::time::sleep(delay).await;
-        action();
-    }) {
+    if let Err(error) = spawn_background_client_task_with_context(
+        context,
+        task_name,
+        Box::pin(async move {
+            tokio::time::sleep(delay).await;
+            action();
+        }),
+    ) {
         tracing::error!(%error, task_name, "failed to spawn delayed client action");
     }
 }
@@ -756,9 +758,13 @@ mod tests {
         let completed = Arc::new(AtomicUsize::new(0));
         let completed_in_task = Arc::clone(&completed);
 
-        let handle = spawn_client_task_with_context(&service_context, "owned-task", async move {
-            completed_in_task.fetch_add(1, Ordering::Release);
-        })
+        let handle = spawn_client_task_with_context(
+            &service_context,
+            "owned-task",
+            Box::pin(async move {
+                completed_in_task.fetch_add(1, Ordering::Release);
+            }),
+        )
         .expect("task should spawn");
 
         assert!(handle.wait_finished(Duration::from_secs(1)));
@@ -780,7 +786,7 @@ mod tests {
 
         for _ in 0..TASKS {
             handles.push(
-                spawn_client_task_with_context(&service_context, "transient-task", async {})
+                spawn_client_task_with_context(&service_context, "transient-task", Box::pin(async {}))
                     .expect("transient task should spawn"),
             );
         }
@@ -804,13 +810,20 @@ mod tests {
     #[tokio::test]
     async fn tracked_task_shutdown_does_not_close_component_owner() {
         let service_context = test_service_context("client-tracked-task-isolation-test");
-        let first =
-            spawn_client_tracked_task_with_context(&service_context, "first-tracked-task", std::future::pending())
-                .expect("first task should spawn");
+        let first = spawn_client_tracked_task_with_context(
+            &service_context,
+            "first-tracked-task",
+            Box::pin(std::future::pending()),
+        )
+        .expect("first task should spawn");
         let (second_shutdown_tx, second_shutdown_rx) = tokio::sync::oneshot::channel();
-        let second = spawn_client_tracked_task_with_context(&service_context, "second-tracked-task", async move {
-            let _ = second_shutdown_rx.await;
-        })
+        let second = spawn_client_tracked_task_with_context(
+            &service_context,
+            "second-tracked-task",
+            Box::pin(async move {
+                let _ = second_shutdown_rx.await;
+            }),
+        )
         .expect("second task should spawn");
 
         let report = first.shutdown_now();
@@ -835,9 +848,12 @@ mod tests {
     #[tokio::test]
     async fn tracked_task_abort_waits_for_registry_removal() {
         let service_context = test_service_context("client-tracked-task-abort-wait-test");
-        let handle =
-            spawn_client_tracked_task_with_context(&service_context, "abort-and-wait-task", std::future::pending())
-                .expect("tracked task should spawn");
+        let handle = spawn_client_tracked_task_with_context(
+            &service_context,
+            "abort-and-wait-task",
+            Box::pin(std::future::pending()),
+        )
+        .expect("tracked task should spawn");
 
         assert!(handle.abort_and_wait(Duration::from_secs(1)).await);
         assert_eq!(service_context.task_group().task_count(), 0);

--- a/rocketmq-client/src/stat/consumer_stats_manager.rs
+++ b/rocketmq-client/src/stat/consumer_stats_manager.rs
@@ -355,7 +355,7 @@ fn spawn_stats_task<F>(
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    match spawn_client_tracked_task_with_context(service_context, thread_name, task) {
+    match spawn_client_tracked_task_with_context(service_context, thread_name, Box::pin(task)) {
         Ok(handle) => Some(ConsumerStatsTask { handle }),
         Err(error) => {
             warn!("Failed to spawn {} background task: {}", thread_name, error);

--- a/rocketmq-client/src/trace/async_trace_dispatcher.rs
+++ b/rocketmq-client/src/trace/async_trace_dispatcher.rs
@@ -689,7 +689,7 @@ fn spawn_trace_task<F>(
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    spawn_client_tracked_task_with_context(service_context, thread_name, task)
+    spawn_client_tracked_task_with_context(service_context, thread_name, Box::pin(task))
         .map(TraceTaskHandle::Tracked)
         .map_err(|error| trace_dispatcher_startup_failed(thread_name, error))
 }

--- a/rocketmq-client/tests/windows_consumer_process_startup.rs
+++ b/rocketmq-client/tests/windows_consumer_process_startup.rs
@@ -1,0 +1,261 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(windows)]
+
+use std::io::Write;
+use std::net::TcpListener;
+use std::net::TcpStream;
+use std::process::Child;
+use std::process::Command;
+use std::process::Output;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
+
+use rocketmq_client_rust::ClientRuntime;
+use rocketmq_client_rust::ClientRuntimeConfig;
+use rocketmq_client_rust::ConsumeConcurrentlyContext;
+use rocketmq_client_rust::ConsumeConcurrentlyStatus;
+use rocketmq_client_rust::DefaultMQPushConsumer;
+use rocketmq_client_rust::MQPushConsumer;
+use rocketmq_client_rust::MessageListenerConcurrently;
+use rocketmq_error::RocketMQResult;
+use rocketmq_model::common::message::message_ext::MessageExt;
+use rocketmq_namesrv::bootstrap::Builder as NameServerBuilder;
+use rocketmq_namesrv::NamesrvConfig;
+use rocketmq_observability::TelemetryHandle;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeContext;
+use rocketmq_runtime::RuntimeOwner;
+use rocketmq_transport::api::v1::ServerConfig;
+use tokio::sync::oneshot;
+
+const CHILD_MODE_ENV: &str = "ROCKETMQ_CLIENT_STACK_TEST_CHILD";
+const NAMESRV_ADDR_ENV: &str = "ROCKETMQ_CLIENT_STACK_TEST_NAMESRV_ADDR";
+const STARTUP_MARKER: &str = "CLIENT_STACK_STARTUP_OK";
+const WINDOWS_MAIN_STACK_SIZE: usize = 1024 * 1024;
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+struct ConsumerProcess {
+    child: Option<Child>,
+}
+
+impl ConsumerProcess {
+    fn new(child: Child) -> Self {
+        Self { child: Some(child) }
+    }
+
+    fn child_mut(&mut self) -> &mut Child {
+        self.child.as_mut().expect("consumer process should be present")
+    }
+
+    fn wait_with_output(mut self) -> Output {
+        self.child
+            .take()
+            .expect("consumer process should be present")
+            .wait_with_output()
+            .expect("collect consumer process output")
+    }
+
+    fn terminate_with_output(mut self) -> Output {
+        let mut child = self.child.take().expect("consumer process should be present");
+        if child.try_wait().expect("inspect consumer process status").is_none() {
+            child.kill().expect("terminate consumer process");
+        }
+        child.wait_with_output().expect("collect consumer process output")
+    }
+}
+
+impl Drop for ConsumerProcess {
+    fn drop(&mut self) {
+        let Some(mut child) = self.child.take() else {
+            return;
+        };
+        if child.try_wait().ok().flatten().is_none() {
+            let _ = child.kill();
+        }
+        let _ = child.wait();
+    }
+}
+
+struct NoopMessageListener;
+
+impl MessageListenerConcurrently for NoopMessageListener {
+    fn consume_message(
+        &self,
+        _messages: &[&MessageExt],
+        _context: &ConsumeConcurrentlyContext,
+    ) -> RocketMQResult<ConsumeConcurrentlyStatus> {
+        Ok(ConsumeConcurrentlyStatus::ConsumeSuccess)
+    }
+}
+
+fn available_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("reserve NameServer listener")
+        .local_addr()
+        .expect("NameServer listener address")
+        .port()
+}
+
+fn process_output(output: &Output) -> String {
+    format!(
+        "status: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+async fn start_namesrv(root: &std::path::Path, port: u16) -> (oneshot::Sender<()>, tokio::task::JoinHandle<()>) {
+    let namesrv_root = root.join("namesrv");
+    std::fs::create_dir_all(&namesrv_root).expect("create NameServer root");
+    let namesrv_config = NamesrvConfig {
+        rocketmq_home: root.to_string_lossy().into_owned(),
+        kv_config_path: namesrv_root.join("kvConfig.json").to_string_lossy().into_owned(),
+        config_store_path: namesrv_root.join("namesrv.properties").to_string_lossy().into_owned(),
+        ..NamesrvConfig::default()
+    };
+    let server_config = ServerConfig {
+        bind_address: "127.0.0.1".to_owned(),
+        listen_port: u32::from(port),
+        ..ServerConfig::default()
+    };
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let service_context = RuntimeContext::from_current("client-process-stack-test").service_context("namesrv");
+    let handle = tokio::spawn(async move {
+        NameServerBuilder::new(service_context, TelemetryHandle::noop())
+            .set_name_server_config(namesrv_config)
+            .set_server_config(server_config)
+            .build()
+            .boot_with_shutdown(async move {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .expect("run test NameServer");
+    });
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while TcpStream::connect(("127.0.0.1", port)).is_err() {
+        assert!(Instant::now() < deadline, "NameServer did not start listening");
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+    (shutdown_tx, handle)
+}
+
+fn run_consumer_child() {
+    let namesrv_addr = std::env::var(NAMESRV_ADDR_ENV).expect("child NameServer address should be present");
+    let thread = std::thread::Builder::new()
+        .name("rocketmq-client-stack-probe".to_owned())
+        .stack_size(WINDOWS_MAIN_STACK_SIZE)
+        .spawn(move || {
+            let owner = RuntimeOwner::new(RuntimeConfig {
+                worker_threads: 2,
+                thread_name: "rocketmq-client-stack-test".to_owned(),
+                ..RuntimeConfig::default()
+            })
+            .expect("create client process runtime");
+            let client_runtime = ClientRuntime::try_new(
+                owner.root_context().component("client"),
+                ClientRuntimeConfig::default(),
+                TelemetryHandle::noop(),
+            )
+            .expect("create client runtime");
+            owner.block_on(run_consumer_startup(client_runtime, namesrv_addr));
+        })
+        .expect("start 1 MiB consumer startup thread");
+
+    thread.join().expect("consumer startup thread should not panic");
+}
+
+async fn run_consumer_startup(client_runtime: Arc<ClientRuntime>, namesrv_addr: String) {
+    let mut consumer = DefaultMQPushConsumer::builder(client_runtime)
+        .consumer_group(format!("windows_stack_test_{}", std::process::id()))
+        .name_server_addr(namesrv_addr)
+        .build();
+    consumer
+        .subscribe("WindowsStackOverflowTest", "*")
+        .await
+        .expect("subscribe test topic");
+    consumer.register_message_listener_concurrently(NoopMessageListener);
+    consumer.start().await.expect("start test consumer");
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    println!("{STARTUP_MARKER}");
+    std::io::stdout().flush().expect("flush startup marker");
+    std::process::exit(0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn windows_consumer_starts_without_stack_overflow() {
+    if std::env::var_os(CHILD_MODE_ENV).is_some() {
+        run_consumer_child();
+        return;
+    }
+
+    let root = tempfile::tempdir().expect("create client process root");
+    let namesrv_port = available_port();
+    let namesrv_addr = format!("127.0.0.1:{namesrv_port}");
+    let (namesrv_shutdown, namesrv_handle) = start_namesrv(root.path(), namesrv_port).await;
+    let child = Command::new(std::env::current_exe().expect("resolve client stack test executable"))
+        .arg("--exact")
+        .arg("windows_consumer_starts_without_stack_overflow")
+        .arg("--nocapture")
+        .env(CHILD_MODE_ENV, "1")
+        .env(NAMESRV_ADDR_ENV, &namesrv_addr)
+        .env("RUST_LOG", "warn")
+        .env_remove("NAMESRV_ADDR")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("start consumer process");
+    let mut consumer = ConsumerProcess::new(child);
+
+    let deadline = Instant::now() + STARTUP_TIMEOUT;
+    let output = loop {
+        if consumer
+            .child_mut()
+            .try_wait()
+            .expect("inspect consumer startup status")
+            .is_some()
+        {
+            break consumer.wait_with_output();
+        }
+        if Instant::now() >= deadline {
+            let output = consumer.terminate_with_output();
+            panic!("Consumer startup timed out:\n{}", process_output(&output));
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    };
+
+    assert!(
+        output.status.success(),
+        "Consumer exited before startup completed:\n{}",
+        process_output(&output)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains(STARTUP_MARKER),
+        "Consumer did not emit startup marker:\n{}",
+        process_output(&output)
+    );
+
+    namesrv_shutdown.send(()).expect("request NameServer shutdown");
+    tokio::time::timeout(Duration::from_secs(10), namesrv_handle)
+        .await
+        .expect("NameServer shutdown should be bounded")
+        .expect("NameServer task should not panic");
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9516

### Brief Description

- Heap-erase client-owned futures before they enter the generic task-group spawn chain, preventing large generated async state from exhausting the default Windows startup stack.
- Apply the boundary consistently to client background and tracked task submissions without changing the public client API or quickstart configuration.
- Add a Windows process-level regression test that starts a push consumer on a 1 MiB thread stack against an in-process NameServer and checks successful startup.

### How Did You Test This Change?

- `cargo test -p rocketmq-client-rust --test windows_consumer_process_startup -- --nocapture`: passed (1 test).
- `cargo test -p rocketmq-client-rust --lib`: passed (1,066 tests).
- `cargo check -p rocketmq-client-rust --tests`: passed.
- `cargo clippy -p rocketmq-client-rust --no-deps --all-targets --all-features -- -D warnings`: passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- `cargo fmt -p rocketmq-client-rust -- --check` and `git diff --check`: passed.
- `./scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` and `./scripts/check-agents-routing.ps1`: passed.
- `rocketmq-example`: package format check and `cargo clippy --all-targets -- -D warnings` passed.
- `rocketmq-sre`: locked workspace check, all-target/all-feature Clippy, documentation, source-layout guard, and execution-dependency guard passed.
- Manually ran the consumer quickstart against a local NameServer and Broker; startup, broker connection, heartbeat, and rebalance completed without a stack overflow.

The root and `rocketmq-example` `cargo fmt --all -- --check` commands could not start on Windows because the generated rustfmt command exceeded the platform command-line limit (`os error 206`); the affected package format checks passed. The full `rocketmq-sre` test run remains blocked by unrelated Windows mock-engine stack tests and existing semantic registry assertions for the `mcp` owner; the mock-engine tests pass with `RUST_MIN_STACK=16777216`, and none of these failing tests exercise the changed client task boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability and consistency of background client operations, including consumer, producer, connection, rebalance, persistence, and statistics tasks.
  - Preserved existing shutdown handling, error reporting, callbacks, and scheduling behavior while reducing runtime compatibility issues.

- **Tests**
  - Added Windows integration coverage verifying successful client and consumer startup with limited thread-stack resources.
  - Added safeguards for startup timeouts, process cleanup, and embedded service lifecycle handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->