### PR TITLE
[ISSUE #9574]✨Orchestrate crash-safe candidate lifecycle finalization

### DIFF
--- a/distribution/candidate-route-denominator.json
+++ b/distribution/candidate-route-denominator.json
@@ -4,6 +4,14 @@
     "release-preparation-aggregate": [
       "R11-aggregate-validate"
     ],
+    "full-matrix-finalizer": [
+      "prepare-common",
+      "build-linux",
+      "build-windows",
+      "build-macos",
+      "aggregate",
+      "full-matrix"
+    ],
     "handoff-draft": [
       "H01-LINUX",
       "H01-WINDOWS",

--- a/distribution/candidate-stage-outcome-index.schema.json
+++ b/distribution/candidate-stage-outcome-index.schema.json
@@ -46,6 +46,7 @@
       "required": [
         "job_id", "worker_id", "target", "status", "workflow_result",
         "expected_result_ids", "result_ids", "missing_result_ids",
+        "expected_route_ids", "route_ids", "missing_route_ids",
         "result_files", "event_files", "context_files"
       ],
       "properties": {
@@ -63,6 +64,18 @@
           "items": {"type": "string", "minLength": 1}
         },
         "missing_result_ids": {
+          "type": "array", "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "expected_route_ids": {
+          "type": "array", "minItems": 1, "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "route_ids": {
+          "type": "array", "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "missing_route_ids": {
           "type": "array", "uniqueItems": true,
           "items": {"type": "string", "minLength": 1}
         },

--- a/distribution/candidate-stage-outcome-policy.json
+++ b/distribution/candidate-stage-outcome-policy.json
@@ -2,14 +2,37 @@
   "schema_version": 1,
   "profiles": {
     "release-candidate": [
-      {"job_id": "prepare-common", "target": null, "result_ids": ["prepare-common"]},
-      {"job_id": "build-linux", "target": "x86_64-unknown-linux-gnu", "result_ids": ["S01"]},
-      {"job_id": "build-windows", "target": "x86_64-pc-windows-msvc", "result_ids": ["S02"]},
-      {"job_id": "build-macos", "target": "x86_64-apple-darwin", "result_ids": ["S03"]},
-      {"job_id": "aggregate", "target": null, "result_ids": ["aggregate"]},
+      {"job_id": "prepare-common", "target": null, "result_ids": ["prepare-common"], "route_ids": ["prepare-common"]},
+      {
+        "job_id": "build-linux",
+        "target": "x86_64-unknown-linux-gnu",
+        "result_ids": ["S01"],
+        "route_ids": ["build-linux"]
+      },
+      {
+        "job_id": "build-windows",
+        "target": "x86_64-pc-windows-msvc",
+        "result_ids": ["S02"],
+        "route_ids": ["build-windows"]
+      },
+      {
+        "job_id": "build-macos",
+        "target": "x86_64-apple-darwin",
+        "result_ids": ["S03"],
+        "route_ids": ["build-macos"]
+      },
+      {
+        "job_id": "aggregate",
+        "target": null,
+        "result_ids": [
+          "aggregate", "R01-RELEASE-VERSION", "R01-CANDIDATE-LIFECYCLE", "R01-CORE-IMAGE-WORKFLOW"
+        ],
+        "route_ids": ["aggregate"]
+      },
       {
         "job_id": "full-matrix",
         "target": null,
+        "route_ids": ["full-matrix"],
         "result_ids": [
           "P01", "P02", "P03", "P04", "P05", "P06", "P07", "P08", "P09", "P10", "P11", "P12",
           "I01", "I02", "I03", "I04", "I05", "M01", "L01", "A01",

--- a/distribution/transfer_candidate.py
+++ b/distribution/transfer_candidate.py
@@ -19,7 +19,15 @@ if str(ROOT / "distribution") not in sys.path:
     sys.path.insert(0, str(ROOT / "distribution"))
 
 from release_archive_common import ArchiveError, load_candidate, require_relative_path
-from release_state import read_json, resolve_existing_file, resolve_within
+from release_state import (
+    ReleaseStateError,
+    ensure_no_digest_fields,
+    read_json,
+    resolve_existing_file,
+    resolve_within,
+    validate_candidate,
+    validate_series,
+)
 
 
 EXCLUDED_PREFIXES = (
@@ -155,6 +163,39 @@ def export_build_source(candidate_manifest: Path, output: Path, source_root: Pat
     )
 
 
+def export_build_control(candidate_manifest: Path, output: Path) -> Path:
+    """Export current control state without reopening sealed artifact mutation."""
+
+    manifest = resolve_existing_file(candidate_manifest, "candidate manifest")
+    candidate = read_json(manifest)
+    validate_candidate(candidate)
+    ensure_no_digest_fields(candidate)
+    root = Path(candidate["candidate_root"]).resolve()
+    if root != manifest.parent:
+        raise ArchiveError("candidate manifest and candidate root disagree")
+    output = resolve_within(root, output, "candidate transfer output")
+    if output.exists():
+        raise ArchiveError(f"candidate transfer bundle already exists: {output}")
+    records = [("CANDIDATE_RUN.json", manifest)]
+    series = candidate.get("series_manifest")
+    if not isinstance(series, str):
+        raise ArchiveError("candidate has no release-series manifest")
+    series_path = resolve_existing_file(Path(series), "release series")
+    series_value = read_json(series_path)
+    validate_series(series_value)
+    ensure_no_digest_fields(series_value)
+    head = series_value.get("head")
+    if (
+        series_value["pending_operation"] is not None
+        or candidate["series_generation"] != series_value["generation"]
+        or not isinstance(head, dict)
+        or head.get("ordinal") != candidate["ordinal"]
+    ):
+        raise ArchiveError("candidate and release series are not at one committed generation")
+    records.append(("RELEASE_SERIES.json", series_path))
+    return _write_bundle(candidate, bundle_kind="build-control", output=output, records=records)
+
+
 def _safe_member(member: tarfile.TarInfo) -> PurePosixPath:
     path = PurePosixPath(member.name)
     if path.is_absolute() or ".." in path.parts or member.issym() or member.islnk():
@@ -234,26 +275,12 @@ def main(argv: list[str] | None = None) -> int:
     try:
         if args.command == "export-build-source":
             output = export_build_source(args.candidate_manifest, args.output, args.source_root)
+        elif args.command == "export-build-control":
+            output = export_build_control(args.candidate_manifest, args.output)
         elif args.command == "import":
             output = import_bundle(args.bundle, args.output)
         else:
             manifest, candidate, root = load_candidate(args.candidate_manifest)
-            if args.command == "export-build-control":
-                records = [("CANDIDATE_RUN.json", manifest)]
-                series = read_json(manifest).get("series_manifest")
-                if isinstance(series, str) and Path(series).is_file():
-                    records.append(("RELEASE_SERIES.json", Path(series)))
-                output_path = resolve_within(root, args.output, "candidate transfer output")
-                if output_path.exists():
-                    raise ArchiveError(f"candidate transfer bundle already exists: {output_path}")
-                output = _write_bundle(
-                    read_json(manifest),
-                    bundle_kind="build-control",
-                    output=output_path,
-                    records=records,
-                )
-                print(f"CANDIDATE_TRANSFER_OK command={args.command} output={output}")
-                return 0
             if args.command == "export-target":
                 from release_archive_common import sealed_partial_path, resolve_candidate_path
 
@@ -323,7 +350,7 @@ def main(argv: list[str] | None = None) -> int:
             )
         print(f"CANDIDATE_TRANSFER_OK command={args.command} output={output}")
         return 0
-    except (ArchiveError, OSError, KeyError, json.JSONDecodeError) as error:
+    except (ReleaseStateError, OSError, KeyError, json.JSONDecodeError) as error:
         print(f"CANDIDATE_TRANSFER_FAILED detail={error}", file=sys.stderr)
         return 1
 

--- a/scripts/collect_candidate_stage_outcomes.py
+++ b/scripts/collect_candidate_stage_outcomes.py
@@ -75,7 +75,7 @@ def _load_policy(path: Path, profile: str) -> list[dict[str, Any]]:
     job_ids: list[str] = []
     normalized: list[dict[str, Any]] = []
     for entry in entries:
-        if not isinstance(entry, dict) or set(entry) != {"job_id", "target", "result_ids"}:
+        if not isinstance(entry, dict) or set(entry) != {"job_id", "target", "result_ids", "route_ids"}:
             raise OutcomeError("candidate outcome policy entry is invalid")
         job_id = require_safe_id(entry.get("job_id"), "job_id")
         target = entry.get("target")
@@ -91,8 +91,25 @@ def _load_policy(path: Path, profile: str) -> list[dict[str, Any]]:
         normalized_result_ids = [require_safe_id(result_id, "result_id") for result_id in result_ids]
         if len(normalized_result_ids) != len(set(normalized_result_ids)):
             raise OutcomeError(f"candidate outcome result denominator contains duplicates: {job_id}")
+        route_ids = entry.get("route_ids")
+        if (
+            not isinstance(route_ids, list)
+            or not route_ids
+            or any(not isinstance(route_id, str) for route_id in route_ids)
+        ):
+            raise OutcomeError(f"candidate outcome route denominator is invalid: {job_id}")
+        normalized_route_ids = [require_safe_id(route_id, "route_id") for route_id in route_ids]
+        if len(normalized_route_ids) != len(set(normalized_route_ids)):
+            raise OutcomeError(f"candidate outcome route denominator contains duplicates: {job_id}")
         job_ids.append(job_id)
-        normalized.append({"job_id": job_id, "target": target, "result_ids": normalized_result_ids})
+        normalized.append(
+            {
+                "job_id": job_id,
+                "target": target,
+                "result_ids": normalized_result_ids,
+                "route_ids": normalized_route_ids,
+            }
+        )
     if len(job_ids) != len(set(job_ids)):
         raise OutcomeError("candidate outcome policy contains duplicate jobs")
     return normalized
@@ -152,7 +169,7 @@ def _validate_bundle(
     candidate: dict[str, Any],
     expected: dict[str, Any],
     workflow_result: str,
-) -> tuple[dict[str, Any], list[tuple[str, Path]], list[str]]:
+) -> tuple[dict[str, Any], list[tuple[str, Path]], list[str], list[str]]:
     outcome_path = resolve_existing_file(bundle / OUTCOME_NAME, "candidate job outcome")
     outcome = read_json(outcome_path)
     _validate_payload_identity(outcome, candidate, "candidate job outcome")
@@ -256,7 +273,13 @@ def _validate_bundle(
     missing_result_ids = sorted(set(expected["result_ids"]) - set(result_ids))
     if outcome["status"] == "success" and missing_result_ids:
         raise OutcomeError(f"successful job is missing required results: {expected['job_id']}")
-    return outcome, payloads, result_ids
+    unknown_route_ids = sorted(routes - set(expected["route_ids"]))
+    if unknown_route_ids:
+        raise OutcomeError(f"candidate event route is outside the job denominator: {unknown_route_ids[0]}")
+    missing_route_ids = sorted(set(expected["route_ids"]) - routes)
+    if outcome["status"] == "success" and missing_route_ids:
+        raise OutcomeError(f"successful job is missing required routes: {expected['job_id']}")
+    return outcome, payloads, result_ids, sorted(routes)
 
 
 def _copy_payload(source: Path, destination: Path) -> None:
@@ -324,13 +347,18 @@ def collect_outcomes(
                         "expected_result_ids": entry["result_ids"],
                         "result_ids": [],
                         "missing_result_ids": entry["result_ids"],
+                        "expected_route_ids": entry["route_ids"],
+                        "route_ids": [],
+                        "missing_route_ids": entry["route_ids"],
                         "result_files": [],
                         "event_files": [],
                         "context_files": [],
                     }
                 )
                 continue
-            outcome, payloads, result_ids = _validate_bundle(bundle, candidate, entry, workflow[job_id])
+            outcome, payloads, result_ids, route_ids = _validate_bundle(
+                bundle, candidate, entry, workflow[job_id]
+            )
             copied = {"results": [], "events": [], "contexts": []}
             for relative, source in payloads:
                 category = PurePosixPath(relative).parts[0]
@@ -351,6 +379,9 @@ def collect_outcomes(
                     "expected_result_ids": entry["result_ids"],
                     "result_ids": result_ids,
                     "missing_result_ids": sorted(set(entry["result_ids"]) - set(result_ids)),
+                    "expected_route_ids": entry["route_ids"],
+                    "route_ids": route_ids,
+                    "missing_route_ids": sorted(set(entry["route_ids"]) - set(route_ids)),
                     "result_files": copied["results"],
                     "event_files": copied["events"],
                     "context_files": copied["contexts"],

--- a/scripts/release_evidence_guard.py
+++ b/scripts/release_evidence_guard.py
@@ -319,6 +319,7 @@ def build_evidence(
     required_result_ids: list[str],
     output: Path,
     required_capability_ids: list[str] | None = None,
+    release_result_ids: list[str] | None = None,
     no_remote_evidence: Path | None = None,
     event_root: Path | None = None,
     context_root: Path | None = None,
@@ -327,6 +328,16 @@ def build_evidence(
         raise EvidenceError("phase/gate_stage is outside the 1.0 candidate evidence contract")
     if not required_result_ids or len(set(required_result_ids)) != len(required_result_ids):
         raise EvidenceError("required result IDs must be a non-empty unique denominator")
+    if release_result_ids is None:
+        release_result_ids = required_result_ids
+    if (
+        not release_result_ids
+        or len(set(release_result_ids)) != len(release_result_ids)
+        or not set(release_result_ids).issubset(required_result_ids)
+    ):
+        raise EvidenceError("release result IDs must be a non-empty unique subset of required results")
+    if gate_stage != "full-matrix" and release_result_ids != required_result_ids:
+        raise EvidenceError("only the full-matrix gate may separate release and scenario result IDs")
     if gate_stage == "final-handoff" and tuple(required_result_ids) != FINAL_HANDOFF_RESULT_IDS:
         raise EvidenceError("final-handoff result denominator is not the frozen H01-H05 sequence")
     manifest = resolve_existing_file(candidate_manifest, "candidate_manifest")
@@ -402,7 +413,7 @@ def build_evidence(
         "required_result_ids": required_result_ids,
         "results": results,
         "capability_results": capability_results,
-        "release_result_ids": {result_id: "passed" for result_id in required_result_ids},
+        "release_result_ids": {result_id: "passed" for result_id in release_result_ids},
         "failed_result_ids": [],
         "all_required_passed": True,
         "remote_publication": {"status": remote_status},
@@ -424,6 +435,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--phase", type=int, choices=(5, 6), required=True)
     parser.add_argument("--gate-stage", choices=("release-preparation", "full-matrix", "final-handoff"), required=True)
     parser.add_argument("--require-result-ids", required=True)
+    parser.add_argument("--release-result-ids")
     parser.add_argument("--require-capability-ids")
     parser.add_argument("--no-remote-evidence", type=Path)
     parser.add_argument("--event-root", type=Path)
@@ -438,6 +450,7 @@ def main(argv: list[str] | None = None) -> int:
             gate_stage=args.gate_stage,
             required_result_ids=_csv(args.require_result_ids),
             required_capability_ids=_csv(args.require_capability_ids) if args.require_capability_ids else None,
+            release_result_ids=_csv(args.release_result_ids) if args.release_result_ids else None,
             no_remote_evidence=args.no_remote_evidence,
             event_root=args.event_root,
             context_root=args.context_root,

--- a/scripts/run-v1-candidate-lifecycle.ps1
+++ b/scripts/run-v1-candidate-lifecycle.ps1
@@ -1,0 +1,30 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("StageRc", "FinalizeRc", "FinalizeFinalFunctional", "RejectFinalHandoff")]
+    [string]$Mode,
+    [Parameter(Mandatory = $true)]
+    [string]$CandidateManifest,
+    [string]$StageOutcomesIndex,
+    [string]$ParentManifest,
+    [string]$SourceRoot,
+    [string]$RejectionReason
+)
+
+$ErrorActionPreference = "Stop"
+$PSNativeCommandUseErrorActionPreference = $true
+$python = if ($env:PYTHON) { $env:PYTHON } else { "python" }
+$arguments = @(
+    "scripts/v1_candidate_lifecycle.py",
+    "--mode", $Mode,
+    "--candidate-manifest", $CandidateManifest
+)
+if ($StageOutcomesIndex) { $arguments += @("--stage-outcomes-index", $StageOutcomesIndex) }
+if ($ParentManifest) { $arguments += @("--parent-manifest", $ParentManifest) }
+if ($SourceRoot) { $arguments += @("--source-root", $SourceRoot) }
+if ($RejectionReason) { $arguments += @("--rejection-reason", $RejectionReason) }
+
+& $python @arguments
+exit $LASTEXITCODE

--- a/scripts/run-v1-candidate-lifecycle.sh
+++ b/scripts/run-v1-candidate-lifecycle.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+set -euo pipefail
+
+mode=""
+candidate_manifest=""
+stage_outcomes_index=""
+parent_manifest=""
+source_root=""
+rejection_reason=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode) mode="$2"; shift 2 ;;
+    --candidate-manifest) candidate_manifest="$2"; shift 2 ;;
+    --stage-outcomes-index) stage_outcomes_index="$2"; shift 2 ;;
+    --parent-manifest) parent_manifest="$2"; shift 2 ;;
+    --source-root) source_root="$2"; shift 2 ;;
+    --rejection-reason) rejection_reason="$2"; shift 2 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+case "$mode" in
+  StageRc|FinalizeRc|FinalizeFinalFunctional|RejectFinalHandoff) ;;
+  *) echo "--mode is required" >&2; exit 2 ;;
+esac
+[[ -f "$candidate_manifest" ]] || { echo "--candidate-manifest is required" >&2; exit 2; }
+
+python_command="${PYTHON:-python}"
+arguments=(
+  scripts/v1_candidate_lifecycle.py
+  --mode "$mode"
+  --candidate-manifest "$candidate_manifest"
+)
+[[ -z "$stage_outcomes_index" ]] || arguments+=(--stage-outcomes-index "$stage_outcomes_index")
+[[ -z "$parent_manifest" ]] || arguments+=(--parent-manifest "$parent_manifest")
+[[ -z "$source_root" ]] || arguments+=(--source-root "$source_root")
+[[ -z "$rejection_reason" ]] || arguments+=(--rejection-reason "$rejection_reason")
+
+"$python_command" "${arguments[@]}"

--- a/scripts/tests/test_candidate_stage_outcomes.py
+++ b/scripts/tests/test_candidate_stage_outcomes.py
@@ -59,6 +59,9 @@ class CandidateStageOutcomeTests(unittest.TestCase):
             self.assertTrue(index["all_required_passed"])
             self.assertEqual([], index["failed_job_ids"])
             self.assertEqual(["build-linux", "aggregate"], [item["job_id"] for item in index["jobs"]])
+            self.assertEqual(["build-linux"], index["jobs"][0]["expected_route_ids"])
+            self.assertEqual(["build-linux"], index["jobs"][0]["route_ids"])
+            self.assertEqual([], index["jobs"][0]["missing_route_ids"])
             self.assertEqual(2, len(list((output / "results").rglob("*.json"))))
             self.assertEqual(4, len(list((output / "events").rglob("*.json"))))
             self.assertEqual(2, len(list((output / "contexts").rglob("*.json"))))
@@ -468,8 +471,14 @@ class CandidateStageOutcomeTests(unittest.TestCase):
                             "job_id": "build-linux",
                             "target": "x86_64-unknown-linux-gnu",
                             "result_ids": ["build-linux"],
+                            "route_ids": ["build-linux"],
                         },
-                        {"job_id": "aggregate", "target": None, "result_ids": ["aggregate"]},
+                        {
+                            "job_id": "aggregate",
+                            "target": None,
+                            "result_ids": ["aggregate"],
+                            "route_ids": ["aggregate"],
+                        },
                     ]
                 },
             },

--- a/scripts/tests/test_candidate_transfer.py
+++ b/scripts/tests/test_candidate_transfer.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import tempfile
 import unittest
 
-from scripts.tests.release_archive_test_support import create_candidate
 from scripts.tests.release_test_support import load_module, read_json
 
 
@@ -15,11 +14,16 @@ class CandidateTransferTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.transfer = load_module("transfer_candidate_test", "distribution/transfer_candidate.py")
+        cls.series = load_module("release_series_for_transfer_test", "distribution/release_series.py")
+        cls.candidate = load_module("candidate_run_for_transfer_test", "distribution/candidate_run.py")
 
     def test_control_bundle_carries_candidate_and_external_series(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             base = Path(temporary)
-            candidate = create_candidate(base)
+            series = self.series.create_series(base / "series", "1.0", "community-v1")
+            candidate = self.candidate.create_candidate(
+                base / "candidates", "1.0.0-rc.1", "local", 1, series
+            )
             root = candidate.parent
             bundle = root / "transfer" / "CANDIDATE_BUILD_CONTROL_BUNDLE.tar"
             result = self.transfer.main(

--- a/scripts/tests/test_release_evidence_guard.py
+++ b/scripts/tests/test_release_evidence_guard.py
@@ -76,6 +76,35 @@ class ReleaseEvidenceGuardTests(unittest.TestCase):
             self.assertEqual(value["release_result_ids"], {"R01": "passed", "R02": "passed"})
             self.assertNotIn("sha256", str(value).lower())
 
+    def test_gate_can_separate_release_results_from_the_full_result_denominator(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            candidate = create_candidate(root)
+            results = root / "results"
+            self._result(candidate, results, "R01")
+            self._result(candidate, results, "P01")
+            for result_id in ("R01", "P01"):
+                path = results / f"{result_id}.json"
+                value = read_json(path)
+                value["phase"] = 6
+                value["gate_stage"] = "full-matrix"
+                write_json(path, value)
+            output = root / "EVIDENCE_INDEX.json"
+
+            self.guard.build_evidence(
+                candidate,
+                results,
+                phase=6,
+                gate_stage="full-matrix",
+                required_result_ids=["R01", "P01"],
+                release_result_ids=["R01"],
+                output=output,
+            )
+
+            value = read_json(output)
+            self.assertEqual({"R01": "passed"}, value["release_result_ids"])
+            self.assertEqual(["R01", "P01"], value["required_result_ids"])
+
     def test_missing_duplicate_unknown_and_zero_executed_results_fail_closed(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/tests/test_v1_candidate_lifecycle.py
+++ b/scripts/tests/test_v1_candidate_lifecycle.py
@@ -1,0 +1,404 @@
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.tests.release_test_support import (
+    ROOT,
+    create_source_bundle,
+    load_module,
+    read_json,
+    write_json,
+)
+
+
+RUNNER = ROOT / "scripts" / "v1_candidate_lifecycle.py"
+
+
+class V1CandidateLifecycleTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.series = load_module("release_series_for_v1_runner", "distribution/release_series.py")
+        cls.candidate = load_module("candidate_run_for_v1_runner", "distribution/candidate_run.py")
+        cls.collector = load_module(
+            "candidate_outcome_collector_for_v1_runner",
+            "scripts/collect_candidate_stage_outcomes.py",
+        )
+
+    def test_stage_rc_uses_the_atomic_lifecycle_route(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            series = self.series.create_series(root / "series", "1.0", "candidate-runner")
+            candidate = self.candidate.create_candidate(
+                root / "candidates", "1.0.0-rc.1", "rc1", 1, series
+            )
+
+            completed = self._run("StageRc", candidate)
+
+            self.assertEqual(0, completed.returncode, completed.stdout + completed.stderr)
+            value = read_json(candidate)
+            self.assertEqual("staged-rc", value["state"])
+            self.assertFalse(value["sealed"])
+            event = read_json(candidate.parent / "lifecycle/events/candidate-stage-rc.completed.json")
+            self.assertTrue(event["lifecycle_atomic_completion"])
+            self.assertTrue(
+                (candidate.parent / f"transfer/CANDIDATE_CONTROL_BUNDLE.g{value['generation']}.tar").is_file()
+            )
+            series_value = read_json(series)
+            self.assertTrue(
+                (
+                    series.parent
+                    / f"RELEASE_SERIES_CONTROL_BUNDLE.g{series_value['generation']}.tar"
+                ).is_file()
+            )
+
+    def test_cross_platform_entrypoints_are_fail_fast_thin_wrappers(self) -> None:
+        powershell = (ROOT / "scripts/run-v1-candidate-lifecycle.ps1").read_text(encoding="utf-8")
+        shell = (ROOT / "scripts/run-v1-candidate-lifecycle.sh").read_text(encoding="utf-8")
+
+        self.assertIn('$PSNativeCommandUseErrorActionPreference = $true', powershell)
+        self.assertIn('"scripts/v1_candidate_lifecycle.py"', powershell)
+        self.assertIn("set -euo pipefail", shell)
+        self.assertIn("scripts/v1_candidate_lifecycle.py", shell)
+        for mode in ("StageRc", "FinalizeRc", "FinalizeFinalFunctional", "RejectFinalHandoff"):
+            self.assertIn(mode, powershell)
+            self.assertIn(mode, shell)
+
+    def test_finalize_rc_closes_all_gates_and_seals_the_candidate(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            series = self.series.create_series(root / "series", "1.0", "candidate-runner")
+            candidate = self.candidate.create_candidate(
+                root / "candidates", "1.0.0-rc.1", "rc1", 1, series
+            )
+            source = create_source_bundle(
+                candidate.parent / "CORE_SOURCE_TRANSFER.tar",
+                version="1.0.0-rc.1",
+                run_id="rc1",
+                attempt=1,
+            )
+            self.candidate.record_build_source_bundle(candidate, source)
+            self.assertEqual(0, self._run("StageRc", candidate).returncode)
+            outcome_index = self._successful_outcomes(root, candidate)
+
+            completed = self._run(
+                "FinalizeRc",
+                candidate,
+                "--stage-outcomes-index",
+                str(outcome_index),
+            )
+
+            self.assertEqual(0, completed.returncode, completed.stdout + completed.stderr)
+            value = read_json(candidate)
+            self.assertEqual("rc-candidate-ready", value["state"])
+            self.assertTrue(value["sealed"])
+            self.assertIsInstance(value["source_snapshot"], str)
+            self.assertTrue(Path(value["source_snapshot"]).is_file())
+            self.assertTrue((candidate.parent / "evidence/FULL_MATRIX_EVIDENCE.json").is_file())
+            self.assertTrue((candidate.parent / "evidence/NO_REMOTE_PUBLICATION.json").is_file())
+            event = read_json(
+                outcome_index.parent / "events/candidate-finalize-ready.completed.json"
+            )
+            self.assertTrue(event["lifecycle_atomic_completion"])
+            self.assertTrue(
+                (candidate.parent / f"transfer/CANDIDATE_CONTROL_BUNDLE.g{value['generation']}.tar").is_file()
+            )
+
+    def test_missing_worker_is_sealed_as_a_rejected_rc_before_failure_returns(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            series = self.series.create_series(root / "series", "1.0", "candidate-runner")
+            candidate = self.candidate.create_candidate(
+                root / "candidates", "1.0.0-rc.1", "rc1", 1, series
+            )
+            self.assertEqual(0, self._run("StageRc", candidate).returncode)
+            outcome_index = self._successful_outcomes(root, candidate, missing_job="full-matrix")
+
+            completed = self._run(
+                "FinalizeRc",
+                candidate,
+                "--stage-outcomes-index",
+                str(outcome_index),
+            )
+
+            self.assertEqual(1, completed.returncode)
+            value = read_json(candidate)
+            self.assertEqual("rejected", value["state"])
+            self.assertTrue(value["sealed"])
+            self.assertEqual("FinalizeRc gate failure", value["rejection_reason"])
+            event = read_json(
+                candidate.parent / "lifecycle/events/candidate-finalize-reject.completed.json"
+            )
+            self.assertTrue(event["lifecycle_atomic_completion"])
+            self.assertTrue(
+                (candidate.parent / f"transfer/CANDIDATE_CONTROL_BUNDLE.g{value['generation']}.tar").is_file()
+            )
+
+    def test_mixed_candidate_outcome_index_rejects_the_open_candidate(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            series = self.series.create_series(root / "series", "1.0", "candidate-runner")
+            candidate = self.candidate.create_candidate(
+                root / "candidates", "1.0.0-rc.1", "rc1", 1, series
+            )
+            self.assertEqual(0, self._run("StageRc", candidate).returncode)
+            outcome_index = self._successful_outcomes(root, candidate)
+            index = read_json(outcome_index)
+            index["candidate_id"] = "another-candidate"
+            write_json(outcome_index, index)
+
+            completed = self._run(
+                "FinalizeRc",
+                candidate,
+                "--stage-outcomes-index",
+                str(outcome_index),
+            )
+
+            self.assertEqual(1, completed.returncode)
+            value = read_json(candidate)
+            self.assertEqual("rejected", value["state"])
+            self.assertTrue(value["sealed"])
+            self.assertFalse((candidate.parent / "evidence/FULL_MATRIX_EVIDENCE.json").exists())
+
+    def test_publication_credentials_force_a_sealed_rejection(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            series = self.series.create_series(root / "series", "1.0", "candidate-runner")
+            candidate = self.candidate.create_candidate(
+                root / "candidates", "1.0.0-rc.1", "rc1", 1, series
+            )
+            self.assertEqual(0, self._run("StageRc", candidate).returncode)
+            outcome_index = self._successful_outcomes(root, candidate)
+            environment = os.environ.copy()
+            environment["CRATES_IO_TOKEN"] = "fixture-secret"
+
+            completed = self._run(
+                "FinalizeRc",
+                candidate,
+                "--stage-outcomes-index",
+                str(outcome_index),
+                environment=environment,
+            )
+
+            self.assertEqual(1, completed.returncode)
+            self.assertEqual("rejected", read_json(candidate)["state"])
+            no_remote = read_json(candidate.parent / "evidence/NO_REMOTE_PUBLICATION.json")
+            self.assertEqual("violation-detected", no_remote["remote_publication"]["status"])
+            self.assertEqual(["CRATES_IO_TOKEN"], no_remote["publishing_credential_names"])
+            self.assertNotIn("fixture-secret", str(no_remote))
+
+    def test_finalize_final_requires_delta_and_enters_open_ga_candidate_state(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            series = self.series.create_series(root / "series", "1.0", "candidate-runner")
+            parent: Path | None = None
+            for suffix in (1, 2):
+                candidate = self.candidate.create_candidate(
+                    root / "candidates",
+                    f"1.0.0-rc.{suffix}",
+                    f"rc{suffix}",
+                    1,
+                    series,
+                )
+                source = create_source_bundle(
+                    candidate.parent / "CORE_SOURCE_TRANSFER.tar",
+                    version=f"1.0.0-rc.{suffix}",
+                    run_id=f"rc{suffix}",
+                    attempt=1,
+                )
+                self.candidate.record_build_source_bundle(candidate, source)
+                self.assertEqual(0, self._run("StageRc", candidate).returncode)
+                outcomes = self._successful_outcomes(root / f"rc{suffix}", candidate)
+                finalized = self._run(
+                    "FinalizeRc",
+                    candidate,
+                    "--stage-outcomes-index",
+                    str(outcomes),
+                )
+                self.assertEqual(0, finalized.returncode, finalized.stdout + finalized.stderr)
+                parent = candidate
+            self.assertIsNotNone(parent)
+            final = self.candidate.create_candidate(
+                root / "candidates", "1.0.0", "final", 1, series
+            )
+            outcomes = self._successful_outcomes(root / "final", final)
+            parent_value = read_json(parent)
+            parent_source = Path(parent_value["source_snapshot"]).parent / "source"
+
+            completed = self._run(
+                "FinalizeFinalFunctional",
+                final,
+                "--stage-outcomes-index",
+                str(outcomes),
+                "--parent-manifest",
+                str(parent),
+                "--source-root",
+                str(parent_source),
+            )
+
+            self.assertEqual(0, completed.returncode, completed.stdout + completed.stderr)
+            value = read_json(final)
+            self.assertEqual("ga-candidate-ready", value["state"])
+            self.assertFalse(value["sealed"])
+            delta = read_json(final.parent / "evidence/FINAL_CANDIDATE_DELTA.json")
+            self.assertEqual("passed", delta["status"])
+            self.assertEqual(parent_value["candidate_id"], delta["parentCandidateId"])
+
+            rejected = self._run(
+                "RejectFinalHandoff",
+                final,
+                "--rejection-reason",
+                "final handoff verification failed",
+            )
+
+            self.assertEqual(0, rejected.returncode, rejected.stdout + rejected.stderr)
+            rejected_value = read_json(final)
+            self.assertEqual("rejected", rejected_value["state"])
+            self.assertTrue(rejected_value["sealed"])
+            self.assertEqual(
+                "final handoff verification failed", rejected_value["rejection_reason"]
+            )
+
+    def _successful_outcomes(
+        self,
+        root: Path,
+        candidate: Path,
+        *,
+        missing_job: str | None = None,
+    ) -> Path:
+        identity = read_json(candidate)
+        policy = ROOT / "distribution/candidate-stage-outcome-policy.json"
+        entries = self.collector._load_policy(policy, "release-candidate")
+        bundles = root / "bundles"
+        workflow_jobs: dict[str, str] = {}
+        required_capabilities = [
+            *(f"F-{index:02d}" for index in range(1, 19)),
+            *(f"G-{index:02d}" for index in range(1, 6)),
+        ]
+        common = {
+            "candidate_id": identity["candidate_id"],
+            "version": identity["version"],
+            "run_id": identity["run_id"],
+            "attempt": identity["attempt"],
+        }
+        for entry in entries:
+            job_id = entry["job_id"]
+            if job_id == missing_job:
+                workflow_jobs[job_id] = "failure"
+                continue
+            worker_id = f"worker-{job_id}"
+            job_root = bundles / job_id
+            result_files: list[str] = []
+            for result_id in entry["result_ids"]:
+                relative = f"results/{result_id}.json"
+                result_files.append(relative)
+                is_test = result_id[0] in {"P", "I", "M", "L", "A", "U", "S"}
+                write_json(
+                    job_root / relative,
+                    {
+                        "schema_version": 1,
+                        **common,
+                        "phase": 6,
+                        "gate_stage": "full-matrix",
+                        "result_id": result_id,
+                        "result_kind": "test" if is_test else "check",
+                        "status": "passed",
+                        "command": ["python", "fixture.py", result_id],
+                        "exit_code": 0,
+                        "matched_test_count": 1 if is_test else 0,
+                        "executed_test_count": 1 if is_test else 0,
+                        "passed_test_count": 1 if is_test else 0,
+                        "failed_test_count": 0,
+                        "ignored_test_count": 0,
+                        "capability_ids": required_capabilities if result_id == "P01" else [],
+                        "result_path": f"results/{job_id}/{result_id}.json",
+                    },
+                )
+            event_pairs: list[dict[str, str]] = []
+            for route_id in entry["route_ids"]:
+                started = f"events/{route_id}.started.json"
+                completed = f"events/{route_id}.completed.json"
+                event_pairs.append({"route_id": route_id, "started": started, "completed": completed})
+                event = {
+                    "schema_version": 1,
+                    **common,
+                    "route_id": route_id,
+                    "worker_id": worker_id,
+                    "context_path": f"contexts/{worker_id}.json",
+                }
+                write_json(job_root / started, {**event, "status": "started", "command": ["python", "worker.py"]})
+                write_json(job_root / completed, {**event, "status": "passed", "exit_code": 0})
+            context = f"contexts/{worker_id}.json"
+            write_json(
+                job_root / context,
+                {
+                    "schema_version": 1,
+                    **common,
+                    "worker_id": worker_id,
+                    "publish_input": False,
+                    "publishing_credentials_provided": False,
+                },
+            )
+            write_json(
+                job_root / "CANDIDATE_STAGE_OUTCOME.json",
+                {
+                    "schema_version": 1,
+                    **common,
+                    "job_id": job_id,
+                    "worker_id": worker_id,
+                    "target": entry["target"],
+                    "status": "success",
+                    "workflow_result": "success",
+                    "sealed": True,
+                    "result_files": result_files,
+                    "event_pairs": event_pairs,
+                    "context_files": [context],
+                },
+            )
+            workflow_jobs[job_id] = "success"
+        workflow = root / "workflow-results.json"
+        write_json(workflow, {"schema_version": 1, **common, "jobs": workflow_jobs})
+        return self.collector.collect_outcomes(
+            candidate,
+            bundles,
+            workflow,
+            policy,
+            "release-candidate",
+            root / "candidate-outcomes",
+        )
+
+    @staticmethod
+    def _run(
+        mode: str,
+        candidate: Path,
+        *arguments: str,
+        environment: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(RUNNER),
+                "--mode",
+                mode,
+                "--candidate-manifest",
+                str(candidate),
+                *arguments,
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=60,
+            env=environment,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/v1_candidate_lifecycle.py
+++ b/scripts/v1_candidate_lifecycle.py
@@ -1,0 +1,749 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+"""Drive one candidate to a verified lifecycle state or a sealed rejection."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path, PurePosixPath
+import subprocess
+import sys
+import tarfile
+from typing import Any, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DISTRIBUTION = ROOT / "distribution"
+for import_root in (ROOT, DISTRIBUTION):
+    if str(import_root) not in sys.path:
+        sys.path.insert(0, str(import_root))
+
+from release_state import (
+    ReleaseStateError,
+    ensure_no_digest_fields,
+    read_json,
+    resolve_existing_file,
+    validate_candidate,
+    validate_series,
+)
+from capture_candidate_execution_context import capture_context
+from collect_candidate_stage_outcomes import _load_policy
+
+
+class CandidateLifecycleError(ReleaseStateError):
+    """Raised when the high-level candidate lifecycle cannot close safely."""
+
+
+MODES = {"StageRc", "FinalizeRc", "FinalizeFinalFunctional", "RejectFinalHandoff"}
+LIFECYCLE_WORKER = "candidate-lifecycle-finalizer"
+REJECTION_WORKER = "candidate-lifecycle-rejector"
+OUTCOME_POLICY = ROOT / "distribution/candidate-stage-outcome-policy.json"
+LIFECYCLE_CONFIG = ROOT / "distribution/config/release-lifecycle.json"
+OUTCOME_INDEX_FIELDS = {
+    "schema_version",
+    "candidate_id",
+    "version",
+    "run_id",
+    "attempt",
+    "profile",
+    "expected_job_ids",
+    "jobs",
+    "failed_job_ids",
+    "all_required_passed",
+    "remote_publication",
+}
+OUTCOME_JOB_FIELDS = {
+    "job_id",
+    "worker_id",
+    "target",
+    "status",
+    "workflow_result",
+    "expected_result_ids",
+    "result_ids",
+    "missing_result_ids",
+    "expected_route_ids",
+    "route_ids",
+    "missing_route_ids",
+    "result_files",
+    "event_files",
+    "context_files",
+}
+
+
+def _candidate(path: Path) -> tuple[Path, dict]:
+    manifest = resolve_existing_file(path, "candidate manifest")
+    value = read_json(manifest)
+    validate_candidate(value)
+    ensure_no_digest_fields(value)
+    if Path(value["candidate_root"]).resolve() != manifest.parent:
+        raise CandidateLifecycleError("candidate manifest and candidate root disagree")
+    return manifest, value
+
+
+def _run(command: Sequence[str]) -> None:
+    completed = subprocess.run(list(command), cwd=ROOT, check=False)
+    if completed.returncode != 0:
+        raise CandidateLifecycleError(
+            f"candidate lifecycle child failed with exit code {completed.returncode}: {command[0]}"
+        )
+
+
+def _wrapped(
+    candidate_manifest: Path,
+    *,
+    route_id: str,
+    worker_id: str,
+    context: Path,
+    event_root: Path,
+    command: Sequence[str],
+) -> None:
+    _run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/release_candidate_command.py"),
+            "run",
+            "--candidate-manifest",
+            str(candidate_manifest),
+            "--route-id",
+            route_id,
+            "--worker-id",
+            worker_id,
+            "--context",
+            str(context),
+            "--event-root",
+            str(event_root),
+            "--",
+            *command,
+        ]
+    )
+
+
+def _context(
+    candidate_manifest: Path,
+    root: Path,
+    worker_id: str = LIFECYCLE_WORKER,
+) -> tuple[Path, Path]:
+    context_root = root / "contexts"
+    event_root = root / "events"
+    context = context_root / f"{worker_id}.json"
+    if not context.is_file():
+        context = capture_context(candidate_manifest, worker_id, context_root)
+    return context, event_root
+
+
+def _export_candidate_control(candidate_manifest: Path) -> Path:
+    _manifest, candidate = _candidate(candidate_manifest)
+    output = (
+        Path(candidate["candidate_root"])
+        / "transfer"
+        / f"CANDIDATE_CONTROL_BUNDLE.g{candidate['generation']}.tar"
+    )
+    if not output.is_file():
+        _run(
+            [
+                sys.executable,
+                str(ROOT / "distribution/transfer_candidate.py"),
+                "export-build-control",
+                "--candidate-manifest",
+                str(candidate_manifest),
+                "--output",
+                str(output),
+            ]
+        )
+    _validate_candidate_control(output, candidate_manifest, Path(candidate["series_manifest"]))
+    series = read_json(resolve_existing_file(Path(candidate["series_manifest"]), "release series"))
+    series_bundle = (
+        Path(candidate["series_manifest"]).resolve().parent
+        / f"RELEASE_SERIES_CONTROL_BUNDLE.g{series['generation']}.tar"
+    )
+    if not series_bundle.is_file():
+        raise CandidateLifecycleError("release-series control bundle was not created")
+    return output
+
+
+def _validate_candidate_control(bundle: Path, candidate_manifest: Path, series_manifest: Path) -> None:
+    candidate = read_json(candidate_manifest)
+    series = read_json(resolve_existing_file(series_manifest, "release series"))
+    validate_candidate(candidate)
+    validate_series(series)
+    try:
+        with tarfile.open(resolve_existing_file(bundle, "candidate control bundle"), "r") as archive:
+            members = archive.getmembers()
+            names = [member.name for member in members]
+            expected_names = {
+                "CANDIDATE_TRANSFER.json",
+                "payload/CANDIDATE_RUN.json",
+                "payload/RELEASE_SERIES.json",
+            }
+            if set(names) != expected_names or len(names) != len(expected_names):
+                raise CandidateLifecycleError("candidate control bundle members are not closed")
+            for member in members:
+                if not member.isfile() or member.issym() or member.islnk():
+                    raise CandidateLifecycleError("candidate control bundle contains an unsafe member")
+            control_file = archive.extractfile("CANDIDATE_TRANSFER.json")
+            candidate_file = archive.extractfile("payload/CANDIDATE_RUN.json")
+            series_file = archive.extractfile("payload/RELEASE_SERIES.json")
+            if control_file is None or candidate_file is None or series_file is None:
+                raise CandidateLifecycleError("candidate control bundle is unreadable")
+            control = json.loads(control_file.read())
+            archived_candidate = json.loads(candidate_file.read())
+            archived_series = json.loads(series_file.read())
+    except (tarfile.TarError, json.JSONDecodeError, UnicodeDecodeError) as error:
+        raise CandidateLifecycleError(f"candidate control bundle is invalid: {error}") from error
+    identity = (
+        control.get("candidate_id"),
+        control.get("version"),
+        control.get("run_id"),
+        control.get("attempt"),
+    )
+    expected_identity = (
+        candidate["candidate_id"],
+        candidate["version"],
+        candidate["run_id"],
+        candidate["attempt"],
+    )
+    files = control.get("files")
+    expected_files = {
+        "CANDIDATE_RUN.json": candidate_manifest.stat().st_size,
+        "RELEASE_SERIES.json": series_manifest.stat().st_size,
+    }
+    actual_files = (
+        {item.get("path"): item.get("size") for item in files if isinstance(item, dict)}
+        if isinstance(files, list)
+        else {}
+    )
+    if (
+        control.get("schema_version") != 1
+        or control.get("bundle_kind") != "build-control"
+        or identity != expected_identity
+        or not isinstance(files, list)
+        or len(files) != len(expected_files)
+        or actual_files != expected_files
+        or archived_candidate != candidate
+        or archived_series != series
+    ):
+        raise CandidateLifecycleError("candidate control bundle does not match committed state")
+    for value in (control, archived_candidate, archived_series):
+        ensure_no_digest_fields(value)
+
+
+def _safe_index_file(root: Path, relative: Any, prefix: str) -> Path:
+    if not isinstance(relative, str) or "\\" in relative:
+        raise CandidateLifecycleError("candidate stage outcome contains an unsafe path")
+    path = PurePosixPath(relative)
+    if path.is_absolute() or len(path.parts) < 3 or path.parts[0] != prefix:
+        raise CandidateLifecycleError("candidate stage outcome path has the wrong canonical root")
+    if any(part in {"", ".", ".."} for part in path.parts):
+        raise CandidateLifecycleError("candidate stage outcome contains an unsafe path")
+    resolved = root.joinpath(*path.parts).resolve()
+    try:
+        resolved.relative_to(root.resolve())
+    except ValueError as error:
+        raise CandidateLifecycleError("candidate stage outcome path escapes its root") from error
+    return resolve_existing_file(resolved, "candidate stage outcome payload")
+
+
+def _stage_outcomes(
+    candidate_manifest: Path,
+    index_path: Path,
+) -> tuple[Path, list[str]]:
+    _manifest, candidate = _candidate(candidate_manifest)
+    if index_path.is_symlink() or index_path.name != "CANDIDATE_STAGE_OUTCOMES.json":
+        raise CandidateLifecycleError("candidate stage outcome index path is invalid")
+    index_path = resolve_existing_file(index_path, "candidate stage outcome index")
+    root = index_path.parent.resolve()
+    index = read_json(index_path)
+    ensure_no_digest_fields(index)
+    identity = (
+        index.get("candidate_id"),
+        index.get("version"),
+        index.get("run_id"),
+        index.get("attempt"),
+    )
+    expected_identity = (
+        candidate["candidate_id"],
+        candidate["version"],
+        candidate["run_id"],
+        candidate["attempt"],
+    )
+    entries = _load_policy(OUTCOME_POLICY, "release-candidate")
+    expected_job_ids = [entry["job_id"] for entry in entries]
+    jobs = index.get("jobs")
+    if (
+        index.get("schema_version") != 1
+        or set(index) != OUTCOME_INDEX_FIELDS
+        or identity != expected_identity
+        or index.get("profile") != "release-candidate"
+        or index.get("expected_job_ids") != expected_job_ids
+        or not isinstance(jobs, list)
+        or len(jobs) != len(entries)
+        or index.get("remote_publication") != {"status": "not-executed"}
+    ):
+        raise CandidateLifecycleError("candidate stage outcome index identity or denominator is invalid")
+    required_results: list[str] = []
+    required_routes: list[str] = []
+    failed_jobs: list[str] = []
+    declared_files = {index_path.name}
+    for job, expected in zip(jobs, entries, strict=True):
+        if not isinstance(job, dict) or set(job) != OUTCOME_JOB_FIELDS:
+            raise CandidateLifecycleError("candidate stage outcome job fields are not closed")
+        if (
+            job.get("job_id") != expected["job_id"]
+            or job.get("target") != expected["target"]
+            or job.get("expected_result_ids") != expected["result_ids"]
+            or job.get("expected_route_ids") != expected["route_ids"]
+        ):
+            raise CandidateLifecycleError(f"candidate stage outcome job denominator is invalid: {expected['job_id']}")
+        required_results.extend(expected["result_ids"])
+        required_routes.extend(expected["route_ids"])
+        success = job.get("status") == "success" and job.get("workflow_result") == "success"
+        if success and (
+            job.get("result_ids") != expected["result_ids"]
+            or job.get("missing_result_ids") != []
+            or job.get("route_ids") != expected["route_ids"]
+            or job.get("missing_route_ids") != []
+        ):
+            raise CandidateLifecycleError(f"successful candidate job is incomplete: {expected['job_id']}")
+        if not success:
+            failed_jobs.append(expected["job_id"])
+        files = {
+            "results": job.get("result_files"),
+            "events": job.get("event_files"),
+            "contexts": job.get("context_files"),
+        }
+        if any(not isinstance(paths, list) for paths in files.values()):
+            raise CandidateLifecycleError(f"candidate job payload index is invalid: {expected['job_id']}")
+        for prefix, paths in files.items():
+            for relative in paths:
+                path = _safe_index_file(root, relative, prefix)
+                if path.is_symlink():
+                    raise CandidateLifecycleError("candidate stage outcome payload is a symbolic link")
+                declared_files.add(path.relative_to(root).as_posix())
+    if len(required_results) != len(set(required_results)) or len(required_routes) != len(set(required_routes)):
+        raise CandidateLifecycleError("candidate result or route denominator contains duplicates")
+    declared_routes = candidate.get("route_denominator", {}).get("audit_points", {}).get(
+        "full-matrix-finalizer"
+    )
+    if declared_routes != required_routes:
+        raise CandidateLifecycleError("candidate route denominator does not match stage outcomes")
+    if index.get("failed_job_ids") != failed_jobs or index.get("all_required_passed") != (not failed_jobs):
+        raise CandidateLifecycleError("candidate stage outcome aggregate status is inconsistent")
+    actual_files: set[str] = set()
+    for path in root.rglob("*"):
+        if path.is_symlink():
+            raise CandidateLifecycleError("candidate stage outcome root contains a symbolic link")
+        if path.is_file():
+            actual_files.add(path.relative_to(root).as_posix())
+    if actual_files != declared_files:
+        raise CandidateLifecycleError("candidate stage outcome root has undeclared or missing files")
+    if failed_jobs:
+        raise CandidateLifecycleError("candidate stage outcomes contain failed or missing workers")
+    return root, required_results
+
+
+def _finalizer_paths(candidate_manifest: Path, outcome_root: Path) -> tuple[Path, Path, Path, Path]:
+    manifest, _candidate_value = _candidate(candidate_manifest)
+    context, event_root = _context(manifest, outcome_root)
+    evidence_root = manifest.parent / "evidence"
+    evidence_root.mkdir(parents=True, exist_ok=True)
+    return context, event_root, evidence_root, outcome_root / "results"
+
+
+def _run_candidate_validation(
+    candidate_manifest: Path,
+    context: Path,
+    event_root: Path,
+) -> None:
+    _wrapped(
+        candidate_manifest,
+        route_id="candidate-finalize-validate",
+        worker_id=LIFECYCLE_WORKER,
+        context=context,
+        event_root=event_root,
+        command=[
+            sys.executable,
+            str(ROOT / "distribution/candidate_run.py"),
+            "validate",
+            "--candidate-manifest",
+            str(candidate_manifest),
+        ],
+    )
+
+
+def _run_no_remote(
+    candidate_manifest: Path,
+    context: Path,
+    event_root: Path,
+    evidence_root: Path,
+) -> Path:
+    output = evidence_root / "NO_REMOTE_PUBLICATION.json"
+    route_id = "candidate-finalize-no-remote"
+    _wrapped(
+        candidate_manifest,
+        route_id=route_id,
+        worker_id=LIFECYCLE_WORKER,
+        context=context,
+        event_root=event_root,
+        command=[
+            sys.executable,
+            str(ROOT / "scripts/no_remote_publication_guard.py"),
+            "--candidate-manifest",
+            str(candidate_manifest),
+            "--phase",
+            "6",
+            "--audit-point",
+            "full-matrix-finalizer",
+            "--current-route-id",
+            route_id,
+            "--context-root",
+            str(context.parent),
+            "--event-root",
+            str(event_root),
+            "--output",
+            str(output),
+        ],
+    )
+    return output
+
+
+def _run_full_matrix_evidence(
+    candidate_manifest: Path,
+    context: Path,
+    event_root: Path,
+    evidence_root: Path,
+    result_root: Path,
+    required_results: list[str],
+    no_remote: Path,
+) -> Path:
+    config = read_json(LIFECYCLE_CONFIG)
+    capabilities = config.get("required_capabilities")
+    release_results = config.get("phase5_required_result_ids")
+    if not isinstance(capabilities, list) or not isinstance(release_results, list):
+        raise CandidateLifecycleError("release lifecycle result denominator is invalid")
+    output = evidence_root / "FULL_MATRIX_EVIDENCE.json"
+    _wrapped(
+        candidate_manifest,
+        route_id="candidate-finalize-evidence",
+        worker_id=LIFECYCLE_WORKER,
+        context=context,
+        event_root=event_root,
+        command=[
+            sys.executable,
+            str(ROOT / "scripts/release_evidence_guard.py"),
+            "--candidate-manifest",
+            str(candidate_manifest),
+            "--result-root",
+            str(result_root),
+            "--phase",
+            "6",
+            "--gate-stage",
+            "full-matrix",
+            "--require-result-ids",
+            ",".join(required_results),
+            "--release-result-ids",
+            ",".join(release_results),
+            "--require-capability-ids",
+            ",".join(capabilities),
+            "--no-remote-evidence",
+            str(no_remote),
+            "--output",
+            str(output),
+        ],
+    )
+    return output
+
+
+def _run_source_snapshot(
+    candidate_manifest: Path,
+    context: Path,
+    event_root: Path,
+) -> None:
+    _wrapped(
+        candidate_manifest,
+        route_id="candidate-finalize-source-snapshot",
+        worker_id=LIFECYCLE_WORKER,
+        context=context,
+        event_root=event_root,
+        command=[
+            sys.executable,
+            str(ROOT / "distribution/create_candidate_source_snapshot.py"),
+            "--candidate-manifest",
+            str(candidate_manifest),
+        ],
+    )
+
+
+def _run_final_delta(
+    candidate_manifest: Path,
+    context: Path,
+    event_root: Path,
+    evidence_root: Path,
+    parent_manifest: Path,
+    source_root: Path,
+) -> None:
+    _wrapped(
+        candidate_manifest,
+        route_id="candidate-finalize-delta",
+        worker_id=LIFECYCLE_WORKER,
+        context=context,
+        event_root=event_root,
+        command=[
+            sys.executable,
+            str(ROOT / "scripts/final_candidate_delta_guard.py"),
+            "--candidate-manifest",
+            str(candidate_manifest),
+            "--parent-manifest",
+            str(parent_manifest),
+            "--source-root",
+            str(source_root),
+            "--output",
+            str(evidence_root / "FINAL_CANDIDATE_DELTA.json"),
+        ],
+    )
+
+
+def _transition_ready(
+    candidate_manifest: Path,
+    context: Path,
+    event_root: Path,
+    gate_evidence: Path,
+    transition: str,
+) -> None:
+    route_id = "candidate-finalize-ready"
+    _wrapped(
+        candidate_manifest,
+        route_id=route_id,
+        worker_id=LIFECYCLE_WORKER,
+        context=context,
+        event_root=event_root,
+        command=[
+            sys.executable,
+            str(ROOT / "scripts/release_lifecycle_guard.py"),
+            "--candidate-manifest",
+            str(candidate_manifest),
+            "--transition",
+            transition,
+            "--phase",
+            "6",
+            "--gate-evidence",
+            str(gate_evidence),
+            "--current-route-id",
+            route_id,
+        ],
+    )
+
+
+def _reject(
+    candidate_manifest: Path,
+    *,
+    root: Path,
+    reason: str,
+) -> None:
+    manifest, candidate = _candidate(candidate_manifest)
+    if candidate["sealed"]:
+        _export_candidate_control(manifest)
+        return
+    context, event_root = _context(manifest, root, REJECTION_WORKER)
+    route_id = "candidate-finalize-reject"
+    _wrapped(
+        manifest,
+        route_id=route_id,
+        worker_id=REJECTION_WORKER,
+        context=context,
+        event_root=event_root,
+        command=[
+            sys.executable,
+            str(ROOT / "scripts/release_lifecycle_guard.py"),
+            "--candidate-manifest",
+            str(manifest),
+            "--transition",
+            "rejected",
+            "--phase",
+            "6",
+            "--rejection-reason",
+            reason,
+            "--current-route-id",
+            route_id,
+        ],
+    )
+    _export_candidate_control(manifest)
+
+
+def finalize(
+    mode: str,
+    candidate_manifest: Path,
+    stage_outcomes_index: Path | None,
+    parent_manifest: Path | None,
+    source_root: Path | None,
+) -> None:
+    manifest, candidate = _candidate(candidate_manifest)
+    target_state = "rc-candidate-ready" if mode == "FinalizeRc" else "ga-candidate-ready"
+    expected_kind = "rc" if mode == "FinalizeRc" else "final"
+    if candidate["candidate_kind"] != expected_kind:
+        raise CandidateLifecycleError(f"{mode} requires a {expected_kind} candidate")
+    if candidate["state"] == target_state:
+        _export_candidate_control(manifest)
+        return
+    if stage_outcomes_index is None:
+        try:
+            _reject(manifest, root=manifest.parent / "lifecycle", reason=f"{mode} has no stage outcome index")
+        finally:
+            raise CandidateLifecycleError(f"{mode} requires --stage-outcomes-index")
+    outcome_root = stage_outcomes_index.resolve().parent
+    rejection_root = manifest.parent / "lifecycle"
+    try:
+        outcome_root, required_results = _stage_outcomes(manifest, stage_outcomes_index)
+        rejection_root = outcome_root
+        context, event_root, evidence_root, result_root = _finalizer_paths(manifest, outcome_root)
+        _run_candidate_validation(manifest, context, event_root)
+        no_remote = _run_no_remote(manifest, context, event_root, evidence_root)
+        gate = _run_full_matrix_evidence(
+            manifest,
+            context,
+            event_root,
+            evidence_root,
+            result_root,
+            required_results,
+            no_remote,
+        )
+        if mode == "FinalizeRc":
+            _run_source_snapshot(manifest, context, event_root)
+            transition = "rc-candidate-ready"
+        else:
+            if parent_manifest is None or source_root is None:
+                raise CandidateLifecycleError(
+                    "FinalizeFinalFunctional requires --parent-manifest and --source-root"
+                )
+            _run_final_delta(
+                manifest,
+                context,
+                event_root,
+                evidence_root,
+                parent_manifest,
+                source_root,
+            )
+            transition = "ga-candidate-ready"
+        _transition_ready(manifest, context, event_root, gate, transition)
+        _export_candidate_control(manifest)
+    except (ReleaseStateError, OSError) as error:
+        current = read_json(manifest)
+        if not current["sealed"]:
+            _reject(
+                manifest,
+                root=rejection_root,
+                reason=f"{mode} gate failure",
+            )
+        raise CandidateLifecycleError(str(error)) from error
+
+
+def reject_final_handoff(candidate_manifest: Path, reason: str | None) -> None:
+    manifest, candidate = _candidate(candidate_manifest)
+    if candidate["candidate_kind"] != "final":
+        raise CandidateLifecycleError("RejectFinalHandoff requires a final candidate")
+    if candidate["state"] == "rejected" and candidate["sealed"]:
+        _export_candidate_control(manifest)
+        return
+    if candidate["state"] != "ga-candidate-ready" or candidate["sealed"]:
+        raise CandidateLifecycleError("RejectFinalHandoff requires an open ga-candidate-ready final")
+    _reject(
+        manifest,
+        root=manifest.parent / "lifecycle",
+        reason=reason or "final publication handoff failed",
+    )
+
+
+def stage_rc(candidate_manifest: Path) -> None:
+    manifest, candidate = _candidate(candidate_manifest)
+    if candidate["candidate_kind"] != "rc":
+        raise CandidateLifecycleError("StageRc requires an RC candidate")
+    if candidate["state"] == "staged-rc" and not candidate["sealed"]:
+        _export_candidate_control(manifest)
+        return
+    if candidate["state"] != "development" or candidate["sealed"]:
+        raise CandidateLifecycleError("StageRc requires an unsealed development RC")
+    context, event_root = _context(manifest, manifest.parent / "lifecycle")
+    route_id = "candidate-stage-rc"
+    _wrapped(
+        manifest,
+        route_id=route_id,
+        worker_id=LIFECYCLE_WORKER,
+        context=context,
+        event_root=event_root,
+        command=[
+            sys.executable,
+            str(ROOT / "scripts/release_lifecycle_guard.py"),
+            "--candidate-manifest",
+            str(manifest),
+            "--transition",
+            "staged-rc",
+            "--phase",
+            "6",
+            "--current-route-id",
+            route_id,
+        ],
+    )
+    _export_candidate_control(manifest)
+
+
+def execute(
+    mode: str,
+    candidate_manifest: Path,
+    *,
+    stage_outcomes_index: Path | None,
+    parent_manifest: Path | None,
+    source_root: Path | None,
+    rejection_reason: str | None,
+) -> None:
+    if mode == "StageRc":
+        try:
+            stage_rc(candidate_manifest)
+        except (ReleaseStateError, OSError) as error:
+            manifest, candidate = _candidate(candidate_manifest)
+            if not candidate["sealed"]:
+                _reject(
+                    manifest,
+                    root=manifest.parent / "lifecycle",
+                    reason="StageRc transition failed",
+                )
+            raise CandidateLifecycleError(str(error)) from error
+        return
+    if mode in {"FinalizeRc", "FinalizeFinalFunctional"}:
+        finalize(mode, candidate_manifest, stage_outcomes_index, parent_manifest, source_root)
+        return
+    reject_final_handoff(candidate_manifest, rejection_reason)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=sorted(MODES), required=True)
+    parser.add_argument("--candidate-manifest", type=Path, required=True)
+    parser.add_argument("--stage-outcomes-index", type=Path)
+    parser.add_argument("--parent-manifest", type=Path)
+    parser.add_argument("--source-root", type=Path)
+    parser.add_argument("--rejection-reason")
+    args = parser.parse_args(argv)
+    try:
+        execute(
+            args.mode,
+            args.candidate_manifest,
+            stage_outcomes_index=args.stage_outcomes_index,
+            parent_manifest=args.parent_manifest,
+            source_root=args.source_root,
+            rejection_reason=args.rejection_reason,
+        )
+    except (ReleaseStateError, OSError) as error:
+        print(f"V1_CANDIDATE_LIFECYCLE_FAILED mode={args.mode} detail={error}", file=sys.stderr)
+        return 1
+    value = read_json(args.candidate_manifest)
+    print(
+        "V1_CANDIDATE_LIFECYCLE_OK "
+        f"mode={args.mode} state={value['state']} sealed={str(value['sealed']).lower()}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9574

### Brief Description

- Add fail-fast PowerShell and Bash entrypoints for candidate lifecycle orchestration.
- Close candidate job, result, and route denominators before lifecycle transitions.
- Drive successful transitions and deterministic rejection through the audited command wrapper and atomic lifecycle operations.
- Export and validate generation-scoped candidate and series control bundles without content-digest gates.
- Preserve the preparation-only boundary: no registry, container, GitHub Release, or other remote publication is performed.

### How Did You Test This Change?

- `python -m unittest scripts.tests.test_v1_candidate_lifecycle scripts.tests.test_candidate_stage_outcomes scripts.tests.test_release_evidence_guard scripts.tests.test_candidate_transfer scripts.tests.test_release_lifecycle scripts.tests.test_release_candidate_command scripts.tests.test_candidate_run scripts.tests.test_release_series scripts.tests.test_candidate_source_snapshot scripts.tests.test_final_candidate_delta_guard scripts.tests.test_no_remote_publication_guard scripts.tests.test_release_preparation_runner` (88 tests passed)
- `python -m py_compile distribution/transfer_candidate.py scripts/v1_candidate_lifecycle.py`
- `bash -n scripts/run-v1-candidate-lifecycle.sh`
- PowerShell parser validation for `scripts/run-v1-candidate-lifecycle.ps1`
- `python scripts/no_remote_publication_guard.py --phase 6 --static-only`
- `.\scripts\check-agents-routing.ps1`
- JSON parsing for the changed candidate policy and schema files
- `git diff --check`
- `python scripts/core_release_static_guard.py` completed with the changed release routes passing. The command still reports the same pre-existing architecture dependency, module maintainability, and architecture release findings reproduced on `main`; this change introduces no new findings in those categories.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a complete v1 candidate lifecycle workflow for staging, finalizing, and rejecting candidates.
  * Added cross-platform command wrappers for running lifecycle operations.
  * Added build-control bundle export with candidate and release validation.
  * Added route tracking to stage outcomes, including expected, observed, and missing routes.
  * Added support for selecting release-specific results when generating evidence.

* **Bug Fixes**
  * Improved validation and reporting for incomplete, unknown, or mismatched workflow results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->