### PR TITLE
[ISSUE #9612]🐛Fix push consumer shutdown lifecycle

### DIFF
--- a/rocketmq-client/examples/broadcast/push_consumer.rs
+++ b/rocketmq-client/examples/broadcast/push_consumer.rs
@@ -53,6 +53,7 @@ pub async fn main() -> RocketMQResult<()> {
     consumer.start().await?;
     let _ = tokio::signal::ctrl_c().await;
 
+    consumer.shutdown().await;
     example_runtime.shutdown().await;
 
     Ok(())

--- a/rocketmq-client/examples/consumer/pop_consumer.rs
+++ b/rocketmq-client/examples/consumer/pop_consumer.rs
@@ -50,6 +50,7 @@ pub async fn main() -> RocketMQResult<()> {
     consumer.start().await?;
     let _ = tokio::signal::ctrl_c().await;
 
+    consumer.shutdown().await;
     example_runtime.shutdown().await;
 
     Ok(())

--- a/rocketmq-client/examples/ordermessage/ordermessage_consumer.rs
+++ b/rocketmq-client/examples/ordermessage/ordermessage_consumer.rs
@@ -57,6 +57,7 @@ pub async fn main() -> RocketMQResult<()> {
     consumer.start().await?;
     let _ = tokio::signal::ctrl_c().await;
 
+    consumer.shutdown().await;
     example_runtime.shutdown().await;
 
     Ok(())

--- a/rocketmq-client/examples/quickstart/consumer.rs
+++ b/rocketmq-client/examples/quickstart/consumer.rs
@@ -48,6 +48,7 @@ pub async fn main() -> RocketMQResult<()> {
     consumer.start().await?;
     let _ = tokio::signal::ctrl_c().await;
 
+    consumer.shutdown().await;
     example_runtime.shutdown().await;
 
     Ok(())

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -684,10 +684,11 @@ impl DefaultMQPushConsumerImpl {
                 );
             }
             ServiceState::Running => {
-                if let Some(consume_message_concurrently_service) = self.consume_message_service() {
-                    consume_message_concurrently_service
-                        .shutdown(await_terminate_millis)
-                        .await;
+                if let Some(consume_message_service) = self.consume_message_service() {
+                    consume_message_service.shutdown(await_terminate_millis).await;
+                }
+                if let Some(consume_message_pop_service) = self.consume_message_pop_service() {
+                    consume_message_pop_service.shutdown(await_terminate_millis).await;
                 }
                 self.persist_consumer_offset().await;
                 if let Some(offset_store) = self.offset_store() {
@@ -2567,6 +2568,54 @@ mod tests {
             .await
             .expect("shutdown should acquire the released lifecycle transition")
             .expect("shutdown task should not panic");
+    }
+
+    #[tokio::test]
+    async fn shutdown_stops_standard_and_pop_consume_services() {
+        let consumer = Arc::new(new_running_impl());
+        consumer.initialize_self_reference();
+        let consumer_config = consumer.consumer_config_snapshot();
+        let client_config = consumer.client_config_snapshot();
+        let listener: Arc<dyn MessageListenerConcurrently> = Arc::new(NoopConcurrentListener);
+        let standard_service = Arc::new(ConsumeMessageConcurrentlyService::new(
+            consumer.service_context.component("shutdown-standard-consume"),
+            consumer.telemetry_handle().clone(),
+            consumer.client_metrics().clone(),
+            client_config.clone(),
+            consumer_config.clone(),
+            consumer_config.consumer_group.clone(),
+            listener.clone(),
+            Some(Arc::downgrade(&consumer)),
+        ));
+        let pop_service = Arc::new(ConsumeMessagePopConcurrentlyService::new(
+            consumer.service_context.component("shutdown-pop-consume"),
+            consumer.telemetry_handle().clone(),
+            consumer.client_metrics().clone(),
+            client_config,
+            consumer_config.clone(),
+            consumer_config.consumer_group.clone(),
+            listener,
+            Some(Arc::downgrade(&consumer)),
+        ));
+        consumer.set_component(
+            &consumer.consume_message_service,
+            Some(Arc::new(ConsumeMessageServiceGeneral::new(
+                Some(standard_service.clone()),
+                None,
+            ))),
+        );
+        consumer.set_component(
+            &consumer.consume_message_pop_service,
+            Some(Arc::new(ConsumeMessagePopServiceGeneral::new(
+                Some(pop_service.clone()),
+                None,
+            ))),
+        );
+
+        consumer.shutdown(1_000).await;
+
+        assert!(standard_service.is_shutdown());
+        assert!(pop_service.stopped.load(Ordering::Acquire));
     }
 
     fn message_queue() -> MessageQueue {

--- a/rocketmq-client/tests/windows_consumer_process_startup.rs
+++ b/rocketmq-client/tests/windows_consumer_process_startup.rs
@@ -46,6 +46,7 @@ use tokio::sync::oneshot;
 const CHILD_MODE_ENV: &str = "ROCKETMQ_CLIENT_STACK_TEST_CHILD";
 const NAMESRV_ADDR_ENV: &str = "ROCKETMQ_CLIENT_STACK_TEST_NAMESRV_ADDR";
 const STARTUP_MARKER: &str = "CLIENT_STACK_STARTUP_OK";
+const SHUTDOWN_MARKER: &str = "CLIENT_STACK_SHUTDOWN_OK";
 const WINDOWS_MAIN_STACK_SIZE: usize = 1024 * 1024;
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
@@ -175,7 +176,12 @@ fn run_consumer_child() {
                 TelemetryHandle::noop(),
             )
             .expect("create client runtime");
-            owner.block_on(run_consumer_startup(client_runtime, namesrv_addr));
+            owner.block_on(run_consumer_startup(Arc::clone(&client_runtime), namesrv_addr));
+            let report = owner.block_on(client_runtime.shutdown());
+            assert!(report.is_healthy(), "{}", report.to_json());
+            owner
+                .shutdown_runtime_blocking()
+                .expect("consumer process runtime should stop cleanly");
         })
         .expect("start 1 MiB consumer startup thread");
 
@@ -197,7 +203,10 @@ async fn run_consumer_startup(client_runtime: Arc<ClientRuntime>, namesrv_addr: 
 
     println!("{STARTUP_MARKER}");
     std::io::stdout().flush().expect("flush startup marker");
-    std::process::exit(0);
+
+    consumer.shutdown().await;
+    println!("{SHUTDOWN_MARKER}");
+    std::io::stdout().flush().expect("flush shutdown marker");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -250,6 +259,11 @@ async fn windows_consumer_starts_without_stack_overflow() {
     assert!(
         String::from_utf8_lossy(&output.stdout).contains(STARTUP_MARKER),
         "Consumer did not emit startup marker:\n{}",
+        process_output(&output)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains(SHUTDOWN_MARKER),
+        "Consumer did not complete clean shutdown:\n{}",
         process_output(&output)
     );
 


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9612

### Brief Description

- Shut down both the standard and POP consume services during the running push consumer lifecycle transition.
- Explicitly shut down consumers before the shared example runtime in the quickstart, broadcast, POP, and orderly consumer examples.
- Add focused coverage that verifies both consume services receive the shutdown signal.
- Extend the Windows consumer process test to perform real consumer and runtime cleanup and require a successful shutdown marker instead of bypassing cleanup with `process::exit(0)`.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-client-rust -- --check`: passed.
- `cargo test -p rocketmq-client-rust shutdown_stops_standard_and_pop_consume_services`: passed.
- `cargo test -p rocketmq-client-rust --test windows_consumer_process_startup -- --nocapture`: passed, 1 test in 2.58 seconds.
- `cargo check -p rocketmq-client-rust --examples`: passed.
- `cargo build -p rocketmq-client-rust --example consumer`: passed.
- `cargo test -p rocketmq-client-rust --lib`: passed, 1,067 tests.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`: passed.
- `git diff --check`: passed.
- `cargo fmt --all -- --check`: attempted but could not complete on Windows because rustfmt hit OS error 206 for the workspace-wide command length.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consumer shutdown to stop all consuming services cleanly.
  * Ensured consumers gracefully shut down after termination signals in broadcast, pop, ordered-message, and quickstart examples.
  * Improved Windows consumer process shutdown handling and verification.
* **Tests**
  * Added coverage confirming consuming services reach a stopped state during shutdown.
  * Enhanced Windows process checks for both startup and clean shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->