### PR TITLE
[ISSUE #9635]♻️Consolidate RemotingCommand legacy compatibility facades

### DIFF
--- a/rocketmq-protocol/src/protocol/remoting_command.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command.rs
@@ -78,6 +78,7 @@ mod encode;
 mod extension_fields;
 mod flags;
 mod frame;
+mod legacy_api;
 
 use extension_fields::ExtensionFields;
 
@@ -180,70 +181,6 @@ impl fmt::Display for RemotingCommand {
 impl Default for RemotingCommand {
     fn default() -> Self {
         Self::with_resolved_defaults(0, SerializeType::JSON)
-    }
-}
-
-impl RemotingCommand {
-    /// Legacy ambiguous-success response factory.
-    ///
-    /// New code should call [`Self::create_success_response_command`] so the
-    /// response intent is visible during review. Call
-    /// [`Self::create_java_default_error_response_command`] when matching
-    /// Java's unset-response behavior instead.
-    #[deprecated(
-        note = "use create_success_response_command for SUCCESS or create_java_default_error_response_command for Java-compatible unset errors"
-    )]
-    pub fn create_response_command() -> Self {
-        Self::create_success_response_command()
-    }
-
-    /// Legacy ambiguous-success typed-header response factory.
-    ///
-    /// New code should call [`Self::create_success_response_command_with_header`].
-    /// Call [`Self::create_java_default_error_response_command_with_header`]
-    /// when matching Java's unset-response behavior instead.
-    #[deprecated(
-        note = "use create_success_response_command_with_header for SUCCESS or create_java_default_error_response_command_with_header for Java-compatible unset errors"
-    )]
-    pub fn create_response_command_with_header(header: impl CommandCustomHeader + Sync + Send + 'static) -> Self {
-        Self::create_success_response_command_with_header(header)
-    }
-
-    /// Convert custom header to network format (merge into ext_fields)
-    #[inline]
-    pub fn make_custom_header_to_net(&mut self) {
-        let _ = self.try_make_custom_header_to_net();
-    }
-
-    #[inline]
-    pub fn materialize_custom_header_to_ext_fields(&mut self) {
-        self.make_custom_header_to_net();
-    }
-
-    pub fn read_custom_header_ref_unchecked<T>(&self) -> rocketmq_error::RocketMQResult<&T>
-    where
-        T: CommandCustomHeader + Sync + Send + 'static,
-    {
-        self.try_read_custom_header_ref::<T>()
-    }
-
-    /// Compatibility name for the former shared-reference mutation escape.
-    ///
-    /// Mutation now requires exclusive access to this command and succeeds only
-    /// when the safely shared header is uniquely owned.
-    #[deprecated(note = "use read_custom_header_mut; shared-reference mutation is no longer supported")]
-    pub fn read_custom_header_mut_from_ref<T>(&mut self) -> Option<&mut T>
-    where
-        T: CommandCustomHeader + Sync + Send + 'static,
-    {
-        self.read_custom_header_mut::<T>()
-    }
-
-    pub fn read_custom_header_mut_unchecked<T>(&mut self) -> rocketmq_error::RocketMQResult<&mut T>
-    where
-        T: CommandCustomHeader + Sync + Send + 'static,
-    {
-        self.try_read_custom_header_mut::<T>()
     }
 }
 

--- a/rocketmq-protocol/src/protocol/remoting_command/custom_header.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command/custom_header.rs
@@ -198,16 +198,6 @@ impl RemotingCommand {
             .map_err(|source| required_header_decode_error(operation, source))
     }
 
-    pub fn read_custom_header_ref<T>(&self) -> Option<&T>
-    where
-        T: CommandCustomHeader + Sync + Send + 'static,
-    {
-        match self.command_custom_header.as_ref() {
-            None => None,
-            Some(value) => value.as_ref().as_any().downcast_ref::<T>(),
-        }
-    }
-
     pub fn try_read_custom_header_ref<T>(&self) -> rocketmq_error::RocketMQResult<&T>
     where
         T: CommandCustomHeader + Sync + Send + 'static,
@@ -220,21 +210,6 @@ impl RemotingCommand {
                 .downcast_ref::<T>()
                 .ok_or_else(Self::custom_header_type_mismatch_error::<T>),
         }
-    }
-
-    pub fn read_custom_header_mut<T>(&mut self) -> Option<&mut T>
-    where
-        T: CommandCustomHeader + Sync + Send + 'static,
-    {
-        let header = self.command_custom_header.as_ref()?;
-        if Arc::strong_count(header) != 1 || !header.as_ref().as_any().is::<T>() {
-            return None;
-        }
-        self.invalidate_materialized_custom_header();
-        Arc::get_mut(self.command_custom_header.as_mut()?)?
-            .as_mut()
-            .as_any_mut()
-            .downcast_mut::<T>()
     }
 
     pub fn try_read_custom_header_mut<T>(&mut self) -> rocketmq_error::RocketMQResult<&mut T>

--- a/rocketmq-protocol/src/protocol/remoting_command/encode.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command/encode.rs
@@ -23,38 +23,32 @@ mod json;
 mod rocketmq;
 
 impl RemotingCommand {
-    /// Encode header with optimized path selection
     #[inline]
-    pub fn header_encode(&mut self) -> Option<Bytes> {
+    pub(super) fn try_header_encode(&mut self) -> rocketmq_error::RocketMQResult<Bytes> {
         match self.serialize_type {
             SerializeType::ROCKETMQ => {
                 let mut encoded = BytesMut::new();
-                RocketMQSerializable::try_rocketmq_protocol_encode(self, &mut encoded).ok()?;
-                Some(encoded.freeze())
+                RocketMQSerializable::try_rocketmq_protocol_encode(self, &mut encoded)
+                    .map_err(|error| rocketmq_error::RocketMQError::request_header_error(error.to_string()))?;
+                Ok(encoded.freeze())
             }
             SerializeType::JSON => {
-                self.try_make_custom_header_to_net().ok()?;
+                self.try_make_custom_header_to_net()
+                    .map_err(|error| rocketmq_error::RocketMQError::request_header_error(error.to_string()))?;
                 #[cfg(feature = "simd")]
                 {
-                    match simd_json::to_vec(self) {
-                        Ok(value) => Some(Bytes::from(value)),
-                        Err(_) => None,
-                    }
+                    simd_json::to_vec(self).map(Bytes::from).map_err(|error| {
+                        rocketmq_error::SerializationError::encode_failed("remoting-command", error.to_string()).into()
+                    })
                 }
                 #[cfg(not(feature = "simd"))]
                 {
-                    match serde_json::to_vec(self) {
-                        Ok(value) => Some(Bytes::from(value)),
-                        Err(_) => None,
-                    }
+                    serde_json::to_vec(self).map(Bytes::from).map_err(|error| {
+                        rocketmq_error::SerializationError::encode_failed("remoting-command", error.to_string()).into()
+                    })
                 }
             }
         }
-    }
-
-    #[inline]
-    pub fn fast_header_encode(&mut self, dst: &mut BytesMut) {
-        let _ = self.try_fast_header_encode(dst);
     }
 
     /// Encodes the frame header and rolls the destination back on failure.

--- a/rocketmq-protocol/src/protocol/remoting_command/frame.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command/frame.rs
@@ -20,21 +20,16 @@ use super::RemotingCommand;
 use super::SerializeType;
 
 impl RemotingCommand {
-    /// Encode header with body length information
     #[inline]
-    pub fn encode_header(&mut self) -> Option<Bytes> {
-        let body_length = self.body.as_ref().map_or(0, |b| b.len());
-        self.encode_header_with_body_length(body_length)
-    }
-
-    /// Optimized header encoding with pre-calculated capacity
-    #[inline]
-    pub fn encode_header_with_body_length(&mut self, body_length: usize) -> Option<Bytes> {
+    pub(super) fn try_encode_header_with_body_length(
+        &mut self,
+        body_length: usize,
+    ) -> rocketmq_error::RocketMQResult<Bytes> {
         // Encode header data
-        let header_data = self.header_encode()?;
+        let header_data = self.try_header_encode()?;
         let header_len = header_data.len();
         let (total_length, marked_header_length) =
-            Self::checked_frame_lengths(header_len, body_length, self.serialize_type).ok()?;
+            Self::checked_frame_lengths(header_len, body_length, self.serialize_type)?;
 
         // Allocate exact capacity
         let mut result = BytesMut::with_capacity(8 + header_len);
@@ -48,7 +43,7 @@ impl RemotingCommand {
         // Write header data
         result.put(header_data);
 
-        Some(result.freeze())
+        Ok(result.freeze())
     }
 
     pub(super) fn checked_frame_lengths(

--- a/rocketmq-protocol/src/protocol/remoting_command/legacy_api.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command/legacy_api.rs
@@ -1,0 +1,129 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::Bytes;
+use bytes::BytesMut;
+
+use super::RemotingCommand;
+use crate::protocol::command_custom_header::CommandCustomHeader;
+
+impl RemotingCommand {
+    /// Legacy ambiguous-success response factory.
+    ///
+    /// New code should call [`Self::create_success_response_command`] so the
+    /// response intent is visible during review. Call
+    /// [`Self::create_java_default_error_response_command`] when matching
+    /// Java's unset-response behavior instead.
+    #[deprecated(
+        note = "use create_success_response_command for SUCCESS or create_java_default_error_response_command for Java-compatible unset errors"
+    )]
+    pub fn create_response_command() -> Self {
+        Self::create_success_response_command()
+    }
+
+    /// Legacy ambiguous-success typed-header response factory.
+    ///
+    /// New code should call [`Self::create_success_response_command_with_header`].
+    /// Call [`Self::create_java_default_error_response_command_with_header`]
+    /// when matching Java's unset-response behavior instead.
+    #[deprecated(
+        note = "use create_success_response_command_with_header for SUCCESS or create_java_default_error_response_command_with_header for Java-compatible unset errors"
+    )]
+    pub fn create_response_command_with_header(header: impl CommandCustomHeader + Sync + Send + 'static) -> Self {
+        Self::create_success_response_command_with_header(header)
+    }
+
+    /// Convert custom header to network format (merge into ext_fields)
+    #[inline]
+    pub fn make_custom_header_to_net(&mut self) {
+        let _ = self.try_make_custom_header_to_net();
+    }
+
+    #[inline]
+    pub fn materialize_custom_header_to_ext_fields(&mut self) {
+        let _ = self.try_make_custom_header_to_net();
+    }
+
+    #[deprecated(
+        since = "1.0.0",
+        note = "use try_read_custom_header_ref; this compatibility alias is fallible despite its historical unchecked name"
+    )]
+    pub fn read_custom_header_ref_unchecked<T>(&self) -> rocketmq_error::RocketMQResult<&T>
+    where
+        T: CommandCustomHeader + Sync + Send + 'static,
+    {
+        self.try_read_custom_header_ref::<T>()
+    }
+
+    /// Compatibility name for the former shared-reference mutation escape.
+    ///
+    /// Mutation now requires exclusive access to this command and succeeds only
+    /// when the safely shared header is uniquely owned.
+    #[deprecated(note = "use read_custom_header_mut; shared-reference mutation is no longer supported")]
+    pub fn read_custom_header_mut_from_ref<T>(&mut self) -> Option<&mut T>
+    where
+        T: CommandCustomHeader + Sync + Send + 'static,
+    {
+        self.try_read_custom_header_mut::<T>().ok()
+    }
+
+    #[deprecated(
+        since = "1.0.0",
+        note = "use try_read_custom_header_mut; this compatibility alias is fallible despite its historical unchecked name"
+    )]
+    pub fn read_custom_header_mut_unchecked<T>(&mut self) -> rocketmq_error::RocketMQResult<&mut T>
+    where
+        T: CommandCustomHeader + Sync + Send + 'static,
+    {
+        self.try_read_custom_header_mut::<T>()
+    }
+
+    pub fn read_custom_header_ref<T>(&self) -> Option<&T>
+    where
+        T: CommandCustomHeader + Sync + Send + 'static,
+    {
+        self.try_read_custom_header_ref::<T>().ok()
+    }
+
+    pub fn read_custom_header_mut<T>(&mut self) -> Option<&mut T>
+    where
+        T: CommandCustomHeader + Sync + Send + 'static,
+    {
+        self.try_read_custom_header_mut::<T>().ok()
+    }
+
+    /// Encode header with optimized path selection
+    #[inline]
+    pub fn header_encode(&mut self) -> Option<Bytes> {
+        self.try_header_encode().ok()
+    }
+
+    #[inline]
+    pub fn fast_header_encode(&mut self, dst: &mut BytesMut) {
+        let _ = self.try_fast_header_encode(dst);
+    }
+
+    /// Encode header with body length information
+    #[inline]
+    pub fn encode_header(&mut self) -> Option<Bytes> {
+        let body_length = self.body.as_ref().map_or(0, |b| b.len());
+        self.try_encode_header_with_body_length(body_length).ok()
+    }
+
+    /// Optimized header encoding with pre-calculated capacity
+    #[inline]
+    pub fn encode_header_with_body_length(&mut self, body_length: usize) -> Option<Bytes> {
+        self.try_encode_header_with_body_length(body_length).ok()
+    }
+}

--- a/rocketmq-protocol/src/protocol/remoting_command/tests.rs
+++ b/rocketmq-protocol/src/protocol/remoting_command/tests.rs
@@ -440,6 +440,10 @@ fn rocketmq_frame_encoding_does_not_preflight_custom_header_lengths() {
 }
 
 #[test]
+#[allow(
+    deprecated,
+    reason = "verifies the deprecated unchecked compatibility alias preserves its typed error result"
+)]
 fn try_read_custom_header_ref_reports_missing_header() {
     let command = RemotingCommand::create_remoting_command(1);
 
@@ -450,6 +454,10 @@ fn try_read_custom_header_ref_reports_missing_header() {
 }
 
 #[test]
+#[allow(
+    deprecated,
+    reason = "verifies the deprecated unchecked compatibility alias preserves its typed error result"
+)]
 fn try_read_custom_header_ref_reports_type_mismatch() {
     let command = RemotingCommand::create_request_command(1, TestCustomHeader::default());
 
@@ -1103,4 +1111,186 @@ fn fast_rocketmq_encode_frame_decodes_with_body() {
     assert_eq!(decoded.code(), 100);
     assert_eq!(decoded.opaque(), 7);
     assert_eq!(decoded.get_body(), Some(&body));
+}
+
+#[test]
+#[allow(
+    deprecated,
+    reason = "verifies legacy header read compatibility facades during their deprecation window"
+)]
+fn legacy_header_read_facades_match_typed_results() {
+    let command = RemotingCommand::create_request_command(1, TestCustomHeader { value: 7 });
+
+    assert_eq!(
+        command
+            .read_custom_header_ref::<TestCustomHeader>()
+            .map(|header| header.value),
+        Some(7)
+    );
+    assert_eq!(
+        command
+            .read_custom_header_ref_unchecked::<TestCustomHeader>()
+            .unwrap()
+            .value,
+        7
+    );
+
+    let missing = RemotingCommand::create_remoting_command(1);
+    assert!(missing.read_custom_header_ref::<TestCustomHeader>().is_none());
+    assert!(missing.read_custom_header_ref_unchecked::<TestCustomHeader>().is_err());
+
+    assert!(command.read_custom_header_ref::<OtherCustomHeader>().is_none());
+    assert!(command.read_custom_header_ref_unchecked::<OtherCustomHeader>().is_err());
+}
+
+#[test]
+#[allow(
+    deprecated,
+    reason = "verifies legacy mutable compatibility facades preserve typed invalidation and shared-header behavior"
+)]
+fn legacy_mutable_header_facades_preserve_typed_invalidation_and_shared_errors() {
+    let mut command = RemotingCommand::create_request_command(1, TestCustomHeader { value: 7 });
+    command.try_make_custom_header_to_net().unwrap();
+
+    command
+        .read_custom_header_mut::<TestCustomHeader>()
+        .expect("unique legacy header should be mutable")
+        .value = 9;
+    assert!(!command.custom_header_to_net);
+    command.make_custom_header_to_net();
+    assert_eq!(
+        command
+            .ext_fields()
+            .and_then(|fields| fields.get("value"))
+            .map(CheetahString::as_str),
+        Some("9")
+    );
+
+    let mut from_ref = RemotingCommand::create_request_command(1, TestCustomHeader { value: 3 });
+    from_ref
+        .read_custom_header_mut_from_ref::<TestCustomHeader>()
+        .expect("legacy shared-reference compatibility name should mutate unique headers")
+        .value = 4;
+    assert_eq!(
+        from_ref.try_read_custom_header_ref::<TestCustomHeader>().unwrap().value,
+        4
+    );
+
+    let mut unchecked = RemotingCommand::create_request_command(1, TestCustomHeader { value: 5 });
+    unchecked
+        .read_custom_header_mut_unchecked::<TestCustomHeader>()
+        .unwrap()
+        .value = 6;
+    assert_eq!(
+        unchecked
+            .try_read_custom_header_ref::<TestCustomHeader>()
+            .unwrap()
+            .value,
+        6
+    );
+
+    let _shared = command.clone();
+    assert!(command.read_custom_header_mut::<TestCustomHeader>().is_none());
+    assert!(command.read_custom_header_mut_from_ref::<TestCustomHeader>().is_none());
+    assert!(command.read_custom_header_mut_unchecked::<TestCustomHeader>().is_err());
+}
+
+#[test]
+fn legacy_materializers_preserve_typed_failure_state() {
+    use crate::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader;
+
+    for materializer in ["make", "materialize"] {
+        let header = SendMessageResponseHeader::new("typed".into(), 1, 2, None, None, None);
+        let mut command = RemotingCommand::create_success_response_command_with_header(header)
+            .set_ext_fields(HashMap::from([("msgId".into(), "dynamic".into())]));
+
+        match materializer {
+            "make" => command.make_custom_header_to_net(),
+            "materialize" => command.materialize_custom_header_to_ext_fields(),
+            _ => unreachable!("test enumerates the two legacy materializers"),
+        }
+
+        assert!(!command.custom_header_to_net, "{materializer}");
+        assert_eq!(
+            command
+                .ext_fields()
+                .and_then(|fields| fields.get("msgId"))
+                .map(CheetahString::as_str),
+            Some("dynamic"),
+            "{materializer}"
+        );
+    }
+}
+
+#[test]
+fn legacy_header_and_frame_facades_match_typed_bytes() {
+    for serialize_type in [SerializeType::JSON, SerializeType::ROCKETMQ] {
+        let command = RemotingCommand::create_request_command(1, TestCustomHeader { value: 7 })
+            .set_serialize_type(serialize_type);
+
+        let mut typed_header = command.clone();
+        let expected_header = typed_header.try_header_encode().unwrap();
+        let mut legacy_header = command.clone();
+        assert_eq!(legacy_header.header_encode(), Some(expected_header));
+
+        let mut typed_frame = command.clone();
+        let expected_frame = typed_frame.try_encode_header_with_body_length(0).unwrap();
+        let mut legacy_frame = command.clone();
+        assert_eq!(legacy_frame.encode_header(), Some(expected_frame.clone()));
+        assert_eq!(legacy_frame.encode_header_with_body_length(0), Some(expected_frame));
+    }
+}
+
+#[test]
+fn legacy_header_and_fast_facades_map_typed_failures_without_mutation() {
+    use crate::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader;
+
+    for serialize_type in [SerializeType::JSON, SerializeType::ROCKETMQ] {
+        let header = SendMessageResponseHeader::new("typed".into(), 1, 2, None, None, None);
+        let command = RemotingCommand::create_success_response_command_with_header(header)
+            .set_serialize_type(serialize_type)
+            .set_ext_fields(HashMap::from([("msgId".into(), "dynamic".into())]));
+
+        let mut typed_header = command.clone();
+        assert!(typed_header.try_header_encode().is_err());
+        let mut legacy_header = command.clone();
+        assert!(legacy_header.header_encode().is_none());
+
+        let mut typed_frame = command.clone();
+        assert!(typed_frame.try_encode_header_with_body_length(0).is_err());
+        let mut legacy_frame = command.clone();
+        assert!(legacy_frame.encode_header().is_none());
+
+        let mut destination = BytesMut::from(&b"prefix"[..]);
+        let mut legacy_fast = command.clone();
+        legacy_fast.fast_header_encode(&mut destination);
+        assert_eq!(destination.as_ref(), b"prefix");
+    }
+}
+
+#[test]
+#[allow(
+    deprecated,
+    reason = "verifies ambiguous response compatibility factories retain their documented SUCCESS behavior"
+)]
+fn legacy_response_factories_preserve_success_semantics() {
+    let response = RemotingCommand::create_response_command();
+    assert_eq!(
+        response.code(),
+        crate::code::response_code::RemotingSysResponseCode::Success as i32
+    );
+    assert!(response.is_response_type());
+
+    let response_with_header = RemotingCommand::create_response_command_with_header(TestCustomHeader { value: 7 });
+    assert_eq!(
+        response_with_header.code(),
+        crate::code::response_code::RemotingSysResponseCode::Success as i32
+    );
+    assert_eq!(
+        response_with_header
+            .try_read_custom_header_ref::<TestCustomHeader>()
+            .unwrap()
+            .value,
+        7
+    );
 }

--- a/rocketmq-protocol/tests/remoting_legacy_api_deprecation_ui.rs
+++ b/rocketmq-protocol/tests/remoting_legacy_api_deprecation_ui.rs
@@ -1,0 +1,19 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[test]
+fn unchecked_header_aliases_emit_migration_diagnostics() {
+    let tests = trybuild::TestCases::new();
+    tests.compile_fail("tests/ui/remoting_legacy_api_deprecation/fail/*.rs");
+}

--- a/rocketmq-protocol/tests/ui/remoting_legacy_api_deprecation/fail/unchecked_aliases.rs
+++ b/rocketmq-protocol/tests/ui/remoting_legacy_api_deprecation/fail/unchecked_aliases.rs
@@ -1,0 +1,10 @@
+#![deny(deprecated)]
+
+use rocketmq_protocol::protocol::header::client_request_header::GetRouteInfoRequestHeader;
+use rocketmq_protocol::RemotingCommand;
+
+fn main() {
+    let mut command = RemotingCommand::create_request_command(1, GetRouteInfoRequestHeader::new("topic-a", None));
+    let _ = command.read_custom_header_ref_unchecked::<GetRouteInfoRequestHeader>();
+    let _ = command.read_custom_header_mut_unchecked::<GetRouteInfoRequestHeader>();
+}

--- a/rocketmq-protocol/tests/ui/remoting_legacy_api_deprecation/fail/unchecked_aliases.stderr
+++ b/rocketmq-protocol/tests/ui/remoting_legacy_api_deprecation/fail/unchecked_aliases.stderr
@@ -1,0 +1,17 @@
+error: use of deprecated method `rocketmq_protocol::protocol::remoting_command::legacy_api::<impl rocketmq_protocol::RemotingCommand>::read_custom_header_ref_unchecked`: use try_read_custom_header_ref; this compatibility alias is fallible despite its historical unchecked name
+ --> tests/ui/remoting_legacy_api_deprecation/fail/unchecked_aliases.rs:8:21
+  |
+8 |     let _ = command.read_custom_header_ref_unchecked::<GetRouteInfoRequestHeader>();
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+note: the lint level is defined here
+ --> tests/ui/remoting_legacy_api_deprecation/fail/unchecked_aliases.rs:1:9
+  |
+1 | #![deny(deprecated)]
+  |         ^^^^^^^^^^
+
+error: use of deprecated method `rocketmq_protocol::protocol::remoting_command::legacy_api::<impl rocketmq_protocol::RemotingCommand>::read_custom_header_mut_unchecked`: use try_read_custom_header_mut; this compatibility alias is fallible despite its historical unchecked name
+ --> tests/ui/remoting_legacy_api_deprecation/fail/unchecked_aliases.rs:9:21
+  |
+9 |     let _ = command.read_custom_header_mut_unchecked::<GetRouteInfoRequestHeader>();
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/rocketmq-protocol/tests/ui/remoting_response_factory_deprecation/fail/ambiguous_aliases.stderr
+++ b/rocketmq-protocol/tests/ui/remoting_response_factory_deprecation/fail/ambiguous_aliases.stderr
@@ -1,4 +1,4 @@
-error: use of deprecated associated function `rocketmq_protocol::RemotingCommand::create_response_command`: use create_success_response_command for SUCCESS or create_java_default_error_response_command for Java-compatible unset errors
+error: use of deprecated associated function `rocketmq_protocol::protocol::remoting_command::legacy_api::<impl rocketmq_protocol::RemotingCommand>::create_response_command`: use create_success_response_command for SUCCESS or create_java_default_error_response_command for Java-compatible unset errors
  --> tests/ui/remoting_response_factory_deprecation/fail/ambiguous_aliases.rs:7:30
   |
 7 |     let _ = RemotingCommand::create_response_command();
@@ -10,7 +10,7 @@ note: the lint level is defined here
 1 | #![deny(deprecated)]
   |         ^^^^^^^^^^
 
-error: use of deprecated associated function `rocketmq_protocol::RemotingCommand::create_response_command_with_header`: use create_success_response_command_with_header for SUCCESS or create_java_default_error_response_command_with_header for Java-compatible unset errors
+error: use of deprecated associated function `rocketmq_protocol::protocol::remoting_command::legacy_api::<impl rocketmq_protocol::RemotingCommand>::create_response_command_with_header`: use create_success_response_command_with_header for SUCCESS or create_java_default_error_response_command_with_header for Java-compatible unset errors
  --> tests/ui/remoting_response_factory_deprecation/fail/ambiguous_aliases.rs:8:30
   |
 8 |     let _ = RemotingCommand::create_response_command_with_header(GetRouteInfoRequestHeader::new("topic-a", None));

--- a/scripts/module-maintainability-baseline.json
+++ b/scripts/module-maintainability-baseline.json
@@ -6146,8 +6146,8 @@
       "reexports": 0
     },
     "rocketmq-protocol/src/protocol/remoting_command.rs": {
-      "production_lines": 203,
-      "public_items": 14,
+      "production_lines": 163,
+      "public_items": 7,
       "reexports": 0
     },
     "rocketmq-protocol/src/protocol/remoting_command/accessors.rs": {
@@ -6161,8 +6161,8 @@
       "reexports": 0
     },
     "rocketmq-protocol/src/protocol/remoting_command/custom_header.rs": {
-      "production_lines": 265,
-      "public_items": 15,
+      "production_lines": 248,
+      "public_items": 13,
       "reexports": 0
     },
     "rocketmq-protocol/src/protocol/remoting_command/decode.rs": {
@@ -6176,8 +6176,8 @@
       "reexports": 0
     },
     "rocketmq-protocol/src/protocol/remoting_command/encode.rs": {
-      "production_lines": 76,
-      "public_items": 3,
+      "production_lines": 72,
+      "public_items": 1,
       "reexports": 0
     },
     "rocketmq-protocol/src/protocol/remoting_command/encode/json.rs": {
@@ -6201,8 +6201,13 @@
       "reexports": 0
     },
     "rocketmq-protocol/src/protocol/remoting_command/frame.rs": {
-      "production_lines": 61,
-      "public_items": 3,
+      "production_lines": 59,
+      "public_items": 1,
+      "reexports": 0
+    },
+    "rocketmq-protocol/src/protocol/remoting_command/legacy_api.rs": {
+      "production_lines": 82,
+      "public_items": 13,
       "reexports": 0
     },
     "rocketmq-protocol/src/protocol/remoting_command_compat.rs": {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9635

### Brief Description

- Centralize 13 RemotingCommand compatibility facades in the private `legacy_api.rs` sibling module while preserving public paths and signatures.
- Route silent and `Option` compatibility methods directly through typed fallible implementations, including private header and frame helpers with unchanged JSON, ROCKETMQ, state, rollback, and wire behavior.
- Deprecate the two historical unchecked custom-header aliases and add focused parity and compile-fail coverage.
- Relocate only the five affected maintainability inventory records while preserving the `rocketmq-protocol` aggregate at 1691 public items and 296 re-exports.

### How Did You Test This Change?

- Passed package format, all-feature check, focused default and SIMD tests, both deprecation UI suites, response-factory contracts, five wire and compatibility contract suites, the full `rocketmq-protocol` suite, and the full `rocketmq-transport` suite.
- Passed package and workspace all-target/all-feature Clippy, the renamed-consumer locked offline check, standalone example all-target/all-feature Clippy, and the fixed-nightly fuzz check.
- Stable-surface and public API intent guards passed. The core-release aggregate reproduced the exact clean-base dependency, maintainability, and release-plan findings with no candidate additions.
- Root and standalone example workspace format checks both reproduce the clean-base Windows OS error 206; the affected package format check passes.
- `git diff --check` passes with exactly 11 planned paths and no generated artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added fallible custom-header access and encoding APIs that report missing data, type mismatches, serialization failures, and frame-size errors explicitly.
  - Added compatibility support for existing response creation, header access, materialization, and encoding workflows.

- **Bug Fixes**
  - Prevented header and frame encoding failures from being silently ignored.
  - Improved error handling for shared or invalid custom-header data.

- **Documentation**
  - Deprecated legacy access and encoding aliases now provide migration guidance and replacement API suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->