### PR TITLE
[ISSUE #9681]🚀Persist dashboard history and coordinate retention

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-web/README.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/README.md
@@ -44,6 +44,9 @@ $env:DASHBOARD_WEB_LOGIN_REQUIRED="false"
 $env:DASHBOARD_WEB_USERNAME="admin"
 $env:DASHBOARD_WEB_PASSWORD="rocketmq"
 $env:DASHBOARD_WEB_HISTORY_INTERVAL_SECS="60"
+$env:DASHBOARD_WEB_HISTORY_RETENTION_DAYS="30"
+$env:DASHBOARD_WEB_HISTORY_RETENTION_BATCH_SIZE="500"
+$env:DASHBOARD_WEB_HISTORY_LEASE_TTL_SECS="30"
 $env:DASHBOARD_WEB_USE_VIP_CHANNEL="false"
 $env:DASHBOARD_WEB_USE_TLS="false"
 $env:DASHBOARD_WEB_ROCKETMQ_ACCESS_KEY="<access-key>"
@@ -191,10 +194,29 @@ npm run build
 - DLQ query by key/messageId, bounded page-scan query, batch direct-consume resend, and JSON/CSV export payloads.
 - Web service modules use the feature-gated common `DashboardAdminFacade` for core Dashboard, Topic, Consumer, Producer, Broker, and Message operations.
 - Auth/session API with optional environment-driven login requirement, protected API middleware, and frontend login flow.
-- Dashboard history APIs backed by an in-memory background collector; set `DASHBOARD_WEB_HISTORY_INTERVAL_SECS=0` to disable collection.
+- Dashboard history APIs persist UTC-day JSONL segments for File and durable rows for SQLite, MySQL, and PostgreSQL. Set `DASHBOARD_WEB_HISTORY_INTERVAL_SECS=0` to disable collection. Retention removes samples older than `DASHBOARD_WEB_HISTORY_RETENTION_DAYS` in bounded batches; File retention removes complete UTC-day segments, so it can retain part of the cutoff day until the next day. SQL collectors use a database-clock task lease, while the File backend uses its data-directory lock.
+- History capacity coverage uses a 500-sample append batch, 200-row first and continuation pages, and 10,000 rows of bounded retention work. The SQL query and retention indexes are `dashboard_history_sample_query_idx` and `dashboard_history_sample_retention_idx`.
 - React + TypeScript + Vite frontend.
 - Dashboard app shell with sidebar, top status bar, light/dark theme, dense tables, search, pagination, loading/error/empty states, confirmation dialogs, and message detail drawer.
 - Frontend routes for Dashboard, Topics, Consumers, Producers, Brokers, Messages, DLQ, ACL, Monitors, and Config.
+
+### History storage capacity baseline
+
+The following 2026-08-24 baseline was measured on a local Windows Docker Desktop host with fresh named volumes. It writes 10,000 samples in batches of at most 500, reads a 200-row first and continuation page, then converges 10,000 expired rows. Container scheduling, host load, and filesystem performance affect the timings, so these are recorded measurements rather than latency limits.
+
+| Backend | Append 500 | First page 200 | Continuation 200 | Retention 10,000 | Query-plan evidence |
+| --- | ---: | ---: | ---: | ---: | --- |
+| File (mounted volume) | 19 ms | 37 ms | 39 ms | 56 ms | UTC environment/day JSONL segments; no SQL plan |
+| SQLite (mounted database) | 11 ms | 1 ms | 1 ms | 89 ms | `dashboard_history_sample_query_idx` |
+| MySQL 8.4 | 43 ms | 2 ms | 3 ms | 381 ms | `dashboard_history_sample_retention_idx`, `range`, no `ALL` scan |
+| PostgreSQL 15 | 22 ms | 3 ms | 2 ms | 78 ms | `Index Scan` on `dashboard_history_sample_retention_idx` |
+
+Reproduce the complete File, mounted SQLite, MySQL, and PostgreSQL functional and capacity matrix from this directory:
+
+```bash
+docker compose -f docker-compose.storage-test.yml up --build --abort-on-container-exit --exit-code-from storage-test-runner
+docker compose -f docker-compose.storage-test.yml down -v --remove-orphans
+```
 
 ## TODO
 

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.toml
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.toml
@@ -32,3 +32,4 @@ rocketmq-runtime = { version = "1.0.0", path = "../../../rocketmq-runtime" }
 
 [dev-dependencies]
 tempfile = "3"
+tokio = { version = "1", features = ["test-util"] }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/migrations/mysql/0001_initial.sql
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/migrations/mysql/0001_initial.sql
@@ -82,8 +82,8 @@ CREATE TABLE IF NOT EXISTS dashboard_audit_event (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS dashboard_task_lease (
-    lease_name VARCHAR(128) PRIMARY KEY,
-    holder_id VARCHAR(128) NOT NULL,
+    lease_name VARBINARY(128) PRIMARY KEY,
+    holder_id VARBINARY(128) NOT NULL,
     expires_at_ms BIGINT NOT NULL,
     fencing_token BIGINT NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/migrations/mysql/0003_history_retention.sql
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/migrations/mysql/0003_history_retention.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS dashboard_history_sample (
+    environment_id VARBINARY(36) NOT NULL,
+    metric_name VARBINARY(64) NOT NULL,
+    bucket_ms BIGINT NOT NULL,
+    dimensions_json VARBINARY(512) NOT NULL,
+    value DOUBLE NOT NULL,
+    UNIQUE KEY dashboard_history_sample_query_idx(environment_id, metric_name, dimensions_json, bucket_ms),
+    KEY dashboard_history_sample_retention_idx(environment_id, bucket_ms)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+INSERT IGNORE INTO dashboard_schema_migration (version, applied_at_ms) VALUES (3, 0);

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/migrations/postgres/0001_initial.sql
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/migrations/postgres/0001_initial.sql
@@ -77,8 +77,8 @@ CREATE TABLE IF NOT EXISTS dashboard_audit_event (
 CREATE INDEX IF NOT EXISTS dashboard_audit_event_created_idx ON dashboard_audit_event(created_at_ms DESC);
 
 CREATE TABLE IF NOT EXISTS dashboard_task_lease (
-    lease_name VARCHAR(128) PRIMARY KEY,
-    holder_id VARCHAR(128) NOT NULL,
+    lease_name VARCHAR(128) COLLATE "C" PRIMARY KEY,
+    holder_id VARCHAR(128) COLLATE "C" NOT NULL,
     expires_at_ms BIGINT NOT NULL,
     fencing_token BIGINT NOT NULL
 );

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/migrations/postgres/0003_history_retention.sql
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/migrations/postgres/0003_history_retention.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS dashboard_history_sample (
+    environment_id VARCHAR(36) COLLATE "C" NOT NULL,
+    metric_name VARCHAR(64) COLLATE "C" NOT NULL,
+    bucket_ms BIGINT NOT NULL,
+    dimensions_json VARCHAR(512) COLLATE "C" NOT NULL,
+    value DOUBLE PRECISION NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS dashboard_history_sample_query_idx
+    ON dashboard_history_sample(environment_id, metric_name, dimensions_json, bucket_ms);
+CREATE INDEX IF NOT EXISTS dashboard_history_sample_retention_idx
+    ON dashboard_history_sample(environment_id, bucket_ms);
+INSERT INTO dashboard_schema_migration (version, applied_at_ms) VALUES (3, 0)
+ON CONFLICT (version) DO NOTHING;

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/migrations/sqlite/0003_history_retention.sql
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/migrations/sqlite/0003_history_retention.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS dashboard_history_sample (
+    environment_id TEXT COLLATE BINARY NOT NULL,
+    metric_name TEXT COLLATE BINARY NOT NULL,
+    bucket_ms INTEGER NOT NULL,
+    dimensions_json TEXT COLLATE BINARY NOT NULL,
+    value REAL NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS dashboard_history_sample_query_idx
+    ON dashboard_history_sample(environment_id, metric_name, dimensions_json, bucket_ms);
+CREATE INDEX IF NOT EXISTS dashboard_history_sample_retention_idx
+    ON dashboard_history_sample(environment_id, bucket_ms);
+INSERT OR IGNORE INTO dashboard_schema_migration (version, applied_at_ms) VALUES (3, 0);

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/health_api.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/health_api.rs
@@ -21,7 +21,7 @@ use axum::extract::State;
 use axum::http::StatusCode;
 
 pub async fn health(State(state): State<AppState>) -> (StatusCode, Json<ApiResponse<HealthStatus>>) {
-    readiness_response(readiness_status(&state.persistence).await)
+    readiness_response(readiness_status(&state.persistence, state.history_runtime.health().await).await)
 }
 
 pub async fn live() -> Json<ApiResponse<HealthStatus>> {
@@ -29,7 +29,7 @@ pub async fn live() -> Json<ApiResponse<HealthStatus>> {
 }
 
 pub async fn ready(State(state): State<AppState>) -> (StatusCode, Json<ApiResponse<HealthStatus>>) {
-    readiness_response(readiness_status(&state.persistence).await)
+    readiness_response(readiness_status(&state.persistence, state.history_runtime.health().await).await)
 }
 
 fn readiness_response(status: HealthStatus) -> (StatusCode, Json<ApiResponse<HealthStatus>>) {
@@ -71,6 +71,7 @@ mod tests {
                 pool_size: None,
                 idle_connections: None,
             }),
+            history: None,
         });
 
         assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/config/app_config.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/config/app_config.rs
@@ -27,6 +27,9 @@ pub struct AppConfig {
     pub storage: StorageConfig,
     pub auth: AuthConfig,
     pub dashboard_history_interval_secs: u64,
+    pub dashboard_history_retention_days: u32,
+    pub dashboard_history_retention_batch_size: u32,
+    pub dashboard_history_lease_ttl_secs: u64,
     pub initial_config: DashboardConfigView,
     pub admin_credentials: Option<AdminCredentials>,
 }
@@ -39,6 +42,18 @@ impl fmt::Debug for AppConfig {
             .field("storage", &self.storage)
             .field("auth", &self.auth)
             .field("dashboard_history_interval_secs", &self.dashboard_history_interval_secs)
+            .field(
+                "dashboard_history_retention_days",
+                &self.dashboard_history_retention_days,
+            )
+            .field(
+                "dashboard_history_retention_batch_size",
+                &self.dashboard_history_retention_batch_size,
+            )
+            .field(
+                "dashboard_history_lease_ttl_secs",
+                &self.dashboard_history_lease_ttl_secs,
+            )
             .field("initial_config", &self.initial_config)
             .field("admin_credentials", &self.admin_credentials.as_ref().map(|_| REDACTED))
             .finish()
@@ -251,6 +266,21 @@ impl AppConfig {
                 password: env::var("DASHBOARD_WEB_PASSWORD").unwrap_or_else(|_| "rocketmq".to_string()),
             },
             dashboard_history_interval_secs: parse_u64_env("DASHBOARD_WEB_HISTORY_INTERVAL_SECS", 60)?,
+            dashboard_history_retention_days: positive_u32(
+                "DASHBOARD_WEB_HISTORY_RETENTION_DAYS",
+                parse_u32_env("DASHBOARD_WEB_HISTORY_RETENTION_DAYS", 30)?,
+                36_500,
+            )?,
+            dashboard_history_retention_batch_size: positive_u32(
+                "DASHBOARD_WEB_HISTORY_RETENTION_BATCH_SIZE",
+                parse_u32_env("DASHBOARD_WEB_HISTORY_RETENTION_BATCH_SIZE", 500)?,
+                5_000,
+            )?,
+            dashboard_history_lease_ttl_secs: positive_u64(
+                "DASHBOARD_WEB_HISTORY_LEASE_TTL_SECS",
+                parse_u64_env("DASHBOARD_WEB_HISTORY_LEASE_TTL_SECS", 30)?,
+                86_400,
+            )?,
             initial_config,
             admin_credentials: admin_credentials_from_env()?,
         })
@@ -326,6 +356,26 @@ fn parse_u64_env(name: &str, default_value: u64) -> Result<u64, DashboardError> 
         .map(|value| value.unwrap_or(default_value))
 }
 
+fn positive_u32(name: &str, value: u32, maximum: u32) -> Result<u32, DashboardError> {
+    if value == 0 || value > maximum {
+        Err(DashboardError::Config(format!(
+            "{name} must be between 1 and {maximum}"
+        )))
+    } else {
+        Ok(value)
+    }
+}
+
+fn positive_u64(name: &str, value: u64, maximum: u64) -> Result<u64, DashboardError> {
+    if value == 0 || value > maximum {
+        Err(DashboardError::Config(format!(
+            "{name} must be between 1 and {maximum}"
+        )))
+    } else {
+        Ok(value)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -394,6 +444,9 @@ mod tests {
                 password: "dashboard-secret".to_string(),
             },
             dashboard_history_interval_secs: 60,
+            dashboard_history_retention_days: 30,
+            dashboard_history_retention_batch_size: 500,
+            dashboard_history_lease_ttl_secs: 30,
             initial_config: DashboardConfigView::default(),
             admin_credentials: Some(
                 AdminCredentials::try_new("access-value", "secret-value", Some("token-value".to_string()))

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/model/dashboard_model.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/model/dashboard_model.rs
@@ -11,8 +11,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use crate::model::EnvironmentId;
+use crate::model::StorageBackend;
+use chrono::TimeZone;
+use chrono::Utc;
 use serde::Deserialize;
 use serde::Serialize;
+use std::collections::BTreeMap;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -47,6 +52,10 @@ pub struct TopicCurrentMetric {
 pub struct DashboardHistoryQuery {
     pub date: String,
     pub topic_name: Option<String>,
+    #[serde(default)]
+    pub limit: Option<u32>,
+    #[serde(default)]
+    pub cursor: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -57,6 +66,9 @@ pub struct DashboardHistorySeries {
     pub topic_name: Option<String>,
     pub collected: bool,
     pub points: Vec<DashboardHistoryPoint>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
+    pub health: DashboardHistoryHealth,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -64,4 +76,101 @@ pub struct DashboardHistorySeries {
 pub struct DashboardHistoryPoint {
     pub timestamp: i64,
     pub value: f64,
+}
+
+/// Sanitized state of the persistent history collector.  It deliberately
+/// excludes connection strings, lease holder identities, and sample values.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DashboardHistoryHealth {
+    pub backend: StorageBackend,
+    pub connectivity: String,
+    pub role: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lease_expires_at_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_collection_at_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_append_at_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_retention_at_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recent_error: Option<String>,
+}
+
+/// A normalized dimension carried by a persisted metric sample.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "camelCase")]
+pub struct MetricDimension {
+    pub key: String,
+    pub value: String,
+}
+
+/// A durable dashboard metric. The idempotency key is environment, metric,
+/// bucket, and the normalized dimensions.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct MetricSample {
+    pub environment_id: EnvironmentId,
+    pub metric: String,
+    pub bucket_ms: i64,
+    pub dimensions: Vec<MetricDimension>,
+    pub value: f64,
+}
+
+impl MetricSample {
+    pub const MAX_METRIC_LENGTH: usize = 64;
+    pub const MAX_DIMENSIONS: usize = 16;
+    pub const MAX_DIMENSION_KEY_LENGTH: usize = 64;
+    pub const MAX_DIMENSION_VALUE_LENGTH: usize = 256;
+    pub const MAX_DIMENSIONS_JSON_LENGTH: usize = 512;
+
+    /// Validates the sample and sorts dimensions by their business key.
+    pub fn normalize(&mut self) -> Result<(), String> {
+        if self.environment_id.0.is_empty() || self.environment_id.0.len() > 36 {
+            return Err("history sample environment is invalid".to_string());
+        }
+        if self.metric.is_empty() || self.metric.len() > Self::MAX_METRIC_LENGTH {
+            return Err("history metric is invalid".to_string());
+        }
+        if self.bucket_ms < 0 || Utc.timestamp_millis_opt(self.bucket_ms).single().is_none() || !self.value.is_finite()
+        {
+            return Err("history sample value is invalid".to_string());
+        }
+        if self.value == 0.0 {
+            self.value = 0.0;
+        }
+        if self.dimensions.len() > Self::MAX_DIMENSIONS {
+            return Err("history sample has too many dimensions".to_string());
+        }
+        self.dimensions.sort_by(|left, right| left.key.cmp(&right.key));
+        for dimension in &self.dimensions {
+            if dimension.key.is_empty()
+                || dimension.key.len() > Self::MAX_DIMENSION_KEY_LENGTH
+                || dimension.value.len() > Self::MAX_DIMENSION_VALUE_LENGTH
+            {
+                return Err("history sample dimension is invalid".to_string());
+            }
+        }
+        if self.dimensions.windows(2).any(|pair| pair[0].key == pair[1].key) {
+            return Err("history sample dimensions contain a duplicate key".to_string());
+        }
+        if self.dimensions_json()?.len() > Self::MAX_DIMENSIONS_JSON_LENGTH {
+            return Err("history sample dimensions are too large".to_string());
+        }
+        Ok(())
+    }
+
+    /// Returns the deterministic JSON representation used by every backend.
+    pub fn dimensions_json(&self) -> Result<String, String> {
+        serde_json::to_string(&self.dimensions).map_err(|_| "history dimensions are invalid".to_string())
+    }
+
+    /// Returns dimensions in the form used by API filtering and cursor binding.
+    pub fn dimensions_map(&self) -> BTreeMap<String, String> {
+        self.dimensions
+            .iter()
+            .map(|dimension| (dimension.key.clone(), dimension.value.clone()))
+            .collect()
+    }
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/model/health_model.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/model/health_model.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use crate::model::DashboardHistoryHealth;
 use crate::persistence::StorageHealth;
 use serde::Deserialize;
 use serde::Serialize;
@@ -21,4 +22,6 @@ pub struct HealthStatus {
     pub status: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub storage: Option<StorageHealth>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub history: Option<DashboardHistoryHealth>,
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence.rs
@@ -15,12 +15,18 @@ pub mod backend;
 pub mod environment_repository;
 pub mod error;
 pub mod file_store;
+pub mod history_repository;
+pub mod lease_repository;
 pub mod migration;
 pub mod monitor_repository;
 pub mod sql_store;
 
 #[cfg(test)]
 mod contract_tests;
+
+#[cfg(test)]
+#[path = "persistence/history_capacity_tests.rs"]
+mod history_capacity_tests;
 
 use crate::config::StorageConfig;
 use crate::model::StorageBackend;

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/file_store.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/file_store.rs
@@ -42,6 +42,9 @@ use tokio::sync::RwLock;
 use tokio::sync::RwLockReadGuard;
 use tokio::sync::oneshot;
 
+#[path = "history_file_store.rs"]
+mod history_file_store;
+
 const FORMAT_VERSION: u32 = 1;
 const MIN_AVAILABLE_BYTES: u64 = 64 * 1024 * 1024;
 
@@ -71,6 +74,7 @@ impl FileDirectoryLock {
             return Err(PersistenceError::LockUnavailable);
         }
         recover_incomplete_snapshot_transactions(root)?;
+        history_file_store::recover_history_file_operations(root)?;
         initialize_manifest(root)?;
         Ok(Self { _file: file })
     }
@@ -261,6 +265,8 @@ pub struct FilePersistence {
     unavailable: Arc<AtomicBool>,
     write_lock: Arc<RwLock<()>>,
     mutation_blocker: Arc<FileMutationBlocker>,
+    #[cfg(test)]
+    history_replace_failpoint: Arc<std::sync::atomic::AtomicU8>,
 }
 
 impl FilePersistence {
@@ -284,6 +290,8 @@ impl FilePersistence {
             unavailable: Arc::new(AtomicBool::new(false)),
             write_lock: Arc::new(RwLock::new(())),
             mutation_blocker: Arc::new(FileMutationBlocker::default()),
+            #[cfg(test)]
+            history_replace_failpoint: Arc::new(std::sync::atomic::AtomicU8::new(0)),
         })
     }
 
@@ -305,6 +313,11 @@ impl FilePersistence {
     #[cfg(test)]
     pub(crate) fn clear_test_committed_cleanup_blocker(&self) {
         self.mutation_blocker.clear_committed_cleanup();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_history_replace_failpoint(&self, point: u8) {
+        self.history_replace_failpoint.store(point, AtomicOrdering::SeqCst);
     }
 
     pub async fn write_snapshot(
@@ -711,7 +724,7 @@ impl FilePersistence {
         match self.run_blocking_mutation(name, operation).await {
             FileMutationDispatch::Completed(Ok(outcome)) => self.finalize_file_mutation(outcome).await,
             FileMutationDispatch::Completed(Err(error)) => {
-                let recovery = self.recover_incomplete_transactions_owned().await;
+                let recovery = self.recover_incomplete_file_operations_owned().await;
                 if recovery.is_err() {
                     self.unavailable.store(true, AtomicOrdering::Release);
                 }
@@ -733,7 +746,7 @@ impl FilePersistence {
                     // transaction can still be recovered, but without an
                     // acknowledgement a single-snapshot result is unknown,
                     // so the instance remains poisoned either way.
-                    Err(_) => (false, self.recover_incomplete_transactions_owned().await),
+                    Err(_) => (false, self.recover_incomplete_file_operations_owned().await),
                 };
                 if acknowledged && recovered.is_ok() {
                     self.unavailable.store(false, AtomicOrdering::Release);
@@ -748,7 +761,7 @@ impl FilePersistence {
                 // closure has started. It is never safe to classify it as a
                 // queue rejection or allow this instance to keep serving.
                 self.unavailable.store(true, AtomicOrdering::Release);
-                let _ = self.recover_incomplete_transactions_owned().await;
+                let _ = self.recover_incomplete_file_operations_owned().await;
                 Err(PersistenceError::Runtime(error))
             }
         }
@@ -816,7 +829,7 @@ impl FilePersistence {
     /// than serving a possibly unacknowledged aggregate.
     async fn fail_closed_after_finalize<T>(&self, error: PersistenceError) -> Result<T, PersistenceError> {
         self.unavailable.store(true, AtomicOrdering::Release);
-        let _ = self.recover_incomplete_transactions_owned().await;
+        let _ = self.recover_incomplete_file_operations_owned().await;
         Err(error)
     }
 
@@ -867,13 +880,14 @@ impl FilePersistence {
         }
     }
 
-    /// Replays marker-owned deletion while the repository write gate is held.
-    /// A successful return guarantees that no staged snapshot from a failed
-    /// multi-collection publication remains visible to this process.
-    async fn recover_incomplete_transactions_owned(&self) -> Result<(), PersistenceError> {
+    /// Replays all marker-owned file operations while the repository write
+    /// gate is held. This includes history rewrites, so a failed append never
+    /// leaves a live File instance serving a temporarily absent day segment.
+    async fn recover_incomplete_file_operations_owned(&self) -> Result<(), PersistenceError> {
         let root = self.root.clone();
-        self.run_recovery_operation_owned("dashboard-file-storage-recover-snapshot-transaction", move || {
-            recover_incomplete_snapshot_transactions(&root)
+        self.run_recovery_operation_owned("dashboard-file-storage-recover-file-operations", move || {
+            recover_incomplete_snapshot_transactions(&root)?;
+            history_file_store::recover_history_file_operations(&root)
         })
         .await
     }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/history_capacity_tests.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/history_capacity_tests.rs
@@ -1,0 +1,334 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::TimeRange;
+use crate::config::SqlPoolConfig;
+use crate::config::StorageConfig;
+use crate::model::EnvironmentId;
+use crate::model::MetricSample;
+use crate::model::StorageBackend;
+use crate::persistence::file_store::FilePersistence;
+use crate::persistence::history_repository::HistoryQuery;
+use crate::persistence::history_repository::page_samples;
+use crate::persistence::sql_store::SqlPersistence;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use sqlx::Row;
+use std::time::Instant;
+
+const SAMPLE_COUNT: usize = 10_000;
+const APPEND_BATCH: usize = 500;
+const PAGE_SIZE: u32 = 200;
+const DAY_MS: i64 = 86_400_000;
+
+fn json_field_equals(value: &serde_json::Value, field: &str, expected: &str) -> bool {
+    match value {
+        serde_json::Value::Object(values) => {
+            values
+                .get(field)
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|value| value == expected)
+                || values.values().any(|value| json_field_equals(value, field, expected))
+        }
+        serde_json::Value::Array(values) => values.iter().any(|value| json_field_equals(value, field, expected)),
+        _ => false,
+    }
+}
+
+#[test]
+#[ignore = "requires docker-compose.storage-test.yml"]
+fn docker_file_history_capacity_baseline() {
+    let data_path = std::env::var("ROCKETMQ_DASHBOARD_STORAGE_TEST_FILE_PATH")
+        .expect("ROCKETMQ_DASHBOARD_STORAGE_TEST_FILE_PATH must be set by the storage test runner");
+    let owner = RuntimeOwner::new(RuntimeConfig::default()).expect("runtime owner");
+    owner.block_on(async {
+        let store = FilePersistence::initialize(
+            &StorageConfig {
+                backend: StorageBackend::File,
+                data_path: data_path.into(),
+                database_url: None,
+                pool: SqlPoolConfig::default(),
+            },
+            owner.root_context().component("history-capacity-file"),
+        )
+        .await
+        .expect("file persistence");
+        run_file_capacity(&store).await;
+    });
+    owner.shutdown_runtime_blocking().expect("runtime shutdown");
+}
+
+#[test]
+#[ignore = "requires docker-compose.storage-test.yml"]
+fn docker_sqlite_history_capacity_baseline() {
+    let data_path = std::env::var("ROCKETMQ_DASHBOARD_STORAGE_TEST_SQLITE_PATH")
+        .expect("ROCKETMQ_DASHBOARD_STORAGE_TEST_SQLITE_PATH must be set by the storage test runner");
+    run_sql_capacity(StorageBackend::Sqlite, None, data_path.into());
+}
+
+#[test]
+#[ignore = "requires docker-compose.storage-test.yml"]
+fn docker_mysql_history_capacity_baseline() {
+    let database_url = std::env::var("ROCKETMQ_DASHBOARD_STORAGE_TEST_MYSQL_URL")
+        .expect("ROCKETMQ_DASHBOARD_STORAGE_TEST_MYSQL_URL must be set by the storage test runner");
+    run_sql_capacity(StorageBackend::MySql, Some(database_url), "unused".into());
+}
+
+#[test]
+#[ignore = "requires docker-compose.storage-test.yml"]
+fn docker_postgres_history_capacity_baseline() {
+    let database_url = std::env::var("ROCKETMQ_DASHBOARD_STORAGE_TEST_POSTGRES_URL")
+        .expect("ROCKETMQ_DASHBOARD_STORAGE_TEST_POSTGRES_URL must be set by the storage test runner");
+    run_sql_capacity(StorageBackend::Postgres, Some(database_url), "unused".into());
+}
+
+fn query(environment_id: EnvironmentId, cursor: Option<String>) -> HistoryQuery {
+    let mut query = HistoryQuery {
+        environment_id,
+        metric: "capacity".to_string(),
+        range: TimeRange {
+            start_ms: 0,
+            end_ms: DAY_MS * 20,
+        },
+        dimensions: Vec::new(),
+        limit: PAGE_SIZE,
+        cursor,
+    };
+    query.validate_and_normalize().expect("valid capacity query");
+    query
+}
+
+fn samples(environment_id: &EnvironmentId, batch: usize) -> Vec<MetricSample> {
+    let day = i64::try_from(batch).expect("batch day");
+    (0..APPEND_BATCH)
+        .map(|offset| MetricSample {
+            environment_id: environment_id.clone(),
+            metric: "capacity".to_string(),
+            bucket_ms: day * DAY_MS + i64::try_from(offset).expect("sample offset") * 1_000,
+            dimensions: Vec::new(),
+            value: (batch * APPEND_BATCH + offset) as f64,
+        })
+        .collect()
+}
+
+async fn run_file_capacity(store: &FilePersistence) {
+    let environment_id = EnvironmentId::new();
+    let first = samples(&environment_id, 0);
+    let started = Instant::now();
+    store.append_history(first).await.expect("file append 500");
+    let append_500 = started.elapsed();
+    for batch in 1..(SAMPLE_COUNT / APPEND_BATCH) {
+        store
+            .append_history(samples(&environment_id, batch))
+            .await
+            .expect("file append batch");
+    }
+    let first_page_started = Instant::now();
+    let first_page = page_samples(
+        &query(environment_id.clone(), None),
+        store
+            .read_history(&query(environment_id.clone(), None))
+            .await
+            .expect("file first page read"),
+    )
+    .expect("file first page");
+    let first_page_elapsed = first_page_started.elapsed();
+    assert_eq!(first_page.samples.len(), PAGE_SIZE as usize);
+    let continuation_started = Instant::now();
+    let continuation = page_samples(
+        &query(environment_id.clone(), first_page.next_cursor.clone()),
+        store
+            .read_history(&query(environment_id.clone(), first_page.next_cursor.clone()))
+            .await
+            .expect("file continuation read"),
+    )
+    .expect("file continuation");
+    let continuation_elapsed = continuation_started.elapsed();
+    assert_eq!(continuation.samples.len(), PAGE_SIZE as usize);
+    let retention_started = Instant::now();
+    let mut deleted = 0_u64;
+    let mut result = store
+        .delete_history_before(&environment_id, DAY_MS * 20, 1)
+        .await
+        .expect("file retention");
+    deleted += result.deleted;
+    while result.has_more {
+        result = store
+            .delete_history_before(&environment_id, DAY_MS * 20, 1)
+            .await
+            .expect("file retention convergence");
+        deleted += result.deleted;
+    }
+    assert_eq!(deleted, SAMPLE_COUNT as u64);
+    eprintln!(
+        "history-capacity backend=file samples={SAMPLE_COUNT} append500_ms={} first_page200_ms={} continuation200_ms={} retention10000_ms={}",
+        append_500.as_millis(),
+        first_page_elapsed.as_millis(),
+        continuation_elapsed.as_millis(),
+        retention_started.elapsed().as_millis(),
+    );
+}
+
+fn run_sql_capacity(backend: StorageBackend, database_url: Option<String>, data_path: std::path::PathBuf) {
+    let owner = RuntimeOwner::new(RuntimeConfig::default()).expect("runtime owner");
+    owner.block_on(async {
+        let store = SqlPersistence::initialize(
+            &StorageConfig {
+                backend,
+                data_path,
+                database_url,
+                pool: SqlPoolConfig::default(),
+            },
+            owner.root_context().component(format!("history-capacity-{backend:?}")),
+        )
+        .await
+        .expect("SQL persistence");
+        let environment_id = EnvironmentId::new();
+        let lease = store
+            .acquire_history_lease(&environment_id, "capacity-holder", 30_000)
+            .await
+            .expect("capacity lease")
+            .expect("capacity lease acquired");
+        let started = Instant::now();
+        store
+            .append_history(samples(&environment_id, 0), Some(&lease))
+            .await
+            .expect("SQL append 500");
+        let append_500 = started.elapsed();
+        for batch in 1..(SAMPLE_COUNT / APPEND_BATCH) {
+            store
+                .append_history(samples(&environment_id, batch), Some(&lease))
+                .await
+                .expect("SQL append batch");
+        }
+        assert_query_index(&store, backend, &environment_id).await;
+        let first_page_started = Instant::now();
+        let first_page = store
+            .query_history(query(environment_id.clone(), None))
+            .await
+            .expect("SQL first page");
+        let first_page_elapsed = first_page_started.elapsed();
+        assert_eq!(first_page.samples.len(), PAGE_SIZE as usize);
+        let continuation_started = Instant::now();
+        let continuation = store
+            .query_history(query(environment_id.clone(), first_page.next_cursor.clone()))
+            .await
+            .expect("SQL continuation");
+        let continuation_elapsed = continuation_started.elapsed();
+        assert_eq!(continuation.samples.len(), PAGE_SIZE as usize);
+        let retention_started = Instant::now();
+        let mut deleted = 0_u64;
+        let mut result = store
+            .delete_history_before(&environment_id, DAY_MS * 20, APPEND_BATCH as u32, Some(&lease))
+            .await
+            .expect("SQL retention");
+        deleted += result.deleted;
+        while result.has_more {
+            result = store
+                .delete_history_before(&environment_id, DAY_MS * 20, APPEND_BATCH as u32, Some(&lease))
+                .await
+                .expect("SQL retention convergence");
+            deleted += result.deleted;
+        }
+        assert_eq!(deleted, SAMPLE_COUNT as u64);
+        eprintln!(
+            "history-capacity backend={backend:?} samples={SAMPLE_COUNT} append500_ms={} first_page200_ms={} continuation200_ms={} retention10000_ms={}",
+            append_500.as_millis(),
+            first_page_elapsed.as_millis(),
+            continuation_elapsed.as_millis(),
+            retention_started.elapsed().as_millis(),
+        );
+    });
+    owner.shutdown_runtime_blocking().expect("runtime shutdown");
+}
+
+async fn assert_query_index(store: &SqlPersistence, backend: StorageBackend, environment_id: &EnvironmentId) {
+    let environment_id = &environment_id.0;
+    match backend {
+        StorageBackend::Sqlite => {
+            let rows = sqlx::query(
+                "EXPLAIN QUERY PLAN SELECT bucket_ms FROM dashboard_history_sample \
+                 WHERE environment_id = ? AND metric_name = ? AND dimensions_json = ? \
+                 AND bucket_ms >= ? AND bucket_ms <= ? ORDER BY bucket_ms, dimensions_json LIMIT ?",
+            )
+            .bind(environment_id)
+            .bind("capacity")
+            .bind("[]")
+            .bind(0_i64)
+            .bind(DAY_MS * 20)
+            .bind(i64::from(PAGE_SIZE))
+            .fetch_all(store.sqlite_pool().expect("SQLite pool"))
+            .await
+            .expect("SQLite explain");
+            assert!(
+                rows.iter()
+                    .filter_map(|row| row.try_get::<String, _>("detail").ok())
+                    .any(|detail| { detail.contains("dashboard_history_sample_query_idx") }),
+                "SQLite query plan must use dashboard_history_sample_query_idx"
+            );
+        }
+        StorageBackend::MySql => {
+            let plan = sqlx::query_scalar::<_, String>(
+                "EXPLAIN FORMAT=JSON SELECT bucket_ms FROM dashboard_history_sample \
+                 WHERE environment_id = ? AND metric_name = ? AND dimensions_json = ? \
+                 AND bucket_ms >= ? AND bucket_ms <= ? ORDER BY bucket_ms, dimensions_json LIMIT ?",
+            )
+            .bind(environment_id.as_bytes())
+            .bind(b"capacity".as_slice())
+            .bind(b"[]".as_slice())
+            .bind(0_i64)
+            .bind(DAY_MS * 20)
+            .bind(i64::from(PAGE_SIZE))
+            .fetch_one(store.mysql_pool().expect("MySQL pool"))
+            .await
+            .expect("MySQL explain");
+            let plan = serde_json::from_str::<serde_json::Value>(&plan).expect("MySQL JSON explain");
+            eprintln!("history-capacity explain backend=mysql plan={plan}");
+            assert!(
+                (json_field_equals(&plan, "key", "dashboard_history_sample_query_idx")
+                    || json_field_equals(&plan, "key", "dashboard_history_sample_retention_idx"))
+                    && !json_field_equals(&plan, "access_type", "ALL"),
+                "MySQL query plan must use a dashboard history index without an ALL scan: {plan}"
+            );
+        }
+        StorageBackend::Postgres => {
+            let rows = sqlx::query_scalar::<_, String>(
+                "EXPLAIN (COSTS OFF) SELECT bucket_ms FROM dashboard_history_sample \
+                 WHERE environment_id = $1 AND metric_name = $2 AND dimensions_json = $3 \
+                 AND bucket_ms >= $4 AND bucket_ms <= $5 ORDER BY bucket_ms, dimensions_json LIMIT $6",
+            )
+            .bind(environment_id)
+            .bind("capacity")
+            .bind("[]")
+            .bind(0_i64)
+            .bind(DAY_MS * 20)
+            .bind(i64::from(PAGE_SIZE))
+            .fetch_all(store.postgres_pool().expect("PostgreSQL pool"))
+            .await
+            .expect("PostgreSQL explain");
+            eprintln!("history-capacity explain backend=postgres plans={rows:?}");
+            assert!(
+                rows.iter().any(|line| {
+                    (line.contains("Index Scan")
+                        || line.contains("Index Only Scan")
+                        || line.contains("Bitmap Index Scan"))
+                        && (line.contains("dashboard_history_sample_query_idx")
+                            || line.contains("dashboard_history_sample_retention_idx"))
+                }),
+                "PostgreSQL query plan must use a dashboard history index: {rows:?}"
+            );
+        }
+        StorageBackend::File => unreachable!("File does not have a SQL EXPLAIN plan"),
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/history_file_store.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/history_file_store.rs
@@ -1,0 +1,956 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use super::*;
+use crate::model::EnvironmentId;
+use crate::model::MetricSample;
+use crate::persistence::history_repository::HistoryQuery;
+use crate::persistence::history_repository::HistoryRetentionResult;
+use crate::persistence::history_repository::is_valid_history_timestamp_ms;
+use chrono::TimeZone;
+use chrono::Utc;
+use std::collections::BTreeMap;
+use std::fs::OpenOptions;
+
+impl FilePersistence {
+    pub(crate) async fn append_history(&self, samples: Vec<MetricSample>) -> Result<(), PersistenceError> {
+        let write_guard = self.write_guard().await;
+        self.ensure_available()?;
+        let root = self.root.clone();
+        #[cfg(test)]
+        let replace_failpoint = self.history_replace_failpoint.clone();
+        self.dispatch_file_mutation(write_guard, "dashboard-file-storage-append-history", move || {
+            let environment_id = samples
+                .first()
+                .map(|sample| sample.environment_id.clone())
+                .ok_or_else(|| PersistenceError::InvalidConfig("history append batch is empty".to_string()))?;
+            if samples.iter().any(|sample| sample.environment_id != environment_id) {
+                return Err(PersistenceError::InvalidConfig(
+                    "history append batch must contain exactly one environment".to_string(),
+                ));
+            }
+            let mut grouped = BTreeMap::<String, Vec<MetricSample>>::new();
+            for sample in samples {
+                grouped.entry(history_day(sample.bucket_ms)?).or_default().push(sample);
+            }
+            if grouped.len() != 1 {
+                return Err(PersistenceError::InvalidConfig(
+                    "file history append batches must fit within one UTC day".to_string(),
+                ));
+            }
+            let directory = history_directory(&root, &environment_id);
+            std::fs::create_dir_all(&directory).map_err(PersistenceError::Io)?;
+            let (day, pending) = grouped.into_iter().next().ok_or(PersistenceError::CorruptedData)?;
+            let path = directory.join(format!("{day}.jsonl"));
+            // A rewrite reads the day exactly once, detects conflicts before
+            // publication, then uses a durable marker to recover either the
+            // old or the complete new JSONL generation after interruption.
+            let mut records = read_history_samples_file(&path)?
+                .into_iter()
+                .map(|sample| Ok((history_key(&sample)?, sample)))
+                .collect::<Result<BTreeMap<_, _>, PersistenceError>>()?;
+            for sample in pending {
+                let key = history_key(&sample)?;
+                if let Some(existing) = records.get(&key) {
+                    if existing.value.to_bits() != sample.value.to_bits() {
+                        return Err(PersistenceError::Conflict);
+                    }
+                    continue;
+                }
+                records.insert(key, sample);
+            }
+            #[cfg(test)]
+            replace_history_file(&path, records.into_values().collect(), &replace_failpoint)?;
+            #[cfg(not(test))]
+            replace_history_file(&path, records.into_values().collect())?;
+            Ok(FileMutationOutcome {
+                value: (),
+                finalize: Box::new(|| Ok(())),
+                cleanup: Box::new(|| Ok(())),
+                rollback: Box::new(|| Ok(())),
+            })
+        })
+        .await?;
+        self.record_write();
+        Ok(())
+    }
+
+    pub(crate) async fn read_history(&self, query: &HistoryQuery) -> Result<Vec<MetricSample>, PersistenceError> {
+        self.ensure_available()?;
+        let mut query = query.clone();
+        query.validate_and_normalize()?;
+        let _read_guard = self.read_guard().await;
+        let root = self.root.clone();
+        let environment_id = query.environment_id.clone();
+        let start_day = history_day(query.range.start_ms)?;
+        let end_day = history_day(query.range.end_ms)?;
+        self.service_context
+            .storage_io()
+            .spawn_io("dashboard-file-storage-read-history", move || {
+                let directory = history_directory(&root, &environment_id);
+                if !directory.exists() {
+                    return Ok(Vec::new());
+                }
+                let mut paths = std::fs::read_dir(directory)
+                    .map_err(PersistenceError::Io)?
+                    .filter_map(Result::ok)
+                    .filter_map(|entry| {
+                        let path = entry.path();
+                        let day = path.file_stem()?.to_str()?;
+                        if path.extension().and_then(|value| value.to_str()) == Some("jsonl")
+                            && is_history_day(day)
+                            && day >= start_day.as_str()
+                            && day <= end_day.as_str()
+                        {
+                            Some(path)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>();
+                paths.sort();
+                let mut samples = Vec::new();
+                for path in paths {
+                    samples.extend(read_history_samples_file(&path)?);
+                }
+                Ok(samples)
+            })
+            .await
+            .map_err(PersistenceError::Runtime)?
+    }
+
+    /// File retention removes only complete UTC-day segments before the cutoff
+    /// day. Therefore a cutoff within a day intentionally retains that day's
+    /// samples until the following pass instead of rewriting JSONL files.
+    pub(crate) async fn delete_history_before(
+        &self,
+        environment_id: &EnvironmentId,
+        cutoff_ms: i64,
+        batch_size: u32,
+    ) -> Result<HistoryRetentionResult, PersistenceError> {
+        let write_guard = self.write_guard().await;
+        self.ensure_available()?;
+        if !is_valid_history_timestamp_ms(cutoff_ms) {
+            return Err(PersistenceError::InvalidConfig(
+                "history retention request is invalid".to_string(),
+            ));
+        }
+        let root = self.root.clone();
+        let environment_id = environment_id.clone();
+        let cutoff_day = history_day(cutoff_ms)?;
+        let result = self
+            .dispatch_file_mutation(write_guard, "dashboard-file-storage-retain-history", move || {
+                let directory = history_directory(&root, &environment_id);
+                if !directory.exists() {
+                    return Ok(FileMutationOutcome {
+                        value: HistoryRetentionResult {
+                            deleted: 0,
+                            has_more: false,
+                        },
+                        finalize: Box::new(|| Ok(())),
+                        cleanup: Box::new(|| Ok(())),
+                        rollback: Box::new(|| Ok(())),
+                    });
+                }
+                let mut candidates = std::fs::read_dir(&directory)
+                    .map_err(PersistenceError::Io)?
+                    .filter_map(Result::ok)
+                    .filter_map(|entry| {
+                        let path = entry.path();
+                        let day = path.file_stem()?.to_str()?;
+                        (path.extension().and_then(|value| value.to_str()) == Some("jsonl")
+                            && is_history_day(day)
+                            && day < cutoff_day.as_str())
+                        .then_some(path)
+                    })
+                    .collect::<Vec<_>>();
+                candidates.sort();
+                let has_more = candidates.len() > batch_size as usize;
+                candidates.truncate(batch_size as usize);
+                let deleted = candidates.iter().try_fold(0_u64, |total, path| {
+                    Ok(total + read_history_samples_file(path)?.len() as u64)
+                })?;
+                let trash = directory.join(format!(".retention-{}", uuid::Uuid::now_v7()));
+                if !candidates.is_empty() {
+                    std::fs::create_dir_all(&trash).map_err(PersistenceError::Io)?;
+                }
+                let mut moved = Vec::new();
+                for path in candidates {
+                    let Some(name) = path.file_name() else {
+                        return Err(PersistenceError::CorruptedData);
+                    };
+                    let staged = trash.join(name);
+                    if let Err(error) = std::fs::rename(&path, &staged) {
+                        for (original, staged) in moved.iter().rev() {
+                            let _ = std::fs::rename(staged, original);
+                        }
+                        return Err(PersistenceError::Io(error));
+                    }
+                    moved.push((path, staged));
+                }
+                Ok(FileMutationOutcome {
+                    value: HistoryRetentionResult { deleted, has_more },
+                    finalize: Box::new(|| Ok(())),
+                    cleanup: Box::new(move || {
+                        if trash.exists() {
+                            std::fs::remove_dir_all(trash).map_err(PersistenceError::Io)?;
+                        }
+                        Ok(())
+                    }),
+                    rollback: Box::new(move || {
+                        for (original, staged) in moved.into_iter().rev() {
+                            if staged.exists() {
+                                std::fs::rename(staged, original).map_err(PersistenceError::Io)?;
+                            }
+                        }
+                        Ok(())
+                    }),
+                })
+            })
+            .await?;
+        if result.deleted > 0 {
+            self.record_write();
+        }
+        Ok(result)
+    }
+}
+
+fn history_directory(root: &Path, environment_id: &EnvironmentId) -> PathBuf {
+    let segment = environment_id
+        .0
+        .as_bytes()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    root.join("history").join("metric-samples").join(segment)
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct HistoryReplaceMarker {
+    target: String,
+    temporary: String,
+    backup: String,
+}
+
+fn publish_history_replace_marker(path: &Path, value: &HistoryReplaceMarker) -> Result<(), PersistenceError> {
+    let directory = path.parent().ok_or(PersistenceError::CorruptedData)?;
+    let name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .ok_or(PersistenceError::CorruptedData)?;
+    let pending = directory.join(format!("{name}.pending"));
+    let mut file = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&pending)
+        .map_err(PersistenceError::Io)?;
+    serde_json::to_writer(&mut file, value).map_err(PersistenceError::Serialization)?;
+    file.flush().map_err(PersistenceError::Io)?;
+    file.sync_all().map_err(PersistenceError::Io)?;
+    drop(file);
+    std::fs::rename(pending, path).map_err(PersistenceError::Io)
+}
+
+fn history_key(sample: &MetricSample) -> Result<(String, String, i64, String), PersistenceError> {
+    Ok((
+        sample.environment_id.0.clone(),
+        sample.metric.clone(),
+        sample.bucket_ms,
+        sample.dimensions_json().map_err(PersistenceError::InvalidConfig)?,
+    ))
+}
+
+#[cfg(not(test))]
+fn replace_history_file(path: &Path, samples: Vec<MetricSample>) -> Result<(), PersistenceError> {
+    replace_history_file_inner(path, samples, |_| Ok(()))
+}
+
+#[cfg(test)]
+fn replace_history_file(
+    path: &Path,
+    samples: Vec<MetricSample>,
+    failpoint: &std::sync::atomic::AtomicU8,
+) -> Result<(), PersistenceError> {
+    replace_history_file_inner(path, samples, |stage| {
+        if failpoint
+            .compare_exchange(
+                stage,
+                0,
+                std::sync::atomic::Ordering::SeqCst,
+                std::sync::atomic::Ordering::SeqCst,
+            )
+            .is_ok()
+        {
+            return Err(PersistenceError::Io(std::io::Error::other(
+                "injected history publication interruption",
+            )));
+        }
+        Ok(())
+    })
+}
+
+fn replace_history_file_inner(
+    path: &Path,
+    samples: Vec<MetricSample>,
+    interrupt_after_stage: impl Fn(u8) -> Result<(), PersistenceError>,
+) -> Result<(), PersistenceError> {
+    let directory = path.parent().ok_or(PersistenceError::CorruptedData)?;
+    let suffix = uuid::Uuid::now_v7().to_string();
+    let filename = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or(PersistenceError::CorruptedData)?;
+    let temporary_name = format!(".{filename}.{suffix}.tmp");
+    let backup_name = format!(".{filename}.{suffix}.previous");
+    let marker_name = format!(".history-replace-{suffix}.json");
+    let temporary = directory.join(&temporary_name);
+    let backup = directory.join(&backup_name);
+    let marker = directory.join(&marker_name);
+    let mut file = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&temporary)
+        .map_err(PersistenceError::Io)?;
+    for sample in samples {
+        serde_json::to_writer(&mut file, &sample).map_err(PersistenceError::Serialization)?;
+        file.write_all(b"\n").map_err(PersistenceError::Io)?;
+    }
+    file.flush().map_err(PersistenceError::Io)?;
+    file.sync_all().map_err(PersistenceError::Io)?;
+    drop(file);
+    let marker_value = HistoryReplaceMarker {
+        target: filename.to_string(),
+        temporary: temporary_name,
+        backup: backup_name,
+    };
+    publish_history_replace_marker(&marker, &marker_value)?;
+    interrupt_after_stage(1)?;
+    if path.exists() {
+        std::fs::rename(path, &backup).map_err(PersistenceError::Io)?;
+    }
+    interrupt_after_stage(2)?;
+    std::fs::rename(&temporary, path).map_err(PersistenceError::Io)?;
+    interrupt_after_stage(3)?;
+    if backup.exists() {
+        std::fs::remove_file(&backup).map_err(PersistenceError::Io)?;
+    }
+    std::fs::remove_file(marker).map_err(PersistenceError::Io)
+}
+
+pub(super) fn recover_history_file_operations(root: &Path) -> Result<(), PersistenceError> {
+    let history_root = root.join("history").join("metric-samples");
+    if !history_root.exists() {
+        return Ok(());
+    }
+    for environment in std::fs::read_dir(history_root).map_err(PersistenceError::Io)? {
+        let environment = environment.map_err(PersistenceError::Io)?;
+        let directory = environment.path();
+        if !directory.is_dir() {
+            continue;
+        }
+        for entry in std::fs::read_dir(&directory).map_err(PersistenceError::Io)? {
+            let entry = entry.map_err(PersistenceError::Io)?;
+            let path = entry.path();
+            let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+                continue;
+            };
+            if name.starts_with(".retention-") && path.is_dir() {
+                std::fs::remove_dir_all(path).map_err(PersistenceError::Io)?;
+                continue;
+            }
+            if name.starts_with(".history-replace-") && name.ends_with(".json.pending") {
+                recover_unpublished_history_replace_marker(&directory, &path, name)?;
+                continue;
+            }
+            if !name.starts_with(".history-replace-")
+                || path.extension().and_then(|value| value.to_str()) != Some("json")
+            {
+                continue;
+            }
+            let marker: HistoryReplaceMarker =
+                match serde_json::from_reader(std::fs::File::open(&path).map_err(PersistenceError::Io)?) {
+                    Ok(marker) => marker,
+                    Err(_) if !history_marker_has_sidecars(&directory, name)? => {
+                        std::fs::remove_file(path).map_err(PersistenceError::Io)?;
+                        continue;
+                    }
+                    Err(_) => return Err(PersistenceError::CorruptedData),
+                };
+            let target = directory.join(marker.target);
+            let temporary = directory.join(marker.temporary);
+            let backup = directory.join(marker.backup);
+            if target.exists() {
+                if temporary.exists() {
+                    std::fs::remove_file(temporary).map_err(PersistenceError::Io)?;
+                }
+                if backup.exists() {
+                    std::fs::remove_file(backup).map_err(PersistenceError::Io)?;
+                }
+            } else if temporary.exists() {
+                std::fs::rename(temporary, &target).map_err(PersistenceError::Io)?;
+                if backup.exists() {
+                    std::fs::remove_file(backup).map_err(PersistenceError::Io)?;
+                }
+            } else if backup.exists() {
+                std::fs::rename(backup, &target).map_err(PersistenceError::Io)?;
+            } else {
+                return Err(PersistenceError::CorruptedData);
+            }
+            std::fs::remove_file(path).map_err(PersistenceError::Io)?;
+        }
+    }
+    Ok(())
+}
+
+fn recover_unpublished_history_replace_marker(
+    directory: &Path,
+    pending_marker: &Path,
+    marker_name: &str,
+) -> Result<(), PersistenceError> {
+    let Some(suffix) = pending_history_replace_suffix(marker_name) else {
+        // A torn marker that never had a valid UUID cannot be associated with
+        // any sidecar safely. It is itself disposable, while unrelated files
+        // remain untouched.
+        std::fs::remove_file(pending_marker).map_err(PersistenceError::Io)?;
+        return Ok(());
+    };
+    let mut sidecars = Vec::new();
+    for entry in std::fs::read_dir(directory).map_err(PersistenceError::Io)? {
+        let entry = entry.map_err(PersistenceError::Io)?;
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str() else {
+            continue;
+        };
+        let Some(target_name) = history_sidecar_target_name(name, &suffix) else {
+            continue;
+        };
+        let target = directory.join(target_name);
+        if !target.exists() {
+            // A published marker is required to decide whether the temporary
+            // generation or its backup is authoritative once the target moved.
+            return Err(PersistenceError::CorruptedData);
+        }
+        sidecars.push(entry.path());
+    }
+    for sidecar in sidecars {
+        std::fs::remove_file(sidecar).map_err(PersistenceError::Io)?;
+    }
+    std::fs::remove_file(pending_marker).map_err(PersistenceError::Io)
+}
+
+fn pending_history_replace_suffix(marker_name: &str) -> Option<String> {
+    let suffix = marker_name
+        .strip_prefix(".history-replace-")?
+        .strip_suffix(".json.pending")?;
+    let parsed = uuid::Uuid::parse_str(suffix).ok()?;
+    (parsed.to_string() == suffix).then(|| suffix.to_string())
+}
+
+fn history_sidecar_target_name(name: &str, suffix: &str) -> Option<String> {
+    let name = name.strip_prefix('.')?;
+    for extension in ["tmp", "previous"] {
+        let sidecar_suffix = format!(".{suffix}.{extension}");
+        if let Some(target) = name.strip_suffix(&sidecar_suffix)
+            && let Some(day) = target.strip_suffix(".jsonl")
+            && is_history_day(day)
+        {
+            return Some(target.to_string());
+        }
+    }
+    None
+}
+
+fn history_marker_has_sidecars(directory: &Path, marker_name: &str) -> Result<bool, PersistenceError> {
+    let suffix = marker_name
+        .strip_prefix(".history-replace-")
+        .and_then(|value| value.strip_suffix(".json"))
+        .ok_or(PersistenceError::CorruptedData)?;
+    let temporary_suffix = format!(".{suffix}.tmp");
+    let backup_suffix = format!(".{suffix}.previous");
+    for entry in std::fs::read_dir(directory).map_err(PersistenceError::Io)? {
+        let entry = entry.map_err(PersistenceError::Io)?;
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str() else {
+            continue;
+        };
+        if name.ends_with(&temporary_suffix) || name.ends_with(&backup_suffix) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn history_day(timestamp_ms: i64) -> Result<String, PersistenceError> {
+    Utc.timestamp_millis_opt(timestamp_ms)
+        .single()
+        .map(|timestamp| timestamp.format("%Y-%m-%d").to_string())
+        .ok_or_else(|| PersistenceError::InvalidConfig("history timestamp is invalid".to_string()))
+}
+
+fn is_history_day(value: &str) -> bool {
+    value.len() == 10
+        && value.as_bytes().get(4) == Some(&b'-')
+        && value.as_bytes().get(7) == Some(&b'-')
+        && value
+            .bytes()
+            .enumerate()
+            .all(|(index, byte)| index == 4 || index == 7 || byte.is_ascii_digit())
+}
+
+fn read_history_samples_file(path: &Path) -> Result<Vec<MetricSample>, PersistenceError> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let contents = std::fs::read_to_string(path).map_err(PersistenceError::Io)?;
+    let complete = if contents.ends_with('\n') {
+        contents.as_str()
+    } else {
+        contents.rsplit_once('\n').map_or("", |(complete, _)| complete)
+    };
+    complete
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            let mut sample = serde_json::from_str::<MetricSample>(line).map_err(|_| PersistenceError::CorruptedData)?;
+            sample.normalize().map_err(PersistenceError::InvalidConfig)?;
+            Ok(sample)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FilePersistence;
+    use super::history_directory;
+    use crate::config::SqlPoolConfig;
+    use crate::config::StorageConfig;
+    use crate::model::EnvironmentId;
+    use crate::model::MetricSample;
+    use crate::model::StorageBackend;
+    use crate::persistence::TimeRange;
+    use crate::persistence::error::PersistenceError;
+    use crate::persistence::history_repository::HistoryQuery;
+    use rocketmq_runtime::RuntimeConfig;
+    use rocketmq_runtime::RuntimeOwner;
+    use std::fs::OpenOptions;
+    use std::io::Write;
+
+    fn sample(environment_id: EnvironmentId, bucket_ms: i64, value: f64) -> MetricSample {
+        MetricSample {
+            environment_id,
+            metric: "broker-count".to_string(),
+            bucket_ms,
+            dimensions: Vec::new(),
+            value,
+        }
+    }
+
+    fn query(environment_id: EnvironmentId) -> HistoryQuery {
+        HistoryQuery {
+            environment_id,
+            metric: "broker-count".to_string(),
+            range: TimeRange {
+                start_ms: 0,
+                end_ms: 2_000,
+            },
+            dimensions: Vec::new(),
+            limit: 10,
+            cursor: None,
+        }
+    }
+
+    #[test]
+    fn file_history_reopens_and_deletes_only_complete_expired_days() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let owner = RuntimeOwner::new(RuntimeConfig::default()).expect("runtime owner");
+        owner.block_on(async {
+            let config = StorageConfig {
+                backend: StorageBackend::File,
+                data_path: directory.path().join("dashboard"),
+                database_url: None,
+                pool: SqlPoolConfig::default(),
+            };
+            let environment_id = EnvironmentId::new();
+            let sample = MetricSample {
+                environment_id: environment_id.clone(),
+                metric: "broker-count".to_string(),
+                bucket_ms: 1_000,
+                dimensions: Vec::new(),
+                value: 3.0,
+            };
+            let store = FilePersistence::initialize(&config, owner.root_context().component("history-file"))
+                .await
+                .expect("file persistence");
+            store
+                .append_history(vec![sample.clone()])
+                .await
+                .expect("append history");
+            let other_environment_id = EnvironmentId::new();
+            let other_sample = MetricSample {
+                environment_id: other_environment_id.clone(),
+                metric: "broker-count".to_string(),
+                bucket_ms: 1_000,
+                dimensions: Vec::new(),
+                value: 9.0,
+            };
+            store
+                .append_history(vec![other_sample.clone()])
+                .await
+                .expect("append other environment history");
+            drop(store);
+            let reopened = FilePersistence::initialize(&config, owner.root_context().component("history-file-reopen"))
+                .await
+                .expect("reopen file persistence");
+            let query = HistoryQuery {
+                environment_id,
+                metric: "broker-count".to_string(),
+                range: TimeRange {
+                    start_ms: 0,
+                    end_ms: 2_000,
+                },
+                dimensions: Vec::new(),
+                limit: 10,
+                cursor: None,
+            };
+            assert_eq!(reopened.read_history(&query).await.expect("read history"), vec![sample]);
+            let retention = reopened
+                .delete_history_before(&query.environment_id, 86_400_000, 1)
+                .await
+                .expect("retention");
+            assert_eq!(retention.deleted, 1);
+            assert!(!retention.has_more);
+            let mut invalid_range = query.clone();
+            invalid_range.range.end_ms = i64::MAX;
+            assert!(matches!(
+                reopened.read_history(&invalid_range).await,
+                Err(PersistenceError::InvalidConfig(_))
+            ));
+            assert!(matches!(
+                reopened.delete_history_before(&query.environment_id, i64::MAX, 1).await,
+                Err(PersistenceError::InvalidConfig(_))
+            ));
+            assert_eq!(
+                reopened
+                    .read_history(&HistoryQuery {
+                        environment_id: other_environment_id,
+                        metric: "broker-count".to_string(),
+                        range: TimeRange {
+                            start_ms: 0,
+                            end_ms: 2_000,
+                        },
+                        dimensions: Vec::new(),
+                        limit: 10,
+                        cursor: None,
+                    })
+                    .await
+                    .expect("read isolated environment history"),
+                vec![other_sample]
+            );
+        });
+        owner.shutdown_runtime_blocking().expect("runtime shutdown");
+    }
+
+    #[test]
+    #[ignore = "requires docker-compose.storage-test.yml"]
+    fn docker_file_history_reopens_a_mounted_volume() {
+        let data_path = std::env::var("ROCKETMQ_DASHBOARD_STORAGE_TEST_FILE_PATH")
+            .expect("ROCKETMQ_DASHBOARD_STORAGE_TEST_FILE_PATH must be set by the storage test runner");
+        let owner = RuntimeOwner::new(RuntimeConfig::default()).expect("runtime owner");
+        owner.block_on(async {
+            let config = StorageConfig {
+                backend: StorageBackend::File,
+                data_path: data_path.into(),
+                database_url: None,
+                pool: SqlPoolConfig::default(),
+            };
+            let environment_id = EnvironmentId::new();
+            let expired = MetricSample {
+                environment_id: environment_id.clone(),
+                metric: "broker-count".to_string(),
+                bucket_ms: 1_000,
+                dimensions: Vec::new(),
+                value: 3.0,
+            };
+            let retained = MetricSample {
+                environment_id: environment_id.clone(),
+                metric: "broker-count".to_string(),
+                bucket_ms: 86_401_000,
+                dimensions: Vec::new(),
+                value: 4.0,
+            };
+            let store = FilePersistence::initialize(&config, owner.root_context().component("docker-history-file"))
+                .await
+                .expect("file persistence");
+            store
+                .append_history(vec![expired.clone()])
+                .await
+                .expect("append expired history");
+            store
+                .append_history(vec![retained.clone()])
+                .await
+                .expect("append retained history");
+            drop(store);
+
+            let reopened =
+                FilePersistence::initialize(&config, owner.root_context().component("docker-history-file-reopen"))
+                    .await
+                    .expect("reopen mounted file persistence");
+            let query = HistoryQuery {
+                environment_id,
+                metric: "broker-count".to_string(),
+                range: TimeRange {
+                    start_ms: 0,
+                    end_ms: 172_800_000,
+                },
+                dimensions: Vec::new(),
+                limit: 10,
+                cursor: None,
+            };
+            assert_eq!(
+                reopened.read_history(&query).await.expect("read reopened history"),
+                vec![expired, retained.clone()]
+            );
+            let retention = reopened
+                .delete_history_before(&query.environment_id, 86_400_000, 1)
+                .await
+                .expect("retention");
+            assert_eq!(retention.deleted, 1);
+            assert!(!retention.has_more);
+            assert_eq!(
+                reopened.read_history(&query).await.expect("read retained history"),
+                vec![retained]
+            );
+        });
+        owner.shutdown_runtime_blocking().expect("runtime shutdown");
+    }
+
+    #[test]
+    fn file_history_marker_interruption_recovers_an_entire_old_or_new_batch() {
+        let owner = RuntimeOwner::new(RuntimeConfig::default()).expect("runtime owner");
+        owner.block_on(async {
+            for (stage, expect_new) in [(1, false), (2, true), (3, true)] {
+                let directory = tempfile::tempdir().expect("temporary directory");
+                let config = StorageConfig {
+                    backend: StorageBackend::File,
+                    data_path: directory.path().join("dashboard"),
+                    database_url: None,
+                    pool: SqlPoolConfig::default(),
+                };
+                let environment_id = EnvironmentId::new();
+                let old = sample(environment_id.clone(), 1_000, 1.0);
+                let new = sample(environment_id.clone(), 2_000, 2.0);
+                let store = FilePersistence::initialize(
+                    &config,
+                    owner.root_context().component(format!("history-file-marker-{stage}")),
+                )
+                .await
+                .expect("file persistence");
+                store.append_history(vec![old.clone()]).await.expect("old batch");
+                store.set_history_replace_failpoint(stage);
+                assert!(store.append_history(vec![new.clone()]).await.is_err());
+                let expected = if expect_new {
+                    vec![old.clone(), new.clone()]
+                } else {
+                    vec![old.clone()]
+                };
+                if stage == 2 {
+                    // The failed append recovers while its owned write gate is
+                    // still held, so this live instance never exposes the
+                    // briefly absent target between backup and publication.
+                    assert_eq!(
+                        store
+                            .read_history(&query(environment_id.clone()))
+                            .await
+                            .expect("online recovery after stage two"),
+                        expected
+                    );
+                    store
+                        .append_history(vec![new.clone()])
+                        .await
+                        .expect("idempotent append after online recovery");
+                }
+                drop(store);
+
+                let reopened = FilePersistence::initialize(
+                    &config,
+                    owner
+                        .root_context()
+                        .component(format!("history-file-marker-reopen-{stage}")),
+                )
+                .await
+                .expect("reopen after interrupted publication");
+                assert_eq!(
+                    reopened
+                        .read_history(&query(environment_id))
+                        .await
+                        .expect("recovered batch"),
+                    expected
+                );
+            }
+        });
+        owner.shutdown_runtime_blocking().expect("runtime shutdown");
+    }
+
+    #[test]
+    fn file_history_reopen_discards_empty_or_partial_marker_with_an_intact_target() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let owner = RuntimeOwner::new(RuntimeConfig::default()).expect("runtime owner");
+        owner.block_on(async {
+            let config = StorageConfig {
+                backend: StorageBackend::File,
+                data_path: directory.path().join("dashboard"),
+                database_url: None,
+                pool: SqlPoolConfig::default(),
+            };
+            let environment_id = EnvironmentId::new();
+            let old = sample(environment_id.clone(), 1_000, 1.0);
+            let store =
+                FilePersistence::initialize(&config, owner.root_context().component("history-file-torn-marker"))
+                    .await
+                    .expect("file persistence");
+            store.append_history(vec![old.clone()]).await.expect("old sample");
+            drop(store);
+
+            let history = history_directory(&config.data_path, &environment_id);
+            std::fs::write(history.join(".history-replace-empty.json"), b"").expect("empty marker");
+            std::fs::write(history.join(".history-replace-partial.json"), b"{").expect("partial marker");
+
+            let reopened = FilePersistence::initialize(
+                &config,
+                owner.root_context().component("history-file-torn-marker-reopen"),
+            )
+            .await
+            .expect("intact history target survives torn marker cleanup");
+            assert_eq!(
+                reopened
+                    .read_history(&query(environment_id))
+                    .await
+                    .expect("read intact target"),
+                vec![old]
+            );
+        });
+        owner.shutdown_runtime_blocking().expect("runtime shutdown");
+    }
+
+    #[test]
+    fn file_history_reopen_cleans_only_sidecars_for_an_unpublished_marker() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let owner = RuntimeOwner::new(RuntimeConfig::default()).expect("runtime owner");
+        owner.block_on(async {
+            let config = StorageConfig {
+                backend: StorageBackend::File,
+                data_path: directory.path().join("dashboard"),
+                database_url: None,
+                pool: SqlPoolConfig::default(),
+            };
+            let environment_id = EnvironmentId::new();
+            let old = sample(environment_id.clone(), 1_000, 1.0);
+            let store = FilePersistence::initialize(
+                &config,
+                owner.root_context().component("history-file-unpublished-marker"),
+            )
+            .await
+            .expect("file persistence");
+            store.append_history(vec![old.clone()]).await.expect("old sample");
+            drop(store);
+
+            let history = history_directory(&config.data_path, &environment_id);
+            let suffix = uuid::Uuid::now_v7();
+            let pending_marker = history.join(format!(".history-replace-{suffix}.json.pending"));
+            let temporary = history.join(format!(".1970-01-01.jsonl.{suffix}.tmp"));
+            let backup = history.join(format!(".1970-01-01.jsonl.{suffix}.previous"));
+            let unrelated_suffix = uuid::Uuid::now_v7();
+            let unrelated = history.join(format!(".1970-01-01.jsonl.{unrelated_suffix}.tmp"));
+            std::fs::write(&pending_marker, b"{").expect("torn unpublished marker");
+            std::fs::write(&temporary, b"new complete generation").expect("temporary sidecar");
+            std::fs::write(&backup, b"defensive backup sidecar").expect("backup sidecar");
+            std::fs::write(&unrelated, b"unrelated sidecar").expect("unrelated sidecar");
+
+            let reopened = FilePersistence::initialize(
+                &config,
+                owner.root_context().component("history-file-unpublished-marker-reopen"),
+            )
+            .await
+            .expect("reopen removes unpublished sidecars");
+            assert_eq!(
+                reopened
+                    .read_history(&query(environment_id))
+                    .await
+                    .expect("intact target remains readable"),
+                vec![old]
+            );
+            assert!(!pending_marker.exists());
+            assert!(!temporary.exists());
+            assert!(!backup.exists());
+            assert!(unrelated.exists());
+        });
+        owner.shutdown_runtime_blocking().expect("runtime shutdown");
+    }
+
+    #[test]
+    fn file_history_ignores_a_torn_tail_then_rewrites_and_cleans_retention_trash() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let owner = RuntimeOwner::new(RuntimeConfig::default()).expect("runtime owner");
+        owner.block_on(async {
+            let config = StorageConfig {
+                backend: StorageBackend::File,
+                data_path: directory.path().join("dashboard"),
+                database_url: None,
+                pool: SqlPoolConfig::default(),
+            };
+            let environment_id = EnvironmentId::new();
+            let old = sample(environment_id.clone(), 1_000, 1.0);
+            let new = sample(environment_id.clone(), 2_000, 2.0);
+            let store = FilePersistence::initialize(&config, owner.root_context().component("history-file-tail"))
+                .await
+                .expect("file persistence");
+            store.append_history(vec![old.clone()]).await.expect("old sample");
+            drop(store);
+
+            let history = history_directory(&config.data_path, &environment_id);
+            let mut file = OpenOptions::new()
+                .append(true)
+                .open(history.join("1970-01-01.jsonl"))
+                .expect("history segment");
+            file.write_all(br#"{\"environmentId\":\"torn"#).expect("torn tail");
+            drop(file);
+            let trash = history.join(".retention-crash-leftover");
+            std::fs::create_dir_all(&trash).expect("retention trash");
+            std::fs::write(trash.join("1970-01-01.jsonl"), b"old").expect("retention trash payload");
+
+            let reopened =
+                FilePersistence::initialize(&config, owner.root_context().component("history-file-tail-reopen"))
+                    .await
+                    .expect("reopen cleans retention trash");
+            assert!(!trash.exists());
+            reopened
+                .append_history(vec![new.clone()])
+                .await
+                .expect("append after tail");
+            drop(reopened);
+
+            let verified =
+                FilePersistence::initialize(&config, owner.root_context().component("history-file-tail-verified"))
+                    .await
+                    .expect("verify reopen");
+            assert_eq!(
+                verified
+                    .read_history(&query(environment_id))
+                    .await
+                    .expect("rewritten history"),
+                vec![old, new]
+            );
+        });
+        owner.shutdown_runtime_blocking().expect("runtime shutdown");
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/history_lease_store.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/history_lease_store.rs
@@ -1,0 +1,433 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use super::DatabasePool;
+use super::SqlPersistence;
+use super::map_query_error;
+use crate::model::EnvironmentId;
+use crate::persistence::error::PersistenceError;
+use crate::persistence::lease_repository::HistoryLease;
+use sqlx::QueryBuilder;
+use sqlx::Row;
+
+const SQLITE_CLOCK_MS: &str = "CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)";
+const MYSQL_CLOCK_MS: &str = "TIMESTAMPDIFF(MICROSECOND, '1970-01-01 00:00:00', UTC_TIMESTAMP(3)) DIV 1000";
+const POSTGRES_CLOCK_MS: &str = "FLOOR(EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::BIGINT";
+
+impl SqlPersistence {
+    pub(crate) async fn acquire_history_lease(
+        &self,
+        environment_id: &EnvironmentId,
+        holder_id: &str,
+        ttl_ms: i64,
+    ) -> Result<Option<HistoryLease>, PersistenceError> {
+        match &self.pool {
+            DatabasePool::Sqlite(pool) => acquire_sqlite(pool, environment_id, holder_id, ttl_ms).await,
+            DatabasePool::MySql(pool) => acquire_mysql(pool, environment_id, holder_id, ttl_ms).await,
+            DatabasePool::Postgres(pool) => acquire_postgres(pool, environment_id, holder_id, ttl_ms).await,
+        }
+    }
+
+    pub(crate) async fn renew_history_lease(
+        &self,
+        lease: &HistoryLease,
+        ttl_ms: i64,
+    ) -> Result<Option<HistoryLease>, PersistenceError> {
+        match &self.pool {
+            DatabasePool::Sqlite(pool) => renew_sqlite(pool, lease, ttl_ms).await,
+            DatabasePool::MySql(pool) => renew_mysql(pool, lease, ttl_ms).await,
+            DatabasePool::Postgres(pool) => renew_postgres(pool, lease, ttl_ms).await,
+        }
+    }
+
+    pub(crate) async fn release_history_lease(&self, lease: &HistoryLease) -> Result<bool, PersistenceError> {
+        match &self.pool {
+            DatabasePool::Sqlite(pool) => release_sqlite(pool, lease).await,
+            DatabasePool::MySql(pool) => release_mysql(pool, lease).await,
+            DatabasePool::Postgres(pool) => release_postgres(pool, lease).await,
+        }
+    }
+}
+
+macro_rules! acquire_lease {
+    ($executor:expr, $clock:expr, $environment:expr, $holder:expr, $ttl:expr) => {
+        acquire_lease!(@inner $executor, $clock, $environment, $holder, $ttl, "", "")
+    };
+    ($executor:expr, $clock:expr, $environment:expr, $holder:expr, $ttl:expr, $lock:literal) => {
+        acquire_lease!(@inner $executor, $clock, $environment, $holder, $ttl, $lock, "")
+    };
+    ($executor:expr, $clock:expr, $environment:expr, $holder:expr, $ttl:expr, $lock:literal, $insert_suffix:literal) => {
+        acquire_lease!(@inner $executor, $clock, $environment, $holder, $ttl, $lock, $insert_suffix)
+    };
+    (@inner $executor:expr, $clock:expr, $environment:expr, $holder:expr, $ttl:expr, $lock:expr, $insert_suffix:expr) => {{
+        let name = HistoryLease::name_for($environment);
+        let clock_query = format!("SELECT {}", $clock);
+        let now: i64 = sqlx::query_scalar(&clock_query)
+            .fetch_one($executor)
+            .await
+            .map_err(map_query_error)?;
+        let expires_at_ms = now.checked_add($ttl).ok_or(PersistenceError::Conflict)?;
+        let mut current = QueryBuilder::new(
+            "SELECT expires_at_ms, fencing_token FROM dashboard_task_lease WHERE lease_name = ",
+        );
+        current.push_bind(&name);
+        current.push($lock);
+        let current = current.build().fetch_optional($executor).await.map_err(map_query_error)?;
+        if let Some(row) = current {
+            let expires: i64 = row.try_get("expires_at_ms").map_err(map_query_error)?;
+            let old_token: i64 = row.try_get("fencing_token").map_err(map_query_error)?;
+            if expires > now {
+                Ok(None)
+            } else {
+                let token = old_token.checked_add(1).ok_or(PersistenceError::Conflict)?;
+                let mut update = QueryBuilder::new("UPDATE dashboard_task_lease SET holder_id = ");
+                update.push_bind($holder);
+                update.push(", expires_at_ms = ");
+                update.push_bind(expires_at_ms);
+                update.push(", fencing_token = ");
+                update.push_bind(token);
+                update.push(" WHERE lease_name = ");
+                update.push_bind(&name);
+                update.push(" AND fencing_token = ");
+                update.push_bind(old_token);
+                update.push(" AND expires_at_ms <= ");
+                update.push($clock);
+                let acquired = update.build().execute($executor).await.map_err(map_query_error)?.rows_affected() == 1;
+                Ok(acquired.then(|| HistoryLease::new(
+                    $environment.clone(),
+                    $holder.to_string(),
+                    token,
+                    expires_at_ms,
+                )))
+            }
+        } else {
+            let mut insert = QueryBuilder::new(
+                "INSERT INTO dashboard_task_lease (lease_name, holder_id, expires_at_ms, fencing_token) VALUES (",
+            );
+            insert.push_bind(&name);
+            insert.push(", ");
+            insert.push_bind($holder);
+            insert.push(", ");
+            insert.push_bind(expires_at_ms);
+            insert.push(", 1)");
+            insert.push($insert_suffix);
+            let acquired = insert.build().execute($executor).await.map_err(map_query_error)?.rows_affected() == 1;
+            Ok(acquired.then(|| HistoryLease::new(
+                $environment.clone(),
+                $holder.to_string(),
+                1,
+                expires_at_ms,
+            )))
+        }
+    }};
+}
+
+macro_rules! renew_or_release {
+    ($executor:expr, $clock:expr, $lease:expr, $ttl:expr, $release:expr) => {{
+        let mut update = QueryBuilder::new("UPDATE dashboard_task_lease SET expires_at_ms = ");
+        update.push($clock);
+        if !$release {
+            update.push(" + ");
+            update.push_bind($ttl);
+        }
+        update.push(" WHERE lease_name = ");
+        update.push_bind(&$lease.name);
+        update.push(" AND holder_id = ");
+        update.push_bind(&$lease.holder_id);
+        update.push(" AND fencing_token = ");
+        update.push_bind($lease.fencing_token);
+        update.push(" AND expires_at_ms > ");
+        update.push($clock);
+        update
+            .build()
+            .execute($executor)
+            .await
+            .map_err(map_query_error)?
+            .rows_affected()
+    }};
+}
+
+async fn acquire_sqlite(
+    pool: &sqlx::SqlitePool,
+    environment_id: &EnvironmentId,
+    holder: &str,
+    ttl: i64,
+) -> Result<Option<HistoryLease>, PersistenceError> {
+    let mut connection = pool.acquire().await.map_err(map_query_error)?;
+    sqlx::query("BEGIN IMMEDIATE")
+        .execute(&mut *connection)
+        .await
+        .map_err(map_query_error)?;
+    let result = acquire_lease!(&mut *connection, SQLITE_CLOCK_MS, environment_id, holder, ttl);
+    finish_sqlite(&mut connection, result).await
+}
+
+async fn acquire_mysql(
+    pool: &sqlx::MySqlPool,
+    environment_id: &EnvironmentId,
+    holder: &str,
+    ttl: i64,
+) -> Result<Option<HistoryLease>, PersistenceError> {
+    for _ in 0..3 {
+        match acquire_mysql_once(pool, environment_id, holder, ttl).await {
+            Ok(lease) => return Ok(lease),
+            Err(error) if mysql_lease_retryable(&error) => tokio::task::yield_now().await,
+            Err(error) => return Err(error),
+        }
+    }
+    // A contended standby acquire is an ordinary condition, not a storage
+    // outage. The next renewal tick will retry without exposing a stale error.
+    Ok(None)
+}
+
+async fn acquire_mysql_once(
+    pool: &sqlx::MySqlPool,
+    environment_id: &EnvironmentId,
+    holder: &str,
+    ttl: i64,
+) -> Result<Option<HistoryLease>, PersistenceError> {
+    let name = HistoryLease::name_for(environment_id);
+    let clock_query = format!("SELECT {MYSQL_CLOCK_MS}");
+    let now: i64 = sqlx::query_scalar(&clock_query)
+        .fetch_one(pool)
+        .await
+        .map_err(map_query_error)?;
+    let expires_at_ms = now.checked_add(ttl).ok_or(PersistenceError::Conflict)?;
+    // INSERT IGNORE is used only to create the missing lease row. It avoids a
+    // preceding SELECT ... FOR UPDATE gap lock; all update paths below remain
+    // exact holder/token/expiry checks and never silence other write errors.
+    let inserted = sqlx::query(
+        "INSERT IGNORE INTO dashboard_task_lease \
+         (lease_name, holder_id, expires_at_ms, fencing_token) VALUES (?, ?, ?, 1)",
+    )
+    .bind(&name)
+    .bind(holder)
+    .bind(expires_at_ms)
+    .execute(pool)
+    .await
+    .map_err(map_query_error)?
+    .rows_affected();
+    if inserted == 1 {
+        return Ok(Some(HistoryLease::new(
+            environment_id.clone(),
+            holder.to_string(),
+            1,
+            expires_at_ms,
+        )));
+    }
+
+    let mut transaction = pool.begin().await.map_err(map_query_error)?;
+    let result = async {
+        let now: i64 = sqlx::query_scalar(&clock_query)
+            .fetch_one(&mut *transaction)
+            .await
+            .map_err(map_query_error)?;
+        let expires_at_ms = now.checked_add(ttl).ok_or(PersistenceError::Conflict)?;
+        let row = sqlx::query(
+            "SELECT expires_at_ms, fencing_token FROM dashboard_task_lease \
+             WHERE lease_name = ? FOR UPDATE",
+        )
+        .bind(&name)
+        .fetch_optional(&mut *transaction)
+        .await
+        .map_err(map_query_error)?;
+        let Some(row) = row else {
+            return Ok(None);
+        };
+        let expires: i64 = row.try_get("expires_at_ms").map_err(map_query_error)?;
+        let old_token: i64 = row.try_get("fencing_token").map_err(map_query_error)?;
+        if expires > now {
+            return Ok(None);
+        }
+        let token = old_token.checked_add(1).ok_or(PersistenceError::Conflict)?;
+        let updated = sqlx::query(
+            "UPDATE dashboard_task_lease SET holder_id = ?, expires_at_ms = ?, fencing_token = ? \
+             WHERE lease_name = ? AND fencing_token = ? AND expires_at_ms <= \
+             TIMESTAMPDIFF(MICROSECOND, '1970-01-01 00:00:00', UTC_TIMESTAMP(3)) DIV 1000",
+        )
+        .bind(holder)
+        .bind(expires_at_ms)
+        .bind(token)
+        .bind(&name)
+        .bind(old_token)
+        .execute(&mut *transaction)
+        .await
+        .map_err(map_query_error)?
+        .rows_affected();
+        Ok((updated == 1).then(|| HistoryLease::new(environment_id.clone(), holder.to_string(), token, expires_at_ms)))
+    }
+    .await;
+    finish_transaction(transaction, result).await
+}
+
+fn mysql_lease_retryable(error: &PersistenceError) -> bool {
+    let PersistenceError::Query(sqlx::Error::Database(database)) = error else {
+        return false;
+    };
+    matches!(database.code().as_deref(), Some("1205" | "1213" | "1062"))
+}
+
+async fn acquire_postgres(
+    pool: &sqlx::PgPool,
+    environment_id: &EnvironmentId,
+    holder: &str,
+    ttl: i64,
+) -> Result<Option<HistoryLease>, PersistenceError> {
+    let mut transaction = pool.begin().await.map_err(map_query_error)?;
+    let result = acquire_lease!(
+        &mut *transaction,
+        POSTGRES_CLOCK_MS,
+        environment_id,
+        holder,
+        ttl,
+        " FOR UPDATE",
+        " ON CONFLICT (lease_name) DO NOTHING"
+    );
+    finish_transaction(transaction, result).await
+}
+
+async fn renew_sqlite(
+    pool: &sqlx::SqlitePool,
+    lease: &HistoryLease,
+    ttl: i64,
+) -> Result<Option<HistoryLease>, PersistenceError> {
+    let mut connection = pool.acquire().await.map_err(map_query_error)?;
+    sqlx::query("BEGIN IMMEDIATE")
+        .execute(&mut *connection)
+        .await
+        .map_err(map_query_error)?;
+    let result = async {
+        if renew_or_release!(&mut *connection, SQLITE_CLOCK_MS, lease, ttl, false) != 1 {
+            return Ok(None);
+        }
+        let clock_query = format!("SELECT {SQLITE_CLOCK_MS}");
+        let now: i64 = sqlx::query_scalar(&clock_query)
+            .fetch_one(&mut *connection)
+            .await
+            .map_err(map_query_error)?;
+        Ok(Some(HistoryLease {
+            expires_at_ms: now.checked_add(ttl).ok_or(PersistenceError::Conflict)?,
+            ..lease.clone()
+        }))
+    }
+    .await;
+    finish_sqlite(&mut connection, result).await
+}
+
+async fn renew_mysql(
+    pool: &sqlx::MySqlPool,
+    lease: &HistoryLease,
+    ttl: i64,
+) -> Result<Option<HistoryLease>, PersistenceError> {
+    let mut transaction = pool.begin().await.map_err(map_query_error)?;
+    let result = async {
+        if renew_or_release!(&mut *transaction, MYSQL_CLOCK_MS, lease, ttl, false) != 1 {
+            return Ok(None);
+        }
+        let clock_query = format!("SELECT {MYSQL_CLOCK_MS}");
+        let now: i64 = sqlx::query_scalar(&clock_query)
+            .fetch_one(&mut *transaction)
+            .await
+            .map_err(map_query_error)?;
+        Ok(Some(HistoryLease {
+            expires_at_ms: now.checked_add(ttl).ok_or(PersistenceError::Conflict)?,
+            ..lease.clone()
+        }))
+    }
+    .await;
+    finish_transaction(transaction, result).await
+}
+
+async fn renew_postgres(
+    pool: &sqlx::PgPool,
+    lease: &HistoryLease,
+    ttl: i64,
+) -> Result<Option<HistoryLease>, PersistenceError> {
+    let mut transaction = pool.begin().await.map_err(map_query_error)?;
+    let result = async {
+        if renew_or_release!(&mut *transaction, POSTGRES_CLOCK_MS, lease, ttl, false) != 1 {
+            return Ok(None);
+        }
+        let clock_query = format!("SELECT {POSTGRES_CLOCK_MS}");
+        let now: i64 = sqlx::query_scalar(&clock_query)
+            .fetch_one(&mut *transaction)
+            .await
+            .map_err(map_query_error)?;
+        Ok(Some(HistoryLease {
+            expires_at_ms: now.checked_add(ttl).ok_or(PersistenceError::Conflict)?,
+            ..lease.clone()
+        }))
+    }
+    .await;
+    finish_transaction(transaction, result).await
+}
+
+async fn release_sqlite(pool: &sqlx::SqlitePool, lease: &HistoryLease) -> Result<bool, PersistenceError> {
+    let mut connection = pool.acquire().await.map_err(map_query_error)?;
+    sqlx::query("BEGIN IMMEDIATE")
+        .execute(&mut *connection)
+        .await
+        .map_err(map_query_error)?;
+    let result = async { Ok(renew_or_release!(&mut *connection, SQLITE_CLOCK_MS, lease, 0_i64, true) == 1) }.await;
+    finish_sqlite(&mut connection, result).await
+}
+
+async fn release_mysql(pool: &sqlx::MySqlPool, lease: &HistoryLease) -> Result<bool, PersistenceError> {
+    let mut transaction = pool.begin().await.map_err(map_query_error)?;
+    let result = async { Ok(renew_or_release!(&mut *transaction, MYSQL_CLOCK_MS, lease, 0_i64, true) == 1) }.await;
+    finish_transaction(transaction, result).await
+}
+
+async fn release_postgres(pool: &sqlx::PgPool, lease: &HistoryLease) -> Result<bool, PersistenceError> {
+    let mut transaction = pool.begin().await.map_err(map_query_error)?;
+    let result = async { Ok(renew_or_release!(&mut *transaction, POSTGRES_CLOCK_MS, lease, 0_i64, true) == 1) }.await;
+    finish_transaction(transaction, result).await
+}
+
+async fn finish_sqlite<T>(
+    connection: &mut sqlx::SqliteConnection,
+    result: Result<T, PersistenceError>,
+) -> Result<T, PersistenceError> {
+    match result {
+        Ok(value) => {
+            sqlx::query("COMMIT")
+                .execute(&mut *connection)
+                .await
+                .map_err(map_query_error)?;
+            Ok(value)
+        }
+        Err(error) => {
+            let _ = sqlx::query("ROLLBACK").execute(&mut *connection).await;
+            Err(error)
+        }
+    }
+}
+
+async fn finish_transaction<DB, T>(
+    transaction: sqlx::Transaction<'_, DB>,
+    result: Result<T, PersistenceError>,
+) -> Result<T, PersistenceError>
+where
+    DB: sqlx::Database,
+{
+    match result {
+        Ok(value) => {
+            transaction.commit().await.map_err(map_query_error)?;
+            Ok(value)
+        }
+        Err(error) => {
+            let _ = transaction.rollback().await;
+            Err(error)
+        }
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/history_repository.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/history_repository.rs
@@ -1,0 +1,443 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use crate::model::EnvironmentId;
+use crate::model::MetricDimension;
+use crate::model::MetricSample;
+use crate::persistence::DashboardPersistence;
+use crate::persistence::TimeRange;
+use crate::persistence::backend::PersistenceBackend;
+use crate::persistence::error::PersistenceError;
+use crate::persistence::lease_repository::HistoryLease;
+use chrono::TimeZone;
+use chrono::Utc;
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::BTreeMap;
+
+pub const MAX_HISTORY_PAGE_SIZE: u32 = 5_000;
+pub const MAX_HISTORY_APPEND_BATCH: usize = 500;
+
+/// Returns whether a value is a non-negative UTC epoch millisecond accepted
+/// by every history backend, including the File backend's calendar layout.
+pub(crate) fn is_valid_history_timestamp_ms(value: i64) -> bool {
+    value >= 0 && Utc.timestamp_millis_opt(value).single().is_some()
+}
+
+/// A bounded keyset query over one environment and one metric.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HistoryQuery {
+    pub environment_id: EnvironmentId,
+    pub metric: String,
+    pub range: TimeRange,
+    /// An empty list selects only samples without dimensions. This keeps the
+    /// current dashboard cards exact while still allowing a caller to use a
+    /// metric with several dimension sets through an explicit repository API.
+    pub dimensions: Vec<MetricDimension>,
+    pub limit: u32,
+    pub cursor: Option<String>,
+}
+
+impl HistoryQuery {
+    pub fn validate_and_normalize(&mut self) -> Result<(), PersistenceError> {
+        if self.environment_id.0.is_empty() || self.environment_id.0.len() > 36 {
+            return Err(PersistenceError::InvalidConfig(
+                "history query environment is invalid".to_string(),
+            ));
+        }
+        if self.metric.is_empty() || self.metric.len() > MetricSample::MAX_METRIC_LENGTH {
+            return Err(PersistenceError::InvalidConfig(
+                "history query metric is invalid".to_string(),
+            ));
+        }
+        if !self.range.is_valid()
+            || !is_valid_history_timestamp_ms(self.range.start_ms)
+            || !is_valid_history_timestamp_ms(self.range.end_ms)
+        {
+            return Err(PersistenceError::InvalidConfig(
+                "history query range is invalid".to_string(),
+            ));
+        }
+        if self.limit == 0 || self.limit > MAX_HISTORY_PAGE_SIZE {
+            return Err(PersistenceError::InvalidConfig(
+                "history query limit is invalid".to_string(),
+            ));
+        }
+        normalize_dimensions(&mut self.dimensions).map_err(PersistenceError::InvalidConfig)?;
+        let dimensions_json = self.dimensions_json()?;
+        if dimensions_json.len() > MetricSample::MAX_DIMENSIONS_JSON_LENGTH {
+            return Err(PersistenceError::InvalidConfig(
+                "history query dimensions are too large".to_string(),
+            ));
+        }
+        if let Some(cursor) = &self.cursor {
+            let decoded = HistoryCursor::decode(cursor)?;
+            if decoded.environment_id != self.environment_id.0
+                || decoded.metric != self.metric
+                || decoded.start_ms != self.range.start_ms
+                || decoded.end_ms != self.range.end_ms
+                || decoded.dimensions_json != dimensions_json
+                || decoded.last_bucket_ms < self.range.start_ms
+                || decoded.last_bucket_ms > self.range.end_ms
+                || decoded.last_dimensions_json != dimensions_json
+            {
+                return Err(PersistenceError::InvalidConfig(
+                    "history cursor does not match the query filters".to_string(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    pub fn dimensions_json(&self) -> Result<String, PersistenceError> {
+        serde_json::to_string(&self.dimensions).map_err(PersistenceError::Serialization)
+    }
+
+    pub fn cursor_key(&self) -> Result<Option<(i64, String)>, PersistenceError> {
+        self.cursor
+            .as_deref()
+            .map(HistoryCursor::decode)
+            .transpose()
+            .map(|cursor| cursor.map(|cursor| (cursor.last_bucket_ms, cursor.last_dimensions_json)))
+    }
+}
+
+/// One stable keyset page from history storage.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HistoryPage {
+    pub samples: Vec<MetricSample>,
+    pub next_cursor: Option<String>,
+}
+
+/// The bounded result of one retention pass. Callers repeat while `has_more`
+/// is true; this is intentionally not an unbounded deletion operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HistoryRetentionResult {
+    pub deleted: u64,
+    pub has_more: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct HistoryCursor {
+    environment_id: String,
+    metric: String,
+    start_ms: i64,
+    end_ms: i64,
+    dimensions_json: String,
+    last_bucket_ms: i64,
+    last_dimensions_json: String,
+}
+
+impl HistoryCursor {
+    fn encode(self) -> Result<String, PersistenceError> {
+        let json = serde_json::to_vec(&self).map_err(PersistenceError::Serialization)?;
+        Ok(json.iter().map(|byte| format!("{byte:02x}")).collect())
+    }
+
+    fn decode(value: &str) -> Result<Self, PersistenceError> {
+        if !value.len().is_multiple_of(2) || value.len() > 8_192 {
+            return Err(PersistenceError::InvalidConfig("history cursor is invalid".to_string()));
+        }
+        let bytes = value
+            .as_bytes()
+            .chunks_exact(2)
+            .map(|pair| {
+                let high = hex_nibble(pair[0])?;
+                let low = hex_nibble(pair[1])?;
+                Ok((high << 4) | low)
+            })
+            .collect::<Result<Vec<_>, PersistenceError>>()?;
+        serde_json::from_slice(&bytes)
+            .map_err(|_| PersistenceError::InvalidConfig("history cursor is invalid".to_string()))
+    }
+}
+
+fn hex_nibble(value: u8) -> Result<u8, PersistenceError> {
+    match value {
+        b'0'..=b'9' => Ok(value - b'0'),
+        b'a'..=b'f' => Ok(value - b'a' + 10),
+        b'A'..=b'F' => Ok(value - b'A' + 10),
+        _ => Err(PersistenceError::InvalidConfig("history cursor is invalid".to_string())),
+    }
+}
+
+pub(crate) fn normalize_dimensions(dimensions: &mut [MetricDimension]) -> Result<(), String> {
+    if dimensions.len() > MetricSample::MAX_DIMENSIONS {
+        return Err("history query has too many dimensions".to_string());
+    }
+    dimensions.sort_by(|left, right| left.key.cmp(&right.key));
+    for dimension in dimensions.iter() {
+        if dimension.key.is_empty()
+            || dimension.key.len() > MetricSample::MAX_DIMENSION_KEY_LENGTH
+            || dimension.value.len() > MetricSample::MAX_DIMENSION_VALUE_LENGTH
+        {
+            return Err("history query dimension is invalid".to_string());
+        }
+    }
+    if dimensions.windows(2).any(|pair| pair[0].key == pair[1].key) {
+        return Err("history query dimensions contain a duplicate key".to_string());
+    }
+    Ok(())
+}
+
+pub(crate) fn normalize_samples(mut samples: Vec<MetricSample>) -> Result<Vec<MetricSample>, PersistenceError> {
+    let mut unique = BTreeMap::<(String, String, i64, String), MetricSample>::new();
+    for mut sample in samples.drain(..) {
+        sample.normalize().map_err(PersistenceError::InvalidConfig)?;
+        // JSON does not preserve a useful distinction between positive and
+        // negative zero for dashboard gauges; store the canonical value.
+        if sample.value == 0.0 {
+            sample.value = 0.0;
+        }
+        let dimensions_json = sample.dimensions_json().map_err(PersistenceError::InvalidConfig)?;
+        let key = (
+            sample.environment_id.0.clone(),
+            sample.metric.clone(),
+            sample.bucket_ms,
+            dimensions_json,
+        );
+        if let Some(existing) = unique.get(&key) {
+            if existing.value.to_bits() != sample.value.to_bits() {
+                return Err(PersistenceError::Conflict);
+            }
+            continue;
+        }
+        unique.insert(key, sample);
+    }
+    Ok(unique.into_values().collect())
+}
+
+pub(crate) fn page_samples(
+    query: &HistoryQuery,
+    mut samples: Vec<MetricSample>,
+) -> Result<HistoryPage, PersistenceError> {
+    samples.sort_by(|left, right| {
+        left.bucket_ms
+            .cmp(&right.bucket_ms)
+            .then_with(|| left.dimensions.cmp(&right.dimensions))
+    });
+    let dimensions_json = query.dimensions_json()?;
+    let cursor_key = query.cursor_key()?;
+    let mut matching = samples
+        .into_iter()
+        .filter(|sample| {
+            sample.environment_id == query.environment_id
+                && sample.metric == query.metric
+                && sample.bucket_ms >= query.range.start_ms
+                && sample.bucket_ms <= query.range.end_ms
+                && sample.dimensions_json().ok().as_deref() == Some(dimensions_json.as_str())
+        })
+        .filter(|sample| {
+            let Some((bucket_ms, dimensions)) = &cursor_key else {
+                return true;
+            };
+            sample
+                .dimensions_json()
+                .map(|sample_dimensions| (sample.bucket_ms, sample_dimensions) > (*bucket_ms, dimensions.clone()))
+                .unwrap_or(false)
+        })
+        .collect::<Vec<_>>();
+    let has_more = matching.len() > query.limit as usize;
+    matching.truncate(query.limit as usize);
+    let next_cursor = if has_more {
+        let last = matching.last().ok_or(PersistenceError::CorruptedData)?;
+        HistoryCursor {
+            environment_id: query.environment_id.0.clone(),
+            metric: query.metric.clone(),
+            start_ms: query.range.start_ms,
+            end_ms: query.range.end_ms,
+            dimensions_json,
+            last_bucket_ms: last.bucket_ms,
+            last_dimensions_json: last.dimensions_json().map_err(PersistenceError::InvalidConfig)?,
+        }
+        .encode()
+        .map(Some)?
+    } else {
+        None
+    };
+    Ok(HistoryPage {
+        samples: matching,
+        next_cursor,
+    })
+}
+
+impl DashboardPersistence {
+    pub async fn append_history(
+        &self,
+        samples: Vec<MetricSample>,
+        lease: Option<&HistoryLease>,
+    ) -> Result<(), PersistenceError> {
+        let samples = normalize_samples(samples)?;
+        if samples.is_empty() {
+            return Ok(());
+        }
+        if samples.len() > MAX_HISTORY_APPEND_BATCH {
+            return Err(PersistenceError::InvalidConfig(
+                "history append batch exceeds the bounded storage limit".to_string(),
+            ));
+        }
+        let environment_id = &samples[0].environment_id;
+        if samples.iter().any(|sample| sample.environment_id != *environment_id) {
+            return Err(PersistenceError::InvalidConfig(
+                "history append batch must contain exactly one environment".to_string(),
+            ));
+        }
+        if self.history_uses_sql_lease() && lease.map(HistoryLease::environment_id) != Some(environment_id) {
+            return Err(PersistenceError::Conflict);
+        }
+        match &self.backend {
+            PersistenceBackend::File(store) => store.append_history(samples).await,
+            PersistenceBackend::Sql(store) => store.append_history(samples, lease).await,
+        }
+    }
+
+    pub async fn query_history(&self, mut query: HistoryQuery) -> Result<HistoryPage, PersistenceError> {
+        query.validate_and_normalize()?;
+        match &self.backend {
+            PersistenceBackend::File(store) => page_samples(&query, store.read_history(&query).await?),
+            PersistenceBackend::Sql(store) => store.query_history(query).await,
+        }
+    }
+
+    pub async fn delete_history_before(
+        &self,
+        environment_id: &EnvironmentId,
+        cutoff_ms: i64,
+        batch_size: u32,
+        lease: Option<&HistoryLease>,
+    ) -> Result<HistoryRetentionResult, PersistenceError> {
+        if !is_valid_history_timestamp_ms(cutoff_ms) || batch_size == 0 || batch_size > MAX_HISTORY_PAGE_SIZE {
+            return Err(PersistenceError::InvalidConfig(
+                "history retention request is invalid".to_string(),
+            ));
+        }
+        match &self.backend {
+            PersistenceBackend::File(store) => store.delete_history_before(environment_id, cutoff_ms, batch_size).await,
+            PersistenceBackend::Sql(store) => {
+                if lease.map(HistoryLease::environment_id) != Some(environment_id) {
+                    return Err(PersistenceError::Conflict);
+                }
+                store
+                    .delete_history_before(environment_id, cutoff_ms, batch_size, lease)
+                    .await
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HistoryCursor;
+    use super::HistoryQuery;
+    use super::is_valid_history_timestamp_ms;
+    use super::normalize_samples;
+    use super::page_samples;
+    use crate::model::EnvironmentId;
+    use crate::model::MetricDimension;
+    use crate::model::MetricSample;
+    use crate::persistence::TimeRange;
+    use crate::persistence::error::PersistenceError;
+
+    fn sample(bucket_ms: i64, value: f64) -> MetricSample {
+        MetricSample {
+            environment_id: EnvironmentId("environment-000000000000000000000000".to_string()),
+            metric: "broker-count".to_string(),
+            bucket_ms,
+            dimensions: Vec::new(),
+            value,
+        }
+    }
+
+    fn query(cursor: Option<String>) -> HistoryQuery {
+        HistoryQuery {
+            environment_id: EnvironmentId("environment-000000000000000000000000".to_string()),
+            metric: "broker-count".to_string(),
+            range: TimeRange {
+                start_ms: 0,
+                end_ms: 10,
+            },
+            dimensions: Vec::new(),
+            limit: 2,
+            cursor,
+        }
+    }
+
+    #[test]
+    fn conflicting_batch_is_rejected_before_any_backend_write() {
+        assert!(matches!(
+            normalize_samples(vec![sample(1, 1.0), sample(1, 2.0)]),
+            Err(PersistenceError::Conflict)
+        ));
+    }
+
+    #[test]
+    fn cursor_is_bound_to_the_full_filter_and_never_repeats_a_key() {
+        let mut first_query = query(None);
+        first_query.validate_and_normalize().expect("query");
+        let samples = vec![sample(1, 1.0), sample(2, 2.0), sample(3, 3.0)];
+        let first = page_samples(&first_query, samples.clone()).expect("first page");
+        assert_eq!(first.samples.len(), 2);
+        let second_cursor = first.next_cursor.clone().expect("next cursor");
+        let mut second_query = query(Some(second_cursor));
+        second_query.validate_and_normalize().expect("second query");
+        let second = page_samples(&second_query, samples).expect("second page");
+        assert_eq!(second.samples.len(), 1);
+        assert_eq!(second.samples[0].bucket_ms, 3);
+
+        let mut mismatched = query(first.next_cursor);
+        mismatched.dimensions = vec![MetricDimension {
+            key: "topic".to_string(),
+            value: "orders".to_string(),
+        }];
+        assert!(mismatched.validate_and_normalize().is_err());
+    }
+
+    #[test]
+    fn cursor_rejects_out_of_range_positions_and_tampered_dimensions() {
+        let invalid_position = HistoryCursor {
+            environment_id: "environment-000000000000000000000000".to_string(),
+            metric: "broker-count".to_string(),
+            start_ms: 0,
+            end_ms: 10,
+            dimensions_json: "[]".to_string(),
+            last_bucket_ms: 11,
+            last_dimensions_json: "[]".to_string(),
+        }
+        .encode()
+        .expect("cursor encoding");
+        assert!(query(Some(invalid_position)).validate_and_normalize().is_err());
+
+        let tampered_dimensions = HistoryCursor {
+            environment_id: "environment-000000000000000000000000".to_string(),
+            metric: "broker-count".to_string(),
+            start_ms: 0,
+            end_ms: 10,
+            dimensions_json: "[]".to_string(),
+            last_bucket_ms: 5,
+            last_dimensions_json: "[{\"key\":\"topic\",\"value\":\"orders\"}]".to_string(),
+        }
+        .encode()
+        .expect("cursor encoding");
+        assert!(query(Some(tampered_dimensions)).validate_and_normalize().is_err());
+    }
+
+    #[test]
+    fn utc_history_timestamp_boundaries_reject_i64_max() {
+        assert!(is_valid_history_timestamp_ms(0));
+        assert!(!is_valid_history_timestamp_ms(i64::MAX));
+        let mut query = query(None);
+        query.range.end_ms = i64::MAX;
+        assert!(query.validate_and_normalize().is_err());
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/history_sql_store.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/history_sql_store.rs
@@ -1,0 +1,519 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use super::DatabasePool;
+use super::SqlPersistence;
+use super::map_query_error;
+use crate::model::EnvironmentId;
+use crate::model::MetricSample;
+use crate::persistence::error::PersistenceError;
+use crate::persistence::history_repository::HistoryPage;
+use crate::persistence::history_repository::HistoryQuery;
+use crate::persistence::history_repository::HistoryRetentionResult;
+use crate::persistence::history_repository::is_valid_history_timestamp_ms;
+use crate::persistence::history_repository::page_samples;
+use crate::persistence::lease_repository::HistoryLease;
+use sqlx::QueryBuilder;
+use sqlx::Row;
+use std::collections::BTreeMap;
+
+const SQLITE_CLOCK_MS: &str = "CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)";
+const MYSQL_CLOCK_MS: &str = "TIMESTAMPDIFF(MICROSECOND, '1970-01-01 00:00:00', UTC_TIMESTAMP(3)) DIV 1000";
+const POSTGRES_CLOCK_MS: &str = "FLOOR(EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::BIGINT";
+
+impl SqlPersistence {
+    pub(crate) async fn append_history(
+        &self,
+        samples: Vec<MetricSample>,
+        lease: Option<&HistoryLease>,
+    ) -> Result<(), PersistenceError> {
+        let lease = lease.ok_or(PersistenceError::Conflict)?;
+        let environment_id = samples
+            .first()
+            .map(|sample| &sample.environment_id)
+            .ok_or_else(|| PersistenceError::InvalidConfig("history append batch is empty".to_string()))?;
+        if samples.iter().any(|sample| sample.environment_id != *environment_id)
+            || lease.environment_id() != environment_id
+        {
+            return Err(PersistenceError::Conflict);
+        }
+        match &self.pool {
+            DatabasePool::Sqlite(pool) => append_sqlite(pool, &samples, lease).await,
+            DatabasePool::MySql(pool) => append_mysql(pool, &samples, lease).await,
+            DatabasePool::Postgres(pool) => append_postgres(pool, &samples, lease).await,
+        }
+    }
+
+    pub(crate) async fn query_history(&self, mut query: HistoryQuery) -> Result<HistoryPage, PersistenceError> {
+        query.validate_and_normalize()?;
+        let samples = match &self.pool {
+            DatabasePool::Sqlite(pool) => query_sqlite(pool, &query).await,
+            DatabasePool::MySql(pool) => query_mysql(pool, &query).await,
+            DatabasePool::Postgres(pool) => query_postgres(pool, &query).await,
+        }?;
+        page_samples(&query, samples)
+    }
+
+    pub(crate) async fn delete_history_before(
+        &self,
+        environment_id: &EnvironmentId,
+        cutoff_ms: i64,
+        batch_size: u32,
+        lease: Option<&HistoryLease>,
+    ) -> Result<HistoryRetentionResult, PersistenceError> {
+        if !is_valid_history_timestamp_ms(cutoff_ms) {
+            return Err(PersistenceError::InvalidConfig(
+                "history retention request is invalid".to_string(),
+            ));
+        }
+        let lease = lease.ok_or(PersistenceError::Conflict)?;
+        if lease.environment_id() != environment_id {
+            return Err(PersistenceError::Conflict);
+        }
+        match &self.pool {
+            DatabasePool::Sqlite(pool) => delete_sqlite(pool, environment_id, cutoff_ms, batch_size, lease).await,
+            DatabasePool::MySql(pool) => delete_mysql(pool, environment_id, cutoff_ms, batch_size, lease).await,
+            DatabasePool::Postgres(pool) => delete_postgres(pool, environment_id, cutoff_ms, batch_size, lease).await,
+        }
+    }
+}
+
+macro_rules! lease_is_current {
+    ($executor:expr, $clock:expr, $lease:expr $(, $suffix:literal)?) => {{
+        let mut statement = QueryBuilder::new(
+            "SELECT fencing_token FROM dashboard_task_lease WHERE lease_name = ",
+        );
+        statement.push_bind(&$lease.name);
+        statement.push(" AND holder_id = ");
+        statement.push_bind(&$lease.holder_id);
+        statement.push(" AND fencing_token = ");
+        statement.push_bind($lease.fencing_token);
+        statement.push(" AND expires_at_ms > ");
+        statement.push($clock);
+        $(statement.push($suffix);)?
+        if statement
+            .build()
+            .fetch_optional($executor)
+            .await
+            .map_err(map_query_error)?
+            .is_none()
+        {
+            return Err(PersistenceError::Conflict);
+        }
+    }};
+}
+
+macro_rules! append_rows {
+    ($executor:expr, $samples:expr, $decode:expr) => {{
+        let mut existing_query = QueryBuilder::new(
+            "SELECT environment_id, metric_name, bucket_ms, dimensions_json, value \
+             FROM dashboard_history_sample WHERE ",
+        );
+        let mut first = true;
+        for sample in $samples {
+            let dimensions = sample.dimensions_json().map_err(PersistenceError::InvalidConfig)?;
+            if !first {
+                existing_query.push(" OR ");
+            }
+            first = false;
+            existing_query.push("(environment_id = ");
+            existing_query.push_bind(sample.environment_id.0.clone());
+            existing_query.push(" AND metric_name = ");
+            existing_query.push_bind(sample.metric.clone());
+            existing_query.push(" AND bucket_ms = ");
+            existing_query.push_bind(sample.bucket_ms);
+            existing_query.push(" AND dimensions_json = ");
+            existing_query.push_bind(dimensions);
+            existing_query.push(")");
+        }
+        let existing = existing_query
+            .build()
+            .fetch_all($executor)
+            .await
+            .map_err(map_query_error)?
+            .into_iter()
+            .map($decode)
+            .collect::<Result<Vec<_>, PersistenceError>>()?
+            .into_iter()
+            .map(|sample| {
+                let key = (
+                    sample.environment_id.0.clone(),
+                    sample.metric.clone(),
+                    sample.bucket_ms,
+                    sample.dimensions_json().map_err(PersistenceError::InvalidConfig)?,
+                );
+                Ok((key, sample.value))
+            })
+            .collect::<Result<BTreeMap<_, _>, PersistenceError>>()?;
+        let mut missing = Vec::new();
+        for sample in $samples {
+            let dimensions = sample.dimensions_json().map_err(PersistenceError::InvalidConfig)?;
+            let key = (
+                sample.environment_id.0.clone(),
+                sample.metric.clone(),
+                sample.bucket_ms,
+                dimensions,
+            );
+            if let Some(value) = existing.get(&key) {
+                if value.to_bits() != sample.value.to_bits() {
+                    return Err(PersistenceError::Conflict);
+                }
+            }
+            if !existing.contains_key(&key) {
+                missing.push(sample);
+            }
+        }
+        if !missing.is_empty() {
+            let mut insert = QueryBuilder::new(
+                "INSERT INTO dashboard_history_sample (environment_id, metric_name, bucket_ms, dimensions_json, value) VALUES ",
+            );
+            let mut first = true;
+            for sample in missing {
+                let dimensions = sample.dimensions_json().map_err(PersistenceError::InvalidConfig)?;
+                if !first {
+                    insert.push(", ");
+                }
+                first = false;
+                insert.push("(");
+                insert.push_bind(sample.environment_id.0.clone());
+                insert.push(", ");
+                insert.push_bind(sample.metric.clone());
+                insert.push(", ");
+                insert.push_bind(sample.bucket_ms);
+                insert.push(", ");
+                insert.push_bind(dimensions);
+                insert.push(", ");
+                insert.push_bind(sample.value);
+                insert.push(")");
+            }
+            insert.build().execute($executor).await.map_err(map_query_error)?;
+        }
+    }};
+}
+
+async fn append_sqlite(
+    pool: &sqlx::SqlitePool,
+    samples: &[MetricSample],
+    lease: &HistoryLease,
+) -> Result<(), PersistenceError> {
+    let mut connection = pool.acquire().await.map_err(map_query_error)?;
+    sqlx::query("BEGIN IMMEDIATE")
+        .execute(&mut *connection)
+        .await
+        .map_err(map_query_error)?;
+    let result = async {
+        lease_is_current!(&mut *connection, SQLITE_CLOCK_MS, lease);
+        append_rows!(&mut *connection, samples, history_sample_from_sqlite);
+        Ok(())
+    }
+    .await;
+    finish_sqlite(&mut connection, result).await
+}
+
+async fn append_mysql(
+    pool: &sqlx::MySqlPool,
+    samples: &[MetricSample],
+    lease: &HistoryLease,
+) -> Result<(), PersistenceError> {
+    let mut transaction = pool.begin().await.map_err(map_query_error)?;
+    let result = async {
+        lease_is_current!(&mut *transaction, MYSQL_CLOCK_MS, lease, " FOR UPDATE");
+        append_rows!(&mut *transaction, samples, history_sample_from_mysql);
+        Ok(())
+    }
+    .await;
+    finish_transaction(transaction, result).await
+}
+
+async fn append_postgres(
+    pool: &sqlx::PgPool,
+    samples: &[MetricSample],
+    lease: &HistoryLease,
+) -> Result<(), PersistenceError> {
+    let mut transaction = pool.begin().await.map_err(map_query_error)?;
+    let result = async {
+        lease_is_current!(&mut *transaction, POSTGRES_CLOCK_MS, lease, " FOR UPDATE");
+        append_rows!(&mut *transaction, samples, history_sample_from_postgres);
+        Ok(())
+    }
+    .await;
+    finish_transaction(transaction, result).await
+}
+
+macro_rules! query_rows {
+    ($executor:expr, $query:expr, $decode:expr) => {{
+        let dimensions = $query.dimensions_json()?;
+        let cursor = $query.cursor_key()?;
+        let mut statement = QueryBuilder::new(
+            "SELECT environment_id, metric_name, bucket_ms, dimensions_json, value \
+             FROM dashboard_history_sample WHERE environment_id = ",
+        );
+        statement.push_bind(&$query.environment_id.0);
+        statement.push(" AND metric_name = ");
+        statement.push_bind(&$query.metric);
+        statement.push(" AND dimensions_json = ");
+        statement.push_bind(&dimensions);
+        statement.push(" AND bucket_ms >= ");
+        statement.push_bind($query.range.start_ms);
+        statement.push(" AND bucket_ms <= ");
+        statement.push_bind($query.range.end_ms);
+        if let Some((bucket_ms, cursor_dimensions)) = cursor {
+            statement.push(" AND (bucket_ms > ");
+            statement.push_bind(bucket_ms);
+            statement.push(" OR (bucket_ms = ");
+            statement.push_bind(bucket_ms);
+            statement.push(" AND dimensions_json > ");
+            statement.push_bind(cursor_dimensions);
+            statement.push("))");
+        }
+        statement.push(" ORDER BY bucket_ms ASC, dimensions_json ASC LIMIT ");
+        statement.push_bind(i64::from($query.limit) + 1);
+        statement
+            .build()
+            .fetch_all($executor)
+            .await
+            .map_err(map_query_error)?
+            .into_iter()
+            .map($decode)
+            .collect::<Result<Vec<_>, PersistenceError>>()
+    }};
+}
+
+fn history_sample_from_sqlite(row: sqlx::sqlite::SqliteRow) -> Result<MetricSample, PersistenceError> {
+    history_sample_from_text_fields(
+        row.try_get("environment_id").map_err(map_query_error)?,
+        row.try_get("metric_name").map_err(map_query_error)?,
+        row.try_get("bucket_ms").map_err(map_query_error)?,
+        row.try_get("dimensions_json").map_err(map_query_error)?,
+        row.try_get("value").map_err(map_query_error)?,
+    )
+}
+
+fn history_sample_from_mysql(row: sqlx::mysql::MySqlRow) -> Result<MetricSample, PersistenceError> {
+    history_sample_from_binary_fields(
+        row.try_get("environment_id").map_err(map_query_error)?,
+        row.try_get("metric_name").map_err(map_query_error)?,
+        row.try_get("bucket_ms").map_err(map_query_error)?,
+        row.try_get("dimensions_json").map_err(map_query_error)?,
+        row.try_get("value").map_err(map_query_error)?,
+    )
+}
+
+fn history_sample_from_postgres(row: sqlx::postgres::PgRow) -> Result<MetricSample, PersistenceError> {
+    history_sample_from_text_fields(
+        row.try_get("environment_id").map_err(map_query_error)?,
+        row.try_get("metric_name").map_err(map_query_error)?,
+        row.try_get("bucket_ms").map_err(map_query_error)?,
+        row.try_get("dimensions_json").map_err(map_query_error)?,
+        row.try_get("value").map_err(map_query_error)?,
+    )
+}
+
+fn history_sample_from_binary_fields(
+    environment_id: Vec<u8>,
+    metric: Vec<u8>,
+    bucket_ms: i64,
+    dimensions_json: Vec<u8>,
+    value: f64,
+) -> Result<MetricSample, PersistenceError> {
+    history_sample_from_text_fields(
+        String::from_utf8(environment_id).map_err(|_| PersistenceError::CorruptedData)?,
+        String::from_utf8(metric).map_err(|_| PersistenceError::CorruptedData)?,
+        bucket_ms,
+        String::from_utf8(dimensions_json).map_err(|_| PersistenceError::CorruptedData)?,
+        value,
+    )
+}
+
+fn history_sample_from_text_fields(
+    environment_id: String,
+    metric: String,
+    bucket_ms: i64,
+    dimensions_json: String,
+    value: f64,
+) -> Result<MetricSample, PersistenceError> {
+    let mut sample = MetricSample {
+        environment_id: EnvironmentId(environment_id),
+        metric,
+        bucket_ms,
+        dimensions: serde_json::from_str(&dimensions_json).map_err(|_| PersistenceError::CorruptedData)?,
+        value,
+    };
+    sample.normalize().map_err(|_| PersistenceError::CorruptedData)?;
+    Ok(sample)
+}
+
+macro_rules! history_has_more {
+    ($executor:expr, $environment_id:expr, $cutoff:expr) => {{
+        let mut select = QueryBuilder::new("SELECT 1 FROM dashboard_history_sample WHERE environment_id = ");
+        select.push_bind(&$environment_id.0);
+        select.push(" AND bucket_ms < ");
+        select.push_bind($cutoff);
+        select.push(" LIMIT 1");
+        select
+            .build()
+            .fetch_optional($executor)
+            .await
+            .map_err(map_query_error)?
+            .is_some()
+    }};
+}
+
+async fn query_sqlite(pool: &sqlx::SqlitePool, query: &HistoryQuery) -> Result<Vec<MetricSample>, PersistenceError> {
+    query_rows!(pool, query, history_sample_from_sqlite)
+}
+
+async fn query_mysql(pool: &sqlx::MySqlPool, query: &HistoryQuery) -> Result<Vec<MetricSample>, PersistenceError> {
+    query_rows!(pool, query, history_sample_from_mysql)
+}
+
+async fn query_postgres(pool: &sqlx::PgPool, query: &HistoryQuery) -> Result<Vec<MetricSample>, PersistenceError> {
+    query_rows!(pool, query, history_sample_from_postgres)
+}
+
+async fn delete_sqlite(
+    pool: &sqlx::SqlitePool,
+    environment_id: &EnvironmentId,
+    cutoff: i64,
+    batch: u32,
+    lease: &HistoryLease,
+) -> Result<HistoryRetentionResult, PersistenceError> {
+    let mut connection = pool.acquire().await.map_err(map_query_error)?;
+    sqlx::query("BEGIN IMMEDIATE")
+        .execute(&mut *connection)
+        .await
+        .map_err(map_query_error)?;
+    let result = async {
+        lease_is_current!(&mut *connection, SQLITE_CLOCK_MS, lease);
+        let deleted = sqlx::query(
+            "DELETE FROM dashboard_history_sample WHERE rowid IN (\
+             SELECT rowid FROM dashboard_history_sample WHERE environment_id = ? AND bucket_ms < ? \
+             ORDER BY bucket_ms, environment_id, metric_name, dimensions_json LIMIT ?)",
+        )
+        .bind(&environment_id.0)
+        .bind(cutoff)
+        .bind(i64::from(batch))
+        .execute(&mut *connection)
+        .await
+        .map_err(map_query_error)?
+        .rows_affected();
+        let has_more = history_has_more!(&mut *connection, environment_id, cutoff);
+        Ok(HistoryRetentionResult { deleted, has_more })
+    }
+    .await;
+    finish_sqlite(&mut connection, result).await
+}
+
+async fn delete_mysql(
+    pool: &sqlx::MySqlPool,
+    environment_id: &EnvironmentId,
+    cutoff: i64,
+    batch: u32,
+    lease: &HistoryLease,
+) -> Result<HistoryRetentionResult, PersistenceError> {
+    let mut transaction = pool.begin().await.map_err(map_query_error)?;
+    let result = async {
+        lease_is_current!(&mut *transaction, MYSQL_CLOCK_MS, lease, " FOR UPDATE");
+        let deleted = sqlx::query(
+            "DELETE FROM dashboard_history_sample WHERE environment_id = ? AND bucket_ms < ? \
+             ORDER BY bucket_ms, environment_id, metric_name, dimensions_json LIMIT ?",
+        )
+        .bind(&environment_id.0)
+        .bind(cutoff)
+        .bind(i64::from(batch))
+        .execute(&mut *transaction)
+        .await
+        .map_err(map_query_error)?
+        .rows_affected();
+        let has_more = history_has_more!(&mut *transaction, environment_id, cutoff);
+        Ok(HistoryRetentionResult { deleted, has_more })
+    }
+    .await;
+    finish_transaction(transaction, result).await
+}
+
+async fn delete_postgres(
+    pool: &sqlx::PgPool,
+    environment_id: &EnvironmentId,
+    cutoff: i64,
+    batch: u32,
+    lease: &HistoryLease,
+) -> Result<HistoryRetentionResult, PersistenceError> {
+    let mut transaction = pool.begin().await.map_err(map_query_error)?;
+    let result = async {
+        lease_is_current!(&mut *transaction, POSTGRES_CLOCK_MS, lease, " FOR UPDATE");
+        let deleted = sqlx::query(
+            "WITH candidates AS (\
+             SELECT ctid FROM dashboard_history_sample WHERE environment_id = $1 AND bucket_ms < $2 \
+             ORDER BY bucket_ms, environment_id, metric_name, dimensions_json LIMIT $3) \
+             DELETE FROM dashboard_history_sample WHERE ctid IN (SELECT ctid FROM candidates)",
+        )
+        .bind(&environment_id.0)
+        .bind(cutoff)
+        .bind(i64::from(batch))
+        .execute(&mut *transaction)
+        .await
+        .map_err(map_query_error)?
+        .rows_affected();
+        let has_more = history_has_more!(&mut *transaction, environment_id, cutoff);
+        Ok(HistoryRetentionResult { deleted, has_more })
+    }
+    .await;
+    finish_transaction(transaction, result).await
+}
+
+async fn finish_sqlite<T>(
+    connection: &mut sqlx::SqliteConnection,
+    result: Result<T, PersistenceError>,
+) -> Result<T, PersistenceError> {
+    match result {
+        Ok(value) => {
+            sqlx::query("COMMIT")
+                .execute(&mut *connection)
+                .await
+                .map_err(map_query_error)?;
+            Ok(value)
+        }
+        Err(error) => {
+            let _ = sqlx::query("ROLLBACK").execute(&mut *connection).await;
+            Err(error)
+        }
+    }
+}
+
+async fn finish_transaction<DB, T>(
+    transaction: sqlx::Transaction<'_, DB>,
+    result: Result<T, PersistenceError>,
+) -> Result<T, PersistenceError>
+where
+    DB: sqlx::Database,
+{
+    match result {
+        Ok(value) => {
+            transaction.commit().await.map_err(map_query_error)?;
+            Ok(value)
+        }
+        Err(error) => {
+            let _ = transaction.rollback().await;
+            Err(error)
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "history_sql_store_tests.rs"]
+mod tests;
+
+#[cfg(test)]
+#[path = "history_sql_store_contract_tests.rs"]
+mod contract_tests;

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/history_sql_store_contract_tests.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/history_sql_store_contract_tests.rs
@@ -1,0 +1,500 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::SqlPersistence;
+use crate::config::SqlPoolConfig;
+use crate::config::StorageConfig;
+use crate::model::EnvironmentId;
+use crate::model::MetricDimension;
+use crate::model::MetricSample;
+use crate::model::StorageBackend;
+use crate::persistence::TimeRange;
+use crate::persistence::error::PersistenceError;
+use crate::persistence::history_repository::HistoryQuery;
+use crate::persistence::lease_repository::HistoryLease;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+
+#[test]
+fn sqlite_history_cursor_multidimension_atomicity_and_cutoff_contract() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let owner = RuntimeOwner::new(RuntimeConfig::default()).expect("runtime owner");
+    owner.block_on(async {
+        let store = SqlPersistence::initialize(
+            &StorageConfig {
+                backend: StorageBackend::Sqlite,
+                data_path: directory.path().join("dashboard.db"),
+                database_url: None,
+                pool: SqlPoolConfig::default(),
+            },
+            owner.root_context().component("sqlite-history-contract"),
+        )
+        .await
+        .expect("SQLite persistence");
+        let environment_id = EnvironmentId::new();
+        let lease = store
+            .acquire_history_lease(&environment_id, "sqlite-contract", 30_000)
+            .await
+            .expect("SQLite lease")
+            .expect("SQLite lease acquired");
+        assert_invalid_time_boundaries(&store, &environment_id, &lease).await;
+
+        let mut multi = sample(
+            environment_id.clone(),
+            "multi",
+            1_000,
+            vec![
+                MetricDimension {
+                    key: "zone".to_string(),
+                    value: "west".to_string(),
+                },
+                MetricDimension {
+                    key: "cluster".to_string(),
+                    value: "primary".to_string(),
+                },
+            ],
+            1.0,
+        );
+        multi.normalize().expect("multi-dimensional normalization");
+        store
+            .append_history(vec![multi.clone()], Some(&lease))
+            .await
+            .expect("multi append");
+        assert_eq!(
+            store
+                .query_history(query(
+                    environment_id.clone(),
+                    "multi",
+                    vec![
+                        MetricDimension {
+                            key: "zone".to_string(),
+                            value: "west".to_string(),
+                        },
+                        MetricDimension {
+                            key: "cluster".to_string(),
+                            value: "primary".to_string(),
+                        },
+                    ],
+                    10,
+                    None,
+                ))
+                .await
+                .expect("normalized multi query")
+                .samples,
+            vec![multi]
+        );
+
+        let cursor_samples = (0..3)
+            .map(|offset| {
+                sample(
+                    environment_id.clone(),
+                    "cursor",
+                    2_000 + offset,
+                    Vec::new(),
+                    offset as f64,
+                )
+            })
+            .collect::<Vec<_>>();
+        store
+            .append_history(cursor_samples.clone(), Some(&lease))
+            .await
+            .expect("cursor append");
+        let first = store
+            .query_history(query(environment_id.clone(), "cursor", Vec::new(), 1, None))
+            .await
+            .expect("first cursor page");
+        let second = store
+            .query_history(query(
+                environment_id.clone(),
+                "cursor",
+                Vec::new(),
+                1,
+                first.next_cursor.clone(),
+            ))
+            .await
+            .expect("second cursor page");
+        assert_ne!(first.samples[0].bucket_ms, second.samples[0].bucket_ms);
+
+        let existing = sample(environment_id.clone(), "atomic", 3_000, Vec::new(), 1.0);
+        let new_sample = sample(environment_id.clone(), "atomic", 3_001, Vec::new(), 2.0);
+        store
+            .append_history(vec![existing.clone()], Some(&lease))
+            .await
+            .expect("atomic setup");
+        assert!(matches!(
+            store
+                .append_history(
+                    vec![
+                        new_sample,
+                        sample(environment_id.clone(), "atomic", 3_000, Vec::new(), 3.0)
+                    ],
+                    Some(&lease),
+                )
+                .await,
+            Err(PersistenceError::Conflict)
+        ));
+        assert_eq!(
+            store
+                .query_history(query(environment_id.clone(), "atomic", Vec::new(), 10, None))
+                .await
+                .expect("atomic query")
+                .samples,
+            vec![existing]
+        );
+
+        let cutoff_environment = EnvironmentId::new();
+        let cutoff_lease = store
+            .acquire_history_lease(&cutoff_environment, "sqlite-cutoff", 30_000)
+            .await
+            .expect("cutoff lease")
+            .expect("cutoff lease acquired");
+        let old = sample(cutoff_environment.clone(), "cutoff", 4_000, Vec::new(), 1.0);
+        let exact = sample(cutoff_environment.clone(), "cutoff", 4_001, Vec::new(), 2.0);
+        store
+            .append_history(vec![old, exact.clone()], Some(&cutoff_lease))
+            .await
+            .expect("cutoff setup");
+        assert_eq!(
+            store
+                .delete_history_before(&cutoff_environment, 4_001, 10, Some(&cutoff_lease))
+                .await
+                .expect("exact cutoff retention")
+                .deleted,
+            1
+        );
+        assert_eq!(
+            store
+                .query_history(query(cutoff_environment, "cutoff", Vec::new(), 10, None))
+                .await
+                .expect("exact cutoff query")
+                .samples,
+            vec![exact]
+        );
+    });
+    owner.shutdown_runtime_blocking().expect("runtime shutdown");
+}
+
+#[test]
+#[ignore = "requires docker-compose.storage-test.yml"]
+fn docker_mysql_history_identity_cursor_and_retention_contract() {
+    let database_url = std::env::var("ROCKETMQ_DASHBOARD_STORAGE_TEST_MYSQL_URL")
+        .expect("ROCKETMQ_DASHBOARD_STORAGE_TEST_MYSQL_URL must be set by the storage test runner");
+    docker_history_identity_cursor_and_retention_contract(StorageBackend::MySql, database_url);
+}
+
+#[test]
+#[ignore = "requires docker-compose.storage-test.yml"]
+fn docker_postgres_history_identity_cursor_and_retention_contract() {
+    let database_url = std::env::var("ROCKETMQ_DASHBOARD_STORAGE_TEST_POSTGRES_URL")
+        .expect("ROCKETMQ_DASHBOARD_STORAGE_TEST_POSTGRES_URL must be set by the storage test runner");
+    docker_history_identity_cursor_and_retention_contract(StorageBackend::Postgres, database_url);
+}
+
+fn sample(
+    environment_id: EnvironmentId,
+    metric: &str,
+    bucket_ms: i64,
+    dimensions: Vec<MetricDimension>,
+    value: f64,
+) -> MetricSample {
+    MetricSample {
+        environment_id,
+        metric: metric.to_string(),
+        bucket_ms,
+        dimensions,
+        value,
+    }
+}
+
+fn query(
+    environment_id: EnvironmentId,
+    metric: &str,
+    dimensions: Vec<MetricDimension>,
+    limit: u32,
+    cursor: Option<String>,
+) -> HistoryQuery {
+    let mut query = HistoryQuery {
+        environment_id,
+        metric: metric.to_string(),
+        range: TimeRange {
+            start_ms: 0,
+            end_ms: 100_000,
+        },
+        dimensions,
+        limit,
+        cursor,
+    };
+    query.validate_and_normalize().expect("valid history query");
+    query
+}
+
+fn docker_history_identity_cursor_and_retention_contract(backend: StorageBackend, database_url: String) {
+    let owner = RuntimeOwner::new(RuntimeConfig::default()).expect("runtime owner");
+    owner.block_on(async {
+        let store = SqlPersistence::initialize(
+            &StorageConfig {
+                backend,
+                data_path: "unused".into(),
+                database_url: Some(database_url),
+                pool: SqlPoolConfig::default(),
+            },
+            owner.root_context().component("docker-history-identity-contract"),
+        )
+        .await
+        .expect("SQL persistence");
+
+        // Binary (MySQL) and C-collated (PostgreSQL) identity must preserve
+        // spaces, case, and UTF-8 bytes rather than applying a collation.
+        for (index, identity) in ["x", "x ", "X", "节点"].into_iter().enumerate() {
+            let environment_id = EnvironmentId(identity.to_string());
+            let lease = store
+                .acquire_history_lease(&environment_id, &format!("exact-{index}"), 30_000)
+                .await
+                .expect("identity lease")
+                .expect("identity lease acquired");
+            let record = sample(
+                environment_id.clone(),
+                identity,
+                1_000,
+                vec![MetricDimension {
+                    key: "label".to_string(),
+                    value: identity.to_string(),
+                }],
+                index as f64,
+            );
+            store
+                .append_history(vec![record.clone()], Some(&lease))
+                .await
+                .expect("exact identity append");
+            assert_eq!(
+                store
+                    .query_history(query(
+                        environment_id,
+                        identity,
+                        vec![MetricDimension {
+                            key: "label".to_string(),
+                            value: identity.to_string(),
+                        }],
+                        10,
+                        None,
+                    ))
+                    .await
+                    .expect("exact identity query")
+                    .samples,
+                vec![record]
+            );
+        }
+
+        let environment_id = EnvironmentId::new();
+        let lease = store
+            .acquire_history_lease(&environment_id, "contract-holder", 30_000)
+            .await
+            .expect("contract lease")
+            .expect("contract lease acquired");
+        assert_invalid_time_boundaries(&store, &environment_id, &lease).await;
+        let mut normalized = sample(
+            environment_id.clone(),
+            "multi-dimensional",
+            2_000,
+            vec![
+                MetricDimension {
+                    key: "zone".to_string(),
+                    value: "west".to_string(),
+                },
+                MetricDimension {
+                    key: "cluster".to_string(),
+                    value: "primary".to_string(),
+                },
+            ],
+            1.0,
+        );
+        normalized.normalize().expect("normalized dimensions");
+        store
+            .append_history(vec![normalized.clone()], Some(&lease))
+            .await
+            .expect("multi-dimensional append");
+        let normalized_page = store
+            .query_history(query(
+                environment_id.clone(),
+                "multi-dimensional",
+                vec![
+                    MetricDimension {
+                        key: "zone".to_string(),
+                        value: "west".to_string(),
+                    },
+                    MetricDimension {
+                        key: "cluster".to_string(),
+                        value: "primary".to_string(),
+                    },
+                ],
+                10,
+                None,
+            ))
+            .await
+            .expect("normalized query");
+        assert_eq!(normalized_page.samples, vec![normalized]);
+
+        let cursor_samples = (0..3)
+            .map(|offset| {
+                sample(
+                    environment_id.clone(),
+                    "cursor",
+                    10_000 + offset * 1_000,
+                    Vec::new(),
+                    offset as f64,
+                )
+            })
+            .collect::<Vec<_>>();
+        store
+            .append_history(cursor_samples.clone(), Some(&lease))
+            .await
+            .expect("cursor samples");
+        let first_page = store
+            .query_history(query(environment_id.clone(), "cursor", Vec::new(), 1, None))
+            .await
+            .expect("first cursor page");
+        let second_page = store
+            .query_history(query(
+                environment_id.clone(),
+                "cursor",
+                Vec::new(),
+                1,
+                first_page.next_cursor.clone(),
+            ))
+            .await
+            .expect("second cursor page");
+        let third_page = store
+            .query_history(query(
+                environment_id.clone(),
+                "cursor",
+                Vec::new(),
+                1,
+                second_page.next_cursor.clone(),
+            ))
+            .await
+            .expect("third cursor page");
+        assert_eq!(
+            [first_page.samples, second_page.samples, third_page.samples]
+                .into_iter()
+                .flatten()
+                .map(|sample| sample.bucket_ms)
+                .collect::<Vec<_>>(),
+            cursor_samples
+                .into_iter()
+                .map(|sample| sample.bucket_ms)
+                .collect::<Vec<_>>()
+        );
+        assert!(third_page.next_cursor.is_none());
+
+        let existing = sample(environment_id.clone(), "atomic", 20_000, Vec::new(), 1.0);
+        store
+            .append_history(vec![existing.clone()], Some(&lease))
+            .await
+            .expect("existing atomic sample");
+        let new_sample = sample(environment_id.clone(), "atomic", 21_000, Vec::new(), 2.0);
+        let conflicting = sample(environment_id.clone(), "atomic", 20_000, Vec::new(), 3.0);
+        assert!(matches!(
+            store
+                .append_history(vec![new_sample.clone(), conflicting], Some(&lease))
+                .await,
+            Err(PersistenceError::Conflict)
+        ));
+        assert_eq!(
+            store
+                .query_history(query(environment_id.clone(), "atomic", Vec::new(), 10, None))
+                .await
+                .expect("atomic rollback query")
+                .samples,
+            vec![existing]
+        );
+
+        let boundary_environment = EnvironmentId::new();
+        let boundary_lease = store
+            .acquire_history_lease(&boundary_environment, "boundary-holder", 30_000)
+            .await
+            .expect("boundary lease")
+            .expect("boundary lease acquired");
+        let boundary_old = sample(boundary_environment.clone(), "boundary", 30_000, Vec::new(), 1.0);
+        let boundary_exact = sample(boundary_environment.clone(), "boundary", 31_000, Vec::new(), 2.0);
+        store
+            .append_history(vec![boundary_old, boundary_exact.clone()], Some(&boundary_lease))
+            .await
+            .expect("boundary samples");
+        let deleted = store
+            .delete_history_before(&boundary_environment, 31_000, 1, Some(&boundary_lease))
+            .await
+            .expect("exact boundary retention");
+        assert_eq!(deleted.deleted, 1);
+        assert_eq!(
+            store
+                .query_history(query(boundary_environment, "boundary", Vec::new(), 10, None))
+                .await
+                .expect("boundary query")
+                .samples,
+            vec![boundary_exact]
+        );
+
+        let other_environment = EnvironmentId::new();
+        let other_lease = store
+            .acquire_history_lease(&other_environment, "other-environment", 30_000)
+            .await
+            .expect("other lease")
+            .expect("other lease acquired");
+        let other = sample(other_environment.clone(), "isolated", 40_000, Vec::new(), 9.0);
+        let own = sample(environment_id.clone(), "isolated", 40_000, Vec::new(), 1.0);
+        store
+            .append_history(vec![other.clone()], Some(&other_lease))
+            .await
+            .expect("other append");
+        store.append_history(vec![own], Some(&lease)).await.expect("own append");
+        store
+            .delete_history_before(&environment_id, 41_000, 10, Some(&lease))
+            .await
+            .expect("isolated retention");
+        assert_eq!(
+            store
+                .query_history(query(other_environment, "isolated", Vec::new(), 10, None))
+                .await
+                .expect("other environment survives")
+                .samples,
+            vec![other]
+        );
+    });
+    owner.shutdown_runtime_blocking().expect("runtime shutdown");
+}
+
+async fn assert_invalid_time_boundaries(store: &SqlPersistence, environment_id: &EnvironmentId, lease: &HistoryLease) {
+    assert!(matches!(
+        store
+            .query_history(HistoryQuery {
+                environment_id: environment_id.clone(),
+                metric: "invalid-time".to_string(),
+                range: TimeRange {
+                    start_ms: 0,
+                    end_ms: i64::MAX,
+                },
+                dimensions: Vec::new(),
+                limit: 1,
+                cursor: None,
+            })
+            .await,
+        Err(PersistenceError::InvalidConfig(_))
+    ));
+    assert!(matches!(
+        store
+            .delete_history_before(environment_id, i64::MAX, 1, Some(lease))
+            .await,
+        Err(PersistenceError::InvalidConfig(_))
+    ));
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/history_sql_store_docker_tests.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/history_sql_store_docker_tests.rs
@@ -1,0 +1,82 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::SqlPersistence;
+use crate::config::SqlPoolConfig;
+use crate::config::StorageConfig;
+use crate::model::EnvironmentId;
+use crate::model::MetricSample;
+use crate::model::StorageBackend;
+use crate::persistence::TimeRange;
+use crate::persistence::history_repository::HistoryQuery;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+
+#[test]
+#[ignore = "requires docker-compose.storage-test.yml"]
+fn docker_sqlite_history_reopens_a_mounted_database() {
+    let data_path = std::env::var("ROCKETMQ_DASHBOARD_STORAGE_TEST_SQLITE_PATH")
+        .expect("ROCKETMQ_DASHBOARD_STORAGE_TEST_SQLITE_PATH must be set by the storage test runner");
+    let owner = RuntimeOwner::new(RuntimeConfig::default()).expect("runtime owner");
+    owner.block_on(async {
+        let config = StorageConfig {
+            backend: StorageBackend::Sqlite,
+            data_path: data_path.into(),
+            database_url: None,
+            pool: SqlPoolConfig::default(),
+        };
+        let environment_id = EnvironmentId::new();
+        let sample = MetricSample {
+            environment_id: environment_id.clone(),
+            metric: "broker-count".to_string(),
+            bucket_ms: 1_000,
+            dimensions: Vec::new(),
+            value: 3.0,
+        };
+        let store = SqlPersistence::initialize(&config, owner.root_context().component("docker-history-sqlite"))
+            .await
+            .expect("SQLite persistence");
+        let lease = store
+            .acquire_history_lease(&environment_id, "test-holder", 30_000)
+            .await
+            .expect("lease query")
+            .expect("lease acquired");
+        store
+            .append_history(vec![sample.clone()], Some(&lease))
+            .await
+            .expect("append history");
+        drop(store);
+
+        let reopened =
+            SqlPersistence::initialize(&config, owner.root_context().component("docker-history-sqlite-reopen"))
+                .await
+                .expect("reopen mounted SQLite persistence");
+        let page = reopened
+            .query_history(HistoryQuery {
+                environment_id,
+                metric: "broker-count".to_string(),
+                range: TimeRange {
+                    start_ms: 0,
+                    end_ms: 2_000,
+                },
+                dimensions: Vec::new(),
+                limit: 10,
+                cursor: None,
+            })
+            .await
+            .expect("read reopened history");
+        assert_eq!(page.samples, vec![sample]);
+    });
+    owner.shutdown_runtime_blocking().expect("runtime shutdown");
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/history_sql_store_tests.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/history_sql_store_tests.rs
@@ -1,0 +1,459 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::SqlPersistence;
+use crate::config::SqlPoolConfig;
+use crate::config::StorageConfig;
+use crate::model::EnvironmentId;
+use crate::model::MetricSample;
+use crate::model::StorageBackend;
+use crate::persistence::TimeRange;
+use crate::persistence::error::PersistenceError;
+use crate::persistence::history_repository::HistoryQuery;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+
+fn sample(environment_id: EnvironmentId, bucket_ms: i64, value: f64) -> MetricSample {
+    MetricSample {
+        environment_id,
+        metric: "broker-count".to_string(),
+        bucket_ms,
+        dimensions: Vec::new(),
+        value,
+    }
+}
+
+#[test]
+fn sqlite_history_is_idempotent_conflict_checked_and_reopens() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let owner = RuntimeOwner::new(RuntimeConfig::default()).expect("runtime owner");
+    owner.block_on(async {
+        let config = StorageConfig {
+            backend: StorageBackend::Sqlite,
+            data_path: directory.path().join("dashboard.db"),
+            database_url: None,
+            pool: SqlPoolConfig::default(),
+        };
+        let environment_id = EnvironmentId::new();
+        let store = SqlPersistence::initialize(&config, owner.root_context().component("history-sqlite"))
+            .await
+            .expect("SQLite persistence");
+        let lease = store
+            .acquire_history_lease(&environment_id, "test-holder", 30_000)
+            .await
+            .expect("lease query")
+            .expect("lease acquired");
+        let initial = sample(environment_id.clone(), 1_000, 3.0);
+        store
+            .append_history(vec![initial.clone()], Some(&lease))
+            .await
+            .expect("first append");
+        store
+            .append_history(vec![initial.clone()], Some(&lease))
+            .await
+            .expect("idempotent append");
+        let page = store
+            .query_history(HistoryQuery {
+                environment_id: environment_id.clone(),
+                metric: "broker-count".to_string(),
+                range: TimeRange {
+                    start_ms: 0,
+                    end_ms: 2_000,
+                },
+                dimensions: Vec::new(),
+                limit: 10,
+                cursor: None,
+            })
+            .await
+            .expect("history query");
+        assert_eq!(page.samples, vec![initial.clone()]);
+        assert!(matches!(
+            store
+                .append_history(vec![sample(environment_id.clone(), 1_000, 4.0)], Some(&lease))
+                .await,
+            Err(PersistenceError::Conflict)
+        ));
+        drop(store);
+
+        let reopened = SqlPersistence::initialize(&config, owner.root_context().component("history-sqlite-reopen"))
+            .await
+            .expect("reopen SQLite persistence");
+        let page = reopened
+            .query_history(HistoryQuery {
+                environment_id,
+                metric: "broker-count".to_string(),
+                range: TimeRange {
+                    start_ms: 0,
+                    end_ms: 2_000,
+                },
+                dimensions: Vec::new(),
+                limit: 10,
+                cursor: None,
+            })
+            .await
+            .expect("reopened history query");
+        assert_eq!(page.samples, vec![initial]);
+    });
+    owner.shutdown_runtime_blocking().expect("runtime shutdown");
+}
+
+#[test]
+fn sqlite_history_lease_rejects_stale_holder_writes() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let owner = RuntimeOwner::new(RuntimeConfig::default()).expect("runtime owner");
+    owner.block_on(async {
+        let config = StorageConfig {
+            backend: StorageBackend::Sqlite,
+            data_path: directory.path().join("dashboard.db"),
+            database_url: None,
+            pool: SqlPoolConfig::default(),
+        };
+        let store = SqlPersistence::initialize(&config, owner.root_context().component("history-lease"))
+            .await
+            .expect("SQLite persistence");
+        let environment_id = EnvironmentId::new();
+        let first = store
+            .acquire_history_lease(&environment_id, "first-holder", 30_000)
+            .await
+            .expect("first lease query")
+            .expect("first lease acquired");
+        sqlx::query("UPDATE dashboard_task_lease SET expires_at_ms = 0 WHERE lease_name = ?")
+            .bind(&first.name)
+            .execute(store.sqlite_pool().expect("SQLite pool"))
+            .await
+            .expect("expire first lease");
+
+        let second = store
+            .acquire_history_lease(&environment_id, "second-holder", 30_000)
+            .await
+            .expect("second lease query")
+            .expect("second lease acquired");
+        assert_eq!(second.fencing_token, first.fencing_token + 1);
+        assert!(
+            store
+                .renew_history_lease(&first, 30_000)
+                .await
+                .expect("stale renewal query")
+                .is_none()
+        );
+        assert!(!store.release_history_lease(&first).await.expect("stale release query"));
+        assert!(matches!(
+            store
+                .append_history(vec![sample(environment_id.clone(), 1_000, 1.0)], Some(&first))
+                .await,
+            Err(PersistenceError::Conflict)
+        ));
+        assert!(matches!(
+            store
+                .delete_history_before(&environment_id, 3_000, 1, Some(&first))
+                .await,
+            Err(PersistenceError::Conflict)
+        ));
+        store
+            .append_history(vec![sample(environment_id.clone(), 2_000, 2.0)], Some(&second))
+            .await
+            .expect("current holder append");
+        assert!(matches!(
+            store
+                .append_history(vec![sample(EnvironmentId::new(), 2_000, 2.0)], Some(&second))
+                .await,
+            Err(PersistenceError::Conflict)
+        ));
+        assert!(matches!(
+            store
+                .delete_history_before(&EnvironmentId::new(), 3_000, 1, Some(&second))
+                .await,
+            Err(PersistenceError::Conflict)
+        ));
+        assert!(
+            store
+                .release_history_lease(&second)
+                .await
+                .expect("current release query")
+        );
+        assert!(matches!(
+            store
+                .append_history(vec![sample(environment_id, 3_000, 3.0)], Some(&second))
+                .await,
+            Err(PersistenceError::Conflict)
+        ));
+    });
+    owner.shutdown_runtime_blocking().expect("runtime shutdown");
+}
+
+#[test]
+fn sqlite_history_retention_reports_exact_convergence() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let owner = RuntimeOwner::new(RuntimeConfig::default()).expect("runtime owner");
+    owner.block_on(async {
+        let store = SqlPersistence::initialize(
+            &StorageConfig {
+                backend: StorageBackend::Sqlite,
+                data_path: directory.path().join("dashboard.db"),
+                database_url: None,
+                pool: SqlPoolConfig::default(),
+            },
+            owner.root_context().component("history-retention"),
+        )
+        .await
+        .expect("SQLite persistence");
+        let environment_id = EnvironmentId::new();
+        let lease = store
+            .acquire_history_lease(&environment_id, "test-holder", 30_000)
+            .await
+            .expect("lease query")
+            .expect("lease acquired");
+        store
+            .append_history(
+                vec![
+                    sample(environment_id.clone(), 1_000, 1.0),
+                    sample(environment_id.clone(), 2_000, 2.0),
+                ],
+                Some(&lease),
+            )
+            .await
+            .expect("exact batch append");
+        let other_environment_id = EnvironmentId::new();
+        let other_lease = store
+            .acquire_history_lease(&other_environment_id, "other-holder", 30_000)
+            .await
+            .expect("other lease query")
+            .expect("other lease acquired");
+        let other_sample = sample(other_environment_id.clone(), 1_000, 9.0);
+        store
+            .append_history(vec![other_sample.clone()], Some(&other_lease))
+            .await
+            .expect("other environment append");
+        let exact = store
+            .delete_history_before(&environment_id, 3_000, 2, Some(&lease))
+            .await
+            .expect("exact batch retention");
+        assert_eq!(exact.deleted, 2);
+        assert!(!exact.has_more);
+        assert_eq!(
+            store
+                .query_history(HistoryQuery {
+                    environment_id: other_environment_id,
+                    metric: "broker-count".to_string(),
+                    range: TimeRange {
+                        start_ms: 0,
+                        end_ms: 2_000,
+                    },
+                    dimensions: Vec::new(),
+                    limit: 10,
+                    cursor: None,
+                })
+                .await
+                .expect("other environment history")
+                .samples,
+            vec![other_sample]
+        );
+
+        store
+            .append_history(
+                vec![
+                    sample(environment_id.clone(), 4_000, 4.0),
+                    sample(environment_id.clone(), 5_000, 5.0),
+                    sample(environment_id.clone(), 6_000, 6.0),
+                ],
+                Some(&lease),
+            )
+            .await
+            .expect("over-batch append");
+        let first = store
+            .delete_history_before(&environment_id, 7_000, 2, Some(&lease))
+            .await
+            .expect("first over-batch retention");
+        assert_eq!(first.deleted, 2);
+        assert!(first.has_more);
+        let second = store
+            .delete_history_before(&environment_id, 7_000, 2, Some(&lease))
+            .await
+            .expect("second over-batch retention");
+        assert_eq!(second.deleted, 1);
+        assert!(!second.has_more);
+    });
+    owner.shutdown_runtime_blocking().expect("runtime shutdown");
+}
+
+#[test]
+#[ignore = "requires docker-compose.storage-test.yml"]
+fn docker_mysql_history_lease_contract() {
+    let database_url = std::env::var("ROCKETMQ_DASHBOARD_STORAGE_TEST_MYSQL_URL")
+        .expect("ROCKETMQ_DASHBOARD_STORAGE_TEST_MYSQL_URL must be set by the storage test runner");
+    docker_history_lease_contract(StorageBackend::MySql, database_url);
+}
+
+#[test]
+#[ignore = "requires docker-compose.storage-test.yml"]
+fn docker_postgres_history_lease_contract() {
+    let database_url = std::env::var("ROCKETMQ_DASHBOARD_STORAGE_TEST_POSTGRES_URL")
+        .expect("ROCKETMQ_DASHBOARD_STORAGE_TEST_POSTGRES_URL must be set by the storage test runner");
+    docker_history_lease_contract(StorageBackend::Postgres, database_url);
+}
+
+fn docker_history_lease_contract(backend: StorageBackend, database_url: String) {
+    let owner = RuntimeOwner::new(RuntimeConfig::default()).expect("runtime owner");
+    owner.block_on(async {
+        let store = SqlPersistence::initialize(
+            &StorageConfig {
+                backend,
+                data_path: "unused".into(),
+                database_url: Some(database_url),
+                pool: SqlPoolConfig::default(),
+            },
+            owner.root_context().component("docker-history-lease"),
+        )
+        .await
+        .expect("SQL persistence");
+        if backend == StorageBackend::MySql {
+            let concurrent_environment = EnvironmentId::new();
+            let (left, right) = tokio::join!(
+                store.acquire_history_lease(&concurrent_environment, "concurrent-left", 30_000),
+                store.acquire_history_lease(&concurrent_environment, "concurrent-right", 30_000),
+            );
+            assert_eq!(
+                [left.expect("left acquire"), right.expect("right acquire")]
+                    .into_iter()
+                    .flatten()
+                    .count(),
+                1,
+                "exactly one MySQL contender acquires a missing lease row"
+            );
+        }
+        let environment_id = EnvironmentId::new();
+        let first = store
+            .acquire_history_lease(&environment_id, "first-holder", 30_000)
+            .await
+            .expect("first lease query")
+            .expect("first lease acquired");
+        assert!(
+            store
+                .acquire_history_lease(&environment_id, "second-holder", 30_000)
+                .await
+                .expect("active lease query")
+                .is_none()
+        );
+
+        let initial = sample(environment_id.clone(), 1_000, 3.0);
+        store
+            .append_history(vec![initial.clone()], Some(&first))
+            .await
+            .expect("first append");
+        store
+            .append_history(vec![initial.clone()], Some(&first))
+            .await
+            .expect("idempotent append");
+        match backend {
+            StorageBackend::MySql => {
+                sqlx::query("UPDATE dashboard_task_lease SET expires_at_ms = 0 WHERE lease_name = ?")
+                    .bind(&first.name)
+                    .execute(store.mysql_pool().expect("MySQL pool"))
+                    .await
+                    .expect("expire first lease");
+            }
+            StorageBackend::Postgres => {
+                sqlx::query("UPDATE dashboard_task_lease SET expires_at_ms = 0 WHERE lease_name = $1")
+                    .bind(&first.name)
+                    .execute(store.postgres_pool().expect("PostgreSQL pool"))
+                    .await
+                    .expect("expire first lease");
+            }
+            StorageBackend::File | StorageBackend::Sqlite => unreachable!("SQL Docker test backend"),
+        }
+        let second = store
+            .acquire_history_lease(&environment_id, "second-holder", 30_000)
+            .await
+            .expect("second lease query")
+            .expect("second lease acquired");
+        assert_eq!(second.fencing_token, first.fencing_token + 1);
+        assert!(
+            store
+                .renew_history_lease(&first, 30_000)
+                .await
+                .expect("stale renewal query")
+                .is_none()
+        );
+        assert!(!store.release_history_lease(&first).await.expect("stale release query"));
+        assert!(matches!(
+            store
+                .append_history(vec![sample(environment_id.clone(), 2_000, 4.0)], Some(&first))
+                .await,
+            Err(PersistenceError::Conflict)
+        ));
+        assert!(matches!(
+            store
+                .delete_history_before(&environment_id, 2_000, 1, Some(&first))
+                .await,
+            Err(PersistenceError::Conflict)
+        ));
+        let page = store
+            .query_history(HistoryQuery {
+                environment_id: environment_id.clone(),
+                metric: "broker-count".to_string(),
+                range: TimeRange {
+                    start_ms: 0,
+                    end_ms: 2_000,
+                },
+                dimensions: Vec::new(),
+                limit: 10,
+                cursor: None,
+            })
+            .await
+            .expect("history query");
+        assert_eq!(page.samples, vec![initial]);
+        let mut retention = store
+            .delete_history_before(&environment_id, 2_000, 1, Some(&second))
+            .await
+            .expect("retention");
+        assert_eq!(retention.deleted, 1);
+        while retention.has_more {
+            retention = store
+                .delete_history_before(&environment_id, 2_000, 1, Some(&second))
+                .await
+                .expect("retention convergence");
+        }
+        assert!(
+            store
+                .query_history(HistoryQuery {
+                    environment_id: environment_id.clone(),
+                    metric: "broker-count".to_string(),
+                    range: TimeRange {
+                        start_ms: 0,
+                        end_ms: 2_000,
+                    },
+                    dimensions: Vec::new(),
+                    limit: 10,
+                    cursor: None,
+                })
+                .await
+                .expect("retained history query")
+                .samples
+                .is_empty()
+        );
+        assert!(
+            store
+                .release_history_lease(&second)
+                .await
+                .expect("current release query")
+        );
+        assert!(matches!(
+            store
+                .append_history(vec![sample(environment_id, 3_000, 5.0)], Some(&second))
+                .await,
+            Err(PersistenceError::Conflict)
+        ));
+    });
+    owner.shutdown_runtime_blocking().expect("runtime shutdown");
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/lease_repository.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/lease_repository.rs
@@ -1,0 +1,117 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use crate::model::EnvironmentId;
+use crate::model::StorageBackend;
+use crate::persistence::DashboardPersistence;
+use crate::persistence::backend::PersistenceBackend;
+use crate::persistence::error::PersistenceError;
+
+/// Opaque authority granted by the SQL task lease. The holder identity is
+/// never serialized or exposed through a dashboard API.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HistoryLease {
+    pub(crate) environment_id: EnvironmentId,
+    pub(crate) name: String,
+    pub(crate) holder_id: String,
+    pub(crate) fencing_token: i64,
+    pub(crate) expires_at_ms: i64,
+}
+
+impl HistoryLease {
+    pub(crate) fn new(
+        environment_id: EnvironmentId,
+        holder_id: String,
+        fencing_token: i64,
+        expires_at_ms: i64,
+    ) -> Self {
+        Self {
+            name: Self::name_for(&environment_id),
+            environment_id,
+            holder_id,
+            fencing_token,
+            expires_at_ms,
+        }
+    }
+
+    pub(crate) fn name_for(environment_id: &EnvironmentId) -> String {
+        format!("dashboard-history:{}", environment_id.0)
+    }
+
+    pub fn environment_id(&self) -> &EnvironmentId {
+        &self.environment_id
+    }
+
+    pub fn expires_at_ms(&self) -> i64 {
+        self.expires_at_ms
+    }
+}
+
+impl DashboardPersistence {
+    pub async fn acquire_history_lease(
+        &self,
+        environment_id: &EnvironmentId,
+        holder_id: &str,
+        ttl_ms: i64,
+    ) -> Result<Option<HistoryLease>, PersistenceError> {
+        validate_lease_request(environment_id, holder_id, ttl_ms)?;
+        match &self.backend {
+            PersistenceBackend::File(_) => Ok(None),
+            PersistenceBackend::Sql(store) => store.acquire_history_lease(environment_id, holder_id, ttl_ms).await,
+        }
+    }
+
+    pub async fn renew_history_lease(
+        &self,
+        lease: &HistoryLease,
+        ttl_ms: i64,
+    ) -> Result<Option<HistoryLease>, PersistenceError> {
+        validate_lease_request(&lease.environment_id, &lease.holder_id, ttl_ms)?;
+        match &self.backend {
+            PersistenceBackend::File(_) => Ok(Some(lease.clone())),
+            PersistenceBackend::Sql(store) => store.renew_history_lease(lease, ttl_ms).await,
+        }
+    }
+
+    pub async fn release_history_lease(&self, lease: &HistoryLease) -> Result<bool, PersistenceError> {
+        match &self.backend {
+            PersistenceBackend::File(_) => Ok(true),
+            PersistenceBackend::Sql(store) => store.release_history_lease(lease).await,
+        }
+    }
+
+    pub fn history_uses_sql_lease(&self) -> bool {
+        matches!(
+            self.storage_backend(),
+            StorageBackend::Sqlite | StorageBackend::MySql | StorageBackend::Postgres
+        )
+    }
+}
+
+fn validate_lease_request(
+    environment_id: &EnvironmentId,
+    holder_id: &str,
+    ttl_ms: i64,
+) -> Result<(), PersistenceError> {
+    if environment_id.0.is_empty()
+        || environment_id.0.len() > 36
+        || holder_id.is_empty()
+        || holder_id.len() > 128
+        || ttl_ms <= 0
+    {
+        return Err(PersistenceError::InvalidConfig(
+            "history lease request is invalid".to_string(),
+        ));
+    }
+    Ok(())
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/migration.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/migration.rs
@@ -20,10 +20,13 @@ use sqlx::{MySqlConnection, PgConnection, SqliteConnection};
 
 const SQLITE_INITIAL: &str = include_str!("../../migrations/sqlite/0001_initial.sql");
 const SQLITE_PHASE_TWO: &str = include_str!("../../migrations/sqlite/0002_environment_endpoint_constraints.sql");
+const SQLITE_PHASE_THREE: &str = include_str!("../../migrations/sqlite/0003_history_retention.sql");
 const MYSQL_INITIAL: &str = include_str!("../../migrations/mysql/0001_initial.sql");
 const MYSQL_PHASE_TWO: &str = include_str!("../../migrations/mysql/0002_environment_endpoint_constraints.sql");
+const MYSQL_PHASE_THREE: &str = include_str!("../../migrations/mysql/0003_history_retention.sql");
 const POSTGRES_INITIAL: &str = include_str!("../../migrations/postgres/0001_initial.sql");
 const POSTGRES_PHASE_TWO: &str = include_str!("../../migrations/postgres/0002_environment_endpoint_constraints.sql");
+const POSTGRES_PHASE_THREE: &str = include_str!("../../migrations/postgres/0003_history_retention.sql");
 const MYSQL_MIGRATION_LOCK: &str = "rocketmq_dashboard_schema_migration";
 const POSTGRES_MIGRATION_LOCK: i64 = 7_246_920_002;
 
@@ -95,6 +98,14 @@ async fn migrate_sqlite_locked(connection: &mut SqliteConnection) -> Result<i64,
         .map_err(map_query_error)?;
     if version < 2 {
         migrate_sqlite_phase_two(connection).await?;
+    }
+    if version < 3 {
+        for statement in statements(SQLITE_PHASE_THREE) {
+            sqlx::query(statement)
+                .execute(&mut *connection)
+                .await
+                .map_err(|_| PersistenceError::MigrationFailed)?;
+        }
     }
     schema_version_sqlite_connection(connection).await
 }
@@ -175,6 +186,14 @@ async fn migrate_mysql_locked(connection: &mut MySqlConnection) -> Result<i64, P
             .await
             .map_err(|_| PersistenceError::MigrationFailed)?;
     }
+    if version < 3 {
+        for statement in statements(MYSQL_PHASE_THREE) {
+            sqlx::query(statement)
+                .execute(&mut *connection)
+                .await
+                .map_err(|_| PersistenceError::MigrationFailed)?;
+        }
+    }
     schema_version_mysql_connection(connection).await
 }
 
@@ -211,6 +230,14 @@ async fn migrate_postgres_locked(connection: &mut PgConnection) -> Result<i64, P
             .execute(&mut *transaction)
             .await
             .map_err(|_| PersistenceError::MigrationFailed)?;
+    }
+    if version < 3 {
+        for statement in statements(POSTGRES_PHASE_THREE) {
+            sqlx::query(statement)
+                .execute(&mut *transaction)
+                .await
+                .map_err(|_| PersistenceError::MigrationFailed)?;
+        }
     }
     transaction.commit().await.map_err(map_query_error)?;
     schema_version_postgres_connection(connection).await
@@ -374,7 +401,7 @@ mod tests {
             .await
             .expect("simulate the first phase-two DDL");
 
-        assert_eq!(migrate_sqlite(&pool).await.expect("resume migration"), 2);
+        assert_eq!(migrate_sqlite(&pool).await.expect("resume migration"), 3);
         let enabled_column: i64 = sqlx::query_scalar(
             "SELECT COUNT(*) FROM pragma_table_info('dashboard_endpoint') WHERE name = 'is_enabled'",
         )
@@ -408,8 +435,8 @@ mod tests {
         apply_sqlite_initial(&first).await;
 
         let (first_version, second_version) = tokio::join!(migrate_sqlite(&first), migrate_sqlite(&second));
-        assert_eq!(first_version.expect("first migration"), 2);
-        assert_eq!(second_version.expect("second migration"), 2);
+        assert_eq!(first_version.expect("first migration"), 3);
+        assert_eq!(second_version.expect("second migration"), 3);
     }
 
     #[tokio::test]
@@ -422,7 +449,7 @@ mod tests {
             .connect(&url)
             .await
             .expect("connect MySQL storage test database");
-        assert_eq!(migrate_mysql(&pool).await.expect("prepare migration"), 2);
+        assert_eq!(migrate_mysql(&pool).await.expect("prepare migration"), 3);
 
         // Leave the first phase-two DDL in place, then roll the remaining
         // schema changes back to emulate a connection loss between DDLs.
@@ -433,7 +460,7 @@ mod tests {
             .await
             .expect("acquire migration lock for partial DDL setup");
         assert_eq!(lock, 1, "migration setup must acquire the advisory lock");
-        sqlx::query("DELETE FROM dashboard_schema_migration WHERE version = 2")
+        sqlx::query("DELETE FROM dashboard_schema_migration WHERE version >= 2")
             .execute(&pool)
             .await
             .expect("remove migration marker");
@@ -456,7 +483,7 @@ mod tests {
             .expect("release migration lock after partial DDL setup");
         assert_eq!(released, 1, "migration setup must release the advisory lock");
 
-        assert_eq!(migrate_mysql(&pool).await.expect("resume migration"), 2);
+        assert_eq!(migrate_mysql(&pool).await.expect("resume migration"), 3);
         let active_index: i64 = sqlx::query_scalar(
             "SELECT COUNT(DISTINCT index_name) FROM information_schema.statistics \
              WHERE table_schema = DATABASE() AND table_name = 'dashboard_endpoint' \
@@ -480,8 +507,8 @@ mod tests {
             .expect("connect MySQL storage test database");
 
         let (first, second) = tokio::join!(migrate_mysql(&pool), migrate_mysql(&pool));
-        assert_eq!(first.expect("first concurrent migration"), 2);
-        assert_eq!(second.expect("second concurrent migration"), 2);
+        assert_eq!(first.expect("first concurrent migration"), 3);
+        assert_eq!(second.expect("second concurrent migration"), 3);
     }
 
     #[tokio::test]
@@ -494,7 +521,7 @@ mod tests {
             .connect(&url)
             .await
             .expect("connect MySQL storage test database");
-        assert_eq!(migrate_mysql(&pool).await.expect("prepare migration"), 2);
+        assert_eq!(migrate_mysql(&pool).await.expect("prepare migration"), 3);
         let suffix = chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default();
         let environment_id = format!("mbf-{suffix}");
         let endpoint_id = format!("mbe-{suffix}");
@@ -516,11 +543,11 @@ mod tests {
         .execute(&pool)
         .await
         .expect("seed active MySQL endpoint with legacy role");
-        sqlx::query("DELETE FROM dashboard_schema_migration WHERE version = 2")
+        sqlx::query("DELETE FROM dashboard_schema_migration WHERE version >= 2")
             .execute(&pool)
             .await
             .expect("remove MySQL phase-two marker");
-        assert_eq!(migrate_mysql(&pool).await.expect("rerun MySQL phase two"), 2);
+        assert_eq!(migrate_mysql(&pool).await.expect("rerun MySQL phase two"), 3);
         let role: String = sqlx::query_scalar("SELECT role FROM dashboard_endpoint WHERE endpoint_id = ?")
             .bind(&endpoint_id)
             .fetch_one(&pool)
@@ -540,8 +567,8 @@ mod tests {
             .await
             .expect("connect PostgreSQL storage test database");
         let (first, second) = tokio::join!(migrate_postgres(&pool), migrate_postgres(&pool));
-        assert_eq!(first.expect("first PostgreSQL migration"), 2);
-        assert_eq!(second.expect("second PostgreSQL migration"), 2);
+        assert_eq!(first.expect("first PostgreSQL migration"), 3);
+        assert_eq!(second.expect("second PostgreSQL migration"), 3);
     }
 
     #[tokio::test]
@@ -554,7 +581,7 @@ mod tests {
             .connect(&url)
             .await
             .expect("connect PostgreSQL storage test database");
-        assert_eq!(migrate_postgres(&pool).await.expect("prepare migration"), 2);
+        assert_eq!(migrate_postgres(&pool).await.expect("prepare migration"), 3);
         let suffix = chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default();
         let environment_id = format!("pbf-{suffix}");
         let endpoint_id = format!("pbe-{suffix}");
@@ -576,11 +603,11 @@ mod tests {
         .execute(&pool)
         .await
         .expect("seed active PostgreSQL endpoint with legacy role");
-        sqlx::query("DELETE FROM dashboard_schema_migration WHERE version = 2")
+        sqlx::query("DELETE FROM dashboard_schema_migration WHERE version >= 2")
             .execute(&pool)
             .await
             .expect("remove PostgreSQL phase-two marker");
-        assert_eq!(migrate_postgres(&pool).await.expect("rerun PostgreSQL phase two"), 2);
+        assert_eq!(migrate_postgres(&pool).await.expect("rerun PostgreSQL phase two"), 3);
         let role: String = sqlx::query_scalar("SELECT role FROM dashboard_endpoint WHERE endpoint_id = $1")
             .bind(&endpoint_id)
             .fetch_one(&pool)

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/sql_store.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/sql_store.rs
@@ -45,6 +45,14 @@ use std::path::PathBuf;
 use std::time::Duration;
 use tokio::time::timeout;
 
+#[path = "history_lease_store.rs"]
+mod history_lease_store;
+#[path = "history_sql_store.rs"]
+mod history_sql_store;
+#[cfg(test)]
+#[path = "history_sql_store_docker_tests.rs"]
+mod history_sql_store_docker_tests;
+
 pub enum DatabasePool {
     Sqlite(SqlitePool),
     MySql(MySqlPool),
@@ -1181,7 +1189,7 @@ mod tests {
             let first = SqlPersistence::initialize(&config, owner.root_context().component("sqlite-first"))
                 .await
                 .expect("first SQLite initialization");
-            assert_eq!(first.schema_version(), 2);
+            assert_eq!(first.schema_version(), 3);
             let health = first.storage_health().await;
             assert!(matches!(health.status, StorageStatus::Available));
             assert!(health.pool_size.is_some());
@@ -1191,7 +1199,7 @@ mod tests {
             let second = SqlPersistence::initialize(&config, owner.root_context().component("sqlite-second"))
                 .await
                 .expect("second SQLite initialization");
-            assert_eq!(second.schema_version(), 2);
+            assert_eq!(second.schema_version(), 3);
         });
         assert!(database_path.exists());
         owner.shutdown_runtime_blocking().expect("runtime shutdown");
@@ -1369,7 +1377,7 @@ mod tests {
                 SqlPersistence::initialize(&config, owner.root_context().component("docker-storage-test-first"))
                     .await
                     .expect("first storage initialization");
-            assert_eq!(first.schema_version(), 2);
+            assert_eq!(first.schema_version(), 3);
             assert_eq!(first.storage_health().await.status, StorageStatus::Available);
             assert_schema_metadata(&first).await;
             drop(first);
@@ -1377,7 +1385,7 @@ mod tests {
                 SqlPersistence::initialize(&config, owner.root_context().component("docker-storage-test-second"))
                     .await
                     .expect("second storage initialization");
-            assert_eq!(second.schema_version(), 2);
+            assert_eq!(second.schema_version(), 3);
             assert_eq!(second.storage_health().await.status, StorageStatus::Available);
         });
         if config.backend == StorageBackend::Sqlite {

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/dashboard_service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/dashboard_service.rs
@@ -12,21 +12,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use crate::error::DashboardError;
+use crate::model::DashboardHistoryHealth;
 use crate::model::DashboardHistoryPoint;
 use crate::model::DashboardHistoryQuery;
 use crate::model::DashboardHistorySeries;
 use crate::model::DashboardOverview;
 use crate::model::DashboardTopicCurrent;
+use crate::model::EnvironmentId;
+use crate::model::MetricDimension;
+use crate::model::MetricSample;
+use crate::model::StorageBackend;
+use crate::persistence::DashboardPersistence;
+use crate::persistence::TimeRange;
+use crate::persistence::history_repository::HistoryQuery;
+use crate::persistence::lease_repository::HistoryLease;
 use crate::state::AppState;
 use crate::state::WebAdminFacade;
+#[path = "history_collector_schedule.rs"]
+mod history_collector_schedule;
+use chrono::NaiveDate;
 use chrono::Utc;
-use std::collections::VecDeque;
-use std::future::Future;
+use history_collector_schedule::HistoryCollectorSchedule;
+use history_collector_schedule::HistoryCollectorState;
+use rocketmq_runtime::ChildServiceContext;
 use std::sync::Arc;
-use std::sync::Mutex;
 use tokio::sync::RwLock;
-use tokio::task::AbortHandle;
-use tokio::time::Duration;
+use tokio::time::MissedTickBehavior;
+
+const DEFAULT_HISTORY_PAGE_SIZE: u32 = 1_440;
 
 pub async fn overview(state: &AppState) -> Result<DashboardOverview, DashboardError> {
     state.admin_facade().dashboard_overview().await
@@ -40,282 +53,352 @@ pub async fn broker_history(
     state: &AppState,
     query: DashboardHistoryQuery,
 ) -> Result<DashboardHistorySeries, DashboardError> {
-    Ok(state.history_store.broker_series(query).await)
+    history_series(state, query, "broker-count", "broker", Vec::new()).await
 }
 
 pub async fn topic_history(
     state: &AppState,
     query: DashboardHistoryQuery,
 ) -> Result<DashboardHistorySeries, DashboardError> {
-    Ok(state.history_store.topic_series(query).await)
+    let metric = if query.topic_name.is_some() {
+        "topic-total-messages"
+    } else {
+        "topic-count"
+    };
+    let dimensions = query
+        .topic_name
+        .as_deref()
+        .map(|topic| {
+            vec![MetricDimension {
+                key: "topic".to_string(),
+                value: topic.to_string(),
+            }]
+        })
+        .unwrap_or_default();
+    history_series(state, query, metric, "topic", dimensions).await
 }
 
-#[derive(Debug, Clone, Default)]
-pub struct DashboardHistoryStore {
-    samples: Arc<RwLock<VecDeque<DashboardHistorySample>>>,
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct DashboardTaskManager {
-    inner: Arc<DashboardTaskManagerInner>,
-}
-
-#[derive(Debug, Default)]
-struct DashboardTaskManagerInner {
-    abort_handles: Mutex<Vec<AbortHandle>>,
-}
-
-impl DashboardTaskManager {
-    pub fn spawn<F>(&self, task_name: &'static str, task: F) -> Result<(), DashboardError>
-    where
-        F: Future<Output = ()> + Send + 'static,
-    {
-        let mut abort_handles = self.inner.abort_handles.lock().map_err(|_| {
-            DashboardError::Internal(format!(
-                "dashboard task manager lock poisoned while spawning {task_name}"
-            ))
-        })?;
-        let handle = tokio::task::spawn(async move {
-            tracing::debug!(task = task_name, "Dashboard background task started");
-            task.await;
-            tracing::debug!(task = task_name, "Dashboard background task stopped");
-        });
-        abort_handles.push(handle.abort_handle());
-        drop(handle);
-        Ok(())
-    }
-}
-
-impl Drop for DashboardTaskManagerInner {
-    fn drop(&mut self) {
-        if let Ok(abort_handles) = self.abort_handles.get_mut() {
-            for abort_handle in abort_handles.drain(..) {
-                abort_handle.abort();
-            }
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-struct DashboardHistorySample {
-    date: String,
-    timestamp: i64,
-    broker_count: f64,
-    topic_count: f64,
-    topics: Vec<TopicHistorySample>,
-}
-
-#[derive(Debug, Clone)]
-struct TopicHistorySample {
-    topic: String,
-    total_msg: f64,
-}
-
-impl DashboardHistoryStore {
-    const MAX_SAMPLES: usize = 2_880;
-
-    pub async fn record(&self, overview: DashboardOverview, topic_current: DashboardTopicCurrent) {
-        let now = Utc::now();
-        let sample = DashboardHistorySample {
-            date: now.format("%Y-%m-%d").to_string(),
-            timestamp: now.timestamp_millis(),
-            broker_count: overview.broker_count as f64,
-            topic_count: topic_current.total_topics as f64,
-            topics: topic_current
-                .top_topics
-                .into_iter()
-                .map(|topic| TopicHistorySample {
-                    topic: topic.topic,
-                    total_msg: topic.total_msg as f64,
-                })
-                .collect(),
-        };
-
-        let mut samples = self.samples.write().await;
-        samples.push_back(sample);
-        while samples.len() > Self::MAX_SAMPLES {
-            samples.pop_front();
-        }
-    }
-
-    pub async fn broker_series(&self, query: DashboardHistoryQuery) -> DashboardHistorySeries {
-        let samples = self.samples.read().await;
-        let points = samples
-            .iter()
-            .filter(|sample| sample.date == query.date)
-            .map(|sample| DashboardHistoryPoint {
-                timestamp: sample.timestamp,
-                value: sample.broker_count,
-            })
-            .collect::<Vec<_>>();
-        DashboardHistorySeries {
-            date: query.date,
-            metric: "broker".to_string(),
-            topic_name: None,
-            collected: !points.is_empty(),
-            points,
-        }
-    }
-
-    pub async fn topic_series(&self, query: DashboardHistoryQuery) -> DashboardHistorySeries {
-        let samples = self.samples.read().await;
-        let points = samples
-            .iter()
-            .filter(|sample| sample.date == query.date)
-            .filter_map(|sample| {
-                let value = match query.topic_name.as_deref() {
-                    Some(topic_name) => sample
-                        .topics
-                        .iter()
-                        .find(|topic| topic.topic == topic_name)
-                        .map(|topic| topic.total_msg),
-                    None => Some(sample.topic_count),
-                }?;
-                Some(DashboardHistoryPoint {
-                    timestamp: sample.timestamp,
-                    value,
-                })
-            })
-            .collect::<Vec<_>>();
-        DashboardHistorySeries {
-            date: query.date,
-            metric: "topic".to_string(),
-            topic_name: query.topic_name,
-            collected: !points.is_empty(),
-            points,
-        }
-    }
-}
-
-pub fn spawn_dashboard_history_collector(
-    task_manager: &DashboardTaskManager,
-    admin_facade: WebAdminFacade,
-    history_store: DashboardHistoryStore,
-    interval_secs: u64,
-) -> Result<(), DashboardError> {
-    task_manager.spawn("dashboard-history-collector", async move {
-        let mut interval = tokio::time::interval(Duration::from_secs(interval_secs.max(1)));
-        loop {
-            interval.tick().await;
-            match collect_history_sample(&admin_facade, &history_store).await {
-                Ok(()) => {}
-                Err(error) => {
-                    tracing::debug!(error = %error, "Dashboard history sample collection failed");
-                }
-            }
-        }
+async fn history_series(
+    state: &AppState,
+    query: DashboardHistoryQuery,
+    storage_metric: &str,
+    response_metric: &str,
+    dimensions: Vec<MetricDimension>,
+) -> Result<DashboardHistorySeries, DashboardError> {
+    let history = state
+        .persistence
+        .query_history(HistoryQuery {
+            environment_id: state.published().environment.environment_id,
+            metric: storage_metric.to_string(),
+            range: query_date_range(&query.date)?,
+            dimensions,
+            limit: query.limit.unwrap_or(DEFAULT_HISTORY_PAGE_SIZE),
+            cursor: query.cursor,
+        })
+        .await?;
+    let points = history
+        .samples
+        .into_iter()
+        .map(|sample| DashboardHistoryPoint {
+            timestamp: sample.bucket_ms,
+            value: sample.value,
+        })
+        .collect::<Vec<_>>();
+    Ok(DashboardHistorySeries {
+        date: query.date,
+        metric: response_metric.to_string(),
+        topic_name: query.topic_name,
+        collected: !points.is_empty(),
+        points,
+        next_cursor: history.next_cursor,
+        health: state.history_runtime.health().await,
     })
 }
 
+fn query_date_range(value: &str) -> Result<TimeRange, DashboardError> {
+    let date = NaiveDate::parse_from_str(value, "%Y-%m-%d")
+        .map_err(|_| DashboardError::Validation("history date must use YYYY-MM-DD".to_string()))?;
+    let start_ms = date
+        .and_hms_opt(0, 0, 0)
+        .ok_or_else(|| DashboardError::Validation("history date is invalid".to_string()))?
+        .and_utc()
+        .timestamp_millis();
+    Ok(TimeRange {
+        start_ms,
+        end_ms: start_ms + 86_400_000 - 1,
+    })
+}
+
+#[derive(Debug, Clone)]
+pub struct DashboardHistoryRuntime {
+    state: Arc<RwLock<DashboardHistoryHealth>>,
+}
+
+impl DashboardHistoryRuntime {
+    pub fn new(backend: StorageBackend) -> Self {
+        Self {
+            state: Arc::new(RwLock::new(DashboardHistoryHealth {
+                backend,
+                connectivity: "available".to_string(),
+                role: "standby".to_string(),
+                lease_expires_at_ms: None,
+                last_collection_at_ms: None,
+                last_append_at_ms: None,
+                last_retention_at_ms: None,
+                recent_error: None,
+            })),
+        }
+    }
+
+    pub async fn health(&self) -> DashboardHistoryHealth {
+        self.state.read().await.clone()
+    }
+
+    async fn set_leader(&self, expiry: Option<i64>) {
+        let mut health = self.state.write().await;
+        health.connectivity = "available".to_string();
+        health.role = "leader".to_string();
+        health.lease_expires_at_ms = expiry;
+        health.recent_error = None;
+    }
+
+    async fn set_standby(&self) {
+        let mut health = self.state.write().await;
+        health.connectivity = "available".to_string();
+        health.role = "standby".to_string();
+        health.lease_expires_at_ms = None;
+        health.recent_error = None;
+    }
+
+    /// Records a lease loss without hiding the storage failure that caused it.
+    async fn set_standby_after_error(&self) {
+        let mut health = self.state.write().await;
+        health.role = "standby".to_string();
+        health.lease_expires_at_ms = None;
+    }
+
+    async fn success(&self) {
+        let now = Utc::now().timestamp_millis();
+        let mut health = self.state.write().await;
+        health.connectivity = "available".to_string();
+        health.last_collection_at_ms = Some(now);
+        health.last_append_at_ms = Some(now);
+        health.recent_error = None;
+    }
+
+    async fn retention(&self) {
+        self.state.write().await.last_retention_at_ms = Some(Utc::now().timestamp_millis());
+    }
+
+    async fn unavailable(&self, message: &'static str) {
+        let mut health = self.state.write().await;
+        health.connectivity = "unavailable".to_string();
+        health.recent_error = Some(message.to_string());
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct HistoryCollectorConfig {
+    pub interval_secs: u64,
+    pub retention_days: u32,
+    pub retention_batch_size: u32,
+    pub lease_ttl_secs: u64,
+}
+
+pub fn start_dashboard_history_collector(
+    service_context: ChildServiceContext,
+    persistence: Arc<DashboardPersistence>,
+    admin_facade: WebAdminFacade,
+    environment_id: EnvironmentId,
+    config: HistoryCollectorConfig,
+    runtime: DashboardHistoryRuntime,
+) -> Result<(), DashboardError> {
+    if config.interval_secs == 0 {
+        return Ok(());
+    }
+    let cancellation = service_context.task_group().cancellation_token();
+    service_context
+        .spawn_service("dashboard-history-collector", async move {
+            let holder_id = uuid::Uuid::now_v7().to_string();
+            let ttl_ms = i64::try_from(config.lease_ttl_secs)
+                .ok()
+                .and_then(|seconds| seconds.checked_mul(1_000))
+                .filter(|ttl| *ttl > 0)
+                .unwrap_or(30_000);
+            let schedule = HistoryCollectorSchedule::new(config.interval_secs, ttl_ms);
+            let mut renewal = tokio::time::interval(schedule.renewal_period());
+            renewal.set_missed_tick_behavior(MissedTickBehavior::Skip);
+            let mut collection = tokio::time::interval(schedule.collection_period());
+            collection.set_missed_tick_behavior(MissedTickBehavior::Skip);
+            let mut retention = tokio::time::interval(schedule.retention_period());
+            retention.set_missed_tick_behavior(MissedTickBehavior::Skip);
+            let mut lease: Option<HistoryLease> = None;
+            let mut collector = HistoryCollectorState::default();
+
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = cancellation.cancelled() => break,
+                    _ = renewal.tick() => {
+                        let mut lease_failed = false;
+                        if persistence.history_uses_sql_lease() {
+                            lease = match lease.take() {
+                                Some(current) => match persistence.renew_history_lease(&current, ttl_ms).await {
+                                    Ok(renewed) => renewed,
+                                    Err(_) => {
+                                        runtime.unavailable("history lease is unavailable").await;
+                                        lease_failed = true;
+                                        None
+                                    }
+                                },
+                                None => match persistence.acquire_history_lease(&environment_id, &holder_id, ttl_ms).await {
+                                    Ok(acquired) => acquired,
+                                    Err(_) => {
+                                        runtime.unavailable("history lease is unavailable").await;
+                                        lease_failed = true;
+                                        None
+                                    }
+                                },
+                            };
+                        }
+                        if persistence.history_uses_sql_lease() && lease.is_none() {
+                            collector.lost_lease();
+                            if lease_failed {
+                                runtime.set_standby_after_error().await;
+                            } else {
+                                runtime.set_standby().await;
+                            }
+                            continue;
+                        }
+                        collector.became_leader();
+                        runtime.set_leader(lease.as_ref().map(HistoryLease::expires_at_ms)).await;
+                    }
+                    _ = collection.tick(), if collector.can_collect() => {
+                        match collect_history_sample(&persistence, &admin_facade, &environment_id, config.interval_secs, lease.as_ref()).await {
+                            Ok(()) => {
+                                runtime.success().await;
+                            }
+                            Err(_) => {
+                                runtime.unavailable("history collection is unavailable").await;
+                                if persistence.history_uses_sql_lease() {
+                                    lease = None;
+                                    collector.lost_lease();
+                                    runtime.set_standby_after_error().await;
+                                }
+                            }
+                        }
+                    }
+                    _ = retention.tick(), if collector.is_leader() => collector.retention_due(),
+                    _ = tokio::task::yield_now(), if collector.can_retain() => {
+                        let cutoff = Utc::now().timestamp_millis()
+                            .saturating_sub(i64::from(config.retention_days) * 86_400_000);
+                        match persistence
+                            .delete_history_before(&environment_id, cutoff, config.retention_batch_size, lease.as_ref())
+                            .await
+                        {
+                            Ok(result) => {
+                                runtime.retention().await;
+                                collector.completed_retention_batch(result.has_more);
+                            }
+                            Err(_) => {
+                                collector.completed_retention_batch(false);
+                                runtime.unavailable("history retention is unavailable").await;
+                                if persistence.history_uses_sql_lease() {
+                                    lease = None;
+                                    collector.lost_lease();
+                                    runtime.set_standby_after_error().await;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            runtime.set_standby().await;
+            if let Some(lease) = collector.cancel(&mut lease) {
+                let _ = persistence.release_history_lease(&lease).await;
+            }
+        })
+        .map_err(|error| DashboardError::internal_source("Could not start history collector", error))?;
+    Ok(())
+}
+
 async fn collect_history_sample(
+    persistence: &DashboardPersistence,
     admin_facade: &WebAdminFacade,
-    history_store: &DashboardHistoryStore,
+    environment_id: &EnvironmentId,
+    interval_secs: u64,
+    lease: Option<&HistoryLease>,
 ) -> Result<(), DashboardError> {
     let overview = admin_facade.dashboard_overview().await?;
-    let topic_current = match admin_facade.provider().topic_current().await {
-        Ok(topic_current) => topic_current,
-        Err(error) => {
-            tracing::debug!(error = %error, "Topic current collection failed; recording empty topic history sample");
-            DashboardTopicCurrent {
-                total_topics: 0,
-                top_topics: Vec::new(),
-            }
-        }
-    };
-    history_store.record(overview, topic_current).await;
+    let interval_ms = i64::try_from(interval_secs)
+        .ok()
+        .and_then(|seconds| seconds.checked_mul(1_000))
+        .filter(|value| *value > 0)
+        .ok_or_else(|| DashboardError::Config("history interval is invalid".to_string()))?;
+    let now = Utc::now().timestamp_millis();
+    let bucket_ms = now - now.rem_euclid(interval_ms);
+    let mut samples = vec![MetricSample {
+        environment_id: environment_id.clone(),
+        metric: "broker-count".to_string(),
+        bucket_ms,
+        dimensions: Vec::new(),
+        value: overview.broker_count as f64,
+    }];
+    if let Ok(topics) = admin_facade.provider().topic_current().await {
+        samples.push(MetricSample {
+            environment_id: environment_id.clone(),
+            metric: "topic-count".to_string(),
+            bucket_ms,
+            dimensions: Vec::new(),
+            value: topics.total_topics as f64,
+        });
+        samples.extend(topics.top_topics.into_iter().map(|topic| MetricSample {
+            environment_id: environment_id.clone(),
+            metric: "topic-total-messages".to_string(),
+            bucket_ms,
+            dimensions: vec![MetricDimension {
+                key: "topic".to_string(),
+                value: topic.topic,
+            }],
+            value: topic.total_msg as f64,
+        }));
+    }
+    persistence.append_history(samples, lease).await?;
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::DashboardHistoryStore;
-    use super::DashboardTaskManager;
-    use crate::model::DashboardHistoryQuery;
-    use crate::model::DashboardOverview;
-    use crate::model::DashboardTopicCurrent;
-    use crate::model::TopicCurrentMetric;
-    use chrono::Utc;
-    use std::future;
-    use tokio::sync::oneshot;
-    use tokio::time::Duration;
-    use tokio::time::timeout;
+    use super::DashboardHistoryRuntime;
+    use super::query_date_range;
+    use crate::model::StorageBackend;
 
-    struct DropSignal(Option<oneshot::Sender<()>>);
-
-    impl Drop for DropSignal {
-        fn drop(&mut self) {
-            if let Some(sender) = self.0.take() {
-                let _ = sender.send(());
-            }
-        }
+    #[test]
+    fn history_date_is_a_single_utc_day() {
+        let range = query_date_range("2026-08-24").expect("date range");
+        assert_eq!(range.end_ms - range.start_ms, 86_399_999);
     }
 
     #[tokio::test]
-    async fn dashboard_task_manager_drop_aborts_spawned_tasks() {
-        let manager = DashboardTaskManager::default();
-        let (started_tx, started_rx) = oneshot::channel();
-        let (dropped_tx, dropped_rx) = oneshot::channel();
+    async fn lease_error_remains_visible_until_a_normal_standby_or_leader_transition() {
+        let runtime = DashboardHistoryRuntime::new(StorageBackend::Sqlite);
+        runtime.unavailable("history lease is unavailable").await;
+        runtime.set_standby_after_error().await;
+        let failed = runtime.health().await;
+        assert_eq!(failed.connectivity, "unavailable");
+        assert_eq!(failed.role, "standby");
+        assert_eq!(failed.recent_error.as_deref(), Some("history lease is unavailable"));
 
-        manager
-            .spawn("dashboard-test-task", async move {
-                let _drop_signal = DropSignal(Some(dropped_tx));
-                let _ = started_tx.send(());
-                future::pending::<()>().await;
-            })
-            .expect("dashboard task should spawn");
+        runtime.set_standby().await;
+        let standby = runtime.health().await;
+        assert_eq!(standby.connectivity, "available");
+        assert!(standby.recent_error.is_none());
 
-        started_rx.await.expect("task should start");
-        drop(manager);
-
-        timeout(Duration::from_secs(1), dropped_rx)
-            .await
-            .expect("task should be aborted when manager is dropped")
-            .expect("drop signal should be sent");
-    }
-
-    #[tokio::test]
-    async fn history_store_returns_broker_and_topic_points() {
-        let store = DashboardHistoryStore::default();
-        let date = Utc::now().format("%Y-%m-%d").to_string();
-        store
-            .record(
-                DashboardOverview {
-                    current_namesrv: Some("127.0.0.1:9876".to_string()),
-                    broker_count: 3,
-                    topic_count: 2,
-                    consumer_group_count: 1,
-                    producer_count: 1,
-                    message_backlog: 0,
-                    system_status: "UP".to_string(),
-                },
-                DashboardTopicCurrent {
-                    total_topics: 2,
-                    top_topics: vec![TopicCurrentMetric {
-                        topic: "TopicTest".to_string(),
-                        total_msg: 42,
-                        in_tps: 0.0,
-                        out_tps: 0.0,
-                    }],
-                },
-            )
-            .await;
-
-        let broker_series = store
-            .broker_series(DashboardHistoryQuery {
-                date: date.clone(),
-                topic_name: None,
-            })
-            .await;
-        assert!(broker_series.collected);
-        assert_eq!(broker_series.points[0].value, 3.0);
-
-        let topic_series = store
-            .topic_series(DashboardHistoryQuery {
-                date,
-                topic_name: Some("TopicTest".to_string()),
-            })
-            .await;
-        assert!(topic_series.collected);
-        assert_eq!(topic_series.points[0].value, 42.0);
+        runtime.unavailable("history collection is unavailable").await;
+        runtime.set_leader(Some(1_000)).await;
+        let leader = runtime.health().await;
+        assert_eq!(leader.connectivity, "available");
+        assert_eq!(leader.role, "leader");
+        assert!(leader.recent_error.is_none());
     }
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/health_service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/health_service.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use crate::model::DashboardHistoryHealth;
 use crate::model::HealthStatus;
 use crate::persistence::DashboardPersistence;
 use crate::persistence::StorageHealth;
@@ -20,11 +21,14 @@ pub fn liveness_status() -> HealthStatus {
     HealthStatus {
         status: "UP".to_string(),
         storage: None,
+        history: None,
     }
 }
 
-pub async fn readiness_status(persistence: &DashboardPersistence) -> HealthStatus {
-    readiness_status_from_storage(persistence.storage_health().await)
+pub async fn readiness_status(persistence: &DashboardPersistence, history: DashboardHistoryHealth) -> HealthStatus {
+    let mut status = readiness_status_from_storage(persistence.storage_health().await);
+    status.history = Some(history);
+    status
 }
 
 pub fn readiness_status_from_storage(storage: StorageHealth) -> HealthStatus {
@@ -35,6 +39,7 @@ pub fn readiness_status_from_storage(storage: StorageHealth) -> HealthStatus {
             "DOWN".to_string()
         },
         storage: Some(storage),
+        history: None,
     }
 }
 

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/history_collector_schedule.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/history_collector_schedule.rs
@@ -1,0 +1,167 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use tokio::time::Duration;
+
+/// Fixed ticker periods and small mutable state for the history collector.
+///
+/// Keeping this separate from I/O lets the collector prioritize cancellation
+/// and lease renewal while retention drains bounded batches cooperatively.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct HistoryCollectorSchedule {
+    renewal_period: Duration,
+    collection_period: Duration,
+    retention_period: Duration,
+}
+
+impl HistoryCollectorSchedule {
+    pub(super) fn new(collection_interval_secs: u64, lease_ttl_ms: i64) -> Self {
+        let renewal_ms = u64::try_from((lease_ttl_ms / 3).max(1)).unwrap_or(u64::MAX);
+        Self {
+            renewal_period: Duration::from_millis(renewal_ms),
+            collection_period: Duration::from_secs(collection_interval_secs),
+            retention_period: Duration::from_secs(collection_interval_secs.saturating_mul(10).max(1)),
+        }
+    }
+
+    pub(super) const fn renewal_period(self) -> Duration {
+        self.renewal_period
+    }
+
+    pub(super) const fn collection_period(self) -> Duration {
+        self.collection_period
+    }
+
+    pub(super) const fn retention_period(self) -> Duration {
+        self.retention_period
+    }
+}
+
+#[derive(Debug, Default)]
+pub(super) struct HistoryCollectorState {
+    leader: bool,
+    retention_pending: bool,
+}
+
+impl HistoryCollectorState {
+    pub(super) fn became_leader(&mut self) {
+        self.leader = true;
+    }
+
+    pub(super) fn lost_lease(&mut self) {
+        self.leader = false;
+        self.retention_pending = false;
+    }
+
+    pub(super) const fn is_leader(&self) -> bool {
+        self.leader
+    }
+
+    pub(super) const fn can_collect(&self) -> bool {
+        self.leader
+    }
+
+    pub(super) fn retention_due(&mut self) {
+        if self.leader {
+            self.retention_pending = true;
+        }
+    }
+
+    pub(super) const fn can_retain(&self) -> bool {
+        self.leader && self.retention_pending
+    }
+
+    pub(super) fn completed_retention_batch(&mut self, has_more: bool) {
+        self.retention_pending = self.leader && has_more;
+    }
+
+    /// Cancellation stops new work before moving the lease out for its
+    /// conditional holder/token release. A standby that never acquired a
+    /// lease therefore never attempts a release write.
+    pub(super) fn cancel<T>(&mut self, lease: &mut Option<T>) -> Option<T> {
+        self.lost_lease();
+        lease.take()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HistoryCollectorSchedule;
+    use super::HistoryCollectorState;
+    use std::future::poll_fn;
+    use std::task::Poll;
+    use tokio::time::Duration;
+    use tokio::time::Instant;
+    use tokio::time::interval_at;
+
+    #[tokio::test(start_paused = true)]
+    async fn one_second_collection_tick_is_independent_of_lease_renewal() {
+        let schedule = HistoryCollectorSchedule::new(1, 30_000);
+        assert_eq!(schedule.collection_period(), Duration::from_secs(1));
+        assert_eq!(schedule.renewal_period(), Duration::from_secs(10));
+
+        let start = Instant::now();
+        let mut collection = interval_at(start + schedule.collection_period(), schedule.collection_period());
+        let mut renewal = interval_at(start + schedule.renewal_period(), schedule.renewal_period());
+        tokio::time::advance(Duration::from_secs(1)).await;
+        collection.tick().await;
+        let mut renewal_tick = std::pin::pin!(renewal.tick());
+        let renewal_is_ready = poll_fn(|context| match renewal_tick.as_mut().poll(context) {
+            Poll::Ready(_) => Poll::Ready(true),
+            Poll::Pending => Poll::Ready(false),
+        })
+        .await;
+        assert!(
+            !renewal_is_ready,
+            "renewal must not gate the one-second collection tick"
+        );
+    }
+
+    #[test]
+    fn retention_drains_one_bounded_batch_at_a_time_until_converged() {
+        let mut state = HistoryCollectorState::default();
+        state.became_leader();
+        state.retention_due();
+        assert!(state.can_retain());
+        state.completed_retention_batch(true);
+        assert!(state.can_retain(), "has_more schedules the next yielded pass");
+        state.completed_retention_batch(false);
+        assert!(!state.can_retain());
+    }
+
+    #[test]
+    fn lease_loss_cancels_collection_and_pending_retention() {
+        let mut state = HistoryCollectorState::default();
+        state.became_leader();
+        state.retention_due();
+        state.lost_lease();
+        assert!(!state.is_leader());
+        assert!(!state.can_collect());
+        assert!(!state.can_retain());
+    }
+
+    #[test]
+    fn cancellation_releases_only_an_acquired_lease() {
+        let mut leader = HistoryCollectorState::default();
+        leader.became_leader();
+        let mut acquired = Some("holder-token");
+        assert_eq!(leader.cancel(&mut acquired), Some("holder-token"));
+        assert!(acquired.is_none());
+        assert!(!leader.can_collect());
+
+        let mut standby = HistoryCollectorState::default();
+        let mut no_lease = None::<()>;
+        assert!(standby.cancel(&mut no_lease).is_none());
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/state/app_state.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/state/app_state.rs
@@ -22,9 +22,9 @@ use crate::persistence::StorageHealth;
 use crate::persistence::StorageStatus;
 use crate::persistence::error::PersistenceError;
 use crate::service::AuthState;
-use crate::service::DashboardHistoryStore;
-use crate::service::DashboardTaskManager;
-use crate::service::spawn_dashboard_history_collector;
+use crate::service::DashboardHistoryRuntime;
+use crate::service::HistoryCollectorConfig;
+use crate::service::start_dashboard_history_collector;
 use rocketmq_admin_core::client_adapter::ClientRuntime;
 use rocketmq_dashboard_common::DashboardAdminFacade;
 use std::future::Future;
@@ -59,8 +59,7 @@ pub struct AppState {
     pub(crate) environment_refresh_lock: Arc<Mutex<()>>,
     persisted_mutation_context: rocketmq_runtime::ChildServiceContext,
     pub auth_state: Arc<AuthState>,
-    pub history_store: DashboardHistoryStore,
-    pub dashboard_tasks: DashboardTaskManager,
+    pub history_runtime: DashboardHistoryRuntime,
     pub published_environment: Arc<std::sync::RwLock<PublishedEnvironment>>,
     pub admin_client: DashboardAdminClient,
     #[cfg(test)]
@@ -93,23 +92,33 @@ impl AppState {
         );
         ensure_persistence_ready(persistence.storage_health().await)?;
         let auth_state = Arc::new(AuthState::new(config.auth));
-        let history_store = DashboardHistoryStore::default();
-        let dashboard_tasks = DashboardTaskManager::default();
         let environment = load_or_create_default_environment(&persistence, &config.initial_config).await?;
+        let history_environment_id = environment.environment_id.clone();
         let published_environment = Arc::new(std::sync::RwLock::new(PublishedEnvironment::from_environment(
             environment,
             persistence.storage_backend(),
         )));
         let convergence_context = client_runtime.component("dashboard-environment-convergence");
         let persisted_mutation_context = client_runtime.component("dashboard-persisted-mutation-owner");
-        let admin_client =
-            DashboardAdminClient::new(published_environment.clone(), client_runtime, config.admin_credentials);
+        let admin_client = DashboardAdminClient::new(
+            published_environment.clone(),
+            client_runtime.clone(),
+            config.admin_credentials,
+        );
+        let history_runtime = DashboardHistoryRuntime::new(persistence.storage_backend());
         if config.dashboard_history_interval_secs > 0 {
-            spawn_dashboard_history_collector(
-                &dashboard_tasks,
+            start_dashboard_history_collector(
+                client_runtime.component("dashboard-history-collector"),
+                persistence.clone(),
                 DashboardAdminFacade::new(admin_client.clone()),
-                history_store.clone(),
-                config.dashboard_history_interval_secs,
+                history_environment_id,
+                HistoryCollectorConfig {
+                    interval_secs: config.dashboard_history_interval_secs,
+                    retention_days: config.dashboard_history_retention_days,
+                    retention_batch_size: config.dashboard_history_retention_batch_size,
+                    lease_ttl_secs: config.dashboard_history_lease_ttl_secs,
+                },
+                history_runtime.clone(),
             )?;
         }
 
@@ -119,8 +128,7 @@ impl AppState {
             environment_refresh_lock: Arc::new(Mutex::new(())),
             persisted_mutation_context,
             auth_state,
-            history_store,
-            dashboard_tasks,
+            history_runtime,
             published_environment,
             admin_client,
             #[cfg(test)]
@@ -391,6 +399,9 @@ mod tests {
                 password: "test-password".to_string(),
             },
             dashboard_history_interval_secs: 0,
+            dashboard_history_retention_days: 30,
+            dashboard_history_retention_batch_size: 500,
+            dashboard_history_lease_ttl_secs: 30,
             initial_config: DashboardConfigView::default(),
             admin_credentials: None,
         }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/api/dashboard_api.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/api/dashboard_api.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readHistoryPages } from './dashboard_api';
+import type { DashboardHistoryQuery, DashboardHistorySeries } from '../types/dashboard';
+
+const query: DashboardHistoryQuery = { date: '2026-08-24' };
+
+function page(timestamp: number, nextCursor: string | null): DashboardHistorySeries {
+  return {
+    date: query.date,
+    metric: 'broker',
+    collected: true,
+    points: [{ timestamp, value: timestamp }],
+    nextCursor
+  };
+}
+
+describe('readHistoryPages', () => {
+  it('merges every cursor page, including the latest point from the continuation', async () => {
+    const request = vi
+      .fn<(request: DashboardHistoryQuery) => Promise<DashboardHistorySeries>>()
+      .mockResolvedValueOnce(page(1, 'cursor-1'))
+      .mockResolvedValueOnce(page(2, null));
+
+    await expect(readHistoryPages(request, query)).resolves.toMatchObject({
+      points: [{ timestamp: 1 }, { timestamp: 2 }],
+      nextCursor: null
+    });
+    expect(request).toHaveBeenNthCalledWith(1, { date: query.date, cursor: undefined });
+    expect(request).toHaveBeenNthCalledWith(2, { date: query.date, cursor: 'cursor-1' });
+  });
+
+  it('stops after the safe 64-page maximum', async () => {
+    const request = vi.fn<(request: DashboardHistoryQuery) => Promise<DashboardHistorySeries>>((request) =>
+      Promise.resolve(page(1, `cursor-${request.cursor ?? 'first'}`))
+    );
+
+    await expect(readHistoryPages(request, query)).rejects.toThrow('safe page limit');
+    expect(request).toHaveBeenCalledTimes(64);
+  });
+
+  it('propagates a continuation-page failure', async () => {
+    const request = vi
+      .fn<(request: DashboardHistoryQuery) => Promise<DashboardHistorySeries>>()
+      .mockResolvedValueOnce(page(1, 'cursor-1'))
+      .mockRejectedValueOnce(new Error('second page unavailable'));
+
+    await expect(readHistoryPages(request, query)).rejects.toThrow('second page unavailable');
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/api/dashboard_api.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/api/dashboard_api.ts
@@ -11,11 +11,31 @@ function toQueryString(params: DashboardHistoryQuery) {
   return `?${search.toString()}`;
 }
 
+const MAX_HISTORY_PAGES = 64;
+
+export async function readHistoryPages(
+  request: (query: DashboardHistoryQuery) => Promise<DashboardHistorySeries>,
+  query: DashboardHistoryQuery
+): Promise<DashboardHistorySeries> {
+  const points = [] as DashboardHistorySeries['points'];
+  let cursor = query.cursor;
+  for (let page = 0; page < MAX_HISTORY_PAGES; page += 1) {
+    const response = await request({ ...query, cursor });
+    points.push(...response.points);
+    if (!response.nextCursor) return { ...response, points, nextCursor: null };
+    cursor = response.nextCursor;
+  }
+  throw new Error('History response exceeded the safe page limit');
+}
+
+const brokerHistoryPage = (query: DashboardHistoryQuery) =>
+  apiClient.get<DashboardHistorySeries>(`/api/dashboard/brokers/history${toQueryString(query)}`);
+const topicHistoryPage = (query: DashboardHistoryQuery) =>
+  apiClient.get<DashboardHistorySeries>(`/api/dashboard/topics/history${toQueryString(query)}`);
+
 export const dashboardApi = {
   overview: () => apiClient.get<DashboardOverview>('/api/dashboard/overview'),
   topicCurrent: () => apiClient.get<DashboardTopicCurrent>('/api/dashboard/topic-current'),
-  brokerHistory: (query: DashboardHistoryQuery) =>
-    apiClient.get<DashboardHistorySeries>(`/api/dashboard/brokers/history${toQueryString(query)}`),
-  topicHistory: (query: DashboardHistoryQuery) =>
-    apiClient.get<DashboardHistorySeries>(`/api/dashboard/topics/history${toQueryString(query)}`)
+  brokerHistory: (query: DashboardHistoryQuery) => readHistoryPages(brokerHistoryPage, query),
+  topicHistory: (query: DashboardHistoryQuery) => readHistoryPages(topicHistoryPage, query)
 };

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/DashboardPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/DashboardPage.tsx
@@ -337,8 +337,8 @@ function HistoryCard({ title, description, series, error, loading, errorTitle, d
           <CardDescription>{description}</CardDescription>
         </div>
         <StatusBadge
-          status={loading ? 'Loading' : error ? 'Unavailable' : series?.collected ? 'Collected' : 'Warming up'}
-          tone={loading ? undefined : error ? 'danger' : series?.collected ? 'success' : 'warning'}
+          status={historyStatus(series, loading, error)}
+          tone={loading ? undefined : error ? 'danger' : series?.health?.connectivity === 'unavailable' ? 'danger' : series?.collected ? 'success' : 'warning'}
         />
       </CardHeader>
       <CardContent>
@@ -360,6 +360,17 @@ function HistoryCard({ title, description, series, error, loading, errorTitle, d
       </CardContent>
     </Card>
   );
+}
+
+function historyStatus(series: DashboardHistorySeries | null, loading: boolean, error: string | null) {
+  if (loading) return 'Loading';
+  if (error) return 'Unavailable';
+  if (series?.health) {
+    return series.health.connectivity === 'available'
+      ? `${series.health.backend} · ${series.health.role}`
+      : `${series.health.backend} · unavailable`;
+  }
+  return series?.collected ? 'Collected' : 'Warming up';
 }
 
 function HistoryUnavailable({ title, detail }: { title: string; detail: string }) {

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/types/dashboard.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/types/dashboard.ts
@@ -23,6 +23,8 @@ export interface TopicCurrentMetric {
 export interface DashboardHistoryQuery {
   date: string;
   topicName?: string;
+  limit?: number;
+  cursor?: string;
 }
 
 export interface DashboardHistorySeries {
@@ -31,9 +33,22 @@ export interface DashboardHistorySeries {
   topicName?: string | null;
   collected: boolean;
   points: DashboardHistoryPoint[];
+  nextCursor?: string | null;
+  health?: DashboardHistoryHealth;
 }
 
 export interface DashboardHistoryPoint {
   timestamp: number;
   value: number;
+}
+
+export interface DashboardHistoryHealth {
+  backend: 'file' | 'sqlite' | 'mysql' | 'postgres';
+  connectivity: 'available' | 'unavailable';
+  role: 'leader' | 'standby';
+  leaseExpiresAtMs?: number | null;
+  lastCollectionAtMs?: number | null;
+  lastAppendAtMs?: number | null;
+  lastRetentionAtMs?: number | null;
+  recentError?: string | null;
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9681

### Brief Description

Persist Web Dashboard broker and topic history through the File, SQLite, MySQL, and PostgreSQL backends. This adds environment-scoped samples, stable cursor queries, bounded retention, database-clock collector leases for multi-node SQL deployments, lifecycle-owned collection, storage health reporting, and frontend pagination that always reaches the latest persisted point.

The File backend keeps plain UTC-day JSONL segments with atomic replacement and crash recovery. SQL backends use byte-exact identities, set-based batch writes, and indexed environment/time queries. Shared contracts cover idempotency, conflict atomicity, lease fencing, retention convergence, malformed-tail recovery, and cross-backend timestamp behavior.

### How Did You Test This Change?

- `cargo check --all-targets --all-features`: passed.
- `cargo clippy --all-targets --all-features -- -D warnings`: passed.
- `cargo build --all-targets --all-features`: passed.
- `cargo test --all-targets --all-features`: passed with 133 tests and 21 Docker-only tests ignored in the local run.
- `cargo test --lib history_ --no-fail-fast`: passed with 18 tests and 10 Docker-only tests ignored.
- Changed Rust files checked with `rustfmt --edition 2024 --check`: passed. The aggregate `cargo fmt --all -- --check` command exceeded the Windows command-line path limit (`os error 206`).
- `npm ci`: passed.
- `npm test -- --run`: passed with 53 files and 359 tests.
- `npm run build`: passed.
- `./scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`: passed.
- `docker compose -f docker-compose.storage-test.yml up --build --abort-on-container-exit --exit-code-from storage-test-runner`: passed on fresh File and mounted SQLite volumes with MySQL 8.4 and PostgreSQL 15, with 154 tests, 0 failures, and 0 ignored.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent metric history across file, SQLite, MySQL, and PostgreSQL storage.
  * Added cursor-based pagination for broker and topic history, including automatic page aggregation.
  * Added configurable history retention, collection limits, and lease coordination.
  * Added history health details showing storage backend, connectivity, role, lease status, and recent errors.
* **Bug Fixes**
  * Improved recovery after interrupted history writes and retention operations.
* **Documentation**
  * Documented history configuration, retention behavior, and storage capacity guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->