### PR TITLE
[ISSUE #9676]🐛Make maintainability history deterministic per source revision

### DIFF
--- a/scripts/module_maintainability_guard.py
+++ b/scripts/module_maintainability_guard.py
@@ -27,6 +27,8 @@ import sys
 from collections import defaultdict
 from dataclasses import asdict
 from dataclasses import dataclass
+from datetime import datetime
+from datetime import timezone
 from pathlib import Path
 from typing import Any
 
@@ -135,18 +137,40 @@ def crate_name(relative: Path) -> str:
     return parts[0]
 
 
-def git_history(root: Path) -> dict[str, History]:
-    command = [
-        "git",
-        "log",
-        "--since=12 months ago",
-        "--format=@@%H%x09%ae%x09%s",
-        "--name-only",
-        "--no-renames",
-        "--",
-        "*.rs",
-    ]
+def history_window(root: Path) -> tuple[int, int]:
+    """Return the UTC calendar-year window anchored to the checked-out HEAD."""
+    result = subprocess.run(
+        ["git", "show", "-s", "--format=%ct", "HEAD"],
+        cwd=root,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        check=True,
+    )
+    anchor_epoch = int(result.stdout.strip())
+    anchor = datetime.fromtimestamp(anchor_epoch, tz=timezone.utc)
     try:
+        cutoff = anchor.replace(year=anchor.year - 1)
+    except ValueError:
+        cutoff = anchor.replace(year=anchor.year - 1, day=28)
+    return int(cutoff.timestamp()), anchor_epoch
+
+
+def git_history(root: Path) -> dict[str, History]:
+    try:
+        cutoff_epoch, anchor_epoch = history_window(root)
+        command = [
+            "git",
+            "log",
+            f"--since=@{cutoff_epoch}",
+            f"--until=@{anchor_epoch}",
+            "--format=@@%H%x09%ae%x09%s",
+            "--name-only",
+            "--no-renames",
+            "--",
+            "*.rs",
+        ]
         result = subprocess.run(
             command,
             cwd=root,
@@ -156,7 +180,7 @@ def git_history(root: Path) -> dict[str, History]:
             capture_output=True,
             check=True,
         )
-    except (OSError, subprocess.CalledProcessError):
+    except (OSError, OverflowError, ValueError, subprocess.CalledProcessError):
         return {}
 
     commits: dict[str, set[str]] = defaultdict(set)

--- a/scripts/tests/test_module_maintainability_guard.py
+++ b/scripts/tests/test_module_maintainability_guard.py
@@ -15,8 +15,15 @@
 from __future__ import annotations
 
 import json
+import os
+import shutil
+import subprocess
+import tempfile
 import unittest
+from datetime import datetime
+from datetime import timezone
 from pathlib import Path
+from unittest import mock
 
 from scripts import module_maintainability_guard as guard
 
@@ -66,6 +73,79 @@ def decision_section(path: str, *, outcome: str = "retained") -> str:
 
 
 class ModuleMaintainabilityGuardTests(unittest.TestCase):
+    def test_history_window_uses_utc_calendar_year_and_clamps_leap_day(self) -> None:
+        anchor = datetime(2024, 2, 29, 23, 59, 58, tzinfo=timezone.utc)
+        completed = subprocess.CompletedProcess([], 0, f"{int(anchor.timestamp())}\n", "")
+
+        with mock.patch.object(guard.subprocess, "run", return_value=completed) as run:
+            cutoff_epoch, anchor_epoch = guard.history_window(Path("fixture"))
+
+        self.assertEqual(int(anchor.timestamp()), anchor_epoch)
+        self.assertEqual(
+            int(datetime(2023, 2, 28, 23, 59, 58, tzinfo=timezone.utc).timestamp()),
+            cutoff_epoch,
+        )
+        self.assertEqual(
+            ["git", "show", "-s", "--format=%ct", "HEAD"],
+            run.call_args.args[0],
+        )
+
+    def test_same_head_uses_fixed_history_arguments_independent_of_wall_clock(self) -> None:
+        anchor_epoch = int(datetime(2025, 3, 1, 0, 0, tzinfo=timezone.utc).timestamp())
+        history = "@@commit\tauthor@example.test\tfix fixture\nfixture.rs\n"
+
+        def run(command: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+            if command[1] == "show":
+                return subprocess.CompletedProcess(command, 0, f"{anchor_epoch}\n", "")
+            return subprocess.CompletedProcess(command, 0, history, "")
+
+        with mock.patch.object(guard.subprocess, "run", side_effect=run) as mocked:
+            first = guard.git_history(Path("fixture"))
+            second = guard.git_history(Path("fixture"))
+
+        self.assertEqual(first, second)
+        log_commands = [call.args[0] for call in mocked.call_args_list if call.args[0][1] == "log"]
+        self.assertEqual(2, len(log_commands))
+        self.assertEqual(log_commands[0], log_commands[1])
+
+    def test_history_log_is_bounded_to_the_fixed_head_window(self) -> None:
+        anchor_epoch = int(datetime(2025, 3, 1, 0, 0, tzinfo=timezone.utc).timestamp())
+
+        def run(command: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+            if command[1] == "show":
+                return subprocess.CompletedProcess(command, 0, f"{anchor_epoch}\n", "")
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        with mock.patch.object(guard.subprocess, "run", side_effect=run) as mocked:
+            guard.git_history(Path("fixture"))
+
+        log_command = next(call.args[0] for call in mocked.call_args_list if call.args[0][1] == "log")
+        self.assertIn("--since=@1709251200", log_command)
+        self.assertIn("--until=@1740787200", log_command)
+        self.assertNotIn("--since=12 months ago", log_command)
+
+    def test_invalid_head_timestamp_fails_closed_without_running_git_log(self) -> None:
+        completed = subprocess.CompletedProcess([], 0, "not-a-timestamp\n", "")
+
+        with mock.patch.object(guard.subprocess, "run", return_value=completed) as run:
+            self.assertEqual({}, guard.git_history(Path("fixture")))
+
+        self.assertEqual(1, run.call_count)
+        self.assertEqual(["git", "show", "-s", "--format=%ct", "HEAD"], run.call_args.args[0])
+
+    def test_nonrepresentable_head_timestamp_fails_closed_without_running_git_log(self) -> None:
+        completed = subprocess.CompletedProcess([], 0, "9223372036854775807\n", "")
+
+        with (
+            mock.patch.object(guard.subprocess, "run", return_value=completed) as run,
+            mock.patch.object(guard, "datetime") as date_time,
+        ):
+            date_time.fromtimestamp.side_effect = OverflowError("timestamp out of range")
+            self.assertEqual({}, guard.git_history(Path("fixture")))
+
+        self.assertEqual(1, run.call_count)
+        self.assertEqual(["git", "show", "-s", "--format=%ct", "HEAD"], run.call_args.args[0])
+
     def test_ranking_uses_history_and_ownership_not_only_lines(self) -> None:
         large_static = guard.score_metrics(1_000, 0, 0, 0, 1, 0, guard.History())
         smaller_high_churn = guard.score_metrics(
@@ -187,6 +267,93 @@ pub struct RuntimeState;
         findings = guard.validate_decision_ledger([hotspot], document)
 
         self.assertEqual({"incomplete-hotspot-decision"}, {finding.code for finding in findings})
+
+
+class GitHistoryWindowTests(unittest.TestCase):
+    def init_repo(self) -> Path:
+        directory = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, directory, ignore_errors=True)
+        for command in (
+            ["git", "init", "--quiet"],
+            ["git", "config", "user.name", "Fixture Author"],
+            ["git", "config", "user.email", "fixture@example.test"],
+        ):
+            subprocess.run(command, cwd=directory, check=True)
+        return directory
+
+    def commit(
+        self,
+        root: Path,
+        timestamp: str,
+        body: str = "pub struct Fixture;\n",
+        *,
+        path: str = "fixture.rs",
+    ) -> None:
+        (root / path).write_text(body, encoding="utf-8")
+        environment = os.environ | {
+            "GIT_AUTHOR_DATE": timestamp,
+            "GIT_COMMITTER_DATE": timestamp,
+        }
+        subprocess.run(["git", "add", path], cwd=root, check=True)
+        subprocess.run(
+            ["git", "commit", "--quiet", "-m", "fixture history"],
+            cwd=root,
+            check=True,
+            env=environment,
+        )
+
+    def test_history_includes_fixed_window_boundaries(self) -> None:
+        root = self.init_repo()
+        self.commit(root, "2020-01-01T00:00:00+0000", path="initial.rs")
+        self.commit(
+            root,
+            "2024-02-29T23:59:59+0000",
+            "pub struct BeforeCutoff;\n",
+            path="before_cutoff.rs",
+        )
+        self.commit(
+            root,
+            "2024-03-01T00:00:00+0000",
+            "pub struct Cutoff;\n",
+            path="cutoff.rs",
+        )
+        self.commit(
+            root,
+            "2025-03-01T00:00:00+0000",
+            "pub struct Anchor;\n",
+            path="anchor.rs",
+        )
+
+        history = guard.git_history(root)
+
+        self.assertEqual(guard.History(commits=1, contributors=1, defects=0), history["cutoff.rs"])
+        self.assertEqual(guard.History(commits=1, contributors=1, defects=0), history["anchor.rs"])
+        self.assertNotIn("before_cutoff.rs", history)
+
+    def test_history_excludes_a_future_dated_ancestor(self) -> None:
+        root = self.init_repo()
+        self.commit(root, "2020-01-01T00:00:00+0000", path="initial.rs")
+        self.commit(root, "2024-03-01T00:00:00+0000", path="cutoff.rs")
+        self.commit(root, "2025-03-01T00:00:01+0000", path="future.rs")
+        self.commit(root, "2025-03-01T00:00:00+0000", path="anchor.rs")
+
+        history = guard.git_history(root)
+
+        self.assertIn("cutoff.rs", history)
+        self.assertIn("anchor.rs", history)
+        self.assertNotIn("future.rs", history)
+
+    def test_new_head_advances_window_and_counts_its_commit(self) -> None:
+        root = self.init_repo()
+        self.commit(root, "2024-06-01T00:00:00+0000")
+        self.commit(root, "2025-01-01T00:00:00+0000", "pub struct FirstHead;\n")
+
+        before = guard.git_history(root)
+        self.commit(root, "2025-02-01T00:00:00+0000", "pub struct SecondHead;\n")
+        after = guard.git_history(root)
+
+        self.assertEqual(2, before["fixture.rs"].commits)
+        self.assertEqual(3, after["fixture.rs"].commits)
 
 
 class RepositoryModuleMaintainabilityContracts(unittest.TestCase):


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9676

### Brief Description

Anchor the one-calendar-year maintainability history window to the checked-out HEAD committer timestamp in UTC instead of the wall clock. Pass fixed epoch bounds to Git, clamp February 29 to February 28 in the preceding year, exclude future-dated ancestors, and preserve the existing empty-history fallback for Git invocation and timestamp conversion failures.

Add deterministic mock and temporary-repository coverage for UTC calendar-year arithmetic, boundary inclusion, fixed same-HEAD arguments, future-dated ancestors, invalid timestamps, and window advancement after a new HEAD. No maintainability schema, policy, baseline, or generated board artifact is changed.

### How Did You Test This Change?

- The 18 focused maintainability history tests passed.
- `python -B -m unittest scripts.tests.test_module_maintainability_guard -v` ran 21 tests: 20 passed, and the only failure was the pre-existing 36-finding baseline drift reproduced unchanged on the base revision.
- `python -B scripts/module_maintainability_guard.py --scope core-release` produced the same 36 pre-existing findings on candidate and base.
- `python -B scripts/core_release_static_guard.py` produced the same pre-existing failing routes on candidate and base: `architecture-dependency`, `module-maintainability`, and `architecture-release`.
- Two same-HEAD baseline and report generations were byte-identical.
- `git diff --check` passed.
