### PR TITLE
[ISSUE #9607]🐛Fix consumer offset reset persistence

### DIFF
--- a/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
+++ b/rocketmq-broker/src/offset/manager/consumer_offset_manager.rs
@@ -324,11 +324,16 @@ where
         let _transition = self.consumer_offset_wrapper.data_version_transition.lock();
         let key = build_topic_group_lookup_key(topic, group);
         let mut write_guard = self.consumer_offset_wrapper.reset_offset_table.write();
-        let offset_table = write_guard.get_mut(key.as_str());
-        match offset_table {
-            None => None,
-            Some(value) => value.remove(&queue_id),
+        let reset_offset = write_guard
+            .get_mut(key.as_str())
+            .and_then(|offset_table| offset_table.remove(&queue_id));
+        if write_guard
+            .get(key.as_str())
+            .is_some_and(|offset_table| offset_table.is_empty())
+        {
+            write_guard.remove(key.as_str());
         }
+        reset_offset
     }
 
     pub fn assign_reset_offset(&self, topic: &CheetahString, group: &CheetahString, queue_id: i32, offset: i64) {
@@ -336,6 +341,16 @@ where
         let key = build_topic_group_key(topic, group);
         self.consumer_offset_wrapper
             .reset_offset_table
+            .write()
+            .entry(key.clone())
+            .or_default()
+            .insert(queue_id, offset);
+
+        // Keep the durable consumer position aligned with the transient reset marker. Once the
+        // consumer observes and removes the marker, progress queries and subsequent commits must
+        // continue from the reset position instead of falling back to the previous larger offset.
+        self.consumer_offset_wrapper
+            .offset_table
             .write()
             .entry(key)
             .or_default()
@@ -444,8 +459,14 @@ where
     pub fn query_offset(&self, group: &CheetahString, topic: &CheetahString, queue_id: i32) -> i64 {
         let key = build_topic_group_lookup_key(topic, group);
         if self.broker_config.use_server_side_reset_offset {
-            if let Some(value) = self.consumer_offset_wrapper.reset_offset_table.read().get(key.as_str()) {
-                return *value.get(&queue_id).unwrap_or(&-1);
+            if let Some(offset) = self
+                .consumer_offset_wrapper
+                .reset_offset_table
+                .read()
+                .get(key.as_str())
+                .and_then(|offset_table| offset_table.get(&queue_id))
+            {
+                return *offset;
             }
         }
         if let Some(value) = self.consumer_offset_wrapper.offset_table.read().get(key.as_str()) {
@@ -1170,6 +1191,29 @@ mod tests {
     }
 
     #[test]
+    fn reset_offset_updates_committed_position_and_preserves_other_queues() {
+        let manager = new_manager();
+        let topic = CheetahString::from_static_str("topic-a");
+        let group = CheetahString::from_static_str("group-a");
+
+        manager.commit_offset("127.0.0.1:10911".into(), &group, &topic, 0, 42);
+        manager.commit_offset("127.0.0.1:10911".into(), &group, &topic, 1, 64);
+        manager.assign_reset_offset(&topic, &group, 0, 7);
+
+        assert_eq!(manager.query_offset(&group, &topic, 0), 7);
+        assert_eq!(manager.query_offset(&group, &topic, 1), 64);
+        assert_eq!(manager.query_then_erase_reset_offset(&topic, &group, 0), Some(7));
+        assert_eq!(manager.query_offset(&group, &topic, 0), 7);
+        assert_eq!(manager.query_offset(&group, &topic, 1), 64);
+        assert!(!manager.has_offset_reset(group.as_str(), topic.as_str(), 0));
+        assert!(!manager
+            .consumer_offset_wrapper
+            .reset_offset_table
+            .read()
+            .contains_key("topic-a@group-a"));
+    }
+
+    #[test]
     fn query_capability_reads_live_offsets_without_keeping_manager_alive() {
         let manager = Arc::new(new_manager());
         let capability = manager.query_capability();
@@ -1523,7 +1567,7 @@ mod tests {
     }
 
     #[test]
-    fn json_round_trip_preserves_version_reset_and_pull_tables_without_committed_offsets() {
+    fn json_round_trip_preserves_committed_reset_and_pull_offsets() {
         let manager = new_manager();
         let group = CheetahString::from_static_str("group-a");
         let topic = CheetahString::from_static_str("topic-a");
@@ -1543,6 +1587,7 @@ mod tests {
 
         assert_eq!(restored.data_version().counter(), 1);
         assert_eq!(restored.query_then_erase_reset_offset(&topic, &group, 0), Some(5));
+        assert_eq!(restored.query_offset(&group, &topic, 0), 5);
         assert_eq!(
             restored
                 .consumer_offset_wrapper

--- a/rocketmq-broker/src/processor/admin_broker_processor/consumer_request_handler.rs
+++ b/rocketmq-broker/src/processor/admin_broker_processor/consumer_request_handler.rs
@@ -1344,6 +1344,8 @@ mod tests {
     async fn invoke_broker_to_reset_offset_assigns_server_side_offset() {
         let runtime = new_test_runtime("reset-offset").await;
         let admin = runtime.admin_runtime_for_test();
+        let topic = CheetahString::from_static_str("topic-a");
+        let group = CheetahString::from_static_str("group-a");
         let _ = admin
             .topic_config_manager()
             .update_topic_config(TopicConfig::with_queues("topic-a", 1, 1), 0);
@@ -1354,6 +1356,9 @@ mod tests {
         admin
             .subscription_group_manager()
             .update_subscription_group_config(&mut group_config);
+        admin
+            .consumer_offset_manager()
+            .commit_offset("127.0.0.1:10911".into(), &group, &topic, 0, 9);
 
         let handler = ConsumerRequestHandler::new();
         let channel = create_test_channel().await;
@@ -1361,8 +1366,8 @@ mod tests {
         let mut request = RemotingCommand::create_request_command(
             RequestCode::InvokeBrokerToResetOffset,
             ResetOffsetRequestHeader {
-                topic: CheetahString::from_static_str("topic-a"),
-                group: CheetahString::from_static_str("group-a"),
+                topic: topic.clone(),
+                group: group.clone(),
                 queue_id: 0,
                 offset: None,
                 timestamp: -1,
@@ -1396,6 +1401,25 @@ mod tests {
         )
         .expect("decode reset offset body");
         assert_eq!(body.offset_table.len(), 1);
+        let reset_offset = *body
+            .offset_table
+            .values()
+            .next()
+            .expect("reset response should contain a queue offset");
+        assert_eq!(
+            admin.consumer_offset_manager().query_offset(&group, &topic, 0),
+            reset_offset
+        );
+        assert_eq!(
+            admin
+                .consumer_offset_manager()
+                .query_then_erase_reset_offset(&topic, &group, 0),
+            Some(reset_offset)
+        );
+        assert_eq!(
+            admin.consumer_offset_manager().query_offset(&group, &topic, 0),
+            reset_offset
+        );
 
         let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
     }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/ConsumerDetailContent.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/ConsumerDetailContent.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { configApi } from '../../api/config_api';
@@ -127,10 +127,27 @@ describe('ConsumerDetailContent', () => {
     await screen.findByRole('tab', { name: 'Overview' });
 
     await user.click(screen.getByRole('tab', { name: 'Reset offset' }));
-    await user.clear(screen.getByRole('spinbutton', { name: 'Reset timestamp' }));
     await user.click(screen.getByRole('button', { name: 'Review reset' }));
-    expect(await screen.findByRole('alert')).toBeInTheDocument();
+    expect(await screen.findByRole('alert')).toHaveTextContent('Select a valid reset time.');
     expect(consumerApi.resetOffset).not.toHaveBeenCalled();
+  });
+
+  it('resets to an explicit local time and explains that current time skips replay', async () => {
+    const user = userEvent.setup();
+    const resetTimestamp = new Date(2026, 7, 15, 10, 30, 0, 0).getTime();
+    renderContent('order-service', 'reset');
+
+    expect(await screen.findByText(/Selecting the current time moves the group to the queue tail/)).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('Reset time'), { target: { value: '2026-08-15T10:30' } });
+    await user.click(screen.getByRole('button', { name: 'Review reset' }));
+    expect(screen.getByRole('alertdialog')).toHaveTextContent(new Date(resetTimestamp).toLocaleString());
+    await user.click(screen.getByRole('button', { name: 'Confirm reset' }));
+
+    await waitFor(() => expect(consumerApi.resetOffset).toHaveBeenCalledWith('order-service', {
+      topic: 'orders',
+      resetTimestamp,
+      force: false
+    }));
   });
 
   it('groups broker configuration and keeps the retry policy collapsed until requested', async () => {

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/ConsumerDetailContent.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/ConsumerDetailContent.tsx
@@ -18,6 +18,7 @@ import { Button } from '../../components/ui/Button';
 import { Input } from '../../components/ui/Input';
 import { Label } from '../../components/ui/Label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../components/ui/Tabs';
+import { parseLocalDateTime } from '../../components/TopicResetOffsetDialog';
 import type {
   ConsumerConfigView,
   ConsumerConfigTarget,
@@ -82,7 +83,7 @@ export default function ConsumerDetailContent({ group, initialTab = 'overview' }
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [resetTopic, setResetTopic] = useState('');
-  const [resetTimestamp, setResetTimestamp] = useState(() => String(Date.now()));
+  const [resetTime, setResetTime] = useState('');
   const [forceReset, setForceReset] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -148,6 +149,7 @@ export default function ConsumerDetailContent({ group, initialTab = 'overview' }
     setClientsError(null);
     setConfigError(null);
     setResetTopic('');
+    setResetTime('');
     setValidationError(null);
     setNotice(null);
     setConfirmOpen(false);
@@ -168,17 +170,13 @@ export default function ConsumerDetailContent({ group, initialTab = 'overview' }
   const topicOptions = useMemo(() => topics.map((topic) => topic.topic), [topics]);
 
   const reviewReset = () => {
-    const timestamp = Number(resetTimestamp);
+    const timestamp = parseLocalDateTime(resetTime);
     if (!resetTopic) {
       setValidationError('Select a topic before resetting offsets.');
       return;
     }
-    if (!resetTimestamp.trim() || !Number.isFinite(timestamp)) {
-      setValidationError('Reset timestamp must be a millisecond timestamp.');
-      return;
-    }
-    if (!Number.isSafeInteger(timestamp) || timestamp < 0) {
-      setValidationError('Reset timestamp must be a non-negative safe integer.');
+    if (timestamp === null) {
+      setValidationError('Select a valid reset time.');
       return;
     }
     setValidationError(null);
@@ -186,6 +184,12 @@ export default function ConsumerDetailContent({ group, initialTab = 'overview' }
   };
 
   const resetOffsets = async () => {
+    const resetTimestamp = parseLocalDateTime(resetTime);
+    if (resetTimestamp === null) {
+      setValidationError('Select a valid reset time.');
+      setConfirmOpen(false);
+      return;
+    }
     const operationToken = ++resetOperationToken.current;
     const operationGroup = group;
     const operationTopic = resetTopic;
@@ -193,7 +197,7 @@ export default function ConsumerDetailContent({ group, initialTab = 'overview' }
     try {
       await consumerApi.resetOffset(operationGroup, {
         topic: operationTopic,
-        resetTimestamp: Number(resetTimestamp),
+        resetTimestamp,
         force: forceReset
       });
       if (operationToken !== resetOperationToken.current || currentGroupRef.current !== operationGroup) return;
@@ -360,7 +364,10 @@ export default function ConsumerDetailContent({ group, initialTab = 'overview' }
           <section className="danger-zone consumer-reset-panel">
             <div>
               <h3>Reset consumer offsets</h3>
-              <p>Move this group to a timestamp for one topic. Review the target carefully before confirming.</p>
+              <p>
+                Choose a time before the messages you want to replay. Selecting the current time moves the group to
+                the queue tail, so no messages or lag will remain.
+              </p>
             </div>
             <div className="form-grid consumer-reset-form">
               <div className="field">
@@ -375,14 +382,13 @@ export default function ConsumerDetailContent({ group, initialTab = 'overview' }
                 </select>
               </div>
               <div className="field">
-                <Label htmlFor="consumer-reset-timestamp">Reset timestamp</Label>
+                <Label htmlFor="consumer-reset-time">Reset time</Label>
                 <Input
-                  id="consumer-reset-timestamp"
-                  type="number"
-                  min="0"
+                  id="consumer-reset-time"
+                  type="datetime-local"
                   step="1"
-                  value={resetTimestamp}
-                  onChange={(event) => setResetTimestamp(event.target.value)}
+                  value={resetTime}
+                  onChange={(event) => setResetTime(event.target.value)}
                 />
               </div>
               <label className="compact-check" htmlFor="consumer-force-reset">
@@ -407,7 +413,7 @@ export default function ConsumerDetailContent({ group, initialTab = 'overview' }
         <AlertDialogContent>
           <AlertDialogTitle>Reset consumer offset?</AlertDialogTitle>
           <AlertDialogDescription>
-            Reset {group} on {resetTopic} to timestamp {resetTimestamp}{forceReset ? ' with force enabled' : ''}?
+            Reset {group} on {resetTopic} to {formatResetTime(resetTime)}{forceReset ? ' with force enabled' : ''}?
           </AlertDialogDescription>
           <div className="ui-alert-dialog-actions">
             <AlertDialogCancel disabled={resetting}>Cancel</AlertDialogCancel>
@@ -430,6 +436,11 @@ export default function ConsumerDetailContent({ group, initialTab = 'overview' }
 function formatTimestamp(value: number): string {
   if (!value) return '-';
   return new Date(value).toLocaleString();
+}
+
+function formatResetTime(value: string): string {
+  const timestamp = parseLocalDateTime(value);
+  return timestamp === null ? 'the selected local time' : new Date(timestamp).toLocaleString();
 }
 
 interface ConsumerConfigurationTargetCardProps {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9607

### Brief Description

- Persist each server-side reset target in both the transient reset table and the committed consumer offset table so removing the delivery marker cannot restore an older position.
- Fall back to committed offsets for queues without an exact reset entry and remove empty reset-topic entries after delivery.
- Extend broker regression coverage to verify that reset targets remain authoritative after transient delivery state is erased.
- Replace the Dashboard's raw current-millisecond default with an explicit local date-time input and explain that selecting the current time moves the group to the queue tail.
- Add Dashboard coverage for reset-time validation, parsing, confirmation, and API submission.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-broker -- --check`: passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- `cargo test -p rocketmq-broker offset::manager::consumer_offset_manager::tests::`: passed, 18 tests.
- `cargo test -p rocketmq-broker invoke_broker_to_reset_offset_assigns_server_side_offset`: passed, 1 test.
- `npm test -- --run src/pages/consumers/ConsumerDetailContent.test.tsx`: passed, 4 tests.
- `npm test -- --run`: passed, 52 files and 338 tests.
- `npm run build`: passed.
- `git diff --check`: passed.
- `cargo fmt --all -- --check`: attempted but could not complete on Windows because the formatter hit OS error 206, indicating that a generated command line or path exceeded the platform length limit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Consumer offsets can now be reset using a local date and time.
  - Reset confirmations display the selected local time before submission.
  - Reset requests preserve committed offsets for other queues.

- **Bug Fixes**
  - Consumer offset queries now correctly fall back to committed offsets when no reset marker exists for a queue.
  - Reset markers are fully cleared after all queue offsets are removed, while the committed reset position remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->