### PR TITLE
[ISSUE #9651]♻️Extract Tokio client API facades

### DIFF
--- a/rocketmq-transport/src/clients/rocketmq_tokio_client.rs
+++ b/rocketmq-transport/src/clients/rocketmq_tokio_client.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ops::Deref;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
@@ -28,13 +27,10 @@ use rocketmq_error::RpcClientError;
 use rocketmq_runtime::common::time_utils::current_millis;
 use rocketmq_runtime::ChildServiceContext;
 use rocketmq_runtime::ResourcePermit;
-use rocketmq_runtime::ShutdownDeadline;
-use rocketmq_runtime::ShutdownReport;
 #[cfg(test)]
 use rocketmq_runtime::TaskGroup;
 #[cfg(test)]
 use rocketmq_runtime::TaskGroupLifecycleState;
-use serde::Serialize;
 use tokio::time;
 use tracing::debug;
 use tracing::error;
@@ -43,7 +39,6 @@ use tracing::warn;
 
 use crate::base::connection_net_event::ConnectionNetEvent;
 use crate::base::pending_request_table::PendingRequestTable;
-use crate::base::pending_request_table::PendingRequestUsage;
 use crate::clients::client::SessionConnectTarget;
 use crate::clients::nameserver_endpoint::ConnectTarget;
 use crate::clients::nameserver_endpoint::NameServerEndpoint;
@@ -59,18 +54,26 @@ use crate::runtime::config::client_config::GoAwayPolicy;
 use crate::runtime::config::client_config::MaintenanceConfig;
 use crate::runtime::config::client_config::TransportClientConfig;
 use crate::runtime::processor::RequestProcessor;
+#[cfg(test)]
 use crate::runtime::RPCHook;
 use crate::security::TransportSecurity;
 use crate::telemetry::TransportGoAwayOutcome;
 use crate::telemetry::TransportTelemetry;
+#[cfg(test)]
 use crate::tls::TlsConfig;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 
+mod api;
 mod connection_registry;
 mod endpoint_state;
 mod lifecycle;
 mod nameserver;
+
+pub use api::{
+    ClientShutdownReport, ClientSnapshot, ClientStartReport, ConnectionShutdownReport, PendingUsage, RemotingClient,
+    RemotingClientBuilder, RequestTarget, SendReceipt, TransportClientBuilder,
+};
 
 use connection_registry::ConnectionRegistry;
 use endpoint_state::EndpointLease;
@@ -240,230 +243,6 @@ pub struct TransportClient<PR = DefaultRequestProcessor> {
     go_away_policy: GoAwayPolicy,
 }
 
-/// Builds a persistent endpoint client without exposing positional optional capabilities.
-pub struct TransportClientBuilder<PR> {
-    config: Arc<TransportClientConfig>,
-    processor: PR,
-    service_context: ChildServiceContext,
-    connection_events: Option<tokio::sync::broadcast::Sender<ConnectionNetEvent>>,
-    transport_security: Option<Arc<TransportSecurity>>,
-    telemetry: TransportTelemetry,
-    frame_limits: FrameLimits,
-    go_away_policy: GoAwayPolicy,
-}
-
-impl<PR> TransportClientBuilder<PR>
-where
-    PR: RequestProcessor + Sync + Clone + 'static,
-{
-    pub fn connection_events(mut self, events: tokio::sync::broadcast::Sender<ConnectionNetEvent>) -> Self {
-        self.connection_events = Some(events);
-        self
-    }
-
-    pub fn transport_security(mut self, transport_security: Arc<TransportSecurity>) -> Self {
-        self.transport_security = Some(transport_security);
-        self
-    }
-
-    pub fn telemetry(mut self, telemetry: TransportTelemetry) -> Self {
-        self.telemetry = telemetry;
-        self
-    }
-
-    /// Applies one validated frame profile to every connection created by this client.
-    pub fn frame_limits(mut self, frame_limits: FrameLimits) -> RocketMQResult<Self> {
-        frame_limits.validate()?;
-        self.frame_limits = frame_limits;
-        Ok(self)
-    }
-
-    /// Applies an explicit allowlist for one bounded `GO_AWAY` reconnect retry.
-    #[must_use]
-    pub fn go_away_policy(mut self, policy: GoAwayPolicy) -> Self {
-        self.go_away_policy = policy;
-        self
-    }
-
-    pub fn build(self) -> RocketMQResult<TransportClient<PR>> {
-        let mut client = TransportClient::build_inner(
-            self.config,
-            self.processor,
-            self.connection_events,
-            self.service_context,
-            self.telemetry,
-            self.frame_limits,
-            self.go_away_policy,
-        )?;
-        if let Some(transport_security) = self.transport_security {
-            client = client.with_transport_security(transport_security);
-        }
-        Ok(client)
-    }
-}
-
-/// Nameserver-aware remoting client.
-///
-/// This type composes the canonical persistent [`TransportClient`]. It never
-/// owns a second connection registry, writer queue, or pending-request table.
-#[derive(Clone)]
-pub struct RemotingClient<PR = DefaultRequestProcessor> {
-    transport: Arc<TransportClient<PR>>,
-}
-
-impl<PR> RemotingClient<PR>
-where
-    PR: RequestProcessor + Sync + Clone + 'static,
-{
-    pub fn builder(
-        config: Arc<TransportClientConfig>,
-        processor: PR,
-        service_context: ChildServiceContext,
-    ) -> RemotingClientBuilder<PR> {
-        RemotingClientBuilder {
-            transport: TransportClient::builder(config, processor, service_context),
-        }
-    }
-
-    pub fn transport_client(&self) -> Arc<TransportClient<PR>> {
-        Arc::clone(&self.transport)
-    }
-
-    pub async fn start(self: &Arc<Self>) -> RocketMQResult<ClientStartReport> {
-        self.transport.start().await
-    }
-
-    /// Gracefully shuts down the canonical transport by the caller's absolute deadline.
-    ///
-    /// This forwards the same deadline without converting it to a new duration,
-    /// so nested lifecycle owners share one drain budget.
-    pub async fn shutdown_until(&self, deadline: ShutdownDeadline) -> RocketMQResult<ClientShutdownReport> {
-        Ok(self.transport.shutdown_graceful(deadline).await)
-    }
-}
-
-impl<PR> Deref for RemotingClient<PR> {
-    type Target = TransportClient<PR>;
-
-    fn deref(&self) -> &Self::Target {
-        self.transport.as_ref()
-    }
-}
-
-pub struct RemotingClientBuilder<PR> {
-    transport: TransportClientBuilder<PR>,
-}
-
-impl<PR> RemotingClientBuilder<PR>
-where
-    PR: RequestProcessor + Sync + Clone + 'static,
-{
-    pub fn connection_events(mut self, events: tokio::sync::broadcast::Sender<ConnectionNetEvent>) -> Self {
-        self.transport = self.transport.connection_events(events);
-        self
-    }
-
-    pub fn transport_security(mut self, transport_security: Arc<TransportSecurity>) -> Self {
-        self.transport = self.transport.transport_security(transport_security);
-        self
-    }
-
-    pub fn telemetry(mut self, telemetry: TransportTelemetry) -> Self {
-        self.transport = self.transport.telemetry(telemetry);
-        self
-    }
-
-    /// Applies one validated frame profile to every connection created by this client.
-    pub fn frame_limits(mut self, frame_limits: FrameLimits) -> RocketMQResult<Self> {
-        self.transport = self.transport.frame_limits(frame_limits)?;
-        Ok(self)
-    }
-
-    /// Applies an explicit allowlist for one bounded `GO_AWAY` reconnect retry.
-    #[must_use]
-    pub fn go_away_policy(mut self, policy: GoAwayPolicy) -> Self {
-        self.transport = self.transport.go_away_policy(policy);
-        self
-    }
-
-    pub fn build(self) -> RocketMQResult<RemotingClient<PR>> {
-        Ok(RemotingClient {
-            transport: Arc::new(self.transport.build()?),
-        })
-    }
-}
-
-#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize)]
-pub struct ClientStartReport {
-    pub background_tasks_started: usize,
-    pub already_running: bool,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct ConnectionShutdownReport {
-    pub addr: CheetahString,
-    pub report: ShutdownReport,
-}
-
-#[derive(Debug, Clone, Default, Serialize)]
-pub struct ClientShutdownReport {
-    pub background: Option<ShutdownReport>,
-    pub workers: Option<ShutdownReport>,
-    pub connections: Vec<ConnectionShutdownReport>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub enum RequestTarget {
-    Endpoint(CheetahString),
-    NameServer,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct SendReceipt {
-    pub endpoint: CheetahString,
-    pub written_at_millis: u64,
-}
-
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
-pub struct PendingUsage {
-    pub count: usize,
-    pub retained_bytes: usize,
-    pub rejected_count: usize,
-    pub rejected_bytes: usize,
-}
-
-impl From<PendingRequestUsage> for PendingUsage {
-    fn from(usage: PendingRequestUsage) -> Self {
-        Self {
-            count: usage.count,
-            retained_bytes: usage.bytes,
-            rejected_count: usage.rejected_count,
-            rejected_bytes: usage.rejected_bytes,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
-pub struct ClientSnapshot {
-    pub connection_count: usize,
-    pub connect_flight_count: usize,
-    pub configured_name_server_count: usize,
-    pub available_name_server_count: usize,
-    pub healthy_name_server_count: usize,
-    pub probing_name_server_count: usize,
-    pub draining_name_server_count: usize,
-    pub circuit_open_name_server_count: usize,
-    pub pending: PendingUsage,
-}
-
-impl ClientShutdownReport {
-    pub fn is_healthy(&self) -> bool {
-        self.background.as_ref().is_none_or(ShutdownReport::is_healthy)
-            && self.workers.as_ref().is_none_or(ShutdownReport::is_healthy)
-            && self.connections.iter().all(|connection| connection.report.is_healthy())
-    }
-}
-
 impl<PR> Clone for TransportClient<PR> {
     fn clone(&self) -> Self {
         Self {
@@ -496,23 +275,6 @@ impl<PR> Clone for TransportClient<PR> {
 
 impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
     const NAMESERVER_SCAN_INTERVAL: Duration = Duration::from_secs(30);
-
-    pub fn builder(
-        tokio_client_config: Arc<TransportClientConfig>,
-        processor: PR,
-        service_context: ChildServiceContext,
-    ) -> TransportClientBuilder<PR> {
-        TransportClientBuilder {
-            config: tokio_client_config,
-            processor,
-            service_context,
-            connection_events: None,
-            transport_security: None,
-            telemetry: TransportTelemetry::noop(),
-            frame_limits: FrameLimits::java_compatibility(),
-            go_away_policy: GoAwayPolicy::default(),
-        }
-    }
 
     #[cfg(test)]
     pub(crate) fn build_for_test(
@@ -575,26 +337,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
         })
     }
 
-    /// Installs an optional transport signer for newly created outbound sessions.
-    pub fn with_transport_security(mut self, transport_security: Arc<TransportSecurity>) -> Self {
-        self.transport_security = Some(transport_security);
-        self
-    }
-
-    /// Returns whether newly created outbound connections use TLS.
-    #[inline]
-    pub fn is_use_tls(&self) -> bool {
-        self.tokio_client_config.tls.enable
-    }
-
-    /// Returns the TLS configuration used when creating new outbound connections.
-    #[inline]
-    pub fn tls_config(&self) -> &TlsConfig {
-        &self.tokio_client_config.tls
-    }
-
-    #[must_use]
-    pub fn snapshot(&self) -> ClientSnapshot {
+    fn snapshot_inner(&self) -> ClientSnapshot {
         let state = self.endpoint_state.load();
         let healthy_name_server_count = state
             .endpoints()
@@ -634,7 +377,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
         }
     }
 
-    pub fn update_name_server_address_list_sync(&self, addrs: Vec<CheetahString>) {
+    fn update_name_server_address_list_sync_inner(&self, addrs: Vec<CheetahString>) {
         if addrs.is_empty() {
             return;
         }
@@ -652,17 +395,15 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
                 }
             })
             .collect();
-        self.apply_name_server_endpoint_snapshot_sync(endpoints, Duration::from_secs(30));
+        self.apply_name_server_endpoint_snapshot_sync_inner(endpoints, Duration::from_secs(30));
     }
 
-    /// Atomically applies resolved NameServer targets and starts bounded retirement for removals.
-    pub fn update_name_server_connect_targets_sync(&self, targets: Vec<ConnectTarget>, drain_timeout: Duration) {
+    fn update_name_server_connect_targets_sync_inner(&self, targets: Vec<ConnectTarget>, drain_timeout: Duration) {
         let endpoints = Self::name_server_connect_targets_to_endpoints(targets);
-        self.apply_name_server_endpoint_snapshot_sync(endpoints, drain_timeout);
+        self.apply_name_server_endpoint_snapshot_sync_inner(endpoints, drain_timeout);
     }
 
-    /// Atomically publishes a complete selector snapshot.
-    pub fn apply_name_server_endpoint_snapshot_sync(
+    fn apply_name_server_endpoint_snapshot_sync_inner(
         &self,
         endpoints: Vec<NameServerEndpoint>,
         drain_timeout: Duration,
@@ -1017,16 +758,6 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
 }
 
 impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
-    pub fn register_rpc_hook(&self, hook: Arc<dyn RPCHook>) {
-        self.cmd_handler.register_rpc_hook(hook);
-    }
-
-    pub fn clear_rpc_hook(&self) {
-        self.cmd_handler.clear_rpc_hook();
-    }
-}
-
-impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
     const MAX_GO_AWAY_ATTEMPTS: usize = 2;
 
     fn session_cache_identity(
@@ -1124,40 +855,11 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
             None => client.send_until(request, deadline).await,
         }
     }
-
-    /// Sends a one-way command while transferring an existing process-budget
-    /// reservation into the transport writer.
-    pub async fn invoke_oneway_with_permit(
-        &self,
-        addr: &CheetahString,
-        request: RemotingCommand,
-        deadline: RequestDeadline,
-        permit: ResourcePermit,
-    ) -> RocketMQResult<()> {
-        self.invoke_oneway_until(addr, request, deadline, Some(permit)).await
-    }
 }
 
 impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
-    pub async fn update_name_server_address_list(&self, addrs: Vec<CheetahString>) {
-        self.update_name_server_address_list_sync(addrs);
-    }
-
-    pub fn get_name_server_address_list(&self) -> Vec<CheetahString> {
-        self.endpoint_state
-            .load()
-            .endpoints()
-            .iter()
-            .map(NameServerEndpoint::compatibility_address)
-            .collect()
-    }
-
-    pub fn get_available_name_srv_list(&self) -> Vec<CheetahString> {
-        self.endpoint_state.load().available().iter().cloned().collect()
-    }
-
     /// Sends one canonical request under an absolute deadline.
-    pub async fn request(
+    async fn request_inner(
         &self,
         target: RequestTarget,
         request: RemotingCommand,
@@ -1173,7 +875,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
     }
 
     /// Sends one command and resolves only after the sole writer has completed it.
-    pub async fn send_oneway(
+    async fn send_oneway_inner(
         &self,
         target: RequestTarget,
         request: RemotingCommand,
@@ -1233,53 +935,6 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
                 result
             }
         }
-    }
-
-    /// Send request and wait for response with timeout.
-    ///
-    /// # Flow
-    /// ```text
-    /// 1. Get/create client connection         (~100ns fast path, ~50ms slow)
-    /// 2. Send request with timeout            (network RTT + processing)
-    /// 3. Record latency / error metrics       (~10ns)
-    /// ```
-    ///
-    /// # Error Handling
-    ///
-    /// Returns `RocketMQError` for all failures:
-    /// - Client unavailable (no connection)
-    /// - Network I/O error (send/recv failure)
-    /// - Timeout (no response within deadline)
-    ///
-    /// # Arguments
-    ///
-    /// * `addr` - Target address (None = use nameserver)
-    /// * `request` - Command to send
-    /// * `timeout_millis` - Max wait time for response
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// # use crate::clients::TransportClient;
-    /// # use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
-    /// # async fn example(client: &TransportClient) -> rocketmq_error::RocketMQResult<()> {
-    /// let request = RemotingCommand::create_request_command(/* ... */);
-    /// let response = client.invoke_request(
-    ///     Some(&"127.0.0.1:10911".into()),
-    ///     request,
-    ///     3000 // 3 second timeout
-    /// ).await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub async fn invoke_request(
-        &self,
-        addr: Option<&CheetahString>,
-        request: RemotingCommand,
-        timeout_millis: u64,
-    ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
-        self.invoke_request_with_deadline(addr, request, RequestDeadline::from_timeout_millis(timeout_millis))
-            .await
     }
 
     pub async fn invoke_request_with_deadline(
@@ -1529,26 +1184,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
         unreachable!("GO_AWAY attempt loop has a fixed non-zero bound")
     }
 
-    pub async fn invoke_request_oneway_with_deadline(
-        &self,
-        addr: &CheetahString,
-        request: RemotingCommand,
-        deadline: RequestDeadline,
-    ) -> RocketMQResult<()> {
-        self.invoke_oneway_until(addr, request, deadline, None).await
-    }
-
-    pub async fn invoke_request_oneway(
-        &self,
-        addr: &CheetahString,
-        request: RemotingCommand,
-        timeout_millis: u64,
-    ) -> RocketMQResult<()> {
-        self.invoke_request_oneway_with_deadline(addr, request, RequestDeadline::from_timeout_millis(timeout_millis))
-            .await
-    }
-
-    pub fn is_address_reachable(&self, addr: &CheetahString) {
+    fn is_address_reachable_inner(&self, addr: &CheetahString) {
         if self.connection_registry.healthy_session(addr, None).is_some() {
             return;
         }
@@ -1559,7 +1195,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
         }
     }
 
-    pub fn close_clients(&self, addrs: Vec<String>) {
+    fn close_clients_inner(&self, addrs: Vec<String>) {
         for addr in &addrs {
             let key = CheetahString::from(addr.as_str());
             if !self.connection_registry.remove_sessions_by_identity(&key).is_empty() {
@@ -1568,7 +1204,7 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
         }
     }
 
-    pub fn register_processor(&self, processor: impl RequestProcessor + Sync) {
+    fn register_processor_inner(&self, processor: impl RequestProcessor + Sync) {
         let _ = &processor;
         warn!("dynamic request processor registration is not supported by TransportClient after construction");
     }

--- a/rocketmq-transport/src/clients/rocketmq_tokio_client/api.rs
+++ b/rocketmq-transport/src/clients/rocketmq_tokio_client/api.rs
@@ -1,0 +1,467 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ops::Deref;
+use std::sync::Arc;
+use std::time::Duration;
+
+use cheetah_string::CheetahString;
+use rocketmq_error::RocketMQResult;
+use rocketmq_runtime::ChildServiceContext;
+use rocketmq_runtime::ResourcePermit;
+use rocketmq_runtime::ShutdownDeadline;
+use rocketmq_runtime::ShutdownReport;
+use serde::Serialize;
+
+use crate::base::connection_net_event::ConnectionNetEvent;
+use crate::base::pending_request_table::PendingRequestUsage;
+use crate::clients::nameserver_endpoint::ConnectTarget;
+use crate::clients::nameserver_endpoint::NameServerEndpoint;
+use crate::codec::remoting_command_codec::FrameLimits;
+use crate::deadline::RequestDeadline;
+use crate::request_processor::default_request_processor::DefaultRequestProcessor;
+use crate::runtime::config::client_config::GoAwayPolicy;
+use crate::runtime::config::client_config::TransportClientConfig;
+use crate::runtime::processor::RequestProcessor;
+use crate::runtime::RPCHook;
+use crate::security::TransportSecurity;
+use crate::telemetry::TransportTelemetry;
+use crate::tls::TlsConfig;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+
+use super::TransportClient;
+
+/// Builds a persistent endpoint client without exposing positional optional capabilities.
+pub struct TransportClientBuilder<PR> {
+    config: Arc<TransportClientConfig>,
+    processor: PR,
+    service_context: ChildServiceContext,
+    connection_events: Option<tokio::sync::broadcast::Sender<ConnectionNetEvent>>,
+    transport_security: Option<Arc<TransportSecurity>>,
+    telemetry: TransportTelemetry,
+    frame_limits: FrameLimits,
+    go_away_policy: GoAwayPolicy,
+}
+
+impl<PR> TransportClientBuilder<PR>
+where
+    PR: RequestProcessor + Sync + Clone + 'static,
+{
+    pub fn connection_events(mut self, events: tokio::sync::broadcast::Sender<ConnectionNetEvent>) -> Self {
+        self.connection_events = Some(events);
+        self
+    }
+
+    pub fn transport_security(mut self, transport_security: Arc<TransportSecurity>) -> Self {
+        self.transport_security = Some(transport_security);
+        self
+    }
+
+    pub fn telemetry(mut self, telemetry: TransportTelemetry) -> Self {
+        self.telemetry = telemetry;
+        self
+    }
+
+    /// Applies one validated frame profile to every connection created by this client.
+    pub fn frame_limits(mut self, frame_limits: FrameLimits) -> RocketMQResult<Self> {
+        frame_limits.validate()?;
+        self.frame_limits = frame_limits;
+        Ok(self)
+    }
+
+    /// Applies an explicit allowlist for one bounded `GO_AWAY` reconnect retry.
+    #[must_use]
+    pub fn go_away_policy(mut self, policy: GoAwayPolicy) -> Self {
+        self.go_away_policy = policy;
+        self
+    }
+
+    pub fn build(self) -> RocketMQResult<TransportClient<PR>> {
+        let mut client = TransportClient::build_inner(
+            self.config,
+            self.processor,
+            self.connection_events,
+            self.service_context,
+            self.telemetry,
+            self.frame_limits,
+            self.go_away_policy,
+        )?;
+        if let Some(transport_security) = self.transport_security {
+            client = client.with_transport_security(transport_security);
+        }
+        Ok(client)
+    }
+}
+
+/// Nameserver-aware remoting client.
+///
+/// This type composes the canonical persistent [`TransportClient`]. It never
+/// owns a second connection registry, writer queue, or pending-request table.
+#[derive(Clone)]
+pub struct RemotingClient<PR = DefaultRequestProcessor> {
+    transport: Arc<TransportClient<PR>>,
+}
+
+impl<PR> RemotingClient<PR>
+where
+    PR: RequestProcessor + Sync + Clone + 'static,
+{
+    pub fn builder(
+        config: Arc<TransportClientConfig>,
+        processor: PR,
+        service_context: ChildServiceContext,
+    ) -> RemotingClientBuilder<PR> {
+        RemotingClientBuilder {
+            transport: TransportClient::builder(config, processor, service_context),
+        }
+    }
+
+    pub fn transport_client(&self) -> Arc<TransportClient<PR>> {
+        Arc::clone(&self.transport)
+    }
+
+    pub async fn start(self: &Arc<Self>) -> RocketMQResult<ClientStartReport> {
+        self.transport.start().await
+    }
+
+    /// Gracefully shuts down the canonical transport by the caller's absolute deadline.
+    ///
+    /// This forwards the same deadline without converting it to a new duration,
+    /// so nested lifecycle owners share one drain budget.
+    pub async fn shutdown_until(&self, deadline: ShutdownDeadline) -> RocketMQResult<ClientShutdownReport> {
+        Ok(self.transport.shutdown_graceful(deadline).await)
+    }
+}
+
+impl<PR> Deref for RemotingClient<PR> {
+    type Target = TransportClient<PR>;
+
+    fn deref(&self) -> &Self::Target {
+        self.transport.as_ref()
+    }
+}
+
+pub struct RemotingClientBuilder<PR> {
+    transport: TransportClientBuilder<PR>,
+}
+
+impl<PR> RemotingClientBuilder<PR>
+where
+    PR: RequestProcessor + Sync + Clone + 'static,
+{
+    pub fn connection_events(mut self, events: tokio::sync::broadcast::Sender<ConnectionNetEvent>) -> Self {
+        self.transport = self.transport.connection_events(events);
+        self
+    }
+
+    pub fn transport_security(mut self, transport_security: Arc<TransportSecurity>) -> Self {
+        self.transport = self.transport.transport_security(transport_security);
+        self
+    }
+
+    pub fn telemetry(mut self, telemetry: TransportTelemetry) -> Self {
+        self.transport = self.transport.telemetry(telemetry);
+        self
+    }
+
+    /// Applies one validated frame profile to every connection created by this client.
+    pub fn frame_limits(mut self, frame_limits: FrameLimits) -> RocketMQResult<Self> {
+        self.transport = self.transport.frame_limits(frame_limits)?;
+        Ok(self)
+    }
+
+    /// Applies an explicit allowlist for one bounded `GO_AWAY` reconnect retry.
+    #[must_use]
+    pub fn go_away_policy(mut self, policy: GoAwayPolicy) -> Self {
+        self.transport = self.transport.go_away_policy(policy);
+        self
+    }
+
+    pub fn build(self) -> RocketMQResult<RemotingClient<PR>> {
+        Ok(RemotingClient {
+            transport: Arc::new(self.transport.build()?),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize)]
+pub struct ClientStartReport {
+    pub background_tasks_started: usize,
+    pub already_running: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ConnectionShutdownReport {
+    pub addr: CheetahString,
+    pub report: ShutdownReport,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ClientShutdownReport {
+    pub background: Option<ShutdownReport>,
+    pub workers: Option<ShutdownReport>,
+    pub connections: Vec<ConnectionShutdownReport>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum RequestTarget {
+    Endpoint(CheetahString),
+    NameServer,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SendReceipt {
+    pub endpoint: CheetahString,
+    pub written_at_millis: u64,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+pub struct PendingUsage {
+    pub count: usize,
+    pub retained_bytes: usize,
+    pub rejected_count: usize,
+    pub rejected_bytes: usize,
+}
+
+impl From<PendingRequestUsage> for PendingUsage {
+    fn from(usage: PendingRequestUsage) -> Self {
+        Self {
+            count: usage.count,
+            retained_bytes: usage.bytes,
+            rejected_count: usage.rejected_count,
+            rejected_bytes: usage.rejected_bytes,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct ClientSnapshot {
+    pub connection_count: usize,
+    pub connect_flight_count: usize,
+    pub configured_name_server_count: usize,
+    pub available_name_server_count: usize,
+    pub healthy_name_server_count: usize,
+    pub probing_name_server_count: usize,
+    pub draining_name_server_count: usize,
+    pub circuit_open_name_server_count: usize,
+    pub pending: PendingUsage,
+}
+
+impl ClientShutdownReport {
+    pub fn is_healthy(&self) -> bool {
+        self.background.as_ref().is_none_or(ShutdownReport::is_healthy)
+            && self.workers.as_ref().is_none_or(ShutdownReport::is_healthy)
+            && self.connections.iter().all(|connection| connection.report.is_healthy())
+    }
+}
+
+impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
+    pub fn builder(
+        tokio_client_config: Arc<TransportClientConfig>,
+        processor: PR,
+        service_context: ChildServiceContext,
+    ) -> TransportClientBuilder<PR> {
+        TransportClientBuilder {
+            config: tokio_client_config,
+            processor,
+            service_context,
+            connection_events: None,
+            transport_security: None,
+            telemetry: TransportTelemetry::noop(),
+            frame_limits: FrameLimits::java_compatibility(),
+            go_away_policy: GoAwayPolicy::default(),
+        }
+    }
+
+    /// Installs an optional transport signer for newly created outbound sessions.
+    pub fn with_transport_security(mut self, transport_security: Arc<TransportSecurity>) -> Self {
+        self.transport_security = Some(transport_security);
+        self
+    }
+
+    /// Returns whether newly created outbound connections use TLS.
+    #[inline]
+    pub fn is_use_tls(&self) -> bool {
+        self.tokio_client_config.tls.enable
+    }
+
+    /// Returns the TLS configuration used when creating new outbound connections.
+    #[inline]
+    pub fn tls_config(&self) -> &TlsConfig {
+        &self.tokio_client_config.tls
+    }
+
+    #[must_use]
+    pub fn snapshot(&self) -> ClientSnapshot {
+        self.snapshot_inner()
+    }
+
+    pub fn update_name_server_address_list_sync(&self, addrs: Vec<CheetahString>) {
+        self.update_name_server_address_list_sync_inner(addrs);
+    }
+
+    /// Atomically applies resolved NameServer targets and starts bounded retirement for removals.
+    pub fn update_name_server_connect_targets_sync(&self, targets: Vec<ConnectTarget>, drain_timeout: Duration) {
+        self.update_name_server_connect_targets_sync_inner(targets, drain_timeout);
+    }
+
+    /// Atomically publishes a complete selector snapshot.
+    pub fn apply_name_server_endpoint_snapshot_sync(
+        &self,
+        endpoints: Vec<NameServerEndpoint>,
+        drain_timeout: Duration,
+    ) {
+        self.apply_name_server_endpoint_snapshot_sync_inner(endpoints, drain_timeout);
+    }
+
+    pub fn register_rpc_hook(&self, hook: Arc<dyn RPCHook>) {
+        self.cmd_handler.register_rpc_hook(hook);
+    }
+
+    pub fn clear_rpc_hook(&self) {
+        self.cmd_handler.clear_rpc_hook();
+    }
+
+    pub async fn update_name_server_address_list(&self, addrs: Vec<CheetahString>) {
+        self.update_name_server_address_list_sync_inner(addrs);
+    }
+
+    pub fn get_name_server_address_list(&self) -> Vec<CheetahString> {
+        self.endpoint_state
+            .load()
+            .endpoints()
+            .iter()
+            .map(NameServerEndpoint::compatibility_address)
+            .collect()
+    }
+
+    pub fn get_available_name_srv_list(&self) -> Vec<CheetahString> {
+        self.endpoint_state.load().available().iter().cloned().collect()
+    }
+
+    /// Sends one canonical request under an absolute deadline.
+    pub async fn request(
+        &self,
+        target: RequestTarget,
+        request: RemotingCommand,
+        deadline: RequestDeadline,
+    ) -> RocketMQResult<RemotingCommand> {
+        self.request_inner(target, request, deadline).await
+    }
+
+    /// Sends one command and resolves only after the sole writer has completed it.
+    pub async fn send_oneway(
+        &self,
+        target: RequestTarget,
+        request: RemotingCommand,
+        deadline: RequestDeadline,
+    ) -> RocketMQResult<SendReceipt> {
+        self.send_oneway_inner(target, request, deadline).await
+    }
+
+    /// Send request and wait for response with timeout.
+    ///
+    /// # Flow
+    /// ```text
+    /// 1. Get/create client connection         (~100ns fast path, ~50ms slow)
+    /// 2. Send request with timeout            (network RTT + processing)
+    /// 3. Record latency / error metrics       (~10ns)
+    /// ```
+    ///
+    /// # Error Handling
+    ///
+    /// Returns `RocketMQError` for all failures:
+    /// - Client unavailable (no connection)
+    /// - Network I/O error (send/recv failure)
+    /// - Timeout (no response within deadline)
+    ///
+    /// # Arguments
+    ///
+    /// * `addr` - Target address (None = use nameserver)
+    /// * `request` - Command to send
+    /// * `timeout_millis` - Max wait time for response
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// # use crate::clients::TransportClient;
+    /// # use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+    /// # async fn example(client: &TransportClient) -> rocketmq_error::RocketMQResult<()> {
+    /// let request = RemotingCommand::create_request_command(/* ... */);
+    /// let response = client.invoke_request(
+    ///     Some(&"127.0.0.1:10911".into()),
+    ///     request,
+    ///     3000 // 3 second timeout
+    /// ).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn invoke_request(
+        &self,
+        addr: Option<&CheetahString>,
+        request: RemotingCommand,
+        timeout_millis: u64,
+    ) -> RocketMQResult<RemotingCommand> {
+        self.invoke_request_with_deadline(addr, request, RequestDeadline::from_timeout_millis(timeout_millis))
+            .await
+    }
+
+    /// Sends a one-way command while transferring an existing process-budget
+    /// reservation into the transport writer.
+    pub async fn invoke_oneway_with_permit(
+        &self,
+        addr: &CheetahString,
+        request: RemotingCommand,
+        deadline: RequestDeadline,
+        permit: ResourcePermit,
+    ) -> RocketMQResult<()> {
+        self.invoke_oneway_until(addr, request, deadline, Some(permit)).await
+    }
+
+    pub async fn invoke_request_oneway_with_deadline(
+        &self,
+        addr: &CheetahString,
+        request: RemotingCommand,
+        deadline: RequestDeadline,
+    ) -> RocketMQResult<()> {
+        self.invoke_oneway_until(addr, request, deadline, None).await
+    }
+
+    pub async fn invoke_request_oneway(
+        &self,
+        addr: &CheetahString,
+        request: RemotingCommand,
+        timeout_millis: u64,
+    ) -> RocketMQResult<()> {
+        self.invoke_oneway_until(
+            addr,
+            request,
+            RequestDeadline::from_timeout_millis(timeout_millis),
+            None,
+        )
+        .await
+    }
+
+    pub fn is_address_reachable(&self, addr: &CheetahString) {
+        self.is_address_reachable_inner(addr);
+    }
+
+    pub fn close_clients(&self, addrs: Vec<String>) {
+        self.close_clients_inner(addrs);
+    }
+
+    pub fn register_processor(&self, processor: impl RequestProcessor + Sync) {
+        self.register_processor_inner(processor);
+    }
+}

--- a/scripts/module-maintainability-baseline.json
+++ b/scripts/module-maintainability-baseline.json
@@ -106,7 +106,7 @@
     },
     "rocketmq-transport": {
       "public_items": 644,
-      "reexports": 177
+      "reexports": 178
     }
   },
   "files": {
@@ -10926,8 +10926,13 @@
       "reexports": 0
     },
     "rocketmq-transport/src/clients/rocketmq_tokio_client.rs": {
-      "production_lines": 1241,
-      "public_items": 51,
+      "production_lines": 976,
+      "public_items": 2,
+      "reexports": 1
+    },
+    "rocketmq-transport/src/clients/rocketmq_tokio_client/api.rs": {
+      "production_lines": 339,
+      "public_items": 49,
       "reexports": 0
     },
     "rocketmq-transport/src/clients/rocketmq_tokio_client/lifecycle.rs": {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9651

### Brief Description

- Extract the Tokio client builders, remoting composition facade, reports, request DTOs, and public forwarding methods into the private `rocketmq_tokio_client/api.rs` child module.
- Re-export the moved types from `rocketmq_tokio_client.rs` so the canonical parent, `api::v1`, and prelude paths and signatures remain unchanged.
- Keep `TransportClient` state, construction, lifecycle, connection, and request implementation in the parent module, and refresh only the measured maintainability baseline entries.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-transport -- --check` - passed.
- `cargo test -p rocketmq-transport --lib rocketmq_tokio_client` - passed (54 tests).
- `cargo test -p rocketmq-transport --test public_api_v1 --test public_api_contract` - passed (18 tests).
- `cargo test -p rocketmq-transport` - passed.
- `cargo doc -p rocketmq-transport --no-deps` - passed; the pre-existing private intra-doc link warning in `rocketmq-transport/src/tls.rs` is unchanged.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` - passed.
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` - passed.
- `python scripts/module_maintainability_guard.py --scope core-release` - exited 1 with the same 36 pre-existing findings as base commit `651d912`.
- `python scripts/core_release_static_guard.py` - exited 1 with the same pre-existing failing routes as base commit `651d912`: `architecture-dependency`, `module-maintainability`, and `architecture-release`.
- `git diff --check 651d912b8caaa4244ccb5e70dbe2278a0837c9ca..HEAD` - passed.
