### PR TITLE
[ISSUE #9629]✨Unify dashboard entity detail workspaces

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/EntityDetailPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/EntityDetailPage.tsx
@@ -1,0 +1,46 @@
+import { ArrowLeft } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import { cn } from '../lib/cn';
+import PageHeader from './PageHeader';
+import { buttonVariants } from './ui/Button';
+
+interface EntityDetailPageProps {
+  title: string;
+  description: string;
+  backTo: string;
+  backLabel: string;
+  actions?: ReactNode;
+  className?: string;
+  children: ReactNode;
+}
+
+export default function EntityDetailPage({
+  title,
+  description,
+  backTo,
+  backLabel,
+  actions,
+  className,
+  children
+}: EntityDetailPageProps) {
+  return (
+    <div className={cn('entity-full-page', className)} data-surface="frosted">
+      <div className="entity-full-page-header">
+        <PageHeader
+          title={title}
+          description={description}
+          actions={
+            <>
+              <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} to={backTo}>
+                <ArrowLeft size={14} aria-hidden="true" /> {backLabel}
+              </Link>
+              {actions}
+            </>
+          }
+        />
+      </div>
+      <div className="entity-full-page-body">{children}</div>
+    </div>
+  );
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/EntitySheet.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/EntitySheet.tsx
@@ -5,16 +5,18 @@ interface EntitySheetProps {
   open: boolean;
   title: string;
   description?: string;
+  actions?: ReactNode;
   onOpenChange: (open: boolean) => void;
   restoreFocusRef?: RefObject<HTMLElement | null>;
   children: ReactNode;
 }
 
-export default function EntitySheet({ open, title, description, onOpenChange, restoreFocusRef, children }: EntitySheetProps) {
+export default function EntitySheet({ open, title, description, actions, onOpenChange, restoreFocusRef, children }: EntitySheetProps) {
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
         className="entity-sheet"
+        data-surface="frosted"
         onCloseAutoFocus={(event) => {
           if (!restoreFocusRef?.current) return;
           event.preventDefault();
@@ -25,6 +27,7 @@ export default function EntitySheet({ open, title, description, onOpenChange, re
           <SheetTitle>{title}</SheetTitle>
           {description ? <SheetDescription>{description}</SheetDescription> : null}
         </SheetHeader>
+        {actions ? <div className="entity-sheet-actions" role="toolbar" aria-label="Detail actions">{actions}</div> : null}
         <div className="entity-sheet-body">{children}</div>
       </SheetContent>
     </Sheet>

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/operational-workspace.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/operational-workspace.test.tsx
@@ -71,7 +71,13 @@ describe('operational workspace components', () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
     render(
-      <EntitySheet open title="broker-a" description="Broker runtime and configuration" onOpenChange={onOpenChange}>
+      <EntitySheet
+        open
+        title="broker-a"
+        description="Broker runtime and configuration"
+        actions={<button type="button">Restart broker</button>}
+        onOpenChange={onOpenChange}
+      >
         <Tabs defaultValue="overview">
           <TabsList aria-label="Broker detail sections">
             <TabsTrigger value="overview">Overview</TabsTrigger>
@@ -83,8 +89,9 @@ describe('operational workspace components', () => {
       </EntitySheet>
     );
 
-    expect(screen.getByRole('dialog', { name: 'broker-a' })).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: 'broker-a' })).toHaveAttribute('data-surface', 'frosted');
     expect(screen.getByText('Broker runtime and configuration')).toBeInTheDocument();
+    expect(screen.getByRole('toolbar', { name: 'Detail actions' })).toContainElement(screen.getByRole('button', { name: 'Restart broker' }));
     const overview = screen.getByRole('tab', { name: 'Overview' });
     overview.focus();
     await user.keyboard('{ArrowRight}');

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/BrokerDetailPage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/BrokerDetailPage.test.tsx
@@ -46,6 +46,8 @@ describe('BrokerDetailPage', () => {
     expect(screen.getByText('V5_3_1')).toBeInTheDocument();
     expect(screen.getByText('MASTER')).toBeInTheDocument();
     expect(screen.getByRole('group', { name: 'Produce TPS: 12.5' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'broker-a' }).closest('[data-surface="frosted"]')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Back to cluster' })).toHaveAttribute('href', '/brokers');
     expect(brokerApi.list).toHaveBeenCalledTimes(1);
     expect(screen.queryByText('Available from cluster inventory')).not.toBeInTheDocument();
   });

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/BrokerDetailPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/BrokerDetailPage.tsx
@@ -1,11 +1,9 @@
-import { ArrowLeft } from 'lucide-react';
-import { Link, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { brokerApi } from '../api/broker_api';
+import EntityDetailPage from '../components/EntityDetailPage';
 import ErrorState from '../components/ErrorState';
 import LoadingState from '../components/LoadingState';
-import PageHeader from '../components/PageHeader';
-import { buttonVariants } from '../components/ui/Button';
 import type { BrokerInfo } from '../types/broker';
 import BrokerDetailContent from './brokers/BrokerDetailContent';
 
@@ -39,16 +37,13 @@ export default function BrokerDetailPage() {
   }, [loadBroker]);
 
   return (
-    <div className="broker-detail-page">
-      <PageHeader
-        title={brokerName}
-        description="Inspect runtime evidence and safely review broker configuration."
-        actions={
-          <Link className={buttonVariants({ variant: 'outline', size: 'sm' })} to="/brokers">
-            <ArrowLeft size={14} aria-hidden="true" /> Back to cluster
-          </Link>
-        }
-      />
+    <EntityDetailPage
+      className="broker-detail-page"
+      title={brokerName}
+      description="Inspect runtime evidence and safely review broker configuration."
+      backTo="/brokers"
+      backLabel="Back to cluster"
+    >
       {loading ? <LoadingState label="Loading broker overview" /> : null}
       {!loading && error ? <ErrorState message={error} onRetry={() => void loadBroker()} /> : null}
       {!loading && !error && !broker ? (
@@ -59,6 +54,6 @@ export default function BrokerDetailPage() {
         />
       ) : null}
       {!loading && !error && broker ? <BrokerDetailContent brokerName={brokerName} broker={broker} /> : null}
-    </div>
+    </EntityDetailPage>
   );
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConsumerDetailPage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConsumerDetailPage.test.tsx
@@ -60,6 +60,8 @@ describe('ConsumerDetailPage', () => {
     );
 
     expect(await screen.findByRole('heading', { name: 'order-service' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'order-service' }).closest('[data-surface="frosted"]')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Back to groups' })).toHaveAttribute('href', '/consumers');
     expect(await screen.findByRole('tab', { name: 'Overview' })).toBeInTheDocument();
   });
 

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConsumerDetailPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConsumerDetailPage.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { consumerApi } from '../api/consumer_api';
 import ConsumerDeleteDialog from '../components/ConsumerDeleteDialog';
+import EntityDetailPage from '../components/EntityDetailPage';
 import ConsumerMutationDialog from '../components/ConsumerMutationDialog';
-import PageHeader from '../components/PageHeader';
 import { Button } from '../components/ui/Button';
 import type { ConsumerGroupListItem, ConsumerSummaryView } from '../types/consumer';
 import { useConsumerQueryScope } from './consumers/ConsumerQueryScopeProvider';
@@ -48,16 +48,17 @@ export default function ConsumerDetailPage() {
   } : null;
 
   return (
-    <div className="entity-workspace consumer-detail-page">
-      <PageHeader
-        title={group}
-        description="Inspect API-backed group identity, connections, progress, configuration, and protected offset maintenance."
-        actions={<>
-          <Button type="button" variant="outline" onClick={() => navigate('/consumers')}>Back to groups</Button>
-          <Button type="button" variant="outline" disabled={!listItem} onClick={() => setEditOpen(true)}>Edit configuration</Button>
-          <Button type="button" variant="destructive" disabled={!listItem} onClick={() => setDeleteOpen(true)}>Delete group</Button>
-        </>}
-      />
+    <EntityDetailPage
+      className="entity-workspace consumer-detail-page"
+      title={group}
+      description="Inspect API-backed group identity, connections, progress, configuration, and protected offset maintenance."
+      backTo="/consumers"
+      backLabel="Back to groups"
+      actions={<>
+        <Button type="button" variant="outline" size="sm" disabled={!listItem} onClick={() => setEditOpen(true)}>Edit configuration</Button>
+        <Button type="button" variant="destructive" size="sm" disabled={!listItem} onClick={() => setDeleteOpen(true)}>Delete group</Button>
+      </>}
+    >
       <ConsumerDetailContent group={group} initialTab={initialTab} />
 
       <ConsumerMutationDialog
@@ -73,6 +74,6 @@ export default function ConsumerDetailPage() {
         onOpenChange={setDeleteOpen}
         onSucceeded={() => navigate('/consumers')}
       />
-    </div>
+    </EntityDetailPage>
   );
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/TopicDetailPage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/TopicDetailPage.test.tsx
@@ -43,6 +43,8 @@ describe('TopicDetailPage', () => {
     );
 
     expect(await screen.findByRole('heading', { name: 'orders' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'orders' }).closest('[data-surface="frosted"]')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Back to topics' })).toHaveAttribute('href', '/topics');
     expect(await screen.findByRole('group', { name: 'Queue entries: 2' })).toBeInTheDocument();
     expect(topicApi.route).not.toHaveBeenCalled();
 

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/TopicDetailPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/TopicDetailPage.tsx
@@ -1,14 +1,19 @@
 import { useParams } from 'react-router-dom';
-import PageHeader from '../components/PageHeader';
+import EntityDetailPage from '../components/EntityDetailPage';
 import TopicDetailContent from './topics/TopicDetailContent';
 
 export default function TopicDetailPage() {
   const { topic = '' } = useParams();
 
   return (
-    <div className="entity-detail-page">
-      <PageHeader title={topic} description="Inspect topic offsets, route queues, and API-backed configuration." />
+    <EntityDetailPage
+      className="entity-detail-page topic-detail-page"
+      title={topic}
+      description="Inspect topic offsets, route queues, and API-backed configuration."
+      backTo="/topics"
+      backLabel="Back to topics"
+    >
       <TopicDetailContent topicName={topic} />
-    </div>
+    </EntityDetailPage>
   );
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/TopicListPage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/TopicListPage.test.tsx
@@ -404,6 +404,7 @@ describe('TopicListPage', () => {
   it('refreshes only config and the catalog after Edit while preserving the detail tab', async () => {
     const user = userEvent.setup();
     const refreshedOrders = { ...topics[0], category: 'EDITED', messageType: 'FIFO' };
+    vi.mocked(topicApi.get).mockResolvedValue(refreshedOrders);
     vi.mocked(topicApi.list)
       .mockResolvedValueOnce(listView)
       .mockResolvedValueOnce({ ...listView, items: [refreshedOrders, ...topics.slice(1)] });

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/TopicListPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/TopicListPage.tsx
@@ -502,6 +502,26 @@ export default function TopicListPage() {
         title={selectedTopic?.topic ?? 'Topic details'}
         description={selectedTopic ? `${selectedTopic.category} · ${selectedTopic.brokerName || 'All brokers'}` : undefined}
         restoreFocusRef={detailTriggerRef}
+        actions={selectedTopic && getTopicActionAvailability(selectedTopic).deleteTopic ? (
+          <>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => handleMenuAction('delete-broker', selectedTopic)}
+            >
+              <Trash2 size={15} aria-hidden="true" /> Delete from broker
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              onClick={() => handleMenuAction('delete-topic', selectedTopic)}
+            >
+              <Trash2 size={15} aria-hidden="true" /> Delete topic
+            </Button>
+          </>
+        ) : undefined}
         onOpenChange={(open) => {
           if (!open) {
             selectedTopicRef.current = null;
@@ -510,36 +530,14 @@ export default function TopicListPage() {
         }}
       >
         {selectedTopic ? (
-          <>
-            {getTopicActionAvailability(selectedTopic).deleteTopic ? (
-              <div className="entity-row-actions">
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => handleMenuAction('delete-broker', selectedTopic)}
-                >
-                  <Trash2 size={15} aria-hidden="true" /> Delete from broker
-                </Button>
-                <Button
-                  type="button"
-                  variant="destructive"
-                  size="sm"
-                  onClick={() => handleMenuAction('delete-topic', selectedTopic)}
-                >
-                  <Trash2 size={15} aria-hidden="true" /> Delete topic
-                </Button>
-              </div>
-            ) : null}
-            <TopicDetailContent
-              topicName={selectedTopic.topic}
-              topic={selectedTopic}
-              resourceRevisions={detailRevisions}
-              onEdit={getTopicActionAvailability(selectedTopic).edit ? (config) => openEdit(selectedTopic, config) : undefined}
-              onReset={getTopicActionAvailability(selectedTopic).reset ? (group) => openConsumerAction('reset', selectedTopic, group) : undefined}
-              onSkip={getTopicActionAvailability(selectedTopic).skip ? (group) => openConsumerAction('skip', selectedTopic, group) : undefined}
-            />
-          </>
+          <TopicDetailContent
+            topicName={selectedTopic.topic}
+            topic={selectedTopic}
+            resourceRevisions={detailRevisions}
+            onEdit={getTopicActionAvailability(selectedTopic).edit ? (config) => openEdit(selectedTopic, config) : undefined}
+            onReset={getTopicActionAvailability(selectedTopic).reset ? (group) => openConsumerAction('reset', selectedTopic, group) : undefined}
+            onSkip={getTopicActionAvailability(selectedTopic).skip ? (group) => openConsumerAction('skip', selectedTopic, group) : undefined}
+          />
         ) : null}
       </EntitySheet>
       <TopicConsumerActionDialog

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/brokers/BrokerDetailContent.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/brokers/BrokerDetailContent.test.tsx
@@ -32,6 +32,12 @@ const brokerB: BrokerInfo = {
   version: '5.4.0'
 };
 
+const preciseBroker: BrokerInfo = {
+  ...broker,
+  produceTps: 133.0211239537,
+  consumeTps: 133.0211239537
+};
+
 describe('BrokerDetailContent', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -56,6 +62,14 @@ describe('BrokerDetailContent', () => {
     expect(screen.getByRole('group', { name: 'Produce TPS: 128.4' })).toBeInTheDocument();
     expect(brokerApi.runtime).not.toHaveBeenCalled();
     expect(brokerApi.config).not.toHaveBeenCalled();
+  });
+
+  it('rounds high-precision throughput so metric cards stay readable in drawers', () => {
+    renderAtRoute(<BrokerDetailContent brokerName="broker-a" broker={preciseBroker} />, '/brokers');
+
+    expect(screen.getByRole('group', { name: 'Produce TPS: 133.02' })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Consume TPS: 133.02' })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Combined TPS: 266.04' })).toBeInTheDocument();
   });
 
   it('loads runtime data once on demand and caches it for the open session', async () => {

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/brokers/BrokerDetailContent.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/brokers/BrokerDetailContent.tsx
@@ -193,9 +193,9 @@ export default function BrokerDetailContent({ brokerName, broker, initialTab = '
           </div>
           {broker ? (
             <div className="broker-throughput-grid">
-              <MetricCard label="Produce TPS" value={broker.produceTps} detail="Current reported ingress" />
-              <MetricCard label="Consume TPS" value={broker.consumeTps} detail="Current reported egress" />
-              <MetricCard label="Combined TPS" value={Number((broker.produceTps + broker.consumeTps).toFixed(2))} detail="Produce plus consume" />
+              <MetricCard label="Produce TPS" value={formatTps(broker.produceTps)} detail="Current reported ingress" />
+              <MetricCard label="Consume TPS" value={formatTps(broker.consumeTps)} detail="Current reported egress" />
+              <MetricCard label="Combined TPS" value={formatTps(broker.produceTps + broker.consumeTps)} detail="Produce plus consume" />
             </div>
           ) : null}
         </TabsContent>
@@ -283,4 +283,8 @@ function IdentityItem({ label, value, mono = false, status = false }: { label: s
       {status ? <StatusBadge status={value} tone={value === 'Unknown' ? 'neutral' : 'info'} /> : <strong className={mono ? 'mono' : undefined}>{value}</strong>}
     </div>
   );
+}
+
+function formatTps(value: number) {
+  return Number(value.toFixed(2));
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/topics/TopicDetailContent.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/topics/TopicDetailContent.test.tsx
@@ -80,7 +80,7 @@ describe('TopicDetailContent', () => {
     vi.mocked(topicApi.config).mockResolvedValue(configFixture);
   });
 
-  it('loads route and status independently and caches both for the selected topic', async () => {
+  it('refreshes route and status whenever their tabs are activated', async () => {
     const user = userEvent.setup();
     renderAtRoute(<TopicDetailContent topicName="orders" topic={topicFixture} />, '/topics');
 
@@ -96,10 +96,53 @@ describe('TopicDetailContent', () => {
     await user.click(screen.getByRole('tab', { name: 'Overview' }));
     await user.click(screen.getByRole('tab', { name: 'Routes and status' }));
 
-    expect(topicApi.stats).toHaveBeenCalledTimes(1);
-    expect(topicApi.route).toHaveBeenCalledTimes(1);
+    expect(topicApi.stats).toHaveBeenCalledTimes(4);
+    expect(topicApi.route).toHaveBeenCalledTimes(2);
+    expect(topicApi.get).toHaveBeenCalledTimes(1);
     expect(topicApi.consumers).not.toHaveBeenCalled();
     expect(topicApi.config).not.toHaveBeenCalled();
+  });
+
+  it('refreshes when the already selected tab is clicked again', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<TopicDetailContent topicName="orders" topic={topicFixture} />, '/topics');
+
+    expect(await screen.findByRole('group', { name: 'Queue entries: 2' })).toBeInTheDocument();
+    await user.click(screen.getByRole('tab', { name: 'Overview' }));
+    await waitFor(() => expect(topicApi.stats).toHaveBeenCalledTimes(2));
+    expect(topicApi.get).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('tab', { name: 'Routes and status' }));
+    await waitFor(() => expect(topicApi.route).toHaveBeenCalledTimes(1));
+    await user.click(screen.getByRole('tab', { name: 'Routes and status' }));
+    await waitFor(() => expect(topicApi.route).toHaveBeenCalledTimes(2));
+    expect(topicApi.stats).toHaveBeenCalledTimes(4);
+  });
+
+  it('refreshes the resource set for each tab from the contextual refresh control', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<TopicDetailContent topicName="orders" topic={topicFixture} />, '/topics');
+
+    expect(await screen.findByRole('group', { name: 'Queue entries: 2' })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Refresh Overview' }));
+    await waitFor(() => expect(topicApi.stats).toHaveBeenCalledTimes(2));
+    expect(topicApi.get).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('tab', { name: 'Routes and status' }));
+    await waitFor(() => expect(topicApi.route).toHaveBeenCalledTimes(1));
+    await user.click(screen.getByRole('button', { name: 'Refresh Routes and status' }));
+    await waitFor(() => expect(topicApi.route).toHaveBeenCalledTimes(2));
+    expect(topicApi.stats).toHaveBeenCalledTimes(4);
+
+    await user.click(screen.getByRole('tab', { name: 'Consumers' }));
+    await waitFor(() => expect(topicApi.consumers).toHaveBeenCalledTimes(1));
+    await user.click(screen.getByRole('button', { name: 'Refresh Consumers' }));
+    await waitFor(() => expect(topicApi.consumers).toHaveBeenCalledTimes(2));
+
+    await user.click(screen.getByRole('tab', { name: 'Configuration' }));
+    await waitFor(() => expect(topicApi.config).toHaveBeenCalledTimes(1));
+    await user.click(screen.getByRole('button', { name: 'Refresh Configuration' }));
+    await waitFor(() => expect(topicApi.config).toHaveBeenCalledTimes(2));
   });
 
   it('loads topic identity for a direct route when list context is unavailable', async () => {
@@ -262,7 +305,7 @@ describe('TopicDetailContent', () => {
     expect(await screen.findByRole('combobox', { name: 'Configuration broker' })).toHaveTextContent('broker-a');
     await user.click(screen.getByRole('tab', { name: 'Routes and status' }));
 
-    expect(topicApi.route).toHaveBeenCalledTimes(1);
+    expect(topicApi.route).toHaveBeenCalledTimes(2);
     expect(topicApi.config).toHaveBeenCalledTimes(2);
     expect(screen.getByRole('region', { name: 'Topic routes' })).toBeInTheDocument();
   });
@@ -304,7 +347,8 @@ describe('TopicDetailContent', () => {
       brokerSelect.focus();
       await user.keyboard('{Enter}');
       await user.click(screen.getByRole('option', { name: 'broker-b' }));
-      expect(screen.getByRole('status', { name: 'Loading topic configuration' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Refreshing Configuration' })).toBeInTheDocument();
+      expect(screen.getByText('cleanup.policy')).toBeInTheDocument();
 
       brokerSelect.focus();
       await user.keyboard('{Enter}');
@@ -324,12 +368,12 @@ describe('TopicDetailContent', () => {
           olderBrokerBRequest.reject(new Error('stale broker-b failed'));
         }
       });
-      expect(screen.getByRole('status', { name: 'Loading topic configuration' })).toBeInTheDocument();
-      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Refreshing Configuration' })).toBeInTheDocument();
+      expect(screen.queryByText('stale broker-b failed')).not.toBeInTheDocument();
       expect(screen.queryByText('64')).not.toBeInTheDocument();
 
       await act(async () => brokerARequest.resolve({ ...configFixture, readQueueNums: 12 }));
-      expect(screen.getByRole('status', { name: 'Loading topic configuration' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Refreshing Configuration' })).toBeInTheDocument();
       expect(screen.queryByText('12')).not.toBeInTheDocument();
 
       await act(async () => latestBrokerBRequest.resolve({

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/topics/TopicDetailContent.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/topics/TopicDetailContent.tsx
@@ -1,5 +1,5 @@
-import { Database, SlidersHorizontal } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { Database, RefreshCw, SlidersHorizontal } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState, type KeyboardEvent } from 'react';
 import { topicApi } from '../../api/topic_api';
 import AppDataTable, { type AppDataTableColumn } from '../../components/AppDataTable';
 import ErrorState from '../../components/ErrorState';
@@ -64,6 +64,12 @@ const emptyResource = <T,>(topicName: string, data: T | null = null): ResourceSt
 
 const errorMessage = (error: unknown) => error instanceof Error ? error.message : String(error);
 const EMPTY_REVISIONS: TopicDetailResourceRevisions = {};
+const TAB_LABELS: Record<TopicDetailTab, string> = {
+  overview: 'Overview',
+  routes: 'Routes and status',
+  consumers: 'Consumers',
+  configuration: 'Configuration'
+};
 
 export default function TopicDetailContent({
   topicName,
@@ -109,6 +115,7 @@ export default function TopicDetailContent({
   const consumersPendingRef = useRef(new Map<string, number>());
   const configPendingRef = useRef(new Map<string, number>());
   const resourceRevisionsRef = useRef({ topicName, revisions: resourceRevisions });
+  const selectedTabClickRef = useRef<TopicDetailTab | null>(null);
   topicNameRef.current = topicName;
 
   const activeTab = tabState.topicName === topicName ? tabState.tab : initialTab;
@@ -122,7 +129,7 @@ export default function TopicDetailContent({
   const selectedBroker = selectedBrokerState.topicName === topicName
     ? selectedBrokerState.brokerName
     : undefined;
-  const topicInfo = providedTopic ?? identity.data;
+  const topicInfo = identity.data ?? providedTopic;
 
   useEffect(() => {
     if (stateTopicRef.current === topicName) return;
@@ -153,20 +160,30 @@ export default function TopicDetailContent({
       : emptyResource(topicName, providedTopic));
   }, [providedTopic, topicName]);
 
-  const loadIdentity = useCallback(async () => {
+  const loadIdentity = useCallback(async (force = false) => {
     const requestTopic = topicName;
     const requestKey = requestTopic;
-    if (identityPendingRef.current.has(requestKey)) return;
+    if (!force && identityPendingRef.current.has(requestKey)) return;
     const requestId = ++identityRequestRef.current;
     identityPendingRef.current.set(requestKey, requestId);
-    setIdentityState({ topicName: requestTopic, data: null, loading: true, error: null });
+    setIdentityState((current) => ({
+      topicName: requestTopic,
+      data: current.topicName === requestTopic ? current.data : null,
+      loading: true,
+      error: null
+    }));
     try {
       const nextTopic = await topicApi.get(requestTopic);
       if (requestId !== identityRequestRef.current || topicNameRef.current !== requestTopic) return;
       setIdentityState({ topicName: requestTopic, data: nextTopic, loading: false, error: null });
     } catch (requestError) {
       if (requestId !== identityRequestRef.current || topicNameRef.current !== requestTopic) return;
-      setIdentityState({ topicName: requestTopic, data: null, loading: false, error: errorMessage(requestError) });
+      setIdentityState((current) => ({
+        topicName: requestTopic,
+        data: current.topicName === requestTopic ? current.data : null,
+        loading: false,
+        error: errorMessage(requestError)
+      }));
     } finally {
       if (identityPendingRef.current.get(requestKey) === requestId) {
         identityPendingRef.current.delete(requestKey);
@@ -294,6 +311,25 @@ export default function TopicDetailContent({
     }
   }, [topicName]);
 
+  const refreshTab = useCallback((tab: TopicDetailTab) => {
+    switch (tab) {
+      case 'overview':
+        void loadIdentity(true);
+        void loadStats(true);
+        break;
+      case 'routes':
+        void loadRoute(true);
+        void loadStats(true);
+        break;
+      case 'consumers':
+        void loadConsumers(true);
+        break;
+      case 'configuration':
+        void loadConfig(selectedBroker, true);
+        break;
+    }
+  }, [loadConfig, loadConsumers, loadIdentity, loadRoute, loadStats, selectedBroker]);
+
   useEffect(() => {
     const previous = resourceRevisionsRef.current;
     resourceRevisionsRef.current = { topicName, revisions: resourceRevisions };
@@ -410,19 +446,106 @@ export default function TopicDetailContent({
     ? Array.from(new Set([config.data.brokerName, ...config.data.brokerNameList].filter(Boolean)))
     : [];
   const mutationAllowed = !topicInfo?.systemTopic;
+  const activeTabLoading = activeTab === 'overview'
+    ? identity.loading || stats.loading
+    : activeTab === 'routes'
+      ? route.loading || stats.loading
+      : activeTab === 'consumers'
+        ? consumers.loading
+        : config.loading;
+  const activeTabError = activeTab === 'overview'
+    ? identity.error || stats.error
+    : activeTab === 'routes'
+      ? route.error || stats.error
+      : activeTab === 'consumers'
+        ? consumers.error
+        : config.error;
+  const activeTabLabel = TAB_LABELS[activeTab];
+
+  const handleTabChange = (value: string) => {
+    const nextTab = value as TopicDetailTab;
+    setTabState({ topicName, tab: nextTab });
+    refreshTab(nextTab);
+  };
+
+  const prepareTabClick = (tab: TopicDetailTab) => {
+    selectedTabClickRef.current = tab === activeTab ? tab : null;
+  };
+
+  const finishTabClick = (tab: TopicDetailTab) => {
+    if (selectedTabClickRef.current === tab) refreshTab(tab);
+    selectedTabClickRef.current = null;
+  };
+
+  const handleSelectedTabKeyDown = (event: KeyboardEvent, tab: TopicDetailTab) => {
+    if (!event.repeat && tab === activeTab && (event.key === 'Enter' || event.key === ' ')) {
+      refreshTab(tab);
+    }
+  };
 
   return (
     <div className="entity-detail-content topic-detail-content">
       <Tabs
+        className="topic-detail-tabs"
         value={activeTab}
-        onValueChange={(value) => setTabState({ topicName, tab: value as TopicDetailTab })}
+        onValueChange={handleTabChange}
       >
-        <TabsList aria-label="Topic detail sections">
-          <TabsTrigger value="overview">Overview</TabsTrigger>
-          <TabsTrigger value="routes">Routes and status</TabsTrigger>
-          <TabsTrigger value="consumers">Consumers</TabsTrigger>
-          <TabsTrigger value="configuration">Configuration</TabsTrigger>
-        </TabsList>
+        <div className="topic-detail-tab-bar">
+          <TabsList aria-label="Topic detail sections">
+            <TabsTrigger
+              value="overview"
+              onPointerDownCapture={() => prepareTabClick('overview')}
+              onClick={() => finishTabClick('overview')}
+              onKeyDown={(event) => handleSelectedTabKeyDown(event, 'overview')}
+            >
+              Overview
+            </TabsTrigger>
+            <TabsTrigger
+              value="routes"
+              onPointerDownCapture={() => prepareTabClick('routes')}
+              onClick={() => finishTabClick('routes')}
+              onKeyDown={(event) => handleSelectedTabKeyDown(event, 'routes')}
+            >
+              Routes and status
+            </TabsTrigger>
+            <TabsTrigger
+              value="consumers"
+              onPointerDownCapture={() => prepareTabClick('consumers')}
+              onClick={() => finishTabClick('consumers')}
+              onKeyDown={(event) => handleSelectedTabKeyDown(event, 'consumers')}
+            >
+              Consumers
+            </TabsTrigger>
+            <TabsTrigger
+              value="configuration"
+              onPointerDownCapture={() => prepareTabClick('configuration')}
+              onClick={() => finishTabClick('configuration')}
+              onKeyDown={(event) => handleSelectedTabKeyDown(event, 'configuration')}
+            >
+              Configuration
+            </TabsTrigger>
+          </TabsList>
+          <div className="topic-detail-refresh-control">
+            <span
+              className={activeTabError ? 'topic-detail-refresh-error' : undefined}
+              title={activeTabError ?? undefined}
+              aria-live="polite"
+            >
+              {activeTabError ? 'Refresh failed' : `${activeTabLabel} data`}
+            </span>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              loading={activeTabLoading}
+              aria-label={activeTabLoading ? `Refreshing ${activeTabLabel}` : `Refresh ${activeTabLabel}`}
+              onClick={() => refreshTab(activeTab)}
+            >
+              {!activeTabLoading ? <RefreshCw size={15} aria-hidden="true" /> : null}
+              {activeTabLoading ? 'Refreshing' : 'Refresh'}
+            </Button>
+          </div>
+        </div>
 
         <TabsContent value="overview">
           <div className="entity-identity-grid">
@@ -433,11 +556,11 @@ export default function TopicDetailContent({
             <IdentityItem label="Permission" value={getTopicPermissionLabel(topicInfo?.perm ?? 0)} mono />
             <IdentityItem label="Ordered" value={topicInfo?.order ? 'Yes' : 'No'} />
           </div>
-          {stats.loading ? <LoadingState label="Loading topic overview" /> : null}
-          {!stats.loading && stats.error ? (
+          {stats.loading && !stats.data ? <LoadingState label="Loading topic overview" /> : null}
+          {!stats.loading && stats.error && !stats.data ? (
             <ErrorState message={stats.error} onRetry={() => void loadStats()} retryLabel="Retry stats" />
           ) : null}
-          {!stats.loading && !stats.error && stats.data ? (
+          {stats.data ? (
             <div className="metric-grid entity-detail-metrics">
               <MetricCard label="Queue entries" value={stats.data.queueCount} icon={<Database size={17} />} />
               <MetricCard label="Messages" value={stats.data.totalMessageCount} icon={<Database size={17} />} />
@@ -462,8 +585,8 @@ export default function TopicDetailContent({
               pageSize={Math.max(route.data?.queues.length ?? 0, 1)}
               total={route.data?.queues.length ?? 0}
               onPageChange={() => undefined}
-              loading={route.loading}
-              error={route.error}
+              loading={route.loading && !route.data}
+              error={route.data ? null : route.error}
               onRetry={() => void loadRoute()}
               retryLabel="Retry routes"
               emptyTitle="No route queues"
@@ -484,8 +607,8 @@ export default function TopicDetailContent({
               pageSize={Math.max(stats.data?.offsets.length ?? 0, 1)}
               total={stats.data?.offsets.length ?? 0}
               onPageChange={() => undefined}
-              loading={stats.loading}
-              error={stats.error}
+              loading={stats.loading && !stats.data}
+              error={stats.data ? null : stats.error}
               onRetry={() => void loadStats()}
               retryLabel="Retry status"
               emptyTitle="No queue offsets"
@@ -508,8 +631,8 @@ export default function TopicDetailContent({
               pageSize={Math.max(consumers.data?.items.length ?? 0, 1)}
               total={consumers.data?.items.length ?? 0}
               onPageChange={() => undefined}
-              loading={consumers.loading}
-              error={consumers.error}
+              loading={consumers.loading && !consumers.data}
+              error={consumers.data ? null : consumers.error}
               onRetry={() => void loadConsumers()}
               retryLabel="Retry consumers"
               emptyTitle="No consumers"
@@ -547,15 +670,15 @@ export default function TopicDetailContent({
               ) : null}
             </div>
 
-            {config.loading ? <LoadingState label="Loading topic configuration" /> : null}
-            {!config.loading && config.error ? (
+            {config.loading && !config.data ? <LoadingState label="Loading topic configuration" /> : null}
+            {!config.loading && config.error && !config.data ? (
               <ErrorState
                 message={config.error}
                 onRetry={() => void loadConfig(selectedBroker)}
                 retryLabel="Retry configuration"
               />
             ) : null}
-            {!config.loading && !config.error && config.data ? (
+            {config.data ? (
               <>
                 {config.data.inconsistentFields.length > 0 ? (
                   <div className="state-block state-block-error" role="alert">

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/pages.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/pages.css
@@ -133,19 +133,188 @@
 }
 
 .entity-sheet {
-  width: min(500px, 100vw) !important;
-  padding: 20px;
+  width: min(720px, calc(100vw - 32px)) !important;
+  max-width: 100vw;
+  display: flex;
+  overflow: hidden;
+  flex-direction: column;
+  padding: 0;
   background: var(--card);
-  box-shadow: -18px 0 40px rgb(0 0 0 / 0.28);
+  background: var(--glass-surface);
+  border-left-color: var(--glass-border);
+  box-shadow: var(--glass-shadow), inset 1px 0 rgb(255 255 255 / 0.04);
+  backdrop-filter: blur(24px) saturate(135%);
+  -webkit-backdrop-filter: blur(24px) saturate(135%);
+  isolation: isolate;
+}
+
+.entity-sheet:focus {
+  outline: none;
 }
 
 .entity-sheet-header {
-  padding-bottom: 16px;
-  border-bottom: 1px solid var(--border);
+  flex: 0 0 auto;
+  gap: 5px;
+  padding: 22px 60px 18px 24px;
+  border-bottom: 1px solid var(--glass-border);
+  background: color-mix(in srgb, var(--chrome) 72%, transparent);
+}
+
+.entity-sheet .ui-sheet-title {
+  overflow: hidden;
+  font-size: 18px;
+  line-height: 25px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.entity-sheet .ui-sheet-description {
+  overflow: hidden;
+  margin-top: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.entity-sheet > .ui-overlay-close {
+  top: 18px;
+  right: 20px;
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--glass-border);
+  background: var(--glass-control);
+  box-shadow: inset 0 1px rgb(255 255 255 / 0.05), 0 8px 20px rgb(0 0 0 / 0.14);
+  backdrop-filter: blur(12px) saturate(130%);
+  -webkit-backdrop-filter: blur(12px) saturate(130%);
+}
+
+.entity-sheet > .ui-overlay-close:hover {
+  border-color: color-mix(in srgb, var(--primary) 34%, var(--glass-border));
+  background: var(--glass-control-hover);
+}
+
+.entity-sheet-actions {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 24px;
+  border-bottom: 1px solid var(--glass-border);
+  background: color-mix(in srgb, var(--card) 48%, transparent);
 }
 
 .entity-sheet-body {
-  padding-top: 16px;
+  min-height: 0;
+  flex: 1 1 auto;
+  overflow: auto;
+  padding: 20px 24px 28px;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+}
+
+.entity-sheet .ui-button {
+  box-shadow: inset 0 1px rgb(255 255 255 / 0.06), 0 8px 20px rgb(0 0 0 / 0.12);
+  backdrop-filter: blur(12px) saturate(130%);
+  -webkit-backdrop-filter: blur(12px) saturate(130%);
+  transition: border-color 150ms ease, background-color 150ms ease, color 150ms ease, transform 150ms ease;
+}
+
+.entity-sheet .ui-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.entity-sheet .ui-button-default {
+  border-color: color-mix(in srgb, var(--primary) 46%, var(--glass-border));
+  background: color-mix(in srgb, var(--primary) 22%, transparent);
+  color: color-mix(in srgb, var(--foreground) 90%, var(--primary));
+}
+
+.entity-sheet .ui-button-default:hover {
+  background: color-mix(in srgb, var(--primary) 31%, transparent);
+}
+
+.entity-sheet .ui-button-secondary,
+.entity-sheet .ui-button-outline,
+.entity-sheet .ui-button-ghost {
+  border-color: var(--glass-border);
+  background: var(--glass-control);
+  color: var(--foreground);
+}
+
+.entity-sheet .ui-button-secondary:hover,
+.entity-sheet .ui-button-outline:hover,
+.entity-sheet .ui-button-ghost:hover {
+  border-color: color-mix(in srgb, var(--primary) 30%, var(--glass-border));
+  background: var(--glass-control-hover);
+}
+
+.entity-sheet .ui-button-destructive {
+  border-color: color-mix(in srgb, var(--destructive) 52%, var(--glass-border));
+  background: color-mix(in srgb, var(--destructive) 20%, transparent);
+  color: color-mix(in srgb, var(--foreground) 88%, var(--destructive));
+}
+
+.entity-sheet .ui-button-destructive:hover {
+  border-color: color-mix(in srgb, var(--destructive) 72%, var(--glass-border));
+  background: color-mix(in srgb, var(--destructive) 29%, transparent);
+}
+
+.entity-sheet .ui-tabs-list {
+  border-color: var(--glass-border);
+  background: color-mix(in srgb, var(--background) 58%, transparent);
+  box-shadow: inset 0 1px rgb(255 255 255 / 0.035);
+  backdrop-filter: blur(14px) saturate(125%);
+  -webkit-backdrop-filter: blur(14px) saturate(125%);
+}
+
+.entity-sheet .ui-tabs-trigger {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--muted-foreground);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.entity-sheet .ui-tabs-trigger:hover {
+  background: var(--glass-control);
+  color: var(--foreground);
+}
+
+.entity-sheet .ui-tabs-trigger[data-state='active'] {
+  background: color-mix(in srgb, var(--primary) 18%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--primary) 30%, transparent), inset 0 -2px var(--primary);
+  color: var(--foreground);
+}
+
+.entity-sheet .metric-card,
+.entity-sheet .entity-identity-grid,
+.entity-sheet .entity-description-grid,
+.entity-sheet .message-detail-identity,
+.entity-sheet .message-properties-table,
+.entity-sheet .message-body-block,
+.entity-sheet .kv-shell,
+.entity-sheet .danger-zone,
+.entity-sheet .message-resend-panel {
+  border-color: var(--glass-border);
+  background: color-mix(in srgb, var(--card) 64%, transparent);
+  box-shadow: inset 0 1px rgb(255 255 255 / 0.035);
+}
+
+.entity-sheet .entity-identity-item,
+.entity-sheet .entity-description-grid > div,
+.entity-sheet .message-properties-table th {
+  background: color-mix(in srgb, var(--muted-surface) 62%, transparent);
+}
+
+.entity-sheet .ui-input,
+.entity-sheet .ui-select-trigger,
+.entity-sheet .ui-select-native,
+.entity-sheet select,
+.entity-sheet textarea {
+  border-color: var(--glass-border);
+  background: color-mix(in srgb, var(--background) 64%, transparent);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
 }
 
 /* Messaging entity workspaces */
@@ -264,6 +433,58 @@
 
 .entity-detail-content > .ui-tabs > .ui-tabs-list .ui-tabs-trigger {
   width: 100%;
+}
+
+.topic-detail-tab-bar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 12px;
+}
+
+.entity-sheet .topic-detail-tab-bar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: stretch;
+  gap: 10px;
+}
+
+.entity-sheet .topic-detail-tab-bar > .ui-tabs-list {
+  width: 100%;
+  flex-basis: auto;
+}
+
+.entity-sheet .topic-detail-refresh-control {
+  justify-content: flex-end;
+  min-height: 34px;
+}
+
+.topic-detail-tab-bar > .ui-tabs-list {
+  width: min(100%, 654px);
+  flex: 0 1 654px;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.topic-detail-tab-bar .ui-tabs-trigger {
+  width: 100%;
+}
+
+.topic-detail-refresh-control {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 10px;
+}
+
+.topic-detail-refresh-control > span {
+  color: var(--muted-foreground);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.topic-detail-refresh-control > .topic-detail-refresh-error {
+  color: var(--destructive);
 }
 
 .entity-detail-metrics {
@@ -950,6 +1171,21 @@
     flex: 1 0 max-content;
   }
 
+  .topic-detail-tab-bar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .topic-detail-tab-bar > .ui-tabs-list {
+    width: 100%;
+    flex-basis: auto;
+    overflow-x: auto;
+  }
+
+  .topic-detail-refresh-control {
+    justify-content: space-between;
+  }
+
   .entity-auxiliary-error,
   .producer-query-controls {
     align-items: stretch;
@@ -961,7 +1197,19 @@
   }
 
   .entity-sheet {
-    padding: 16px;
+    width: 100vw !important;
+  }
+
+  .entity-sheet-header {
+    padding: 18px 56px 15px 18px;
+  }
+
+  .entity-sheet-actions {
+    padding: 10px 18px;
+  }
+
+  .entity-sheet-body {
+    padding: 16px 18px 22px;
   }
 
   .app-data-table-footer {
@@ -977,6 +1225,29 @@
   .entity-detail-metrics,
   .broker-throughput-grid {
     grid-template-columns: 1fr;
+  }
+
+  .entity-sheet-actions .ui-button {
+    flex: 1 1 100%;
+  }
+
+  .entity-sheet .topic-detail-tab-bar > .ui-tabs-list {
+    display: flex;
+    overflow-x: auto;
+  }
+
+  .entity-sheet .topic-detail-tab-bar .ui-tabs-trigger {
+    flex: 1 0 max-content;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .entity-sheet .ui-button {
+    transition: none;
+  }
+
+  .entity-sheet .ui-button:hover:not(:disabled) {
+    transform: none;
   }
 }
 
@@ -1558,5 +1829,240 @@
 
   .dlq-action-bar .ui-button {
     width: 100%;
+  }
+}
+
+/* Unified frosted full-page entity details */
+.entity-full-page {
+  min-width: 0;
+  display: grid;
+  gap: 14px;
+}
+
+.entity-full-page-header {
+  min-width: 0;
+  overflow: hidden;
+  padding: 18px 20px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius);
+  background: var(--glass-surface);
+  box-shadow: var(--glass-shadow), inset 0 1px rgb(255 255 255 / 0.045);
+  backdrop-filter: blur(24px) saturate(135%);
+  -webkit-backdrop-filter: blur(24px) saturate(135%);
+}
+
+.entity-full-page-header .page-header {
+  align-items: flex-start;
+}
+
+.entity-full-page-header .page-header > div:first-child {
+  min-width: 0;
+}
+
+.entity-full-page-header .page-header h1,
+.entity-full-page-header .page-header p {
+  overflow-wrap: anywhere;
+}
+
+.entity-full-page-header .page-header-actions {
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.entity-full-page-body {
+  min-width: 0;
+  display: grid;
+  gap: 16px;
+}
+
+.entity-full-page-body > *,
+.entity-full-page .entity-detail-content,
+.entity-full-page .entity-detail-content > [data-orientation='horizontal'],
+.entity-full-page .broker-detail-tabs,
+.entity-full-page .topic-detail-tabs {
+  min-width: 0;
+}
+
+.broker-detail-page .entity-full-page-body,
+.broker-detail-page .broker-detail-content {
+  min-height: 0;
+  height: 100%;
+}
+
+.entity-full-page .ui-button {
+  border-color: var(--glass-border);
+  background: var(--glass-control);
+  box-shadow: inset 0 1px rgb(255 255 255 / 0.06), 0 8px 20px rgb(0 0 0 / 0.12);
+  backdrop-filter: blur(12px) saturate(130%);
+  -webkit-backdrop-filter: blur(12px) saturate(130%);
+  transition: border-color 150ms ease, background-color 150ms ease, color 150ms ease, transform 150ms ease;
+}
+
+.entity-full-page .ui-button:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--primary) 30%, var(--glass-border));
+  background: var(--glass-control-hover);
+  transform: translateY(-1px);
+}
+
+.entity-full-page .ui-button-default {
+  border-color: color-mix(in srgb, var(--primary) 46%, var(--glass-border));
+  background: color-mix(in srgb, var(--primary) 22%, transparent);
+  color: color-mix(in srgb, var(--foreground) 90%, var(--primary));
+}
+
+.entity-full-page .ui-button-default:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--primary) 31%, transparent);
+}
+
+.entity-full-page .ui-button-destructive {
+  border-color: color-mix(in srgb, var(--destructive) 52%, var(--glass-border));
+  background: color-mix(in srgb, var(--destructive) 20%, transparent);
+  color: color-mix(in srgb, var(--foreground) 88%, var(--destructive));
+}
+
+.entity-full-page .ui-button-destructive:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--destructive) 72%, var(--glass-border));
+  background: color-mix(in srgb, var(--destructive) 29%, transparent);
+}
+
+.entity-full-page .ui-tabs-list,
+.entity-full-page .entity-detail-content > .ui-tabs > .ui-tabs-list,
+.entity-full-page .broker-detail-content .ui-tabs-list,
+.entity-full-page .topic-detail-tab-bar > .ui-tabs-list {
+  width: fit-content;
+  max-width: 100%;
+  min-height: 42px;
+  display: flex;
+  justify-self: start;
+  overflow-x: auto;
+  flex: 0 1 auto;
+  gap: 4px;
+  padding: 4px;
+  border-color: var(--glass-border);
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--glass-surface-strong) 82%, transparent);
+  box-shadow: inset 0 1px rgb(255 255 255 / 0.045), 0 10px 28px rgb(0 0 0 / 0.12);
+  backdrop-filter: blur(18px) saturate(130%);
+  -webkit-backdrop-filter: blur(18px) saturate(130%);
+  scrollbar-width: thin;
+}
+
+.entity-full-page .ui-tabs-trigger,
+.entity-full-page .entity-detail-content > .ui-tabs > .ui-tabs-list .ui-tabs-trigger,
+.entity-full-page .broker-detail-content .ui-tabs-trigger,
+.entity-full-page .topic-detail-tab-bar .ui-tabs-trigger {
+  width: auto;
+  min-width: 126px;
+  flex: 0 0 auto;
+  padding: 0 16px;
+  border-radius: calc(var(--radius) - 3px);
+  color: var(--muted-foreground);
+  white-space: nowrap;
+}
+
+.entity-full-page .ui-tabs-trigger:hover,
+.entity-full-page .entity-detail-content > .ui-tabs > .ui-tabs-list .ui-tabs-trigger:hover,
+.entity-full-page .broker-detail-content .ui-tabs-trigger:hover,
+.entity-full-page .topic-detail-tab-bar .ui-tabs-trigger:hover {
+  background: var(--glass-control);
+  color: var(--foreground);
+}
+
+.entity-full-page .ui-tabs-trigger[data-state='active'],
+.entity-full-page .entity-detail-content > .ui-tabs > .ui-tabs-list .ui-tabs-trigger[data-state='active'],
+.entity-full-page .broker-detail-content .ui-tabs-trigger[data-state='active'],
+.entity-full-page .topic-detail-tab-bar .ui-tabs-trigger[data-state='active'] {
+  background: color-mix(in srgb, var(--primary) 19%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--primary) 32%, transparent), inset 0 -2px var(--primary);
+  color: var(--foreground);
+  font-weight: 700;
+}
+
+.entity-full-page .metric-card,
+.entity-full-page .kv-shell,
+.entity-full-page .entity-table-card,
+.entity-full-page .app-data-table,
+.entity-full-page .consumer-configuration-target,
+.entity-full-page .consumer-configuration-group,
+.entity-full-page .consumer-configuration-attributes,
+.entity-full-page .danger-zone {
+  border-color: var(--glass-border);
+  background: color-mix(in srgb, var(--card) 66%, transparent);
+  box-shadow: inset 0 1px rgb(255 255 255 / 0.035), 0 12px 32px rgb(0 0 0 / 0.08);
+  backdrop-filter: blur(16px) saturate(125%);
+  -webkit-backdrop-filter: blur(16px) saturate(125%);
+}
+
+.entity-full-page .broker-identity-grid,
+.entity-full-page .entity-identity-grid,
+.entity-full-page .entity-description-grid {
+  border-color: var(--glass-border);
+  background: var(--glass-border);
+  box-shadow: inset 0 1px rgb(255 255 255 / 0.035), 0 12px 32px rgb(0 0 0 / 0.08);
+}
+
+.entity-full-page .broker-identity-item,
+.entity-full-page .entity-identity-item,
+.entity-full-page .entity-description-grid > div {
+  background: color-mix(in srgb, var(--card) 66%, transparent);
+  backdrop-filter: blur(16px) saturate(125%);
+  -webkit-backdrop-filter: blur(16px) saturate(125%);
+}
+
+.entity-full-page .ui-input,
+.entity-full-page .ui-select-trigger,
+.entity-full-page .ui-select-native,
+.entity-full-page select,
+.entity-full-page textarea {
+  border-color: var(--glass-border);
+  background: color-mix(in srgb, var(--background) 64%, transparent);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+}
+
+@media (max-width: 760px) {
+  .entity-full-page-header {
+    padding: 16px;
+  }
+
+  .entity-full-page-header .page-header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .entity-full-page-header .page-header-actions {
+    justify-content: flex-start;
+  }
+
+  .entity-full-page .ui-tabs-list,
+  .entity-full-page .entity-detail-content > .ui-tabs > .ui-tabs-list,
+  .entity-full-page .broker-detail-content .ui-tabs-list,
+  .entity-full-page .topic-detail-tab-bar > .ui-tabs-list {
+    width: 100%;
+  }
+
+  .entity-full-page .ui-tabs-trigger,
+  .entity-full-page .entity-detail-content > .ui-tabs > .ui-tabs-list .ui-tabs-trigger,
+  .entity-full-page .broker-detail-content .ui-tabs-trigger,
+  .entity-full-page .topic-detail-tab-bar .ui-tabs-trigger {
+    min-width: max-content;
+    flex: 1 0 auto;
+  }
+}
+
+@media (max-width: 520px) {
+  .entity-full-page-header .page-header-actions .ui-button {
+    flex: 1 1 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .entity-full-page .ui-button {
+    transition: none;
+  }
+
+  .entity-full-page .ui-button:hover:not(:disabled) {
+    transform: none;
   }
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/tokens.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/tokens.css
@@ -30,6 +30,12 @@
   --accent: var(--warning);
   --danger: var(--destructive);
   --shadow: 0 16px 40px rgb(0 0 0 / 0.45);
+  --glass-surface: color-mix(in srgb, var(--card) 84%, transparent);
+  --glass-surface-strong: color-mix(in srgb, var(--muted-surface) 88%, transparent);
+  --glass-control: color-mix(in srgb, var(--foreground) 6%, transparent);
+  --glass-control-hover: color-mix(in srgb, var(--foreground) 11%, transparent);
+  --glass-border: color-mix(in srgb, var(--foreground) 14%, var(--border));
+  --glass-shadow: -24px 0 64px rgb(0 0 0 / 0.46);
   --radius: 8px;
   --radius-sm: 6px;
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9629

### Brief Description

- Adds a shared frosted-glass full-page detail shell for broker, topic, and consumer workspaces.
- Standardizes entity drawers, headers, action groups, compact tabs, cards, inputs, and responsive behavior.
- Refreshes topic detail data when tabs are selected again and provides a consistent manual refresh action.
- Improves dense JSON-backed values and broker metrics so they remain readable without breaking row layouts.
- Adds regression coverage for shared detail layouts, topic refresh behavior, and responsive navigation.

### How Did You Test This Change?

- `npm ci`
- `npm test -- --run` (52 test files and 341 tests passed)
- `npm run build`
- `git diff --check`
- Manually verified broker, topic, and consumer full-page views at desktop and narrow viewport sizes, including tab interaction, refresh behavior, horizontal overflow, and browser console output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added refreshed frosted-glass layouts for broker, consumer, and topic detail pages.
  - Added contextual action toolbars for detail sheets and pages.
  - Added tab-specific refresh controls for topic details, including keyboard support and background refresh states.
  - Added clearer back navigation and responsive layouts.

- **Improvements**
  - Broker throughput metrics now display consistently to two decimal places.
  - Enhanced responsive styling, controls, tabs, data panels, and reduced-motion support.

- **Bug Fixes**
  - Improved topic identity and resource refresh handling while preserving existing data during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->