### PR TITLE
[ISSUE #9671]🐛Restore recursion limits for Client test targets

### DIFF
--- a/rocketmq-client/tests/batch_admin_delete.rs
+++ b/rocketmq-client/tests/batch_admin_delete.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 use std::collections::HashSet;
 
 use cheetah_string::CheetahString;

--- a/rocketmq-client/tests/client_config_behavior.rs
+++ b/rocketmq-client/tests/client_config_behavior.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 use rocketmq_client_rust::ClientConfig;
 
 #[test]

--- a/rocketmq-client/tests/latency_fault_java_compat.rs
+++ b/rocketmq-client/tests/latency_fault_java_compat.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 use rocketmq_client_rust::test_support::LatencyFaultJavaCompatHarness;
 use rocketmq_runtime::RuntimeConfig;
 use rocketmq_runtime::RuntimeOwner;

--- a/rocketmq-client/tests/lite_pull_suspend_timeout.rs
+++ b/rocketmq-client/tests/lite_pull_suspend_timeout.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 use rocketmq_client_rust::test_support::run_lite_pull_suspend_timeout_probe;
 
 #[test]

--- a/rocketmq-client/tests/nameserver_dns_discovery.rs
+++ b/rocketmq-client/tests/nameserver_dns_discovery.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
 #![cfg(all(feature = "nameserver-dns-discovery", feature = "test-support"))]
 
 use rocketmq_client_rust::test_support::run_nameserver_discovery_lifecycle_probe;

--- a/rocketmq-client/tests/pop_retry_policy.rs
+++ b/rocketmq-client/tests/pop_retry_policy.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 use rocketmq_client_rust::pop_retry_subscription_topics;
 use rocketmq_client_rust::resolve_pop_retry_topic;
 use rocketmq_model::common::pop_retry_policy::PopRetryTopicVersion;

--- a/rocketmq-client/tests/socks_proxy_config.rs
+++ b/rocketmq-client/tests/socks_proxy_config.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 use rocketmq_client_rust::ClientConfig;
 
 #[test]

--- a/rocketmq-client/tests/transport_security_profiles.rs
+++ b/rocketmq-client/tests/transport_security_profiles.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
+
 use std::fs;
 use std::sync::Arc;
 use std::time::Duration;

--- a/rocketmq-client/tests/windows_consumer_process_startup.rs
+++ b/rocketmq-client/tests/windows_consumer_process_startup.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![recursion_limit = "256"]
 #![cfg(windows)]
 
 use std::io::Write;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9671

### Brief Description

- Add the repository-standard `#![recursion_limit = "256"]` attribute to nine Client integration-test crate roots.
- Restore the invariant enforced by `target_recursion_limit_contract` without weakening or excluding any Cargo target from the contract.
- Keep existing feature and platform crate attributes intact for the NameServer DNS and Windows startup targets.

### How Did You Test This Change?

- `cargo test -p rocketmq-client-rust --test target_recursion_limit_contract`: passed.
- `cargo fmt -p rocketmq-client-rust -- --check`: passed.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- `git diff --check`: passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test suite compatibility by increasing the permitted recursion depth across client behavior, networking, configuration, discovery, retry, security, and Windows startup tests.
  * Supports more reliable test compilation and execution without changing end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->