### PR TITLE
[ISSUE #9597]📝Clarify module size guidelines in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,8 +71,9 @@
   module-wide `allow(warnings)` or broad Clippy-group suppression.
 - Prefer native `async fn` methods in traits. `#[allow(async_fn_in_trait)]` is permitted when required by the
   lint for an intentional public async trait API; do not add `#[async_trait]`.
-- Treat roughly 500 lines as a module review signal and avoid extending high-touch modules beyond roughly 800
-  lines without a strong local reason. Do not split unrelated legacy modules solely to meet a number.
+- Treat roughly 500 lines of code as a module review signal and avoid extending high-touch modules beyond roughly
+  800 lines of code without a strong local reason. For this guideline, exclude comments, attributes/annotations,
+  blank lines, and `use` imports. Do not split unrelated legacy modules solely to meet a number.
 - Keep comments focused on invariants, ordering, error handling, protocol compatibility, or concurrency assumptions; do not restate the code.
 
 ### Errors, unsafe code, async ownership, and tracing


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #9597

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified module-size guidelines by specifying which lines are excluded from approximate line-count thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->