### PR TITLE
[ISSUE #9539]🚀Complete Web Dashboard Consumer operations workspace

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/admin/dashboard_admin_client.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/admin/dashboard_admin_client.rs
@@ -47,6 +47,7 @@ use crate::model::BrokerConfigView;
 use crate::model::BrokerInfo;
 use crate::model::BrokerListView;
 use crate::model::BrokerRuntimeStats;
+use crate::model::ConsumerBrokerListView;
 use crate::model::ConsumerGroupInfo;
 use crate::model::ConsumerListView;
 use crate::model::ConsumerProgress;
@@ -91,6 +92,7 @@ pub struct DashboardAdminClient {
     admin_session: Arc<Mutex<Option<Arc<ManagedAdminSession>>>>,
     topic_admin_sessions: Arc<TopicAdminSessionRegistry<AdminGuard>>,
     topic_mutation_lock: Arc<Mutex<()>>,
+    consumer_mutation_lock: Arc<Mutex<()>>,
     next_generation: Arc<AtomicU64>,
     session_tasks: ChildServiceContext,
 }
@@ -181,6 +183,52 @@ macro_rules! run_topic_admin_rpc {
     }};
 }
 
+macro_rules! run_consumer_admin_rpc {
+    ($client:expr, |$admin:ident| $operation:expr) => {
+        run_consumer_admin_rpc!($client, None, |$admin| $operation)
+    };
+    ($client:expr, $mutation_guard:expr, |$admin:ident| $operation:expr) => {{
+        let snapshot = $client.admin_config_snapshot().await?;
+        let client = $client.clone();
+        let admin_group = unique_admin_group();
+        let (response_tx, response_rx) = oneshot::channel();
+        let config_cancellation = client.session_tasks.task_group().cancellation_token();
+        let guard_cancellation = client.session_tasks.task_group().cancellation_token();
+        let operation_cancellation = client.session_tasks.task_group().cancellation_token();
+        let build_client = client.clone();
+        let build_snapshot = snapshot.clone();
+        let mutation_guard = $mutation_guard;
+        client
+            .session_tasks
+            .spawn_service(format!("consumer-admin-rpc-{admin_group}"), async move {
+                let result = run_topic_mutation_with_guard(mutation_guard, async move {
+                    run_tracked_topic_admin_service(
+                        &client.topic_admin_sessions,
+                        &client.config,
+                        snapshot,
+                        config_cancellation.cancelled(),
+                        guard_cancellation.cancelled(),
+                        operation_cancellation.cancelled(),
+                        move || async move { build_client.build_topic_admin_guard(&build_snapshot, admin_group).await },
+                        move |guard| {
+                            Box::pin(async move {
+                                let $admin = guard.inner_mut();
+                                Box::pin($operation).await.map_err(DashboardError::from)
+                            })
+                        },
+                    )
+                    .await
+                })
+                .await;
+                let _ = response_tx.send(result);
+            })
+            .map_err(|error| DashboardError::Internal(format!("Could not start consumer admin RPC: {error}")))?;
+        response_rx
+            .await
+            .map_err(|_| DashboardError::Internal("Consumer admin RPC stopped before returning a result".to_string()))?
+    }};
+}
+
 async fn run_topic_mutation_with_guard<T, F>(mutation_guard: Option<OwnedMutexGuard<()>>, operation: F) -> T
 where
     F: Future<Output = T>,
@@ -193,6 +241,9 @@ mod topic;
 mod topic_session;
 
 use self::topic_session::*;
+
+mod consumer;
+mod consumer_operations;
 
 impl ManagedAdminSession {
     async fn lease(&self) -> Result<AdminSessionLease, DashboardError> {
@@ -261,6 +312,7 @@ impl DashboardAdminClient {
             admin_session: Arc::new(Mutex::new(None)),
             topic_admin_sessions: Arc::new(TopicAdminSessionRegistry::default()),
             topic_mutation_lock: Arc::new(Mutex::new(())),
+            consumer_mutation_lock: Arc::new(Mutex::new(())),
             next_generation: Arc::new(AtomicU64::new(1)),
             session_tasks,
         }
@@ -268,6 +320,10 @@ impl DashboardAdminClient {
 
     pub(crate) async fn acquire_topic_mutation_lock(&self) -> OwnedMutexGuard<()> {
         Arc::clone(&self.topic_mutation_lock).lock_owned().await
+    }
+
+    pub(crate) async fn acquire_consumer_mutation_lock(&self) -> OwnedMutexGuard<()> {
+        Arc::clone(&self.consumer_mutation_lock).lock_owned().await
     }
 
     pub async fn shutdown(&self) {
@@ -418,9 +474,26 @@ impl DashboardAdminClient {
             reset_timestamp: request.reset_timestamp as u64,
             force: request.force,
         };
-        let result = run_admin_rpc!(self, |admin| admin.dashboard_reset_consumer(&request))?;
+        let mutation_guard = self.acquire_consumer_mutation_lock().await;
+        let result = run_consumer_admin_rpc!(self, Some(mutation_guard), |admin| admin
+            .dashboard_reset_consumer(&request))?;
         Ok(MutationResult {
             message: result.message,
+        })
+    }
+
+    pub async fn consumer_brokers(&self, group: &str) -> Result<ConsumerBrokerListView, DashboardError> {
+        validate_name(group, "Consumer group")?;
+        let list = run_admin_rpc!(self, |admin| admin.dashboard_consumer_brokers(group))?;
+        Ok(ConsumerBrokerListView {
+            items: list
+                .items
+                .into_iter()
+                .map(|item| crate::model::ConsumerBrokerInfo {
+                    broker_name: item.broker_name,
+                    broker_address: item.broker_address,
+                })
+                .collect(),
         })
     }
 

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/admin/dashboard_admin_client/consumer.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/admin/dashboard_admin_client/consumer.rs
@@ -1,0 +1,611 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_admin_core::core::AdminError;
+use rocketmq_admin_core::core::consumer as core_consumer;
+use rocketmq_admin_core::core::consumer::ConsumerDiagnosticAdmin;
+use rocketmq_admin_core::core::consumer::ConsumerQueryAdmin;
+
+use super::*;
+use crate::model::*;
+
+impl DashboardAdminClient {
+    pub async fn consumer_group_list(&self, query: ConsumerQuery) -> Result<ConsumerGroupListView, DashboardError> {
+        let config = self.config.read().await.clone();
+        let scope = resolve_consumer_query_scope(&config, &query)?;
+        let address = scope.address.clone();
+        let skip_system = query.skip_system.unwrap_or(false);
+        let list = run_consumer_admin_rpc!(self, |admin| async move {
+            let request = core_consumer::DashboardConsumerGroupListRequest {
+                skip_sys_group: skip_system,
+                address,
+            };
+            admin.query_dashboard_consumer_groups(&request).await
+        })?;
+
+        Ok(ConsumerGroupListView {
+            items: list.items.into_iter().map(map_consumer_group_list_item).collect(),
+            total: 0,
+            query_scope: scope,
+            capabilities: ConsumerCapabilities {
+                connections: true,
+                progress: true,
+                configuration: true,
+                running_info: true,
+                jstack: true,
+            },
+        })
+    }
+
+    pub async fn consumer_summary(
+        &self,
+        group: &str,
+        query: ConsumerQuery,
+    ) -> Result<ConsumerSummaryView, DashboardError> {
+        let group = normalize_consumer_group(group)?;
+        let config = self.config.read().await.clone();
+        let scope = resolve_consumer_query_scope(&config, &query)?;
+        let address = scope.address.clone();
+        let list = run_consumer_admin_rpc!(self, |admin| async move {
+            let request = core_consumer::DashboardConsumerGroupListRequest {
+                skip_sys_group: false,
+                address,
+            };
+            admin.query_dashboard_consumer_groups(&request).await
+        })?;
+        let item = list
+            .items
+            .into_iter()
+            .find(|item| item.raw_group_name == group || item.display_group_name == group)
+            .ok_or_else(|| DashboardError::NotFound(format!("Consumer group `{group}` was not found")))?;
+
+        Ok(map_consumer_summary(item, scope))
+    }
+
+    pub async fn consumer_connections(
+        &self,
+        group: &str,
+        query: ConsumerQuery,
+    ) -> Result<ConsumerConnectionView, DashboardError> {
+        let group = normalize_consumer_group(group)?;
+        let config = self.config.read().await.clone();
+        let scope = resolve_consumer_query_scope(&config, &query)?;
+        let address = scope.address.clone();
+        let connection = run_consumer_admin_rpc!(self, |admin| async move {
+            let request = core_consumer::DashboardConsumerConnectionRequest {
+                consumer_group: group.clone(),
+                address,
+            };
+            admin.query_dashboard_consumer_connection(&request).await
+        })?;
+
+        Ok(map_consumer_connection(connection, scope))
+    }
+
+    pub async fn consumer_progress_view(
+        &self,
+        group: &str,
+        query: ConsumerQuery,
+    ) -> Result<ConsumerProgressView, DashboardError> {
+        let group = normalize_consumer_group(group)?;
+        let config = self.config.read().await.clone();
+        let scope = resolve_consumer_query_scope(&config, &query)?;
+        let address = scope.address.clone();
+        let progress = run_consumer_admin_rpc!(self, |admin| async move {
+            let request = core_consumer::DashboardConsumerProgressRequest {
+                consumer_group: group.clone(),
+                address,
+            };
+            admin.query_dashboard_consumer_progress(&request).await
+        })?;
+
+        Ok(map_consumer_progress(progress, scope))
+    }
+
+    pub async fn consumer_config_view(
+        &self,
+        group: &str,
+        query: ConsumerQuery,
+    ) -> Result<ConsumerConfigView, DashboardError> {
+        let group = normalize_consumer_group(group)?;
+        let config = self.config.read().await.clone();
+        let scope = resolve_consumer_query_scope(&config, &query)?;
+        let group_owned = group.clone();
+        let fetches = run_consumer_admin_rpc!(self, |admin| async move {
+            let list_request = core_consumer::DashboardConsumerGroupListRequest {
+                skip_sys_group: false,
+                address: None,
+            };
+            let list = admin.query_dashboard_consumer_groups(&list_request).await?;
+            let item = list
+                .items
+                .into_iter()
+                .find(|item| item.raw_group_name == group_owned || item.display_group_name == group_owned)
+                .ok_or_else(|| AdminError::not_found("consumerGroup", group_owned.clone()))?;
+
+            let mut fetches = Vec::with_capacity(item.broker_addresses.len());
+            for broker_address in item.broker_addresses {
+                let request = core_consumer::DashboardConsumerConfigRequest {
+                    consumer_group: group_owned.clone(),
+                    address: Some(broker_address.clone()),
+                };
+                let result = admin.query_dashboard_consumer_config(&request).await;
+                fetches.push(ConsumerConfigTargetFetch { broker_address, result });
+            }
+            Ok::<_, AdminError>(fetches)
+        })?;
+
+        Ok(map_consumer_config(&group, fetches, scope))
+    }
+
+    pub async fn consumer_running_info(
+        &self,
+        group: &str,
+        client_id: &str,
+        query: ConsumerQuery,
+        include_jstack: bool,
+    ) -> Result<ConsumerRunningInfoView, DashboardError> {
+        let group = normalize_consumer_group(group)?;
+        self.resolve_and_query_running_info(&group, client_id, query, include_jstack)
+            .await
+    }
+
+    pub async fn consumer_jstack(
+        &self,
+        group: &str,
+        client_id: &str,
+        query: ConsumerQuery,
+    ) -> Result<ConsumerJStackView, DashboardError> {
+        let group = normalize_consumer_group(group)?;
+        let running_info = self
+            .resolve_and_query_running_info(&group, client_id, query, true)
+            .await?;
+        Ok(ConsumerJStackView {
+            consumer_group: running_info.consumer_group,
+            client_id: running_info.client_id,
+            jstack: running_info.jstack,
+            truncated: running_info.truncated,
+        })
+    }
+
+    async fn resolve_and_query_running_info(
+        &self,
+        group: &str,
+        client_id: &str,
+        query: ConsumerQuery,
+        include_jstack: bool,
+    ) -> Result<ConsumerRunningInfoView, DashboardError> {
+        let config = self.config.read().await.clone();
+        let _scope = resolve_consumer_query_scope(&config, &query)?;
+        let group = group.to_string();
+        let client_id = client_id.trim().to_string();
+        let request =
+            core_consumer::DashboardConsumerRunningInfoRequest::try_new(group, client_id, include_jstack, 1024 * 1024)?;
+        let running_info =
+            run_consumer_admin_rpc!(self, |admin| { admin.query_dashboard_consumer_running_info(&request) })?;
+        Ok(map_consumer_running_info(running_info))
+    }
+}
+
+pub(super) fn resolve_consumer_query_scope(
+    config: &DashboardConfigView,
+    query: &ConsumerQuery,
+) -> Result<ConsumerQueryScope, DashboardError> {
+    match query.mode {
+        ConsumerQueryMode::NameServer => Ok(ConsumerQueryScope {
+            mode: ConsumerQueryMode::NameServer,
+            address: None,
+        }),
+        ConsumerQueryMode::Proxy => {
+            let requested = query
+                .proxy_address
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty());
+            let address = match requested {
+                Some(address) => {
+                    if !config
+                        .proxy_addr_list
+                        .iter()
+                        .any(|candidate| candidate.trim() == address)
+                    {
+                        return Err(DashboardError::Validation(format!(
+                            "Proxy address `{address}` is not configured"
+                        )));
+                    }
+                    address.to_string()
+                }
+                None => config
+                    .current_proxy_addr
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_string)
+                    .ok_or_else(|| {
+                        DashboardError::Validation(
+                            "Proxy Client mode requires a configured current Proxy endpoint".to_string(),
+                        )
+                    })?,
+            };
+            Ok(ConsumerQueryScope {
+                mode: ConsumerQueryMode::Proxy,
+                address: Some(address),
+            })
+        }
+    }
+}
+
+pub(super) struct ConsumerConfigTargetFetch {
+    broker_address: String,
+    result: Result<core_consumer::DashboardConsumerConfig, AdminError>,
+}
+
+fn map_consumer_group_list_item(item: core_consumer::DashboardConsumerGroupItem) -> ConsumerGroupListItem {
+    ConsumerGroupListItem {
+        display_group_name: item.display_group_name,
+        raw_group_name: item.raw_group_name,
+        category: item.category,
+        connection_count: item.connection_count,
+        consume_tps: item.consume_tps,
+        diff_total: item.diff_total,
+        message_model: item.message_model,
+        consume_type: item.consume_type,
+        version: item.version,
+        version_desc: item.version_desc,
+        broker_names: item.broker_names,
+        broker_addresses: item.broker_addresses,
+        update_timestamp: item.update_timestamp,
+    }
+}
+
+fn map_consumer_summary(
+    item: core_consumer::DashboardConsumerGroupItem,
+    query_scope: ConsumerQueryScope,
+) -> ConsumerSummaryView {
+    ConsumerSummaryView {
+        group: item.raw_group_name.clone(),
+        display_group_name: item.display_group_name,
+        category: item.category,
+        connection_count: item.connection_count,
+        consume_tps: item.consume_tps,
+        diff_total: item.diff_total,
+        message_model: item.message_model,
+        consume_type: item.consume_type,
+        version: item.version,
+        version_desc: item.version_desc,
+        broker_names: item.broker_names,
+        broker_addresses: item.broker_addresses,
+        update_timestamp: item.update_timestamp,
+        query_scope,
+    }
+}
+
+fn map_consumer_connection(
+    connection: core_consumer::DashboardConsumerConnection,
+    query_scope: ConsumerQueryScope,
+) -> ConsumerConnectionView {
+    ConsumerConnectionView {
+        group: connection.consumer_group,
+        connection_count: connection.connection_count,
+        consume_type: connection.consume_type,
+        message_model: connection.message_model,
+        consume_from_where: connection.consume_from_where,
+        connections: connection
+            .connections
+            .into_iter()
+            .map(|item| ConsumerConnectionItem {
+                client_id: item.client_id,
+                client_addr: item.client_addr,
+                language: item.language,
+                version: item.version,
+                version_desc: item.version_desc,
+                capabilities: ConsumerClientCapabilities {
+                    running_info: true,
+                    jstack: true,
+                    running_info_reason: None,
+                    jstack_reason: None,
+                },
+            })
+            .collect(),
+        subscriptions: connection
+            .subscriptions
+            .into_iter()
+            .map(|item| ConsumerSubscriptionItem {
+                topic: item.topic,
+                sub_string: item.sub_string,
+                expression_type: item.expression_type,
+                tags_set: item.tags_set,
+                code_set: item.code_set,
+                sub_version: item.sub_version,
+            })
+            .collect(),
+        query_scope,
+    }
+}
+
+fn map_consumer_progress(
+    progress: core_consumer::DashboardConsumerProgress,
+    query_scope: ConsumerQueryScope,
+) -> ConsumerProgressView {
+    ConsumerProgressView {
+        group: progress.consumer_group,
+        topic_count: progress.topic_count,
+        total_diff: progress.total_diff,
+        topics: progress
+            .topics
+            .into_iter()
+            .map(|topic| ConsumerProgressTopic {
+                topic: topic.topic,
+                diff_total: topic.diff_total,
+                last_timestamp: topic.last_timestamp,
+                queues: topic
+                    .queues
+                    .into_iter()
+                    .map(|queue| ConsumerProgressTopicQueue {
+                        broker_name: queue.broker_name,
+                        queue_id: queue.queue_id,
+                        broker_offset: queue.broker_offset,
+                        consumer_offset: queue.consumer_offset,
+                        diff_total: queue.diff_total,
+                        client_info: queue.client_info,
+                        last_timestamp: queue.last_timestamp,
+                    })
+                    .collect(),
+            })
+            .collect(),
+        query_scope,
+    }
+}
+
+fn map_consumer_config(
+    group: &str,
+    fetches: Vec<ConsumerConfigTargetFetch>,
+    query_scope: ConsumerQueryScope,
+) -> ConsumerConfigView {
+    let mut targets = Vec::with_capacity(fetches.len());
+    for fetch in fetches {
+        match fetch.result {
+            Ok(config) => targets.push(ConsumerConfigTarget {
+                broker_name: config.broker_name.clone(),
+                broker_address: config.broker_address.clone(),
+                config: Some(map_consumer_config_value(&config)),
+                subscription_topics: config.subscription_topics,
+                attributes: config
+                    .attributes
+                    .into_iter()
+                    .map(map_consumer_config_attribute)
+                    .collect(),
+                error: None,
+            }),
+            Err(error) => targets.push(ConsumerConfigTarget {
+                broker_name: fetch.broker_address.clone(),
+                broker_address: fetch.broker_address,
+                config: None,
+                subscription_topics: Vec::new(),
+                attributes: Vec::new(),
+                error: Some(error.to_string()),
+            }),
+        }
+    }
+
+    let successful = targets
+        .iter()
+        .filter_map(|target| target.config.as_ref())
+        .collect::<Vec<_>>();
+    let effective = successful.first().map(|first| {
+        let mut effective = (*first).clone();
+        if successful.iter().any(|value| *value != &effective) {
+            effective = ConsumerConfigValue::default();
+        }
+        effective
+    });
+    let inconsistent_fields = collect_inconsistent_config_fields(successful.as_slice());
+
+    ConsumerConfigView {
+        group: group.to_string(),
+        effective,
+        inconsistent_fields,
+        targets,
+        query_scope,
+    }
+}
+
+fn map_consumer_config_value(config: &core_consumer::DashboardConsumerConfig) -> ConsumerConfigValue {
+    ConsumerConfigValue {
+        consume_enable: config.consume_enable,
+        consume_from_min_enable: config.consume_from_min_enable,
+        consume_broadcast_enable: config.consume_broadcast_enable,
+        consume_message_orderly: config.consume_message_orderly,
+        retry_queue_nums: config.retry_queue_nums,
+        retry_max_times: config.retry_max_times,
+        broker_id: config.broker_id,
+        which_broker_when_consume_slowly: config.which_broker_when_consume_slowly,
+        notify_consumer_ids_changed_enable: config.notify_consumer_ids_changed_enable,
+        group_sys_flag: config.group_sys_flag,
+        consume_timeout_minute: config.consume_timeout_minute,
+        group_retry_policy_json: config.group_retry_policy_json.clone(),
+    }
+}
+
+fn map_consumer_config_attribute(
+    attribute: core_consumer::DashboardConsumerConfigAttribute,
+) -> ConsumerConfigAttribute {
+    ConsumerConfigAttribute {
+        key: attribute.key,
+        value: attribute.value,
+    }
+}
+
+fn collect_inconsistent_config_fields(values: &[&ConsumerConfigValue]) -> Vec<String> {
+    let Some(first) = values.first() else {
+        return Vec::new();
+    };
+    let mut fields = Vec::new();
+    if values.iter().any(|value| value.consume_enable != first.consume_enable) {
+        fields.push("consumeEnable".to_string());
+    }
+    if values
+        .iter()
+        .any(|value| value.consume_from_min_enable != first.consume_from_min_enable)
+    {
+        fields.push("consumeFromMinEnable".to_string());
+    }
+    if values
+        .iter()
+        .any(|value| value.consume_broadcast_enable != first.consume_broadcast_enable)
+    {
+        fields.push("consumeBroadcastEnable".to_string());
+    }
+    if values
+        .iter()
+        .any(|value| value.consume_message_orderly != first.consume_message_orderly)
+    {
+        fields.push("consumeMessageOrderly".to_string());
+    }
+    if values
+        .iter()
+        .any(|value| value.retry_queue_nums != first.retry_queue_nums)
+    {
+        fields.push("retryQueueNums".to_string());
+    }
+    if values
+        .iter()
+        .any(|value| value.retry_max_times != first.retry_max_times)
+    {
+        fields.push("retryMaxTimes".to_string());
+    }
+    if values.iter().any(|value| value.broker_id != first.broker_id) {
+        fields.push("brokerId".to_string());
+    }
+    if values
+        .iter()
+        .any(|value| value.which_broker_when_consume_slowly != first.which_broker_when_consume_slowly)
+    {
+        fields.push("whichBrokerWhenConsumeSlowly".to_string());
+    }
+    if values
+        .iter()
+        .any(|value| value.notify_consumer_ids_changed_enable != first.notify_consumer_ids_changed_enable)
+    {
+        fields.push("notifyConsumerIdsChangedEnable".to_string());
+    }
+    if values.iter().any(|value| value.group_sys_flag != first.group_sys_flag) {
+        fields.push("groupSysFlag".to_string());
+    }
+    if values
+        .iter()
+        .any(|value| value.consume_timeout_minute != first.consume_timeout_minute)
+    {
+        fields.push("consumeTimeoutMinute".to_string());
+    }
+    if values
+        .iter()
+        .any(|value| value.group_retry_policy_json != first.group_retry_policy_json)
+    {
+        fields.push("groupRetryPolicyJson".to_string());
+    }
+    fields
+}
+
+fn map_consumer_running_info(running_info: core_consumer::DashboardConsumerRunningInfo) -> ConsumerRunningInfoView {
+    ConsumerRunningInfoView {
+        consumer_group: running_info.consumer_group,
+        client_id: running_info.client_id,
+        properties: running_info
+            .properties
+            .into_iter()
+            .map(map_consumer_config_attribute)
+            .collect(),
+        subscriptions: running_info
+            .subscriptions
+            .into_iter()
+            .map(|item| ConsumerSubscriptionItem {
+                topic: item.topic,
+                sub_string: item.sub_string,
+                expression_type: item.expression_type,
+                tags_set: item.tags_set,
+                code_set: item.code_set,
+                sub_version: item.sub_version,
+            })
+            .collect(),
+        process_queues: running_info
+            .process_queues
+            .into_iter()
+            .map(|queue| ConsumerProcessQueue {
+                topic: queue.topic,
+                broker_name: queue.broker_name,
+                queue_id: queue.queue_id,
+                cached_message_count: queue.cached_message_count,
+                cached_message_size_in_mib: queue.cached_message_size_in_mib,
+                commit_offset: queue.commit_offset,
+                dropped: queue.dropped,
+                last_consume_timestamp: queue.last_consume_timestamp,
+            })
+            .collect(),
+        jstack: running_info.jstack,
+        truncated: running_info.truncated,
+    }
+}
+
+fn normalize_consumer_group(group: &str) -> Result<String, DashboardError> {
+    let group = group.trim();
+    if group.is_empty() {
+        return Err(DashboardError::Validation("Consumer group is required".to_string()));
+    }
+    Ok(group.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_with_proxies(proxies: &[&str], current: Option<&str>) -> DashboardConfigView {
+        DashboardConfigView {
+            proxy_addr_list: proxies.iter().map(|value| (*value).to_string()).collect(),
+            current_proxy_addr: current.map(str::to_string),
+            ..DashboardConfigView::default()
+        }
+    }
+
+    #[test]
+    fn proxy_scope_requires_the_configured_current_endpoint() {
+        let config = config_with_proxies(&["proxy-a:8081"], Some("proxy-a:8081"));
+        assert_eq!(
+            resolve_consumer_query_scope(&config, &ConsumerQuery::proxy(None))
+                .unwrap()
+                .address(),
+            Some("proxy-a:8081")
+        );
+        assert!(
+            resolve_consumer_query_scope(&config, &ConsumerQuery::proxy(Some("proxy-b:8081".to_string()))).is_err()
+        );
+        assert!(
+            resolve_consumer_query_scope(
+                &config_with_proxies(&["proxy-a:8081"], None),
+                &ConsumerQuery::proxy(None)
+            )
+            .is_err()
+        );
+    }
+
+    impl ConsumerQuery {
+        fn proxy(address: Option<String>) -> Self {
+            Self {
+                mode: ConsumerQueryMode::Proxy,
+                proxy_address: address,
+                skip_system: None,
+            }
+        }
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/admin/dashboard_admin_client/consumer_operations.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/admin/dashboard_admin_client/consumer_operations.rs
@@ -1,0 +1,223 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_admin_core::core::AdminError;
+use rocketmq_admin_core::core::consumer as core_consumer;
+use rocketmq_admin_core::core::consumer::ConsumerBatchMutationAdmin;
+use rocketmq_admin_core::core::consumer::ConsumerQueryAdmin;
+
+use super::*;
+use crate::model::*;
+
+impl DashboardAdminClient {
+    pub async fn create_consumer_group(
+        &self,
+        group: &str,
+        request: ConsumerUpsertView,
+    ) -> Result<ConsumerOperationResult, DashboardError> {
+        let mutation_guard = self.acquire_consumer_mutation_lock().await;
+        self.upsert_consumer_group_with_guard(group, request, "CREATE", mutation_guard)
+            .await
+    }
+
+    pub async fn update_consumer_group(
+        &self,
+        group: &str,
+        request: ConsumerUpsertView,
+    ) -> Result<ConsumerOperationResult, DashboardError> {
+        let mutation_guard = self.acquire_consumer_mutation_lock().await;
+        self.upsert_consumer_group_with_guard(group, request, "UPDATE", mutation_guard)
+            .await
+    }
+
+    pub async fn delete_consumer_group(
+        &self,
+        group: &str,
+        request: ConsumerDeleteView,
+    ) -> Result<ConsumerOperationResult, DashboardError> {
+        let group = validate_consumer_mutation_group(group)?;
+        let selected_broker_names = canonicalize_consumer_broker_names(request.broker_names)?;
+        let mutation_guard = self.acquire_consumer_mutation_lock().await;
+        let operation_group = group.clone();
+        let selected_for_call = selected_broker_names.clone();
+
+        let batch_result = run_consumer_admin_rpc!(self, Some(mutation_guard), |admin| async move {
+            let list_request = core_consumer::DashboardConsumerGroupListRequest {
+                skip_sys_group: false,
+                address: None,
+            };
+            let list = admin.query_dashboard_consumer_groups(&list_request).await?;
+            let item = list
+                .items
+                .into_iter()
+                .find(|item| item.raw_group_name == operation_group || item.display_group_name == operation_group)
+                .ok_or_else(|| AdminError::not_found("consumerGroup", operation_group.clone()))?;
+            let delete_request = core_consumer::ConsumerBatchDeleteRequest::try_new(
+                operation_group,
+                selected_for_call,
+                item.broker_names,
+            )?;
+            admin.delete_consumer_group_batch(&delete_request).await
+        })?;
+
+        Ok(map_consumer_batch_result(batch_result, "DELETE", &group))
+    }
+
+    async fn upsert_consumer_group_with_guard(
+        &self,
+        group: &str,
+        request: ConsumerUpsertView,
+        operation: &str,
+        mutation_guard: tokio::sync::OwnedMutexGuard<()>,
+    ) -> Result<ConsumerOperationResult, DashboardError> {
+        let group = validate_consumer_mutation_group(group)?;
+        let core_request = core_consumer::DashboardConsumerUpsertRequest {
+            cluster_name_list: request.cluster_name_list,
+            broker_name_list: request.broker_name_list,
+            consumer_group: group.clone(),
+            consume_enable: request.consume_enable,
+            consume_from_min_enable: request.consume_from_min_enable,
+            consume_broadcast_enable: request.consume_broadcast_enable,
+            consume_message_orderly: request.consume_message_orderly,
+            retry_queue_nums: request.retry_queue_nums,
+            retry_max_times: request.retry_max_times,
+            broker_id: request.broker_id,
+            which_broker_when_consume_slowly: request.which_broker_when_consume_slowly,
+            notify_consumer_ids_changed_enable: request.notify_consumer_ids_changed_enable,
+            group_sys_flag: request.group_sys_flag,
+            consume_timeout_minute: request.consume_timeout_minute,
+        };
+        let batch_request = core_consumer::ConsumerBatchUpsertRequest::try_new(core_request)?;
+        let batch_result = run_consumer_admin_rpc!(self, Some(mutation_guard), |admin| async move {
+            admin.upsert_consumer_group_batch(&batch_request).await
+        })?;
+
+        Ok(map_consumer_batch_result(batch_result, operation, &group))
+    }
+}
+
+fn validate_consumer_mutation_group(group: &str) -> Result<String, DashboardError> {
+    let group = group.trim();
+    if group.is_empty() {
+        return Err(DashboardError::Validation("Consumer group is required".to_string()));
+    }
+    if group.starts_with("%SYS%") || local_is_system_consumer_group(group) {
+        return Err(DashboardError::Validation(
+            "System consumer groups cannot be mutated".to_string(),
+        ));
+    }
+    Ok(group.to_string())
+}
+
+fn canonicalize_consumer_broker_names(names: Vec<String>) -> Result<Vec<String>, DashboardError> {
+    let mut names = names
+        .into_iter()
+        .map(|name| name.trim().to_string())
+        .filter(|name| !name.is_empty())
+        .collect::<Vec<_>>();
+    names.sort();
+    names.dedup();
+    if names.is_empty() {
+        return Err(DashboardError::Validation(
+            "Select at least one broker before deleting the consumer group".to_string(),
+        ));
+    }
+    Ok(names)
+}
+
+fn map_consumer_batch_result(
+    result: core_consumer::DashboardConsumerBatchResult,
+    operation: &str,
+    group: &str,
+) -> ConsumerOperationResult {
+    let targets = result
+        .targets
+        .into_iter()
+        .map(|target| ConsumerTargetResult {
+            target: target.target,
+            kind: target.kind,
+            success: target.success,
+            message: target.message,
+        })
+        .collect::<Vec<_>>();
+    let success = result.success && targets.iter().all(|target| target.success);
+    let target_count = targets.len();
+    ConsumerOperationResult {
+        operation: operation.to_string(),
+        consumer_group: group.to_string(),
+        success,
+        target_count,
+        message: if success {
+            format!("Consumer group `{group}` operation completed")
+        } else {
+            format!("Consumer group `{group}` operation completed with failed targets")
+        },
+        targets,
+    }
+}
+
+fn local_is_system_consumer_group(group: &str) -> bool {
+    group.starts_with("CID_RMQ_SYS_")
+        || matches!(
+            group,
+            "TOOLS_CONSUMER"
+                | "FILTERSRV_CONSUMER"
+                | "SELF_TEST_C_GROUP"
+                | "CID_ONS-HTTP-PROXY"
+                | "CID_ONSAPI_PULL"
+                | "CID_ONSAPI_PERMISSION"
+                | "CID_ONSAPI_OWNER"
+                | "CID_RMQ_SYS_TRANS"
+                | "CID_DefaultHeartBeatSyncerTopic"
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn batch_result(targets: Vec<(&str, bool)>) -> core_consumer::DashboardConsumerBatchResult {
+        core_consumer::DashboardConsumerBatchResult {
+            consumer_group: "orders-consumer".to_string(),
+            success: targets.iter().all(|(_, success)| *success),
+            targets: targets
+                .into_iter()
+                .map(|(target, success)| core_consumer::DashboardConsumerTargetOutcome {
+                    target: target.to_string(),
+                    kind: "BROKER".to_string(),
+                    success,
+                    message: if success {
+                        "ok".to_string()
+                    } else {
+                        "failed".to_string()
+                    },
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn operation_result_keeps_failed_targets_and_never_flattens_partial_success() {
+        let view = map_consumer_batch_result(
+            batch_result(vec![("broker-a", true), ("broker-b", false)]),
+            "UPDATE",
+            "orders-consumer",
+        );
+        assert_eq!(view.operation, "UPDATE");
+        assert!(!view.success);
+        assert_eq!(view.target_count, 2);
+        assert_eq!(view.targets[1].target, "broker-b");
+        assert!(!view.targets[1].success);
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/consumer_api.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/consumer_api.rs
@@ -13,28 +13,137 @@
 // limitations under the License.
 use crate::error::DashboardError;
 use crate::model::ApiResponse;
-use crate::model::ConsumerListView;
-use crate::model::ConsumerProgress;
+use crate::model::ConsumerBrokerListView;
+use crate::model::ConsumerConfigView;
+use crate::model::ConsumerConnectionView;
+use crate::model::ConsumerDeleteView;
+use crate::model::ConsumerGroupListView;
+use crate::model::ConsumerJStackView;
+use crate::model::ConsumerOperationResult;
+use crate::model::ConsumerProgressView;
+use crate::model::ConsumerQuery;
 use crate::model::ConsumerResetOffsetRequest;
+use crate::model::ConsumerRunningInfoView;
+use crate::model::ConsumerSummaryView;
+use crate::model::ConsumerUpsertView;
 use crate::model::MutationResult;
 use crate::service;
 use crate::state::AppState;
 use axum::Json;
 use axum::extract::Path;
+use axum::extract::Query;
 use axum::extract::State;
 
 pub async fn list_consumers(
     State(state): State<AppState>,
-) -> Result<Json<ApiResponse<ConsumerListView>>, DashboardError> {
-    Ok(Json(ApiResponse::success(service::list_consumers(&state).await?)))
+    Query(query): Query<ConsumerQuery>,
+) -> Result<Json<ApiResponse<ConsumerGroupListView>>, DashboardError> {
+    Ok(Json(ApiResponse::success(
+        service::list_consumers(&state, query).await?,
+    )))
+}
+
+pub async fn consumer_summary(
+    State(state): State<AppState>,
+    Path(group): Path<String>,
+    Query(query): Query<ConsumerQuery>,
+) -> Result<Json<ApiResponse<ConsumerSummaryView>>, DashboardError> {
+    Ok(Json(ApiResponse::success(
+        service::consumer_summary(&state, &group, query).await?,
+    )))
+}
+
+pub async fn consumer_connections(
+    State(state): State<AppState>,
+    Path(group): Path<String>,
+    Query(query): Query<ConsumerQuery>,
+) -> Result<Json<ApiResponse<ConsumerConnectionView>>, DashboardError> {
+    Ok(Json(ApiResponse::success(
+        service::consumer_connections(&state, &group, query).await?,
+    )))
 }
 
 pub async fn consumer_progress(
     State(state): State<AppState>,
     Path(group): Path<String>,
-) -> Result<Json<ApiResponse<ConsumerProgress>>, DashboardError> {
+    Query(query): Query<ConsumerQuery>,
+) -> Result<Json<ApiResponse<ConsumerProgressView>>, DashboardError> {
     Ok(Json(ApiResponse::success(
-        service::consumer_progress(&state, &group).await?,
+        service::consumer_progress(&state, &group, query).await?,
+    )))
+}
+
+pub async fn consumer_config(
+    State(state): State<AppState>,
+    Path(group): Path<String>,
+    Query(query): Query<ConsumerQuery>,
+) -> Result<Json<ApiResponse<ConsumerConfigView>>, DashboardError> {
+    Ok(Json(ApiResponse::success(
+        service::consumer_config(&state, &group, query).await?,
+    )))
+}
+
+pub async fn consumer_running_info(
+    State(state): State<AppState>,
+    Path((group, client_id)): Path<(String, String)>,
+    Query(query): Query<ConsumerQuery>,
+) -> Result<Json<ApiResponse<ConsumerRunningInfoView>>, DashboardError> {
+    Ok(Json(ApiResponse::success(
+        service::consumer_running_info(&state, &group, &client_id, query).await?,
+    )))
+}
+
+pub async fn consumer_jstack(
+    State(state): State<AppState>,
+    Path((group, client_id)): Path<(String, String)>,
+    Query(query): Query<ConsumerQuery>,
+) -> Result<Json<ApiResponse<ConsumerJStackView>>, DashboardError> {
+    Ok(Json(ApiResponse::success(
+        service::consumer_jstack(&state, &group, &client_id, query).await?,
+    )))
+}
+
+pub async fn consumer_brokers(
+    State(state): State<AppState>,
+    Path(group): Path<String>,
+) -> Result<Json<ApiResponse<ConsumerBrokerListView>>, DashboardError> {
+    Ok(Json(ApiResponse::success(
+        service::consumer_brokers(&state, &group).await?,
+    )))
+}
+
+pub async fn create_consumer(
+    State(state): State<AppState>,
+    Json(request): Json<ConsumerUpsertView>,
+) -> Result<Json<ApiResponse<ConsumerOperationResult>>, DashboardError> {
+    let group = request
+        .consumer_group
+        .clone()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| DashboardError::Validation("Consumer group is required".to_string()))?;
+    Ok(Json(ApiResponse::success(
+        service::create_consumer(&state, &group, request).await?,
+    )))
+}
+
+pub async fn update_consumer(
+    State(state): State<AppState>,
+    Path(group): Path<String>,
+    Json(request): Json<ConsumerUpsertView>,
+) -> Result<Json<ApiResponse<ConsumerOperationResult>>, DashboardError> {
+    Ok(Json(ApiResponse::success(
+        service::update_consumer(&state, &group, request).await?,
+    )))
+}
+
+pub async fn delete_consumer(
+    State(state): State<AppState>,
+    Path(group): Path<String>,
+    Json(request): Json<ConsumerDeleteView>,
+) -> Result<Json<ApiResponse<ConsumerOperationResult>>, DashboardError> {
+    Ok(Json(ApiResponse::success(
+        service::delete_consumer(&state, &group, request).await?,
     )))
 }
 

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/router.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/router.rs
@@ -66,9 +66,31 @@ pub fn build_router(state: AppState) -> Router {
             "/api/topics/{topic}/brokers/{broker}",
             delete(topic_api::delete_topic_from_broker),
         )
-        .route("/api/consumers", get(consumer_api::list_consumers))
-        .route("/api/consumers/{group}", get(consumer_api::consumer_progress))
+        .route(
+            "/api/consumers",
+            get(consumer_api::list_consumers).post(consumer_api::create_consumer),
+        )
+        .route(
+            "/api/consumers/{group}",
+            get(consumer_api::consumer_summary)
+                .put(consumer_api::update_consumer)
+                .delete(consumer_api::delete_consumer),
+        )
+        .route(
+            "/api/consumers/{group}/connections",
+            get(consumer_api::consumer_connections),
+        )
         .route("/api/consumers/{group}/progress", get(consumer_api::consumer_progress))
+        .route("/api/consumers/{group}/config", get(consumer_api::consumer_config))
+        .route(
+            "/api/consumers/{group}/clients/{clientId}/running-info",
+            get(consumer_api::consumer_running_info),
+        )
+        .route(
+            "/api/consumers/{group}/clients/{clientId}/jstack",
+            get(consumer_api::consumer_jstack),
+        )
+        .route("/api/consumers/{group}/brokers", get(consumer_api::consumer_brokers))
         .route("/api/consumers/{group}/reset-offset", post(consumer_api::reset_offset))
         .route("/api/producers", get(producer_api::list_producers))
         .route("/api/producers/connections", get(producer_api::producer_connections))

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/model/consumer_model.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/model/consumer_model.rs
@@ -53,8 +53,306 @@ pub struct ConsumerQueueProgress {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+pub struct ConsumerBrokerInfo {
+    pub broker_name: String,
+    pub broker_address: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumerBrokerListView {
+    pub items: Vec<ConsumerBrokerInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct ConsumerResetOffsetRequest {
     pub topic: String,
     pub reset_timestamp: i64,
     pub force: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ConsumerQueryMode {
+    #[default]
+    NameServer,
+    Proxy,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct ConsumerQuery {
+    pub mode: ConsumerQueryMode,
+    pub proxy_address: Option<String>,
+    pub skip_system: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumerQueryScope {
+    pub mode: ConsumerQueryMode,
+    pub address: Option<String>,
+}
+
+impl ConsumerQueryScope {
+    #[must_use]
+    pub fn address(&self) -> Option<&str> {
+        self.address.as_deref()
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumerCapabilities {
+    pub connections: bool,
+    pub progress: bool,
+    pub configuration: bool,
+    pub running_info: bool,
+    pub jstack: bool,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumerClientCapabilities {
+    pub running_info: bool,
+    pub jstack: bool,
+    pub running_info_reason: Option<String>,
+    pub jstack_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumerGroupListItem {
+    pub display_group_name: String,
+    pub raw_group_name: String,
+    pub category: String,
+    pub connection_count: usize,
+    pub consume_tps: i64,
+    pub diff_total: i64,
+    pub message_model: String,
+    pub consume_type: String,
+    pub version: Option<i32>,
+    pub version_desc: String,
+    pub broker_names: Vec<String>,
+    pub broker_addresses: Vec<String>,
+    pub update_timestamp: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumerGroupListView {
+    pub items: Vec<ConsumerGroupListItem>,
+    pub total: usize,
+    pub query_scope: ConsumerQueryScope,
+    pub capabilities: ConsumerCapabilities,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumerSummaryView {
+    pub group: String,
+    pub display_group_name: String,
+    pub category: String,
+    pub connection_count: usize,
+    pub consume_tps: i64,
+    pub diff_total: i64,
+    pub message_model: String,
+    pub consume_type: String,
+    pub version: Option<i32>,
+    pub version_desc: String,
+    pub broker_names: Vec<String>,
+    pub broker_addresses: Vec<String>,
+    pub update_timestamp: i64,
+    pub query_scope: ConsumerQueryScope,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumerConnectionItem {
+    pub client_id: String,
+    pub client_addr: String,
+    pub language: String,
+    pub version: i32,
+    pub version_desc: String,
+    pub capabilities: ConsumerClientCapabilities,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumerSubscriptionItem {
+    pub topic: String,
+    pub sub_string: String,
+    pub expression_type: String,
+    pub tags_set: Vec<String>,
+    pub code_set: Vec<i32>,
+    pub sub_version: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumerConnectionView {
+    pub group: String,
+    pub connection_count: usize,
+    pub consume_type: String,
+    pub message_model: String,
+    pub consume_from_where: String,
+    pub connections: Vec<ConsumerConnectionItem>,
+    pub subscriptions: Vec<ConsumerSubscriptionItem>,
+    pub query_scope: ConsumerQueryScope,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumerProgressTopicQueue {
+    pub broker_name: String,
+    pub queue_id: i32,
+    pub broker_offset: i64,
+    pub consumer_offset: i64,
+    pub diff_total: i64,
+    pub client_info: String,
+    pub last_timestamp: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumerProgressTopic {
+    pub topic: String,
+    pub diff_total: i64,
+    pub last_timestamp: i64,
+    pub queues: Vec<ConsumerProgressTopicQueue>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumerProgressView {
+    pub group: String,
+    pub topic_count: usize,
+    pub total_diff: i64,
+    pub topics: Vec<ConsumerProgressTopic>,
+    pub query_scope: ConsumerQueryScope,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumerConfigAttribute {
+    pub key: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumerConfigValue {
+    pub consume_enable: bool,
+    pub consume_from_min_enable: bool,
+    pub consume_broadcast_enable: bool,
+    pub consume_message_orderly: bool,
+    pub retry_queue_nums: i32,
+    pub retry_max_times: i32,
+    pub broker_id: u64,
+    pub which_broker_when_consume_slowly: u64,
+    pub notify_consumer_ids_changed_enable: bool,
+    pub group_sys_flag: i32,
+    pub consume_timeout_minute: i32,
+    pub group_retry_policy_json: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumerConfigTarget {
+    pub broker_name: String,
+    pub broker_address: String,
+    pub config: Option<ConsumerConfigValue>,
+    pub subscription_topics: Vec<String>,
+    pub attributes: Vec<ConsumerConfigAttribute>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumerConfigView {
+    pub group: String,
+    pub effective: Option<ConsumerConfigValue>,
+    pub inconsistent_fields: Vec<String>,
+    pub targets: Vec<ConsumerConfigTarget>,
+    pub query_scope: ConsumerQueryScope,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumerProcessQueue {
+    pub topic: String,
+    pub broker_name: String,
+    pub queue_id: i32,
+    pub cached_message_count: i64,
+    pub cached_message_size_in_mib: i64,
+    pub commit_offset: i64,
+    pub dropped: bool,
+    pub last_consume_timestamp: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumerRunningInfoView {
+    pub consumer_group: String,
+    pub client_id: String,
+    pub properties: Vec<ConsumerConfigAttribute>,
+    pub subscriptions: Vec<ConsumerSubscriptionItem>,
+    pub process_queues: Vec<ConsumerProcessQueue>,
+    pub jstack: Option<String>,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumerJStackView {
+    pub consumer_group: String,
+    pub client_id: String,
+    pub jstack: Option<String>,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumerTargetResult {
+    pub target: String,
+    pub kind: String,
+    pub success: bool,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumerOperationResult {
+    pub operation: String,
+    pub consumer_group: String,
+    pub success: bool,
+    pub target_count: usize,
+    pub message: String,
+    pub targets: Vec<ConsumerTargetResult>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumerUpsertView {
+    pub consumer_group: Option<String>,
+    pub cluster_name_list: Vec<String>,
+    pub broker_name_list: Vec<String>,
+    pub consume_enable: bool,
+    pub consume_from_min_enable: bool,
+    pub consume_broadcast_enable: bool,
+    pub consume_message_orderly: bool,
+    pub retry_queue_nums: i32,
+    pub retry_max_times: i32,
+    pub broker_id: u64,
+    pub which_broker_when_consume_slowly: u64,
+    pub notify_consumer_ids_changed_enable: bool,
+    pub group_sys_flag: i32,
+    pub consume_timeout_minute: i32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumerDeleteView {
+    pub broker_names: Vec<String>,
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/consumer_service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/consumer_service.rs
@@ -12,18 +12,105 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use crate::error::DashboardError;
-use crate::model::ConsumerListView;
-use crate::model::ConsumerProgress;
+use crate::model::ConsumerBrokerListView;
+use crate::model::ConsumerConfigView;
+use crate::model::ConsumerConnectionView;
+use crate::model::ConsumerDeleteView;
+use crate::model::ConsumerGroupListView;
+use crate::model::ConsumerJStackView;
+use crate::model::ConsumerOperationResult;
+use crate::model::ConsumerProgressView;
+use crate::model::ConsumerQuery;
 use crate::model::ConsumerResetOffsetRequest;
+use crate::model::ConsumerRunningInfoView;
+use crate::model::ConsumerSummaryView;
+use crate::model::ConsumerUpsertView;
 use crate::model::MutationResult;
 use crate::state::AppState;
 
-pub async fn list_consumers(state: &AppState) -> Result<ConsumerListView, DashboardError> {
-    state.admin_facade().list_consumer_groups().await
+pub async fn list_consumers(state: &AppState, query: ConsumerQuery) -> Result<ConsumerGroupListView, DashboardError> {
+    state.admin_client.consumer_group_list(query).await
 }
 
-pub async fn consumer_progress(state: &AppState, group: &str) -> Result<ConsumerProgress, DashboardError> {
-    state.admin_facade().consumer_progress(group).await
+pub async fn consumer_brokers(state: &AppState, group: &str) -> Result<ConsumerBrokerListView, DashboardError> {
+    state.admin_client.consumer_brokers(group).await
+}
+
+pub async fn consumer_summary(
+    state: &AppState,
+    group: &str,
+    query: ConsumerQuery,
+) -> Result<ConsumerSummaryView, DashboardError> {
+    state.admin_client.consumer_summary(group, query).await
+}
+
+pub async fn consumer_connections(
+    state: &AppState,
+    group: &str,
+    query: ConsumerQuery,
+) -> Result<ConsumerConnectionView, DashboardError> {
+    state.admin_client.consumer_connections(group, query).await
+}
+
+pub async fn consumer_progress(
+    state: &AppState,
+    group: &str,
+    query: ConsumerQuery,
+) -> Result<ConsumerProgressView, DashboardError> {
+    state.admin_client.consumer_progress_view(group, query).await
+}
+
+pub async fn consumer_config(
+    state: &AppState,
+    group: &str,
+    query: ConsumerQuery,
+) -> Result<ConsumerConfigView, DashboardError> {
+    state.admin_client.consumer_config_view(group, query).await
+}
+
+pub async fn consumer_running_info(
+    state: &AppState,
+    group: &str,
+    client_id: &str,
+    query: ConsumerQuery,
+) -> Result<ConsumerRunningInfoView, DashboardError> {
+    state
+        .admin_client
+        .consumer_running_info(group, client_id, query, false)
+        .await
+}
+
+pub async fn consumer_jstack(
+    state: &AppState,
+    group: &str,
+    client_id: &str,
+    query: ConsumerQuery,
+) -> Result<ConsumerJStackView, DashboardError> {
+    state.admin_client.consumer_jstack(group, client_id, query).await
+}
+
+pub async fn create_consumer(
+    state: &AppState,
+    group: &str,
+    request: ConsumerUpsertView,
+) -> Result<ConsumerOperationResult, DashboardError> {
+    state.admin_client.create_consumer_group(group, request).await
+}
+
+pub async fn update_consumer(
+    state: &AppState,
+    group: &str,
+    request: ConsumerUpsertView,
+) -> Result<ConsumerOperationResult, DashboardError> {
+    state.admin_client.update_consumer_group(group, request).await
+}
+
+pub async fn delete_consumer(
+    state: &AppState,
+    group: &str,
+    request: ConsumerDeleteView,
+) -> Result<ConsumerOperationResult, DashboardError> {
+    state.admin_client.delete_consumer_group(group, request).await
 }
 
 pub async fn reset_consumer_offset(

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/design-qa.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/design-qa.md
@@ -1,39 +1,19 @@
-# Topic Design QA
+# Consumer Full Operations Design QA
 
-## Evidence
+**Date:** 2026-08-16
+**Status:** Passed automated validation; real-environment browser QA not completed.
 
-- Source visual truth: `%TEMP%\rocketmq-topic-task9-qa\java-topic-list-1280x720.png` and `%TEMP%\rocketmq-topic-task9-qa\java-topic-create-1280x720.png`, captured from the local Java Topic page. These temporary screenshots are QA evidence and are not committed.
-- Browser-rendered implementation: `%TEMP%\rocketmq-topic-task9-qa\rust-topic-list-1280x720.png`, `%TEMP%\rocketmq-topic-task9-qa\rust-topic-create-1280x720.png`, `%TEMP%\rocketmq-topic-task9-qa\rust-topic-list-768x1024.png`, and `%TEMP%\rocketmq-topic-task9-qa\rust-topic-create-768x1024.png`, captured from the local Rust Topic page in the selected in-app browser. These screenshots are not committed.
-- Single full-view comparison input: `%TEMP%\rocketmq-topic-task9-qa\java-rust-topic-comparison-1280x720.png` (Java left, Rust right; list above, create form below; not committed).
-- Viewport: both desktop pages reported the same `1280 x 720` CSS viewport with `devicePixelRatio = 1.5`. The browser capture surface produced `1253 x 705` source pixels for both Java states, `1265 x 712` implementation pixels for the Rust list, and `1280 x 720` implementation pixels for the Rust create dialog. The single comparison downsampled each capture to `620 x 349` solely to place the four states in one equal-size grid. Responsive implementation evidence used a controlled `768 x 1024` frame inside the same in-app browser.
-- State: Java Topic list and Add Topic form; Rust Topic inventory and Create topic form, plus the Rust list and form at the narrow breakpoint.
-- Focused region comparison: no extra crop was needed because form labels, inputs, focus rings, borders, and the complete visible inventory rows remained legible in the native full-view captures and in the combined input.
+## Viewport
+- Desktop and narrow viewport checks not performed against a live RocketMQ cluster.
 
-## Findings
+## Validated states
+- Frontend TypeScript production build.
+- Full frontend test suite.
+- Backend Consumer API build, tests, Clippy, and runtime ownership audit.
+- Source policy scans found no new gradient, hard-coded white, internal parity copy, or product raw Consumer button.
 
-- No actionable P0, P1, or P2 mismatch remains. The Rust page intentionally applies the approved dark monochrome operations-dashboard direction rather than copying the Java page's legacy light styling.
-- Typography and hierarchy are coherent: compact system text, monospaced operational identifiers, clear page and dialog headings, and readable secondary metadata.
-- Spacing and density are appropriate for an operations surface. The Rust inventory exposes filters, target metadata, pagination, and actions without the sparse dead space present in the Java reference.
-- Borders, dark tokens, field focus, disabled actions, and destructive affordances remain distinguishable. Source scans found no gradient, hard-coded white, migration/parity copy, or raw Topic `<button>` markup.
-- The narrow view has no page-level horizontal overflow (`clientWidth = scrollWidth = 753`); the wide operational table owns its horizontal overflow (`clientWidth = 703`, `scrollWidth = 1120`), and the create form resolves to one column.
-- The screen uses coherent Lucide interface icons and no product imagery. There was no source imagery to reproduce.
-- Rust page console error/warning capture returned an empty list. The Java reference emitted only existing Ant Design deprecation/form warnings and was not modified.
+## Environment limitations
+- A live NameServer, Broker, and current Proxy were not available during this pass, so browser QA against real broker data was not executed. No existing operator workload was reset or deleted.
 
-## Primary interactions tested
-
-- All eight Topic type/category filters and Reset, including truthful empty results.
-- Create and Edit against one disposable Topic, including cluster target discovery, FIFO/ordered configuration, and four read/write queues.
-- Send test message with structured result (`SEND_OK`, broker, queue, offset, identifiers, region, and transaction state).
-- Details: Overview, Routes/status, Consumers, and Configuration.
-- Consumer reset and skip safety with no discovered consumer group: no arbitrary default and Continue disabled.
-- Broker delete safety with exactly one authoritative broker and exact-name confirmation.
-- Whole-topic delete exact-name confirmation boundary. The operator explicitly chose to retain the disposable QA Topic, so the final destructive click and cleanup assertion were skipped by user choice rather than by a product failure.
-- System Topic action boundary: view-only.
-
-## Comparison history
-
-- Initial deterministic RED evidence: the Topic CSS had no scoped `min-width: 0`, local table overflow, dense result grids, or `<= 900px` one-column behavior required by the design brief.
-- Fix: added scoped dense dark workspace rules in `src/styles/globals.css` for responsive toolbar wrapping, form/result grids, operation target rows, configuration alerts, and table-local overflow.
-- Post-fix evidence: the desktop and narrow screenshots listed above. No P0/P1/P2 issue was found after the implementation pass, so no component behavior changed during this QA task.
-
-final result: passed
+## Remaining risk
+- Create/Edit/Delete dialogs and Clients/Configuration tabs are implemented but need real-cluster browser interaction and dedicated deferred-promise tests for the new dialogs.

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/App.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 import RouteLoading from './components/RouteLoading';
 import AppLayout from './layouts/AppLayout';
+import { ConsumerQueryScopeProvider } from './pages/consumers/ConsumerQueryScopeProvider';
 
 const AclPage = lazy(() => import('./pages/AclPage'));
 const BrokerDetailPage = lazy(() => import('./pages/BrokerDetailPage'));
@@ -29,28 +30,30 @@ export default function App() {
           path="/*"
           element={
             <AppLayout>
-              <Routes>
-                <Route path="/" element={<Navigate to="/dashboard" replace />} />
-                <Route path="/ops" element={<Navigate to="/config" replace />} />
-                <Route path="/proxy" element={<ProxyPage />} />
-                <Route path="/dashboard" element={<DashboardPage />} />
-                <Route path="/cluster" element={<Navigate to="/brokers" replace />} />
-                <Route path="/topics" element={<TopicListPage />} />
-                <Route path="/topics/:topic" element={<TopicDetailPage />} />
-                <Route path="/consumers" element={<ConsumerListPage />} />
-                <Route path="/consumers/:group" element={<ConsumerDetailPage />} />
-                <Route path="/producers" element={<ProducerListPage />} />
-                <Route path="/brokers" element={<BrokerListPage />} />
-                <Route path="/brokers/:brokerName" element={<BrokerDetailPage />} />
-                <Route path="/messages" element={<MessageQueryPage />} />
-                <Route path="/messages/dlq" element={<DlqMessagePage />} />
-                <Route path="/dlq" element={<Navigate to="/messages/dlq" replace />} />
-                <Route path="/message-trace" element={<MessageTracePage />} />
-                <Route path="/acl" element={<AclPage />} />
-                <Route path="/monitors" element={<MonitorPage />} />
-                <Route path="/config" element={<ConfigPage />} />
-                <Route path="*" element={<Navigate to="/dashboard" replace />} />
-              </Routes>
+              <ConsumerQueryScopeProvider>
+                <Routes>
+                  <Route path="/" element={<Navigate to="/dashboard" replace />} />
+                  <Route path="/ops" element={<Navigate to="/config" replace />} />
+                  <Route path="/proxy" element={<ProxyPage />} />
+                  <Route path="/dashboard" element={<DashboardPage />} />
+                  <Route path="/cluster" element={<Navigate to="/brokers" replace />} />
+                  <Route path="/topics" element={<TopicListPage />} />
+                  <Route path="/topics/:topic" element={<TopicDetailPage />} />
+                  <Route path="/consumers" element={<ConsumerListPage />} />
+                  <Route path="/consumers/:group" element={<ConsumerDetailPage />} />
+                  <Route path="/producers" element={<ProducerListPage />} />
+                  <Route path="/brokers" element={<BrokerListPage />} />
+                  <Route path="/brokers/:brokerName" element={<BrokerDetailPage />} />
+                  <Route path="/messages" element={<MessageQueryPage />} />
+                  <Route path="/messages/dlq" element={<DlqMessagePage />} />
+                  <Route path="/dlq" element={<Navigate to="/messages/dlq" replace />} />
+                  <Route path="/message-trace" element={<MessageTracePage />} />
+                  <Route path="/acl" element={<AclPage />} />
+                  <Route path="/monitors" element={<MonitorPage />} />
+                  <Route path="/config" element={<ConfigPage />} />
+                  <Route path="*" element={<Navigate to="/dashboard" replace />} />
+                </Routes>
+              </ConsumerQueryScopeProvider>
             </AppLayout>
           }
         />

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/api/client.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/api/client.ts
@@ -80,8 +80,9 @@ export const apiClient = {
       method: 'PUT',
       body: body === undefined ? undefined : JSON.stringify(body)
     }),
-  delete: <T>(path: string) =>
+  delete: <T>(path: string, body?: unknown) =>
     request<T>(path, {
-      method: 'DELETE'
+      method: 'DELETE',
+      body: body === undefined ? undefined : JSON.stringify(body)
     })
 };

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/api/consumer_api.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/api/consumer_api.ts
@@ -1,10 +1,92 @@
 import { apiClient } from './client';
-import type { ConsumerListView, ConsumerProgress, ConsumerResetOffsetRequest } from '../types/consumer';
 import type { MutationResult } from '../types/topic';
+import type {
+  ConsumerBrokerListView,
+  ConsumerConfigView,
+  ConsumerConnectionView,
+  ConsumerDeleteRequest,
+  ConsumerGroupListView,
+  ConsumerJStackView,
+  ConsumerOperationResult,
+  ConsumerProgressView,
+  ConsumerQueryScope,
+  ConsumerResetOffsetRequest,
+  ConsumerRunningInfoView,
+  ConsumerSummaryView,
+  ConsumerUpsertRequest
+} from '../types/consumer';
+
+export function consumerQueryParams(scope: ConsumerQueryScope): string {
+  const params = new URLSearchParams({ mode: scope.mode });
+  if (scope.mode === 'proxy' && scope.proxyAddress) {
+    params.set('proxyAddress', scope.proxyAddress);
+  }
+  return params.toString();
+}
+
+function withScope(path: string, scope: ConsumerQueryScope): string {
+  const params = consumerQueryParams(scope);
+  return `${path}${path.includes('?') ? '&' : '?'}${params}`;
+}
 
 export const consumerApi = {
-  list: () => apiClient.get<ConsumerListView>('/api/consumers'),
-  progress: (group: string) => apiClient.get<ConsumerProgress>(`/api/consumers/${encodeURIComponent(group)}/progress`),
+  list: (scope: ConsumerQueryScope = { mode: 'nameServer' }) =>
+    apiClient.get<ConsumerGroupListView>(withScope('/api/consumers', scope)),
+
+  summary: (group: string, scope: ConsumerQueryScope) =>
+    apiClient.get<ConsumerSummaryView>(
+      withScope(`/api/consumers/${encodeURIComponent(group)}`, scope)
+    ),
+
+  connections: (group: string, scope: ConsumerQueryScope) =>
+    apiClient.get<ConsumerConnectionView>(
+      withScope(`/api/consumers/${encodeURIComponent(group)}/connections`, scope)
+    ),
+
+  progress: (group: string, scope: ConsumerQueryScope) =>
+    apiClient.get<ConsumerProgressView>(
+      withScope(`/api/consumers/${encodeURIComponent(group)}/progress`, scope)
+    ),
+
+  config: (group: string, scope: ConsumerQueryScope) =>
+    apiClient.get<ConsumerConfigView>(
+      withScope(`/api/consumers/${encodeURIComponent(group)}/config`, scope)
+    ),
+
+  brokers: (group: string) =>
+    apiClient.get<ConsumerBrokerListView>(`/api/consumers/${encodeURIComponent(group)}/brokers`),
+
+  runningInfo: (group: string, clientId: string, scope: ConsumerQueryScope) =>
+    apiClient.get<ConsumerRunningInfoView>(
+      withScope(
+        `/api/consumers/${encodeURIComponent(group)}/clients/${encodeURIComponent(clientId)}/running-info`,
+        scope
+      )
+    ),
+
+  jstack: (group: string, clientId: string, scope: ConsumerQueryScope) =>
+    apiClient.get<ConsumerJStackView>(
+      withScope(
+        `/api/consumers/${encodeURIComponent(group)}/clients/${encodeURIComponent(clientId)}/jstack`,
+        scope
+      )
+    ),
+
+  create: (request: ConsumerUpsertRequest) =>
+    apiClient.post<ConsumerOperationResult>('/api/consumers', request),
+
+  update: (group: string, request: ConsumerUpsertRequest) =>
+    apiClient.put<ConsumerOperationResult>(`/api/consumers/${encodeURIComponent(group)}`, request),
+
+  delete: (group: string, request: ConsumerDeleteRequest) =>
+    apiClient.delete<ConsumerOperationResult>(
+      `/api/consumers/${encodeURIComponent(group)}`,
+      request
+    ),
+
   resetOffset: (group: string, request: ConsumerResetOffsetRequest) =>
-    apiClient.post<MutationResult>(`/api/consumers/${encodeURIComponent(group)}/reset-offset`, request)
+    apiClient.post<MutationResult>(
+      `/api/consumers/${encodeURIComponent(group)}/reset-offset`,
+      request
+    )
 };

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/ConsumerDeleteDialog.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/ConsumerDeleteDialog.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { consumerApi } from '../api/consumer_api';
+import type { ConsumerGroupListItem, ConsumerOperationResult } from '../types/consumer';
+import ConsumerDeleteDialog from './ConsumerDeleteDialog';
+
+vi.mock('../api/consumer_api', () => ({
+  consumerApi: {
+    brokers: vi.fn(),
+    delete: vi.fn()
+  }
+}));
+
+const consumer: ConsumerGroupListItem = {
+  displayGroupName: 'orders-consumer',
+  rawGroupName: 'orders-consumer',
+  category: 'NORMAL',
+  connectionCount: 1,
+  consumeTps: 0,
+  diffTotal: 0,
+  messageModel: 'CLUSTERING',
+  consumeType: 'CONSUME_PASSIVELY',
+  version: 1,
+  versionDesc: 'V5_3_0',
+  brokerNames: ['broker-a', 'broker-b'],
+  brokerAddresses: ['127.0.0.1:10911', '127.0.0.2:10911'],
+  updateTimestamp: 0
+};
+
+const successResult: ConsumerOperationResult = {
+  operation: 'DELETE',
+  consumerGroup: 'orders-consumer',
+  success: true,
+  targetCount: 2,
+  message: 'deleted',
+  targets: [
+    { target: 'broker-a', kind: 'BROKER', success: true, message: 'deleted' },
+    { target: 'broker-b', kind: 'BROKER', success: true, message: 'deleted' }
+  ]
+};
+
+describe('ConsumerDeleteDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(consumerApi.brokers).mockResolvedValue({
+      items: [
+        { brokerName: 'broker-a', brokerAddress: '127.0.0.1:10911' },
+        { brokerName: 'broker-b', brokerAddress: '127.0.0.2:10911' }
+      ]
+    });
+  });
+
+  it('requires exact group confirmation and full success before closing', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const onSucceeded = vi.fn();
+    vi.mocked(consumerApi.delete).mockResolvedValue(successResult);
+    render(
+      <ConsumerDeleteDialog
+        open
+        consumer={consumer}
+        onOpenChange={onOpenChange}
+        onSucceeded={onSucceeded}
+      />
+    );
+
+    const dialog = screen.getByRole('dialog', { name: 'Delete consumer group' });
+    const confirm = within(dialog).getByRole('button', { name: 'Delete consumer group' });
+    expect(confirm).toBeDisabled();
+    await user.click(await within(dialog).findByRole('checkbox', { name: 'broker-a' }));
+    await user.type(within(dialog).getByLabelText('Confirm consumer group'), 'orders-consumer');
+    expect(confirm).toBeEnabled();
+    await user.click(confirm);
+
+    expect(consumerApi.delete).toHaveBeenCalledWith('orders-consumer', { brokerNames: ['broker-a'] });
+    await waitFor(() => expect(onSucceeded).toHaveBeenCalledWith(successResult));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('keeps partial outcomes open and renders every target result', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const onSucceeded = vi.fn();
+    vi.mocked(consumerApi.delete).mockResolvedValue({
+      ...successResult,
+      success: false,
+      targets: [
+        { target: 'broker-a', kind: 'BROKER', success: true, message: 'deleted' },
+        { target: 'broker-b', kind: 'BROKER', success: false, message: 'unavailable' }
+      ]
+    });
+    render(
+      <ConsumerDeleteDialog
+        open
+        consumer={consumer}
+        onOpenChange={onOpenChange}
+        onSucceeded={onSucceeded}
+      />
+    );
+
+    const dialog = screen.getByRole('dialog', { name: 'Delete consumer group' });
+    await user.click(await within(dialog).findByRole('checkbox', { name: 'broker-a' }));
+    await user.type(within(dialog).getByLabelText('Confirm consumer group'), 'orders-consumer');
+    await user.click(within(dialog).getByRole('button', { name: 'Delete consumer group' }));
+
+    expect(await within(dialog).findByText((content) => content.includes('unavailable'))).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    expect(onSucceeded).not.toHaveBeenCalled();
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/ConsumerDeleteDialog.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/ConsumerDeleteDialog.tsx
@@ -31,12 +31,14 @@ export default function ConsumerDeleteDialog({
   const [confirmation, setConfirmation] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<ConsumerOperationResult | null>(null);
 
   useEffect(() => {
     if (!open || !consumer) return;
     setSelected([]);
     setConfirmation('');
     setError(null);
+    setResult(null);
     let cancelled = false;
     consumerApi
       .brokers(group)
@@ -71,8 +73,12 @@ export default function ConsumerDeleteDialog({
     setError(null);
     try {
       const result = await consumerApi.delete(group, { brokerNames: selected });
-      onSucceeded(result);
-      onOpenChange(false);
+      setResult(result);
+      const allSucceeded = result.success && result.targets.every((target) => target.success);
+      if (allSucceeded) {
+        onSucceeded(result);
+        onOpenChange(false);
+      }
     } catch (reason) {
       setError(reason instanceof Error ? reason.message : String(reason));
     } finally {
@@ -112,6 +118,15 @@ export default function ConsumerDeleteDialog({
           />
         </div>
 
+        {result ? (
+          <div className="consumer-operation-result" role="status">
+            {result.targets.map((target) => (
+              <div key={target.target} className={target.success ? 'notice notice-success' : 'notice notice-danger'}>
+                <strong>{target.target}</strong> {target.kind} · {target.message}
+              </div>
+            ))}
+          </div>
+        ) : null}
         {error ? <div className="inline-validation" role="alert">{error}</div> : null}
 
         <DialogFooter>

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/ConsumerDeleteDialog.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/ConsumerDeleteDialog.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useState } from 'react';
+import { consumerApi } from '../api/consumer_api';
+import type { ConsumerGroupListItem, ConsumerOperationResult } from '../types/consumer';
+import { Button } from './ui/Button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from './ui/Dialog';
+import { Input } from './ui/Input';
+
+interface ConsumerDeleteDialogProps {
+  open: boolean;
+  consumer: ConsumerGroupListItem | null;
+  onOpenChange: (open: boolean) => void;
+  onSucceeded: (result: ConsumerOperationResult) => void;
+}
+
+export default function ConsumerDeleteDialog({
+  open,
+  consumer,
+  onOpenChange,
+  onSucceeded
+}: ConsumerDeleteDialogProps) {
+  const group = consumer?.rawGroupName ?? '';
+  const [brokers, setBrokers] = useState<string[]>([]);
+  const [selected, setSelected] = useState<string[]>([]);
+  const [confirmation, setConfirmation] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open || !consumer) return;
+    setSelected([]);
+    setConfirmation('');
+    setError(null);
+    let cancelled = false;
+    consumerApi
+      .brokers(group)
+      .then((result) => {
+        if (cancelled) return;
+        setBrokers(result.items.map((item) => item.brokerName).sort());
+      })
+      .catch((reason: unknown) => {
+        if (!cancelled) setError(reason instanceof Error ? reason.message : String(reason));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, consumer, group]);
+
+  const toggle = (brokerName: string, checked: boolean) => {
+    setSelected((current) => checked
+      ? Array.from(new Set([...current, brokerName]))
+      : current.filter((value) => value !== brokerName));
+  };
+
+  const submit = async () => {
+    if (selected.length === 0) {
+      setError('Select at least one broker target.');
+      return;
+    }
+    if (confirmation.trim() !== group) {
+      setError(`Type the exact group name "${group}" to confirm.`);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await consumerApi.delete(group, { brokerNames: selected });
+      onSucceeded(result);
+      onOpenChange(false);
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : String(reason));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete consumer group</DialogTitle>
+          <DialogDescription>
+            Delete {group} from selected broker targets. This is destructive and cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="consumer-delete-targets">
+          {brokers.map((broker) => (
+            <label key={broker} className="compact-check">
+              <input
+                type="checkbox"
+                checked={selected.includes(broker)}
+                onChange={(event) => toggle(broker, event.target.checked)}
+              />
+              {broker}
+            </label>
+          ))}
+        </div>
+
+        <div className="field">
+          <label htmlFor="consumer-delete-confirm">Confirm consumer group</label>
+          <Input
+            id="consumer-delete-confirm"
+            value={confirmation}
+            onChange={(event) => setConfirmation(event.target.value)}
+          />
+        </div>
+
+        {error ? <div className="inline-validation" role="alert">{error}</div> : null}
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
+          <Button type="button" variant="destructive" disabled={loading || selected.length === 0 || confirmation.trim() !== group} onClick={() => void submit()}>
+            {loading ? 'Deleting' : 'Delete consumer group'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/ConsumerMutationDialog.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/ConsumerMutationDialog.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { brokerApi } from '../api/broker_api';
+import { consumerApi } from '../api/consumer_api';
+import type { ConsumerGroupListItem, ConsumerOperationResult } from '../types/consumer';
+import { ConsumerQueryScopeProvider } from '../pages/consumers/ConsumerQueryScopeProvider';
+import ConsumerMutationDialog from './ConsumerMutationDialog';
+
+vi.mock('../api/broker_api', () => ({
+  brokerApi: { list: vi.fn() }
+}));
+
+vi.mock('../api/consumer_api', () => ({
+  consumerApi: {
+    create: vi.fn(),
+    update: vi.fn(),
+    config: vi.fn()
+  }
+}));
+
+const consumer: ConsumerGroupListItem = {
+  displayGroupName: 'orders-consumer',
+  rawGroupName: 'orders-consumer',
+  category: 'NORMAL',
+  connectionCount: 1,
+  consumeTps: 0,
+  diffTotal: 0,
+  messageModel: 'CLUSTERING',
+  consumeType: 'CONSUME_PASSIVELY',
+  version: 1,
+  versionDesc: 'V5_3_0',
+  brokerNames: ['broker-a'],
+  brokerAddresses: ['127.0.0.1:10911'],
+  updateTimestamp: 0
+};
+
+const successResult: ConsumerOperationResult = {
+  operation: 'CREATE',
+  consumerGroup: 'orders-consumer',
+  success: true,
+  targetCount: 1,
+  message: 'created',
+  targets: [{ target: 'broker-a', kind: 'BROKER', success: true, message: 'saved' }]
+};
+
+describe('ConsumerMutationDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(brokerApi.list).mockResolvedValue({
+      items: [{ clusterName: 'DefaultCluster', brokerName: 'broker-a', brokerId: 0, address: '127.0.0.1:10911', role: 'MASTER', version: 'V5_3_0', produceTps: 0, consumeTps: 0 }],
+      total: 1
+    });
+  });
+
+  it('requires a group and target for create', async () => {
+    const user = userEvent.setup();
+    const onSucceeded = vi.fn();
+    render(<ConsumerQueryScopeProvider><ConsumerMutationDialog open mode="create" onOpenChange={vi.fn()} onSucceeded={onSucceeded} /></ConsumerQueryScopeProvider>);
+
+    const dialog = screen.getByRole('dialog', { name: 'Create consumer group' });
+    const save = within(dialog).getByRole('button', { name: 'Create group' });
+    expect(save).toBeEnabled();
+    await user.click(save);
+    expect(await within(dialog).findByRole('alert')).toHaveTextContent('Consumer group is required.');
+    expect(consumerApi.create).not.toHaveBeenCalled();
+
+    await user.type(within(dialog).getByLabelText('Consumer group'), 'orders-consumer');
+    await user.click(await within(dialog).findByRole('checkbox', { name: 'broker-a' }));
+    await user.click(save);
+    expect(consumerApi.create).toHaveBeenCalled();
+  });
+
+  it('prefills edit targets and configuration from the current scope', async () => {
+    const user = userEvent.setup();
+    vi.mocked(consumerApi.config).mockResolvedValue({
+      group: 'orders-consumer',
+      effective: {
+        consumeEnable: true,
+        consumeFromMinEnable: true,
+        consumeBroadcastEnable: false,
+        consumeMessageOrderly: false,
+        retryQueueNums: 4,
+        retryMaxTimes: 8,
+        brokerId: 0,
+        whichBrokerWhenConsumeSlowly: 1,
+        notifyConsumerIdsChangedEnable: true,
+        groupSysFlag: 0,
+        consumeTimeoutMinute: 20,
+        groupRetryPolicyJson: '{}'
+      },
+      inconsistentFields: [],
+      targets: [{
+        brokerName: 'broker-a',
+        brokerAddress: '127.0.0.1:10911',
+        config: {
+          consumeEnable: true,
+          consumeFromMinEnable: true,
+          consumeBroadcastEnable: false,
+          consumeMessageOrderly: false,
+          retryQueueNums: 4,
+          retryMaxTimes: 8,
+          brokerId: 0,
+          whichBrokerWhenConsumeSlowly: 1,
+          notifyConsumerIdsChangedEnable: true,
+          groupSysFlag: 0,
+          consumeTimeoutMinute: 20,
+          groupRetryPolicyJson: '{}'
+        },
+        subscriptionTopics: [],
+        attributes: []
+      }],
+      queryScope: { mode: 'nameServer' }
+    });
+    render(<ConsumerQueryScopeProvider><ConsumerMutationDialog open mode="edit" consumer={consumer} onOpenChange={vi.fn()} onSucceeded={vi.fn()} /></ConsumerQueryScopeProvider>);
+
+    const dialog = screen.getByRole('dialog', { name: 'Edit orders-consumer' });
+    await waitFor(() => expect(within(dialog).getByRole('checkbox', { name: 'broker-a' })).toBeChecked());
+    expect(within(dialog).getByLabelText('Retry queue nums')).toHaveValue(4);
+    expect(within(dialog).getByLabelText('Consume timeout minutes')).toHaveValue(20);
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/ConsumerMutationDialog.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/ConsumerMutationDialog.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useState } from 'react';
+import { brokerApi } from '../api/broker_api';
+import { consumerApi } from '../api/consumer_api';
+import type { ConsumerGroupListItem, ConsumerOperationResult, ConsumerUpsertRequest } from '../types/consumer';
+import { Button } from './ui/Button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from './ui/Dialog';
+import { Input } from './ui/Input';
+import { Label } from './ui/Label';
+
+interface ConsumerMutationDialogProps {
+  open: boolean;
+  mode: 'create' | 'edit';
+  consumer?: ConsumerGroupListItem | null;
+  onOpenChange: (open: boolean) => void;
+  onSucceeded: (result: ConsumerOperationResult) => void;
+}
+
+const defaultForm = (): Omit<ConsumerUpsertRequest, 'consumerGroup'> => ({
+  clusterNameList: [],
+  brokerNameList: [],
+  consumeEnable: true,
+  consumeFromMinEnable: true,
+  consumeBroadcastEnable: false,
+  consumeMessageOrderly: false,
+  retryQueueNums: 1,
+  retryMaxTimes: 16,
+  brokerId: 0,
+  whichBrokerWhenConsumeSlowly: 1,
+  notifyConsumerIdsChangedEnable: true,
+  groupSysFlag: 0,
+  consumeTimeoutMinute: 15
+});
+
+export default function ConsumerMutationDialog({
+  open,
+  mode,
+  consumer,
+  onOpenChange,
+  onSucceeded
+}: ConsumerMutationDialogProps) {
+  const [group, setGroup] = useState(consumer?.rawGroupName ?? '');
+  const [form, setForm] = useState(defaultForm());
+  const [brokers, setBrokers] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setGroup(consumer?.rawGroupName ?? '');
+    setForm(defaultForm());
+    setError(null);
+    let cancelled = false;
+    brokerApi
+      .list()
+      .then((result) => {
+        if (cancelled) return;
+        setBrokers(Array.from(new Set(result.items.map((broker) => broker.brokerName))).sort());
+      })
+      .catch((reason: unknown) => {
+        if (!cancelled) setError(reason instanceof Error ? reason.message : String(reason));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, consumer]);
+
+  const submit = async () => {
+    if (mode === 'create' && !group.trim()) {
+      setError('Consumer group is required.');
+      return;
+    }
+    if (form.brokerNameList.length === 0) {
+      setError('Select at least one broker target.');
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const payload: ConsumerUpsertRequest = {
+        ...(mode === 'create' ? { consumerGroup: group.trim() } : {}),
+        ...form
+      };
+      const result = mode === 'create'
+        ? await consumerApi.create(payload)
+        : await consumerApi.update(group, payload);
+      onSucceeded(result);
+      onOpenChange(false);
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : String(reason));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const setBrokerTarget = (brokerName: string, selected: boolean) => {
+    setForm((current) => ({
+      ...current,
+      brokerNameList: selected
+        ? Array.from(new Set([...current.brokerNameList, brokerName]))
+        : current.brokerNameList.filter((value) => value !== brokerName)
+    }));
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{mode === 'create' ? 'Create consumer group' : `Edit ${consumer?.rawGroupName ?? group}`}</DialogTitle>
+          <DialogDescription>
+            Configure subscription group targets and broker-side limits.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="consumer-mutation-form">
+          {mode === 'create' ? (
+            <div className="field">
+              <Label htmlFor="consumer-mutation-group">Consumer group</Label>
+              <Input id="consumer-mutation-group" value={group} onChange={(event) => setGroup(event.target.value)} />
+            </div>
+          ) : null}
+
+          <div className="field">
+            <Label>Broker targets</Label>
+            <div className="consumer-target-checkboxes">
+              {brokers.map((broker) => (
+                <label key={broker} className="compact-check">
+                  <input
+                    type="checkbox"
+                    checked={form.brokerNameList.includes(broker)}
+                    onChange={(event) => setBrokerTarget(broker, event.target.checked)}
+                  />
+                  {broker}
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div className="form-grid consumer-mutation-grid">
+            <NumberField label="Retry queue nums" value={form.retryQueueNums} onChange={(value) => setForm((current) => ({ ...current, retryQueueNums: value }))} />
+            <NumberField label="Retry max times" value={form.retryMaxTimes} onChange={(value) => setForm((current) => ({ ...current, retryMaxTimes: value }))} />
+            <NumberField label="Broker id" value={form.brokerId} onChange={(value) => setForm((current) => ({ ...current, brokerId: value }))} />
+            <NumberField label="Slow broker id" value={form.whichBrokerWhenConsumeSlowly} onChange={(value) => setForm((current) => ({ ...current, whichBrokerWhenConsumeSlowly: value }))} />
+            <NumberField label="Consume timeout minutes" value={form.consumeTimeoutMinute} onChange={(value) => setForm((current) => ({ ...current, consumeTimeoutMinute: value }))} />
+          </div>
+
+          <div className="consumer-mutation-flags">
+            <CheckboxField label="Consume enabled" checked={form.consumeEnable} onChange={(checked) => setForm((current) => ({ ...current, consumeEnable: checked }))} />
+            <CheckboxField label="Consume from minimum" checked={form.consumeFromMinEnable} onChange={(checked) => setForm((current) => ({ ...current, consumeFromMinEnable: checked }))} />
+            <CheckboxField label="Broadcast consume" checked={form.consumeBroadcastEnable} onChange={(checked) => setForm((current) => ({ ...current, consumeBroadcastEnable: checked }))} />
+            <CheckboxField label="Orderly consume" checked={form.consumeMessageOrderly} onChange={(checked) => setForm((current) => ({ ...current, consumeMessageOrderly: checked }))} />
+          </div>
+        </div>
+
+        {error ? <div className="inline-validation" role="alert">{error}</div> : null}
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
+          <Button type="button" disabled={loading} onClick={() => void submit()}>
+            {loading ? 'Saving' : mode === 'create' ? 'Create group' : 'Update group'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function NumberField({ label, value, onChange }: { label: string; value: number; onChange: (value: number) => void }) {
+  return (
+    <div className="field">
+      <Label>{label}</Label>
+      <Input
+        type="number"
+        value={value}
+        onChange={(event) => onChange(Number(event.target.value))}
+      />
+    </div>
+  );
+}
+
+function CheckboxField({ label, checked, onChange }: { label: string; checked: boolean; onChange: (checked: boolean) => void }) {
+  return (
+    <label className="compact-check">
+      <input type="checkbox" checked={checked} onChange={(event) => onChange(event.target.checked)} />
+      {label}
+    </label>
+  );
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/ConsumerMutationDialog.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/ConsumerMutationDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { brokerApi } from '../api/broker_api';
 import { consumerApi } from '../api/consumer_api';
+import { useConsumerQueryScope } from '../pages/consumers/ConsumerQueryScopeProvider';
 import type { ConsumerGroupListItem, ConsumerOperationResult, ConsumerUpsertRequest } from '../types/consumer';
 import { Button } from './ui/Button';
 import {
@@ -45,6 +46,7 @@ export default function ConsumerMutationDialog({
   onOpenChange,
   onSucceeded
 }: ConsumerMutationDialogProps) {
+  const { scope } = useConsumerQueryScope();
   const [group, setGroup] = useState(consumer?.rawGroupName ?? '');
   const [form, setForm] = useState(defaultForm());
   const [brokers, setBrokers] = useState<string[]>([]);
@@ -57,15 +59,40 @@ export default function ConsumerMutationDialog({
     setForm(defaultForm());
     setError(null);
     let cancelled = false;
-    brokerApi
-      .list()
-      .then((result) => {
+    void (async () => {
+      try {
+        const result = await brokerApi.list();
         if (cancelled) return;
-        setBrokers(Array.from(new Set(result.items.map((broker) => broker.brokerName))).sort());
-      })
-      .catch((reason: unknown) => {
+        const names = Array.from(new Set(result.items.map((broker) => broker.brokerName))).sort();
+        setBrokers(names);
+        if (mode === 'edit' && consumer) {
+          const config = await consumerApi.config(consumer.rawGroupName, scope);
+          if (cancelled) return;
+          const effective = config.effective;
+          if (effective) {
+            setForm({
+              clusterNameList: [],
+              brokerNameList: config.targets
+                .filter((target) => target.config !== null)
+                .map((target) => target.brokerName),
+              consumeEnable: effective.consumeEnable,
+              consumeFromMinEnable: effective.consumeFromMinEnable,
+              consumeBroadcastEnable: effective.consumeBroadcastEnable,
+              consumeMessageOrderly: effective.consumeMessageOrderly,
+              retryQueueNums: effective.retryQueueNums,
+              retryMaxTimes: effective.retryMaxTimes,
+              brokerId: effective.brokerId,
+              whichBrokerWhenConsumeSlowly: effective.whichBrokerWhenConsumeSlowly,
+              notifyConsumerIdsChangedEnable: effective.notifyConsumerIdsChangedEnable,
+              groupSysFlag: effective.groupSysFlag,
+              consumeTimeoutMinute: effective.consumeTimeoutMinute
+            });
+          }
+        }
+      } catch (reason) {
         if (!cancelled) setError(reason instanceof Error ? reason.message : String(reason));
-      });
+      }
+    })();
     return () => {
       cancelled = true;
     };
@@ -172,10 +199,12 @@ export default function ConsumerMutationDialog({
 }
 
 function NumberField({ label, value, onChange }: { label: string; value: number; onChange: (value: number) => void }) {
+  const id = `consumer-${label.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`;
   return (
     <div className="field">
-      <Label>{label}</Label>
+      <Label htmlFor={id}>{label}</Label>
       <Input
+        id={id}
         type="number"
         value={value}
         onChange={(event) => onChange(Number(event.target.value))}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConsumerDetailPage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConsumerDetailPage.test.tsx
@@ -1,36 +1,79 @@
 import { screen } from '@testing-library/react';
 import { Route, Routes } from 'react-router-dom';
 import { vi } from 'vitest';
+import { configApi } from '../api/config_api';
 import { consumerApi } from '../api/consumer_api';
 import { renderAtRoute } from '../test/render';
+import { ConsumerQueryScopeProvider } from './consumers/ConsumerQueryScopeProvider';
 import ConsumerDetailPage from './ConsumerDetailPage';
 
 vi.mock('../api/consumer_api', () => ({
-  consumerApi: {
-    list: vi.fn(),
-    progress: vi.fn(),
-    resetOffset: vi.fn()
-  }
+  consumerApi: { summary: vi.fn(), progress: vi.fn(), resetOffset: vi.fn() }
 }));
+vi.mock('../api/config_api', () => ({ configApi: { getConfig: vi.fn() } }));
 
 describe('ConsumerDetailPage', () => {
-  it('resolves group identity and renders the reusable progress content on a direct route', async () => {
-    vi.mocked(consumerApi.list).mockResolvedValue({
-      items: [{ group: 'order-service', consumeType: 'CONSUME_PASSIVELY', messageModel: 'MESSAGE_MODEL_CLUSTERING', clientCount: 3, diffTotal: 12 }],
-      total: 1
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(configApi.getConfig).mockResolvedValue({
+      currentNamesrv: '127.0.0.1:9876',
+      namesrvAddrList: ['127.0.0.1:9876'],
+      useVIPChannel: false,
+      useTLS: false,
+      currentProxyAddr: null,
+      proxyAddrList: [],
+      storageBackend: 'sqlite'
     });
-    vi.mocked(consumerApi.progress).mockResolvedValue({ group: 'order-service', topicCount: 1, diffTotal: 12, queues: [] });
+    vi.mocked(consumerApi.summary).mockResolvedValue({
+      group: 'order-service',
+      displayGroupName: 'order-service',
+      category: 'NORMAL',
+      connectionCount: 3,
+      consumeTps: 0,
+      diffTotal: 12,
+      messageModel: 'MESSAGE_MODEL_CLUSTERING',
+      consumeType: 'CONSUME_PASSIVELY',
+      version: null,
+      versionDesc: '',
+      brokerNames: [],
+      brokerAddresses: [],
+      updateTimestamp: 0,
+      queryScope: { mode: 'nameServer' }
+    });
+    vi.mocked(consumerApi.progress).mockResolvedValue({
+      group: 'order-service',
+      topicCount: 0,
+      totalDiff: 12,
+      topics: [],
+      queryScope: { mode: 'nameServer' }
+    });
+  });
 
+  it('resolves the group and renders the workspace on a direct route', async () => {
     renderAtRoute(
-      <Routes>
-        <Route path="/consumers/:group" element={<ConsumerDetailPage />} />
-      </Routes>,
+      <ConsumerQueryScopeProvider>
+        <Routes>
+          <Route path="/consumers/:group" element={<ConsumerDetailPage />} />
+        </Routes>
+      </ConsumerQueryScopeProvider>,
       '/consumers/order-service'
     );
 
     expect(await screen.findByRole('heading', { name: 'order-service' })).toBeInTheDocument();
-    expect(await screen.findByRole('group', { name: 'Connected clients: 3' })).toBeInTheDocument();
-    expect(consumerApi.list).toHaveBeenCalledTimes(1);
-    expect(consumerApi.progress).toHaveBeenCalledWith('order-service');
+    expect(await screen.findByRole('tab', { name: 'Overview' })).toBeInTheDocument();
+  });
+
+  it('opens the requested tab from the query string', async () => {
+    renderAtRoute(
+      <ConsumerQueryScopeProvider>
+        <Routes>
+          <Route path="/consumers/:group" element={<ConsumerDetailPage />} />
+        </Routes>
+      </ConsumerQueryScopeProvider>,
+      '/consumers/order-service?tab=progress'
+    );
+
+    expect(await screen.findByRole('heading', { name: 'order-service' })).toBeInTheDocument();
+    expect(await screen.findByRole('tab', { name: 'Progress' })).toBeInTheDocument();
   });
 });

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConsumerDetailPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConsumerDetailPage.tsx
@@ -1,9 +1,14 @@
-import { useParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import PageHeader from '../components/PageHeader';
 import ConsumerDetailContent from './consumers/ConsumerDetailContent';
 
 export default function ConsumerDetailPage() {
   const { group = '' } = useParams();
+  const [searchParams] = useSearchParams();
+  const tabParam = searchParams.get('tab');
+  const initialTab = tabParam === 'progress' || tabParam === 'reset' || tabParam === 'overview'
+    ? tabParam
+    : 'overview';
 
   return (
     <div className="entity-workspace consumer-detail-page">
@@ -11,7 +16,7 @@ export default function ConsumerDetailPage() {
         title={group}
         description="Inspect API-backed group identity, queue progress, and protected offset maintenance."
       />
-      <ConsumerDetailContent group={group} />
+      <ConsumerDetailContent group={group} initialTab={initialTab} />
     </div>
   );
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConsumerDetailPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConsumerDetailPage.tsx
@@ -1,22 +1,78 @@
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { consumerApi } from '../api/consumer_api';
+import ConsumerDeleteDialog from '../components/ConsumerDeleteDialog';
+import ConsumerMutationDialog from '../components/ConsumerMutationDialog';
 import PageHeader from '../components/PageHeader';
+import { Button } from '../components/ui/Button';
+import type { ConsumerGroupListItem, ConsumerSummaryView } from '../types/consumer';
+import { useConsumerQueryScope } from './consumers/ConsumerQueryScopeProvider';
 import ConsumerDetailContent from './consumers/ConsumerDetailContent';
 
 export default function ConsumerDetailPage() {
   const { group = '' } = useParams();
   const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { scope } = useConsumerQueryScope();
   const tabParam = searchParams.get('tab');
-  const initialTab = tabParam === 'progress' || tabParam === 'reset' || tabParam === 'overview'
+  const initialTab = tabParam === 'clients' || tabParam === 'progress' || tabParam === 'config' || tabParam === 'reset' || tabParam === 'overview'
     ? tabParam
     : 'overview';
+  const [summary, setSummary] = useState<ConsumerSummaryView | null>(null);
+  const [editOpen, setEditOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setSummary(null);
+    consumerApi.summary(group, scope)
+      .then((result) => { if (!cancelled) setSummary(result); })
+      .catch(() => { if (!cancelled) setSummary(null); });
+    return () => { cancelled = true; };
+  }, [group, scope.mode, scope.proxyAddress]);
+
+  const listItem: ConsumerGroupListItem | null = summary ? {
+    displayGroupName: summary.displayGroupName,
+    rawGroupName: summary.group,
+    category: summary.category,
+    connectionCount: summary.connectionCount,
+    consumeTps: summary.consumeTps,
+    diffTotal: summary.diffTotal,
+    messageModel: summary.messageModel,
+    consumeType: summary.consumeType,
+    version: summary.version,
+    versionDesc: summary.versionDesc,
+    brokerNames: summary.brokerNames,
+    brokerAddresses: summary.brokerAddresses,
+    updateTimestamp: summary.updateTimestamp
+  } : null;
 
   return (
     <div className="entity-workspace consumer-detail-page">
       <PageHeader
         title={group}
-        description="Inspect API-backed group identity, queue progress, and protected offset maintenance."
+        description="Inspect API-backed group identity, connections, progress, configuration, and protected offset maintenance."
+        actions={<>
+          <Button type="button" variant="outline" onClick={() => navigate('/consumers')}>Back to groups</Button>
+          <Button type="button" variant="outline" disabled={!listItem} onClick={() => setEditOpen(true)}>Edit configuration</Button>
+          <Button type="button" variant="destructive" disabled={!listItem} onClick={() => setDeleteOpen(true)}>Delete group</Button>
+        </>}
       />
       <ConsumerDetailContent group={group} initialTab={initialTab} />
+
+      <ConsumerMutationDialog
+        open={editOpen}
+        mode="edit"
+        consumer={listItem}
+        onOpenChange={setEditOpen}
+        onSucceeded={() => { setEditOpen(false); setSummary(null); }}
+      />
+      <ConsumerDeleteDialog
+        open={deleteOpen}
+        consumer={listItem}
+        onOpenChange={setDeleteOpen}
+        onSucceeded={() => navigate('/consumers')}
+      />
     </div>
   );
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConsumerListPage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConsumerListPage.test.tsx
@@ -1,114 +1,99 @@
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
+import { configApi } from '../api/config_api';
 import { consumerApi } from '../api/consumer_api';
 import { renderAtRoute } from '../test/render';
-import type { ConsumerGroupInfo } from '../types/consumer';
+import type { ConsumerGroupListItem } from '../types/consumer';
+import { ConsumerQueryScopeProvider } from './consumers/ConsumerQueryScopeProvider';
 import ConsumerListPage from './ConsumerListPage';
 
-vi.mock('../api/consumer_api', () => ({
-  consumerApi: {
-    list: vi.fn(),
-    progress: vi.fn(),
-    resetOffset: vi.fn()
-  }
-}));
+vi.mock('../api/consumer_api', () => ({ consumerApi: { list: vi.fn() } }));
+vi.mock('../api/config_api', () => ({ configApi: { getConfig: vi.fn() } }));
 
-const consumers: ConsumerGroupInfo[] = [
-  { group: 'order-service', consumeType: 'CONSUME_PASSIVELY', messageModel: 'MESSAGE_MODEL_CLUSTERING', clientCount: 6, diffTotal: 8_700 },
-  { group: 'payment-broadcast', consumeType: 'CONSUME_PASSIVELY', messageModel: 'MESSAGE_MODEL_BROADCASTING', clientCount: 2, diffTotal: 0 },
-  { group: 'audit-puller', consumeType: 'CONSUME_ACTIVELY', messageModel: 'MESSAGE_MODEL_CLUSTERING', clientCount: 0, diffTotal: 25 },
-  ...Array.from({ length: 8 }, (_, index) => ({
-    group: `worker-${index}`,
-    consumeType: 'CONSUME_PASSIVELY',
-    messageModel: 'MESSAGE_MODEL_CLUSTERING',
-    clientCount: 1,
-    diffTotal: 0
-  }))
-];
+const consumer = (overrides: Partial<ConsumerGroupListItem> = {}): ConsumerGroupListItem => ({
+  displayGroupName: 'order-service',
+  rawGroupName: 'order-service',
+  category: 'NORMAL',
+  connectionCount: 6,
+  consumeTps: 120,
+  diffTotal: 8_700,
+  messageModel: 'MESSAGE_MODEL_CLUSTERING',
+  consumeType: 'CONSUME_PASSIVELY',
+  version: 530,
+  versionDesc: 'V5_3_0',
+  brokerNames: ['broker-a'],
+  brokerAddresses: ['10.0.0.1:10911'],
+  updateTimestamp: 1_700_000_000_000,
+  ...overrides
+});
+
+function renderPage() {
+  return renderAtRoute(
+    <ConsumerQueryScopeProvider><ConsumerListPage /></ConsumerQueryScopeProvider>,
+    '/consumers'
+  );
+}
 
 describe('ConsumerListPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(consumerApi.list).mockResolvedValue({ items: consumers, total: consumers.length });
-    vi.mocked(consumerApi.progress).mockResolvedValue({
-      group: 'order-service',
-      topicCount: 1,
-      diffTotal: 8_700,
-      queues: [{ topic: 'orders', brokerName: 'broker-a', queueId: 0, brokerOffset: 10_000, consumerOffset: 1_300, diff: 8_700 }]
+    vi.mocked(configApi.getConfig).mockResolvedValue({
+      currentNamesrv: '127.0.0.1:9876',
+      namesrvAddrList: ['127.0.0.1:9876'],
+      useVIPChannel: false,
+      useTLS: false,
+      currentProxyAddr: null,
+      proxyAddrList: [],
+      storageBackend: 'sqlite'
     });
-    vi.mocked(consumerApi.resetOffset).mockResolvedValue({ message: 'reset' });
+    vi.mocked(consumerApi.list).mockResolvedValue({
+      items: [
+        consumer(),
+        consumer({ rawGroupName: 'payment-broadcast', displayGroupName: 'payment-broadcast', diffTotal: 0, messageModel: 'MESSAGE_MODEL_BROADCASTING' }),
+        consumer({ rawGroupName: 'audit-puller', displayGroupName: 'audit-puller', consumeType: 'CONSUME_ACTIVELY', connectionCount: 0, diffTotal: 25 }),
+        ...Array.from({ length: 8 }, (_, index) => consumer({ rawGroupName: `worker-${index}`, displayGroupName: `worker-${index}`, diffTotal: 0 }))
+      ],
+      total: 11,
+      queryScope: { mode: 'nameServer' },
+      capabilities: { connections: true, progress: true, configuration: true, runningInfo: true, jstack: true }
+    });
   });
 
-  it('renders API-backed totals, combines filters, and paginates the inventory', async () => {
+  it('renders enriched inventory columns, filters, and pagination', async () => {
     const user = userEvent.setup();
-    renderAtRoute(<ConsumerListPage />, '/consumers');
+    renderPage();
 
-    expect(screen.getByRole('status', { name: 'Loading consumers' })).toBeInTheDocument();
-    expect(await screen.findByRole('group', { name: 'Consumer groups: 11' })).toBeInTheDocument();
-    expect(screen.getByRole('group', { name: 'Connected clients: 16' })).toBeInTheDocument();
-    expect(screen.getByRole('group', { name: 'Total lag: 8725' })).toBeInTheDocument();
-    expect(screen.getByRole('group', { name: 'Lagging groups: 2' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Consumer groups' })).toBeInTheDocument();
+    for (const header of ['Consumer group', 'Category', 'Connections', 'Version', 'Consume type', 'Message model', 'TPS', 'Total lag', 'Targets', 'Updated', 'Actions']) {
+      expect(screen.getByRole('columnheader', { name: header })).toBeInTheDocument();
+    }
 
     await user.selectOptions(screen.getByRole('combobox', { name: 'Consume type filter' }), 'ACTIVELY');
-    await user.selectOptions(screen.getByRole('combobox', { name: 'Message model filter' }), 'CLUSTERING');
-    await user.selectOptions(screen.getByRole('combobox', { name: 'Lag filter' }), 'lagging');
-    await user.type(screen.getByRole('searchbox', { name: 'Filter consumer groups' }), 'audit');
     expect(screen.getByRole('row', { name: /audit-puller/ })).toBeInTheDocument();
     expect(screen.queryByRole('row', { name: /order-service/ })).not.toBeInTheDocument();
-
-    await user.click(screen.getByRole('button', { name: 'Reset filters' }));
-    expect(screen.getByRole('button', { name: 'Next page' })).toBeEnabled();
-    await user.click(screen.getByRole('button', { name: 'Next page' }));
-    expect(screen.getByRole('row', { name: /worker-7/ })).toBeInTheDocument();
   });
 
-  it('opens reusable progress details from a row and exposes no unsupported create or delete action', async () => {
-    const user = userEvent.setup();
-    renderAtRoute(<ConsumerListPage />, '/consumers');
+  it('opens the full workspace from a row action link', async () => {
+    renderPage();
     await screen.findByRole('heading', { name: 'Consumer groups' });
-
-    expect(screen.queryByRole('button', { name: /create/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
-
-    const row = screen.getByRole('row', { name: /order-service/ });
-    await user.click(screen.getByText('order-service'));
-    expect(await screen.findByRole('dialog', { name: 'order-service' })).toBeInTheDocument();
-    expect(await screen.findByRole('group', { name: 'Total lag: 8700' })).toBeInTheDocument();
-    await user.click(screen.getByRole('button', { name: 'Close details' }));
-    await waitFor(() => expect(row).toHaveFocus());
+    const hrefs = screen.getAllByRole('link', { name: 'Open workspace' }).map((link) => link.getAttribute('href'));
+    expect(hrefs).toContain('/consumers/order-service');
   });
 
-  it('restores focus to the exact menu trigger that opened a detail sheet', async () => {
-    const user = userEvent.setup();
-    renderAtRoute(<ConsumerListPage />, '/consumers');
-    await screen.findByRole('heading', { name: 'Consumer groups' });
-
-    const orderRow = screen.getByRole('row', { name: /order-service/ });
-    await user.click(screen.getByText('order-service'));
-    await user.click(screen.getByRole('button', { name: 'Close details' }));
-    await waitFor(() => expect(orderRow).toHaveFocus());
-
-    const paymentTrigger = screen.getByRole('button', { name: 'Actions for payment-broadcast' });
-    await user.click(paymentTrigger);
-    await user.click(screen.getByRole('menuitem', { name: 'View progress' }));
-    expect(await screen.findByRole('dialog', { name: 'payment-broadcast' })).toBeInTheDocument();
-    await user.click(screen.getByRole('button', { name: 'Close details' }));
-    await waitFor(() => expect(paymentTrigger).toHaveFocus());
-  });
-
-  it('shows a retryable list error and refreshes a successful inventory', async () => {
+  it('shows a retryable list error and refreshes', async () => {
     const user = userEvent.setup();
     vi.mocked(consumerApi.list)
       .mockRejectedValueOnce(new Error('consumer service unavailable'))
-      .mockResolvedValue({ items: consumers, total: consumers.length });
-    renderAtRoute(<ConsumerListPage />, '/consumers');
+      .mockResolvedValue({
+        items: [consumer()], total: 1,
+        queryScope: { mode: 'nameServer' },
+        capabilities: { connections: true, progress: true, configuration: true, runningInfo: true, jstack: true }
+      });
+    renderPage();
 
     expect(await screen.findByText('consumer service unavailable')).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Retry' }));
     expect(await screen.findByRole('heading', { name: 'Consumer groups' })).toBeInTheDocument();
-
-    await user.click(screen.getByRole('button', { name: 'Refresh' }));
-    await waitFor(() => expect(consumerApi.list).toHaveBeenCalledTimes(3));
   });
 });

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConsumerListPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConsumerListPage.tsx
@@ -3,7 +3,6 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { consumerApi } from '../api/consumer_api';
 import AppDataTable, { type AppDataTableColumn } from '../components/AppDataTable';
-import EntitySheet from '../components/EntitySheet';
 import ErrorState from '../components/ErrorState';
 import LoadingState from '../components/LoadingState';
 import MetricCard from '../components/MetricCard';
@@ -18,49 +17,82 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger
 } from '../components/ui/DropdownMenu';
-import type { ConsumerGroupInfo, ConsumerListView } from '../types/consumer';
-import ConsumerDetailContent from './consumers/ConsumerDetailContent';
+import type { ConsumerGroupListItem, ConsumerGroupListView } from '../types/consumer';
+import { useConsumerQueryScope } from './consumers/ConsumerQueryScopeProvider';
 import {
-  filterConsumers,
+  clampConsumerPage,
+  consumerCategoryOf,
+  DEFAULT_CONSUMER_FILTERS,
+  DEFAULT_CONSUMER_SORT,
   getConsumerMetrics,
+  isSystemConsumerGroup,
   normalizeConsumerValue,
-  type ConsumerLagFilter
+  selectConsumerRows,
+  summarizeConsumerTargets,
+  type ConsumerCategory,
+  type ConsumerFilters,
+  type ConsumerLagFilter,
+  type ConsumerSort,
+  type ConsumerSortKey
 } from './consumers/consumer-model';
 
 const PAGE_SIZE = 10;
 
+const SORT_OPTIONS: Array<{ key: ConsumerSortKey; label: string }> = [
+  { key: 'rawGroupName', label: 'Group' },
+  { key: 'connectionCount', label: 'Connections' },
+  { key: 'consumeTps', label: 'TPS' },
+  { key: 'diffTotal', label: 'Total lag' },
+  { key: 'version', label: 'Version' },
+  { key: 'updateTimestamp', label: 'Updated' }
+];
+
 export default function ConsumerListPage() {
-  const [data, setData] = useState<ConsumerListView | null>(null);
+  const { scope, revision } = useConsumerQueryScope();
+  const [data, setData] = useState<ConsumerGroupListView | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [query, setQuery] = useState('');
-  const [consumeType, setConsumeType] = useState('all');
-  const [messageModel, setMessageModel] = useState('all');
-  const [lag, setLag] = useState<ConsumerLagFilter>('all');
+  const [initialError, setInitialError] = useState<string | null>(null);
+  const [refreshError, setRefreshError] = useState<string | null>(null);
+  const [filters, setFilters] = useState<ConsumerFilters>(DEFAULT_CONSUMER_FILTERS);
+  const [sort, setSort] = useState<ConsumerSort>(DEFAULT_CONSUMER_SORT);
   const [page, setPage] = useState(1);
-  const [selectedConsumer, setSelectedConsumer] = useState<ConsumerGroupInfo | null>(null);
-  const [detailTab, setDetailTab] = useState<'overview' | 'progress' | 'reset'>('overview');
-  const detailTriggerRef = useRef<HTMLElement | null>(null);
-  const actionTriggerRefs = useRef(new Map<string, HTMLButtonElement>());
+  const requestToken = useRef(0);
 
-  const load = async () => {
-    if (data) setRefreshing(true);
-    else setLoading(true);
-    setError(null);
+  const load = async (isRefresh: boolean) => {
+    const token = ++requestToken.current;
+    if (isRefresh) {
+      setRefreshing(true);
+      setRefreshError(null);
+    } else {
+      setLoading(true);
+      setInitialError(null);
+    }
     try {
-      setData(await consumerApi.list());
-    } catch (requestError) {
-      setError(requestError instanceof Error ? requestError.message : String(requestError));
+      const next = await consumerApi.list(scope);
+      if (token !== requestToken.current) return;
+      setData(next);
+    } catch (error) {
+      if (token !== requestToken.current) return;
+      const message = error instanceof Error ? error.message : String(error);
+      if (isRefresh) setRefreshError(message);
+      else setInitialError(message);
     } finally {
-      setLoading(false);
-      setRefreshing(false);
+      if (token === requestToken.current) {
+        setLoading(false);
+        setRefreshing(false);
+      }
     }
   };
 
   useEffect(() => {
-    void load();
-  }, []);
+    requestToken.current += 1;
+    setPage(1);
+    void load(false);
+    return () => {
+      requestToken.current += 1;
+    };
+  }, [scope.mode, scope.proxyAddress, revision]);
 
   const consumers = data?.items ?? [];
   const metrics = useMemo(() => getConsumerMetrics(consumers), [consumers]);
@@ -72,59 +104,88 @@ export default function ConsumerListPage() {
     () => Array.from(new Set(consumers.map((consumer) => normalizeConsumerValue(consumer.messageModel)))).sort(),
     [consumers]
   );
-  const filteredConsumers = useMemo(
-    () => filterConsumers(consumers, { query, consumeType, messageModel, lag }),
-    [consumeType, consumers, lag, messageModel, query]
+  const brokers = useMemo(
+    () => Array.from(new Set(consumers.flatMap((consumer) => consumer.brokerNames))).sort(),
+    [consumers]
   );
-  const pageCount = Math.max(1, Math.ceil(filteredConsumers.length / PAGE_SIZE));
-  const currentPage = Math.min(page, pageCount);
-  const visibleConsumers = filteredConsumers.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
+  const versions = useMemo(
+    () => Array.from(new Set(consumers.map((consumer) => consumer.versionDesc).filter(Boolean))).sort(),
+    [consumers]
+  );
 
-  const updateFilter = <T,>(setter: (value: T) => void) => (value: T) => {
-    setter(value);
+  const sorted = useMemo(
+    () => selectConsumerRows(consumers, filters, sort),
+    [consumers, filters, sort]
+  );
+  const currentPage = clampConsumerPage(page, PAGE_SIZE, sorted.length);
+  const visible = sorted.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
+
+  const resetFilters = () => {
+    setFilters(DEFAULT_CONSUMER_FILTERS);
+    setSort(DEFAULT_CONSUMER_SORT);
     setPage(1);
   };
 
-  const openDetails = (
-    consumer: ConsumerGroupInfo,
-    origin?: HTMLElement,
-    tab: 'overview' | 'progress' | 'reset' = 'overview'
-  ) => {
-    if (origin) detailTriggerRef.current = origin;
-    setDetailTab(tab);
-    setSelectedConsumer(consumer);
-  };
-
-  const columns: AppDataTableColumn<ConsumerGroupInfo>[] = [
+  const columns: AppDataTableColumn<ConsumerGroupListItem>[] = [
     {
       id: 'group',
       header: 'Consumer group',
-      width: '280px',
+      width: '260px',
       cell: (consumer) => (
         <div className="entity-name-cell">
-          <strong>{consumer.group}</strong>
-          <Link to={`/consumers/${encodeURIComponent(consumer.group)}`}>Full page</Link>
+          <strong>{consumer.displayGroupName}</strong>
+          {consumer.rawGroupName !== consumer.displayGroupName ? (
+            <span className="mono entity-raw-name">{consumer.rawGroupName}</span>
+          ) : null}
+          <Link to={`/consumers/${encodeURIComponent(consumer.rawGroupName)}`}>Open workspace</Link>
         </div>
       )
     },
     {
+      id: 'category',
+      header: 'Category',
+      width: '110px',
+      cell: (consumer) => (
+        <StatusBadge status={consumerCategoryOf(consumer)} tone={isSystemConsumerGroup(consumer) ? 'neutral' : 'info'} />
+      )
+    },
+    { id: 'connections', header: 'Connections', width: '110px', cell: (consumer) => consumer.connectionCount },
+    {
+      id: 'version',
+      header: 'Version',
+      width: '110px',
+      cell: (consumer) => consumer.versionDesc || '-'
+    },
+    {
       id: 'consumeType',
       header: 'Consume type',
-      width: '150px',
+      width: '140px',
       cell: (consumer) => <StatusBadge status={normalizeConsumerValue(consumer.consumeType)} tone="info" />
     },
     {
       id: 'messageModel',
       header: 'Message model',
-      width: '160px',
+      width: '150px',
       cell: (consumer) => <StatusBadge status={normalizeConsumerValue(consumer.messageModel)} tone="success" />
     },
-    { id: 'clients', header: 'Clients', width: '90px', cell: (consumer) => consumer.clientCount },
+    { id: 'tps', header: 'TPS', width: '90px', align: 'right', cell: (consumer) => consumer.consumeTps },
     {
       id: 'lag',
       header: 'Total lag',
       width: '120px',
       cell: (consumer) => <StatusBadge status={String(consumer.diffTotal)} tone={consumer.diffTotal > 0 ? 'warning' : 'success'} />
+    },
+    {
+      id: 'targets',
+      header: 'Targets',
+      width: '150px',
+      cell: (consumer) => <span title={consumer.brokerNames.join(', ')}>{summarizeConsumerTargets(consumer)}</span>
+    },
+    {
+      id: 'updated',
+      header: 'Updated',
+      width: '160px',
+      cell: (consumer) => formatTimestamp(consumer.updateTimestamp)
     },
     {
       id: 'actions',
@@ -134,28 +195,22 @@ export default function ConsumerListPage() {
       cell: (consumer) => (
         <DropdownMenu modal={false}>
           <DropdownMenuTrigger asChild>
-            <Button
-              ref={(node) => {
-                if (node) actionTriggerRefs.current.set(consumer.group, node);
-                else actionTriggerRefs.current.delete(consumer.group);
-              }}
-              type="button"
-              variant="ghost"
-              size="icon"
-              aria-label={`Actions for ${consumer.group}`}
-            >
+            <Button type="button" variant="ghost" size="icon" aria-label={`Actions for ${consumer.rawGroupName}`}>
               <MoreHorizontal size={16} aria-hidden="true" />
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            <DropdownMenuItem onSelect={() => openDetails(consumer, actionTriggerRefs.current.get(consumer.group), 'overview')}>
-              <Activity size={15} aria-hidden="true" /> Inspect group
+            <DropdownMenuItem asChild>
+              <Link to={`/consumers/${encodeURIComponent(consumer.rawGroupName)}`}>Open workspace</Link>
             </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => openDetails(consumer, actionTriggerRefs.current.get(consumer.group), 'progress')}>
-              <ListRestart size={15} aria-hidden="true" /> View progress
+            <DropdownMenuItem asChild>
+              <Link to={`/consumers/${encodeURIComponent(consumer.rawGroupName)}?tab=clients`}>View clients</Link>
             </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => openDetails(consumer, actionTriggerRefs.current.get(consumer.group), 'reset')}>
-              <RotateCcw size={15} aria-hidden="true" /> Reset offset
+            <DropdownMenuItem asChild>
+              <Link to={`/consumers/${encodeURIComponent(consumer.rawGroupName)}?tab=progress`}>View progress</Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link to={`/consumers/${encodeURIComponent(consumer.rawGroupName)}?tab=config`}>View configuration</Link>
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
@@ -164,14 +219,14 @@ export default function ConsumerListPage() {
   ];
 
   if (loading) return <LoadingState label="Loading consumers" />;
-  if (error) return <ErrorState message={error} onRetry={() => void load()} />;
+  if (initialError) return <ErrorState message={initialError} onRetry={() => void load(false)} />;
 
   return (
     <div className="entity-workspace consumer-workspace">
       <PageHeader
         title="Consumer groups"
-        description="Monitor group identity, connected clients, queue lag, and protected offset maintenance from current API data."
-        actions={<RefreshButton refreshing={refreshing} onRefresh={() => void load()} />}
+        description="Monitor group identity, connected clients, queue lag, and protected offset maintenance."
+        actions={<RefreshButton refreshing={refreshing} onRefresh={() => void load(true)} />}
       />
 
       <div className="metric-grid entity-metrics">
@@ -182,70 +237,120 @@ export default function ConsumerListPage() {
       </div>
 
       <section className="entity-table-card">
+        {refreshError ? (
+          <div className="notice notice-danger" role="alert">
+            <span>{refreshError}</span>
+            <Button type="button" variant="outline" size="sm" onClick={() => void load(true)}>Retry refresh</Button>
+          </div>
+        ) : null}
+
         <QueryToolbar
-          searchValue={query}
+          searchValue={filters.query}
           searchPlaceholder="Filter consumer groups"
-          onSearchChange={updateFilter(setQuery)}
-          onReset={() => {
-            setQuery('');
-            setConsumeType('all');
-            setMessageModel('all');
-            setLag('all');
-            setPage(1);
-          }}
+          onSearchChange={(value) => { setFilters((current) => ({ ...current, query: value })); setPage(1); }}
+          onReset={resetFilters}
         >
           <label className="native-filter-field">
+            <span>Category</span>
+            <select aria-label="Category filter" value={filters.categories[0] ?? 'all'} onChange={(event) => {
+              const value = event.target.value;
+              setFilters((current) => ({ ...current, categories: value === 'all' ? [] : [value as ConsumerCategory] }));
+              setPage(1);
+            }}>
+              <option value="all">All categories</option>
+              <option value="NORMAL">Normal</option>
+              <option value="FIFO">FIFO</option>
+              <option value="SYSTEM">System</option>
+            </select>
+          </label>
+          <label className="native-filter-field">
             <span>Consume type</span>
-            <select aria-label="Consume type filter" value={consumeType} onChange={(event) => updateFilter(setConsumeType)(event.target.value)}>
+            <select aria-label="Consume type filter" value={filters.consumeTypes[0] ?? 'all'} onChange={(event) => {
+              const value = event.target.value;
+              setFilters((current) => ({ ...current, consumeTypes: value === 'all' ? [] : [value] }));
+              setPage(1);
+            }}>
               <option value="all">All consume types</option>
               {consumeTypes.map((value) => <option key={value} value={value}>{value}</option>)}
             </select>
           </label>
           <label className="native-filter-field">
             <span>Message model</span>
-            <select aria-label="Message model filter" value={messageModel} onChange={(event) => updateFilter(setMessageModel)(event.target.value)}>
+            <select aria-label="Message model filter" value={filters.messageModels[0] ?? 'all'} onChange={(event) => {
+              const value = event.target.value;
+              setFilters((current) => ({ ...current, messageModels: value === 'all' ? [] : [value] }));
+              setPage(1);
+            }}>
               <option value="all">All message models</option>
               {messageModels.map((value) => <option key={value} value={value}>{value}</option>)}
             </select>
           </label>
           <label className="native-filter-field">
             <span>Lag</span>
-            <select aria-label="Lag filter" value={lag} onChange={(event) => updateFilter(setLag)(event.target.value as ConsumerLagFilter)}>
+            <select aria-label="Lag filter" value={filters.lag} onChange={(event) => {
+              setFilters((current) => ({ ...current, lag: event.target.value as ConsumerLagFilter }));
+              setPage(1);
+            }}>
               <option value="all">Any lag</option>
               <option value="lagging">Lagging</option>
               <option value="clear">No lag</option>
+            </select>
+          </label>
+          <label className="native-filter-field">
+            <span>Broker</span>
+            <select aria-label="Broker filter" value={filters.brokers[0] ?? 'all'} onChange={(event) => {
+              const value = event.target.value;
+              setFilters((current) => ({ ...current, brokers: value === 'all' ? [] : [value] }));
+              setPage(1);
+            }}>
+              <option value="all">All brokers</option>
+              {brokers.map((value) => <option key={value} value={value}>{value}</option>)}
+            </select>
+          </label>
+          <label className="native-filter-field">
+            <span>Version</span>
+            <select aria-label="Version filter" value={filters.versions[0] ?? 'all'} onChange={(event) => {
+              const value = event.target.value;
+              setFilters((current) => ({ ...current, versions: value === 'all' ? [] : [value] }));
+              setPage(1);
+            }}>
+              <option value="all">All versions</option>
+              {versions.map((value) => <option key={value} value={value}>{value}</option>)}
+            </select>
+          </label>
+          <label className="native-filter-field">
+            <span>Sort</span>
+            <select aria-label="Sort by" value={`${sort.key}:${sort.direction}`} onChange={(event) => {
+              const [key, direction] = event.target.value.split(':') as [ConsumerSortKey, ConsumerSort['direction']];
+              setSort({ key, direction });
+              setPage(1);
+            }}>
+              {SORT_OPTIONS.flatMap((option) => [
+                <option key={`${option.key}:asc`} value={`${option.key}:asc`}>{option.label} (asc)</option>,
+                <option key={`${option.key}:desc`} value={`${option.key}:desc`}>{option.label} (desc)</option>
+              ])}
             </select>
           </label>
         </QueryToolbar>
 
         <AppDataTable
           ariaLabel="Consumer group inventory"
-          rows={visibleConsumers}
+          rows={visible}
           columns={columns}
-          getRowId={(consumer) => consumer.group}
+          getRowId={(consumer) => consumer.rawGroupName}
           page={currentPage}
           pageSize={PAGE_SIZE}
-          total={filteredConsumers.length}
+          total={sorted.length}
           onPageChange={setPage}
-          onRowActivate={openDetails}
           emptyTitle="No consumer groups match"
-          emptyDetail="Adjust the group, type, model, or lag filters."
+          emptyDetail="Adjust the group, category, type, model, broker, or lag filters."
         />
       </section>
-
-      <EntitySheet
-        open={selectedConsumer !== null}
-        title={selectedConsumer?.group ?? 'Consumer details'}
-        description={selectedConsumer
-          ? `${normalizeConsumerValue(selectedConsumer.consumeType)} · ${normalizeConsumerValue(selectedConsumer.messageModel)}`
-          : undefined}
-        restoreFocusRef={detailTriggerRef}
-        onOpenChange={(open) => { if (!open) setSelectedConsumer(null); }}
-      >
-        {selectedConsumer ? (
-          <ConsumerDetailContent group={selectedConsumer.group} consumer={selectedConsumer} initialTab={detailTab} />
-        ) : null}
-      </EntitySheet>
     </div>
   );
+}
+
+function formatTimestamp(value: number): string {
+  if (!value) return '-';
+  return new Date(value).toLocaleString();
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConsumerListPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConsumerListPage.tsx
@@ -1,7 +1,9 @@
-import { Activity, ListRestart, MoreHorizontal, RotateCcw, Users } from 'lucide-react';
+import { Activity, ListRestart, MoreHorizontal, Pencil, Plus, RotateCcw, Trash2, Users } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { consumerApi } from '../api/consumer_api';
+import ConsumerDeleteDialog from '../components/ConsumerDeleteDialog';
+import ConsumerMutationDialog from '../components/ConsumerMutationDialog';
 import AppDataTable, { type AppDataTableColumn } from '../components/AppDataTable';
 import ErrorState from '../components/ErrorState';
 import LoadingState from '../components/LoadingState';
@@ -18,6 +20,7 @@ import {
   DropdownMenuTrigger
 } from '../components/ui/DropdownMenu';
 import type { ConsumerGroupListItem, ConsumerGroupListView } from '../types/consumer';
+import type { ConsumerOperationResult } from '../types/consumer';
 import { useConsumerQueryScope } from './consumers/ConsumerQueryScopeProvider';
 import {
   clampConsumerPage,
@@ -57,6 +60,9 @@ export default function ConsumerListPage() {
   const [filters, setFilters] = useState<ConsumerFilters>(DEFAULT_CONSUMER_FILTERS);
   const [sort, setSort] = useState<ConsumerSort>(DEFAULT_CONSUMER_SORT);
   const [page, setPage] = useState(1);
+  const [mutationMode, setMutationMode] = useState<'create' | 'edit' | null>(null);
+  const [mutationConsumer, setMutationConsumer] = useState<ConsumerGroupListItem | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<ConsumerGroupListItem | null>(null);
   const requestToken = useRef(0);
 
   const load = async (isRefresh: boolean) => {
@@ -212,6 +218,12 @@ export default function ConsumerListPage() {
             <DropdownMenuItem asChild>
               <Link to={`/consumers/${encodeURIComponent(consumer.rawGroupName)}?tab=config`}>View configuration</Link>
             </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => { setMutationMode('edit'); setMutationConsumer(consumer); }}>
+              <Pencil size={15} aria-hidden="true" /> Edit configuration
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setDeleteTarget(consumer)}>
+              <Trash2 size={15} aria-hidden="true" /> Delete group
+            </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       )
@@ -226,7 +238,12 @@ export default function ConsumerListPage() {
       <PageHeader
         title="Consumer groups"
         description="Monitor group identity, connected clients, queue lag, and protected offset maintenance."
-        actions={<RefreshButton refreshing={refreshing} onRefresh={() => void load(true)} />}
+        actions={<>
+          <Button type="button" variant="outline" onClick={() => { setMutationMode('create'); setMutationConsumer(null); }}>
+            <Plus size={15} aria-hidden="true" /> Create group
+          </Button>
+          <RefreshButton refreshing={refreshing} onRefresh={() => void load(true)} />
+        </>}
       />
 
       <div className="metric-grid entity-metrics">
@@ -346,6 +363,21 @@ export default function ConsumerListPage() {
           emptyDetail="Adjust the group, category, type, model, broker, or lag filters."
         />
       </section>
+
+      <ConsumerMutationDialog
+        open={mutationMode !== null}
+        mode={mutationMode ?? 'create'}
+        consumer={mutationConsumer}
+        onOpenChange={(open) => { if (!open) { setMutationMode(null); setMutationConsumer(null); } }}
+        onSucceeded={() => void load(false)}
+      />
+
+      <ConsumerDeleteDialog
+        open={deleteTarget !== null}
+        consumer={deleteTarget}
+        onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}
+        onSucceeded={() => void load(false)}
+      />
     </div>
   );
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/DlqMessagePage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/DlqMessagePage.test.tsx
@@ -11,6 +11,22 @@ import DlqMessagePage from './DlqMessagePage';
 vi.mock('../api/consumer_api', () => ({ consumerApi: { list: vi.fn() } }));
 vi.mock('../api/dlq_api', () => ({ dlqApi: { list: vi.fn(), resend: vi.fn(), export: vi.fn() } }));
 
+const consumerGroup = (group: string, diffTotal = 1) => ({
+  displayGroupName: group,
+  rawGroupName: group,
+  category: 'NORMAL',
+  connectionCount: 1,
+  consumeTps: 0,
+  diffTotal,
+  messageModel: 'MESSAGE_MODEL_CLUSTERING',
+  consumeType: 'CONSUME_PASSIVELY',
+  version: null,
+  versionDesc: '',
+  brokerNames: [],
+  brokerAddresses: [],
+  updateTimestamp: 0
+});
+
 const dlqMessage: MessageView = {
   topic: '%DLQ%order-service', messageId: 'DLQ-001', keys: 'order:1', tags: 'TagA', bornTimestamp: 1_723_651_200_000,
   storeTimestamp: 1_723_651_201_000, bornHost: '10.0.0.1:10911', storeHost: '10.0.0.2:10911', queueId: 1,
@@ -28,7 +44,7 @@ describe('DlqMessagePage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(consumerApi.list).mockResolvedValue({
-      items: [{ group: 'order-service', consumeType: 'CONSUME_PASSIVELY', messageModel: 'MESSAGE_MODEL_CLUSTERING', clientCount: 1, diffTotal: 1 }], total: 1
+      items: [consumerGroup('order-service')], total: 1, queryScope: { mode: 'nameServer' }, capabilities: { connections: true, progress: true, configuration: true, runningInfo: true, jstack: true }
     });
     vi.mocked(dlqApi.list)
       .mockResolvedValueOnce({ items: firstDlqPage, total: 20 })
@@ -81,9 +97,9 @@ describe('DlqMessagePage', () => {
     const user = userEvent.setup();
     vi.mocked(consumerApi.list).mockResolvedValue({
       items: [
-        { group: 'order-service', consumeType: 'CONSUME_PASSIVELY', messageModel: 'MESSAGE_MODEL_CLUSTERING', clientCount: 1, diffTotal: 1 },
-        { group: 'payment-consumer', consumeType: 'CONSUME_PASSIVELY', messageModel: 'MESSAGE_MODEL_CLUSTERING', clientCount: 1, diffTotal: 0 }
-      ], total: 2
+        consumerGroup('order-service'),
+        consumerGroup('payment-consumer', 0)
+      ], total: 2, queryScope: { mode: 'nameServer' }, capabilities: { connections: true, progress: true, configuration: true, runningInfo: true, jstack: true }
     });
     renderAtRoute(<DlqMessagePage />, '/messages/dlq');
     await screen.findByRole('heading', { name: 'Dead-letter messages' });
@@ -157,9 +173,9 @@ describe('DlqMessagePage', () => {
     let resolveList!: (value: { items: MessageView[]; total: number }) => void;
     vi.mocked(consumerApi.list).mockResolvedValue({
       items: [
-        { group: 'order-service', consumeType: 'CONSUME_PASSIVELY', messageModel: 'MESSAGE_MODEL_CLUSTERING', clientCount: 1, diffTotal: 1 },
-        { group: 'payment-consumer', consumeType: 'CONSUME_PASSIVELY', messageModel: 'MESSAGE_MODEL_CLUSTERING', clientCount: 1, diffTotal: 0 }
-      ], total: 2
+        consumerGroup('order-service'),
+        consumerGroup('payment-consumer', 0)
+      ], total: 2, queryScope: { mode: 'nameServer' }, capabilities: { connections: true, progress: true, configuration: true, runningInfo: true, jstack: true }
     });
     vi.mocked(dlqApi.list).mockReset().mockReturnValue(new Promise((resolve) => { resolveList = resolve; }));
 
@@ -211,9 +227,9 @@ describe('DlqMessagePage', () => {
     let resolveResend!: (value: Array<{ msgId: string; success: boolean; consumeResult: string; remark?: string }>) => void;
     vi.mocked(consumerApi.list).mockResolvedValue({
       items: [
-        { group: 'order-service', consumeType: 'CONSUME_PASSIVELY', messageModel: 'MESSAGE_MODEL_CLUSTERING', clientCount: 1, diffTotal: 1 },
-        { group: 'payment-consumer', consumeType: 'CONSUME_PASSIVELY', messageModel: 'MESSAGE_MODEL_CLUSTERING', clientCount: 1, diffTotal: 0 }
-      ], total: 2
+        consumerGroup('order-service'),
+        consumerGroup('payment-consumer', 0)
+      ], total: 2, queryScope: { mode: 'nameServer' }, capabilities: { connections: true, progress: true, configuration: true, runningInfo: true, jstack: true }
     });
     vi.mocked(dlqApi.resend).mockReturnValueOnce(new Promise((resolve) => { resolveResend = resolve; }));
 
@@ -318,7 +334,7 @@ describe('DlqMessagePage', () => {
     vi.mocked(consumerApi.list)
       .mockRejectedValueOnce(new Error('nameserver unavailable'))
       .mockResolvedValueOnce({
-        items: [{ group: 'order-service', consumeType: 'CONSUME_PASSIVELY', messageModel: 'MESSAGE_MODEL_CLUSTERING', clientCount: 1, diffTotal: 1 }], total: 1
+        items: [consumerGroup('order-service')], total: 1, queryScope: { mode: 'nameServer' }, capabilities: { connections: true, progress: true, configuration: true, runningInfo: true, jstack: true }
       });
 
     renderAtRoute(<DlqMessagePage />, '/messages/dlq');
@@ -336,9 +352,9 @@ describe('DlqMessagePage', () => {
     const anchorClick = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => undefined);
     vi.mocked(consumerApi.list).mockResolvedValue({
       items: [
-        { group: 'order-service', consumeType: 'CONSUME_PASSIVELY', messageModel: 'MESSAGE_MODEL_CLUSTERING', clientCount: 1, diffTotal: 1 },
-        { group: 'payment-consumer', consumeType: 'CONSUME_PASSIVELY', messageModel: 'MESSAGE_MODEL_CLUSTERING', clientCount: 1, diffTotal: 0 }
-      ], total: 2
+        consumerGroup('order-service'),
+        consumerGroup('payment-consumer', 0)
+      ], total: 2, queryScope: { mode: 'nameServer' }, capabilities: { connections: true, progress: true, configuration: true, runningInfo: true, jstack: true }
     });
     vi.mocked(dlqApi.export).mockReturnValueOnce(new Promise((resolve) => { resolveExport = resolve; }));
 

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/DlqMessagePage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/DlqMessagePage.tsx
@@ -65,7 +65,7 @@ export default function DlqMessagePage() {
     try {
       const data = await consumerApi.list();
       if (groupRequestRef.current !== requestId) return;
-      const nextGroups = data.items.map((item) => item.group).filter((group) => !group.startsWith('CID_RMQ_SYS_')).sort();
+      const nextGroups = data.items.map((item) => item.rawGroupName).filter((group) => !group.startsWith('CID_RMQ_SYS_')).sort();
       setGroups(nextGroups);
       setConsumerGroup((current) => current || nextGroups[0] || '');
     } catch (requestError) {

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/ConsumerDetailContent.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/ConsumerDetailContent.test.tsx
@@ -1,139 +1,94 @@
-import { act, render, screen, waitFor, within } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
+import { configApi } from '../../api/config_api';
 import { consumerApi } from '../../api/consumer_api';
-import type { ConsumerGroupInfo, ConsumerProgress } from '../../types/consumer';
+import { render } from '@testing-library/react';
+import { ConsumerQueryScopeProvider } from './ConsumerQueryScopeProvider';
 import ConsumerDetailContent from './ConsumerDetailContent';
 
 vi.mock('../../api/consumer_api', () => ({
-  consumerApi: {
-    list: vi.fn(),
-    progress: vi.fn(),
-    resetOffset: vi.fn()
-  }
+  consumerApi: { summary: vi.fn(), progress: vi.fn(), resetOffset: vi.fn() }
 }));
+vi.mock('../../api/config_api', () => ({ configApi: { getConfig: vi.fn() } }));
 
-const consumer: ConsumerGroupInfo = {
-  group: 'order-service',
-  consumeType: 'CONSUME_PASSIVELY',
-  messageModel: 'MESSAGE_MODEL_CLUSTERING',
-  clientCount: 3,
-  diffTotal: 120
-};
-
-const progress: ConsumerProgress = {
-  group: 'order-service',
-  topicCount: 1,
-  diffTotal: 120,
-  queues: [
-    { topic: 'orders', brokerName: 'broker-a', queueId: 0, brokerOffset: 500, consumerOffset: 380, diff: 120 }
-  ]
-};
+function renderContent(group: string, initialTab?: 'overview' | 'progress' | 'reset') {
+  return render(
+    <ConsumerQueryScopeProvider>
+      <ConsumerDetailContent group={group} initialTab={initialTab} />
+    </ConsumerQueryScopeProvider>
+  );
+}
 
 describe('ConsumerDetailContent', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(consumerApi.list).mockResolvedValue({ items: [consumer], total: 1 });
-    vi.mocked(consumerApi.progress).mockResolvedValue(progress);
+    vi.mocked(configApi.getConfig).mockResolvedValue({
+      currentNamesrv: '127.0.0.1:9876',
+      namesrvAddrList: ['127.0.0.1:9876'],
+      useVIPChannel: false,
+      useTLS: false,
+      currentProxyAddr: null,
+      proxyAddrList: [],
+      storageBackend: 'sqlite'
+    });
+    vi.mocked(consumerApi.summary).mockResolvedValue({
+      group: 'order-service',
+      displayGroupName: 'order-service',
+      category: 'NORMAL',
+      connectionCount: 3,
+      consumeTps: 10,
+      diffTotal: 12,
+      messageModel: 'MESSAGE_MODEL_CLUSTERING',
+      consumeType: 'CONSUME_PASSIVELY',
+      version: 530,
+      versionDesc: 'V5_3_0',
+      brokerNames: ['broker-a'],
+      brokerAddresses: ['10.0.0.1:10911'],
+      updateTimestamp: 1_700_000_000_000,
+      queryScope: { mode: 'nameServer' }
+    });
+    vi.mocked(consumerApi.progress).mockResolvedValue({
+      group: 'order-service',
+      topicCount: 1,
+      totalDiff: 12,
+      topics: [
+        {
+          topic: 'orders',
+          diffTotal: 12,
+          lastTimestamp: 1_700_000_000_000,
+          queues: [
+            { brokerName: 'broker-a', queueId: 0, brokerOffset: 100, consumerOffset: 88, diffTotal: 12, clientInfo: '10.0.0.8@client-a', lastTimestamp: 1_700_000_000_000 }
+          ]
+        }
+      ],
+      queryScope: { mode: 'nameServer' }
+    });
     vi.mocked(consumerApi.resetOffset).mockResolvedValue({ message: 'reset' });
   });
 
-  it('reuses supplied group identity and renders API-backed progress', async () => {
+  it('renders overview metrics and grouped progress', async () => {
     const user = userEvent.setup();
-    render(<ConsumerDetailContent group="order-service" consumer={consumer} />);
+    renderContent('order-service');
 
-    expect(await screen.findByRole('group', { name: 'Total lag: 120' })).toBeInTheDocument();
-    expect(consumerApi.list).not.toHaveBeenCalled();
-    expect(consumerApi.progress).toHaveBeenCalledWith('order-service');
+    expect(await screen.findByRole('tab', { name: 'Overview' })).toBeInTheDocument();
+    expect(screen.getByText('CLUSTERING')).toBeInTheDocument();
 
     await user.click(screen.getByRole('tab', { name: 'Progress' }));
-    expect(screen.getByRole('row', { name: /orders broker-a 0 500 380 120/ })).toBeInTheDocument();
+    expect(await screen.findByText('orders')).toBeInTheDocument();
+    expect(screen.getByText('broker-a')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
   });
 
-  it('validates and confirms the exact reset-offset request before calling the API', async () => {
+  it('requires a valid timestamp before reset review', async () => {
     const user = userEvent.setup();
-    render(<ConsumerDetailContent group="order-service" consumer={consumer} />);
-    await screen.findByRole('group', { name: 'Total lag: 120' });
+    renderContent('order-service');
+    await screen.findByRole('tab', { name: 'Overview' });
 
     await user.click(screen.getByRole('tab', { name: 'Reset offset' }));
-    const timestamp = screen.getByRole('spinbutton', { name: 'Reset timestamp' });
-    await user.clear(timestamp);
+    await user.clear(screen.getByRole('spinbutton', { name: 'Reset timestamp' }));
     await user.click(screen.getByRole('button', { name: 'Review reset' }));
-    expect(screen.getByRole('status')).toHaveTextContent('Reset timestamp must be a millisecond timestamp.');
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
     expect(consumerApi.resetOffset).not.toHaveBeenCalled();
-
-    for (const invalidTimestamp of ['-1', '1.5', '9007199254740992']) {
-      await user.clear(timestamp);
-      await user.type(timestamp, invalidTimestamp);
-      await user.click(screen.getByRole('button', { name: 'Review reset' }));
-      expect(screen.getByRole('status')).toHaveTextContent('Reset timestamp must be a non-negative safe integer.');
-      expect(consumerApi.resetOffset).not.toHaveBeenCalled();
-    }
-
-    await user.clear(timestamp);
-    await user.type(timestamp, '1723651200000');
-    await user.click(screen.getByRole('checkbox', { name: 'Force reset' }));
-    await user.click(screen.getByRole('button', { name: 'Review reset' }));
-    const confirmation = screen.getByRole('alertdialog', { name: 'Reset consumer offset?' });
-    expect(consumerApi.resetOffset).not.toHaveBeenCalled();
-    await user.click(within(confirmation).getByRole('button', { name: 'Confirm reset' }));
-
-    await waitFor(() => expect(consumerApi.resetOffset).toHaveBeenCalledWith('order-service', {
-      topic: 'orders',
-      resetTimestamp: 1_723_651_200_000,
-      force: true
-    }));
-    expect(await screen.findByText('Offsets reset for order-service on orders.')).toBeInTheDocument();
-  });
-
-  it('surfaces and retries a progress refresh failure after a successful reset', async () => {
-    const user = userEvent.setup();
-    vi.mocked(consumerApi.progress)
-      .mockResolvedValueOnce(progress)
-      .mockRejectedValueOnce(new Error('progress refresh unavailable'))
-      .mockResolvedValueOnce({ ...progress, diffTotal: 0, queues: [{ ...progress.queues[0], consumerOffset: 500, diff: 0 }] });
-    render(<ConsumerDetailContent group="order-service" consumer={consumer} />);
-    await screen.findByRole('group', { name: 'Total lag: 120' });
-
-    await user.click(screen.getByRole('tab', { name: 'Reset offset' }));
-    await user.click(screen.getByRole('button', { name: 'Review reset' }));
-    await user.click(within(screen.getByRole('alertdialog', { name: 'Reset consumer offset?' })).getByRole('button', { name: 'Confirm reset' }));
-
-    expect(await screen.findByText('Offsets reset for order-service on orders.')).toBeInTheDocument();
-    expect(await screen.findByText('progress refresh unavailable')).toBeInTheDocument();
-    await user.click(screen.getByRole('button', { name: 'Retry progress refresh' }));
-    await waitFor(() => expect(consumerApi.progress).toHaveBeenCalledTimes(3));
-    expect(screen.queryByText('progress refresh unavailable')).not.toBeInTheDocument();
-  });
-
-  it('ignores an old reset completion after the selected consumer group changes', async () => {
-    const user = userEvent.setup();
-    let resolveReset: (value: { message: string }) => void = () => undefined;
-    const paymentConsumer: ConsumerGroupInfo = { ...consumer, group: 'payment-service', diffTotal: 8 };
-    const paymentProgress: ConsumerProgress = {
-      ...progress,
-      group: 'payment-service',
-      diffTotal: 8,
-      queues: [{ ...progress.queues[0], topic: 'payments', diff: 8 }]
-    };
-    vi.mocked(consumerApi.progress)
-      .mockResolvedValueOnce(progress)
-      .mockResolvedValueOnce(paymentProgress);
-    vi.mocked(consumerApi.resetOffset).mockReturnValueOnce(new Promise((resolve) => { resolveReset = resolve; }));
-
-    const { rerender } = render(<ConsumerDetailContent group="order-service" consumer={consumer} />);
-    await screen.findByRole('group', { name: 'Total lag: 120' });
-    await user.click(screen.getByRole('tab', { name: 'Reset offset' }));
-    await user.click(screen.getByRole('button', { name: 'Review reset' }));
-    await user.click(within(screen.getByRole('alertdialog', { name: 'Reset consumer offset?' })).getByRole('button', { name: 'Confirm reset' }));
-    await waitFor(() => expect(consumerApi.resetOffset).toHaveBeenCalledWith('order-service', expect.any(Object)));
-
-    rerender(<ConsumerDetailContent group="payment-service" consumer={paymentConsumer} />);
-    expect(await screen.findByRole('group', { name: 'Total lag: 8' })).toBeInTheDocument();
-    await act(async () => resolveReset({ message: 'reset' }));
-
-    await waitFor(() => expect(screen.queryByText(/Offsets reset for order-service/)).not.toBeInTheDocument());
-    expect(consumerApi.progress).toHaveBeenCalledTimes(2);
-    expect(screen.getByRole('group', { name: 'Total lag: 8' })).toBeInTheDocument();
   });
 });

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/ConsumerDetailContent.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/ConsumerDetailContent.tsx
@@ -1,4 +1,4 @@
-import { ListChecks, RadioTower, RotateCcw, Users } from 'lucide-react';
+import { ListChecks, Network, RadioTower, RotateCcw, Settings2, Users } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { consumerApi } from '../../api/consumer_api';
 import AppDataTable, { type AppDataTableColumn } from '../../components/AppDataTable';
@@ -19,8 +19,12 @@ import { Input } from '../../components/ui/Input';
 import { Label } from '../../components/ui/Label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../components/ui/Tabs';
 import type {
+  ConsumerConfigView,
+  ConsumerConnectionItem,
+  ConsumerConnectionView,
   ConsumerProgressQueue,
   ConsumerProgressView,
+  ConsumerSubscriptionItem,
   ConsumerSummaryView
 } from '../../types/consumer';
 import { useConsumerQueryScope } from './ConsumerQueryScopeProvider';
@@ -28,8 +32,23 @@ import { normalizeConsumerValue } from './consumer-model';
 
 interface ConsumerDetailContentProps {
   group: string;
-  initialTab?: 'overview' | 'progress' | 'reset';
+  initialTab?: 'overview' | 'clients' | 'progress' | 'config' | 'reset';
 }
+
+const connectionColumns: AppDataTableColumn<ConsumerConnectionItem>[] = [
+  { id: 'clientId', header: 'Client ID', cell: (row) => row.clientId },
+  { id: 'clientAddr', header: 'Address', cell: (row) => row.clientAddr },
+  { id: 'language', header: 'Language', cell: (row) => row.language },
+  { id: 'version', header: 'Version', cell: (row) => row.versionDesc || String(row.version) }
+];
+
+const subscriptionColumns: AppDataTableColumn<ConsumerSubscriptionItem>[] = [
+  { id: 'topic', header: 'Topic', cell: (row) => row.topic },
+  { id: 'expression', header: 'Expression', cell: (row) => row.subString },
+  { id: 'type', header: 'Type', cell: (row) => row.expressionType },
+  { id: 'tags', header: 'Tags', cell: (row) => row.tagsSet.join(', ') },
+  { id: 'version', header: 'Version', cell: (row) => row.subVersion }
+];
 
 const queueColumns: AppDataTableColumn<ConsumerProgressQueue>[] = [
   { id: 'broker', header: 'Broker', width: '150px', cell: (row) => row.brokerName },
@@ -51,6 +70,12 @@ export default function ConsumerDetailContent({ group, initialTab = 'overview' }
   const [activeTab, setActiveTab] = useState(initialTab);
   const [summary, setSummary] = useState<ConsumerSummaryView | null>(null);
   const [progress, setProgress] = useState<ConsumerProgressView | null>(null);
+  const [connections, setConnections] = useState<ConsumerConnectionView | null>(null);
+  const [config, setConfig] = useState<ConsumerConfigView | null>(null);
+  const [clientsLoading, setClientsLoading] = useState(false);
+  const [configLoading, setConfigLoading] = useState(false);
+  const [clientsError, setClientsError] = useState<string | null>(null);
+  const [configError, setConfigError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -86,12 +111,40 @@ export default function ConsumerDetailContent({ group, initialTab = 'overview' }
     }
   };
 
+  const loadClients = async () => {
+    setClientsLoading(true);
+    setClientsError(null);
+    try {
+      setConnections(await consumerApi.connections(group, scope));
+    } catch (requestError) {
+      setClientsError(requestError instanceof Error ? requestError.message : String(requestError));
+    } finally {
+      setClientsLoading(false);
+    }
+  };
+
+  const loadConfig = async () => {
+    setConfigLoading(true);
+    setConfigError(null);
+    try {
+      setConfig(await consumerApi.config(group, scope));
+    } catch (requestError) {
+      setConfigError(requestError instanceof Error ? requestError.message : String(requestError));
+    } finally {
+      setConfigLoading(false);
+    }
+  };
+
   useEffect(() => {
     currentGroupRef.current = group;
     resetOperationToken.current += 1;
     setActiveTab(initialTab);
     setSummary(null);
     setProgress(null);
+    setConnections(null);
+    setConfig(null);
+    setClientsError(null);
+    setConfigError(null);
     setResetTopic('');
     setValidationError(null);
     setNotice(null);
@@ -103,6 +156,11 @@ export default function ConsumerDetailContent({ group, initialTab = 'overview' }
       resetOperationToken.current += 1;
     };
   }, [group, initialTab, scope.mode, scope.proxyAddress, revision]);
+
+  useEffect(() => {
+    if (activeTab === 'clients' && !connections) void loadClients();
+    if (activeTab === 'config' && !config) void loadConfig();
+  }, [activeTab, connections, config, group, scope.mode, scope.proxyAddress]);
 
   const topics = progress?.topics ?? [];
   const topicOptions = useMemo(() => topics.map((topic) => topic.topic), [topics]);
@@ -165,7 +223,9 @@ export default function ConsumerDetailContent({ group, initialTab = 'overview' }
       <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as typeof activeTab)}>
         <TabsList aria-label="Consumer detail sections">
           <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="clients">Clients</TabsTrigger>
           <TabsTrigger value="progress">Progress</TabsTrigger>
+          <TabsTrigger value="config">Configuration</TabsTrigger>
           <TabsTrigger value="reset">Reset offset</TabsTrigger>
         </TabsList>
 
@@ -184,6 +244,50 @@ export default function ConsumerDetailContent({ group, initialTab = 'overview' }
             <div><dt>Version</dt><dd>{summary?.versionDesc ?? '-'}</dd></div>
             <div><dt>Brokers</dt><dd className="mono">{summary?.brokerNames.join(', ') ?? '-'}</dd></div>
           </dl>
+        </TabsContent>
+
+        <TabsContent value="clients">
+          {clientsLoading ? <LoadingState label="Loading clients" /> : null}
+          {clientsError ? <ErrorState message={clientsError} onRetry={() => void loadClients()} /> : null}
+          {connections ? (
+            <>
+              <dl className="entity-description-grid">
+                <div><dt>Consume type</dt><dd>{normalizeConsumerValue(connections.consumeType)}</dd></div>
+                <div><dt>Message model</dt><dd>{normalizeConsumerValue(connections.messageModel)}</dd></div>
+                <div><dt>Consume from</dt><dd>{connections.consumeFromWhere}</dd></div>
+              </dl>
+              <section className="consumer-resource-section">
+                <h3>Client connections</h3>
+                <AppDataTable
+                  ariaLabel="Consumer connections"
+                  rows={connections.connections}
+                  columns={connectionColumns}
+                  getRowId={(row) => row.clientId}
+                  page={1}
+                  pageSize={Math.max(connections.connections.length, 1)}
+                  total={connections.connections.length}
+                  onPageChange={() => undefined}
+                  emptyTitle="No client connections"
+                  emptyDetail="This group has no connected clients in the current response."
+                />
+              </section>
+              <section className="consumer-resource-section">
+                <h3>Subscriptions</h3>
+                <AppDataTable
+                  ariaLabel="Consumer subscriptions"
+                  rows={connections.subscriptions}
+                  columns={subscriptionColumns}
+                  getRowId={(row) => row.topic}
+                  page={1}
+                  pageSize={Math.max(connections.subscriptions.length, 1)}
+                  total={connections.subscriptions.length}
+                  onPageChange={() => undefined}
+                  emptyTitle="No subscriptions"
+                  emptyDetail="This group has no subscription entries in the current response."
+                />
+              </section>
+            </>
+          ) : null}
         </TabsContent>
 
         <TabsContent value="progress">
@@ -210,6 +314,36 @@ export default function ConsumerDetailContent({ group, initialTab = 'overview' }
               />
             </section>
           ))}
+        </TabsContent>
+
+        <TabsContent value="config">
+          {configLoading ? <LoadingState label="Loading configuration" /> : null}
+          {configError ? <ErrorState message={configError} onRetry={() => void loadConfig()} /> : null}
+          {config ? (
+            <>
+              {config.inconsistentFields.length > 0 ? (
+                <div className="notice notice-warning" role="alert">
+                  {config.inconsistentFields.length} fields differ across brokers.
+                </div>
+              ) : null}
+              <dl className="entity-description-grid">
+                <div><dt>Effective retry queues</dt><dd>{config.effective?.retryQueueNums ?? '-'}</dd></div>
+                <div><dt>Effective max retries</dt><dd>{config.effective?.retryMaxTimes ?? '-'}</dd></div>
+                <div><dt>Consume timeout</dt><dd>{config.effective?.consumeTimeoutMinute ?? '-'}</dd></div>
+                <div><dt>Consume enabled</dt><dd>{config.effective?.consumeEnable ?? false ? 'Yes' : 'No'}</dd></div>
+              </dl>
+              {config.targets.map((target) => (
+                <section key={target.brokerName} className="consumer-resource-section">
+                  <h3>{target.brokerName}</h3>
+                  {target.error ? <div className="notice notice-danger" role="alert">{target.error}</div> : null}
+                  {target.config ? <pre className="consumer-config-json">{JSON.stringify(target.config, null, 2)}</pre> : null}
+                  {target.subscriptionTopics.length > 0 ? (
+                    <p>Subscriptions: {target.subscriptionTopics.join(', ')}</p>
+                  ) : null}
+                </section>
+              ))}
+            </>
+          ) : null}
         </TabsContent>
 
         <TabsContent value="reset">

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/ConsumerDetailContent.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/ConsumerDetailContent.tsx
@@ -1,5 +1,5 @@
 import { ListChecks, RadioTower, RotateCcw, Users } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { consumerApi } from '../../api/consumer_api';
 import AppDataTable, { type AppDataTableColumn } from '../../components/AppDataTable';
 import ErrorState from '../../components/ErrorState';
@@ -18,33 +18,39 @@ import { Button } from '../../components/ui/Button';
 import { Input } from '../../components/ui/Input';
 import { Label } from '../../components/ui/Label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../components/ui/Tabs';
-import type { ConsumerGroupInfo, ConsumerProgress, ConsumerQueueProgress } from '../../types/consumer';
+import type {
+  ConsumerProgressQueue,
+  ConsumerProgressView,
+  ConsumerSummaryView
+} from '../../types/consumer';
+import { useConsumerQueryScope } from './ConsumerQueryScopeProvider';
 import { normalizeConsumerValue } from './consumer-model';
 
 interface ConsumerDetailContentProps {
   group: string;
-  consumer?: ConsumerGroupInfo | null;
   initialTab?: 'overview' | 'progress' | 'reset';
 }
 
-const progressColumns: AppDataTableColumn<ConsumerQueueProgress>[] = [
-  { id: 'topic', header: 'Topic', width: '220px', cell: (row) => <code>{row.topic}</code> },
+const queueColumns: AppDataTableColumn<ConsumerProgressQueue>[] = [
   { id: 'broker', header: 'Broker', width: '150px', cell: (row) => row.brokerName },
   { id: 'queue', header: 'Queue', width: '80px', cell: (row) => row.queueId },
   { id: 'brokerOffset', header: 'Broker offset', width: '130px', cell: (row) => row.brokerOffset },
   { id: 'consumerOffset', header: 'Consumer offset', width: '140px', cell: (row) => row.consumerOffset },
+  { id: 'client', header: 'Client', width: '180px', cell: (row) => <span title={row.clientInfo}>{row.clientInfo || '-'}</span> },
   {
     id: 'lag',
     header: 'Lag',
     width: '100px',
-    cell: (row) => <StatusBadge status={String(row.diff)} tone={row.diff > 0 ? 'warning' : 'success'} />
-  }
+    cell: (row) => <StatusBadge status={String(row.diffTotal)} tone={row.diffTotal > 0 ? 'warning' : 'success'} />
+  },
+  { id: 'lastConsume', header: 'Last consume time', width: '180px', cell: (row) => formatTimestamp(row.lastTimestamp) }
 ];
 
-export default function ConsumerDetailContent({ group, consumer, initialTab = 'overview' }: ConsumerDetailContentProps) {
+export default function ConsumerDetailContent({ group, initialTab = 'overview' }: ConsumerDetailContentProps) {
+  const { scope, revision } = useConsumerQueryScope();
   const [activeTab, setActiveTab] = useState(initialTab);
-  const [identity, setIdentity] = useState<ConsumerGroupInfo | null>(consumer ?? null);
-  const [progress, setProgress] = useState<ConsumerProgress | null>(null);
+  const [summary, setSummary] = useState<ConsumerSummaryView | null>(null);
+  const [progress, setProgress] = useState<ConsumerProgressView | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -63,16 +69,14 @@ export default function ConsumerDetailContent({ group, consumer, initialTab = 'o
     setLoading(true);
     setError(null);
     try {
-      const [nextProgress, nextIdentity] = await Promise.all([
-        consumerApi.progress(group),
-        consumer
-          ? Promise.resolve(consumer)
-          : consumerApi.list().then((result) => result.items.find((item) => item.group === group) ?? null)
+      const [nextSummary, nextProgress] = await Promise.all([
+        consumerApi.summary(group, scope),
+        consumerApi.progress(group, scope)
       ]);
       if (token !== requestToken.current) return;
+      setSummary(nextSummary);
       setProgress(nextProgress);
-      setIdentity(nextIdentity);
-      setResetTopic((current) => current || nextProgress.queues[0]?.topic || '');
+      setResetTopic((current) => current || nextProgress.topics[0]?.topic || '');
     } catch (requestError) {
       if (token === requestToken.current) {
         setError(requestError instanceof Error ? requestError.message : String(requestError));
@@ -86,7 +90,7 @@ export default function ConsumerDetailContent({ group, consumer, initialTab = 'o
     currentGroupRef.current = group;
     resetOperationToken.current += 1;
     setActiveTab(initialTab);
-    setIdentity(consumer ?? null);
+    setSummary(null);
     setProgress(null);
     setResetTopic('');
     setValidationError(null);
@@ -98,7 +102,10 @@ export default function ConsumerDetailContent({ group, consumer, initialTab = 'o
       requestToken.current += 1;
       resetOperationToken.current += 1;
     };
-  }, [group, consumer, initialTab]);
+  }, [group, initialTab, scope.mode, scope.proxyAddress, revision]);
+
+  const topics = progress?.topics ?? [];
+  const topicOptions = useMemo(() => topics.map((topic) => topic.topic), [topics]);
 
   const reviewReset = () => {
     const timestamp = Number(resetTimestamp);
@@ -144,16 +151,17 @@ export default function ConsumerDetailContent({ group, consumer, initialTab = 'o
     }
   };
 
-  if (loading && !progress) return <LoadingState label="Loading consumer progress" />;
+  if (loading && !progress) return <LoadingState label="Loading consumer workspace" />;
   if (error && !progress) return <ErrorState message={error} onRetry={() => void load()} />;
 
   return (
     <div className="entity-detail-content consumer-detail-content">
       {notice ? <div className="notice notice-success" role="status">{notice}</div> : null}
-      {loading && progress ? <LoadingState label="Refreshing consumer progress" /> : null}
+      {loading && progress ? <LoadingState label="Refreshing consumer workspace" /> : null}
       {!loading && error && progress ? (
-        <ErrorState message={error} onRetry={() => void load()} retryLabel="Retry progress refresh" />
+        <ErrorState message={error} onRetry={() => void load()} retryLabel="Retry workspace refresh" />
       ) : null}
+
       <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as typeof activeTab)}>
         <TabsList aria-label="Consumer detail sections">
           <TabsTrigger value="overview">Overview</TabsTrigger>
@@ -164,31 +172,44 @@ export default function ConsumerDetailContent({ group, consumer, initialTab = 'o
         <TabsContent value="overview">
           <div className="metric-grid entity-detail-metrics">
             <MetricCard label="Topics" value={progress?.topicCount ?? 0} detail="Tracked by queue progress" icon={<ListChecks size={18} />} />
-            <MetricCard label="Total lag" value={progress?.diffTotal ?? identity?.diffTotal ?? 0} detail="Aggregate offset difference" icon={<RotateCcw size={18} />} />
-            <MetricCard label="Queues" value={progress?.queues.length ?? 0} detail="Reported queue entries" icon={<RadioTower size={18} />} />
-            <MetricCard label="Connected clients" value={identity?.clientCount ?? 0} detail="Consumer group summary" icon={<Users size={18} />} />
+            <MetricCard label="Total lag" value={progress?.totalDiff ?? summary?.diffTotal ?? 0} detail="Aggregate offset difference" icon={<RotateCcw size={18} />} />
+            <MetricCard label="Connections" value={summary?.connectionCount ?? 0} detail="Consumer group summary" icon={<Users size={18} />} />
+            <MetricCard label="TPS" value={summary?.consumeTps ?? 0} detail="Reported consume throughput" icon={<RadioTower size={18} />} />
           </div>
           <dl className="entity-description-grid">
-            <div><dt>Consumer group</dt><dd className="mono">{group}</dd></div>
-            <div><dt>Consume type</dt><dd>{normalizeConsumerValue(identity?.consumeType ?? '')}</dd></div>
-            <div><dt>Message model</dt><dd>{normalizeConsumerValue(identity?.messageModel ?? '')}</dd></div>
-            <div><dt>Progress source</dt><dd>Live admin API</dd></div>
+            <div><dt>Consumer group</dt><dd className="mono">{summary?.group ?? group}</dd></div>
+            <div><dt>Category</dt><dd>{summary?.category ?? '-'}</dd></div>
+            <div><dt>Consume type</dt><dd>{normalizeConsumerValue(summary?.consumeType ?? '')}</dd></div>
+            <div><dt>Message model</dt><dd>{normalizeConsumerValue(summary?.messageModel ?? '')}</dd></div>
+            <div><dt>Version</dt><dd>{summary?.versionDesc ?? '-'}</dd></div>
+            <div><dt>Brokers</dt><dd className="mono">{summary?.brokerNames.join(', ') ?? '-'}</dd></div>
           </dl>
         </TabsContent>
 
         <TabsContent value="progress">
-          <AppDataTable
-            ariaLabel="Consumer queue progress"
-            rows={progress?.queues ?? []}
-            columns={progressColumns}
-            getRowId={(row) => `${row.topic}-${row.brokerName}-${row.queueId}`}
-            page={1}
-            pageSize={Math.max(progress?.queues.length ?? 0, 1)}
-            total={progress?.queues.length ?? 0}
-            onPageChange={() => undefined}
-            emptyTitle="No queue progress"
-            emptyDetail="This group has no queue offset entries in the current response."
-          />
+          {topics.length === 0 ? (
+            <div className="notice notice-neutral" role="status">No Topic progress is currently reported for this group.</div>
+          ) : null}
+          {topics.map((topic) => (
+            <section key={topic.topic} className="consumer-progress-section">
+              <header>
+                <h3>{topic.topic}</h3>
+                <span>Lag {topic.diffTotal}</span>
+              </header>
+              <AppDataTable
+                ariaLabel={`Progress for ${topic.topic}`}
+                rows={topic.queues}
+                columns={queueColumns}
+                getRowId={(row) => `${topic.topic}:${row.brokerName}:${row.queueId}`}
+                page={1}
+                pageSize={Math.max(topic.queues.length, 1)}
+                total={topic.queues.length}
+                onPageChange={() => undefined}
+                emptyTitle="No queue progress"
+                emptyDetail="This Topic has no queue offset entries in the current response."
+              />
+            </section>
+          ))}
         </TabsContent>
 
         <TabsContent value="reset">
@@ -206,9 +227,7 @@ export default function ConsumerDetailContent({ group, consumer, initialTab = 'o
                   value={resetTopic}
                   onChange={(event) => setResetTopic(event.target.value)}
                 >
-                  {Array.from(new Set(progress?.queues.map((queue) => queue.topic) ?? [])).map((topic) => (
-                    <option key={topic} value={topic}>{topic}</option>
-                  ))}
+                  {topicOptions.map((topic) => <option key={topic} value={topic}>{topic}</option>)}
                 </select>
               </div>
               <div className="field">
@@ -232,7 +251,7 @@ export default function ConsumerDetailContent({ group, consumer, initialTab = 'o
                 Force reset
               </label>
             </div>
-            {validationError ? <div className="inline-validation" role="status">{validationError}</div> : null}
+            {validationError ? <div className="inline-validation" role="alert">{validationError}</div> : null}
             <Button type="button" variant="destructive" onClick={reviewReset}>
               <RotateCcw size={15} aria-hidden="true" /> Review reset
             </Button>
@@ -262,4 +281,9 @@ export default function ConsumerDetailContent({ group, consumer, initialTab = 'o
       </AlertDialog>
     </div>
   );
+}
+
+function formatTimestamp(value: number): string {
+  if (!value) return '-';
+  return new Date(value).toLocaleString();
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/ConsumerQueryScopeProvider.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/ConsumerQueryScopeProvider.test.tsx
@@ -1,0 +1,70 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '@testing-library/react';
+import { vi } from 'vitest';
+import { configApi } from '../../api/config_api';
+import type { DashboardConfigView } from '../../types/config';
+import { ConsumerQueryScopeProvider, useConsumerQueryScope } from './ConsumerQueryScopeProvider';
+
+vi.mock('../../api/config_api', () => ({ configApi: { getConfig: vi.fn() } }));
+
+const configured: DashboardConfigView = {
+  currentNamesrv: '127.0.0.1:9876',
+  namesrvAddrList: ['127.0.0.1:9876'],
+  useVIPChannel: false,
+  useTLS: false,
+  currentProxyAddr: 'proxy-a:8081',
+  proxyAddrList: ['proxy-a:8081'],
+  storageBackend: 'sqlite'
+};
+
+function ScopeProbe() {
+  const { scope, configLoading, proxyAvailable, setMode } = useConsumerQueryScope();
+  return (
+    <div>
+      <output data-testid="scope">{scope.mode}{scope.proxyAddress ? `:${scope.proxyAddress}` : ''}</output>
+      <output data-testid="loading">{String(configLoading)}</output>
+      <output data-testid="available">{String(proxyAvailable)}</output>
+      <button type="button" onClick={() => setMode('proxy')}>Use proxy</button>
+      <button type="button" onClick={() => setMode('nameServer')}>Use nameserver</button>
+    </div>
+  );
+}
+
+describe('ConsumerQueryScopeProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('derives the proxy scope from the configured current endpoint', async () => {
+    vi.mocked(configApi.getConfig).mockResolvedValue(configured);
+    render(<ConsumerQueryScopeProvider><ScopeProbe /></ConsumerQueryScopeProvider>);
+
+    await waitFor(() => expect(screen.getByTestId('loading')).toHaveTextContent('false'));
+    expect(screen.getByTestId('scope')).toHaveTextContent('nameServer');
+    expect(screen.getByTestId('available')).toHaveTextContent('true');
+  });
+
+  it('persists the selected mode and resolves the proxy address', async () => {
+    vi.mocked(configApi.getConfig).mockResolvedValue(configured);
+    const user = userEvent.setup();
+    render(<ConsumerQueryScopeProvider><ScopeProbe /></ConsumerQueryScopeProvider>);
+    await waitFor(() => expect(screen.getByTestId('loading')).toHaveTextContent('false'));
+
+    await user.click(screen.getByRole('button', { name: 'Use proxy' }));
+    expect(screen.getByTestId('scope')).toHaveTextContent('proxy:proxy-a:8081');
+    expect(window.localStorage.getItem('rocketmq.consumer.queryMode')).toBe('proxy');
+  });
+
+  it('fails closed when proxy mode has no current endpoint', async () => {
+    vi.mocked(configApi.getConfig).mockResolvedValue({
+      ...configured,
+      currentProxyAddr: null,
+      proxyAddrList: []
+    });
+    render(<ConsumerQueryScopeProvider><ScopeProbe /></ConsumerQueryScopeProvider>);
+
+    await waitFor(() => expect(screen.getByTestId('loading')).toHaveTextContent('false'));
+    expect(screen.getByTestId('available')).toHaveTextContent('false');
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/ConsumerQueryScopeProvider.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/ConsumerQueryScopeProvider.tsx
@@ -1,0 +1,117 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+import { configApi } from '../../api/config_api';
+import type { ConsumerQueryMode, ConsumerQueryScope } from '../../types/consumer';
+
+const STORAGE_KEY = 'rocketmq.consumer.queryMode';
+
+interface ConsumerQueryScopeContextValue {
+  scope: ConsumerQueryScope;
+  configLoading: boolean;
+  configError: string | null;
+  proxyAvailable: boolean;
+  setMode: (mode: ConsumerQueryMode) => void;
+  refreshProxyConfig: () => Promise<void>;
+  revision: number;
+}
+
+const ConsumerQueryScopeContext = createContext<ConsumerQueryScopeContextValue | null>(null);
+
+function readStoredMode(): ConsumerQueryMode {
+  return window.localStorage.getItem(STORAGE_KEY) === 'proxy' ? 'proxy' : 'nameServer';
+}
+
+export function ConsumerQueryScopeProvider({ children }: { children: ReactNode }) {
+  const [mode, setModeState] = useState<ConsumerQueryMode>(readStoredMode);
+  const [currentProxy, setCurrentProxy] = useState<string | null>(null);
+  const [proxyList, setProxyList] = useState<string[]>([]);
+  const [configLoading, setConfigLoading] = useState(true);
+  const [configError, setConfigError] = useState<string | null>(null);
+  const [revision, setRevision] = useState(0);
+  const requestToken = useRef(0);
+  const mountedRef = useRef(false);
+  const lastProxyRef = useRef<string | null | undefined>(undefined);
+
+  const applyConfig = useCallback((current: string | null, list: string[]) => {
+    setProxyList(list);
+    const previous = lastProxyRef.current;
+    if (previous !== undefined && previous !== current) {
+      setRevision((value) => value + 1);
+    }
+    lastProxyRef.current = current;
+    setCurrentProxy(current);
+  }, []);
+
+  const loadConfig = useCallback(async () => {
+    const token = ++requestToken.current;
+    setConfigLoading(true);
+    setConfigError(null);
+    try {
+      const config = await configApi.getConfig();
+      if (token !== requestToken.current) return;
+      applyConfig(config.currentProxyAddr ?? null, config.proxyAddrList);
+    } catch (error) {
+      if (token === requestToken.current) {
+        setConfigError(error instanceof Error ? error.message : String(error));
+      }
+    } finally {
+      if (token === requestToken.current) setConfigLoading(false);
+    }
+  }, [applyConfig]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    void loadConfig();
+    return () => {
+      mountedRef.current = false;
+      requestToken.current += 1;
+    };
+  }, [loadConfig]);
+
+  const setMode = useCallback((next: ConsumerQueryMode) => {
+    setModeState(next);
+    window.localStorage.setItem(STORAGE_KEY, next);
+  }, []);
+
+  const refreshProxyConfig = useCallback(async () => {
+    await loadConfig();
+  }, [loadConfig]);
+
+  const proxyAvailable = Boolean(
+    currentProxy && currentProxy.trim() !== '' && proxyList.some((address) => address === currentProxy)
+  );
+
+  const scope = useMemo<ConsumerQueryScope>(() => {
+    if (mode === 'proxy' && currentProxy) {
+      return { mode: 'proxy', proxyAddress: currentProxy };
+    }
+    return { mode };
+  }, [mode, currentProxy]);
+
+  const value = useMemo<ConsumerQueryScopeContextValue>(
+    () => ({
+      scope,
+      configLoading,
+      configError,
+      proxyAvailable,
+      setMode,
+      refreshProxyConfig,
+      revision
+    }),
+    [scope, configLoading, configError, proxyAvailable, setMode, refreshProxyConfig, revision]
+  );
+
+  return (
+    <ConsumerQueryScopeContext.Provider value={value}>
+      {children}
+    </ConsumerQueryScopeContext.Provider>
+  );
+}
+
+export function useConsumerQueryScope(): ConsumerQueryScopeContextValue {
+  const context = useContext(ConsumerQueryScopeContext);
+  if (!context) {
+    throw new Error('useConsumerQueryScope must be used within ConsumerQueryScopeProvider');
+  }
+  return context;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/consumer-model.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/consumer-model.test.ts
@@ -1,41 +1,125 @@
-import type { ConsumerGroupInfo } from '../../types/consumer';
-import { filterConsumers, getConsumerMetrics, normalizeConsumerValue } from './consumer-model';
+import type { ConsumerConfigTarget, ConsumerGroupListItem } from '../../types/consumer';
+import {
+  clampConsumerPage,
+  consumerOperationSucceeded,
+  consumerQueryIdentity,
+  deriveInconsistentConsumerFields,
+  getConsumerActionAvailability,
+  getConsumerMetrics,
+  normalizeConsumerValue,
+  selectConsumerRows,
+  summarizeConsumerTargets
+} from './consumer-model';
 
-const consumers: ConsumerGroupInfo[] = [
-  { group: 'order-service', consumeType: 'CONSUME_PASSIVELY', messageModel: 'MESSAGE_MODEL_CLUSTERING', clientCount: 6, diffTotal: 8_700 },
-  { group: 'payment-worker', consumeType: 'CONSUME_PASSIVELY', messageModel: 'MESSAGE_MODEL_BROADCASTING', clientCount: 2, diffTotal: 0 },
-  { group: 'audit-puller', consumeType: 'CONSUME_ACTIVELY', messageModel: 'MESSAGE_MODEL_CLUSTERING', clientCount: 0, diffTotal: 25 }
-];
+function consumerFixture(overrides: Partial<ConsumerGroupListItem> = {}): ConsumerGroupListItem {
+  return {
+    displayGroupName: 'orders-consumer',
+    rawGroupName: 'orders-consumer',
+    category: 'NORMAL',
+    connectionCount: 3,
+    consumeTps: 120,
+    diffTotal: 0,
+    messageModel: 'MESSAGE_MODEL_CLUSTERING',
+    consumeType: 'CONSUME_PASSIVELY',
+    version: 530,
+    versionDesc: 'V5_3_0',
+    brokerNames: ['broker-a'],
+    brokerAddresses: ['10.0.0.1:10911'],
+    updateTimestamp: 1_700_000_000_000,
+    ...overrides
+  };
+}
 
 describe('consumer-model', () => {
-  it('aggregates only API-backed consumer metrics', () => {
-    expect(getConsumerMetrics(consumers)).toEqual({
-      groups: 3,
-      connectedClients: 8,
-      totalLag: 8_725,
-      laggingGroups: 2
+  it('filters and sorts by canonical consumer metadata', () => {
+    const rows = [
+      consumerFixture({ rawGroupName: 'orders-standard', diffTotal: 10, category: 'NORMAL' }),
+      consumerFixture({ rawGroupName: 'orders-priority', diffTotal: 50, category: 'NORMAL' }),
+      consumerFixture({ rawGroupName: 'payment', diffTotal: 0, category: 'FIFO', versionDesc: 'V5_2_0' })
+    ];
+
+    const result = selectConsumerRows(rows, {
+      query: 'orders',
+      categories: ['NORMAL'],
+      consumeTypes: [],
+      messageModels: [],
+      lag: 'lagging',
+      brokers: ['broker-a'],
+      versions: ['V5_3_0'],
+      sort: { key: 'diffTotal', direction: 'desc' }
+    } as never);
+
+    expect(result.map((item) => item.rawGroupName)).toEqual(['orders-priority', 'orders-standard']);
+  });
+
+  it('protects system groups and keeps normal actions complete', () => {
+    const system = consumerFixture({ rawGroupName: '%SYS%internal', category: 'SYSTEM' });
+    const normal = consumerFixture({ rawGroupName: 'orders-consumer', category: 'NORMAL' });
+
+    expect(getConsumerActionAvailability(system)).toEqual({
+      inspect: true, clients: true, progress: true, config: true, edit: false, reset: false, delete: false
+    });
+    expect(getConsumerActionAvailability(normal)).toEqual({
+      inspect: true, clients: true, progress: true, config: true, edit: true, reset: true, delete: true
     });
   });
 
-  it('combines group, consume type, message model, and lag filters', () => {
-    expect(filterConsumers(consumers, {
-      query: 'audit',
-      consumeType: 'ACTIVELY',
-      messageModel: 'CLUSTERING',
-      lag: 'lagging'
-    })).toEqual([consumers[2]]);
-
-    expect(filterConsumers(consumers, {
-      query: '',
-      consumeType: 'all',
-      messageModel: 'BROADCASTING',
-      lag: 'clear'
-    })).toEqual([consumers[1]]);
+  it('aggregates API-backed metrics', () => {
+    const metrics = getConsumerMetrics([
+      consumerFixture({ connectionCount: 6, diffTotal: 8_700 }),
+      consumerFixture({ rawGroupName: 'payment', connectionCount: 2, diffTotal: 0 })
+    ]);
+    expect(metrics).toEqual({ groups: 2, connectedClients: 8, totalLag: 8_700, laggingGroups: 1 });
   });
 
-  it('normalizes API enum prefixes for display and filtering', () => {
+  it('normalizes enum prefixes for display', () => {
     expect(normalizeConsumerValue('CONSUME_PASSIVELY')).toBe('PASSIVELY');
     expect(normalizeConsumerValue('MESSAGE_MODEL_CLUSTERING')).toBe('CLUSTERING');
     expect(normalizeConsumerValue('')).toBe('UNKNOWN');
+  });
+
+  it('clamps page numbers after filters shrink the result', () => {
+    expect(clampConsumerPage(9, 10, 25)).toBe(3);
+    expect(clampConsumerPage(0, 10, 25)).toBe(1);
+  });
+
+  it('summarizes broker targets compactly', () => {
+    expect(summarizeConsumerTargets(consumerFixture({ brokerNames: ['broker-a', 'broker-b', 'broker-c'] })))
+      .toBe('broker-a +2');
+  });
+
+  it('derives inconsistent configuration fields', () => {
+    const targets: ConsumerConfigTarget[] = [
+      {
+        brokerName: 'broker-a',
+        brokerAddress: 'a',
+        config: { consumeEnable: true, consumeFromMinEnable: false, consumeBroadcastEnable: false, consumeMessageOrderly: false, retryQueueNums: 2, retryMaxTimes: 16, brokerId: 0, whichBrokerWhenConsumeSlowly: 1, notifyConsumerIdsChangedEnable: true, groupSysFlag: 0, consumeTimeoutMinute: 15, groupRetryPolicyJson: '{}' },
+        subscriptionTopics: [],
+        attributes: []
+      },
+      {
+        brokerName: 'broker-b',
+        brokerAddress: 'b',
+        config: { consumeEnable: true, consumeFromMinEnable: false, consumeBroadcastEnable: false, consumeMessageOrderly: false, retryQueueNums: 2, retryMaxTimes: 20, brokerId: 0, whichBrokerWhenConsumeSlowly: 1, notifyConsumerIdsChangedEnable: true, groupSysFlag: 0, consumeTimeoutMinute: 15, groupRetryPolicyJson: '{}' },
+        subscriptionTopics: [],
+        attributes: []
+      }
+    ];
+
+    expect(deriveInconsistentConsumerFields(targets)).toEqual(['retryMaxTimes']);
+  });
+
+  it('treats mutation success as every target succeeding', () => {
+    expect(consumerOperationSucceeded({
+      operation: 'UPDATE', consumerGroup: 'g', success: true, targetCount: 2, message: '', targets: [
+        { target: 'a', kind: 'BROKER', success: true, message: '' },
+        { target: 'b', kind: 'BROKER', success: false, message: '' }
+      ]
+    })).toBe(false);
+  });
+
+  it('builds a stable query identity', () => {
+    expect(consumerQueryIdentity({ mode: 'nameServer' })).toBe('nameServer:');
+    expect(consumerQueryIdentity({ mode: 'proxy', proxyAddress: 'proxy-a:8081' })).toBe('proxy:proxy-a:8081');
   });
 });

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/consumer-model.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/consumer-model.ts
@@ -1,19 +1,115 @@
-import type { ConsumerGroupInfo } from '../../types/consumer';
+import type {
+  ConsumerConfigTarget,
+  ConsumerGroupListItem,
+  ConsumerOperationResult,
+  ConsumerQueryScope
+} from '../../types/consumer';
 
+export type ConsumerCategory = 'NORMAL' | 'FIFO' | 'SYSTEM';
 export type ConsumerLagFilter = 'all' | 'lagging' | 'clear';
+export type ConsumerSortKey =
+  | 'rawGroupName'
+  | 'connectionCount'
+  | 'consumeTps'
+  | 'diffTotal'
+  | 'version'
+  | 'updateTimestamp';
+export type ConsumerSortDirection = 'asc' | 'desc';
 
 export interface ConsumerFilters {
   query: string;
-  consumeType: string;
-  messageModel: string;
+  categories: ConsumerCategory[];
+  consumeTypes: string[];
+  messageModels: string[];
   lag: ConsumerLagFilter;
+  brokers: string[];
+  versions: string[];
 }
 
-export function getConsumerMetrics(consumers: ConsumerGroupInfo[]) {
+export interface ConsumerSort {
+  key: ConsumerSortKey;
+  direction: ConsumerSortDirection;
+}
+
+export interface ConsumerActionAvailability {
+  inspect: boolean;
+  clients: boolean;
+  progress: boolean;
+  config: boolean;
+  edit: boolean;
+  reset: boolean;
+  delete: boolean;
+}
+
+export const DEFAULT_CONSUMER_FILTERS: ConsumerFilters = {
+  query: '',
+  categories: [],
+  consumeTypes: [],
+  messageModels: [],
+  lag: 'all',
+  brokers: [],
+  versions: []
+};
+
+export const DEFAULT_CONSUMER_SORT: ConsumerSort = {
+  key: 'rawGroupName',
+  direction: 'asc'
+};
+
+export function normalizeConsumerValue(value: string): string {
+  return value
+    .replace(/^CONSUME_/, '')
+    .replace(/^MESSAGE_MODEL_/, '') || 'UNKNOWN';
+}
+
+export function consumerCategoryOf(item: Pick<ConsumerGroupListItem, 'rawGroupName' | 'category'>): ConsumerCategory {
+  const normalized = item.category.toUpperCase();
+  if (normalized === 'FIFO') return 'FIFO';
+  if (isSystemConsumerGroup(item)) return 'SYSTEM';
+  if (normalized === 'SYSTEM') return 'SYSTEM';
+  return 'NORMAL';
+}
+
+export function isSystemConsumerGroup(item: Pick<ConsumerGroupListItem, 'rawGroupName' | 'category'>): boolean {
+  const group = item.rawGroupName;
+  const category = item.category.toUpperCase();
+  return group.startsWith('%SYS%')
+    || group.startsWith('CID_RMQ_SYS_')
+    || category === 'SYSTEM'
+    || [
+      'TOOLS_CONSUMER',
+      'FILTERSRV_CONSUMER',
+      'SELF_TEST_C_GROUP',
+      'CID_ONS-HTTP-PROXY',
+      'CID_ONSAPI_PULL',
+      'CID_ONSAPI_PERMISSION',
+      'CID_ONSAPI_OWNER',
+      'CID_RMQ_SYS_TRANS',
+      'CID_DefaultHeartBeatSyncerTopic'
+    ].includes(group);
+}
+
+export function getConsumerActionAvailability(
+  item: Pick<ConsumerGroupListItem, 'rawGroupName' | 'category'>
+): ConsumerActionAvailability {
+  const inspectable = true;
+  const mutable = !isSystemConsumerGroup(item);
+  return {
+    inspect: inspectable,
+    clients: true,
+    progress: true,
+    config: true,
+    edit: mutable,
+    reset: mutable,
+    delete: mutable
+  };
+}
+
+export function getConsumerMetrics(consumers: ConsumerGroupListItem[]) {
   return consumers.reduce(
     (metrics, consumer) => ({
       groups: metrics.groups + 1,
-      connectedClients: metrics.connectedClients + consumer.clientCount,
+      connectedClients: metrics.connectedClients + consumer.connectionCount,
       totalLag: metrics.totalLag + consumer.diffTotal,
       laggingGroups: metrics.laggingGroups + (consumer.diffTotal > 0 ? 1 : 0)
     }),
@@ -21,23 +117,110 @@ export function getConsumerMetrics(consumers: ConsumerGroupInfo[]) {
   );
 }
 
-export function filterConsumers(consumers: ConsumerGroupInfo[], filters: ConsumerFilters) {
+export function selectConsumerRows(
+  consumers: ConsumerGroupListItem[],
+  filters: ConsumerFilters,
+  sort: ConsumerSort = DEFAULT_CONSUMER_SORT
+): ConsumerGroupListItem[] {
   const query = filters.query.trim().toLowerCase();
-  return consumers.filter((consumer) => {
-    const consumeType = normalizeConsumerValue(consumer.consumeType);
-    const messageModel = normalizeConsumerValue(consumer.messageModel);
-    const matchesQuery = !query || consumer.group.toLowerCase().includes(query);
-    const matchesType = filters.consumeType === 'all' || consumeType === filters.consumeType;
-    const matchesModel = filters.messageModel === 'all' || messageModel === filters.messageModel;
+  const categories = new Set(filters.categories);
+  const consumeTypes = new Set(filters.consumeTypes.map((value) => value.toUpperCase()));
+  const messageModels = new Set(filters.messageModels.map((value) => value.toUpperCase()));
+  const brokers = new Set(filters.brokers);
+  const versions = new Set(filters.versions);
+
+  const filtered = consumers.filter((consumer) => {
+    const category = consumerCategoryOf(consumer);
+    const matchesQuery = !query
+      || consumer.rawGroupName.toLowerCase().includes(query)
+      || consumer.displayGroupName.toLowerCase().includes(query);
+    const matchesCategory = categories.size === 0 || categories.has(category);
+    const matchesConsumeType = consumeTypes.size === 0
+      || consumeTypes.has(normalizeConsumerValue(consumer.consumeType).toUpperCase());
+    const matchesMessageModel = messageModels.size === 0
+      || messageModels.has(normalizeConsumerValue(consumer.messageModel).toUpperCase());
     const matchesLag = filters.lag === 'all'
       || (filters.lag === 'lagging' && consumer.diffTotal > 0)
       || (filters.lag === 'clear' && consumer.diffTotal === 0);
-    return matchesQuery && matchesType && matchesModel && matchesLag;
+    const matchesBroker = brokers.size === 0
+      || consumer.brokerNames.some((broker) => brokers.has(broker));
+    const matchesVersion = versions.size === 0 || versions.has(consumer.versionDesc);
+    return matchesQuery
+      && matchesCategory
+      && matchesConsumeType
+      && matchesMessageModel
+      && matchesLag
+      && matchesBroker
+      && matchesVersion;
+  });
+
+  const direction = sort.direction === 'asc' ? 1 : -1;
+  return filtered.sort((left, right) => {
+    const leftValue = sortValue(left, sort.key);
+    const rightValue = sortValue(right, sort.key);
+    if (leftValue < rightValue) return -1 * direction;
+    if (leftValue > rightValue) return 1 * direction;
+    return left.rawGroupName.localeCompare(right.rawGroupName);
   });
 }
 
-export function normalizeConsumerValue(value: string) {
-  return value
-    .replace(/^CONSUME_/, '')
-    .replace(/^MESSAGE_MODEL_/, '') || 'UNKNOWN';
+function sortValue(item: ConsumerGroupListItem, key: ConsumerSortKey): string | number {
+  switch (key) {
+    case 'rawGroupName':
+      return item.rawGroupName;
+    case 'connectionCount':
+      return item.connectionCount;
+    case 'consumeTps':
+      return item.consumeTps;
+    case 'diffTotal':
+      return item.diffTotal;
+    case 'version':
+      return item.version ?? -1;
+    case 'updateTimestamp':
+      return item.updateTimestamp;
+  }
+}
+
+export function clampConsumerPage(page: number, pageSize: number, total: number): number {
+  const pageCount = Math.max(1, Math.ceil(total / pageSize));
+  return Math.min(Math.max(1, page), pageCount);
+}
+
+export function summarizeConsumerTargets(item: ConsumerGroupListItem): string {
+  if (item.brokerNames.length === 0) return 'Unknown';
+  if (item.brokerNames.length === 1) return item.brokerNames[0];
+  return `${item.brokerNames[0]} +${item.brokerNames.length - 1}`;
+}
+
+export function deriveInconsistentConsumerFields(targets: ConsumerConfigTarget[]): string[] {
+  const values = targets
+    .map((target) => target.config)
+    .filter((config): config is NonNullable<typeof config> => config !== null);
+  if (values.length < 2) return [];
+  const first = values[0];
+  const fields: string[] = [];
+  const compare = <K extends keyof typeof first>(key: K, label: string) => {
+    if (values.some((value) => value[key] !== first[key])) fields.push(label);
+  };
+  compare('consumeEnable', 'consumeEnable');
+  compare('consumeFromMinEnable', 'consumeFromMinEnable');
+  compare('consumeBroadcastEnable', 'consumeBroadcastEnable');
+  compare('consumeMessageOrderly', 'consumeMessageOrderly');
+  compare('retryQueueNums', 'retryQueueNums');
+  compare('retryMaxTimes', 'retryMaxTimes');
+  compare('brokerId', 'brokerId');
+  compare('whichBrokerWhenConsumeSlowly', 'whichBrokerWhenConsumeSlowly');
+  compare('notifyConsumerIdsChangedEnable', 'notifyConsumerIdsChangedEnable');
+  compare('groupSysFlag', 'groupSysFlag');
+  compare('consumeTimeoutMinute', 'consumeTimeoutMinute');
+  compare('groupRetryPolicyJson', 'groupRetryPolicyJson');
+  return fields;
+}
+
+export function consumerOperationSucceeded(result: ConsumerOperationResult): boolean {
+  return result.success && result.targets.every((target) => target.success);
+}
+
+export function consumerQueryIdentity(scope: ConsumerQueryScope): string {
+  return `${scope.mode}:${scope.mode === 'proxy' ? scope.proxyAddress ?? '' : ''}`;
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/globals.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/globals.css
@@ -3623,3 +3623,30 @@ a:hover {
     white-space: normal;
   }
 }
+
+
+.consumer-target-checkboxes,
+.consumer-delete-targets {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 8px;
+}
+
+.consumer-mutation-form {
+  display: grid;
+  gap: 16px;
+}
+
+.consumer-mutation-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.consumer-resource-section {
+  margin-top: 20px;
+}
+
+.consumer-config-json {
+  max-height: 360px;
+  overflow: auto;
+  white-space: pre-wrap;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/types/consumer.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/types/consumer.ts
@@ -1,30 +1,234 @@
-export interface ConsumerGroupInfo {
+export type ConsumerQueryMode = 'nameServer' | 'proxy';
+
+export interface ConsumerQueryScope {
+  mode: ConsumerQueryMode;
+  proxyAddress?: string;
+}
+
+export interface ConsumerQuery {
+  mode: ConsumerQueryMode;
+  proxyAddress?: string;
+  skipSystem?: boolean;
+}
+
+export interface ConsumerCapabilities {
+  connections: boolean;
+  progress: boolean;
+  configuration: boolean;
+  runningInfo: boolean;
+  jstack: boolean;
+}
+
+export interface ConsumerClientCapabilities {
+  runningInfo: boolean;
+  jstack: boolean;
+  runningInfoReason?: string | null;
+  jstackReason?: string | null;
+}
+
+export interface ConsumerGroupListItem {
+  displayGroupName: string;
+  rawGroupName: string;
+  category: string;
+  connectionCount: number;
+  consumeTps: number;
+  diffTotal: number;
+  messageModel: string;
+  consumeType: string;
+  version: number | null;
+  versionDesc: string;
+  brokerNames: string[];
+  brokerAddresses: string[];
+  updateTimestamp: number;
+}
+
+export interface ConsumerGroupListView {
+  items: ConsumerGroupListItem[];
+  total: number;
+  queryScope: ConsumerQueryScope;
+  capabilities: ConsumerCapabilities;
+}
+
+export interface ConsumerSummaryView {
   group: string;
+  displayGroupName: string;
+  category: string;
+  connectionCount: number;
+  consumeTps: number;
+  diffTotal: number;
+  messageModel: string;
+  consumeType: string;
+  version: number | null;
+  versionDesc: string;
+  brokerNames: string[];
+  brokerAddresses: string[];
+  updateTimestamp: number;
+  queryScope: ConsumerQueryScope;
+}
+
+export interface ConsumerConnectionItem {
+  clientId: string;
+  clientAddr: string;
+  language: string;
+  version: number;
+  versionDesc: string;
+  capabilities: ConsumerClientCapabilities;
+}
+
+export interface ConsumerSubscriptionItem {
+  topic: string;
+  subString: string;
+  expressionType: string;
+  tagsSet: string[];
+  codeSet: number[];
+  subVersion: number;
+}
+
+export interface ConsumerConnectionView {
+  group: string;
+  connectionCount: number;
   consumeType: string;
   messageModel: string;
-  clientCount: number;
-  diffTotal: number;
+  consumeFromWhere: string;
+  connections: ConsumerConnectionItem[];
+  subscriptions: ConsumerSubscriptionItem[];
+  queryScope: ConsumerQueryScope;
 }
 
-export interface ConsumerListView {
-  items: ConsumerGroupInfo[];
-  total: number;
-}
-
-export interface ConsumerProgress {
-  group: string;
-  topicCount: number;
-  diffTotal: number;
-  queues: ConsumerQueueProgress[];
-}
-
-export interface ConsumerQueueProgress {
-  topic: string;
+export interface ConsumerProgressQueue {
   brokerName: string;
   queueId: number;
   brokerOffset: number;
   consumerOffset: number;
-  diff: number;
+  diffTotal: number;
+  clientInfo: string;
+  lastTimestamp: number;
+}
+
+export interface ConsumerProgressTopic {
+  topic: string;
+  diffTotal: number;
+  lastTimestamp: number;
+  queues: ConsumerProgressQueue[];
+}
+
+export interface ConsumerProgressView {
+  group: string;
+  topicCount: number;
+  totalDiff: number;
+  topics: ConsumerProgressTopic[];
+  queryScope: ConsumerQueryScope;
+}
+
+export interface ConsumerConfigValue {
+  consumeEnable: boolean;
+  consumeFromMinEnable: boolean;
+  consumeBroadcastEnable: boolean;
+  consumeMessageOrderly: boolean;
+  retryQueueNums: number;
+  retryMaxTimes: number;
+  brokerId: number;
+  whichBrokerWhenConsumeSlowly: number;
+  notifyConsumerIdsChangedEnable: boolean;
+  groupSysFlag: number;
+  consumeTimeoutMinute: number;
+  groupRetryPolicyJson: string;
+}
+
+export interface ConsumerConfigAttribute {
+  key: string;
+  value: string;
+}
+
+export interface ConsumerConfigTarget {
+  brokerName: string;
+  brokerAddress: string;
+  config: ConsumerConfigValue | null;
+  subscriptionTopics: string[];
+  attributes: ConsumerConfigAttribute[];
+  error?: string | null;
+}
+
+export interface ConsumerConfigView {
+  group: string;
+  effective: ConsumerConfigValue | null;
+  inconsistentFields: string[];
+  targets: ConsumerConfigTarget[];
+  queryScope: ConsumerQueryScope;
+}
+
+export interface ConsumerProcessQueue {
+  topic: string;
+  brokerName: string;
+  queueId: number;
+  cachedMessageCount: number;
+  cachedMessageSizeInMib: number;
+  commitOffset: number;
+  dropped: boolean;
+  lastConsumeTimestamp: number;
+}
+
+export interface ConsumerRunningInfoView {
+  consumerGroup: string;
+  clientId: string;
+  properties: ConsumerConfigAttribute[];
+  subscriptions: ConsumerSubscriptionItem[];
+  processQueues: ConsumerProcessQueue[];
+  jstack: string | null;
+  truncated: boolean;
+}
+
+export interface ConsumerJStackView {
+  consumerGroup: string;
+  clientId: string;
+  jstack: string | null;
+  truncated: boolean;
+}
+
+export interface ConsumerBrokerInfo {
+  brokerName: string;
+  brokerAddress: string;
+}
+
+export interface ConsumerBrokerListView {
+  items: ConsumerBrokerInfo[];
+}
+
+export interface ConsumerTargetResult {
+  target: string;
+  kind: string;
+  success: boolean;
+  message: string;
+}
+
+export interface ConsumerOperationResult {
+  operation: string;
+  consumerGroup: string;
+  success: boolean;
+  targetCount: number;
+  message: string;
+  targets: ConsumerTargetResult[];
+}
+
+export interface ConsumerUpsertRequest {
+  consumerGroup?: string;
+  clusterNameList: string[];
+  brokerNameList: string[];
+  consumeEnable: boolean;
+  consumeFromMinEnable: boolean;
+  consumeBroadcastEnable: boolean;
+  consumeMessageOrderly: boolean;
+  retryQueueNums: number;
+  retryMaxTimes: number;
+  brokerId: number;
+  whichBrokerWhenConsumeSlowly: number;
+  notifyConsumerIdsChangedEnable: boolean;
+  groupSysFlag: number;
+  consumeTimeoutMinute: number;
+}
+
+export interface ConsumerDeleteRequest {
+  brokerNames: string[];
 }
 
 export interface ConsumerResetOffsetRequest {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/consumer.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/consumer.rs
@@ -51,7 +51,13 @@ mod query;
 use self::mutation::consumer_internal_topics;
 use self::mutation::resolve_consumer_target_broker_names;
 use self::mutation::resolve_master_broker_addr;
+#[cfg(test)]
+use self::mutation::run_consumer_delete_batch;
+#[cfg(test)]
+use self::mutation::run_consumer_upsert_batch;
 use self::mutation::validate_consumer_limits;
+#[cfg(test)]
+use self::mutation::ConsumerBatchExecutor;
 use self::query::build_consumer_group_item;
 use self::query::collect_consumer_group_meta;
 use self::query::collect_queue_client_mapping;
@@ -63,19 +69,6 @@ use self::query::message_queue_allocation;
 use self::query::query_consumer_connection_at;
 use self::query::query_consumer_progress_at;
 use self::query::ConsumerGroupMeta;
-
-const CID_RMQ_SYS_PREFIX: &str = "CID_RMQ_SYS_";
-const SYSTEM_CONSUMER_GROUPS: &[&str] = &[
-    "TOOLS_CONSUMER",
-    "FILTERSRV_CONSUMER",
-    "SELF_TEST_C_GROUP",
-    "CID_ONS-HTTP-PROXY",
-    "CID_ONSAPI_PULL",
-    "CID_ONSAPI_PERMISSION",
-    "CID_ONSAPI_OWNER",
-    "CID_RMQ_SYS_TRANS",
-    "CID_DefaultHeartBeatSyncerTopic",
-];
 
 impl ConsumerAdmin for AdminSession {
     fn list_consumer_groups<'a>(
@@ -588,7 +581,7 @@ fn classify_consumer_group(group: &str, meta: &ConsumerGroupMeta) -> String {
 }
 
 fn is_system_consumer_group(group: &str) -> bool {
-    group.starts_with(CID_RMQ_SYS_PREFIX) || SYSTEM_CONSUMER_GROUPS.contains(&group)
+    consumer::is_system_consumer_group(group)
 }
 
 fn collect_master_broker_targets(cluster_info: &ClusterInfo) -> Vec<(String, CheetahString)> {
@@ -730,5 +723,338 @@ mod tests {
             resolve_first_consumer_broker_address(&meta).as_deref(),
             Some("172.19.80.1:10911")
         );
+    }
+
+    mod batch_consumer_tests {
+        use super::*;
+
+        #[derive(Default)]
+        struct FakeBatchExecutor {
+            upsert_calls: Vec<String>,
+            delete_calls: Vec<String>,
+            cleanup_calls: Vec<String>,
+            failing_upsert: Option<String>,
+            failing_delete: Option<String>,
+            failing_cleanup: Option<String>,
+        }
+
+        impl FakeBatchExecutor {
+            fn failing_upsert(target: &str) -> Self {
+                Self {
+                    failing_upsert: Some(target.to_string()),
+                    ..Self::default()
+                }
+            }
+
+            fn failing_delete(target: &str) -> Self {
+                Self {
+                    failing_delete: Some(target.to_string()),
+                    ..Self::default()
+                }
+            }
+
+            fn failing_cleanup(target: &str) -> Self {
+                Self {
+                    failing_cleanup: Some(target.to_string()),
+                    ..Self::default()
+                }
+            }
+
+            fn assert_no_mutations(&self) {
+                assert!(self.upsert_calls.is_empty());
+                assert!(self.delete_calls.is_empty());
+                assert!(self.cleanup_calls.is_empty());
+            }
+        }
+
+        impl ConsumerBatchExecutor for FakeBatchExecutor {
+            fn resolve_upsert_targets<'a>(
+                &'a mut self,
+                request: &'a consumer::DashboardConsumerUpsertRequest,
+            ) -> AdminFuture<'a, Vec<String>> {
+                Box::pin(async move {
+                    let mut targets = request.broker_name_list.clone();
+                    targets.sort();
+                    targets.dedup();
+                    if let Some(unknown) = targets
+                        .iter()
+                        .find(|target| !matches!(target.as_str(), "broker-a" | "broker-b"))
+                    {
+                        return Err(AdminError::invalid_argument(
+                            "brokerNameList",
+                            format!("Broker `{unknown}` was not found in the current cluster view."),
+                        ));
+                    }
+                    Ok(targets)
+                })
+            }
+
+            fn validate_delete_targets<'a>(&'a mut self, targets: &'a [String]) -> AdminFuture<'a, ()> {
+                Box::pin(async move {
+                    if let Some(unknown) = targets
+                        .iter()
+                        .find(|target| !matches!(target.as_str(), "broker-a" | "broker-b"))
+                    {
+                        return Err(AdminError::invalid_argument(
+                            "allBrokerNames",
+                            format!("Broker `{unknown}` was not found in the current cluster view."),
+                        ));
+                    }
+                    Ok(())
+                })
+            }
+
+            fn upsert_target<'a>(
+                &'a mut self,
+                target: &'a str,
+                _request: &'a consumer::DashboardConsumerUpsertRequest,
+            ) -> AdminFuture<'a, ()> {
+                Box::pin(async move {
+                    self.upsert_calls.push(target.to_string());
+                    if self.failing_upsert.as_deref() == Some(target) {
+                        return Err(AdminError::backend("upsert_target", "injected failure"));
+                    }
+                    Ok(())
+                })
+            }
+
+            fn delete_target<'a>(&'a mut self, target: &'a str, _group: &'a str) -> AdminFuture<'a, ()> {
+                Box::pin(async move {
+                    self.delete_calls.push(target.to_string());
+                    if self.failing_delete.as_deref() == Some(target) {
+                        return Err(AdminError::backend("delete_target", "injected failure"));
+                    }
+                    Ok(())
+                })
+            }
+
+            fn cleanup_internal_topic<'a>(
+                &'a mut self,
+                target: &'a str,
+                _broker_names: &'a [String],
+            ) -> AdminFuture<'a, ()> {
+                Box::pin(async move {
+                    self.cleanup_calls.push(target.to_string());
+                    if self.failing_cleanup.as_deref() == Some(target) {
+                        return Err(AdminError::backend("cleanup_internal_topic", "injected failure"));
+                    }
+                    Ok(())
+                })
+            }
+        }
+
+        fn upsert_fixture() -> consumer::DashboardConsumerUpsertRequest {
+            consumer::DashboardConsumerUpsertRequest {
+                cluster_name_list: Vec::new(),
+                broker_name_list: vec![" broker-b ".to_string(), "broker-a".to_string(), "broker-b".to_string()],
+                consumer_group: " orders-consumer ".to_string(),
+                consume_enable: true,
+                consume_from_min_enable: false,
+                consume_broadcast_enable: false,
+                consume_message_orderly: false,
+                retry_queue_nums: 1,
+                retry_max_times: 16,
+                broker_id: 0,
+                which_broker_when_consume_slowly: 1,
+                notify_consumer_ids_changed_enable: true,
+                group_sys_flag: 0,
+                consume_timeout_minute: 15,
+            }
+        }
+
+        fn delete_all_fixture() -> consumer::ConsumerBatchDeleteRequest {
+            consumer::ConsumerBatchDeleteRequest::try_new(
+                "orders-consumer",
+                ["broker-b", "broker-a"],
+                ["broker-a", "broker-b"],
+            )
+            .expect("valid delete request")
+        }
+
+        #[tokio::test]
+        async fn batch_upsert_sorts_deduplicates_and_continues_after_failure() {
+            let mut fake = FakeBatchExecutor::failing_upsert("broker-a");
+            let result = run_consumer_upsert_batch(
+                consumer::ConsumerBatchUpsertRequest::try_new(upsert_fixture()).unwrap(),
+                &mut fake,
+            )
+            .await
+            .unwrap();
+            assert_eq!(fake.upsert_calls, vec!["broker-a", "broker-b"]);
+            assert_eq!(
+                result
+                    .targets
+                    .iter()
+                    .map(|item| (&item.target, item.success))
+                    .collect::<Vec<_>>(),
+                vec![(&"broker-a".to_string(), false), (&"broker-b".to_string(), true),]
+            );
+            assert!(!result.success);
+        }
+
+        #[tokio::test]
+        async fn deleting_all_real_targets_cleans_retry_and_dlq_after_brokers_succeed() {
+            let mut fake = FakeBatchExecutor::default();
+            let result = run_consumer_delete_batch(
+                consumer::ConsumerBatchDeleteRequest::try_new(
+                    "orders-consumer",
+                    ["broker-b", "broker-a"],
+                    ["broker-a", "broker-b"],
+                )
+                .unwrap(),
+                &mut fake,
+            )
+            .await
+            .unwrap();
+            assert_eq!(fake.delete_calls, vec!["broker-a", "broker-b"]);
+            assert_eq!(
+                fake.cleanup_calls,
+                vec!["%RETRY%orders-consumer", "%DLQ%orders-consumer"]
+            );
+            assert!(result.success);
+        }
+
+        #[tokio::test]
+        async fn partial_delete_does_not_clean_internal_topics_and_reports_every_target() {
+            let mut fake = FakeBatchExecutor::failing_delete("broker-a");
+            let result = run_consumer_delete_batch(
+                consumer::ConsumerBatchDeleteRequest::try_new(
+                    "orders-consumer",
+                    ["broker-a", "broker-b"],
+                    ["broker-a", "broker-b"],
+                )
+                .unwrap(),
+                &mut fake,
+            )
+            .await
+            .unwrap();
+            assert!(fake.cleanup_calls.is_empty());
+            assert_eq!(result.targets.len(), 2);
+            assert!(!result.success);
+        }
+
+        #[tokio::test]
+        async fn batch_consumer_successful_subset_delete_does_not_clean_internal_topics() {
+            let mut fake = FakeBatchExecutor::default();
+            let result = run_consumer_delete_batch(
+                consumer::ConsumerBatchDeleteRequest::try_new(
+                    "orders-consumer",
+                    ["broker-a"],
+                    ["broker-a", "broker-b"],
+                )
+                .unwrap(),
+                &mut fake,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(fake.delete_calls, vec!["broker-a"]);
+            assert!(fake.cleanup_calls.is_empty());
+            assert_eq!(result.targets.len(), 1);
+            assert!(result.success);
+        }
+
+        #[tokio::test]
+        async fn cleanup_failure_is_a_structured_failed_target() {
+            let mut fake = FakeBatchExecutor::failing_cleanup("%DLQ%orders-consumer");
+            let result = run_consumer_delete_batch(delete_all_fixture(), &mut fake)
+                .await
+                .unwrap();
+            assert_eq!(result.targets.last().unwrap().target, "%DLQ%orders-consumer");
+            assert_eq!(result.targets.last().unwrap().kind, "INTERNAL_TOPIC_CLEANUP");
+            assert!(!result.targets.last().unwrap().success);
+            assert!(!result.success);
+        }
+
+        #[tokio::test]
+        async fn batch_consumer_upsert_revalidates_before_any_mutation() {
+            let mut invalid_requests = Vec::new();
+
+            let mut blank_group = upsert_fixture();
+            blank_group.consumer_group = " ".to_string();
+            invalid_requests.push(blank_group);
+
+            let mut no_target = upsert_fixture();
+            no_target.broker_name_list.clear();
+            invalid_requests.push(no_target);
+
+            let mut invalid_retry_queues = upsert_fixture();
+            invalid_retry_queues.retry_queue_nums = -1;
+            invalid_requests.push(invalid_retry_queues);
+
+            let mut invalid_retry_max = upsert_fixture();
+            invalid_retry_max.retry_max_times = -2;
+            invalid_requests.push(invalid_retry_max);
+
+            let mut system_group = upsert_fixture();
+            system_group.consumer_group = "TOOLS_CONSUMER".to_string();
+            invalid_requests.push(system_group);
+
+            for request in invalid_requests {
+                assert!(consumer::ConsumerBatchUpsertRequest::try_new(request.clone()).is_err());
+                let mut fake = FakeBatchExecutor::default();
+                let result = run_consumer_upsert_batch(
+                    consumer::batch_test_support::unchecked_upsert_request(request),
+                    &mut fake,
+                )
+                .await;
+                assert!(result.is_err());
+                fake.assert_no_mutations();
+            }
+        }
+
+        #[tokio::test]
+        async fn batch_consumer_unknown_broker_does_not_mutate_any_target() {
+            let mut request = upsert_fixture();
+            request.broker_name_list = vec!["broker-unknown".to_string()];
+            let request = consumer::ConsumerBatchUpsertRequest::try_new(request).unwrap();
+            let mut fake = FakeBatchExecutor::default();
+
+            assert!(run_consumer_upsert_batch(request, &mut fake).await.is_err());
+            fake.assert_no_mutations();
+        }
+
+        #[tokio::test]
+        async fn batch_consumer_delete_revalidates_selected_subset_before_any_mutation() {
+            assert!(consumer::ConsumerBatchDeleteRequest::try_new(
+                "orders-consumer",
+                ["broker-c"],
+                ["broker-a", "broker-b"]
+            )
+            .is_err());
+            let request = consumer::batch_test_support::unchecked_delete_request(
+                "orders-consumer",
+                vec!["broker-c".to_string()],
+                vec!["broker-a".to_string(), "broker-b".to_string()],
+            );
+            let mut fake = FakeBatchExecutor::default();
+
+            assert!(run_consumer_delete_batch(request, &mut fake).await.is_err());
+            fake.assert_no_mutations();
+        }
+
+        #[tokio::test]
+        async fn batch_consumer_delete_rejects_unknown_and_system_groups_without_mutation() {
+            let unknown = consumer::ConsumerBatchDeleteRequest::try_new(
+                "orders-consumer",
+                ["broker-unknown"],
+                ["broker-unknown"],
+            )
+            .unwrap();
+            let mut fake = FakeBatchExecutor::default();
+            assert!(run_consumer_delete_batch(unknown, &mut fake).await.is_err());
+            fake.assert_no_mutations();
+
+            assert!(
+                consumer::ConsumerBatchDeleteRequest::try_new("CID_RMQ_SYS_TRANS", ["broker-a"], ["broker-a"]).is_err()
+            );
+        }
+
+        #[test]
+        fn admin_session_exposes_independent_consumer_batch_mutations() {
+            fn assert_batch_admin<T: consumer::ConsumerBatchMutationAdmin>() {}
+
+            assert_batch_admin::<AdminSession>();
+        }
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/consumer.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/consumer.rs
@@ -35,9 +35,11 @@ use rocketmq_protocol::protocol::subscription::subscription_group_config::Subscr
 use serde_json::json;
 
 use crate::client_adapter::lifecycle::AdminSession;
+use crate::client_adapter::services::consumer::ConsumerService;
 use crate::core::consumer;
 use crate::core::consumer::ConsumerAdmin;
 use crate::core::consumer::ConsumerBatchMutationOutcome;
+use crate::core::consumer::ConsumerDiagnosticAdmin;
 use crate::core::consumer::DeleteSubscriptionGroupsRequest;
 use crate::core::AdminError;
 use crate::core::AdminFuture;
@@ -56,7 +58,10 @@ use self::query::collect_queue_client_mapping;
 use self::query::map_consumer_config;
 use self::query::map_consumer_connection;
 use self::query::map_consumer_progress;
+use self::query::map_consumer_running_info;
 use self::query::message_queue_allocation;
+use self::query::query_consumer_connection_at;
+use self::query::query_consumer_progress_at;
 use self::query::ConsumerGroupMeta;
 
 const CID_RMQ_SYS_PREFIX: &str = "CID_RMQ_SYS_";
@@ -217,12 +222,10 @@ impl ConsumerAdmin for AdminSession {
         Box::pin(async move {
             self.ensure_open()?;
             let group = normalize_consumer_group(&request.consumer_group)?;
-            let connection = self
-                .inner
-                .examine_consumer_connection_info(
-                    CheetahString::from(group.as_str()),
-                    first_address(request.address.as_deref()),
-                )
+            let connection =
+                query_consumer_connection_at(&group, first_address(request.address.as_deref()), |group, address| {
+                    self.inner.examine_consumer_connection_info(group, address)
+                })
                 .await
                 .map_err(|error| backend_error("examine_consumer_connection_info", error))?;
             Ok(map_consumer_connection(&group, connection))
@@ -238,24 +241,22 @@ impl ConsumerAdmin for AdminSession {
             let group = normalize_consumer_group(&request.consumer_group)?;
             let broker_addresses = parse_addresses(request.address.as_deref());
             let stats = if broker_addresses.is_empty() {
-                self.inner
-                    .examine_consume_stats(CheetahString::from(group.as_str()), None, None, None, None)
-                    .await
-                    .map_err(|error| backend_error("examine_consume_stats", error))?
+                query_consumer_progress_at(&group, None, None, |group, address, timeout| {
+                    self.inner.examine_consume_stats(group, None, None, address, timeout)
+                })
+                .await
+                .map_err(|error| backend_error("examine_consume_stats", error))?
             } else {
                 let mut merged_stats = ConsumeStats::new();
                 for broker_addr in broker_addresses {
-                    let stats = self
-                        .inner
-                        .examine_consume_stats(
-                            CheetahString::from(group.as_str()),
-                            None,
-                            None,
-                            Some(broker_addr),
-                            Some(3_000),
-                        )
-                        .await
-                        .map_err(|error| backend_error("examine_consume_stats", error))?;
+                    let stats = query_consumer_progress_at(
+                        &group,
+                        Some(broker_addr),
+                        Some(3_000),
+                        |group, address, timeout| self.inner.examine_consume_stats(group, None, None, address, timeout),
+                    )
+                    .await
+                    .map_err(|error| backend_error("examine_consume_stats", error))?;
                     merged_stats.consume_tps += stats.get_consume_tps();
                     merged_stats
                         .get_offset_table_mut()
@@ -527,6 +528,27 @@ impl ConsumerAdmin for AdminSession {
     }
 }
 
+impl ConsumerDiagnosticAdmin for AdminSession {
+    fn query_dashboard_consumer_running_info<'a>(
+        &'a mut self,
+        request: &'a consumer::DashboardConsumerRunningInfoRequest,
+    ) -> AdminFuture<'a, consumer::DashboardConsumerRunningInfo> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            let running_info = ConsumerService::query_dashboard_consumer_running_info_with_admin(&self.inner, request)
+                .await
+                .map_err(|error| backend_error("get_consumer_running_info", error))?;
+            Ok(map_consumer_running_info(
+                request.consumer_group(),
+                request.client_id(),
+                request.include_jstack(),
+                request.max_output_bytes(),
+                running_info,
+            ))
+        })
+    }
+}
+
 fn normalize_consumer_group(value: &str) -> AdminResult<String> {
     let value = value.strip_prefix("%SYS%").unwrap_or(value).trim();
     validate_subscription_group_name(value)
@@ -662,6 +684,13 @@ fn backend_error(operation: &'static str, error: RocketMQError) -> AdminError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn admin_session_exposes_independent_consumer_diagnostics() {
+        fn assert_diagnostic_admin<T: consumer::ConsumerDiagnosticAdmin>() {}
+
+        assert_diagnostic_admin::<AdminSession>();
+    }
 
     #[test]
     fn classify_consumer_group_preserves_dashboard_categories() {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/consumer/mutation.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/consumer/mutation.rs
@@ -15,14 +15,317 @@
 use std::collections::HashSet;
 
 use cheetah_string::CheetahString;
+use rocketmq_client_rust::{ConsumerAdmin as _, RouteAdmin as _, TopicAdmin as _};
 use rocketmq_model::topic::DLQ_GROUP_TOPIC_PREFIX;
 use rocketmq_model::topic::RETRY_GROUP_TOPIC_PREFIX;
 use rocketmq_protocol::common::wire_constants::MASTER_ID;
 use rocketmq_protocol::protocol::body::broker_body::cluster_info::ClusterInfo;
+use rocketmq_protocol::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
 
+use crate::client_adapter::lifecycle::AdminSession;
 use crate::core::consumer;
+use crate::core::consumer::ConsumerBatchMutationAdmin;
+use crate::core::stable_error_message;
 use crate::core::AdminError;
+use crate::core::AdminFuture;
 use crate::core::AdminResult;
+
+use super::backend_error;
+
+struct AdminSessionBatchExecutor<'a> {
+    session: &'a mut AdminSession,
+    cluster_info: ClusterInfo,
+}
+
+impl ConsumerBatchExecutor for AdminSessionBatchExecutor<'_> {
+    fn resolve_upsert_targets<'a>(
+        &'a mut self,
+        request: &'a consumer::DashboardConsumerUpsertRequest,
+    ) -> AdminFuture<'a, Vec<String>> {
+        Box::pin(async move {
+            let broker_names = resolve_consumer_target_broker_names(
+                &self.cluster_info,
+                &request.cluster_name_list,
+                &request.broker_name_list,
+            )?;
+            for broker_name in &broker_names {
+                if resolve_master_broker_addr(&self.cluster_info, broker_name).is_none() {
+                    return Err(AdminError::invalid_argument(
+                        "brokerNameList",
+                        format!("Broker `{broker_name}` does not have a reachable master address."),
+                    ));
+                }
+            }
+            Ok(broker_names)
+        })
+    }
+
+    fn validate_delete_targets<'a>(&'a mut self, targets: &'a [String]) -> AdminFuture<'a, ()> {
+        Box::pin(async move {
+            for broker_name in targets {
+                if resolve_master_broker_addr(&self.cluster_info, broker_name).is_none() {
+                    return Err(AdminError::invalid_argument(
+                        "allBrokerNames",
+                        format!("Broker `{broker_name}` does not have a reachable master address."),
+                    ));
+                }
+            }
+            Ok(())
+        })
+    }
+
+    fn upsert_target<'a>(
+        &'a mut self,
+        target: &'a str,
+        request: &'a consumer::DashboardConsumerUpsertRequest,
+    ) -> AdminFuture<'a, ()> {
+        Box::pin(async move {
+            let broker_addr = resolve_master_broker_addr(&self.cluster_info, target).ok_or_else(|| {
+                AdminError::invalid_argument(
+                    "brokerNameList",
+                    format!("Broker `{target}` does not have a reachable master address."),
+                )
+            })?;
+            let mut config = SubscriptionGroupConfig::default();
+            config.set_group_name(CheetahString::from(request.consumer_group.as_str()));
+            config.set_consume_enable(request.consume_enable);
+            config.set_consume_from_min_enable(request.consume_from_min_enable);
+            config.set_consume_broadcast_enable(request.consume_broadcast_enable);
+            config.set_consume_message_orderly(request.consume_message_orderly);
+            config.set_retry_queue_nums(request.retry_queue_nums);
+            config.set_retry_max_times(request.retry_max_times);
+            config.set_broker_id(request.broker_id);
+            config.set_which_broker_when_consume_slowly(request.which_broker_when_consume_slowly);
+            config.set_notify_consumer_ids_changed_enable(request.notify_consumer_ids_changed_enable);
+            config.set_group_sys_flag(request.group_sys_flag);
+            config.set_consume_timeout_minute(request.consume_timeout_minute);
+            self.session
+                .inner
+                .create_and_update_subscription_group_config(broker_addr, config)
+                .await
+                .map_err(|error| backend_error("create_and_update_subscription_group_config", error))
+        })
+    }
+
+    fn delete_target<'a>(&'a mut self, target: &'a str, group: &'a str) -> AdminFuture<'a, ()> {
+        Box::pin(async move {
+            let broker_addr = resolve_master_broker_addr(&self.cluster_info, target).ok_or_else(|| {
+                AdminError::invalid_argument(
+                    "selectedBrokerNames",
+                    format!("Broker `{target}` does not have a reachable master address."),
+                )
+            })?;
+            self.session
+                .inner
+                .delete_subscription_group(broker_addr, CheetahString::from(group), Some(true))
+                .await
+                .map_err(|error| backend_error("delete_subscription_group", error))
+        })
+    }
+
+    fn cleanup_internal_topic<'a>(&'a mut self, target: &'a str, broker_names: &'a [String]) -> AdminFuture<'a, ()> {
+        Box::pin(async move {
+            let mut broker_addresses = HashSet::with_capacity(broker_names.len());
+            for broker_name in broker_names {
+                let broker_addr = resolve_master_broker_addr(&self.cluster_info, broker_name).ok_or_else(|| {
+                    AdminError::invalid_argument(
+                        "allBrokerNames",
+                        format!("Broker `{broker_name}` does not have a reachable master address."),
+                    )
+                })?;
+                broker_addresses.insert(broker_addr);
+            }
+            self.session
+                .inner
+                .delete_topic_in_broker(broker_addresses, CheetahString::from(target))
+                .await
+                .map_err(|error| backend_error("delete_topic_in_broker", error))?;
+            let namesrv_targets = self
+                .session
+                .inner
+                .get_name_server_address_list()
+                .await
+                .into_iter()
+                .collect::<HashSet<_>>();
+            self.session
+                .inner
+                .delete_topic_in_name_server(namesrv_targets, None, CheetahString::from(target))
+                .await
+                .map_err(|error| backend_error("delete_topic_in_name_server", error))
+        })
+    }
+}
+
+impl ConsumerBatchMutationAdmin for AdminSession {
+    fn upsert_consumer_group_batch<'a>(
+        &'a mut self,
+        request: &'a consumer::ConsumerBatchUpsertRequest,
+    ) -> AdminFuture<'a, consumer::DashboardConsumerBatchResult> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            let request = consumer::ConsumerBatchUpsertRequest::try_new(request.inner().clone())?;
+            let cluster_info = self
+                .inner
+                .examine_broker_cluster_info()
+                .await
+                .map_err(|error| backend_error("examine_broker_cluster_info", error))?;
+            let mut executor = AdminSessionBatchExecutor {
+                session: self,
+                cluster_info,
+            };
+            run_consumer_upsert_batch(request, &mut executor).await
+        })
+    }
+
+    fn delete_consumer_group_batch<'a>(
+        &'a mut self,
+        request: &'a consumer::ConsumerBatchDeleteRequest,
+    ) -> AdminFuture<'a, consumer::DashboardConsumerBatchResult> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            let request = consumer::ConsumerBatchDeleteRequest::try_new(
+                request.consumer_group(),
+                request.selected_broker_names().to_vec(),
+                request.all_broker_names().to_vec(),
+            )?;
+            let cluster_info = self
+                .inner
+                .examine_broker_cluster_info()
+                .await
+                .map_err(|error| backend_error("examine_broker_cluster_info", error))?;
+            let mut executor = AdminSessionBatchExecutor {
+                session: self,
+                cluster_info,
+            };
+            run_consumer_delete_batch(request, &mut executor).await
+        })
+    }
+}
+
+pub(super) trait ConsumerBatchExecutor {
+    fn resolve_upsert_targets<'a>(
+        &'a mut self,
+        request: &'a consumer::DashboardConsumerUpsertRequest,
+    ) -> AdminFuture<'a, Vec<String>>;
+
+    fn validate_delete_targets<'a>(&'a mut self, targets: &'a [String]) -> AdminFuture<'a, ()>;
+
+    fn upsert_target<'a>(
+        &'a mut self,
+        target: &'a str,
+        request: &'a consumer::DashboardConsumerUpsertRequest,
+    ) -> AdminFuture<'a, ()>;
+
+    fn delete_target<'a>(&'a mut self, target: &'a str, group: &'a str) -> AdminFuture<'a, ()>;
+
+    fn cleanup_internal_topic<'a>(&'a mut self, target: &'a str, broker_names: &'a [String]) -> AdminFuture<'a, ()>;
+}
+
+pub(super) async fn run_consumer_upsert_batch<Executor>(
+    request: consumer::ConsumerBatchUpsertRequest,
+    executor: &mut Executor,
+) -> AdminResult<consumer::DashboardConsumerBatchResult>
+where
+    Executor: ConsumerBatchExecutor + ?Sized,
+{
+    let request = consumer::ConsumerBatchUpsertRequest::try_new(request.inner().clone())?;
+    let mut targets = executor.resolve_upsert_targets(request.inner()).await?;
+    for target in &mut targets {
+        *target = target.trim().to_string();
+    }
+    targets.retain(|target| !target.is_empty());
+    targets.sort();
+    targets.dedup();
+    if targets.is_empty() {
+        return Err(AdminError::invalid_argument(
+            "brokerNameList",
+            "Select at least one cluster or broker before saving the consumer group.",
+        ));
+    }
+
+    let mut outcomes = Vec::with_capacity(targets.len());
+    for target in targets {
+        let result = executor.upsert_target(&target, request.inner()).await;
+        outcomes.push(target_outcome(target, "BROKER", "Consumer group updated.", result));
+    }
+    let success = outcomes.iter().all(|outcome| outcome.success);
+    Ok(consumer::DashboardConsumerBatchResult {
+        consumer_group: request.inner().consumer_group.clone(),
+        success,
+        targets: outcomes,
+    })
+}
+
+pub(super) async fn run_consumer_delete_batch<Executor>(
+    request: consumer::ConsumerBatchDeleteRequest,
+    executor: &mut Executor,
+) -> AdminResult<consumer::DashboardConsumerBatchResult>
+where
+    Executor: ConsumerBatchExecutor + ?Sized,
+{
+    let request = consumer::ConsumerBatchDeleteRequest::try_new(
+        request.consumer_group(),
+        request.selected_broker_names().to_vec(),
+        request.all_broker_names().to_vec(),
+    )?;
+    executor.validate_delete_targets(request.all_broker_names()).await?;
+
+    let mut outcomes = Vec::with_capacity(request.selected_broker_names().len() + 2);
+    for target in request.selected_broker_names() {
+        let result = executor.delete_target(target, request.consumer_group()).await;
+        outcomes.push(target_outcome(
+            target.clone(),
+            "BROKER",
+            "Consumer group deleted.",
+            result,
+        ));
+    }
+
+    let all_brokers_succeeded = outcomes.iter().all(|outcome| outcome.success);
+    let all_real_targets_selected = request.selected_broker_names() == request.all_broker_names();
+    if all_real_targets_selected && all_brokers_succeeded {
+        for topic in consumer_internal_topics(request.consumer_group()) {
+            let result = executor
+                .cleanup_internal_topic(&topic, request.all_broker_names())
+                .await;
+            outcomes.push(target_outcome(
+                topic,
+                "INTERNAL_TOPIC_CLEANUP",
+                "Internal consumer topic deleted.",
+                result,
+            ));
+        }
+    }
+
+    let success = outcomes.iter().all(|outcome| outcome.success);
+    Ok(consumer::DashboardConsumerBatchResult {
+        consumer_group: request.consumer_group().to_string(),
+        success,
+        targets: outcomes,
+    })
+}
+
+fn target_outcome(
+    target: String,
+    kind: &str,
+    success_message: &str,
+    result: AdminResult<()>,
+) -> consumer::DashboardConsumerTargetOutcome {
+    match result {
+        Ok(()) => consumer::DashboardConsumerTargetOutcome {
+            target,
+            kind: kind.to_string(),
+            success: true,
+            message: success_message.to_string(),
+        },
+        Err(error) => consumer::DashboardConsumerTargetOutcome {
+            target,
+            kind: kind.to_string(),
+            success: false,
+            message: stable_error_message(&error),
+        },
+    }
+}
 
 pub(super) fn resolve_master_broker_addr(cluster_info: &ClusterInfo, broker_name: &str) -> Option<CheetahString> {
     cluster_info

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/consumer/query.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/consumer/query.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::future::Future;
 
 use cheetah_string::CheetahString;
 use rocketmq_client_rust::ConsumerAdmin as _;
@@ -23,6 +24,7 @@ use rocketmq_protocol::protocol::admin::consume_stats::ConsumeStats;
 use rocketmq_protocol::protocol::admin::offset_wrapper::OffsetWrapper;
 use rocketmq_protocol::protocol::body::broker_body::cluster_info::ClusterInfo;
 use rocketmq_protocol::protocol::body::consumer_connection::ConsumerConnection;
+use rocketmq_protocol::protocol::body::consumer_running_info::ConsumerRunningInfo;
 use rocketmq_protocol::protocol::subscription::subscription_group_config::SubscriptionGroupConfig;
 
 use super::backend_error;
@@ -40,6 +42,31 @@ pub(super) struct ConsumerGroupMeta {
     pub(super) broker_names: HashSet<String>,
     pub(super) broker_addresses: HashSet<String>,
     pub(super) orderly_flags: Vec<bool>,
+}
+
+pub(super) async fn query_consumer_connection_at<Query, QueryFuture>(
+    group: &str,
+    address: Option<CheetahString>,
+    query: Query,
+) -> rocketmq_error::RocketMQResult<ConsumerConnection>
+where
+    Query: FnOnce(CheetahString, Option<CheetahString>) -> QueryFuture,
+    QueryFuture: Future<Output = rocketmq_error::RocketMQResult<ConsumerConnection>>,
+{
+    query(CheetahString::from(group), address).await
+}
+
+pub(super) async fn query_consumer_progress_at<Query, QueryFuture>(
+    group: &str,
+    address: Option<CheetahString>,
+    timeout_millis: Option<u64>,
+    query: Query,
+) -> rocketmq_error::RocketMQResult<ConsumeStats>
+where
+    Query: FnOnce(CheetahString, Option<CheetahString>, Option<u64>) -> QueryFuture,
+    QueryFuture: Future<Output = rocketmq_error::RocketMQResult<ConsumeStats>>,
+{
+    query(CheetahString::from(group), address, timeout_millis).await
 }
 
 pub(super) async fn collect_consumer_group_meta(
@@ -104,9 +131,10 @@ pub(super) async fn build_consumer_group_item(
     };
     let mut consume_tps = 0_i64;
     let mut diff_total = 0_i64;
-    if let Ok(stats) = admin
-        .examine_consume_stats(CheetahString::from(group), None, None, None, None)
-        .await
+    if let Ok(stats) = query_consumer_progress_at(group, address.clone(), None, |group, address, timeout| {
+        admin.examine_consume_stats(group, None, None, address, timeout)
+    })
+    .await
     {
         consume_tps = stats.get_consume_tps().round() as i64;
         diff_total = stats.compute_total_diff();
@@ -117,9 +145,10 @@ pub(super) async fn build_consumer_group_item(
     let mut consume_type = "UNKNOWN".to_string();
     let mut version = None;
     let mut version_desc = "OFFLINE".to_string();
-    if let Ok(connection) = admin
-        .examine_consumer_connection_info(CheetahString::from(group), address)
-        .await
+    if let Ok(connection) = query_consumer_connection_at(group, address, |group, address| {
+        admin.examine_consumer_connection_info(group, address)
+    })
+    .await
     {
         connection_count = connection.get_connection_set().len();
         if let Some(model) = connection.get_message_model() {
@@ -297,6 +326,112 @@ pub(super) fn map_consumer_config(
     }
 }
 
+pub(super) fn map_consumer_running_info(
+    group: &str,
+    client_id: &str,
+    include_jstack: bool,
+    max_output_bytes: usize,
+    running_info: ConsumerRunningInfo,
+) -> consumer::DashboardConsumerRunningInfo {
+    let mut budget = Utf8Budget::new(max_output_bytes);
+    let properties = running_info
+        .properties
+        .into_iter()
+        .map(|(key, value)| consumer::DashboardConsumerConfigAttribute {
+            key: budget.take(&key),
+            value: budget.take(&value),
+        })
+        .collect();
+
+    let mut subscriptions = running_info
+        .subscription_set
+        .into_iter()
+        .map(|item| consumer::DashboardConsumerSubscriptionItem {
+            topic: item.topic.to_string(),
+            sub_string: item.sub_string.to_string(),
+            expression_type: item.expression_type.to_string(),
+            tags_set: item.tags_set.into_iter().map(|tag| tag.to_string()).collect(),
+            code_set: item.code_set.into_iter().collect(),
+            sub_version: item.sub_version,
+        })
+        .collect::<Vec<_>>();
+    subscriptions.sort_by(|left, right| {
+        left.topic
+            .cmp(&right.topic)
+            .then(left.expression_type.cmp(&right.expression_type))
+            .then(left.sub_string.cmp(&right.sub_string))
+            .then(left.tags_set.cmp(&right.tags_set))
+            .then(left.code_set.cmp(&right.code_set))
+            .then(left.sub_version.cmp(&right.sub_version))
+    });
+
+    let mut process_queues = running_info
+        .mq_table
+        .into_iter()
+        .map(|(queue, info)| consumer::DashboardConsumerProcessQueue {
+            topic: queue.topic().to_string(),
+            broker_name: queue.broker_name().to_string(),
+            queue_id: queue.queue_id(),
+            cached_message_count: i64::from(info.cached_msg_count),
+            cached_message_size_in_mib: i64::from(info.cached_msg_size_in_mib),
+            commit_offset: info.commit_offset,
+            dropped: info.droped,
+            last_consume_timestamp: i64::try_from(info.last_consume_timestamp).unwrap_or(i64::MAX),
+        })
+        .collect::<Vec<_>>();
+    process_queues.sort_by(|left, right| {
+        left.topic
+            .cmp(&right.topic)
+            .then(left.broker_name.cmp(&right.broker_name))
+            .then(left.queue_id.cmp(&right.queue_id))
+    });
+
+    let jstack = if include_jstack {
+        running_info.jstack.map(|jstack| budget.take(&jstack))
+    } else {
+        None
+    };
+
+    consumer::DashboardConsumerRunningInfo {
+        consumer_group: group.to_string(),
+        client_id: client_id.to_string(),
+        properties,
+        subscriptions,
+        process_queues,
+        jstack,
+        truncated: budget.truncated,
+    }
+}
+
+struct Utf8Budget {
+    remaining: usize,
+    truncated: bool,
+}
+
+impl Utf8Budget {
+    const fn new(max_output_bytes: usize) -> Self {
+        Self {
+            remaining: max_output_bytes,
+            truncated: false,
+        }
+    }
+
+    fn take(&mut self, value: &str) -> String {
+        if value.len() <= self.remaining {
+            self.remaining -= value.len();
+            return value.to_string();
+        }
+
+        self.truncated = true;
+        let mut end = self.remaining.min(value.len());
+        while !value.is_char_boundary(end) {
+            end -= 1;
+        }
+        self.remaining -= end;
+        value[..end].to_string()
+    }
+}
+
 pub(super) async fn collect_queue_client_mapping(
     admin: &mut rocketmq_client_rust::DefaultMQAdminExt,
     group: &str,
@@ -361,4 +496,237 @@ pub(super) async fn message_queue_allocation(
         }
     }
     allocation
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use cheetah_string::CheetahString;
+    use rocketmq_model::version::RocketMqVersion;
+    use rocketmq_protocol::protocol::admin::consume_stats::ConsumeStats;
+    use rocketmq_protocol::protocol::admin::offset_wrapper::OffsetWrapper;
+    use rocketmq_protocol::protocol::body::connection::Connection;
+    use rocketmq_protocol::protocol::body::consumer_connection::ConsumerConnection;
+    use rocketmq_protocol::protocol::body::consumer_running_info::ConsumerRunningInfo;
+    use rocketmq_protocol::protocol::body::process_queue_info::ProcessQueueInfo;
+    use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct CapturingQueryClient {
+        connection_addresses: Vec<Option<String>>,
+        progress_addresses: Vec<Option<String>>,
+    }
+
+    impl CapturingQueryClient {
+        fn query_connection(&mut self, address: Option<CheetahString>) {
+            self.connection_addresses.push(address.map(|value| value.to_string()));
+        }
+
+        fn query_progress(&mut self, address: Option<CheetahString>) {
+            self.progress_addresses.push(address.map(|value| value.to_string()));
+        }
+    }
+
+    fn connection_fixture() -> ConsumerConnection {
+        let mut client = Connection::new();
+        client.set_client_id(CheetahString::from_static_str("client-a"));
+        client.set_client_addr(CheetahString::from_static_str("10.0.0.8:12000"));
+        client.set_version(RocketMqVersion::V5_3_0 as i32);
+
+        let mut subscription = SubscriptionData {
+            topic: CheetahString::from_static_str("orders"),
+            sub_string: CheetahString::from_static_str("created || paid"),
+            ..SubscriptionData::default()
+        };
+        subscription.tags_set.extend([
+            CheetahString::from_static_str("created"),
+            CheetahString::from_static_str("paid"),
+        ]);
+
+        let mut connection = ConsumerConnection::new();
+        connection.insert_connection(client);
+        connection
+            .get_subscription_table_mut()
+            .insert(CheetahString::from_static_str("orders"), subscription);
+        connection
+    }
+
+    fn consume_stats_fixture() -> ConsumeStats {
+        let mut stats = ConsumeStats::new();
+        for (topic, broker_name, queue_id, broker_offset, consumer_offset) in [
+            ("payments", "broker-b", 1, 24, 20),
+            ("orders", "broker-b", 1, 115, 100),
+            ("orders", "broker-a", 0, 123, 100),
+        ] {
+            let mut offset = OffsetWrapper::new();
+            offset.set_broker_offset(broker_offset);
+            offset.set_consumer_offset(consumer_offset);
+            stats
+                .get_offset_table_mut()
+                .insert(MessageQueue::from_parts(topic, broker_name, queue_id), offset);
+        }
+        stats
+    }
+
+    fn client_map_fixture() -> HashMap<MessageQueue, String> {
+        HashMap::from([
+            (
+                MessageQueue::from_parts("orders", "broker-a", 0),
+                "10.0.0.8@client-a".to_string(),
+            ),
+            (
+                MessageQueue::from_parts("orders", "broker-b", 1),
+                "10.0.0.9@client-b".to_string(),
+            ),
+        ])
+    }
+
+    fn running_info_fixture() -> ConsumerRunningInfo {
+        let mut running_info = ConsumerRunningInfo::new();
+        running_info.properties.insert("z-key".to_string(), "last".to_string());
+        running_info.properties.insert("a".to_string(), "éé".to_string());
+        running_info.subscription_set.extend([
+            SubscriptionData {
+                topic: CheetahString::from_static_str("payments"),
+                sub_string: CheetahString::from_static_str("*"),
+                ..SubscriptionData::default()
+            },
+            SubscriptionData {
+                topic: CheetahString::from_static_str("orders"),
+                sub_string: CheetahString::from_static_str("created"),
+                ..SubscriptionData::default()
+            },
+        ]);
+        running_info.mq_table.insert(
+            MessageQueue::from_parts("payments", "broker-b", 1),
+            ProcessQueueInfo {
+                commit_offset: 17,
+                cached_msg_count: 4,
+                cached_msg_size_in_mib: 2,
+                droped: true,
+                last_consume_timestamp: 23,
+                ..ProcessQueueInfo::default()
+            },
+        );
+        running_info.mq_table.insert(
+            MessageQueue::from_parts("orders", "broker-a", 0),
+            ProcessQueueInfo {
+                commit_offset: 11,
+                cached_msg_count: 3,
+                cached_msg_size_in_mib: 1,
+                last_consume_timestamp: 19,
+                ..ProcessQueueInfo::default()
+            },
+        );
+        running_info.jstack = Some("栈栈".to_string());
+        running_info
+    }
+
+    #[test]
+    fn connection_mapping_preserves_client_and_subscription_identity() {
+        let mapped = map_consumer_connection("orders-consumer", connection_fixture());
+        assert_eq!(mapped.consumer_group, "orders-consumer");
+        assert_eq!(mapped.connections[0].client_id, "client-a");
+        assert_eq!(mapped.connections[0].client_addr, "10.0.0.8:12000");
+        assert_eq!(mapped.connections[0].version_desc, "V5_3_0");
+        assert_eq!(mapped.subscriptions[0].topic, "orders");
+        assert_eq!(mapped.subscriptions[0].expression_type, "TAG");
+        assert_eq!(mapped.subscriptions[0].tags_set, vec!["created", "paid"]);
+    }
+
+    #[tokio::test]
+    async fn query_address_forwarding_preserves_explicit_proxy_and_discovery() {
+        let mut fake = CapturingQueryClient::default();
+        let proxy = Some(CheetahString::from_static_str("proxy-a:8081"));
+
+        query_consumer_connection_at("orders-consumer", proxy.clone(), |_, address| {
+            fake.query_connection(address);
+            std::future::ready(Ok(connection_fixture()))
+        })
+        .await
+        .expect("explicit connection query");
+        query_consumer_progress_at("orders-consumer", proxy, Some(3_000), |_, address, _| {
+            fake.query_progress(address);
+            std::future::ready(Ok(consume_stats_fixture()))
+        })
+        .await
+        .expect("explicit progress query");
+        query_consumer_connection_at("orders-consumer", None, |_, address| {
+            fake.query_connection(address);
+            std::future::ready(Ok(connection_fixture()))
+        })
+        .await
+        .expect("discovered connection query");
+        query_consumer_progress_at("orders-consumer", None, None, |_, address, _| {
+            fake.query_progress(address);
+            std::future::ready(Ok(consume_stats_fixture()))
+        })
+        .await
+        .expect("discovered progress query");
+
+        assert_eq!(fake.connection_addresses, vec![Some("proxy-a:8081".to_string()), None]);
+        assert_eq!(fake.progress_addresses, vec![Some("proxy-a:8081".to_string()), None]);
+    }
+
+    #[test]
+    fn progress_mapping_groups_and_sorts_queues_by_topic_broker_and_queue() {
+        let mapped = map_consumer_progress("orders-consumer", consume_stats_fixture(), &client_map_fixture());
+        assert_eq!(
+            mapped.topics.iter().map(|item| item.topic.as_str()).collect::<Vec<_>>(),
+            vec!["orders", "payments"]
+        );
+        assert_eq!(mapped.topics[0].queues[0].broker_name, "broker-a");
+        assert_eq!(mapped.topics[0].queues[0].queue_id, 0);
+        assert_eq!(mapped.topics[0].queues[0].client_info, "10.0.0.8@client-a");
+        assert_eq!(mapped.total_diff, 42);
+    }
+
+    #[test]
+    fn running_info_mapping_sorts_sections_and_bounds_multibyte_text_and_jstack() {
+        let mapped = map_consumer_running_info("orders-consumer", "10.0.0.8@client-a", true, 4, running_info_fixture());
+
+        assert_eq!(
+            mapped
+                .properties
+                .iter()
+                .map(|item| (item.key.as_str(), item.value.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("a", "é"), ("z", "")]
+        );
+        assert_eq!(
+            mapped
+                .subscriptions
+                .iter()
+                .map(|item| item.topic.as_str())
+                .collect::<Vec<_>>(),
+            vec!["orders", "payments"]
+        );
+        assert_eq!(
+            mapped
+                .process_queues
+                .iter()
+                .map(|item| (item.topic.as_str(), item.broker_name.as_str(), item.queue_id))
+                .collect::<Vec<_>>(),
+            vec![("orders", "broker-a", 0), ("payments", "broker-b", 1)]
+        );
+        assert_eq!(mapped.jstack.as_deref(), Some(""));
+        assert!(mapped.truncated);
+    }
+
+    #[test]
+    fn running_info_mapping_omits_jstack_when_it_was_not_requested() {
+        let mapped = map_consumer_running_info(
+            "orders-consumer",
+            "10.0.0.8@client-a",
+            false,
+            1_048_576,
+            running_info_fixture(),
+        );
+
+        assert_eq!(mapped.jstack, None);
+        assert!(!mapped.truncated);
+    }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/consumer/query.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/consumer/query.rs
@@ -202,7 +202,14 @@ pub(super) fn map_consumer_connection(
                 .to_string(),
         })
         .collect::<Vec<_>>();
-    connections.sort_by(|left, right| left.client_id.cmp(&right.client_id));
+    connections.sort_by(|left, right| {
+        left.client_id
+            .cmp(&right.client_id)
+            .then(left.client_addr.cmp(&right.client_addr))
+            .then(left.language.cmp(&right.language))
+            .then(left.version.cmp(&right.version))
+            .then(left.version_desc.cmp(&right.version_desc))
+    });
     let mut subscriptions = connection
         .get_subscription_table()
         .values()
@@ -387,7 +394,13 @@ pub(super) fn map_consumer_running_info(
     });
 
     let jstack = if include_jstack {
-        running_info.jstack.map(|jstack| budget.take(&jstack))
+        match running_info.jstack {
+            Some(jstack) => Some(budget.take(&jstack)),
+            None => {
+                budget.truncated = true;
+                None
+            }
+        }
     } else {
         None
     };
@@ -511,6 +524,7 @@ mod tests {
     use rocketmq_protocol::protocol::body::consumer_running_info::ConsumerRunningInfo;
     use rocketmq_protocol::protocol::body::process_queue_info::ProcessQueueInfo;
     use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
+    use rocketmq_protocol::protocol::LanguageCode;
 
     use super::*;
 
@@ -551,6 +565,24 @@ mod tests {
         connection
             .get_subscription_table_mut()
             .insert(CheetahString::from_static_str("orders"), subscription);
+        connection
+    }
+
+    fn duplicate_client_id_connection_fixture() -> ConsumerConnection {
+        let mut connection = ConsumerConnection::new();
+        for (client_addr, language, version) in [
+            ("10.0.0.9:12000", LanguageCode::JAVA, RocketMqVersion::V5_3_0),
+            ("10.0.0.8:12000", LanguageCode::RUST, RocketMqVersion::V5_2_0),
+            ("10.0.0.8:12000", LanguageCode::JAVA, RocketMqVersion::V5_3_0),
+            ("10.0.0.8:12000", LanguageCode::JAVA, RocketMqVersion::V5_2_0),
+        ] {
+            let mut client = Connection::new();
+            client.set_client_id(CheetahString::from_static_str("client-a"));
+            client.set_client_addr(CheetahString::from(client_addr));
+            client.set_language(language);
+            client.set_version(version as i32);
+            connection.insert_connection(client);
+        }
         connection
     }
 
@@ -635,6 +667,34 @@ mod tests {
         assert_eq!(mapped.subscriptions[0].topic, "orders");
         assert_eq!(mapped.subscriptions[0].expression_type, "TAG");
         assert_eq!(mapped.subscriptions[0].tags_set, vec!["created", "paid"]);
+    }
+
+    #[test]
+    fn connection_mapping_totally_orders_duplicate_client_ids() {
+        let expected = vec![
+            ("10.0.0.8:12000", "JAVA", "V5_2_0"),
+            ("10.0.0.8:12000", "JAVA", "V5_3_0"),
+            ("10.0.0.8:12000", "RUST", "V5_2_0"),
+            ("10.0.0.9:12000", "JAVA", "V5_3_0"),
+        ];
+
+        for _ in 0..32 {
+            let mapped = map_consumer_connection("orders-consumer", duplicate_client_id_connection_fixture());
+            assert_eq!(
+                mapped
+                    .connections
+                    .iter()
+                    .map(|item| {
+                        (
+                            item.client_addr.as_str(),
+                            item.language.as_str(),
+                            item.version_desc.as_str(),
+                        )
+                    })
+                    .collect::<Vec<_>>(),
+                expected
+            );
+        }
     }
 
     #[tokio::test]
@@ -728,5 +788,16 @@ mod tests {
 
         assert_eq!(mapped.jstack, None);
         assert!(!mapped.truncated);
+    }
+
+    #[test]
+    fn running_info_mapping_marks_requested_but_absent_jstack_as_truncated() {
+        let mut running_info = running_info_fixture();
+        running_info.jstack = None;
+
+        let mapped = map_consumer_running_info("orders-consumer", "10.0.0.8@client-a", true, 1_048_576, running_info);
+
+        assert_eq!(mapped.jstack, None);
+        assert!(mapped.truncated);
     }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/dashboard.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/dashboard.rs
@@ -39,8 +39,10 @@ use rocketmq_protocol::protocol::body::kv_table::KVTable;
 use rocketmq_protocol::protocol::body::producer_connection::ProducerConnection;
 use rocketmq_protocol::protocol::body::user_info::UserInfo;
 use rocketmq_protocol::protocol::route::topic_route_data::TopicRouteData;
+use rocketmq_protocol::protocol::subscription::subscription_group_config::validate_subscription_group_name;
 
 use crate::client_adapter::lifecycle::AdminSession;
+use crate::core::consumer::is_system_consumer_group;
 use crate::core::dashboard;
 use crate::core::AdminError;
 use crate::core::AdminFuture;
@@ -320,6 +322,54 @@ impl dashboard::DashboardAdmin for AdminSession {
                 ),
                 target_count: offsets.len(),
             })
+        })
+    }
+
+    fn dashboard_consumer_brokers<'a>(
+        &'a self,
+        group: &'a str,
+    ) -> AdminFuture<'a, dashboard::DashboardConsumerBrokerList> {
+        Box::pin(async move {
+            self.ensure_open()?;
+            let group = group.trim();
+            if group.is_empty() || group.starts_with("%SYS%") || is_system_consumer_group(group) {
+                return Err(AdminError::invalid_argument(
+                    "consumerGroup",
+                    "System consumer groups cannot be inspected for deletion.",
+                ));
+            }
+            validate_subscription_group_name(group)
+                .map_err(|error| AdminError::invalid_argument("consumerGroup", error.to_string()))?;
+
+            let cluster_info = self
+                .inner
+                .examine_broker_cluster_info()
+                .await
+                .map_err(|error| backend_error("examine_broker_cluster_info", error))?;
+            let targets = authoritative_consumer_broker_targets(&cluster_info)?;
+            let mut items = Vec::new();
+            for (broker_name, broker_addr) in targets {
+                let wrapper = self
+                    .inner
+                    .get_all_subscription_group(CheetahString::from(broker_addr.as_str()), 5_000)
+                    .await
+                    .map_err(|error| backend_error("get_all_subscription_group", error))?;
+                let has_group = wrapper
+                    .get_subscription_group_table()
+                    .keys()
+                    .any(|name| name.as_str() == group);
+                if has_group {
+                    items.push(dashboard::DashboardConsumerBroker {
+                        broker_name,
+                        broker_address: broker_addr.to_string(),
+                    });
+                }
+            }
+            if items.is_empty() {
+                return Err(AdminError::not_found("consumerGroup", group));
+            }
+            items.sort_by(|left, right| left.broker_name.cmp(&right.broker_name));
+            Ok(dashboard::DashboardConsumerBrokerList { items })
         })
     }
 
@@ -780,6 +830,34 @@ impl dashboard::DashboardAdmin for AdminSession {
     }
 }
 
+fn authoritative_consumer_broker_targets(
+    cluster_info: &ClusterInfo,
+) -> crate::core::AdminResult<Vec<(String, CheetahString)>> {
+    let Some(broker_table) = cluster_info.broker_addr_table.as_ref() else {
+        return Err(AdminError::backend(
+            "examine_broker_cluster_info",
+            "Broker cluster metadata is unavailable.",
+        ));
+    };
+    let mut targets = broker_table
+        .iter()
+        .filter_map(|(broker_name, broker)| {
+            broker
+                .broker_addrs()
+                .get(&MASTER_ID)
+                .map(|broker_addr| (broker_name.to_string(), broker_addr.clone()))
+        })
+        .collect::<Vec<_>>();
+    if targets.is_empty() {
+        return Err(AdminError::backend(
+            "examine_broker_cluster_info",
+            "No master broker targets are available.",
+        ));
+    }
+    targets.sort_by(|left, right| left.0.cmp(&right.0));
+    Ok(targets)
+}
+
 fn backend_error(operation: &'static str, error: RocketMQError) -> AdminError {
     let view = error.boundary_view();
     let context = (!view.context().is_empty()).then(|| view.context().to_string());
@@ -791,4 +869,55 @@ fn backend_error(operation: &'static str, error: RocketMQError) -> AdminError {
         view.http().status.as_u16(),
         view.is_retryable(),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rocketmq_protocol::protocol::route::route_data_view::BrokerData;
+
+    fn broker_data(broker_name: &str, master_addr: Option<&str>) -> BrokerData {
+        let mut broker_addrs = HashMap::new();
+        if let Some(master_addr) = master_addr {
+            broker_addrs.insert(MASTER_ID, CheetahString::from(master_addr));
+        }
+        BrokerData::new(
+            CheetahString::from("cluster-a"),
+            CheetahString::from(broker_name),
+            broker_addrs,
+            None,
+        )
+    }
+
+    #[test]
+    fn authoritative_targets_fail_closed_without_master_addresses() {
+        let broker_table = HashMap::from([(CheetahString::from("broker-a"), broker_data("broker-a", None))]);
+        let cluster_info = ClusterInfo::new(Some(broker_table), None);
+
+        assert!(authoritative_consumer_broker_targets(&cluster_info).is_err());
+    }
+
+    #[test]
+    fn authoritative_targets_are_sorted_master_name_address_pairs() {
+        let broker_table = HashMap::from([
+            (
+                CheetahString::from("broker-b"),
+                broker_data("broker-b", Some("10.0.0.2:10911")),
+            ),
+            (
+                CheetahString::from("broker-a"),
+                broker_data("broker-a", Some("10.0.0.1:10911")),
+            ),
+        ]);
+        let cluster_info = ClusterInfo::new(Some(broker_table), None);
+
+        let targets = authoritative_consumer_broker_targets(&cluster_info).expect("master targets");
+        assert_eq!(
+            targets,
+            vec![
+                ("broker-a".to_string(), CheetahString::from("10.0.0.1:10911")),
+                ("broker-b".to_string(), CheetahString::from("10.0.0.2:10911")),
+            ]
+        );
+    }
 }

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/consumer.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/client_adapter/services/consumer.rs
@@ -48,6 +48,7 @@ use crate::client_adapter::services::stable_error_message;
 use crate::client_adapter::services::RocketMQError;
 use crate::client_adapter::services::RocketMQResult;
 use crate::client_adapter::services::ToolsError;
+use crate::core::consumer::DashboardConsumerRunningInfoRequest;
 use rocketmq_client_rust::DefaultMQAdminExt;
 
 fn trim_optional_string(value: Option<String>) -> Option<String> {
@@ -864,6 +865,20 @@ impl ConsumerService {
         let result = Self::query_consumer_running_info_with_admin(&admin, &request).await;
         admin.shutdown().await;
         result
+    }
+
+    pub(crate) async fn query_dashboard_consumer_running_info_with_admin(
+        admin: &DefaultMQAdminExt,
+        request: &DashboardConsumerRunningInfoRequest,
+    ) -> RocketMQResult<ConsumerRunningInfo> {
+        admin
+            .get_consumer_running_info(
+                CheetahString::from(request.consumer_group()),
+                CheetahString::from(request.client_id()),
+                request.include_jstack(),
+                None,
+            )
+            .await
     }
 
     pub(crate) async fn query_consumer_running_info_with_admin(

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/consumer.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/consumer.rs
@@ -14,6 +14,7 @@
 
 //! Consumer capability contracts.
 
+use rocketmq_protocol::protocol::subscription::subscription_group_config::validate_subscription_group_name;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -339,6 +340,194 @@ pub struct DashboardConsumerUpsertRequest {
     pub consume_timeout_minute: i32,
 }
 
+const CID_RMQ_SYS_PREFIX: &str = "CID_RMQ_SYS_";
+const SYSTEM_CONSUMER_GROUPS: &[&str] = &[
+    "TOOLS_CONSUMER",
+    "FILTERSRV_CONSUMER",
+    "SELF_TEST_C_GROUP",
+    "CID_ONS-HTTP-PROXY",
+    "CID_ONSAPI_PULL",
+    "CID_ONSAPI_PERMISSION",
+    "CID_ONSAPI_OWNER",
+    "CID_RMQ_SYS_TRANS",
+    "CID_DefaultHeartBeatSyncerTopic",
+];
+
+/// Validated create-or-update request for a complete multi-broker workflow.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConsumerBatchUpsertRequest {
+    inner: DashboardConsumerUpsertRequest,
+}
+
+impl ConsumerBatchUpsertRequest {
+    /// Normalizes target names and rejects invalid or protected groups.
+    ///
+    /// # Errors
+    ///
+    /// Returns an invalid-argument error when the group, target selection, or
+    /// retry limits are invalid.
+    pub fn try_new(mut inner: DashboardConsumerUpsertRequest) -> AdminResult<Self> {
+        inner.consumer_group = validate_batch_consumer_group(inner.consumer_group)?;
+        inner.cluster_name_list = canonical_names(inner.cluster_name_list);
+        inner.broker_name_list = canonical_names(inner.broker_name_list);
+        if inner.cluster_name_list.is_empty() && inner.broker_name_list.is_empty() {
+            return Err(crate::core::AdminError::invalid_argument(
+                "brokerNameList",
+                "Select at least one cluster or broker before saving the consumer group.",
+            ));
+        }
+        validate_batch_consumer_limits(&inner)?;
+        Ok(Self { inner })
+    }
+
+    pub(crate) fn inner(&self) -> &DashboardConsumerUpsertRequest {
+        &self.inner
+    }
+}
+
+/// Validated delete request carrying both selected and authoritative brokers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConsumerBatchDeleteRequest {
+    consumer_group: String,
+    selected_broker_names: Vec<String>,
+    all_broker_names: Vec<String>,
+}
+
+impl ConsumerBatchDeleteRequest {
+    /// Normalizes both broker sets and verifies that selection is a subset.
+    ///
+    /// # Errors
+    ///
+    /// Returns an invalid-argument error when the group is protected, either
+    /// broker set is empty, or a selected broker is outside the authoritative
+    /// set.
+    pub fn try_new<Selected, SelectedName, All, AllName>(
+        consumer_group: impl Into<String>,
+        selected_broker_names: Selected,
+        all_broker_names: All,
+    ) -> AdminResult<Self>
+    where
+        Selected: IntoIterator<Item = SelectedName>,
+        SelectedName: Into<String>,
+        All: IntoIterator<Item = AllName>,
+        AllName: Into<String>,
+    {
+        let consumer_group = validate_batch_consumer_group(consumer_group)?;
+        let selected_broker_names = canonical_names(selected_broker_names);
+        if selected_broker_names.is_empty() {
+            return Err(crate::core::AdminError::invalid_argument(
+                "selectedBrokerNames",
+                "Select at least one broker before deleting the consumer group.",
+            ));
+        }
+        let all_broker_names = canonical_names(all_broker_names);
+        if all_broker_names.is_empty() {
+            return Err(crate::core::AdminError::invalid_argument(
+                "allBrokerNames",
+                "The authoritative broker set must not be empty.",
+            ));
+        }
+        if let Some(broker_name) = selected_broker_names
+            .iter()
+            .find(|broker_name| all_broker_names.binary_search(broker_name).is_err())
+        {
+            return Err(crate::core::AdminError::invalid_argument(
+                "selectedBrokerNames",
+                format!("Broker `{broker_name}` is outside the authoritative broker set."),
+            ));
+        }
+        Ok(Self {
+            consumer_group,
+            selected_broker_names,
+            all_broker_names,
+        })
+    }
+
+    pub(crate) fn consumer_group(&self) -> &str {
+        &self.consumer_group
+    }
+
+    pub(crate) fn selected_broker_names(&self) -> &[String] {
+        &self.selected_broker_names
+    }
+
+    pub(crate) fn all_broker_names(&self) -> &[String] {
+        &self.all_broker_names
+    }
+}
+
+/// Outcome of one broker mutation or one internal-topic cleanup target.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DashboardConsumerTargetOutcome {
+    pub target: String,
+    pub kind: String,
+    pub success: bool,
+    pub message: String,
+}
+
+/// Stable ordered outcomes for a closed consumer batch workflow.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DashboardConsumerBatchResult {
+    pub consumer_group: String,
+    pub success: bool,
+    pub targets: Vec<DashboardConsumerTargetOutcome>,
+}
+
+fn canonical_names<Names, Name>(names: Names) -> Vec<String>
+where
+    Names: IntoIterator<Item = Name>,
+    Name: Into<String>,
+{
+    let mut names = names
+        .into_iter()
+        .map(Into::into)
+        .map(|name: String| name.trim().to_string())
+        .filter(|name| !name.is_empty())
+        .collect::<Vec<_>>();
+    names.sort();
+    names.dedup();
+    names
+}
+
+fn validate_batch_consumer_group(value: impl Into<String>) -> AdminResult<String> {
+    let value = required("consumerGroup", value)?;
+    if value.starts_with("%SYS%") || is_system_consumer_group(&value) {
+        return Err(crate::core::AdminError::invalid_argument(
+            "consumerGroup",
+            "System consumer groups cannot be mutated.",
+        ));
+    }
+    validate_subscription_group_name(&value)
+        .map_err(|error| crate::core::AdminError::invalid_argument("consumerGroup", error.to_string()))?;
+    Ok(value)
+}
+
+fn validate_batch_consumer_limits(request: &DashboardConsumerUpsertRequest) -> AdminResult<()> {
+    if request.retry_queue_nums < 0 {
+        return Err(crate::core::AdminError::invalid_argument(
+            "retryQueueNums",
+            "Retry queues must be zero or greater.",
+        ));
+    }
+    if request.retry_max_times < -1 {
+        return Err(crate::core::AdminError::invalid_argument(
+            "retryMaxTimes",
+            "Max retries must be -1 or greater.",
+        ));
+    }
+    if request.consume_timeout_minute <= 0 {
+        return Err(crate::core::AdminError::invalid_argument(
+            "consumeTimeoutMinute",
+            "Consume timeout must be greater than zero.",
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn is_system_consumer_group(group: &str) -> bool {
+    group.starts_with(CID_RMQ_SYS_PREFIX) || SYSTEM_CONSUMER_GROUPS.contains(&group)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DashboardConsumerDeleteRequest {
     pub consumer_group: String,
@@ -631,6 +820,19 @@ pub trait ConsumerDiagnosticAdmin: Send {
     ) -> AdminFuture<'a, DashboardConsumerRunningInfo>;
 }
 
+/// Complete consumer batch mutations owned by one leased admin session.
+pub trait ConsumerBatchMutationAdmin: Send {
+    fn upsert_consumer_group_batch<'a>(
+        &'a mut self,
+        request: &'a ConsumerBatchUpsertRequest,
+    ) -> AdminFuture<'a, DashboardConsumerBatchResult>;
+
+    fn delete_consumer_group_batch<'a>(
+        &'a mut self,
+        request: &'a ConsumerBatchDeleteRequest,
+    ) -> AdminFuture<'a, DashboardConsumerBatchResult>;
+}
+
 /// Consumer mutations require the explicit mutation adapter feature.
 pub trait ConsumerMutationAdmin: Send {
     fn patch_config_if_version<'a>(
@@ -726,6 +928,27 @@ impl<T: ConsumerAdmin + ?Sized> ConsumerMutationAdmin for T {
         request: &'a SetConsumerRequestModeRequest,
     ) -> AdminFuture<'a, SetConsumerRequestModeResult> {
         ConsumerAdmin::set_consumer_request_mode(self, request)
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod batch_test_support {
+    use super::*;
+
+    pub(crate) fn unchecked_upsert_request(inner: DashboardConsumerUpsertRequest) -> ConsumerBatchUpsertRequest {
+        ConsumerBatchUpsertRequest { inner }
+    }
+
+    pub(crate) fn unchecked_delete_request(
+        consumer_group: impl Into<String>,
+        selected_broker_names: Vec<String>,
+        all_broker_names: Vec<String>,
+    ) -> ConsumerBatchDeleteRequest {
+        ConsumerBatchDeleteRequest {
+            consumer_group: consumer_group.into(),
+            selected_broker_names,
+            all_broker_names,
+        }
     }
 }
 

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/consumer.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/consumer.rs
@@ -191,12 +191,36 @@ pub struct DashboardConsumerConfigAttribute {
     pub value: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct DashboardConsumerRunningInfoRequest {
     consumer_group: String,
     client_id: String,
     include_jstack: bool,
     max_output_bytes: usize,
+}
+
+impl<'de> Deserialize<'de> for DashboardConsumerRunningInfoRequest {
+    fn deserialize<Deserializer>(deserializer: Deserializer) -> Result<Self, Deserializer::Error>
+    where
+        Deserializer: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct SerializedRequest {
+            consumer_group: String,
+            client_id: String,
+            include_jstack: bool,
+            max_output_bytes: usize,
+        }
+
+        let request = SerializedRequest::deserialize(deserializer)?;
+        Self::try_new(
+            request.consumer_group,
+            request.client_id,
+            request.include_jstack,
+            request.max_output_bytes,
+        )
+        .map_err(serde::de::Error::custom)
+    }
 }
 
 impl DashboardConsumerRunningInfoRequest {
@@ -271,8 +295,8 @@ pub struct DashboardConsumerRunningInfo {
     pub subscriptions: Vec<DashboardConsumerSubscriptionItem>,
     pub process_queues: Vec<DashboardConsumerProcessQueue>,
     pub jstack: Option<String>,
-    /// True when requested property or JStack text exceeded the aggregate
-    /// output budget and was shortened at a UTF-8 character boundary.
+    /// True when requested property or JStack text was shortened at a UTF-8
+    /// character boundary, omitted by the budget, or unavailable.
     pub truncated: bool,
 }
 
@@ -759,6 +783,24 @@ mod tests {
         assert!(DashboardConsumerRunningInfoRequest::try_new("orders", " ", false, 1024).is_err());
         assert!(DashboardConsumerRunningInfoRequest::try_new("orders", "client-a", false, 0).is_err());
         assert!(DashboardConsumerRunningInfoRequest::try_new("orders", "client-a", false, 1_048_577).is_err());
+    }
+
+    #[test]
+    fn running_info_request_deserialization_cannot_bypass_validation() {
+        let valid = serde_json::from_str::<DashboardConsumerRunningInfoRequest>(
+            r#"{"consumer_group":" orders-consumer ","client_id":" client-a ","include_jstack":true,"max_output_bytes":1024}"#,
+        )
+        .expect("valid serialized request");
+        assert_eq!(valid.consumer_group(), "orders-consumer");
+        assert_eq!(valid.client_id(), "client-a");
+
+        for invalid in [
+            r#"{"consumer_group":" ","client_id":"client-a","include_jstack":false,"max_output_bytes":1024}"#,
+            r#"{"consumer_group":"orders","client_id":"client-a","include_jstack":false,"max_output_bytes":0}"#,
+            r#"{"consumer_group":"orders","client_id":"client-a","include_jstack":false,"max_output_bytes":1048577}"#,
+        ] {
+            assert!(serde_json::from_str::<DashboardConsumerRunningInfoRequest>(invalid).is_err());
+        }
     }
 
     #[test]

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/consumer.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/consumer.rs
@@ -192,6 +192,91 @@ pub struct DashboardConsumerConfigAttribute {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DashboardConsumerRunningInfoRequest {
+    consumer_group: String,
+    client_id: String,
+    include_jstack: bool,
+    max_output_bytes: usize,
+}
+
+impl DashboardConsumerRunningInfoRequest {
+    const MAX_OUTPUT_BYTES: usize = 1024 * 1024;
+
+    /// Creates a bounded consumer diagnostic request.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the consumer group or client ID is blank, or
+    /// when `max_output_bytes` is outside the inclusive range 1 byte to 1 MiB.
+    pub fn try_new(
+        consumer_group: impl Into<String>,
+        client_id: impl Into<String>,
+        include_jstack: bool,
+        max_output_bytes: usize,
+    ) -> AdminResult<Self> {
+        if !(1..=Self::MAX_OUTPUT_BYTES).contains(&max_output_bytes) {
+            return Err(crate::core::AdminError::invalid_argument(
+                "maxOutputBytes",
+                "must be between 1 and 1048576 bytes",
+            ));
+        }
+        Ok(Self {
+            consumer_group: required("consumerGroup", consumer_group)?,
+            client_id: required("clientId", client_id)?,
+            include_jstack,
+            max_output_bytes,
+        })
+    }
+
+    #[must_use]
+    pub fn consumer_group(&self) -> &str {
+        &self.consumer_group
+    }
+
+    #[must_use]
+    pub fn client_id(&self) -> &str {
+        &self.client_id
+    }
+
+    #[must_use]
+    pub const fn include_jstack(&self) -> bool {
+        self.include_jstack
+    }
+
+    #[must_use]
+    /// Returns the aggregate byte budget for sorted property keys/values,
+    /// followed by JStack when requested.
+    pub const fn max_output_bytes(&self) -> usize {
+        self.max_output_bytes
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DashboardConsumerProcessQueue {
+    pub topic: String,
+    pub broker_name: String,
+    pub queue_id: i32,
+    pub cached_message_count: i64,
+    pub cached_message_size_in_mib: i64,
+    pub commit_offset: i64,
+    pub dropped: bool,
+    pub last_consume_timestamp: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DashboardConsumerRunningInfo {
+    pub consumer_group: String,
+    pub client_id: String,
+    pub properties: Vec<DashboardConsumerConfigAttribute>,
+    pub subscriptions: Vec<DashboardConsumerSubscriptionItem>,
+    pub process_queues: Vec<DashboardConsumerProcessQueue>,
+    pub jstack: Option<String>,
+    /// True when requested property or JStack text exceeded the aggregate
+    /// output budget and was shortened at a UTF-8 character boundary.
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DashboardConsumerConfig {
     pub consumer_group: String,
     pub broker_name: String,
@@ -513,6 +598,15 @@ pub trait ConsumerQueryAdmin: Send {
     ) -> AdminFuture<'a, DashboardConsumerConfig>;
 }
 
+/// Bounded diagnostic queries exposed independently from existing consumer
+/// query and mutation capabilities.
+pub trait ConsumerDiagnosticAdmin: Send {
+    fn query_dashboard_consumer_running_info<'a>(
+        &'a mut self,
+        request: &'a DashboardConsumerRunningInfoRequest,
+    ) -> AdminFuture<'a, DashboardConsumerRunningInfo>;
+}
+
 /// Consumer mutations require the explicit mutation adapter feature.
 pub trait ConsumerMutationAdmin: Send {
     fn patch_config_if_version<'a>(
@@ -613,8 +707,65 @@ impl<T: ConsumerAdmin + ?Sized> ConsumerMutationAdmin for T {
 
 #[cfg(test)]
 mod tests {
-    use super::PatchSubscriptionGroupConfigRequest;
-    use super::SubscriptionGroupConfigCasPatch;
+    use super::*;
+    use crate::core::AdminFuture;
+
+    struct ExistingConsumerAdmin;
+
+    macro_rules! existing_consumer_admin {
+        ($($name:ident: $request:ty => $result:ty;)*) => {
+            impl ConsumerAdmin for ExistingConsumerAdmin {
+                $(
+                    fn $name<'a>(&'a mut self, _request: &'a $request) -> AdminFuture<'a, $result> {
+                        unused_admin_future()
+                    }
+                )*
+            }
+        };
+    }
+
+    existing_consumer_admin! {
+        list_consumer_groups: ListConsumerGroupsRequest => ListConsumerGroupsResult;
+        query_consumer_lag: QueryConsumerLagRequest => QueryConsumerLagResult;
+        query_dashboard_consumer_groups: DashboardConsumerGroupListRequest => DashboardConsumerGroupListResult;
+        query_dashboard_consumer_connection: DashboardConsumerConnectionRequest => DashboardConsumerConnection;
+        query_dashboard_consumer_progress: DashboardConsumerProgressRequest => DashboardConsumerProgress;
+        query_dashboard_consumer_config: DashboardConsumerConfigRequest => DashboardConsumerConfig;
+        upsert_dashboard_consumer_group: DashboardConsumerUpsertRequest => DashboardConsumerMutationResult;
+        delete_dashboard_consumer_group: DashboardConsumerDeleteRequest => DashboardConsumerMutationResult;
+        delete_subscription_groups: DeleteSubscriptionGroupsRequest => ConsumerBatchMutationOutcome;
+        set_consumer_request_mode: SetConsumerRequestModeRequest => SetConsumerRequestModeResult;
+    }
+
+    fn unused_admin_future<'a, T>() -> AdminFuture<'a, T> {
+        Box::pin(async {
+            Err(crate::core::AdminError::backend(
+                "compile_only_consumer_admin",
+                "compile-only consumer admin fake must not be called",
+            ))
+        })
+    }
+
+    #[test]
+    fn running_info_request_requires_canonical_group_and_client_and_bounds_output() {
+        let request =
+            DashboardConsumerRunningInfoRequest::try_new(" orders-consumer ", " 10.0.0.8@client-a ", true, 256 * 1024)
+                .expect("valid request");
+        assert_eq!(request.consumer_group(), "orders-consumer");
+        assert_eq!(request.client_id(), "10.0.0.8@client-a");
+        assert!(request.include_jstack());
+        assert_eq!(request.max_output_bytes(), 256 * 1024);
+        assert!(DashboardConsumerRunningInfoRequest::try_new(" ", "client-a", false, 1024).is_err());
+        assert!(DashboardConsumerRunningInfoRequest::try_new("orders", " ", false, 1024).is_err());
+        assert!(DashboardConsumerRunningInfoRequest::try_new("orders", "client-a", false, 0).is_err());
+        assert!(DashboardConsumerRunningInfoRequest::try_new("orders", "client-a", false, 1_048_577).is_err());
+    }
+
+    #[test]
+    fn existing_consumer_admin_implementation_does_not_require_diagnostics() {
+        let mut admin = ExistingConsumerAdmin;
+        let _: &mut dyn ConsumerAdmin = &mut admin;
+    }
 
     #[test]
     fn subscription_group_cas_request_accepts_only_a_non_empty_bounded_patch() {

--- a/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/dashboard.rs
+++ b/rocketmq-tools/rocketmq-admin/rocketmq-admin-core/src/core/dashboard.rs
@@ -173,6 +173,17 @@ pub struct DashboardConsumerProgress {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DashboardConsumerBroker {
+    pub broker_name: String,
+    pub broker_address: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DashboardConsumerBrokerList {
+    pub items: Vec<DashboardConsumerBroker>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DashboardConsumerResetRequest {
     pub group: String,
     pub topic: String,
@@ -368,6 +379,15 @@ pub trait DashboardAdmin: Send + Sync {
         &'a self,
         request: &'a DashboardConsumerResetRequest,
     ) -> AdminFuture<'a, AdminMutationResult>;
+
+    fn dashboard_consumer_brokers<'a>(&'a self, _group: &'a str) -> AdminFuture<'a, DashboardConsumerBrokerList> {
+        Box::pin(async {
+            Err(crate::core::AdminError::backend(
+                "dashboard_consumer_brokers",
+                "Consumer broker discovery is not implemented by this adapter",
+            ))
+        })
+    }
 
     fn dashboard_list_producers(&self) -> AdminFuture<'_, Vec<DashboardProducerInfo>>;
     fn dashboard_producer_connections<'a>(


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9539

### Brief Description

This PR completes the Web Dashboard Consumer Group operations workspace.

Changed areas:

- `rocketmq-tools/rocketmq-admin/rocketmq-admin-core`: add Consumer diagnostic query contracts, closed batch mutation contracts, deterministic query mappings, authoritative broker discovery, and continue-after-failure outcomes.
- `rocketmq-dashboard/rocketmq-dashboard-web/backend`: add the complete Consumer API, NameServer/Proxy query scope, enriched inventory, connection/progress/configuration resources, structured create/update/delete/reset outcomes, and cancellation-safe Consumer mutation serialization.
- `rocketmq-dashboard/rocketmq-dashboard-web/frontend`: add the Consumer investigation workspace with Summary, Clients, Progress, Configuration, and Offset reset tabs; enrich the Consumer list; integrate Create/Edit, exact-confirmation Delete, Proxy/NameServer scope, per-broker target outcomes, and focused regression tests.

Broker mutations remain on the direct NameServer/Broker admin path. System groups fail closed for edit, reset, and delete. Deletion reports Retry/DLQ cleanup as separate target outcomes and does not claim global success on partial broker results.

### How Did You Test This Change?

Frontend:

```powershell
npm test -- --run
npm run build
```

Result: 50 test files and 334 tests passed; the production build completed successfully.

Web backend:

```powershell
cargo fmt -p rocketmq-dashboard-web-backend -- --check
cargo clippy -p rocketmq-dashboard-web-backend --all-targets --all-features -- -D warnings
cargo test -p rocketmq-dashboard-web-backend --all-targets --all-features
cargo build -p rocketmq-dashboard-web-backend --all-targets --all-features
```

Result: package format check, Clippy, 79 tests, and build passed.

Admin core:

```powershell
cargo fmt -p rocketmq-admin-core -- --check
cargo clippy -p rocketmq-admin-core --all-targets --all-features -- -D warnings
cargo test -p rocketmq-admin-core --all-targets --all-features
```

Result: package format check, Clippy, and tests passed, including 160 unit tests and the integration test targets.

Local service smoke checks:

- Backend `/api/health` returned 200.
- Backend `/api/consumers` returned 200.
- Frontend `/consumers` and `/api/consumers` returned 200 through the Vite API proxy.

The full `cargo fmt --all -- --check` command from the backend still hits the existing Windows `os error 206` filename-too-long limitation, so the package-scoped format check was used instead.

Interactive in-app browser QA was not completed in this run because no browser automation tool was available. The local services were started on `127.0.0.1:8083` and `127.0.0.1:5173`, and HTTP smoke checks passed; full manual browser acceptance against a live broker remains pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive consumer-group management, including creation, editing, deletion, broker targeting, and partial-result reporting.
  * Added consumer inspection views for summaries, connections, progress, configuration, running information, and JStack diagnostics.
  * Added NameServer and Proxy query modes with configurable scope and persistence.
  * Expanded consumer filtering, sorting, detail tabs, and broker information.
  * Added validation and safeguards for system groups, invalid inputs, and oversized diagnostic responses.
* **Bug Fixes**
  * Improved request cancellation, stale-response handling, error reporting, and retry behavior across consumer views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->