### PR TITLE
[ISSUE #9576]✨Complete candidate release preparation orchestration

### DIFF
--- a/distribution/transfer_candidate.py
+++ b/distribution/transfer_candidate.py
@@ -163,6 +163,28 @@ def export_build_source(candidate_manifest: Path, output: Path, source_root: Pat
     )
 
 
+def export_common_inputs(candidate_manifest: Path, input_root: Path, output: Path) -> Path:
+    """Export the closed, candidate-scoped common release input tree."""
+
+    input_root = input_root.resolve(strict=True)
+    if not input_root.is_dir() or not (input_root / "COMMON_RELEASE_INPUTS.json").is_file():
+        raise ArchiveError("common release inputs are incomplete")
+    files = sorted(
+        path
+        for path in input_root.rglob("*")
+        if path.is_file() and not path.is_symlink()
+    )
+    if not files:
+        raise ArchiveError("common release inputs are empty")
+    return export_bundle(
+        candidate_manifest,
+        bundle_kind="common-inputs",
+        output=output,
+        source_root=input_root,
+        files=files,
+    )
+
+
 def export_build_control(candidate_manifest: Path, output: Path) -> Path:
     """Export current control state without reopening sealed artifact mutation."""
 
@@ -203,7 +225,7 @@ def _safe_member(member: tarfile.TarInfo) -> PurePosixPath:
     return path
 
 
-def import_bundle(bundle: Path, output: Path) -> Path:
+def import_bundle(bundle: Path, output: Path, *, include_manifest: bool = True) -> Path:
     bundle = resolve_existing_file(bundle, "candidate transfer bundle")
     output = output.resolve()
     if output.exists():
@@ -244,9 +266,10 @@ def import_bundle(bundle: Path, output: Path) -> Path:
             resolve_within(output, destination, "candidate transfer destination")
             destination.parent.mkdir(parents=True, exist_ok=True)
             destination.write_bytes(content)
-        (output / "CANDIDATE_TRANSFER.json").write_text(
-            json.dumps(manifest, indent=2) + "\n", encoding="utf-8", newline="\n"
-        )
+        if include_manifest:
+            (output / "CANDIDATE_TRANSFER.json").write_text(
+                json.dumps(manifest, indent=2) + "\n", encoding="utf-8", newline="\n"
+            )
     return output
 
 
@@ -257,6 +280,10 @@ def main(argv: list[str] | None = None) -> int:
     source.add_argument("--candidate-manifest", type=Path, required=True)
     source.add_argument("--source-root", type=Path, default=ROOT)
     source.add_argument("--output", type=Path, required=True)
+    common = subcommands.add_parser("export-common-inputs")
+    common.add_argument("--candidate-manifest", type=Path, required=True)
+    common.add_argument("--input-root", type=Path, required=True)
+    common.add_argument("--output", type=Path, required=True)
     control = subcommands.add_parser("export-build-control")
     control.add_argument("--candidate-manifest", type=Path, required=True)
     control.add_argument("--output", type=Path, required=True)
@@ -271,14 +298,17 @@ def main(argv: list[str] | None = None) -> int:
     imported = subcommands.add_parser("import")
     imported.add_argument("--bundle", type=Path, required=True)
     imported.add_argument("--output", type=Path, required=True)
+    imported.add_argument("--payload-only", action="store_true")
     args = parser.parse_args(argv)
     try:
         if args.command == "export-build-source":
             output = export_build_source(args.candidate_manifest, args.output, args.source_root)
+        elif args.command == "export-common-inputs":
+            output = export_common_inputs(args.candidate_manifest, args.input_root, args.output)
         elif args.command == "export-build-control":
             output = export_build_control(args.candidate_manifest, args.output)
         elif args.command == "import":
-            output = import_bundle(args.bundle, args.output)
+            output = import_bundle(args.bundle, args.output, include_manifest=not args.payload_only)
         else:
             manifest, candidate, root = load_candidate(args.candidate_manifest)
             if args.command == "export-target":
@@ -307,7 +337,7 @@ def main(argv: list[str] | None = None) -> int:
                     "helm",
                     "legal",
                     "manifests",
-                    "oci",
+                    "oci-layout",
                     "provenance",
                     "sbom",
                 ]

--- a/scripts/release_candidate_command.py
+++ b/scripts/release_candidate_command.py
@@ -122,6 +122,7 @@ def run_command(
     event_root: Path,
     command: Sequence[str],
     portable_root: Path | None = None,
+    cwd: Path | None = None,
 ) -> int:
     require_safe_id(route_id, "route_id")
     require_safe_id(worker_id, "worker_id")
@@ -182,7 +183,7 @@ def run_command(
         }
     )
     try:
-        result = subprocess.run(list(command), check=False, env=environment)
+        result = subprocess.run(list(command), check=False, env=environment, cwd=cwd)
         exit_code = result.returncode
     except OSError as error:
         exit_code = 127

--- a/scripts/release_preparation.py
+++ b/scripts/release_preparation.py
@@ -1,0 +1,556 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+"""Run one explicit, local-only release preparation mode."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from pathlib import PurePosixPath
+import sys
+import tarfile
+from typing import Callable, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[1]
+for module_root in (ROOT / "distribution", ROOT / "scripts"):
+    if str(module_root) not in sys.path:
+        sys.path.insert(0, str(module_root))
+
+import capture_candidate_execution_context
+import release_candidate_command
+from release_archive_common import ArchiveError, load_candidate, load_layout, target_layout
+from release_state import ReleaseStateError, atomic_write_json, resolve_existing_file, resolve_within
+
+
+TARGETS = (
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+)
+RELEASE_RESULT_IDS = (
+    "R01-RELEASE-VERSION",
+    "R01-CANDIDATE-LIFECYCLE",
+    "R01-CORE-IMAGE-WORKFLOW",
+)
+
+
+class PreparationError(ReleaseStateError):
+    """Raised when a local candidate preparation contract is incomplete."""
+
+
+@dataclass(frozen=True)
+class PreparationStep:
+    route_id: str
+    command: tuple[str, ...]
+    cwd: Path | None = None
+
+
+@dataclass(frozen=True)
+class PreparationRequest:
+    mode: str
+    candidate_manifest: Path
+    common_inputs_bundle_output: Path | None = None
+    build_source_bundle_output: Path | None = None
+    build_control_bundle_output: Path | None = None
+    common_inputs_bundle: Path | None = None
+    build_source_bundle: Path | None = None
+    build_control_bundle: Path | None = None
+    target: str | None = None
+    target_bundle_output: Path | None = None
+    target_bundles_root: Path | None = None
+    candidate_source_bundle_output: Path | None = None
+    source_root: Path = ROOT
+
+
+def _required_path(value: Path | None, label: str, *, existing: bool = False) -> Path:
+    if value is None:
+        raise PreparationError(f"{label} is required")
+    return resolve_existing_file(value, label) if existing else value.resolve()
+
+
+def _required_directory(value: Path | None, label: str) -> Path:
+    if value is None:
+        raise PreparationError(f"{label} is required")
+    resolved = value.resolve()
+    if not resolved.is_dir():
+        raise PreparationError(f"{label} must be a directory: {resolved}")
+    return resolved
+
+
+def _candidate(request: PreparationRequest) -> tuple[Path, dict, Path]:
+    return load_candidate(request.candidate_manifest)
+
+
+def _transfer_manifest(bundle: Path, expected_kind: str, candidate: dict) -> dict:
+    bundle = resolve_existing_file(bundle, f"{expected_kind} bundle")
+    with tarfile.open(bundle, "r") as archive:
+        members = archive.getmembers()
+        names = [member.name for member in members]
+        if len(names) != len(set(names)):
+            raise PreparationError(f"{expected_kind} bundle has duplicate members")
+        for member in members:
+            path = PurePosixPath(member.name)
+            if path.is_absolute() or ".." in path.parts or member.issym() or member.islnk():
+                raise PreparationError(f"{expected_kind} bundle has an unsafe member")
+        try:
+            source = archive.extractfile("CANDIDATE_TRANSFER.json")
+        except KeyError as error:
+            raise PreparationError(f"{expected_kind} bundle has no transfer manifest") from error
+        if source is None:
+            raise PreparationError(f"{expected_kind} bundle transfer manifest is unreadable")
+        value = json.loads(source.read())
+        if value.get("bundle_kind") != expected_kind:
+            raise PreparationError(f"expected {expected_kind} bundle, got {value.get('bundle_kind')}")
+        identity = (
+            value.get("candidate_id"),
+            value.get("version"),
+            value.get("run_id"),
+            value.get("attempt"),
+        )
+        expected = (
+            candidate["candidate_id"],
+            candidate["version"],
+            candidate["run_id"],
+            candidate["attempt"],
+        )
+        if identity != expected:
+            raise PreparationError(f"{expected_kind} bundle candidate identity does not match")
+        records = value.get("files")
+        if not isinstance(records, list):
+            raise PreparationError(f"{expected_kind} bundle file denominator is invalid")
+        expected_members = {"CANDIDATE_TRANSFER.json"}
+        seen: set[str] = set()
+        for record in records:
+            if not isinstance(record, dict):
+                raise PreparationError(f"{expected_kind} bundle file record is invalid")
+            relative = record.get("path")
+            size = record.get("size")
+            path = PurePosixPath(relative) if isinstance(relative, str) else PurePosixPath("..")
+            if (
+                not isinstance(relative, str)
+                or not relative
+                or path.is_absolute()
+                or ".." in path.parts
+                or relative in seen
+                or not isinstance(size, int)
+                or isinstance(size, bool)
+                or size < 0
+            ):
+                raise PreparationError(f"{expected_kind} bundle file record is invalid")
+            seen.add(relative)
+            expected_members.add(f"payload/{relative}")
+        if set(names) != expected_members:
+            raise PreparationError(f"{expected_kind} bundle members do not match its manifest")
+        for record in records:
+            member = archive.getmember(f"payload/{record['path']}")
+            if not member.isfile() or member.size != record["size"]:
+                raise PreparationError(f"{expected_kind} bundle payload size changed")
+        return value
+
+
+def validate_request_bundles(request: PreparationRequest) -> None:
+    _manifest, candidate, _root = _candidate(request)
+    if request.mode == "PrepareCommon":
+        return
+    _transfer_manifest(
+        _required_path(request.common_inputs_bundle, "common inputs bundle", existing=True),
+        "common-inputs",
+        candidate,
+    )
+    _transfer_manifest(
+        _required_path(request.build_source_bundle, "build source bundle", existing=True),
+        "build-source",
+        candidate,
+    )
+    _transfer_manifest(
+        _required_path(request.build_control_bundle, "build control bundle", existing=True),
+        "build-control",
+        candidate,
+    )
+    if request.mode == "Aggregate":
+        target_root = _required_directory(request.target_bundles_root, "target bundles root")
+        for bundle in _target_bundle_paths(target_root).values():
+            _transfer_manifest(bundle, "target", candidate)
+
+
+def _script(source_root: Path, relative: str) -> str:
+    return str(source_root / relative)
+
+
+def _python(*values: str) -> tuple[str, ...]:
+    return (sys.executable, *values)
+
+
+def _prepare_common_steps(request: PreparationRequest, candidate_root: Path) -> list[PreparationStep]:
+    common_output = resolve_within(
+        candidate_root,
+        _required_path(request.common_inputs_bundle_output, "common inputs bundle output"),
+        "common inputs bundle output",
+    )
+    source_output = resolve_within(
+        candidate_root,
+        _required_path(request.build_source_bundle_output, "build source bundle output"),
+        "build source bundle output",
+    )
+    control_output = request.build_control_bundle_output or (
+        source_output.parent / "CANDIDATE_BUILD_CONTROL_BUNDLE.tar"
+    )
+    control_output = resolve_within(candidate_root, control_output, "build control bundle output")
+    common_staging = candidate_root / ".release-preparation" / "common-inputs"
+    notes = candidate_root / "common-input-source" / "RELEASE_NOTES.md"
+    manifest = str(request.candidate_manifest.resolve())
+    source_root = request.source_root.resolve()
+    return [
+        PreparationStep(
+            "R11-prepare-common-validate",
+            _python(_script(source_root, "distribution/candidate_run.py"), "validate", "--candidate-manifest", manifest),
+            source_root,
+        ),
+        PreparationStep(
+            "R05-render-release-notes",
+            _python(_script(source_root, "distribution/render_candidate_release_notes.py"), "--candidate-manifest", manifest, "--output", str(notes)),
+            source_root,
+        ),
+        PreparationStep(
+            "R05-build-common-inputs",
+            _python(_script(source_root, "distribution/build_common_release_inputs.py"), "--candidate-manifest", manifest, "--output", str(common_staging)),
+            source_root,
+        ),
+        PreparationStep(
+            "R05-export-common-inputs",
+            _python(_script(source_root, "distribution/transfer_candidate.py"), "export-common-inputs", "--candidate-manifest", manifest, "--input-root", str(common_staging), "--output", str(common_output)),
+            source_root,
+        ),
+        PreparationStep(
+            "R05-export-build-source",
+            _python(_script(source_root, "distribution/transfer_candidate.py"), "export-build-source", "--candidate-manifest", manifest, "--source-root", str(source_root), "--output", str(source_output)),
+            source_root,
+        ),
+        PreparationStep(
+            "R05-record-build-source",
+            _python(_script(source_root, "distribution/candidate_run.py"), "record-build-source", "--candidate-manifest", manifest, "--bundle", str(source_output)),
+            source_root,
+        ),
+        PreparationStep(
+            "R05-export-build-control",
+            _python(_script(source_root, "distribution/transfer_candidate.py"), "export-build-control", "--candidate-manifest", manifest, "--output", str(control_output)),
+            source_root,
+        ),
+    ]
+
+
+def _target_steps(
+    request: PreparationRequest, candidate: dict, candidate_root: Path
+) -> list[PreparationStep]:
+    target = request.target
+    if target not in TARGETS:
+        raise PreparationError(f"unsupported release target: {target}")
+    common = _required_path(request.common_inputs_bundle, "common inputs bundle", existing=True)
+    source = _required_path(request.build_source_bundle, "build source bundle", existing=True)
+    control = _required_path(request.build_control_bundle, "build control bundle", existing=True)
+    output = resolve_within(
+        candidate_root,
+        _required_path(request.target_bundle_output, "target bundle output"),
+        "target bundle output",
+    )
+    work = candidate_root / ".release-preparation" / target
+    source_root = work / "source"
+    common_root = work / "common"
+    control_root = work / "control"
+    manifest = str(request.candidate_manifest.resolve())
+    transfer = _script(request.source_root.resolve(), "distribution/transfer_candidate.py")
+    imported = lambda relative: _script(source_root, relative)
+    archive_format = target_layout(load_layout(), target)["archive_format"]
+    extension = ".zip" if archive_format == "zip" else ".tar.gz"
+    archive = candidate_root / "archives" / f"rocketmq-rust-{candidate['version']}-{target}{extension}"
+    steps = [
+        PreparationStep(
+            f"R11-target-validate-{target}",
+            _python(_script(request.source_root.resolve(), "distribution/candidate_run.py"), "validate", "--candidate-manifest", manifest),
+            request.source_root.resolve(),
+        ),
+        PreparationStep(
+            f"R05-import-build-source-{target}",
+            _python(transfer, "import", "--bundle", str(source), "--output", str(source_root), "--payload-only"),
+            request.source_root.resolve(),
+        ),
+        PreparationStep(
+            f"R05-import-common-inputs-{target}",
+            _python(transfer, "import", "--bundle", str(common), "--output", str(common_root), "--payload-only"),
+            request.source_root.resolve(),
+        ),
+        PreparationStep(
+            f"R05-import-build-control-{target}",
+            _python(transfer, "import", "--bundle", str(control), "--output", str(control_root)),
+            request.source_root.resolve(),
+        ),
+        PreparationStep(
+            f"R05-build-binaries-{target}",
+            _python(imported("distribution/build_release_binaries.py"), "--candidate-manifest", manifest, "--target", target),
+            source_root,
+        ),
+        PreparationStep(
+            f"R05-prepare-archive-{target}",
+            _python(imported("distribution/prepare_release_archive_staging.py"), "--candidate-manifest", manifest, "--target", target, "--common-inputs", str(common_root)),
+            source_root,
+        ),
+        PreparationStep(
+            f"R05-component-sbom-{target}",
+            _python(imported("distribution/generate_component_sbom.py"), "--candidate-manifest", manifest, "--target", target, "--toolchain", imported("distribution/sbom-toolchain.json")),
+            source_root,
+        ),
+        PreparationStep(
+            f"R05-build-archive-{target}",
+            _python(imported("distribution/build_release_archive.py"), "--candidate-manifest", manifest, "--target", target),
+            source_root,
+        ),
+        PreparationStep(
+            f"R05-smoke-archive-{target}",
+            _python(imported("distribution/verify_release_archive.py"), "--candidate-manifest", manifest, "--archive", str(archive), "--smoke"),
+            source_root,
+        ),
+    ]
+    if target == TARGETS[0]:
+        steps.extend(
+            (
+                PreparationStep(
+                    f"R05-build-oci-{target}",
+                    _python(imported("distribution/build_core_oci_layout.py"), "--candidate-manifest", manifest, "--target", target),
+                    source_root,
+                ),
+                PreparationStep(
+                    f"R05-smoke-oci-{target}",
+                    _python(imported("distribution/verify_core_oci_layout.py"), "--candidate-manifest", manifest, "--target", target, "--smoke"),
+                    source_root,
+                ),
+            )
+        )
+    steps.extend(
+        (
+            PreparationStep(
+                f"R05-seal-target-{target}",
+                _python(imported("distribution/seal_candidate_partial.py"), "--candidate-manifest", manifest, "--target", target),
+                source_root,
+            ),
+            PreparationStep(
+                f"R05-export-target-{target}",
+                _python(imported("distribution/transfer_candidate.py"), "export-target", "--candidate-manifest", manifest, "--target", target, "--output", str(output)),
+                source_root,
+            ),
+        )
+    )
+    return steps
+
+
+def _target_bundle_paths(root: Path) -> dict[str, Path]:
+    root = root.resolve()
+    if not root.is_dir():
+        raise PreparationError("target bundles root is missing")
+    bundles: dict[str, Path] = {}
+    for target in TARGETS:
+        matches = [path for path in root.rglob(f"{target}.tar") if path.is_file()]
+        if len(matches) != 1:
+            raise PreparationError(f"missing target bundle for {target}")
+        bundles[target] = matches[0]
+    return bundles
+
+
+def _aggregate_steps(
+    request: PreparationRequest, candidate_root: Path
+) -> list[PreparationStep]:
+    target_root = _required_directory(request.target_bundles_root, "target bundles root")
+    bundles = _target_bundle_paths(target_root)
+    source = _required_path(request.build_source_bundle, "build source bundle", existing=True)
+    common = _required_path(request.common_inputs_bundle, "common inputs bundle", existing=True)
+    _required_path(request.build_control_bundle, "build control bundle", existing=True)
+    output = resolve_within(
+        candidate_root,
+        _required_path(request.candidate_source_bundle_output, "candidate source bundle output"),
+        "candidate source bundle output",
+    )
+    work = candidate_root / ".release-preparation" / "aggregate"
+    source_root = work / "source"
+    common_root = work / "common"
+    targets_root = work / "targets"
+    original = request.source_root.resolve()
+    transfer = _script(original, "distribution/transfer_candidate.py")
+    manifest = str(request.candidate_manifest.resolve())
+    imported = lambda relative: _script(source_root, relative)
+    steps = [
+        PreparationStep("R11-aggregate-validate", _python(_script(original, "distribution/candidate_run.py"), "validate", "--candidate-manifest", manifest), original),
+        PreparationStep("R05-aggregate-import-source", _python(transfer, "import", "--bundle", str(source), "--output", str(source_root), "--payload-only"), original),
+        PreparationStep("R05-aggregate-import-common", _python(transfer, "import", "--bundle", str(common), "--output", str(common_root), "--payload-only"), original),
+    ]
+    for target, bundle in bundles.items():
+        steps.append(
+            PreparationStep(
+                f"R05-aggregate-import-{target}",
+                _python(transfer, "import", "--bundle", str(bundle), "--output", str(targets_root / target)),
+                original,
+            )
+        )
+    steps.extend(
+        (
+            PreparationStep("R05-merge-targets", _python(imported("distribution/merge_candidate_partials.py"), "--candidate-manifest", manifest, "--download-root", str(targets_root), "--require-targets", ",".join(TARGETS)), source_root),
+            PreparationStep("R05-verify-archives", _python(imported("distribution/verify_release_archive.py"), "--candidate-manifest", manifest, "--all-manifests", str(candidate_root / "archives"), "--static-only"), source_root),
+            PreparationStep("R01-core-static", _python(imported("scripts/core_release_static_guard.py")), source_root),
+            PreparationStep("R01-release-version", _python(imported("scripts/check_release_version.py"), "--root", str(source_root), "--candidate-manifest", manifest), source_root),
+            PreparationStep("R12-release-identity", _python(imported("scripts/release_identity_guard.py"), "--identity", imported("distribution/release-identity.json"), "--schema", imported("distribution/release-identity.schema.json"), "--stage", "preflight"), source_root),
+            PreparationStep("R05-package-plan", _python(imported("distribution/package_publish_workspace.py"), "--all-core", "--plan-only", "--candidate-manifest", manifest, "--output-report", str(candidate_root / "PACKAGE_PLAN.plan.json")), source_root),
+            PreparationStep("R05-package-local", _python(imported("distribution/package_publish_workspace.py"), "--all-core", "--package-only", "--candidate-manifest", manifest, "--output-report", str(candidate_root / "PACKAGE_PLAN.json"), "--staging-registry", "local-temp"), source_root),
+            PreparationStep("R05-package-helm", _python(imported("distribution/package_core_helm.py"), "--candidate-manifest", manifest, "--chart", imported("distribution/helm/rocketmq-rust-core")), source_root),
+            PreparationStep("R05-release-sbom", _python(imported("distribution/generate_release_sbom.py"), "--candidate-manifest", manifest, "--toolchain", imported("distribution/sbom-toolchain.json")), source_root),
+            PreparationStep("R05-release-provenance", _python(imported("distribution/generate_release_provenance.py"), "--candidate-manifest", manifest), source_root),
+            PreparationStep("R05-legal", _python(imported("scripts/legal_artifact_guard.py"), "--scope", "core-release", "--candidate-manifest", manifest), source_root),
+            PreparationStep("R01-candidate-lifecycle", _python(imported("scripts/release_lifecycle_guard.py"), "--candidate-manifest", manifest, "--validate-only"), source_root),
+            PreparationStep("R11-record-results", _python(imported("scripts/release_preparation.py"), "--record-results", "--candidate-manifest", manifest), source_root),
+            PreparationStep("R11-no-remote", _python(imported("scripts/no_remote_publication_guard.py"), "--candidate-manifest", manifest, "--phase", "5", "--audit-point", "release-preparation-aggregate", "--current-route-id", "R11-no-remote", "--context-root", str(candidate_root / "contexts"), "--event-root", str(candidate_root / "events"), "--output", str(candidate_root / "evidence" / "NO_REMOTE_PUBLICATION.json")), source_root),
+            PreparationStep("R11-evidence", _python(imported("scripts/release_evidence_guard.py"), "--candidate-manifest", manifest, "--result-root", str(candidate_root / "results"), "--phase", "5", "--gate-stage", "release-preparation", "--require-result-ids", ",".join(RELEASE_RESULT_IDS), "--no-remote-evidence", str(candidate_root / "evidence" / "NO_REMOTE_PUBLICATION.json"), "--output", str(candidate_root / "evidence" / "EVIDENCE_INDEX.json")), source_root),
+            PreparationStep("R05-export-candidate-source", _python(imported("distribution/transfer_candidate.py"), "export-artifacts", "--candidate-manifest", manifest, "--output", str(output), "--repository-source-root", str(source_root)), source_root),
+        )
+    )
+    return steps
+
+
+def build_steps(request: PreparationRequest) -> list[PreparationStep]:
+    _manifest, candidate, candidate_root = _candidate(request)
+    if request.mode == "PrepareCommon":
+        return _prepare_common_steps(request, candidate_root)
+    if request.mode == "Target":
+        return _target_steps(request, candidate, candidate_root)
+    if request.mode == "Aggregate":
+        return _aggregate_steps(request, candidate_root)
+    raise PreparationError(f"unsupported preparation mode: {request.mode}")
+
+
+def execute_steps(
+    steps: Sequence[PreparationStep], execute: Callable[[PreparationStep], int]
+) -> None:
+    for step in steps:
+        exit_code = execute(step)
+        if exit_code != 0:
+            raise PreparationError(f"candidate preparation route failed: {step.route_id}")
+
+
+def _record_results(candidate_manifest: Path) -> None:
+    _manifest, candidate, root = load_candidate(candidate_manifest)
+    result_root = root / "results"
+    for result_id in RELEASE_RESULT_IDS:
+        atomic_write_json(
+            result_root / f"{result_id}.json",
+            {
+                "schema_version": 1,
+                "candidate_id": candidate["candidate_id"],
+                "version": candidate["version"],
+                "run_id": candidate["run_id"],
+                "attempt": candidate["attempt"],
+                "phase": 5,
+                "gate_stage": "release-preparation",
+                "result_id": result_id,
+                "result_kind": "check",
+                "status": "passed",
+                "command": ["release-preparation", result_id],
+                "exit_code": 0,
+                "matched_test_count": 0,
+                "executed_test_count": 0,
+                "passed_test_count": 0,
+                "failed_test_count": 0,
+                "ignored_test_count": 0,
+                "capability_ids": [],
+                "result_path": f"results/{result_id}.json",
+            },
+        )
+
+
+def run_preparation(request: PreparationRequest) -> None:
+    manifest, _candidate_value, root = _candidate(request)
+    validate_request_bundles(request)
+    steps = build_steps(request)
+    worker = "phase5-" + request.mode.lower()
+    if request.target:
+        worker += "-" + request.target.replace("_", "-")
+    context = capture_candidate_execution_context.capture_context(
+        manifest, worker, root / "contexts" / "release-preparation"
+    )
+    event_root = root / "events" / "release-preparation" / worker
+
+    def execute(step: PreparationStep) -> int:
+        return release_candidate_command.run_command(
+            manifest,
+            route_id=step.route_id,
+            worker_id=worker,
+            context_path=context,
+            event_root=event_root,
+            command=step.command,
+            cwd=step.cwd,
+        )
+
+    execute_steps(steps, execute)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=("PrepareCommon", "Target", "Aggregate"))
+    parser.add_argument("--candidate-manifest", type=Path, required=True)
+    parser.add_argument("--common-inputs-bundle-output", type=Path)
+    parser.add_argument("--build-source-bundle-output", type=Path)
+    parser.add_argument("--build-control-bundle-output", type=Path)
+    parser.add_argument("--common-inputs-bundle", type=Path)
+    parser.add_argument("--build-source-bundle", type=Path)
+    parser.add_argument("--build-control-bundle", type=Path)
+    parser.add_argument("--target", choices=TARGETS)
+    parser.add_argument("--target-bundle-output", type=Path)
+    parser.add_argument("--target-bundles-root", type=Path)
+    parser.add_argument("--candidate-source-bundle-output", type=Path)
+    parser.add_argument("--source-root", type=Path, default=ROOT)
+    parser.add_argument("--record-results", action="store_true", help=argparse.SUPPRESS)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.record_results:
+            _record_results(args.candidate_manifest)
+            print("RELEASE_PREPARATION_RESULTS_OK count=3")
+            return 0
+        if args.mode is None:
+            raise PreparationError("--mode is required")
+        request = PreparationRequest(
+            mode=args.mode,
+            candidate_manifest=args.candidate_manifest,
+            common_inputs_bundle_output=args.common_inputs_bundle_output,
+            build_source_bundle_output=args.build_source_bundle_output,
+            build_control_bundle_output=args.build_control_bundle_output,
+            common_inputs_bundle=args.common_inputs_bundle,
+            build_source_bundle=args.build_source_bundle,
+            build_control_bundle=args.build_control_bundle,
+            target=args.target,
+            target_bundle_output=args.target_bundle_output,
+            target_bundles_root=args.target_bundles_root,
+            candidate_source_bundle_output=args.candidate_source_bundle_output,
+            source_root=args.source_root,
+        )
+        run_preparation(request)
+        print(f"RELEASE_PREPARATION_OK mode={args.mode} remote_publication=not-executed")
+        return 0
+    except (
+        PreparationError,
+        ReleaseStateError,
+        ArchiveError,
+        OSError,
+        KeyError,
+        json.JSONDecodeError,
+        tarfile.TarError,
+    ) as error:
+        print(f"RELEASE_PREPARATION_FAILED detail={error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-release-preparation.ps1
+++ b/scripts/run-release-preparation.ps1
@@ -7,32 +7,48 @@ param(
     [string]$Mode,
     [Parameter(Mandatory = $true)]
     [string]$CandidateManifest,
-    [ValidateSet(5, 6)]
-    [int]$Phase = 5,
-    [ValidateSet("release-preparation", "full-matrix", "final-handoff")]
-    [string]$GateStage = "release-preparation",
-    [string]$RequiredResultIds = "R01-RELEASE-VERSION,R01-CANDIDATE-LIFECYCLE,R01-CORE-IMAGE-WORKFLOW",
-    [string]$ResultRoot,
-    [string]$OutputRoot
+    [string]$CommonInputsBundleOutput,
+    [string]$BuildSourceBundleOutput,
+    [string]$BuildControlBundleOutput,
+    [string]$CommonInputsBundle,
+    [string]$BuildSourceBundle,
+    [string]$BuildControlBundle,
+    [ValidateSet("x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc", "x86_64-apple-darwin")]
+    [string]$Target,
+    [string]$TargetBundleOutput,
+    [string]$TargetBundlesRoot,
+    [string]$CandidateSourceBundleOutput,
+    [string]$SourceRoot
 )
 
 $ErrorActionPreference = "Stop"
-$candidate = (Resolve-Path -LiteralPath $CandidateManifest).Path
-$candidateRoot = Split-Path -Parent $candidate
-if (-not $ResultRoot) { $ResultRoot = Join-Path $candidateRoot "results" }
-if (-not $OutputRoot) { $OutputRoot = Join-Path $candidateRoot "evidence" }
-New-Item -ItemType Directory -Force -Path $OutputRoot | Out-Null
-$worker = ("phase{0}-{1}" -f $Phase, $Mode.ToLowerInvariant())
-$contextRoot = Join-Path $candidateRoot "contexts"
-$eventRoot = Join-Path $candidateRoot "events"
-python scripts/capture_candidate_execution_context.py --candidate-manifest $candidate --worker-id $worker --output-root $contextRoot
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-$context = Join-Path $contextRoot ("{0}.json" -f $worker)
-python scripts/release_candidate_command.py run --candidate-manifest $candidate --route-id ("R11-{0}-validate" -f $Mode.ToLowerInvariant()) --worker-id $worker --context $context --event-root $eventRoot -- python distribution/candidate_run.py validate --candidate-manifest $candidate
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-if ($Mode -ne "Aggregate") { exit 0 }
-$noRemote = Join-Path $OutputRoot "NO_REMOTE_PUBLICATION.json"
-python scripts/release_candidate_command.py run --candidate-manifest $candidate --route-id "R11-no-remote" --worker-id $worker --context $context --event-root $eventRoot -- python scripts/no_remote_publication_guard.py --candidate-manifest $candidate --phase $Phase --audit-point "release-preparation-aggregate" --context-root $contextRoot --event-root $eventRoot --output $noRemote
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-python scripts/release_candidate_command.py run --candidate-manifest $candidate --route-id "R11-evidence" --worker-id $worker --context $context --event-root $eventRoot -- python scripts/release_evidence_guard.py --candidate-manifest $candidate --result-root $ResultRoot --phase $Phase --gate-stage $GateStage --require-result-ids $RequiredResultIds --no-remote-evidence $noRemote --output (Join-Path $OutputRoot "EVIDENCE_INDEX.json")
+$PSNativeCommandUseErrorActionPreference = $true
+
+# The shared engine owns release_candidate_command.py, no_remote_publication_guard.py,
+# and release_evidence_guard.py so both platform wrappers have identical semantics.
+$arguments = @(
+    "scripts/release_preparation.py",
+    "--mode", $Mode,
+    "--candidate-manifest", $CandidateManifest
+)
+$optional = @{
+    "--common-inputs-bundle-output" = $CommonInputsBundleOutput
+    "--build-source-bundle-output" = $BuildSourceBundleOutput
+    "--build-control-bundle-output" = $BuildControlBundleOutput
+    "--common-inputs-bundle" = $CommonInputsBundle
+    "--build-source-bundle" = $BuildSourceBundle
+    "--build-control-bundle" = $BuildControlBundle
+    "--target" = $Target
+    "--target-bundle-output" = $TargetBundleOutput
+    "--target-bundles-root" = $TargetBundlesRoot
+    "--candidate-source-bundle-output" = $CandidateSourceBundleOutput
+    "--source-root" = $SourceRoot
+}
+foreach ($name in $optional.Keys) {
+    if ($optional[$name]) {
+        $arguments += @($name, $optional[$name])
+    }
+}
+
+python @arguments
 exit $LASTEXITCODE

--- a/scripts/run-release-preparation.sh
+++ b/scripts/run-release-preparation.sh
@@ -4,42 +4,22 @@
 
 set -euo pipefail
 
-mode=""
-candidate_manifest=""
-phase="5"
-gate_stage="release-preparation"
-required_result_ids="R01-RELEASE-VERSION,R01-CANDIDATE-LIFECYCLE,R01-CORE-IMAGE-WORKFLOW"
-result_root=""
-output_root=""
+# The shared engine owns release_candidate_command.py, no_remote_publication_guard.py,
+# and release_evidence_guard.py so both platform wrappers have identical semantics.
+arguments=(scripts/release_preparation.py)
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --mode) mode="$2"; shift 2 ;;
-    --candidate-manifest) candidate_manifest="$2"; shift 2 ;;
-    --phase) phase="$2"; shift 2 ;;
-    --gate-stage) gate_stage="$2"; shift 2 ;;
-    --require-result-ids) required_result_ids="$2"; shift 2 ;;
-    --result-root) result_root="$2"; shift 2 ;;
-    --output-root) output_root="$2"; shift 2 ;;
-    *) echo "unknown argument: $1" >&2; exit 2 ;;
+    --mode|--candidate-manifest|--common-inputs-bundle-output|--build-source-bundle-output|--build-control-bundle-output|--common-inputs-bundle|--build-source-bundle|--build-control-bundle|--target|--target-bundle-output|--target-bundles-root|--candidate-source-bundle-output|--source-root)
+      [[ $# -ge 2 ]] || { echo "missing value for $1" >&2; exit 2; }
+      arguments+=("$1" "$2")
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 2
+      ;;
   esac
 done
-case "$mode" in PrepareCommon|Target|Aggregate) ;; *) echo "--mode PrepareCommon|Target|Aggregate is required" >&2; exit 2 ;; esac
-[[ -f "$candidate_manifest" ]] || { echo "--candidate-manifest is required" >&2; exit 2; }
-[[ "$phase" == "5" || "$phase" == "6" ]] || { echo "--phase must be 5 or 6" >&2; exit 2; }
+
 python_command="${PYTHON:-python}"
-candidate_manifest="$($python_command -c 'import pathlib,sys; print(pathlib.Path(sys.argv[1]).resolve())' "$candidate_manifest")"
-candidate_root="$(dirname "$candidate_manifest")"
-result_root="${result_root:-$candidate_root/results}"
-output_root="${output_root:-$candidate_root/evidence}"
-mkdir -p "$output_root"
-mode_lower="$(printf '%s' "$mode" | tr '[:upper:]' '[:lower:]')"
-worker="phase${phase}-${mode_lower}"
-context_root="$candidate_root/contexts"
-event_root="$candidate_root/events"
-"$python_command" scripts/capture_candidate_execution_context.py --candidate-manifest "$candidate_manifest" --worker-id "$worker" --output-root "$context_root"
-context="$context_root/$worker.json"
-"$python_command" scripts/release_candidate_command.py run --candidate-manifest "$candidate_manifest" --route-id "R11-${mode_lower}-validate" --worker-id "$worker" --context "$context" --event-root "$event_root" -- "$python_command" distribution/candidate_run.py validate --candidate-manifest "$candidate_manifest"
-[[ "$mode" == "Aggregate" ]] || exit 0
-no_remote="$output_root/NO_REMOTE_PUBLICATION.json"
-"$python_command" scripts/release_candidate_command.py run --candidate-manifest "$candidate_manifest" --route-id R11-no-remote --worker-id "$worker" --context "$context" --event-root "$event_root" -- "$python_command" scripts/no_remote_publication_guard.py --candidate-manifest "$candidate_manifest" --phase "$phase" --audit-point release-preparation-aggregate --context-root "$context_root" --event-root "$event_root" --output "$no_remote"
-"$python_command" scripts/release_candidate_command.py run --candidate-manifest "$candidate_manifest" --route-id R11-evidence --worker-id "$worker" --context "$context" --event-root "$event_root" -- "$python_command" scripts/release_evidence_guard.py --candidate-manifest "$candidate_manifest" --result-root "$result_root" --phase "$phase" --gate-stage "$gate_stage" --require-result-ids "$required_result_ids" --no-remote-evidence "$no_remote" --output "$output_root/EVIDENCE_INDEX.json"
+"$python_command" "${arguments[@]}"

--- a/scripts/tests/test_candidate_transfer.py
+++ b/scripts/tests/test_candidate_transfer.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import tempfile
 import unittest
 
-from scripts.tests.release_test_support import load_module, read_json
+from scripts.tests.release_test_support import ROOT, load_module, read_json, write_json
 
 
 class CandidateTransferTests(unittest.TestCase):
@@ -36,6 +36,97 @@ class CandidateTransferTests(unittest.TestCase):
             self.assertEqual("build-control", manifest["bundle_kind"])
             self.assertTrue((imported / "CANDIDATE_RUN.json").is_file())
             self.assertTrue((imported / "RELEASE_SERIES.json").is_file())
+
+    def test_common_inputs_bundle_preserves_closed_candidate_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            candidate = self.candidate.create_candidate(
+                base / "candidates",
+                "1.0.0-rc.1",
+                "local",
+                1,
+                self.series.create_series(base / "series", "1.0", "community-v1"),
+            )
+            common = candidate.parent / "common-inputs-staging"
+            common.mkdir(parents=True)
+            (common / "COMMON_RELEASE_INPUTS.json").write_text(
+                '{"schema_version":1}\n', encoding="utf-8"
+            )
+            (common / "RELEASE_NOTES.md").write_text("candidate notes\n", encoding="utf-8")
+            bundle = candidate.parent / "common-inputs" / "COMMON_RELEASE_INPUTS.tar"
+
+            result = self.transfer.main(
+                [
+                    "export-common-inputs",
+                    "--candidate-manifest",
+                    str(candidate),
+                    "--input-root",
+                    str(common),
+                    "--output",
+                    str(bundle),
+                ]
+            )
+
+            self.assertEqual(0, result)
+            imported = self.transfer.import_bundle(bundle, base / "imported-common")
+            transfer = read_json(imported / "CANDIDATE_TRANSFER.json")
+            self.assertEqual("common-inputs", transfer["bundle_kind"])
+            self.assertEqual(read_json(candidate)["candidate_id"], transfer["candidate_id"])
+            self.assertEqual(
+                ["COMMON_RELEASE_INPUTS.json", "RELEASE_NOTES.md"],
+                sorted(entry["path"] for entry in transfer["files"]),
+            )
+
+            payload_only = base / "payload-only"
+            result = self.transfer.main(
+                [
+                    "import",
+                    "--bundle",
+                    str(bundle),
+                    "--output",
+                    str(payload_only),
+                    "--payload-only",
+                ]
+            )
+            self.assertEqual(0, result)
+            self.assertEqual(
+                ["COMMON_RELEASE_INPUTS.json", "RELEASE_NOTES.md"],
+                sorted(path.name for path in payload_only.iterdir()),
+            )
+
+    def test_artifact_bundle_keeps_local_oci_layouts(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            candidate = self.candidate.create_candidate(
+                base / "candidates",
+                "1.0.0-rc.1",
+                "local",
+                1,
+                self.series.create_series(base / "series", "1.0", "community-v1"),
+            )
+            root = candidate.parent
+            write_json(root / "ARTIFACT_INDEX.json", {"schema_version": 1, "artifacts": []})
+            write_json(root / "evidence" / "EVIDENCE_INDEX.json", {"schema_version": 1})
+            write_json(root / "evidence" / "NO_REMOTE_PUBLICATION.json", {"schema_version": 1})
+            layout = root / "oci-layout" / "broker" / "oci-layout"
+            write_json(layout, {"imageLayoutVersion": "1.0.0"})
+            bundle = root / "transfer" / "CANDIDATE_SOURCE_BUNDLE.tar"
+
+            result = self.transfer.main(
+                [
+                    "export-artifacts",
+                    "--candidate-manifest",
+                    str(candidate),
+                    "--output",
+                    str(bundle),
+                    "--repository-source-root",
+                    str(ROOT),
+                ]
+            )
+
+            self.assertEqual(0, result)
+            imported = self.transfer.import_bundle(bundle, base / "imported-artifacts")
+            self.assertTrue((imported / "oci-layout" / "broker" / "oci-layout").is_file())
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_release_candidate_command.py
+++ b/scripts/tests/test_release_candidate_command.py
@@ -214,6 +214,36 @@ class ReleaseCandidateCommandTests(unittest.TestCase):
                 )
             self.assertEqual(exit_code, 0)
 
+    def test_candidate_command_runs_from_the_declared_canonical_source_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            series = self.series.create_series(root / "series", "1.0", "community-v1")
+            candidate = self.candidate.create_candidate(
+                root / "candidates", "1.0.0-rc.1", "rc1", 1, series
+            )
+            context = self.context.capture_context(candidate, "source-1", root / "context")
+            source = root / "canonical-source"
+            source.mkdir()
+            output = root / "observed-cwd.txt"
+
+            exit_code = self.command.run_command(
+                candidate,
+                route_id="R01-canonical-source",
+                worker_id="source-1",
+                context_path=context,
+                event_root=root / "events",
+                command=[
+                    sys.executable,
+                    "-c",
+                    "from pathlib import Path; import sys; Path(sys.argv[1]).write_text(str(Path.cwd()))",
+                    str(output),
+                ],
+                cwd=source,
+            )
+
+            self.assertEqual(0, exit_code)
+            self.assertEqual(source.resolve(), Path(output.read_text(encoding="utf-8")))
+
     def test_sealed_candidate_cannot_capture_a_new_execution_context(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/tests/test_release_preparation_runner.py
+++ b/scripts/tests/test_release_preparation_runner.py
@@ -6,18 +6,25 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import tarfile
 import tempfile
 import unittest
 from pathlib import Path
 
 from scripts.tests.release_archive_test_support import create_candidate
-from scripts.tests.release_test_support import read_json, write_json
+from scripts.tests.release_test_support import load_module, read_json
 
 
 ROOT = Path(__file__).resolve().parents[2]
 
 
 class ReleasePreparationRunnerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.runner = load_module("release_preparation_test", "scripts/release_preparation.py")
+        cls.series = load_module("release_series_preparation_test", "distribution/release_series.py")
+        cls.candidate = load_module("candidate_run_preparation_test", "distribution/candidate_run.py")
+
     def test_both_runners_are_fail_fast_and_never_publish(self) -> None:
         powershell = (ROOT / "scripts" / "run-release-preparation.ps1").read_text(encoding="utf-8")
         bash = (ROOT / "scripts" / "run-release-preparation.sh").read_text(encoding="utf-8")
@@ -34,8 +41,168 @@ class ReleasePreparationRunnerTests(unittest.TestCase):
             self.assertIn("no_remote_publication_guard.py", source)
             self.assertIn("release_evidence_guard.py", source)
 
+    def test_prepare_common_plan_produces_closed_source_and_control_inputs(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            candidate = create_candidate(root)
+            candidate_root = candidate.parent
+            request = self.runner.PreparationRequest(
+                mode="PrepareCommon",
+                candidate_manifest=candidate,
+                common_inputs_bundle_output=candidate_root / "common" / "COMMON_RELEASE_INPUTS.tar",
+                build_source_bundle_output=candidate_root / "source" / "CORE_SOURCE_TRANSFER.tar",
+                build_control_bundle_output=candidate_root / "control" / "CANDIDATE_BUILD_CONTROL_BUNDLE.tar",
+            )
+
+            routes = [step.route_id for step in self.runner.build_steps(request)]
+
+            self.assertEqual(
+                [
+                    "R11-prepare-common-validate",
+                    "R05-render-release-notes",
+                    "R05-build-common-inputs",
+                    "R05-export-common-inputs",
+                    "R05-export-build-source",
+                    "R05-record-build-source",
+                    "R05-export-build-control",
+                ],
+                routes,
+            )
+
+    def test_prepare_common_executes_and_seals_portable_inputs(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            base = Path(directory)
+            series = self.series.create_series(base / "series", "1.0", "community-v1")
+            candidate = self.candidate.create_candidate(
+                base / "candidates", "1.0.0-rc.1", "local", 1, series
+            )
+            root = candidate.parent
+            common = root / "common" / "COMMON_RELEASE_INPUTS.tar"
+            source = root / "source" / "CORE_SOURCE_TRANSFER.tar"
+            control = root / "source" / "CANDIDATE_BUILD_CONTROL_BUNDLE.tar"
+
+            self.runner.run_preparation(
+                self.runner.PreparationRequest(
+                    mode="PrepareCommon",
+                    candidate_manifest=candidate,
+                    common_inputs_bundle_output=common,
+                    build_source_bundle_output=source,
+                    build_control_bundle_output=control,
+                )
+            )
+
+            self.assertTrue(common.is_file())
+            self.assertTrue(source.is_file())
+            self.assertTrue(control.is_file())
+            candidate_value = read_json(candidate)
+            self.assertEqual(str(source.resolve()), candidate_value["build_source_bundle"])
+            self.assertGreater(candidate_value["generation"], 0)
+
+    def test_target_plan_consumes_sealed_inputs_and_exports_one_target(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            candidate = create_candidate(root)
+            candidate_root = candidate.parent
+            common = candidate_root / "COMMON_RELEASE_INPUTS.tar"
+            source = candidate_root / "CORE_SOURCE_TRANSFER.tar"
+            control = candidate_root / "CANDIDATE_BUILD_CONTROL_BUNDLE.tar"
+            for path in (common, source, control):
+                path.write_bytes(b"fixture")
+            request = self.runner.PreparationRequest(
+                mode="Target",
+                candidate_manifest=candidate,
+                common_inputs_bundle=common,
+                build_source_bundle=source,
+                build_control_bundle=control,
+                target="x86_64-unknown-linux-gnu",
+                target_bundle_output=candidate_root / "targets" / "linux.tar",
+            )
+
+            routes = [step.route_id for step in self.runner.build_steps(request)]
+
+            self.assertEqual("R05-import-build-source-x86_64-unknown-linux-gnu", routes[1])
+            self.assertIn("R05-build-archive-x86_64-unknown-linux-gnu", routes)
+            self.assertIn("R05-build-oci-x86_64-unknown-linux-gnu", routes)
+            self.assertEqual("R05-export-target-x86_64-unknown-linux-gnu", routes[-1])
+
+    def test_aggregate_plan_requires_the_complete_target_denominator(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            candidate = create_candidate(root)
+            bundles = root / "target-bundles"
+            bundles.mkdir()
+            for target in self.runner.TARGETS[:-1]:
+                (bundles / f"{target}.tar").write_bytes(b"fixture")
+            request = self.runner.PreparationRequest(
+                mode="Aggregate",
+                candidate_manifest=candidate,
+                target_bundles_root=bundles,
+                candidate_source_bundle_output=candidate.parent / "transfer" / "CANDIDATE_SOURCE_BUNDLE.tar",
+            )
+
+            with self.assertRaisesRegex(self.runner.PreparationError, "missing target bundle"):
+                self.runner.build_steps(request)
+
+    def test_execution_stops_at_the_first_failed_route(self) -> None:
+        steps = [
+            self.runner.PreparationStep("first", ("python", "first.py")),
+            self.runner.PreparationStep("second", ("python", "second.py")),
+        ]
+        executed: list[str] = []
+
+        def execute(step):
+            executed.append(step.route_id)
+            return 17
+
+        with self.assertRaisesRegex(self.runner.PreparationError, "first"):
+            self.runner.execute_steps(steps, execute)
+        self.assertEqual(["first"], executed)
+
+    def test_target_rejects_a_cross_candidate_input_bundle(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            candidate = create_candidate(root)
+            value = read_json(candidate)
+            bundles = []
+            for name, kind in (
+                ("common.tar", "common-inputs"),
+                ("source.tar", "build-source"),
+                ("control.tar", "build-control"),
+            ):
+                bundle = root / name
+                manifest = root / f"{name}.json"
+                manifest.write_text(
+                    json.dumps(
+                        {
+                            "schema_version": 1,
+                            "bundle_kind": kind,
+                            "candidate_id": "another-candidate",
+                            "version": value["version"],
+                            "run_id": value["run_id"],
+                            "attempt": value["attempt"],
+                            "files": [],
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                with tarfile.open(bundle, "w") as archive:
+                    archive.add(manifest, arcname="CANDIDATE_TRANSFER.json")
+                bundles.append(bundle)
+            request = self.runner.PreparationRequest(
+                mode="Target",
+                candidate_manifest=candidate,
+                common_inputs_bundle=bundles[0],
+                build_source_bundle=bundles[1],
+                build_control_bundle=bundles[2],
+                target="x86_64-unknown-linux-gnu",
+                target_bundle_output=candidate.parent / "target.tar",
+            )
+
+            with self.assertRaisesRegex(self.runner.PreparationError, "candidate identity"):
+                self.runner.validate_request_bundles(request)
+
     @unittest.skipUnless(os.name == "nt", "PowerShell runner integration is Windows-specific")
-    def test_aggregate_selects_the_frozen_no_remote_route_denominator(self) -> None:
+    def test_aggregate_without_platform_inputs_fails_closed(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             candidate = create_candidate(root)
@@ -46,36 +213,6 @@ class ReleasePreparationRunnerTests(unittest.TestCase):
                 )
             )
             candidate.write_text(json.dumps(candidate_value), encoding="utf-8")
-            result_root = root / "results"
-            for result_id in (
-                "R01-RELEASE-VERSION",
-                "R01-CANDIDATE-LIFECYCLE",
-                "R01-CORE-IMAGE-WORKFLOW",
-            ):
-                write_json(
-                    result_root / f"{result_id}.json",
-                    {
-                        "schema_version": 1,
-                        "candidate_id": candidate_value["candidate_id"],
-                        "version": candidate_value["version"],
-                        "run_id": candidate_value["run_id"],
-                        "attempt": candidate_value["attempt"],
-                        "phase": 5,
-                        "gate_stage": "release-preparation",
-                        "result_id": result_id,
-                        "result_kind": "check",
-                        "status": "passed",
-                        "command": ["python", "fixture.py"],
-                        "exit_code": 0,
-                        "matched_test_count": 0,
-                        "executed_test_count": 0,
-                        "passed_test_count": 0,
-                        "failed_test_count": 0,
-                        "ignored_test_count": 0,
-                        "capability_ids": [],
-                        "result_path": f"results/{result_id}.json",
-                    },
-                )
             output_root = root / "evidence"
 
             completed = subprocess.run(
@@ -88,10 +225,6 @@ class ReleasePreparationRunnerTests(unittest.TestCase):
                     "Aggregate",
                     "-CandidateManifest",
                     str(candidate),
-                    "-ResultRoot",
-                    str(result_root),
-                    "-OutputRoot",
-                    str(output_root),
                 ],
                 cwd=ROOT,
                 capture_output=True,
@@ -100,10 +233,9 @@ class ReleasePreparationRunnerTests(unittest.TestCase):
                 timeout=30,
             )
 
-            self.assertEqual(0, completed.returncode, completed.stdout + completed.stderr)
-            no_remote = read_json(output_root / "NO_REMOTE_PUBLICATION.json")
-            self.assertEqual("release-preparation-aggregate", no_remote["audit_point"])
-            self.assertEqual(["R11-aggregate-validate"], no_remote["required_route_ids"])
+            self.assertNotEqual(0, completed.returncode, completed.stdout + completed.stderr)
+            self.assertIn("bundle is required", completed.stdout + completed.stderr)
+            self.assertFalse((output_root / "NO_REMOTE_PUBLICATION.json").exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9576

### Brief Description

- Add one shared, fail-fast release-preparation engine for PrepareCommon, Target, and Aggregate modes.
- Produce closed common-input, canonical source, and build-control bundles; validate candidate identity before consuming any transferred input.
- Build and seal one explicit platform target at a time, then require the complete Linux, Windows, and macOS denominator before aggregation.
- Compose the existing archive, local OCI, local crate package, Helm, legal, SBOM, provenance, evidence, and lifecycle validation tools through audited candidate command routes.
- Preserve payload-only canonical source restoration and include local OCI layouts in the final candidate source bundle.
- Keep the operation preparation-only with no registry, image, Chart, GitHub Release, tag, or other remote publication.

### How Did You Test This Change?

- `python -m unittest scripts.tests.test_candidate_transfer scripts.tests.test_release_preparation_runner scripts.tests.test_release_candidate_command scripts.tests.test_common_release_inputs scripts.tests.test_candidate_release_notes scripts.tests.test_release_binary_build scripts.tests.test_release_archive_staging scripts.tests.test_component_sbom scripts.tests.test_release_archive scripts.tests.test_candidate_partial_seal scripts.tests.test_candidate_partial_merge scripts.tests.test_core_oci_layout scripts.tests.test_package_core_helm scripts.tests.test_legal_artifact_guard scripts.tests.test_release_sbom scripts.tests.test_release_provenance scripts.tests.test_release_identity_guard scripts.tests.test_release_version scripts.tests.test_no_remote_publication_guard scripts.tests.test_release_evidence_guard scripts.tests.test_release_lifecycle scripts.tests.test_candidate_run scripts.tests.test_release_series` (107 tests passed)
- `python -m py_compile distribution/transfer_candidate.py scripts/release_candidate_command.py scripts/release_preparation.py`
- `bash -n scripts/run-release-preparation.sh`
- PowerShell parser validation for `scripts/run-release-preparation.ps1`
- `python scripts/no_remote_publication_guard.py --phase 5 --static-only`
- `.\scripts\check-agents-routing.ps1`
- `git diff --check`
- `python scripts/core_release_static_guard.py` completed with all changed release-preparation routes passing. It still reports the existing architecture dependency, module maintainability, and package-planner findings reproduced on `main`.
- Two `test_package_publish_workspace` cases remain blocked by the same pre-existing core crate dependency cycle and fail identically on `main`; no planner baseline or dependency rule was changed in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added commands to export common release inputs and prepare releases locally.
  * Added support for preparing common inputs, platform-specific targets, and aggregate releases.
  * Added validation for candidate bundles, target platforms, and required release inputs.
  * Added payload-only imports and improved artifact exports to preserve OCI layouts.

* **Bug Fixes**
  * Release preparation now stops safely when validation or execution fails.
  * Commands can run from the declared source directory for consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->