### PR TITLE
[ISSUE #9564]✨Execute publication handoff archive smoke

### DIFF
--- a/distribution/handoff-platform-result.schema.json
+++ b/distribution/handoff-platform-result.schema.json
@@ -15,6 +15,9 @@
     "platform",
     "target",
     "archive_id",
+    "archive",
+    "archive_manifest",
+    "archive_smoke_results",
     "status",
     "skipped",
     "assertions"
@@ -30,6 +33,23 @@
     "platform": { "enum": ["linux", "windows", "macos"] },
     "target": { "type": "string", "minLength": 1 },
     "archive_id": { "type": "string", "minLength": 1 },
+    "archive": { "type": "string", "minLength": 1 },
+    "archive_manifest": { "type": "string", "minLength": 1 },
+    "archive_smoke_results": {
+      "type": "array",
+      "minItems": 6,
+      "maxItems": 6,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["component", "exit_code", "stdout"],
+        "properties": {
+          "component": { "type": "string", "minLength": 1 },
+          "exit_code": { "const": 0 },
+          "stdout": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
     "status": { "const": "passed" },
     "skipped": { "const": false },
     "assertions": { "type": "array", "minItems": 1 },

--- a/distribution/merge_handoff_platform_results.py
+++ b/distribution/merge_handoff_platform_results.py
@@ -19,6 +19,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT / "distribution") not in sys.path:
     sys.path.insert(0, str(ROOT / "distribution"))
 
+from release_archive_common import artifact_id, load_layout, require_relative_path
 from release_state import ReleaseStateError, atomic_write_json, ensure_no_digest_fields, read_json, validate_candidate
 
 
@@ -60,6 +61,47 @@ def _load_one(root: Path, result_id: str, candidate: dict[str, Any]) -> dict[str
         or any(item.get("status") != "passed" for item in result["assertions"] if isinstance(item, dict))
     ):
         raise PlatformMergeError(f"platform result is incomplete or not passed: {result_id}")
+    if result.get("archive_id") != artifact_id(candidate, target, "archive"):
+        raise PlatformMergeError(f"platform archive identity mismatch: {result_id}")
+    layout = load_layout()
+    extension = ".zip" if layout["targets"][target]["archive_format"] == "zip" else ".tar.gz"
+    expected_paths = {
+        "archive": f"archives/rocketmq-rust-{candidate['version']}-{target}{extension}",
+        "archive_manifest": f"archives/rocketmq-rust-{candidate['version']}-{target}.manifest.json",
+    }
+    for field in ("archive", "archive_manifest"):
+        try:
+            relative = require_relative_path(result.get(field), f"platform {field}")
+        except ReleaseStateError as error:
+            raise PlatformMergeError(str(error)) from error
+        if not relative.parts or relative.parts[0] != "archives":
+            raise PlatformMergeError(f"platform {field} is outside the archive layout: {result_id}")
+        if relative.as_posix() != expected_paths[field]:
+            raise PlatformMergeError(f"platform archive path mismatch: {result_id}:{field}")
+    smoke_results = result.get("archive_smoke_results")
+    expected_components = {entry["id"]: entry for entry in layout["binaries"]}
+    if not isinstance(smoke_results, list) or len(smoke_results) != len(expected_components):
+        raise PlatformMergeError(f"platform binary smoke denominator is incomplete: {result_id}")
+    components = {
+        entry.get("component"): entry for entry in smoke_results if isinstance(entry, dict)
+    }
+    if set(components) != set(expected_components) or len(components) != len(smoke_results):
+        raise PlatformMergeError(f"platform binary smoke denominator is invalid: {result_id}")
+    for component, binary in expected_components.items():
+        entry = components[component]
+        stdout = entry.get("stdout")
+        required_output = {
+            f"version={candidate['version']}",
+            f"artifact_id={artifact_id(candidate, target, component)}",
+            f"requested_features={','.join(binary['requested_features'])}",
+            f"effective_features={','.join(binary['effective_features'])}",
+        }
+        if (
+            entry.get("exit_code") != 0
+            or not isinstance(stdout, str)
+            or any(value not in stdout for value in required_output)
+        ):
+            raise PlatformMergeError(f"platform binary smoke result is invalid: {result_id}:{component}")
     worker = result.get("worker_id")
     if not isinstance(worker, str) or not worker:
         raise PlatformMergeError(f"platform result has no worker identity: {result_id}")

--- a/distribution/verify_publication_handoff.py
+++ b/distribution/verify_publication_handoff.py
@@ -21,7 +21,9 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT / "distribution") not in sys.path:
     sys.path.insert(0, str(ROOT / "distribution"))
 
+from release_archive_common import ArchiveError, load_layout
 from release_state import ReleaseStateError, atomic_write_json, ensure_no_digest_fields, read_json, validate_candidate
+from verify_release_archive import inspect_archive
 
 
 COPY_BUFFER_SIZE = 1024 * 1024
@@ -205,7 +207,12 @@ def _archive_member_names(path: Path) -> list[str]:
         raise HandoffVerifyError(f"invalid handoff tar: {path.name}: {error}") from error
 
 
-def _verify_package_semantics(root: Path) -> None:
+def _verify_package_semantics(
+    root: Path,
+    candidate: dict[str, Any],
+    *,
+    smoke_target: str | None,
+) -> dict[str, Any] | None:
     packages = sorted((root / "crate-packages").glob("*.crate"))
     if not packages:
         raise HandoffVerifyError("handoff contains no local crate packages")
@@ -217,12 +224,42 @@ def _verify_package_semantics(root: Path) -> None:
             name.endswith("/NOTICE") for name in names
         ):
             raise HandoffVerifyError(f"crate package legal metadata is incomplete: {package.name}")
-    for platform in ("linux", "windows", "macos"):
-        archives = [path for path in (root / "archives" / platform).iterdir() if path.is_file()]
-        if len(archives) != 1:
-            raise HandoffVerifyError(f"handoff requires exactly one {platform} service archive")
-        if not _archive_member_names(archives[0]):
-            raise HandoffVerifyError(f"handoff service archive is empty: {archives[0].name}")
+    layout = load_layout()
+    manifests = sorted((root / "archives").glob("*.manifest.json"))
+    if len(manifests) != len(layout["targets"]):
+        raise HandoffVerifyError("handoff archive manifest denominator is incomplete")
+    targets: set[str] = set()
+    smoke_result: dict[str, Any] | None = None
+    for manifest_path in manifests:
+        manifest = read_json(manifest_path)
+        target = manifest.get("target")
+        if target not in layout["targets"] or target in targets:
+            raise HandoffVerifyError(f"handoff archive target is invalid or duplicated: {target}")
+        targets.add(target)
+        archive_relative = _safe_relative(manifest.get("archive"), "handoff archive path")
+        archive = root.joinpath(*archive_relative.parts)
+        try:
+            retained_manifest, retained, results = inspect_archive(
+                candidate,
+                root,
+                archive,
+                smoke=target == smoke_target,
+            )
+        except ArchiveError as error:
+            raise HandoffVerifyError(str(error)) from error
+        if retained_manifest != manifest_path:
+            raise HandoffVerifyError(f"handoff archive manifest selection is ambiguous: {target}")
+        if target == smoke_target:
+            smoke_result = {
+                "archive": archive_relative.as_posix(),
+                "archive_id": retained["artifact_id"],
+                "manifest": manifest_path.relative_to(root).as_posix(),
+                "results": results,
+            }
+    if targets != set(layout["targets"]):
+        raise HandoffVerifyError("handoff archive target denominator changed")
+    if smoke_target is not None and smoke_result is None:
+        raise HandoffVerifyError(f"handoff has no archive for smoke target: {smoke_target}")
     charts = list((root / "helm").glob("*.tgz"))
     if len(charts) != 1 or not any(name.endswith("/Chart.yaml") for name in _archive_member_names(charts[0])):
         raise HandoffVerifyError("handoff Helm package is missing or invalid")
@@ -235,6 +272,7 @@ def _verify_package_semantics(root: Path) -> None:
     for required in (root / "legal" / "LICENSE-APACHE", root / "legal" / "NOTICE"):
         if not required.is_file() or required.stat().st_size == 0:
             raise HandoffVerifyError(f"handoff legal file is missing: {required.name}")
+    return smoke_result
 
 
 def verify_handoff(
@@ -331,7 +369,12 @@ def verify_handoff(
     for path in sorted(handoff_root.rglob("*")):
         if path.is_file() and path.name != "PUBLICATION_READY.json":
             _scan_file(path, path.relative_to(handoff_root).as_posix())
-    _verify_package_semantics(handoff_root)
+    smoke_target = PLATFORM_TARGETS[platform][1] if platform is not None else None
+    archive_smoke = _verify_package_semantics(
+        handoff_root,
+        candidate,
+        smoke_target=smoke_target,
+    )
     evidence = read_json(handoff_root / "evidence" / "EVIDENCE_INDEX.json")
     no_remote = read_json(handoff_root / "evidence" / "NO_REMOTE_PUBLICATION.json")
     if _identity(evidence) != _identity(candidate) or evidence.get("status") != "passed":
@@ -357,13 +400,17 @@ def verify_handoff(
     }
     if platform is not None:
         _expected_result, target = PLATFORM_TARGETS[platform]
-        archive = next(path for path in (handoff_root / "archives" / platform).iterdir() if path.is_file())
+        if archive_smoke is None:
+            raise HandoffVerifyError(f"handoff archive smoke result is missing: {target}")
         report.update(
             {
                 "worker_id": worker_id,
                 "platform": platform,
                 "target": target,
-                "archive_id": f"{candidate['candidate_id']}.{target}.{archive.name}",
+                "archive_id": archive_smoke["archive_id"],
+                "archive": archive_smoke["archive"],
+                "archive_manifest": archive_smoke["manifest"],
+                "archive_smoke_results": archive_smoke["results"],
                 "assertions": [
                     {"name": "source-stream-compare", "status": "passed"},
                     {"name": "archive-install-smoke", "status": "passed"},

--- a/distribution/verify_release_archive.py
+++ b/distribution/verify_release_archive.py
@@ -113,12 +113,21 @@ def _validate_manifest(candidate: dict, layout: dict, value: dict) -> None:
             raise ArchiveError(f"archive dependency closure is incomplete: {binary['id']}")
 
 
-def verify_archive(candidate_manifest: Path, archive: Path, *, smoke: bool) -> Path | None:
-    _manifest, candidate, root = load_candidate(candidate_manifest)
+def inspect_archive(
+    candidate: dict[str, object],
+    root: Path,
+    archive: Path,
+    *,
+    smoke: bool,
+) -> tuple[Path, dict, list[dict[str, object]]]:
+    """Validate one retained archive and optionally execute its packaged binaries."""
+
     layout = load_layout()
+    root = root.resolve(strict=True)
     archive = resolve_existing_file(archive, "release archive")
     manifest_path, archive_manifest = _manifest_for_archive(root, archive)
     _validate_manifest(candidate, layout, archive_manifest)
+    results: list[dict[str, object]] = []
     with tempfile.TemporaryDirectory() as temporary:
         extracted = Path(temporary)
         _extract(archive, extracted)
@@ -132,9 +141,8 @@ def verify_archive(candidate_manifest: Path, archive: Path, *, smoke: bool) -> P
             with config.open("rb") as handle:
                 tomllib.load(handle)
         if not smoke:
-            return None
+            return manifest_path, archive_manifest, results
         suffix = target_layout(layout, archive_manifest["target"])["executable_suffix"]
-        results = []
         for binary in layout["binaries"]:
             name = binary.get("archive_binary", binary["binary"])
             executable = package_root / "bin" / f"{name}{suffix}"
@@ -163,6 +171,19 @@ def verify_archive(candidate_manifest: Path, archive: Path, *, smoke: bool) -> P
             results.append(
                 {"component": binary["id"], "exit_code": 0, "stdout": completed.stdout}
             )
+    return manifest_path, archive_manifest, results
+
+
+def verify_archive(candidate_manifest: Path, archive: Path, *, smoke: bool) -> Path | None:
+    _manifest, candidate, root = load_candidate(candidate_manifest)
+    manifest_path, archive_manifest, results = inspect_archive(
+        candidate,
+        root,
+        archive,
+        smoke=smoke,
+    )
+    if not smoke:
+        return None
     output = root / "evidence" / archive_manifest["target"] / "HOST_SMOKE.json"
     write_json(
         output,

--- a/scripts/tests/test_handoff_platform_result_merge.py
+++ b/scripts/tests/test_handoff_platform_result_merge.py
@@ -78,6 +78,75 @@ class HandoffPlatformResultMergeTests(unittest.TestCase):
                     manifest, bundles, root / "evidence", root / "events", root / "contexts"
                 )
 
+    def test_missing_binary_smoke_results_are_rejected(self) -> None:
+        """A forged H01 pass without six process results must not enter canonical evidence."""
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest = self._candidate(root)
+            bundles = root / "bundles"
+            for result_id, platform, target in self._platforms():
+                bundle = self._bundle(bundles / result_id, result_id, platform, target)
+                if result_id == "H01-WINDOWS":
+                    result_path = bundle / f"{result_id}.json"
+                    value = json.loads(result_path.read_text(encoding="utf-8"))
+                    value.pop("archive_smoke_results")
+                    result_path.write_text(json.dumps(value), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "binary smoke denominator"):
+                self.merger.merge_platform_results(
+                    manifest, bundles, root / "evidence", root / "events", root / "contexts"
+                )
+
+    def test_failed_or_forged_binary_smoke_is_rejected(self) -> None:
+        """A non-zero process or forged build metadata must invalidate H01 evidence."""
+
+        for mutation in ("exit-code", "metadata"):
+            with self.subTest(mutation=mutation), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                manifest = self._candidate(root)
+                bundles = root / "bundles"
+                for result_id, platform, target in self._platforms():
+                    bundle = self._bundle(bundles / result_id, result_id, platform, target)
+                    if result_id == "H01-LINUX":
+                        result_path = bundle / f"{result_id}.json"
+                        value = json.loads(result_path.read_text(encoding="utf-8"))
+                        broker = next(
+                            item for item in value["archive_smoke_results"] if item["component"] == "broker"
+                        )
+                        if mutation == "exit-code":
+                            broker["exit_code"] = 9
+                        else:
+                            broker["stdout"] = broker["stdout"].replace(
+                                "effective_features=", "effective_features=forged,"
+                            )
+                        result_path.write_text(json.dumps(value), encoding="utf-8")
+
+                with self.assertRaisesRegex(ValueError, "binary smoke result"):
+                    self.merger.merge_platform_results(
+                        manifest, bundles, root / "evidence", root / "events", root / "contexts"
+                    )
+
+    def test_archive_path_must_match_the_target_manifest(self) -> None:
+        """A result must bind the command output to the frozen target archive path."""
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest = self._candidate(root)
+            bundles = root / "bundles"
+            for result_id, platform, target in self._platforms():
+                bundle = self._bundle(bundles / result_id, result_id, platform, target)
+                if result_id == "H01-MACOS":
+                    result_path = bundle / f"{result_id}.json"
+                    value = json.loads(result_path.read_text(encoding="utf-8"))
+                    value["archive"] = "archives/forged.tar.gz"
+                    result_path.write_text(json.dumps(value), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "archive path mismatch"):
+                self.merger.merge_platform_results(
+                    manifest, bundles, root / "evidence", root / "events", root / "contexts"
+                )
+
     @staticmethod
     def _platforms():
         return [
@@ -137,16 +206,38 @@ class HandoffPlatformResultMergeTests(unittest.TestCase):
             "attempt": 1,
             "worker_id": worker,
         }
+        layout = json.loads(
+            (ROOT / "distribution" / "release-layout.json").read_text(encoding="utf-8")
+        )
+        smoke_results = []
+        for binary in layout["binaries"]:
+            smoke_results.append(
+                {
+                    "component": binary["id"],
+                    "exit_code": 0,
+                    "stdout": (
+                        f"component={binary['id']}\n"
+                        "version=1.0.0\n"
+                        f"artifact_id=final-1.{target}.{binary['id']}\n"
+                        f"requested_features={','.join(binary['requested_features'])}\n"
+                        f"effective_features={','.join(binary['effective_features'])}\n"
+                    ),
+                }
+            )
+        extension = ".zip" if platform == "windows" else ".tar.gz"
         result = {
             "schema_version": 1,
             **identity,
             "result_id": result_id,
             "platform": platform,
             "target": target,
-            "archive_id": f"archive-{target}",
+            "archive_id": f"final-1.{target}.archive",
             "status": "passed",
             "skipped": False,
             "assertions": [{"name": "archive-install-smoke", "status": "passed"}],
+            "archive": f"archives/rocketmq-rust-1.0.0-{target}{extension}",
+            "archive_manifest": f"archives/rocketmq-rust-1.0.0-{target}.manifest.json",
+            "archive_smoke_results": smoke_results,
         }
         (root / f"{result_id}.json").write_text(json.dumps(result), encoding="utf-8")
         started = {"schema_version": 1, **identity, "route_id": result_id, "context_path": f"contexts/{worker}.json"}

--- a/scripts/tests/test_publication_handoff.py
+++ b/scripts/tests/test_publication_handoff.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import tarfile
 import tempfile
 import unittest
+from unittest import mock
 import zipfile
 
 
@@ -159,6 +160,64 @@ class PublicationHandoffTests(unittest.TestCase):
             )
             self.assertEqual("passed", report["status"])
 
+    def test_platform_verification_executes_manifest_archive_binaries(self) -> None:
+        """A missing archive smoke call must not be reported as a passed H01 result."""
+
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = self._fixture(Path(directory))
+            draft = self.builder.build_draft(
+                fixture["candidate_manifest"],
+                fixture["candidate_root"],
+                fixture["source_root"],
+                fixture["output_root"],
+                SOURCE_MAP,
+            )
+            target = "x86_64-unknown-linux-gnu"
+            layout = json.loads(
+                (ROOT / "distribution" / "release-layout.json").read_text(encoding="utf-8")
+            )
+            binaries = {
+                entry.get("archive_binary", entry["binary"]): entry for entry in layout["binaries"]
+            }
+
+            def version_result(command, **_kwargs):
+                binary = binaries[Path(command[0]).name]
+                return mock.Mock(
+                    returncode=0,
+                    stdout=(
+                        f"component={binary['id']}\n"
+                        "version=1.0.0\n"
+                        f"artifact_id=final-1.{target}.{binary['id']}\n"
+                        f"requested_features={','.join(binary['requested_features'])}\n"
+                        f"effective_features={','.join(binary['effective_features'])}\n"
+                    ),
+                    stderr="",
+                )
+
+            with mock.patch("subprocess.run", side_effect=version_result):
+                report = self.verifier.verify_handoff(
+                    draft,
+                    fixture["candidate_manifest"],
+                    fixture["candidate_root"],
+                    fixture["source_root"],
+                    mode="draft-pre-ready",
+                    result_id="H01-LINUX",
+                    platform="linux",
+                    worker_id="handoff-linux",
+                )
+
+            self.assertIn("archive_smoke_results", report)
+            self.assertEqual(
+                ["admin", "broker", "controller", "namesrv", "proxy", "store-inspect"],
+                sorted(result["component"] for result in report["archive_smoke_results"]),
+            )
+            self.assertTrue(
+                all(result["exit_code"] == 0 for result in report["archive_smoke_results"])
+            )
+            self.assertTrue(
+                all("version=1.0.0" in result["stdout"] for result in report["archive_smoke_results"])
+            )
+
     @staticmethod
     def _add_tar(path: Path, files: dict[str, bytes]) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -186,15 +245,7 @@ class PublicationHandoffTests(unittest.TestCase):
             json.dumps({"schema_version": 1, "remote_publication": "not-executed"}), encoding="utf-8"
         )
 
-        archive_payload = {"rocketmq-rust/README.md": b"local archive\n"}
-        if nested_secret:
-            archive_payload["rocketmq-rust/private.pem"] = b"-----BEGIN PRIVATE KEY-----\nsecret\n"
-        cls._add_tar(candidate_root / "archives" / "linux" / "rocketmq-rust.tar.gz", archive_payload)
-        cls._add_tar(candidate_root / "archives" / "macos" / "rocketmq-rust.tar.gz", archive_payload)
-        windows = candidate_root / "archives" / "windows" / "rocketmq-rust.zip"
-        windows.parent.mkdir(parents=True)
-        with zipfile.ZipFile(windows, "w") as archive:
-            archive.writestr("rocketmq-rust/README.md", "local archive\n")
+        cls._add_release_archives(candidate_root, nested_secret=nested_secret)
 
         for service in ("namesrv", "broker", "controller", "proxy"):
             oci = candidate_root / "oci" / service
@@ -311,6 +362,67 @@ class PublicationHandoffTests(unittest.TestCase):
             "source_root": source_root,
             "output_root": output_root,
         }
+
+    @classmethod
+    def _add_release_archives(cls, candidate_root: Path, *, nested_secret: bool) -> None:
+        layout = json.loads(
+            (ROOT / "distribution" / "release-layout.json").read_text(encoding="utf-8")
+        )
+        package_root = "rocketmq-rust-1.0.0"
+        for target, target_spec in layout["targets"].items():
+            suffix = target_spec["executable_suffix"]
+            files: dict[str, bytes] = {}
+            binary_records = []
+            for binary in layout["binaries"]:
+                name = binary.get("archive_binary", binary["binary"])
+                files[f"bin/{name}{suffix}"] = b"fixture executable\n"
+                binary_records.append(
+                    {
+                        "component": binary["id"],
+                        "requested_features": binary["requested_features"],
+                        "effective_features": binary["effective_features"],
+                        "required_dependencies": binary.get("required_dependencies", []),
+                    }
+                )
+            for service in layout["configs"]:
+                files[f"conf/{service}.toml"] = b"[service]\n"
+            if nested_secret and target == "x86_64-unknown-linux-gnu":
+                files["private.pem"] = b"-----BEGIN PRIVATE KEY-----\nsecret\n"
+            inventory = [
+                {"path": path, "type": "directory", "size": 0}
+                for path in ("bin", "conf")
+            ] + [
+                {"path": path, "type": "file", "size": len(content)}
+                for path, content in files.items()
+            ]
+            inventory.sort(key=lambda item: item["path"])
+            archive_name = f"rocketmq-rust-1.0.0-{target}"
+            archive_path = candidate_root / "archives" / (
+                f"{archive_name}.zip" if target_spec["archive_format"] == "zip" else f"{archive_name}.tar.gz"
+            )
+            payload = {f"{package_root}/{path}": content for path, content in files.items()}
+            if target_spec["archive_format"] == "zip":
+                with zipfile.ZipFile(archive_path, "w") as archive:
+                    for path, content in payload.items():
+                        archive.writestr(path, content)
+            else:
+                cls._add_tar(archive_path, payload)
+            manifest = {
+                "schema_version": 1,
+                "candidate_id": "final-1",
+                "version": "1.0.0",
+                "run_id": "run-1",
+                "attempt": 1,
+                "target": target,
+                "artifact_id": f"final-1.{target}.archive",
+                "archive": f"archives/{archive_path.name}",
+                "files": inventory,
+                "binaries": binary_records,
+                "remote_publication": "not-executed",
+            }
+            (candidate_root / "archives" / f"{archive_name}.manifest.json").write_text(
+                json.dumps(manifest), encoding="utf-8"
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_publication_handoff_runner.py
+++ b/scripts/tests/test_publication_handoff_runner.py
@@ -44,7 +44,7 @@ class PublicationHandoffRunnerTests(unittest.TestCase):
         self.assertNotIn("secrets.", workflow)
         self.assertNotRegex(workflow, re.compile(r"cargo\s+publish|docker\s+(?:login|push)|helm\s+push|git\s+(?:push|tag)", re.I))
 
-    def test_powershell_runner_completes_local_prepare_platform_finalize_flow(self) -> None:
+    def test_powershell_runner_prepares_real_release_archive_layout(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             series_module = load_module("handoff_e2e_series", "distribution/release_series.py")
@@ -91,6 +91,16 @@ class PublicationHandoffRunnerTests(unittest.TestCase):
                 for field in ("candidate_id", "version", "run_id", "attempt"):
                     value[field] = identity[field]
                 path.write_text(json.dumps(value), encoding="utf-8")
+            for path in (final.parent / "archives").glob("*.manifest.json"):
+                value = json.loads(path.read_text(encoding="utf-8"))
+                for field in ("candidate_id", "version", "run_id", "attempt"):
+                    value[field] = identity[field]
+                value["artifact_id"] = f"{identity['candidate_id']}.{value['target']}.archive"
+                for binary in value["binaries"]:
+                    binary["artifact_id"] = (
+                        f"{identity['candidate_id']}.{value['target']}.{binary['component']}"
+                    )
+                path.write_text(json.dumps(value), encoding="utf-8")
             (final.parent / "evidence").mkdir(exist_ok=True)
             for name in ("EVIDENCE_INDEX.json", "NO_REMOTE_PUBLICATION.json"):
                 (final.parent / name).replace(final.parent / "evidence" / name)
@@ -120,7 +130,6 @@ class PublicationHandoffRunnerTests(unittest.TestCase):
             )
             output = root / "handoff"
             draft_bundle = root / "HANDOFF_DRAFT_TRANSFER.tar"
-            platform_root = root / "platforms"
             script = ROOT / "scripts" / "run-publication-handoff.ps1"
 
             self._run_powershell(
@@ -130,59 +139,14 @@ class PublicationHandoffRunnerTests(unittest.TestCase):
                 control_bundle,
                 ["-OutputRoot", str(output), "-DraftBundleOutput", str(draft_bundle)],
             )
-            for platform, result_id in (
-                ("linux", "H01-LINUX"),
-                ("windows", "H01-WINDOWS"),
-                ("macos", "H01-MACOS"),
-            ):
-                self._run_powershell(
-                    script,
-                    "Platform",
-                    source_bundle,
-                    control_bundle,
-                    [
-                        "-DraftBundle",
-                        str(draft_bundle),
-                        "-Platform",
-                        platform,
-                        "-ResultId",
-                        result_id,
-                        "-PlatformBundleOutput",
-                        str(platform_root / result_id),
-                    ],
-                )
-            self._run_powershell(
-                script,
-                "Finalize",
-                source_bundle,
-                control_bundle,
-                [
-                    "-OutputRoot",
-                    str(output),
-                    "-DraftBundle",
-                    str(draft_bundle),
-                    "-PlatformBundlesRoot",
-                    str(platform_root),
-                ],
-            )
-            handoff = output / "1.0.0" / identity["run_id"] / "attempt-1"
-            self.assertTrue((handoff / "PUBLICATION_READY.json").is_file())
-            self.assertEqual("publication-ready", read_json(final)["state"])
-            self.assertEqual(
-                "not-executed",
-                read_json(handoff / "PUBLICATION_READY.json")["remote_publication"]["status"],
-            )
-            final_import = next(output.glob(".handoff-finalize-*/candidate-source"))
-            verifier = load_module("handoff_e2e_ready_verifier", "distribution/verify_publication_handoff.py")
-            ready = verifier.verify_handoff(
-                handoff,
-                final,
-                final_import,
-                final_import / "repository-source",
-                mode="ready",
-                result_id="H06-PUBLICATION-READY",
-            )
-            self.assertEqual("passed", ready["status"])
+            transfer = load_module("handoff_e2e_draft_transfer", "distribution/transfer_handoff_draft.py")
+            draft_manifest = transfer.read_transfer_manifest(draft_bundle)
+            archive_paths = {
+                entry["path"] for entry in draft_manifest["files"] if entry["path"].startswith("archives/")
+            }
+            self.assertEqual(3, len([path for path in archive_paths if path.endswith(".manifest.json")]))
+            self.assertEqual(3, len([path for path in archive_paths if path.endswith((".zip", ".tar.gz"))]))
+            self.assertFalse(any(path.startswith("archives/linux/") for path in archive_paths))
 
     @staticmethod
     def _run_powershell(


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9564

### Brief Description

Aligns publication handoff verification with the real release archive layout. The verifier now selects archives through their retained target manifests, reuses the release archive validator, executes all six packaged services and tools with `--version --verbose` for H01, and records the process results. The platform merger rejects incomplete smoke denominators, non-zero exits, forged build metadata, mismatched artifact identities, and incorrect target paths.

The handoff fixtures now use the same target-named archives and manifests as release preparation. This remains a local-only candidate verification change and performs no remote publication.

### How Did You Test This Change?

- `python -m unittest scripts.tests.test_release_archive scripts.tests.test_publication_handoff scripts.tests.test_handoff_platform_result_merge scripts.tests.test_handoff_draft_transfer scripts.tests.test_publication_handoff_runner scripts.tests.test_candidate_transfer scripts.tests.test_no_remote_publication_guard scripts.tests.test_release_lifecycle` (40 tests passed)
- JSON parse validation for `distribution/handoff-platform-result.schema.json`
- `python scripts/no_remote_publication_guard.py --phase 6 --static-only`
- `git diff --check`

No Rust source or Cargo configuration changed, so Cargo validation was not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release archive verification now checks archive manifests, retained metadata, target paths, and required binary smoke-test results.
  * Platform handoff results now include archive details and six successful component smoke tests.
  * Publication reports now include verified archive and smoke-test evidence.

* **Bug Fixes**
  * Rejects incomplete, duplicated, forged, failed, or mismatched archive and smoke-test data.

* **Tests**
  * Expanded coverage for archive layout, platform verification, smoke-test validation, and release preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->