### PR TITLE
[ISSUE #9643]♻️Preserve typed errors across Tokio connect flights

### DIFF
--- a/rocketmq-error/src/lib.rs
+++ b/rocketmq-error/src/lib.rs
@@ -61,6 +61,7 @@ mod filter_error;
 mod kind;
 mod observability_error;
 mod policy;
+mod shared;
 mod spec;
 mod unified;
 
@@ -102,6 +103,7 @@ pub use policy::ErrorSeverity;
 pub use policy::ObserveSpec;
 pub use policy::RecoverySpec;
 pub use policy::RetryClass;
+pub use shared::SharedRocketMQError;
 pub use spec::error_spec;
 pub use spec::ErrorSpec;
 pub use spec::ALL_ERROR_SPECS;

--- a/rocketmq-error/src/shared.rs
+++ b/rocketmq-error/src/shared.rs
@@ -1,0 +1,106 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error as StdError;
+use std::fmt;
+use std::sync::Arc;
+
+use crate::BoundaryErrorView;
+use crate::DomainError;
+use crate::ErrorCode;
+use crate::ErrorContext;
+use crate::ErrorKind;
+use crate::ErrorSeverity;
+use crate::ErrorSpec;
+use crate::RecoverySpec;
+use crate::RedactionPolicy;
+use crate::RetryClass;
+use crate::RocketMQError;
+
+/// An immutable, cloneable snapshot of a [`RocketMQError`].
+///
+/// Re-wrapping an existing [`RocketMQError::Shared`] value preserves its
+/// allocation so concurrent consumers retain one typed error snapshot.
+#[derive(Clone, Debug)]
+pub struct SharedRocketMQError(Arc<RocketMQError>);
+
+impl SharedRocketMQError {
+    /// Shares an error without changing its typed metadata or source chain.
+    pub fn new(error: RocketMQError) -> Self {
+        match error {
+            RocketMQError::Shared(error) => error,
+            error => Self(Arc::new(error)),
+        }
+    }
+
+    /// Returns the original typed error snapshot.
+    pub fn as_error(&self) -> &RocketMQError {
+        self.0.as_ref()
+    }
+
+    /// Returns this snapshot as the public shared error variant.
+    pub fn into_error(self) -> RocketMQError {
+        RocketMQError::Shared(self)
+    }
+}
+
+impl fmt::Display for SharedRocketMQError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_error().fmt(formatter)
+    }
+}
+
+impl StdError for SharedRocketMQError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        Some(self.as_error())
+    }
+}
+
+impl DomainError for SharedRocketMQError {
+    fn kind(&self) -> ErrorKind {
+        self.as_error().kind()
+    }
+
+    fn context(&self) -> ErrorContext {
+        self.as_error().context()
+    }
+
+    fn spec(&self) -> &'static ErrorSpec {
+        DomainError::spec(self.as_error())
+    }
+
+    fn code(&self) -> ErrorCode {
+        DomainError::code(self.as_error())
+    }
+
+    fn recovery(&self) -> RecoverySpec {
+        DomainError::recovery(self.as_error())
+    }
+
+    fn retry(&self) -> RetryClass {
+        DomainError::retry(self.as_error())
+    }
+
+    fn severity(&self) -> ErrorSeverity {
+        DomainError::severity(self.as_error())
+    }
+
+    fn redaction(&self) -> RedactionPolicy {
+        DomainError::redaction(self.as_error())
+    }
+
+    fn boundary_view(&self) -> BoundaryErrorView {
+        DomainError::boundary_view(self.as_error())
+    }
+}

--- a/rocketmq-error/src/unified.rs
+++ b/rocketmq-error/src/unified.rs
@@ -35,6 +35,7 @@ use crate::boundary::BoundaryErrorView;
 use crate::context::ErrorContext;
 use crate::context::Sensitive;
 use crate::kind::ErrorKind;
+use crate::shared::SharedRocketMQError;
 use crate::spec::ErrorSpec;
 pub use network::NetworkError;
 pub use protocol::ProtocolError;
@@ -86,6 +87,10 @@ pub use crate::controller_error::ControllerError;
 /// ```
 #[derive(Debug, Error)]
 pub enum RocketMQError {
+    /// An immutable shared snapshot of a typed RocketMQ error.
+    #[error(transparent)]
+    Shared(#[from] SharedRocketMQError),
+
     // ============================================================================
     // Network Errors
     // ============================================================================
@@ -660,6 +665,7 @@ impl RocketMQError {
     #[inline]
     pub fn kind(&self) -> ErrorKind {
         match self {
+            Self::Shared(error) => error.as_error().kind(),
             Self::Network(_) => ErrorKind::Network,
             Self::Serialization(_) => ErrorKind::Serialization,
             Self::Protocol(_) => ErrorKind::Protocol,
@@ -750,6 +756,7 @@ impl RocketMQError {
     /// adapters can safely render the context without leaking raw values.
     pub fn context(&self) -> ErrorContext {
         match self {
+            Self::Shared(error) => error.as_error().context(),
             Self::Network(error) => {
                 ErrorContext::new().with_sensitive("addr", Sensitive::new(error.addr().to_string()))
             }

--- a/rocketmq-error/tests/shared_error_contract.rs
+++ b/rocketmq-error/tests/shared_error_contract.rs
@@ -1,0 +1,112 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error as _;
+use std::io;
+
+use rocketmq_error::DomainError;
+use rocketmq_error::FilterCompileError;
+use rocketmq_error::FilterCompileErrorKind;
+use rocketmq_error::FilterCompileSource;
+use rocketmq_error::FilterCompileStage;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::SharedRocketMQError;
+
+fn assert_shared_contract(error: RocketMQError) {
+    let expected_kind = error.kind();
+    let expected_context = error.context();
+    let expected_boundary = error.boundary_view();
+    let expected_retry = error.retry();
+    let expected_severity = error.severity();
+    let expected_redaction = error.redaction();
+    let expected_display = error.to_string();
+    let expected_source = error.source().map(ToString::to_string);
+    let expected_nested_source = error
+        .source()
+        .and_then(|source| source.source())
+        .map(ToString::to_string);
+
+    let shared = SharedRocketMQError::new(error);
+    let cloned = shared.clone();
+
+    for snapshot in [&shared, &cloned] {
+        assert_eq!(snapshot.kind(), expected_kind);
+        assert_eq!(snapshot.context(), expected_context);
+        assert_eq!(snapshot.boundary_view(), expected_boundary);
+        assert_eq!(snapshot.retry(), expected_retry);
+        assert_eq!(snapshot.severity(), expected_severity);
+        assert_eq!(snapshot.redaction(), expected_redaction);
+        assert_eq!(snapshot.to_string(), expected_display);
+    }
+    assert!(std::ptr::eq(shared.as_error(), cloned.as_error()));
+
+    let source = shared.source().expect("shared error source");
+    let original = source
+        .downcast_ref::<RocketMQError>()
+        .expect("shared source must be the original RocketMQ error");
+    assert!(std::ptr::eq(shared.as_error(), original));
+    assert_eq!(source.to_string(), expected_display);
+    assert_eq!(source.source().map(ToString::to_string), expected_source);
+    assert_eq!(
+        source
+            .source()
+            .and_then(|nested| nested.source())
+            .map(ToString::to_string),
+        expected_nested_source
+    );
+
+    let wrapped = cloned.into_error();
+    assert_eq!(wrapped.kind(), expected_kind);
+    assert_eq!(wrapped.context(), expected_context);
+    assert_eq!(wrapped.boundary_view(), expected_boundary);
+    assert_eq!(wrapped.to_string(), expected_display);
+}
+
+#[test]
+fn shared_error_clones_preserve_typed_metadata_and_source_chains() {
+    assert_shared_contract(RocketMQError::network_connection_failed(
+        "127.0.0.1:10911",
+        "connection refused",
+    ));
+    let config_invalid_value = RocketMQError::ConfigInvalidValue {
+        key: "connect.timeout",
+        value: "invalid".to_owned(),
+        reason: "must be positive".to_owned(),
+    };
+    assert_eq!(
+        config_invalid_value.context().to_string(),
+        "key=connect.timeout, value=<redacted>, reason=<redacted>"
+    );
+    assert_shared_contract(config_invalid_value);
+    assert_shared_contract(RocketMQError::ClientNotStarted);
+    assert_shared_contract(RocketMQError::from(io::Error::new(
+        io::ErrorKind::ConnectionRefused,
+        io::Error::new(io::ErrorKind::TimedOut, "inner connect timeout"),
+    )));
+    assert_shared_contract(RocketMQError::from(FilterCompileError::new_with_source(
+        FilterCompileErrorKind::UnexpectedToken,
+        FilterCompileStage::Parse,
+        Some(12),
+        FilterCompileSource::Sql92,
+    )));
+}
+
+#[test]
+fn rewrapping_a_shared_error_reuses_the_original_snapshot() {
+    let shared = SharedRocketMQError::new(RocketMQError::ClientNotStarted);
+    let rewrapped = SharedRocketMQError::new(shared.clone().into_error());
+
+    assert!(std::ptr::eq(shared.as_error(), rewrapped.as_error()));
+    assert_eq!(shared.to_string(), rewrapped.to_string());
+}

--- a/rocketmq-transport/src/clients/rocketmq_tokio_client/connection_registry.rs
+++ b/rocketmq-transport/src/clients/rocketmq_tokio_client/connection_registry.rs
@@ -19,6 +19,7 @@ use dashmap::DashMap;
 use parking_lot::Mutex;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
+use rocketmq_error::SharedRocketMQError;
 
 use super::endpoint_state::EndpointLease;
 use crate::clients::TransportSession;
@@ -91,7 +92,7 @@ impl<PR> RegisteredSession<PR> {
 
 enum ConnectFlightState<PR> {
     Connecting,
-    Complete(Box<Result<Option<TransportSession<PR>>, Arc<str>>>),
+    Complete(Box<Result<Option<TransportSession<PR>>, SharedRocketMQError>>),
 }
 
 /// A shared connection attempt associated with one endpoint generation.
@@ -122,8 +123,12 @@ where
     }
 
     pub(super) fn complete(&self, result: RocketMQResult<Option<TransportSession<PR>>>) {
-        *self.state.lock() =
-            ConnectFlightState::Complete(Box::new(result.map_err(|error| Arc::<str>::from(error.to_string()))));
+        let mut state = self.state.lock();
+        if matches!(*state, ConnectFlightState::Complete(_)) {
+            return;
+        }
+        *state = ConnectFlightState::Complete(Box::new(result.map_err(SharedRocketMQError::new)));
+        drop(state);
         self.changed.notify_waiters();
     }
 
@@ -137,9 +142,7 @@ where
             tokio::pin!(changed);
             changed.as_mut().enable();
             if let ConnectFlightState::Complete(result) = &*self.state.lock() {
-                return (**result).clone().map_err(|message| {
-                    RocketMQError::network_connection_failed(target.to_string(), message.to_string())
-                });
+                return (**result).clone().map_err(SharedRocketMQError::into_error);
             }
             deadline
                 .timeout(changed)
@@ -419,5 +422,162 @@ where
         self.sessions
             .get(&RegistryKey::from_lease(identity.clone(), Some(lease)))
             .is_some_and(|entry| entry.value().belongs_to(lease))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error as _;
+    use std::io;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::time::Duration;
+
+    use rocketmq_error::DomainError;
+    use tokio::sync::Barrier;
+    use tokio::sync::Notify;
+    use tokio::task::JoinSet;
+
+    use super::*;
+    use crate::deadline::RequestDeadline;
+    use crate::request_processor::default_request_processor::DefaultRequestProcessor;
+
+    async fn assert_connect_flight_preserves_failure(error: RocketMQError) {
+        const WAITERS: usize = 3;
+
+        let expected_kind = error.kind();
+        let expected_context = error.context();
+        let expected_boundary = error.boundary_view();
+        let expected_retry = error.retry();
+        let expected_severity = error.severity();
+        let expected_redaction = error.redaction();
+        let expected_display = error.to_string();
+        let expected_source = error.source().map(ToString::to_string);
+
+        let flight = Arc::new(ConnectFlight::<DefaultRequestProcessor>::new(None));
+        let target = CheetahString::from_static_str("127.0.0.1:10911");
+        let barrier = Arc::new(Barrier::new(WAITERS + 1));
+        let ready_count = Arc::new(AtomicUsize::new(0));
+        let waiters_ready = Arc::new(Notify::new());
+        let mut tasks = JoinSet::new();
+
+        {
+            let barrier = Arc::clone(&barrier);
+            let flight = Arc::clone(&flight);
+            let target = target.clone();
+            let waiters_ready = Arc::clone(&waiters_ready);
+            tasks.spawn(async move {
+                barrier.wait().await;
+                waiters_ready.notified().await;
+                flight.complete(Err(error));
+                flight
+                    .wait(RequestDeadline::after(Duration::from_secs(1)), &target)
+                    .await
+            });
+        }
+
+        for _ in 0..WAITERS {
+            let barrier = Arc::clone(&barrier);
+            let flight = Arc::clone(&flight);
+            let target = target.clone();
+            let ready_count = Arc::clone(&ready_count);
+            let waiters_ready = Arc::clone(&waiters_ready);
+            tasks.spawn(async move {
+                barrier.wait().await;
+                if ready_count.fetch_add(1, Ordering::AcqRel) + 1 == WAITERS {
+                    waiters_ready.notify_one();
+                }
+                flight
+                    .wait(RequestDeadline::after(Duration::from_secs(1)), &target)
+                    .await
+            });
+        }
+
+        let mut snapshots = Vec::with_capacity(WAITERS + 1);
+        while let Some(result) = tasks.join_next().await {
+            let error = match result.expect("connect-flight task must complete") {
+                Err(error) => error,
+                Ok(_) => panic!("connect flight must return the shared failure"),
+            };
+            let RocketMQError::Shared(snapshot) = error else {
+                panic!("connect flight must return a shared typed error");
+            };
+            snapshots.push(snapshot);
+        }
+
+        let first = snapshots.first().expect("leader and waiters return snapshots");
+        for snapshot in &snapshots {
+            assert_eq!(snapshot.kind(), expected_kind);
+            assert_eq!(snapshot.context(), expected_context);
+            assert_eq!(snapshot.boundary_view(), expected_boundary);
+            assert_eq!(snapshot.retry(), expected_retry);
+            assert_eq!(snapshot.severity(), expected_severity);
+            assert_eq!(snapshot.redaction(), expected_redaction);
+            assert_eq!(snapshot.to_string(), expected_display);
+            assert!(std::ptr::eq(first.as_error(), snapshot.as_error()));
+
+            let source = snapshot.source().expect("shared error source");
+            let original = source
+                .downcast_ref::<RocketMQError>()
+                .expect("shared source must be the original error");
+            assert!(std::ptr::eq(snapshot.as_error(), original));
+            assert_eq!(source.to_string(), expected_display);
+            assert_eq!(source.source().map(ToString::to_string), expected_source);
+        }
+
+        flight.complete(Err(RocketMQError::ClientNotStarted));
+        let error = match flight
+            .wait(RequestDeadline::after(Duration::from_secs(1)), &target)
+            .await
+        {
+            Err(error) => error,
+            Ok(_) => panic!("a completed flight cannot be overwritten"),
+        };
+        let RocketMQError::Shared(snapshot) = error else {
+            panic!("completed flight must retain its shared error");
+        };
+        assert!(std::ptr::eq(first.as_error(), snapshot.as_error()));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn connect_flight_shares_exact_typed_failures_with_leader_and_waiters() {
+        assert_connect_flight_preserves_failure(RocketMQError::network_connection_failed(
+            "127.0.0.1:10911",
+            "connection refused",
+        ))
+        .await;
+        assert_connect_flight_preserves_failure(RocketMQError::ConfigInvalidValue {
+            key: "connect.timeout",
+            value: "invalid".to_owned(),
+            reason: "must be positive".to_owned(),
+        })
+        .await;
+        assert_connect_flight_preserves_failure(RocketMQError::ClientNotStarted).await;
+        assert_connect_flight_preserves_failure(RocketMQError::from(io::Error::new(
+            io::ErrorKind::ConnectionRefused,
+            io::Error::new(io::ErrorKind::TimedOut, "inner connect timeout"),
+        )))
+        .await;
+    }
+
+    #[test]
+    fn connect_flight_failure_cleanup_is_identity_conditional() {
+        let registry = ConnectionRegistry::<DefaultRequestProcessor>::new();
+        let identity = CheetahString::from_static_str("127.0.0.1:10911");
+        let (failed, leader) = registry.acquire_flight(identity.clone(), None);
+        assert!(leader);
+
+        failed.complete(Err(RocketMQError::ClientNotStarted));
+        registry.remove_flight_if_matches(&identity, &failed);
+        assert_eq!(registry.flight_count(), 0);
+
+        let (replacement, replacement_leader) = registry.acquire_flight(identity.clone(), None);
+        assert!(replacement_leader);
+        registry.remove_flight_if_matches(&identity, &failed);
+        assert_eq!(registry.flight_count(), 1);
+        assert!(!Arc::ptr_eq(&failed, &replacement));
+
+        registry.remove_flight_if_matches(&identity, &replacement);
+        assert_eq!(registry.flight_count(), 0);
     }
 }

--- a/scripts/module-maintainability-baseline.json
+++ b/scripts/module-maintainability-baseline.json
@@ -29,8 +29,8 @@
       "reexports": 102
     },
     "rocketmq-error": {
-      "public_items": 252,
-      "reexports": 56
+      "public_items": 256,
+      "reexports": 57
     },
     "rocketmq-filter": {
       "public_items": 106,
@@ -3306,9 +3306,9 @@
       "reexports": 0
     },
     "rocketmq-error/src/lib.rs": {
-      "production_lines": 59,
+      "production_lines": 61,
       "public_items": 0,
-      "reexports": 46
+      "reexports": 47
     },
     "rocketmq-error/src/observability_error.rs": {
       "production_lines": 106,
@@ -3318,6 +3318,11 @@
     "rocketmq-error/src/policy.rs": {
       "production_lines": 105,
       "public_items": 8,
+      "reexports": 0
+    },
+    "rocketmq-error/src/shared.rs": {
+      "production_lines": 69,
+      "public_items": 4,
       "reexports": 0
     },
     "rocketmq-error/src/spec.rs": {
@@ -3331,7 +3336,7 @@
       "reexports": 0
     },
     "rocketmq-error/src/unified.rs": {
-      "production_lines": 838,
+      "production_lines": 843,
       "public_items": 59,
       "reexports": 10
     },
@@ -10926,7 +10931,7 @@
       "reexports": 0
     },
     "rocketmq-transport/src/clients/rocketmq_tokio_client/connection_registry.rs": {
-      "production_lines": 366,
+      "production_lines": 369,
       "public_items": 0,
       "reexports": 0
     },


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9643

### Brief Description

Preserve the original typed RocketMQ error across Tokio connect-flight leaders and waiters by sharing an immutable error snapshot instead of flattening failures into strings and reconstructing generic network errors.

### How Did You Test This Change?

Added shared-error metadata and source-chain contract tests, deterministic leader/multiple-waiter connect-flight tests for all current failure categories, and ran the applicable error, transport, runtime, API, workspace, and standalone-consumer validation profiles.