### PR TITLE
[ISSUE #9673]♻️Converge Tokio client compatibility facades

### DIFF
--- a/rocketmq-doc/en/release/1.0/api-migration.md
+++ b/rocketmq-doc/en/release/1.0/api-migration.md
@@ -41,6 +41,31 @@ let runtime = ClientRuntime::new(config);
 let runtime = ClientRuntime::try_new(service_context, config, telemetry_handle)?;
 ```
 
+### Tokio client cached-session reconciliation
+
+`TransportClient::is_address_reachable` is retained as a deprecated
+compatibility facade, but it has never performed a DNS, socket, or network
+reachability probe. It only inspected the direct cached session and removed an
+unhealthy entry.
+
+Use `reconcile_cached_connection` when application logic needs the typed cache
+result:
+
+```rust,ignore
+use rocketmq_transport::api::v1::CachedConnectionState;
+
+match client.reconcile_cached_connection(&address) {
+    CachedConnectionState::Healthy => {}
+    CachedConnectionState::UnhealthyRetired => reconnect_after_cleanup(),
+    CachedConnectionState::Absent => connect_if_needed(),
+}
+```
+
+Request processors are fixed when a client is built. Replace the deprecated
+`register_processor` compatibility call with
+`TransportClient::builder(...).build()?` or
+`RemotingClient::builder(...).build()?` so configuration failures remain typed.
+
 Applications own the runtime and pass an `Arc<ClientRuntime>` to producers and
 consumers. Client APIs do not create hidden Tokio runtimes.
 

--- a/rocketmq-transport/src/clients/rocketmq_tokio_client.rs
+++ b/rocketmq-transport/src/clients/rocketmq_tokio_client.rs
@@ -27,8 +27,6 @@ use rocketmq_runtime::ChildServiceContext;
 use rocketmq_runtime::TaskGroup;
 #[cfg(test)]
 use rocketmq_runtime::TaskGroupLifecycleState;
-use tracing::debug;
-use tracing::info;
 use tracing::warn;
 
 use crate::base::connection_net_event::ConnectionNetEvent;
@@ -53,6 +51,7 @@ use crate::telemetry::TransportTelemetry;
 use crate::tls::TlsConfig;
 
 mod api;
+mod compatibility;
 mod connect_flight;
 mod connection_registry;
 mod endpoint_state;
@@ -64,6 +63,7 @@ pub use api::{
     ClientShutdownReport, ClientSnapshot, ClientStartReport, ConnectionShutdownReport, PendingUsage, RemotingClient,
     RemotingClientBuilder, RequestTarget, SendReceipt, TransportClientBuilder,
 };
+pub use compatibility::CachedConnectionState;
 
 use connection_registry::ConnectionRegistry;
 use endpoint_state::EndpointStateStore;
@@ -438,33 +438,6 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
         }) {
             warn!("[SCAN] Removed idle/unhealthy connection: {}", addr);
         }
-    }
-}
-
-impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
-    fn is_address_reachable_inner(&self, addr: &CheetahString) {
-        if self.connection_registry.healthy_session(addr, None).is_some() {
-            return;
-        }
-        if self.connection_registry.remove_unhealthy_session(addr) {
-            warn!("Removed unhealthy connection for {}", addr);
-        } else {
-            debug!("No connection found for {}", addr);
-        }
-    }
-
-    fn close_clients_inner(&self, addrs: Vec<String>) {
-        for addr in &addrs {
-            let key = CheetahString::from(addr.as_str());
-            if !self.connection_registry.remove_sessions_by_identity(&key).is_empty() {
-                info!("Closed client connection for {}", addr);
-            }
-        }
-    }
-
-    fn register_processor_inner(&self, processor: impl RequestProcessor + Sync) {
-        let _ = &processor;
-        warn!("dynamic request processor registration is not supported by TransportClient after construction");
     }
 }
 

--- a/rocketmq-transport/src/clients/rocketmq_tokio_client/api.rs
+++ b/rocketmq-transport/src/clients/rocketmq_tokio_client/api.rs
@@ -40,6 +40,7 @@ use crate::telemetry::TransportTelemetry;
 use crate::tls::TlsConfig;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 
+use super::CachedConnectionState;
 use super::TransportClient;
 
 /// Builds a persistent endpoint client without exposing positional optional capabilities.
@@ -453,6 +454,23 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
         .await
     }
 
+    /// Reconciles one direct cached connection without performing network I/O.
+    ///
+    /// The returned state only describes the direct-session cache at this instant.
+    /// It is not a DNS, socket, or network reachability probe.
+    pub fn reconcile_cached_connection(&self, addr: &CheetahString) -> CachedConnectionState {
+        self.reconcile_cached_connection_inner(addr)
+    }
+
+    /// Retained compatibility facade for direct cached-session cleanup.
+    ///
+    /// This method is not a DNS, socket, or network reachability probe. Use
+    /// [`Self::reconcile_cached_connection`] when the caller needs the typed
+    /// cache state.
+    #[deprecated(
+        since = "1.0.0",
+        note = "use TransportClient::reconcile_cached_connection; is_address_reachable is not a network probe"
+    )]
     pub fn is_address_reachable(&self, addr: &CheetahString) {
         self.is_address_reachable_inner(addr);
     }
@@ -461,6 +479,14 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
         self.close_clients_inner(addrs);
     }
 
+    /// Retained compatibility facade for request processors fixed at construction.
+    ///
+    /// Use [`TransportClient::builder`] or [`RemotingClient::builder`] and
+    /// propagate the fallible `build()?` result instead.
+    #[deprecated(
+        since = "1.0.0",
+        note = "request processors are fixed at construction; use TransportClient::builder(...).build()? or RemotingClient::builder(...).build()?"
+    )]
     pub fn register_processor(&self, processor: impl RequestProcessor + Sync) {
         self.register_processor_inner(processor);
     }

--- a/rocketmq-transport/src/clients/rocketmq_tokio_client/compatibility.rs
+++ b/rocketmq-transport/src/clients/rocketmq_tokio_client/compatibility.rs
@@ -1,0 +1,161 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cheetah_string::CheetahString;
+use tracing::debug;
+use tracing::info;
+use tracing::warn;
+
+use super::TransportClient;
+use crate::runtime::processor::RequestProcessor;
+
+/// The result of reconciling one direct cached transport session.
+///
+/// This is a point-in-time observation. Existing clones of a retired session
+/// remain valid Rust values, but the direct registry no longer selects them.
+#[must_use]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum CachedConnectionState {
+    /// A direct cached session exists and is healthy.
+    Healthy,
+    /// An unhealthy direct cached session was removed.
+    UnhealthyRetired,
+    /// No direct cached session exists.
+    Absent,
+}
+
+impl<PR: RequestProcessor + Sync + Clone + 'static> TransportClient<PR> {
+    pub(super) fn reconcile_cached_connection_inner(&self, addr: &CheetahString) -> CachedConnectionState {
+        self.connection_registry.reconcile_direct_session(addr)
+    }
+
+    pub(super) fn is_address_reachable_inner(&self, addr: &CheetahString) {
+        match self.reconcile_cached_connection_inner(addr) {
+            CachedConnectionState::Healthy => {}
+            CachedConnectionState::UnhealthyRetired => warn!("Removed unhealthy connection for {}", addr),
+            CachedConnectionState::Absent => debug!("No connection found for {}", addr),
+        }
+    }
+
+    pub(super) fn close_clients_inner(&self, addrs: Vec<String>) {
+        for addr in &addrs {
+            let key = CheetahString::from(addr.as_str());
+            if !self.connection_registry.remove_sessions_by_identity(&key).is_empty() {
+                info!("Closed client connection for {}", addr);
+            }
+        }
+    }
+
+    pub(super) fn register_processor_inner(&self, processor: impl RequestProcessor + Sync) {
+        let _ = &processor;
+        warn!("dynamic request processor registration is not supported by TransportClient after construction");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use rocketmq_runtime::RuntimeContext;
+    use tokio::net::TcpListener;
+
+    use super::*;
+    use crate::request_processor::default_request_processor::DefaultRequestProcessor;
+    use crate::runtime::config::client_config::TransportClientConfig;
+
+    #[tokio::test]
+    async fn reconciliation_reports_absent_healthy_and_retired_direct_sessions() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
+        let addr = listener.local_addr().expect("listener address");
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (socket, _) = listener.accept().await.expect("accept client connection");
+            let _socket = socket;
+            let _ = release_rx.await;
+        });
+        let runtime = RuntimeContext::from_current("compatibility-reconciliation");
+        let client = Arc::new(TransportClient::build_for_test(
+            Arc::new(TransportClientConfig::default()),
+            DefaultRequestProcessor,
+            runtime.service_context("client"),
+        ));
+        client.start().await.expect("start client");
+        let target = CheetahString::from_string(addr.to_string());
+
+        assert_eq!(
+            client.reconcile_cached_connection_inner(&target),
+            CachedConnectionState::Absent
+        );
+        let session = client
+            .create_client(&target, Duration::from_secs(1))
+            .await
+            .expect("create cached direct session");
+        assert_eq!(
+            client.reconcile_cached_connection_inner(&target),
+            CachedConnectionState::Healthy
+        );
+
+        session.retire_after_timeout().await;
+        assert_eq!(
+            client.reconcile_cached_connection_inner(&target),
+            CachedConnectionState::UnhealthyRetired
+        );
+        assert_eq!(
+            client.reconcile_cached_connection_inner(&target),
+            CachedConnectionState::Absent
+        );
+
+        let _ = client.shutdown_now();
+        let _ = release_tx.send(());
+        server.await.expect("server task");
+    }
+
+    #[tokio::test]
+    async fn legacy_reachability_facade_keeps_unhealthy_cache_cleanup() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
+        let addr = listener.local_addr().expect("listener address");
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (socket, _) = listener.accept().await.expect("accept client connection");
+            let _socket = socket;
+            let _ = release_rx.await;
+        });
+        let runtime = RuntimeContext::from_current("legacy-reachability-cleanup");
+        let client = Arc::new(TransportClient::build_for_test(
+            Arc::new(TransportClientConfig::default()),
+            DefaultRequestProcessor,
+            runtime.service_context("client"),
+        ));
+        client.start().await.expect("start client");
+        let target = CheetahString::from_string(addr.to_string());
+        let session = client
+            .create_client(&target, Duration::from_secs(1))
+            .await
+            .expect("create cached direct session");
+        session.retire_after_timeout().await;
+
+        // This validates the retained compatibility call site while keeping its deprecation scoped to this test.
+        #[allow(deprecated)]
+        client.is_address_reachable(&target);
+        assert_eq!(
+            client.reconcile_cached_connection_inner(&target),
+            CachedConnectionState::Absent
+        );
+
+        let _ = client.shutdown_now();
+        let _ = release_tx.send(());
+        server.await.expect("server task");
+    }
+}

--- a/rocketmq-transport/src/clients/rocketmq_tokio_client/connection_registry.rs
+++ b/rocketmq-transport/src/clients/rocketmq_tokio_client/connection_registry.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use cheetah_string::CheetahString;
 use dashmap::DashMap;
 
+use super::compatibility::CachedConnectionState;
 use super::connect_flight::ConnectFlight;
 use super::endpoint_state::EndpointLease;
 use crate::clients::TransportSession;
@@ -205,12 +206,18 @@ where
         })
     }
 
-    pub(super) fn remove_unhealthy_session(&self, identity: &CheetahString) -> bool {
-        self.sessions
-            .remove_if(&RegistryKey::direct(identity.clone()), |_, current| {
-                !current.session().connection().is_healthy()
-            })
-            .is_some()
+    /// Reconciles one direct entry while holding the entry lock for its full observation and removal.
+    pub(super) fn reconcile_direct_session(&self, identity: &CheetahString) -> CachedConnectionState {
+        match self.sessions.entry(RegistryKey::direct(identity.clone())) {
+            dashmap::mapref::entry::Entry::Vacant(_) => CachedConnectionState::Absent,
+            dashmap::mapref::entry::Entry::Occupied(entry) if entry.get().session().connection().is_healthy() => {
+                CachedConnectionState::Healthy
+            }
+            dashmap::mapref::entry::Entry::Occupied(entry) => {
+                entry.remove();
+                CachedConnectionState::UnhealthyRetired
+            }
+        }
     }
 
     #[cfg(test)]
@@ -366,13 +373,18 @@ where
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::sync::Barrier;
     use std::time::Duration;
 
     use rocketmq_error::RocketMQError;
+    use rocketmq_runtime::RuntimeContext;
+    use tokio::net::TcpListener;
 
     use super::*;
+    use crate::clients::rocketmq_tokio_client::TransportClient;
     use crate::deadline::RequestDeadline;
     use crate::request_processor::default_request_processor::DefaultRequestProcessor;
+    use crate::runtime::config::client_config::TransportClientConfig;
 
     #[test]
     fn connect_flight_failure_cleanup_is_identity_conditional() {
@@ -414,11 +426,74 @@ mod tests {
             panic!("shutdown completion must preserve the typed shared error");
         };
         assert!(matches!(snapshot.as_error(), RocketMQError::ClientNotStarted));
-
         let (replacement, replacement_leader) = registry.acquire_flight(identity.clone(), None);
         assert!(replacement_leader);
         registry.remove_flight_if_matches(&identity, &retired);
         assert_eq!(registry.flight_count(), 1);
         assert!(!Arc::ptr_eq(&retired, &replacement));
+    }
+    #[tokio::test]
+    async fn direct_reconciliation_keeps_a_concurrent_healthy_replacement() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
+        let address = listener.local_addr().expect("listener address");
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (first, _) = listener.accept().await.expect("accept first client");
+            let (second, _) = listener.accept().await.expect("accept replacement client");
+            let _connections = (first, second);
+            let _ = release_rx.await;
+        });
+        let client = Arc::new(TransportClient::build_for_test(
+            Arc::new(TransportClientConfig::default()),
+            DefaultRequestProcessor,
+            RuntimeContext::from_current("registry-reconcile-first").service_context("client"),
+        ));
+        client.start().await.expect("start first client");
+        let replacement_owner = Arc::new(TransportClient::build_for_test(
+            Arc::new(TransportClientConfig::default()),
+            DefaultRequestProcessor,
+            RuntimeContext::from_current("registry-reconcile-replacement").service_context("client"),
+        ));
+        replacement_owner.start().await.expect("start replacement owner");
+        let identity = CheetahString::from_string(address.to_string());
+        let original = client
+            .create_client(&identity, Duration::from_secs(1))
+            .await
+            .expect("create original session");
+        let replacement = replacement_owner
+            .create_client(&identity, Duration::from_secs(1))
+            .await
+            .expect("create replacement session");
+        original.retire_after_timeout().await;
+        let registry_for_reconcile = Arc::clone(&client.connection_registry);
+        let registry_for_replace = Arc::clone(&client.connection_registry);
+        let replacement_for_replace = replacement.clone();
+        let reconcile_barrier = Arc::new(Barrier::new(2));
+        let replacement_barrier = Arc::clone(&reconcile_barrier);
+        let state = std::thread::scope(|scope| {
+            let reconcile = scope.spawn(|| {
+                reconcile_barrier.wait();
+                registry_for_reconcile.reconcile_direct_session(&identity)
+            });
+            let replace = scope.spawn(|| {
+                replacement_barrier.wait();
+                registry_for_replace.insert_session(identity.clone(), replacement_for_replace, None, || true);
+            });
+            replace.join().expect("replacement thread");
+            reconcile.join().expect("reconciliation thread")
+        });
+        assert!(matches!(
+            state,
+            CachedConnectionState::Healthy | CachedConnectionState::UnhealthyRetired
+        ));
+        let cached = client
+            .connection_registry
+            .healthy_session(&identity, None)
+            .expect("healthy replacement must remain cached");
+        assert!(cached.is_same_registry_session(&replacement));
+        let _ = client.shutdown_now();
+        let _ = replacement_owner.shutdown_now();
+        let _ = release_tx.send(());
+        server.await.expect("server task");
     }
 }

--- a/rocketmq-transport/src/public_api.rs
+++ b/rocketmq-transport/src/public_api.rs
@@ -31,6 +31,7 @@ pub use crate::clients::nameserver_endpoint::diff_name_server_endpoints;
 pub use crate::clients::nameserver_endpoint::ConnectTarget;
 pub use crate::clients::nameserver_endpoint::NameServerEndpoint;
 pub use crate::clients::nameserver_endpoint::NameServerEndpointDiff;
+pub use crate::clients::rocketmq_tokio_client::CachedConnectionState;
 pub use crate::clients::rocketmq_tokio_client::ClientShutdownReport;
 pub use crate::clients::rocketmq_tokio_client::ClientSnapshot;
 pub use crate::clients::rocketmq_tokio_client::ClientStartReport;

--- a/rocketmq-transport/tests/public_api_contract.rs
+++ b/rocketmq-transport/tests/public_api_contract.rs
@@ -15,6 +15,7 @@
 use std::time::Duration;
 
 use rocketmq_transport::api::v1::AdmissionLimits;
+use rocketmq_transport::api::v1::CachedConnectionState;
 use rocketmq_transport::api::v1::DefaultRequestProcessor;
 use rocketmq_transport::api::v1::FileTransferMode;
 use rocketmq_transport::api::v1::FrameLimits;
@@ -876,6 +877,9 @@ fn api_v1_reexports_versioned_capabilities_and_dtos() {
     let _: Option<TransportClient<DefaultRequestProcessor>> = None;
     let _: Option<RemotingClient<DefaultRequestProcessor>> = None;
     let _: Option<TransportServer<DefaultRequestProcessor>> = None;
+    let _: CachedConnectionState = CachedConnectionState::Absent;
+    let _ = CachedConnectionState::Healthy;
+    let _ = CachedConnectionState::UnhealthyRetired;
     let _ = RequestDeadline::after(Duration::from_millis(1));
     assert_serialization_contract::<String>();
     assert_processor_contract::<DefaultRequestProcessor>();

--- a/rocketmq-transport/tests/public_api_v1.rs
+++ b/rocketmq-transport/tests/public_api_v1.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 
 use rocketmq_runtime::RuntimeContext;
 use rocketmq_runtime::ShutdownDeadline;
+use rocketmq_transport::api::v1::CachedConnectionState;
 use rocketmq_transport::api::v1::ClientShutdownReport;
 use rocketmq_transport::api::v1::ClientSnapshot;
 use rocketmq_transport::api::v1::DefaultRequestProcessor;
@@ -66,6 +67,22 @@ fn assert_stable_shutdown_methods(client: &TransportClient<DefaultRequestProcess
     let _: fn(&TransportClient<DefaultRequestProcessor>) -> ClientShutdownReport = TransportClient::shutdown_now;
 }
 
+fn assert_cached_connection_state(state: CachedConnectionState) {
+    assert!(matches!(
+        state,
+        CachedConnectionState::Healthy | CachedConnectionState::UnhealthyRetired | CachedConnectionState::Absent
+    ));
+}
+
+/// This compatibility assertion intentionally exercises retained deprecated names.
+#[allow(deprecated)]
+fn assert_legacy_compatibility_methods(client: &TransportClient<DefaultRequestProcessor>) {
+    let address = "127.0.0.1:10911".into();
+    client.is_address_reachable(&address);
+    client.close_clients(Vec::new());
+    client.register_processor(DefaultRequestProcessor);
+}
+
 fn assert_prelude_processor<T: PreludeRequestProcessor>() {}
 
 #[test]
@@ -94,6 +111,8 @@ async fn versioned_api_constructs_canonical_client_and_server() {
     .unwrap();
     assert_stable_async_methods(&transport, RequestTarget::NameServer);
     assert_stable_shutdown_methods(&transport);
+    assert_cached_connection_state(transport.reconcile_cached_connection(&"127.0.0.1:10911".into()));
+    assert_legacy_compatibility_methods(&transport);
 
     let remoting = RemotingClient::builder(
         config,

--- a/scripts/module-maintainability-baseline.json
+++ b/scripts/module-maintainability-baseline.json
@@ -105,8 +105,8 @@
       "reexports": 90
     },
     "rocketmq-transport": {
-      "public_items": 644,
-      "reexports": 178
+      "public_items": 646,
+      "reexports": 180
     }
   },
   "files": {
@@ -10931,13 +10931,18 @@
       "reexports": 0
     },
     "rocketmq-transport/src/clients/rocketmq_tokio_client.rs": {
-      "production_lines": 325,
+      "production_lines": 301,
       "public_items": 1,
-      "reexports": 1
+      "reexports": 2
     },
     "rocketmq-transport/src/clients/rocketmq_tokio_client/api.rs": {
-      "production_lines": 339,
-      "public_items": 49,
+      "production_lines": 351,
+      "public_items": 50,
+      "reexports": 0
+    },
+    "rocketmq-transport/src/clients/rocketmq_tokio_client/compatibility.rs": {
+      "production_lines": 37,
+      "public_items": 1,
       "reexports": 0
     },
     "rocketmq-transport/src/clients/rocketmq_tokio_client/connect_flight.rs": {
@@ -10946,7 +10951,7 @@
       "reexports": 0
     },
     "rocketmq-transport/src/clients/rocketmq_tokio_client/connection_registry.rs": {
-      "production_lines": 314,
+      "production_lines": 320,
       "public_items": 0,
       "reexports": 0
     },
@@ -11151,9 +11156,9 @@
       "reexports": 0
     },
     "rocketmq-transport/src/public_api.rs": {
-      "production_lines": 137,
+      "production_lines": 138,
       "public_items": 0,
-      "reexports": 132
+      "reexports": 133
     },
     "rocketmq-transport/src/remoting.rs": {
       "production_lines": 304,

--- a/scripts/public-api-intent.json
+++ b/scripts/public-api-intent.json
@@ -6168,6 +6168,15 @@
         },
         {
           "category": "stable",
+          "declaration": "pub use crate::clients::rocketmq_tokio_client::CachedConnectionState",
+          "identity": "rocketmq-transport/src/public_api.rs:pub use crate::clients::rocketmq_tokio_client::CachedConnectionState",
+          "owner": "transport",
+          "path": "rocketmq-transport/src/public_api.rs",
+          "rationale": "deliberate root entry point",
+          "removal_condition": "retain while the stable entry point remains supported"
+        },
+        {
+          "category": "stable",
           "declaration": "pub use crate::clients::rocketmq_tokio_client::ClientShutdownReport",
           "identity": "rocketmq-transport/src/public_api.rs:pub use crate::clients::rocketmq_tokio_client::ClientShutdownReport",
           "owner": "transport",
@@ -7202,7 +7211,7 @@
           "removal_condition": "retain while the stable entry point remains supported"
         }
       ],
-      "maximum_exports": 144
+      "maximum_exports": 145
     }
   },
   "policy": "Every deliberate export is classified; additions and count growth fail closed.",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9673

### Brief Description

- Add `CachedConnectionState` and an atomic, replacement-safe `reconcile_cached_connection` operation for direct cached transport sessions. Observation and unhealthy-entry retirement now share the registry entry lock, so a concurrent healthy replacement is preserved.
- Retain `is_address_reachable` and `register_processor` as deprecated legacy facades while documenting their actual contracts. The reachability facade performs no DNS, socket, or network probe; request processors remain fixed at fallible builder construction.
- Move legacy facade implementation ownership into a private `compatibility` module while keeping the supported typed state available through `rocketmq_transport::api::v1`. The transport prelude is intentionally unchanged.
- Cover absent, healthy, retired, legacy-cleanup, and concurrent-replacement behavior, and extend the public API contract tests without widening the prelude.
- Update the 1.0 migration guide plus the public API, API-intent, and module-maintainability baselines. The API refresh contains exactly 25 compatible additions across five transport profiles and no other API differences; the maintainability baseline records 2,237 files, 27 crates, 20 ranked hotspots, and no new findings.

### How Did You Test This Change?

Passed validation:

- `cargo fmt -p rocketmq-transport -- --check`
- Focused cached-session reconciliation, legacy-facade, and concurrent-replacement tests
- `cargo test -p rocketmq-transport --lib` (`242 passed`)
- `cargo test -p rocketmq-transport --test public_api_contract` (`15 passed`)
- `cargo test -p rocketmq-transport --test public_api_v1` (`3 passed`)
- Transport all-features tests, no-default-features library tests, and doctests
- Public API intent guard (`rocketmq-transport=145`), fresh 50-profile snapshot comparison, stable-surface target guard, and two byte-identical maintainability baseline generations
- Module maintainability guard (`2,237 files`, `27 crates`, `20 ranked hotspots`, no new findings)
- Runtime ownership audit with boundary-baseline enforcement
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo test -p rocketmq-client-rust --lib` (`1,067 passed`)
- Standalone example Clippy and the applicable RocketMQ MCP check, boundary, test, Clippy, and documentation commands

Known failures were reproduced on the clean base with the same failure sets:

- `RUSTDOCFLAGS="-D warnings" cargo doc -p rocketmq-transport --no-deps --all-features` reports the existing `rocketmq-transport/src/tls.rs:664` Rustdoc failure.
- `python scripts/run_architecture_tests.py --tier pr_static` reports the same six existing static-guard failures.
- The error architecture guard reports the same 19 existing findings as the clean base: 17 source-stringification findings and 2 redaction findings.
- `cargo test -p rocketmq-broker --lib` has the same one existing failing test.
- The standalone example format invocation returns the same Windows exit code 206 path-length failure; its Clippy validation passes.
- The SRE all-features test profile reproduces the same Windows stack overflow, and the SRE control-plane test reproduces the same single existing failure; the remaining applicable SRE checks, Clippy, documentation, and boundary validation pass.

No candidate-new validation failures were found.
