### PR TITLE
[ISSUE #9572]✨Close candidate job outcome denominator

### DIFF
--- a/distribution/candidate-stage-outcome-index.schema.json
+++ b/distribution/candidate-stage-outcome-index.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rocketmq-rust.local/schemas/candidate-stage-outcome-index.schema.json",
+  "title": "RocketMQ Rust candidate job outcome index",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version", "candidate_id", "version", "run_id", "attempt", "profile",
+    "expected_job_ids", "jobs", "failed_job_ids", "all_required_passed", "remote_publication"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "candidate_id": {"type": "string", "minLength": 1},
+    "version": {"type": "string", "minLength": 1},
+    "run_id": {"type": "string", "minLength": 1},
+    "attempt": {"type": "integer", "minimum": 1},
+    "profile": {"type": "string", "minLength": 1},
+    "expected_job_ids": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "jobs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/job"}
+    },
+    "failed_job_ids": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "all_required_passed": {"type": "boolean"},
+    "remote_publication": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": {"status": {"const": "not-executed"}}
+    }
+  },
+  "$defs": {
+    "job": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "job_id", "worker_id", "target", "status", "workflow_result",
+        "expected_result_ids", "result_ids", "missing_result_ids",
+        "result_files", "event_files", "context_files"
+      ],
+      "properties": {
+        "job_id": {"type": "string", "minLength": 1},
+        "worker_id": {"type": ["string", "null"]},
+        "target": {"type": ["string", "null"]},
+        "status": {"enum": ["success", "failed", "cancelled", "missing-worker"]},
+        "workflow_result": {"enum": ["success", "failure", "cancelled", "skipped"]},
+        "expected_result_ids": {
+          "type": "array", "minItems": 1, "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "result_ids": {
+          "type": "array", "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "missing_result_ids": {
+          "type": "array", "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "result_files": {"type": "array", "uniqueItems": true, "items": {"type": "string"}},
+        "event_files": {"type": "array", "uniqueItems": true, "items": {"type": "string"}},
+        "context_files": {"type": "array", "uniqueItems": true, "items": {"type": "string"}}
+      }
+    }
+  }
+}

--- a/distribution/candidate-stage-outcome-policy.json
+++ b/distribution/candidate-stage-outcome-policy.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "profiles": {
+    "release-candidate": [
+      {"job_id": "prepare-common", "target": null, "result_ids": ["prepare-common"]},
+      {"job_id": "build-linux", "target": "x86_64-unknown-linux-gnu", "result_ids": ["S01"]},
+      {"job_id": "build-windows", "target": "x86_64-pc-windows-msvc", "result_ids": ["S02"]},
+      {"job_id": "build-macos", "target": "x86_64-apple-darwin", "result_ids": ["S03"]},
+      {"job_id": "aggregate", "target": null, "result_ids": ["aggregate"]},
+      {
+        "job_id": "full-matrix",
+        "target": null,
+        "result_ids": [
+          "P01", "P02", "P03", "P04", "P05", "P06", "P07", "P08", "P09", "P10", "P11", "P12",
+          "I01", "I02", "I03", "I04", "I05", "M01", "L01", "A01",
+          "U01-LF", "U01-MP", "U01-RDB", "U01-CMP", "U01-POP", "U01-TMR", "U01-TRD", "U01-CTL",
+          "U01-UPG", "U01"
+        ]
+      }
+    ]
+  }
+}

--- a/distribution/candidate-stage-outcome.schema.json
+++ b/distribution/candidate-stage-outcome.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rocketmq-rust.local/schemas/candidate-stage-outcome.schema.json",
+  "title": "RocketMQ Rust immutable candidate job outcome",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version", "candidate_id", "version", "run_id", "attempt", "job_id",
+    "worker_id", "target", "status", "workflow_result", "sealed", "result_files",
+    "event_pairs", "context_files"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "candidate_id": {"type": "string", "minLength": 1},
+    "version": {"type": "string", "minLength": 1},
+    "run_id": {"type": "string", "minLength": 1},
+    "attempt": {"type": "integer", "minimum": 1},
+    "job_id": {"type": "string", "minLength": 1},
+    "worker_id": {"type": "string", "minLength": 1},
+    "target": {"type": ["string", "null"], "minLength": 1},
+    "status": {"enum": ["success", "failed", "cancelled"]},
+    "workflow_result": {"enum": ["success", "failure", "cancelled", "skipped"]},
+    "sealed": {"const": true},
+    "result_files": {
+      "type": "array", "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "event_pairs": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["route_id", "started", "completed"],
+        "properties": {
+          "route_id": {"type": "string", "minLength": 1},
+          "started": {"type": "string", "minLength": 1},
+          "completed": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "context_files": {
+      "type": "array", "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
+    }
+  }
+}

--- a/scripts/collect_candidate_stage_outcomes.py
+++ b/scripts/collect_candidate_stage_outcomes.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+"""Close candidate job outcomes into one atomic lifecycle input."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path, PurePosixPath
+import shutil
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DISTRIBUTION = ROOT / "distribution"
+if str(DISTRIBUTION) not in sys.path:
+    sys.path.insert(0, str(DISTRIBUTION))
+
+from release_state import (
+    ReleaseStateError,
+    atomic_write_json,
+    ensure_no_digest_fields,
+    read_json,
+    require_safe_id,
+    resolve_existing_file,
+    validate_candidate,
+)
+
+
+DEFAULT_POLICY = DISTRIBUTION / "candidate-stage-outcome-policy.json"
+OUTCOME_NAME = "CANDIDATE_STAGE_OUTCOME.json"
+INDEX_NAME = "CANDIDATE_STAGE_OUTCOMES.json"
+WORKFLOW_RESULTS = {"success", "failure", "cancelled", "skipped"}
+OUTCOME_STATUS_BY_WORKFLOW_RESULT = {
+    "success": "success",
+    "failure": "failed",
+    "cancelled": "cancelled",
+    "skipped": "cancelled",
+}
+
+
+class OutcomeError(ReleaseStateError):
+    """Raised when job outcomes are ambiguous, incomplete, or unsafe."""
+
+
+def _identity(value: dict[str, Any]) -> tuple[Any, ...]:
+    return value.get("candidate_id"), value.get("version"), value.get("run_id"), value.get("attempt")
+
+
+def _safe_relative(value: Any, label: str) -> PurePosixPath:
+    if not isinstance(value, str) or not value or "\\" in value:
+        raise OutcomeError(f"{label} must be a safe POSIX relative path")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise OutcomeError(f"{label} must be a safe POSIX relative path")
+    return path
+
+
+def _load_policy(path: Path, profile: str) -> list[dict[str, Any]]:
+    require_safe_id(profile, "profile")
+    value = read_json(resolve_existing_file(path, "candidate outcome policy"))
+    ensure_no_digest_fields(value)
+    if value.get("schema_version") != 1 or set(value) != {"schema_version", "profiles"}:
+        raise OutcomeError("candidate outcome policy fields are invalid")
+    profiles = value.get("profiles")
+    if not isinstance(profiles, dict):
+        raise OutcomeError("candidate outcome policy profiles are invalid")
+    entries = profiles.get(profile)
+    if not isinstance(entries, list) or not entries:
+        raise OutcomeError(f"candidate outcome policy profile is missing: {profile}")
+    job_ids: list[str] = []
+    normalized: list[dict[str, Any]] = []
+    for entry in entries:
+        if not isinstance(entry, dict) or set(entry) != {"job_id", "target", "result_ids"}:
+            raise OutcomeError("candidate outcome policy entry is invalid")
+        job_id = require_safe_id(entry.get("job_id"), "job_id")
+        target = entry.get("target")
+        if target is not None:
+            require_safe_id(target, "target")
+        result_ids = entry.get("result_ids")
+        if (
+            not isinstance(result_ids, list)
+            or not result_ids
+            or any(not isinstance(result_id, str) for result_id in result_ids)
+        ):
+            raise OutcomeError(f"candidate outcome result denominator is invalid: {job_id}")
+        normalized_result_ids = [require_safe_id(result_id, "result_id") for result_id in result_ids]
+        if len(normalized_result_ids) != len(set(normalized_result_ids)):
+            raise OutcomeError(f"candidate outcome result denominator contains duplicates: {job_id}")
+        job_ids.append(job_id)
+        normalized.append({"job_id": job_id, "target": target, "result_ids": normalized_result_ids})
+    if len(job_ids) != len(set(job_ids)):
+        raise OutcomeError("candidate outcome policy contains duplicate jobs")
+    return normalized
+
+
+def _load_workflow_results(path: Path, candidate: dict[str, Any], expected: set[str]) -> dict[str, str]:
+    value = read_json(resolve_existing_file(path, "workflow results"))
+    ensure_no_digest_fields(value)
+    allowed = {"schema_version", "candidate_id", "version", "run_id", "attempt", "jobs"}
+    if set(value) != allowed or value.get("schema_version") != 1 or _identity(value) != _identity(candidate):
+        raise OutcomeError("workflow results belong to another candidate")
+    jobs = value.get("jobs")
+    if not isinstance(jobs, dict) or set(jobs) != expected:
+        raise OutcomeError("workflow job result denominator is incomplete or contains extras")
+    if any(not isinstance(result, str) or result not in WORKFLOW_RESULTS for result in jobs.values()):
+        raise OutcomeError("workflow job result contains an invalid status")
+    return jobs
+
+
+def _bundle_files(bundle: Path) -> set[str]:
+    files: set[str] = set()
+    for path in sorted(bundle.rglob("*")):
+        if path.is_symlink():
+            raise OutcomeError(f"candidate outcome bundle contains a symbolic link: {path}")
+        if path.is_file():
+            files.add(path.relative_to(bundle).as_posix())
+        elif not path.is_dir():
+            raise OutcomeError(f"candidate outcome bundle contains an unsupported file: {path}")
+    return files
+
+
+def _bundle_path(bundle: Path, relative: str, label: str) -> Path:
+    path = _safe_relative(relative, label)
+    resolved = bundle.joinpath(*path.parts).resolve()
+    try:
+        resolved.relative_to(bundle.resolve())
+    except ValueError as error:
+        raise OutcomeError(f"{label} escapes its bundle") from error
+    return resolve_existing_file(resolved, label)
+
+
+def _categorized_relative(value: Any, category: str, label: str) -> str:
+    path = _safe_relative(value, label)
+    if len(path.parts) < 2 or path.parts[0] != category:
+        raise OutcomeError(f"{label} must be below {category}/")
+    return path.as_posix()
+
+
+def _validate_payload_identity(value: dict[str, Any], candidate: dict[str, Any], label: str) -> None:
+    ensure_no_digest_fields(value)
+    if value.get("schema_version") != 1 or _identity(value) != _identity(candidate):
+        raise OutcomeError(f"{label} belongs to another candidate")
+
+
+def _validate_bundle(
+    bundle: Path,
+    candidate: dict[str, Any],
+    expected: dict[str, Any],
+    workflow_result: str,
+) -> tuple[dict[str, Any], list[tuple[str, Path]], list[str]]:
+    outcome_path = resolve_existing_file(bundle / OUTCOME_NAME, "candidate job outcome")
+    outcome = read_json(outcome_path)
+    _validate_payload_identity(outcome, candidate, "candidate job outcome")
+    allowed = {
+        "schema_version", "candidate_id", "version", "run_id", "attempt", "job_id",
+        "worker_id", "target", "status", "workflow_result", "sealed", "result_files",
+        "event_pairs", "context_files",
+    }
+    if set(outcome) != allowed:
+        raise OutcomeError(f"candidate job outcome fields are not closed: {expected['job_id']}")
+    worker_id = require_safe_id(outcome.get("worker_id"), "worker_id")
+    if (
+        outcome.get("job_id") != expected["job_id"]
+        or outcome.get("target") != expected["target"]
+        or outcome.get("workflow_result") != workflow_result
+        or outcome.get("sealed") is not True
+        or outcome.get("status") not in {"success", "failed", "cancelled"}
+        or outcome.get("status") != OUTCOME_STATUS_BY_WORKFLOW_RESULT[workflow_result]
+    ):
+        raise OutcomeError(f"candidate job outcome disagrees with workflow result: {expected['job_id']}")
+    result_files = outcome.get("result_files")
+    event_pairs = outcome.get("event_pairs")
+    context_files = outcome.get("context_files")
+    if not all(isinstance(value, list) for value in (result_files, event_pairs, context_files)):
+        raise OutcomeError(f"candidate job outcome payload lists are invalid: {expected['job_id']}")
+    if outcome["status"] == "success" and (not result_files or not event_pairs or not context_files):
+        raise OutcomeError(f"successful candidate job outcome is incomplete: {expected['job_id']}")
+    payloads: list[tuple[str, Path]] = []
+    declared = {OUTCOME_NAME}
+    result_ids: list[str] = []
+    for relative in result_files:
+        normalized = _categorized_relative(relative, "results", "candidate result")
+        path = _bundle_path(bundle, normalized, "candidate result")
+        value = read_json(path)
+        _validate_payload_identity(value, candidate, "candidate result")
+        result_id = require_safe_id(value.get("result_id"), "result_id")
+        result_status = value.get("status")
+        if result_id in result_ids:
+            raise OutcomeError(f"candidate result ID is duplicated: {result_id}")
+        if result_id not in expected["result_ids"]:
+            raise OutcomeError(f"candidate result ID is outside the job denominator: {result_id}")
+        if result_status not in {"passed", "failed", "cancelled"}:
+            raise OutcomeError(f"candidate result status is invalid: {result_id}")
+        if outcome["status"] == "success" and result_status != "passed":
+            raise OutcomeError(f"successful job has a non-passed result: {expected['job_id']}")
+        result_ids.append(result_id)
+        declared.add(normalized)
+        payloads.append((normalized, path))
+    routes: set[str] = set()
+    for pair in event_pairs:
+        if not isinstance(pair, dict) or set(pair) != {"route_id", "started", "completed"}:
+            raise OutcomeError(f"candidate event pair is invalid: {expected['job_id']}")
+        route_id = require_safe_id(pair.get("route_id"), "route_id")
+        if route_id in routes:
+            raise OutcomeError(f"candidate event route is duplicated: {route_id}")
+        routes.add(route_id)
+        started_relative = _categorized_relative(pair["started"], "events", "started event")
+        completed_relative = _categorized_relative(pair["completed"], "events", "completed event")
+        started_path = _bundle_path(bundle, started_relative, "started event")
+        completed_path = _bundle_path(bundle, completed_relative, "completed event")
+        started = read_json(started_path)
+        completed = read_json(completed_path)
+        for value, label in ((started, "started event"), (completed, "completed event")):
+            _validate_payload_identity(value, candidate, label)
+            if value.get("route_id") != route_id or value.get("worker_id") != worker_id:
+                raise OutcomeError(f"candidate event identity is invalid: {route_id}")
+        completed_status = completed.get("status")
+        exit_code = completed.get("exit_code")
+        if started.get("status") != "started":
+            raise OutcomeError(f"candidate started event status is invalid: {route_id}")
+        if (
+            completed_status not in {"passed", "failed", "cancelled"}
+            or not isinstance(exit_code, int)
+            or isinstance(exit_code, bool)
+            or (completed_status == "passed") != (exit_code == 0)
+        ):
+            raise OutcomeError(f"candidate completed event status is invalid: {route_id}")
+        if outcome["status"] == "success" and (
+            completed_status != "passed" or exit_code != 0
+        ):
+            raise OutcomeError(f"successful job has a failed event: {route_id}")
+        for normalized, path in ((started_relative, started_path), (completed_relative, completed_path)):
+            declared.add(normalized)
+            payloads.append((normalized, path))
+    contexts: set[str] = set()
+    for relative in context_files:
+        normalized = _categorized_relative(relative, "contexts", "execution context")
+        path = _bundle_path(bundle, normalized, "execution context")
+        value = read_json(path)
+        _validate_payload_identity(value, candidate, "execution context")
+        context_worker = require_safe_id(value.get("worker_id"), "context worker_id")
+        if context_worker in contexts or context_worker != worker_id:
+            raise OutcomeError(f"candidate execution context is invalid: {expected['job_id']}")
+        contexts.add(context_worker)
+        if value.get("publish_input") is not False or value.get("publishing_credentials_provided") is not False:
+            raise OutcomeError(f"candidate execution context is publication-enabled: {expected['job_id']}")
+        declared.add(normalized)
+        payloads.append((normalized, path))
+    if _bundle_files(bundle) != declared:
+        raise OutcomeError(f"candidate job outcome bundle has undeclared or missing files: {expected['job_id']}")
+    missing_result_ids = sorted(set(expected["result_ids"]) - set(result_ids))
+    if outcome["status"] == "success" and missing_result_ids:
+        raise OutcomeError(f"successful job is missing required results: {expected['job_id']}")
+    return outcome, payloads, result_ids
+
+
+def _copy_payload(source: Path, destination: Path) -> None:
+    if destination.exists():
+        raise OutcomeError(f"candidate outcome destination collides: {destination}")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, destination)
+    with source.open("rb") as source_file, destination.open("rb") as destination_file:
+        while True:
+            source_chunk = source_file.read(1024 * 1024)
+            destination_chunk = destination_file.read(1024 * 1024)
+            if source_chunk != destination_chunk:
+                raise OutcomeError(f"candidate outcome copy changed bytes: {destination}")
+            if not source_chunk:
+                break
+
+
+def collect_outcomes(
+    candidate_manifest: Path,
+    bundles_root: Path,
+    workflow_results: Path,
+    policy: Path,
+    profile: str,
+    output_root: Path,
+) -> Path:
+    candidate = read_json(resolve_existing_file(candidate_manifest, "candidate manifest"))
+    validate_candidate(candidate)
+    ensure_no_digest_fields(candidate)
+    expected = _load_policy(policy, profile)
+    expected_ids = [entry["job_id"] for entry in expected]
+    workflow = _load_workflow_results(workflow_results, candidate, set(expected_ids))
+    bundles_root = bundles_root.resolve()
+    if not bundles_root.is_dir():
+        raise OutcomeError("candidate job bundle root is missing")
+    bundle_jobs: set[str] = set()
+    for path in bundles_root.iterdir():
+        if path.is_symlink() or not path.is_dir():
+            raise OutcomeError(f"candidate job bundle root contains an unsupported entry: {path.name}")
+        bundle_jobs.add(path.name)
+    unknown_jobs = bundle_jobs - set(expected_ids)
+    if unknown_jobs:
+        raise OutcomeError(f"unknown job bundle: {', '.join(sorted(unknown_jobs))}")
+    output_root = output_root.resolve()
+    if output_root.exists():
+        raise OutcomeError(f"candidate outcome output already exists: {output_root}")
+    staging = output_root.with_name(f".{output_root.name}.staging")
+    if staging.exists():
+        raise OutcomeError(f"stale candidate outcome staging directory exists: {staging}")
+    jobs: list[dict[str, Any]] = []
+    failed: list[str] = []
+    try:
+        staging.mkdir(parents=True)
+        for entry in expected:
+            job_id = entry["job_id"]
+            bundle = bundles_root / job_id
+            if not bundle.is_dir():
+                failed.append(job_id)
+                jobs.append(
+                    {
+                        "job_id": job_id,
+                        "worker_id": None,
+                        "target": entry["target"],
+                        "status": "missing-worker",
+                        "workflow_result": workflow[job_id],
+                        "expected_result_ids": entry["result_ids"],
+                        "result_ids": [],
+                        "missing_result_ids": entry["result_ids"],
+                        "result_files": [],
+                        "event_files": [],
+                        "context_files": [],
+                    }
+                )
+                continue
+            outcome, payloads, result_ids = _validate_bundle(bundle, candidate, entry, workflow[job_id])
+            copied = {"results": [], "events": [], "contexts": []}
+            for relative, source in payloads:
+                category = PurePosixPath(relative).parts[0]
+                if category not in copied:
+                    raise OutcomeError(f"candidate payload has an unsupported category: {relative}")
+                destination_relative = f"{category}/{job_id}/" + "/".join(PurePosixPath(relative).parts[1:])
+                _copy_payload(source, staging.joinpath(*PurePosixPath(destination_relative).parts))
+                copied[category].append(destination_relative)
+            if outcome["status"] != "success":
+                failed.append(job_id)
+            jobs.append(
+                {
+                    "job_id": job_id,
+                    "worker_id": outcome["worker_id"],
+                    "target": entry["target"],
+                    "status": outcome["status"],
+                    "workflow_result": workflow[job_id],
+                    "expected_result_ids": entry["result_ids"],
+                    "result_ids": result_ids,
+                    "missing_result_ids": sorted(set(entry["result_ids"]) - set(result_ids)),
+                    "result_files": copied["results"],
+                    "event_files": copied["events"],
+                    "context_files": copied["contexts"],
+                }
+            )
+        index = {
+            "schema_version": 1,
+            "candidate_id": candidate["candidate_id"],
+            "version": candidate["version"],
+            "run_id": candidate["run_id"],
+            "attempt": candidate["attempt"],
+            "profile": profile,
+            "expected_job_ids": expected_ids,
+            "jobs": jobs,
+            "failed_job_ids": failed,
+            "all_required_passed": not failed,
+            "remote_publication": {"status": "not-executed"},
+        }
+        ensure_no_digest_fields(index)
+        atomic_write_json(staging / INDEX_NAME, index)
+        os.replace(staging, output_root)
+    except Exception:
+        if staging.exists():
+            shutil.rmtree(staging)
+        raise
+    return output_root / INDEX_NAME
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate-manifest", type=Path, required=True)
+    parser.add_argument("--bundles-root", type=Path, required=True)
+    parser.add_argument("--workflow-results", type=Path, required=True)
+    parser.add_argument("--policy", type=Path, default=DEFAULT_POLICY)
+    parser.add_argument("--profile", required=True)
+    parser.add_argument("--output-root", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        output = collect_outcomes(
+            args.candidate_manifest,
+            args.bundles_root,
+            args.workflow_results,
+            args.policy,
+            args.profile,
+            args.output_root,
+        )
+    except (OutcomeError, OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        print(f"CANDIDATE_STAGE_OUTCOMES_FAILED detail={error}", file=sys.stderr)
+        return 1
+    value = read_json(output)
+    print(
+        "CANDIDATE_STAGE_OUTCOMES_OK "
+        f"jobs={len(value['jobs'])} failed={len(value['failed_job_ids'])} output={output}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_candidate_stage_outcomes.py
+++ b/scripts/tests/test_candidate_stage_outcomes.py
@@ -1,0 +1,606 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from scripts.tests.release_archive_test_support import create_candidate
+from scripts.tests.release_test_support import read_json, write_json
+
+
+ROOT = Path(__file__).resolve().parents[2]
+COLLECTOR = ROOT / "scripts" / "collect_candidate_stage_outcomes.py"
+
+
+class CandidateStageOutcomeTests(unittest.TestCase):
+    def test_successful_worker_bundles_are_closed_and_atomically_merged(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            candidate = create_candidate(root)
+            policy = self._policy(root)
+            workflow = self._workflow_results(root, candidate, {"build-linux": "success", "aggregate": "success"})
+            bundles = root / "bundles"
+            self._bundle(bundles / "build-linux", candidate, "build-linux", "linux-worker", "x86_64-unknown-linux-gnu")
+            self._bundle(bundles / "aggregate", candidate, "aggregate", "aggregate-worker", None)
+            output = root / "canonical"
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(COLLECTOR),
+                    "--candidate-manifest",
+                    str(candidate),
+                    "--bundles-root",
+                    str(bundles),
+                    "--workflow-results",
+                    str(workflow),
+                    "--policy",
+                    str(policy),
+                    "--profile",
+                    "fixture",
+                    "--output-root",
+                    str(output),
+                ],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=30,
+            )
+
+            self.assertEqual(0, completed.returncode, completed.stdout + completed.stderr)
+            index = read_json(output / "CANDIDATE_STAGE_OUTCOMES.json")
+            self.assertTrue(index["all_required_passed"])
+            self.assertEqual([], index["failed_job_ids"])
+            self.assertEqual(["build-linux", "aggregate"], [item["job_id"] for item in index["jobs"]])
+            self.assertEqual(2, len(list((output / "results").rglob("*.json"))))
+            self.assertEqual(4, len(list((output / "events").rglob("*.json"))))
+            self.assertEqual(2, len(list((output / "contexts").rglob("*.json"))))
+
+    def test_missing_bundle_is_synthesized_as_a_rejection_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            candidate = create_candidate(root)
+            policy = self._policy(root)
+            workflow = self._workflow_results(
+                root,
+                candidate,
+                {"build-linux": "success", "aggregate": "failure"},
+            )
+            bundles = root / "bundles"
+            self._bundle(
+                bundles / "build-linux",
+                candidate,
+                "build-linux",
+                "linux-worker",
+                "x86_64-unknown-linux-gnu",
+            )
+            output = root / "canonical"
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(COLLECTOR),
+                    "--candidate-manifest",
+                    str(candidate),
+                    "--bundles-root",
+                    str(bundles),
+                    "--workflow-results",
+                    str(workflow),
+                    "--policy",
+                    str(policy),
+                    "--profile",
+                    "fixture",
+                    "--output-root",
+                    str(output),
+                ],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=30,
+            )
+
+            self.assertEqual(0, completed.returncode, completed.stdout + completed.stderr)
+            index = read_json(output / "CANDIDATE_STAGE_OUTCOMES.json")
+            self.assertFalse(index["all_required_passed"])
+            self.assertEqual(["aggregate"], index["failed_job_ids"])
+            aggregate = next(item for item in index["jobs"] if item["job_id"] == "aggregate")
+            self.assertEqual("missing-worker", aggregate["status"])
+            self.assertEqual("failure", aggregate["workflow_result"])
+
+    def test_mixed_candidate_payload_fails_without_publishing_partial_output(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            candidate = create_candidate(root)
+            policy = self._policy(root)
+            workflow = self._workflow_results(
+                root,
+                candidate,
+                {"build-linux": "success", "aggregate": "success"},
+            )
+            bundles = root / "bundles"
+            self._bundle(
+                bundles / "build-linux",
+                candidate,
+                "build-linux",
+                "linux-worker",
+                "x86_64-unknown-linux-gnu",
+            )
+            self._bundle(bundles / "aggregate", candidate, "aggregate", "aggregate-worker", None)
+            result_path = bundles / "build-linux/results/build-linux.json"
+            result = read_json(result_path)
+            result["candidate_id"] = "another-candidate"
+            write_json(result_path, result)
+            output = root / "canonical"
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(COLLECTOR),
+                    "--candidate-manifest",
+                    str(candidate),
+                    "--bundles-root",
+                    str(bundles),
+                    "--workflow-results",
+                    str(workflow),
+                    "--policy",
+                    str(policy),
+                    "--profile",
+                    "fixture",
+                    "--output-root",
+                    str(output),
+                ],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=30,
+            )
+
+            self.assertEqual(1, completed.returncode)
+            self.assertIn("belongs to another candidate", completed.stderr)
+            self.assertFalse(output.exists())
+            self.assertFalse(output.with_name(f".{output.name}.staging").exists())
+
+    def test_undeclared_bundle_file_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            candidate = create_candidate(root)
+            policy = self._policy(root)
+            workflow = self._workflow_results(
+                root,
+                candidate,
+                {"build-linux": "success", "aggregate": "success"},
+            )
+            bundles = root / "bundles"
+            self._bundle(
+                bundles / "build-linux",
+                candidate,
+                "build-linux",
+                "linux-worker",
+                "x86_64-unknown-linux-gnu",
+            )
+            self._bundle(bundles / "aggregate", candidate, "aggregate", "aggregate-worker", None)
+            (bundles / "aggregate/undeclared.txt").write_text("not indexed\n", encoding="utf-8")
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(COLLECTOR),
+                    "--candidate-manifest",
+                    str(candidate),
+                    "--bundles-root",
+                    str(bundles),
+                    "--workflow-results",
+                    str(workflow),
+                    "--policy",
+                    str(policy),
+                    "--profile",
+                    "fixture",
+                    "--output-root",
+                    str(root / "canonical"),
+                ],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=30,
+            )
+
+            self.assertEqual(1, completed.returncode)
+            self.assertIn("undeclared or missing files", completed.stderr)
+
+    def test_failed_worker_bundle_is_preserved_as_rejection_input(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            candidate = create_candidate(root)
+            policy = self._policy(root)
+            workflow = self._workflow_results(
+                root,
+                candidate,
+                {"build-linux": "failure", "aggregate": "success"},
+            )
+            bundles = root / "bundles"
+            self._bundle(
+                bundles / "build-linux",
+                candidate,
+                "build-linux",
+                "linux-worker",
+                "x86_64-unknown-linux-gnu",
+                status="failed",
+                workflow_result="failure",
+            )
+            self._bundle(bundles / "aggregate", candidate, "aggregate", "aggregate-worker", None)
+            output = root / "canonical"
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(COLLECTOR),
+                    "--candidate-manifest",
+                    str(candidate),
+                    "--bundles-root",
+                    str(bundles),
+                    "--workflow-results",
+                    str(workflow),
+                    "--policy",
+                    str(policy),
+                    "--profile",
+                    "fixture",
+                    "--output-root",
+                    str(output),
+                ],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=30,
+            )
+
+            self.assertEqual(0, completed.returncode, completed.stdout + completed.stderr)
+            index = read_json(output / "CANDIDATE_STAGE_OUTCOMES.json")
+            self.assertEqual(["build-linux"], index["failed_job_ids"])
+            failed = next(item for item in index["jobs"] if item["job_id"] == "build-linux")
+            self.assertEqual("failed", failed["status"])
+            self.assertTrue(failed["result_files"])
+            self.assertTrue(failed["event_files"])
+            self.assertTrue(failed["context_files"])
+
+    def test_unknown_job_bundle_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            candidate = create_candidate(root)
+            policy = self._policy(root)
+            workflow = self._workflow_results(
+                root,
+                candidate,
+                {"build-linux": "success", "aggregate": "success"},
+            )
+            bundles = root / "bundles"
+            self._bundle(
+                bundles / "build-linux",
+                candidate,
+                "build-linux",
+                "linux-worker",
+                "x86_64-unknown-linux-gnu",
+            )
+            self._bundle(bundles / "aggregate", candidate, "aggregate", "aggregate-worker", None)
+            self._bundle(bundles / "unknown", candidate, "unknown", "unknown-worker", None)
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(COLLECTOR),
+                    "--candidate-manifest",
+                    str(candidate),
+                    "--bundles-root",
+                    str(bundles),
+                    "--workflow-results",
+                    str(workflow),
+                    "--policy",
+                    str(policy),
+                    "--profile",
+                    "fixture",
+                    "--output-root",
+                    str(root / "canonical"),
+                ],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=30,
+            )
+
+            self.assertEqual(1, completed.returncode)
+            self.assertIn("unknown job bundle", completed.stderr)
+
+    def test_workflow_result_must_be_a_known_string(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            candidate = create_candidate(root)
+            policy = self._policy(root)
+            workflow = self._workflow_results(
+                root,
+                candidate,
+                {"build-linux": {"result": "success"}, "aggregate": "success"},
+            )
+            bundles = root / "bundles"
+            bundles.mkdir()
+
+            completed = self._collect(root, candidate, policy, workflow, bundles)
+
+            self.assertEqual(1, completed.returncode)
+            self.assertIn("invalid status", completed.stderr)
+            self.assertNotIn("Traceback", completed.stderr)
+
+    def test_worker_status_must_exactly_match_the_workflow_result(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            candidate = create_candidate(root)
+            policy = self._policy(root)
+            workflow = self._workflow_results(
+                root,
+                candidate,
+                {"build-linux": "cancelled", "aggregate": "success"},
+            )
+            bundles = root / "bundles"
+            self._bundle(
+                bundles / "build-linux",
+                candidate,
+                "build-linux",
+                "linux-worker",
+                "x86_64-unknown-linux-gnu",
+                status="failed",
+                workflow_result="cancelled",
+            )
+            self._bundle(bundles / "aggregate", candidate, "aggregate", "aggregate-worker", None)
+
+            completed = self._collect(root, candidate, policy, workflow, bundles)
+
+            self.assertEqual(1, completed.returncode)
+            self.assertIn("disagrees with workflow result", completed.stderr)
+
+    def test_stale_staging_directory_is_not_overwritten(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            candidate = create_candidate(root)
+            policy = self._policy(root)
+            workflow = self._workflow_results(
+                root,
+                candidate,
+                {"build-linux": "success", "aggregate": "success"},
+            )
+            bundles = root / "bundles"
+            self._bundle(
+                bundles / "build-linux",
+                candidate,
+                "build-linux",
+                "linux-worker",
+                "x86_64-unknown-linux-gnu",
+            )
+            self._bundle(bundles / "aggregate", candidate, "aggregate", "aggregate-worker", None)
+            stale = root / ".canonical.staging"
+            stale.mkdir()
+            marker = stale / "interrupted.txt"
+            marker.write_text("preserve for audit\n", encoding="utf-8")
+
+            completed = self._collect(root, candidate, policy, workflow, bundles)
+
+            self.assertEqual(1, completed.returncode)
+            self.assertIn("stale candidate outcome staging", completed.stderr)
+            self.assertTrue(marker.is_file())
+            self.assertFalse((root / "canonical").exists())
+
+    def test_payload_path_cannot_escape_the_worker_bundle(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            candidate = create_candidate(root)
+            policy = self._policy(root)
+            workflow = self._workflow_results(
+                root,
+                candidate,
+                {"build-linux": "success", "aggregate": "success"},
+            )
+            bundles = root / "bundles"
+            self._bundle(
+                bundles / "build-linux",
+                candidate,
+                "build-linux",
+                "linux-worker",
+                "x86_64-unknown-linux-gnu",
+            )
+            self._bundle(bundles / "aggregate", candidate, "aggregate", "aggregate-worker", None)
+            outcome_path = bundles / "build-linux/CANDIDATE_STAGE_OUTCOME.json"
+            outcome = read_json(outcome_path)
+            outcome["result_files"] = ["../outside.json"]
+            write_json(outcome_path, outcome)
+
+            completed = self._collect(root, candidate, policy, workflow, bundles)
+
+            self.assertEqual(1, completed.returncode)
+            self.assertIn("safe POSIX relative path", completed.stderr)
+
+    def test_successful_job_must_cover_its_result_denominator(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            candidate = create_candidate(root)
+            policy = self._policy(root)
+            policy_value = read_json(policy)
+            policy_value["profiles"]["fixture"][1]["result_ids"].append("another-result")
+            write_json(policy, policy_value)
+            workflow = self._workflow_results(
+                root,
+                candidate,
+                {"build-linux": "success", "aggregate": "success"},
+            )
+            bundles = root / "bundles"
+            self._bundle(
+                bundles / "build-linux",
+                candidate,
+                "build-linux",
+                "linux-worker",
+                "x86_64-unknown-linux-gnu",
+            )
+            self._bundle(bundles / "aggregate", candidate, "aggregate", "aggregate-worker", None)
+
+            completed = self._collect(root, candidate, policy, workflow, bundles)
+
+            self.assertEqual(1, completed.returncode)
+            self.assertIn("missing required results", completed.stderr)
+
+    @staticmethod
+    def _policy(root: Path) -> Path:
+        path = root / "policy.json"
+        write_json(
+            path,
+            {
+                "schema_version": 1,
+                "profiles": {
+                    "fixture": [
+                        {
+                            "job_id": "build-linux",
+                            "target": "x86_64-unknown-linux-gnu",
+                            "result_ids": ["build-linux"],
+                        },
+                        {"job_id": "aggregate", "target": None, "result_ids": ["aggregate"]},
+                    ]
+                },
+            },
+        )
+        return path
+
+    @staticmethod
+    def _workflow_results(root: Path, candidate: Path, jobs: dict[str, object]) -> Path:
+        identity = read_json(candidate)
+        path = root / "workflow-results.json"
+        write_json(
+            path,
+            {
+                "schema_version": 1,
+                "candidate_id": identity["candidate_id"],
+                "version": identity["version"],
+                "run_id": identity["run_id"],
+                "attempt": identity["attempt"],
+                "jobs": jobs,
+            },
+        )
+        return path
+
+    @staticmethod
+    def _collect(
+        root: Path,
+        candidate: Path,
+        policy: Path,
+        workflow: Path,
+        bundles: Path,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(COLLECTOR),
+                "--candidate-manifest",
+                str(candidate),
+                "--bundles-root",
+                str(bundles),
+                "--workflow-results",
+                str(workflow),
+                "--policy",
+                str(policy),
+                "--profile",
+                "fixture",
+                "--output-root",
+                str(root / "canonical"),
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+
+    @staticmethod
+    def _bundle(
+        root: Path,
+        candidate: Path,
+        job_id: str,
+        worker_id: str,
+        target: str | None,
+        *,
+        status: str = "success",
+        workflow_result: str = "success",
+    ) -> None:
+        identity = read_json(candidate)
+        common = {
+            "candidate_id": identity["candidate_id"],
+            "version": identity["version"],
+            "run_id": identity["run_id"],
+            "attempt": identity["attempt"],
+        }
+        result_path = f"results/{job_id}.json"
+        started_path = f"events/{job_id}.started.json"
+        completed_path = f"events/{job_id}.completed.json"
+        context_path = f"contexts/{worker_id}.json"
+        write_json(
+            root / result_path,
+            {
+                "schema_version": 1,
+                **common,
+                "result_id": job_id,
+                "status": "passed" if status == "success" else "failed",
+            },
+        )
+        event = {
+            "schema_version": 1,
+            **common,
+            "route_id": job_id,
+            "worker_id": worker_id,
+            "context_path": context_path,
+        }
+        write_json(root / started_path, {**event, "status": "started", "command": ["python", "worker.py"]})
+        write_json(
+            root / completed_path,
+            {
+                **event,
+                "status": "passed" if status == "success" else "failed",
+                "exit_code": 0 if status == "success" else 1,
+            },
+        )
+        write_json(
+            root / context_path,
+            {
+                "schema_version": 1,
+                **common,
+                "worker_id": worker_id,
+                "publish_input": False,
+                "publishing_credentials_provided": False,
+            },
+        )
+        write_json(
+            root / "CANDIDATE_STAGE_OUTCOME.json",
+            {
+                "schema_version": 1,
+                **common,
+                "job_id": job_id,
+                "worker_id": worker_id,
+                "target": target,
+                "status": status,
+                "workflow_result": workflow_result,
+                "sealed": True,
+                "result_files": [result_path],
+                "event_pairs": [
+                    {"route_id": job_id, "started": started_path, "completed": completed_path}
+                ],
+                "context_files": [context_path],
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9572

### Brief Description

- Add closed schemas and a machine-readable job, target, and result denominator for candidate stage outcomes.
- Validate candidate identity, workflow status, safe paths, result/event/context fragments, and exact successful-job coverage before atomically publishing the canonical outcome index.
- Preserve failed workers as rejection input, synthesize missing workers, reject mixed or undeclared payloads, and compare copied bytes without content digests.

### How Did You Test This Change?

- `python -m unittest scripts.tests.test_candidate_stage_outcomes scripts.tests.test_candidate_run scripts.tests.test_candidate_transfer scripts.tests.test_release_candidate_command scripts.tests.test_release_lifecycle` (44 tests passed)
- `python -m py_compile scripts/collect_candidate_stage_outcomes.py scripts/tests/test_candidate_stage_outcomes.py`
- `python scripts/no_remote_publication_guard.py --phase 6 --static-only`
- `.\scripts\check-agents-routing.ps1`
- `git diff --check`
