### PR TITLE
[ISSUE #9627]♻️Partition RemotingCommand state and custom-header implementations

### DIFF
--- a/rocketmq-protocol/src/protocol/remoting_command.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command.rs
@@ -12,17 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
 use std::fmt;
 use std::sync::atomic::AtomicI32;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+#[cfg(test)]
+use std::collections::HashMap;
+
 use bytes::BufMut;
 use bytes::Bytes;
 use bytes::BytesMut;
 use cheetah_string::CheetahString;
-use rocketmq_model::version::RocketMqVersion;
 use serde::ser::SerializeMap;
 use serde::Deserialize;
 use serde::Deserializer;
@@ -31,19 +32,16 @@ use serde::Serializer;
 
 use super::RemotingCommandType;
 use super::SerializeType;
-use crate::code::request_code::RequestCode;
 use crate::protocol::command_custom_header::CommandCustomHeader;
-use crate::protocol::command_custom_header::FromMap;
 use crate::protocol::command_custom_header::HeaderEncodeCapability;
 use crate::protocol::header_codec::write_json_string;
 use crate::protocol::header_codec::BinaryHeaderFields;
-use crate::protocol::header_codec::HeaderCodecError;
 use crate::protocol::header_codec::JsonHeaderFields;
-use crate::protocol::header_field_merge::merge_header_and_dynamic;
-use crate::protocol::remoting_command_defaults::application_remoting_command_factory;
-use crate::protocol::remoting_command_defaults::RemotingCommandDefaults;
 use crate::protocol::LanguageCode;
 use crate::rocketmq_serializable::RocketMQSerializable;
+
+#[cfg(test)]
+use crate::protocol::command_custom_header::FromMap;
 
 pub const SERIALIZE_TYPE_PROPERTY: &str = "rocketmq.serialize.type";
 pub const SERIALIZE_TYPE_ENV: &str = "ROCKETMQ_SERIALIZE_TYPE";
@@ -99,7 +97,11 @@ const fn language_name(language: LanguageCode) -> &'static str {
     }
 }
 
+mod accessors;
+mod constructors;
+mod custom_header;
 mod extension_fields;
+mod flags;
 mod json_decode;
 
 use extension_fields::ExtensionFields;
@@ -209,136 +211,6 @@ impl Default for RemotingCommand {
 }
 
 impl RemotingCommand {
-    /// Constructs a command from defaults resolved by the owning facade.
-    ///
-    /// The protocol crate deliberately does not read process environment or configuration files.
-    /// Legacy facades resolve those sources and pass the resulting wire values here.
-    pub fn with_resolved_defaults(version: i32, serialize_type: SerializeType) -> Self {
-        let opaque = next_request_id();
-        RemotingCommand {
-            code: 0,
-            language: LanguageCode::RUST, // Replace with your actual enum variant
-            version,
-            opaque,
-            flag: 0,
-            remark: None,
-            ext_fields: ExtensionFields::default(),
-            body: None,
-            suspended: false,
-            command_custom_header: None,
-            custom_header_to_net: false,
-            serialize_type,
-        }
-    }
-
-    pub(crate) fn from_binary_wire_parts(
-        code: i32,
-        language: LanguageCode,
-        version: i32,
-        opaque: i32,
-        flag: i32,
-        remark: Option<CheetahString>,
-        ext_fields: BinaryHeaderFields,
-    ) -> Self {
-        Self {
-            code,
-            language,
-            version,
-            opaque,
-            flag,
-            remark,
-            ext_fields: ExtensionFields::from_rocketmq_raw(ext_fields),
-            body: None,
-            suspended: false,
-            command_custom_header: None,
-            custom_header_to_net: false,
-            serialize_type: SerializeType::ROCKETMQ,
-        }
-    }
-}
-
-impl RemotingCommand {
-    pub(crate) const RPC_ONEWAY: i32 = 1;
-    pub(crate) const RPC_TYPE: i32 = 0;
-}
-
-impl RemotingCommand {
-    pub fn new_request(code: impl Into<i32>, body: impl Into<Bytes>) -> Self {
-        application_remoting_command_factory().create_request(code, body)
-    }
-
-    pub fn create_request_command<T>(code: impl Into<i32>, header: T) -> Self
-    where
-        T: CommandCustomHeader + Sync + Send + 'static,
-    {
-        application_remoting_command_factory().create_request_command(code, header)
-    }
-
-    /// Creates a request using defaults resolved by the transport/facade owner.
-    pub fn create_request_command_with_defaults<T>(
-        code: impl Into<i32>,
-        header: T,
-        version: i32,
-        serialize_type: SerializeType,
-    ) -> Self
-    where
-        T: CommandCustomHeader + Sync + Send + 'static,
-    {
-        crate::protocol::remoting_command_defaults::RemotingCommandFactory::new(RemotingCommandDefaults::new(
-            version,
-            serialize_type,
-        ))
-        .create_request_command(code, header)
-    }
-
-    pub fn create_remoting_command(code: impl Into<i32>) -> Self {
-        application_remoting_command_factory().create_remoting_command(code)
-    }
-
-    pub fn get_and_add() -> i32 {
-        next_request_id()
-    }
-
-    pub fn create_response_command_with_code(code: impl Into<i32>) -> Self {
-        application_remoting_command_factory().create_response_command_with_code(code)
-    }
-
-    /// Creates a response with an explicit code and typed custom header.
-    pub fn create_response_command_with_code_and_header(
-        code: impl Into<i32>,
-        header: impl CommandCustomHeader + Sync + Send + 'static,
-    ) -> Self {
-        application_remoting_command_factory().create_response_command_with_code_and_header(code, header)
-    }
-
-    pub fn create_response_command_with_code_remark(code: impl Into<i32>, remark: impl Into<CheetahString>) -> Self {
-        application_remoting_command_factory().create_response_command_with_code_remark(code, remark)
-    }
-
-    /// Creates an explicitly successful response.
-    pub fn create_success_response_command() -> Self {
-        application_remoting_command_factory().create_success_response_command()
-    }
-
-    /// Creates an explicitly successful response with a typed custom header.
-    pub fn create_success_response_command_with_header(
-        header: impl CommandCustomHeader + Sync + Send + 'static,
-    ) -> Self {
-        application_remoting_command_factory().create_success_response_command_with_header(header)
-    }
-
-    /// Creates the unset error response used by Java's typed-header factory.
-    pub fn create_java_default_error_response_command() -> Self {
-        application_remoting_command_factory().create_java_default_error_response_command()
-    }
-
-    /// Creates the unset Java-compatible error response with a typed header.
-    pub fn create_java_default_error_response_command_with_header(
-        header: impl CommandCustomHeader + Sync + Send + 'static,
-    ) -> Self {
-        application_remoting_command_factory().create_java_default_error_response_command_with_header(header)
-    }
-
     /// Legacy ambiguous-success response factory.
     ///
     /// New code should call [`Self::create_success_response_command`] so the
@@ -362,193 +234,6 @@ impl RemotingCommand {
     )]
     pub fn create_response_command_with_header(header: impl CommandCustomHeader + Sync + Send + 'static) -> Self {
         Self::create_success_response_command_with_header(header)
-    }
-
-    pub fn set_command_custom_header<T>(mut self, command_custom_header: T) -> Self
-    where
-        T: CommandCustomHeader + Sync + Send + 'static,
-    {
-        self.invalidate_materialized_custom_header();
-        self.command_custom_header = Some(Arc::new(Box::new(command_custom_header)));
-        self.custom_header_to_net = false;
-        self
-    }
-
-    pub fn set_command_custom_header_boxed(
-        mut self,
-        command_custom_header: Box<dyn CommandCustomHeader + Send + Sync + 'static>,
-    ) -> Self {
-        self.invalidate_materialized_custom_header();
-        self.command_custom_header = Some(Arc::new(command_custom_header));
-        self.custom_header_to_net = false;
-        self
-    }
-
-    pub fn set_command_custom_header_origin<T>(mut self, command_custom_header: Option<T>) -> Self
-    where
-        T: std::ops::Deref<Target = Box<dyn CommandCustomHeader + Send + Sync + 'static>>,
-    {
-        self.invalidate_materialized_custom_header();
-        if let Some(header_fields) = command_custom_header.as_ref().and_then(|header| header.to_map()) {
-            self.ext_fields.get_or_insert_map().extend(header_fields);
-        }
-        self.command_custom_header = None;
-        self.custom_header_to_net = true;
-        self
-    }
-
-    pub fn set_command_custom_header_ref<T>(&mut self, command_custom_header: T)
-    where
-        T: CommandCustomHeader + Sync + Send + 'static,
-    {
-        self.invalidate_materialized_custom_header();
-        self.command_custom_header = Some(Arc::new(Box::new(command_custom_header)));
-        self.custom_header_to_net = false;
-    }
-
-    pub fn set_code(mut self, code: impl Into<i32>) -> Self {
-        self.code = code.into();
-        self
-    }
-
-    pub fn set_code_ref(&mut self, code: impl Into<i32>) {
-        self.code = code.into();
-    }
-
-    pub fn set_code_mut(&mut self, code: impl Into<i32>) -> &mut Self {
-        self.code = code.into();
-        self
-    }
-
-    pub fn set_language(mut self, language: LanguageCode) -> Self {
-        self.language = language;
-        self
-    }
-
-    pub fn set_version_ref(&mut self, version: i32) {
-        self.version = version;
-    }
-
-    pub fn set_version(mut self, version: i32) -> Self {
-        self.version = version;
-        self
-    }
-
-    #[inline]
-    pub fn set_opaque(mut self, opaque: i32) -> Self {
-        self.opaque = opaque;
-        self
-    }
-
-    #[inline]
-    pub fn set_opaque_mut(&mut self, opaque: i32) {
-        self.opaque = opaque;
-    }
-
-    #[inline]
-    pub fn set_flag(mut self, flag: i32) -> Self {
-        self.flag = flag;
-        self
-    }
-
-    #[inline]
-    pub fn set_remark_option(mut self, remark: Option<impl Into<CheetahString>>) -> Self {
-        self.remark = remark.map(|item| item.into());
-        self
-    }
-
-    #[inline]
-    pub fn set_remark(mut self, remark: impl Into<CheetahString>) -> Self {
-        self.remark = Some(remark.into());
-        self
-    }
-
-    #[inline]
-    pub fn set_remark_option_mut(&mut self, remark: Option<impl Into<CheetahString>>) {
-        self.remark = remark.map(|item| item.into());
-    }
-
-    #[inline]
-    pub fn set_remark_mut(&mut self, remark: impl Into<CheetahString>) {
-        self.remark = Some(remark.into());
-    }
-
-    #[inline]
-    pub fn set_ext_fields(mut self, ext_fields: HashMap<CheetahString, CheetahString>) -> Self {
-        self.ext_fields.replace_map(ext_fields);
-        self.custom_header_to_net = false;
-        self
-    }
-
-    #[cfg(test)]
-    fn set_binary_ext_fields(mut self, ext_fields: BinaryHeaderFields) -> Self {
-        self.ext_fields = ExtensionFields::from_rocketmq_raw(ext_fields);
-        self.custom_header_to_net = false;
-        self
-    }
-
-    #[inline]
-    pub fn set_body(mut self, body: impl Into<Bytes>) -> Self {
-        self.body = Some(body.into());
-        self
-    }
-
-    #[inline]
-    pub fn set_body_mut_ref(&mut self, body: impl Into<Bytes>) {
-        self.body = Some(body.into());
-    }
-
-    #[inline]
-    pub fn set_suspended(mut self, suspended: bool) -> Self {
-        self.suspended = suspended;
-        self
-    }
-
-    #[inline]
-    pub fn set_suspended_ref(&mut self, suspended: bool) {
-        self.suspended = suspended;
-    }
-
-    #[inline]
-    pub fn set_serialize_type(mut self, serialize_type: SerializeType) -> Self {
-        self.serialize_type = serialize_type;
-        self
-    }
-
-    #[inline]
-    pub(crate) fn set_serialize_type_ref(&mut self, serialize_type: SerializeType) {
-        self.serialize_type = serialize_type;
-    }
-
-    #[inline]
-    pub fn mark_response_type(mut self) -> Self {
-        let mark = 1 << Self::RPC_TYPE;
-        self.flag |= mark;
-        self
-    }
-
-    #[inline]
-    pub fn mark_response_type_ref(&mut self) {
-        let mark = 1 << Self::RPC_TYPE;
-        self.flag |= mark;
-    }
-
-    #[inline]
-    pub fn mark_oneway_rpc(mut self) -> Self {
-        let mark = 1 << Self::RPC_ONEWAY;
-        self.flag |= mark;
-        self
-    }
-
-    #[inline]
-    pub fn mark_oneway_rpc_ref(&mut self) {
-        let mark = 1 << Self::RPC_ONEWAY;
-        self.flag |= mark;
-    }
-
-    #[inline]
-    pub fn get_serialize_type(&self) -> SerializeType {
-        self.serialize_type
     }
 
     /// Encode header with optimized path selection
@@ -617,55 +302,9 @@ impl RemotingCommand {
         let _ = self.try_make_custom_header_to_net();
     }
 
-    /// Fallibly merges the custom header into dynamic extension fields.
-    ///
-    /// # Errors
-    ///
-    /// Returns a typed validation, conversion, alias, or dynamic-field
-    /// collision error without mutating this command.
-    pub fn try_make_custom_header_to_net(&mut self) -> Result<(), HeaderCodecError> {
-        if self.custom_header_to_net {
-            return Ok(());
-        }
-
-        if let Some(header) = self.command_custom_header_ref() {
-            let merged = merge_header_and_dynamic(header, self.ext_fields.as_map())?;
-            self.ext_fields.replace_map(merged);
-        }
-        self.custom_header_to_net = true;
-        Ok(())
-    }
-
     #[inline]
     pub fn materialize_custom_header_to_ext_fields(&mut self) {
         self.make_custom_header_to_net();
-    }
-
-    fn invalidate_materialized_custom_header(&mut self) {
-        if !self.custom_header_to_net {
-            return;
-        }
-
-        let owned_keys = match (self.command_custom_header_ref(), self.ext_fields.as_map()) {
-            (Some(header), Some(fields)) => {
-                let mut keys = fields
-                    .keys()
-                    .filter(|key| header.contains_wire_key(key.as_str()))
-                    .cloned()
-                    .collect::<Vec<_>>();
-                if let Some(legacy_fields) = header.to_map() {
-                    keys.extend(legacy_fields.into_keys());
-                }
-                keys
-            }
-            _ => Vec::new(),
-        };
-        if let Some(fields) = self.ext_fields.as_map_mut() {
-            for key in owned_keys {
-                fields.remove(&key);
-            }
-        }
-        self.custom_header_to_net = false;
     }
 
     #[inline]
@@ -1054,247 +693,8 @@ impl RemotingCommand {
     }
 
     #[inline]
-    pub fn get_body(&self) -> Option<&Bytes> {
-        self.body.as_ref()
-    }
-
-    #[inline]
-    pub fn get_body_mut(&mut self) -> Option<&mut Bytes> {
-        self.body.as_mut()
-    }
-
-    #[inline]
     pub fn mark_serialize_type(header_length: i32, protocol_type: SerializeType) -> i32 {
         ((protocol_type.get_code() as i32) << 24) | (header_length & 0x00FFFFFF)
-    }
-
-    #[inline]
-    pub fn code(&self) -> i32 {
-        self.code
-    }
-
-    #[inline]
-    pub fn request_code(&self) -> RequestCode {
-        RequestCode::from(self.code)
-    }
-
-    #[inline]
-    pub fn code_ref(&self) -> &i32 {
-        &self.code
-    }
-
-    #[inline]
-    pub fn language(&self) -> LanguageCode {
-        self.language
-    }
-
-    #[inline]
-    pub fn version(&self) -> i32 {
-        self.version
-    }
-
-    pub fn rocketmq_version(&self) -> RocketMqVersion {
-        RocketMqVersion::from_ordinal(self.version as u32)
-    }
-
-    #[inline]
-    pub fn opaque(&self) -> i32 {
-        self.opaque
-    }
-
-    #[inline]
-    pub fn flag(&self) -> i32 {
-        self.flag
-    }
-
-    #[inline]
-    pub fn remark(&self) -> Option<&CheetahString> {
-        self.remark.as_ref()
-    }
-
-    #[inline]
-    pub fn ext_fields(&self) -> Option<&HashMap<CheetahString, CheetahString>> {
-        self.ext_fields.as_map()
-    }
-
-    #[inline]
-    pub fn body(&self) -> Option<&Bytes> {
-        self.body.as_ref()
-    }
-
-    #[inline]
-    pub fn take_body(&mut self) -> Option<Bytes> {
-        self.body.take()
-    }
-
-    #[inline]
-    pub fn suspended(&self) -> bool {
-        self.suspended
-    }
-
-    #[inline]
-    pub fn serialize_type(&self) -> SerializeType {
-        self.serialize_type
-    }
-
-    pub fn decode_command_custom_header<T>(&self) -> rocketmq_error::RocketMQResult<T>
-    where
-        T: FromMap<Target = T, Error = rocketmq_error::RocketMQError>,
-    {
-        if T::SUPPORTS_HEADER_FIELD_SOURCE {
-            if let Some(source) = self.ext_fields.as_field_source() {
-                return T::from_field_source(source);
-            }
-        }
-        match self.ext_fields.as_map() {
-            None => Err(rocketmq_error::RocketMQError::Serialization(
-                rocketmq_error::SerializationError::DecodeFailed {
-                    format: "header",
-                    message: "ExtFields is None".to_string(),
-                },
-            )),
-            Some(header) => T::from(header),
-        }
-    }
-
-    pub fn decode_command_custom_header_fast<T>(&self) -> rocketmq_error::RocketMQResult<T>
-    where
-        T: FromMap<Target = T, Error = rocketmq_error::RocketMQError>,
-        T: Default + CommandCustomHeader,
-    {
-        if T::SUPPORTS_HEADER_FIELD_SOURCE {
-            if let Some(source) = self.ext_fields.as_field_source() {
-                return T::from_field_source(source);
-            }
-        }
-        match self.ext_fields.as_map() {
-            None => Err(rocketmq_error::RocketMQError::Serialization(
-                rocketmq_error::SerializationError::DecodeFailed {
-                    format: "header",
-                    message: "ExtFields is None".to_string(),
-                },
-            )),
-            Some(header) => {
-                let mut target = T::default();
-                if target.support_fast_codec() {
-                    target.decode_fast(header)?;
-                    target.check_fields()?;
-                    Ok(target)
-                } else {
-                    T::from(header)
-                }
-            }
-        }
-    }
-
-    /// Decodes a required custom request header and classifies any failure at
-    /// the request-header boundary.
-    ///
-    /// `operation` must be a static, low-cardinality description. It is exposed
-    /// as structured error context, while the source retains the decoder cause.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`rocketmq_error::RocketMQError::RequestHeaderSource`] when the
-    /// extension fields are absent or the header cannot be decoded.
-    pub fn decode_required_header<T>(&self, operation: &'static str) -> rocketmq_error::RocketMQResult<T>
-    where
-        T: FromMap<Target = T, Error = rocketmq_error::RocketMQError>,
-    {
-        self.decode_command_custom_header::<T>()
-            .map_err(|source| required_header_decode_error(operation, source))
-    }
-
-    /// Decodes a required custom request header through the fast codec when the
-    /// header supports it and classifies any failure at the request-header
-    /// boundary.
-    ///
-    /// `operation` must be a static, low-cardinality description. It is exposed
-    /// as structured error context, while the source retains the decoder cause.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`rocketmq_error::RocketMQError::RequestHeaderSource`] when the
-    /// extension fields are absent or the header cannot be decoded.
-    pub fn decode_required_header_fast<T>(&self, operation: &'static str) -> rocketmq_error::RocketMQResult<T>
-    where
-        T: FromMap<Target = T, Error = rocketmq_error::RocketMQError>,
-        T: Default + CommandCustomHeader,
-    {
-        self.decode_command_custom_header_fast::<T>()
-            .map_err(|source| required_header_decode_error(operation, source))
-    }
-
-    #[inline]
-    pub fn is_response_type(&self) -> bool {
-        let bits = 1 << Self::RPC_TYPE;
-        (self.flag & bits) == bits
-    }
-
-    #[inline]
-    pub fn is_oneway_rpc(&self) -> bool {
-        let bits = 1 << Self::RPC_ONEWAY;
-        (self.flag & bits) == bits
-    }
-
-    pub fn get_type(&self) -> RemotingCommandType {
-        if self.is_response_type() {
-            RemotingCommandType::RESPONSE
-        } else {
-            RemotingCommandType::REQUEST
-        }
-    }
-
-    #[inline]
-    pub fn with_opaque(&mut self, opaque: i32) -> &mut Self {
-        self.opaque = opaque;
-        self
-    }
-
-    pub fn add_ext_field(&mut self, key: impl Into<CheetahString>, value: impl Into<CheetahString>) -> &mut Self {
-        self.ext_fields.get_or_insert_map().insert(key.into(), value.into());
-        self
-    }
-
-    #[inline]
-    pub fn with_code(&mut self, code: impl Into<i32>) -> &mut Self {
-        self.code = code.into();
-        self
-    }
-
-    #[inline]
-    pub fn with_remark(&mut self, remark: impl Into<CheetahString>) -> &mut Self {
-        self.remark = Some(remark.into());
-        self
-    }
-
-    #[inline]
-    pub fn get_ext_fields(&self) -> Option<&HashMap<CheetahString, CheetahString>> {
-        self.ext_fields.as_map()
-    }
-
-    pub fn read_custom_header_ref<T>(&self) -> Option<&T>
-    where
-        T: CommandCustomHeader + Sync + Send + 'static,
-    {
-        match self.command_custom_header.as_ref() {
-            None => None,
-            Some(value) => value.as_ref().as_any().downcast_ref::<T>(),
-        }
-    }
-
-    pub fn try_read_custom_header_ref<T>(&self) -> rocketmq_error::RocketMQResult<&T>
-    where
-        T: CommandCustomHeader + Sync + Send + 'static,
-    {
-        match self.command_custom_header.as_ref() {
-            None => Err(Self::custom_header_missing_error::<T>()),
-            Some(value) => value
-                .as_ref()
-                .as_any()
-                .downcast_ref::<T>()
-                .ok_or_else(Self::custom_header_type_mismatch_error::<T>),
-        }
     }
 
     pub fn read_custom_header_ref_unchecked<T>(&self) -> rocketmq_error::RocketMQResult<&T>
@@ -1302,21 +702,6 @@ impl RemotingCommand {
         T: CommandCustomHeader + Sync + Send + 'static,
     {
         self.try_read_custom_header_ref::<T>()
-    }
-
-    pub fn read_custom_header_mut<T>(&mut self) -> Option<&mut T>
-    where
-        T: CommandCustomHeader + Sync + Send + 'static,
-    {
-        let header = self.command_custom_header.as_ref()?;
-        if Arc::strong_count(header) != 1 || !header.as_ref().as_any().is::<T>() {
-            return None;
-        }
-        self.invalidate_materialized_custom_header();
-        Arc::get_mut(self.command_custom_header.as_mut()?)?
-            .as_mut()
-            .as_any_mut()
-            .downcast_mut::<T>()
     }
 
     /// Compatibility name for the former shared-reference mutation escape.
@@ -1331,132 +716,12 @@ impl RemotingCommand {
         self.read_custom_header_mut::<T>()
     }
 
-    pub fn try_read_custom_header_mut<T>(&mut self) -> rocketmq_error::RocketMQResult<&mut T>
-    where
-        T: CommandCustomHeader + Sync + Send + 'static,
-    {
-        match self.command_custom_header.as_ref() {
-            None => return Err(Self::custom_header_missing_error::<T>()),
-            Some(value) if Arc::strong_count(value) != 1 => return Err(Self::custom_header_shared_error()),
-            Some(value) if !value.as_ref().as_any().is::<T>() => {
-                return Err(Self::custom_header_type_mismatch_error::<T>());
-            }
-            Some(_) => {}
-        }
-        self.invalidate_materialized_custom_header();
-        Arc::get_mut(
-            self.command_custom_header
-                .as_mut()
-                .ok_or_else(Self::custom_header_missing_error::<T>)?,
-        )
-        .ok_or_else(Self::custom_header_shared_error)?
-        .as_mut()
-        .as_any_mut()
-        .downcast_mut::<T>()
-        .ok_or_else(Self::custom_header_type_mismatch_error::<T>)
-    }
-
     pub fn read_custom_header_mut_unchecked<T>(&mut self) -> rocketmq_error::RocketMQResult<&mut T>
     where
         T: CommandCustomHeader + Sync + Send + 'static,
     {
         self.try_read_custom_header_mut::<T>()
     }
-
-    pub fn command_custom_header_ref(&self) -> Option<&dyn CommandCustomHeader> {
-        match self.command_custom_header.as_ref() {
-            None => None,
-            Some(value) => Some(value.as_ref().as_ref()),
-        }
-    }
-
-    pub(crate) fn custom_header_encode_capability(&self) -> HeaderEncodeCapability {
-        if self.custom_header_to_net {
-            HeaderEncodeCapability::MapOnly
-        } else {
-            self.command_custom_header_ref()
-                .map_or(HeaderEncodeCapability::MapOnly, CommandCustomHeader::encode_capability)
-        }
-    }
-
-    pub fn command_custom_header_mut(&mut self) -> Option<&mut dyn CommandCustomHeader> {
-        if self
-            .command_custom_header
-            .as_ref()
-            .is_none_or(|header| Arc::strong_count(header) != 1)
-        {
-            return None;
-        }
-        self.invalidate_materialized_custom_header();
-        match self.command_custom_header.as_mut() {
-            None => None,
-            Some(value) => Arc::get_mut(value).map(|header| header.as_mut() as &mut dyn CommandCustomHeader),
-        }
-    }
-
-    pub fn create_new_request_id() -> i32 {
-        next_request_id()
-    }
-
-    #[inline]
-    pub fn add_ext_field_if_not_exist(&mut self, key: impl Into<CheetahString>, value: impl Into<CheetahString>) {
-        self.ext_fields
-            .get_or_insert_map()
-            .entry(key.into())
-            .or_insert(value.into());
-    }
-
-    /// Ensures the extension fields map is initialized.
-    ///
-    /// If `ext_fields` is `None`, initializes it with an empty `HashMap`.
-    /// This method is idempotent and safe to call multiple times.
-    #[inline]
-    pub fn ensure_ext_fields_initialized(&mut self) {
-        if self.ext_fields.is_absent() {
-            let _ = self.ext_fields.get_or_insert_map();
-        }
-    }
-
-    fn custom_header_missing_error<T>() -> rocketmq_error::RocketMQError
-    where
-        T: CommandCustomHeader + Sync + Send + 'static,
-    {
-        rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
-            format: "header",
-            message: format!(
-                "Command custom header is missing; expected {}.",
-                std::any::type_name::<T>()
-            ),
-        })
-    }
-
-    fn custom_header_type_mismatch_error<T>() -> rocketmq_error::RocketMQError
-    where
-        T: CommandCustomHeader + Sync + Send + 'static,
-    {
-        rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
-            format: "header",
-            message: format!(
-                "Command custom header type mismatch; expected {}.",
-                std::any::type_name::<T>()
-            ),
-        })
-    }
-
-    fn custom_header_shared_error() -> rocketmq_error::RocketMQError {
-        rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
-            format: "header",
-            message: "Command custom header is shared by a cloned command and cannot be mutated safely.".to_string(),
-        })
-    }
-}
-
-#[inline]
-fn required_header_decode_error(
-    operation: &'static str,
-    source: rocketmq_error::RocketMQError,
-) -> rocketmq_error::RocketMQError {
-    rocketmq_error::RocketMQError::request_header_source(operation, source)
 }
 
 /// Extract header length from the combined serialize_type field
@@ -1480,20 +745,6 @@ pub fn parse_serialize_type(size: i32) -> rocketmq_error::RocketMQResult<Seriali
             serialize_type: code,
         })
     })
-}
-
-impl AsRef<RemotingCommand> for RemotingCommand {
-    #[inline]
-    fn as_ref(&self) -> &RemotingCommand {
-        self
-    }
-}
-
-impl AsMut<RemotingCommand> for RemotingCommand {
-    #[inline]
-    fn as_mut(&mut self) -> &mut RemotingCommand {
-        self
-    }
 }
 
 #[cfg(test)]

--- a/rocketmq-protocol/src/protocol/remoting_command/accessors.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command/accessors.rs
@@ -1,0 +1,274 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use bytes::Bytes;
+use cheetah_string::CheetahString;
+use rocketmq_model::version::RocketMqVersion;
+
+use super::RemotingCommand;
+use super::SerializeType;
+use crate::code::request_code::RequestCode;
+use crate::protocol::LanguageCode;
+
+#[cfg(test)]
+use super::ExtensionFields;
+#[cfg(test)]
+use crate::protocol::header_codec::BinaryHeaderFields;
+
+impl RemotingCommand {
+    pub fn set_code(mut self, code: impl Into<i32>) -> Self {
+        self.code = code.into();
+        self
+    }
+
+    pub fn set_code_ref(&mut self, code: impl Into<i32>) {
+        self.code = code.into();
+    }
+
+    pub fn set_code_mut(&mut self, code: impl Into<i32>) -> &mut Self {
+        self.code = code.into();
+        self
+    }
+
+    pub fn set_language(mut self, language: LanguageCode) -> Self {
+        self.language = language;
+        self
+    }
+
+    pub fn set_version_ref(&mut self, version: i32) {
+        self.version = version;
+    }
+
+    pub fn set_version(mut self, version: i32) -> Self {
+        self.version = version;
+        self
+    }
+
+    #[inline]
+    pub fn set_opaque(mut self, opaque: i32) -> Self {
+        self.opaque = opaque;
+        self
+    }
+
+    #[inline]
+    pub fn set_opaque_mut(&mut self, opaque: i32) {
+        self.opaque = opaque;
+    }
+
+    #[inline]
+    pub fn set_remark_option(mut self, remark: Option<impl Into<CheetahString>>) -> Self {
+        self.remark = remark.map(|item| item.into());
+        self
+    }
+
+    #[inline]
+    pub fn set_remark(mut self, remark: impl Into<CheetahString>) -> Self {
+        self.remark = Some(remark.into());
+        self
+    }
+
+    #[inline]
+    pub fn set_remark_option_mut(&mut self, remark: Option<impl Into<CheetahString>>) {
+        self.remark = remark.map(|item| item.into());
+    }
+
+    #[inline]
+    pub fn set_remark_mut(&mut self, remark: impl Into<CheetahString>) {
+        self.remark = Some(remark.into());
+    }
+
+    #[inline]
+    pub fn set_ext_fields(mut self, ext_fields: HashMap<CheetahString, CheetahString>) -> Self {
+        self.ext_fields.replace_map(ext_fields);
+        self.custom_header_to_net = false;
+        self
+    }
+
+    #[cfg(test)]
+    pub(super) fn set_binary_ext_fields(mut self, ext_fields: BinaryHeaderFields) -> Self {
+        self.ext_fields = ExtensionFields::from_rocketmq_raw(ext_fields);
+        self.custom_header_to_net = false;
+        self
+    }
+
+    #[inline]
+    pub fn set_body(mut self, body: impl Into<Bytes>) -> Self {
+        self.body = Some(body.into());
+        self
+    }
+
+    #[inline]
+    pub fn set_body_mut_ref(&mut self, body: impl Into<Bytes>) {
+        self.body = Some(body.into());
+    }
+
+    #[inline]
+    pub fn set_suspended(mut self, suspended: bool) -> Self {
+        self.suspended = suspended;
+        self
+    }
+
+    #[inline]
+    pub fn set_suspended_ref(&mut self, suspended: bool) {
+        self.suspended = suspended;
+    }
+
+    #[inline]
+    pub fn set_serialize_type(mut self, serialize_type: SerializeType) -> Self {
+        self.serialize_type = serialize_type;
+        self
+    }
+
+    #[inline]
+    pub(crate) fn set_serialize_type_ref(&mut self, serialize_type: SerializeType) {
+        self.serialize_type = serialize_type;
+    }
+
+    #[inline]
+    pub fn get_body(&self) -> Option<&Bytes> {
+        self.body.as_ref()
+    }
+
+    #[inline]
+    pub fn get_body_mut(&mut self) -> Option<&mut Bytes> {
+        self.body.as_mut()
+    }
+
+    #[inline]
+    pub fn code(&self) -> i32 {
+        self.code
+    }
+
+    #[inline]
+    pub fn request_code(&self) -> RequestCode {
+        RequestCode::from(self.code)
+    }
+
+    #[inline]
+    pub fn code_ref(&self) -> &i32 {
+        &self.code
+    }
+
+    #[inline]
+    pub fn language(&self) -> LanguageCode {
+        self.language
+    }
+
+    #[inline]
+    pub fn version(&self) -> i32 {
+        self.version
+    }
+
+    pub fn rocketmq_version(&self) -> RocketMqVersion {
+        RocketMqVersion::from_ordinal(self.version as u32)
+    }
+
+    #[inline]
+    pub fn opaque(&self) -> i32 {
+        self.opaque
+    }
+
+    #[inline]
+    pub fn remark(&self) -> Option<&CheetahString> {
+        self.remark.as_ref()
+    }
+
+    #[inline]
+    pub fn ext_fields(&self) -> Option<&HashMap<CheetahString, CheetahString>> {
+        self.ext_fields.as_map()
+    }
+
+    #[inline]
+    pub fn body(&self) -> Option<&Bytes> {
+        self.body.as_ref()
+    }
+
+    #[inline]
+    pub fn take_body(&mut self) -> Option<Bytes> {
+        self.body.take()
+    }
+
+    #[inline]
+    pub fn suspended(&self) -> bool {
+        self.suspended
+    }
+
+    #[inline]
+    pub fn serialize_type(&self) -> SerializeType {
+        self.serialize_type
+    }
+
+    #[inline]
+    pub fn with_opaque(&mut self, opaque: i32) -> &mut Self {
+        self.opaque = opaque;
+        self
+    }
+
+    pub fn add_ext_field(&mut self, key: impl Into<CheetahString>, value: impl Into<CheetahString>) -> &mut Self {
+        self.ext_fields.get_or_insert_map().insert(key.into(), value.into());
+        self
+    }
+
+    #[inline]
+    pub fn with_code(&mut self, code: impl Into<i32>) -> &mut Self {
+        self.code = code.into();
+        self
+    }
+
+    #[inline]
+    pub fn with_remark(&mut self, remark: impl Into<CheetahString>) -> &mut Self {
+        self.remark = Some(remark.into());
+        self
+    }
+
+    #[inline]
+    pub fn get_ext_fields(&self) -> Option<&HashMap<CheetahString, CheetahString>> {
+        self.ext_fields.as_map()
+    }
+
+    #[inline]
+    pub fn add_ext_field_if_not_exist(&mut self, key: impl Into<CheetahString>, value: impl Into<CheetahString>) {
+        self.ext_fields
+            .get_or_insert_map()
+            .entry(key.into())
+            .or_insert(value.into());
+    }
+
+    /// Ensures the extension fields map is initialized.
+    ///
+    /// If `ext_fields` is `None`, initializes it with an empty `HashMap`.
+    /// This method is idempotent and safe to call multiple times.
+    #[inline]
+    pub fn ensure_ext_fields_initialized(&mut self) {
+        if self.ext_fields.is_absent() {
+            let _ = self.ext_fields.get_or_insert_map();
+        }
+    }
+}
+
+impl AsRef<RemotingCommand> for RemotingCommand {
+    #[inline]
+    fn as_ref(&self) -> &RemotingCommand {
+        self
+    }
+}
+
+impl AsMut<RemotingCommand> for RemotingCommand {
+    #[inline]
+    fn as_mut(&mut self) -> &mut RemotingCommand {
+        self
+    }
+}

--- a/rocketmq-protocol/src/protocol/remoting_command/constructors.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command/constructors.rs
@@ -1,0 +1,155 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::Bytes;
+use cheetah_string::CheetahString;
+
+use super::next_request_id;
+use super::ExtensionFields;
+use super::RemotingCommand;
+use super::SerializeType;
+use crate::protocol::command_custom_header::CommandCustomHeader;
+use crate::protocol::header_codec::BinaryHeaderFields;
+use crate::protocol::remoting_command_defaults::application_remoting_command_factory;
+use crate::protocol::remoting_command_defaults::RemotingCommandDefaults;
+use crate::protocol::LanguageCode;
+
+impl RemotingCommand {
+    /// Constructs a command from defaults resolved by the owning facade.
+    ///
+    /// The protocol crate deliberately does not read process environment or configuration files.
+    /// Legacy facades resolve those sources and pass the resulting wire values here.
+    pub fn with_resolved_defaults(version: i32, serialize_type: SerializeType) -> Self {
+        let opaque = next_request_id();
+        RemotingCommand {
+            code: 0,
+            language: LanguageCode::RUST, // Replace with your actual enum variant
+            version,
+            opaque,
+            flag: 0,
+            remark: None,
+            ext_fields: ExtensionFields::default(),
+            body: None,
+            suspended: false,
+            command_custom_header: None,
+            custom_header_to_net: false,
+            serialize_type,
+        }
+    }
+
+    pub(crate) fn from_binary_wire_parts(
+        code: i32,
+        language: LanguageCode,
+        version: i32,
+        opaque: i32,
+        flag: i32,
+        remark: Option<CheetahString>,
+        ext_fields: BinaryHeaderFields,
+    ) -> Self {
+        Self {
+            code,
+            language,
+            version,
+            opaque,
+            flag,
+            remark,
+            ext_fields: ExtensionFields::from_rocketmq_raw(ext_fields),
+            body: None,
+            suspended: false,
+            command_custom_header: None,
+            custom_header_to_net: false,
+            serialize_type: SerializeType::ROCKETMQ,
+        }
+    }
+
+    pub fn new_request(code: impl Into<i32>, body: impl Into<Bytes>) -> Self {
+        application_remoting_command_factory().create_request(code, body)
+    }
+
+    pub fn create_request_command<T>(code: impl Into<i32>, header: T) -> Self
+    where
+        T: CommandCustomHeader + Sync + Send + 'static,
+    {
+        application_remoting_command_factory().create_request_command(code, header)
+    }
+
+    /// Creates a request using defaults resolved by the transport/facade owner.
+    pub fn create_request_command_with_defaults<T>(
+        code: impl Into<i32>,
+        header: T,
+        version: i32,
+        serialize_type: SerializeType,
+    ) -> Self
+    where
+        T: CommandCustomHeader + Sync + Send + 'static,
+    {
+        crate::protocol::remoting_command_defaults::RemotingCommandFactory::new(RemotingCommandDefaults::new(
+            version,
+            serialize_type,
+        ))
+        .create_request_command(code, header)
+    }
+
+    pub fn create_remoting_command(code: impl Into<i32>) -> Self {
+        application_remoting_command_factory().create_remoting_command(code)
+    }
+
+    pub fn get_and_add() -> i32 {
+        next_request_id()
+    }
+
+    pub fn create_response_command_with_code(code: impl Into<i32>) -> Self {
+        application_remoting_command_factory().create_response_command_with_code(code)
+    }
+
+    /// Creates a response with an explicit code and typed custom header.
+    pub fn create_response_command_with_code_and_header(
+        code: impl Into<i32>,
+        header: impl CommandCustomHeader + Sync + Send + 'static,
+    ) -> Self {
+        application_remoting_command_factory().create_response_command_with_code_and_header(code, header)
+    }
+
+    pub fn create_response_command_with_code_remark(code: impl Into<i32>, remark: impl Into<CheetahString>) -> Self {
+        application_remoting_command_factory().create_response_command_with_code_remark(code, remark)
+    }
+
+    /// Creates an explicitly successful response.
+    pub fn create_success_response_command() -> Self {
+        application_remoting_command_factory().create_success_response_command()
+    }
+
+    /// Creates an explicitly successful response with a typed custom header.
+    pub fn create_success_response_command_with_header(
+        header: impl CommandCustomHeader + Sync + Send + 'static,
+    ) -> Self {
+        application_remoting_command_factory().create_success_response_command_with_header(header)
+    }
+
+    /// Creates the unset error response used by Java's typed-header factory.
+    pub fn create_java_default_error_response_command() -> Self {
+        application_remoting_command_factory().create_java_default_error_response_command()
+    }
+
+    /// Creates the unset Java-compatible error response with a typed header.
+    pub fn create_java_default_error_response_command_with_header(
+        header: impl CommandCustomHeader + Sync + Send + 'static,
+    ) -> Self {
+        application_remoting_command_factory().create_java_default_error_response_command_with_header(header)
+    }
+
+    pub fn create_new_request_id() -> i32 {
+        next_request_id()
+    }
+}

--- a/rocketmq-protocol/src/protocol/remoting_command/custom_header.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command/custom_header.rs
@@ -1,0 +1,336 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use super::RemotingCommand;
+use crate::protocol::command_custom_header::CommandCustomHeader;
+use crate::protocol::command_custom_header::FromMap;
+use crate::protocol::command_custom_header::HeaderEncodeCapability;
+use crate::protocol::header_codec::HeaderCodecError;
+use crate::protocol::header_field_merge::merge_header_and_dynamic;
+
+impl RemotingCommand {
+    pub fn set_command_custom_header<T>(mut self, command_custom_header: T) -> Self
+    where
+        T: CommandCustomHeader + Sync + Send + 'static,
+    {
+        self.invalidate_materialized_custom_header();
+        self.command_custom_header = Some(Arc::new(Box::new(command_custom_header)));
+        self.custom_header_to_net = false;
+        self
+    }
+
+    pub fn set_command_custom_header_boxed(
+        mut self,
+        command_custom_header: Box<dyn CommandCustomHeader + Send + Sync + 'static>,
+    ) -> Self {
+        self.invalidate_materialized_custom_header();
+        self.command_custom_header = Some(Arc::new(command_custom_header));
+        self.custom_header_to_net = false;
+        self
+    }
+
+    pub fn set_command_custom_header_origin<T>(mut self, command_custom_header: Option<T>) -> Self
+    where
+        T: std::ops::Deref<Target = Box<dyn CommandCustomHeader + Send + Sync + 'static>>,
+    {
+        self.invalidate_materialized_custom_header();
+        if let Some(header_fields) = command_custom_header.as_ref().and_then(|header| header.to_map()) {
+            self.ext_fields.get_or_insert_map().extend(header_fields);
+        }
+        self.command_custom_header = None;
+        self.custom_header_to_net = true;
+        self
+    }
+
+    pub fn set_command_custom_header_ref<T>(&mut self, command_custom_header: T)
+    where
+        T: CommandCustomHeader + Sync + Send + 'static,
+    {
+        self.invalidate_materialized_custom_header();
+        self.command_custom_header = Some(Arc::new(Box::new(command_custom_header)));
+        self.custom_header_to_net = false;
+    }
+
+    /// Fallibly merges the custom header into dynamic extension fields.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed validation, conversion, alias, or dynamic-field
+    /// collision error without mutating this command.
+    pub fn try_make_custom_header_to_net(&mut self) -> Result<(), HeaderCodecError> {
+        if self.custom_header_to_net {
+            return Ok(());
+        }
+
+        if let Some(header) = self.command_custom_header_ref() {
+            let merged = merge_header_and_dynamic(header, self.ext_fields.as_map())?;
+            self.ext_fields.replace_map(merged);
+        }
+        self.custom_header_to_net = true;
+        Ok(())
+    }
+
+    fn invalidate_materialized_custom_header(&mut self) {
+        if !self.custom_header_to_net {
+            return;
+        }
+
+        let owned_keys = match (self.command_custom_header_ref(), self.ext_fields.as_map()) {
+            (Some(header), Some(fields)) => {
+                let mut keys = fields
+                    .keys()
+                    .filter(|key| header.contains_wire_key(key.as_str()))
+                    .cloned()
+                    .collect::<Vec<_>>();
+                if let Some(legacy_fields) = header.to_map() {
+                    keys.extend(legacy_fields.into_keys());
+                }
+                keys
+            }
+            _ => Vec::new(),
+        };
+        if let Some(fields) = self.ext_fields.as_map_mut() {
+            for key in owned_keys {
+                fields.remove(&key);
+            }
+        }
+        self.custom_header_to_net = false;
+    }
+
+    pub fn decode_command_custom_header<T>(&self) -> rocketmq_error::RocketMQResult<T>
+    where
+        T: FromMap<Target = T, Error = rocketmq_error::RocketMQError>,
+    {
+        if T::SUPPORTS_HEADER_FIELD_SOURCE {
+            if let Some(source) = self.ext_fields.as_field_source() {
+                return T::from_field_source(source);
+            }
+        }
+        match self.ext_fields.as_map() {
+            None => Err(rocketmq_error::RocketMQError::Serialization(
+                rocketmq_error::SerializationError::DecodeFailed {
+                    format: "header",
+                    message: "ExtFields is None".to_string(),
+                },
+            )),
+            Some(header) => T::from(header),
+        }
+    }
+
+    pub fn decode_command_custom_header_fast<T>(&self) -> rocketmq_error::RocketMQResult<T>
+    where
+        T: FromMap<Target = T, Error = rocketmq_error::RocketMQError>,
+        T: Default + CommandCustomHeader,
+    {
+        if T::SUPPORTS_HEADER_FIELD_SOURCE {
+            if let Some(source) = self.ext_fields.as_field_source() {
+                return T::from_field_source(source);
+            }
+        }
+        match self.ext_fields.as_map() {
+            None => Err(rocketmq_error::RocketMQError::Serialization(
+                rocketmq_error::SerializationError::DecodeFailed {
+                    format: "header",
+                    message: "ExtFields is None".to_string(),
+                },
+            )),
+            Some(header) => {
+                let mut target = T::default();
+                if target.support_fast_codec() {
+                    target.decode_fast(header)?;
+                    target.check_fields()?;
+                    Ok(target)
+                } else {
+                    T::from(header)
+                }
+            }
+        }
+    }
+
+    /// Decodes a required custom request header and classifies any failure at
+    /// the request-header boundary.
+    ///
+    /// `operation` must be a static, low-cardinality description. It is exposed
+    /// as structured error context, while the source retains the decoder cause.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`rocketmq_error::RocketMQError::RequestHeaderSource`] when the
+    /// extension fields are absent or the header cannot be decoded.
+    pub fn decode_required_header<T>(&self, operation: &'static str) -> rocketmq_error::RocketMQResult<T>
+    where
+        T: FromMap<Target = T, Error = rocketmq_error::RocketMQError>,
+    {
+        self.decode_command_custom_header::<T>()
+            .map_err(|source| required_header_decode_error(operation, source))
+    }
+
+    /// Decodes a required custom request header through the fast codec when the
+    /// header supports it and classifies any failure at the request-header
+    /// boundary.
+    ///
+    /// `operation` must be a static, low-cardinality description. It is exposed
+    /// as structured error context, while the source retains the decoder cause.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`rocketmq_error::RocketMQError::RequestHeaderSource`] when the
+    /// extension fields are absent or the header cannot be decoded.
+    pub fn decode_required_header_fast<T>(&self, operation: &'static str) -> rocketmq_error::RocketMQResult<T>
+    where
+        T: FromMap<Target = T, Error = rocketmq_error::RocketMQError>,
+        T: Default + CommandCustomHeader,
+    {
+        self.decode_command_custom_header_fast::<T>()
+            .map_err(|source| required_header_decode_error(operation, source))
+    }
+
+    pub fn read_custom_header_ref<T>(&self) -> Option<&T>
+    where
+        T: CommandCustomHeader + Sync + Send + 'static,
+    {
+        match self.command_custom_header.as_ref() {
+            None => None,
+            Some(value) => value.as_ref().as_any().downcast_ref::<T>(),
+        }
+    }
+
+    pub fn try_read_custom_header_ref<T>(&self) -> rocketmq_error::RocketMQResult<&T>
+    where
+        T: CommandCustomHeader + Sync + Send + 'static,
+    {
+        match self.command_custom_header.as_ref() {
+            None => Err(Self::custom_header_missing_error::<T>()),
+            Some(value) => value
+                .as_ref()
+                .as_any()
+                .downcast_ref::<T>()
+                .ok_or_else(Self::custom_header_type_mismatch_error::<T>),
+        }
+    }
+
+    pub fn read_custom_header_mut<T>(&mut self) -> Option<&mut T>
+    where
+        T: CommandCustomHeader + Sync + Send + 'static,
+    {
+        let header = self.command_custom_header.as_ref()?;
+        if Arc::strong_count(header) != 1 || !header.as_ref().as_any().is::<T>() {
+            return None;
+        }
+        self.invalidate_materialized_custom_header();
+        Arc::get_mut(self.command_custom_header.as_mut()?)?
+            .as_mut()
+            .as_any_mut()
+            .downcast_mut::<T>()
+    }
+
+    pub fn try_read_custom_header_mut<T>(&mut self) -> rocketmq_error::RocketMQResult<&mut T>
+    where
+        T: CommandCustomHeader + Sync + Send + 'static,
+    {
+        match self.command_custom_header.as_ref() {
+            None => return Err(Self::custom_header_missing_error::<T>()),
+            Some(value) if Arc::strong_count(value) != 1 => return Err(Self::custom_header_shared_error()),
+            Some(value) if !value.as_ref().as_any().is::<T>() => {
+                return Err(Self::custom_header_type_mismatch_error::<T>());
+            }
+            Some(_) => {}
+        }
+        self.invalidate_materialized_custom_header();
+        Arc::get_mut(
+            self.command_custom_header
+                .as_mut()
+                .ok_or_else(Self::custom_header_missing_error::<T>)?,
+        )
+        .ok_or_else(Self::custom_header_shared_error)?
+        .as_mut()
+        .as_any_mut()
+        .downcast_mut::<T>()
+        .ok_or_else(Self::custom_header_type_mismatch_error::<T>)
+    }
+
+    pub fn command_custom_header_ref(&self) -> Option<&dyn CommandCustomHeader> {
+        match self.command_custom_header.as_ref() {
+            None => None,
+            Some(value) => Some(value.as_ref().as_ref()),
+        }
+    }
+
+    pub(crate) fn custom_header_encode_capability(&self) -> HeaderEncodeCapability {
+        if self.custom_header_to_net {
+            HeaderEncodeCapability::MapOnly
+        } else {
+            self.command_custom_header_ref()
+                .map_or(HeaderEncodeCapability::MapOnly, CommandCustomHeader::encode_capability)
+        }
+    }
+
+    pub fn command_custom_header_mut(&mut self) -> Option<&mut dyn CommandCustomHeader> {
+        if self
+            .command_custom_header
+            .as_ref()
+            .is_none_or(|header| Arc::strong_count(header) != 1)
+        {
+            return None;
+        }
+        self.invalidate_materialized_custom_header();
+        match self.command_custom_header.as_mut() {
+            None => None,
+            Some(value) => Arc::get_mut(value).map(|header| header.as_mut() as &mut dyn CommandCustomHeader),
+        }
+    }
+
+    fn custom_header_missing_error<T>() -> rocketmq_error::RocketMQError
+    where
+        T: CommandCustomHeader + Sync + Send + 'static,
+    {
+        rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
+            format: "header",
+            message: format!(
+                "Command custom header is missing; expected {}.",
+                std::any::type_name::<T>()
+            ),
+        })
+    }
+
+    fn custom_header_type_mismatch_error<T>() -> rocketmq_error::RocketMQError
+    where
+        T: CommandCustomHeader + Sync + Send + 'static,
+    {
+        rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
+            format: "header",
+            message: format!(
+                "Command custom header type mismatch; expected {}.",
+                std::any::type_name::<T>()
+            ),
+        })
+    }
+
+    fn custom_header_shared_error() -> rocketmq_error::RocketMQError {
+        rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
+            format: "header",
+            message: "Command custom header is shared by a cloned command and cannot be mutated safely.".to_string(),
+        })
+    }
+}
+
+#[inline]
+fn required_header_decode_error(
+    operation: &'static str,
+    source: rocketmq_error::RocketMQError,
+) -> rocketmq_error::RocketMQError {
+    rocketmq_error::RocketMQError::request_header_source(operation, source)
+}

--- a/rocketmq-protocol/src/protocol/remoting_command/flags.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command/flags.rs
@@ -1,0 +1,84 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::RemotingCommand;
+use super::RemotingCommandType;
+use super::SerializeType;
+
+impl RemotingCommand {
+    pub(crate) const RPC_ONEWAY: i32 = 1;
+    pub(crate) const RPC_TYPE: i32 = 0;
+
+    #[inline]
+    pub fn set_flag(mut self, flag: i32) -> Self {
+        self.flag = flag;
+        self
+    }
+
+    #[inline]
+    pub fn mark_response_type(mut self) -> Self {
+        let mark = 1 << Self::RPC_TYPE;
+        self.flag |= mark;
+        self
+    }
+
+    #[inline]
+    pub fn mark_response_type_ref(&mut self) {
+        let mark = 1 << Self::RPC_TYPE;
+        self.flag |= mark;
+    }
+
+    #[inline]
+    pub fn mark_oneway_rpc(mut self) -> Self {
+        let mark = 1 << Self::RPC_ONEWAY;
+        self.flag |= mark;
+        self
+    }
+
+    #[inline]
+    pub fn mark_oneway_rpc_ref(&mut self) {
+        let mark = 1 << Self::RPC_ONEWAY;
+        self.flag |= mark;
+    }
+
+    #[inline]
+    pub fn get_serialize_type(&self) -> SerializeType {
+        self.serialize_type
+    }
+
+    #[inline]
+    pub fn flag(&self) -> i32 {
+        self.flag
+    }
+
+    #[inline]
+    pub fn is_response_type(&self) -> bool {
+        let bits = 1 << Self::RPC_TYPE;
+        (self.flag & bits) == bits
+    }
+
+    #[inline]
+    pub fn is_oneway_rpc(&self) -> bool {
+        let bits = 1 << Self::RPC_ONEWAY;
+        (self.flag & bits) == bits
+    }
+
+    pub fn get_type(&self) -> RemotingCommandType {
+        if self.is_response_type() {
+            RemotingCommandType::RESPONSE
+        } else {
+            RemotingCommandType::REQUEST
+        }
+    }
+}

--- a/scripts/module-maintainability-baseline.json
+++ b/scripts/module-maintainability-baseline.json
@@ -6146,13 +6146,33 @@
       "reexports": 0
     },
     "rocketmq-protocol/src/protocol/remoting_command.rs": {
-      "production_lines": 1198,
-      "public_items": 102,
+      "production_lines": 587,
+      "public_items": 23,
+      "reexports": 0
+    },
+    "rocketmq-protocol/src/protocol/remoting_command/accessors.rs": {
+      "production_lines": 198,
+      "public_items": 40,
+      "reexports": 0
+    },
+    "rocketmq-protocol/src/protocol/remoting_command/constructors.rs": {
+      "production_lines": 105,
+      "public_items": 14,
+      "reexports": 0
+    },
+    "rocketmq-protocol/src/protocol/remoting_command/custom_header.rs": {
+      "production_lines": 265,
+      "public_items": 15,
       "reexports": 0
     },
     "rocketmq-protocol/src/protocol/remoting_command/extension_fields.rs": {
       "production_lines": 142,
       "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-protocol/src/protocol/remoting_command/flags.rs": {
+      "production_lines": 57,
+      "public_items": 10,
       "reexports": 0
     },
     "rocketmq-protocol/src/protocol/remoting_command/json_decode.rs": {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9627

### Brief Description

- Partition `RemotingCommand` constructors, state accessors, flags, and typed custom-header behavior into private sibling modules while retaining the parent type, codec paths, and legacy facade.
- Preserve public paths and signatures, wire behavior, request-ID semantics, custom-header behavior, and malformed-frame consumption.
- Relocate the existing maintainability source inventory without changing its crate-wide public-item or re-export totals.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-protocol -- --check`
- Focused default and `simd` `RemotingCommand` tests (43 each).
- Baseline contract (3), wire golden (5), and Java compatibility (4) integration tests.
- `cargo test -p rocketmq-protocol`
- Package and workspace all-target, all-feature Clippy with warnings denied.
- Candidate-versus-clean-base `python scripts/core_release_static_guard.py` structured-finding comparison; no new finding and one existing hotspot removed.
- Locked offline renamed-consumer check, standalone example Clippy, and pinned-nightly fuzz all-target/all-feature check.
- Root and standalone example format checks compared with clean base; both reproduce the same Windows OS 206 limitation.
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded APIs for creating, configuring, and inspecting remoting commands.
  - Added support for typed custom headers, including encoding, decoding, validation, and mutable access.
  - Added command flag controls for response, one-way RPC, and serialization behavior.
  - Added helpers for request and response creation, success and error responses, and request ID generation.

- **Refactor**
  - Reorganized remoting-command functionality into focused modules without changing the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->