### PR TITLE
[ISSUE #9596]🧪Freeze remoting wire, buffer, and public API contracts

### DIFF
--- a/rocketmq-protocol/tests/remoting_command_contract.rs
+++ b/rocketmq-protocol/tests/remoting_command_contract.rs
@@ -1,0 +1,273 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Public-path, defaults, flags, and decoder cursor contracts for remoting commands.
+
+use std::any::TypeId;
+use std::collections::HashMap;
+
+use bytes::BufMut;
+use bytes::BytesMut;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand as CanonicalRemotingCommand;
+use rocketmq_protocol::protocol::LanguageCode;
+use rocketmq_protocol::protocol::RemotingCommand as ProtocolRemotingCommand;
+use rocketmq_protocol::protocol::SerializeType;
+use rocketmq_protocol::RemotingCommand as RootRemotingCommand;
+
+const TRAILING_BYTES: &[u8] = &[0xde, 0xad, 0xbe, 0xef, 0x7f];
+const FALLBACK_ONLY_JSON_HEADER: &[u8; 151] =
+    b"{\"code\":10,\"language\":\"RUST\",\"version\":501,\"opaque\":7,\"flag\":0,\"remark\":null,\"extFields\":{\"queueId\":\"1\"},\"extra\":true,\"serializeTypeCurrentRPC\":\"JSON\"}";
+const FALLBACK_ONLY_JSON_FRAME: &[u8; 159] = b"\x00\x00\x00\x9b\x00\x00\x00\x97\
+{\"code\":10,\"language\":\"RUST\",\"version\":501,\"opaque\":7,\"flag\":0,\"remark\":null,\"extFields\":{\"queueId\":\"1\"},\"extra\":true,\"serializeTypeCurrentRPC\":\"JSON\"}";
+
+fn complete_frame(marked_header_length: i32, header: &[u8]) -> Vec<u8> {
+    let mut frame = BytesMut::with_capacity(8 + header.len());
+    frame.put_i32(i32::try_from(4 + header.len()).expect("test frame length must fit i32"));
+    frame.put_i32(marked_header_length);
+    frame.extend_from_slice(header);
+    frame.to_vec()
+}
+
+fn complete_frame_for(header: &[u8], serialize_type: SerializeType) -> Vec<u8> {
+    let header_length = i32::try_from(header.len()).expect("test header length must fit i32");
+    complete_frame(
+        CanonicalRemotingCommand::mark_serialize_type(header_length, serialize_type),
+        header,
+    )
+}
+
+fn binary_header(extension_fields: &[u8]) -> Vec<u8> {
+    let mut header = BytesMut::new();
+    header.put_i16(1);
+    header.put_u8(LanguageCode::RUST.get_code());
+    header.put_i16(0);
+    header.put_i32(7);
+    header.put_i32(0);
+    header.put_i32(0);
+    header.put_i32(i32::try_from(extension_fields.len()).expect("test extension fields must fit i32"));
+    header.extend_from_slice(extension_fields);
+    header.to_vec()
+}
+
+fn assert_complete_frame_is_consumed_on_error(name: &str, frame: &[u8]) {
+    let mut input = BytesMut::with_capacity(frame.len() + TRAILING_BYTES.len());
+    input.extend_from_slice(frame);
+    input.extend_from_slice(TRAILING_BYTES);
+
+    let error = match CanonicalRemotingCommand::decode(&mut input) {
+        Err(error) => error,
+        Ok(None) => panic!("{name} must be a complete malformed frame"),
+        Ok(Some(_)) => panic!("{name} unexpectedly decoded"),
+    };
+
+    assert_eq!(input.as_ref(), TRAILING_BYTES, "{name}: {error}");
+}
+
+fn decode_json_header(header: &str) -> CanonicalRemotingCommand {
+    let mut input = BytesMut::from(header.as_bytes());
+    let header_length = input.len();
+    let command = CanonicalRemotingCommand::header_decode(&mut input, header_length, SerializeType::JSON)
+        .expect("JSON header must decode")
+        .expect("JSON header must produce a command");
+    assert!(input.is_empty());
+    command
+}
+
+#[test]
+fn public_paths_name_the_same_remoting_command_type_and_behavior() {
+    assert_eq!(
+        TypeId::of::<RootRemotingCommand>(),
+        TypeId::of::<CanonicalRemotingCommand>()
+    );
+    assert_eq!(
+        TypeId::of::<ProtocolRemotingCommand>(),
+        TypeId::of::<CanonicalRemotingCommand>()
+    );
+
+    let root = RootRemotingCommand::with_resolved_defaults(501, SerializeType::JSON)
+        .set_code(105)
+        .set_opaque(0x1122_3344);
+    let canonical: CanonicalRemotingCommand = root.clone();
+    let protocol: ProtocolRemotingCommand = canonical.clone();
+
+    for command in [&root, &canonical, &protocol] {
+        assert_eq!(command.code(), 105);
+        assert_eq!(command.version(), 501);
+        assert_eq!(command.opaque(), 0x1122_3344);
+        assert_eq!(command.flag(), 0);
+    }
+}
+
+#[test]
+fn explicit_defaults_serde_names_and_flag_bits_are_stable() {
+    let command = CanonicalRemotingCommand::with_resolved_defaults(0, SerializeType::JSON).set_opaque(0x1122_3344);
+
+    assert_eq!(command.code(), 0);
+    assert_eq!(command.language(), LanguageCode::RUST);
+    assert_eq!(command.version(), 0);
+    assert_eq!(command.opaque(), 0x1122_3344);
+    assert_eq!(command.flag(), 0);
+    assert!(command.remark().is_none());
+    assert!(command.ext_fields().is_none());
+    assert!(command.body().is_none());
+    assert_eq!(command.get_serialize_type(), SerializeType::JSON);
+    assert_eq!(
+        serde_json::to_string(&command).expect("default command must serialize"),
+        r#"{"code":0,"language":"RUST","version":0,"opaque":287454020,"flag":0,"remark":null,"extFields":null,"serializeTypeCurrentRPC":"JSON"}"#
+    );
+
+    let response = command.clone().mark_response_type();
+    let oneway = command.clone().mark_oneway_rpc();
+    let combined = command.mark_response_type().mark_oneway_rpc();
+
+    assert_eq!(response.flag(), 1);
+    assert!(response.is_response_type());
+    assert!(!response.is_oneway_rpc());
+    assert_eq!(oneway.flag(), 2);
+    assert!(!oneway.is_response_type());
+    assert!(oneway.is_oneway_rpc());
+    assert_eq!(combined.flag(), 3);
+    assert!(combined.is_response_type());
+    assert!(combined.is_oneway_rpc());
+}
+
+#[test]
+fn json_absent_null_and_empty_extension_fields_remain_distinct() {
+    let absent = decode_json_header(
+        r#"{"code":1,"language":"RUST","version":0,"opaque":7,"flag":0,"serializeTypeCurrentRPC":"JSON"}"#,
+    );
+    let null = decode_json_header(
+        r#"{"code":1,"language":"RUST","version":0,"opaque":7,"flag":0,"remark":null,"extFields":null,"serializeTypeCurrentRPC":"JSON"}"#,
+    );
+    let empty = decode_json_header(
+        r#"{"code":1,"language":"RUST","version":0,"opaque":7,"flag":0,"remark":null,"extFields":{},"serializeTypeCurrentRPC":"JSON"}"#,
+    );
+
+    assert!(absent.remark().is_none());
+    assert!(absent.ext_fields().is_none());
+    assert!(null.remark().is_none());
+    assert!(null.ext_fields().is_none());
+    assert_eq!(empty.ext_fields(), Some(&HashMap::new()));
+}
+
+#[test]
+fn complete_malformed_frames_with_serialization_header_consume_only_the_declared_frame() {
+    let invalid_marked_header_length = complete_frame(
+        CanonicalRemotingCommand::mark_serialize_type(1, SerializeType::JSON),
+        &[],
+    );
+    let invalid_serialize_type = complete_frame(0x0200_0000, &[]);
+    let malformed_json = complete_frame_for(b"{", SerializeType::JSON);
+
+    let invalid_utf8 = binary_header(&[0x00, 0x01, 0xff, 0x00, 0x00, 0x00, 0x01, b'v']);
+    let truncated_key = binary_header(&[0x00, 0x02, b'k']);
+    let overlong_value = binary_header(&[0x00, 0x01, b'k', 0x00, 0x00, 0x00, 0x04, b'v']);
+    let malformed_binary = [
+        ("invalid UTF-8 extension field", invalid_utf8),
+        ("truncated extension-field key", truncated_key),
+        ("overlong extension-field value", overlong_value),
+    ];
+
+    assert_complete_frame_is_consumed_on_error("invalid marked header length", &invalid_marked_header_length);
+    assert_complete_frame_is_consumed_on_error("invalid serialization type", &invalid_serialize_type);
+    assert_complete_frame_is_consumed_on_error("malformed JSON header", &malformed_json);
+    for (name, header) in malformed_binary {
+        let frame = complete_frame_for(&header, SerializeType::ROCKETMQ);
+        assert_complete_frame_is_consumed_on_error(name, &frame);
+    }
+}
+
+#[test]
+fn complete_outer_frames_shorter_than_serialization_header_error_without_consumption() {
+    for announced_payload_size in 0_u8..=3 {
+        let payload = vec![0xa0 + announced_payload_size; announced_payload_size as usize];
+        let mut input = BytesMut::with_capacity(4 + payload.len() + TRAILING_BYTES.len());
+        input.put_i32(i32::from(announced_payload_size));
+        input.extend_from_slice(&payload);
+        input.extend_from_slice(TRAILING_BYTES);
+        let original = input.clone();
+
+        // Compatibility exception: a complete envelope shorter than the four-byte serialization
+        // header errors before the decoder splits the declared frame, so the full input is retained.
+        assert!(CanonicalRemotingCommand::decode(&mut input).is_err());
+        assert_eq!(input, original, "announced payload size {announced_payload_size}");
+    }
+}
+
+#[test]
+fn fallback_only_complete_json_frame_consumes_only_the_declared_frame() {
+    assert_eq!(&FALLBACK_ONLY_JSON_FRAME[8..], FALLBACK_ONLY_JSON_HEADER);
+    let mut input = BytesMut::with_capacity(FALLBACK_ONLY_JSON_FRAME.len() + TRAILING_BYTES.len());
+    input.extend_from_slice(FALLBACK_ONLY_JSON_FRAME);
+    input.extend_from_slice(TRAILING_BYTES);
+
+    let command = CanonicalRemotingCommand::decode(&mut input)
+        .expect("fallback-only complete JSON frame must decode")
+        .expect("fallback-only JSON frame must be complete");
+
+    assert_eq!(command.code(), 10);
+    assert_eq!(command.language(), LanguageCode::RUST);
+    assert_eq!(command.version(), 501);
+    assert_eq!(command.opaque(), 7);
+    assert_eq!(command.flag(), 0);
+    assert!(command.remark().is_none());
+    assert_eq!(
+        command.ext_fields(),
+        Some(&HashMap::from([("queueId".into(), "1".into())]))
+    );
+    assert!(command.body().is_none());
+    assert_eq!(command.get_serialize_type(), SerializeType::JSON);
+    assert_eq!(input.as_ref(), TRAILING_BYTES);
+}
+
+#[test]
+fn direct_header_decode_fallback_cursor_difference_is_recorded() {
+    let mut input = BytesMut::from(FALLBACK_ONLY_JSON_HEADER.as_slice());
+    let header_length = input.len();
+
+    let command = CanonicalRemotingCommand::header_decode(&mut input, header_length, SerializeType::JSON)
+        .expect("fallback-only JSON header must decode")
+        .expect("fallback-only JSON header must produce a command");
+
+    assert_eq!(command.code(), 10);
+    assert_eq!(command.language(), LanguageCode::RUST);
+    assert_eq!(command.version(), 501);
+    assert_eq!(command.opaque(), 7);
+    assert_eq!(command.flag(), 0);
+    assert!(command.remark().is_none());
+    assert_eq!(
+        command.ext_fields(),
+        Some(&HashMap::from([("queueId".into(), "1".into())]))
+    );
+    assert!(command.body().is_none());
+    assert_eq!(command.get_serialize_type(), SerializeType::JSON);
+
+    // Known compatibility debt: direct fallback decoding has feature-dependent cursor behavior.
+    // Outer `decode` parity, including trailing-byte preservation, is tested separately above.
+    #[cfg(not(feature = "simd"))]
+    assert_eq!(input.as_ref(), FALLBACK_ONLY_JSON_HEADER);
+    #[cfg(feature = "simd")]
+    assert!(input.is_empty());
+}
+
+#[test]
+fn incomplete_outer_frame_does_not_consume_or_modify_input() {
+    let mut input = BytesMut::from(&[0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x04, b'{'][..]);
+    let original = input.clone();
+
+    let decoded = CanonicalRemotingCommand::decode(&mut input).expect("incomplete frame must not be an error");
+
+    assert!(decoded.is_none());
+    assert_eq!(input, original);
+}

--- a/rocketmq-protocol/tests/remoting_wire_golden.rs
+++ b/rocketmq-protocol/tests/remoting_wire_golden.rs
@@ -19,10 +19,29 @@ use std::collections::HashMap;
 use bytes::Bytes;
 use bytes::BytesMut;
 use cheetah_string::CheetahString;
+use rocketmq_protocol::protocol::header::get_min_offset_request_header::GetMinOffsetRequestHeader;
+use rocketmq_protocol::protocol::header::notification_response_header::NotificationResponseHeader;
 use rocketmq_protocol::protocol::LanguageCode;
 use rocketmq_protocol::protocol::SerializeType;
 use rocketmq_protocol::EncodedFrame;
 use rocketmq_protocol::RemotingCommand;
+
+const JSON_REQUEST_FRAME: &[u8; 182] = b"\x00\x00\x00\xb2\x00\x00\x00\xac\
+{\"code\":31,\"language\":\"JAVA\",\"version\":321,\"opaque\":16909060,\"flag\":0,\"remark\":\"json-request\",\"extFields\":{\"queueId\":\"7\",\"topic\":\"TopicA\"},\"serializeTypeCurrentRPC\":\"JSON\"}JR";
+const JSON_RESPONSE_FRAME: &[u8; 178] = b"\x00\x00\x00\xae\x00\x00\x00\xa8\
+{\"code\":0,\"language\":\"RUST\",\"version\":322,\"opaque\":-1234567,\"flag\":1,\"remark\":null,\"extFields\":{\"hasMsg\":\"true\",\"pollingFull\":\"false\"},\"serializeTypeCurrentRPC\":\"JSON\"}JS";
+const ROCKETMQ_REQUEST_FRAME: &[u8; 77] = b"\
+\x00\x00\x00\x49\x01\x00\x00\x42\
+\x00\x1f\x00\x01\x43\x7f\xff\xff\xff\x00\x00\x00\x02\
+\x00\x00\x00\x0ebinary-request\
+\x00\x00\x00\x1f\x00\x07queueId\x00\x00\x00\x018\x00\x05topic\x00\x00\x00\x06TopicB\
+\x00\xffR";
+const ROCKETMQ_RESPONSE_FRAME: &[u8; 70] = b"\
+\x00\x00\x00\x42\x01\x00\x00\x3c\
+\x00\x00\x0c\x01\x44\x80\x00\x00\x00\x00\x00\x00\x03\
+\x00\x00\x00\x00\x00\x00\x00\x27\
+\x00\x06hasMsg\x00\x00\x00\x05false\
+\x00\x0bpollingFull\x00\x00\x00\x05falseBR";
 
 fn decode_hex_fixture(fixture: &str) -> Vec<u8> {
     let encoded = fixture
@@ -176,4 +195,190 @@ fn deterministic_remoting_cases_round_trip_without_trailing_bytes() {
             "seed={SEED:#018x} case={case}"
         );
     }
+}
+
+#[test]
+fn json_request_and_response_frames_match_exact_wire_bytes() {
+    let request = RemotingCommand::with_resolved_defaults(321, SerializeType::JSON)
+        .set_code(31)
+        .set_language(LanguageCode::JAVA)
+        .set_opaque(0x0102_0304)
+        .set_remark("json-request")
+        .set_command_custom_header(GetMinOffsetRequestHeader {
+            topic: "TopicA".into(),
+            queue_id: 7,
+            topic_request_header: None,
+        })
+        .set_body(Bytes::from_static(b"JR"));
+    let response = RemotingCommand::with_resolved_defaults(322, SerializeType::JSON)
+        .set_code(0)
+        .set_language(LanguageCode::RUST)
+        .set_opaque(-1_234_567)
+        .mark_response_type()
+        .set_command_custom_header(NotificationResponseHeader {
+            has_msg: true,
+            ..Default::default()
+        })
+        .set_body(Bytes::from_static(b"JS"));
+
+    let actual_request = EncodedFrame::from_command(request)
+        .expect("JSON request must encode")
+        .into_bytes();
+    let actual_response = EncodedFrame::from_command(response)
+        .expect("JSON response must encode")
+        .into_bytes();
+
+    assert_eq!(actual_request.as_ref(), JSON_REQUEST_FRAME);
+    assert_eq!(actual_response.as_ref(), JSON_RESPONSE_FRAME);
+    assert_eq!(&JSON_REQUEST_FRAME[4..8], &[0x00, 0x00, 0x00, 0xac]);
+    assert_eq!(&JSON_RESPONSE_FRAME[4..8], &[0x00, 0x00, 0x00, 0xa8]);
+
+    let mut request_input = BytesMut::from(JSON_REQUEST_FRAME.as_slice());
+    let request = RemotingCommand::decode(&mut request_input)
+        .expect("JSON request fixture must decode")
+        .expect("JSON request fixture must be complete");
+    assert!(request_input.is_empty());
+    assert_eq!(request.code(), 31);
+    assert_eq!(request.language(), LanguageCode::JAVA);
+    assert_eq!(request.version(), 321);
+    assert_eq!(request.opaque(), 0x0102_0304);
+    assert_eq!(request.flag(), 0);
+    assert_eq!(request.remark().map(CheetahString::as_str), Some("json-request"));
+    assert_eq!(
+        request.ext_fields(),
+        Some(&HashMap::from([
+            (CheetahString::from("queueId"), CheetahString::from("7")),
+            (CheetahString::from("topic"), CheetahString::from("TopicA")),
+        ]))
+    );
+    assert_eq!(request.body().map(Bytes::as_ref), Some(b"JR".as_slice()));
+    assert_eq!(request.get_serialize_type(), SerializeType::JSON);
+    let header = request
+        .decode_command_custom_header::<GetMinOffsetRequestHeader>()
+        .expect("typed JSON request header must decode");
+    assert_eq!(header.topic, "TopicA");
+    assert_eq!(header.queue_id, 7);
+
+    let mut response_input = BytesMut::from(JSON_RESPONSE_FRAME.as_slice());
+    let response = RemotingCommand::decode(&mut response_input)
+        .expect("JSON response fixture must decode")
+        .expect("JSON response fixture must be complete");
+    assert!(response_input.is_empty());
+    assert_eq!(response.code(), 0);
+    assert_eq!(response.language(), LanguageCode::RUST);
+    assert_eq!(response.version(), 322);
+    assert_eq!(response.opaque(), -1_234_567);
+    assert_eq!(response.flag(), 1);
+    assert!(response.is_response_type());
+    assert!(!response.is_oneway_rpc());
+    assert!(response.remark().is_none());
+    assert_eq!(
+        response.ext_fields(),
+        Some(&HashMap::from([
+            (CheetahString::from("hasMsg"), CheetahString::from("true")),
+            (CheetahString::from("pollingFull"), CheetahString::from("false"),),
+        ]))
+    );
+    assert_eq!(response.body().map(Bytes::as_ref), Some(b"JS".as_slice()));
+    assert_eq!(response.get_serialize_type(), SerializeType::JSON);
+    let header = response
+        .decode_command_custom_header::<NotificationResponseHeader>()
+        .expect("typed JSON response header must decode");
+    assert!(header.has_msg);
+    assert!(!header.polling_full);
+}
+
+#[test]
+fn rocketmq_request_and_response_frames_match_exact_wire_bytes() {
+    let request = RemotingCommand::with_resolved_defaults(323, SerializeType::ROCKETMQ)
+        .set_code(31)
+        .set_language(LanguageCode::JAVA)
+        .set_opaque(i32::MAX)
+        .mark_oneway_rpc()
+        .set_remark("binary-request")
+        .set_command_custom_header(GetMinOffsetRequestHeader {
+            topic: "TopicB".into(),
+            queue_id: 8,
+            topic_request_header: None,
+        })
+        .set_body(Bytes::from_static(&[0x00, 0xff, 0x52]));
+    let response = RemotingCommand::with_resolved_defaults(324, SerializeType::ROCKETMQ)
+        .set_code(0)
+        .set_language(LanguageCode::RUST)
+        .set_opaque(i32::MIN)
+        .mark_response_type()
+        .mark_oneway_rpc()
+        .set_command_custom_header(NotificationResponseHeader {
+            has_msg: false,
+            ..Default::default()
+        })
+        .set_body(Bytes::from_static(b"BR"));
+
+    let actual_request = EncodedFrame::from_command(request)
+        .expect("ROCKETMQ request must encode")
+        .into_bytes();
+    let actual_response = EncodedFrame::from_command(response)
+        .expect("ROCKETMQ response must encode")
+        .into_bytes();
+
+    assert_eq!(actual_request.as_ref(), ROCKETMQ_REQUEST_FRAME);
+    assert_eq!(actual_response.as_ref(), ROCKETMQ_RESPONSE_FRAME);
+    assert_eq!(&ROCKETMQ_REQUEST_FRAME[4..8], &[0x01, 0x00, 0x00, 0x42]);
+    assert_eq!(&ROCKETMQ_RESPONSE_FRAME[4..8], &[0x01, 0x00, 0x00, 0x3c]);
+
+    let mut request_input = BytesMut::from(ROCKETMQ_REQUEST_FRAME.as_slice());
+    let request = RemotingCommand::decode(&mut request_input)
+        .expect("ROCKETMQ request fixture must decode")
+        .expect("ROCKETMQ request fixture must be complete");
+    assert!(request_input.is_empty());
+    assert_eq!(request.code(), 31);
+    assert_eq!(request.language(), LanguageCode::JAVA);
+    assert_eq!(request.version(), 323);
+    assert_eq!(request.opaque(), i32::MAX);
+    assert_eq!(request.flag(), 2);
+    assert!(!request.is_response_type());
+    assert!(request.is_oneway_rpc());
+    assert_eq!(request.remark().map(CheetahString::as_str), Some("binary-request"));
+    assert_eq!(
+        request.ext_fields(),
+        Some(&HashMap::from([
+            (CheetahString::from("queueId"), CheetahString::from("8")),
+            (CheetahString::from("topic"), CheetahString::from("TopicB")),
+        ]))
+    );
+    assert_eq!(request.body().map(Bytes::as_ref), Some([0x00, 0xff, 0x52].as_slice()));
+    assert_eq!(request.get_serialize_type(), SerializeType::ROCKETMQ);
+    let header = request
+        .decode_command_custom_header::<GetMinOffsetRequestHeader>()
+        .expect("typed ROCKETMQ request header must decode");
+    assert_eq!(header.topic, "TopicB");
+    assert_eq!(header.queue_id, 8);
+
+    let mut response_input = BytesMut::from(ROCKETMQ_RESPONSE_FRAME.as_slice());
+    let response = RemotingCommand::decode(&mut response_input)
+        .expect("ROCKETMQ response fixture must decode")
+        .expect("ROCKETMQ response fixture must be complete");
+    assert!(response_input.is_empty());
+    assert_eq!(response.code(), 0);
+    assert_eq!(response.language(), LanguageCode::RUST);
+    assert_eq!(response.version(), 324);
+    assert_eq!(response.opaque(), i32::MIN);
+    assert_eq!(response.flag(), 3);
+    assert!(response.is_response_type());
+    assert!(response.is_oneway_rpc());
+    assert!(response.remark().is_none());
+    assert_eq!(
+        response.ext_fields(),
+        Some(&HashMap::from([
+            (CheetahString::from("hasMsg"), CheetahString::from("false")),
+            (CheetahString::from("pollingFull"), CheetahString::from("false"),),
+        ]))
+    );
+    assert_eq!(response.body().map(Bytes::as_ref), Some(b"BR".as_slice()));
+    assert_eq!(response.get_serialize_type(), SerializeType::ROCKETMQ);
+    let header = response
+        .decode_command_custom_header::<NotificationResponseHeader>()
+        .expect("typed ROCKETMQ response header must decode");
+    assert!(!header.has_msg);
+    assert!(!header.polling_full);
 }

--- a/rocketmq-transport/tests/public_api_contract.rs
+++ b/rocketmq-transport/tests/public_api_contract.rs
@@ -12,61 +12,850 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::time::Duration;
+
 use rocketmq_transport::api::v1::AdmissionLimits;
+use rocketmq_transport::api::v1::DefaultRequestProcessor;
 use rocketmq_transport::api::v1::FileTransferMode;
 use rocketmq_transport::api::v1::FrameLimits;
 use rocketmq_transport::api::v1::OneShotTransportClient;
+use rocketmq_transport::api::v1::RemotingClient;
+use rocketmq_transport::api::v1::RemotingDeserializable;
+use rocketmq_transport::api::v1::RemotingSerializable;
+use rocketmq_transport::api::v1::RequestDeadline;
+use rocketmq_transport::api::v1::RequestProcessor;
 use rocketmq_transport::api::v1::ServerConfig;
+use rocketmq_transport::api::v1::TransportClient;
 use rocketmq_transport::api::v1::TransportClientConfig;
+use rocketmq_transport::api::v1::TransportServer;
 
-#[test]
-fn transport_consumers_use_only_versioned_capabilities_and_dtos() {
-    let source = include_str!("../src/lib.rs");
-    assert!(
-        source.lines().all(|line| {
-            let line = line.trim_start();
-            !line.starts_with("pub use ") || line == "pub use crate::public_api::*;"
-        }),
-        "crate-root re-exports bypass the versioned `api::v1` compatibility boundary"
-    );
-    assert!(source.contains("pub mod api {"));
-    assert!(source.contains("pub mod v1 {"));
-    assert!(source.contains("pub use crate::public_api::*;"));
+fn assert_serialization_contract<T: RemotingSerializable + RemotingDeserializable>() {}
 
-    for module in [
-        "admission",
-        "base",
-        "buffer",
-        "client",
-        "clients",
-        "codec",
-        "common",
-        "config",
-        "config_support",
-        "connection",
-        "connection_context",
-        "deadline",
-        "discovery",
-        "error_helpers",
-        "error_response",
-        "local",
-        "net",
-        "remoting",
-        "remoting_server",
-        "request_processor",
-        "rpc",
-        "runtime",
-        "security",
-        "server",
-        "smart_encode_buffer",
-        "tls",
-    ] {
-        assert!(
-            !source.contains(&format!("pub mod {module};")),
-            "`rocketmq-transport` implementation module `{module}` must remain private"
-        );
+fn assert_processor_contract<T: RequestProcessor>() {}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum TokenKind {
+    Ident(String),
+    ColonColon,
+    Semi,
+    Star,
+    Comma,
+    Hash,
+    Bang,
+    LBrace,
+    RBrace,
+    LParen,
+    RParen,
+    LBracket,
+    RBracket,
+    Other(char),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct Token {
+    kind: TokenKind,
+    offset: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct SurfaceError {
+    offset: usize,
+    message: &'static str,
+}
+
+impl std::fmt::Display for SurfaceError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{} at byte {}", self.message, self.offset)
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct PublicUse {
+    module_path: String,
+    use_tree: String,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct PublicBoundary {
+    modules: Vec<String>,
+    uses: Vec<PublicUse>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Visibility {
+    Private,
+    Restricted,
+    Public,
+}
+
+#[derive(Debug)]
+enum Scope {
+    Module { name: String, externally_public: bool },
+    Other,
+}
+
+fn surface_error(offset: usize, message: &'static str) -> SurfaceError {
+    SurfaceError { offset, message }
+}
+
+fn scan_quoted_literal(bytes: &[u8], quote: usize, message: &'static str) -> Result<usize, SurfaceError> {
+    let mut cursor = quote + 1;
+    while cursor < bytes.len() {
+        match bytes[cursor] {
+            b'\\' => cursor = cursor.saturating_add(2),
+            b'"' => return Ok(cursor + 1),
+            _ => cursor += 1,
+        }
+    }
+    Err(surface_error(quote, message))
+}
+
+fn raw_string_open(bytes: &[u8], start: usize, prefix_bytes: usize) -> Option<(usize, usize)> {
+    let mut cursor = start + prefix_bytes;
+    let mut hashes = 0;
+    while bytes.get(cursor) == Some(&b'#') {
+        hashes += 1;
+        cursor += 1;
+    }
+    (bytes.get(cursor) == Some(&b'"')).then_some((cursor + 1, hashes))
+}
+
+fn scan_raw_string(bytes: &[u8], start: usize, content_start: usize, hashes: usize) -> Result<usize, SurfaceError> {
+    let mut cursor = content_start;
+    while cursor < bytes.len() {
+        if bytes[cursor] == b'"' {
+            let hashes_end = cursor + 1 + hashes;
+            if bytes
+                .get(cursor + 1..hashes_end)
+                .is_some_and(|closing| closing.iter().all(|byte| *byte == b'#'))
+            {
+                return Ok(hashes_end);
+            }
+        }
+        cursor += 1;
+    }
+    Err(surface_error(start, "unterminated raw string literal"))
+}
+
+fn char_literal_end(source: &str, quote: usize) -> Option<usize> {
+    let bytes = source.as_bytes();
+    let content = quote + 1;
+    let content_end = if bytes.get(content) == Some(&b'\\') {
+        match bytes.get(content + 1) {
+            Some(b'u') if bytes.get(content + 2) == Some(&b'{') => {
+                content + 3 + bytes.get(content + 3..)?.iter().position(|byte| *byte == b'}')? + 1
+            }
+            Some(b'x') => content.checked_add(4)?,
+            Some(_) => content.checked_add(2)?,
+            None => return None,
+        }
+    } else {
+        let character = source.get(content..)?.chars().next()?;
+        if matches!(character, '\n' | '\r' | '\'') {
+            return None;
+        }
+        content + character.len_utf8()
+    };
+    (bytes.get(content_end) == Some(&b'\'')).then_some(content_end + 1)
+}
+
+fn is_rust_pattern_whitespace(character: char) -> bool {
+    matches!(
+        character,
+        '\u{0009}'..='\u{000d}' | '\u{0020}' | '\u{0085}' | '\u{200e}' | '\u{200f}' | '\u{2028}' | '\u{2029}'
+    )
+}
+
+fn tokenize(source: &str) -> Result<Vec<Token>, SurfaceError> {
+    let bytes = source.as_bytes();
+    let mut tokens = Vec::new();
+    let mut cursor = 0;
+
+    while cursor < bytes.len() {
+        let character = source
+            .get(cursor..)
+            .and_then(|remaining| remaining.chars().next())
+            .ok_or_else(|| surface_error(cursor, "tokenizer cursor is not on a UTF-8 boundary"))?;
+        if is_rust_pattern_whitespace(character) {
+            cursor += character.len_utf8();
+            continue;
+        }
+        if bytes.get(cursor..cursor + 2) == Some(b"//") {
+            cursor += 2;
+            while cursor < bytes.len() && bytes[cursor] != b'\n' {
+                cursor += 1;
+            }
+            continue;
+        }
+        if bytes.get(cursor..cursor + 2) == Some(b"/*") {
+            let comment_start = cursor;
+            let mut depth = 1_usize;
+            cursor += 2;
+            while cursor < bytes.len() && depth != 0 {
+                if bytes.get(cursor..cursor + 2) == Some(b"/*") {
+                    depth += 1;
+                    cursor += 2;
+                } else if bytes.get(cursor..cursor + 2) == Some(b"*/") {
+                    depth -= 1;
+                    cursor += 2;
+                } else {
+                    cursor += 1;
+                }
+            }
+            if depth != 0 {
+                return Err(surface_error(comment_start, "unterminated block comment"));
+            }
+            continue;
+        }
+
+        if bytes.get(cursor..cursor + 2) == Some(b"br") {
+            if let Some((content_start, hashes)) = raw_string_open(bytes, cursor, 2) {
+                cursor = scan_raw_string(bytes, cursor, content_start, hashes)?;
+                continue;
+            }
+        }
+        if bytes.get(cursor..cursor + 2) == Some(b"cr") {
+            if let Some((content_start, hashes)) = raw_string_open(bytes, cursor, 2) {
+                cursor = scan_raw_string(bytes, cursor, content_start, hashes)?;
+                continue;
+            }
+        }
+        if bytes[cursor] == b'r' {
+            if let Some((content_start, hashes)) = raw_string_open(bytes, cursor, 1) {
+                cursor = scan_raw_string(bytes, cursor, content_start, hashes)?;
+                continue;
+            }
+        }
+        if bytes.get(cursor..cursor + 2) == Some(b"b\"") {
+            cursor = scan_quoted_literal(bytes, cursor + 1, "unterminated byte string literal")?;
+            continue;
+        }
+        if bytes[cursor] == b'"' {
+            cursor = scan_quoted_literal(bytes, cursor, "unterminated string literal")?;
+            continue;
+        }
+        if bytes.get(cursor..cursor + 2) == Some(b"b'") {
+            if let Some(end) = char_literal_end(source, cursor + 1) {
+                cursor = end;
+                continue;
+            }
+        }
+        if bytes[cursor] == b'\'' {
+            if let Some(end) = char_literal_end(source, cursor) {
+                cursor = end;
+                continue;
+            }
+        }
+
+        let offset = cursor;
+        let kind = if bytes[cursor].is_ascii_alphabetic() || bytes[cursor] == b'_' {
+            cursor += 1;
+            while cursor < bytes.len() && (bytes[cursor].is_ascii_alphanumeric() || bytes[cursor] == b'_') {
+                cursor += 1;
+            }
+            TokenKind::Ident(source[offset..cursor].to_owned())
+        } else if bytes.get(cursor..cursor + 2) == Some(b"::") {
+            cursor += 2;
+            TokenKind::ColonColon
+        } else if character.is_ascii() {
+            cursor += 1;
+            match character as u8 {
+                b';' => TokenKind::Semi,
+                b'*' => TokenKind::Star,
+                b',' => TokenKind::Comma,
+                b'#' => TokenKind::Hash,
+                b'!' => TokenKind::Bang,
+                b'{' => TokenKind::LBrace,
+                b'}' => TokenKind::RBrace,
+                b'(' => TokenKind::LParen,
+                b')' => TokenKind::RParen,
+                b'[' => TokenKind::LBracket,
+                b']' => TokenKind::RBracket,
+                other => TokenKind::Other(other as char),
+            }
+        } else {
+            cursor += character.len_utf8();
+            TokenKind::Other(character)
+        };
+        tokens.push(Token { kind, offset });
     }
 
+    Ok(tokens)
+}
+
+fn closing_delimiter(kind: &TokenKind) -> Option<TokenKind> {
+    match kind {
+        TokenKind::LBrace => Some(TokenKind::RBrace),
+        TokenKind::LParen => Some(TokenKind::RParen),
+        TokenKind::LBracket => Some(TokenKind::RBracket),
+        _ => None,
+    }
+}
+
+fn skip_balanced(tokens: &[Token], opening: usize) -> Result<usize, SurfaceError> {
+    let mut expected = vec![closing_delimiter(&tokens[opening].kind)
+        .ok_or_else(|| surface_error(tokens[opening].offset, "expected an opening delimiter"))?];
+    let mut cursor = opening + 1;
+    while cursor < tokens.len() {
+        if let Some(closing) = closing_delimiter(&tokens[cursor].kind) {
+            expected.push(closing);
+        } else if matches!(
+            tokens[cursor].kind,
+            TokenKind::RBrace | TokenKind::RParen | TokenKind::RBracket
+        ) {
+            if expected.last() != Some(&tokens[cursor].kind) {
+                return Err(surface_error(tokens[cursor].offset, "mismatched delimiter"));
+            }
+            expected.pop();
+            if expected.is_empty() {
+                return Ok(cursor + 1);
+            }
+        }
+        cursor += 1;
+    }
+    Err(surface_error(tokens[opening].offset, "unterminated delimiter"))
+}
+
+fn skip_attribute(tokens: &[Token], start: usize) -> Result<Option<usize>, SurfaceError> {
+    if !matches!(tokens[start].kind, TokenKind::Hash) {
+        return Ok(None);
+    }
+    let mut bracket = start + 1;
+    if tokens
+        .get(bracket)
+        .is_some_and(|token| matches!(token.kind, TokenKind::Bang))
+    {
+        bracket += 1;
+    }
+    if tokens
+        .get(bracket)
+        .is_none_or(|token| !matches!(token.kind, TokenKind::LBracket))
+    {
+        return Ok(None);
+    }
+    skip_balanced(tokens, bracket).map(Some)
+}
+
+fn is_ident(token: Option<&Token>, expected: &str) -> bool {
+    token.is_some_and(|token| matches!(&token.kind, TokenKind::Ident(actual) if actual == expected))
+}
+
+fn is_macro_invocation(tokens: &[Token], start: usize) -> bool {
+    let mut cursor = start;
+    if tokens
+        .get(cursor)
+        .is_some_and(|token| matches!(token.kind, TokenKind::ColonColon))
+    {
+        cursor += 1;
+    }
+    if !tokens
+        .get(cursor)
+        .is_some_and(|token| matches!(token.kind, TokenKind::Ident(_)))
+    {
+        return false;
+    }
+    cursor += 1;
+    while tokens
+        .get(cursor)
+        .is_some_and(|token| matches!(token.kind, TokenKind::ColonColon))
+    {
+        cursor += 1;
+        if !tokens
+            .get(cursor)
+            .is_some_and(|token| matches!(token.kind, TokenKind::Ident(_)))
+        {
+            return false;
+        }
+        cursor += 1;
+    }
+    tokens
+        .get(cursor)
+        .is_some_and(|token| matches!(token.kind, TokenKind::Bang))
+        && tokens
+            .get(cursor + 1)
+            .is_some_and(|token| matches!(token.kind, TokenKind::LBrace | TokenKind::LParen | TokenKind::LBracket))
+}
+
+fn parse_visibility(tokens: &[Token], start: usize) -> Result<(Visibility, usize), SurfaceError> {
+    if !is_ident(tokens.get(start), "pub") {
+        return Ok((Visibility::Private, start));
+    }
+    if tokens
+        .get(start + 1)
+        .is_some_and(|token| matches!(token.kind, TokenKind::LParen))
+    {
+        return Ok((Visibility::Restricted, skip_balanced(tokens, start + 1)?));
+    }
+    Ok((Visibility::Public, start + 1))
+}
+
+struct ModuleDeclaration<'a> {
+    visibility: Visibility,
+    name: &'a str,
+    terminator: usize,
+    inline: bool,
+}
+
+fn parse_module_declaration<'a>(
+    tokens: &'a [Token],
+    start: usize,
+) -> Result<Option<ModuleDeclaration<'a>>, SurfaceError> {
+    let (visibility, module) = parse_visibility(tokens, start)?;
+    if !is_ident(tokens.get(module), "mod") {
+        return Ok(None);
+    }
+    let name_token = tokens
+        .get(module + 1)
+        .ok_or_else(|| surface_error(tokens[module].offset, "module declaration is missing a name"))?;
+    let TokenKind::Ident(name) = &name_token.kind else {
+        return Err(surface_error(name_token.offset, "module declaration is missing a name"));
+    };
+    let terminator = module + 2;
+    let inline = match tokens.get(terminator).map(|token| &token.kind) {
+        Some(TokenKind::Semi) => false,
+        Some(TokenKind::LBrace) => true,
+        Some(_) => {
+            return Err(surface_error(
+                tokens[terminator].offset,
+                "module declaration is missing its terminator",
+            ))
+        }
+        None => {
+            return Err(surface_error(
+                name_token.offset,
+                "module declaration is missing its terminator",
+            ))
+        }
+    };
+    Ok(Some(ModuleDeclaration {
+        visibility,
+        name,
+        terminator,
+        inline,
+    }))
+}
+
+fn normalized_use_tree(tokens: &[Token]) -> String {
+    let mut normalized = String::new();
+    for token in tokens {
+        match &token.kind {
+            TokenKind::Ident(identifier) => normalized.push_str(identifier),
+            TokenKind::ColonColon => normalized.push_str("::"),
+            TokenKind::Star => normalized.push('*'),
+            TokenKind::Comma => normalized.push(','),
+            TokenKind::LBrace => normalized.push('{'),
+            TokenKind::RBrace => normalized.push('}'),
+            TokenKind::LParen => normalized.push('('),
+            TokenKind::RParen => normalized.push(')'),
+            TokenKind::LBracket => normalized.push('['),
+            TokenKind::RBracket => normalized.push(']'),
+            TokenKind::Hash => normalized.push('#'),
+            TokenKind::Bang => normalized.push('!'),
+            TokenKind::Other(character) => normalized.push(*character),
+            TokenKind::Semi => normalized.push(';'),
+        }
+    }
+    normalized
+}
+
+struct UseDeclaration {
+    visibility: Visibility,
+    use_tree: String,
+    end: usize,
+}
+
+fn parse_use_declaration(tokens: &[Token], start: usize) -> Result<Option<UseDeclaration>, SurfaceError> {
+    let (visibility, use_keyword) = parse_visibility(tokens, start)?;
+    if !is_ident(tokens.get(use_keyword), "use") {
+        return Ok(None);
+    }
+    let tree_start = use_keyword + 1;
+    let mut cursor = tree_start;
+    let mut delimiters = Vec::new();
+    while cursor < tokens.len() {
+        if let Some(closing) = closing_delimiter(&tokens[cursor].kind) {
+            delimiters.push(closing);
+        } else if matches!(
+            tokens[cursor].kind,
+            TokenKind::RBrace | TokenKind::RParen | TokenKind::RBracket
+        ) {
+            if delimiters.last() != Some(&tokens[cursor].kind) {
+                return Err(surface_error(tokens[cursor].offset, "mismatched delimiter in use tree"));
+            }
+            delimiters.pop();
+        } else if matches!(tokens[cursor].kind, TokenKind::Semi) && delimiters.is_empty() {
+            return Ok(Some(UseDeclaration {
+                visibility,
+                use_tree: normalized_use_tree(&tokens[tree_start..cursor]),
+                end: cursor + 1,
+            }));
+        }
+        cursor += 1;
+    }
+    Err(surface_error(
+        tokens[use_keyword].offset,
+        "use declaration is missing its semicolon",
+    ))
+}
+
+fn module_path(scopes: &[Scope]) -> String {
+    scopes
+        .iter()
+        .filter_map(|scope| match scope {
+            Scope::Module { name, .. } => Some(name.as_str()),
+            Scope::Other => None,
+        })
+        .collect::<Vec<_>>()
+        .join("::")
+}
+
+fn parent_is_externally_public(scopes: &[Scope]) -> bool {
+    scopes.iter().all(|scope| {
+        matches!(
+            scope,
+            Scope::Module {
+                externally_public: true,
+                ..
+            }
+        )
+    })
+}
+
+fn inspect_public_boundary(source: &str) -> Result<PublicBoundary, SurfaceError> {
+    let tokens = tokenize(source)?;
+    let mut modules = Vec::new();
+    let mut uses = Vec::new();
+    let mut scopes = Vec::new();
+    let mut cursor = 0;
+
+    while cursor < tokens.len() {
+        if let Some(after_attribute) = skip_attribute(&tokens, cursor)? {
+            cursor = after_attribute;
+            continue;
+        }
+
+        let at_module_scope = scopes.iter().all(|scope| matches!(scope, Scope::Module { .. }));
+        if at_module_scope {
+            if parent_is_externally_public(&scopes) && is_macro_invocation(&tokens, cursor) {
+                return Err(surface_error(
+                    tokens[cursor].offset,
+                    "macro invocation at an externally public module scope is unsupported",
+                ));
+            }
+            if let Some(declaration) = parse_module_declaration(&tokens, cursor)? {
+                let externally_public =
+                    parent_is_externally_public(&scopes) && declaration.visibility == Visibility::Public;
+                if externally_public {
+                    let parent = module_path(&scopes);
+                    modules.push(if parent.is_empty() {
+                        declaration.name.to_owned()
+                    } else {
+                        format!("{parent}::{}", declaration.name)
+                    });
+                }
+                if declaration.inline {
+                    scopes.push(Scope::Module {
+                        name: declaration.name.to_owned(),
+                        externally_public,
+                    });
+                }
+                cursor = declaration.terminator + 1;
+                continue;
+            }
+            if let Some(declaration) = parse_use_declaration(&tokens, cursor)? {
+                if parent_is_externally_public(&scopes) && declaration.visibility == Visibility::Public {
+                    uses.push(PublicUse {
+                        module_path: module_path(&scopes),
+                        use_tree: declaration.use_tree,
+                    });
+                }
+                cursor = declaration.end;
+                continue;
+            }
+        }
+
+        match tokens[cursor].kind {
+            TokenKind::LBrace => scopes.push(Scope::Other),
+            TokenKind::RBrace => {
+                scopes
+                    .pop()
+                    .ok_or_else(|| surface_error(tokens[cursor].offset, "unmatched closing brace"))?;
+            }
+            _ => {}
+        }
+        cursor += 1;
+    }
+
+    if !scopes.is_empty() {
+        return Err(surface_error(source.len(), "unclosed brace scope"));
+    }
+    modules.sort();
+    Ok(PublicBoundary { modules, uses })
+}
+
+fn validate_public_boundary(boundary: &PublicBoundary) -> Result<(), String> {
+    let expected_modules = ["api", "api::v1", "benchmark_support", "prelude", "test_support"];
+    if boundary.modules != expected_modules {
+        return Err(format!("unexpected public modules: {:?}", boundary.modules));
+    }
+    let top_level_modules = boundary
+        .modules
+        .iter()
+        .filter(|path| !path.contains("::"))
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    if top_level_modules != ["api", "benchmark_support", "prelude", "test_support"] {
+        return Err(format!("unexpected top-level public modules: {top_level_modules:?}"));
+    }
+    let v1_modules = boundary
+        .modules
+        .iter()
+        .filter(|path| path.rsplit("::").next() == Some("v1"))
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    if v1_modules != ["api::v1"] {
+        return Err(format!("unexpected public v1 modules: {v1_modules:?}"));
+    }
+    let expected_uses = [PublicUse {
+        module_path: "api::v1".to_owned(),
+        use_tree: "crate::public_api::*".to_owned(),
+    }];
+    if boundary.uses != expected_uses {
+        return Err(format!("unexpected public uses: {:?}", boundary.uses));
+    }
+    Ok(())
+}
+
+#[test]
+fn lib_rs_exposes_only_the_curated_versioned_boundary() {
+    let boundary = inspect_public_boundary(include_str!("../src/lib.rs")).expect("lib.rs must tokenize and parse");
+    validate_public_boundary(&boundary).expect("lib.rs must expose only the curated public boundary");
+}
+
+#[test]
+fn root_glob_with_attribute_and_comment_split_is_rejected() {
+    let boundary = inspect_public_boundary("#[rustfmt::skip] pub /* boundary */ use crate::public_api::*;")
+        .expect("fixture must parse");
+
+    assert_eq!(
+        boundary.uses,
+        [PublicUse {
+            module_path: String::new(),
+            use_tree: "crate::public_api::*".to_owned(),
+        }]
+    );
+    assert!(validate_public_boundary(&boundary).is_err());
+}
+
+#[test]
+fn comment_split_public_module_is_detected_and_rejected() {
+    let boundary = inspect_public_boundary("pub /* boundary */ mod leaked {}").expect("fixture must parse");
+
+    assert_eq!(boundary.modules, ["leaked"]);
+    assert!(validate_public_boundary(&boundary).is_err());
+}
+
+#[test]
+fn rust_pattern_whitespace_between_public_keywords_is_detected() {
+    const LEFT_TO_RIGHT_MARK: char = '\u{200e}';
+    let mut encoded = [0_u8; 4];
+    assert_eq!(
+        LEFT_TO_RIGHT_MARK.encode_utf8(&mut encoded).as_bytes(),
+        &[0xe2, 0x80, 0x8e]
+    );
+
+    let root_glob_source = format!("pub{LEFT_TO_RIGHT_MARK}use crate::public_api::*;");
+    let boundary = inspect_public_boundary(&root_glob_source).expect("root glob fixture must parse");
+    assert_eq!(
+        boundary.uses,
+        [PublicUse {
+            module_path: String::new(),
+            use_tree: "crate::public_api::*".to_owned(),
+        }]
+    );
+    assert!(validate_public_boundary(&boundary).is_err());
+
+    let public_module_source = format!("pub{LEFT_TO_RIGHT_MARK}mod leaked {{}}");
+    let boundary = inspect_public_boundary(&public_module_source).expect("public module fixture must parse");
+    assert_eq!(boundary.modules, ["leaked"]);
+    assert!(validate_public_boundary(&boundary).is_err());
+}
+
+#[test]
+fn nested_block_comment_before_forbidden_item_is_skipped() {
+    let boundary =
+        inspect_public_boundary("/* outer /* nested pub mod fake {} */ still outer */ pub use crate::leaked::*;")
+            .expect("fixture must parse");
+
+    assert_eq!(
+        boundary.uses,
+        [PublicUse {
+            module_path: String::new(),
+            use_tree: "crate::leaked::*".to_owned(),
+        }]
+    );
+    assert!(validate_public_boundary(&boundary).is_err());
+}
+
+#[test]
+fn literal_contents_do_not_corrupt_module_context() {
+    let source = r####"
+const NORMAL: &str = "}\
+pub mod fake_normal {}
+pub use crate::fake_normal::*; \" pub mod fake_escaped {} {";
+const RAW: &str = r###"} pub mod fake_raw {} pub use crate::fake_raw::*; {"###;
+const BYTES: &[u8] = b"} pub mod fake_bytes {} {";
+const RAW_BYTES: &[u8] = br##"} pub use crate::fake_raw_bytes::*; {"##;
+const CHARACTER: char = '}';
+const BYTE_CHARACTER: u8 = b'{';
+pub mod benchmark_support;
+pub mod prelude;
+pub mod test_support;
+pub mod api { pub mod v1 { pub use crate::public_api::*; } }
+"####;
+    let boundary = inspect_public_boundary(source).expect("literal fixture must parse");
+
+    validate_public_boundary(&boundary).expect("literal contents must not affect the public boundary");
+}
+
+#[test]
+fn raw_c_literal_braces_do_not_hide_unexpected_public_module() {
+    let source = r#####"
+const _: &std::ffi::CStr = cr####"} pub mod fake {} {"####;
+const _: &std::ffi::CStr = cr#"" { ""#; pub mod leaked {} const _: &std::ffi::CStr = cr#"" } ""#;
+mod public_api {}
+pub mod benchmark_support {}
+pub mod prelude {}
+pub mod test_support {}
+pub mod api { pub mod v1 { pub use crate::public_api::*; } }
+"#####;
+    let boundary = inspect_public_boundary(source).expect("raw C string fixture must parse");
+
+    assert_eq!(
+        boundary.modules,
+        [
+            "api",
+            "api::v1",
+            "benchmark_support",
+            "leaked",
+            "prelude",
+            "test_support"
+        ]
+    );
+    assert_eq!(
+        boundary.uses,
+        [PublicUse {
+            module_path: "api::v1".to_owned(),
+            use_tree: "crate::public_api::*".to_owned(),
+        }]
+    );
+    assert!(validate_public_boundary(&boundary).is_err());
+}
+
+#[test]
+fn root_macro_invocation_that_expands_a_public_module_is_rejected() {
+    let source = r#"
+macro_rules! expose_module { () => { pub mod leaked {} }; }
+expose_module!();
+mod public_api {}
+pub mod benchmark_support {}
+pub mod prelude {}
+pub mod test_support {}
+pub mod api { pub mod v1 { pub use crate::public_api::*; } }
+"#;
+    let error = inspect_public_boundary(source).expect_err("root macro invocation must be rejected");
+
+    assert_eq!(
+        error.message,
+        "macro invocation at an externally public module scope is unsupported"
+    );
+    assert_eq!(
+        error.offset,
+        source
+            .find("expose_module!();")
+            .expect("fixture must contain the invocation")
+    );
+}
+
+#[test]
+fn public_api_macro_invocation_that_expands_a_public_use_is_rejected() {
+    let source = r#"
+mod hidden { pub struct Hidden; }
+macro_rules! expose_hidden { () => { pub use crate::hidden::*; }; }
+mod public_api {}
+pub mod benchmark_support {}
+pub mod prelude {}
+pub mod test_support {}
+pub mod api { pub mod v1 { expose_hidden!(); pub use crate::public_api::*; } }
+"#;
+    let error = inspect_public_boundary(source).expect_err("api::v1 macro invocation must be rejected");
+
+    assert_eq!(
+        error.message,
+        "macro invocation at an externally public module scope is unsupported"
+    );
+    assert_eq!(
+        error.offset,
+        source
+            .find("expose_hidden!();")
+            .expect("fixture must contain the invocation")
+    );
+}
+
+#[test]
+fn macro_definition_and_isolated_private_invocation_do_not_corrupt_public_scope() {
+    let source = r#"
+macro_rules! private_items { ($($item:item)*) => {}; }
+mod isolated { private_items! { pub mod fake {} } }
+mod public_api {}
+pub mod benchmark_support {}
+pub mod prelude {}
+pub mod test_support {}
+pub mod api { pub mod v1 { pub use crate::public_api::*; } }
+"#;
+    let boundary = inspect_public_boundary(source).expect("private macro fixture must parse");
+
+    validate_public_boundary(&boundary).expect("isolated private macros must not affect the public boundary");
+}
+
+#[test]
+fn attributes_and_multiple_items_per_line_are_parsed_structurally() {
+    let source = r#"
+#[cfg(feature = "test-support")] pub mod benchmark_support; #[doc = "pub mod fake_doc {}"] pub mod prelude;
+#[cfg(any(test, feature = "test-support"))] pub mod test_support; #[rustfmt::skip] pub mod api { #[allow(dead_code)] pub mod v1 { pub use crate /* path */ :: public_api /* glob */ :: * ; } }
+"#;
+    let boundary = inspect_public_boundary(source).expect("attribute fixture must parse");
+
+    validate_public_boundary(&boundary).expect("attributes and item layout must not affect the public boundary");
+}
+
+#[test]
+fn restricted_visibility_is_not_externally_public() {
+    let source = "pub(crate) mod internal; pub(in crate) use crate::internal::*; mod private { pub mod nested {} pub use crate::nested::*; }";
+    let boundary = inspect_public_boundary(source).expect("restricted fixture must parse");
+
+    assert!(boundary.modules.is_empty());
+    assert!(boundary.uses.is_empty());
+}
+
+#[test]
+fn valid_nested_api_v1_glob_is_accepted() {
+    let source = "pub mod benchmark_support; pub mod prelude; pub mod test_support; pub mod api { pub mod v1 { pub use crate::public_api::*; } }";
+    let boundary = inspect_public_boundary(source).expect("valid boundary fixture must parse");
+
+    validate_public_boundary(&boundary).expect("the expected api::v1 boundary must be accepted");
+}
+
+#[test]
+fn malformed_fixture_returns_a_clear_scanner_error() {
+    let error =
+        inspect_public_boundary("/* outer /* nested */").expect_err("unterminated nested comment must be rejected");
+
+    assert_eq!(error.message, "unterminated block comment");
+}
+
+#[test]
+fn api_v1_reexports_versioned_capabilities_and_dtos() {
     let _ = AdmissionLimits::default();
     let _ = FrameLimits::default();
     let _ = ServerConfig::default();
@@ -84,4 +873,10 @@ fn transport_consumers_use_only_versioned_capabilities_and_dtos() {
         socks_proxy: Default::default(),
     };
     let _: Option<OneShotTransportClient> = None;
+    let _: Option<TransportClient<DefaultRequestProcessor>> = None;
+    let _: Option<RemotingClient<DefaultRequestProcessor>> = None;
+    let _: Option<TransportServer<DefaultRequestProcessor>> = None;
+    let _ = RequestDeadline::after(Duration::from_millis(1));
+    assert_serialization_contract::<String>();
+    assert_processor_contract::<DefaultRequestProcessor>();
 }

--- a/rocketmq-transport/tests/public_api_v1.rs
+++ b/rocketmq-transport/tests/public_api_v1.rs
@@ -28,6 +28,14 @@ use rocketmq_transport::api::v1::ServerConfig;
 use rocketmq_transport::api::v1::TransportClient;
 use rocketmq_transport::api::v1::TransportClientConfig;
 use rocketmq_transport::api::v1::TransportServer;
+use rocketmq_transport::prelude::OneShotTransportClient as PreludeOneShotTransportClient;
+use rocketmq_transport::prelude::RemotingClient as PreludeRemotingClient;
+use rocketmq_transport::prelude::RequestDeadline as PreludeRequestDeadline;
+use rocketmq_transport::prelude::RequestProcessor as PreludeRequestProcessor;
+use rocketmq_transport::prelude::ServerConfig as PreludeServerConfig;
+use rocketmq_transport::prelude::TransportClient as PreludeTransportClient;
+use rocketmq_transport::prelude::TransportClientConfig as PreludeTransportClientConfig;
+use rocketmq_transport::prelude::TransportServer as PreludeTransportServer;
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 
@@ -49,6 +57,20 @@ fn assert_stable_async_methods(client: &TransportClient<DefaultRequestProcessor>
     let oneway_future = client.send_oneway(target, request, deadline);
     let _: &dyn std::future::Future<Output = rocketmq_error::RocketMQResult<_>> = &request_future;
     let _: &dyn std::future::Future<Output = rocketmq_error::RocketMQResult<SendReceipt>> = &oneway_future;
+}
+
+fn assert_prelude_processor<T: PreludeRequestProcessor>() {}
+
+#[test]
+fn prelude_reexports_the_curated_composition_root_surface() {
+    let _ = PreludeServerConfig::default();
+    let _ = PreludeTransportClientConfig::default();
+    let _ = PreludeRequestDeadline::after(Duration::from_millis(1));
+    let _: Option<PreludeOneShotTransportClient> = None;
+    let _: Option<PreludeTransportClient<DefaultRequestProcessor>> = None;
+    let _: Option<PreludeRemotingClient<DefaultRequestProcessor>> = None;
+    let _: Option<PreludeTransportServer<DefaultRequestProcessor>> = None;
+    assert_prelude_processor::<DefaultRequestProcessor>();
 }
 
 #[tokio::test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9596

### Brief Description

This test-only change freezes the externally observable remoting and transport contracts before internal restructuring.

- Literal byte-for-byte JSON and ROCKETMQ request and response frames freeze fixed metadata, flags, typed headers, extension fields, and body bytes.
- RemotingCommand crate-root and canonical paths, defaults, JSON field names, flag bits, and decoder buffer cursor behavior are recorded as compatibility contracts while trailing bytes remain preserved.
- Complete malformed frames consume exactly their declared envelope. A complete outer frame shorter than the four-byte serialization header is an explicit compatibility exception and returns an error without consuming input. Direct header_decode fallback cursor behavior remains feature-dependent compatibility debt and is recorded without changing production behavior.
- The curated api::v1 and prelude re-exports remain the public surface, while implementation modules remain private.

### How Did You Test This Change?

- Protocol default focused tests passed: cargo test -p rocketmq-protocol --test remoting_wire_golden --test remoting_command_contract.
- Protocol SIMD focused tests passed: cargo test -p rocketmq-protocol --features simd --test remoting_wire_golden --test remoting_command_contract.
- Transport default configuration passed: cargo test -p rocketmq-transport --test public_api_contract --test public_api_v1.
- Transport SIMD configuration passed: cargo test -p rocketmq-transport --features simd --test public_api_contract --test public_api_v1.
- Transport no-default-features configuration passed: cargo test -p rocketmq-transport --no-default-features --test public_api_contract --test public_api_v1.
- Transport no-default-features plus SIMD configuration passed: cargo test -p rocketmq-transport --no-default-features --features simd --test public_api_contract --test public_api_v1.
- Workspace Clippy passed: cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings.
- Scoped rustfmt check passed for the four changed test files.
- git diff --check passed.
- Root cargo fmt --all -- --check was unavailable on Windows because Cargo returned File name or extension too long (os error 206); it was not counted as passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive contract coverage for remoting commands, including defaults, flags, field handling, malformed frames, and incomplete data.
  * Added wire-format verification for JSON and RocketMQ serialization, including metadata, extensions, bodies, and custom headers.
  * Expanded transport API checks to validate supported public modules, versioned interfaces, re-exports, configuration, clients, servers, and request processors.
  * Added coverage for the curated transport prelude and improved parser robustness across varied source formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->