### PR TITLE
[ISSUE #9582]✨Close release candidates with an always-run finalizer

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -53,14 +53,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: core-release-candidate-${{ github.run_id }}-${{ github.run_attempt }}
+  group: core-release-candidate-${{ inputs.series_id }}
   cancel-in-progress: false
 
 jobs:
   prepare-common:
     runs-on: ubuntu-latest
-    outputs:
-      common_artifact: ${{ steps.outputs.outputs.common_artifact }}
     steps:
       - uses: actions/checkout@v7
       - name: Download explicit parent control generation
@@ -71,8 +69,9 @@ jobs:
           path: ${{ runner.temp }}/parent-control
           github-token: ${{ github.token }}
           run-id: ${{ inputs.parent_control_run_id }}
-      - name: Create the candidate and portable preparation inputs
-        id: outputs
+      - name: Prepare portable candidate inputs
+        id: prepare
+        continue-on-error: true
         shell: pwsh
         env:
           CANDIDATE_VERSION: ${{ inputs.version }}
@@ -83,80 +82,56 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
-          $parentInputs = @(
-            $env:PARENT_CONTROL_RUN_ID,
-            $env:PARENT_CONTROL_ARTIFACT,
-            $env:PARENT_SERIES_GENERATION
-          )
+          $parentInputs = @($env:PARENT_CONTROL_RUN_ID, $env:PARENT_CONTROL_ARTIFACT, $env:PARENT_SERIES_GENERATION)
           $specified = @($parentInputs | Where-Object { $_ }).Count
-          if ($specified -ne 0 -and $specified -ne 3) {
-            throw 'parent control run, artifact, and generation must be provided together'
-          }
-
+          if ($specified -ne 0 -and $specified -ne 3) { throw 'parent control inputs must be provided together' }
           python scripts/set_workspace_version.py --version $env:CANDIDATE_VERSION
           $stateRoot = Join-Path $env:RUNNER_TEMP 'candidate-state'
           if ($specified -eq 0) {
-            python distribution/release_series.py create `
-              --release-line 1.0 `
-              --series-id $env:RELEASE_SERIES_ID `
-              --root (Join-Path $stateRoot 'series')
+            python distribution/release_series.py create --release-line 1.0 --series-id $env:RELEASE_SERIES_ID --root (Join-Path $stateRoot 'series')
           } else {
-            $parentBundles = @(Get-ChildItem (Join-Path $env:RUNNER_TEMP 'parent-control') -Recurse -File -Filter '*.tar')
-            if ($parentBundles.Count -ne 1) {
-              throw 'the parent control artifact must contain exactly one series control bundle'
-            }
-            python distribution/release_series.py import-control `
-              --bundle $parentBundles[0].FullName `
-              --destination (Join-Path $stateRoot 'series') `
-              --expected-generation $env:PARENT_SERIES_GENERATION
+            $parents = @(Get-ChildItem (Join-Path $env:RUNNER_TEMP 'parent-control') -Recurse -File -Filter '*.tar')
+            if ($parents.Count -ne 1) { throw 'exactly one parent series control bundle is required' }
+            python distribution/release_series.py import-control --bundle $parents[0].FullName --destination (Join-Path $stateRoot 'series') --expected-generation $env:PARENT_SERIES_GENERATION
           }
-          $seriesManifests = @(Get-ChildItem (Join-Path $stateRoot 'series') -Recurse -File -Filter 'RELEASE_SERIES.json')
-          if ($seriesManifests.Count -ne 1) {
-            throw 'exactly one release-series manifest is required'
-          }
-          $seriesManifest = $seriesManifests[0].FullName
-          python distribution/candidate_run.py create `
-            --version $env:CANDIDATE_VERSION `
-            --run-id "gha-$env:GITHUB_RUN_ID" `
-            --attempt $env:GITHUB_RUN_ATTEMPT `
-            --root (Join-Path $stateRoot 'candidates') `
-            --series-manifest $seriesManifest
-          $candidateManifests = @(Get-ChildItem (Join-Path $stateRoot 'candidates') -Recurse -File -Filter 'CANDIDATE_RUN.json')
-          if ($candidateManifests.Count -ne 1) {
-            throw 'exactly one current candidate manifest is required'
-          }
-          $candidateManifest = $candidateManifests[0].FullName
+          $series = @(Get-ChildItem (Join-Path $stateRoot 'series') -Recurse -File -Filter 'RELEASE_SERIES.json')
+          if ($series.Count -ne 1) { throw 'exactly one release-series manifest is required' }
+          python distribution/candidate_run.py create --version $env:CANDIDATE_VERSION --run-id "gha-$env:GITHUB_RUN_ID" --attempt $env:GITHUB_RUN_ATTEMPT --root (Join-Path $stateRoot 'candidates') --series-manifest $series[0].FullName
+          $manifests = @(Get-ChildItem (Join-Path $stateRoot 'candidates') -Recurse -File -Filter 'CANDIDATE_RUN.json')
+          if ($manifests.Count -ne 1) { throw 'exactly one candidate manifest is required' }
+          $manifest = $manifests[0].FullName
           if ($env:CANDIDATE_VERSION -match '-rc\.') {
-            pwsh -NoProfile -File scripts/run-v1-candidate-lifecycle.ps1 `
-              -Mode StageRc `
-              -CandidateManifest $candidateManifest
+            pwsh -NoProfile -File scripts/run-v1-candidate-lifecycle.ps1 -Mode StageRc -CandidateManifest $manifest
           }
-          $candidateRoot = Split-Path $candidateManifest
-          $transferRoot = Join-Path $candidateRoot 'transfer'
-          $commonBundle = Join-Path $transferRoot 'COMMON_RELEASE_INPUTS.tar'
-          $sourceBundle = Join-Path $transferRoot 'CORE_SOURCE_TRANSFER.tar'
-          $controlBundle = Join-Path $transferRoot 'CANDIDATE_BUILD_CONTROL_BUNDLE.tar'
-          pwsh -NoProfile -File scripts/run-release-preparation.ps1 `
-            -Mode PrepareCommon `
-            -CandidateManifest $candidateManifest `
-            -CommonInputsBundleOutput $commonBundle `
-            -BuildSourceBundleOutput $sourceBundle `
-            -BuildControlBundleOutput $controlBundle `
-            -SourceRoot $env:GITHUB_WORKSPACE
-          "common_artifact=core-release-common-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT" >> $env:GITHUB_OUTPUT
-          "common_bundle=$commonBundle" >> $env:GITHUB_OUTPUT
-          "source_bundle=$sourceBundle" >> $env:GITHUB_OUTPUT
-          "control_bundle=$controlBundle" >> $env:GITHUB_OUTPUT
-      - name: Upload sealed common, source, and control inputs
+          $root = Split-Path $manifest
+          python scripts/run_candidate_workflow_job.py `
+            --candidate-manifest $manifest --job-id prepare-common --worker-id prepare-common `
+            --result-ids prepare-common --output (Join-Path $env:RUNNER_TEMP 'stage-outcomes/prepare-common') `
+            -- pwsh -NoProfile -File scripts/run-release-preparation.ps1 -Mode PrepareCommon `
+              -CandidateManifest $manifest `
+              -CommonInputsBundleOutput (Join-Path $root 'transfer/COMMON_RELEASE_INPUTS.tar') `
+              -BuildSourceBundleOutput (Join-Path $root 'transfer/CORE_SOURCE_TRANSFER.tar') `
+              -BuildControlBundleOutput (Join-Path $root 'transfer/CANDIDATE_BUILD_CONTROL_BUNDLE.tar') `
+              -SourceRoot $env:GITHUB_WORKSPACE
+      - name: Upload common candidate inputs
+        if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ steps.outputs.outputs.common_artifact }}
-          path: |
-            ${{ steps.outputs.outputs.common_bundle }}
-            ${{ steps.outputs.outputs.source_bundle }}
-            ${{ steps.outputs.outputs.control_bundle }}
+          name: core-release-common-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/candidate-state/candidates/**/transfer/*.tar
           if-no-files-found: error
           retention-days: 14
+      - name: Upload prepare-common outcome
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: prepare-common
+          path: ${{ runner.temp }}/stage-outcomes/prepare-common
+          if-no-files-found: error
+          retention-days: 14
+      - name: Propagate preparation failure
+        if: ${{ steps.prepare.outcome != 'success' }}
+        run: exit 1
 
   build-target:
     needs: prepare-common
@@ -166,56 +141,67 @@ jobs:
         include:
           - runner: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            job_id: build-linux
+            result_id: S01
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
+            job_id: build-windows
+            result_id: S02
           - runner: macos-latest
             target: x86_64-apple-darwin
+            job_id: build-macos
+            result_id: S03
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/download-artifact@v7
         with:
-          name: ${{ needs.prepare-common.outputs.common_artifact }}
+          name: core-release-common-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/candidate-inputs
-      - name: Import candidate control and run the target preparation
-        id: target
+      - name: Build candidate target
+        id: build
+        continue-on-error: true
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
-          $inputRoot = Join-Path $env:RUNNER_TEMP 'candidate-inputs'
-          $commonBundle = @(Get-ChildItem $inputRoot -Recurse -File -Filter 'COMMON_RELEASE_INPUTS.tar')
-          $sourceBundle = @(Get-ChildItem $inputRoot -Recurse -File -Filter 'CORE_SOURCE_TRANSFER.tar')
-          $controlBundle = @(Get-ChildItem $inputRoot -Recurse -File -Filter 'CANDIDATE_BUILD_CONTROL_BUNDLE.tar')
-          if ($commonBundle.Count -ne 1 -or $sourceBundle.Count -ne 1 -or $controlBundle.Count -ne 1) {
-            throw 'common, source, and control inputs must each exist exactly once'
-          }
-          $workerRoot = Join-Path $env:RUNNER_TEMP 'candidate-worker'
+          $inputs = Join-Path $env:RUNNER_TEMP 'candidate-inputs'
+          $common = @(Get-ChildItem $inputs -Recurse -File -Filter 'COMMON_RELEASE_INPUTS.tar')
+          $source = @(Get-ChildItem $inputs -Recurse -File -Filter 'CORE_SOURCE_TRANSFER.tar')
+          $control = @(Get-ChildItem $inputs -Recurse -File -Filter 'CANDIDATE_BUILD_CONTROL_BUNDLE.tar')
+          if ($common.Count -ne 1 -or $source.Count -ne 1 -or $control.Count -ne 1) { throw 'candidate inputs are incomplete' }
           $selector = Join-Path $env:RUNNER_TEMP 'candidate-selector.json'
-          python distribution/transfer_candidate.py import-build-control `
-            --bundle $controlBundle[0].FullName `
-            --output $workerRoot `
-            --build-source-bundle $sourceBundle[0].FullName `
-            --selector-output $selector
+          python distribution/transfer_candidate.py import-build-control --bundle $control[0].FullName --output (Join-Path $env:RUNNER_TEMP 'candidate-worker') --build-source-bundle $source[0].FullName --selector-output $selector
           $candidate = Get-Content $selector -Raw | ConvertFrom-Json
           $targetBundle = Join-Path $candidate.candidate_root 'target-bundles/${{ matrix.target }}.tar'
-          pwsh -NoProfile -File scripts/run-release-preparation.ps1 `
-            -Mode Target `
-            -CandidateManifest $candidate.candidate_manifest `
-            -CommonInputsBundle $commonBundle[0].FullName `
-            -BuildSourceBundle $sourceBundle[0].FullName `
-            -BuildControlBundle $controlBundle[0].FullName `
-            -Target '${{ matrix.target }}' `
-            -TargetBundleOutput $targetBundle `
-            -SourceRoot $env:GITHUB_WORKSPACE
+          python scripts/run_candidate_workflow_job.py `
+            --candidate-manifest $candidate.candidate_manifest --job-id '${{ matrix.job_id }}' `
+            --worker-id '${{ matrix.job_id }}' --target '${{ matrix.target }}' `
+            --result-ids '${{ matrix.result_id }}' --output (Join-Path $env:RUNNER_TEMP 'stage-outcomes/${{ matrix.job_id }}') `
+            -- pwsh -NoProfile -File scripts/run-release-preparation.ps1 -Mode Target `
+              -CandidateManifest $candidate.candidate_manifest -CommonInputsBundle $common[0].FullName `
+              -BuildSourceBundle $source[0].FullName -BuildControlBundle $control[0].FullName `
+              -Target '${{ matrix.target }}' -TargetBundleOutput $targetBundle -SourceRoot $env:GITHUB_WORKSPACE
           "target_bundle=$targetBundle" >> $env:GITHUB_OUTPUT
-      - name: Upload the sealed target bundle
+      - name: Upload target bundle
+        if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: core-release-${{ matrix.target }}-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ steps.target.outputs.target_bundle }}
+          name: core-release-target-${{ matrix.job_id }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.build.outputs.target_bundle }}
           if-no-files-found: error
           retention-days: 14
+      - name: Upload target outcome
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.job_id }}
+          path: ${{ runner.temp }}/stage-outcomes/${{ matrix.job_id }}
+          if-no-files-found: error
+          retention-days: 14
+      - name: Propagate target failure
+        if: ${{ steps.build.outcome != 'success' }}
+        run: exit 1
 
   aggregate:
     needs: [prepare-common, build-target]
@@ -224,57 +210,230 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/download-artifact@v7
         with:
-          name: ${{ needs.prepare-common.outputs.common_artifact }}
+          name: core-release-common-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/candidate-inputs
       - uses: actions/download-artifact@v7
         with:
-          pattern: core-release-*-${{ github.run_id }}-${{ github.run_attempt }}
+          pattern: core-release-target-*-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/target-bundles
-      - name: Import candidate control and aggregate all target bundles
+      - name: Aggregate candidate artifacts
         id: aggregate
+        continue-on-error: true
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
-          $inputRoot = Join-Path $env:RUNNER_TEMP 'candidate-inputs'
-          $commonBundle = @(Get-ChildItem $inputRoot -Recurse -File -Filter 'COMMON_RELEASE_INPUTS.tar')
-          $sourceBundle = @(Get-ChildItem $inputRoot -Recurse -File -Filter 'CORE_SOURCE_TRANSFER.tar')
-          $controlBundle = @(Get-ChildItem $inputRoot -Recurse -File -Filter 'CANDIDATE_BUILD_CONTROL_BUNDLE.tar')
-          if ($commonBundle.Count -ne 1 -or $sourceBundle.Count -ne 1 -or $controlBundle.Count -ne 1) {
-            throw 'common, source, and control inputs must each exist exactly once'
-          }
-          $workerRoot = Join-Path $env:RUNNER_TEMP 'candidate-aggregate'
+          $inputs = Join-Path $env:RUNNER_TEMP 'candidate-inputs'
+          $common = @(Get-ChildItem $inputs -Recurse -File -Filter 'COMMON_RELEASE_INPUTS.tar')
+          $source = @(Get-ChildItem $inputs -Recurse -File -Filter 'CORE_SOURCE_TRANSFER.tar')
+          $control = @(Get-ChildItem $inputs -Recurse -File -Filter 'CANDIDATE_BUILD_CONTROL_BUNDLE.tar')
+          if ($common.Count -ne 1 -or $source.Count -ne 1 -or $control.Count -ne 1) { throw 'candidate inputs are incomplete' }
           $selector = Join-Path $env:RUNNER_TEMP 'candidate-selector.json'
-          python distribution/transfer_candidate.py import-build-control `
-            --bundle $controlBundle[0].FullName `
-            --output $workerRoot `
-            --build-source-bundle $sourceBundle[0].FullName `
-            --selector-output $selector
+          python distribution/transfer_candidate.py import-build-control --bundle $control[0].FullName --output (Join-Path $env:RUNNER_TEMP 'candidate-aggregate') --build-source-bundle $source[0].FullName --selector-output $selector
           $candidate = Get-Content $selector -Raw | ConvertFrom-Json
           $candidateSource = Join-Path $candidate.candidate_root 'transfer/CANDIDATE_SOURCE_BUNDLE.tar'
-          pwsh -NoProfile -File scripts/run-release-preparation.ps1 `
-            -Mode Aggregate `
-            -CandidateManifest $candidate.candidate_manifest `
-            -CommonInputsBundle $commonBundle[0].FullName `
-            -BuildSourceBundle $sourceBundle[0].FullName `
-            -BuildControlBundle $controlBundle[0].FullName `
-            -TargetBundlesRoot (Join-Path $env:RUNNER_TEMP 'target-bundles') `
-            -CandidateSourceBundleOutput $candidateSource `
-            -SourceRoot $env:GITHUB_WORKSPACE
+          python scripts/run_candidate_workflow_job.py `
+            --candidate-manifest $candidate.candidate_manifest --job-id aggregate --worker-id aggregate `
+            --result-ids aggregate,R01-RELEASE-VERSION,R01-CANDIDATE-LIFECYCLE,R01-CORE-IMAGE-WORKFLOW `
+            --output (Join-Path $env:RUNNER_TEMP 'stage-outcomes/aggregate') `
+            -- pwsh -NoProfile -File scripts/run-release-preparation.ps1 -Mode Aggregate `
+              -CandidateManifest $candidate.candidate_manifest -CommonInputsBundle $common[0].FullName `
+              -BuildSourceBundle $source[0].FullName -BuildControlBundle $control[0].FullName `
+              -TargetBundlesRoot (Join-Path $env:RUNNER_TEMP 'target-bundles') `
+              -CandidateSourceBundleOutput $candidateSource -SourceRoot $env:GITHUB_WORKSPACE
           $aggregateControl = Join-Path $candidate.candidate_root 'transfer/CANDIDATE_AGGREGATE_CONTROL_BUNDLE.tar'
-          python distribution/transfer_candidate.py export-build-control `
-            --candidate-manifest $candidate.candidate_manifest `
-            --output $aggregateControl
-          "candidate_source=$candidateSource" >> $env:GITHUB_OUTPUT
-          "aggregate_control=$aggregateControl" >> $env:GITHUB_OUTPUT
+          python distribution/transfer_candidate.py export-build-control --candidate-manifest $candidate.candidate_manifest --output $aggregateControl
+          Copy-Item -LiteralPath $source[0].FullName -Destination (Join-Path $candidate.candidate_root 'transfer/CORE_SOURCE_TRANSFER.tar')
+          "candidate_root=$($candidate.candidate_root)" >> $env:GITHUB_OUTPUT
       - name: Prove the candidate workflow has no publication route
+        if: ${{ steps.aggregate.outcome == 'success' }}
         run: python scripts/no_remote_publication_guard.py --phase 5 --static-only
       - name: Upload aggregate candidate state
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: core-release-aggregate-${{ github.run_id }}-${{ github.run_attempt }}
-          path: |
-            ${{ steps.aggregate.outputs.candidate_source }}
-            ${{ steps.aggregate.outputs.aggregate_control }}
+          path: ${{ steps.aggregate.outputs.candidate_root }}/transfer/*.tar
           if-no-files-found: error
           retention-days: 14
+      - name: Upload aggregate outcome
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: aggregate
+          path: ${{ runner.temp }}/stage-outcomes/aggregate
+          if-no-files-found: error
+          retention-days: 14
+      - name: Propagate aggregate failure
+        if: ${{ steps.aggregate.outcome != 'success' }}
+        run: exit 1
+
+  full-matrix:
+    needs: aggregate
+    runs-on: [self-hosted, linux, x64, rocketmq-release-candidate]
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v7
+        with:
+          name: core-release-aggregate-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/candidate-aggregate
+      - name: Run the short functional matrix
+        id: matrix
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+          $inputs = Join-Path $env:RUNNER_TEMP 'candidate-aggregate'
+          $artifacts = @(Get-ChildItem $inputs -Recurse -File -Filter 'CANDIDATE_SOURCE_BUNDLE.tar')
+          $control = @(Get-ChildItem $inputs -Recurse -File -Filter 'CANDIDATE_AGGREGATE_CONTROL_BUNDLE.tar')
+          $source = @(Get-ChildItem $inputs -Recurse -File -Filter 'CORE_SOURCE_TRANSFER.tar')
+          if ($artifacts.Count -ne 1 -or $control.Count -ne 1 -or $source.Count -ne 1) { throw 'aggregate candidate inputs are incomplete' }
+          $selector = Join-Path $env:RUNNER_TEMP 'candidate-selector.json'
+          python distribution/transfer_candidate.py import-build-control --bundle $control[0].FullName --output (Join-Path $env:RUNNER_TEMP 'candidate-full-matrix') --build-source-bundle $source[0].FullName --selector-output $selector
+          $candidate = Get-Content $selector -Raw | ConvertFrom-Json
+          python distribution/transfer_candidate.py import-artifacts --bundle $artifacts[0].FullName --candidate-manifest $candidate.candidate_manifest
+          $resultIds = @(
+            'P01','P02','P03','P04','P05','P06','P07','P08','P09','P10','P11','P12',
+            'I01','I02','I03','I04','I05','M01','L01','A01',
+            'U01-LF','U01-MP','U01-RDB','U01-CMP','U01-POP','U01-TMR','U01-TRD','U01-CTL','U01-UPG','U01'
+          ) -join ','
+          python scripts/run_candidate_workflow_job.py `
+            --candidate-manifest $candidate.candidate_manifest --job-id full-matrix --worker-id full-matrix `
+            --result-ids $resultIds --output (Join-Path $env:RUNNER_TEMP 'stage-outcomes/full-matrix') `
+            -- pwsh -NoProfile -File scripts/run-v1-functional-acceptance.ps1 `
+              -CandidateManifest $candidate.candidate_manifest -AllScenarios -SkipInstallationScenarios
+      - name: Upload functional matrix outcome
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: full-matrix
+          path: ${{ runner.temp }}/stage-outcomes/full-matrix
+          if-no-files-found: error
+          retention-days: 14
+      - name: Propagate functional matrix failure
+        if: ${{ steps.matrix.outcome != 'success' }}
+        run: exit 1
+
+  candidate-lifecycle-finalizer:
+    if: always()
+    needs: [prepare-common, build-target, aggregate, full-matrix]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Download common control fallback
+        continue-on-error: true
+        uses: actions/download-artifact@v7
+        with:
+          name: core-release-common-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/candidate-common
+      - name: Download aggregate candidate state
+        continue-on-error: true
+        uses: actions/download-artifact@v7
+        with:
+          name: core-release-aggregate-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/candidate-aggregate
+      - name: Download job outcomes
+        continue-on-error: true
+        uses: actions/download-artifact@v7
+        with:
+          pattern: build-*
+          path: ${{ runner.temp }}/stage-outcomes
+      - name: Download prepare-common outcome
+        continue-on-error: true
+        uses: actions/download-artifact@v7
+        with:
+          name: prepare-common
+          path: ${{ runner.temp }}/stage-outcomes/prepare-common
+      - name: Download aggregate outcome
+        continue-on-error: true
+        uses: actions/download-artifact@v7
+        with:
+          name: aggregate
+          path: ${{ runner.temp }}/stage-outcomes/aggregate
+      - name: Download functional matrix outcome
+        continue-on-error: true
+        uses: actions/download-artifact@v7
+        with:
+          name: full-matrix
+          path: ${{ runner.temp }}/stage-outcomes/full-matrix
+      - name: Collect outcomes and close the candidate
+        id: finalize
+        continue-on-error: true
+        shell: pwsh
+        env:
+          PREPARE_RESULT: ${{ needs.prepare-common.result }}
+          TARGET_RESULT: ${{ needs.build-target.result }}
+          AGGREGATE_RESULT: ${{ needs.aggregate.result }}
+          MATRIX_RESULT: ${{ needs.full-matrix.result }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+          $aggregateRoot = Join-Path $env:RUNNER_TEMP 'candidate-aggregate'
+          $commonRoot = Join-Path $env:RUNNER_TEMP 'candidate-common'
+          $control = @(Get-ChildItem $aggregateRoot -Recurse -File -Filter 'CANDIDATE_AGGREGATE_CONTROL_BUNDLE.tar' -ErrorAction SilentlyContinue)
+          if ($control.Count -eq 0) { $control = @(Get-ChildItem $commonRoot -Recurse -File -Filter 'CANDIDATE_BUILD_CONTROL_BUNDLE.tar' -ErrorAction SilentlyContinue) }
+          if ($control.Count -eq 0) { $control = @(Get-ChildItem $commonRoot -Recurse -File -Filter 'CANDIDATE_CONTROL_BUNDLE.g*.tar' -ErrorAction SilentlyContinue | Sort-Object Name | Select-Object -Last 1) }
+          $source = @(Get-ChildItem $aggregateRoot,$commonRoot -Recurse -File -Filter 'CORE_SOURCE_TRANSFER.tar' -ErrorAction SilentlyContinue | Select-Object -First 1)
+          if ($control.Count -ne 1 -or $source.Count -ne 1) { throw 'no committed candidate control generation is available' }
+          $selector = Join-Path $env:RUNNER_TEMP 'candidate-selector.json'
+          python distribution/transfer_candidate.py import-build-control --bundle $control[0].FullName --output (Join-Path $env:RUNNER_TEMP 'candidate-finalizer') --build-source-bundle $source[0].FullName --selector-output $selector
+          $candidate = Get-Content $selector -Raw | ConvertFrom-Json
+          $artifacts = @(Get-ChildItem $aggregateRoot -Recurse -File -Filter 'CANDIDATE_SOURCE_BUNDLE.tar' -ErrorAction SilentlyContinue)
+          if ($artifacts.Count -eq 1) { python distribution/transfer_candidate.py import-artifacts --bundle $artifacts[0].FullName --candidate-manifest $candidate.candidate_manifest }
+          $candidateValue = Get-Content $candidate.candidate_manifest -Raw | ConvertFrom-Json
+          function Get-TargetResult([string]$jobId) {
+            $outcome = Join-Path $env:RUNNER_TEMP "stage-outcomes/$jobId/CANDIDATE_STAGE_OUTCOME.json"
+            if (Test-Path -LiteralPath $outcome) { return (Get-Content $outcome -Raw | ConvertFrom-Json).workflow_result }
+            if ($env:TARGET_RESULT -in @('cancelled','skipped')) { return $env:TARGET_RESULT }
+            return 'failure'
+          }
+          $workflowResults = Join-Path $env:RUNNER_TEMP 'WORKFLOW_RESULTS.json'
+          @{
+            schema_version = 1; candidate_id = $candidateValue.candidate_id; version = $candidateValue.version
+            run_id = $candidateValue.run_id; attempt = $candidateValue.attempt
+            jobs = @{
+              'prepare-common' = $env:PREPARE_RESULT; 'build-linux' = (Get-TargetResult 'build-linux')
+              'build-windows' = (Get-TargetResult 'build-windows'); 'build-macos' = (Get-TargetResult 'build-macos')
+              'aggregate' = $env:AGGREGATE_RESULT; 'full-matrix' = $env:MATRIX_RESULT
+            }
+          } | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $workflowResults -Encoding utf8
+          $outcomeRoot = Join-Path $candidate.candidate_root 'stage-outcomes'
+          $PSNativeCommandUseErrorActionPreference = $false
+          python scripts/collect_candidate_stage_outcomes.py --candidate-manifest $candidate.candidate_manifest --bundles-root (Join-Path $env:RUNNER_TEMP 'stage-outcomes') --workflow-results $workflowResults --profile release-candidate --output-root $outcomeRoot
+          $collectorExit = $LASTEXITCODE
+          $PSNativeCommandUseErrorActionPreference = $true
+          $arguments = @('-NoProfile','-File','scripts/run-v1-candidate-lifecycle.ps1','-CandidateManifest',$candidate.candidate_manifest)
+          if ($candidateValue.candidate_kind -eq 'rc') {
+            $arguments += @('-Mode','FinalizeRc')
+          } else {
+            $arguments += @('-Mode','FinalizeFinalFunctional','-ParentManifest',$candidateValue.parent_manifest,'-SourceRoot',$env:GITHUB_WORKSPACE)
+          }
+          if ($collectorExit -eq 0) { $arguments += @('-StageOutcomesIndex',(Join-Path $outcomeRoot 'CANDIDATE_STAGE_OUTCOMES.json')) }
+          $PSNativeCommandUseErrorActionPreference = $false
+          & pwsh @arguments
+          $lifecycleExit = $LASTEXITCODE
+          $PSNativeCommandUseErrorActionPreference = $true
+          "control_root=$($candidate.candidate_root)" >> $env:GITHUB_OUTPUT
+          "series_root=$(Split-Path $candidateValue.series_manifest)" >> $env:GITHUB_OUTPUT
+          if ($lifecycleExit -ne 0) { exit $lifecycleExit }
+      - name: Upload committed candidate control generation
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: candidate-control-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.finalize.outputs.control_root }}/transfer/CANDIDATE_CONTROL_BUNDLE.g*.tar
+          if-no-files-found: error
+          retention-days: 30
+      - name: Upload committed release-series control generation
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-series-control-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.finalize.outputs.series_root }}/RELEASE_SERIES_CONTROL_BUNDLE.g*.tar
+          if-no-files-found: error
+          retention-days: 30
+      - name: Propagate lifecycle result
+        if: ${{ steps.finalize.outcome != 'success' }}
+        run: exit 1

--- a/distribution/transfer_candidate.py
+++ b/distribution/transfer_candidate.py
@@ -8,6 +8,7 @@ import argparse
 import io
 import json
 from pathlib import Path, PurePosixPath
+import shutil
 import subprocess
 import sys
 import tarfile
@@ -300,6 +301,64 @@ def import_build_control(
     return candidate_manifest
 
 
+def import_artifacts(bundle: Path, candidate_manifest: Path) -> Path:
+    """Restore one artifact bundle into its relocated candidate root."""
+
+    candidate_manifest = resolve_existing_file(candidate_manifest, "candidate manifest")
+    candidate = read_json(candidate_manifest)
+    validate_candidate(candidate)
+    candidate_root = Path(candidate["candidate_root"]).resolve()
+    if candidate_root != candidate_manifest.parent.resolve():
+        raise ArchiveError("candidate manifest and candidate root disagree")
+    bundle = resolve_existing_file(bundle, "candidate artifact bundle")
+    with tempfile.TemporaryDirectory(dir=candidate_root.parent) as temporary:
+        payload_root = import_bundle(bundle, Path(temporary) / "payload")
+        transfer = read_json(payload_root / "CANDIDATE_TRANSFER.json")
+        identity = (
+            transfer.get("candidate_id"),
+            transfer.get("version"),
+            transfer.get("run_id"),
+            transfer.get("attempt"),
+            transfer.get("series_generation"),
+        )
+        expected = (
+            candidate.get("candidate_id"),
+            candidate.get("version"),
+            candidate.get("run_id"),
+            candidate.get("attempt"),
+            candidate.get("series_generation"),
+        )
+        if transfer.get("bundle_kind") != "artifacts" or identity != expected:
+            raise ArchiveError("candidate artifact bundle identity does not match")
+        records = transfer.get("files")
+        if not isinstance(records, list) or not records:
+            raise ArchiveError("candidate artifact bundle has no closed file denominator")
+        copies: list[tuple[Path, Path]] = []
+        for record in records:
+            if not isinstance(record, dict) or set(record) != {"path", "type", "size"}:
+                raise ArchiveError("candidate artifact bundle contains an invalid file record")
+            relative = require_relative_path(record.get("path"), "candidate artifact path")
+            source = resolve_existing_file(payload_root / relative, "candidate artifact payload")
+            if record.get("type") != "file" or record.get("size") != source.stat().st_size:
+                raise ArchiveError(f"candidate artifact record is inconsistent: {relative}")
+            destination = resolve_within(
+                candidate_root, candidate_root / relative, "candidate artifact destination"
+            )
+            if destination.exists():
+                if not destination.is_file() or destination.read_bytes() != source.read_bytes():
+                    raise ArchiveError(f"candidate artifact destination collides: {relative}")
+                continue
+            copies.append((source, destination))
+        for source, destination in copies:
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            temporary_destination = destination.with_name(destination.name + ".candidate-import.tmp")
+            if temporary_destination.exists():
+                raise ArchiveError(f"candidate artifact temporary destination exists: {destination}")
+            shutil.copyfile(source, temporary_destination)
+            temporary_destination.replace(destination)
+    return candidate_manifest
+
+
 def write_build_control_selector(candidate_manifest: Path, output: Path) -> Path:
     """Write the worker-local candidate selector produced by a control import."""
 
@@ -409,6 +468,9 @@ def main(argv: list[str] | None = None) -> int:
     control_import.add_argument("--output", type=Path, required=True)
     control_import.add_argument("--selector-output", type=Path, required=True)
     control_import.add_argument("--build-source-bundle", type=Path)
+    artifact_import = subcommands.add_parser("import-artifacts")
+    artifact_import.add_argument("--bundle", type=Path, required=True)
+    artifact_import.add_argument("--candidate-manifest", type=Path, required=True)
     args = parser.parse_args(argv)
     try:
         if args.command == "export-build-source":
@@ -426,6 +488,8 @@ def main(argv: list[str] | None = None) -> int:
                 build_source_bundle=args.build_source_bundle,
             )
             output = write_build_control_selector(candidate_manifest, args.selector_output)
+        elif args.command == "import-artifacts":
+            output = import_artifacts(args.bundle, args.candidate_manifest)
         else:
             manifest, candidate, root = load_candidate(args.candidate_manifest)
             if args.command == "export-target":

--- a/scripts/run-v1-functional-acceptance.ps1
+++ b/scripts/run-v1-functional-acceptance.ps1
@@ -11,6 +11,8 @@ param(
     [string]$Scenario,
     [Parameter(Mandatory = $true, ParameterSetName = 'All')]
     [switch]$AllScenarios,
+    [Parameter(ParameterSetName = 'All')]
+    [switch]$SkipInstallationScenarios,
     [string]$Matrix = 'scripts/v1-functional-test-matrix.json',
     [string]$Target
 )
@@ -23,5 +25,6 @@ switch ($PSCmdlet.ParameterSetName) {
     'Scenario' { $arguments += @('--scenario', $Scenario) }
     'All' { $arguments += '--all-scenarios' }
 }
+if ($SkipInstallationScenarios) { $arguments += '--skip-installation-scenarios' }
 & python @arguments
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/scripts/run-v1-functional-acceptance.sh
+++ b/scripts/run-v1-functional-acceptance.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 candidate_manifest=""
 matrix="scripts/v1-functional-test-matrix.json"
 target=""
+skip_installation_scenarios="false"
 selection=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -16,6 +17,7 @@ while [[ $# -gt 0 ]]; do
     --profile) selection=(--profile "$2"); shift 2 ;;
     --scenario) selection=(--scenario "$2"); shift 2 ;;
     --all-scenarios) selection=(--all-scenarios); shift ;;
+    --skip-installation-scenarios) skip_installation_scenarios="true"; shift ;;
     *) echo "unknown argument: $1" >&2; exit 2 ;;
   esac
 done
@@ -26,4 +28,5 @@ if [[ -z "$candidate_manifest" || ${#selection[@]} -eq 0 ]]; then
 fi
 arguments=(scripts/v1_functional_acceptance.py --candidate-manifest "$candidate_manifest" --matrix "$matrix")
 if [[ -n "$target" ]]; then arguments+=(--target "$target"); fi
+if [[ "$skip_installation_scenarios" == "true" ]]; then arguments+=(--skip-installation-scenarios); fi
 python "${arguments[@]}" "${selection[@]}"

--- a/scripts/run_candidate_workflow_job.py
+++ b/scripts/run_candidate_workflow_job.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RocketMQ Rust Authors
+# Licensed under the Apache License, Version 2.0.
+
+"""Run one candidate workflow job and seal its portable outcome bundle."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+import tempfile
+from typing import Any, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[1]
+for module_root in (ROOT / "distribution", ROOT / "scripts"):
+    if str(module_root) not in sys.path:
+        sys.path.insert(0, str(module_root))
+
+import capture_candidate_execution_context
+import release_candidate_command
+from release_state import (
+    ReleaseStateError,
+    atomic_write_json,
+    read_json,
+    require_safe_id,
+    resolve_existing_file,
+    validate_candidate,
+)
+
+
+class WorkflowJobError(ReleaseStateError):
+    """Raised when a workflow job cannot produce an attributable outcome."""
+
+
+def _identity(candidate: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "candidate_id": candidate["candidate_id"],
+        "version": candidate["version"],
+        "run_id": candidate["run_id"],
+        "attempt": candidate["attempt"],
+    }
+
+
+def _result_record(
+    candidate: dict[str, Any], result_id: str, status: str, command: Sequence[str]
+) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        **_identity(candidate),
+        "phase": 6,
+        "gate_stage": "full-matrix",
+        "result_id": result_id,
+        "result_kind": "check",
+        "status": status,
+        "command": list(command),
+        "exit_code": 0 if status == "passed" else 1,
+        "matched_test_count": 0,
+        "executed_test_count": 0,
+        "passed_test_count": 0,
+        "failed_test_count": 0 if status == "passed" else 1,
+        "ignored_test_count": 0,
+        "capability_ids": [],
+        "result_path": f"results/{result_id}.json",
+    }
+
+
+def _copy_or_record_result(
+    candidate: dict[str, Any],
+    candidate_root: Path,
+    staging: Path,
+    result_id: str,
+    status: str,
+    command: Sequence[str],
+) -> str:
+    require_safe_id(result_id, "result_id")
+    relative = f"results/{result_id}.json"
+    source = candidate_root / relative
+    destination = staging / relative
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if source.is_file():
+        value = read_json(source)
+        if any(value.get(key) != expected for key, expected in _identity(candidate).items()):
+            raise WorkflowJobError(f"candidate result belongs to another candidate: {result_id}")
+        if value.get("result_id") != result_id:
+            raise WorkflowJobError(f"candidate result ID is inconsistent: {result_id}")
+        value["phase"] = 6
+        value["gate_stage"] = "full-matrix"
+        value["result_path"] = relative
+        atomic_write_json(destination, value)
+    else:
+        atomic_write_json(destination, _result_record(candidate, result_id, status, command))
+    return relative
+
+
+def _publish_bundle(staging: Path, output: Path) -> None:
+    output = output.resolve()
+    if output.exists():
+        raise WorkflowJobError(f"candidate workflow outcome already exists: {output}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    staging.replace(output)
+
+
+def run_job(
+    candidate_manifest: Path,
+    *,
+    job_id: str,
+    worker_id: str,
+    target: str | None,
+    result_ids: Sequence[str],
+    output: Path,
+    command: Sequence[str],
+) -> int:
+    require_safe_id(job_id, "job_id")
+    require_safe_id(worker_id, "worker_id")
+    if target is not None:
+        require_safe_id(target, "target")
+    if not result_ids or len(result_ids) != len(set(result_ids)):
+        raise WorkflowJobError("result ID denominator must be non-empty and unique")
+    if not command:
+        raise WorkflowJobError("candidate workflow command cannot be empty")
+
+    candidate_manifest = resolve_existing_file(candidate_manifest, "candidate manifest")
+    candidate = read_json(candidate_manifest)
+    validate_candidate(candidate)
+    candidate_root = Path(candidate["candidate_root"]).resolve()
+    if candidate_root != candidate_manifest.parent.resolve():
+        raise WorkflowJobError("candidate manifest and root disagree")
+
+    output = output.resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=output.parent) as temporary:
+        staging = Path(temporary) / job_id
+        context = capture_candidate_execution_context.capture_context(
+            candidate_manifest, worker_id, staging / "contexts"
+        )
+        event_root = staging / "events"
+        exit_code = release_candidate_command.run_command(
+            candidate_manifest,
+            route_id=job_id,
+            worker_id=worker_id,
+            context_path=context,
+            event_root=event_root,
+            command=command,
+            portable_root=staging,
+            cwd=ROOT,
+        )
+        workflow_result = "success" if exit_code == 0 else "failure"
+        result_status = "passed" if exit_code == 0 else "failed"
+        result_files = [
+            _copy_or_record_result(
+                candidate,
+                candidate_root,
+                staging,
+                result_id,
+                result_status,
+                command,
+            )
+            for result_id in result_ids
+        ]
+        started = f"events/{job_id}.started.json"
+        completed = f"events/{job_id}.completed.json"
+        context_relative = f"contexts/{worker_id}.json"
+        for relative in (started, completed, context_relative):
+            resolve_existing_file(staging / relative, relative)
+        atomic_write_json(
+            staging / "CANDIDATE_STAGE_OUTCOME.json",
+            {
+                "schema_version": 1,
+                **_identity(candidate),
+                "job_id": job_id,
+                "worker_id": worker_id,
+                "target": target,
+                "status": result_status.replace("passed", "success"),
+                "workflow_result": workflow_result,
+                "sealed": True,
+                "result_files": result_files,
+                "event_pairs": [
+                    {"route_id": job_id, "started": started, "completed": completed}
+                ],
+                "context_files": [context_relative],
+            },
+        )
+        _publish_bundle(staging, output)
+    return exit_code
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate-manifest", type=Path, required=True)
+    parser.add_argument("--job-id", required=True)
+    parser.add_argument("--worker-id", required=True)
+    parser.add_argument("--target")
+    parser.add_argument("--result-ids", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    command = args.command[1:] if args.command and args.command[0] == "--" else args.command
+    try:
+        return run_job(
+            args.candidate_manifest,
+            job_id=args.job_id,
+            worker_id=args.worker_id,
+            target=args.target,
+            result_ids=tuple(item for item in args.result_ids.split(",") if item),
+            output=args.output,
+            command=command,
+        )
+    except (ReleaseStateError, OSError, json.JSONDecodeError) as error:
+        print(f"CANDIDATE_WORKFLOW_JOB_FAILED detail={error}", file=sys.stderr)
+        return 125
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/v1_functional_acceptance.py
+++ b/scripts/v1_functional_acceptance.py
@@ -181,11 +181,16 @@ def select_routes(
     profile: str | None = None,
     scenario: str | None = None,
     all_scenarios: bool = False,
+    skip_installation_scenarios: bool = False,
 ) -> tuple[str, ...]:
     if sum((profile is not None, scenario is not None, all_scenarios)) != 1:
         raise AcceptanceError("select exactly one Profile, Scenario, or AllScenarios mode")
     if all_scenarios:
+        if skip_installation_scenarios:
+            return tuple(result_id for result_id in REQUIRED_RESULT_IDS if not result_id.startswith("S"))
         return REQUIRED_RESULT_IDS
+    if skip_installation_scenarios:
+        raise AcceptanceError("installation scenarios can only be skipped with AllScenarios")
     selected = profile or scenario
     assert selected is not None
     try:
@@ -774,6 +779,7 @@ def parser() -> argparse.ArgumentParser:
     selection.add_argument("--scenario")
     selection.add_argument("--all-scenarios", action="store_true")
     selection.add_argument("--execute-one", help=argparse.SUPPRESS)
+    command.add_argument("--skip-installation-scenarios", action="store_true")
     return command
 
 
@@ -787,7 +793,11 @@ def main(argv: list[str] | None = None) -> int:
             execute_one(candidate, matrix, args.execute_one, args.target)
             return 0
         selected = select_routes(
-            matrix, profile=args.profile, scenario=args.scenario, all_scenarios=args.all_scenarios
+            matrix,
+            profile=args.profile,
+            scenario=args.scenario,
+            all_scenarios=args.all_scenarios,
+            skip_installation_scenarios=args.skip_installation_scenarios,
         )
         return run_selected(candidate, matrix, matrix_path, selected, args.target)
     except (AcceptanceError, OSError, json.JSONDecodeError) as error:


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9582

### Brief Description

- Extends the release-candidate workflow through target preparation, the short functional matrix, immutable job outcome collection, and an always-run lifecycle finalizer.
- Adds a candidate-scoped workflow job wrapper that records portable results, events, and execution context before sealing each outcome bundle.
- Adds safe artifact restoration for relocated candidate roots and keeps platform installation evidence with its owning target job.
- Exports separate candidate and release-series control artifacts for an explicitly selected follow-up run.
- Keeps the workflow preparation-only; it does not publish crates, GitHub releases, container images, or Helm charts.

### How Did You Test This Change?

- `python -m py_compile distribution/transfer_candidate.py scripts/run_candidate_workflow_job.py scripts/v1_functional_acceptance.py`
- `python scripts/no_remote_publication_guard.py --phase 5 --static-only` (`NO_REMOTE_PUBLICATION_STATIC_OK workflows=3`)
- `git diff --check`
- The full candidate workflow was not executed, as requested. Independent local YAML parsing was unavailable because the environment has neither PyYAML nor Ruby.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for importing candidate artifacts with validation and collision handling.
  - Added a workflow job runner that publishes validated execution outcomes.
  - Enhanced release-candidate workflows with candidate finalization, result aggregation, full-matrix testing, and failure reporting.

- **Improvements**
  - Added `--skip-installation-scenarios` to functional acceptance scripts, allowing installation checks to be excluded when running all scenarios.
  - Improved validation and transfer of build and release artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->