### PR TITLE
[ISSUE #9580]✨Make release candidate preparation portable

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -3,17 +3,53 @@ name: Core release candidate preparation
 on:
   workflow_dispatch:
     inputs:
-      candidate_manifest:
-        description: Candidate manifest path in the prepared workspace
+      version:
+        description: Exact unpublished candidate version
         required: true
+        type: string
+      series_id:
+        description: Release-series identifier
+        required: true
+        default: community-v1
+        type: string
+      parent_control_run_id:
+        description: Prior workflow run containing the explicit parent series control artifact
+        required: false
+        default: ""
+        type: string
+      parent_control_artifact:
+        description: Exact prior series control artifact name
+        required: false
+        default: ""
+        type: string
+      parent_series_generation:
+        description: Expected committed generation in the parent control artifact
+        required: false
+        default: ""
         type: string
   workflow_call:
     inputs:
-      candidate_manifest:
+      version:
         required: true
+        type: string
+      series_id:
+        required: true
+        type: string
+      parent_control_run_id:
+        required: false
+        default: ""
+        type: string
+      parent_control_artifact:
+        required: false
+        default: ""
+        type: string
+      parent_series_generation:
+        required: false
+        default: ""
         type: string
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -23,12 +59,102 @@ concurrency:
 jobs:
   prepare-common:
     runs-on: ubuntu-latest
+    outputs:
+      common_artifact: ${{ steps.outputs.outputs.common_artifact }}
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/upload-artifact@v7
+      - name: Download explicit parent control generation
+        if: ${{ inputs.parent_control_artifact != '' }}
+        uses: actions/download-artifact@v7
         with:
-          name: core-release-candidate-input
-          path: ${{ inputs.candidate_manifest }}
+          name: ${{ inputs.parent_control_artifact }}
+          path: ${{ runner.temp }}/parent-control
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.parent_control_run_id }}
+      - name: Create the candidate and portable preparation inputs
+        id: outputs
+        shell: pwsh
+        env:
+          CANDIDATE_VERSION: ${{ inputs.version }}
+          RELEASE_SERIES_ID: ${{ inputs.series_id }}
+          PARENT_CONTROL_RUN_ID: ${{ inputs.parent_control_run_id }}
+          PARENT_CONTROL_ARTIFACT: ${{ inputs.parent_control_artifact }}
+          PARENT_SERIES_GENERATION: ${{ inputs.parent_series_generation }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+          $parentInputs = @(
+            $env:PARENT_CONTROL_RUN_ID,
+            $env:PARENT_CONTROL_ARTIFACT,
+            $env:PARENT_SERIES_GENERATION
+          )
+          $specified = @($parentInputs | Where-Object { $_ }).Count
+          if ($specified -ne 0 -and $specified -ne 3) {
+            throw 'parent control run, artifact, and generation must be provided together'
+          }
+
+          python scripts/set_workspace_version.py --version $env:CANDIDATE_VERSION
+          $stateRoot = Join-Path $env:RUNNER_TEMP 'candidate-state'
+          if ($specified -eq 0) {
+            python distribution/release_series.py create `
+              --release-line 1.0 `
+              --series-id $env:RELEASE_SERIES_ID `
+              --root (Join-Path $stateRoot 'series')
+          } else {
+            $parentBundles = @(Get-ChildItem (Join-Path $env:RUNNER_TEMP 'parent-control') -Recurse -File -Filter '*.tar')
+            if ($parentBundles.Count -ne 1) {
+              throw 'the parent control artifact must contain exactly one series control bundle'
+            }
+            python distribution/release_series.py import-control `
+              --bundle $parentBundles[0].FullName `
+              --destination (Join-Path $stateRoot 'series') `
+              --expected-generation $env:PARENT_SERIES_GENERATION
+          }
+          $seriesManifests = @(Get-ChildItem (Join-Path $stateRoot 'series') -Recurse -File -Filter 'RELEASE_SERIES.json')
+          if ($seriesManifests.Count -ne 1) {
+            throw 'exactly one release-series manifest is required'
+          }
+          $seriesManifest = $seriesManifests[0].FullName
+          python distribution/candidate_run.py create `
+            --version $env:CANDIDATE_VERSION `
+            --run-id "gha-$env:GITHUB_RUN_ID" `
+            --attempt $env:GITHUB_RUN_ATTEMPT `
+            --root (Join-Path $stateRoot 'candidates') `
+            --series-manifest $seriesManifest
+          $candidateManifests = @(Get-ChildItem (Join-Path $stateRoot 'candidates') -Recurse -File -Filter 'CANDIDATE_RUN.json')
+          if ($candidateManifests.Count -ne 1) {
+            throw 'exactly one current candidate manifest is required'
+          }
+          $candidateManifest = $candidateManifests[0].FullName
+          if ($env:CANDIDATE_VERSION -match '-rc\.') {
+            pwsh -NoProfile -File scripts/run-v1-candidate-lifecycle.ps1 `
+              -Mode StageRc `
+              -CandidateManifest $candidateManifest
+          }
+          $candidateRoot = Split-Path $candidateManifest
+          $transferRoot = Join-Path $candidateRoot 'transfer'
+          $commonBundle = Join-Path $transferRoot 'COMMON_RELEASE_INPUTS.tar'
+          $sourceBundle = Join-Path $transferRoot 'CORE_SOURCE_TRANSFER.tar'
+          $controlBundle = Join-Path $transferRoot 'CANDIDATE_BUILD_CONTROL_BUNDLE.tar'
+          pwsh -NoProfile -File scripts/run-release-preparation.ps1 `
+            -Mode PrepareCommon `
+            -CandidateManifest $candidateManifest `
+            -CommonInputsBundleOutput $commonBundle `
+            -BuildSourceBundleOutput $sourceBundle `
+            -BuildControlBundleOutput $controlBundle `
+            -SourceRoot $env:GITHUB_WORKSPACE
+          "common_artifact=core-release-common-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT" >> $env:GITHUB_OUTPUT
+          "common_bundle=$commonBundle" >> $env:GITHUB_OUTPUT
+          "source_bundle=$sourceBundle" >> $env:GITHUB_OUTPUT
+          "control_bundle=$controlBundle" >> $env:GITHUB_OUTPUT
+      - name: Upload sealed common, source, and control inputs
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.outputs.outputs.common_artifact }}
+          path: |
+            ${{ steps.outputs.outputs.common_bundle }}
+            ${{ steps.outputs.outputs.source_bundle }}
+            ${{ steps.outputs.outputs.control_bundle }}
           if-no-files-found: error
           retention-days: 14
 
@@ -47,34 +173,108 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
-      - name: Validate local-only candidate contract
+      - uses: actions/download-artifact@v7
+        with:
+          name: ${{ needs.prepare-common.outputs.common_artifact }}
+          path: ${{ runner.temp }}/candidate-inputs
+      - name: Import candidate control and run the target preparation
+        id: target
         shell: pwsh
         run: |
-          python distribution/build_release_binaries.py --help
-          python distribution/build_release_archive.py --help
-          python distribution/verify_release_archive.py --help
-      - uses: actions/upload-artifact@v7
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+          $inputRoot = Join-Path $env:RUNNER_TEMP 'candidate-inputs'
+          $commonBundle = @(Get-ChildItem $inputRoot -Recurse -File -Filter 'COMMON_RELEASE_INPUTS.tar')
+          $sourceBundle = @(Get-ChildItem $inputRoot -Recurse -File -Filter 'CORE_SOURCE_TRANSFER.tar')
+          $controlBundle = @(Get-ChildItem $inputRoot -Recurse -File -Filter 'CANDIDATE_BUILD_CONTROL_BUNDLE.tar')
+          if ($commonBundle.Count -ne 1 -or $sourceBundle.Count -ne 1 -or $controlBundle.Count -ne 1) {
+            throw 'common, source, and control inputs must each exist exactly once'
+          }
+          $workerRoot = Join-Path $env:RUNNER_TEMP 'candidate-worker'
+          $selector = Join-Path $env:RUNNER_TEMP 'candidate-selector.json'
+          python distribution/transfer_candidate.py import-build-control `
+            --bundle $controlBundle[0].FullName `
+            --output $workerRoot `
+            --build-source-bundle $sourceBundle[0].FullName `
+            --selector-output $selector
+          $candidate = Get-Content $selector -Raw | ConvertFrom-Json
+          $targetBundle = Join-Path $candidate.candidate_root 'target-bundles/${{ matrix.target }}.tar'
+          pwsh -NoProfile -File scripts/run-release-preparation.ps1 `
+            -Mode Target `
+            -CandidateManifest $candidate.candidate_manifest `
+            -CommonInputsBundle $commonBundle[0].FullName `
+            -BuildSourceBundle $sourceBundle[0].FullName `
+            -BuildControlBundle $controlBundle[0].FullName `
+            -Target '${{ matrix.target }}' `
+            -TargetBundleOutput $targetBundle `
+            -SourceRoot $env:GITHUB_WORKSPACE
+          "target_bundle=$targetBundle" >> $env:GITHUB_OUTPUT
+      - name: Upload the sealed target bundle
+        uses: actions/upload-artifact@v7
         with:
-          name: core-release-${{ matrix.target }}-${{ github.run_attempt }}
-          path: target/v1-release
-          if-no-files-found: warn
+          name: core-release-${{ matrix.target }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.target.outputs.target_bundle }}
+          if-no-files-found: error
           retention-days: 14
 
   aggregate:
-    needs: build-target
+    needs: [prepare-common, build-target]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: actions/download-artifact@v7
         with:
-          pattern: core-release-*-${{ github.run_attempt }}
-          path: target/v1-release/downloads
-      - name: Validate aggregation tools
+          name: ${{ needs.prepare-common.outputs.common_artifact }}
+          path: ${{ runner.temp }}/candidate-inputs
+      - uses: actions/download-artifact@v7
+        with:
+          pattern: core-release-*-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/target-bundles
+      - name: Import candidate control and aggregate all target bundles
+        id: aggregate
+        shell: pwsh
         run: |
-          python distribution/merge_candidate_partials.py --help
-          python distribution/transfer_candidate.py --help
-          python distribution/generate_release_sbom.py --help
-          python distribution/generate_release_provenance.py --help
-          python scripts/legal_artifact_guard.py --help
-      - name: Prove candidate workflows cannot publish remotely
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+          $inputRoot = Join-Path $env:RUNNER_TEMP 'candidate-inputs'
+          $commonBundle = @(Get-ChildItem $inputRoot -Recurse -File -Filter 'COMMON_RELEASE_INPUTS.tar')
+          $sourceBundle = @(Get-ChildItem $inputRoot -Recurse -File -Filter 'CORE_SOURCE_TRANSFER.tar')
+          $controlBundle = @(Get-ChildItem $inputRoot -Recurse -File -Filter 'CANDIDATE_BUILD_CONTROL_BUNDLE.tar')
+          if ($commonBundle.Count -ne 1 -or $sourceBundle.Count -ne 1 -or $controlBundle.Count -ne 1) {
+            throw 'common, source, and control inputs must each exist exactly once'
+          }
+          $workerRoot = Join-Path $env:RUNNER_TEMP 'candidate-aggregate'
+          $selector = Join-Path $env:RUNNER_TEMP 'candidate-selector.json'
+          python distribution/transfer_candidate.py import-build-control `
+            --bundle $controlBundle[0].FullName `
+            --output $workerRoot `
+            --build-source-bundle $sourceBundle[0].FullName `
+            --selector-output $selector
+          $candidate = Get-Content $selector -Raw | ConvertFrom-Json
+          $candidateSource = Join-Path $candidate.candidate_root 'transfer/CANDIDATE_SOURCE_BUNDLE.tar'
+          pwsh -NoProfile -File scripts/run-release-preparation.ps1 `
+            -Mode Aggregate `
+            -CandidateManifest $candidate.candidate_manifest `
+            -CommonInputsBundle $commonBundle[0].FullName `
+            -BuildSourceBundle $sourceBundle[0].FullName `
+            -BuildControlBundle $controlBundle[0].FullName `
+            -TargetBundlesRoot (Join-Path $env:RUNNER_TEMP 'target-bundles') `
+            -CandidateSourceBundleOutput $candidateSource `
+            -SourceRoot $env:GITHUB_WORKSPACE
+          $aggregateControl = Join-Path $candidate.candidate_root 'transfer/CANDIDATE_AGGREGATE_CONTROL_BUNDLE.tar'
+          python distribution/transfer_candidate.py export-build-control `
+            --candidate-manifest $candidate.candidate_manifest `
+            --output $aggregateControl
+          "candidate_source=$candidateSource" >> $env:GITHUB_OUTPUT
+          "aggregate_control=$aggregateControl" >> $env:GITHUB_OUTPUT
+      - name: Prove the candidate workflow has no publication route
         run: python scripts/no_remote_publication_guard.py --phase 5 --static-only
+      - name: Upload aggregate candidate state
+        uses: actions/upload-artifact@v7
+        with:
+          name: core-release-aggregate-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ steps.aggregate.outputs.candidate_source }}
+            ${{ steps.aggregate.outputs.aggregate_control }}
+          if-no-files-found: error
+          retention-days: 14

--- a/distribution/candidate-transfer.schema.json
+++ b/distribution/candidate-transfer.schema.json
@@ -2,14 +2,15 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "RocketMQ Rust candidate transfer bundle",
   "type": "object",
-  "required": ["schema_version", "bundle_kind", "candidate_id", "version", "run_id", "attempt", "files"],
+  "required": ["schema_version", "bundle_kind", "candidate_id", "version", "run_id", "attempt", "series_generation", "files"],
   "properties": {
     "schema_version": {"const": 1},
-    "bundle_kind": {"enum": ["build-source", "build-control", "target", "artifacts"]},
+    "bundle_kind": {"enum": ["build-source", "build-control", "common-inputs", "target", "artifacts"]},
     "candidate_id": {"type": "string"},
     "version": {"type": "string"},
     "run_id": {"type": "string"},
     "attempt": {"type": "integer", "minimum": 1},
+    "series_generation": {"type": "integer", "minimum": 1},
     "files": {"type": "array"}
   },
   "additionalProperties": false

--- a/distribution/transfer_candidate.py
+++ b/distribution/transfer_candidate.py
@@ -11,6 +11,7 @@ from pathlib import Path, PurePosixPath
 import subprocess
 import sys
 import tarfile
+import tempfile
 from typing import Any
 
 
@@ -19,7 +20,9 @@ if str(ROOT / "distribution") not in sys.path:
     sys.path.insert(0, str(ROOT / "distribution"))
 
 from release_archive_common import ArchiveError, load_candidate, require_relative_path
+from release_series import export_control_bundle, import_control_bundle
 from release_state import (
+    atomic_write_json,
     ReleaseStateError,
     ensure_no_digest_fields,
     read_json,
@@ -113,6 +116,7 @@ def _write_bundle(
         "version": candidate["version"],
         "run_id": candidate["run_id"],
         "attempt": candidate["attempt"],
+        "series_generation": candidate["series_generation"],
         "files": manifest_records,
     }
     output.parent.mkdir(parents=True, exist_ok=True)
@@ -198,7 +202,6 @@ def export_build_control(candidate_manifest: Path, output: Path) -> Path:
     output = resolve_within(root, output, "candidate transfer output")
     if output.exists():
         raise ArchiveError(f"candidate transfer bundle already exists: {output}")
-    records = [("CANDIDATE_RUN.json", manifest)]
     series = candidate.get("series_manifest")
     if not isinstance(series, str):
         raise ArchiveError("candidate has no release-series manifest")
@@ -214,8 +217,110 @@ def export_build_control(candidate_manifest: Path, output: Path) -> Path:
         or head.get("ordinal") != candidate["ordinal"]
     ):
         raise ArchiveError("candidate and release series are not at one committed generation")
-    records.append(("RELEASE_SERIES.json", series_path))
-    return _write_bundle(candidate, bundle_kind="build-control", output=output, records=records)
+    with tempfile.TemporaryDirectory() as temporary:
+        portable_series = Path(temporary) / "RELEASE_SERIES_CONTROL_BUNDLE.tar"
+        export_control_bundle(series_path, portable_series)
+        return _write_bundle(
+            candidate,
+            bundle_kind="build-control",
+            output=output,
+            records=[("RELEASE_SERIES_CONTROL_BUNDLE.tar", portable_series)],
+        )
+
+
+def import_build_control(
+    bundle: Path, output: Path, *, build_source_bundle: Path | None = None
+) -> Path:
+    """Import one committed candidate generation into a worker-local root."""
+
+    bundle = resolve_existing_file(bundle, "build control bundle")
+    output = output.resolve()
+    if output.exists():
+        raise ArchiveError(f"build control import already exists: {output}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=output.parent) as temporary:
+        payload_root = import_bundle(bundle, Path(temporary) / "payload")
+        transfer = read_json(payload_root / "CANDIDATE_TRANSFER.json")
+        if transfer.get("bundle_kind") != "build-control":
+            raise ArchiveError("candidate transfer bundle is not build-control state")
+        records = transfer.get("files")
+        if records != [
+            {
+                "path": "RELEASE_SERIES_CONTROL_BUNDLE.tar",
+                "type": "file",
+                "size": (payload_root / "RELEASE_SERIES_CONTROL_BUNDLE.tar").stat().st_size,
+            }
+        ]:
+            raise ArchiveError("build control bundle has an invalid payload denominator")
+        generation = transfer.get("series_generation")
+        if not isinstance(generation, int) or isinstance(generation, bool) or generation < 0:
+            raise ArchiveError("build control bundle has an invalid series generation")
+        series_manifest = import_control_bundle(
+            payload_root / "RELEASE_SERIES_CONTROL_BUNDLE.tar",
+            output,
+            expected_generation=generation,
+        )
+    series = read_json(series_manifest)
+    head = series.get("head")
+    if not isinstance(head, dict):
+        raise ArchiveError("build control release series has no current candidate")
+    candidate_manifest = resolve_existing_file(
+        Path(head.get("candidate_manifest", "")), "build control candidate manifest"
+    )
+    candidate = read_json(candidate_manifest)
+    validate_candidate(candidate)
+    identity = (
+        candidate.get("candidate_id"),
+        candidate.get("version"),
+        candidate.get("run_id"),
+        candidate.get("attempt"),
+        candidate.get("series_generation"),
+    )
+    expected = (
+        transfer.get("candidate_id"),
+        transfer.get("version"),
+        transfer.get("run_id"),
+        transfer.get("attempt"),
+        generation,
+    )
+    if identity != expected:
+        raise ArchiveError("imported build control candidate identity does not match")
+    if (
+        Path(candidate["candidate_root"]).resolve() != candidate_manifest.parent.resolve()
+        or Path(candidate["series_manifest"]).resolve() != series_manifest.resolve()
+        or candidate["ordinal"] != head.get("ordinal")
+    ):
+        raise ArchiveError("imported build control ownership is inconsistent")
+    if build_source_bundle is not None:
+        source = resolve_existing_file(build_source_bundle, "build source bundle")
+        if candidate.get("build_source_bundle") is None:
+            raise ArchiveError("build control candidate has no canonical source bundle")
+        candidate["build_source_bundle"] = str(source)
+        atomic_write_json(candidate_manifest, candidate)
+    return candidate_manifest
+
+
+def write_build_control_selector(candidate_manifest: Path, output: Path) -> Path:
+    """Write the worker-local candidate selector produced by a control import."""
+
+    candidate_manifest = resolve_existing_file(candidate_manifest, "candidate manifest")
+    candidate = read_json(candidate_manifest)
+    validate_candidate(candidate)
+    output = output.resolve()
+    atomic_write_json(
+        output,
+        {
+            "schema_version": 1,
+            "candidate_id": candidate["candidate_id"],
+            "version": candidate["version"],
+            "run_id": candidate["run_id"],
+            "attempt": candidate["attempt"],
+            "series_generation": candidate["series_generation"],
+            "candidate_manifest": str(candidate_manifest),
+            "candidate_root": str(candidate_manifest.parent),
+        },
+    )
+    return output
 
 
 def _safe_member(member: tarfile.TarInfo) -> PurePosixPath:
@@ -299,6 +404,11 @@ def main(argv: list[str] | None = None) -> int:
     imported.add_argument("--bundle", type=Path, required=True)
     imported.add_argument("--output", type=Path, required=True)
     imported.add_argument("--payload-only", action="store_true")
+    control_import = subcommands.add_parser("import-build-control")
+    control_import.add_argument("--bundle", type=Path, required=True)
+    control_import.add_argument("--output", type=Path, required=True)
+    control_import.add_argument("--selector-output", type=Path, required=True)
+    control_import.add_argument("--build-source-bundle", type=Path)
     args = parser.parse_args(argv)
     try:
         if args.command == "export-build-source":
@@ -309,6 +419,13 @@ def main(argv: list[str] | None = None) -> int:
             output = export_build_control(args.candidate_manifest, args.output)
         elif args.command == "import":
             output = import_bundle(args.bundle, args.output, include_manifest=not args.payload_only)
+        elif args.command == "import-build-control":
+            candidate_manifest = import_build_control(
+                args.bundle,
+                args.output,
+                build_source_bundle=args.build_source_bundle,
+            )
+            output = write_build_control_selector(candidate_manifest, args.selector_output)
         else:
             manifest, candidate, root = load_candidate(args.candidate_manifest)
             if args.command == "export-target":

--- a/scripts/release_preparation.py
+++ b/scripts/release_preparation.py
@@ -111,12 +111,14 @@ def _transfer_manifest(bundle: Path, expected_kind: str, candidate: dict) -> dic
             value.get("version"),
             value.get("run_id"),
             value.get("attempt"),
+            value.get("series_generation"),
         )
         expected = (
             candidate["candidate_id"],
             candidate["version"],
             candidate["run_id"],
             candidate["attempt"],
+            candidate["series_generation"],
         )
         if identity != expected:
             raise PreparationError(f"{expected_kind} bundle candidate identity does not match")

--- a/scripts/tests/test_candidate_transfer.py
+++ b/scripts/tests/test_candidate_transfer.py
@@ -3,7 +3,9 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+import shutil
 import tempfile
 import unittest
 
@@ -34,8 +36,46 @@ class CandidateTransferTests(unittest.TestCase):
             imported = self.transfer.import_bundle(bundle, base / "imported")
             manifest = read_json(imported / "CANDIDATE_TRANSFER.json")
             self.assertEqual("build-control", manifest["bundle_kind"])
-            self.assertTrue((imported / "CANDIDATE_RUN.json").is_file())
-            self.assertTrue((imported / "RELEASE_SERIES.json").is_file())
+            self.assertEqual(read_json(candidate)["series_generation"], manifest["series_generation"])
+            self.assertTrue((imported / "RELEASE_SERIES_CONTROL_BUNDLE.tar").is_file())
+
+    def test_control_bundle_import_relocates_the_committed_series(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            producer_root = base / "producer"
+            series = self.series.create_series(
+                producer_root / "series", "1.0", "community-v1"
+            )
+            candidate = self.candidate.create_candidate(
+                producer_root / "candidates", "1.0.0-rc.1", "local", 1, series
+            )
+            candidate_id = read_json(candidate)["candidate_id"]
+            produced_bundle = (
+                candidate.parent / "transfer" / "CANDIDATE_BUILD_CONTROL_BUNDLE.tar"
+            )
+            self.transfer.export_build_control(candidate, produced_bundle)
+            bundle = base / "CANDIDATE_BUILD_CONTROL_BUNDLE.tar"
+            shutil.copy2(produced_bundle, bundle)
+
+            shutil.rmtree(producer_root / "series")
+            shutil.rmtree(producer_root / "candidates" / "1.0.0-rc.1" / "local" / "attempt-1")
+            worker_root = base / "isolated-worker"
+
+            imported_candidate = self.transfer.import_build_control(bundle, worker_root)
+
+            imported = read_json(imported_candidate)
+            imported_series_path = Path(imported["series_manifest"])
+            imported_series = read_json(imported_series_path)
+            self.assertEqual(candidate_id, imported["candidate_id"])
+            self.assertEqual(imported_candidate.parent, Path(imported["candidate_root"]))
+            self.assertEqual(
+                imported_candidate.resolve(),
+                Path(imported_series["head"]["candidate_manifest"]).resolve(),
+            )
+            for path in (imported_candidate, imported_series_path):
+                self.assertTrue(path.resolve().is_relative_to(worker_root.resolve()))
+            self.assertNotIn(str(producer_root.resolve()), json.dumps(imported_series))
+            self.assertNotIn(str(producer_root.resolve()), json.dumps(imported))
 
     def test_common_inputs_bundle_preserves_closed_candidate_identity(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/scripts/tests/test_release_binary_build.py
+++ b/scripts/tests/test_release_binary_build.py
@@ -50,6 +50,18 @@ class ReleaseBinaryBuildTests(unittest.TestCase):
         for forbidden in ("gh release", "cargo publish", "docker push", "helm push"):
             self.assertNotIn(forbidden, source)
 
+    def test_candidate_workflow_executes_the_real_preparation_pipeline(self) -> None:
+        workflow = ROOT / ".github" / "workflows" / "release-candidate.yml"
+        source = workflow.read_text(encoding="utf-8")
+
+        self.assertNotIn("--help", source)
+        self.assertIn("-Mode PrepareCommon", source)
+        self.assertIn("-Mode Target", source)
+        self.assertIn("-Mode Aggregate", source)
+        self.assertIn("import-build-control", source)
+        self.assertIn("actions/upload-artifact@v7", source)
+        self.assertIn("actions/download-artifact@v7", source)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/v1_candidate_lifecycle.py
+++ b/scripts/v1_candidate_lifecycle.py
@@ -7,11 +7,10 @@
 from __future__ import annotations
 
 import argparse
-import json
 from pathlib import Path, PurePosixPath
 import subprocess
 import sys
-import tarfile
+import tempfile
 from typing import Any, Sequence
 
 
@@ -31,6 +30,7 @@ from release_state import (
 )
 from capture_candidate_execution_context import capture_context
 from collect_candidate_stage_outcomes import _load_policy
+from transfer_candidate import import_build_control
 
 
 class CandidateLifecycleError(ReleaseStateError):
@@ -169,64 +169,52 @@ def _validate_candidate_control(bundle: Path, candidate_manifest: Path, series_m
     series = read_json(resolve_existing_file(series_manifest, "release series"))
     validate_candidate(candidate)
     validate_series(series)
-    try:
-        with tarfile.open(resolve_existing_file(bundle, "candidate control bundle"), "r") as archive:
-            members = archive.getmembers()
-            names = [member.name for member in members]
-            expected_names = {
-                "CANDIDATE_TRANSFER.json",
-                "payload/CANDIDATE_RUN.json",
-                "payload/RELEASE_SERIES.json",
-            }
-            if set(names) != expected_names or len(names) != len(expected_names):
-                raise CandidateLifecycleError("candidate control bundle members are not closed")
-            for member in members:
-                if not member.isfile() or member.issym() or member.islnk():
-                    raise CandidateLifecycleError("candidate control bundle contains an unsafe member")
-            control_file = archive.extractfile("CANDIDATE_TRANSFER.json")
-            candidate_file = archive.extractfile("payload/CANDIDATE_RUN.json")
-            series_file = archive.extractfile("payload/RELEASE_SERIES.json")
-            if control_file is None or candidate_file is None or series_file is None:
-                raise CandidateLifecycleError("candidate control bundle is unreadable")
-            control = json.loads(control_file.read())
-            archived_candidate = json.loads(candidate_file.read())
-            archived_series = json.loads(series_file.read())
-    except (tarfile.TarError, json.JSONDecodeError, UnicodeDecodeError) as error:
-        raise CandidateLifecycleError(f"candidate control bundle is invalid: {error}") from error
-    identity = (
-        control.get("candidate_id"),
-        control.get("version"),
-        control.get("run_id"),
-        control.get("attempt"),
-    )
-    expected_identity = (
-        candidate["candidate_id"],
-        candidate["version"],
-        candidate["run_id"],
-        candidate["attempt"],
-    )
-    files = control.get("files")
-    expected_files = {
-        "CANDIDATE_RUN.json": candidate_manifest.stat().st_size,
-        "RELEASE_SERIES.json": series_manifest.stat().st_size,
+    with tempfile.TemporaryDirectory() as temporary:
+        imported_manifest = import_build_control(bundle, Path(temporary) / "control")
+        archived_candidate = read_json(imported_manifest)
+        archived_series = read_json(Path(archived_candidate["series_manifest"]))
+
+    candidate_path_fields = {"candidate_root", "series_manifest", "parent_manifest"}
+    comparable_candidate = {
+        key: value for key, value in candidate.items() if key not in candidate_path_fields
     }
-    actual_files = (
-        {item.get("path"): item.get("size") for item in files if isinstance(item, dict)}
-        if isinstance(files, list)
-        else {}
+    comparable_archived_candidate = {
+        key: value
+        for key, value in archived_candidate.items()
+        if key not in candidate_path_fields
+    }
+
+    def comparable_entry(entry: dict[str, Any]) -> dict[str, Any]:
+        return {
+            key: value
+            for key, value in entry.items()
+            if key not in {"candidate_manifest", "parent_manifest"}
+        }
+
+    series_fields = {
+        key: value for key, value in series.items() if key not in {"entries", "head"}
+    }
+    archived_series_fields = {
+        key: value
+        for key, value in archived_series.items()
+        if key not in {"entries", "head"}
+    }
+    series_entries = [comparable_entry(entry) for entry in series["entries"]]
+    archived_entries = [comparable_entry(entry) for entry in archived_series["entries"]]
+    series_head = comparable_entry(series["head"]) if series["head"] is not None else None
+    archived_head = (
+        comparable_entry(archived_series["head"])
+        if archived_series["head"] is not None
+        else None
     )
     if (
-        control.get("schema_version") != 1
-        or control.get("bundle_kind") != "build-control"
-        or identity != expected_identity
-        or not isinstance(files, list)
-        or len(files) != len(expected_files)
-        or actual_files != expected_files
-        or archived_candidate != candidate
-        or archived_series != series
+        comparable_archived_candidate != comparable_candidate
+        or archived_series_fields != series_fields
+        or archived_entries != series_entries
+        or archived_head != series_head
     ):
         raise CandidateLifecycleError("candidate control bundle does not match committed state")
-    for value in (control, archived_candidate, archived_series):
+    for value in (archived_candidate, archived_series):
         ensure_no_digest_fields(value)
 
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9580

### Brief Description

- replace placeholder release-candidate workflow checks with real `PrepareCommon`, platform `Target`, and `Aggregate` orchestration
- carry candidate control state as a portable release-series generation and relocate it into each isolated worker
- bind transferred bundles to the same candidate identity and series generation
- preserve the local-only boundary while transferring common, source, target, and aggregate candidate artifacts
- update candidate lifecycle validation and the transfer schema for the portable control format

### How Did You Test This Change?

- `python -m unittest scripts.tests.test_candidate_transfer scripts.tests.test_release_binary_build`: 8 tests passed before the final schema, lifecycle-validator, and workflow hardening edits
- `git diff --check`: passed before commit
- Per maintainer direction, no broader test suite, cross-platform build, or final post-edit test run was executed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release candidates can now be created using a version and release-series identifier.
  * Optional parent release controls support continuing an existing release series.
  * Release preparation now shares validated inputs across targets and produces combined candidate artifacts.
* **Bug Fixes**
  * Added validation to prevent mismatched release-series generations and candidate ownership.
  * Improved portability when transferring release controls between build environments.
  * Added safeguards preventing unintended publication during candidate aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->