### PR TITLE
[ISSUE #9541]✨Increase MESSAGE_COUNT to 100 million and implement graceful shutdown handling in producer

### DIFF
--- a/rocketmq-client/examples/quickstart/producer.rs
+++ b/rocketmq-client/examples/quickstart/producer.rs
@@ -21,7 +21,7 @@ use rocketmq_client_rust::DefaultMQProducer;
 use rocketmq_error::RocketMQResult;
 use rocketmq_model::common::message::message_single::Message;
 
-pub const MESSAGE_COUNT: usize = 1;
+pub const MESSAGE_COUNT: usize = 100000000;
 pub const PRODUCER_GROUP: &str = "please_rename_unique_group_name";
 pub const DEFAULT_NAMESRVADDR: &str = "127.0.0.1:9876";
 pub const TOPIC: &str = "TopicTest";
@@ -41,15 +41,26 @@ pub async fn main() -> RocketMQResult<()> {
 
     producer.start().await?;
 
-    for _ in 0..10 {
+    let mut shutdown_signal = Box::pin(tokio::signal::ctrl_c());
+    for _ in 0..MESSAGE_COUNT {
         let message = Message::builder()
             .topic(TOPIC)
             .tags(TAG)
             .body_slice("Hello RocketMQ".as_bytes())
             .build_unchecked();
 
-        let send_result = producer.send_with_timeout(message, 2000).await?;
-        println!("send result: {:?}", send_result);
+        tokio::select! {
+            signal = &mut shutdown_signal => {
+                if signal.is_ok() {
+                    println!("Ctrl-C received, shutting down gracefully");
+                }
+                break;
+            }
+            result = producer.send_with_timeout(message, 2000) => {
+                let send_result = result?;
+                println!("send result: {:?}", send_result);
+            }
+        }
     }
     producer.shutdown().await;
 


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #9541

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Examples**
  * Updated the producer quickstart to send up to 100 million messages.
  * Added graceful interruption with Ctrl-C while messages are being sent.
  * Continued reporting successful sends and surfacing send failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->