### PR TITLE
[ISSUE #9664]♻️Extract Tokio client request, one-way, and GO_AWAY orchestration

### DIFF
--- a/rocketmq-transport/src/clients/rocketmq_tokio_client.rs
+++ b/rocketmq-transport/src/clients/rocketmq_tokio_client.rs
@@ -20,20 +20,14 @@ use std::time::Duration;
 
 use cheetah_string::CheetahString;
 use parking_lot::Mutex;
-use rocketmq_error::NetworkError;
-use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
-use rocketmq_error::RpcClientError;
 use rocketmq_runtime::common::time_utils::current_millis;
 use rocketmq_runtime::ChildServiceContext;
-use rocketmq_runtime::ResourcePermit;
 #[cfg(test)]
 use rocketmq_runtime::TaskGroup;
 #[cfg(test)]
 use rocketmq_runtime::TaskGroupLifecycleState;
-use tokio::time;
 use tracing::debug;
-use tracing::error;
 use tracing::info;
 use tracing::warn;
 
@@ -41,9 +35,7 @@ use crate::base::connection_net_event::ConnectionNetEvent;
 use crate::base::pending_request_table::PendingRequestTable;
 use crate::clients::nameserver_endpoint::ConnectTarget;
 use crate::clients::nameserver_endpoint::NameServerEndpoint;
-use crate::clients::TransportSession;
 use crate::codec::remoting_command_codec::FrameLimits;
-use crate::deadline::RequestDeadline;
 use crate::remoting::inner::RemotingGeneralHandler;
 use crate::request_processor::default_request_processor::DefaultRequestProcessor;
 #[cfg(test)]
@@ -56,12 +48,9 @@ use crate::runtime::processor::RequestProcessor;
 #[cfg(test)]
 use crate::runtime::RPCHook;
 use crate::security::TransportSecurity;
-use crate::telemetry::TransportGoAwayOutcome;
 use crate::telemetry::TransportTelemetry;
 #[cfg(test)]
 use crate::tls::TlsConfig;
-use rocketmq_protocol::code::response_code::ResponseCode;
-use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 
 mod api;
 mod connect_flight;
@@ -69,6 +58,7 @@ mod connection_registry;
 mod endpoint_state;
 mod lifecycle;
 mod nameserver;
+mod request;
 
 pub use api::{
     ClientShutdownReport, ClientSnapshot, ClientStartReport, ConnectionShutdownReport, PendingUsage, RemotingClient,
@@ -76,7 +66,6 @@ pub use api::{
 };
 
 use connection_registry::ConnectionRegistry;
-use endpoint_state::EndpointLease;
 use endpoint_state::EndpointStateStore;
 use lifecycle::ClientLifecycle;
 use nameserver::NameServerHealth;
@@ -453,432 +442,6 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
 }
 
 impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
-    const MAX_GO_AWAY_ATTEMPTS: usize = 2;
-
-    fn session_cache_identity(
-        &self,
-        requested_addr: Option<&CheetahString>,
-        session: &TransportSession<PR>,
-    ) -> CheetahString {
-        requested_addr
-            .cloned()
-            .or_else(|| self.connection_registry.session_identity(session))
-            .or_else(|| self.endpoint_state.load().chosen().cloned())
-            .unwrap_or_else(|| CheetahString::from_string(session.remote_address().to_string()))
-    }
-
-    fn remove_cached_session_if_matches(&self, identity: &CheetahString, expected: &TransportSession<PR>) -> bool {
-        self.connection_registry
-            .remove_session_if_matches(identity, expected)
-            .is_some()
-    }
-
-    fn start_go_away_drain(&self, identity: CheetahString, session: TransportSession<PR>) {
-        session.begin_drain();
-        let drain_timeout = session.max_pending_request_age();
-        let task_name = format!("rocketmq.transport.go-away-drain.{identity}");
-        let spawned = self.spawn_worker_task(task_name, async move {
-            let report = session.drain_and_close(drain_timeout).await;
-            if !report.is_healthy() {
-                warn!(report = %report.to_json(), "GO_AWAY session drain was unhealthy");
-            }
-        });
-        if spawned.is_none() {
-            warn!(%identity, "GO_AWAY session drain could not be scheduled because the client is shutting down");
-        }
-    }
-
-    fn record_nameserver_outcome(
-        &self,
-        addr: Option<&CheetahString>,
-        lease: Option<&EndpointLease>,
-        latency: Duration,
-        success: bool,
-    ) {
-        let (Some(addr), Some(lease)) = (addr, lease) else {
-            return;
-        };
-        self.nameserver_health
-            .record_outcome_if_current(addr, lease, latency, success, || self.endpoint_state.is_current(lease));
-    }
-
-    async fn invoke_oneway_until(
-        &self,
-        addr: &CheetahString,
-        request: RemotingCommand,
-        deadline: RequestDeadline,
-        permit: Option<ResourcePermit>,
-    ) -> RocketMQResult<()> {
-        self.invoke_oneway_until_inner(addr, request, deadline, permit).await
-    }
-
-    async fn invoke_oneway_until_inner(
-        &self,
-        addr: &CheetahString,
-        request: RemotingCommand,
-        deadline: RequestDeadline,
-        permit: Option<ResourcePermit>,
-    ) -> RocketMQResult<()> {
-        deadline.ensure_before_send(addr.to_string())?;
-        if self.is_stopping() {
-            return Err(RocketMQError::ClientNotStarted);
-        }
-        let Some(mut client) = self.get_and_create_client_until(Some(addr), deadline).await? else {
-            return Err(RocketMQError::network_connection_failed(
-                addr.to_string(),
-                "one-way client unavailable",
-            ));
-        };
-        if self.is_stopping() {
-            return Err(RocketMQError::ClientNotStarted);
-        }
-
-        let mut request = request;
-        let remote_address = client.remote_address();
-        if let Some(hooks) = self.cmd_handler.hook_snapshot() {
-            request.make_custom_header_to_net();
-            self.cmd_handler.do_before_rpc_hooks_with_snapshot(
-                Some(hooks.as_ref()),
-                remote_address,
-                Some(&mut request),
-            )?;
-        }
-        deadline.ensure_before_send(remote_address.to_string())?;
-        request.mark_oneway_rpc_ref();
-        match permit {
-            Some(permit) => client.send_until_with_permit(request, deadline, permit).await,
-            None => client.send_until(request, deadline).await,
-        }
-    }
-}
-
-impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
-    /// Sends one canonical request under an absolute deadline.
-    async fn request_inner(
-        &self,
-        target: RequestTarget,
-        request: RemotingCommand,
-        deadline: RequestDeadline,
-    ) -> RocketMQResult<RemotingCommand> {
-        match target {
-            RequestTarget::Endpoint(endpoint) => {
-                self.invoke_request_with_deadline(Some(&endpoint), request, deadline)
-                    .await
-            }
-            RequestTarget::NameServer => self.invoke_request_with_deadline(None, request, deadline).await,
-        }
-    }
-
-    /// Sends one command and resolves only after the sole writer has completed it.
-    async fn send_oneway_inner(
-        &self,
-        target: RequestTarget,
-        request: RemotingCommand,
-        deadline: RequestDeadline,
-    ) -> RocketMQResult<SendReceipt> {
-        match target {
-            RequestTarget::Endpoint(endpoint) => {
-                self.invoke_oneway_until(&endpoint, request, deadline, None).await?;
-                Ok(SendReceipt {
-                    endpoint,
-                    written_at_millis: current_millis(),
-                })
-            }
-            RequestTarget::NameServer => {
-                let started_at = time::Instant::now();
-                deadline.ensure_before_send("<nameserver>")?;
-                let Some(selection) = self.get_and_create_nameserver_client_until(deadline).await? else {
-                    return Err(RocketMQError::network_connection_failed(
-                        "<nameserver>",
-                        "one-way nameserver client unavailable",
-                    ));
-                };
-                let metric_identity = selection.identity.clone();
-                let metric_lease = selection.lease.clone();
-                let selection_generation = selection.state.generation();
-                let mut client = selection.session;
-                debug!(
-                    selected = %metric_identity,
-                    generation = selection_generation,
-                    "Sending one-way request to selected nameserver"
-                );
-                let result = async {
-                    let endpoint = CheetahString::from_string(client.remote_address().to_string());
-                    let mut request = request;
-                    if let Some(hooks) = self.cmd_handler.hook_snapshot() {
-                        request.make_custom_header_to_net();
-                        self.cmd_handler.do_before_rpc_hooks_with_snapshot(
-                            Some(hooks.as_ref()),
-                            client.remote_address(),
-                            Some(&mut request),
-                        )?;
-                    }
-                    request.mark_oneway_rpc_ref();
-                    client.send_until(request, deadline).await?;
-                    Ok(SendReceipt {
-                        endpoint,
-                        written_at_millis: current_millis(),
-                    })
-                }
-                .await;
-                self.record_nameserver_outcome(
-                    Some(&metric_identity),
-                    Some(&metric_lease),
-                    started_at.elapsed(),
-                    result.is_ok(),
-                );
-                result
-            }
-        }
-    }
-
-    pub async fn invoke_request_with_deadline(
-        &self,
-        addr: Option<&CheetahString>,
-        request: RemotingCommand,
-        deadline: RequestDeadline,
-    ) -> rocketmq_error::RocketMQResult<RemotingCommand> {
-        let nameserver_request = addr.is_none_or(CheetahString::is_empty);
-        let start = time::Instant::now();
-        let timeout_millis = deadline.budget_millis();
-        let target = if nameserver_request {
-            "<nameserver>".to_string()
-        } else {
-            addr.map_or_else(|| "<nameserver>".to_string(), ToString::to_string)
-        };
-        deadline.ensure_before_send(target.clone())?;
-        let nameserver_diagnostics = nameserver_request.then(|| self.endpoint_state.load());
-        let nameserver_selection = if nameserver_request {
-            self.get_and_create_nameserver_client_until(deadline).await?
-        } else {
-            None
-        };
-        let nameserver_metric_addr = nameserver_selection
-            .as_ref()
-            .map(|selection| selection.identity.clone());
-        let nameserver_lease = nameserver_selection.as_ref().map(|selection| selection.lease.clone());
-        let nameserver_generation = nameserver_selection
-            .as_ref()
-            .map(|selection| selection.state.generation());
-        let mut client = match nameserver_selection {
-            Some(selection) => Some(selection.session),
-            None if nameserver_request => None,
-            None => self.get_and_create_client_until(addr, deadline).await?,
-        }
-        .ok_or_else(|| {
-            if target == "<nameserver>" {
-                if let Some(state) = nameserver_diagnostics.as_ref() {
-                    error!(
-                        "Failed to get client for <nameserver>. Diagnostics: configured_list={:?}, available_set={:?}, \
-                         cached_choice={:?}, connections={}",
-                        state.endpoints(),
-                        state.available(),
-                        state.chosen(),
-                        self.connection_registry.len()
-                    );
-                }
-            } else {
-                error!("Failed to get client for {}", target);
-            }
-
-            RocketMQError::network_connection_failed(target.clone(), "Failed to connect")
-        })?;
-
-        if self.is_stopping() {
-            return Err(RocketMQError::ClientNotStarted);
-        }
-
-        let mut request = request;
-        let initial_remote_address = client.remote_address();
-        deadline.ensure_before_send(initial_remote_address.to_string())?;
-        let hooks = self.cmd_handler.hook_snapshot();
-        let request_for_after = if let Some(hooks) = hooks {
-            request.make_custom_header_to_net();
-            self.cmd_handler.do_before_rpc_hooks_with_snapshot(
-                Some(hooks.as_ref()),
-                initial_remote_address,
-                Some(&mut request),
-            )?;
-            deadline.ensure_before_send(initial_remote_address.to_string())?;
-            Some((request.clone(), hooks))
-        } else {
-            None
-        };
-        let apply_final_hooks =
-            |mut response: RemotingCommand, remote_address: std::net::SocketAddr| -> RocketMQResult<RemotingCommand> {
-                if let Some((request, hooks)) = request_for_after.as_ref() {
-                    self.cmd_handler.do_after_rpc_hooks_with_snapshot(
-                        Some(hooks.as_ref()),
-                        remote_address,
-                        request,
-                        Some(&mut response),
-                    )?;
-                }
-                if deadline.is_expired() {
-                    return Err(RocketMQError::network_response_timeout(
-                        remote_address.to_string(),
-                        timeout_millis,
-                    ));
-                }
-                Ok(response)
-            };
-        let retry_allowed = self.go_away_policy.allows_request(request.code()) && !request.is_oneway_rpc();
-        let retry_request = request.clone();
-        let mut attempted_retry = false;
-
-        for attempt in 0..Self::MAX_GO_AWAY_ATTEMPTS {
-            let remote_address = client.remote_address();
-            let identity = if nameserver_request {
-                self.connection_registry
-                    .session_identity(&client)
-                    .or_else(|| nameserver_metric_addr.clone())
-                    .unwrap_or_else(|| CheetahString::from_string(remote_address.to_string()))
-            } else {
-                self.session_cache_identity(addr, &client)
-            };
-            let mut attempt_request = retry_request.clone();
-            if attempt > 0 {
-                attempt_request.set_opaque_mut(RemotingCommand::get_and_add());
-            }
-
-            match client.send_read(attempt_request, deadline).await {
-                Ok(response) if response.code() == ResponseCode::GoAway.to_i32() => {
-                    self.telemetry.record_go_away(TransportGoAwayOutcome::Received);
-                    if !retry_allowed {
-                        let response = apply_final_hooks(response, remote_address)?;
-                        let latency = start.elapsed();
-                        self.record_nameserver_outcome(
-                            nameserver_metric_addr.as_ref(),
-                            nameserver_lease.as_ref(),
-                            latency,
-                            true,
-                        );
-                        debug!(
-                            remote_addr = %identity,
-                            elapsed_ms = latency.as_millis() as u64,
-                            "request completed with GO_AWAY retry disabled"
-                        );
-                        return Ok(response);
-                    }
-                    self.remove_cached_session_if_matches(&identity, &client);
-                    self.start_go_away_drain(identity.clone(), client);
-
-                    if attempt + 1 == Self::MAX_GO_AWAY_ATTEMPTS {
-                        self.telemetry.record_go_away(TransportGoAwayOutcome::RetryFailed);
-                        self.record_nameserver_outcome(
-                            nameserver_metric_addr.as_ref(),
-                            nameserver_lease.as_ref(),
-                            start.elapsed(),
-                            false,
-                        );
-                        return Err(RpcClientError::unexpected_response_code(
-                            response.code(),
-                            "GO_AWAY after replacement-connection retry",
-                        )
-                        .into());
-                    }
-
-                    attempted_retry = true;
-                    if let Err(error) = deadline.ensure_before_send(identity.to_string()) {
-                        self.telemetry.record_go_away(TransportGoAwayOutcome::RetryFailed);
-                        self.record_nameserver_outcome(
-                            nameserver_metric_addr.as_ref(),
-                            nameserver_lease.as_ref(),
-                            start.elapsed(),
-                            false,
-                        );
-                        return Err(error);
-                    }
-                    let replacement = match self.get_and_create_client_until(addr, deadline).await {
-                        Ok(Some(replacement)) => Ok(replacement),
-                        Ok(None) => Err(RocketMQError::network_connection_failed(
-                            identity.to_string(),
-                            "GO_AWAY replacement connection unavailable",
-                        )),
-                        Err(error) => Err(error),
-                    };
-                    client = match replacement {
-                        Ok(replacement) => replacement,
-                        Err(error) => {
-                            self.telemetry.record_go_away(TransportGoAwayOutcome::RetryFailed);
-                            self.record_nameserver_outcome(
-                                nameserver_metric_addr.as_ref(),
-                                nameserver_lease.as_ref(),
-                                start.elapsed(),
-                                false,
-                            );
-                            return Err(error);
-                        }
-                    };
-                }
-                Ok(response) => {
-                    let response = match apply_final_hooks(response, remote_address) {
-                        Ok(response) => response,
-                        Err(error) => {
-                            if attempted_retry {
-                                self.telemetry.record_go_away(TransportGoAwayOutcome::RetryFailed);
-                            }
-                            self.record_nameserver_outcome(
-                                nameserver_metric_addr.as_ref(),
-                                nameserver_lease.as_ref(),
-                                start.elapsed(),
-                                false,
-                            );
-                            return Err(error);
-                        }
-                    };
-                    if attempted_retry {
-                        self.telemetry.record_go_away(TransportGoAwayOutcome::RetrySuccess);
-                    }
-                    let latency = start.elapsed();
-                    self.record_nameserver_outcome(
-                        nameserver_metric_addr.as_ref(),
-                        nameserver_lease.as_ref(),
-                        latency,
-                        true,
-                    );
-                    debug!(
-                        remote_addr = %identity,
-                        nameserver_generation = ?nameserver_generation,
-                        elapsed_ms = latency.as_millis() as u64,
-                        "request completed"
-                    );
-                    return Ok(response);
-                }
-                Err(error) => {
-                    if matches!(
-                        error,
-                        RocketMQError::Network(
-                            NetworkError::WriteTimeout { .. } | NetworkError::ResponseTimeout { .. }
-                        )
-                    ) {
-                        client.retire_after_timeout().await;
-                        self.remove_cached_session_if_matches(&identity, &client);
-                    }
-                    if attempted_retry {
-                        self.telemetry.record_go_away(TransportGoAwayOutcome::RetryFailed);
-                    }
-                    let latency = start.elapsed();
-                    self.record_nameserver_outcome(
-                        nameserver_metric_addr.as_ref(),
-                        nameserver_lease.as_ref(),
-                        latency,
-                        false,
-                    );
-                    warn!(
-                        remote_addr = %identity,
-                        elapsed_ms = latency.as_millis() as u64,
-                        error = ?error,
-                        "request failed"
-                    );
-                    return Err(error);
-                }
-            }
-        }
-
-        unreachable!("GO_AWAY attempt loop has a fixed non-zero bound")
-    }
-
     fn is_address_reachable_inner(&self, addr: &CheetahString) {
         if self.connection_registry.healthy_session(addr, None).is_some() {
             return;

--- a/rocketmq-transport/src/clients/rocketmq_tokio_client/nameserver.rs
+++ b/rocketmq-transport/src/clients/rocketmq_tokio_client/nameserver.rs
@@ -272,6 +272,21 @@ impl Drop for DrainingEndpointGuard {
 }
 
 impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
+    /// Records request completion only while the selected endpoint lease is current.
+    pub(super) fn record_nameserver_outcome(
+        &self,
+        addr: Option<&CheetahString>,
+        lease: Option<&EndpointLease>,
+        latency: Duration,
+        success: bool,
+    ) {
+        let (Some(addr), Some(lease)) = (addr, lease) else {
+            return;
+        };
+        self.nameserver_health
+            .record_outcome_if_current(addr, lease, latency, success, || self.endpoint_state.is_current(lease));
+    }
+
     pub(super) fn apply_name_server_endpoint_snapshot(
         &self,
         endpoints: Vec<NameServerEndpoint>,

--- a/rocketmq-transport/src/clients/rocketmq_tokio_client/request.rs
+++ b/rocketmq-transport/src/clients/rocketmq_tokio_client/request.rs
@@ -1,0 +1,439 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Canonical request and one-way execution for the Tokio transport client.
+
+use cheetah_string::CheetahString;
+use rocketmq_error::NetworkError;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_error::RpcClientError;
+use rocketmq_runtime::common::time_utils::current_millis;
+use rocketmq_runtime::ResourcePermit;
+use tokio::time;
+use tracing::debug;
+use tracing::error;
+use tracing::warn;
+
+use super::RequestTarget;
+use super::SendReceipt;
+use super::TransportClient;
+use crate::clients::TransportSession;
+use crate::deadline::RequestDeadline;
+use crate::runtime::processor::RequestProcessor;
+use crate::telemetry::TransportGoAwayOutcome;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+
+impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
+    pub(super) fn session_cache_identity(
+        &self,
+        requested_addr: Option<&CheetahString>,
+        session: &TransportSession<PR>,
+    ) -> CheetahString {
+        requested_addr
+            .cloned()
+            .or_else(|| self.connection_registry.session_identity(session))
+            .or_else(|| self.endpoint_state.load().chosen().cloned())
+            .unwrap_or_else(|| CheetahString::from_string(session.remote_address().to_string()))
+    }
+
+    pub(super) fn remove_cached_session_if_matches(
+        &self,
+        identity: &CheetahString,
+        expected: &TransportSession<PR>,
+    ) -> bool {
+        self.connection_registry
+            .remove_session_if_matches(identity, expected)
+            .is_some()
+    }
+
+    fn start_go_away_drain(&self, identity: CheetahString, session: TransportSession<PR>) {
+        session.begin_drain();
+        let drain_timeout = session.max_pending_request_age();
+        let task_name = format!("rocketmq.transport.go-away-drain.{identity}");
+        let spawned = self.spawn_worker_task(task_name, async move {
+            let report = session.drain_and_close(drain_timeout).await;
+            if !report.is_healthy() {
+                warn!(report = %report.to_json(), "GO_AWAY session drain was unhealthy");
+            }
+        });
+        if spawned.is_none() {
+            warn!(%identity, "GO_AWAY session drain could not be scheduled because the client is shutting down");
+        }
+    }
+
+    pub(super) async fn invoke_oneway_until(
+        &self,
+        addr: &CheetahString,
+        request: RemotingCommand,
+        deadline: RequestDeadline,
+        permit: Option<ResourcePermit>,
+    ) -> RocketMQResult<()> {
+        deadline.ensure_before_send(addr.to_string())?;
+        if self.is_stopping() {
+            return Err(RocketMQError::ClientNotStarted);
+        }
+        let Some(mut client) = self.get_and_create_client_until(Some(addr), deadline).await? else {
+            return Err(RocketMQError::network_connection_failed(
+                addr.to_string(),
+                "one-way client unavailable",
+            ));
+        };
+        if self.is_stopping() {
+            return Err(RocketMQError::ClientNotStarted);
+        }
+
+        let mut request = request;
+        let remote_address = client.remote_address();
+        if let Some(hooks) = self.cmd_handler.hook_snapshot() {
+            request.make_custom_header_to_net();
+            self.cmd_handler.do_before_rpc_hooks_with_snapshot(
+                Some(hooks.as_ref()),
+                remote_address,
+                Some(&mut request),
+            )?;
+        }
+        deadline.ensure_before_send(remote_address.to_string())?;
+        request.mark_oneway_rpc_ref();
+        match permit {
+            Some(permit) => client.send_until_with_permit(request, deadline, permit).await,
+            None => client.send_until(request, deadline).await,
+        }
+    }
+
+    /// Sends one canonical request under an absolute deadline.
+    pub(super) async fn request_inner(
+        &self,
+        target: RequestTarget,
+        request: RemotingCommand,
+        deadline: RequestDeadline,
+    ) -> RocketMQResult<RemotingCommand> {
+        match target {
+            RequestTarget::Endpoint(endpoint) => {
+                self.invoke_request_with_deadline(Some(&endpoint), request, deadline)
+                    .await
+            }
+            RequestTarget::NameServer => self.invoke_request_with_deadline(None, request, deadline).await,
+        }
+    }
+
+    /// Sends one command and resolves only after the sole writer has completed it.
+    pub(super) async fn send_oneway_inner(
+        &self,
+        target: RequestTarget,
+        request: RemotingCommand,
+        deadline: RequestDeadline,
+    ) -> RocketMQResult<SendReceipt> {
+        match target {
+            RequestTarget::Endpoint(endpoint) => {
+                self.invoke_oneway_until(&endpoint, request, deadline, None).await?;
+                Ok(SendReceipt {
+                    endpoint,
+                    written_at_millis: current_millis(),
+                })
+            }
+            RequestTarget::NameServer => {
+                let started_at = time::Instant::now();
+                deadline.ensure_before_send("<nameserver>")?;
+                let Some(selection) = self.get_and_create_nameserver_client_until(deadline).await? else {
+                    return Err(RocketMQError::network_connection_failed(
+                        "<nameserver>",
+                        "one-way nameserver client unavailable",
+                    ));
+                };
+                let metric_identity = selection.identity.clone();
+                let metric_lease = selection.lease.clone();
+                let selection_generation = selection.state.generation();
+                let mut client = selection.session;
+                debug!(
+                    selected = %metric_identity,
+                    generation = selection_generation,
+                    "Sending one-way request to selected nameserver"
+                );
+                let result = async {
+                    let endpoint = CheetahString::from_string(client.remote_address().to_string());
+                    let mut request = request;
+                    if let Some(hooks) = self.cmd_handler.hook_snapshot() {
+                        request.make_custom_header_to_net();
+                        self.cmd_handler.do_before_rpc_hooks_with_snapshot(
+                            Some(hooks.as_ref()),
+                            client.remote_address(),
+                            Some(&mut request),
+                        )?;
+                    }
+                    request.mark_oneway_rpc_ref();
+                    client.send_until(request, deadline).await?;
+                    Ok(SendReceipt {
+                        endpoint,
+                        written_at_millis: current_millis(),
+                    })
+                }
+                .await;
+                self.record_nameserver_outcome(
+                    Some(&metric_identity),
+                    Some(&metric_lease),
+                    started_at.elapsed(),
+                    result.is_ok(),
+                );
+                result
+            }
+        }
+    }
+
+    pub async fn invoke_request_with_deadline(
+        &self,
+        addr: Option<&CheetahString>,
+        request: RemotingCommand,
+        deadline: RequestDeadline,
+    ) -> RocketMQResult<RemotingCommand> {
+        let nameserver_request = addr.is_none_or(CheetahString::is_empty);
+        let start = time::Instant::now();
+        let timeout_millis = deadline.budget_millis();
+        let target = if nameserver_request {
+            "<nameserver>".to_string()
+        } else {
+            addr.map_or_else(|| "<nameserver>".to_string(), ToString::to_string)
+        };
+        deadline.ensure_before_send(target.clone())?;
+        let nameserver_diagnostics = nameserver_request.then(|| self.endpoint_state.load());
+        let nameserver_selection = if nameserver_request {
+            self.get_and_create_nameserver_client_until(deadline).await?
+        } else {
+            None
+        };
+        let nameserver_metric_addr = nameserver_selection
+            .as_ref()
+            .map(|selection| selection.identity.clone());
+        let nameserver_lease = nameserver_selection.as_ref().map(|selection| selection.lease.clone());
+        let nameserver_generation = nameserver_selection
+            .as_ref()
+            .map(|selection| selection.state.generation());
+        let mut client = match nameserver_selection {
+            Some(selection) => Some(selection.session),
+            None if nameserver_request => None,
+            None => self.get_and_create_client_until(addr, deadline).await?,
+        }
+        .ok_or_else(|| {
+            if target == "<nameserver>" {
+                if let Some(state) = nameserver_diagnostics.as_ref() {
+                    error!(
+                        "Failed to get client for <nameserver>. Diagnostics: configured_list={:?}, available_set={:?}, \\
+                         cached_choice={:?}, connections={}",
+                        state.endpoints(),
+                        state.available(),
+                        state.chosen(),
+                        self.connection_registry.len()
+                    );
+                }
+            } else {
+                error!("Failed to get client for {}", target);
+            }
+
+            RocketMQError::network_connection_failed(target.clone(), "Failed to connect")
+        })?;
+
+        if self.is_stopping() {
+            return Err(RocketMQError::ClientNotStarted);
+        }
+
+        let mut request = request;
+        let initial_remote_address = client.remote_address();
+        deadline.ensure_before_send(initial_remote_address.to_string())?;
+        let hooks = self.cmd_handler.hook_snapshot();
+        let request_for_after = if let Some(hooks) = hooks {
+            request.make_custom_header_to_net();
+            self.cmd_handler.do_before_rpc_hooks_with_snapshot(
+                Some(hooks.as_ref()),
+                initial_remote_address,
+                Some(&mut request),
+            )?;
+            deadline.ensure_before_send(initial_remote_address.to_string())?;
+            Some((request.clone(), hooks))
+        } else {
+            None
+        };
+        let apply_final_hooks =
+            |mut response: RemotingCommand, remote_address: std::net::SocketAddr| -> RocketMQResult<RemotingCommand> {
+                if let Some((request, hooks)) = request_for_after.as_ref() {
+                    self.cmd_handler.do_after_rpc_hooks_with_snapshot(
+                        Some(hooks.as_ref()),
+                        remote_address,
+                        request,
+                        Some(&mut response),
+                    )?;
+                }
+                if deadline.is_expired() {
+                    return Err(RocketMQError::network_response_timeout(
+                        remote_address.to_string(),
+                        timeout_millis,
+                    ));
+                }
+                Ok(response)
+            };
+        let retry_allowed = self.go_away_policy.allows_request(request.code()) && !request.is_oneway_rpc();
+        let retry_request = request.clone();
+        let mut attempted_retry = false;
+
+        loop {
+            let remote_address = client.remote_address();
+            let identity = if nameserver_request {
+                self.connection_registry
+                    .session_identity(&client)
+                    .or_else(|| nameserver_metric_addr.clone())
+                    .unwrap_or_else(|| CheetahString::from_string(remote_address.to_string()))
+            } else {
+                self.session_cache_identity(addr, &client)
+            };
+            let mut attempt_request = retry_request.clone();
+            if attempted_retry {
+                attempt_request.set_opaque_mut(RemotingCommand::get_and_add());
+            }
+
+            match client.send_read(attempt_request, deadline).await {
+                Ok(response) if response.code() == ResponseCode::GoAway.to_i32() => {
+                    self.telemetry.record_go_away(TransportGoAwayOutcome::Received);
+                    if !retry_allowed {
+                        let response = apply_final_hooks(response, remote_address)?;
+                        let latency = start.elapsed();
+                        self.record_nameserver_outcome(
+                            nameserver_metric_addr.as_ref(),
+                            nameserver_lease.as_ref(),
+                            latency,
+                            true,
+                        );
+                        debug!(
+                            remote_addr = %identity,
+                            elapsed_ms = latency.as_millis() as u64,
+                            "request completed with GO_AWAY retry disabled"
+                        );
+                        return Ok(response);
+                    }
+                    self.remove_cached_session_if_matches(&identity, &client);
+                    self.start_go_away_drain(identity.clone(), client);
+
+                    if attempted_retry {
+                        self.telemetry.record_go_away(TransportGoAwayOutcome::RetryFailed);
+                        self.record_nameserver_outcome(
+                            nameserver_metric_addr.as_ref(),
+                            nameserver_lease.as_ref(),
+                            start.elapsed(),
+                            false,
+                        );
+                        return Err(RpcClientError::unexpected_response_code(
+                            response.code(),
+                            "GO_AWAY after replacement-connection retry",
+                        )
+                        .into());
+                    }
+
+                    attempted_retry = true;
+                    if let Err(error) = deadline.ensure_before_send(identity.to_string()) {
+                        self.telemetry.record_go_away(TransportGoAwayOutcome::RetryFailed);
+                        self.record_nameserver_outcome(
+                            nameserver_metric_addr.as_ref(),
+                            nameserver_lease.as_ref(),
+                            start.elapsed(),
+                            false,
+                        );
+                        return Err(error);
+                    }
+                    let replacement = match self.get_and_create_client_until(addr, deadline).await {
+                        Ok(Some(replacement)) => Ok(replacement),
+                        Ok(None) => Err(RocketMQError::network_connection_failed(
+                            identity.to_string(),
+                            "GO_AWAY replacement connection unavailable",
+                        )),
+                        Err(error) => Err(error),
+                    };
+                    client = match replacement {
+                        Ok(replacement) => replacement,
+                        Err(error) => {
+                            self.telemetry.record_go_away(TransportGoAwayOutcome::RetryFailed);
+                            self.record_nameserver_outcome(
+                                nameserver_metric_addr.as_ref(),
+                                nameserver_lease.as_ref(),
+                                start.elapsed(),
+                                false,
+                            );
+                            return Err(error);
+                        }
+                    };
+                }
+                Ok(response) => {
+                    let response = match apply_final_hooks(response, remote_address) {
+                        Ok(response) => response,
+                        Err(error) => {
+                            if attempted_retry {
+                                self.telemetry.record_go_away(TransportGoAwayOutcome::RetryFailed);
+                            }
+                            self.record_nameserver_outcome(
+                                nameserver_metric_addr.as_ref(),
+                                nameserver_lease.as_ref(),
+                                start.elapsed(),
+                                false,
+                            );
+                            return Err(error);
+                        }
+                    };
+                    if attempted_retry {
+                        self.telemetry.record_go_away(TransportGoAwayOutcome::RetrySuccess);
+                    }
+                    let latency = start.elapsed();
+                    self.record_nameserver_outcome(
+                        nameserver_metric_addr.as_ref(),
+                        nameserver_lease.as_ref(),
+                        latency,
+                        true,
+                    );
+                    debug!(
+                        remote_addr = %identity,
+                        nameserver_generation = ?nameserver_generation,
+                        elapsed_ms = latency.as_millis() as u64,
+                        "request completed"
+                    );
+                    return Ok(response);
+                }
+                Err(error) => {
+                    if matches!(
+                        error,
+                        RocketMQError::Network(
+                            NetworkError::WriteTimeout { .. } | NetworkError::ResponseTimeout { .. }
+                        )
+                    ) {
+                        client.retire_after_timeout().await;
+                        self.remove_cached_session_if_matches(&identity, &client);
+                    }
+                    if attempted_retry {
+                        self.telemetry.record_go_away(TransportGoAwayOutcome::RetryFailed);
+                    }
+                    let latency = start.elapsed();
+                    self.record_nameserver_outcome(
+                        nameserver_metric_addr.as_ref(),
+                        nameserver_lease.as_ref(),
+                        latency,
+                        false,
+                    );
+                    warn!(
+                        remote_addr = %identity,
+                        elapsed_ms = latency.as_millis() as u64,
+                        error = ?error,
+                        "request failed"
+                    );
+                    return Err(error);
+                }
+            }
+        }
+    }
+}

--- a/rocketmq-transport/src/clients/rocketmq_tokio_client/tests.rs
+++ b/rocketmq-transport/src/clients/rocketmq_tokio_client/tests.rs
@@ -18,16 +18,21 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_runtime::RuntimeContext;
+use tokio::io::AsyncReadExt;
 use tokio::net::TcpListener;
 
 use super::*;
 use crate::connection::Connection;
+use crate::deadline::RequestDeadline;
 use crate::request_processor::default_request_processor::DefaultRequestProcessor;
 use crate::runtime::config::client_config::TransportClientConfig;
 use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use tokio::time;
 
 use self::runtime_test_support::test_service_context;
 
@@ -71,6 +76,26 @@ impl RPCHook for CountingHook {
         );
         response.ensure_ext_fields_initialized();
         response.add_ext_field("afterHook", "true");
+        Ok(())
+    }
+}
+
+struct RejectingRequestHook {
+    calls: AtomicUsize,
+}
+
+impl RPCHook for RejectingRequestHook {
+    fn do_before_request(&self, _remote_addr: SocketAddr, _request: &mut RemotingCommand) -> RocketMQResult<()> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Err(RocketMQError::illegal_argument("injected request hook rejection"))
+    }
+
+    fn do_after_response(
+        &self,
+        _remote_addr: SocketAddr,
+        _request: &RemotingCommand,
+        _response: &mut RemotingCommand,
+    ) -> RocketMQResult<()> {
         Ok(())
     }
 }
@@ -369,6 +394,48 @@ async fn stale_probe_result_cannot_update_replaced_generation() {
 }
 
 #[tokio::test]
+async fn stale_nameserver_request_outcome_cannot_mutate_a_readded_generation() {
+    let client = TransportClient::build_for_test(
+        Arc::new(TransportClientConfig::default()),
+        DefaultRequestProcessor,
+        test_service_context("stale-request-outcome-generation-test"),
+    );
+    let endpoint = NameServerEndpoint::legacy("127.0.0.1:9876").expect("valid nameserver");
+    let identity = endpoint.identity().clone();
+    client.apply_name_server_endpoint_snapshot_sync(vec![endpoint.clone()], Duration::ZERO);
+    let stale_lease = client
+        .endpoint_state
+        .load()
+        .lease_for(&identity)
+        .expect("initial endpoint lease");
+
+    client.apply_name_server_endpoint_snapshot_sync(Vec::new(), Duration::ZERO);
+    client.apply_name_server_endpoint_snapshot_sync(vec![endpoint], Duration::ZERO);
+    let readded_lease = client
+        .endpoint_state
+        .load()
+        .lease_for(&identity)
+        .expect("re-added endpoint lease");
+    assert!(!readded_lease.same_generation(&stale_lease));
+    client
+        .nameserver_health
+        .connection_admission_if_current(&identity, &readded_lease, || {
+            client.endpoint_state.is_current(&readded_lease)
+        });
+    assert!(client
+        .nameserver_health
+        .owns_latency_for_test(&identity, &readded_lease));
+
+    client.record_nameserver_outcome(Some(&identity), Some(&stale_lease), Duration::from_millis(1), false);
+
+    assert_eq!(client.nameserver_health.latency_error_count_for_test(&identity), 0);
+    assert!(client
+        .nameserver_health
+        .owns_latency_for_test(&identity, &readded_lease));
+    client.shutdown();
+}
+
+#[tokio::test]
 async fn stale_connect_completion_cannot_register_into_new_generation() {
     let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
     let addr = listener.local_addr().expect("listener addr");
@@ -652,6 +719,50 @@ async fn invoke_request_runs_outbound_rpc_hooks() {
 
     server.await.expect("server task");
     client.shutdown();
+}
+
+#[tokio::test]
+async fn request_before_hook_error_is_preserved_without_writing_a_frame() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind hook peer");
+    let target = CheetahString::from_string(listener.local_addr().expect("hook peer address").to_string());
+    let peer = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept hook client");
+        let mut byte = [0_u8; 1];
+        socket.read(&mut byte).await.expect("read hook client")
+    });
+    let client = TransportClient::build_for_test(
+        Arc::new(TransportClientConfig::default()),
+        DefaultRequestProcessor,
+        test_service_context("remoting-client-request-hook-error-test"),
+    );
+    let hook = Arc::new(RejectingRequestHook {
+        calls: AtomicUsize::new(0),
+    });
+    client.register_rpc_hook(hook.clone());
+
+    let result = client
+        .invoke_request(
+            Some(&target),
+            RemotingCommand::create_remoting_command(RequestCode::GetBrokerClusterInfo),
+            3_000,
+        )
+        .await;
+    let error = match result {
+        Err(error) => error,
+        Ok(_) => panic!("request hook rejection must be returned"),
+    };
+
+    assert!(matches!(
+        error,
+        RocketMQError::IllegalArgument(message) if message == "injected request hook rejection"
+    ));
+    assert_eq!(hook.calls.load(Ordering::SeqCst), 1);
+    client.shutdown();
+    assert_eq!(
+        peer.await.expect("hook peer task"),
+        0,
+        "hook rejection must not write bytes"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/rocketmq-transport/tests/go_away_reconnect.rs
+++ b/rocketmq-transport/tests/go_away_reconnect.rs
@@ -25,7 +25,9 @@ use std::sync::Mutex;
 use std::time::Duration;
 
 use cheetah_string::CheetahString;
+use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
+use rocketmq_error::RpcClientError;
 use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::command_custom_header::CommandCustomHeader;
@@ -534,7 +536,11 @@ async fn a_second_go_away_fails_without_an_unbounded_retry() {
         Err(error) => error,
     };
 
-    assert!(error.to_string().contains("GO_AWAY"), "{error}");
+    let RocketMQError::Rpc(RpcClientError::UnexpectedResponseCode { code, code_name }) = error else {
+        panic!("second GO_AWAY must preserve the typed unexpected-response error");
+    };
+    assert_eq!(code, ResponseCode::GoAway.to_i32());
+    assert_eq!(code_name, "GO_AWAY after replacement-connection retry");
     assert_eq!(handler.calls.load(Ordering::SeqCst), 2);
     assert_eq!(hook.before.load(Ordering::SeqCst), 1);
     assert_eq!(hook.after.load(Ordering::SeqCst), 0);

--- a/scripts/module-maintainability-baseline.json
+++ b/scripts/module-maintainability-baseline.json
@@ -10926,8 +10926,8 @@
       "reexports": 0
     },
     "rocketmq-transport/src/clients/rocketmq_tokio_client.rs": {
-      "production_lines": 736,
-      "public_items": 2,
+      "production_lines": 326,
+      "public_items": 1,
       "reexports": 1
     },
     "rocketmq-transport/src/clients/rocketmq_tokio_client/api.rs": {
@@ -10956,8 +10956,13 @@
       "reexports": 0
     },
     "rocketmq-transport/src/clients/rocketmq_tokio_client/nameserver.rs": {
-      "production_lines": 468,
+      "production_lines": 481,
       "public_items": 0,
+      "reexports": 0
+    },
+    "rocketmq-transport/src/clients/rocketmq_tokio_client/request.rs": {
+      "production_lines": 397,
+      "public_items": 1,
       "reexports": 0
     },
     "rocketmq-transport/src/codec.rs": {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9664

### Brief Description

Extracts canonical request, one-way, RPC hook, GO_AWAY retry, timeout-retirement, and NameServer outcome orchestration from the Tokio client parent into a private request module.

The change preserves public API paths and signatures, one absolute request deadline, one allowlisted non-oneway replacement retry, replacement-safe lifecycle-owned draining, typed second-GO_AWAY failure, hook ordering and errors, and generation-aware NameServer health updates. It also removes the bounded-loop `unreachable!` debt and updates only the reviewed maintainability records.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-transport -- --check`
- Focused request-hook and stale-NameServer-generation unit tests
- GO_AWAY (10), one-way (6), NameServer lifecycle (3), and public API (18) integration tests
- `cargo test -p rocketmq-transport --lib --all-features` (239 passed)
- `cargo test -p rocketmq-transport --all-features`
- `cargo doc -p rocketmq-transport --no-deps --all-features` (passed with one unchanged Rustdoc warning)
- Package and workspace all-targets/all-features Clippy with warnings denied
- Runtime ownership, error hygiene, Rust hygiene, maintainability, public API, stable-surface, and core-release static guards
- Compared nonzero repository guard output with the base and confirmed no new candidate findings