### PR TITLE
[ISSUE #9652]🐛Gate broker pre-online service to slave-acting-master mode

### DIFF
--- a/rocketmq-broker/src/broker_runtime/request_pipeline/startup.rs
+++ b/rocketmq-broker/src/broker_runtime/request_pipeline/startup.rs
@@ -236,7 +236,11 @@ impl BrokerRuntime {
             topic_route_info_manager.start();
         }
 
-        if self.composition.state.broker_pre_online_service.is_none() {
+        let broker_config = self.composition.state.broker_config();
+        if broker_config.enable_slave_acting_master
+            && !broker_config.skip_pre_online
+            && self.composition.state.broker_pre_online_service.is_none()
+        {
             self.composition.state.broker_pre_online_service = Some(
                 self.composition
                     .state

--- a/rocketmq-broker/tests/broker_runtime/unit.rs
+++ b/rocketmq-broker/tests/broker_runtime/unit.rs
@@ -6382,6 +6382,10 @@ async fn three_controller_two_broker_controller_mode_failover_reregisters_namesr
     configure_namesrv(&mut rejoining_broker, &namesrv_addr).await;
     initialize_controller_mode_broker(&mut rejoining_broker, "rejoining broker").await;
     rejoining_broker.start().await.expect("rejoining broker should start");
+    assert!(
+        rejoining_broker.composition.state.broker_pre_online_service.is_none(),
+        "controller mode must not start the slave-acting-master pre-online service",
+    );
     let current_leader_manager = controllers
         .iter()
         .find(|manager| manager.is_leader())


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9652

### Brief Description

Gate `BrokerPreOnlineService` creation with `enable_slave_acting_master && !skip_pre_online`, matching the Java broker lifecycle boundary. This prevents a controller-mode broker that is returning as a slave from publishing a premature broker ID `0` registration and replacing the active promoted master in NameServer.

Add a deterministic assertion to the controller failover regression test so the invalid service startup is detected even when the timing-dependent registration race does not reproduce.

### How Did You Test This Change?

- Passed `cargo test -p rocketmq-broker --lib --all-features broker_runtime::tests::three_controller_two_broker_controller_mode_failover_reregisters_namesrv_and_updates_store_ha -- --exact`.
- Passed `cargo fmt -p rocketmq-broker -- --check`.
- Passed `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`.
- Passed `./scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`.
- Passed `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`.
- The full `rocketmq-broker` all-features library suite was also attempted. The target regression passed, while the unrelated existing `broker_runtime_tieredstore_start_shutdown_e2e` test still failed because Store HA startup returned `unavailable`. Two additional failures observed only during the concurrent suite passed when rerun individually.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented rejoining controller-mode brokers from starting the slave-acting-master pre-online service when it is not applicable.
  * Preserved existing startup behavior when the service is already configured.

* **Tests**
  * Added coverage verifying the pre-online service is not started incorrectly during broker rejoin operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->