### PR TITLE
[ISSUE #9630]♻️Partition RemotingCommand frame encoding and decoding

### DIFF
--- a/rocketmq-protocol/src/protocol/remoting_command.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command.rs
@@ -20,9 +20,7 @@ use std::sync::Arc;
 #[cfg(test)]
 use std::collections::HashMap;
 
-use bytes::BufMut;
 use bytes::Bytes;
-use bytes::BytesMut;
 use cheetah_string::CheetahString;
 use serde::ser::SerializeMap;
 use serde::Deserialize;
@@ -33,15 +31,16 @@ use serde::Serializer;
 use super::RemotingCommandType;
 use super::SerializeType;
 use crate::protocol::command_custom_header::CommandCustomHeader;
-use crate::protocol::command_custom_header::HeaderEncodeCapability;
-use crate::protocol::header_codec::write_json_string;
 use crate::protocol::header_codec::BinaryHeaderFields;
 use crate::protocol::header_codec::JsonHeaderFields;
 use crate::protocol::LanguageCode;
-use crate::rocketmq_serializable::RocketMQSerializable;
 
 #[cfg(test)]
 use crate::protocol::command_custom_header::FromMap;
+#[cfg(test)]
+use bytes::BufMut;
+#[cfg(test)]
+use bytes::BytesMut;
 
 pub const SERIALIZE_TYPE_PROPERTY: &str = "rocketmq.serialize.type";
 pub const SERIALIZE_TYPE_ENV: &str = "ROCKETMQ_SERIALIZE_TYPE";
@@ -71,42 +70,16 @@ fn next_request_id() -> i32 {
     next_request_id_from(&REQUEST_ID)
 }
 
-#[inline]
-fn write_json_i32(out: &mut BytesMut, value: i32) {
-    let mut buffer = itoa::Buffer::new();
-    out.extend_from_slice(buffer.format(value).as_bytes());
-}
-
-#[inline]
-const fn language_name(language: LanguageCode) -> &'static str {
-    match language {
-        LanguageCode::JAVA => "JAVA",
-        LanguageCode::CPP => "CPP",
-        LanguageCode::DOTNET => "DOTNET",
-        LanguageCode::PYTHON => "PYTHON",
-        LanguageCode::DELPHI => "DELPHI",
-        LanguageCode::ERLANG => "ERLANG",
-        LanguageCode::RUBY => "RUBY",
-        LanguageCode::OTHER => "OTHER",
-        LanguageCode::HTTP => "HTTP",
-        LanguageCode::GO => "GO",
-        LanguageCode::PHP => "PHP",
-        LanguageCode::OMS => "OMS",
-        LanguageCode::RUST => "RUST",
-        LanguageCode::NODE_JS => "NODE_JS",
-    }
-}
-
 mod accessors;
 mod constructors;
 mod custom_header;
+mod decode;
+mod encode;
 mod extension_fields;
 mod flags;
-mod json_decode;
+mod frame;
 
 use extension_fields::ExtensionFields;
-use json_decode::try_decode_json_header;
-use json_decode::try_decode_json_header_bytes;
 
 fn serialize_ext_fields<S>(ext_fields: &ExtensionFields, serializer: S) -> Result<S::Ok, S::Error>
 where
@@ -236,66 +209,6 @@ impl RemotingCommand {
         Self::create_success_response_command_with_header(header)
     }
 
-    /// Encode header with optimized path selection
-    #[inline]
-    pub fn header_encode(&mut self) -> Option<Bytes> {
-        match self.serialize_type {
-            SerializeType::ROCKETMQ => {
-                let mut encoded = BytesMut::new();
-                RocketMQSerializable::try_rocketmq_protocol_encode(self, &mut encoded).ok()?;
-                Some(encoded.freeze())
-            }
-            SerializeType::JSON => {
-                self.try_make_custom_header_to_net().ok()?;
-                #[cfg(feature = "simd")]
-                {
-                    match simd_json::to_vec(self) {
-                        Ok(value) => Some(Bytes::from(value)),
-                        Err(_) => None,
-                    }
-                }
-                #[cfg(not(feature = "simd"))]
-                {
-                    match serde_json::to_vec(self) {
-                        Ok(value) => Some(Bytes::from(value)),
-                        Err(_) => None,
-                    }
-                }
-            }
-        }
-    }
-
-    /// Encode header with body length information
-    #[inline]
-    pub fn encode_header(&mut self) -> Option<Bytes> {
-        let body_length = self.body.as_ref().map_or(0, |b| b.len());
-        self.encode_header_with_body_length(body_length)
-    }
-
-    /// Optimized header encoding with pre-calculated capacity
-    #[inline]
-    pub fn encode_header_with_body_length(&mut self, body_length: usize) -> Option<Bytes> {
-        // Encode header data
-        let header_data = self.header_encode()?;
-        let header_len = header_data.len();
-        let (total_length, marked_header_length) =
-            Self::checked_frame_lengths(header_len, body_length, self.serialize_type).ok()?;
-
-        // Allocate exact capacity
-        let mut result = BytesMut::with_capacity(8 + header_len);
-
-        // Write total length
-        result.put_i32(total_length);
-
-        // Write serialize type with embedded header length
-        result.put_i32(marked_header_length);
-
-        // Write header data
-        result.put(header_data);
-
-        Some(result.freeze())
-    }
-
     /// Convert custom header to network format (merge into ext_fields)
     #[inline]
     pub fn make_custom_header_to_net(&mut self) {
@@ -305,396 +218,6 @@ impl RemotingCommand {
     #[inline]
     pub fn materialize_custom_header_to_ext_fields(&mut self) {
         self.make_custom_header_to_net();
-    }
-
-    #[inline]
-    pub fn fast_header_encode(&mut self, dst: &mut BytesMut) {
-        let _ = self.try_fast_header_encode(dst);
-    }
-
-    /// Encodes the frame header and rolls the destination back on failure.
-    ///
-    /// # Errors
-    ///
-    /// Returns the custom-header validation or direct-binary encoding failure.
-    #[inline]
-    pub fn try_fast_header_encode(&mut self, dst: &mut BytesMut) -> rocketmq_error::RocketMQResult<()> {
-        let body_length = self.body.as_ref().map_or(0, Bytes::len);
-        self.try_fast_header_encode_with_body_length(dst, body_length)
-    }
-
-    #[inline]
-    pub(crate) fn try_fast_header_encode_with_body_length(
-        &mut self,
-        dst: &mut BytesMut,
-        body_length: usize,
-    ) -> rocketmq_error::RocketMQResult<()> {
-        let checkpoint = dst.len();
-        let result = match self.body.as_ref() {
-            Some(body) if body.len() != body_length => Err(rocketmq_error::SerializationError::encode_failed(
-                "remoting-command",
-                "explicit body length does not match the in-memory body",
-            )
-            .into()),
-            _ => self.try_fast_header_encode_inner(dst, body_length),
-        };
-        if result.is_err() {
-            dst.truncate(checkpoint);
-        }
-        result
-    }
-
-    #[inline]
-    fn try_fast_header_encode_inner(
-        &mut self,
-        dst: &mut BytesMut,
-        body_length: usize,
-    ) -> rocketmq_error::RocketMQResult<()> {
-        match self.serialize_type {
-            SerializeType::JSON => self.fast_encode_json(dst, body_length),
-            SerializeType::ROCKETMQ => self.fast_encode_rocketmq(dst, body_length),
-        }
-    }
-
-    /// Optimized JSON encoding with pre-calculated capacity and zero-copy optimizations
-    #[inline]
-    fn fast_encode_json(&mut self, dst: &mut BytesMut, body_length: usize) -> rocketmq_error::RocketMQResult<()> {
-        let direct_fields = !self.custom_header_to_net
-            && self.ext_fields.is_absent()
-            && self
-                .command_custom_header_ref()
-                .is_some_and(CommandCustomHeader::supports_direct_json_fields);
-        if direct_fields {
-            return self.fast_encode_json_direct(dst, body_length);
-        }
-
-        self.try_make_custom_header_to_net()
-            .map_err(|error| rocketmq_error::RocketMQError::request_header_error(error.to_string()))?;
-
-        let estimated_header_size = self.estimate_json_header_size();
-        let begin_index = dst.len();
-
-        dst.reserve(8 + estimated_header_size);
-        dst.put_i64(0);
-        let header_index = dst.len();
-
-        #[cfg(feature = "simd")]
-        let encode_result = simd_json::to_writer((&mut *dst).writer(), self);
-
-        #[cfg(not(feature = "simd"))]
-        let encode_result = serde_json::to_writer((&mut *dst).writer(), self);
-
-        encode_result.map_err(|error| {
-            rocketmq_error::SerializationError::encode_failed("remoting-command", error.to_string())
-        })?;
-        let header_length = dst.len() - header_index;
-        let (total_length, marked_header_length) =
-            Self::checked_frame_lengths(header_length, body_length, SerializeType::JSON)?;
-
-        dst[begin_index..begin_index + 4].copy_from_slice(&total_length.to_be_bytes());
-        dst[begin_index + 4..begin_index + 8].copy_from_slice(&marked_header_length.to_be_bytes());
-        Ok(())
-    }
-
-    #[inline]
-    fn fast_encode_json_direct(&self, dst: &mut BytesMut, body_length: usize) -> rocketmq_error::RocketMQResult<()> {
-        let header = self.command_custom_header_ref().ok_or_else(|| {
-            rocketmq_error::SerializationError::encode_failed(
-                "remoting-command",
-                "direct JSON header capability was selected without a custom header",
-            )
-        })?;
-        let begin_index = dst.len();
-
-        // Avoid a full preflight walk over every typed field. A single 1 KiB
-        // allocation covers normal request headers and lets unusually large
-        // values fall back to BytesMut's regular growth policy.
-        dst.reserve(1024);
-        dst.put_i64(0);
-        let header_index = dst.len();
-
-        dst.extend_from_slice(b"{\"code\":");
-        write_json_i32(dst, self.code);
-        dst.extend_from_slice(b",\"language\":");
-        write_json_string(dst, language_name(self.language));
-        dst.extend_from_slice(b",\"version\":");
-        write_json_i32(dst, self.version);
-        dst.extend_from_slice(b",\"opaque\":");
-        write_json_i32(dst, self.opaque);
-        dst.extend_from_slice(b",\"flag\":");
-        write_json_i32(dst, self.flag);
-        dst.extend_from_slice(b",\"remark\":");
-        if let Some(remark) = &self.remark {
-            write_json_string(dst, remark.as_str());
-        } else {
-            dst.extend_from_slice(b"null");
-        }
-        dst.extend_from_slice(b",\"extFields\":");
-        header
-            .encode_direct_json_fields(dst)
-            .map_err(|error| rocketmq_error::RocketMQError::request_header_error(error.to_string()))?;
-        dst.extend_from_slice(b",\"serializeTypeCurrentRPC\":\"JSON\"}");
-
-        let header_length = dst.len() - header_index;
-        let (total_length, marked_header_length) =
-            Self::checked_frame_lengths(header_length, body_length, SerializeType::JSON)?;
-        dst[begin_index..begin_index + 4].copy_from_slice(&total_length.to_be_bytes());
-        dst[begin_index + 4..begin_index + 8].copy_from_slice(&marked_header_length.to_be_bytes());
-        Ok(())
-    }
-
-    /// Optimized ROCKETMQ binary encoding with minimal allocations
-    #[inline]
-    fn fast_encode_rocketmq(&mut self, dst: &mut BytesMut, body_length: usize) -> rocketmq_error::RocketMQResult<()> {
-        let begin_index = dst.len();
-        dst.reserve(8 + RocketMQSerializable::INITIAL_ENCODE_CAPACITY);
-        dst.put_i64(0); // Placeholder for total_length + serialize_type
-
-        let capability = self.custom_header_encode_capability();
-
-        let direct_header = (capability == HeaderEncodeCapability::DirectBinary
-            && self.remark.is_none()
-            && self.ext_fields.is_absent())
-        .then(|| self.command_custom_header_ref())
-        .flatten();
-        let header_size = match direct_header {
-            Some(header) => RocketMQSerializable::try_rocketmq_protocol_encode_direct(self, header, dst),
-            None => RocketMQSerializable::try_rocketmq_protocol_encode_with_capability(self, dst, capability),
-        }
-        .map_err(|error| rocketmq_error::RocketMQError::request_header_error(error.to_string()))?;
-        let (total_length, serialize_type) =
-            Self::checked_frame_lengths(header_size, body_length, SerializeType::ROCKETMQ)?;
-
-        // Write total_length and serialize_type at the beginning (in-place update)
-        let total_length = total_length.to_be_bytes();
-        let serialize_type_bytes = serialize_type.to_be_bytes();
-
-        dst[begin_index..begin_index + 4].copy_from_slice(&total_length);
-        dst[begin_index + 4..begin_index + 8].copy_from_slice(&serialize_type_bytes);
-        Ok(())
-    }
-
-    fn checked_frame_lengths(
-        header_length: usize,
-        body_length: usize,
-        serialize_type: SerializeType,
-    ) -> rocketmq_error::RocketMQResult<(i32, i32)> {
-        const MAX_HEADER_LENGTH: usize = 0x00ff_ffff;
-        if header_length > MAX_HEADER_LENGTH {
-            return Err(rocketmq_error::SerializationError::encode_failed(
-                "remoting-command",
-                format!("encoded header is {header_length} bytes, exceeding the 24-bit wire limit"),
-            )
-            .into());
-        }
-        let payload_length = 4usize
-            .checked_add(header_length)
-            .and_then(|length| length.checked_add(body_length))
-            .ok_or_else(|| {
-                rocketmq_error::SerializationError::encode_failed("remoting-command", "encoded frame length overflow")
-            })?;
-        let total_length = i32::try_from(payload_length).map_err(|_| {
-            rocketmq_error::SerializationError::encode_failed(
-                "remoting-command",
-                format!("encoded payload is {payload_length} bytes, exceeding the signed 32-bit wire limit"),
-            )
-        })?;
-        let header_length = i32::try_from(header_length).map_err(|_| {
-            rocketmq_error::SerializationError::encode_failed("remoting-command", "encoded header length overflow")
-        })?;
-        Ok((
-            total_length,
-            RemotingCommand::mark_serialize_type(header_length, serialize_type),
-        ))
-    }
-
-    /// Estimate JSON header size to reduce buffer reallocations
-    /// This is an approximation based on typical field sizes
-    #[inline]
-    fn estimate_json_header_size(&self) -> usize {
-        let mut size = 100; // Base JSON overhead
-
-        if let Some(ref remark) = self.remark {
-            size += remark.len() + 20; // "remark":"..." + quotes
-        }
-
-        if let Some(ext) = self.ext_fields.as_map() {
-            // Approximate: each entry adds ~30 bytes overhead + key/value lengths
-            size += ext.iter().map(|(k, v)| k.len() + v.len() + 30).sum::<usize>();
-        }
-
-        size
-    }
-
-    /// Decodes one command with the historical 16 MiB announced-payload ceiling.
-    ///
-    /// Transport owners with an explicit total-wire limit should use
-    /// [`Self::decode_with_max_frame_bytes`] so inbound and outbound policy stays symmetric.
-    #[inline]
-    pub fn decode(src: &mut BytesMut) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        Self::decode_with_max_frame_bytes(src, 16 * 1024 * 1024 + 4)
-    }
-
-    /// Decodes one command bounded by a caller-owned complete wire-frame limit.
-    ///
-    /// `max_frame_bytes` includes the four-byte announced-length prefix.
-    ///
-    /// # Errors
-    ///
-    /// Returns a serialization error for a negative, overflowing, oversized, or malformed frame.
-    #[inline]
-    pub fn decode_with_max_frame_bytes(
-        src: &mut BytesMut,
-        max_frame_bytes: usize,
-    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        const FRAME_HEADER_SIZE: usize = 4;
-        const SERIALIZE_TYPE_SIZE: usize = 4;
-        const MIN_PAYLOAD_SIZE: usize = SERIALIZE_TYPE_SIZE; // Minimum: just serialize_type field
-
-        let available = src.len();
-
-        // Early return if not enough data for frame header
-        if available < FRAME_HEADER_SIZE {
-            return Ok(None);
-        }
-
-        // Read total size without advancing the buffer (peek)
-        let announced_size = i32::from_be_bytes([src[0], src[1], src[2], src[3]]);
-        let total_size = usize::try_from(announced_size).map_err(|_| {
-            rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
-                format: "remoting_command",
-                message: format!("Invalid negative frame size {announced_size}"),
-            })
-        })?;
-        let full_frame_size = total_size.checked_add(FRAME_HEADER_SIZE).ok_or_else(|| {
-            rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
-                format: "remoting_command",
-                message: format!("Frame size {total_size} overflows the wire envelope"),
-            })
-        })?;
-
-        if full_frame_size > max_frame_bytes {
-            return Err(rocketmq_error::RocketMQError::Serialization(
-                rocketmq_error::SerializationError::DecodeFailed {
-                    format: "remoting_command",
-                    message: format!("Wire frame size {full_frame_size} exceeds configured limit {max_frame_bytes}"),
-                },
-            ));
-        }
-
-        // Wait for complete frame
-        if available < full_frame_size {
-            return Ok(None);
-        }
-
-        // Now validate minimum total_size (we have the complete frame)
-        if total_size < MIN_PAYLOAD_SIZE {
-            return Err(rocketmq_error::RocketMQError::Serialization(
-                rocketmq_error::SerializationError::DecodeFailed {
-                    format: "remoting_command",
-                    message: format!("Invalid total_size {total_size}, minimum required is {MIN_PAYLOAD_SIZE}"),
-                },
-            ));
-        }
-
-        // Extract the complete frame before validating the marked header so
-        // malformed complete frames preserve the established consume-on-error
-        // behavior.
-        let frame_data = src.split_to(full_frame_size);
-        let ori_header_length = i32::from_be_bytes([frame_data[4], frame_data[5], frame_data[6], frame_data[7]]);
-        let header_length = parse_header_length(ori_header_length);
-
-        // Validate header length
-        if header_length > total_size - SERIALIZE_TYPE_SIZE {
-            return Err(rocketmq_error::RocketMQError::Serialization(
-                rocketmq_error::SerializationError::DecodeFailed {
-                    format: "remoting_command",
-                    message: format!("Invalid header length {header_length}, total size {total_size}"),
-                },
-            ));
-        }
-
-        let protocol_type = parse_serialize_type(ori_header_length)?;
-        let frame = frame_data.freeze();
-        let header_start = FRAME_HEADER_SIZE + SERIALIZE_TYPE_SIZE;
-        let header_end = header_start + header_length;
-        let mut cmd = match protocol_type {
-            SerializeType::ROCKETMQ => {
-                RocketMQSerializable::rocket_mq_protocol_decode_bytes(frame.slice(header_start..header_end))?
-            }
-            SerializeType::JSON => {
-                if let Some(cmd) = try_decode_json_header_bytes(frame.slice(header_start..header_end)) {
-                    cmd
-                } else {
-                    // Unsupported JSON shapes retain the Serde/SIMD
-                    // compatibility path. Copying is confined to this cold
-                    // fallback after consuming the complete frame.
-                    let mut header_data = BytesMut::from(&frame[header_start..header_end]);
-                    Self::decode_json_header_fallback(&mut header_data, header_length)?
-                }
-            }
-        };
-        cmd.set_serialize_type_ref(protocol_type);
-        if header_end < frame.len() {
-            cmd.set_body_mut_ref(frame.slice(header_end..));
-        }
-        Ok(Some(cmd))
-    }
-
-    #[cold]
-    #[inline(never)]
-    fn decode_json_header_fallback(
-        src: &mut BytesMut,
-        _header_length: usize,
-    ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
-        #[cfg(feature = "simd")]
-        {
-            let mut slice = src.split_to(_header_length).to_vec();
-            simd_json::from_slice::<RemotingCommand>(&mut slice).map_err(|error| {
-                rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
-                    format: "json",
-                    message: format!("SIMD JSON deserialization error: {error}"),
-                })
-            })
-        }
-
-        #[cfg(not(feature = "simd"))]
-        {
-            serde_json::from_slice::<RemotingCommand>(src).map_err(|error| {
-                rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
-                    format: "json",
-                    message: format!("JSON deserialization error: {error}"),
-                })
-            })
-        }
-    }
-
-    /// Optimized header decoding with type-based dispatch
-    #[inline]
-    pub fn header_decode(
-        src: &mut BytesMut,
-        header_length: usize,
-        type_: SerializeType,
-    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        match type_ {
-            SerializeType::JSON => {
-                if let Some(cmd) = try_decode_json_header(src, header_length) {
-                    return Ok(Some(cmd.set_serialize_type(SerializeType::JSON)));
-                }
-                let cmd = Self::decode_json_header_fallback(src, header_length)?;
-                Ok(Some(cmd.set_serialize_type(SerializeType::JSON)))
-            }
-            SerializeType::ROCKETMQ => {
-                // Deserialize binary header
-                let cmd = RocketMQSerializable::rocket_mq_protocol_decode(src, header_length)?;
-                Ok(Some(cmd.set_serialize_type(SerializeType::ROCKETMQ)))
-            }
-        }
-    }
-
-    #[inline]
-    pub fn mark_serialize_type(header_length: i32, protocol_type: SerializeType) -> i32 {
-        ((protocol_type.get_code() as i32) << 24) | (header_length & 0x00FFFFFF)
     }
 
     pub fn read_custom_header_ref_unchecked<T>(&self) -> rocketmq_error::RocketMQResult<&T>

--- a/rocketmq-protocol/src/protocol/remoting_command/decode.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command/decode.rs
@@ -1,0 +1,194 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::BytesMut;
+
+use super::parse_header_length;
+use super::parse_serialize_type;
+use super::RemotingCommand;
+use super::SerializeType;
+use crate::rocketmq_serializable::RocketMQSerializable;
+
+mod json;
+
+use json::try_decode_json_header;
+use json::try_decode_json_header_bytes;
+
+impl RemotingCommand {
+    /// Decodes one command with the historical 16 MiB announced-payload ceiling.
+    ///
+    /// Transport owners with an explicit total-wire limit should use
+    /// [`Self::decode_with_max_frame_bytes`] so inbound and outbound policy stays symmetric.
+    #[inline]
+    pub fn decode(src: &mut BytesMut) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        Self::decode_with_max_frame_bytes(src, 16 * 1024 * 1024 + 4)
+    }
+
+    /// Decodes one command bounded by a caller-owned complete wire-frame limit.
+    ///
+    /// `max_frame_bytes` includes the four-byte announced-length prefix.
+    ///
+    /// # Errors
+    ///
+    /// Returns a serialization error for a negative, overflowing, oversized, or malformed frame.
+    #[inline]
+    pub fn decode_with_max_frame_bytes(
+        src: &mut BytesMut,
+        max_frame_bytes: usize,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        const FRAME_HEADER_SIZE: usize = 4;
+        const SERIALIZE_TYPE_SIZE: usize = 4;
+        const MIN_PAYLOAD_SIZE: usize = SERIALIZE_TYPE_SIZE; // Minimum: just serialize_type field
+
+        let available = src.len();
+
+        // Early return if not enough data for frame header
+        if available < FRAME_HEADER_SIZE {
+            return Ok(None);
+        }
+
+        // Read total size without advancing the buffer (peek)
+        let announced_size = i32::from_be_bytes([src[0], src[1], src[2], src[3]]);
+        let total_size = usize::try_from(announced_size).map_err(|_| {
+            rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
+                format: "remoting_command",
+                message: format!("Invalid negative frame size {announced_size}"),
+            })
+        })?;
+        let full_frame_size = total_size.checked_add(FRAME_HEADER_SIZE).ok_or_else(|| {
+            rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
+                format: "remoting_command",
+                message: format!("Frame size {total_size} overflows the wire envelope"),
+            })
+        })?;
+
+        if full_frame_size > max_frame_bytes {
+            return Err(rocketmq_error::RocketMQError::Serialization(
+                rocketmq_error::SerializationError::DecodeFailed {
+                    format: "remoting_command",
+                    message: format!("Wire frame size {full_frame_size} exceeds configured limit {max_frame_bytes}"),
+                },
+            ));
+        }
+
+        // Wait for complete frame
+        if available < full_frame_size {
+            return Ok(None);
+        }
+
+        // Now validate minimum total_size (we have the complete frame)
+        if total_size < MIN_PAYLOAD_SIZE {
+            return Err(rocketmq_error::RocketMQError::Serialization(
+                rocketmq_error::SerializationError::DecodeFailed {
+                    format: "remoting_command",
+                    message: format!("Invalid total_size {total_size}, minimum required is {MIN_PAYLOAD_SIZE}"),
+                },
+            ));
+        }
+
+        // Extract the complete frame before validating the marked header so
+        // malformed complete frames preserve the established consume-on-error
+        // behavior.
+        let frame_data = src.split_to(full_frame_size);
+        let ori_header_length = i32::from_be_bytes([frame_data[4], frame_data[5], frame_data[6], frame_data[7]]);
+        let header_length = parse_header_length(ori_header_length);
+
+        // Validate header length
+        if header_length > total_size - SERIALIZE_TYPE_SIZE {
+            return Err(rocketmq_error::RocketMQError::Serialization(
+                rocketmq_error::SerializationError::DecodeFailed {
+                    format: "remoting_command",
+                    message: format!("Invalid header length {header_length}, total size {total_size}"),
+                },
+            ));
+        }
+
+        let protocol_type = parse_serialize_type(ori_header_length)?;
+        let frame = frame_data.freeze();
+        let header_start = FRAME_HEADER_SIZE + SERIALIZE_TYPE_SIZE;
+        let header_end = header_start + header_length;
+        let mut cmd = match protocol_type {
+            SerializeType::ROCKETMQ => {
+                RocketMQSerializable::rocket_mq_protocol_decode_bytes(frame.slice(header_start..header_end))?
+            }
+            SerializeType::JSON => {
+                if let Some(cmd) = try_decode_json_header_bytes(frame.slice(header_start..header_end)) {
+                    cmd
+                } else {
+                    // Unsupported JSON shapes retain the Serde/SIMD
+                    // compatibility path. Copying is confined to this cold
+                    // fallback after consuming the complete frame.
+                    let mut header_data = BytesMut::from(&frame[header_start..header_end]);
+                    Self::decode_json_header_fallback(&mut header_data, header_length)?
+                }
+            }
+        };
+        cmd.set_serialize_type_ref(protocol_type);
+        if header_end < frame.len() {
+            cmd.set_body_mut_ref(frame.slice(header_end..));
+        }
+        Ok(Some(cmd))
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn decode_json_header_fallback(
+        src: &mut BytesMut,
+        _header_length: usize,
+    ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
+        #[cfg(feature = "simd")]
+        {
+            let mut slice = src.split_to(_header_length).to_vec();
+            simd_json::from_slice::<RemotingCommand>(&mut slice).map_err(|error| {
+                rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
+                    format: "json",
+                    message: format!("SIMD JSON deserialization error: {error}"),
+                })
+            })
+        }
+
+        #[cfg(not(feature = "simd"))]
+        {
+            serde_json::from_slice::<RemotingCommand>(src).map_err(|error| {
+                rocketmq_error::RocketMQError::Serialization(rocketmq_error::SerializationError::DecodeFailed {
+                    format: "json",
+                    message: format!("JSON deserialization error: {error}"),
+                })
+            })
+        }
+    }
+
+    /// Optimized header decoding with type-based dispatch
+    #[inline]
+    pub fn header_decode(
+        src: &mut BytesMut,
+        header_length: usize,
+        type_: SerializeType,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        match type_ {
+            SerializeType::JSON => {
+                if let Some(cmd) = try_decode_json_header(src, header_length) {
+                    return Ok(Some(cmd.set_serialize_type(SerializeType::JSON)));
+                }
+                let cmd = Self::decode_json_header_fallback(src, header_length)?;
+                Ok(Some(cmd.set_serialize_type(SerializeType::JSON)))
+            }
+            SerializeType::ROCKETMQ => {
+                // Deserialize binary header
+                let cmd = RocketMQSerializable::rocket_mq_protocol_decode(src, header_length)?;
+                Ok(Some(cmd.set_serialize_type(SerializeType::ROCKETMQ)))
+            }
+        }
+    }
+}

--- a/rocketmq-protocol/src/protocol/remoting_command/decode/json.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command/decode/json.rs
@@ -18,8 +18,8 @@ use bytes::Bytes;
 use bytes::BytesMut;
 use cheetah_string::CheetahString;
 
-use super::extension_fields::ExtensionFields;
-use super::RemotingCommand;
+use super::super::extension_fields::ExtensionFields;
+use super::super::RemotingCommand;
 use crate::protocol::header_codec::JsonHeaderFields;
 use crate::protocol::LanguageCode;
 use crate::protocol::SerializeType;

--- a/rocketmq-protocol/src/protocol/remoting_command/encode.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command/encode.rs
@@ -1,0 +1,103 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::Bytes;
+use bytes::BytesMut;
+
+use super::RemotingCommand;
+use super::SerializeType;
+use crate::rocketmq_serializable::RocketMQSerializable;
+
+mod json;
+mod rocketmq;
+
+impl RemotingCommand {
+    /// Encode header with optimized path selection
+    #[inline]
+    pub fn header_encode(&mut self) -> Option<Bytes> {
+        match self.serialize_type {
+            SerializeType::ROCKETMQ => {
+                let mut encoded = BytesMut::new();
+                RocketMQSerializable::try_rocketmq_protocol_encode(self, &mut encoded).ok()?;
+                Some(encoded.freeze())
+            }
+            SerializeType::JSON => {
+                self.try_make_custom_header_to_net().ok()?;
+                #[cfg(feature = "simd")]
+                {
+                    match simd_json::to_vec(self) {
+                        Ok(value) => Some(Bytes::from(value)),
+                        Err(_) => None,
+                    }
+                }
+                #[cfg(not(feature = "simd"))]
+                {
+                    match serde_json::to_vec(self) {
+                        Ok(value) => Some(Bytes::from(value)),
+                        Err(_) => None,
+                    }
+                }
+            }
+        }
+    }
+
+    #[inline]
+    pub fn fast_header_encode(&mut self, dst: &mut BytesMut) {
+        let _ = self.try_fast_header_encode(dst);
+    }
+
+    /// Encodes the frame header and rolls the destination back on failure.
+    ///
+    /// # Errors
+    ///
+    /// Returns the custom-header validation or direct-binary encoding failure.
+    #[inline]
+    pub fn try_fast_header_encode(&mut self, dst: &mut BytesMut) -> rocketmq_error::RocketMQResult<()> {
+        let body_length = self.body.as_ref().map_or(0, Bytes::len);
+        self.try_fast_header_encode_with_body_length(dst, body_length)
+    }
+
+    #[inline]
+    pub(crate) fn try_fast_header_encode_with_body_length(
+        &mut self,
+        dst: &mut BytesMut,
+        body_length: usize,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        let checkpoint = dst.len();
+        let result = match self.body.as_ref() {
+            Some(body) if body.len() != body_length => Err(rocketmq_error::SerializationError::encode_failed(
+                "remoting-command",
+                "explicit body length does not match the in-memory body",
+            )
+            .into()),
+            _ => self.try_fast_header_encode_inner(dst, body_length),
+        };
+        if result.is_err() {
+            dst.truncate(checkpoint);
+        }
+        result
+    }
+
+    #[inline]
+    fn try_fast_header_encode_inner(
+        &mut self,
+        dst: &mut BytesMut,
+        body_length: usize,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        match self.serialize_type {
+            SerializeType::JSON => self.fast_encode_json(dst, body_length),
+            SerializeType::ROCKETMQ => self.fast_encode_rocketmq(dst, body_length),
+        }
+    }
+}

--- a/rocketmq-protocol/src/protocol/remoting_command/encode/json.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command/encode/json.rs
@@ -1,0 +1,159 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::BufMut;
+use bytes::BytesMut;
+
+use super::super::RemotingCommand;
+use super::super::SerializeType;
+use crate::protocol::command_custom_header::CommandCustomHeader;
+use crate::protocol::header_codec::write_json_string;
+use crate::protocol::LanguageCode;
+
+#[inline]
+fn write_json_i32(out: &mut BytesMut, value: i32) {
+    let mut buffer = itoa::Buffer::new();
+    out.extend_from_slice(buffer.format(value).as_bytes());
+}
+
+#[inline]
+const fn language_name(language: LanguageCode) -> &'static str {
+    match language {
+        LanguageCode::JAVA => "JAVA",
+        LanguageCode::CPP => "CPP",
+        LanguageCode::DOTNET => "DOTNET",
+        LanguageCode::PYTHON => "PYTHON",
+        LanguageCode::DELPHI => "DELPHI",
+        LanguageCode::ERLANG => "ERLANG",
+        LanguageCode::RUBY => "RUBY",
+        LanguageCode::OTHER => "OTHER",
+        LanguageCode::HTTP => "HTTP",
+        LanguageCode::GO => "GO",
+        LanguageCode::PHP => "PHP",
+        LanguageCode::OMS => "OMS",
+        LanguageCode::RUST => "RUST",
+        LanguageCode::NODE_JS => "NODE_JS",
+    }
+}
+
+impl RemotingCommand {
+    /// Optimized JSON encoding with pre-calculated capacity and zero-copy optimizations
+    #[inline]
+    pub(super) fn fast_encode_json(
+        &mut self,
+        dst: &mut BytesMut,
+        body_length: usize,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        let direct_fields = !self.custom_header_to_net
+            && self.ext_fields.is_absent()
+            && self
+                .command_custom_header_ref()
+                .is_some_and(CommandCustomHeader::supports_direct_json_fields);
+        if direct_fields {
+            return self.fast_encode_json_direct(dst, body_length);
+        }
+
+        self.try_make_custom_header_to_net()
+            .map_err(|error| rocketmq_error::RocketMQError::request_header_error(error.to_string()))?;
+
+        let estimated_header_size = self.estimate_json_header_size();
+        let begin_index = dst.len();
+
+        dst.reserve(8 + estimated_header_size);
+        dst.put_i64(0);
+        let header_index = dst.len();
+
+        #[cfg(feature = "simd")]
+        let encode_result = simd_json::to_writer((&mut *dst).writer(), self);
+
+        #[cfg(not(feature = "simd"))]
+        let encode_result = serde_json::to_writer((&mut *dst).writer(), self);
+
+        encode_result.map_err(|error| {
+            rocketmq_error::SerializationError::encode_failed("remoting-command", error.to_string())
+        })?;
+        let header_length = dst.len() - header_index;
+        let (total_length, marked_header_length) =
+            Self::checked_frame_lengths(header_length, body_length, SerializeType::JSON)?;
+
+        dst[begin_index..begin_index + 4].copy_from_slice(&total_length.to_be_bytes());
+        dst[begin_index + 4..begin_index + 8].copy_from_slice(&marked_header_length.to_be_bytes());
+        Ok(())
+    }
+
+    #[inline]
+    fn fast_encode_json_direct(&self, dst: &mut BytesMut, body_length: usize) -> rocketmq_error::RocketMQResult<()> {
+        let header = self.command_custom_header_ref().ok_or_else(|| {
+            rocketmq_error::SerializationError::encode_failed(
+                "remoting-command",
+                "direct JSON header capability was selected without a custom header",
+            )
+        })?;
+        let begin_index = dst.len();
+
+        // Avoid a full preflight walk over every typed field. A single 1 KiB
+        // allocation covers normal request headers and lets unusually large
+        // values fall back to BytesMut's regular growth policy.
+        dst.reserve(1024);
+        dst.put_i64(0);
+        let header_index = dst.len();
+
+        dst.extend_from_slice(b"{\"code\":");
+        write_json_i32(dst, self.code);
+        dst.extend_from_slice(b",\"language\":");
+        write_json_string(dst, language_name(self.language));
+        dst.extend_from_slice(b",\"version\":");
+        write_json_i32(dst, self.version);
+        dst.extend_from_slice(b",\"opaque\":");
+        write_json_i32(dst, self.opaque);
+        dst.extend_from_slice(b",\"flag\":");
+        write_json_i32(dst, self.flag);
+        dst.extend_from_slice(b",\"remark\":");
+        if let Some(remark) = &self.remark {
+            write_json_string(dst, remark.as_str());
+        } else {
+            dst.extend_from_slice(b"null");
+        }
+        dst.extend_from_slice(b",\"extFields\":");
+        header
+            .encode_direct_json_fields(dst)
+            .map_err(|error| rocketmq_error::RocketMQError::request_header_error(error.to_string()))?;
+        dst.extend_from_slice(b",\"serializeTypeCurrentRPC\":\"JSON\"}");
+
+        let header_length = dst.len() - header_index;
+        let (total_length, marked_header_length) =
+            Self::checked_frame_lengths(header_length, body_length, SerializeType::JSON)?;
+        dst[begin_index..begin_index + 4].copy_from_slice(&total_length.to_be_bytes());
+        dst[begin_index + 4..begin_index + 8].copy_from_slice(&marked_header_length.to_be_bytes());
+        Ok(())
+    }
+
+    /// Estimate JSON header size to reduce buffer reallocations
+    /// This is an approximation based on typical field sizes
+    #[inline]
+    fn estimate_json_header_size(&self) -> usize {
+        let mut size = 100; // Base JSON overhead
+
+        if let Some(ref remark) = self.remark {
+            size += remark.len() + 20; // "remark":"..." + quotes
+        }
+
+        if let Some(ext) = self.ext_fields.as_map() {
+            // Approximate: each entry adds ~30 bytes overhead + key/value lengths
+            size += ext.iter().map(|(k, v)| k.len() + v.len() + 30).sum::<usize>();
+        }
+
+        size
+    }
+}

--- a/rocketmq-protocol/src/protocol/remoting_command/encode/rocketmq.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command/encode/rocketmq.rs
@@ -1,0 +1,58 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::BufMut;
+use bytes::BytesMut;
+
+use super::super::RemotingCommand;
+use super::super::SerializeType;
+use crate::protocol::command_custom_header::HeaderEncodeCapability;
+use crate::rocketmq_serializable::RocketMQSerializable;
+
+impl RemotingCommand {
+    /// Optimized ROCKETMQ binary encoding with minimal allocations
+    #[inline]
+    pub(super) fn fast_encode_rocketmq(
+        &mut self,
+        dst: &mut BytesMut,
+        body_length: usize,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        let begin_index = dst.len();
+        dst.reserve(8 + RocketMQSerializable::INITIAL_ENCODE_CAPACITY);
+        dst.put_i64(0); // Placeholder for total_length + serialize_type
+
+        let capability = self.custom_header_encode_capability();
+
+        let direct_header = (capability == HeaderEncodeCapability::DirectBinary
+            && self.remark.is_none()
+            && self.ext_fields.is_absent())
+        .then(|| self.command_custom_header_ref())
+        .flatten();
+        let header_size = match direct_header {
+            Some(header) => RocketMQSerializable::try_rocketmq_protocol_encode_direct(self, header, dst),
+            None => RocketMQSerializable::try_rocketmq_protocol_encode_with_capability(self, dst, capability),
+        }
+        .map_err(|error| rocketmq_error::RocketMQError::request_header_error(error.to_string()))?;
+        let (total_length, serialize_type) =
+            Self::checked_frame_lengths(header_size, body_length, SerializeType::ROCKETMQ)?;
+
+        // Write total_length and serialize_type at the beginning (in-place update)
+        let total_length = total_length.to_be_bytes();
+        let serialize_type_bytes = serialize_type.to_be_bytes();
+
+        dst[begin_index..begin_index + 4].copy_from_slice(&total_length);
+        dst[begin_index + 4..begin_index + 8].copy_from_slice(&serialize_type_bytes);
+        Ok(())
+    }
+}

--- a/rocketmq-protocol/src/protocol/remoting_command/frame.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command/frame.rs
@@ -1,0 +1,92 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::BufMut;
+use bytes::Bytes;
+use bytes::BytesMut;
+
+use super::RemotingCommand;
+use super::SerializeType;
+
+impl RemotingCommand {
+    /// Encode header with body length information
+    #[inline]
+    pub fn encode_header(&mut self) -> Option<Bytes> {
+        let body_length = self.body.as_ref().map_or(0, |b| b.len());
+        self.encode_header_with_body_length(body_length)
+    }
+
+    /// Optimized header encoding with pre-calculated capacity
+    #[inline]
+    pub fn encode_header_with_body_length(&mut self, body_length: usize) -> Option<Bytes> {
+        // Encode header data
+        let header_data = self.header_encode()?;
+        let header_len = header_data.len();
+        let (total_length, marked_header_length) =
+            Self::checked_frame_lengths(header_len, body_length, self.serialize_type).ok()?;
+
+        // Allocate exact capacity
+        let mut result = BytesMut::with_capacity(8 + header_len);
+
+        // Write total length
+        result.put_i32(total_length);
+
+        // Write serialize type with embedded header length
+        result.put_i32(marked_header_length);
+
+        // Write header data
+        result.put(header_data);
+
+        Some(result.freeze())
+    }
+
+    pub(super) fn checked_frame_lengths(
+        header_length: usize,
+        body_length: usize,
+        serialize_type: SerializeType,
+    ) -> rocketmq_error::RocketMQResult<(i32, i32)> {
+        const MAX_HEADER_LENGTH: usize = 0x00ff_ffff;
+        if header_length > MAX_HEADER_LENGTH {
+            return Err(rocketmq_error::SerializationError::encode_failed(
+                "remoting-command",
+                format!("encoded header is {header_length} bytes, exceeding the 24-bit wire limit"),
+            )
+            .into());
+        }
+        let payload_length = 4usize
+            .checked_add(header_length)
+            .and_then(|length| length.checked_add(body_length))
+            .ok_or_else(|| {
+                rocketmq_error::SerializationError::encode_failed("remoting-command", "encoded frame length overflow")
+            })?;
+        let total_length = i32::try_from(payload_length).map_err(|_| {
+            rocketmq_error::SerializationError::encode_failed(
+                "remoting-command",
+                format!("encoded payload is {payload_length} bytes, exceeding the signed 32-bit wire limit"),
+            )
+        })?;
+        let header_length = i32::try_from(header_length).map_err(|_| {
+            rocketmq_error::SerializationError::encode_failed("remoting-command", "encoded header length overflow")
+        })?;
+        Ok((
+            total_length,
+            RemotingCommand::mark_serialize_type(header_length, serialize_type),
+        ))
+    }
+
+    #[inline]
+    pub fn mark_serialize_type(header_length: i32, protocol_type: SerializeType) -> i32 {
+        ((protocol_type.get_code() as i32) << 24) | (header_length & 0x00FFFFFF)
+    }
+}

--- a/scripts/module-maintainability-baseline.json
+++ b/scripts/module-maintainability-baseline.json
@@ -6146,8 +6146,8 @@
       "reexports": 0
     },
     "rocketmq-protocol/src/protocol/remoting_command.rs": {
-      "production_lines": 587,
-      "public_items": 23,
+      "production_lines": 203,
+      "public_items": 14,
       "reexports": 0
     },
     "rocketmq-protocol/src/protocol/remoting_command/accessors.rs": {
@@ -6165,6 +6165,31 @@
       "public_items": 15,
       "reexports": 0
     },
+    "rocketmq-protocol/src/protocol/remoting_command/decode.rs": {
+      "production_lines": 139,
+      "public_items": 3,
+      "reexports": 0
+    },
+    "rocketmq-protocol/src/protocol/remoting_command/decode/json.rs": {
+      "production_lines": 702,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-protocol/src/protocol/remoting_command/encode.rs": {
+      "production_lines": 76,
+      "public_items": 3,
+      "reexports": 0
+    },
+    "rocketmq-protocol/src/protocol/remoting_command/encode/json.rs": {
+      "production_lines": 119,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-protocol/src/protocol/remoting_command/encode/rocketmq.rs": {
+      "production_lines": 36,
+      "public_items": 0,
+      "reexports": 0
+    },
     "rocketmq-protocol/src/protocol/remoting_command/extension_fields.rs": {
       "production_lines": 142,
       "public_items": 0,
@@ -6175,9 +6200,9 @@
       "public_items": 10,
       "reexports": 0
     },
-    "rocketmq-protocol/src/protocol/remoting_command/json_decode.rs": {
-      "production_lines": 680,
-      "public_items": 0,
+    "rocketmq-protocol/src/protocol/remoting_command/frame.rs": {
+      "production_lines": 61,
+      "public_items": 3,
       "reexports": 0
     },
     "rocketmq-protocol/src/protocol/remoting_command_compat.rs": {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9630

### Brief Description

- Split `RemotingCommand` frame construction, encoding dispatch, JSON and ROCKETMQ encoding, and decoding into private sibling modules.
- Preserve existing public paths and signatures, JSON/ROCKETMQ wire bytes, buffer rollback, incomplete-frame retention, complete malformed-frame consumption, extension-field ordering, and the fuzz entry point.
- Move the private JSON fast parser under `decode/` and relocate only its exact maintainability inventory without changing crate aggregates or public surface baselines.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-protocol -- --check`
- Focused default and `simd` `RemotingCommand` suites (43 tests each).
- Five contract and Java compatibility suites (24 tests).
- `cargo test -p rocketmq-protocol`
- `cargo test -p rocketmq-transport`
- Package and workspace all-target, all-feature Clippy with warnings denied.
- Candidate-versus-clean-base direct and core-release guard comparisons; no new findings.
- Locked offline renamed-consumer check, standalone example Clippy, and pinned-nightly fuzz all-target/all-feature check.
- Root and standalone example format checks against clean base; both reproduced the same Windows OS error 206.
- `git diff --check`