### PR TITLE
[ISSUE #9529]✨Add deterministic Java 5.5 interop acceptance

### DIFF
--- a/rocketmq-client/Cargo.toml
+++ b/rocketmq-client/Cargo.toml
@@ -211,6 +211,10 @@ name = "client_lifecycle_probes_test"
 required-features = ["test-support"]
 
 [[test]]
+name = "latency_fault_java_compat"
+required-features = ["test-support"]
+
+[[test]]
 name = "integration_tests"
 required-features = ["test-support"]
 

--- a/rocketmq-client/src/latency/latency_fault_tolerance_impl.rs
+++ b/rocketmq-client/src/latency/latency_fault_tolerance_impl.rs
@@ -14,6 +14,8 @@
 
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU32;
+#[cfg(any(test, feature = "test-support"))]
+use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering as AtomicOrdering;
 use std::sync::Arc;
 use std::time::Duration;
@@ -35,8 +37,46 @@ const DETECTOR_TASK_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 const DETECTOR_SCAN_INITIAL_DELAY: Duration = Duration::from_secs(3);
 const DETECTOR_SCAN_INTERVAL: Duration = Duration::from_secs(3);
 
+pub(crate) trait FaultClock: Send + Sync {
+    fn now_millis(&self) -> u64;
+}
+
+struct SystemFaultClock;
+
+impl FaultClock for SystemFaultClock {
+    fn now_millis(&self) -> u64 {
+        current_millis()
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+pub(crate) struct ManualFaultClock {
+    now_millis: AtomicU64,
+}
+
+#[cfg(any(test, feature = "test-support"))]
+impl ManualFaultClock {
+    pub(crate) fn new(now_millis: u64) -> Self {
+        Self {
+            now_millis: AtomicU64::new(now_millis),
+        }
+    }
+
+    pub(crate) fn set_now_millis(&self, now_millis: u64) {
+        self.now_millis.store(now_millis, AtomicOrdering::Release);
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+impl FaultClock for ManualFaultClock {
+    fn now_millis(&self) -> u64 {
+        self.now_millis.load(AtomicOrdering::Acquire)
+    }
+}
+
 pub struct LatencyFaultToleranceImpl<R, S> {
     service_context: ChildServiceContext,
+    clock: Arc<dyn FaultClock>,
     fault_item_table: DashMap<CheetahString, Arc<FaultItem>>,
     detect_timeout: AtomicU32,
     detect_interval: AtomicU32,
@@ -109,8 +149,13 @@ pub struct LatencyFaultDetectorLifecycleProbe {
 
 impl<R, S> LatencyFaultToleranceImpl<R, S> {
     pub fn new(service_context: ChildServiceContext) -> Self {
+        Self::new_with_clock_inner(service_context, Arc::new(SystemFaultClock))
+    }
+
+    fn new_with_clock_inner(service_context: ChildServiceContext, clock: Arc<dyn FaultClock>) -> Self {
         Self {
             service_context,
+            clock,
             resolver: RwLock::new(None),
             service_detector: RwLock::new(None),
             fault_item_table: Default::default(),
@@ -119,6 +164,11 @@ impl<R, S> LatencyFaultToleranceImpl<R, S> {
             start_detector_enable: AtomicBool::new(false),
             detector_lifecycle: Mutex::new(DetectorLifecycle::default()),
         }
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub(crate) fn new_with_clock(service_context: ChildServiceContext, clock: Arc<dyn FaultClock>) -> Self {
+        Self::new_with_clock_inner(service_context, clock)
     }
 
     pub fn set_resolver(&self, resolver: R) {
@@ -135,6 +185,19 @@ impl<R, S> LatencyFaultToleranceImpl<R, S> {
             self.detect_interval.load(AtomicOrdering::Acquire),
             self.detect_timeout.load(AtomicOrdering::Acquire),
         )
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub(crate) fn fault_item_state_for_test(&self, name: &CheetahString) -> Option<(bool, bool, u64, u64)> {
+        let now_millis = self.clock.now_millis();
+        self.fault_item_table.get(name).map(|item| {
+            (
+                item.is_available_at(now_millis),
+                item.is_reachable(),
+                item.get_start_timestamp(),
+                item.get_current_latency(),
+            )
+        })
     }
 
     pub async fn shutdown_detector(&self) -> bool {
@@ -192,7 +255,7 @@ where
             .or_insert_with(|| Arc::new(FaultItem::new(name.clone())));
 
         entry.set_current_latency(current_latency);
-        entry.update_not_available_duration(not_available_duration);
+        entry.update_not_available_duration_at(not_available_duration, self.clock.now_millis());
         entry.set_reachable(reachable);
 
         if !reachable {
@@ -202,7 +265,10 @@ where
 
     #[inline]
     fn is_available(&self, name: &CheetahString) -> bool {
-        self.fault_item_table.get(name).is_none_or(|item| item.is_available())
+        let now_millis = self.clock.now_millis();
+        self.fault_item_table
+            .get(name)
+            .is_none_or(|item| item.is_available_at(now_millis))
     }
 
     #[inline]
@@ -281,12 +347,11 @@ where
             .iter()
             .filter_map(|entry| {
                 let fault_item = entry.value();
-                if current_millis() as i64 - (fault_item.check_stamp.load(std::sync::atomic::Ordering::Relaxed) as i64)
-                    < 0
-                {
+                let now_millis = self.clock.now_millis();
+                if now_millis as i64 - (fault_item.check_stamp.load(std::sync::atomic::Ordering::Relaxed) as i64) < 0 {
                     return None;
                 }
-                let next_check_stamp = current_millis() + detect_interval as u64;
+                let next_check_stamp = now_millis + detect_interval as u64;
                 fault_item
                     .check_stamp
                     .store(next_check_stamp, std::sync::atomic::Ordering::Release);
@@ -486,7 +551,10 @@ impl FaultItem {
     }
 
     pub fn update_not_available_duration(&self, not_available_duration: u64) {
-        let now = current_millis();
+        self.update_not_available_duration_at(not_available_duration, current_millis());
+    }
+
+    fn update_not_available_duration_at(&self, not_available_duration: u64, now: u64) {
         if not_available_duration > 0
             && now + not_available_duration > self.start_timestamp.load(std::sync::atomic::Ordering::Relaxed)
         {
@@ -507,8 +575,11 @@ impl FaultItem {
     }
 
     pub fn is_available(&self) -> bool {
-        let now = current_millis();
-        now >= self.start_timestamp.load(std::sync::atomic::Ordering::Relaxed)
+        self.is_available_at(current_millis())
+    }
+
+    fn is_available_at(&self, now_millis: u64) -> bool {
+        now_millis >= self.start_timestamp.load(std::sync::atomic::Ordering::Relaxed)
     }
 
     pub fn is_reachable(&self) -> bool {

--- a/rocketmq-client/src/latency/mq_fault_strategy.rs
+++ b/rocketmq-client/src/latency/mq_fault_strategy.rs
@@ -22,6 +22,8 @@ use rocketmq_runtime::ChildServiceContext;
 
 use crate::base::client_config::ClientConfig;
 use crate::latency::latency_fault_tolerance::LatencyFaultTolerance;
+#[cfg(any(test, feature = "test-support"))]
+use crate::latency::latency_fault_tolerance_impl::FaultClock;
 use crate::latency::latency_fault_tolerance_impl::LatencyFaultToleranceImpl;
 use crate::producer::producer_impl::default_mq_producer_impl::DefaultResolver;
 use crate::producer::producer_impl::default_mq_producer_impl::DefaultServiceDetector;
@@ -45,6 +47,23 @@ impl MQFaultStrategy {
 
     pub fn new(service_context: ChildServiceContext, client_config: &ClientConfig) -> Self {
         let tolerance_impl = LatencyFaultToleranceImpl::new(service_context);
+        Self::from_tolerance_impl(tolerance_impl, client_config)
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub(crate) fn new_with_fault_clock(
+        service_context: ChildServiceContext,
+        client_config: &ClientConfig,
+        clock: Arc<dyn FaultClock>,
+    ) -> Self {
+        let tolerance_impl = LatencyFaultToleranceImpl::new_with_clock(service_context, clock);
+        Self::from_tolerance_impl(tolerance_impl, client_config)
+    }
+
+    fn from_tolerance_impl(
+        tolerance_impl: LatencyFaultToleranceImpl<DefaultResolver, DefaultServiceDetector>,
+        client_config: &ClientConfig,
+    ) -> Self {
         tolerance_impl.set_detect_interval(client_config.detect_interval);
         tolerance_impl.set_detect_timeout(client_config.detect_timeout);
         tolerance_impl.set_start_detector_enable(client_config.start_detector_enable);
@@ -181,6 +200,20 @@ impl MQFaultStrategy {
             }
         }
         0
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub(crate) fn not_available_duration_for_test(&self, current_latency: u64, isolation: bool) -> u64 {
+        self.compute_not_available_duration(if isolation {
+            Self::ISOLATION_LATENCY_MS
+        } else {
+            current_latency
+        })
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub(crate) fn fault_item_state_for_test(&self, broker_name: &CheetahString) -> Option<(bool, bool, u64, u64)> {
+        self.latency_fault_tolerance.fault_item_state_for_test(broker_name)
     }
 
     #[inline]

--- a/rocketmq-client/src/test_support.rs
+++ b/rocketmq-client/src/test_support.rs
@@ -17,6 +17,100 @@
 //! This module is excluded from default production builds. Consumers must opt
 //! in with the `test-support` feature.
 
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use rocketmq_model::common::message::message_queue::MessageQueue;
+use rocketmq_runtime::ChildServiceContext;
+
+use crate::base::client_config::ClientConfig;
+use crate::latency::latency_fault_tolerance_impl::ManualFaultClock;
+use crate::latency::mq_fault_strategy::MQFaultStrategy;
+
+/// Deterministic state captured from the real latency-fault table.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LatencyFaultJavaCompatState {
+    pub available: bool,
+    pub reachable: bool,
+    pub unavailable_until_ms: u64,
+    pub current_latency_ms: u64,
+}
+
+/// Manual-clock facade used by the Java 5.5 latency-fault acceptance corpus.
+pub struct LatencyFaultJavaCompatHarness {
+    clock: Arc<ManualFaultClock>,
+    strategy: MQFaultStrategy,
+}
+
+impl LatencyFaultJavaCompatHarness {
+    pub fn new(
+        service_context: ChildServiceContext,
+        now_ms: u64,
+        latency_max_ms: Vec<u64>,
+        not_available_duration_ms: Vec<u64>,
+    ) -> Self {
+        assert!(!latency_max_ms.is_empty(), "latency thresholds must not be empty");
+        assert_eq!(
+            latency_max_ms.len(),
+            not_available_duration_ms.len(),
+            "latency thresholds and durations must have equal lengths"
+        );
+        let clock = Arc::new(ManualFaultClock::new(now_ms));
+        let mut config = ClientConfig::default();
+        config.set_send_latency_enable(true);
+        let mut strategy = MQFaultStrategy::new_with_fault_clock(service_context, &config, clock.clone());
+        strategy.set_latency_max(latency_max_ms);
+        strategy.set_not_available_duration(not_available_duration_ms);
+        Self { clock, strategy }
+    }
+
+    pub fn set_now_ms(&self, now_ms: u64) {
+        self.clock.set_now_millis(now_ms);
+    }
+
+    pub fn not_available_duration(&self, latency_ms: u64, isolation: bool) -> u64 {
+        self.strategy.not_available_duration_for_test(latency_ms, isolation)
+    }
+
+    pub async fn update(&self, broker: &str, latency_ms: u64, isolation: bool, reachable: bool) {
+        self.strategy
+            .update_fault_item(CheetahString::from_slice(broker), latency_ms, isolation, reachable)
+            .await;
+    }
+
+    pub fn state(&self, broker: &str) -> Option<LatencyFaultJavaCompatState> {
+        self.strategy
+            .fault_item_state_for_test(&CheetahString::from_slice(broker))
+            .map(
+                |(available, reachable, unavailable_until_ms, current_latency_ms)| LatencyFaultJavaCompatState {
+                    available,
+                    reachable,
+                    unavailable_until_ms,
+                    current_latency_ms,
+                },
+            )
+    }
+
+    pub fn select(&self, brokers: &[String], last_broker: Option<&str>) -> Option<String> {
+        let mut topic_publish_info = TopicPublishInfo::new();
+        topic_publish_info.message_queue_list = brokers
+            .iter()
+            .enumerate()
+            .map(|(queue_id, broker)| {
+                MessageQueue::from_parts(
+                    "LatencyFaultJavaCompat",
+                    broker.as_str(),
+                    i32::try_from(queue_id).expect("compatibility corpus queue count fits i32"),
+                )
+            })
+            .collect();
+        let last_broker = last_broker.map(CheetahString::from_slice);
+        self.strategy
+            .select_one_message_queue(&topic_publish_info, last_broker.as_ref(), true)
+            .map(|queue| queue.broker_name().to_string())
+    }
+}
+
 pub use crate::consumer::consumer_impl::consume_message_concurrently_service::{
     run_concurrent_clean_expire_lifecycle_probe, ConcurrentCleanExpireLifecycleProbe,
 };

--- a/rocketmq-client/tests/latency_fault_java_compat.rs
+++ b/rocketmq-client/tests/latency_fault_java_compat.rs
@@ -1,0 +1,134 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_client_rust::test_support::LatencyFaultJavaCompatHarness;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Corpus {
+    schema_version: u32,
+    java_version: String,
+    latency_max_ms: Vec<u64>,
+    not_available_duration_ms: Vec<u64>,
+    state_cases: Vec<StateCase>,
+    selection_cases: Vec<SelectionCase>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StateCase {
+    id: String,
+    initial_now_ms: u64,
+    latency_ms: u64,
+    isolation: bool,
+    reachable: bool,
+    expected_duration_ms: u64,
+    checks: Vec<StateCheck>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StateCheck {
+    at_ms: u64,
+    available: bool,
+    reachable: bool,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SelectionCase {
+    id: String,
+    initial_now_ms: u64,
+    updates: Vec<FaultUpdate>,
+    selection_at_ms: u64,
+    queues: Vec<String>,
+    last_broker: Option<String>,
+    expected_broker: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FaultUpdate {
+    at_ms: u64,
+    broker: String,
+    latency_ms: u64,
+    isolation: bool,
+    reachable: bool,
+}
+
+fn corpus() -> Corpus {
+    serde_json::from_str(include_str!("../../scripts/fixtures/latency-fault-corpus.json"))
+        .expect("valid Java 5.5 latency-fault corpus")
+}
+
+#[test]
+fn latency_windows_match_java_55_with_a_manual_clock() {
+    let corpus = corpus();
+    assert_eq!(corpus.schema_version, 1);
+    assert_eq!(corpus.java_version, "5.5.0");
+    let owner = RuntimeOwner::new(RuntimeConfig::server_default("latency-fault-java-compat"))
+        .expect("runtime owner should start");
+
+    for case in corpus.state_cases {
+        let harness = LatencyFaultJavaCompatHarness::new(
+            owner.root_context().component(case.id.clone()),
+            case.initial_now_ms,
+            corpus.latency_max_ms.clone(),
+            corpus.not_available_duration_ms.clone(),
+        );
+        assert_eq!(
+            harness.not_available_duration(case.latency_ms, case.isolation),
+            case.expected_duration_ms,
+            "{}",
+            case.id
+        );
+        owner.block_on(harness.update("broker-a", case.latency_ms, case.isolation, case.reachable));
+        for check in case.checks {
+            harness.set_now_ms(check.at_ms);
+            let state = harness.state("broker-a").expect("fault item should exist");
+            assert_eq!(state.available, check.available, "{} at {}", case.id, check.at_ms);
+            assert_eq!(state.reachable, check.reachable, "{} at {}", case.id, check.at_ms);
+        }
+    }
+}
+
+#[test]
+fn selection_avoidance_recovery_and_route_changes_match_java_55() {
+    let corpus = corpus();
+    let owner = RuntimeOwner::new(RuntimeConfig::server_default("latency-fault-selection-compat"))
+        .expect("runtime owner should start");
+
+    for case in corpus.selection_cases {
+        let harness = LatencyFaultJavaCompatHarness::new(
+            owner.root_context().component(case.id.clone()),
+            case.initial_now_ms,
+            corpus.latency_max_ms.clone(),
+            corpus.not_available_duration_ms.clone(),
+        );
+        for update in case.updates {
+            harness.set_now_ms(update.at_ms);
+            owner.block_on(harness.update(&update.broker, update.latency_ms, update.isolation, update.reachable));
+        }
+        harness.set_now_ms(case.selection_at_ms);
+        assert_eq!(
+            harness.select(&case.queues, case.last_broker.as_deref()),
+            Some(case.expected_broker.clone()),
+            "{}",
+            case.id
+        );
+    }
+}

--- a/scripts/fixtures/latency-fault-corpus.json
+++ b/scripts/fixtures/latency-fault-corpus.json
@@ -1,0 +1,78 @@
+{
+  "schemaVersion": 1,
+  "javaVersion": "5.5.0",
+  "latencyMaxMs": [50, 100, 550, 1800, 3000, 5000, 15000],
+  "notAvailableDurationMs": [0, 0, 2000, 5000, 6000, 10000, 30000],
+  "stateCases": [
+    {
+      "id": "slow-broker-window",
+      "initialNowMs": 1000,
+      "latencyMs": 550,
+      "isolation": false,
+      "reachable": true,
+      "expectedDurationMs": 2000,
+      "checks": [
+        {"atMs": 2999, "available": false, "reachable": true},
+        {"atMs": 3000, "available": true, "reachable": true}
+      ]
+    },
+    {
+      "id": "connection-isolation-window",
+      "initialNowMs": 5000,
+      "latencyMs": 1,
+      "isolation": true,
+      "reachable": false,
+      "expectedDurationMs": 10000,
+      "checks": [
+        {"atMs": 14999, "available": false, "reachable": false},
+        {"atMs": 15000, "available": true, "reachable": false}
+      ]
+    }
+  ],
+  "selectionCases": [
+    {
+      "id": "avoid-slow-and-unreachable-brokers",
+      "initialNowMs": 1000,
+      "updates": [
+        {"atMs": 1000, "broker": "broker-a", "latencyMs": 550, "isolation": false, "reachable": true},
+        {"atMs": 1000, "broker": "broker-b", "latencyMs": 1, "isolation": true, "reachable": false}
+      ],
+      "selectionAtMs": 1500,
+      "queues": ["broker-a", "broker-b", "broker-c"],
+      "lastBroker": null,
+      "expectedBroker": "broker-c"
+    },
+    {
+      "id": "probe-recovery-enters-reachable-fallback",
+      "initialNowMs": 1000,
+      "updates": [
+        {"atMs": 1000, "broker": "broker-b", "latencyMs": 1, "isolation": true, "reachable": false},
+        {"atMs": 2000, "broker": "broker-b", "latencyMs": 1, "isolation": false, "reachable": true}
+      ],
+      "selectionAtMs": 2000,
+      "queues": ["broker-b", "broker-c"],
+      "lastBroker": "broker-c",
+      "expectedBroker": "broker-b"
+    },
+    {
+      "id": "route-removal-excludes-stale-broker",
+      "initialNowMs": 1000,
+      "updates": [
+        {"atMs": 1000, "broker": "broker-a", "latencyMs": 550, "isolation": false, "reachable": true}
+      ],
+      "selectionAtMs": 1500,
+      "queues": ["broker-c"],
+      "lastBroker": null,
+      "expectedBroker": "broker-c"
+    },
+    {
+      "id": "retry-does-not-stick-to-last-broker",
+      "initialNowMs": 1000,
+      "updates": [],
+      "selectionAtMs": 1000,
+      "queues": ["broker-a", "broker-b"],
+      "lastBroker": "broker-a",
+      "expectedBroker": "broker-b"
+    }
+  ]
+}

--- a/scripts/interop/run_v1_interop.py
+++ b/scripts/interop/run_v1_interop.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+RESULT_IDS = ("I01", "I02", "I03", "I04", "I05")
+EXCLUDED_MODES = {"Java Controller", "Java AutoSwitchHA", "DLedger CommitLog"}
+JAVA_VERSION = "5.5.0"
+MAX_TIMEOUT_SECONDS = 600
+REQUIRED_CAPABILITIES = {
+    "I01": {"send", "pull", "pop", "transaction", "timer", "query"},
+    "I02": {"send", "pull", "pop", "transaction", "timer", "query", "error-code"},
+    "I03": {"active-route", "auth", "opaque", "response"},
+    "I04": {"settings", "fifo", "lite", "retry", "renewal"},
+    "I05": {"java-master-rust-slave", "rust-master-java-slave", "replication", "reconnect", "tail-truncate"},
+}
+REQUIRED_NEGATIVE_CASES = {
+    "I01": {"unknown-code", "invalid-expression", "permission-denied", "timeout"},
+    "I02": {"unknown-code", "invalid-expression", "permission-denied", "timeout"},
+    "I03": {"unknown-code", "permission-denied", "timeout"},
+    "I04": {"invalid-expression", "permission-denied", "timeout"},
+    "I05": {"timeout", "malformed-frame"},
+}
+
+
+class InteropError(ValueError):
+    pass
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def atomic_write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def load_matrix(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise InteropError(f"unable to read interop matrix: {error}") from error
+    validate_matrix(value)
+    return value
+
+
+def _unique_non_empty_strings(scenario_id: str, field: str, value: Any) -> list[str]:
+    if (
+        not isinstance(value, list)
+        or not value
+        or any(not isinstance(item, str) or not item.strip() for item in value)
+        or len(value) != len(set(value))
+    ):
+        raise InteropError(f"{scenario_id}: {field} must be a non-empty unique string list")
+    return value
+
+
+def validate_matrix(matrix: dict[str, Any]) -> None:
+    if matrix.get("schemaVersion") != 1:
+        raise InteropError("v1 interop matrix schemaVersion must be 1")
+    if matrix.get("javaVersion") != JAVA_VERSION:
+        raise InteropError(f"v1 interop matrix must use Java {JAVA_VERSION}")
+    if matrix.get("resultIds") != list(RESULT_IDS):
+        raise InteropError("v1 interop matrix resultIds must be I01 through I05 in order")
+    if set(matrix.get("excludedModes", [])) != EXCLUDED_MODES:
+        raise InteropError("v1 interop matrix must exclude Java Controller, AutoSwitchHA, and DLedger CommitLog")
+    if matrix.get("remotePublication") != "not-executed":
+        raise InteropError("v1 interop matrix cannot perform remote publication")
+
+    scenarios = matrix.get("scenarios")
+    if not isinstance(scenarios, list) or len(scenarios) != len(RESULT_IDS):
+        raise InteropError("v1 interop matrix must contain exactly five scenarios")
+    ids = [scenario.get("id") for scenario in scenarios if isinstance(scenario, dict)]
+    if len(ids) != len(scenarios) or len(ids) != len(set(ids)):
+        raise InteropError("scenario ids must be non-empty and unique")
+    if ids != list(RESULT_IDS):
+        raise InteropError("scenario order and identities must match resultIds")
+
+    for scenario in scenarios:
+        scenario_id = scenario["id"]
+        for field in ("client", "server"):
+            if not isinstance(scenario.get(field), str) or not scenario[field].strip():
+                raise InteropError(f"{scenario_id}: {field} must be a non-empty string")
+        for field in ("capabilities", "negativeCases", "requiredAssertions", "requiredEvidence"):
+            _unique_non_empty_strings(scenario_id, field, scenario.get(field))
+        missing_capabilities = REQUIRED_CAPABILITIES[scenario_id].difference(scenario["capabilities"])
+        if missing_capabilities:
+            raise InteropError(
+                f"{scenario_id}: missing required capabilities: {', '.join(sorted(missing_capabilities))}"
+            )
+        missing_negative_cases = REQUIRED_NEGATIVE_CASES[scenario_id].difference(scenario["negativeCases"])
+        if missing_negative_cases:
+            raise InteropError(
+                f"{scenario_id}: missing required negative cases: {', '.join(sorted(missing_negative_cases))}"
+            )
+
+    i05 = scenarios[-1]
+    required_ha_capabilities = {"java-master-rust-slave", "rust-master-java-slave"}
+    if not required_ha_capabilities.issubset(i05["capabilities"]):
+        raise InteropError("I05 must cover both DefaultHA directions")
+    forbidden = " ".join(i05["capabilities"] + [i05["client"], i05["server"]]).lower()
+    if any(value in forbidden for value in ("controller", "autoswitch", "dledger")):
+        raise InteropError("I05 supports DefaultHA only")
+
+
+def load_candidate(path: Path) -> dict[str, Any]:
+    try:
+        candidate = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise InteropError(f"unable to read candidate manifest: {error}") from error
+    if candidate.get("schema_version") != 1:
+        raise InteropError("candidate manifest schema_version must be 1")
+    for field in ("candidate_id", "version", "run_id", "candidate_root"):
+        if not isinstance(candidate.get(field), str) or not candidate[field].strip():
+            raise InteropError(f"candidate manifest {field} must be a non-empty string")
+    if not isinstance(candidate.get("attempt"), int) or candidate["attempt"] < 1:
+        raise InteropError("candidate manifest attempt must be a positive integer")
+    candidate_root = Path(candidate["candidate_root"]).resolve()
+    if candidate_root != path.resolve().parent:
+        raise InteropError("candidate_root must be the directory containing CANDIDATE_RUN.json")
+    return candidate
+
+
+def select_scenarios(
+    matrix: dict[str, Any], scenario_id: str | None, run_all: bool
+) -> list[dict[str, Any]]:
+    if run_all == (scenario_id is not None):
+        raise InteropError("select exactly one --scenario or --all")
+    if run_all:
+        return list(matrix["scenarios"])
+    selected = [scenario for scenario in matrix["scenarios"] if scenario["id"] == scenario_id]
+    if not selected:
+        raise InteropError(f"unknown interop scenario: {scenario_id}")
+    return selected
+
+
+def _driver_command(
+    driver: Path,
+    contract: Path,
+    candidate_manifest: Path,
+    result_path: Path,
+    work_dir: Path,
+) -> list[str]:
+    prefix = [sys.executable, str(driver)] if driver.suffix.lower() == ".py" else [str(driver)]
+    return prefix + [
+        "--contract",
+        str(contract),
+        "--candidate-manifest",
+        str(candidate_manifest),
+        "--result",
+        str(result_path),
+        "--work-dir",
+        str(work_dir),
+    ]
+
+
+def _terminate_process_tree(process: subprocess.Popen[str]) -> None:
+    if process.poll() is not None:
+        return
+    if os.name == "nt":
+        subprocess.run(
+            ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    else:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    if process.poll() is None:
+        process.kill()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+
+
+def _run_child(command: list[str], work_dir: Path, timeout_seconds: int) -> tuple[int, str, str]:
+    options: dict[str, Any] = {
+        "cwd": work_dir,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "text": True,
+    }
+    if os.name == "nt":
+        options["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+    else:
+        options["start_new_session"] = True
+    process = subprocess.Popen(command, **options)
+    try:
+        stdout, stderr = process.communicate(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired as error:
+        _terminate_process_tree(process)
+        stdout, stderr = process.communicate()
+        error.stdout = stdout
+        error.stderr = stderr
+        raise
+    return process.returncode, stdout, stderr
+
+
+def validate_result(
+    scenario: dict[str, Any],
+    result: dict[str, Any],
+    candidate: dict[str, Any],
+    scenario_root: Path,
+) -> None:
+    scenario_id = scenario["id"]
+    expected_identity = {
+        "schemaVersion": 1,
+        "resultId": scenario_id,
+        "candidateId": candidate["candidate_id"],
+        "version": candidate["version"],
+        "runId": candidate["run_id"],
+        "attempt": candidate["attempt"],
+        "javaVersion": JAVA_VERSION,
+        "remotePublication": "not-executed",
+    }
+    for field, expected in expected_identity.items():
+        if result.get(field) != expected:
+            raise InteropError(f"{scenario_id}: result {field} does not match the candidate contract")
+    if result.get("status") != "passed":
+        raise InteropError(f"{scenario_id}: status must be passed; skipped and partial results fail")
+
+    assertions = result.get("assertions")
+    if not isinstance(assertions, dict) or set(assertions) != set(scenario["requiredAssertions"]):
+        raise InteropError(f"{scenario_id}: assertion set does not match the matrix")
+    if any(value is not True for value in assertions.values()):
+        raise InteropError(f"{scenario_id}: every assertion must pass")
+
+    evidence = result.get("evidence")
+    if not isinstance(evidence, dict) or set(evidence) != set(scenario["requiredEvidence"]):
+        raise InteropError(f"{scenario_id}: evidence set does not match the matrix")
+    root = scenario_root.resolve()
+    for name, value in evidence.items():
+        if not isinstance(value, str) or not value.strip():
+            raise InteropError(f"{scenario_id}: {name} evidence path must be a non-empty string")
+        path = (root / value).resolve()
+        if not path.is_relative_to(root):
+            raise InteropError(f"{scenario_id}: {name} evidence escapes the scenario directory")
+        if not path.is_file():
+            raise InteropError(f"{scenario_id}: missing {name} evidence: {value}")
+
+
+def run_scenario(
+    scenario: dict[str, Any],
+    candidate: dict[str, Any],
+    candidate_manifest: Path,
+    driver: Path,
+    output_root: Path,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    scenario_id = scenario["id"]
+    scenario_root = output_root / "scenarios" / scenario_id
+    if scenario_root.exists():
+        raise InteropError(f"{scenario_id}: scenario output already exists")
+    work_dir = scenario_root / "work"
+    work_dir.mkdir(parents=True)
+    contract = scenario_root / "contract.json"
+    result_path = scenario_root / "result.json"
+    atomic_write_json(contract, scenario)
+    try:
+        return_code, stdout, stderr = _run_child(
+            _driver_command(driver, contract, candidate_manifest.resolve(), result_path, work_dir),
+            work_dir,
+            timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as error:
+        (scenario_root / "stdout.log").write_text(error.stdout or "", encoding="utf-8")
+        (scenario_root / "stderr.log").write_text(error.stderr or "", encoding="utf-8")
+        raise InteropError(f"{scenario_id}: timed out after {timeout_seconds} seconds") from error
+    (scenario_root / "stdout.log").write_text(stdout, encoding="utf-8")
+    (scenario_root / "stderr.log").write_text(stderr, encoding="utf-8")
+    if return_code != 0:
+        raise InteropError(f"{scenario_id}: case driver exited with {return_code}")
+    if not result_path.is_file():
+        raise InteropError(f"{scenario_id}: missing result")
+    try:
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise InteropError(f"{scenario_id}: result is not valid JSON: {error}") from error
+    validate_result(scenario, result, candidate, scenario_root)
+    return result
+
+
+def execute(args: argparse.Namespace) -> int:
+    matrix = load_matrix(args.matrix.resolve())
+    candidate_manifest = args.candidate_manifest.resolve()
+    candidate = load_candidate(candidate_manifest)
+    scenarios = select_scenarios(matrix, args.scenario, args.run_all)
+    driver_value = args.case_driver or os.environ.get("ROCKETMQ_V1_INTEROP_CASE_DRIVER")
+    if not driver_value:
+        raise InteropError("--case-driver or ROCKETMQ_V1_INTEROP_CASE_DRIVER is required")
+    driver = Path(driver_value).resolve()
+    if not driver.is_file():
+        raise InteropError(f"interop case driver does not exist: {driver}")
+    if not 1 <= args.timeout_seconds <= MAX_TIMEOUT_SECONDS:
+        raise InteropError(f"--timeout-seconds must be between 1 and {MAX_TIMEOUT_SECONDS}")
+    if not 1 <= args.max_workers <= len(RESULT_IDS):
+        raise InteropError(f"--max-workers must be between 1 and {len(RESULT_IDS)}")
+
+    output_root = (
+        args.output.resolve()
+        if args.output is not None
+        else Path(candidate["candidate_root"]).resolve() / "evidence" / "v1-interop"
+    )
+    if (output_root / "run.json").exists():
+        raise InteropError("interop run output already contains run.json")
+    output_root.mkdir(parents=True, exist_ok=True)
+    run = {
+        "schemaVersion": 1,
+        "candidateId": candidate["candidate_id"],
+        "version": candidate["version"],
+        "runId": candidate["run_id"],
+        "attempt": candidate["attempt"],
+        "javaVersion": JAVA_VERSION,
+        "scenarioIds": [scenario["id"] for scenario in scenarios],
+        "status": "running",
+        "startedAt": utc_now(),
+        "remotePublication": "not-executed",
+    }
+    atomic_write_json(output_root / "run.json", run)
+
+    try:
+        results_by_id: dict[str, dict[str, Any]] = {}
+        with ThreadPoolExecutor(max_workers=min(args.max_workers, len(scenarios))) as executor:
+            futures = {
+                executor.submit(
+                    run_scenario,
+                    scenario,
+                    candidate,
+                    candidate_manifest,
+                    driver,
+                    output_root,
+                    args.timeout_seconds,
+                ): scenario["id"]
+                for scenario in scenarios
+            }
+            for future in as_completed(futures):
+                results_by_id[futures[future]] = future.result()
+        results = [results_by_id[scenario["id"]] for scenario in scenarios]
+    except (InteropError, OSError, subprocess.SubprocessError) as error:
+        atomic_write_json(
+            output_root / "run.json",
+            {**run, "status": "failed", "completedAt": utc_now(), "error": str(error)},
+        )
+        print(f"v1 interoperability failed: {error}", file=sys.stderr)
+        return 1
+
+    atomic_write_json(
+        output_root / "run.json",
+        {**run, "status": "passed", "completedAt": utc_now(), "results": results},
+    )
+    print(f"passed {len(results)} v1 interoperability scenarios")
+    return 0
+
+
+def parser() -> argparse.ArgumentParser:
+    root = Path(__file__).resolve().parents[2]
+    command = argparse.ArgumentParser(description="Run bounded Java 5.5/Rust 1.0 interoperability scenarios")
+    command.add_argument("--candidate-manifest", type=Path, required=True)
+    command.add_argument("--matrix", type=Path, default=Path(__file__).with_name("v1-interop-matrix.json"))
+    selection = command.add_mutually_exclusive_group(required=True)
+    selection.add_argument("--scenario", choices=RESULT_IDS)
+    selection.add_argument("--all", dest="run_all", action="store_true")
+    command.add_argument("--case-driver")
+    command.add_argument("--output", type=Path)
+    command.add_argument("--timeout-seconds", type=int, default=MAX_TIMEOUT_SECONDS)
+    command.add_argument("--max-workers", type=int, default=2)
+    command.set_defaults(repository_root=root)
+    return command
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        return execute(parser().parse_args(argv))
+    except (InteropError, OSError, json.JSONDecodeError) as error:
+        print(f"v1 interoperability failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/interop/v1-interop-matrix.json
+++ b/scripts/interop/v1-interop-matrix.json
@@ -1,0 +1,54 @@
+{
+  "schemaVersion": 1,
+  "javaVersion": "5.5.0",
+  "resultIds": ["I01", "I02", "I03", "I04", "I05"],
+  "excludedModes": ["Java Controller", "Java AutoSwitchHA", "DLedger CommitLog"],
+  "remotePublication": "not-executed",
+  "scenarios": [
+    {
+      "id": "I01",
+      "client": "java-client",
+      "server": "rust-namesrv-broker",
+      "capabilities": ["send", "pull", "pop", "transaction", "timer", "query"],
+      "negativeCases": ["unknown-code", "invalid-expression", "permission-denied", "timeout"],
+      "requiredAssertions": ["response-code", "header-body", "message-id", "queue-offset", "physical-offset", "properties", "consume-state", "side-effects"],
+      "requiredEvidence": ["driver-log", "comparison"]
+    },
+    {
+      "id": "I02",
+      "client": "rust-client",
+      "server": "java-namesrv-broker",
+      "capabilities": ["send", "pull", "pop", "transaction", "timer", "query", "error-code"],
+      "negativeCases": ["unknown-code", "invalid-expression", "permission-denied", "timeout"],
+      "requiredAssertions": ["response-code", "header-body", "message-id", "queue-offset", "physical-offset", "properties", "consume-state", "side-effects"],
+      "requiredEvidence": ["driver-log", "comparison"]
+    },
+    {
+      "id": "I03",
+      "client": "java-client",
+      "server": "rust-remoting-proxy",
+      "capabilities": ["active-route", "auth", "opaque", "response"],
+      "negativeCases": ["unknown-code", "permission-denied", "timeout"],
+      "requiredAssertions": ["response-code", "header-body", "opaque", "auth", "side-effects"],
+      "requiredEvidence": ["driver-log", "comparison"]
+    },
+    {
+      "id": "I04",
+      "client": "java-grpc-client",
+      "server": "rust-grpc-proxy",
+      "capabilities": ["settings", "fifo", "lite", "retry", "renewal"],
+      "negativeCases": ["invalid-expression", "permission-denied", "timeout"],
+      "requiredAssertions": ["grpc-code", "settings", "properties", "consume-state", "side-effects"],
+      "requiredEvidence": ["driver-log", "comparison"]
+    },
+    {
+      "id": "I05",
+      "client": "java-default-ha-peer",
+      "server": "rust-default-ha-peer",
+      "capabilities": ["java-master-rust-slave", "rust-master-java-slave", "replication", "reconnect", "tail-truncate"],
+      "negativeCases": ["timeout", "malformed-frame"],
+      "requiredAssertions": ["message-id", "queue-offset", "physical-offset", "properties", "confirm-offset", "tail-truncate", "side-effects"],
+      "requiredEvidence": ["driver-log", "comparison"]
+    }
+  ]
+}

--- a/scripts/tests/test_v1_interop_matrix.py
+++ b/scripts/tests/test_v1_interop_matrix.py
@@ -1,0 +1,246 @@
+# Copyright 2026 The RocketMQ Rust Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RUNNER_PATH = ROOT / "scripts" / "interop" / "run_v1_interop.py"
+MATRIX_PATH = ROOT / "scripts" / "interop" / "v1-interop-matrix.json"
+
+
+def load_runner():
+    spec = importlib.util.spec_from_file_location("run_v1_interop", RUNNER_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("unable to load v1 interop runner")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class V1InteropMatrixTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.assertTrue(RUNNER_PATH.is_file(), "the v1 interop runner must be implemented")
+        self.runner = load_runner()
+        self.matrix = self.runner.load_matrix(MATRIX_PATH)
+
+    def test_matrix_freezes_java_version_scope_and_five_result_ids(self) -> None:
+        self.assertEqual("5.5.0", self.matrix["javaVersion"])
+        self.assertEqual(["I01", "I02", "I03", "I04", "I05"], self.matrix["resultIds"])
+        self.assertEqual({item["id"] for item in self.matrix["scenarios"]}, set(self.matrix["resultIds"]))
+        self.assertEqual(
+            {"Java Controller", "Java AutoSwitchHA", "DLedger CommitLog"},
+            set(self.matrix["excludedModes"]),
+        )
+
+    def test_matrix_rejects_duplicate_ids_or_missing_negative_coverage(self) -> None:
+        duplicate = json.loads(json.dumps(self.matrix))
+        duplicate["scenarios"][1]["id"] = "I01"
+        with self.assertRaisesRegex(ValueError, "unique"):
+            self.runner.validate_matrix(duplicate)
+
+        incomplete = json.loads(json.dumps(self.matrix))
+        incomplete["scenarios"][0]["negativeCases"] = []
+        with self.assertRaisesRegex(ValueError, "negativeCases"):
+            self.runner.validate_matrix(incomplete)
+
+        capability_drift = json.loads(json.dumps(self.matrix))
+        capability_drift["scenarios"][0]["capabilities"].remove("send")
+        with self.assertRaisesRegex(ValueError, "required capabilities"):
+            self.runner.validate_matrix(capability_drift)
+
+    def test_scenario_selector_never_turns_one_result_into_aggregate_success(self) -> None:
+        selected = self.runner.select_scenarios(self.matrix, scenario_id="I03", run_all=False)
+        self.assertEqual(["I03"], [item["id"] for item in selected])
+        selected = self.runner.select_scenarios(self.matrix, scenario_id=None, run_all=True)
+        self.assertEqual(self.matrix["resultIds"], [item["id"] for item in selected])
+        with self.assertRaisesRegex(ValueError, "exactly one"):
+            self.runner.select_scenarios(self.matrix, scenario_id=None, run_all=False)
+
+    def test_single_scenario_executes_real_child_and_validates_result(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            candidate = self._write_candidate(root)
+            driver = self._write_driver(root)
+            output = root / "output"
+
+            exit_code = self.runner.main(
+                [
+                    "--candidate-manifest",
+                    str(candidate),
+                    "--matrix",
+                    str(MATRIX_PATH),
+                    "--scenario",
+                    "I01",
+                    "--case-driver",
+                    str(driver),
+                    "--output",
+                    str(output),
+                    "--timeout-seconds",
+                    "2",
+                ]
+            )
+
+            self.assertEqual(0, exit_code)
+            run = json.loads((output / "run.json").read_text(encoding="utf-8"))
+            self.assertEqual("passed", run["status"])
+            self.assertEqual(["I01"], run["scenarioIds"])
+            self.assertTrue((output / "scenarios" / "I01" / "result.json").is_file())
+
+    def test_missing_skipped_failed_and_timed_out_children_fail_closed(self) -> None:
+        for mode, message in [
+            ("missing", "missing result"),
+            ("skipped", "status must be passed"),
+            ("exit", "exited with 7"),
+            ("timeout", "timed out"),
+        ]:
+            with self.subTest(mode=mode), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                candidate = self._write_candidate(root)
+                driver = self._write_driver(root)
+                output = root / "output"
+                with patch.dict(os.environ, {"FAKE_INTEROP_MODE": mode}):
+                    exit_code = self.runner.main(
+                        [
+                            "--candidate-manifest",
+                            str(candidate),
+                            "--matrix",
+                            str(MATRIX_PATH),
+                            "--scenario",
+                            "I02",
+                            "--case-driver",
+                            str(driver),
+                            "--output",
+                            str(output),
+                            "--timeout-seconds",
+                            "1",
+                        ]
+                    )
+                self.assertEqual(1, exit_code)
+                run = json.loads((output / "run.json").read_text(encoding="utf-8"))
+                self.assertEqual("failed", run["status"])
+                self.assertIn(message, run["error"])
+
+    def test_all_requires_five_independent_results(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            candidate = self._write_candidate(root)
+            driver = self._write_driver(root)
+            output = root / "output"
+            exit_code = self.runner.main(
+                [
+                    "--candidate-manifest",
+                    str(candidate),
+                    "--matrix",
+                    str(MATRIX_PATH),
+                    "--all",
+                    "--case-driver",
+                    str(driver),
+                    "--output",
+                    str(output),
+                    "--timeout-seconds",
+                    "2",
+                    "--max-workers",
+                    "2",
+                ]
+            )
+            self.assertEqual(0, exit_code)
+            run = json.loads((output / "run.json").read_text(encoding="utf-8"))
+            self.assertEqual(self.matrix["resultIds"], run["scenarioIds"])
+            self.assertEqual(5, len(run["results"]))
+
+    @staticmethod
+    def _write_candidate(root: Path) -> Path:
+        candidate_root = root / "candidate"
+        candidate_root.mkdir()
+        manifest = candidate_root / "CANDIDATE_RUN.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "candidate_id": "1.0.0-rc.1-local-attempt1",
+                    "version": "1.0.0-rc.1",
+                    "run_id": "local",
+                    "attempt": 1,
+                    "candidate_root": str(candidate_root),
+                }
+            ),
+            encoding="utf-8",
+        )
+        return manifest
+
+    @staticmethod
+    def _write_driver(root: Path) -> Path:
+        driver = root / "fake_interop_driver.py"
+        driver.write_text(
+            textwrap.dedent(
+                """
+                import argparse
+                import json
+                import os
+                import sys
+                import time
+                from pathlib import Path
+
+                parser = argparse.ArgumentParser()
+                parser.add_argument("--contract", type=Path, required=True)
+                parser.add_argument("--candidate-manifest", type=Path, required=True)
+                parser.add_argument("--result", type=Path, required=True)
+                parser.add_argument("--work-dir", type=Path, required=True)
+                args = parser.parse_args()
+                mode = os.environ.get("FAKE_INTEROP_MODE", "passed")
+                if mode == "timeout":
+                    time.sleep(5)
+                if mode == "exit":
+                    raise SystemExit(7)
+                if mode == "missing":
+                    raise SystemExit(0)
+                contract = json.loads(args.contract.read_text(encoding="utf-8"))
+                candidate = json.loads(args.candidate_manifest.read_text(encoding="utf-8"))
+                evidence = args.work_dir / "evidence"
+                evidence.mkdir(parents=True, exist_ok=True)
+                for name in contract["requiredEvidence"]:
+                    (evidence / f"{name}.txt").write_text(name, encoding="utf-8")
+                result = {
+                    "schemaVersion": 1,
+                    "resultId": contract["id"],
+                    "candidateId": candidate["candidate_id"],
+                    "version": candidate["version"],
+                    "runId": candidate["run_id"],
+                    "attempt": candidate["attempt"],
+                    "javaVersion": "5.5.0",
+                    "status": "skipped" if mode == "skipped" else "passed",
+                    "assertions": {name: True for name in contract["requiredAssertions"]},
+                    "evidence": {name: f"work/evidence/{name}.txt" for name in contract["requiredEvidence"]},
+                    "remotePublication": "not-executed",
+                }
+                args.result.write_text(json.dumps(result), encoding="utf-8")
+                """
+            ),
+            encoding="utf-8",
+        )
+        return driver
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9529

### Brief Description

Add a bounded, fail-closed Java 5.5/Rust interoperability acceptance matrix for client, broker, proxy, gRPC, and DefaultHA scenarios. Add deterministic latency-fault compatibility coverage using a manual test clock and freeze the Java 5.5 threshold corpus. Java Controller, AutoSwitchHA, and DLedger CommitLog remain explicitly excluded, and the runner records remote publication as not executed.

### How Did You Test This Change?

- `python -m unittest scripts.tests.test_v1_interop_matrix` (6 passed)
- `python -m unittest scripts.tests.test_default_ha_interop` (5 passed)
- `cargo test -p rocketmq-client-rust --features test-support --test latency_fault_java_compat` (2 passed)
- `cargo test -p rocketmq-client-rust latency_fault --lib` (10 passed)
- `cargo fmt -p rocketmq-client-rust -- --check`
- `cargo clippy -p rocketmq-client-rust --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check` from `rocketmq-example`
- `cargo clippy --all-targets -- -D warnings` from `rocketmq-example`
- `.\scripts\check-agents-routing.ps1`
- `git diff --check`

The live I01-I05 cross-runtime matrix was not executed in this short implementation task; the new runner and fail-closed contract tests prepare that bounded candidate validation for a later acceptance run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved latency-fault handling for broker availability, isolation windows, recovery, and route selection.
  - Added compatibility coverage for RocketMQ Java 5.5 latency-fault behavior.
  - Added interoperability validation across defined Java/Rust scenarios.

- **Bug Fixes**
  - Improved consistency of broker selection and retry rotation when brokers are slow, unavailable, or recovering.

- **Tests**
  - Added comprehensive checks for latency calculations, state transitions, recovery, and cross-language compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->