### PR TITLE
[ISSUE #9169]✨Skip lifecycle in namesrv shutdown tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **fix(namesrv):** Exclude the lifecycle handle from shutdown-report tracing instrumentation ([#9169](https://github.com/mxsm/rocketmq-rust/issues/9169))
 - **refactor(error):** Preserve typed header, JSON, and authorization sources through Controller maintenance handling while retaining the existing error kinds and redacted boundary projections.
 - **fix(controller):** Route online consensus membership changes through `apply_membership_change`, which requires a maintenance authorization grant, optimistic membership version, idempotency key, quorum checks, and audit facts. Direct public `add_learner` and `change_membership` mutation methods are no longer exposed; embedders must migrate online changes to the authorized boundary.
 - **refactor(proxy):** Remove the hidden `rocketmq_broker::proxy_adapter_compat` re-export surface. Embedded proxy integrations must import model, protocol, store, transport, and observability types from their owning crates and use `ProxyBrokerFacade` for Broker use cases.

--- a/rocketmq-namesrv/src/bootstrap.rs
+++ b/rocketmq-namesrv/src/bootstrap.rs
@@ -665,7 +665,7 @@ impl NameServerRuntime {
         self.start_with_shutdown_report(None).await.map(|_| ())
     }
 
-    #[instrument(skip(self), name = "runtime_start_with_shutdown_report")]
+    #[instrument(skip(self, lifecycle), name = "runtime_start_with_shutdown_report")]
     async fn start_with_shutdown_report(
         &mut self,
         lifecycle: Option<&ServiceLifecycle>,


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9169

### Brief Description

Exclude the `ServiceLifecycle` handle from the `runtime_start_with_shutdown_report` tracing span in `rocketmq-namesrv`. This matches the existing `self` skip, avoids recording the lifecycle value, and adds the change to the Unreleased changelog.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-namesrv -- --check`
- `cargo check -p rocketmq-namesrv --locked`
- `cargo check -p rocketmq-namesrv --all-features --locked` with Xcode libclang available to the RocksDB build script
- `cargo clippy -p rocketmq-namesrv --all-targets --all-features --locked -- -D warnings`
- `cargo test -p rocketmq-namesrv --lib --locked`: 258 passed; the existing `config::tests::test_namesrv_config` failure reproduced unchanged on clean `origin/main`
- `cargo test -p rocketmq-namesrv --lib --all-features --locked`: 260 passed; the same baseline test failed
- Workspace Clippy was attempted but remains blocked by pre-existing unused/dead-code errors in `rocketmq-store-local`
- The enforcing PowerShell runtime audit was not run because PowerShell 7 is unavailable in this environment



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown-report tracing by excluding internal lifecycle details from recorded diagnostic data.

* **Documentation**
  * Added an unreleased changelog entry describing the tracing update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->