### PR TITLE
[ISSUE #9649]✨Improve Web Dashboard operational workflows

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/admin/dashboard_admin_client.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/admin/dashboard_admin_client.rs
@@ -524,12 +524,7 @@ impl DashboardAdminClient {
             connections: connections
                 .connections
                 .into_iter()
-                .map(|item| ProducerConnectionInfo {
-                    client_id: item.client_id,
-                    client_addr: item.client_addr,
-                    language: item.language,
-                    version: item.version.to_string(),
-                })
+                .map(map_producer_connection)
                 .collect(),
         })
     }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/admin/dashboard_admin_client/mapping.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/admin/dashboard_admin_client/mapping.rs
@@ -52,6 +52,15 @@ pub(super) fn map_broker_info(item: core::DashboardBrokerInfo) -> BrokerInfo {
     }
 }
 
+pub(super) fn map_producer_connection(item: core::DashboardProducerConnection) -> ProducerConnectionInfo {
+    ProducerConnectionInfo {
+        client_id: item.client_id,
+        client_addr: item.client_addr,
+        language: item.language,
+        version: item.version_desc,
+    }
+}
+
 pub(super) fn broker_target(value: &str) -> core::DashboardBrokerTarget {
     if value.contains(':') {
         core::DashboardBrokerTarget {
@@ -312,9 +321,11 @@ mod tests {
     use std::thread;
 
     use rocketmq_admin_core::core::dashboard::DashboardMessage;
+    use rocketmq_admin_core::core::dashboard::DashboardProducerConnection;
 
     use super::csv_escape;
     use super::map_message;
+    use super::map_producer_connection;
     use super::unique_admin_group;
 
     #[test]
@@ -374,6 +385,19 @@ mod tests {
             mapped.properties.get("STORE_MESSAGE_ID").map(String::as_str),
             Some("store-id")
         );
+    }
+
+    #[test]
+    fn maps_producer_version_description_instead_of_protocol_ordinal() {
+        let mapped = map_producer_connection(DashboardProducerConnection {
+            client_id: "client-a".to_string(),
+            client_addr: "127.0.0.1:10911".to_string(),
+            language: "RUST".to_string(),
+            version: 474,
+            version_desc: "V5_3_1_SNAPSHOT".to_string(),
+        });
+
+        assert_eq!(mapped.version, "V5_3_1_SNAPSHOT");
     }
 
     #[test]

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/config_api.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/config_api.rs
@@ -17,6 +17,7 @@ use crate::model::ApiResponse;
 use crate::model::BoolSettingRequest;
 use crate::model::ConfigMutationResult;
 use crate::model::DashboardConfigView;
+use crate::model::NameserverAvailabilityView;
 use crate::model::NameserverListRequest;
 use crate::service::delete_proxy as delete_proxy_service;
 use crate::service::get_config as get_config_service;
@@ -32,6 +33,14 @@ pub async fn get_config(
     State(state): State<AppState>,
 ) -> Result<Json<ApiResponse<DashboardConfigView>>, DashboardError> {
     Ok(Json(ApiResponse::success(get_config_service(&state).await)))
+}
+
+pub async fn get_nameserver_availability(
+    State(state): State<AppState>,
+) -> Result<Json<ApiResponse<NameserverAvailabilityView>>, DashboardError> {
+    Ok(Json(ApiResponse::success(
+        crate::service::get_nameserver_availability(&state).await,
+    )))
 }
 
 pub async fn replace_nameservers(

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/router.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/router.rs
@@ -136,7 +136,9 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/config", get(config_api::get_config))
         .route(
             "/api/config/nameservers",
-            post(config_api::add_nameserver).put(config_api::replace_nameservers),
+            get(config_api::get_nameserver_availability)
+                .post(config_api::add_nameserver)
+                .put(config_api::replace_nameservers),
         )
         .route("/api/config/vip-channel", put(config_api::set_vip_channel))
         .route("/api/config/tls", put(config_api::set_tls))

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/model/config_model.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/model/config_model.rs
@@ -51,6 +51,27 @@ pub struct DashboardConfigView {
     pub storage_backend: StorageBackend,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum NameserverAvailabilityStatus {
+    Available,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct NameserverEndpointAvailability {
+    pub address: String,
+    pub status: NameserverAvailabilityStatus,
+    pub checked_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct NameserverAvailabilityView {
+    pub endpoints: Vec<NameserverEndpointAvailability>,
+}
+
 impl Default for DashboardConfigView {
     fn default() -> Self {
         Self {

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/config_service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/config_service.rs
@@ -16,11 +16,47 @@ use crate::model::AddressRequest;
 use crate::model::BoolSettingRequest;
 use crate::model::ConfigMutationResult;
 use crate::model::DashboardConfigView;
+use crate::model::NameserverAvailabilityStatus;
+use crate::model::NameserverAvailabilityView;
+use crate::model::NameserverEndpointAvailability;
 use crate::model::NameserverListRequest;
 use crate::state::AppState;
+use chrono::Utc;
+use std::time::Duration;
+use tokio::net::TcpStream;
+use tokio::time::timeout;
+
+const NAMESERVER_AVAILABILITY_TIMEOUT: Duration = Duration::from_millis(800);
 
 pub async fn get_config(state: &AppState) -> DashboardConfigView {
     state.dashboard_config.read().await.clone()
+}
+
+pub async fn get_nameserver_availability(state: &AppState) -> NameserverAvailabilityView {
+    let addresses = state.dashboard_config.read().await.namesrv_addr_list.clone();
+    let mut endpoints = Vec::with_capacity(addresses.len());
+
+    for address in addresses {
+        endpoints.push(check_nameserver_endpoint(address).await);
+    }
+
+    NameserverAvailabilityView { endpoints }
+}
+
+async fn check_nameserver_endpoint(address: String) -> NameserverEndpointAvailability {
+    let status = match timeout(NAMESERVER_AVAILABILITY_TIMEOUT, TcpStream::connect(&address)).await {
+        Ok(Ok(stream)) => {
+            drop(stream);
+            NameserverAvailabilityStatus::Available
+        }
+        Ok(Err(_)) | Err(_) => NameserverAvailabilityStatus::Unavailable,
+    };
+
+    NameserverEndpointAvailability {
+        address,
+        status,
+        checked_at: Utc::now().timestamp_millis(),
+    }
 }
 
 pub async fn replace_nameservers(
@@ -186,12 +222,40 @@ fn normalize_address(value: &str, label: &str) -> Result<String, DashboardError>
 
 #[cfg(test)]
 mod tests {
+    use super::check_nameserver_endpoint;
     use super::normalize_address;
+    use crate::model::NameserverAvailabilityStatus;
+    use tokio::net::TcpListener;
 
     #[test]
     fn normalize_address_trims_and_lowercases_host() {
         let address = normalize_address(" LOCALHOST : 9876 ", "NameServer").expect("valid address");
 
         assert_eq!(address, "localhost:9876");
+    }
+
+    #[tokio::test]
+    async fn availability_check_reports_reachable_endpoint() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
+        let address = listener.local_addr().expect("listener address").to_string();
+
+        let result = check_nameserver_endpoint(address.clone()).await;
+
+        assert_eq!(result.address, address);
+        assert_eq!(result.status, NameserverAvailabilityStatus::Available);
+        assert!(result.checked_at > 0);
+    }
+
+    #[tokio::test]
+    async fn availability_check_reports_unreachable_endpoint() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
+        let address = listener.local_addr().expect("listener address").to_string();
+        drop(listener);
+
+        let result = check_nameserver_endpoint(address.clone()).await;
+
+        assert_eq!(result.address, address);
+        assert_eq!(result.status, NameserverAvailabilityStatus::Unavailable);
+        assert!(result.checked_at > 0);
     }
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/api/config_api.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/api/config_api.ts
@@ -4,11 +4,14 @@ import type {
   BoolSettingRequest,
   ConfigMutationResult,
   DashboardConfigView,
+  NameserverAvailabilityView,
   NameserverListRequest
 } from '../types/config';
 
 export const configApi = {
   getConfig: () => apiClient.get<DashboardConfigView>('/api/config'),
+  getNameserverAvailability: () =>
+    apiClient.get<NameserverAvailabilityView>('/api/config/nameservers'),
   replaceNameservers: (request: NameserverListRequest) =>
     apiClient.put<ConfigMutationResult>('/api/config/nameservers', request),
   addNameserver: (request: AddressRequest) =>

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConfigPage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConfigPage.test.tsx
@@ -1,14 +1,15 @@
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { configApi } from '../api/config_api';
 import { renderAtRoute } from '../test/render';
-import type { DashboardConfigView } from '../types/config';
+import type { DashboardConfigView, NameserverAvailabilityView } from '../types/config';
 import ConfigPage from './ConfigPage';
 
 vi.mock('../api/config_api', () => ({
   configApi: {
     getConfig: vi.fn(),
+    getNameserverAvailability: vi.fn(),
     replaceNameservers: vi.fn(),
     addNameserver: vi.fn(),
     setVipChannel: vi.fn(),
@@ -29,6 +30,13 @@ const initialConfig: DashboardConfigView = {
   storageBackend: 'file'
 };
 
+const initialAvailability: NameserverAvailabilityView = {
+  endpoints: [
+    { address: '10.0.0.10:9876', status: 'available', checkedAt: 1_700_000_000_000 },
+    { address: '10.0.0.11:9876', status: 'unavailable', checkedAt: 1_700_000_000_000 }
+  ]
+};
+
 const mockedConfigApi = vi.mocked(configApi);
 
 function mutationResult(config = initialConfig, message = 'Configuration updated') {
@@ -39,6 +47,7 @@ describe('ConfigPage', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     mockedConfigApi.getConfig.mockResolvedValue(initialConfig);
+    mockedConfigApi.getNameserverAvailability.mockResolvedValue(initialAvailability);
     mockedConfigApi.replaceNameservers.mockImplementation((request) => mutationResult({
       ...initialConfig,
       namesrvAddrList: request.namesrvAddrList,
@@ -58,7 +67,8 @@ describe('ConfigPage', () => {
     await screen.findByRole('heading', { name: 'OPS settings' });
 
     await user.selectOptions(screen.getByLabelText('Current NameServer'), '10.0.0.11:9876');
-    await user.click(screen.getByRole('button', { name: 'Save NameServers' }));
+    expect(screen.getByText('Active endpoint change pending')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Apply active endpoint' }));
 
     await waitFor(() => expect(mockedConfigApi.replaceNameservers).toHaveBeenCalledWith({
       namesrvAddrList: ['10.0.0.10:9876', '10.0.0.11:9876'],
@@ -66,6 +76,52 @@ describe('ConfigPage', () => {
     }));
     expect(onConfigUpdated).toHaveBeenCalledTimes(1);
     window.removeEventListener('rocketmq-config-updated', onConfigUpdated);
+  });
+
+  it('only shows active endpoint actions while the selection has unsaved changes', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<ConfigPage />, '/config');
+    await screen.findByRole('heading', { name: 'OPS settings' });
+
+    expect(screen.queryByRole('button', { name: 'Apply active endpoint' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Configuration is current')).not.toBeInTheDocument();
+
+    await user.selectOptions(screen.getByLabelText('Current NameServer'), '10.0.0.11:9876');
+
+    const pendingStatus = screen.getByText('Active endpoint change pending').closest('[role="status"]');
+    expect(pendingStatus).not.toBeNull();
+    expect(within(pendingStatus as HTMLElement).getByText('10.0.0.10:9876')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Apply active endpoint' })).toBeEnabled();
+
+    await user.click(screen.getByRole('button', { name: 'Discard change' }));
+
+    expect(screen.getByLabelText('Current NameServer')).toHaveValue('10.0.0.10:9876');
+    expect(screen.queryByRole('button', { name: 'Apply active endpoint' })).not.toBeInTheDocument();
+  });
+
+  it('shows the endpoint legend and refreshes independent NameServer availability', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<ConfigPage />, '/config');
+
+    const table = await screen.findByRole('table', { name: 'NameServer endpoints' });
+    const unavailableRow = within(table).getByRole('row', { name: /10\.0\.0\.11:9876/ });
+    await waitFor(() => expect(within(unavailableRow).getByText('Unavailable')).toBeInTheDocument());
+    expect(screen.getByLabelText('NameServer endpoint legend')).toHaveTextContent('Current');
+    expect(screen.getByLabelText('NameServer endpoint legend')).toHaveTextContent('Checking');
+
+    let resolveAvailability: ((value: NameserverAvailabilityView) => void) | undefined;
+    mockedConfigApi.getNameserverAvailability.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveAvailability = resolve;
+    }));
+
+    await user.click(screen.getByRole('button', { name: 'Check all NameServer endpoints' }));
+    expect(within(unavailableRow).getByText('Checking')).toBeInTheDocument();
+    resolveAvailability?.({
+      endpoints: initialAvailability.endpoints.map((endpoint) => ({ ...endpoint, status: 'available' }))
+    });
+
+    await waitFor(() => expect(within(unavailableRow).getByText('Available')).toBeInTheDocument());
+    expect(mockedConfigApi.getNameserverAvailability).toHaveBeenCalledTimes(2);
   });
 
   it('adds a NameServer with the exact normalized address and clears the input only after success', async () => {
@@ -116,7 +172,7 @@ describe('ConfigPage', () => {
     expect(screen.getByRole('button', { name: 'Reload OPS settings' })).toBeDisabled();
     expect(screen.getByLabelText('Add NameServer')).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Add NameServer' })).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Remove 10.0.0.10:9876' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Remove 10.0.0.11:9876' })).toBeDisabled();
     expect(mockedConfigApi.getConfig).toHaveBeenCalledTimes(1);
     expect(mockedConfigApi.addNameserver).not.toHaveBeenCalled();
     expect(mockedConfigApi.replaceNameservers).not.toHaveBeenCalled();
@@ -180,22 +236,12 @@ describe('ConfigPage', () => {
     expect(mockedConfigApi.replaceNameservers).not.toHaveBeenCalled();
   });
 
-  it('removes the current NameServer with the remaining endpoint as the exact current fallback', async () => {
-    const user = userEvent.setup();
-    const onConfigUpdated = vi.fn();
-    window.addEventListener('rocketmq-config-updated', onConfigUpdated);
+  it('protects the current NameServer from removal until another endpoint is selected', async () => {
     renderAtRoute(<ConfigPage />, '/config');
     await screen.findByRole('heading', { name: 'OPS settings' });
 
-    await user.click(screen.getByRole('button', { name: 'Remove 10.0.0.10:9876' }));
-    await user.click(screen.getByRole('button', { name: 'Remove NameServer' }));
-
-    await waitFor(() => expect(mockedConfigApi.replaceNameservers).toHaveBeenCalledWith({
-      namesrvAddrList: ['10.0.0.11:9876'],
-      currentNamesrv: '10.0.0.11:9876'
-    }));
-    expect(onConfigUpdated).toHaveBeenCalledTimes(1);
-    window.removeEventListener('rocketmq-config-updated', onConfigUpdated);
+    expect(screen.queryByRole('button', { name: 'Remove 10.0.0.10:9876' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Remove 10.0.0.11:9876' })).toBeEnabled();
   });
 });
 

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConfigPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConfigPage.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, Plus, RefreshCw, RotateCcw, Save, Trash2 } from 'lucide-react';
+import { AlertTriangle, RefreshCw } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { configApi } from '../api/config_api';
 import ErrorState from '../components/ErrorState';
@@ -8,9 +8,8 @@ import StatusBadge from '../components/StatusBadge';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogTitle } from '../components/ui/AlertDialog';
 import { Button } from '../components/ui/Button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/Card';
-import { Input } from '../components/ui/Input';
-import { Label } from '../components/ui/Label';
-import type { ConfigMutationResult, DashboardConfigView } from '../types/config';
+import type { ConfigMutationResult, DashboardConfigView, NameserverAvailabilityView } from '../types/config';
+import ConnectionSettingsSection from './settings/ConnectionSettingsSection';
 import SettingsSectionNav, { type SettingsSection } from './settings/SettingsSectionNav';
 import { isNameserverDraftDirty, normalizeNameserverDraft, type NameserverDraft } from './settings/settings-model';
 
@@ -28,7 +27,11 @@ export default function ConfigPage() {
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<Notice | null>(null);
+  const [nameserverAvailability, setNameserverAvailability] = useState<NameserverAvailabilityView | null>(null);
+  const [availabilityLoading, setAvailabilityLoading] = useState(false);
+  const [availabilityError, setAvailabilityError] = useState<string | null>(null);
   const mutationInFlight = useRef(false);
+  const availabilityRequest = useRef(0);
 
   const load = () => {
     if (isDirty) return;
@@ -36,7 +39,10 @@ export default function ConfigPage() {
     setError(null);
     configApi
       .getConfig()
-      .then((nextConfig) => applyConfig(nextConfig))
+      .then((nextConfig) => {
+        applyConfig(nextConfig);
+        void checkNameserverAvailability();
+      })
       .catch((requestError: Error) => setError(requestError.message))
       .finally(() => setLoading(false));
   };
@@ -61,6 +67,22 @@ export default function ConfigPage() {
     if (message) setNotice({ tone: 'success', message });
   }
 
+  async function checkNameserverAvailability() {
+    const requestId = ++availabilityRequest.current;
+    setAvailabilityLoading(true);
+    setAvailabilityError(null);
+    try {
+      const result = await configApi.getNameserverAvailability();
+      if (requestId === availabilityRequest.current) setNameserverAvailability(result);
+    } catch (requestError) {
+      if (requestId === availabilityRequest.current) {
+        setAvailabilityError(requestError instanceof Error ? requestError.message : 'Unable to check NameServer availability.');
+      }
+    } finally {
+      if (requestId === availabilityRequest.current) setAvailabilityLoading(false);
+    }
+  }
+
   async function runMutation(mutation: () => Promise<ConfigMutationResult>, onSuccess?: () => void) {
     if (mutationInFlight.current) return;
 
@@ -72,6 +94,7 @@ export default function ConfigPage() {
       applyConfig(result.config, result.message || 'Configuration updated.');
       onSuccess?.();
       window.dispatchEvent(new CustomEvent('rocketmq-config-updated'));
+      void checkNameserverAvailability();
     } catch (requestError) {
       setNotice({ tone: 'danger', message: requestError instanceof Error ? requestError.message : 'Configuration update failed.' });
     } finally {
@@ -136,7 +159,7 @@ export default function ConfigPage() {
       <div className="settings-workspace">
         <SettingsSectionNav activeSection={activeSection} onSelect={requestSectionChange} />
         <div className="settings-section-content">
-          {activeSection === 'connection' ? <ConnectionSection draft={nameserverDraft} newNameserver={newNameserver} dirty={isDirty} pending={pending} onDraftChange={setNameserverDraft} onNewNameserverChange={setNewNameserver} onAdd={addNameserver} onRemove={setNameserverToRemove} onSave={saveNameservers} onReset={() => setNameserverDraft(savedDraft)} /> : null}
+          {activeSection === 'connection' ? <ConnectionSettingsSection draft={nameserverDraft} savedCurrentNamesrv={savedDraft?.currentNamesrv ?? null} newNameserver={newNameserver} dirty={isDirty} pending={pending} availability={nameserverAvailability} availabilityLoading={availabilityLoading} availabilityError={availabilityError} onDraftChange={setNameserverDraft} onNewNameserverChange={setNewNameserver} onAdd={addNameserver} onRemove={setNameserverToRemove} onSave={saveNameservers} onReset={() => setNameserverDraft(savedDraft)} onCheckAvailability={() => void checkNameserverAvailability()} /> : null}
           {activeSection === 'security' ? <SecuritySection useVIPChannel={config.useVIPChannel} useTLS={config.useTLS} pending={pending} onToggleVip={() => void runMutation(() => configApi.setVipChannel({ enabled: !config.useVIPChannel }))} onToggleTls={() => void runMutation(() => configApi.setTls({ enabled: !config.useTLS }))} /> : null}
           {activeSection === 'storage' ? <StorageSection storageBackend={storageBackend} /> : null}
         </div>
@@ -157,23 +180,6 @@ export default function ConfigPage() {
       </AlertDialog>
     </>
   );
-}
-
-interface ConnectionSectionProps {
-  draft: NameserverDraft;
-  newNameserver: string;
-  dirty: boolean;
-  pending: boolean;
-  onDraftChange: (draft: NameserverDraft) => void;
-  onNewNameserverChange: (value: string) => void;
-  onAdd: () => void;
-  onRemove: (address: string) => void;
-  onSave: () => void;
-  onReset: () => void;
-}
-
-function ConnectionSection({ draft, newNameserver, dirty, pending, onDraftChange, onNewNameserverChange, onAdd, onRemove, onSave, onReset }: ConnectionSectionProps) {
-  return <Card className="settings-card"><CardHeader><div><CardTitle>Connection</CardTitle><CardDescription>Choose the NameServer endpoint that the dashboard uses for RocketMQ operations.</CardDescription></div><StatusBadge status={draft.currentNamesrv ?? 'unconfigured'} tone={draft.currentNamesrv ? 'success' : 'warning'} /></CardHeader><CardContent className="settings-card-content"><div className="settings-field-grid"><label className="settings-field"><span>Current NameServer</span><select aria-label="Current NameServer" value={draft.currentNamesrv ?? ''} onChange={(event) => onDraftChange({ ...draft, currentNamesrv: event.target.value || null })}>{draft.namesrvAddrList.length === 0 ? <option value="">No NameServers configured</option> : null}{draft.namesrvAddrList.map((address) => <option key={address} value={address}>{address}</option>)}</select></label><div className="settings-field"><span>Configured NameServers</span><div className="settings-address-list" aria-label="Configured NameServers">{draft.namesrvAddrList.length === 0 ? <span className="settings-empty-value">No endpoints configured</span> : null}{draft.namesrvAddrList.map((address) => <span className="settings-address-item" key={address}><code>{address}</code><Button type="button" variant="ghost" size="icon" aria-label={`Remove ${address}`} title={`Remove ${address}`} disabled={pending || dirty} onClick={() => onRemove(address)}><Trash2 size={14} aria-hidden="true" /></Button></span>)}</div></div></div><div className="settings-add-row"><Label htmlFor="new-nameserver">Add NameServer</Label><div><Input id="new-nameserver" value={newNameserver} placeholder="127.0.0.1:9876" disabled={pending || dirty} onChange={(event) => onNewNameserverChange(event.target.value)} onKeyDown={(event) => event.key === 'Enter' && onAdd()} /><Button type="button" onClick={onAdd} disabled={pending || dirty}><Plus size={15} aria-hidden="true" />Add NameServer</Button></div></div><div className="settings-actions"><span>{dirty ? 'Unsaved NameServer changes' : 'NameServer configuration is current'}</span><div><Button type="button" variant="outline" onClick={onReset} disabled={!dirty || pending}><RotateCcw size={15} aria-hidden="true" />Reset draft</Button><Button type="button" onClick={onSave} disabled={!dirty || pending}><Save size={15} aria-hidden="true" />Save NameServers</Button></div></div></CardContent></Card>;
 }
 
 interface SecuritySectionProps { useVIPChannel: boolean; useTLS: boolean; pending: boolean; onToggleVip: () => void; onToggleTls: () => void; }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/MessageQueryPage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/MessageQueryPage.test.tsx
@@ -55,6 +55,32 @@ describe('MessageQueryPage', () => {
     expect(await screen.findByRole('dialog', { name: 'Message detail' })).toBeInTheDocument();
   });
 
+  it('filters and selects the message topic before querying', async () => {
+    const user = userEvent.setup();
+    vi.mocked(topicApi.list).mockResolvedValue({
+      items: [
+        { ...message, topic: 'orders', brokerName: 'broker-a' },
+        { ...message, topic: 'payment-events', brokerName: 'broker-a' },
+        { ...message, topic: 'audit-log', brokerName: 'broker-b' }
+      ],
+      total: 3
+    } as never);
+
+    renderAtRoute(<MessageQueryPage />, '/messages');
+    await screen.findByRole('heading', { name: 'Message search' });
+    await user.click(screen.getByRole('button', { name: 'Message topic' }));
+    await user.type(screen.getByRole('textbox', { name: 'Message topic search' }), 'payment');
+
+    const options = screen.getByRole('listbox', { name: 'Message topic' });
+    expect(within(options).getByRole('option', { name: 'payment-events' })).toBeInTheDocument();
+    expect(within(options).queryByRole('option', { name: 'orders' })).not.toBeInTheDocument();
+    await user.click(within(options).getByRole('option', { name: 'payment-events' }));
+    expect(screen.getByRole('button', { name: 'Message topic' })).toHaveTextContent('payment-events');
+
+    await user.click(screen.getByRole('button', { name: 'Search messages' }));
+    await waitFor(() => expect(messageApi.list).toHaveBeenCalledWith(expect.objectContaining({ topic: 'payment-events' })));
+  });
+
   it('validates time ranges and confirms the exact resend request', async () => {
     const user = userEvent.setup();
     renderAtRoute(<MessageQueryPage />, '/messages');
@@ -213,7 +239,7 @@ describe('MessageQueryPage', () => {
     await user.click(screen.getByRole('button', { name: 'Retry topics' }));
 
     await waitFor(() => expect(topicApi.list).toHaveBeenCalledTimes(2));
-    expect(screen.getByRole('combobox', { name: 'Message topic' })).toHaveValue('orders');
+    expect(screen.getByRole('button', { name: 'Message topic' })).toHaveTextContent('orders');
     expect(screen.queryByText('Topic discovery failed: nameserver unavailable')).not.toBeInTheDocument();
   });
 

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/MessageQueryPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/MessageQueryPage.tsx
@@ -7,6 +7,7 @@ import EntitySheet from '../components/EntitySheet';
 import MetricCard from '../components/MetricCard';
 import PageHeader from '../components/PageHeader';
 import RefreshButton from '../components/RefreshButton';
+import SelectMenu from '../components/SelectMenu';
 import StatusBadge from '../components/StatusBadge';
 import {
   AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription,
@@ -98,6 +99,12 @@ export default function MessageQueryPage() {
   }, [invalidateResend, selected?.messageId]);
 
   const visibleRows = useMemo(() => rows.slice((page - 1) * pageSize, page * pageSize), [page, rows]);
+  const topicOptions = useMemo(
+    () => topics.length === 0
+      ? [{ value: '', label: 'Select a topic' }]
+      : topics.map((topic) => ({ value: topic, label: topic })),
+    [topics]
+  );
   const columns: AppDataTableColumn<MessageView>[] = [
     {
       id: 'message-id', header: 'Message ID', width: '31%',
@@ -231,11 +238,16 @@ export default function MessageQueryPage() {
         <CardContent>
           <div className="message-query-grid">
             <div className="message-query-field">
-              <Label htmlFor="message-topic">Message topic</Label>
-              <select id="message-topic" value={form.topic} onChange={(event) => updateForm({ ...form, topic: event.target.value })}>
-                {topics.length === 0 ? <option value="">Select a topic</option> : null}
-                {topics.map((topic) => <option key={topic} value={topic}>{topic}</option>)}
-              </select>
+              <Label>Message topic</Label>
+              <SelectMenu
+                value={form.topic}
+                options={topicOptions}
+                onChange={(topic) => updateForm({ ...form, topic })}
+                ariaLabel="Message topic"
+                className="message-query-topic-select"
+                searchable
+                searchPlaceholder="Search topics"
+              />
             </div>
             {form.mode === 'topic' ? (
               <>

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ProducerListPage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ProducerListPage.test.tsx
@@ -49,6 +49,18 @@ const connectionView: ProducerConnectionView = {
   ]
 };
 
+async function selectProducerTopic(
+  user: ReturnType<typeof userEvent.setup>,
+  topic: string,
+  query = topic
+) {
+  await user.click(screen.getByRole('button', { name: 'Producer topic' }));
+  const search = screen.getByRole('textbox', { name: 'Producer topic search' });
+  await user.type(search, query);
+  const listbox = screen.getByRole('listbox', { name: 'Producer topic' });
+  await user.click(within(listbox).getByRole('option', { name: topic }));
+}
+
 describe('ProducerListPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -83,7 +95,14 @@ describe('ProducerListPage', () => {
     const producerRow = screen.getByRole('row', { name: /payment-producer/ });
     await user.click(producerRow);
     expect(producerApi.connections).not.toHaveBeenCalled();
-    await user.selectOptions(screen.getByRole('combobox', { name: 'Producer topic' }), 'payment-events');
+    await user.click(screen.getByRole('button', { name: 'Producer topic' }));
+    const topicSearch = screen.getByRole('textbox', { name: 'Producer topic search' });
+    await user.type(topicSearch, 'payment');
+    const topicOptions = screen.getByRole('listbox', { name: 'Producer topic' });
+    expect(within(topicOptions).getByRole('option', { name: 'payment-events' })).toBeInTheDocument();
+    expect(within(topicOptions).queryByRole('option', { name: 'orders' })).not.toBeInTheDocument();
+    await user.click(within(topicOptions).getByRole('option', { name: 'payment-events' }));
+    expect(screen.getByRole('button', { name: 'Producer topic' })).toHaveTextContent('payment-events');
     await user.click(screen.getByRole('button', { name: 'Query producer connections' }));
     expect(producerApi.connections).toHaveBeenCalledWith('payment-events', 'payment-producer');
     expect(screen.getByRole('status', { name: 'Loading producer connections' })).toBeInTheDocument();
@@ -106,7 +125,7 @@ describe('ProducerListPage', () => {
     await screen.findByRole('heading', { name: 'Producers' });
 
     await user.click(screen.getByRole('row', { name: /order-producer/ }));
-    await user.selectOptions(screen.getByRole('combobox', { name: 'Producer topic' }), 'orders');
+    await selectProducerTopic(user, 'orders');
     await user.click(screen.getByRole('button', { name: 'Query producer connections' }));
     expect(await screen.findByText('connection lookup unavailable')).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Retry connection query' }));
@@ -125,11 +144,11 @@ describe('ProducerListPage', () => {
     await screen.findByRole('heading', { name: 'Producers' });
 
     await user.click(screen.getByRole('row', { name: /order-producer/ }));
-    await user.selectOptions(screen.getByRole('combobox', { name: 'Producer topic' }), 'orders');
+    await selectProducerTopic(user, 'orders');
     await user.click(screen.getByRole('button', { name: 'Query producer connections' }));
 
     await user.click(screen.getByRole('row', { name: /payment-producer/ }));
-    await user.selectOptions(screen.getByRole('combobox', { name: 'Producer topic' }), 'payment-events');
+    await selectProducerTopic(user, 'payment-events');
     await user.click(screen.getByRole('button', { name: 'Query producer connections' }));
 
     resolvePayments(connectionView);
@@ -157,6 +176,7 @@ describe('ProducerListPage', () => {
     await user.click(screen.getByRole('button', { name: 'Refresh topics' }));
 
     await waitFor(() => expect(topicApi.list).toHaveBeenCalledTimes(2));
-    expect(await screen.findByRole('option', { name: 'orders' })).toBeInTheDocument();
+    await user.click(await screen.findByRole('button', { name: 'Producer topic' }));
+    expect(screen.getByRole('option', { name: 'orders' })).toBeInTheDocument();
   });
 });

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ProducerListPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ProducerListPage.tsx
@@ -11,6 +11,7 @@ import MetricCard from '../components/MetricCard';
 import PageHeader from '../components/PageHeader';
 import QueryToolbar from '../components/QueryToolbar';
 import RefreshButton from '../components/RefreshButton';
+import SelectMenu from '../components/SelectMenu';
 import StatusBadge from '../components/StatusBadge';
 import { Button } from '../components/ui/Button';
 import type { ProducerConnectionInfo, ProducerConnectionView, ProducerInfo } from '../types/producer';
@@ -61,6 +62,13 @@ export default function ProducerListPage() {
   const availableTopics = useMemo(
     () => Array.from(new Set(topics.map((topic) => topic.topic).filter(Boolean))).sort(),
     [topics]
+  );
+  const topicOptions = useMemo(
+    () => [
+      { value: '', label: 'Select a topic' },
+      ...availableTopics.map((topic) => ({ value: topic, label: topic }))
+    ],
+    [availableTopics]
   );
   const filteredProducers = useMemo(() => filterProducers(items, query), [items, query]);
   const pageCount = Math.max(1, Math.ceil(filteredProducers.length / PAGE_SIZE));
@@ -249,18 +257,18 @@ export default function ProducerListPage() {
           ) : (
             <>
               <div className="producer-query-controls">
-                <label>
+                <div className="producer-topic-field">
                   <span>Topic</span>
-                  <select
-                    className="ui-select-native"
-                    aria-label="Producer topic"
+                  <SelectMenu
                     value={selectedTopic}
-                    onChange={(event) => changeTopic(event.target.value)}
-                  >
-                    <option value="">Select a topic</option>
-                    {availableTopics.map((topic) => <option key={topic} value={topic}>{topic}</option>)}
-                  </select>
-                </label>
+                    options={topicOptions}
+                    onChange={changeTopic}
+                    ariaLabel="Producer topic"
+                    className="producer-connection-topic-select"
+                    searchable
+                    searchPlaceholder="Search topics"
+                  />
+                </div>
                 <Button
                   type="button"
                   variant="outline"

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/ConsumerDetailContent.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/ConsumerDetailContent.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { configApi } from '../../api/config_api';
 import { consumerApi } from '../../api/consumer_api';
+import type { ConsumerProgressView } from '../../types/consumer';
 import { render } from '@testing-library/react';
 import { ConsumerQueryScopeProvider } from './ConsumerQueryScopeProvider';
 import ConsumerDetailContent from './ConsumerDetailContent';
@@ -119,6 +120,39 @@ describe('ConsumerDetailContent', () => {
     expect(await screen.findByText('orders')).toBeInTheDocument();
     expect(screen.getByText('broker-a')).toBeInTheDocument();
     expect(screen.getByText('12')).toBeInTheDocument();
+  });
+
+  it('refreshes the active progress view without shifting the tab layout', async () => {
+    const user = userEvent.setup();
+    renderContent('order-service', 'progress');
+
+    expect(await screen.findByText('Lag 12')).toBeInTheDocument();
+    const refreshedProgress: ConsumerProgressView = {
+      group: 'order-service',
+      topicCount: 1,
+      totalDiff: 7,
+      topics: [{
+        topic: 'orders',
+        diffTotal: 7,
+        lastTimestamp: 1_700_000_000_000,
+        queues: [{
+          brokerName: 'broker-a', queueId: 0, brokerOffset: 100, consumerOffset: 93,
+          diffTotal: 7, clientInfo: '10.0.0.8@client-a', lastTimestamp: 1_700_000_000_000
+        }]
+      }],
+      queryScope: { mode: 'nameServer' }
+    };
+    let resolveRefresh!: (value: typeof refreshedProgress) => void;
+    vi.mocked(consumerApi.progress).mockImplementationOnce(() => new Promise((resolve) => {
+      resolveRefresh = resolve;
+    }));
+
+    await user.click(screen.getByRole('button', { name: 'Refresh' }));
+    expect(screen.getByRole('button', { name: 'Refreshing' })).toBeDisabled();
+    resolveRefresh(refreshedProgress);
+    await waitFor(() => expect(consumerApi.progress).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText('Lag 7')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Progress' })).toHaveAttribute('data-state', 'active');
   });
 
   it('requires a valid timestamp before reset review', async () => {

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/ConsumerDetailContent.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/ConsumerDetailContent.tsx
@@ -5,6 +5,7 @@ import AppDataTable, { type AppDataTableColumn } from '../../components/AppDataT
 import ErrorState from '../../components/ErrorState';
 import LoadingState from '../../components/LoadingState';
 import MetricCard from '../../components/MetricCard';
+import RefreshButton from '../../components/RefreshButton';
 import StatusBadge from '../../components/StatusBadge';
 import {
   AlertDialog,
@@ -168,6 +169,19 @@ export default function ConsumerDetailContent({ group, initialTab = 'overview' }
 
   const topics = progress?.topics ?? [];
   const topicOptions = useMemo(() => topics.map((topic) => topic.topic), [topics]);
+  const refreshing = activeTab === 'clients' ? clientsLoading : activeTab === 'config' ? configLoading : loading;
+
+  const refreshActiveTab = async () => {
+    if (activeTab === 'clients') {
+      await loadClients();
+      return;
+    }
+    if (activeTab === 'config') {
+      await loadConfig();
+      return;
+    }
+    await load();
+  };
 
   const reviewReset = () => {
     const timestamp = parseLocalDateTime(resetTime);
@@ -221,19 +235,23 @@ export default function ConsumerDetailContent({ group, initialTab = 'overview' }
   return (
     <div className="entity-detail-content consumer-detail-content">
       {notice ? <div className="notice notice-success" role="status">{notice}</div> : null}
-      {loading && progress ? <LoadingState label="Refreshing consumer workspace" /> : null}
       {!loading && error && progress ? (
         <ErrorState message={error} onRetry={() => void load()} retryLabel="Retry workspace refresh" />
       ) : null}
 
       <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as typeof activeTab)}>
-        <TabsList aria-label="Consumer detail sections">
-          <TabsTrigger value="overview">Overview</TabsTrigger>
-          <TabsTrigger value="clients">Clients</TabsTrigger>
-          <TabsTrigger value="progress">Progress</TabsTrigger>
-          <TabsTrigger value="config">Configuration</TabsTrigger>
-          <TabsTrigger value="reset">Reset offset</TabsTrigger>
-        </TabsList>
+        <div className="consumer-detail-tab-bar">
+          <TabsList aria-label="Consumer detail sections">
+            <TabsTrigger value="overview">Overview</TabsTrigger>
+            <TabsTrigger value="clients">Clients</TabsTrigger>
+            <TabsTrigger value="progress">Progress</TabsTrigger>
+            <TabsTrigger value="config">Configuration</TabsTrigger>
+            <TabsTrigger value="reset">Reset offset</TabsTrigger>
+          </TabsList>
+          <div className="consumer-detail-refresh-control">
+            <RefreshButton refreshing={refreshing} onRefresh={() => void refreshActiveTab()} />
+          </div>
+        </div>
 
         <TabsContent value="overview">
           <div className="metric-grid entity-detail-metrics">

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/settings/ConnectionSettingsSection.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/settings/ConnectionSettingsSection.tsx
@@ -1,0 +1,268 @@
+import {
+  AlertTriangle,
+  CircleCheck,
+  CircleX,
+  Database,
+  LoaderCircle,
+  Plus,
+  RefreshCw,
+  RotateCcw,
+  Save,
+  Trash2
+} from 'lucide-react';
+import { Badge } from '../../components/ui/Badge';
+import { Button } from '../../components/ui/Button';
+import { Input } from '../../components/ui/Input';
+import { Label } from '../../components/ui/Label';
+import type { NameserverAvailabilityView, NameserverEndpointAvailability } from '../../types/config';
+import type { NameserverDraft } from './settings-model';
+
+interface ConnectionSettingsSectionProps {
+  draft: NameserverDraft;
+  savedCurrentNamesrv: string | null;
+  newNameserver: string;
+  dirty: boolean;
+  pending: boolean;
+  availability: NameserverAvailabilityView | null;
+  availabilityLoading: boolean;
+  availabilityError: string | null;
+  onDraftChange: (draft: NameserverDraft) => void;
+  onNewNameserverChange: (value: string) => void;
+  onAdd: () => void;
+  onRemove: (address: string) => void;
+  onSave: () => void;
+  onReset: () => void;
+  onCheckAvailability: () => void;
+}
+
+type DisplayAvailability = NameserverEndpointAvailability['status'] | 'checking';
+
+export default function ConnectionSettingsSection({
+  draft,
+  savedCurrentNamesrv,
+  newNameserver,
+  dirty,
+  pending,
+  availability,
+  availabilityLoading,
+  availabilityError,
+  onDraftChange,
+  onNewNameserverChange,
+  onAdd,
+  onRemove,
+  onSave,
+  onReset,
+  onCheckAvailability
+}: ConnectionSettingsSectionProps) {
+  const availabilityByAddress = new Map(availability?.endpoints.map((endpoint) => [endpoint.address, endpoint]));
+  const currentAvailability = availabilityFor(draft.currentNamesrv, availabilityByAddress, availabilityLoading);
+
+  return (
+    <section className="settings-connection-panel" aria-labelledby="settings-connection-title">
+      <h2 id="settings-connection-title" className="sr-only">Connection</h2>
+
+      <section className="settings-current-section" aria-labelledby="current-nameserver-heading">
+        <h3 id="current-nameserver-heading">Active NameServer</h3>
+        <div className="settings-current-nameserver">
+          <div className="settings-current-identity">
+            <span className="settings-endpoint-icon"><Database size={18} aria-hidden="true" /></span>
+            <label>
+              <span className="sr-only">Current NameServer</span>
+              <select
+                aria-label="Current NameServer"
+                value={draft.currentNamesrv ?? ''}
+                onChange={(event) => onDraftChange({ ...draft, currentNamesrv: event.target.value || null })}
+              >
+                {draft.namesrvAddrList.length === 0 ? <option value="">No NameServers configured</option> : null}
+                {draft.namesrvAddrList.map((address) => <option key={address} value={address}>{address}</option>)}
+              </select>
+            </label>
+            {draft.currentNamesrv ? <Badge tone={dirty ? 'warning' : 'info'}>{dirty ? 'Pending' : 'Current'}</Badge> : null}
+            <p>
+              {dirty
+                ? 'This endpoint is selected in your draft. Apply the change to make it active.'
+                : 'Clients and dashboard operations use this endpoint.'}
+            </p>
+          </div>
+          <div className="settings-current-status">
+            <AvailabilityState status={currentAvailability.status} />
+            <small>{lastCheckedLabel(currentAvailability.endpoint, availabilityLoading)}</small>
+          </div>
+        </div>
+        {dirty ? (
+          <div className="settings-current-draft" role="status" aria-live="polite">
+            <AlertTriangle size={18} aria-hidden="true" />
+            <div className="settings-current-draft-copy">
+              <strong>Active endpoint change pending</strong>
+              <p>
+                <code>{savedCurrentNamesrv ?? 'None'}</code>
+                <span aria-hidden="true"> → </span>
+                <span className="sr-only"> will change to </span>
+                <code>{draft.currentNamesrv ?? 'None'}</code>
+              </p>
+              <small>Apply or discard this selection before editing the endpoint inventory.</small>
+            </div>
+            <div className="settings-current-draft-actions">
+              <Button type="button" variant="outline" onClick={onReset} disabled={pending}>
+                <RotateCcw size={15} aria-hidden="true" />Discard change
+              </Button>
+              <Button type="button" onClick={onSave} disabled={pending}>
+                <Save size={15} aria-hidden="true" />Apply active endpoint
+              </Button>
+            </div>
+          </div>
+        ) : null}
+      </section>
+
+      <section className="settings-endpoints-section" aria-labelledby="nameserver-endpoints-heading">
+        <div className="settings-endpoints-heading">
+          <div>
+            <h3 id="nameserver-endpoints-heading">NameServer endpoints</h3>
+            <p>Configured endpoints and their latest reachability check.</p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onCheckAvailability}
+            disabled={availabilityLoading || pending}
+            aria-label="Check all NameServer endpoints"
+          >
+            <RefreshCw className={availabilityLoading ? 'spin' : undefined} size={15} aria-hidden="true" />
+            {availabilityLoading ? 'Checking' : 'Check all'}
+          </Button>
+        </div>
+
+        <EndpointLegend />
+
+        {availabilityError ? <div className="settings-availability-error" role="alert">{availabilityError}</div> : null}
+        <div
+          className="settings-endpoint-table-scroll"
+          role="region"
+          aria-label="NameServer endpoint availability"
+          aria-busy={availabilityLoading}
+        >
+          <table className="settings-endpoint-table" aria-label="NameServer endpoints">
+            <thead>
+              <tr>
+                <th scope="col">NameServer endpoint</th>
+                <th scope="col">Role</th>
+                <th scope="col">Availability</th>
+                <th scope="col">Last checked</th>
+                <th scope="col"><span className="sr-only">Actions</span></th>
+              </tr>
+            </thead>
+            <tbody>
+              {draft.namesrvAddrList.map((address) => {
+                const isCurrent = savedCurrentNamesrv === address;
+                const isPending = dirty && draft.currentNamesrv === address;
+                const endpointAvailability = availabilityFor(address, availabilityByAddress, availabilityLoading);
+                return (
+                  <tr key={address}>
+                    <td>
+                      <span className="settings-endpoint-address">
+                        <span className="settings-endpoint-icon"><Database size={16} aria-hidden="true" /></span>
+                        <code>{address}</code>
+                      </span>
+                    </td>
+                    <td>
+                      <Badge tone={isCurrent ? 'info' : isPending ? 'warning' : 'neutral'}>
+                        {isCurrent ? 'Current' : isPending ? 'Pending' : 'Standby'}
+                      </Badge>
+                    </td>
+                    <td><AvailabilityState status={endpointAvailability.status} /></td>
+                    <td><span className="settings-last-checked">{lastCheckedLabel(endpointAvailability.endpoint, availabilityLoading)}</span></td>
+                    <td className="settings-endpoint-actions">
+                      {isCurrent ? (
+                        <span className="settings-current-action" aria-label="Current endpoint cannot be removed">—</span>
+                      ) : (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          aria-label={`Remove ${address}`}
+                          title={`Remove ${address}`}
+                          disabled={pending || dirty}
+                          onClick={() => onRemove(address)}
+                        >
+                          <Trash2 size={15} aria-hidden="true" />
+                        </Button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+              {draft.namesrvAddrList.length === 0 ? (
+                <tr><td className="settings-endpoints-empty" colSpan={5}>No NameServer endpoints configured.</td></tr>
+              ) : null}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <div className="settings-add-row">
+        <div>
+          <Label htmlFor="new-nameserver">Add NameServer</Label>
+          <p>New endpoints are saved immediately after they are added.</p>
+        </div>
+        <div className="settings-add-control">
+          <Input
+            id="new-nameserver"
+            value={newNameserver}
+            placeholder="Enter host:port, e.g. 10.0.0.1:9876"
+            disabled={pending || dirty}
+            onChange={(event) => onNewNameserverChange(event.target.value)}
+            onKeyDown={(event) => event.key === 'Enter' && onAdd()}
+          />
+          <Button type="button" onClick={onAdd} disabled={pending || dirty}>
+            <Plus size={15} aria-hidden="true" />Add NameServer
+          </Button>
+        </div>
+      </div>
+
+    </section>
+  );
+}
+
+function EndpointLegend() {
+  return (
+    <div className="settings-endpoint-legend" aria-label="NameServer endpoint legend">
+      <span><Badge tone="info">Current</Badge><small>Active endpoint used by dashboard operations</small></span>
+      <span><AvailabilityState status="available" /><small>Endpoint is reachable</small></span>
+      <span><AvailabilityState status="unavailable" /><small>Endpoint cannot be reached</small></span>
+      <span><AvailabilityState status="checking" /><small>Availability check in progress</small></span>
+    </div>
+  );
+}
+
+function AvailabilityState({ status }: { status: DisplayAvailability }) {
+  const Icon = status === 'available' ? CircleCheck : status === 'unavailable' ? CircleX : LoaderCircle;
+  const label = status === 'available' ? 'Available' : status === 'unavailable' ? 'Unavailable' : 'Checking';
+  return (
+    <span className={`settings-availability-state is-${status}`}>
+      <Icon className={status === 'checking' ? 'spin' : undefined} size={16} aria-hidden="true" />
+      {label}
+    </span>
+  );
+}
+
+function availabilityFor(
+  address: string | null,
+  availability: Map<string, NameserverEndpointAvailability>,
+  loading: boolean
+): { status: DisplayAvailability; endpoint?: NameserverEndpointAvailability } {
+  if (loading || !address) return { status: 'checking' };
+  const endpoint = availability.get(address);
+  return { status: endpoint?.status ?? 'unavailable', endpoint };
+}
+
+function lastCheckedLabel(endpoint: NameserverEndpointAvailability | undefined, loading: boolean) {
+  if (loading) return 'Checking now';
+  if (!endpoint) return 'Not checked';
+  const elapsedMinutes = Math.max(0, Math.floor((Date.now() - endpoint.checkedAt) / 60_000));
+  if (elapsedMinutes < 1) return 'Just now';
+  if (elapsedMinutes === 1) return '1 min ago';
+  if (elapsedMinutes < 60) return `${elapsedMinutes} min ago`;
+  const elapsedHours = Math.floor(elapsedMinutes / 60);
+  if (elapsedHours === 1) return '1 hour ago';
+  return `${elapsedHours} hours ago`;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/settings/SettingsSectionNav.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/settings/SettingsSectionNav.tsx
@@ -34,7 +34,7 @@ export default function SettingsSectionNav({ activeSection, onSelect }: Settings
             <Icon size={16} aria-hidden="true" />
             <span>
               <strong>{section.label}</strong>
-              <small>{section.description}</small>
+              <small className="sr-only">{section.description}</small>
             </span>
           </Button>
         );

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/pages.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/pages.css
@@ -398,11 +398,40 @@
   background: var(--card);
 }
 
-.producer-query-controls label {
+.producer-topic-field {
   display: grid;
   gap: 5px;
   color: var(--muted-foreground);
   font-size: 11px;
+}
+
+.producer-connections-card {
+  overflow: visible;
+}
+
+.producer-connection-topic-select {
+  width: 100%;
+  min-width: 0;
+}
+
+.producer-connection-topic-select .select-menu-trigger {
+  min-height: 36px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--background);
+}
+
+.producer-connection-topic-select .select-menu-trigger:hover,
+.producer-connection-topic-select .select-menu-trigger[aria-expanded='true'] {
+  border-color: color-mix(in srgb, var(--primary) 52%, var(--border));
+}
+
+.producer-connection-topic-select .select-menu-popover {
+  right: auto;
+  left: 0;
+  width: 100%;
+  min-width: 0;
 }
 
 .producer-empty-topics {
@@ -433,6 +462,38 @@
 
 .entity-detail-content > .ui-tabs > .ui-tabs-list .ui-tabs-trigger {
   width: 100%;
+}
+
+.consumer-detail-tab-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.consumer-detail-tab-bar > .ui-tabs-list {
+  min-width: 0;
+}
+
+.consumer-detail-refresh-control {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+}
+
+.consumer-detail-refresh-control .ui-button {
+  min-height: 42px;
+  padding: 0 14px;
+  border-color: var(--glass-border);
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--glass-surface-strong) 78%, transparent);
+  box-shadow: inset 0 1px rgb(255 255 255 / 0.045), 0 10px 28px rgb(0 0 0 / 0.12);
+  backdrop-filter: blur(18px) saturate(130%);
+  -webkit-backdrop-filter: blur(18px) saturate(130%);
+}
+
+.consumer-detail-refresh-control .ui-button:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--primary) 48%, var(--glass-border));
+  background: color-mix(in srgb, var(--primary) 14%, var(--glass-control));
 }
 
 .topic-detail-tab-bar {
@@ -1176,6 +1237,20 @@
     flex-direction: column;
   }
 
+  .consumer-detail-tab-bar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .consumer-detail-tab-bar > .ui-tabs-list {
+    width: 100%;
+    overflow-x: auto;
+  }
+
+  .consumer-detail-refresh-control {
+    justify-content: flex-end;
+  }
+
   .topic-detail-tab-bar > .ui-tabs-list {
     width: 100%;
     flex-basis: auto;
@@ -1254,28 +1329,31 @@
 /* Message operations */
 .settings-workspace {
   display: grid;
-  grid-template-columns: 220px minmax(0, 1fr);
-  gap: 16px;
-  align-items: start;
+  gap: 0;
+  min-width: 0;
 }
 
 .settings-section-nav {
-  display: grid;
-  gap: 6px;
-  padding: 8px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--card);
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  gap: 8px;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--border);
+  scrollbar-width: thin;
 }
 
 .settings-section-link {
   display: flex;
-  width: 100%;
+  width: auto;
+  min-height: 46px;
   align-items: center;
   gap: 9px;
-  border: 1px solid transparent;
-  border-radius: var(--radius-sm);
-  padding: 10px;
+  flex: 0 0 auto;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  padding: 0 14px;
   background: transparent;
   color: var(--muted-foreground);
   text-align: left;
@@ -1283,26 +1361,19 @@
 
 .settings-section-link:hover,
 .settings-section-link:focus-visible {
-  border-color: var(--border);
-  background: var(--muted-surface);
+  background: color-mix(in srgb, var(--glass-control-hover) 72%, transparent);
   color: var(--foreground);
 }
 
 .settings-section-link.is-active {
-  border-color: color-mix(in srgb, var(--primary) 40%, var(--border));
-  background: color-mix(in srgb, var(--primary) 10%, var(--card));
+  border-bottom-color: var(--primary);
+  background: color-mix(in srgb, var(--primary) 7%, transparent);
   color: var(--primary);
 }
 
-.settings-section-link > span {
-  display: grid;
-  gap: 2px;
-}
-
-.settings-section-link strong { font-size: 12px; }
-.settings-section-link small { color: var(--muted-foreground); font-size: 11px; }
+.settings-section-link strong { font-size: 13px; }
 .settings-section-content { min-width: 0; }
-.settings-card { min-height: 310px; box-shadow: none; }
+.settings-card { min-height: 310px; margin-top: 20px; box-shadow: none; }
 
 .settings-card > .ui-card-header {
   display: flex;
@@ -1314,44 +1385,287 @@
 }
 
 .settings-card-content { display: grid; gap: 18px; }
-.settings-field-grid { display: grid; grid-template-columns: minmax(230px, .9fr) minmax(0, 1.1fr); gap: 14px; }
 
-.settings-field,
-.settings-add-row {
+.settings-connection-panel {
   display: grid;
-  gap: 7px;
-  color: var(--muted-foreground);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: .035em;
-  text-transform: uppercase;
+  min-height: 0;
+  align-content: start;
+  gap: 20px;
+  padding-top: 18px;
 }
 
-.settings-field select {
-  width: 100%;
-  min-height: 36px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  padding: 0 30px 0 10px;
-  background: var(--background);
+.settings-current-section,
+.settings-endpoints-section,
+.settings-add-row {
+  display: grid;
+  gap: 10px;
+}
+
+.settings-current-section h3,
+.settings-endpoints-heading h3,
+.settings-add-row label {
+  margin: 0;
   color: var(--foreground);
-  font: inherit;
-  letter-spacing: normal;
+  font-size: 15px;
+  font-weight: 650;
+  letter-spacing: 0;
   text-transform: none;
 }
 
-.settings-address-list { display: flex; min-height: 36px; align-items: center; gap: 6px; flex-wrap: wrap; }
-.settings-address-item { display: inline-flex; min-width: 0; align-items: center; gap: 4px; flex-wrap: wrap; }
-.settings-address-item code { min-width: 0; overflow-wrap: anywhere; }
-.settings-address-list code { border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 5px 7px; background: var(--background); color: var(--foreground); font-size: 11px; letter-spacing: normal; text-transform: none; }
-.settings-empty-value { color: var(--muted-foreground); font-size: 12px; font-weight: 400; letter-spacing: normal; text-transform: none; }
-.settings-add-row > div { display: flex; gap: 8px; }
-.settings-add-row .ui-input { flex: 1; min-width: 0; }
-.settings-actions,
-.settings-actions > div,
-.settings-toggle-row { display: flex; align-items: center; gap: 8px; }
+.settings-current-nameserver {
+  display: grid;
+  min-height: 86px;
+  grid-template-columns: minmax(0, 1fr) minmax(230px, .34fr);
+  align-items: stretch;
+  overflow: hidden;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--glass-surface) 86%, transparent);
+  box-shadow: inset 0 1px rgb(255 255 255 / 0.035);
+  backdrop-filter: blur(18px) saturate(125%);
+  -webkit-backdrop-filter: blur(18px) saturate(125%);
+}
 
-.settings-actions { justify-content: space-between; border-top: 1px solid var(--border); padding-top: 14px; color: var(--muted-foreground); font-size: 12px; }
+.settings-current-identity {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: auto minmax(180px, 360px) auto;
+  align-content: center;
+  align-items: center;
+  justify-content: start;
+  gap: 4px 12px;
+  padding: 16px 18px;
+}
+
+.settings-current-identity label { min-width: 0; }
+
+.settings-current-identity select {
+  width: 100%;
+  min-height: 36px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  padding: 0 30px 0 8px;
+  background: transparent;
+  color: var(--foreground);
+  font: inherit;
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.settings-current-identity select:hover,
+.settings-current-identity select:focus-visible {
+  background: var(--glass-control);
+  outline: 1px solid color-mix(in srgb, var(--primary) 55%, var(--border));
+}
+
+.settings-current-identity p {
+  grid-column: 2 / -1;
+  margin: 0 0 0 8px;
+  color: var(--muted-foreground);
+  font-size: 12px;
+}
+
+.settings-endpoint-icon {
+  display: inline-grid;
+  width: 34px;
+  height: 34px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: var(--glass-control);
+  color: var(--muted-foreground);
+}
+
+.settings-current-status {
+  display: grid;
+  align-content: center;
+  gap: 5px;
+  border-left: 1px solid var(--border);
+  padding: 16px 22px;
+}
+
+.settings-current-status small,
+.settings-last-checked {
+  color: var(--muted-foreground);
+  font-size: 11px;
+}
+
+.settings-current-draft,
+.settings-current-draft-actions {
+  display: flex;
+  align-items: center;
+}
+
+.settings-current-draft {
+  gap: 12px;
+  border: 1px solid color-mix(in srgb, var(--warning) 34%, var(--glass-border));
+  border-radius: var(--radius);
+  padding: 12px 14px;
+  background: color-mix(in srgb, var(--warning) 7%, var(--glass-surface));
+  color: var(--warning);
+}
+
+.settings-current-draft > svg { flex: 0 0 auto; }
+
+.settings-current-draft-copy {
+  display: grid;
+  min-width: 0;
+  flex: 1;
+  gap: 3px;
+}
+
+.settings-current-draft-copy strong {
+  color: var(--foreground);
+  font-size: 13px;
+}
+
+.settings-current-draft-copy p {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: 12px;
+}
+
+.settings-current-draft-copy small {
+  color: var(--muted-foreground);
+  font-size: 11px;
+}
+
+.settings-current-draft-copy code {
+  color: var(--foreground);
+  font-size: inherit;
+  overflow-wrap: anywhere;
+}
+
+.settings-current-draft-actions {
+  flex: 0 0 auto;
+  gap: 8px;
+}
+
+.settings-endpoints-heading {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.settings-endpoints-heading p,
+.settings-add-row p {
+  margin: 4px 0 0;
+  color: var(--muted-foreground);
+  font-size: 12px;
+}
+
+.settings-endpoint-legend {
+  display: flex;
+  align-items: center;
+  gap: 8px 12px;
+  flex-wrap: wrap;
+  padding: 2px 0;
+}
+
+.settings-endpoint-legend > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.settings-endpoint-legend small {
+  color: var(--muted-foreground);
+  font-size: 10px;
+}
+
+.settings-endpoint-legend .settings-availability-state { font-size: 11px; }
+
+.settings-endpoint-table-scroll {
+  min-width: 0;
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--glass-surface) 84%, transparent);
+}
+
+.settings-endpoint-table {
+  width: 100%;
+  min-width: 760px;
+  border-collapse: collapse;
+}
+
+.settings-endpoint-table th,
+.settings-endpoint-table td {
+  height: 54px;
+  border-bottom: 1px solid var(--border);
+  padding: 0 14px;
+  text-align: left;
+  vertical-align: middle;
+}
+
+.settings-endpoint-table th {
+  height: 42px;
+  background: color-mix(in srgb, var(--muted-surface) 54%, transparent);
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.settings-endpoint-table tbody tr:last-child td { border-bottom: 0; }
+.settings-endpoint-table tbody tr:hover td { background: color-mix(in srgb, var(--primary) 3%, transparent); }
+
+.settings-endpoint-address {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 10px;
+}
+
+.settings-endpoint-address code {
+  color: var(--foreground);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.settings-endpoint-address .settings-endpoint-icon {
+  width: 30px;
+  height: 30px;
+}
+
+.settings-availability-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--muted-foreground);
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.settings-availability-state.is-available { color: var(--success); }
+.settings-availability-state.is-unavailable { color: var(--danger); }
+.settings-availability-state.is-checking { color: var(--info); }
+
+.settings-endpoint-actions { width: 48px; text-align: right !important; }
+.settings-current-action { color: var(--muted-foreground); }
+.settings-endpoints-empty { color: var(--muted-foreground); text-align: center !important; }
+
+.settings-availability-error {
+  border: 1px solid color-mix(in srgb, var(--danger) 35%, var(--border));
+  border-radius: var(--radius-sm);
+  padding: 8px 10px;
+  background: color-mix(in srgb, var(--danger) 8%, transparent);
+  color: var(--danger);
+  font-size: 12px;
+}
+
+.settings-add-control {
+  display: flex;
+  gap: 10px;
+}
+
+.settings-add-control .ui-input { flex: 1; min-width: 0; }
+
+.settings-toggle-row { display: flex; align-items: center; gap: 8px; }
 .settings-toggle-list { gap: 0; }
 .settings-toggle-row { justify-content: space-between; min-height: 82px; border-bottom: 1px solid var(--border); }
 .settings-toggle-row:last-child { border-bottom: 0; }
@@ -1363,20 +1677,29 @@
 .settings-storage-detail dd { margin: 0; color: var(--foreground); font-size: 13px; }
 
 @media (max-width: 760px) {
-  .settings-workspace { grid-template-columns: 1fr; }
-  .settings-section-nav { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-  .settings-section-link { justify-content: center; padding: 9px 6px; }
-  .settings-section-link small { display: none; }
-  .settings-field-grid { grid-template-columns: 1fr; }
-  .settings-add-row > div,
-  .settings-actions { align-items: stretch; flex-direction: column; }
-  .settings-add-row .ui-button,
-  .settings-actions .ui-button { width: 100%; }
+  .settings-section-link { justify-content: center; padding: 0 10px; }
+  .settings-connection-panel { gap: 20px; padding-top: 16px; }
+  .settings-current-nameserver { grid-template-columns: 1fr; }
+  .settings-current-identity { grid-template-columns: auto minmax(0, 1fr) auto; padding: 14px; }
+  .settings-current-status { border-top: 1px solid var(--border); border-left: 0; padding: 12px 14px; }
+  .settings-endpoints-heading { align-items: flex-start; }
+  .settings-endpoint-legend { align-items: flex-start; flex-direction: column; }
+  .settings-add-control,
+  .settings-current-draft { align-items: stretch; flex-direction: column; }
+  .settings-add-control .ui-button,
+  .settings-current-draft .ui-button { width: 100%; }
+  .settings-current-draft-actions { display: grid; width: 100%; grid-template-columns: 1fr 1fr; }
 }
 
 @media (max-width: 520px) {
-  .settings-section-link { flex-direction: column; gap: 4px; }
+  .settings-section-link { flex-direction: column; gap: 3px; }
   .settings-section-link strong { font-size: 11px; }
+  .settings-current-identity { grid-template-columns: auto minmax(0, 1fr); }
+  .settings-current-identity .ui-badge { grid-column: 2; width: fit-content; }
+  .settings-current-identity p { grid-column: 1 / -1; margin-left: 0; }
+  .settings-endpoints-heading { align-items: stretch; flex-direction: column; }
+  .settings-endpoints-heading .ui-button { width: 100%; }
+  .settings-current-draft-actions { grid-template-columns: 1fr; }
   .settings-storage-detail { grid-template-columns: 1fr; }
 }
 
@@ -1385,10 +1708,14 @@
   gap: 14px;
 }
 
-.message-query-card,
 .message-results-card,
 .trace-detail-card {
   overflow: hidden;
+  box-shadow: none;
+}
+
+.message-query-card {
+  overflow: visible;
   box-shadow: none;
 }
 
@@ -1398,6 +1725,10 @@
   align-items: flex-start;
   border-bottom: 1px solid var(--border);
   background: var(--muted-surface);
+}
+
+.message-query-card > .ui-card-header {
+  border-radius: var(--radius) var(--radius) 0 0;
 }
 
 .message-query-card > .ui-card-content,
@@ -1444,6 +1775,36 @@
 .message-query-field select:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--ring) 55%, transparent);
   outline-offset: 1px;
+}
+
+.message-query-topic-select {
+  width: 100%;
+  min-width: 0;
+}
+
+.message-query-topic-select .select-menu-trigger {
+  min-height: 34px;
+  padding: 0 10px;
+  border: 1px solid var(--input);
+  border-radius: var(--radius-sm);
+  background: var(--background);
+}
+
+.message-query-topic-select .select-menu-trigger:hover,
+.message-query-topic-select .select-menu-trigger[aria-expanded='true'] {
+  border-color: color-mix(in srgb, var(--primary) 52%, var(--input));
+}
+
+.message-query-topic-select .select-menu-trigger:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--ring) 55%, transparent);
+  outline-offset: 1px;
+}
+
+.message-query-topic-select .select-menu-popover {
+  right: auto;
+  left: 0;
+  width: 100%;
+  min-width: 0;
 }
 
 .message-query-field-wide {

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/types/config.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/types/config.ts
@@ -10,6 +10,18 @@ export interface DashboardConfigView {
   storageBackend: StorageBackend;
 }
 
+export type NameserverAvailabilityStatus = 'available' | 'unavailable';
+
+export interface NameserverEndpointAvailability {
+  address: string;
+  status: NameserverAvailabilityStatus;
+  checkedAt: number;
+}
+
+export interface NameserverAvailabilityView {
+  endpoints: NameserverEndpointAvailability[];
+}
+
 export interface AddressRequest {
   address: string;
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9649

### Brief Description

- Add searchable topic selection to producer connections and message queries.
- Render readable producer client versions and expose bounded NameServer endpoint availability.
- Add contextual refresh for consumer details and clarify persisted versus pending NameServer activation.
- Add focused backend and frontend tests with responsive operational styling.

### How Did You Test This Change?

- `npm ci`
- `npm test -- --run` (52 test files and 345 tests passed)
- `npm run build`
- `cargo fmt -- --check`
- `cargo build --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings` (blocked by an existing unresolved `SharedRocketMQError` import in `rocketmq-transport`)
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added NameServer availability checks with timestamps, status indicators, retry controls, and endpoint management.
  - Added draft/apply/discard workflows for changing the active NameServer.
  - Replaced topic dropdowns with searchable selectors in message queries and producer connections.
  - Added refresh controls for consumer detail tabs.
- **Bug Fixes**
  - Producer connection versions now display descriptive version information.
  - Prevented removal of the currently active NameServer.
- **Style**
  - Improved responsive settings navigation and connection-management layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->