### PR TITLE
[ISSUE #9640]♻️Publish generation-consistent Tokio client endpoint state

### DIFF
--- a/rocketmq-transport/src/clients/rocketmq_tokio_client.rs
+++ b/rocketmq-transport/src/clients/rocketmq_tokio_client.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashSet;
 use std::future::Future;
 use std::ops::Deref;
 use std::sync::atomic::AtomicU64;
@@ -21,11 +20,8 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
-use arc_swap::ArcSwap;
 use cheetah_string::CheetahString;
-use dashmap::DashMap;
 use parking_lot::Mutex;
-use parking_lot::RwLock;
 use rocketmq_error::NetworkError;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
@@ -50,14 +46,8 @@ use crate::base::connection_net_event::ConnectionNetEvent;
 use crate::base::pending_request_table::PendingRequestTable;
 use crate::base::pending_request_table::PendingRequestUsage;
 use crate::clients::client::SessionConnectTarget;
-use crate::clients::nameserver_endpoint::diff_name_server_endpoints;
 use crate::clients::nameserver_endpoint::ConnectTarget;
 use crate::clients::nameserver_endpoint::NameServerEndpoint;
-use crate::clients::nameserver_failover::build_nameserver_failover_candidates;
-use crate::clients::nameserver_selector::LatencyTracker;
-use crate::clients::reconnect::CircuitAdmission;
-use crate::clients::reconnect::CircuitBreaker;
-use crate::clients::reconnect::CircuitState;
 use crate::clients::TransportSession;
 use crate::codec::remoting_command_codec::FrameLimits;
 use crate::deadline::RequestDeadline;
@@ -74,11 +64,48 @@ use crate::runtime::processor::RequestProcessor;
 use crate::runtime::RPCHook;
 use crate::security::TransportSecurity;
 use crate::telemetry::TransportGoAwayOutcome;
-use crate::telemetry::TransportNameServerFailoverReason;
 use crate::telemetry::TransportTelemetry;
 use crate::tls::TlsConfig;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+
+mod connection_registry;
+mod endpoint_state;
+mod nameserver;
+
+use connection_registry::ConnectionRegistry;
+use endpoint_state::EndpointLease;
+use endpoint_state::EndpointStateStore;
+use nameserver::NameServerHealth;
+
+#[cfg(test)]
+#[derive(Clone)]
+pub(crate) struct EndpointCompletionTestHook {
+    entered: Arc<std::sync::atomic::AtomicBool>,
+    entered_signal: Arc<tokio::sync::Notify>,
+    release: Arc<tokio::sync::Notify>,
+}
+
+#[cfg(test)]
+impl EndpointCompletionTestHook {
+    pub(crate) fn new() -> Self {
+        Self {
+            entered: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            entered_signal: Arc::new(tokio::sync::Notify::new()),
+            release: Arc::new(tokio::sync::Notify::new()),
+        }
+    }
+
+    pub(crate) async fn wait_until_entered(&self) {
+        while !self.entered.load(Ordering::Acquire) {
+            self.entered_signal.notified().await;
+        }
+    }
+
+    pub(crate) fn release(&self) {
+        self.release.notify_one();
+    }
+}
 
 /// High-performance async RocketMQ client with persistent endpoint sessions and auto-reconnection.
 ///
@@ -163,37 +190,18 @@ pub struct TransportClient<PR = DefaultRequestProcessor> {
     /// - Concurrency: Scales linearly with CPU cores (typically 16-64 shards)
     ///
     /// Invariant: Only contains healthy connections (unhealthy removed on error)
-    connection_tables: Arc<DashMap<CheetahString /* ip:port */, TransportSession<PR>>>,
-
-    /// One lifecycle-owned connection attempt per endpoint during cold bursts.
-    connect_flights: Arc<DashMap<CheetahString, Arc<ConnectFlight<PR>>>>,
+    connection_registry: Arc<ConnectionRegistry<PR>>,
     connect_attempts: Arc<AtomicU64>,
     namesrv_draining_count: Arc<AtomicUsize>,
 
     /// List of all nameserver addresses (in priority order)
     ///
     /// Updated via `update_name_server_address_list()`
-    namesrv_endpoints: Arc<ArcSwap<Vec<NameServerEndpoint>>>,
-
-    /// Currently selected nameserver (cached for fast path)
-    ///
-    /// May be `None` if no nameserver available or all unhealthy
-    namesrv_addr_choosed: Arc<RwLock<Option<CheetahString>>>,
-
-    /// Set of healthy/reachable nameservers
-    ///
-    /// Updated asynchronously by health check task (`scan_available_name_srv`)
-    available_namesrv_addr_set: Arc<RwLock<HashSet<CheetahString>>>,
-
-    /// Latency tracker for smart nameserver selection
-    ///
-    /// Tracks P99 latency and error rates to select the best nameserver
-    latency_tracker: LatencyTracker,
-
-    /// Circuit breakers per address to prevent cascading failures
-    ///
-    /// Maps address to circuit breaker state for auto-reconnection
-    circuit_breakers: Arc<DashMap<CheetahString, CircuitBreaker>>,
+    endpoint_state: Arc<EndpointStateStore>,
+    nameserver_health: Arc<NameServerHealth>,
+    direct_circuit_breakers: Arc<dashmap::DashMap<CheetahString, crate::clients::reconnect::CircuitBreaker>>,
+    #[cfg(test)]
+    connect_completion_test_hook: Arc<Mutex<Option<EndpointCompletionTestHook>>>,
 
     /// Token used to signal graceful shutdown of background tasks.
     ///
@@ -377,63 +385,6 @@ where
     }
 }
 
-enum ConnectFlightState<PR> {
-    Connecting,
-    Complete(Box<Result<Option<TransportSession<PR>>, Arc<str>>>),
-}
-
-struct ConnectFlight<PR> {
-    state: Mutex<ConnectFlightState<PR>>,
-    changed: tokio::sync::Notify,
-}
-
-struct DrainingEndpointGuard(Arc<AtomicUsize>);
-
-impl Drop for DrainingEndpointGuard {
-    fn drop(&mut self) {
-        self.0.fetch_sub(1, Ordering::AcqRel);
-    }
-}
-
-impl<PR> ConnectFlight<PR>
-where
-    PR: RequestProcessor + Sync + Clone + 'static,
-{
-    fn new() -> Self {
-        Self {
-            state: Mutex::new(ConnectFlightState::Connecting),
-            changed: tokio::sync::Notify::new(),
-        }
-    }
-
-    fn complete(&self, result: RocketMQResult<Option<TransportSession<PR>>>) {
-        *self.state.lock() =
-            ConnectFlightState::Complete(Box::new(result.map_err(|error| Arc::<str>::from(error.to_string()))));
-        self.changed.notify_waiters();
-    }
-
-    async fn wait(
-        &self,
-        deadline: RequestDeadline,
-        target: &CheetahString,
-    ) -> RocketMQResult<Option<TransportSession<PR>>> {
-        loop {
-            let changed = self.changed.notified();
-            tokio::pin!(changed);
-            changed.as_mut().enable();
-            if let ConnectFlightState::Complete(result) = &*self.state.lock() {
-                return (**result).clone().map_err(|message| {
-                    RocketMQError::network_connection_failed(target.to_string(), message.to_string())
-                });
-            }
-            deadline
-                .timeout(changed)
-                .await
-                .map_err(|_| RocketMQError::network_connection_timeout(target.to_string(), deadline.budget_millis()))?;
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize)]
 pub struct ClientStartReport {
     pub background_tasks_started: usize,
@@ -509,15 +460,14 @@ impl<PR> Clone for TransportClient<PR> {
     fn clone(&self) -> Self {
         Self {
             tokio_client_config: self.tokio_client_config.clone(),
-            connection_tables: self.connection_tables.clone(),
-            connect_flights: self.connect_flights.clone(),
+            connection_registry: self.connection_registry.clone(),
             connect_attempts: self.connect_attempts.clone(),
             namesrv_draining_count: self.namesrv_draining_count.clone(),
-            namesrv_endpoints: self.namesrv_endpoints.clone(),
-            namesrv_addr_choosed: self.namesrv_addr_choosed.clone(),
-            available_namesrv_addr_set: self.available_namesrv_addr_set.clone(),
-            latency_tracker: self.latency_tracker.clone(),
-            circuit_breakers: self.circuit_breakers.clone(),
+            endpoint_state: self.endpoint_state.clone(),
+            nameserver_health: self.nameserver_health.clone(),
+            direct_circuit_breakers: self.direct_circuit_breakers.clone(),
+            #[cfg(test)]
+            connect_completion_test_hook: self.connect_completion_test_hook.clone(),
             shutdown_token: self.shutdown_token.clone(),
             background_task_group: self.background_task_group.clone(),
             worker_task_group: self.worker_task_group.clone(),
@@ -588,15 +538,14 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
         );
         Ok(Self {
             tokio_client_config,
-            connection_tables: Arc::new(DashMap::with_capacity(64)),
-            connect_flights: Arc::new(DashMap::with_capacity(64)),
+            connection_registry: Arc::new(ConnectionRegistry::new()),
             connect_attempts: Arc::new(AtomicU64::new(0)),
             namesrv_draining_count: Arc::new(AtomicUsize::new(0)),
-            namesrv_endpoints: Arc::new(ArcSwap::from_pointee(Vec::new())),
-            namesrv_addr_choosed: Arc::new(RwLock::new(Default::default())),
-            available_namesrv_addr_set: Arc::new(RwLock::new(Default::default())),
-            latency_tracker: LatencyTracker::new(),
-            circuit_breakers: Arc::new(DashMap::with_capacity(64)),
+            endpoint_state: Arc::new(EndpointStateStore::new()),
+            nameserver_health: Arc::new(NameServerHealth::new()),
+            direct_circuit_breakers: Arc::new(dashmap::DashMap::with_capacity(64)),
+            #[cfg(test)]
+            connect_completion_test_hook: Arc::new(Mutex::new(None)),
             shutdown_token: CancellationToken::new(),
             background_task_group: Arc::new(Mutex::new(None)),
             worker_task_group: Arc::new(Mutex::new(None)),
@@ -630,34 +579,37 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
 
     #[must_use]
     pub fn snapshot(&self) -> ClientSnapshot {
-        let endpoints = self.namesrv_endpoints.load();
-        let identities = endpoints
+        let state = self.endpoint_state.load();
+        let healthy_name_server_count = state
+            .endpoints()
             .iter()
-            .map(|endpoint| endpoint.identity())
-            .collect::<HashSet<_>>();
-        let healthy_name_server_count = identities
-            .iter()
-            .filter(|identity| {
-                self.connection_tables
-                    .get(**identity)
-                    .is_some_and(|session| session.connection().is_healthy())
-                    && self.latency_tracker.is_healthy(identity)
+            .filter(|endpoint| {
+                state.lease_for(endpoint.identity()).is_some_and(|lease| {
+                    self.connection_registry
+                        .healthy_session(endpoint.identity(), Some(&lease))
+                        .is_some_and(|session| session.connection().is_healthy())
+                        && self.nameserver_health.is_healthy(endpoint.identity(), &lease)
+                })
             })
             .count();
-        let (probing_name_server_count, circuit_open_name_server_count) = self
-            .circuit_breakers
+        let (probing_name_server_count, circuit_open_name_server_count) = state
+            .endpoints()
             .iter()
-            .filter(|entry| identities.contains(entry.key()))
-            .fold((0, 0), |(probing, open), entry| match entry.state() {
-                CircuitState::Closed => (probing, open),
-                CircuitState::HalfOpen => (probing + 1, open),
-                CircuitState::Open => (probing, open + 1),
+            .filter_map(|endpoint| {
+                state
+                    .lease_for(endpoint.identity())
+                    .and_then(|lease| self.nameserver_health.circuit_state(endpoint.identity(), &lease))
+            })
+            .fold((0, 0), |(probing, open), state| match state {
+                crate::clients::reconnect::CircuitState::Closed => (probing, open),
+                crate::clients::reconnect::CircuitState::HalfOpen => (probing + 1, open),
+                crate::clients::reconnect::CircuitState::Open => (probing, open + 1),
             });
         ClientSnapshot {
-            connection_count: self.connection_tables.len(),
-            connect_flight_count: self.connect_flights.len(),
-            configured_name_server_count: self.namesrv_endpoints.load().len(),
-            available_name_server_count: self.available_namesrv_addr_set.read().len(),
+            connection_count: self.connection_registry.len(),
+            connect_flight_count: self.connection_registry.flight_count(),
+            configured_name_server_count: state.endpoints().len(),
+            available_name_server_count: state.available().len(),
             healthy_name_server_count,
             probing_name_server_count,
             draining_name_server_count: self.namesrv_draining_count.load(Ordering::Acquire),
@@ -689,7 +641,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
 
     /// Atomically applies resolved NameServer targets and starts bounded retirement for removals.
     pub fn update_name_server_connect_targets_sync(&self, targets: Vec<ConnectTarget>, drain_timeout: Duration) {
-        let endpoints = targets.into_iter().map(NameServerEndpoint::resolved).collect();
+        let endpoints = Self::name_server_connect_targets_to_endpoints(targets);
         self.apply_name_server_endpoint_snapshot_sync(endpoints, drain_timeout);
     }
 
@@ -699,50 +651,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
         endpoints: Vec<NameServerEndpoint>,
         drain_timeout: Duration,
     ) {
-        let current = self.namesrv_endpoints.load_full();
-        let diff = diff_name_server_endpoints(&current, &endpoints);
-        if diff.added.is_empty() && diff.removed.is_empty() {
-            return;
-        }
-
-        let old_count = current.len();
-        self.namesrv_endpoints.store(Arc::new(endpoints));
-        info!(
-            added = diff.added.len(),
-            unchanged = diff.unchanged.len(),
-            removed = diff.removed.len(),
-            old_count,
-            new_count = self.namesrv_endpoints.load().len(),
-            "NameServer endpoint snapshot updated"
-        );
-
-        for endpoint in diff.removed {
-            let identity = endpoint.identity().clone();
-            self.available_namesrv_addr_set.write().remove(&identity);
-            if self.namesrv_addr_choosed.read().as_ref() == Some(&identity) {
-                self.namesrv_addr_choosed.write().take();
-            }
-            self.connect_flights.remove(&identity);
-            if let Some((_, session)) = self.connection_tables.remove(&identity) {
-                self.start_removed_endpoint_drain(identity, session, drain_timeout);
-            }
-        }
-    }
-
-    fn name_server_identity_list(&self) -> Vec<CheetahString> {
-        self.namesrv_endpoints
-            .load()
-            .iter()
-            .map(|endpoint| endpoint.identity().clone())
-            .collect()
-    }
-
-    fn name_server_endpoint(&self, identity: &CheetahString) -> Option<NameServerEndpoint> {
-        self.namesrv_endpoints
-            .load()
-            .iter()
-            .find(|endpoint| endpoint.identity() == identity)
-            .cloned()
+        self.apply_name_server_endpoint_snapshot(endpoints, drain_timeout);
     }
 
     fn get_or_create_worker_task_group(&self) -> Option<TaskGroup> {
@@ -771,6 +680,21 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
         self.worker_task_group.lock().as_ref().cloned()
     }
 
+    #[cfg(test)]
+    pub(crate) fn install_connect_completion_test_hook(&self, hook: EndpointCompletionTestHook) {
+        *self.connect_completion_test_hook.lock() = Some(hook);
+    }
+
+    #[cfg(test)]
+    async fn wait_for_connect_completion_test_hook(&self) {
+        let hook = self.connect_completion_test_hook.lock().clone();
+        if let Some(hook) = hook {
+            hook.entered.store(true, Ordering::Release);
+            hook.entered_signal.notify_waiters();
+            hook.release.notified().await;
+        }
+    }
+
     pub(crate) fn spawn_worker_task<F>(&self, name: impl Into<Arc<str>>, future: F) -> Option<TaskId>
     where
         F: Future<Output = ()> + Send + 'static,
@@ -789,164 +713,9 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
             }
         }
     }
-
-    fn start_removed_endpoint_drain(
-        &self,
-        identity: CheetahString,
-        session: TransportSession<PR>,
-        drain_timeout: Duration,
-    ) {
-        session.begin_drain();
-        self.namesrv_draining_count.fetch_add(1, Ordering::AcqRel);
-        let drain_guard = DrainingEndpointGuard(self.namesrv_draining_count.clone());
-        self.telemetry
-            .record_nameserver_failover(TransportNameServerFailoverReason::Draining);
-        let latency_tracker = self.latency_tracker.clone();
-        let circuit_breakers = self.circuit_breakers.clone();
-        let cleanup_identity = identity.clone();
-        let task_name = format!("rocketmq.transport.nameserver-drain.{identity}");
-        let spawned = self.spawn_worker_task(task_name, async move {
-            let _drain_guard = drain_guard;
-            let report = session.drain_and_close(drain_timeout).await;
-            latency_tracker.remove(&cleanup_identity);
-            circuit_breakers.remove(&cleanup_identity);
-            if !report.is_healthy() {
-                warn!(report = %report.to_json(), "removed NameServer endpoint drain was unhealthy");
-            }
-        });
-        if spawned.is_none() {
-            warn!("removed NameServer endpoint drain could not be scheduled because the client is shutting down");
-        }
-    }
 }
 
 impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
-    /// Get or create connection to a healthy nameserver using smart latency-based selection.
-    ///
-    /// # Selection Strategy
-    ///
-    /// **Latency-based**: Selects lowest P99 latency nameserver
-    /// ```text
-    /// namesrv_list = [ns1, ns2, ns3]
-    /// Metrics:
-    ///   ns1: P99=5ms,  errors=0
-    ///   ns2: P99=50ms, errors=0
-    ///   ns3: P99=10ms, errors=3 (unhealthy)
-    ///
-    /// Selection: ns1 (lowest latency + healthy)
-    /// ```
-    ///
-    /// **Scoring Formula**:
-    /// ```text
-    /// score = P99_latency_ms + (consecutive_errors × 100)
-    /// ```
-    ///
-    /// **Fallback**: If no metrics available, uses first nameserver
-    ///
-    /// # Performance Notes
-    ///
-    /// - **Lock Minimization**: Drops lock before expensive `create_client()`
-    /// - **Smart Selection**: O(N) where N = nameserver count (typically <10)
-    /// - **Caching**: Reuses `namesrv_addr_choosed` for fast path
-    ///
-    /// # Returns
-    ///
-    /// * `Some(client)` - Connected to healthy nameserver
-    /// * `None` - No nameservers available or all unhealthy
-    async fn get_and_create_nameserver_client_until(
-        &self,
-        deadline: RequestDeadline,
-    ) -> RocketMQResult<Option<TransportSession<PR>>> {
-        deadline.ensure_before_send("<nameserver>")?;
-        let cached_addr = self.namesrv_addr_choosed.read().clone();
-
-        if let Some(ref addr) = cached_addr {
-            // Quick lookup in the endpoint-session registry.
-            if let Some(client) = self.connection_tables.get(addr) {
-                if client.connection().is_healthy() && self.latency_tracker.is_healthy(addr) {
-                    // Fast path: Cached nameserver is healthy
-                    return Ok(Some(client.value().clone()));
-                }
-                debug!("Cached nameserver {} is unhealthy, selecting new one", addr);
-                self.telemetry
-                    .record_nameserver_failover(TransportNameServerFailoverReason::Unhealthy);
-            }
-        }
-
-        let addr_list = self.name_server_identity_list();
-
-        if addr_list.is_empty() {
-            warn!("No nameservers configured in namesrv_addr_list");
-            return Ok(None);
-        }
-
-        let available = self.available_namesrv_addr_set.read().clone();
-        let mut half_open_probe_selected = false;
-        let mut candidates =
-            build_nameserver_failover_candidates(&addr_list, &available, &self.latency_tracker, |address| {
-                let mut breaker = self
-                    .circuit_breakers
-                    .entry(address.clone())
-                    .or_insert_with(CircuitBreaker::default_breaker);
-                match breaker.connection_admission() {
-                    CircuitAdmission::Regular => true,
-                    CircuitAdmission::Probe if !half_open_probe_selected => {
-                        half_open_probe_selected = true;
-                        true
-                    }
-                    CircuitAdmission::Probe | CircuitAdmission::Rejected => {
-                        self.telemetry
-                            .record_nameserver_failover(TransportNameServerFailoverReason::CircuitOpen);
-                        false
-                    }
-                }
-            });
-        candidates.sort_by_key(|address| {
-            self.connection_tables
-                .get(address)
-                .is_none_or(|session| !session.connection().is_healthy())
-        });
-        if candidates.is_empty() {
-            error!(
-                "Failed to select healthy nameserver. Available list: {:?}, Available set: {:?}",
-                addr_list, available
-            );
-            return Ok(None);
-        }
-
-        let mut last_error = None;
-        for selected_addr in candidates {
-            deadline.ensure_before_send(selected_addr.to_string())?;
-            info!(
-                "Selected nameserver: {} (P99: {:?}, errors: {})",
-                selected_addr,
-                self.latency_tracker
-                    .get_p99(&selected_addr)
-                    .unwrap_or(Duration::from_secs(0)),
-                self.latency_tracker.get_error_count(&selected_addr)
-            );
-            match self.create_client_until(&selected_addr, deadline).await {
-                Ok(Some(client)) => {
-                    self.namesrv_addr_choosed.write().replace(selected_addr);
-                    return Ok(Some(client));
-                }
-                Ok(None) => {}
-                Err(error) => {
-                    self.telemetry
-                        .record_nameserver_failover(TransportNameServerFailoverReason::ConnectFailure);
-                    self.latency_tracker.record_error(&selected_addr);
-                    last_error = Some(error);
-                }
-            }
-        }
-
-        self.namesrv_addr_choosed.write().take();
-        match last_error {
-            Some(error) => Err(error),
-            None => Ok(None),
-        }
-    }
-
     /// Get existing healthy client or create new connection.
     ///
     /// # Flow
@@ -958,17 +727,6 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
     /// # Performance
     /// - **Fast path**: Single lock acquire + HashMap lookup + health check (< 100ns)
     /// - **Slow path**: Lock + TCP handshake + TLS (if enabled) (10-50ms)
-    async fn get_and_create_client(&self, addr: Option<&CheetahString>) -> Option<TransportSession<PR>> {
-        let deadline = RequestDeadline::after(self.tokio_client_config.connect.timeout);
-        match self.get_and_create_client_until(addr, deadline).await {
-            Ok(client) => client,
-            Err(error) => {
-                warn!(error = ?error, "Failed to get or create remoting client");
-                None
-            }
-        }
-    }
-
     async fn get_and_create_client_until(
         &self,
         addr: Option<&CheetahString>,
@@ -976,23 +734,25 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
     ) -> RocketMQResult<Option<TransportSession<PR>>> {
         // Route empty addresses to nameserver
         let target_addr = match addr {
-            None => return self.get_and_create_nameserver_client_until(deadline).await,
-            Some(addr) if addr.is_empty() => return self.get_and_create_nameserver_client_until(deadline).await,
+            None => {
+                return self
+                    .get_and_create_nameserver_client_until(deadline)
+                    .await
+                    .map(|selection| selection.map(|selection| selection.session))
+            }
+            Some(addr) if addr.is_empty() => {
+                return self
+                    .get_and_create_nameserver_client_until(deadline)
+                    .await
+                    .map(|selection| selection.map(|selection| selection.session))
+            }
             Some(addr) => addr,
         };
         deadline.ensure_before_send(target_addr.to_string())?;
 
-        // Fast path: Check the persistent endpoint-session registry.
-        if let Some(client_ref) = self.connection_tables.get(target_addr) {
-            let client = client_ref.value().clone();
-            if client.connection().is_healthy() {
-                return Ok(Some(client)); // Return healthy cached client
-            }
-            // Client unhealthy - will create new connection
-            debug!("Cached client for {} is unhealthy, reconnecting...", target_addr);
+        if let Some(client) = self.connection_registry.healthy_session(target_addr, None) {
+            return Ok(Some(client));
         }
-
-        // Slow path: Create new connection
         self.create_client_until(target_addr, deadline).await
     }
 
@@ -1049,43 +809,61 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
         addr: &CheetahString,
         deadline: RequestDeadline,
     ) -> RocketMQResult<Option<TransportSession<PR>>> {
+        self.create_client_with_lease_until(addr, None, None, deadline).await
+    }
+
+    async fn create_client_for_nameserver_until(
+        &self,
+        addr: &CheetahString,
+        endpoint: NameServerEndpoint,
+        lease: EndpointLease,
+        deadline: RequestDeadline,
+    ) -> RocketMQResult<Option<TransportSession<PR>>> {
+        self.create_client_with_lease_until(addr, Some(endpoint), Some(lease), deadline)
+            .await
+    }
+
+    async fn create_client_with_lease_until(
+        &self,
+        addr: &CheetahString,
+        configured_nameserver: Option<NameServerEndpoint>,
+        lease: Option<EndpointLease>,
+        deadline: RequestDeadline,
+    ) -> RocketMQResult<Option<TransportSession<PR>>> {
         deadline.ensure_before_send(addr.to_string())?;
-        if let Some(client) = self.connection_tables.get(addr) {
-            if client.connection().is_healthy() {
-                return Ok(Some(client.value().clone()));
-            }
+        if !self.can_commit_endpoint_lease(lease.as_ref()) {
+            return Ok(None);
+        }
+        if let Some(client) = self.connection_registry.healthy_session(addr, lease.as_ref()) {
+            return Ok(Some(client));
         }
 
-        let (flight, leader) = match self.connect_flights.entry(addr.clone()) {
-            dashmap::mapref::entry::Entry::Occupied(entry) => (entry.get().clone(), false),
-            dashmap::mapref::entry::Entry::Vacant(entry) => {
-                let flight = Arc::new(ConnectFlight::new());
-                entry.insert(flight.clone());
-                (flight, true)
-            }
-        };
+        let (flight, leader) = self.connection_registry.acquire_flight(addr.clone(), lease.clone());
         if leader {
             let client = self.clone();
             let flight_for_task = flight.clone();
             let target = addr.clone();
-            let configured_nameserver = self.name_server_endpoint(addr);
             let connect_timeout = self.tokio_client_config.connect.timeout;
             let target_for_task = target.clone();
+            let lease_for_task = lease.clone();
             let spawned = self.spawn_worker_task(format!("rocketmq.transport.connect.{target}"), async move {
                 client.connect_attempts.fetch_add(1, Ordering::Relaxed);
                 let result = client
                     .connect_endpoint_until(
                         &target_for_task,
                         configured_nameserver,
+                        lease_for_task,
                         RequestDeadline::after(connect_timeout),
                     )
                     .await;
                 flight_for_task.complete(result);
-                client.connect_flights.remove(&target_for_task);
+                client
+                    .connection_registry
+                    .remove_flight_if_matches(&target_for_task, &flight_for_task);
             });
             if spawned.is_none() {
                 flight.complete(Err(RocketMQError::ClientNotStarted));
-                self.connect_flights.remove(&target);
+                self.connection_registry.remove_flight_if_matches(&target, &flight);
             }
         }
         flight.wait(deadline, addr).await
@@ -1095,29 +873,29 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
         &self,
         addr: &CheetahString,
         configured_nameserver: Option<NameServerEndpoint>,
+        lease: Option<EndpointLease>,
         deadline: RequestDeadline,
     ) -> RocketMQResult<Option<TransportSession<PR>>> {
         deadline.ensure_before_send(addr.to_string())?;
-        // Check if healthy client already exists
-        if let Some(client_ref) = self.connection_tables.get(addr) {
-            let client = client_ref.value().clone();
-            if client.connection().is_healthy() {
-                return Ok(Some(client));
-            }
-            // Client unhealthy - remove it immediately (DashMap allows concurrent removal)
-            drop(client_ref); // Release read guard before removal
-            self.connection_tables.remove(addr);
+        if !self.can_commit_endpoint_lease(lease.as_ref()) {
+            return Ok(None);
+        }
+        if let Some(client) = self.connection_registry.healthy_session(addr, lease.as_ref()) {
+            return Ok(Some(client));
         }
 
-        // Check circuit breaker for this address
-        let mut breaker = self
-            .circuit_breakers
-            .entry(addr.clone())
-            .or_insert_with(CircuitBreaker::default_breaker)
-            .clone();
-
-        // Check if request allowed (CLOSED or HALF_OPEN)
-        if !breaker.allow_request() {
+        let allowed = match lease.as_ref() {
+            Some(lease) => self
+                .nameserver_health
+                .connection_admission_if_current(addr, lease, || self.endpoint_state.is_current(lease))
+                .is_some_and(|admission| admission != crate::clients::reconnect::CircuitAdmission::Rejected),
+            None => self
+                .direct_circuit_breakers
+                .entry(addr.clone())
+                .or_insert_with(crate::clients::reconnect::CircuitBreaker::default_breaker)
+                .allow_request(),
+        };
+        if !allowed {
             warn!("Circuit breaker OPEN for {}, rejecting connection attempt", addr);
             return Ok(None);
         }
@@ -1151,161 +929,71 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
 
         match connect_result {
             Ok(new_client) => {
-                if configured_nameserver.is_some() && self.name_server_endpoint(addr).is_none() {
+                #[cfg(test)]
+                if lease.is_some() {
+                    self.wait_for_connect_completion_test_hook().await;
+                }
+                if !self.can_commit_endpoint_lease(lease.as_ref()) {
                     new_client.begin_drain();
                     let _ = new_client.close_with_report(Duration::from_secs(1)).await;
                     return Ok(None);
                 }
-                // Connection successful - record success in circuit breaker
-                breaker.record_success();
-                self.circuit_breakers.insert(addr.clone(), breaker);
-
-                match self.connection_tables.entry(addr.clone()) {
-                    dashmap::mapref::entry::Entry::Occupied(mut entry) => {
-                        // Check if existing is still healthy
-                        if entry.get().connection().is_healthy() {
-                            info!("Race condition: {} already connected by another task", addr);
-                            return Ok(Some(entry.get().clone()));
+                match lease.as_ref() {
+                    Some(lease) => self
+                        .nameserver_health
+                        .record_connection_success_if_current(addr, lease, || self.endpoint_state.is_current(lease)),
+                    None => {
+                        if let Some(mut breaker) = self.direct_circuit_breakers.get_mut(addr) {
+                            breaker.record_success();
                         }
-                        // Replace unhealthy with new client
-                        entry.insert(new_client.clone());
-                    }
-                    dashmap::mapref::entry::Entry::Vacant(entry) => {
-                        entry.insert(new_client.clone());
                     }
                 }
-
-                info!("Successfully created client for {}", addr);
-                Ok(Some(new_client))
+                let session_lease = lease.clone();
+                match self
+                    .connection_registry
+                    .insert_session(addr.clone(), new_client.clone(), lease, || {
+                        self.can_commit_endpoint_lease(session_lease.as_ref())
+                    }) {
+                    Some(client) => {
+                        info!("Successfully created client for {}", addr);
+                        Ok(Some(client))
+                    }
+                    None => {
+                        new_client.begin_drain();
+                        let _ = new_client.close_with_report(Duration::from_secs(1)).await;
+                        Ok(None)
+                    }
+                }
             }
             Err(error) => {
-                // Connection failed - record failure in circuit breaker
                 error!(remote_addr = %addr, error = ?error, "Failed to connect");
-                breaker.record_failure();
-                self.circuit_breakers.insert(addr.clone(), breaker);
+                match lease.as_ref() {
+                    Some(lease) => self
+                        .nameserver_health
+                        .record_connection_failure_if_current(addr, lease, || self.endpoint_state.is_current(lease)),
+                    None => {
+                        if let Some(mut breaker) = self.direct_circuit_breakers.get_mut(addr) {
+                            breaker.record_failure();
+                        }
+                    }
+                }
                 Err(error)
             }
         }
     }
 
-    /// Background task: Continuously scan nameservers to update availability set.
-    ///
-    /// # Purpose
-    ///
-    /// Maintains `available_namesrv_addr_set` by probing all configured nameservers
-    /// and marking them as available/unavailable based on connection health.
-    ///
-    /// # Algorithm
-    ///
-    /// ```text
-    /// 1. Cleanup phase: Remove stale entries not in namesrv_addr_list
-    /// 2. Probe phase: Test connection to each nameserver
-    /// 3. Update phase: Add/remove from available_namesrv_addr_set
-    /// ```
-    ///
-    /// # Performance
-    ///
-    /// - **Frequency**: Called every `connect_timeout_millis` (typically 3s)
-    /// - **Concurrency**: Parallel probes via `futures::future::join_all`
-    /// - **Overhead**: O(N) where N = number of nameservers (typically < 10)
-    ///
-    /// # Example Timeline
-    ///
-    /// ```text
-    /// T+0s:  Start scan
-    /// T+0s:  Cleanup: Remove ["old-ns:9876"]
-    /// T+0s:  Probe ns1 → Success (mark available)
-    /// T+50ms: Probe ns2 → Timeout (mark unavailable)
-    /// T+100ms: Probe ns3 → Success (mark available)
-    /// T+100ms: Scan complete
-    /// T+3s:  Next scan begins...
-    /// ```
-    async fn scan_available_name_srv(&self) {
-        let addr_list = self.name_server_identity_list();
-
-        if addr_list.is_empty() {
-            debug!("No nameservers configured, skipping availability scan");
-            return;
-        }
-
-        // Collect addresses to remove (avoid holding borrow during mutation)
-        let stale_addrs: Vec<CheetahString> = self
-            .available_namesrv_addr_set
-            .read()
-            .iter()
-            .filter(|addr| !addr_list.contains(addr))
-            .cloned()
-            .collect();
-
-        for stale_addr in stale_addrs {
-            warn!("Removing stale nameserver from available set: {}", stale_addr);
-            self.available_namesrv_addr_set.write().remove(&stale_addr);
-        }
-
-        // Parallel probing reduces total scan time
-        use futures::future::join_all;
-
-        let probe_futures: Vec<_> = addr_list
-            .iter()
-            .map(|addr| {
-                let addr_clone = addr.clone();
-                async move {
-                    let result = self.get_and_create_client(Some(&addr_clone)).await;
-                    (addr_clone, result.is_some())
-                }
-            })
-            .collect();
-
-        // Execute all probes concurrently
-        let results = join_all(probe_futures).await;
-
-        // Update availability set based on probe results
-        for (namesrv_addr, is_available) in results {
-            if is_available {
-                // Connection successful - mark as available
-                if self.available_namesrv_addr_set.write().insert(namesrv_addr.clone()) {
-                    info!("Nameserver {} is now available", namesrv_addr);
-                }
-            } else {
-                // Connection failed - mark as unavailable
-                if self.available_namesrv_addr_set.write().remove(&namesrv_addr) {
-                    warn!("Nameserver {} is now unavailable", namesrv_addr);
-                }
-            }
-        }
-
-        debug!(
-            "Availability scan complete: {}/{} nameservers available",
-            self.available_namesrv_addr_set.read().len(),
-            addr_list.len()
-        );
+    fn can_commit_endpoint_lease(&self, lease: Option<&EndpointLease>) -> bool {
+        lease.is_none_or(|lease| self.endpoint_state.is_current(lease))
     }
 
     /// Scans persistent sessions and removes those that are unhealthy or idle.
     fn scan_idle_connections(&self) {
         let idle_threshold = self.tokio_client_config.maintenance.idle_scan_interval;
         let now_millis = current_millis();
-        let mut stale_addrs = Vec::new();
-
-        for entry in self.connection_tables.iter() {
-            let addr = entry.key().clone();
-            let client = entry.value();
-
-            // Remove connections that are no longer healthy
-            if !client.connection().is_healthy() {
-                stale_addrs.push(addr);
-                continue;
-            }
-
-            if idle_threshold.is_some_and(|threshold| client.idle_for_at(now_millis) >= threshold) {
-                stale_addrs.push(addr);
-            }
-        }
-
-        for addr in &stale_addrs {
-            if self.connection_tables.remove(addr).is_some() {
-                warn!("[SCAN] Removed idle/unhealthy connection: {}", addr);
-            }
+        for addr in self.connection_registry.remove_unhealthy_or_idle(|client| {
+            idle_threshold.is_some_and(|threshold| client.idle_for_at(now_millis) >= threshold)
+        }) {
+            warn!("[SCAN] Removed idle/unhealthy connection: {}", addr);
         }
     }
 
@@ -1325,13 +1013,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
             None => None,
         };
 
-        let addrs: Vec<_> = self.connection_tables.iter().map(|entry| entry.key().clone()).collect();
-        let mut clients = Vec::with_capacity(addrs.len());
-        for addr in addrs {
-            if let Some((addr, client)) = self.connection_tables.remove(&addr) {
-                clients.push((addr, client));
-            }
-        }
+        let clients = self.connection_registry.take_all_sessions();
 
         let mut connections = Vec::with_capacity(clients.len());
         for (addr, client) in clients {
@@ -1339,9 +1021,8 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
             connections.push(ConnectionShutdownReport { addr, report });
         }
 
-        self.namesrv_endpoints.store(Arc::new(Vec::new()));
-        self.namesrv_addr_choosed.write().take();
-        self.available_namesrv_addr_set.write().clear();
+        self.nameserver_health
+            .with_mutation_lock(|| self.endpoint_state.replace_topology(Vec::new()));
 
         ClientShutdownReport {
             background,
@@ -1440,11 +1121,10 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
                 );
             }
         }
-        self.connection_tables.clear();
-        self.connect_flights.clear();
-        self.namesrv_endpoints.store(Arc::new(Vec::new()));
-        self.namesrv_addr_choosed.write().take();
-        self.available_namesrv_addr_set.write().clear();
+        self.connection_registry.take_all_sessions();
+        self.connection_registry.clear_flights();
+        self.nameserver_health
+            .with_mutation_lock(|| self.endpoint_state.replace_topology(Vec::new()));
 
         info!("RemotingClient shutdown complete");
     }
@@ -1468,19 +1148,14 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
     ) -> CheetahString {
         requested_addr
             .cloned()
-            .or_else(|| {
-                self.connection_tables
-                    .iter()
-                    .find(|entry| entry.value().is_same_registry_session(session))
-                    .map(|entry| entry.key().clone())
-            })
-            .or_else(|| self.namesrv_addr_choosed.read().clone())
+            .or_else(|| self.connection_registry.session_identity(session))
+            .or_else(|| self.endpoint_state.load().chosen().cloned())
             .unwrap_or_else(|| CheetahString::from_string(session.remote_address().to_string()))
     }
 
     fn remove_cached_session_if_matches(&self, identity: &CheetahString, expected: &TransportSession<PR>) -> bool {
-        self.connection_tables
-            .remove_if(identity, |_, current| current.is_same_registry_session(expected))
+        self.connection_registry
+            .remove_session_if_matches(identity, expected)
             .is_some()
     }
 
@@ -1499,15 +1174,18 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
         }
     }
 
-    fn record_nameserver_outcome(&self, addr: Option<&CheetahString>, latency: Duration, success: bool) {
-        let Some(addr) = addr else {
+    fn record_nameserver_outcome(
+        &self,
+        addr: Option<&CheetahString>,
+        lease: Option<&EndpointLease>,
+        latency: Duration,
+        success: bool,
+    ) {
+        let (Some(addr), Some(lease)) = (addr, lease) else {
             return;
         };
-        if success {
-            self.latency_tracker.record_success(addr, latency);
-        } else {
-            self.latency_tracker.record_error(addr);
-        }
+        self.nameserver_health
+            .record_outcome_if_current(addr, lease, latency, success, || self.endpoint_state.is_current(lease));
     }
 
     async fn invoke_oneway_until(
@@ -1578,15 +1256,16 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
     }
 
     pub fn get_name_server_address_list(&self) -> Vec<CheetahString> {
-        self.namesrv_endpoints
+        self.endpoint_state
             .load()
+            .endpoints()
             .iter()
             .map(NameServerEndpoint::compatibility_address)
             .collect()
     }
 
     pub fn get_available_name_srv_list(&self) -> Vec<CheetahString> {
-        self.available_namesrv_addr_set.read().iter().cloned().collect()
+        self.endpoint_state.load().available().iter().cloned().collect()
     }
 
     /// Sends one canonical request under an absolute deadline.
@@ -1622,14 +1301,23 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
             }
             RequestTarget::NameServer => {
                 let started_at = time::Instant::now();
+                deadline.ensure_before_send("<nameserver>")?;
+                let Some(selection) = self.get_and_create_nameserver_client_until(deadline).await? else {
+                    return Err(RocketMQError::network_connection_failed(
+                        "<nameserver>",
+                        "one-way nameserver client unavailable",
+                    ));
+                };
+                let metric_identity = selection.identity.clone();
+                let metric_lease = selection.lease.clone();
+                let selection_generation = selection.state.generation();
+                let mut client = selection.session;
+                debug!(
+                    selected = %metric_identity,
+                    generation = selection_generation,
+                    "Sending one-way request to selected nameserver"
+                );
                 let result = async {
-                    deadline.ensure_before_send("<nameserver>")?;
-                    let Some(mut client) = self.get_and_create_client_until(None, deadline).await? else {
-                        return Err(RocketMQError::network_connection_failed(
-                            "<nameserver>",
-                            "one-way nameserver client unavailable",
-                        ));
-                    };
                     let endpoint = CheetahString::from_string(client.remote_address().to_string());
                     let mut request = request;
                     if let Some(hooks) = self.cmd_handler.hook_snapshot() {
@@ -1648,12 +1336,12 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
                     })
                 }
                 .await;
-                let metric_addr = self
-                    .namesrv_addr_choosed
-                    .read()
-                    .clone()
-                    .or_else(|| result.as_ref().ok().map(|receipt| receipt.endpoint.clone()));
-                self.record_nameserver_outcome(metric_addr.as_ref(), started_at.elapsed(), result.is_ok());
+                self.record_nameserver_outcome(
+                    Some(&metric_identity),
+                    Some(&metric_lease),
+                    started_at.elapsed(),
+                    result.is_ok(),
+                );
                 result
             }
         }
@@ -1712,33 +1400,47 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
         request: RemotingCommand,
         deadline: RequestDeadline,
     ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
-        let nameserver_request = addr.is_none();
+        let nameserver_request = addr.is_none_or(CheetahString::is_empty);
         let start = time::Instant::now();
         let timeout_millis = deadline.budget_millis();
-        let target = addr.map_or_else(|| "<nameserver>".to_string(), ToString::to_string);
+        let target = if nameserver_request {
+            "<nameserver>".to_string()
+        } else {
+            addr.map_or_else(|| "<nameserver>".to_string(), ToString::to_string)
+        };
         deadline.ensure_before_send(target.clone())?;
-
-        let mut client = self.get_and_create_client_until(addr, deadline).await?.ok_or_else(|| {
+        let nameserver_diagnostics = nameserver_request.then(|| self.endpoint_state.load());
+        let nameserver_selection = if nameserver_request {
+            self.get_and_create_nameserver_client_until(deadline).await?
+        } else {
+            None
+        };
+        let nameserver_metric_addr = nameserver_selection
+            .as_ref()
+            .map(|selection| selection.identity.clone());
+        let nameserver_lease = nameserver_selection.as_ref().map(|selection| selection.lease.clone());
+        let nameserver_generation = nameserver_selection
+            .as_ref()
+            .map(|selection| selection.state.generation());
+        let mut client = match nameserver_selection {
+            Some(selection) => Some(selection.session),
+            None if nameserver_request => None,
+            None => self.get_and_create_client_until(addr, deadline).await?,
+        }
+        .ok_or_else(|| {
             if target == "<nameserver>" {
-                let configured_list = self.name_server_identity_list();
-                let available_set = self.available_namesrv_addr_set.read().clone();
-                let cached_choice = self.namesrv_addr_choosed.read().clone();
-                error!(
-                    "Failed to get client for <nameserver>. Diagnostics: configured_list={:?}, available_set={:?}, \
-                     cached_choice={:?}, connections={}",
-                    configured_list,
-                    available_set,
-                    cached_choice,
-                    self.connection_tables.len()
-                );
+                if let Some(state) = nameserver_diagnostics.as_ref() {
+                    error!(
+                        "Failed to get client for <nameserver>. Diagnostics: configured_list={:?}, available_set={:?}, \
+                         cached_choice={:?}, connections={}",
+                        state.endpoints(),
+                        state.available(),
+                        state.chosen(),
+                        self.connection_registry.len()
+                    );
+                }
             } else {
                 error!("Failed to get client for {}", target);
-            }
-
-            if nameserver_request {
-                if let Some(addr) = self.namesrv_addr_choosed.read().as_ref() {
-                    self.latency_tracker.record_error(addr);
-                }
             }
 
             RocketMQError::network_connection_failed(target.clone(), "Failed to connect")
@@ -1750,8 +1452,6 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
 
         let mut request = request;
         let initial_remote_address = client.remote_address();
-        let initial_identity = self.session_cache_identity(addr, &client);
-        let nameserver_metric_addr = nameserver_request.then(|| initial_identity.clone());
         deadline.ensure_before_send(initial_remote_address.to_string())?;
         let hooks = self.cmd_handler.hook_snapshot();
         let request_for_after = if let Some(hooks) = hooks {
@@ -1790,7 +1490,14 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
 
         for attempt in 0..Self::MAX_GO_AWAY_ATTEMPTS {
             let remote_address = client.remote_address();
-            let identity = self.session_cache_identity(addr, &client);
+            let identity = if nameserver_request {
+                self.connection_registry
+                    .session_identity(&client)
+                    .or_else(|| nameserver_metric_addr.clone())
+                    .unwrap_or_else(|| CheetahString::from_string(remote_address.to_string()))
+            } else {
+                self.session_cache_identity(addr, &client)
+            };
             let mut attempt_request = retry_request.clone();
             if attempt > 0 {
                 attempt_request.set_opaque_mut(RemotingCommand::get_and_add());
@@ -1802,7 +1509,12 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
                     if !retry_allowed {
                         let response = apply_final_hooks(response, remote_address)?;
                         let latency = start.elapsed();
-                        self.record_nameserver_outcome(nameserver_metric_addr.as_ref(), latency, true);
+                        self.record_nameserver_outcome(
+                            nameserver_metric_addr.as_ref(),
+                            nameserver_lease.as_ref(),
+                            latency,
+                            true,
+                        );
                         debug!(
                             remote_addr = %identity,
                             elapsed_ms = latency.as_millis() as u64,
@@ -1815,7 +1527,12 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
 
                     if attempt + 1 == Self::MAX_GO_AWAY_ATTEMPTS {
                         self.telemetry.record_go_away(TransportGoAwayOutcome::RetryFailed);
-                        self.record_nameserver_outcome(nameserver_metric_addr.as_ref(), start.elapsed(), false);
+                        self.record_nameserver_outcome(
+                            nameserver_metric_addr.as_ref(),
+                            nameserver_lease.as_ref(),
+                            start.elapsed(),
+                            false,
+                        );
                         return Err(RpcClientError::unexpected_response_code(
                             response.code(),
                             "GO_AWAY after replacement-connection retry",
@@ -1826,7 +1543,12 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
                     attempted_retry = true;
                     if let Err(error) = deadline.ensure_before_send(identity.to_string()) {
                         self.telemetry.record_go_away(TransportGoAwayOutcome::RetryFailed);
-                        self.record_nameserver_outcome(nameserver_metric_addr.as_ref(), start.elapsed(), false);
+                        self.record_nameserver_outcome(
+                            nameserver_metric_addr.as_ref(),
+                            nameserver_lease.as_ref(),
+                            start.elapsed(),
+                            false,
+                        );
                         return Err(error);
                     }
                     let replacement = match self.get_and_create_client_until(addr, deadline).await {
@@ -1841,7 +1563,12 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
                         Ok(replacement) => replacement,
                         Err(error) => {
                             self.telemetry.record_go_away(TransportGoAwayOutcome::RetryFailed);
-                            self.record_nameserver_outcome(nameserver_metric_addr.as_ref(), start.elapsed(), false);
+                            self.record_nameserver_outcome(
+                                nameserver_metric_addr.as_ref(),
+                                nameserver_lease.as_ref(),
+                                start.elapsed(),
+                                false,
+                            );
                             return Err(error);
                         }
                     };
@@ -1853,7 +1580,12 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
                             if attempted_retry {
                                 self.telemetry.record_go_away(TransportGoAwayOutcome::RetryFailed);
                             }
-                            self.record_nameserver_outcome(nameserver_metric_addr.as_ref(), start.elapsed(), false);
+                            self.record_nameserver_outcome(
+                                nameserver_metric_addr.as_ref(),
+                                nameserver_lease.as_ref(),
+                                start.elapsed(),
+                                false,
+                            );
                             return Err(error);
                         }
                     };
@@ -1861,9 +1593,15 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
                         self.telemetry.record_go_away(TransportGoAwayOutcome::RetrySuccess);
                     }
                     let latency = start.elapsed();
-                    self.record_nameserver_outcome(nameserver_metric_addr.as_ref(), latency, true);
+                    self.record_nameserver_outcome(
+                        nameserver_metric_addr.as_ref(),
+                        nameserver_lease.as_ref(),
+                        latency,
+                        true,
+                    );
                     debug!(
                         remote_addr = %identity,
+                        nameserver_generation = ?nameserver_generation,
                         elapsed_ms = latency.as_millis() as u64,
                         "request completed"
                     );
@@ -1883,7 +1621,12 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
                         self.telemetry.record_go_away(TransportGoAwayOutcome::RetryFailed);
                     }
                     let latency = start.elapsed();
-                    self.record_nameserver_outcome(nameserver_metric_addr.as_ref(), latency, false);
+                    self.record_nameserver_outcome(
+                        nameserver_metric_addr.as_ref(),
+                        nameserver_lease.as_ref(),
+                        latency,
+                        false,
+                    );
                     warn!(
                         remote_addr = %identity,
                         elapsed_ms = latency.as_millis() as u64,
@@ -1918,13 +1661,10 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
     }
 
     pub fn is_address_reachable(&self, addr: &CheetahString) {
-        if let Some(client_ref) = self.connection_tables.get(addr) {
-            if client_ref.value().connection().is_healthy() {
-                return;
-            }
-            // Connection exists but is unhealthy; drop the guard before removal
-            drop(client_ref);
-            self.connection_tables.remove(addr);
+        if self.connection_registry.healthy_session(addr, None).is_some() {
+            return;
+        }
+        if self.connection_registry.remove_unhealthy_session(addr) {
             warn!("Removed unhealthy connection for {}", addr);
         } else {
             debug!("No connection found for {}", addr);
@@ -1934,7 +1674,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
     pub fn close_clients(&self, addrs: Vec<String>) {
         for addr in &addrs {
             let key = CheetahString::from(addr.as_str());
-            if let Some((_, _client)) = self.connection_tables.remove(&key) {
+            if !self.connection_registry.remove_sessions_by_identity(&key).is_empty() {
                 info!("Closed client connection for {}", addr);
             }
         }

--- a/rocketmq-transport/src/clients/rocketmq_tokio_client/connection_registry.rs
+++ b/rocketmq-transport/src/clients/rocketmq_tokio_client/connection_registry.rs
@@ -1,0 +1,423 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cheetah_string::CheetahString;
+use dashmap::DashMap;
+use parking_lot::Mutex;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+
+use super::endpoint_state::EndpointLease;
+use crate::clients::TransportSession;
+use crate::deadline::RequestDeadline;
+use crate::runtime::processor::RequestProcessor;
+
+/// Session ownership separates direct broker sessions from nameserver sessions
+/// that happen to use the same socket address.
+#[derive(Clone, Copy, Eq, Hash, PartialEq)]
+enum RegistryScope {
+    Direct,
+    NameServer,
+}
+
+#[derive(Clone, Eq, Hash, PartialEq)]
+struct RegistryKey {
+    identity: CheetahString,
+    scope: RegistryScope,
+}
+
+impl RegistryKey {
+    fn from_lease(identity: CheetahString, lease: Option<&EndpointLease>) -> Self {
+        Self {
+            identity,
+            scope: if lease.is_some() {
+                RegistryScope::NameServer
+            } else {
+                RegistryScope::Direct
+            },
+        }
+    }
+
+    fn direct(identity: CheetahString) -> Self {
+        Self {
+            identity,
+            scope: RegistryScope::Direct,
+        }
+    }
+
+    fn nameserver(identity: CheetahString) -> Self {
+        Self {
+            identity,
+            scope: RegistryScope::NameServer,
+        }
+    }
+}
+
+/// A cached session and, for nameservers, the endpoint generation that owns it.
+#[derive(Clone)]
+pub(super) struct RegisteredSession<PR> {
+    session: TransportSession<PR>,
+    lease: Option<EndpointLease>,
+}
+
+impl<PR> RegisteredSession<PR> {
+    pub(super) fn session(&self) -> &TransportSession<PR> {
+        &self.session
+    }
+
+    pub(super) fn into_session(self) -> TransportSession<PR> {
+        self.session
+    }
+
+    pub(super) fn belongs_to(&self, lease: &EndpointLease) -> bool {
+        self.lease
+            .as_ref()
+            .is_some_and(|candidate| candidate.same_generation(lease))
+    }
+}
+
+enum ConnectFlightState<PR> {
+    Connecting,
+    Complete(Box<Result<Option<TransportSession<PR>>, Arc<str>>>),
+}
+
+/// A shared connection attempt associated with one endpoint generation.
+pub(super) struct ConnectFlight<PR> {
+    lease: Option<EndpointLease>,
+    state: Mutex<ConnectFlightState<PR>>,
+    changed: tokio::sync::Notify,
+}
+
+impl<PR> ConnectFlight<PR>
+where
+    PR: RequestProcessor + Sync + Clone + Send + 'static,
+{
+    fn new(lease: Option<EndpointLease>) -> Self {
+        Self {
+            lease,
+            state: Mutex::new(ConnectFlightState::Connecting),
+            changed: tokio::sync::Notify::new(),
+        }
+    }
+
+    pub(super) fn belongs_to(&self, lease: Option<&EndpointLease>) -> bool {
+        match (self.lease.as_ref(), lease) {
+            (None, None) => true,
+            (Some(current), Some(expected)) => current.same_generation(expected),
+            _ => false,
+        }
+    }
+
+    pub(super) fn complete(&self, result: RocketMQResult<Option<TransportSession<PR>>>) {
+        *self.state.lock() =
+            ConnectFlightState::Complete(Box::new(result.map_err(|error| Arc::<str>::from(error.to_string()))));
+        self.changed.notify_waiters();
+    }
+
+    pub(super) async fn wait(
+        &self,
+        deadline: RequestDeadline,
+        target: &CheetahString,
+    ) -> RocketMQResult<Option<TransportSession<PR>>> {
+        loop {
+            let changed = self.changed.notified();
+            tokio::pin!(changed);
+            changed.as_mut().enable();
+            if let ConnectFlightState::Complete(result) = &*self.state.lock() {
+                return (**result).clone().map_err(|message| {
+                    RocketMQError::network_connection_failed(target.to_string(), message.to_string())
+                });
+            }
+            deadline
+                .timeout(changed)
+                .await
+                .map_err(|_| RocketMQError::network_connection_timeout(target.to_string(), deadline.budget_millis()))?;
+        }
+    }
+}
+
+/// Endpoint-session and connect-flight maps with identity-conditional removal.
+pub(super) struct ConnectionRegistry<PR> {
+    sessions: DashMap<RegistryKey, RegisteredSession<PR>>,
+    flights: DashMap<RegistryKey, Arc<ConnectFlight<PR>>>,
+}
+
+impl<PR> ConnectionRegistry<PR>
+where
+    PR: RequestProcessor + Sync + Clone + Send + 'static,
+{
+    pub(super) fn new() -> Self {
+        Self {
+            sessions: DashMap::with_capacity(64),
+            flights: DashMap::with_capacity(64),
+        }
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.sessions.len()
+    }
+
+    #[cfg(test)]
+    pub(super) fn is_empty(&self) -> bool {
+        self.sessions.is_empty()
+    }
+
+    pub(super) fn flight_count(&self) -> usize {
+        self.flights.len()
+    }
+
+    #[cfg(test)]
+    pub(super) fn contains(&self, identity: &CheetahString) -> bool {
+        self.sessions.contains_key(&RegistryKey::direct(identity.clone()))
+            || self.sessions.contains_key(&RegistryKey::nameserver(identity.clone()))
+    }
+
+    pub(super) fn healthy_session(
+        &self,
+        identity: &CheetahString,
+        lease: Option<&EndpointLease>,
+    ) -> Option<TransportSession<PR>> {
+        let key = RegistryKey::from_lease(identity.clone(), lease);
+        self.sessions.get(&key).and_then(|entry| {
+            let registered = entry.value();
+            let generation_matches = lease.is_none_or(|expected| registered.belongs_to(expected));
+            (generation_matches && registered.session().connection().is_healthy()).then(|| registered.session().clone())
+        })
+    }
+
+    pub(super) fn session_identity(&self, session: &TransportSession<PR>) -> Option<CheetahString> {
+        self.sessions
+            .iter()
+            .find(|entry| entry.value().session().is_same_registry_session(session))
+            .map(|entry| entry.key().identity.clone())
+    }
+
+    pub(super) fn insert_session(
+        &self,
+        identity: CheetahString,
+        session: TransportSession<PR>,
+        lease: Option<EndpointLease>,
+        can_commit: impl Fn() -> bool,
+    ) -> Option<TransportSession<PR>> {
+        let key = RegistryKey::from_lease(identity, lease.as_ref());
+        match self.sessions.entry(key) {
+            dashmap::mapref::entry::Entry::Occupied(mut entry) => {
+                let current = entry.get();
+                if current.session().connection().is_healthy() {
+                    let same_generation = match (lease.as_ref(), current.lease.as_ref()) {
+                        (None, _) => true,
+                        (Some(expected), Some(current)) => current.same_generation(expected),
+                        (Some(_), None) => false,
+                    };
+                    if same_generation {
+                        return Some(current.session().clone());
+                    }
+                    if !can_commit() {
+                        return None;
+                    }
+                }
+                if !can_commit() {
+                    return None;
+                }
+                entry.insert(RegisteredSession {
+                    session: session.clone(),
+                    lease,
+                });
+                Some(session)
+            }
+            dashmap::mapref::entry::Entry::Vacant(entry) => {
+                if !can_commit() {
+                    return None;
+                }
+                entry.insert(RegisteredSession {
+                    session: session.clone(),
+                    lease,
+                });
+                Some(session)
+            }
+        }
+    }
+
+    pub(super) fn remove_session_if_matches(
+        &self,
+        identity: &CheetahString,
+        expected: &TransportSession<PR>,
+    ) -> Option<RegisteredSession<PR>> {
+        [
+            RegistryKey::direct(identity.clone()),
+            RegistryKey::nameserver(identity.clone()),
+        ]
+        .into_iter()
+        .find_map(|key| {
+            self.sessions
+                .remove_if(&key, |_, current| current.session().is_same_registry_session(expected))
+                .map(|(_, registered)| registered)
+        })
+    }
+
+    pub(super) fn remove_unhealthy_session(&self, identity: &CheetahString) -> bool {
+        self.sessions
+            .remove_if(&RegistryKey::direct(identity.clone()), |_, current| {
+                !current.session().connection().is_healthy()
+            })
+            .is_some()
+    }
+
+    #[cfg(test)]
+    pub(super) fn remove_session_by_identity(&self, identity: &CheetahString) -> Option<RegisteredSession<PR>> {
+        [
+            RegistryKey::direct(identity.clone()),
+            RegistryKey::nameserver(identity.clone()),
+        ]
+        .into_iter()
+        .find_map(|key| {
+            let expected = self.sessions.get(&key).map(|entry| entry.value().clone())?;
+            self.sessions
+                .remove_if(&key, |_, current| {
+                    current.session().is_same_registry_session(expected.session())
+                })
+                .map(|(_, registered)| registered)
+        })
+    }
+
+    pub(super) fn remove_sessions_by_identity(&self, identity: &CheetahString) -> Vec<RegisteredSession<PR>> {
+        [
+            RegistryKey::direct(identity.clone()),
+            RegistryKey::nameserver(identity.clone()),
+        ]
+        .into_iter()
+        .filter_map(|key| {
+            let expected = self.sessions.get(&key).map(|entry| entry.value().clone())?;
+            self.sessions
+                .remove_if(&key, |_, current| {
+                    current.session().is_same_registry_session(expected.session())
+                })
+                .map(|(_, registered)| registered)
+        })
+        .collect()
+    }
+
+    pub(super) fn remove_session_for_lease(
+        &self,
+        identity: &CheetahString,
+        lease: &EndpointLease,
+    ) -> Option<RegisteredSession<PR>> {
+        self.sessions
+            .remove_if(&RegistryKey::from_lease(identity.clone(), Some(lease)), |_, current| {
+                current.belongs_to(lease)
+            })
+            .map(|(_, registered)| registered)
+    }
+
+    pub(super) fn acquire_flight(
+        &self,
+        identity: CheetahString,
+        lease: Option<EndpointLease>,
+    ) -> (Arc<ConnectFlight<PR>>, bool) {
+        let key = RegistryKey::from_lease(identity, lease.as_ref());
+        match self.flights.entry(key) {
+            dashmap::mapref::entry::Entry::Occupied(entry) if entry.get().belongs_to(lease.as_ref()) => {
+                (Arc::clone(entry.get()), false)
+            }
+            dashmap::mapref::entry::Entry::Occupied(mut entry) => {
+                let flight = Arc::new(ConnectFlight::new(lease));
+                entry.insert(Arc::clone(&flight));
+                (flight, true)
+            }
+            dashmap::mapref::entry::Entry::Vacant(entry) => {
+                let flight = Arc::new(ConnectFlight::new(lease));
+                entry.insert(Arc::clone(&flight));
+                (flight, true)
+            }
+        }
+    }
+
+    pub(super) fn remove_flight_if_matches(&self, identity: &CheetahString, expected: &Arc<ConnectFlight<PR>>) {
+        self.flights.remove_if(
+            &RegistryKey::from_lease(identity.clone(), expected.lease.as_ref()),
+            |_, current| Arc::ptr_eq(current, expected),
+        );
+    }
+
+    pub(super) fn remove_flight_for_lease(&self, identity: &CheetahString, lease: &EndpointLease) {
+        self.flights
+            .remove_if(&RegistryKey::from_lease(identity.clone(), Some(lease)), |_, current| {
+                current.belongs_to(Some(lease))
+            });
+    }
+
+    pub(super) fn remove_unhealthy_or_idle(
+        &self,
+        idle_for: impl Fn(&TransportSession<PR>) -> bool,
+    ) -> Vec<CheetahString> {
+        let entries = self
+            .sessions
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .collect::<Vec<_>>();
+        let mut removed = Vec::new();
+        for (key, expected) in entries {
+            let is_stale = !expected.session().connection().is_healthy() || idle_for(expected.session());
+            if is_stale
+                && self
+                    .sessions
+                    .remove_if(&key, |_, current| {
+                        current.session().is_same_registry_session(expected.session())
+                    })
+                    .is_some()
+            {
+                removed.push(key.identity);
+            }
+        }
+        removed
+    }
+
+    pub(super) fn take_all_sessions(&self) -> Vec<(CheetahString, TransportSession<PR>)> {
+        let entries = self
+            .sessions
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .collect::<Vec<_>>();
+        entries
+            .into_iter()
+            .filter_map(|(key, expected)| {
+                self.sessions
+                    .remove_if(&key, |_, current| {
+                        current.session().is_same_registry_session(expected.session())
+                    })
+                    .map(|(_, registered)| (key.identity, registered.into_session()))
+            })
+            .collect()
+    }
+
+    pub(super) fn clear_flights(&self) {
+        let entries = self
+            .flights
+            .iter()
+            .map(|entry| (entry.key().clone(), Arc::clone(entry.value())))
+            .collect::<Vec<_>>();
+        for (key, expected) in entries {
+            self.remove_flight_if_matches(&key.identity, &expected);
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn has_session_for_lease(&self, identity: &CheetahString, lease: &EndpointLease) -> bool {
+        self.sessions
+            .get(&RegistryKey::from_lease(identity.clone(), Some(lease)))
+            .is_some_and(|entry| entry.value().belongs_to(lease))
+    }
+}

--- a/rocketmq-transport/src/clients/rocketmq_tokio_client/endpoint_state.rs
+++ b/rocketmq-transport/src/clients/rocketmq_tokio_client/endpoint_state.rs
@@ -1,0 +1,260 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use cheetah_string::CheetahString;
+
+use crate::clients::nameserver_endpoint::diff_name_server_endpoints;
+use crate::clients::nameserver_endpoint::NameServerEndpoint;
+use crate::clients::nameserver_endpoint::NameServerEndpointDiff;
+
+/// Immutable endpoint metadata published as one coherent selection view.
+///
+/// Availability and the cached choice are published with the endpoint list.
+/// Each configured endpoint owns a lease that survives topology publications
+/// while its identity is retained, but is replaced after removal and re-add.
+#[derive(Debug)]
+pub(super) struct EndpointState {
+    endpoints: Vec<NameServerEndpoint>,
+    endpoint_leases: HashMap<CheetahString, EndpointLease>,
+    available: HashSet<CheetahString>,
+    chosen: Option<CheetahString>,
+    generation: u64,
+}
+
+/// A generation lease held by nameserver selection, flights, and sessions.
+#[derive(Clone, Debug)]
+pub(super) struct EndpointLease {
+    identity: CheetahString,
+    generation: u64,
+    identity_token: Arc<()>,
+}
+
+impl EndpointLease {
+    fn new(identity: CheetahString, generation: u64) -> Self {
+        Self {
+            identity,
+            generation,
+            identity_token: Arc::new(()),
+        }
+    }
+
+    pub(super) fn identity(&self) -> &CheetahString {
+        &self.identity
+    }
+
+    pub(super) fn same_generation(&self, other: &Self) -> bool {
+        self.identity == other.identity
+            && self.generation == other.generation
+            && Arc::ptr_eq(&self.identity_token, &other.identity_token)
+    }
+}
+
+impl EndpointState {
+    pub(super) fn empty() -> Self {
+        Self {
+            endpoints: Vec::new(),
+            endpoint_leases: HashMap::new(),
+            available: HashSet::new(),
+            chosen: None,
+            generation: 0,
+        }
+    }
+
+    pub(super) fn endpoints(&self) -> &[NameServerEndpoint] {
+        &self.endpoints
+    }
+
+    pub(super) fn available(&self) -> &HashSet<CheetahString> {
+        &self.available
+    }
+
+    pub(super) fn chosen(&self) -> Option<&CheetahString> {
+        self.chosen.as_ref()
+    }
+
+    pub(super) fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    pub(super) fn lease_for(&self, identity: &CheetahString) -> Option<EndpointLease> {
+        self.endpoint_leases.get(identity).cloned()
+    }
+
+    pub(super) fn contains_lease(&self, lease: &EndpointLease) -> bool {
+        self.endpoint_leases
+            .get(lease.identity())
+            .is_some_and(|current| current.same_generation(lease))
+    }
+
+    fn next_topology(&self, endpoints: Vec<NameServerEndpoint>) -> Self {
+        let identities = endpoints
+            .iter()
+            .map(|endpoint| endpoint.identity().clone())
+            .collect::<HashSet<_>>();
+        let generation = self.generation.wrapping_add(1);
+        let endpoint_leases = endpoints
+            .iter()
+            .map(|endpoint| {
+                let identity = endpoint.identity().clone();
+                let lease = self
+                    .lease_for(&identity)
+                    .unwrap_or_else(|| EndpointLease::new(identity.clone(), generation));
+                (identity, lease)
+            })
+            .collect();
+        Self {
+            available: self
+                .available
+                .iter()
+                .filter(|identity| identities.contains(*identity))
+                .cloned()
+                .collect(),
+            chosen: self.chosen.clone().filter(|identity| identities.contains(identity)),
+            endpoints,
+            endpoint_leases,
+            generation,
+        }
+    }
+
+    fn with_availability(&self, lease: &EndpointLease, identity: &CheetahString, is_available: bool) -> Option<Self> {
+        if lease.identity() != identity || !self.contains_lease(lease) {
+            return None;
+        }
+
+        let mut available = self.available.clone();
+        if is_available {
+            available.insert(identity.clone());
+        } else {
+            available.remove(identity);
+        }
+        Some(self.clone_with(available, self.chosen.clone()))
+    }
+
+    fn with_chosen(&self, lease: &EndpointLease) -> Option<Self> {
+        if !self.contains_lease(lease) {
+            return None;
+        }
+        let chosen = Some(lease.identity().clone());
+        Some(self.clone_with(self.available.clone(), chosen))
+    }
+
+    fn without_chosen_if_matches(&self, expected: &EndpointLease) -> Option<Self> {
+        if !self.contains_lease(expected) || self.chosen.as_ref() != Some(expected.identity()) {
+            return None;
+        }
+        Some(self.clone_with(self.available.clone(), None))
+    }
+
+    fn clone_with(&self, available: HashSet<CheetahString>, chosen: Option<CheetahString>) -> Self {
+        Self {
+            endpoints: self.endpoints.clone(),
+            endpoint_leases: self.endpoint_leases.clone(),
+            available,
+            chosen,
+            generation: self.generation,
+        }
+    }
+}
+
+/// The result of atomically replacing the endpoint topology.
+pub(super) struct EndpointTopologyUpdate {
+    pub(super) previous: Arc<EndpointState>,
+    pub(super) current: Arc<EndpointState>,
+    pub(super) diff: NameServerEndpointDiff,
+}
+
+/// One ArcSwap publication point for all nameserver selection metadata.
+pub(super) struct EndpointStateStore {
+    state: ArcSwap<EndpointState>,
+}
+
+impl EndpointStateStore {
+    pub(super) fn new() -> Self {
+        Self {
+            state: ArcSwap::from_pointee(EndpointState::empty()),
+        }
+    }
+
+    pub(super) fn load(&self) -> Arc<EndpointState> {
+        self.state.load_full()
+    }
+
+    pub(super) fn replace_topology(&self, endpoints: Vec<NameServerEndpoint>) -> Option<EndpointTopologyUpdate> {
+        loop {
+            let previous = self.load();
+            let diff = diff_name_server_endpoints(previous.endpoints(), &endpoints);
+            if diff.added.is_empty() && diff.removed.is_empty() {
+                return None;
+            }
+
+            let current = Arc::new(previous.next_topology(endpoints.clone()));
+            let observed = self.state.compare_and_swap(&previous, Arc::clone(&current));
+            if Arc::ptr_eq(&*observed, &previous) {
+                return Some(EndpointTopologyUpdate {
+                    previous,
+                    current,
+                    diff,
+                });
+            }
+        }
+    }
+
+    pub(super) fn update_availability(
+        &self,
+        lease: &EndpointLease,
+        identity: &CheetahString,
+        is_available: bool,
+    ) -> bool {
+        self.update_if_current(lease, |state| state.with_availability(lease, identity, is_available))
+    }
+
+    pub(super) fn set_chosen(&self, lease: &EndpointLease) -> bool {
+        self.update_if_current(lease, |state| state.with_chosen(lease))
+    }
+
+    /// Clears the choice only when the captured endpoint lease still owns it.
+    pub(super) fn clear_chosen_if_matches(&self, expected: &EndpointLease) -> bool {
+        self.update_if_current(expected, |state| state.without_chosen_if_matches(expected))
+    }
+
+    pub(super) fn is_current(&self, lease: &EndpointLease) -> bool {
+        self.load().contains_lease(lease)
+    }
+
+    fn update_if_current(
+        &self,
+        lease: &EndpointLease,
+        update: impl Fn(&EndpointState) -> Option<EndpointState>,
+    ) -> bool {
+        loop {
+            let previous = self.load();
+            if !previous.contains_lease(lease) {
+                return false;
+            }
+            let Some(current) = update(&previous) else {
+                return false;
+            };
+            let current = Arc::new(current);
+            let observed = self.state.compare_and_swap(&previous, current);
+            if Arc::ptr_eq(&*observed, &previous) {
+                return true;
+            }
+        }
+    }
+}

--- a/rocketmq-transport/src/clients/rocketmq_tokio_client/nameserver.rs
+++ b/rocketmq-transport/src/clients/rocketmq_tokio_client/nameserver.rs
@@ -1,0 +1,530 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use cheetah_string::CheetahString;
+use dashmap::DashMap;
+use parking_lot::Mutex;
+use rocketmq_error::RocketMQResult;
+use tracing::debug;
+use tracing::error;
+use tracing::info;
+use tracing::warn;
+
+use super::endpoint_state::EndpointLease;
+use super::endpoint_state::EndpointState;
+use super::TransportClient;
+use crate::clients::nameserver_endpoint::ConnectTarget;
+use crate::clients::nameserver_endpoint::NameServerEndpoint;
+use crate::clients::nameserver_failover::build_nameserver_failover_candidates;
+use crate::clients::nameserver_selector::LatencyTracker;
+use crate::clients::reconnect::CircuitAdmission;
+use crate::clients::reconnect::CircuitBreaker;
+use crate::clients::reconnect::CircuitState;
+use crate::clients::TransportSession;
+use crate::deadline::RequestDeadline;
+use crate::runtime::processor::RequestProcessor;
+use crate::telemetry::TransportNameServerFailoverReason;
+
+struct CircuitRecord {
+    breaker: CircuitBreaker,
+    lease: EndpointLease,
+}
+
+/// Generation-aware nameserver health state.
+///
+/// The mutex serializes only the small ownership transition with latency and
+/// circuit bookkeeping; network work remains outside it.
+pub(super) struct NameServerHealth {
+    latency: LatencyTracker,
+    latency_leases: DashMap<CheetahString, EndpointLease>,
+    circuits: DashMap<CheetahString, CircuitRecord>,
+    mutation_lock: Mutex<()>,
+}
+
+pub(super) struct NameServerSession<PR> {
+    pub(super) session: TransportSession<PR>,
+    pub(super) identity: CheetahString,
+    pub(super) lease: EndpointLease,
+    pub(super) state: Arc<EndpointState>,
+}
+
+impl NameServerHealth {
+    pub(super) fn new() -> Self {
+        Self {
+            latency: LatencyTracker::new(),
+            latency_leases: DashMap::with_capacity(64),
+            circuits: DashMap::with_capacity(64),
+            mutation_lock: Mutex::new(()),
+        }
+    }
+
+    pub(super) fn latency_tracker(&self) -> &LatencyTracker {
+        &self.latency
+    }
+
+    /// Serializes topology publication with health ownership transitions, so a
+    /// caller that observed a lease cannot install it after that lease retired.
+    pub(super) fn with_mutation_lock<T>(&self, action: impl FnOnce() -> T) -> T {
+        let _guard = self.mutation_lock.lock();
+        action()
+    }
+
+    pub(super) fn is_healthy(&self, identity: &CheetahString, lease: &EndpointLease) -> bool {
+        self.latency_leases
+            .get(identity)
+            .is_none_or(|owner| owner.same_generation(lease) && self.latency.is_healthy(identity))
+    }
+
+    pub(super) fn p99(&self, identity: &CheetahString, lease: &EndpointLease) -> Option<Duration> {
+        self.latency_leases
+            .get(identity)
+            .filter(|owner| owner.same_generation(lease))
+            .and_then(|_| self.latency.get_p99(identity))
+    }
+
+    pub(super) fn error_count(&self, identity: &CheetahString, lease: &EndpointLease) -> u32 {
+        self.latency_leases
+            .get(identity)
+            .filter(|owner| owner.same_generation(lease))
+            .map_or(0, |_| self.latency.get_error_count(identity))
+    }
+
+    fn prepare_locked(&self, identity: &CheetahString, lease: &EndpointLease) {
+        let stale_latency_lease = self
+            .latency_leases
+            .get(identity)
+            .filter(|owner| !owner.same_generation(lease))
+            .map(|owner| owner.clone());
+        if stale_latency_lease.is_some_and(|stale| {
+            self.latency_leases
+                .remove_if(identity, |_, owner| owner.same_generation(&stale))
+                .is_some()
+        }) {
+            self.latency.remove(identity);
+        }
+        self.latency_leases
+            .entry(identity.clone())
+            .or_insert_with(|| lease.clone());
+        let stale_circuit_lease = self
+            .circuits
+            .get(identity)
+            .filter(|record| !record.lease.same_generation(lease))
+            .map(|record| record.lease.clone());
+        if let Some(stale) = stale_circuit_lease {
+            self.circuits
+                .remove_if(identity, |_, record| record.lease.same_generation(&stale));
+        }
+    }
+
+    pub(super) fn connection_admission_if_current(
+        &self,
+        identity: &CheetahString,
+        lease: &EndpointLease,
+        is_current: impl FnOnce() -> bool,
+    ) -> Option<CircuitAdmission> {
+        let _guard = self.mutation_lock.lock();
+        if !is_current() {
+            return None;
+        }
+        self.prepare_locked(identity, lease);
+        Some(match self.circuits.entry(identity.clone()) {
+            dashmap::mapref::entry::Entry::Occupied(mut entry) if entry.get().lease.same_generation(lease) => {
+                entry.get_mut().breaker.connection_admission()
+            }
+            dashmap::mapref::entry::Entry::Occupied(mut entry) => {
+                entry.insert(CircuitRecord {
+                    breaker: CircuitBreaker::default_breaker(),
+                    lease: lease.clone(),
+                });
+                entry.get_mut().breaker.connection_admission()
+            }
+            dashmap::mapref::entry::Entry::Vacant(entry) => entry
+                .insert(CircuitRecord {
+                    breaker: CircuitBreaker::default_breaker(),
+                    lease: lease.clone(),
+                })
+                .breaker
+                .connection_admission(),
+        })
+    }
+
+    pub(super) fn record_connection_success_if_current(
+        &self,
+        identity: &CheetahString,
+        lease: &EndpointLease,
+        is_current: impl FnOnce() -> bool,
+    ) {
+        let _guard = self.mutation_lock.lock();
+        if !is_current() {
+            return;
+        }
+        let Some(mut record) = self.circuits.get_mut(identity) else {
+            return;
+        };
+        if record.lease.same_generation(lease) {
+            record.breaker.record_success();
+        }
+    }
+
+    pub(super) fn record_connection_failure_if_current(
+        &self,
+        identity: &CheetahString,
+        lease: &EndpointLease,
+        is_current: impl FnOnce() -> bool,
+    ) {
+        let _guard = self.mutation_lock.lock();
+        if !is_current() {
+            return;
+        }
+        let Some(mut record) = self.circuits.get_mut(identity) else {
+            return;
+        };
+        if record.lease.same_generation(lease) {
+            record.breaker.record_failure();
+        }
+    }
+
+    pub(super) fn record_outcome_if_current(
+        &self,
+        identity: &CheetahString,
+        lease: &EndpointLease,
+        latency: Duration,
+        success: bool,
+        is_current: impl FnOnce() -> bool,
+    ) {
+        let _guard = self.mutation_lock.lock();
+        if !is_current() {
+            return;
+        }
+        if self
+            .latency_leases
+            .get(identity)
+            .is_some_and(|owner| owner.same_generation(lease))
+        {
+            if success {
+                self.latency.record_success(identity, latency);
+            } else {
+                self.latency.record_error(identity);
+            }
+        }
+    }
+
+    pub(super) fn circuit_state(&self, identity: &CheetahString, lease: &EndpointLease) -> Option<CircuitState> {
+        self.circuits
+            .get(identity)
+            .filter(|record| record.lease.same_generation(lease))
+            .map(|record| record.breaker.state())
+    }
+
+    pub(super) fn remove_if_owned(&self, identity: &CheetahString, lease: &EndpointLease) {
+        let _guard = self.mutation_lock.lock();
+        if self
+            .latency_leases
+            .remove_if(identity, |_, owner| owner.same_generation(lease))
+            .is_some()
+        {
+            self.latency.remove(identity);
+        }
+        self.circuits
+            .remove_if(identity, |_, record| record.lease.same_generation(lease));
+    }
+
+    #[cfg(test)]
+    pub(super) fn latency_p99_for_test(&self, identity: &CheetahString) -> Option<Duration> {
+        self.latency.get_p99(identity)
+    }
+
+    #[cfg(test)]
+    pub(super) fn latency_error_count_for_test(&self, identity: &CheetahString) -> u32 {
+        self.latency.get_error_count(identity)
+    }
+
+    #[cfg(test)]
+    pub(super) fn owns_latency_for_test(&self, identity: &CheetahString, lease: &EndpointLease) -> bool {
+        self.latency_leases
+            .get(identity)
+            .is_some_and(|owner| owner.same_generation(lease))
+    }
+}
+
+struct DrainingEndpointGuard(Arc<AtomicUsize>);
+
+impl Drop for DrainingEndpointGuard {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
+    pub(super) fn apply_name_server_endpoint_snapshot(
+        &self,
+        endpoints: Vec<NameServerEndpoint>,
+        drain_timeout: Duration,
+    ) {
+        let update = self
+            .nameserver_health
+            .with_mutation_lock(|| self.endpoint_state.replace_topology(endpoints));
+        let Some(update) = update else {
+            return;
+        };
+        info!(
+            added = update.diff.added.len(),
+            unchanged = update.diff.unchanged.len(),
+            removed = update.diff.removed.len(),
+            old_count = update.previous.endpoints().len(),
+            new_count = update.current.endpoints().len(),
+            generation = update.current.generation(),
+            "NameServer endpoint snapshot updated"
+        );
+
+        for endpoint in update.diff.removed {
+            let identity = endpoint.identity().clone();
+            let Some(retired_lease) = update.previous.lease_for(&identity) else {
+                continue;
+            };
+            self.connection_registry
+                .remove_flight_for_lease(&identity, &retired_lease);
+            let session = self
+                .connection_registry
+                .remove_session_for_lease(&identity, &retired_lease);
+            self.nameserver_health.remove_if_owned(&identity, &retired_lease);
+            if let Some(session) = session {
+                self.start_removed_endpoint_drain(identity, session.into_session(), retired_lease, drain_timeout);
+            }
+        }
+    }
+
+    pub(super) fn name_server_endpoint(state: &EndpointState, identity: &CheetahString) -> Option<NameServerEndpoint> {
+        state
+            .endpoints()
+            .iter()
+            .find(|endpoint| endpoint.identity() == identity)
+            .cloned()
+    }
+
+    fn start_removed_endpoint_drain(
+        &self,
+        identity: CheetahString,
+        session: TransportSession<PR>,
+        lease: EndpointLease,
+        drain_timeout: Duration,
+    ) {
+        session.begin_drain();
+        self.namesrv_draining_count.fetch_add(1, Ordering::AcqRel);
+        let drain_guard = DrainingEndpointGuard(Arc::clone(&self.namesrv_draining_count));
+        self.telemetry
+            .record_nameserver_failover(TransportNameServerFailoverReason::Draining);
+        let client = self.clone();
+        let task_name = format!("rocketmq.transport.nameserver-drain.{identity}");
+        let spawned = self.spawn_worker_task(task_name, async move {
+            let _drain_guard = drain_guard;
+            let report = session.drain_and_close(drain_timeout).await;
+            if !client.endpoint_state.is_current(&lease) {
+                client.nameserver_health.remove_if_owned(&identity, &lease);
+            }
+            if !report.is_healthy() {
+                warn!(report = %report.to_json(), "removed NameServer endpoint drain was unhealthy");
+            }
+        });
+        if spawned.is_none() {
+            warn!("removed NameServer endpoint drain could not be scheduled because the client is shutting down");
+        }
+    }
+
+    pub(super) async fn get_and_create_nameserver_client_until(
+        &self,
+        deadline: RequestDeadline,
+    ) -> RocketMQResult<Option<NameServerSession<PR>>> {
+        deadline.ensure_before_send("<nameserver>")?;
+        let state = self.endpoint_state.load();
+        let cached_addr = state.chosen().cloned();
+
+        if let Some(addr) = cached_addr {
+            if let Some(lease) = state.lease_for(&addr) {
+                if let Some(session) = self.connection_registry.healthy_session(&addr, Some(&lease)) {
+                    if self.nameserver_health.is_healthy(&addr, &lease) && session.connection().is_healthy() {
+                        return Ok(Some(NameServerSession {
+                            session,
+                            identity: addr,
+                            lease,
+                            state,
+                        }));
+                    }
+                }
+            }
+            debug!(%addr, "Cached nameserver is unhealthy, selecting new one");
+            self.telemetry
+                .record_nameserver_failover(TransportNameServerFailoverReason::Unhealthy);
+        }
+
+        let identities = state
+            .endpoints()
+            .iter()
+            .map(|endpoint| endpoint.identity().clone())
+            .collect::<Vec<_>>();
+        if identities.is_empty() {
+            warn!("No nameservers configured in namesrv_addr_list");
+            return Ok(None);
+        }
+
+        let mut half_open_probe_selected = false;
+        let mut candidates = build_nameserver_failover_candidates(
+            &identities,
+            state.available(),
+            self.nameserver_health.latency_tracker(),
+            |identity| {
+                let Some(lease) = state.lease_for(identity) else {
+                    return false;
+                };
+                match self
+                    .nameserver_health
+                    .connection_admission_if_current(identity, &lease, || self.endpoint_state.is_current(&lease))
+                {
+                    Some(CircuitAdmission::Regular) => true,
+                    Some(CircuitAdmission::Probe) if !half_open_probe_selected => {
+                        half_open_probe_selected = true;
+                        true
+                    }
+                    Some(CircuitAdmission::Probe | CircuitAdmission::Rejected) | None => {
+                        self.telemetry
+                            .record_nameserver_failover(TransportNameServerFailoverReason::CircuitOpen);
+                        false
+                    }
+                }
+            },
+        );
+        candidates.sort_by_key(|identity| {
+            state.lease_for(identity).is_none_or(|lease| {
+                self.connection_registry
+                    .healthy_session(identity, Some(&lease))
+                    .is_none()
+            })
+        });
+        if candidates.is_empty() {
+            error!(
+                configured = ?identities,
+                available = ?state.available(),
+                "Failed to select healthy nameserver"
+            );
+            return Ok(None);
+        }
+
+        let mut last_error = None;
+        for identity in candidates {
+            deadline.ensure_before_send(identity.to_string())?;
+            let Some(endpoint) = Self::name_server_endpoint(&state, &identity) else {
+                continue;
+            };
+            let Some(lease) = state.lease_for(&identity) else {
+                continue;
+            };
+            info!(
+                selected = %identity,
+                p99 = ?self.nameserver_health.p99(&identity, &lease),
+                errors = self.nameserver_health.error_count(&identity, &lease),
+                "Selected nameserver"
+            );
+            match self
+                .create_client_for_nameserver_until(&identity, endpoint, lease.clone(), deadline)
+                .await
+            {
+                Ok(Some(session)) => {
+                    self.endpoint_state.set_chosen(&lease);
+                    return Ok(Some(NameServerSession {
+                        session,
+                        identity,
+                        lease,
+                        state,
+                    }));
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    self.telemetry
+                        .record_nameserver_failover(TransportNameServerFailoverReason::ConnectFailure);
+                    self.nameserver_health
+                        .record_outcome_if_current(&identity, &lease, Duration::ZERO, false, || {
+                            self.endpoint_state.is_current(&lease)
+                        });
+                    last_error = Some(error);
+                }
+            }
+        }
+
+        if let Some(chosen) = state.chosen() {
+            if let Some(lease) = state.lease_for(chosen) {
+                self.endpoint_state.clear_chosen_if_matches(&lease);
+            }
+        }
+        match last_error {
+            Some(error) => Err(error),
+            None => Ok(None),
+        }
+    }
+
+    pub(super) async fn scan_available_name_srv(&self) {
+        let state = self.endpoint_state.load();
+        if state.endpoints().is_empty() {
+            debug!("No nameservers configured, skipping availability scan");
+            return;
+        }
+
+        let results = futures::future::join_all(state.endpoints().iter().cloned().map(|endpoint| {
+            let identity = endpoint.identity().clone();
+            let lease = state.lease_for(&identity);
+            async move {
+                let is_available = match lease.as_ref() {
+                    Some(lease) => self
+                        .create_client_for_nameserver_until(
+                            &identity,
+                            endpoint,
+                            lease.clone(),
+                            RequestDeadline::after(self.tokio_client_config.connect.timeout),
+                        )
+                        .await
+                        .is_ok_and(|session| session.is_some()),
+                    None => false,
+                };
+                (identity, lease, is_available)
+            }
+        }))
+        .await;
+
+        let available_count = results.iter().filter(|(_, _, available)| *available).count();
+        for (identity, lease, is_available) in results {
+            if lease.is_some_and(|lease| self.endpoint_state.update_availability(&lease, &identity, is_available)) {
+                if is_available {
+                    info!(%identity, "Nameserver is now available");
+                } else {
+                    warn!(%identity, "Nameserver is now unavailable");
+                }
+            }
+        }
+
+        debug!(
+            available = available_count,
+            configured = state.endpoints().len(),
+            generation = state.generation(),
+            "Availability scan complete"
+        );
+    }
+
+    pub(super) fn name_server_connect_targets_to_endpoints(targets: Vec<ConnectTarget>) -> Vec<NameServerEndpoint> {
+        targets.into_iter().map(NameServerEndpoint::resolved).collect()
+    }
+}

--- a/rocketmq-transport/src/clients/rocketmq_tokio_client/tests.rs
+++ b/rocketmq-transport/src/clients/rocketmq_tokio_client/tests.rs
@@ -202,6 +202,360 @@ async fn concurrent_nameserver_updates_publish_complete_owned_snapshots() {
     client.shutdown();
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn concurrent_endpoint_readers_observe_one_generation() {
+    let client = Arc::new(TransportClient::build_for_test(
+        Arc::new(TransportClientConfig::default()),
+        DefaultRequestProcessor,
+        test_service_context("endpoint-generation-reader-test"),
+    ));
+    let endpoint_a = NameServerEndpoint::legacy("ns-a:9876").expect("valid nameserver");
+    let identity_a = endpoint_a.identity().clone();
+    client.apply_name_server_endpoint_snapshot_sync(vec![endpoint_a.clone()], Duration::ZERO);
+    let first_lease = client
+        .endpoint_state
+        .load()
+        .lease_for(&identity_a)
+        .expect("initial endpoint lease");
+    assert!(client
+        .endpoint_state
+        .update_availability(&first_lease, &identity_a, true));
+    assert!(client.endpoint_state.set_chosen(&first_lease));
+
+    let updater = Arc::clone(&client);
+    let updates = tokio::spawn(async move {
+        for _ in 0..64 {
+            updater.apply_name_server_endpoint_snapshot_sync(
+                vec![
+                    endpoint_a.clone(),
+                    NameServerEndpoint::legacy("ns-b:9876").expect("valid nameserver"),
+                ],
+                Duration::ZERO,
+            );
+            tokio::task::yield_now().await;
+            updater.apply_name_server_endpoint_snapshot_sync(
+                vec![
+                    endpoint_a.clone(),
+                    NameServerEndpoint::legacy("ns-c:9876").expect("valid nameserver"),
+                ],
+                Duration::ZERO,
+            );
+            tokio::task::yield_now().await;
+        }
+    });
+
+    for _ in 0..128 {
+        let state = client.endpoint_state.load();
+        let observed_lease = state.lease_for(&identity_a).expect("configured endpoint lease");
+        assert!(observed_lease.same_generation(&first_lease));
+        assert!(state.available().contains(&identity_a));
+        assert_eq!(state.chosen(), Some(&identity_a));
+        assert!((1..=2).contains(&state.endpoints().len()));
+        assert!(state
+            .endpoints()
+            .iter()
+            .all(|endpoint| state.lease_for(endpoint.identity()).is_some()));
+        tokio::task::yield_now().await;
+    }
+
+    updates.await.expect("endpoint updates should complete");
+    client.shutdown();
+}
+
+#[tokio::test]
+async fn stale_failure_cannot_clear_newer_nameserver_choice() {
+    let client = Arc::new(TransportClient::build_for_test(
+        Arc::new(TransportClientConfig::default()),
+        DefaultRequestProcessor,
+        test_service_context("stale-chosen-clear-test"),
+    ));
+    let endpoint_a = NameServerEndpoint::legacy("ns-a:9876").expect("valid nameserver");
+    let endpoint_b = NameServerEndpoint::legacy("ns-b:9876").expect("valid nameserver");
+    let endpoint_c = NameServerEndpoint::legacy("ns-c:9876").expect("valid nameserver");
+    let identity_a = endpoint_a.identity().clone();
+    let identity_c = endpoint_c.identity().clone();
+
+    client.apply_name_server_endpoint_snapshot_sync(vec![endpoint_a.clone(), endpoint_b.clone()], Duration::ZERO);
+    let stale_a_lease = client.endpoint_state.load().lease_for(&identity_a).expect("S1 A lease");
+    assert!(client.endpoint_state.set_chosen(&stale_a_lease));
+
+    let entered = Arc::new(tokio::sync::Notify::new());
+    let resume = Arc::new(tokio::sync::Notify::new());
+    let entered_wait = entered.notified();
+    tokio::pin!(entered_wait);
+    entered_wait.as_mut().enable();
+    let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+    let stale_store = Arc::clone(&client.endpoint_state);
+    let entered_for_task = Arc::clone(&entered);
+    let resume_for_task = Arc::clone(&resume);
+    let stale_task = tokio::spawn(async move {
+        entered_for_task.notify_one();
+        resume_for_task.notified().await;
+        let _ = result_tx.send(stale_store.clear_chosen_if_matches(&stale_a_lease));
+    });
+    entered_wait.await;
+
+    client.apply_name_server_endpoint_snapshot_sync(vec![endpoint_a, endpoint_b, endpoint_c], Duration::ZERO);
+    let c_lease = client.endpoint_state.load().lease_for(&identity_c).expect("S2 C lease");
+    assert!(client.endpoint_state.set_chosen(&c_lease));
+    resume.notify_one();
+
+    assert!(!result_rx.await.expect("stale clear result"));
+    stale_task.await.expect("stale failure task");
+    let state = client.endpoint_state.load();
+    assert_eq!(state.chosen(), Some(&identity_c));
+    assert!(state
+        .lease_for(&identity_c)
+        .is_some_and(|lease| lease.same_generation(&c_lease)));
+    client.shutdown();
+}
+
+#[tokio::test]
+async fn stale_probe_result_cannot_update_replaced_generation() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
+    let addr = listener.local_addr().expect("listener addr");
+    let (release_server, server_release) = tokio::sync::oneshot::channel();
+    let server = tokio::spawn(async move {
+        let (_socket, _) = listener.accept().await.expect("accept stale probe connection");
+        server_release.await.expect("release probe server");
+    });
+    let client = Arc::new(TransportClient::build_for_test(
+        Arc::new(TransportClientConfig::default()),
+        DefaultRequestProcessor,
+        test_service_context("stale-probe-generation-test"),
+    ));
+    let endpoint = NameServerEndpoint::legacy(addr.to_string()).expect("valid nameserver");
+    let identity = endpoint.identity().clone();
+    client.apply_name_server_endpoint_snapshot_sync(vec![endpoint.clone()], Duration::ZERO);
+    let stale_lease = client
+        .endpoint_state
+        .load()
+        .lease_for(&identity)
+        .expect("initial endpoint lease");
+    let hook = EndpointCompletionTestHook::new();
+    client.install_connect_completion_test_hook(hook.clone());
+    let scan_client = Arc::clone(&client);
+    let scan = tokio::spawn(async move {
+        scan_client.scan_available_name_srv().await;
+    });
+    hook.wait_until_entered().await;
+
+    client.apply_name_server_endpoint_snapshot_sync(Vec::new(), Duration::ZERO);
+    client.apply_name_server_endpoint_snapshot_sync(vec![endpoint.clone()], Duration::ZERO);
+    let readded_lease = client
+        .endpoint_state
+        .load()
+        .lease_for(&identity)
+        .expect("re-added endpoint lease");
+    assert!(!readded_lease.same_generation(&stale_lease));
+    client
+        .nameserver_health
+        .connection_admission_if_current(&identity, &readded_lease, || {
+            client.endpoint_state.is_current(&readded_lease)
+        });
+    assert!(client
+        .nameserver_health
+        .owns_latency_for_test(&identity, &readded_lease));
+    hook.release();
+    scan.await.expect("stale scan should finish");
+
+    assert!(!client.endpoint_state.load().available().contains(&identity));
+    assert!(client
+        .nameserver_health
+        .owns_latency_for_test(&identity, &readded_lease));
+    client.shutdown();
+    release_server.send(()).expect("release probe server");
+    server.await.expect("probe server task");
+}
+
+#[tokio::test]
+async fn stale_connect_completion_cannot_register_into_new_generation() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
+    let addr = listener.local_addr().expect("listener addr");
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+    let server = tokio::spawn(async move {
+        let (_socket, _) = listener.accept().await.expect("accept client");
+        let _ = release_rx.await;
+    });
+    let client = Arc::new(TransportClient::build_for_test(
+        Arc::new(TransportClientConfig::default()),
+        DefaultRequestProcessor,
+        test_service_context("stale-connect-generation-test"),
+    ));
+    let endpoint = NameServerEndpoint::legacy(addr.to_string()).expect("valid nameserver");
+    let identity = endpoint.identity().clone();
+    client.apply_name_server_endpoint_snapshot_sync(vec![endpoint.clone()], Duration::ZERO);
+    let stale_lease = client
+        .endpoint_state
+        .load()
+        .lease_for(&identity)
+        .expect("initial endpoint lease");
+    let hook = EndpointCompletionTestHook::new();
+    client.install_connect_completion_test_hook(hook.clone());
+    let connect_client = Arc::clone(&client);
+    let connect_identity = identity.clone();
+    let connect_endpoint = endpoint.clone();
+    let connect_lease = stale_lease.clone();
+    let connect = tokio::spawn(async move {
+        connect_client
+            .create_client_for_nameserver_until(
+                &connect_identity,
+                connect_endpoint,
+                connect_lease,
+                RequestDeadline::after(Duration::from_secs(1)),
+            )
+            .await
+    });
+    hook.wait_until_entered().await;
+
+    client.apply_name_server_endpoint_snapshot_sync(Vec::new(), Duration::ZERO);
+    client.apply_name_server_endpoint_snapshot_sync(vec![endpoint], Duration::ZERO);
+    let readded_lease = client
+        .endpoint_state
+        .load()
+        .lease_for(&identity)
+        .expect("re-added endpoint lease");
+    hook.release();
+
+    assert!(!client.can_commit_endpoint_lease(Some(&stale_lease)));
+    assert!(connect
+        .await
+        .expect("connect flight task")
+        .expect("stale connection completion")
+        .is_none());
+    assert!(!client
+        .connection_registry
+        .has_session_for_lease(&identity, &stale_lease));
+    assert!(!client
+        .connection_registry
+        .has_session_for_lease(&identity, &readded_lease));
+    client.shutdown();
+    release_tx.send(()).expect("release server");
+    server.await.expect("server task");
+}
+
+#[tokio::test]
+async fn retired_generation_cleanup_preserves_readded_endpoint() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
+    let addr = listener.local_addr().expect("listener addr");
+    let (release_server, server_release) = tokio::sync::oneshot::channel();
+    let server = tokio::spawn(async move {
+        let (_socket, _) = listener.accept().await.expect("accept nameserver session");
+        server_release.await.expect("release retirement server");
+    });
+    let client = TransportClient::build_for_test(
+        Arc::new(TransportClientConfig::default()),
+        DefaultRequestProcessor,
+        test_service_context("retired-generation-cleanup-test"),
+    );
+    let endpoint = NameServerEndpoint::legacy(addr.to_string()).expect("valid nameserver");
+    let identity = endpoint.identity().clone();
+    client.apply_name_server_endpoint_snapshot_sync(vec![endpoint.clone()], Duration::ZERO);
+    let first_lease = client
+        .endpoint_state
+        .load()
+        .lease_for(&identity)
+        .expect("initial endpoint lease");
+    let session = client
+        .create_client_for_nameserver_until(
+            &identity,
+            endpoint.clone(),
+            first_lease.clone(),
+            RequestDeadline::after(Duration::from_secs(1)),
+        )
+        .await
+        .expect("connect initial nameserver")
+        .expect("initial nameserver session");
+    assert!(client
+        .connection_registry
+        .has_session_for_lease(&identity, &first_lease));
+    assert!(client.nameserver_health.owns_latency_for_test(&identity, &first_lease));
+    drop(session);
+
+    client.apply_name_server_endpoint_snapshot_sync(
+        vec![
+            endpoint.clone(),
+            NameServerEndpoint::legacy("ns-b:9876").expect("valid nameserver"),
+        ],
+        Duration::ZERO,
+    );
+    let retained_lease = client
+        .endpoint_state
+        .load()
+        .lease_for(&identity)
+        .expect("retained endpoint lease");
+    assert!(retained_lease.same_generation(&first_lease));
+
+    client.apply_name_server_endpoint_snapshot_sync(
+        vec![NameServerEndpoint::legacy("ns-b:9876").expect("valid nameserver")],
+        Duration::ZERO,
+    );
+    assert!(!client
+        .connection_registry
+        .has_session_for_lease(&identity, &first_lease));
+    assert!(!client.nameserver_health.owns_latency_for_test(&identity, &first_lease));
+    client.shutdown();
+    release_server.send(()).expect("release retirement server");
+    server.await.expect("retirement server task");
+}
+
+#[tokio::test]
+async fn direct_broker_session_survives_nameserver_retirement_at_same_address() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
+    let addr = listener.local_addr().expect("listener addr");
+    let (release_server, server_release) = tokio::sync::oneshot::channel();
+    let server = tokio::spawn(async move {
+        let (_direct_socket, _) = listener.accept().await.expect("accept direct broker session");
+        let (_nameserver_socket, _) = listener.accept().await.expect("accept nameserver session");
+        server_release.await.expect("release shared-address server");
+    });
+    let client = TransportClient::build_for_test(
+        Arc::new(TransportClientConfig::default()),
+        DefaultRequestProcessor,
+        test_service_context("direct-and-nameserver-scope-test"),
+    );
+    let endpoint = NameServerEndpoint::legacy(addr.to_string()).expect("valid nameserver");
+    let identity = endpoint.identity().clone();
+    let direct_session = client
+        .create_client(&identity, Duration::from_secs(1))
+        .await
+        .expect("direct broker session");
+
+    client.apply_name_server_endpoint_snapshot_sync(vec![endpoint.clone()], Duration::ZERO);
+    let nameserver_lease = client
+        .endpoint_state
+        .load()
+        .lease_for(&identity)
+        .expect("nameserver endpoint lease");
+    let nameserver_session = client
+        .create_client_for_nameserver_until(
+            &identity,
+            endpoint,
+            nameserver_lease.clone(),
+            RequestDeadline::after(Duration::from_secs(1)),
+        )
+        .await
+        .expect("connect nameserver session")
+        .expect("nameserver session");
+    assert!(client.connection_registry.healthy_session(&identity, None).is_some());
+    assert!(client
+        .connection_registry
+        .has_session_for_lease(&identity, &nameserver_lease));
+    drop(nameserver_session);
+
+    client.apply_name_server_endpoint_snapshot_sync(Vec::new(), Duration::ZERO);
+    assert!(direct_session.connection().is_healthy());
+    assert!(client.connection_registry.healthy_session(&identity, None).is_some());
+    assert!(!client
+        .connection_registry
+        .has_session_for_lease(&identity, &nameserver_lease));
+
+    drop(direct_session);
+    client.shutdown();
+    release_server.send(()).expect("release shared-address server");
+    server.await.expect("shared-address server task");
+}
+
 #[tokio::test]
 async fn service_context_parents_background_and_worker_tasks() {
     let context = RuntimeContext::from_current("remoting-default-client-parent-test");
@@ -343,7 +697,7 @@ async fn cold_endpoint_burst_uses_one_lifecycle_owned_connect_flight() {
         .expect("burst deadline");
     assert!(responses.into_iter().all(|response| response.is_ok()));
     assert_eq!(client.connect_attempts.load(Ordering::Relaxed), 1);
-    assert_eq!(client.connection_tables.len(), 1);
+    assert_eq!(client.connection_registry.len(), 1);
 
     server.await.expect("server task");
     client.shutdown();
@@ -431,26 +785,28 @@ async fn registry_token_distinguishes_replacements_and_same_port_nameserver_iden
         .create_client(&target, Duration::from_secs(1))
         .await
         .expect("first client");
-    client.connection_tables.remove(&target);
+    client.connection_registry.remove_session_by_identity(&target);
     let replacement = client
         .create_client(&target, Duration::from_secs(1))
         .await
         .expect("replacement client");
-    client.connection_tables.remove(&target);
+    client.connection_registry.remove_session_by_identity(&target);
 
     let first_identity = CheetahString::from_static_str("nameserver-a:9876");
     let replacement_identity = CheetahString::from_static_str("nameserver-b:9876");
-    client.connection_tables.insert(first_identity.clone(), first.clone());
     client
-        .connection_tables
-        .insert(replacement_identity.clone(), replacement.clone());
+        .connection_registry
+        .insert_session(first_identity.clone(), first.clone(), None, || true);
+    client
+        .connection_registry
+        .insert_session(replacement_identity.clone(), replacement.clone(), None, || true);
 
     assert_eq!(client.session_cache_identity(None, &first), first_identity);
     assert_eq!(client.session_cache_identity(None, &replacement), replacement_identity);
     assert!(!client.remove_cached_session_if_matches(&replacement_identity, &first));
-    assert!(client.connection_tables.contains_key(&replacement_identity));
+    assert!(client.connection_registry.contains(&replacement_identity));
     assert!(client.remove_cached_session_if_matches(&first_identity, &first));
-    assert!(client.connection_tables.contains_key(&replacement_identity));
+    assert!(client.connection_registry.contains(&replacement_identity));
 
     client.shutdown();
     let _ = release_tx.send(());
@@ -558,8 +914,8 @@ async fn explicit_broker_requests_do_not_update_nameserver_latency() {
         .await
         .expect("explicit Broker oneway");
 
-    assert_eq!(client.latency_tracker.get_p99(&target), None);
-    assert_eq!(client.latency_tracker.get_error_count(&target), 0);
+    assert_eq!(client.nameserver_health.latency_p99_for_test(&target), None);
+    assert_eq!(client.nameserver_health.latency_error_count_for_test(&target), 0);
     server.await.expect("server task");
     client.shutdown();
 }
@@ -600,8 +956,8 @@ async fn nameserver_request_updates_latency_and_failover_state() {
         .await
         .expect("NameServer request");
 
-    assert!(client.latency_tracker.get_p99(&target).is_some());
-    assert_eq!(client.latency_tracker.get_error_count(&target), 0);
+    assert!(client.nameserver_health.latency_p99_for_test(&target).is_some());
+    assert_eq!(client.nameserver_health.latency_error_count_for_test(&target), 0);
     server.await.expect("server task");
     client.shutdown();
 }
@@ -652,8 +1008,8 @@ async fn unchanged_resolved_endpoint_reuses_connection_and_identity_state() {
     }
 
     assert_eq!(client.connect_attempts.load(Ordering::Relaxed), 1);
-    assert!(client.connection_tables.contains_key(&identity));
-    assert!(client.latency_tracker.get_p99(&identity).is_some());
+    assert!(client.connection_registry.contains(&identity));
+    assert!(client.nameserver_health.latency_p99_for_test(&identity).is_some());
     let snapshot = client.snapshot();
     assert_eq!(snapshot.healthy_name_server_count, 1);
     assert_eq!(snapshot.probing_name_server_count, 0);
@@ -714,9 +1070,12 @@ async fn same_socket_with_new_authority_does_not_reuse_the_old_session() {
         .expect("second authority request");
 
     assert_eq!(client.connect_attempts.load(Ordering::Relaxed), 2);
-    assert!(!client.connection_tables.contains_key(&first.identity()));
-    assert!(client.connection_tables.contains_key(&second.identity()));
-    assert!(client.latency_tracker.get_p99(&second.identity()).is_some());
+    assert!(!client.connection_registry.contains(&first.identity()));
+    assert!(client.connection_registry.contains(&second.identity()));
+    assert!(client
+        .nameserver_health
+        .latency_p99_for_test(&second.identity())
+        .is_some());
     server.await.expect("server task");
     client.shutdown();
 }
@@ -763,7 +1122,7 @@ async fn removed_endpoint_rejects_new_work_and_closes_after_drain_timeout() {
     client.update_name_server_connect_targets_sync(Vec::new(), Duration::from_millis(25));
 
     assert!(client.get_name_server_address_list().is_empty());
-    assert!(!client.connection_tables.contains_key(&identity));
+    assert!(!client.connection_registry.contains(&identity));
     assert!(time::timeout(Duration::from_secs(1), request)
         .await
         .unwrap()
@@ -893,14 +1252,14 @@ async fn shutdown_with_report_closes_connection_table_clients() {
         .await
         .expect("client connection should be created");
     drop(created);
-    assert_eq!(client.connection_tables.len(), 1);
+    assert_eq!(client.connection_registry.len(), 1);
 
     let report = client.shutdown_with_report(Duration::from_secs(1)).await;
 
     assert!(report.is_healthy(), "{report:?}");
     assert_eq!(report.connections.len(), 1);
     assert_eq!(report.connections[0].addr, target);
-    assert!(client.connection_tables.is_empty());
+    assert!(client.connection_registry.is_empty());
     server.abort();
 }
 
@@ -933,7 +1292,7 @@ async fn idle_scan_evicts_an_expired_persistent_session() {
 
     client.scan_idle_connections();
 
-    assert!(client.connection_tables.is_empty());
+    assert!(client.connection_registry.is_empty());
     client.shutdown();
     server.abort();
 }

--- a/scripts/module-maintainability-baseline.json
+++ b/scripts/module-maintainability-baseline.json
@@ -10916,8 +10916,23 @@
       "reexports": 0
     },
     "rocketmq-transport/src/clients/rocketmq_tokio_client.rs": {
-      "production_lines": 1463,
+      "production_lines": 1336,
       "public_items": 54,
+      "reexports": 0
+    },
+    "rocketmq-transport/src/clients/rocketmq_tokio_client/connection_registry.rs": {
+      "production_lines": 366,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-transport/src/clients/rocketmq_tokio_client/endpoint_state.rs": {
+      "production_lines": 206,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-transport/src/clients/rocketmq_tokio_client/nameserver.rs": {
+      "production_lines": 468,
+      "public_items": 0,
       "reexports": 0
     },
     "rocketmq-transport/src/codec.rs": {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9640

### Brief Description

- Publish endpoint snapshots, availability, the chosen endpoint, and generation through one immutable `ArcSwap` state.
- Preserve per-endpoint lease identity across unchanged topology members and reject stale probe, connect, outcome, and retirement mutations.
- Separate direct broker and nameserver registry ownership so same-address broker sessions remain generation-neutral.
- Add deterministic concurrency coverage and relocate only the exact maintainability records for the private module split.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-transport -- --check`
- `cargo check -p rocketmq-transport --all-targets --all-features`
- `cargo test -p rocketmq-transport --lib rocketmq_tokio_client`
- `cargo test -p rocketmq-transport --all-features --lib rocketmq_tokio_client`
- `cargo test -p rocketmq-transport --features test-support --test nameserver_endpoint_lifecycle`
- `cargo test -p rocketmq-transport --all-features`
- `cargo clippy -p rocketmq-transport --all-targets --all-features -- -D warnings`
- `cargo test -p rocketmq-client-rust --lib`
- `cargo test -p rocketmq-broker --lib`
- `cargo doc -p rocketmq-transport --no-deps`
- `.\\scripts\\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `python scripts/core_release_static_guard.py`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `git diff --check`