### PR TITLE
[ISSUE #9614]🐛Fix controller mode broker startup readiness

### DIFF
--- a/rocketmq-broker/src/broker_runtime/lifecycle.rs
+++ b/rocketmq-broker/src/broker_runtime/lifecycle.rs
@@ -1057,11 +1057,14 @@ impl BrokerRuntime {
                 }),
         );
         let live_broker_config = self.composition.state.broker_config();
+        // Controller-mode brokers start fenced and acquire write authority only after the
+        // Controller assigns a role and grants a lease. Process readiness therefore depends on
+        // the recovered store being eligible for promotion, not on already holding that lease.
         let store_writable = self
             .composition
             .state
             .message_store()
-            .is_some_and(|store| BrokerReadStore::put_message_preflight(store).is_writeable());
+            .is_some_and(|store| BrokerReadStore::put_message_preflight(store).is_store_ready_for_promotion());
         let processors_started = self.composition.state.pop_message_processor.is_some()
             && self.composition.state.pop_lite_message_processor.is_some()
             && self.composition.state.ack_message_processor.is_some()


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9614

### Brief Description

Use message store promotion readiness during broker process startup instead of requiring an active Controller write lease. Controller-mode brokers intentionally start fenced while role assignment is pending, so startup now verifies that the recovered store is healthy and eligible for promotion without weakening send-path lease enforcement.

### How Did You Test This Change?

- `cargo test -p rocketmq-broker --lib three_controller_two_broker -- --nocapture` (4 passed)
- `cargo test -p rocketmq-broker --lib` (823 passed, 2 ignored, and 1 unrelated baseline failure in `extended_timer_capability_is_published_from_one_policy_generation`)
- `cargo fmt -p rocketmq-broker -- --check`
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved broker readiness handling in controller mode.
  * Recovered message stores can now be recognized as ready when eligible for promotion, even before becoming immediately writable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->