### PR TITLE
[ISSUE #9520]✨Generate legal SBOM and provenance evidence for core candidates

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -73,3 +73,6 @@ jobs:
         run: |
           python distribution/merge_candidate_partials.py --help
           python distribution/transfer_candidate.py --help
+          python distribution/generate_release_sbom.py --help
+          python distribution/generate_release_provenance.py --help
+          python scripts/legal_artifact_guard.py --help

--- a/distribution/generate_release_provenance.py
+++ b/distribution/generate_release_provenance.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+"""Generate candidate-scoped local provenance without digest readiness fields."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+import tomllib
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT / "distribution") not in sys.path:
+    sys.path.insert(0, str(ROOT / "distribution"))
+
+from release_archive_common import (
+    ArchiveError,
+    candidate_relative,
+    load_candidate,
+    load_layout,
+    write_json,
+)
+from release_artifact_index import register_artifacts
+from release_state import ensure_no_digest_fields, read_json, resolve_existing_file, utc_now
+
+
+def _event_records(root: Path) -> list[dict]:
+    values = []
+    for path in sorted((root / "events").rglob("*.completed.json")):
+        event = read_json(path)
+        values.append(
+            {
+                "path": candidate_relative(root, path, "execution event"),
+                "route_id": event.get("route_id", path.name.removesuffix(".completed.json")),
+                "worker_id": event.get("worker_id", "unrecorded"),
+                "exit_code": event.get("exit_code"),
+                "status": event.get("status", "completed"),
+            }
+        )
+    if not values:
+        raise ArchiveError("candidate provenance has no completed execution events")
+    return values
+
+
+def _context_records(root: Path) -> list[dict]:
+    values = []
+    for path in sorted((root / "contexts").rglob("*.json")):
+        context = read_json(path)
+        values.append(
+            {
+                "path": candidate_relative(root, path, "execution context"),
+                "worker_id": context.get("worker_id", "unrecorded"),
+                "executor": context.get("executor", context.get("execution_mode", "local")),
+            }
+        )
+    if not values:
+        raise ArchiveError("candidate provenance has no execution contexts")
+    return values
+
+
+def generate(candidate_manifest: Path) -> Path:
+    _manifest, candidate, root = load_candidate(candidate_manifest)
+    plan = read_json(resolve_existing_file(root / "PACKAGE_PLAN.json", "package-only report"))
+    if plan.get("registry_publish_count") != 24 or len(plan.get("staged_packages", [])) != 24:
+        raise ArchiveError("provenance package input denominator is incomplete")
+    sbom_index = read_json(resolve_existing_file(root / "sbom" / "SBOM_INDEX.json", "release SBOM index"))
+    if len(sbom_index.get("outputs", [])) != 31:
+        raise ArchiveError("provenance SBOM input denominator is incomplete")
+    artifact_index_path = resolve_existing_file(root / "ARTIFACT_INDEX.json", "candidate artifact index")
+    artifact_index = read_json(artifact_index_path)
+    if artifact_index.get("candidate_id") != candidate["candidate_id"]:
+        raise ArchiveError("provenance artifact index identity mismatch")
+    toolchain = read_json(ROOT / "distribution" / "sbom-toolchain.json")
+    rust_toolchain = tomllib.loads((ROOT / "rust-toolchain.toml").read_text(encoding="utf-8"))
+    outputs = []
+    output_roots = ("crate-packages", "archives", "oci-layout", "helm", "sbom")
+    for directory in output_roots:
+        for path in sorted((root / directory).rglob("*")):
+            if path.is_symlink():
+                raise ArchiveError(f"provenance output contains a link: {path}")
+            if path.is_file():
+                relative = candidate_relative(root, path, "provenance output")
+                outputs.append(
+                    {
+                        "id": relative.replace("/", ":"),
+                        "kind": directory,
+                        "path": relative,
+                        "size": path.stat().st_size,
+                    }
+                )
+    outputs.append(
+        {
+            "id": "artifact-index",
+            "kind": "manifest",
+            "path": candidate_relative(root, artifact_index_path, "candidate artifact index"),
+            "size": artifact_index_path.stat().st_size,
+        }
+    )
+    if not outputs:
+        raise ArchiveError("candidate provenance has no registered outputs")
+    package_versions = [
+        {"name": entry["name"], "version": entry["version"]}
+        for entry in plan["staged_packages"]
+    ]
+    value = {
+        "schema_version": 1,
+        "candidate_id": candidate["candidate_id"],
+        "version": candidate["version"],
+        "run_id": candidate["run_id"],
+        "attempt": candidate["attempt"],
+        "generated_at": utc_now(),
+        "distribution": "unofficial-community",
+        "execution_route": "workflow" if os.environ.get("GITHUB_ACTIONS") == "true" else "local",
+        "targets": sorted(load_layout()["targets"]),
+        "toolchain": {
+            "rust": rust_toolchain["toolchain"]["channel"],
+            "sbom_generator": toolchain["generator"],
+            "sbom_generator_version": toolchain["generator_version"],
+        },
+        "lockfile_mode": "locked",
+        "input_versions": package_versions,
+        "execution_events": _event_records(root),
+        "execution_contexts": _context_records(root),
+        "outputs": outputs,
+        "remote_publication": "not-executed",
+    }
+    ensure_no_digest_fields(value)
+    output = root / "provenance" / "RELEASE_PROVENANCE.json"
+    if output.exists():
+        raise ArchiveError(f"release provenance already exists: {output}")
+    write_json(output, value)
+    register_artifacts(
+        candidate_manifest,
+        [{"id": "release-provenance", "kind": "provenance", "path": output}],
+    )
+    return output
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate-manifest", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        output = generate(args.candidate_manifest)
+        print(f"RELEASE_PROVENANCE_OK output={output} remote_publication=not-executed")
+        return 0
+    except (ArchiveError, OSError, KeyError, json.JSONDecodeError, tomllib.TOMLDecodeError) as error:
+        print(f"RELEASE_PROVENANCE_FAILED detail={error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/distribution/generate_release_sbom.py
+++ b/distribution/generate_release_sbom.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+"""Generate external CycloneDX SBOMs for the complete local candidate set."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT / "distribution") not in sys.path:
+    sys.path.insert(0, str(ROOT / "distribution"))
+
+from build_core_oci_layout import SERVICES
+from release_archive_common import (
+    ArchiveError,
+    candidate_relative,
+    load_candidate,
+    load_layout,
+    resolve_candidate_path,
+    write_json,
+)
+from release_artifact_index import register_artifacts
+from release_state import read_json, resolve_existing_file
+
+
+def _cargo_metadata() -> dict[str, Any]:
+    completed = subprocess.run(
+        ["cargo", "metadata", "--locked", "--offline", "--format-version", "1"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise ArchiveError(f"cargo metadata failed: {completed.stderr.strip()}")
+    return json.loads(completed.stdout)
+
+
+def _component(package: dict[str, Any], *, scope: str) -> dict[str, Any]:
+    license_expression = package.get("license")
+    if not isinstance(license_expression, str) or not license_expression:
+        raise ArchiveError(f"dependency has no license metadata: {package.get('name')}")
+    return {
+        "type": "library",
+        "name": package["name"],
+        "version": package["version"],
+        "bom-ref": f"{package['name']}@{package['version']}",
+        "licenses": [{"expression": license_expression}],
+        "properties": [{"name": "rocketmq:dependency-scope", "value": scope}],
+    }
+
+
+def _package_sbom(
+    candidate: dict[str, Any],
+    package_name: str,
+    version: str,
+    metadata: dict[str, Any],
+    toolchain: dict[str, Any],
+) -> dict[str, Any]:
+    packages = {package["id"]: package for package in metadata.get("packages", [])}
+    roots = [
+        package_id
+        for package_id, package in packages.items()
+        if package.get("name") == package_name and package.get("version") == version
+    ]
+    if len(roots) != 1:
+        raise ArchiveError(f"Cargo metadata does not select one package: {package_name} {version}")
+    nodes = {node["id"]: node for node in metadata.get("resolve", {}).get("nodes", [])}
+    root_id = roots[0]
+    root_node = nodes.get(root_id)
+    if root_node is None:
+        raise ArchiveError(f"Cargo resolve graph has no package node: {package_name}")
+    direct = {dependency["pkg"] for dependency in root_node.get("deps", [])}
+    visited: set[str] = set()
+    pending = list(direct)
+    while pending:
+        package_id = pending.pop()
+        if package_id in visited:
+            continue
+        visited.add(package_id)
+        node = nodes.get(package_id)
+        if node:
+            pending.extend(dependency["pkg"] for dependency in node.get("deps", []))
+    components = [
+        _component(packages[package_id], scope="direct" if package_id in direct else "transitive")
+        for package_id in sorted(visited)
+        if package_id in packages
+    ]
+    root_package = packages[root_id]
+    return {
+        "bomFormat": toolchain["format"],
+        "specVersion": toolchain["spec_version"],
+        "version": 1,
+        "metadata": {
+            "component": _component(root_package, scope="root"),
+            "properties": [
+                {"name": "rocketmq:candidate-id", "value": candidate["candidate_id"]},
+                {"name": "rocketmq:generator", "value": toolchain["generator"]},
+                {"name": "rocketmq:generator-version", "value": toolchain["generator_version"]},
+                {"name": "rocketmq:remote-publication", "value": "not-executed"},
+            ],
+        },
+        "components": components,
+        "dependencies": [
+            {
+                "ref": f"{package_name}@{version}",
+                "dependsOn": [f"{packages[value]['name']}@{packages[value]['version']}" for value in sorted(direct)],
+            }
+        ],
+    }
+
+
+def _application_sbom(
+    candidate: dict[str, Any],
+    *,
+    name: str,
+    components: list[dict[str, Any]],
+    toolchain: dict[str, Any],
+    ownership: str,
+) -> dict[str, Any]:
+    return {
+        "bomFormat": toolchain["format"],
+        "specVersion": toolchain["spec_version"],
+        "version": 1,
+        "metadata": {
+            "component": {
+                "type": "application",
+                "name": name,
+                "version": candidate["version"],
+                "licenses": [{"expression": "Apache-2.0"}],
+            },
+            "properties": [
+                {"name": "rocketmq:candidate-id", "value": candidate["candidate_id"]},
+                {"name": "rocketmq:ownership", "value": ownership},
+                {"name": "rocketmq:generator", "value": toolchain["generator"]},
+                {"name": "rocketmq:generator-version", "value": toolchain["generator_version"]},
+                {"name": "rocketmq:remote-publication", "value": "not-executed"},
+            ],
+        },
+        "components": components,
+    }
+
+
+def generate(candidate_manifest: Path, toolchain_path: Path) -> Path:
+    _manifest, candidate, root = load_candidate(candidate_manifest)
+    toolchain = read_json(resolve_existing_file(toolchain_path, "SBOM toolchain"))
+    if toolchain.get("generator_version") != "1.0.0" or "latest" in json.dumps(toolchain).lower():
+        raise ArchiveError("SBOM toolchain version is not frozen")
+    plan = read_json(resolve_existing_file(root / "PACKAGE_PLAN.json", "package-only report"))
+    staged = plan.get("staged_packages", [])
+    if plan.get("mode") != "package-only" or plan.get("registry_publish_count") != 24 or len(staged) != 24:
+        raise ArchiveError("package-only SBOM denominator must contain 24 staged crates")
+    metadata = _cargo_metadata()
+    outputs: list[dict[str, str]] = []
+    output_root = root / "sbom"
+    if output_root.exists():
+        raise ArchiveError(f"external SBOM root already exists: {output_root}")
+    for package in staged:
+        crate = resolve_existing_file(root / package["crate_path"], f"{package['name']} crate")
+        sbom = _package_sbom(candidate, package["name"], package["version"], metadata, toolchain)
+        output = output_root / "crates" / f"{package['name']}.cdx.json"
+        write_json(output, sbom)
+        outputs.append({"kind": "crate", "owner": package["name"], "input": candidate_relative(root, crate, "crate"), "path": candidate_relative(root, output, "crate SBOM")})
+    release_layout = load_layout()
+    for target in release_layout["targets"]:
+        manifest = root / "archives" / f"rocketmq-rust-{candidate['version']}-{target}.manifest.json"
+        archive_manifest = read_json(resolve_existing_file(manifest, f"{target} archive manifest"))
+        archive = resolve_candidate_path(root, archive_manifest["archive"], f"{target} archive")
+        if not archive.is_file():
+            raise ArchiveError(f"archive is missing: {target}")
+        components = [
+            {
+                "type": "application",
+                "name": entry["component"],
+                "version": candidate["version"],
+                "licenses": [{"expression": "Apache-2.0"}],
+                "properties": [
+                    {"name": "rocketmq:requested-features", "value": ",".join(entry["requested_features"])},
+                    {"name": "rocketmq:effective-features", "value": ",".join(entry["effective_features"])},
+                ],
+            }
+            for entry in archive_manifest["binaries"]
+        ]
+        output = output_root / "archives" / target / "archive.cdx.json"
+        write_json(
+            output,
+            _application_sbom(
+                candidate,
+                name=f"rocketmq-rust-{target}",
+                components=components,
+                toolchain=toolchain,
+                ownership=target,
+            ),
+        )
+        outputs.append({"kind": "archive", "owner": target, "input": candidate_relative(root, archive, "archive"), "path": candidate_relative(root, output, "archive SBOM")})
+    for service in SERVICES:
+        manifest = root / "oci-layout" / service / "OCI_CANDIDATE_MANIFEST.json"
+        image = read_json(resolve_existing_file(manifest, f"{service} OCI manifest"))
+        if image.get("remote_publication") != "not-executed" or image.get("version") != candidate["version"]:
+            raise ArchiveError(f"OCI SBOM input is inconsistent: {service}")
+        components = [
+            {
+                "type": "application",
+                "name": service,
+                "version": candidate["version"],
+                "licenses": [{"expression": "Apache-2.0"}],
+                "properties": [
+                    {"name": "rocketmq:artifact-id", "value": image["artifact_id"]},
+                    {"name": "rocketmq:service", "value": service},
+                ],
+            }
+        ]
+        output = output_root / "oci" / service / "image.cdx.json"
+        write_json(output, _application_sbom(candidate, name=f"rocketmq-rust-{service}", components=components, toolchain=toolchain, ownership=service))
+        outputs.append({"kind": "oci", "owner": service, "input": candidate_relative(root, manifest, "OCI manifest"), "path": candidate_relative(root, output, "OCI SBOM")})
+    if len(outputs) != 31:
+        raise ArchiveError(f"external SBOM denominator changed: {len(outputs)}")
+    index = output_root / "SBOM_INDEX.json"
+    write_json(
+        index,
+        {
+            "schema_version": 1,
+            "candidate_id": candidate["candidate_id"],
+            "version": candidate["version"],
+            "outputs": outputs,
+            "remote_publication": "not-executed",
+        },
+    )
+    register_artifacts(candidate_manifest, [{"id": "release-sbom-index", "kind": "sbom-index", "path": index}])
+    return index
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate-manifest", type=Path, required=True)
+    parser.add_argument("--toolchain", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        output = generate(args.candidate_manifest, args.toolchain)
+        print(f"RELEASE_SBOM_OK outputs=31 index={output} remote_publication=not-executed")
+        return 0
+    except (ArchiveError, OSError, KeyError, json.JSONDecodeError) as error:
+        print(f"RELEASE_SBOM_FAILED detail={error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/distribution/release-provenance.schema.json
+++ b/distribution/release-provenance.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RocketMQ Rust local candidate provenance",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "candidate_id",
+    "version",
+    "run_id",
+    "attempt",
+    "generated_at",
+    "distribution",
+    "execution_route",
+    "targets",
+    "toolchain",
+    "lockfile_mode",
+    "input_versions",
+    "execution_events",
+    "execution_contexts",
+    "outputs",
+    "remote_publication"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "candidate_id": {"type": "string", "minLength": 1},
+    "version": {"type": "string", "minLength": 1},
+    "run_id": {"type": "string", "minLength": 1},
+    "attempt": {"type": "integer", "minimum": 1},
+    "generated_at": {"type": "string", "minLength": 1},
+    "distribution": {"const": "unofficial-community"},
+    "execution_route": {"enum": ["local", "workflow"]},
+    "targets": {"type": "array", "minItems": 3, "uniqueItems": true},
+    "toolchain": {"type": "object"},
+    "lockfile_mode": {"const": "locked"},
+    "input_versions": {"type": "array"},
+    "execution_events": {"type": "array", "minItems": 1},
+    "execution_contexts": {"type": "array", "minItems": 1},
+    "outputs": {"type": "array", "minItems": 1},
+    "remote_publication": {"const": "not-executed"}
+  },
+  "additionalProperties": false
+}

--- a/distribution/release_artifact_index.py
+++ b/distribution/release_artifact_index.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+"""Candidate artifact-index updates shared by local release evidence generators."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT / "distribution") not in sys.path:
+    sys.path.insert(0, str(ROOT / "distribution"))
+
+from release_archive_common import ArchiveError, candidate_relative, load_candidate
+from release_state import atomic_write_json, exclusive_lock, read_json, utc_now
+
+
+def register_artifacts(candidate_manifest: Path, records: list[dict[str, Any]]) -> Path:
+    manifest, candidate, root = load_candidate(candidate_manifest)
+    index_path = root / "ARTIFACT_INDEX.json"
+    with exclusive_lock(root / ".artifact-index.lock"):
+        if index_path.exists():
+            index = read_json(index_path)
+        else:
+            index = {
+                "schema_version": 1,
+                "candidate_id": candidate["candidate_id"],
+                "version": candidate["version"],
+                "run_id": candidate["run_id"],
+                "attempt": candidate["attempt"],
+                "artifacts": [],
+                "remote_publication": "not-executed",
+            }
+        if index.get("candidate_id") != candidate["candidate_id"]:
+            raise ArchiveError("candidate artifact index identity mismatch")
+        artifacts = index.get("artifacts")
+        if not isinstance(artifacts, list):
+            raise ArchiveError("candidate artifact index has no artifacts list")
+        identifiers = {entry.get("id") for entry in artifacts if isinstance(entry, dict)}
+        for record in records:
+            identifier = record.get("id")
+            path = record.get("path")
+            if not isinstance(identifier, str) or not isinstance(path, Path) or not path.is_file():
+                raise ArchiveError("candidate artifact registration is incomplete")
+            if identifier in identifiers:
+                raise ArchiveError(f"candidate artifact is already registered: {identifier}")
+            artifacts.append(
+                {
+                    "id": identifier,
+                    "kind": record["kind"],
+                    "path": candidate_relative(root, path, identifier),
+                }
+            )
+            identifiers.add(identifier)
+        atomic_write_json(index_path, index)
+        relative_index = candidate_relative(root, index_path, "candidate artifact index")
+        if candidate.get("artifact_index") not in (None, relative_index):
+            raise ArchiveError("candidate points to a different artifact index")
+        candidate["artifact_index"] = relative_index
+        candidate["generation"] += 1
+        candidate["updated_at"] = utc_now()
+        atomic_write_json(manifest, candidate)
+    return index_path

--- a/distribution/sbom-toolchain.json
+++ b/distribution/sbom-toolchain.json
@@ -2,7 +2,12 @@
   "schema_version": 1,
   "format": "CycloneDX",
   "spec_version": "1.5",
-  "generator": "distribution/generate_component_sbom.py",
+  "generator": "rocketmq-rust-builtin-sbom",
+  "generator_version": "1.0.0",
+  "generator_entrypoints": [
+    "distribution/generate_component_sbom.py",
+    "distribution/generate_release_sbom.py"
+  ],
   "component_types": ["application", "library"],
   "content_source": "cargo metadata --locked and archive staging inventory",
   "remote_lookup": false

--- a/scripts/legal_artifact_guard.py
+++ b/scripts/legal_artifact_guard.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+"""Verify legal metadata in every local core candidate crate, archive, and OCI layer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+import tarfile
+import zipfile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT / "distribution") not in sys.path:
+    sys.path.insert(0, str(ROOT / "distribution"))
+
+from build_core_oci_layout import SERVICES
+from release_archive_common import ArchiveError, load_candidate, load_layout, resolve_candidate_path
+from release_state import read_json, resolve_existing_file
+
+
+LEGAL = {"LICENSE-APACHE", "NOTICE"}
+
+
+def _crate_legal(crate: Path, name: str, version: str) -> bool:
+    with tarfile.open(crate, "r:gz") as archive:
+        names = set(archive.getnames())
+    root = f"{name}-{version}"
+    return all(f"{root}/{legal}" in names for legal in LEGAL)
+
+
+def _archive_legal(archive: Path) -> bool:
+    if archive.suffix == ".zip":
+        with zipfile.ZipFile(archive) as value:
+            names = set(value.namelist())
+    else:
+        with tarfile.open(archive, "r:gz") as value:
+            names = set(value.getnames())
+    return all(any(name.endswith(f"/{legal}") for name in names) for legal in LEGAL)
+
+
+def _oci_legal(layout: Path) -> bool:
+    # OCI descriptor names are required to locate blobs. They are structural
+    # protocol fields and are never used as this release guard's pass/fail hash.
+    index = read_json(resolve_existing_file(layout / "index.json", "OCI index"))
+    descriptor = index.get("manifests", [None])[0]
+    if not isinstance(descriptor, dict):
+        return False
+    manifest_digest = descriptor.get("digest", "").partition(":")[2]
+    manifest = read_json(resolve_existing_file(layout / "blobs" / "sha256" / manifest_digest, "OCI manifest blob"))
+    layer = manifest.get("layers", [None])[0]
+    if not isinstance(layer, dict):
+        return False
+    layer_digest = layer.get("digest", "").partition(":")[2]
+    with tarfile.open(resolve_existing_file(layout / "blobs" / "sha256" / layer_digest, "OCI layer"), "r") as archive:
+        names = set(archive.getnames())
+    return LEGAL.issubset(names)
+
+
+def audit(candidate_manifest: Path) -> list[str]:
+    findings: list[str] = []
+    _manifest, candidate, root = load_candidate(candidate_manifest)
+    plan = read_json(resolve_existing_file(root / "PACKAGE_PLAN.json", "package-only report"))
+    staged = plan.get("staged_packages", [])
+    if plan.get("registry_publish_count") != 24 or len(staged) != 24:
+        findings.append("crate legal denominator must contain exactly 24 staged packages")
+    for package in staged:
+        try:
+            crate = resolve_candidate_path(root, package["crate_path"], f"{package.get('name')} crate")
+            if not crate.is_file() or not _crate_legal(crate, package["name"], package["version"]):
+                findings.append(f"crate legal files are incomplete: {package.get('name')}")
+        except (ArchiveError, OSError, KeyError, tarfile.TarError) as error:
+            findings.append(f"crate legal inspection failed: {package.get('name')}: {error}")
+    layout = load_layout()
+    for target in layout["targets"]:
+        manifest = root / "archives" / f"rocketmq-rust-{candidate['version']}-{target}.manifest.json"
+        try:
+            value = read_json(resolve_existing_file(manifest, f"{target} archive manifest"))
+            archive = resolve_candidate_path(root, value["archive"], f"{target} archive")
+            if not archive.is_file() or not _archive_legal(archive):
+                findings.append(f"archive legal files are incomplete: {target}")
+        except (ArchiveError, OSError, KeyError, tarfile.TarError, zipfile.BadZipFile) as error:
+            findings.append(f"archive legal inspection failed: {target}: {error}")
+    for service in SERVICES:
+        try:
+            directory = resolve_candidate_path(root, f"oci-layout/{service}", f"{service} OCI layout")
+            if not directory.is_dir() or not _oci_legal(directory):
+                findings.append(f"OCI legal files are incomplete: {service}")
+        except (ArchiveError, OSError, KeyError, IndexError, tarfile.TarError) as error:
+            findings.append(f"OCI legal inspection failed: {service}: {error}")
+    identity = read_json(ROOT / "distribution" / "release-identity.json")
+    if identity.get("identity_kind") != "unofficial-community" or identity.get("official_apache_release") is not False:
+        findings.append("candidate legal identity is not the approved unofficial community distribution")
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scope", choices=["core-release"], required=True)
+    parser.add_argument("--candidate-manifest", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        findings = audit(args.candidate_manifest)
+    except (ArchiveError, OSError, json.JSONDecodeError) as error:
+        findings = [str(error)]
+    if findings:
+        for finding in findings:
+            print(f"LEGAL_ARTIFACT_GUARD_FAILED detail={finding}", file=sys.stderr)
+        return 1
+    print("LEGAL_ARTIFACT_GUARD_OK crates=24 archives=3 oci=4 distribution=unofficial-community")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/release_evidence_test_support.py
+++ b/scripts/tests/release_evidence_test_support.py
@@ -1,0 +1,164 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+import tarfile
+from typing import Any
+import zipfile
+
+from scripts.tests.release_archive_test_support import create_candidate
+from scripts.tests.release_test_support import ROOT, read_json, write_json
+
+
+def _tar_member(archive: tarfile.TarFile, name: str, content: bytes) -> None:
+    info = tarfile.TarInfo(name)
+    info.size = len(content)
+    info.mode = 0o644
+    info.mtime = 0
+    archive.addfile(info, io.BytesIO(content))
+
+
+def seed_complete_candidate(base: Path) -> tuple[Path, dict[str, Any]]:
+    candidate = create_candidate(base)
+    root = candidate.parent
+    candidate_value = read_json(candidate)
+    scope = read_json(ROOT / "scripts" / "core-release-scope.json")
+    packages = [
+        entry["name"]
+        for entry in scope["core_packages"]
+        if entry["classification"] == "registry-publish"
+    ]
+    if len(packages) != 24:
+        raise AssertionError("fixture requires the frozen 24-package denominator")
+    staged = []
+    for name in packages:
+        crate = root / "crate-packages" / f"{name}-1.0.0.crate"
+        crate.parent.mkdir(parents=True, exist_ok=True)
+        with tarfile.open(crate, "w:gz") as archive:
+            package_root = f"{name}-1.0.0"
+            _tar_member(archive, f"{package_root}/Cargo.toml", f'[package]\nname = "{name}"\nversion = "1.0.0"\n'.encode())
+            _tar_member(archive, f"{package_root}/LICENSE-APACHE", b"Apache License\n")
+            _tar_member(archive, f"{package_root}/NOTICE", b"RocketMQ Rust\n")
+        staged.append(
+            {
+                "name": name,
+                "version": "1.0.0",
+                "crate_path": crate.relative_to(root).as_posix(),
+                "legal_files": ["LICENSE-APACHE", "NOTICE"],
+                "status": "packaged-locally",
+            }
+        )
+    write_json(
+        root / "PACKAGE_PLAN.json",
+        {
+            "schema_version": 1,
+            "candidate_id": candidate_value["candidate_id"],
+            "version": "1.0.0",
+            "run_id": candidate_value["run_id"],
+            "attempt": candidate_value["attempt"],
+            "mode": "package-only",
+            "registry_publish_count": 24,
+            "staged_packages": staged,
+            "remote_publication": {"status": "not-executed"},
+        },
+    )
+    release_layout = read_json(ROOT / "distribution" / "release-layout.json")
+    binary_records = [
+        {
+            "component": entry["id"],
+            "requested_features": entry["requested_features"],
+            "effective_features": entry["effective_features"],
+        }
+        for entry in release_layout["binaries"]
+    ]
+    for target, target_spec in release_layout["targets"].items():
+        extension = ".zip" if target_spec["archive_format"] == "zip" else ".tar.gz"
+        archive_path = root / "archives" / f"rocketmq-rust-1.0.0-{target}{extension}"
+        archive_path.parent.mkdir(parents=True, exist_ok=True)
+        package_root = "rocketmq-rust-1.0.0"
+        if extension == ".zip":
+            with zipfile.ZipFile(archive_path, "w") as archive:
+                archive.writestr(f"{package_root}/LICENSE-APACHE", "Apache License\n")
+                archive.writestr(f"{package_root}/NOTICE", "RocketMQ Rust\n")
+        else:
+            with tarfile.open(archive_path, "w:gz") as archive:
+                _tar_member(archive, f"{package_root}/LICENSE-APACHE", b"Apache License\n")
+                _tar_member(archive, f"{package_root}/NOTICE", b"RocketMQ Rust\n")
+        write_json(
+            root / "archives" / f"rocketmq-rust-1.0.0-{target}.manifest.json",
+            {
+                "schema_version": 1,
+                "candidate_id": candidate_value["candidate_id"],
+                "version": "1.0.0",
+                "run_id": candidate_value["run_id"],
+                "attempt": candidate_value["attempt"],
+                "target": target,
+                "archive": archive_path.relative_to(root).as_posix(),
+                "binaries": binary_records,
+                "remote_publication": "not-executed",
+            },
+        )
+    for service in ("namesrv", "broker", "controller", "proxy"):
+        layout = root / "oci-layout" / service
+        blobs = layout / "blobs" / "sha256"
+        blobs.mkdir(parents=True, exist_ok=True)
+        manifest_name = "a" * 64
+        layer_name = "b" * 64
+        write_json(
+            layout / "index.json",
+            {"schemaVersion": 2, "manifests": [{"digest": f"sha256:{manifest_name}"}]},
+        )
+        write_json(
+            blobs / manifest_name,
+            {"schemaVersion": 2, "layers": [{"digest": f"sha256:{layer_name}"}]},
+        )
+        with tarfile.open(blobs / layer_name, "w") as archive:
+            _tar_member(archive, "LICENSE-APACHE", b"Apache License\n")
+            _tar_member(archive, "NOTICE", b"RocketMQ Rust\n")
+        write_json(
+            layout / "OCI_CANDIDATE_MANIFEST.json",
+            {
+                "schema_version": 1,
+                "candidate_id": candidate_value["candidate_id"],
+                "version": "1.0.0",
+                "run_id": candidate_value["run_id"],
+                "attempt": candidate_value["attempt"],
+                "target": "x86_64-unknown-linux-gnu",
+                "service": service,
+                "artifact_id": f"{candidate_value['candidate_id']}.x86_64-unknown-linux-gnu.{service}",
+                "remote_publication": "not-executed",
+            },
+        )
+    write_json(
+        root / "ARTIFACT_INDEX.json",
+        {
+            "schema_version": 1,
+            "candidate_id": candidate_value["candidate_id"],
+            "version": "1.0.0",
+            "run_id": candidate_value["run_id"],
+            "attempt": candidate_value["attempt"],
+            "artifacts": [],
+            "remote_publication": "not-executed",
+        },
+    )
+    write_json(root / "events" / "prepare.completed.json", {"route_id": "R06-prepare", "worker_id": "aggregate", "exit_code": 0, "status": "passed"})
+    write_json(root / "contexts" / "aggregate.json", {"worker_id": "aggregate", "executor": "local"})
+    metadata_packages = []
+    metadata_nodes = []
+    shared_id = "registry+fixture#shared@1.0.0"
+    transitive_id = "registry+fixture#transitive@1.0.0"
+    metadata_packages.append({"id": shared_id, "name": "shared", "version": "1.0.0", "license": "Apache-2.0"})
+    metadata_packages.append(
+        {"id": transitive_id, "name": "transitive", "version": "1.0.0", "license": "Apache-2.0"}
+    )
+    metadata_nodes.append({"id": shared_id, "deps": [{"pkg": transitive_id}]})
+    metadata_nodes.append({"id": transitive_id, "deps": []})
+    for name in packages:
+        package_id = f"path+fixture#{name}@1.0.0"
+        metadata_packages.append({"id": package_id, "name": name, "version": "1.0.0", "license": "Apache-2.0"})
+        metadata_nodes.append({"id": package_id, "deps": [{"pkg": shared_id}]})
+    metadata = {"packages": metadata_packages, "resolve": {"nodes": metadata_nodes}}
+    return candidate, metadata

--- a/scripts/tests/test_legal_artifact_guard.py
+++ b/scripts/tests/test_legal_artifact_guard.py
@@ -1,0 +1,45 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+from pathlib import Path
+import tarfile
+import tempfile
+import unittest
+
+from scripts.tests.release_evidence_test_support import seed_complete_candidate
+from scripts.tests.release_test_support import load_module, read_json
+
+
+class LegalArtifactGuardTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.guard = load_module("legal_artifact_guard_test", "scripts/legal_artifact_guard.py")
+
+    def test_complete_candidate_legal_denominator_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            candidate, _metadata = seed_complete_candidate(Path(temporary))
+            self.assertEqual([], self.guard.audit(candidate))
+
+    def test_missing_crate_notice_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            candidate, _metadata = seed_complete_candidate(Path(temporary))
+            root = candidate.parent
+            package = read_json(root / "PACKAGE_PLAN.json")["staged_packages"][0]
+            crate = root / package["crate_path"]
+            replacement = crate.with_suffix(".tmp")
+            with tarfile.open(crate, "r:gz") as source, tarfile.open(replacement, "w:gz") as output:
+                for member in source.getmembers():
+                    if member.name.endswith("/NOTICE"):
+                        continue
+                    output.addfile(member, source.extractfile(member) if member.isfile() else None)
+            replacement.replace(crate)
+
+            findings = self.guard.audit(candidate)
+
+            self.assertTrue(any("crate legal files are incomplete" in finding for finding in findings))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_release_provenance.py
+++ b/scripts/tests/test_release_provenance.py
@@ -1,0 +1,43 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+from scripts.tests.release_evidence_test_support import seed_complete_candidate
+from scripts.tests.release_test_support import ROOT, load_module, read_json
+
+
+class ReleaseProvenanceTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.sbom = load_module("generate_release_sbom_provenance", "distribution/generate_release_sbom.py")
+        cls.provenance = load_module(
+            "generate_release_provenance_test", "distribution/generate_release_provenance.py"
+        )
+
+    def test_provenance_records_semantics_without_digest_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            candidate, metadata = seed_complete_candidate(Path(temporary))
+            with mock.patch.object(self.sbom, "_cargo_metadata", return_value=metadata):
+                self.sbom.generate(candidate, ROOT / "distribution" / "sbom-toolchain.json")
+
+            output = self.provenance.generate(candidate)
+
+            value = read_json(output)
+            self.assertEqual("unofficial-community", value["distribution"])
+            self.assertEqual("locked", value["lockfile_mode"])
+            self.assertEqual("not-executed", value["remote_publication"])
+            rendered = str(value).lower()
+            for forbidden in ("'sha':", "'sha256':", "'digest':", "'checksum':"):
+                self.assertNotIn(forbidden, rendered)
+            self.assertGreater(len(value["outputs"]), 31)
+            self.assertEqual("ARTIFACT_INDEX.json", read_json(candidate)["artifact_index"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_release_sbom.py
+++ b/scripts/tests/test_release_sbom.py
@@ -1,0 +1,36 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+from scripts.tests.release_evidence_test_support import seed_complete_candidate
+from scripts.tests.release_test_support import ROOT, load_module, read_json
+
+
+class ReleaseSbomTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.generator = load_module("generate_release_sbom_test", "distribution/generate_release_sbom.py")
+
+    def test_complete_candidate_generates_31_external_sboms(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            candidate, metadata = seed_complete_candidate(Path(temporary))
+            with mock.patch.object(self.generator, "_cargo_metadata", return_value=metadata):
+                index = self.generator.generate(candidate, ROOT / "distribution" / "sbom-toolchain.json")
+
+            value = read_json(index)
+            self.assertEqual(31, len(value["outputs"]))
+            self.assertEqual("not-executed", value["remote_publication"])
+            crate_sbom = read_json(candidate.parent / value["outputs"][0]["path"])
+            self.assertEqual("CycloneDX", crate_sbom["bomFormat"])
+            scopes = {entry["properties"][0]["value"] for entry in crate_sbom["components"]}
+            self.assertEqual({"direct", "transitive"}, scopes)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- validate legal metadata across all 24 staged crates, three platform archives, and four core OCI layouts
- generate 31 external CycloneDX SBOMs with direct/transitive dependency scope and frozen local tooling
- generate candidate-scoped provenance from events, contexts, toolchains, versions, and semantic output inventories
- register evidence in the candidate artifact index without digest-based readiness gates or remote publication

## Validation

- 33 focused/package/architecture tests passed
- 14 release workflow/version tests passed
- release identity preflight passed
- AGENTS routing check passed
- git diff --check passed
- real full Cargo dependency metadata was not generated because the current offline cache lacks android_system_properties; the generator correctly failed closed and fixture-backed complete dependency tests passed

Closes #9520