### PR TITLE
[ISSUE #9604]🐛Correct Web Dashboard detail rendering

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/KeyValueTable.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/KeyValueTable.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import KeyValueTable from './KeyValueTable';
+
+describe('KeyValueTable', () => {
+  it('renders JSON values as a compact summary and opens a formatted detail view', async () => {
+    const user = userEvent.setup();
+    render(
+      <KeyValueTable
+        emptyTitle="No values"
+        rows={[
+          { key: 'timerPipelineMetrics', value: '{"retryCount":0,"activeWorkers":2}' },
+          { key: 'timerPrecisionMillis', value: '1000' }
+        ]}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'View JSON for timerPipelineMetrics' })).toHaveTextContent('JSON object · 2 fields');
+    expect(screen.getByText('1000')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'View JSON for timerPipelineMetrics' }));
+
+    expect(await screen.findByRole('dialog')).toHaveTextContent('"retryCount": 0');
+    expect(screen.getByRole('dialog')).toHaveTextContent('"activeWorkers": 2');
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/KeyValueTable.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/KeyValueTable.tsx
@@ -1,6 +1,7 @@
 import { Copy, Search } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import EmptyState from './EmptyState';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from './ui/Dialog';
 
 export interface KeyValueRow {
   key: string;
@@ -12,8 +13,35 @@ interface KeyValueTableProps {
   emptyTitle: string;
 }
 
+interface JsonValue {
+  formatted: string;
+  summary: string;
+}
+
+function parseJsonValue(value: string): JsonValue | null {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (parsed === null || typeof parsed !== 'object') return null;
+
+    if (Array.isArray(parsed)) {
+      return {
+        formatted: JSON.stringify(parsed, null, 2),
+        summary: `JSON array · ${parsed.length} ${parsed.length === 1 ? 'item' : 'items'}`
+      };
+    }
+
+    return {
+      formatted: JSON.stringify(parsed, null, 2),
+      summary: `JSON object · ${Object.keys(parsed).length} ${Object.keys(parsed).length === 1 ? 'field' : 'fields'}`
+    };
+  } catch {
+    return null;
+  }
+}
+
 export default function KeyValueTable({ rows, emptyTitle }: KeyValueTableProps) {
   const [query, setQuery] = useState('');
+  const [jsonDetail, setJsonDetail] = useState<(JsonValue & { key: string }) | null>(null);
 
   const filteredRows = useMemo(() => {
     const normalized = query.trim().toLowerCase();
@@ -38,19 +66,43 @@ export default function KeyValueTable({ rows, emptyTitle }: KeyValueTableProps) 
         <EmptyState title={emptyTitle} />
       ) : (
         <div className="kv-list">
-          {filteredRows.map((row) => (
-            <div className="kv-row" key={row.key}>
-              <div className="kv-key" title={row.key}>
-                {row.key}
+          {filteredRows.map((row) => {
+            const jsonValue = parseJsonValue(row.value);
+
+            return (
+              <div className="kv-row" key={row.key}>
+                <div className="kv-key" title={row.key}>
+                  {row.key}
+                </div>
+                <div className="kv-value" title={jsonValue ? undefined : row.value}>
+                  {jsonValue ? (
+                    <button
+                      type="button"
+                      className="kv-json-button"
+                      aria-label={`View JSON for ${row.key}`}
+                      onClick={() => setJsonDetail({ key: row.key, ...jsonValue })}
+                    >
+                      {jsonValue.summary}
+                    </button>
+                  ) : row.value}
+                </div>
+                <button type="button" className="icon-button" title="Copy row" onClick={() => copyRow(row)}>
+                  <Copy size={14} aria-hidden="true" />
+                </button>
               </div>
-              <code className="kv-value">{row.value}</code>
-              <button type="button" className="icon-button" title="Copy row" onClick={() => copyRow(row)}>
-                <Copy size={14} aria-hidden="true" />
-              </button>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
+      <Dialog open={jsonDetail !== null} onOpenChange={(open) => { if (!open) setJsonDetail(null); }}>
+        <DialogContent className="kv-json-dialog">
+          <DialogHeader>
+            <DialogTitle>{jsonDetail?.key ?? 'JSON value'}</DialogTitle>
+            <DialogDescription>{jsonDetail?.summary ?? 'Formatted JSON value'}</DialogDescription>
+          </DialogHeader>
+          {jsonDetail ? <pre className="kv-json-preview">{jsonDetail.formatted}</pre> : null}
+        </DialogContent>
+      </Dialog>
     </section>
   );
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/BrokerDetailPage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/BrokerDetailPage.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { vi } from 'vitest';
+import { brokerApi } from '../api/broker_api';
+import BrokerDetailPage from './BrokerDetailPage';
+
+vi.mock('../api/broker_api', () => ({
+  brokerApi: { list: vi.fn() }
+}));
+
+function renderDetailPage() {
+  return render(
+    <MemoryRouter initialEntries={['/brokers/broker-a']} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <Routes>
+        <Route path="/brokers/:brokerName" element={<BrokerDetailPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('BrokerDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(brokerApi.list).mockResolvedValue({
+      items: [
+        {
+          clusterName: 'DefaultCluster',
+          brokerName: 'broker-a',
+          brokerId: 0,
+          address: '127.0.0.1:10911',
+          role: 'MASTER',
+          version: 'V5_3_1',
+          produceTps: 12.5,
+          consumeTps: 7.5
+        }
+      ],
+      total: 1
+    });
+  });
+
+  it('hydrates the full-page overview from the cluster inventory', async () => {
+    renderDetailPage();
+
+    expect(await screen.findByText('DefaultCluster')).toBeInTheDocument();
+    expect(screen.getByText('127.0.0.1:10911')).toBeInTheDocument();
+    expect(screen.getByText('V5_3_1')).toBeInTheDocument();
+    expect(screen.getByText('MASTER')).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Produce TPS: 12.5' })).toBeInTheDocument();
+    expect(brokerApi.list).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Available from cluster inventory')).not.toBeInTheDocument();
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/BrokerDetailPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/BrokerDetailPage.tsx
@@ -1,11 +1,42 @@
 import { ArrowLeft } from 'lucide-react';
 import { Link, useParams } from 'react-router-dom';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { brokerApi } from '../api/broker_api';
+import ErrorState from '../components/ErrorState';
+import LoadingState from '../components/LoadingState';
 import PageHeader from '../components/PageHeader';
 import { buttonVariants } from '../components/ui/Button';
+import type { BrokerInfo } from '../types/broker';
 import BrokerDetailContent from './brokers/BrokerDetailContent';
 
 export default function BrokerDetailPage() {
   const { brokerName = '' } = useParams();
+  const [broker, setBroker] = useState<BrokerInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const requestRef = useRef(0);
+
+  const loadBroker = useCallback(async () => {
+    const requestId = ++requestRef.current;
+    setLoading(true);
+    setError(null);
+    setBroker(null);
+    try {
+      const list = await brokerApi.list();
+      if (requestId !== requestRef.current) return;
+      setBroker(list.items.find((item) => item.brokerName === brokerName) ?? null);
+    } catch (requestError) {
+      if (requestId !== requestRef.current) return;
+      setError(requestError instanceof Error ? requestError.message : String(requestError));
+    } finally {
+      if (requestId === requestRef.current) setLoading(false);
+    }
+  }, [brokerName]);
+
+  useEffect(() => {
+    void loadBroker();
+    return () => { requestRef.current += 1; };
+  }, [loadBroker]);
 
   return (
     <div className="broker-detail-page">
@@ -18,7 +49,16 @@ export default function BrokerDetailPage() {
           </Link>
         }
       />
-      <BrokerDetailContent brokerName={brokerName} />
+      {loading ? <LoadingState label="Loading broker overview" /> : null}
+      {!loading && error ? <ErrorState message={error} onRetry={() => void loadBroker()} /> : null}
+      {!loading && !error && !broker ? (
+        <ErrorState
+          message={`Broker ${brokerName} is not present in the current cluster inventory.`}
+          onRetry={() => void loadBroker()}
+          retryLabel="Refresh broker inventory"
+        />
+      ) : null}
+      {!loading && !error && broker ? <BrokerDetailContent brokerName={brokerName} broker={broker} /> : null}
     </div>
   );
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/brokers/BrokerDetailContent.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/brokers/BrokerDetailContent.tsx
@@ -175,7 +175,7 @@ export default function BrokerDetailContent({ brokerName, broker, initialTab = '
 
   return (
     <div className="broker-detail-content">
-      <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as BrokerDetailTab)}>
+      <Tabs className="broker-detail-tabs" value={activeTab} onValueChange={(value) => setActiveTab(value as BrokerDetailTab)}>
         <TabsList aria-label="Broker detail sections">
           <TabsTrigger value="overview">Overview</TabsTrigger>
           <TabsTrigger value="runtime">Runtime</TabsTrigger>
@@ -200,7 +200,7 @@ export default function BrokerDetailContent({ brokerName, broker, initialTab = '
           ) : null}
         </TabsContent>
 
-        <TabsContent value="runtime">
+        <TabsContent className="broker-detail-fill-tab" value="runtime">
           <section className="broker-detail-section">
             <div className="broker-detail-section-heading">
               <div>
@@ -215,7 +215,7 @@ export default function BrokerDetailContent({ brokerName, broker, initialTab = '
           </section>
         </TabsContent>
 
-        <TabsContent value="configuration">
+        <TabsContent className="broker-detail-fill-tab" value="configuration">
           <section className="broker-detail-section">
             <div className="broker-detail-section-heading">
               <div>

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/ConsumerDetailContent.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/ConsumerDetailContent.test.tsx
@@ -8,7 +8,7 @@ import { ConsumerQueryScopeProvider } from './ConsumerQueryScopeProvider';
 import ConsumerDetailContent from './ConsumerDetailContent';
 
 vi.mock('../../api/consumer_api', () => ({
-  consumerApi: { summary: vi.fn(), progress: vi.fn(), resetOffset: vi.fn() }
+  consumerApi: { summary: vi.fn(), progress: vi.fn(), config: vi.fn(), resetOffset: vi.fn() }
 }));
 vi.mock('../../api/config_api', () => ({ configApi: { getConfig: vi.fn() } }));
 
@@ -65,6 +65,47 @@ describe('ConsumerDetailContent', () => {
       queryScope: { mode: 'nameServer' }
     });
     vi.mocked(consumerApi.resetOffset).mockResolvedValue({ message: 'reset' });
+    vi.mocked(consumerApi.config).mockResolvedValue({
+      group: 'order-service',
+      effective: {
+        consumeEnable: true,
+        consumeFromMinEnable: true,
+        consumeBroadcastEnable: false,
+        consumeMessageOrderly: false,
+        retryQueueNums: 1,
+        retryMaxTimes: 16,
+        brokerId: 0,
+        whichBrokerWhenConsumeSlowly: 1,
+        notifyConsumerIdsChangedEnable: true,
+        groupSysFlag: 0,
+        consumeTimeoutMinute: 15,
+        groupRetryPolicyJson: '{"retryPolicy":{"type":"CUSTOMIZED","next":[1000,5000]}}'
+      },
+      inconsistentFields: [],
+      targets: [
+        {
+          brokerName: 'broker-a',
+          brokerAddress: '10.0.0.1:10911',
+          config: {
+            consumeEnable: true,
+            consumeFromMinEnable: true,
+            consumeBroadcastEnable: false,
+            consumeMessageOrderly: false,
+            retryQueueNums: 1,
+            retryMaxTimes: 16,
+            brokerId: 0,
+            whichBrokerWhenConsumeSlowly: 1,
+            notifyConsumerIdsChangedEnable: true,
+            groupSysFlag: 0,
+            consumeTimeoutMinute: 15,
+            groupRetryPolicyJson: '{"retryPolicy":{"type":"CUSTOMIZED","next":[1000,5000]}}'
+          },
+          subscriptionTopics: ['orders'],
+          attributes: []
+        }
+      ],
+      queryScope: { mode: 'nameServer' }
+    });
   });
 
   it('renders overview metrics and grouped progress', async () => {
@@ -90,5 +131,23 @@ describe('ConsumerDetailContent', () => {
     await user.click(screen.getByRole('button', { name: 'Review reset' }));
     expect(await screen.findByRole('alert')).toBeInTheDocument();
     expect(consumerApi.resetOffset).not.toHaveBeenCalled();
+  });
+
+  it('groups broker configuration and keeps the retry policy collapsed until requested', async () => {
+    const user = userEvent.setup();
+    renderContent('order-service');
+
+    await user.click(await screen.findByRole('tab', { name: 'Configuration' }));
+
+    expect(await screen.findByRole('heading', { name: 'Effective settings' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'broker-a' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Consumption' })).toBeInTheDocument();
+    expect(screen.getByText('CUSTOMIZED · 2 retry intervals')).toBeInTheDocument();
+    const retryPolicy = screen.getByText('Retry policy').closest('details');
+    expect(retryPolicy).not.toHaveAttribute('open');
+
+    await user.click(screen.getByText('Retry policy'));
+    expect(retryPolicy).toHaveAttribute('open');
+    expect(screen.getByText(/"retryPolicy"/)).toBeInTheDocument();
   });
 });

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/ConsumerDetailContent.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/ConsumerDetailContent.tsx
@@ -20,6 +20,8 @@ import { Label } from '../../components/ui/Label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../components/ui/Tabs';
 import type {
   ConsumerConfigView,
+  ConsumerConfigTarget,
+  ConsumerConfigValue,
   ConsumerConnectionItem,
   ConsumerConnectionView,
   ConsumerProgressQueue,
@@ -326,22 +328,30 @@ export default function ConsumerDetailContent({ group, initialTab = 'overview' }
                   {config.inconsistentFields.length} fields differ across brokers.
                 </div>
               ) : null}
-              <dl className="entity-description-grid">
-                <div><dt>Effective retry queues</dt><dd>{config.effective?.retryQueueNums ?? '-'}</dd></div>
-                <div><dt>Effective max retries</dt><dd>{config.effective?.retryMaxTimes ?? '-'}</dd></div>
-                <div><dt>Consume timeout</dt><dd>{config.effective?.consumeTimeoutMinute ?? '-'}</dd></div>
-                <div><dt>Consume enabled</dt><dd>{config.effective?.consumeEnable ?? false ? 'Yes' : 'No'}</dd></div>
-              </dl>
-              {config.targets.map((target) => (
-                <section key={target.brokerName} className="consumer-resource-section">
-                  <h3>{target.brokerName}</h3>
-                  {target.error ? <div className="notice notice-danger" role="alert">{target.error}</div> : null}
-                  {target.config ? <pre className="consumer-config-json">{JSON.stringify(target.config, null, 2)}</pre> : null}
-                  {target.subscriptionTopics.length > 0 ? (
-                    <p>Subscriptions: {target.subscriptionTopics.join(', ')}</p>
-                  ) : null}
-                </section>
-              ))}
+              <section className="consumer-configuration-summary" aria-labelledby="effective-configuration-heading">
+                <header className="consumer-configuration-heading">
+                  <div>
+                    <h3 id="effective-configuration-heading">Effective settings</h3>
+                    <p>The values currently shared across the selected brokers.</p>
+                  </div>
+                  <span className="consumer-configuration-count">{config.targets.length} broker{config.targets.length === 1 ? '' : 's'}</span>
+                </header>
+                <dl className="entity-description-grid">
+                  <div><dt>Effective retry queues</dt><dd>{config.effective?.retryQueueNums ?? '-'}</dd></div>
+                  <div><dt>Effective max retries</dt><dd>{config.effective?.retryMaxTimes ?? '-'}</dd></div>
+                  <div><dt>Consume timeout</dt><dd>{config.effective?.consumeTimeoutMinute ?? '-'}</dd></div>
+                  <div><dt>Consume enabled</dt><dd>{config.effective?.consumeEnable ?? false ? 'Yes' : 'No'}</dd></div>
+                </dl>
+              </section>
+              <section className="consumer-configuration-targets" aria-labelledby="broker-configuration-heading">
+                <header className="consumer-configuration-heading">
+                  <div>
+                    <h3 id="broker-configuration-heading">Broker settings</h3>
+                    <p>Review the per-broker behavior before making a configuration change.</p>
+                  </div>
+                </header>
+                {config.targets.map((target) => <ConsumerConfigurationTargetCard key={target.brokerName} target={target} />)}
+              </section>
             </>
           ) : null}
         </TabsContent>
@@ -420,4 +430,143 @@ export default function ConsumerDetailContent({ group, initialTab = 'overview' }
 function formatTimestamp(value: number): string {
   if (!value) return '-';
   return new Date(value).toLocaleString();
+}
+
+interface ConsumerConfigurationTargetCardProps {
+  target: ConsumerConfigTarget;
+}
+
+function ConsumerConfigurationTargetCard({ target }: ConsumerConfigurationTargetCardProps) {
+  const retryPolicy = describeRetryPolicy(target.config?.groupRetryPolicyJson);
+
+  return (
+    <article className="consumer-configuration-target">
+      <header className="consumer-configuration-target-header">
+        <div>
+          <h4>{target.brokerName}</h4>
+          {target.brokerAddress ? <code>{target.brokerAddress}</code> : null}
+        </div>
+        <StatusBadge
+          status={target.error ? 'Unavailable' : target.config ? 'Configured' : 'Not reported'}
+          tone={target.error ? 'danger' : target.config ? 'success' : 'neutral'}
+        />
+      </header>
+      {target.error ? <div className="notice notice-danger" role="alert">{target.error}</div> : null}
+      {target.config ? (
+        <>
+          <div className="consumer-configuration-groups">
+            <ConsumerConfigurationGroup title="Consumption" fields={consumptionFields(target.config)} />
+            <ConsumerConfigurationGroup title="Retry and routing" fields={retryAndRoutingFields(target.config)} />
+          </div>
+          <details className="consumer-retry-policy">
+            <summary>
+              <span>Retry policy</span>
+              <span>{retryPolicy.summary}</span>
+            </summary>
+            <pre>{retryPolicy.content}</pre>
+          </details>
+        </>
+      ) : (
+        <p className="consumer-configuration-unavailable">No configuration was reported by this broker.</p>
+      )}
+      {target.subscriptionTopics.length > 0 ? (
+        <section className="consumer-configuration-subscriptions" aria-label={`Subscriptions on ${target.brokerName}`}>
+          <h5>Subscriptions</h5>
+          <div>
+            {target.subscriptionTopics.map((topic) => <span key={topic} className="consumer-configuration-topic">{topic}</span>)}
+          </div>
+        </section>
+      ) : null}
+      {target.attributes.length > 0 ? (
+        <details className="consumer-configuration-attributes">
+          <summary>Additional attributes · {target.attributes.length}</summary>
+          <dl>
+            {target.attributes.map((attribute) => (
+              <div key={attribute.key}>
+                <dt>{attribute.key}</dt>
+                <dd title={attribute.value}>{attribute.value || '-'}</dd>
+              </div>
+            ))}
+          </dl>
+        </details>
+      ) : null}
+    </article>
+  );
+}
+
+interface ConsumerConfigurationGroupProps {
+  title: string;
+  fields: ConsumerConfigurationField[];
+}
+
+interface ConsumerConfigurationField {
+  label: string;
+  value: string | number;
+  mono?: boolean;
+}
+
+function ConsumerConfigurationGroup({ title, fields }: ConsumerConfigurationGroupProps) {
+  return (
+    <section className="consumer-configuration-group">
+      <h5>{title}</h5>
+      <dl className="consumer-configuration-field-grid">
+        {fields.map((field) => (
+          <div key={field.label}>
+            <dt>{field.label}</dt>
+            <dd className={field.mono ? 'mono' : undefined}>{field.value}</dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}
+
+function consumptionFields(config: ConsumerConfigValue): ConsumerConfigurationField[] {
+  return [
+    { label: 'Consume enabled', value: config.consumeEnable ? 'Yes' : 'No' },
+    { label: 'Start from minimum offset', value: config.consumeFromMinEnable ? 'Yes' : 'No' },
+    { label: 'Broadcast consumption', value: config.consumeBroadcastEnable ? 'Yes' : 'No' },
+    { label: 'Orderly consumption', value: config.consumeMessageOrderly ? 'Yes' : 'No' },
+    { label: 'Notify consumer IDs changed', value: config.notifyConsumerIdsChangedEnable ? 'Yes' : 'No' }
+  ];
+}
+
+function retryAndRoutingFields(config: ConsumerConfigValue): ConsumerConfigurationField[] {
+  return [
+    { label: 'Retry queues', value: config.retryQueueNums },
+    { label: 'Maximum retries', value: config.retryMaxTimes },
+    { label: 'Consume timeout', value: `${config.consumeTimeoutMinute} min` },
+    { label: 'Broker ID', value: config.brokerId, mono: true },
+    { label: 'Slow consumer broker', value: config.whichBrokerWhenConsumeSlowly, mono: true },
+    { label: 'Group system flag', value: config.groupSysFlag, mono: true }
+  ];
+}
+
+function describeRetryPolicy(value: string | undefined): { summary: string; content: string } {
+  if (!value) return { summary: 'No policy reported', content: 'No retry policy was reported.' };
+
+  try {
+    const parsed: unknown = JSON.parse(value);
+    const policy = isRecord(parsed) && isRecord(parsed.retryPolicy) ? parsed.retryPolicy : undefined;
+    const type = readString(policy?.type) ?? readString(isRecord(parsed) ? parsed.type : undefined);
+    const intervals = Array.isArray(policy?.next) ? policy.next.length : undefined;
+    const summary = [type, intervals === undefined ? undefined : `${intervals} retry intervals`]
+      .filter((part): part is string => Boolean(part))
+      .join(' · ');
+
+    return {
+      summary: summary || 'Configured JSON policy',
+      content: JSON.stringify(parsed, null, 2)
+    };
+  } catch {
+    return { summary: 'Raw policy value', content: value };
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/globals.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/globals.css
@@ -3320,9 +3320,49 @@ td code,
 }
 
 .kv-value {
+  overflow: hidden;
   color: var(--muted);
-  white-space: pre-wrap;
-  word-break: break-word;
+  font-family: var(--font-mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.kv-json-button {
+  max-width: 100%;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--primary) 38%, var(--border));
+  border-radius: var(--radius-sm);
+  padding: 4px 8px;
+  background: color-mix(in srgb, var(--primary) 10%, var(--surface));
+  color: var(--primary);
+  font: inherit;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.kv-json-button:hover {
+  background: color-mix(in srgb, var(--primary) 18%, var(--surface));
+  color: var(--foreground);
+}
+
+.kv-json-dialog {
+  width: min(880px, calc(100vw - 32px));
+}
+
+.kv-json-preview {
+  max-height: min(72vh, 720px);
+  margin: 16px 0 0;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 12px;
+  background: var(--background);
+  color: var(--foreground);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.6;
+  white-space: pre;
 }
 
 .kv-row .icon-button {
@@ -3645,8 +3685,235 @@ a:hover {
   margin-top: 20px;
 }
 
-.consumer-config-json {
-  max-height: 360px;
+.consumer-configuration-summary,
+.consumer-configuration-targets {
+  display: grid;
+  gap: 12px;
+}
+
+.consumer-configuration-targets {
+  margin-top: 20px;
+}
+
+.consumer-configuration-heading,
+.consumer-configuration-target-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.consumer-configuration-heading h3,
+.consumer-configuration-target-header h4,
+.consumer-configuration-group h5,
+.consumer-configuration-subscriptions h5 {
+  margin: 0;
+}
+
+.consumer-configuration-heading h3 {
+  font-size: 16px;
+}
+
+.consumer-configuration-heading p {
+  margin: 4px 0 0;
+  color: var(--muted-foreground);
+  font-size: 13px;
+}
+
+.consumer-configuration-count {
+  flex: none;
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.2;
+}
+
+.consumer-configuration-target {
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--card);
+}
+
+.consumer-configuration-target-header {
+  align-items: center;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--muted) 42%, var(--card));
+}
+
+.consumer-configuration-target-header h4 {
+  color: var(--foreground);
+  font-size: 15px;
+}
+
+.consumer-configuration-target-header code {
+  display: block;
+  margin-top: 4px;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.consumer-configuration-target > .notice {
+  margin: 12px;
+}
+
+.consumer-configuration-groups {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  background: var(--border);
+}
+
+.consumer-configuration-group {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+  background: var(--card);
+}
+
+.consumer-configuration-group h5,
+.consumer-configuration-subscriptions h5 {
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.035em;
+  text-transform: uppercase;
+}
+
+.consumer-configuration-field-grid,
+.consumer-configuration-attributes dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) - 2px);
+  background: var(--border);
+}
+
+.consumer-configuration-field-grid > div,
+.consumer-configuration-attributes dl > div {
+  min-width: 0;
+  display: grid;
+  gap: 5px;
+  padding: 10px;
+  background: color-mix(in srgb, var(--muted) 20%, var(--card));
+}
+
+.consumer-configuration-field-grid dt,
+.consumer-configuration-attributes dt {
+  color: var(--muted-foreground);
+  font-size: 11px;
+  line-height: 1.25;
+}
+
+.consumer-configuration-field-grid dd,
+.consumer-configuration-attributes dd {
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  color: var(--foreground);
+  font-size: 13px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.consumer-retry-policy,
+.consumer-configuration-attributes {
+  border-top: 1px solid var(--border);
+}
+
+.consumer-retry-policy summary,
+.consumer-configuration-attributes summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 16px;
+  color: var(--foreground);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.consumer-retry-policy summary > span:last-child {
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 400;
+}
+
+.consumer-retry-policy pre {
+  max-height: 320px;
+  margin: 0;
+  padding: 0 16px 16px;
   overflow: auto;
-  white-space: pre-wrap;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.6;
+  white-space: pre;
+}
+
+.consumer-configuration-subscriptions {
+  display: grid;
+  gap: 8px;
+  padding: 14px 16px;
+  border-top: 1px solid var(--border);
+}
+
+.consumer-configuration-subscriptions > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.consumer-configuration-topic {
+  max-width: 100%;
+  overflow: hidden;
+  padding: 4px 7px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--foreground);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.consumer-configuration-attributes summary {
+  justify-content: flex-start;
+}
+
+.consumer-configuration-attributes dl {
+  margin: 0 16px 16px;
+}
+
+.consumer-configuration-unavailable {
+  margin: 0;
+  padding: 16px;
+  color: var(--muted-foreground);
+  font-size: 13px;
+}
+
+@media (max-width: 760px) {
+  .consumer-configuration-groups,
+  .consumer-configuration-field-grid,
+  .consumer-configuration-attributes dl {
+    grid-template-columns: 1fr;
+  }
+
+  .consumer-configuration-heading,
+  .consumer-configuration-target-header,
+  .consumer-retry-policy summary {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+  }
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/pages.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/pages.css
@@ -646,6 +646,42 @@
 }
 
 /* Broker detail */
+.broker-detail-page {
+  height: calc(100dvh - 104px);
+  min-height: 0;
+  grid-template-rows: auto minmax(0, 1fr);
+}
+
+.broker-detail-content,
+.broker-detail-tabs,
+.broker-detail-fill-tab,
+.broker-detail-fill-tab .broker-detail-section,
+.broker-detail-fill-tab .kv-shell,
+.broker-detail-fill-tab .kv-list {
+  min-height: 0;
+}
+
+.broker-detail-tabs {
+  height: 100%;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+}
+
+.broker-detail-fill-tab[data-state='active'],
+.broker-detail-fill-tab .broker-detail-section,
+.broker-detail-fill-tab .kv-shell {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+}
+
+.broker-detail-fill-tab .kv-list {
+  max-height: none;
+}
+
+.broker-detail-fill-tab {
+  overflow: auto;
+}
+
 .broker-detail-content .ui-tabs-list {
   width: 100%;
   display: grid;
@@ -654,6 +690,23 @@
 
 .broker-detail-content .ui-tabs-trigger {
   width: 100%;
+  transition: background-color 150ms ease, color 150ms ease, box-shadow 150ms ease;
+}
+
+.broker-detail-content .ui-tabs-trigger[data-state='inactive'] {
+  color: var(--muted-foreground);
+}
+
+.broker-detail-content .ui-tabs-trigger[data-state='inactive']:hover {
+  background: color-mix(in srgb, var(--muted-surface) 68%, transparent);
+  color: var(--foreground);
+}
+
+.broker-detail-content .ui-tabs-trigger[data-state='active'] {
+  background: color-mix(in srgb, var(--primary) 14%, var(--muted-surface));
+  box-shadow: inset 0 -2px 0 var(--primary);
+  color: var(--foreground);
+  font-weight: 700;
 }
 
 .broker-identity-grid {
@@ -813,6 +866,10 @@
 }
 
 @media (max-width: 760px) {
+  .broker-detail-page {
+    height: calc(100dvh - 88px);
+  }
+
   .query-toolbar,
   .query-filters {
     align-items: stretch;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9604

### Brief Description

- Hydrate broker overview pages from the current cluster inventory and show explicit loading, retry, and missing-broker states.
- Make broker Runtime and Configuration tabs use the available viewport, with clear active and inactive tab treatment.
- Render serialized JSON values as compact summaries with an accessible formatted-detail dialog, preventing long values from disrupting table rows.
- Present consumer configuration as grouped effective and per-broker settings, with expandable retry-policy and attribute details.
- Add focused regression coverage for broker overview hydration, JSON inspection, and consumer configuration presentation.

### How Did You Test This Change?

- `npm ci`
- `npm test -- --run` (52 test files, 337 tests passed)
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Broker detail pages now load and display current broker information, with loading, error, missing-data, and retry states.
  * Consumer configuration views now show effective settings, broker-specific details, subscriptions, retry policies, and availability status.
  * JSON values display compact previews that open formatted details in a dialog.
* **Style**
  * Improved broker detail tabs, scrolling, responsive layouts, and configuration cards for desktop and mobile.
  * Added clearer typography and visual grouping for configuration data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->