### PR TITLE
[ISSUE #9654]🐛Upgrade fuzz h2 lockfile to 0.4.16

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1214,9 +1214,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9654

### Brief Description

Upgrade the `h2` entry in the standalone fuzz workspace lockfile from 0.4.15 to 0.4.16. Version 0.4.16 contains the fix for RUSTSEC-2026-0258, which could otherwise allow unbounded accumulation of empty HTTP/2 DATA frames.

The lockfile update is intentionally limited to the `h2` version and checksum so it does not introduce unrelated dependency resolution changes.

### How Did You Test This Change?

- Passed `cargo audit --file fuzz/Cargo.lock` with all 480 locked dependencies scanned and no vulnerabilities reported.
- Passed `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`.
- Passed `git diff --check`.
