### PR TITLE
[ISSUE #9639]♻️Add typed SQL filter compile errors

### DIFF
--- a/rocketmq-broker/src/filter/manager/consumer_filter_manager.rs
+++ b/rocketmq-broker/src/filter/manager/consumer_filter_manager.rs
@@ -204,7 +204,7 @@ impl ConsumerFilterManager {
         let expression_text = expression.as_ref().filter(|value| !value.is_empty())?;
         let expression_type = type_.as_ref()?;
         let filter = FilterFactory::instance().get(expression_type.as_str())?;
-        let compiled = filter.compile(expression_text.as_str()).ok()?;
+        let compiled = filter.try_compile(expression_text.as_str()).ok()?;
 
         let mut consumer_filter_data = ConsumerFilterData::default();
         consumer_filter_data.set_topic(topic);
@@ -607,7 +607,7 @@ impl ConsumerFilterManager {
             self.cache_compile_failure(cache_key, format!("unknown filter type: {expression_type}"));
             return None;
         };
-        let compiled = match filter.compile(expression) {
+        let compiled = match filter.try_compile(expression) {
             Ok(compiled) => Arc::<dyn Expression + 'static>::from(compiled),
             Err(error) => {
                 self.stats.compile_failures.fetch_add(1, Ordering::Relaxed);
@@ -764,6 +764,10 @@ mod tests {
     use rocketmq_filter::expression::Value as ExprValue;
     use rocketmq_filter::expression::Value;
     use rocketmq_filter::filter::Filter;
+    #[allow(
+        deprecated,
+        reason = "These compatibility fixtures verify that legacy Filter implementations remain usable."
+    )]
     use rocketmq_filter::filter::FilterError;
 
     fn new_manager() -> ConsumerFilterManager {
@@ -915,6 +919,10 @@ mod tests {
         compile_count: Arc<AtomicUsize>,
     }
 
+    #[allow(
+        deprecated,
+        reason = "This compatibility fixture intentionally implements only the legacy Filter::compile method."
+    )]
     impl Filter for FailingFilter {
         fn compile(&self, _expr: &str) -> Result<Box<dyn Expression>, FilterError> {
             self.compile_count.fetch_add(1, Ordering::Relaxed);
@@ -946,6 +954,10 @@ mod tests {
         filter_type: String,
     }
 
+    #[allow(
+        deprecated,
+        reason = "This compatibility fixture intentionally implements only the legacy Filter::compile method."
+    )]
     impl Filter for PassingFilter {
         fn compile(&self, _expr: &str) -> Result<Box<dyn Expression>, FilterError> {
             Ok(Box::new(LiteralTrueExpression))
@@ -962,6 +974,10 @@ mod tests {
         compile_count: Arc<AtomicUsize>,
     }
 
+    #[allow(
+        deprecated,
+        reason = "This compatibility fixture intentionally implements only the legacy Filter::compile method."
+    )]
     impl Filter for CountingPassingFilter {
         fn compile(&self, _expr: &str) -> Result<Box<dyn Expression>, FilterError> {
             self.compile_count.fetch_add(1, Ordering::Relaxed);

--- a/rocketmq-broker/src/processor/client_manage_processor.rs
+++ b/rocketmq-broker/src/processor/client_manage_processor.rs
@@ -177,7 +177,7 @@ where
         }
 
         match FilterFactory::instance().get(subscription_data.expression_type.as_str()) {
-            Some(filter) => match filter.compile(subscription_data.sub_string.as_str()) {
+            Some(filter) => match filter.try_compile(subscription_data.sub_string.as_str()) {
                 Ok(_) => Ok(Some(response)),
                 Err(error) => Ok(Some(
                     response
@@ -592,6 +592,9 @@ mod tests {
             RemotingResponseCode::from(response.code()),
             RemotingResponseCode::SubscriptionParseFailed
         );
+        let remark = response.remark().expect("parse failure should have a redacted remark");
+        assert!(remark.contains("UnexpectedToken"));
+        assert!(!remark.contains("a >"));
         let _ = std::fs::remove_dir_all(runtime.message_store_config().store_path_root_dir.as_str());
     }
 

--- a/rocketmq-error/src/domain.rs
+++ b/rocketmq-error/src/domain.rs
@@ -24,6 +24,7 @@ use crate::ErrorContext;
 use crate::ErrorKind;
 use crate::ErrorSeverity;
 use crate::ErrorSpec;
+use crate::FilterCompileError;
 use crate::FilterError;
 use crate::NetworkError;
 use crate::ObservabilityError;
@@ -170,6 +171,23 @@ impl DomainError for ControllerError {
 impl DomainError for FilterError {
     fn kind(&self) -> ErrorKind {
         ErrorKind::Filter
+    }
+
+    fn context(&self) -> ErrorContext {
+        match self {
+            FilterError::Compile(error) => error.context(),
+            _ => ErrorContext::new().with_sensitive("domain_error", Sensitive::new(self.to_string())),
+        }
+    }
+}
+
+impl DomainError for FilterCompileError {
+    fn kind(&self) -> ErrorKind {
+        ErrorKind::Filter
+    }
+
+    fn context(&self) -> ErrorContext {
+        FilterCompileError::context(self)
     }
 }
 

--- a/rocketmq-error/src/filter_error.rs
+++ b/rocketmq-error/src/filter_error.rs
@@ -12,9 +12,158 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
+
+use crate::ErrorContext;
+
+/// The category of a SQL filter compilation failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FilterCompileErrorKind {
+    /// The expression did not contain any SQL tokens.
+    EmptyExpression,
+    /// The expression exceeded the configured byte limit.
+    ExpressionTooLarge,
+    /// The expression exceeded the configured token limit.
+    TooManyTokens,
+    /// The expression exceeded the configured parser nesting limit.
+    NestingLimitExceeded,
+    /// The parser encountered an unexpected or missing token.
+    UnexpectedToken,
+    /// A numeric literal could not be parsed safely.
+    InvalidNumber,
+    /// A `BETWEEN` expression used invalid constant bounds.
+    InvalidBetweenBounds,
+    /// An operator was used with an unsupported operand form.
+    UnsupportedOperand,
+    /// A legacy filter implementation returned only an untyped error.
+    LegacyAdapter,
+}
+
+/// The SQL compilation stage at which a filter failure occurred.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FilterCompileStage {
+    /// Tokenizing the SQL expression.
+    Lex,
+    /// Parsing SQL expression structure.
+    Parse,
+    /// Validating expression semantics.
+    Semantic,
+    /// Mapping a legacy filter error into the typed API.
+    Compatibility,
+}
+
+/// A fixed, redaction-safe source classification for filter compilation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FilterCompileSource {
+    /// A SQL-92 message property filter expression.
+    Sql92,
+}
+
+/// A redaction-safe SQL filter compilation error.
+///
+/// Positions are original UTF-8 byte offsets into the submitted expression.
+/// This type deliberately retains neither the expression nor any token, literal,
+/// or property text so it can be surfaced at service boundaries safely.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FilterCompileError {
+    kind: FilterCompileErrorKind,
+    stage: FilterCompileStage,
+    position: Option<usize>,
+    source: Option<FilterCompileSource>,
+}
+
+impl FilterCompileError {
+    /// Creates a redaction-safe compile error at an original UTF-8 byte offset.
+    pub const fn new(kind: FilterCompileErrorKind, stage: FilterCompileStage, position: Option<usize>) -> Self {
+        Self {
+            kind,
+            stage,
+            position,
+            source: None,
+        }
+    }
+
+    /// Creates a redaction-safe compile error with a fixed source classification.
+    pub const fn new_with_source(
+        kind: FilterCompileErrorKind,
+        stage: FilterCompileStage,
+        position: Option<usize>,
+        source: FilterCompileSource,
+    ) -> Self {
+        Self {
+            kind,
+            stage,
+            position,
+            source: Some(source),
+        }
+    }
+
+    /// Returns the stable compile failure category.
+    pub const fn kind(&self) -> FilterCompileErrorKind {
+        self.kind
+    }
+
+    /// Returns the compiler stage that reported the failure.
+    pub const fn stage(&self) -> FilterCompileStage {
+        self.stage
+    }
+
+    /// Returns the original UTF-8 byte offset, when the failure has one.
+    pub const fn position(&self) -> Option<usize> {
+        self.position
+    }
+
+    /// Returns the fixed source classification, when the compiler provided one.
+    pub const fn source(&self) -> Option<FilterCompileSource> {
+        self.source
+    }
+
+    /// Returns structured, redaction-safe context for this compile failure.
+    pub fn context(&self) -> ErrorContext {
+        let context = ErrorContext::new()
+            .with_field("filter_compile_kind", format!("{:?}", self.kind))
+            .with_field("filter_compile_stage", format!("{:?}", self.stage));
+        let context = match self.position {
+            Some(position) => context.with_field("filter_compile_position", position.to_string()),
+            None => context,
+        };
+        match self.source {
+            Some(source) => context.with_field("filter_compile_source", format!("{:?}", source)),
+            None => context,
+        }
+    }
+}
+
+impl fmt::Debug for FilterCompileError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FilterCompileError")
+            .field("kind", &self.kind)
+            .field("stage", &self.stage)
+            .field("position", &self.position)
+            .field("source", &self.source)
+            .finish()
+    }
+}
+
+impl fmt::Display for FilterCompileError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "SQL filter compilation failed: kind={:?}, stage={:?}, position={:?}, source={:?}",
+            self.kind, self.stage, self.position, self.source
+        )
+    }
+}
+
+impl std::error::Error for FilterCompileError {}
+
 /// Error types for Filter operations
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 pub enum FilterError {
+    /// SQL filter compilation failed with structured, redaction-safe details.
+    #[error(transparent)]
+    Compile(FilterCompileError),
+
     #[error("Bytes is empty!")]
     /// Represents the empty bytes case.
     EmptyBytes,
@@ -41,6 +190,11 @@ pub enum FilterError {
 }
 
 impl FilterError {
+    /// Creates a structured SQL filter compilation error wrapper.
+    pub const fn compile(error: FilterCompileError) -> Self {
+        Self::Compile(error)
+    }
+
     /// Creates the empty bytes value.
     pub fn empty_bytes() -> Self {
         FilterError::EmptyBytes

--- a/rocketmq-error/src/lib.rs
+++ b/rocketmq-error/src/lib.rs
@@ -88,6 +88,10 @@ pub use controller_error::ControllerError;
 pub use controller_error::ControllerResult;
 pub use domain::DomainError;
 // Re-export filter error types
+pub use filter_error::FilterCompileError;
+pub use filter_error::FilterCompileErrorKind;
+pub use filter_error::FilterCompileSource;
+pub use filter_error::FilterCompileStage;
 pub use filter_error::FilterError;
 pub use kind::ErrorCategory;
 pub use kind::ErrorCode;

--- a/rocketmq-error/src/unified.rs
+++ b/rocketmq-error/src/unified.rs
@@ -27,6 +27,7 @@ mod tools;
 use std::io;
 
 // Re-export filter error
+pub use crate::filter_error::FilterCompileError;
 pub use crate::filter_error::FilterError;
 pub use crate::observability_error::ObservabilityError;
 
@@ -843,6 +844,7 @@ impl RocketMQError {
                 .with_field("expected", *expected)
                 .with_field("actual", actual.as_str()),
             Self::Tools(error) => error.context(),
+            Self::Filter(FilterError::Compile(error)) => error.context(),
             Self::Filter(error) => ErrorContext::new().with_field("filter_error", error.to_string()),
             Self::Observability(error) => error.context(),
             Self::StorageReadFailed { path, reason } | Self::StorageWriteFailed { path, reason } => ErrorContext::new()
@@ -1290,6 +1292,12 @@ impl RocketMQError {
     #[inline]
     pub fn filter_uninitialized() -> Self {
         Self::Filter(FilterError::uninitialized())
+    }
+}
+
+impl From<FilterCompileError> for RocketMQError {
+    fn from(error: FilterCompileError) -> Self {
+        Self::Filter(FilterError::compile(error))
     }
 }
 

--- a/rocketmq-error/tests/filter_compile_error_contract.rs
+++ b/rocketmq-error/tests/filter_compile_error_contract.rs
@@ -1,0 +1,65 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_error::DomainError;
+use rocketmq_error::ErrorKind;
+use rocketmq_error::FilterCompileError;
+use rocketmq_error::FilterCompileErrorKind;
+use rocketmq_error::FilterCompileSource;
+use rocketmq_error::FilterCompileStage;
+use rocketmq_error::RocketMQError;
+
+#[test]
+fn compile_error_contract_is_typed_and_redaction_safe() {
+    let error = FilterCompileError::new_with_source(
+        FilterCompileErrorKind::UnexpectedToken,
+        FilterCompileStage::Parse,
+        Some(7),
+        FilterCompileSource::Sql92,
+    );
+
+    assert_eq!(error.kind(), FilterCompileErrorKind::UnexpectedToken);
+    assert_eq!(error.stage(), FilterCompileStage::Parse);
+    assert_eq!(error.position(), Some(7));
+    assert_eq!(error.source(), Some(FilterCompileSource::Sql92));
+    assert_eq!(DomainError::kind(&error), ErrorKind::Filter);
+
+    let display = error.to_string();
+    let debug = format!("{error:?}");
+    let context = DomainError::context(&error).to_string();
+    for rendered in [display, debug, context] {
+        assert!(rendered.contains("UnexpectedToken") || rendered.contains("filter_compile_kind"));
+        assert!(!rendered.contains("secret_expression"));
+    }
+
+    let unified: RocketMQError = error.into();
+    assert_eq!(unified.kind(), ErrorKind::Filter);
+    let unified_context = unified.context().to_string();
+    assert!(unified_context.contains("filter_compile_kind=UnexpectedToken"));
+    assert!(unified_context.contains("filter_compile_source=Sql92"));
+    assert!(!unified_context.contains("secret_expression"));
+}
+
+#[test]
+fn legacy_compile_adapter_has_no_source_position() {
+    let error = FilterCompileError::new(
+        FilterCompileErrorKind::LegacyAdapter,
+        FilterCompileStage::Compatibility,
+        None,
+    );
+
+    assert_eq!(error.position(), None);
+    assert_eq!(error.source(), None);
+    assert_eq!(DomainError::kind(&error), ErrorKind::Filter);
+}

--- a/rocketmq-filter/benches/sql_filter_benchmark.rs
+++ b/rocketmq-filter/benches/sql_filter_benchmark.rs
@@ -31,7 +31,7 @@ fn benchmark_sql_compile(c: &mut Criterion) {
             |b, expression| {
                 b.iter(|| {
                     let compiled = filter
-                        .compile(black_box(expression))
+                        .try_compile(black_box(expression))
                         .expect("benchmark expression should compile");
                     black_box(compiled);
                 });
@@ -46,7 +46,7 @@ fn benchmark_sql_evaluate(c: &mut Criterion) {
     let mut group = c.benchmark_group("sql_evaluate");
     let filter = SqlFilter::new();
     let expression = filter
-        .compile("color = 'blue' AND retries >= 3 AND region IN ('hz', 'sh') AND enabled = TRUE")
+        .try_compile("color = 'blue' AND retries >= 3 AND region IN ('hz', 'sh') AND enabled = TRUE")
         .expect("benchmark expression should compile");
     let mut properties = HashMap::with_hasher(RandomState::default());
     properties.insert(CheetahString::from_slice("color"), CheetahString::from_slice("blue"));

--- a/rocketmq-filter/src/filter.rs
+++ b/rocketmq-filter/src/filter.rs
@@ -46,7 +46,7 @@
 //! use rocketmq_filter::filter::{Filter, FilterFactory};
 //!
 //! let filter = FilterFactory::get_sql_filter();
-//! let expr = filter.compile("age > 18 AND region = 'US'")?;
+//! let expr = filter.try_compile("age > 18 AND region = 'US'")?;
 //! ```
 //!
 //! ## Registering Custom Filters
@@ -86,6 +86,14 @@ mod sql_runtime;
 
 pub use filter_factory::FilterFactory;
 pub use filter_spi::Filter;
+#[allow(
+    deprecated,
+    reason = "The re-export preserves the legacy FilterError compatibility surface."
+)]
 pub use filter_spi::FilterError;
 pub use filter_spi::FilterSpi;
 pub use filter_sql_filter::SqlFilter;
+pub use rocketmq_error::FilterCompileError;
+pub use rocketmq_error::FilterCompileErrorKind;
+pub use rocketmq_error::FilterCompileSource;
+pub use rocketmq_error::FilterCompileStage;

--- a/rocketmq-filter/src/filter/filter_factory.rs
+++ b/rocketmq-filter/src/filter/filter_factory.rs
@@ -85,7 +85,7 @@ static FILTER_REGISTRY: LazyLock<DashMap<String, Arc<dyn Filter>>> = LazyLock::n
 ///
 /// // Get a registered filter
 /// if let Some(filter) = factory.get("SQL92") {
-///     let expr = filter.compile("age > 18")?;
+///     let expr = filter.try_compile("age > 18")?;
 /// }
 /// ```
 #[derive(Debug)]
@@ -187,7 +187,7 @@ impl FilterFactory {
     /// ```rust,ignore
     /// let factory = FilterFactory::instance();
     /// if let Some(filter) = factory.get("SQL92") {
-    ///     let expr = filter.compile("age > 18")?;
+    ///     let expr = filter.try_compile("age > 18")?;
     /// }
     /// ```
     ///
@@ -215,7 +215,7 @@ impl FilterFactory {
     /// use rocketmq_filter::filter::FilterFactory;
     ///
     /// let sql_filter = FilterFactory::get_sql_filter();
-    /// let expr = sql_filter.compile("price > 100")?;
+    /// let expr = sql_filter.try_compile("price > 100")?;
     /// ```
     ///
     /// # Panics

--- a/rocketmq-filter/src/filter/filter_spi.rs
+++ b/rocketmq-filter/src/filter/filter_spi.rs
@@ -33,6 +33,10 @@
 
 use std::fmt;
 
+use rocketmq_error::FilterCompileError;
+use rocketmq_error::FilterCompileErrorKind;
+use rocketmq_error::FilterCompileStage;
+
 use crate::expression::Expression;
 
 /// Error type for filter compilation and evaluation failures.
@@ -41,12 +45,17 @@ use crate::expression::Expression;
 /// - Expression parsing errors
 /// - Type conversion failures
 /// - Invalid expression syntax
+#[deprecated(since = "1.0.0", note = "use Filter::try_compile and FilterCompileError")]
 #[derive(Debug, Clone)]
 pub struct FilterError {
     /// Human-readable error message
     message: String,
 }
 
+#[allow(
+    deprecated,
+    reason = "This inherent implementation preserves the legacy string-error compatibility API."
+)]
 impl FilterError {
     /// Creates a new filter error with the given message.
     ///
@@ -65,12 +74,20 @@ impl FilterError {
     }
 }
 
+#[allow(
+    deprecated,
+    reason = "The legacy string-error Display implementation is retained for compatibility."
+)]
 impl fmt::Display for FilterError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "FilterError: {}", self.message)
     }
 }
 
+#[allow(
+    deprecated,
+    reason = "The legacy string-error Error implementation is retained for compatibility."
+)]
 impl std::error::Error for FilterError {}
 
 /// Core trait for message filter implementations.
@@ -127,7 +144,7 @@ pub trait Filter: Send + Sync + fmt::Debug {
     ///
     /// ```rust,ignore
     /// let filter = SqlFilter::new();
-    /// let expr = filter.compile("price > 100 AND category = 'electronics'")?;
+    /// let expr = filter.try_compile("price > 100 AND category = 'electronics'")?;
     /// ```
     ///
     /// # Errors
@@ -136,7 +153,31 @@ pub trait Filter: Send + Sync + fmt::Debug {
     /// - Expression syntax is invalid
     /// - Referenced properties don't exist
     /// - Type constraints are violated
+    #[deprecated(since = "1.0.0", note = "use Filter::try_compile and FilterCompileError")]
+    #[allow(
+        deprecated,
+        reason = "The legacy string-error trait method is retained so existing external filters continue to compile."
+    )]
     fn compile(&self, expr: &str) -> Result<Box<dyn Expression>, FilterError>;
+
+    /// Compiles an expression with structured, redaction-safe failure details.
+    ///
+    /// Filters that only implement the legacy [`Self::compile`] method continue
+    /// to work. Their failures are classified as
+    /// [`FilterCompileErrorKind::LegacyAdapter`] during the compatibility stage.
+    fn try_compile(&self, expr: &str) -> Result<Box<dyn Expression>, FilterCompileError> {
+        #[allow(
+            deprecated,
+            reason = "This default method is the narrow compatibility adapter for legacy Filter implementations."
+        )]
+        self.compile(expr).map_err(|_| {
+            FilterCompileError::new(
+                FilterCompileErrorKind::LegacyAdapter,
+                FilterCompileStage::Compatibility,
+                None,
+            )
+        })
+    }
 
     /// Returns the unique type identifier for this filter.
     ///

--- a/rocketmq-filter/src/filter/filter_sql_filter.rs
+++ b/rocketmq-filter/src/filter/filter_sql_filter.rs
@@ -33,13 +33,18 @@
 //! use rocketmq_filter::filter::{SqlFilter, Filter};
 //!
 //! let filter = SqlFilter::new();
-//! let expr = filter.compile("age > 18 AND region = 'US'")?;
+//! let expr = filter.try_compile("age > 18 AND region = 'US'")?;
 //! ```
 
+use rocketmq_error::FilterCompileError;
 use rocketmq_model::common::filter::expression_type::ExpressionType;
 
 use crate::expression::Expression;
 use crate::filter::filter_spi::Filter;
+#[allow(
+    deprecated,
+    reason = "SqlFilter's deprecated compile wrapper preserves the legacy error type."
+)]
 use crate::filter::filter_spi::FilterError;
 use crate::filter::sql_runtime;
 
@@ -64,7 +69,7 @@ use crate::filter::sql_runtime;
 /// use std::sync::Arc;
 ///
 /// let filter: Arc<dyn Filter> = Arc::new(SqlFilter::new());
-/// let expr = filter.compile("price > 100 AND category = 'electronics'")?;
+/// let expr = filter.try_compile("price > 100 AND category = 'electronics'")?;
 /// ```
 ///
 /// # Performance
@@ -91,7 +96,15 @@ impl SqlFilter {
 }
 
 impl Filter for SqlFilter {
+    #[allow(
+        deprecated,
+        reason = "This compatibility wrapper preserves the deprecated Filter::compile API."
+    )]
     fn compile(&self, expr: &str) -> Result<Box<dyn Expression>, FilterError> {
+        self.try_compile(expr).map_err(sql_runtime::legacy_projection)
+    }
+
+    fn try_compile(&self, expr: &str) -> Result<Box<dyn Expression>, FilterCompileError> {
         sql_runtime::compile_expression(expr)
     }
 
@@ -131,6 +144,10 @@ mod tests {
     }
 
     #[test]
+    #[allow(
+        deprecated,
+        reason = "This test verifies the deprecated compile compatibility wrapper."
+    )]
     fn test_sql_filter_compile_and_evaluate() {
         let filter = SqlFilter::new();
         let expression = filter
@@ -146,6 +163,10 @@ mod tests {
     }
 
     #[test]
+    #[allow(
+        deprecated,
+        reason = "This test verifies the deprecated compile compatibility wrapper."
+    )]
     fn test_sql_filter_rejects_invalid_expression() {
         let filter = SqlFilter::new();
 
@@ -157,13 +178,13 @@ mod tests {
         const SEED: u64 = 0x524d_5146_494c_5445;
         let filter = SqlFilter::new();
         let left = filter
-            .compile("score >= 10 AND color = 'blue'")
+            .try_compile("score >= 10 AND color = 'blue'")
             .expect("left expression");
         let right = filter
-            .compile("color = 'blue' AND score >= 10")
+            .try_compile("color = 'blue' AND score >= 10")
             .expect("right expression");
         let complement = filter
-            .compile("NOT (score >= 10 AND color = 'blue')")
+            .try_compile("NOT (score >= 10 AND color = 'blue')")
             .expect("complement expression");
         let mut state = SEED;
 

--- a/rocketmq-filter/src/filter/sql_runtime.rs
+++ b/rocketmq-filter/src/filter/sql_runtime.rs
@@ -18,12 +18,17 @@ use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
 use cheetah_string::CheetahString;
+use rocketmq_error::{FilterCompileError, FilterCompileErrorKind};
 
 use crate::expression::EvaluationContext;
 use crate::expression::EvaluationError;
 use crate::expression::Expression;
 use crate::expression::Value;
-use crate::filter::filter_spi::FilterError;
+
+mod compile_error;
+
+pub(super) use compile_error::legacy_projection;
+use compile_error::SpannedToken;
 
 const MAX_EXPRESSION_BYTES: usize = 64 * 1024;
 const MAX_SQL_TOKENS: usize = 4_096;
@@ -36,18 +41,20 @@ fn current_millis() -> u64 {
         .as_millis() as u64
 }
 
-pub(crate) fn compile_expression(expr: &str) -> Result<Box<dyn Expression>, FilterError> {
+pub(crate) fn compile_expression(expr: &str) -> Result<Box<dyn Expression>, FilterCompileError> {
     let trimmed = expr.trim();
     if trimmed.is_empty() {
-        return Err(FilterError::new("empty SQL92 expression"));
+        return Err(compile_error::empty_expression());
     }
+    let position_offset = expr.len() - expr.trim_start().len();
     if trimmed.len() > MAX_EXPRESSION_BYTES {
-        return Err(FilterError::new(format!(
-            "SQL92 expression exceeds the {MAX_EXPRESSION_BYTES}-byte limit"
-        )));
+        return Err(compile_error::lex_error(
+            FilterCompileErrorKind::ExpressionTooLarge,
+            position_offset + MAX_EXPRESSION_BYTES,
+        ));
     }
 
-    let mut parser = Parser::new(trimmed)?;
+    let mut parser = Parser::new(trimmed, position_offset)?;
     let root = parser.parse_expression()?;
     parser.expect_end()?;
 
@@ -115,6 +122,13 @@ enum ExprNode {
 }
 
 impl ExprNode {
+    fn literal(&self) -> Option<&Value> {
+        match self {
+            Self::Literal(value) => Some(value),
+            _ => None,
+        }
+    }
+
     fn evaluate(&self, context: &dyn EvaluationContext) -> Result<Value, EvaluationError> {
         match self {
             ExprNode::Literal(value) => Ok(value.clone()),
@@ -392,13 +406,6 @@ fn stringify_value(value: &Value) -> String {
     }
 }
 
-fn literal_value(node: &ExprNode) -> Option<&Value> {
-    match node {
-        ExprNode::Literal(value) => Some(value),
-        _ => None,
-    }
-}
-
 #[derive(Debug, Clone, PartialEq)]
 enum Token {
     Ident(CheetahString),
@@ -429,89 +436,119 @@ enum Token {
     End,
 }
 
+impl Token {
+    fn matches_kind(&self, expected: &Self) -> bool {
+        std::mem::discriminant(self) == std::mem::discriminant(expected)
+    }
+
+    fn into_constant(self) -> Option<Value> {
+        match self {
+            Self::String(value) => Some(Value::String(value)),
+            Self::Long(value) => Some(Value::Long(value)),
+            Self::Double(value) => Some(Value::Double(value)),
+            Self::Boolean(value) => Some(Value::Boolean(value)),
+            Self::Null => Some(Value::Null),
+            _ => None,
+        }
+    }
+
+    fn into_expression(self) -> Option<ExprNode> {
+        match self {
+            Self::Ident(name) => Some(ExprNode::Property(name)),
+            Self::Now => Some(ExprNode::Now),
+            token => token.into_constant().map(ExprNode::Literal),
+        }
+    }
+}
+
 struct Lexer<'a> {
     input: &'a str,
     bytes: &'a [u8],
     cursor: usize,
+    position_offset: usize,
 }
 
 impl<'a> Lexer<'a> {
-    fn new(input: &'a str) -> Self {
+    fn new(input: &'a str, position_offset: usize) -> Self {
         Self {
             input,
             bytes: input.as_bytes(),
             cursor: 0,
+            position_offset,
         }
     }
 
-    fn next_token(&mut self) -> Result<Token, FilterError> {
+    fn next_token(&mut self) -> Result<SpannedToken, FilterCompileError> {
         self.skip_whitespace();
         if self.cursor >= self.bytes.len() {
-            return Ok(Token::End);
+            return Ok(SpannedToken::new(Token::End, self.position_offset + self.cursor));
         }
 
+        let position = self.position_offset + self.cursor;
         let byte = self.bytes[self.cursor];
-        match byte {
+        let token = match byte {
             b'(' => {
                 self.cursor += 1;
-                Ok(Token::LParen)
+                Token::LParen
             }
             b')' => {
                 self.cursor += 1;
-                Ok(Token::RParen)
+                Token::RParen
             }
             b',' => {
                 self.cursor += 1;
-                Ok(Token::Comma)
+                Token::Comma
             }
             b'=' => {
                 self.cursor += 1;
-                Ok(Token::Eq)
+                Token::Eq
+            }
+            b'!' if self.peek_byte(1) == Some(b'=') => {
+                self.cursor += 2;
+                Token::Ne
             }
             b'!' => {
-                if self.peek_byte(1) == Some(b'=') {
-                    self.cursor += 2;
-                    Ok(Token::Ne)
-                } else {
-                    Err(FilterError::new(format!(
-                        "unexpected token '!' at position {}",
-                        self.cursor
-                    )))
-                }
+                return Err(compile_error::lex_error(
+                    FilterCompileErrorKind::UnexpectedToken,
+                    position,
+                ))
             }
             b'<' => {
                 if self.peek_byte(1) == Some(b'=') {
                     self.cursor += 2;
-                    Ok(Token::Lte)
+                    Token::Lte
                 } else if self.peek_byte(1) == Some(b'>') {
                     self.cursor += 2;
-                    Ok(Token::Ne)
+                    Token::Ne
                 } else {
                     self.cursor += 1;
-                    Ok(Token::Lt)
+                    Token::Lt
                 }
             }
             b'>' => {
                 if self.peek_byte(1) == Some(b'=') {
                     self.cursor += 2;
-                    Ok(Token::Gte)
+                    Token::Gte
                 } else {
                     self.cursor += 1;
-                    Ok(Token::Gt)
+                    Token::Gt
                 }
             }
-            b'\'' => self.read_string(),
-            b'-' if self.peek_byte(1).is_some_and(|next| next.is_ascii_digit()) => self.read_number(),
-            b'0'..=b'9' => self.read_number(),
+            b'\'' => self.read_string(position)?,
+            b'-' if self.peek_byte(1).is_some_and(|next| next.is_ascii_digit()) => self.read_number(position)?,
+            b'0'..=b'9' => self.read_number(position)?,
             _ if is_ident_start(byte) => self.read_identifier(),
-            _ => Err(FilterError::new(format!(
-                "unexpected token '{}' at position {}",
-                self.bytes[self.cursor] as char, self.cursor
-            ))),
-        }
+            _ => {
+                return Err(compile_error::lex_error(
+                    FilterCompileErrorKind::UnexpectedToken,
+                    position,
+                ))
+            }
+        };
+        Ok(SpannedToken::new(token, position))
     }
 
-    fn read_string(&mut self) -> Result<Token, FilterError> {
+    fn read_string(&mut self, position: usize) -> Result<Token, FilterCompileError> {
         self.cursor += 1;
         let mut string = String::new();
         while self.cursor < self.bytes.len() {
@@ -530,10 +567,13 @@ impl<'a> Lexer<'a> {
             self.cursor += 1;
         }
 
-        Err(FilterError::new("unterminated string literal"))
+        Err(compile_error::lex_error(
+            FilterCompileErrorKind::UnexpectedToken,
+            position,
+        ))
     }
 
-    fn read_number(&mut self) -> Result<Token, FilterError> {
+    fn read_number(&mut self, position: usize) -> Result<Token, FilterCompileError> {
         let start = self.cursor;
         self.cursor += 1;
         while self.cursor < self.bytes.len() && self.bytes[self.cursor].is_ascii_digit() {
@@ -560,7 +600,10 @@ impl<'a> Lexer<'a> {
                 self.cursor += 1;
             }
             if exponent_start == self.cursor {
-                return Err(FilterError::new("invalid exponent in numeric literal"));
+                return Err(compile_error::lex_error(
+                    FilterCompileErrorKind::InvalidNumber,
+                    position,
+                ));
             }
         }
 
@@ -568,20 +611,23 @@ impl<'a> Lexer<'a> {
         if is_double {
             let value = token
                 .parse::<f64>()
-                .map_err(|error| FilterError::new(format!("invalid number '{token}': {error}")))?;
+                .map_err(|_| compile_error::lex_error(FilterCompileErrorKind::InvalidNumber, position))?;
             if !value.is_finite() {
-                return Err(FilterError::new(format!("invalid number '{token}': overflow")));
+                return Err(compile_error::lex_error(
+                    FilterCompileErrorKind::InvalidNumber,
+                    position,
+                ));
             }
             Ok(Token::Double(value))
         } else {
             token
                 .parse::<i64>()
                 .map(Token::Long)
-                .map_err(|error| FilterError::new(format!("invalid number '{token}': {error}")))
+                .map_err(|_| compile_error::lex_error(FilterCompileErrorKind::InvalidNumber, position))
         }
     }
 
-    fn read_identifier(&mut self) -> Result<Token, FilterError> {
+    fn read_identifier(&mut self) -> Token {
         let start = self.cursor;
         self.cursor += 1;
         while self.cursor < self.bytes.len() && is_ident_part(self.bytes[self.cursor]) {
@@ -591,20 +637,20 @@ impl<'a> Lexer<'a> {
         let ident = &self.input[start..self.cursor];
         let upper = ident.to_ascii_uppercase();
         match upper.as_str() {
-            "AND" => Ok(Token::And),
-            "OR" => Ok(Token::Or),
-            "NOT" => Ok(Token::Not),
-            "IS" => Ok(Token::Is),
-            "IN" => Ok(Token::In),
-            "BETWEEN" => Ok(Token::Between),
-            "CONTAINS" => Ok(Token::Contains),
-            "STARTSWITH" => Ok(Token::StartsWith),
-            "ENDSWITH" => Ok(Token::EndsWith),
-            "TRUE" => Ok(Token::Boolean(true)),
-            "FALSE" => Ok(Token::Boolean(false)),
-            "NULL" => Ok(Token::Null),
-            "NOW" => Ok(Token::Now),
-            _ => Ok(Token::Ident(CheetahString::from_slice(ident))),
+            "AND" => Token::And,
+            "OR" => Token::Or,
+            "NOT" => Token::Not,
+            "IS" => Token::Is,
+            "IN" => Token::In,
+            "BETWEEN" => Token::Between,
+            "CONTAINS" => Token::Contains,
+            "STARTSWITH" => Token::StartsWith,
+            "ENDSWITH" => Token::EndsWith,
+            "TRUE" => Token::Boolean(true),
+            "FALSE" => Token::Boolean(false),
+            "NULL" => Token::Null,
+            "NOW" => Token::Now,
+            _ => Token::Ident(CheetahString::from_slice(ident)),
         }
     }
 
@@ -628,23 +674,26 @@ fn is_ident_part(byte: u8) -> bool {
 }
 
 struct Parser {
-    tokens: Vec<Token>,
+    tokens: Vec<SpannedToken>,
     cursor: usize,
     nesting: usize,
 }
 
 impl Parser {
-    fn new(expr: &str) -> Result<Self, FilterError> {
-        let mut lexer = Lexer::new(expr);
+    fn new(expr: &str, position_offset: usize) -> Result<Self, FilterCompileError> {
+        let mut lexer = Lexer::new(expr, position_offset);
         let mut tokens = Vec::new();
         loop {
             let token = lexer.next_token()?;
-            let is_end = token == Token::End;
+            let is_end = token.token == Token::End;
             tokens.push(token);
             if tokens.len() > MAX_SQL_TOKENS {
-                return Err(FilterError::new(format!(
-                    "SQL92 expression exceeds the {MAX_SQL_TOKENS}-token limit"
-                )));
+                return Err(compile_error::lex_error(
+                    FilterCompileErrorKind::TooManyTokens,
+                    tokens
+                        .last()
+                        .map_or(position_offset + expr.len(), |token| token.position),
+                ));
             }
             if is_end {
                 break;
@@ -658,11 +707,12 @@ impl Parser {
         })
     }
 
-    fn nested<T>(&mut self, parse: impl FnOnce(&mut Self) -> Result<T, FilterError>) -> Result<T, FilterError> {
+    fn nested<T>(
+        &mut self,
+        parse: impl FnOnce(&mut Self) -> Result<T, FilterCompileError>,
+    ) -> Result<T, FilterCompileError> {
         if self.nesting >= MAX_PARSE_NESTING {
-            return Err(FilterError::new(format!(
-                "SQL92 expression exceeds the {MAX_PARSE_NESTING}-level nesting limit"
-            )));
+            return Err(compile_error::nesting_limit_exceeded(self.position()));
         }
         self.nesting += 1;
         let result = parse(self);
@@ -670,13 +720,13 @@ impl Parser {
         result
     }
 
-    fn parse_expression(&mut self) -> Result<ExprNode, FilterError> {
+    fn parse_expression(&mut self) -> Result<ExprNode, FilterCompileError> {
         self.parse_or()
     }
 
-    fn parse_or(&mut self) -> Result<ExprNode, FilterError> {
+    fn parse_or(&mut self) -> Result<ExprNode, FilterCompileError> {
         let mut expr = self.parse_and()?;
-        while self.consume(TokenKind::Or) {
+        while self.consume(Token::Or) {
             let right = self.parse_and()?;
             expr = ExprNode::Logical {
                 op: LogicalOp::Or,
@@ -687,9 +737,9 @@ impl Parser {
         Ok(expr)
     }
 
-    fn parse_and(&mut self) -> Result<ExprNode, FilterError> {
+    fn parse_and(&mut self) -> Result<ExprNode, FilterCompileError> {
         let mut expr = self.parse_not()?;
-        while self.consume(TokenKind::And) {
+        while self.consume(Token::And) {
             let right = self.parse_not()?;
             expr = ExprNode::Logical {
                 op: LogicalOp::And,
@@ -700,8 +750,8 @@ impl Parser {
         Ok(expr)
     }
 
-    fn parse_not(&mut self) -> Result<ExprNode, FilterError> {
-        if self.consume(TokenKind::Not) {
+    fn parse_not(&mut self) -> Result<ExprNode, FilterCompileError> {
+        if self.consume(Token::Not) {
             let expression = self.nested(Self::parse_not)?;
             return Ok(ExprNode::Not(Box::new(expression)));
         }
@@ -709,43 +759,41 @@ impl Parser {
         self.parse_primary()
     }
 
-    fn parse_primary(&mut self) -> Result<ExprNode, FilterError> {
-        if self.consume(TokenKind::LParen) {
+    fn parse_primary(&mut self) -> Result<ExprNode, FilterCompileError> {
+        if self.consume(Token::LParen) {
             let expr = self.nested(Self::parse_expression)?;
-            self.expect(TokenKind::RParen)?;
+            self.expect(Token::RParen)?;
             return Ok(expr);
         }
 
         let left = self.parse_value()?;
-        if self.consume(TokenKind::Is) {
-            let negated = self.consume(TokenKind::Not);
-            self.expect(TokenKind::Null)?;
+        if self.consume(Token::Is) {
+            let negated = self.consume(Token::Not);
+            self.expect(Token::Null)?;
             return Ok(ExprNode::IsNull {
                 expr: Box::new(left),
                 negated,
             });
         }
 
-        let negated_special = self.consume(TokenKind::Not);
-        if self.consume(TokenKind::In) {
+        let negated_special = self.consume(Token::Not);
+        if self.consume(Token::In) {
             return self.parse_in_list(left, negated_special);
         }
-        if self.consume(TokenKind::Between) {
+        if self.consume(Token::Between) {
             return self.parse_between(left, negated_special);
         }
-        if self.consume(TokenKind::Contains) {
+        if self.consume(Token::Contains) {
             return self.parse_string_match(left, StringMatchOp::Contains, negated_special);
         }
-        if self.consume(TokenKind::StartsWith) {
+        if self.consume(Token::StartsWith) {
             return self.parse_string_match(left, StringMatchOp::StartsWith, negated_special);
         }
-        if self.consume(TokenKind::EndsWith) {
+        if self.consume(Token::EndsWith) {
             return self.parse_string_match(left, StringMatchOp::EndsWith, negated_special);
         }
         if negated_special {
-            return Err(FilterError::new(
-                "expected IN, BETWEEN, CONTAINS, STARTSWITH or ENDSWITH after NOT",
-            ));
+            return Err(compile_error::parse_error(self.position()));
         }
 
         if let Some(op) = self.parse_compare_op() {
@@ -760,37 +808,27 @@ impl Parser {
         Ok(ExprNode::BooleanCast(Box::new(left)))
     }
 
-    fn parse_value(&mut self) -> Result<ExprNode, FilterError> {
-        match self.next() {
-            Token::Ident(name) => Ok(ExprNode::Property(name)),
-            Token::String(value) => Ok(ExprNode::Literal(Value::String(value))),
-            Token::Long(value) => Ok(ExprNode::Literal(Value::Long(value))),
-            Token::Double(value) => Ok(ExprNode::Literal(Value::Double(value))),
-            Token::Boolean(value) => Ok(ExprNode::Literal(Value::Boolean(value))),
-            Token::Null => Ok(ExprNode::Literal(Value::Null)),
-            Token::Now => Ok(ExprNode::Now),
-            token => Err(FilterError::new(format!("unexpected token {token:?}"))),
-        }
+    fn parse_value(&mut self) -> Result<ExprNode, FilterCompileError> {
+        let SpannedToken { token, position } = self.next();
+        token
+            .into_expression()
+            .ok_or_else(|| compile_error::parse_error(position))
     }
 
-    fn parse_constant_value(&mut self) -> Result<Value, FilterError> {
-        match self.next() {
-            Token::String(value) => Ok(Value::String(value)),
-            Token::Long(value) => Ok(Value::Long(value)),
-            Token::Double(value) => Ok(Value::Double(value)),
-            Token::Boolean(value) => Ok(Value::Boolean(value)),
-            Token::Null => Ok(Value::Null),
-            token => Err(FilterError::new(format!("expected literal value, got {token:?}"))),
-        }
+    fn parse_constant_value(&mut self) -> Result<Value, FilterCompileError> {
+        let SpannedToken { token, position } = self.next();
+        token
+            .into_constant()
+            .ok_or_else(|| compile_error::parse_error(position))
     }
 
-    fn parse_in_list(&mut self, left: ExprNode, negated: bool) -> Result<ExprNode, FilterError> {
-        self.expect(TokenKind::LParen)?;
+    fn parse_in_list(&mut self, left: ExprNode, negated: bool) -> Result<ExprNode, FilterCompileError> {
+        self.expect(Token::LParen)?;
         let mut items = vec![self.parse_constant_value()?];
-        while self.consume(TokenKind::Comma) {
+        while self.consume(Token::Comma) {
             items.push(self.parse_constant_value()?);
         }
-        self.expect(TokenKind::RParen)?;
+        self.expect(Token::RParen)?;
         Ok(ExprNode::InList {
             expr: Box::new(left),
             items,
@@ -798,21 +836,38 @@ impl Parser {
         })
     }
 
-    fn parse_between(&mut self, left: ExprNode, negated: bool) -> Result<ExprNode, FilterError> {
+    fn parse_between(&mut self, left: ExprNode, negated: bool) -> Result<ExprNode, FilterCompileError> {
+        let low_position = self.position();
         let low = self.parse_value()?;
-        self.expect(TokenKind::And)?;
+        self.expect(Token::And)?;
+        let high_position = self.position();
         let high = self.parse_value()?;
 
-        if let (Some(low), Some(high)) = (literal_value(&low), literal_value(&high)) {
+        if let (Some(low), Some(high)) = (low.literal(), high.literal()) {
             if matches!(low, Value::Null) || matches!(high, Value::Null) {
-                return Err(FilterError::new("Illegal values of between, values can not be null"));
+                return Err(compile_error::semantic_error(
+                    FilterCompileErrorKind::InvalidBetweenBounds,
+                    if matches!(low, Value::Null) {
+                        low_position
+                    } else {
+                        high_position
+                    },
+                ));
             }
-            if let Some(false) =
-                eval_compare_values(CompareOp::Lte, low, high).map_err(|error| FilterError::new(error.to_string()))?
-            {
-                return Err(FilterError::new(format!(
-                    "Illegal values of between, left value({low}) must less than or equal to right value({high})"
-                )));
+            match eval_compare_values(CompareOp::Lte, low, high) {
+                Ok(Some(false)) => {
+                    return Err(compile_error::semantic_error(
+                        FilterCompileErrorKind::InvalidBetweenBounds,
+                        high_position,
+                    ));
+                }
+                Ok(Some(true) | None) => {}
+                Err(_) => {
+                    return Err(compile_error::semantic_error(
+                        FilterCompileErrorKind::UnsupportedOperand,
+                        high_position,
+                    ));
+                }
             }
         }
 
@@ -829,10 +884,12 @@ impl Parser {
         left: ExprNode,
         op: StringMatchOp,
         negated: bool,
-    ) -> Result<ExprNode, FilterError> {
-        let Token::String(search) = self.next() else {
-            return Err(FilterError::new(
-                "string match operators require a quoted string literal",
+    ) -> Result<ExprNode, FilterCompileError> {
+        let token = self.next();
+        let Token::String(search) = token.token else {
+            return Err(compile_error::semantic_error(
+                FilterCompileErrorKind::UnsupportedOperand,
+                token.position,
             ));
         };
         Ok(ExprNode::StringMatch {
@@ -844,40 +901,40 @@ impl Parser {
     }
 
     fn parse_compare_op(&mut self) -> Option<CompareOp> {
-        if self.consume(TokenKind::Eq) {
+        if self.consume(Token::Eq) {
             Some(CompareOp::Eq)
-        } else if self.consume(TokenKind::Ne) {
+        } else if self.consume(Token::Ne) {
             Some(CompareOp::Ne)
-        } else if self.consume(TokenKind::Gte) {
+        } else if self.consume(Token::Gte) {
             Some(CompareOp::Gte)
-        } else if self.consume(TokenKind::Gt) {
+        } else if self.consume(Token::Gt) {
             Some(CompareOp::Gt)
-        } else if self.consume(TokenKind::Lte) {
+        } else if self.consume(Token::Lte) {
             Some(CompareOp::Lte)
-        } else if self.consume(TokenKind::Lt) {
+        } else if self.consume(Token::Lt) {
             Some(CompareOp::Lt)
         } else {
             None
         }
     }
 
-    fn expect_end(&self) -> Result<(), FilterError> {
-        match self.peek() {
+    fn expect_end(&self) -> Result<(), FilterCompileError> {
+        match &self.peek().token {
             Token::End => Ok(()),
-            token => Err(FilterError::new(format!("unexpected trailing token {token:?}"))),
+            _ => Err(compile_error::parse_error(self.position())),
         }
     }
 
-    fn expect(&mut self, kind: TokenKind) -> Result<(), FilterError> {
+    fn expect(&mut self, kind: Token) -> Result<(), FilterCompileError> {
         if self.consume(kind) {
             Ok(())
         } else {
-            Err(FilterError::new(format!("expected {}", kind.as_str())))
+            Err(compile_error::parse_error(self.position()))
         }
     }
 
-    fn consume(&mut self, kind: TokenKind) -> bool {
-        if kind.matches(self.peek()) {
+    fn consume(&mut self, kind: Token) -> bool {
+        if self.peek().token.matches_kind(&kind) {
             self.cursor += 1;
             true
         } else {
@@ -885,90 +942,20 @@ impl Parser {
         }
     }
 
-    fn next(&mut self) -> Token {
+    fn next(&mut self) -> SpannedToken {
         let token = self.peek().clone();
         self.cursor += 1;
         token
     }
 
-    fn peek(&self) -> &Token {
+    fn peek(&self) -> &SpannedToken {
         self.tokens
             .get(self.cursor)
             .unwrap_or_else(|| self.tokens.last().expect("parser always has EOF"))
     }
-}
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum TokenKind {
-    Null,
-    LParen,
-    RParen,
-    Comma,
-    Eq,
-    Ne,
-    Gt,
-    Gte,
-    Lt,
-    Lte,
-    And,
-    Or,
-    Not,
-    Is,
-    In,
-    Between,
-    Contains,
-    StartsWith,
-    EndsWith,
-}
-
-impl TokenKind {
-    fn matches(self, token: &Token) -> bool {
-        matches!(
-            (self, token),
-            (TokenKind::Null, Token::Null)
-                | (TokenKind::LParen, Token::LParen)
-                | (TokenKind::RParen, Token::RParen)
-                | (TokenKind::Comma, Token::Comma)
-                | (TokenKind::Eq, Token::Eq)
-                | (TokenKind::Ne, Token::Ne)
-                | (TokenKind::Gt, Token::Gt)
-                | (TokenKind::Gte, Token::Gte)
-                | (TokenKind::Lt, Token::Lt)
-                | (TokenKind::Lte, Token::Lte)
-                | (TokenKind::And, Token::And)
-                | (TokenKind::Or, Token::Or)
-                | (TokenKind::Not, Token::Not)
-                | (TokenKind::Is, Token::Is)
-                | (TokenKind::In, Token::In)
-                | (TokenKind::Between, Token::Between)
-                | (TokenKind::Contains, Token::Contains)
-                | (TokenKind::StartsWith, Token::StartsWith)
-                | (TokenKind::EndsWith, Token::EndsWith)
-        )
-    }
-
-    fn as_str(self) -> &'static str {
-        match self {
-            TokenKind::Null => "NULL",
-            TokenKind::LParen => "(",
-            TokenKind::RParen => ")",
-            TokenKind::Comma => ",",
-            TokenKind::Eq => "=",
-            TokenKind::Ne => "!=",
-            TokenKind::Gt => ">",
-            TokenKind::Gte => ">=",
-            TokenKind::Lt => "<",
-            TokenKind::Lte => "<=",
-            TokenKind::And => "AND",
-            TokenKind::Or => "OR",
-            TokenKind::Not => "NOT",
-            TokenKind::Is => "IS",
-            TokenKind::In => "IN",
-            TokenKind::Between => "BETWEEN",
-            TokenKind::Contains => "CONTAINS",
-            TokenKind::StartsWith => "STARTSWITH",
-            TokenKind::EndsWith => "ENDSWITH",
-        }
+    fn position(&self) -> usize {
+        self.peek().position
     }
 }
 
@@ -993,33 +980,42 @@ mod tests {
         expression.evaluate(&context)
     }
 
-    fn compile_error(expr: &str) -> String {
+    fn compile_error(expr: &str) -> rocketmq_error::FilterCompileError {
         match compile_expression(expr) {
             Ok(_) => panic!("expression should be rejected"),
-            Err(error) => error.to_string(),
+            Err(error) => error,
         }
     }
 
     #[test]
     fn compile_rejects_empty_expression() {
         let error = compile_error("   ");
-        assert!(error.contains("empty SQL92 expression"));
+        assert_eq!(error.kind(), rocketmq_error::FilterCompileErrorKind::EmptyExpression);
     }
 
     #[test]
     fn compile_rejects_oversized_and_deeply_nested_expressions() {
         let oversized = "x".repeat(MAX_EXPRESSION_BYTES + 1);
-        assert!(compile_error(&oversized).contains("byte limit"));
+        assert_eq!(
+            compile_error(&oversized).kind(),
+            rocketmq_error::FilterCompileErrorKind::ExpressionTooLarge
+        );
 
         let deeply_nested = format!(
             "{}flag{}",
             "(".repeat(MAX_PARSE_NESTING + 1),
             ")".repeat(MAX_PARSE_NESTING + 1)
         );
-        assert!(compile_error(&deeply_nested).contains("nesting limit"));
+        assert_eq!(
+            compile_error(&deeply_nested).kind(),
+            rocketmq_error::FilterCompileErrorKind::NestingLimitExceeded
+        );
 
         let too_many_tokens = "flag OR ".repeat(MAX_SQL_TOKENS / 2 + 1) + "flag";
-        assert!(compile_error(&too_many_tokens).contains("token limit"));
+        assert_eq!(
+            compile_error(&too_many_tokens).kind(),
+            rocketmq_error::FilterCompileErrorKind::TooManyTokens
+        );
     }
 
     #[test]
@@ -1118,19 +1114,22 @@ mod tests {
     #[test]
     fn compile_rejects_illegal_between_bounds() {
         let error = compile_error("a BETWEEN 10 AND 0");
-        assert!(error.contains("Illegal values of between"));
+        assert_eq!(
+            error.kind(),
+            rocketmq_error::FilterCompileErrorKind::InvalidBetweenBounds
+        );
     }
 
     #[test]
     fn compile_rejects_non_string_contains_operand() {
         let error = compile_error("a CONTAINS 1");
-        assert!(error.contains("string match operators require a quoted string literal"));
+        assert_eq!(error.kind(), rocketmq_error::FilterCompileErrorKind::UnsupportedOperand);
     }
 
     #[test]
     fn compile_rejects_invalid_number_exponent() {
         let error = compile_error("a = 1e");
-        assert!(error.contains("invalid exponent"));
+        assert_eq!(error.kind(), rocketmq_error::FilterCompileErrorKind::InvalidNumber);
     }
 
     #[test]
@@ -1142,7 +1141,7 @@ mod tests {
     #[test]
     fn compile_rejects_trailing_tokens() {
         let error = compile_error("a = 1 2");
-        assert!(error.contains("unexpected trailing token"));
+        assert_eq!(error.kind(), rocketmq_error::FilterCompileErrorKind::UnexpectedToken);
     }
 
     #[test]

--- a/rocketmq-filter/src/filter/sql_runtime/compile_error.rs
+++ b/rocketmq-filter/src/filter/sql_runtime/compile_error.rs
@@ -1,0 +1,87 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_error::FilterCompileError;
+use rocketmq_error::FilterCompileErrorKind;
+use rocketmq_error::FilterCompileSource;
+use rocketmq_error::FilterCompileStage;
+
+use super::Token;
+
+/// A token paired with its original UTF-8 byte offset.
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct SpannedToken {
+    pub(super) token: Token,
+    pub(super) position: usize,
+}
+
+impl SpannedToken {
+    pub(super) const fn new(token: Token, position: usize) -> Self {
+        Self { token, position }
+    }
+}
+
+pub(super) const fn lex_error(kind: FilterCompileErrorKind, position: usize) -> FilterCompileError {
+    FilterCompileError::new_with_source(
+        kind,
+        FilterCompileStage::Lex,
+        Some(position),
+        FilterCompileSource::Sql92,
+    )
+}
+
+pub(super) const fn empty_expression() -> FilterCompileError {
+    FilterCompileError::new_with_source(
+        FilterCompileErrorKind::EmptyExpression,
+        FilterCompileStage::Parse,
+        Some(0),
+        FilterCompileSource::Sql92,
+    )
+}
+
+pub(super) const fn nesting_limit_exceeded(position: usize) -> FilterCompileError {
+    FilterCompileError::new_with_source(
+        FilterCompileErrorKind::NestingLimitExceeded,
+        FilterCompileStage::Parse,
+        Some(position),
+        FilterCompileSource::Sql92,
+    )
+}
+
+pub(super) const fn parse_error(position: usize) -> FilterCompileError {
+    FilterCompileError::new_with_source(
+        FilterCompileErrorKind::UnexpectedToken,
+        FilterCompileStage::Parse,
+        Some(position),
+        FilterCompileSource::Sql92,
+    )
+}
+
+pub(super) const fn semantic_error(kind: FilterCompileErrorKind, position: usize) -> FilterCompileError {
+    FilterCompileError::new_with_source(
+        kind,
+        FilterCompileStage::Semantic,
+        Some(position),
+        FilterCompileSource::Sql92,
+    )
+}
+
+#[allow(
+    deprecated,
+    reason = "Only SqlFilter's deprecated compile wrapper projects typed errors to the legacy string error."
+)]
+pub(in crate::filter) fn legacy_projection(error: FilterCompileError) -> super::super::filter_spi::FilterError {
+    let _ = error;
+    super::super::filter_spi::FilterError::new("SQL92 expression compilation failed")
+}

--- a/rocketmq-filter/tests/filter_compile_error_contract.rs
+++ b/rocketmq-filter/tests/filter_compile_error_contract.rs
@@ -1,0 +1,240 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_error::RocketMQError;
+use rocketmq_filter::expression::Expression;
+use rocketmq_filter::filter::Filter;
+use rocketmq_filter::filter::FilterCompileErrorKind;
+use rocketmq_filter::filter::FilterCompileSource;
+use rocketmq_filter::filter::FilterCompileStage;
+use rocketmq_filter::filter::SqlFilter;
+
+fn assert_compile_error(filter: &SqlFilter, expression: &str, kind: FilterCompileErrorKind, stage: FilterCompileStage) {
+    let error = rejected(filter.try_compile(expression));
+    assert_eq!(error.kind(), kind, "expression: {expression:?}");
+    assert_eq!(error.stage(), stage, "expression: {expression:?}");
+    assert_eq!(error.source(), Some(FilterCompileSource::Sql92));
+}
+
+fn rejected<T>(
+    result: Result<T, rocketmq_filter::filter::FilterCompileError>,
+) -> rocketmq_filter::filter::FilterCompileError {
+    match result {
+        Ok(_) => panic!("expression should be rejected"),
+        Err(error) => error,
+    }
+}
+
+#[test]
+fn sql_compile_errors_cover_kinds_stages_and_byte_offsets() {
+    let filter = SqlFilter::new();
+    assert_compile_error(
+        &filter,
+        "   ",
+        FilterCompileErrorKind::EmptyExpression,
+        FilterCompileStage::Parse,
+    );
+    assert_eq!(rejected(filter.try_compile("   ")).position(), Some(0));
+
+    assert_compile_error(
+        &filter,
+        &"x".repeat(64 * 1024 + 1),
+        FilterCompileErrorKind::ExpressionTooLarge,
+        FilterCompileStage::Lex,
+    );
+    assert_compile_error(
+        &filter,
+        &("flag OR ".repeat(2_049) + "flag"),
+        FilterCompileErrorKind::TooManyTokens,
+        FilterCompileStage::Lex,
+    );
+    assert_compile_error(
+        &filter,
+        &("(".repeat(129) + "flag" + &")".repeat(129)),
+        FilterCompileErrorKind::NestingLimitExceeded,
+        FilterCompileStage::Parse,
+    );
+
+    let utf8_with_leading_whitespace = "  name = '秘密' @";
+    let utf8_error = rejected(filter.try_compile(utf8_with_leading_whitespace));
+    assert_eq!(utf8_error.kind(), FilterCompileErrorKind::UnexpectedToken);
+    assert_eq!(utf8_error.stage(), FilterCompileStage::Lex);
+    assert_eq!(utf8_error.position(), utf8_with_leading_whitespace.find('@'));
+    assert_compile_error(
+        &filter,
+        "name = 'unterminated",
+        FilterCompileErrorKind::UnexpectedToken,
+        FilterCompileStage::Lex,
+    );
+    assert_compile_error(
+        &filter,
+        "name = 1e",
+        FilterCompileErrorKind::InvalidNumber,
+        FilterCompileStage::Lex,
+    );
+    assert_compile_error(
+        &filter,
+        "name = 9223372036854775808",
+        FilterCompileErrorKind::InvalidNumber,
+        FilterCompileStage::Lex,
+    );
+    assert_compile_error(
+        &filter,
+        "name = 1e309",
+        FilterCompileErrorKind::InvalidNumber,
+        FilterCompileStage::Lex,
+    );
+
+    assert_compile_error(
+        &filter,
+        "name =",
+        FilterCompileErrorKind::UnexpectedToken,
+        FilterCompileStage::Parse,
+    );
+    assert_compile_error(
+        &filter,
+        "name = 1 2",
+        FilterCompileErrorKind::UnexpectedToken,
+        FilterCompileStage::Parse,
+    );
+    let null_bounds = "name BETWEEN NULL AND 1";
+    assert_compile_error(
+        &filter,
+        null_bounds,
+        FilterCompileErrorKind::InvalidBetweenBounds,
+        FilterCompileStage::Semantic,
+    );
+    assert_eq!(
+        rejected(filter.try_compile(null_bounds)).position(),
+        null_bounds.find("NULL")
+    );
+    let high_null_bounds = "name BETWEEN 1 AND NULL";
+    assert_compile_error(
+        &filter,
+        high_null_bounds,
+        FilterCompileErrorKind::InvalidBetweenBounds,
+        FilterCompileStage::Semantic,
+    );
+    assert_eq!(
+        rejected(filter.try_compile(high_null_bounds)).position(),
+        high_null_bounds.find("NULL")
+    );
+    let reversed_bounds = "name BETWEEN 2 AND 1";
+    assert_compile_error(
+        &filter,
+        reversed_bounds,
+        FilterCompileErrorKind::InvalidBetweenBounds,
+        FilterCompileStage::Semantic,
+    );
+    assert_eq!(
+        rejected(filter.try_compile(reversed_bounds)).position(),
+        reversed_bounds.rfind('1')
+    );
+    let incomparable_bounds = "name BETWEEN TRUE AND FALSE";
+    assert_compile_error(
+        &filter,
+        incomparable_bounds,
+        FilterCompileErrorKind::UnsupportedOperand,
+        FilterCompileStage::Semantic,
+    );
+    assert_eq!(
+        rejected(filter.try_compile(incomparable_bounds)).position(),
+        incomparable_bounds.find("FALSE")
+    );
+    assert_compile_error(
+        &filter,
+        "name CONTAINS 1",
+        FilterCompileErrorKind::UnsupportedOperand,
+        FilterCompileStage::Semantic,
+    );
+}
+
+#[test]
+fn typed_errors_and_unified_context_redact_the_submitted_sql() {
+    let filter = SqlFilter::new();
+    let expression = "property = 'sensitive-literal' @";
+    let error = rejected(filter.try_compile(expression));
+    let typed_context = error.context().to_string();
+    let unified: RocketMQError = error.into();
+    let unified_context = unified.context().to_string();
+
+    for rendered in [error.to_string(), format!("{error:?}"), typed_context, unified_context] {
+        assert!(rendered.contains("UnexpectedToken") || rendered.contains("filter_compile_kind"));
+        assert!(!rendered.contains(expression));
+        assert!(!rendered.contains("sensitive-literal"));
+    }
+}
+
+#[test]
+fn compilation_preserves_trimmed_sql_compatibility_and_original_offsets() {
+    let filter = SqlFilter::new();
+    let surrounded_by_large_ascii_whitespace = format!(
+        "{}name = 'blue'{}",
+        " ".repeat(64 * 1024 + 1),
+        " ".repeat(64 * 1024 + 1)
+    );
+    assert!(filter.try_compile(&surrounded_by_large_ascii_whitespace).is_ok());
+
+    assert!(filter.try_compile("\u{00a0}name = 'blue'\u{00a0}").is_ok());
+
+    let utf8_with_leading_whitespace = "  name = '秘密' @";
+    let error = rejected(filter.try_compile(utf8_with_leading_whitespace));
+    assert_eq!(error.position(), utf8_with_leading_whitespace.find('@'));
+}
+
+#[derive(Debug)]
+struct LegacyOnlyFilter;
+
+#[allow(
+    deprecated,
+    reason = "This dedicated contract test verifies the default legacy Filter compatibility adapter."
+)]
+impl Filter for LegacyOnlyFilter {
+    fn compile(&self, _expr: &str) -> Result<Box<dyn Expression>, rocketmq_filter::filter::FilterError> {
+        Err(rocketmq_filter::filter::FilterError::new("legacy secret expression"))
+    }
+
+    fn of_type(&self) -> &str {
+        "LEGACY_ONLY"
+    }
+}
+
+#[test]
+fn legacy_filters_map_failures_without_leaking_their_message() {
+    let error = rejected(LegacyOnlyFilter.try_compile("legacy secret expression"));
+    assert_eq!(error.kind(), FilterCompileErrorKind::LegacyAdapter);
+    assert_eq!(error.stage(), FilterCompileStage::Compatibility);
+    assert_eq!(error.position(), None);
+    assert_eq!(error.source(), None);
+    assert!(!error.to_string().contains("legacy secret expression"));
+}
+
+#[test]
+#[allow(
+    deprecated,
+    reason = "This dedicated contract test verifies deprecated compile behavior."
+)]
+fn deprecated_compile_preserves_success_and_uses_a_fixed_failure_projection() {
+    let filter = SqlFilter::new();
+    assert!(filter.try_compile("name = 'blue'").is_ok());
+    assert!(filter.compile("name = 'blue'").is_ok());
+    let legacy_error = match filter.compile("name = 'secret") {
+        Ok(_) => panic!("invalid expression should not compile"),
+        Err(error) => error,
+    };
+    assert_eq!(
+        legacy_error.to_string(),
+        "FilterError: SQL92 expression compilation failed"
+    );
+}

--- a/scripts/module-maintainability-baseline.json
+++ b/scripts/module-maintainability-baseline.json
@@ -29,12 +29,12 @@
       "reexports": 102
     },
     "rocketmq-error": {
-      "public_items": 240,
-      "reexports": 51
+      "public_items": 252,
+      "reexports": 56
     },
     "rocketmq-filter": {
       "public_items": 106,
-      "reexports": 17
+      "reexports": 21
     },
     "rocketmq-macros": {
       "public_items": 4,
@@ -3291,13 +3291,13 @@
       "reexports": 0
     },
     "rocketmq-error/src/domain.rs": {
-      "production_lines": 145,
+      "production_lines": 160,
       "public_items": 1,
       "reexports": 0
     },
     "rocketmq-error/src/filter_error.rs": {
-      "production_lines": 35,
-      "public_items": 7,
+      "production_lines": 140,
+      "public_items": 19,
       "reexports": 0
     },
     "rocketmq-error/src/kind.rs": {
@@ -3306,9 +3306,9 @@
       "reexports": 0
     },
     "rocketmq-error/src/lib.rs": {
-      "production_lines": 55,
+      "production_lines": 59,
       "public_items": 0,
-      "reexports": 42
+      "reexports": 46
     },
     "rocketmq-error/src/observability_error.rs": {
       "production_lines": 106,
@@ -3331,9 +3331,9 @@
       "reexports": 0
     },
     "rocketmq-error/src/unified.rs": {
-      "production_lines": 831,
+      "production_lines": 838,
       "public_items": 59,
-      "reexports": 9
+      "reexports": 10
     },
     "rocketmq-error/src/unified/network.rs": {
       "production_lines": 134,
@@ -3396,9 +3396,9 @@
       "reexports": 0
     },
     "rocketmq-filter/src/filter.rs": {
-      "production_lines": 9,
+      "production_lines": 17,
       "public_items": 0,
-      "reexports": 5
+      "reexports": 9
     },
     "rocketmq-filter/src/filter/filter_factory.rs": {
       "production_lines": 40,
@@ -3406,17 +3406,22 @@
       "reexports": 0
     },
     "rocketmq-filter/src/filter/filter_spi.rs": {
-      "production_lines": 27,
+      "production_lines": 61,
       "public_items": 5,
       "reexports": 0
     },
     "rocketmq-filter/src/filter/filter_sql_filter.rs": {
-      "production_lines": 20,
+      "production_lines": 32,
       "public_items": 2,
       "reexports": 0
     },
     "rocketmq-filter/src/filter/sql_runtime.rs": {
-      "production_lines": 872,
+      "production_lines": 860,
+      "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-filter/src/filter/sql_runtime/compile_error.rs": {
+      "production_lines": 63,
       "public_items": 0,
       "reexports": 0
     },


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9639

### Brief Description

- Add redaction-safe typed SQL filter compile errors with stable kind, stage, source classification, and original UTF-8 byte offsets.
- Preserve external `Filter` implementations through a default legacy adapter while deprecating the string-based compile surface with an explicit migration path.
- Map lexer, parser, and semantic failures to typed errors without retaining expressions, tokens, literals, or property values.
- Migrate broker and benchmark callers to `try_compile` while preserving broker response codes and control flow.
- Add compatibility, metadata, redaction, and broker contract coverage, and update only the exact maintainability records.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-error -p rocketmq-filter -p rocketmq-broker -- --check`
- `cargo check -p rocketmq-error -p rocketmq-filter -p rocketmq-broker --all-targets --all-features`
- `cargo test -p rocketmq-error --test filter_compile_error_contract`
- `cargo test -p rocketmq-filter --test filter_compile_error_contract`
- `cargo test -p rocketmq-error --all-features`
- `cargo test -p rocketmq-filter --all-features`
- `cargo test -p rocketmq-broker consumer_filter_manager`
- `cargo test -p rocketmq-broker client_manage_processor`
- `cargo clippy -p rocketmq-error -p rocketmq-filter -p rocketmq-broker --all-targets --all-features -- -D warnings`
- `.\scripts\check-error-hygiene.ps1`
- `python scripts/error_architecture_guard.py`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz`
- `git diff --check`