### PR TITLE
[ISSUE #9686]🚀Persist dashboard sessions and management audit

### DIFF
--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.lock
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.lock
@@ -1071,6 +1071,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -1078,7 +1090,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasm-bindgen",
 ]
@@ -2308,6 +2320,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -2573,9 +2591,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "base64 0.22.1",
  "cheetah-string 2.1.0",
  "chrono",
  "fs4",
+ "futures-util",
+ "getrandom 0.3.4",
  "rocketmq-admin-core",
  "rocketmq-dashboard-common",
  "rocketmq-error",
@@ -2583,10 +2604,12 @@ dependencies = [
  "rocketmq-runtime",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "sqlx",
  "tempfile",
  "thiserror",
  "tokio",
+ "tower",
  "tower-http",
  "tracing",
  "uuid",
@@ -4110,6 +4133,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4553,6 +4585,12 @@ checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.toml
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/Cargo.toml
@@ -14,8 +14,11 @@ anyhow = "1.0.103"
 axum = "0.8"
 cheetah-string = { version = "2.1.0", features = ["serde", "bytes", "simd"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+base64 = "0.22"
+getrandom = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.10"
 thiserror = "2.0"
 tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.6", features = ["cors", "fs", "trace"] }
@@ -31,5 +34,7 @@ rocketmq-observability = { version = "1.0.0", path = "../../../rocketmq-observab
 rocketmq-runtime = { version = "1.0.0", path = "../../../rocketmq-runtime" }
 
 [dev-dependencies]
+futures-util = "0.3"
 tempfile = "3"
 tokio = { version = "1", features = ["test-util"] }
+tower = { version = "0.5", features = ["util"] }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/migrations/mysql/0004_session_audit.sql
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/migrations/mysql/0004_session_audit.sql
@@ -1,0 +1,35 @@
+DROP TABLE IF EXISTS dashboard_audit_event;
+DROP TABLE IF EXISTS dashboard_session;
+CREATE TABLE dashboard_session (
+    session_id CHAR(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL UNIQUE,
+    token_hash BINARY(32) NOT NULL PRIMARY KEY,
+    username VARBINARY(128) NOT NULL,
+    created_at_ms BIGINT NOT NULL,
+    expires_at_ms BIGINT NOT NULL,
+    last_seen_at_ms BIGINT NOT NULL,
+    revoked_at_ms BIGINT NULL,
+    KEY dashboard_session_username_active_idx(username, revoked_at_ms, expires_at_ms, created_at_ms, session_id),
+    KEY dashboard_session_keyset_idx(created_at_ms DESC, session_id DESC),
+    KEY dashboard_session_cleanup_idx(expires_at_ms, revoked_at_ms)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE dashboard_audit_event (
+    event_id VARCHAR(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL PRIMARY KEY,
+    request_id VARCHAR(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    actor_kind VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    actor_username VARBINARY(128) NULL,
+    action VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    resource_type VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    resource_name VARBINARY(255) NULL,
+    environment_id VARCHAR(36) CHARACTER SET ascii COLLATE ascii_bin NULL,
+    outcome VARCHAR(32) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    detail_json TEXT NULL,
+    created_at_ms BIGINT NOT NULL,
+    KEY dashboard_audit_event_keyset_idx(created_at_ms DESC, event_id DESC),
+    KEY dashboard_audit_event_actor_idx(actor_username, created_at_ms DESC, event_id DESC),
+    KEY dashboard_audit_event_retention_idx(created_at_ms),
+    KEY dashboard_audit_event_action_time_idx(action, created_at_ms DESC, event_id DESC),
+    KEY dashboard_audit_event_outcome_time_idx(outcome, created_at_ms DESC, event_id DESC),
+    KEY dashboard_audit_event_environment_time_idx(environment_id, created_at_ms DESC, event_id DESC)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+INSERT IGNORE INTO dashboard_schema_migration (version, applied_at_ms) VALUES (4, 0);

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/migrations/postgres/0004_session_audit.sql
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/migrations/postgres/0004_session_audit.sql
@@ -1,0 +1,45 @@
+DROP TABLE IF EXISTS dashboard_audit_event;
+DROP TABLE IF EXISTS dashboard_session;
+CREATE TABLE dashboard_session (
+    session_id VARCHAR(36) COLLATE "C" NOT NULL UNIQUE,
+    token_hash BYTEA NOT NULL PRIMARY KEY CHECK (octet_length(token_hash) = 32),
+    username VARCHAR(128) COLLATE "C" NOT NULL,
+    created_at_ms BIGINT NOT NULL,
+    expires_at_ms BIGINT NOT NULL,
+    last_seen_at_ms BIGINT NOT NULL,
+    revoked_at_ms BIGINT NULL
+);
+CREATE INDEX IF NOT EXISTS dashboard_session_username_active_idx
+    ON dashboard_session(username, revoked_at_ms, expires_at_ms, created_at_ms DESC, session_id DESC);
+CREATE INDEX IF NOT EXISTS dashboard_session_keyset_idx
+    ON dashboard_session(created_at_ms DESC, session_id DESC);
+CREATE INDEX IF NOT EXISTS dashboard_session_cleanup_idx
+    ON dashboard_session(expires_at_ms, revoked_at_ms);
+
+CREATE TABLE dashboard_audit_event (
+    event_id VARCHAR(36) COLLATE "C" NOT NULL PRIMARY KEY,
+    request_id VARCHAR(36) COLLATE "C" NOT NULL,
+    actor_kind VARCHAR(32) COLLATE "C" NOT NULL,
+    actor_username VARCHAR(128) COLLATE "C" NULL,
+    action VARCHAR(128) COLLATE "C" NOT NULL,
+    resource_type VARCHAR(64) COLLATE "C" NOT NULL,
+    resource_name VARCHAR(255) COLLATE "C" NULL,
+    environment_id VARCHAR(36) COLLATE "C" NULL,
+    outcome VARCHAR(32) COLLATE "C" NOT NULL,
+    detail_json TEXT NULL,
+    created_at_ms BIGINT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS dashboard_audit_event_keyset_idx
+    ON dashboard_audit_event(created_at_ms DESC, event_id DESC);
+CREATE INDEX IF NOT EXISTS dashboard_audit_event_actor_idx
+    ON dashboard_audit_event(actor_username, created_at_ms DESC, event_id DESC);
+CREATE INDEX IF NOT EXISTS dashboard_audit_event_retention_idx
+    ON dashboard_audit_event(created_at_ms);
+CREATE INDEX IF NOT EXISTS dashboard_audit_event_action_time_idx
+    ON dashboard_audit_event(action, created_at_ms DESC, event_id DESC);
+CREATE INDEX IF NOT EXISTS dashboard_audit_event_outcome_time_idx
+    ON dashboard_audit_event(outcome, created_at_ms DESC, event_id DESC);
+CREATE INDEX IF NOT EXISTS dashboard_audit_event_environment_time_idx
+    ON dashboard_audit_event(environment_id, created_at_ms DESC, event_id DESC);
+INSERT INTO dashboard_schema_migration (version, applied_at_ms) VALUES (4, 0)
+ON CONFLICT (version) DO NOTHING;

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/migrations/sqlite/0004_session_audit.sql
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/migrations/sqlite/0004_session_audit.sql
@@ -1,0 +1,44 @@
+DROP TABLE IF EXISTS dashboard_audit_event;
+DROP TABLE IF EXISTS dashboard_session;
+CREATE TABLE dashboard_session (
+    session_id TEXT COLLATE BINARY NOT NULL UNIQUE,
+    token_hash BLOB NOT NULL PRIMARY KEY CHECK (length(token_hash) = 32),
+    username TEXT COLLATE BINARY NOT NULL,
+    created_at_ms INTEGER NOT NULL,
+    expires_at_ms INTEGER NOT NULL,
+    last_seen_at_ms INTEGER NOT NULL,
+    revoked_at_ms INTEGER NULL
+);
+CREATE INDEX IF NOT EXISTS dashboard_session_username_active_idx
+    ON dashboard_session(username, revoked_at_ms, expires_at_ms, created_at_ms DESC, session_id DESC);
+CREATE INDEX IF NOT EXISTS dashboard_session_keyset_idx
+    ON dashboard_session(created_at_ms DESC, session_id DESC);
+CREATE INDEX IF NOT EXISTS dashboard_session_cleanup_idx
+    ON dashboard_session(expires_at_ms, revoked_at_ms);
+
+CREATE TABLE dashboard_audit_event (
+    event_id TEXT COLLATE BINARY NOT NULL PRIMARY KEY,
+    request_id TEXT COLLATE BINARY NOT NULL,
+    actor_kind TEXT COLLATE BINARY NOT NULL,
+    actor_username TEXT COLLATE BINARY NULL,
+    action TEXT COLLATE BINARY NOT NULL,
+    resource_type TEXT COLLATE BINARY NOT NULL,
+    resource_name TEXT COLLATE BINARY NULL,
+    environment_id TEXT COLLATE BINARY NULL,
+    outcome TEXT COLLATE BINARY NOT NULL,
+    detail_json TEXT NULL,
+    created_at_ms INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS dashboard_audit_event_keyset_idx
+    ON dashboard_audit_event(created_at_ms DESC, event_id DESC);
+CREATE INDEX IF NOT EXISTS dashboard_audit_event_actor_idx
+    ON dashboard_audit_event(actor_username, created_at_ms DESC, event_id DESC);
+CREATE INDEX IF NOT EXISTS dashboard_audit_event_retention_idx
+    ON dashboard_audit_event(created_at_ms);
+CREATE INDEX IF NOT EXISTS dashboard_audit_event_action_time_idx
+    ON dashboard_audit_event(action, created_at_ms DESC, event_id DESC);
+CREATE INDEX IF NOT EXISTS dashboard_audit_event_outcome_time_idx
+    ON dashboard_audit_event(outcome, created_at_ms DESC, event_id DESC);
+CREATE INDEX IF NOT EXISTS dashboard_audit_event_environment_time_idx
+    ON dashboard_audit_event(environment_id, created_at_ms DESC, event_id DESC);
+INSERT OR IGNORE INTO dashboard_schema_migration (version, applied_at_ms) VALUES (4, 0);

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 pub mod acl_api;
+pub mod audit_api;
 pub mod auth_api;
 pub mod broker_api;
 pub mod config_api;

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/acl_api.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/acl_api.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use crate::error::DashboardError;
+use crate::middleware::AuditTerminalFactSink;
 use crate::model::AclMutationResult;
 use crate::model::AclPolicyRequest;
 use crate::model::AclPolicyView;
@@ -22,6 +23,7 @@ use crate::model::ApiResponse;
 use crate::service;
 use crate::state::AppState;
 use axum::Json;
+use axum::extract::Extension;
 use axum::extract::Path;
 use axum::extract::Query;
 use axum::extract::State;
@@ -35,29 +37,41 @@ pub async fn list_users(
 
 pub async fn create_user(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
     Json(payload): Json<AclUserUpsertRequest>,
 ) -> Result<Json<ApiResponse<AclMutationResult>>, DashboardError> {
-    Ok(Json(ApiResponse::success(service::create_user(&state, payload).await?)))
+    let result = service::create_user(&state, payload).await?;
+    // Access keys and user credentials are never usable audit resource names.
+    audit
+        .record_success(None, Some(state.published().environment.environment_id))
+        .await;
+    Ok(Json(ApiResponse::success(result)))
 }
 
 pub async fn update_user(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
     Path(access_key): Path<String>,
     Json(payload): Json<AclUserUpsertRequest>,
 ) -> Result<Json<ApiResponse<AclMutationResult>>, DashboardError> {
-    Ok(Json(ApiResponse::success(
-        service::update_user(&state, &access_key, payload).await?,
-    )))
+    let result = service::update_user(&state, &access_key, payload).await?;
+    audit
+        .record_success(None, Some(state.published().environment.environment_id))
+        .await;
+    Ok(Json(ApiResponse::success(result)))
 }
 
 pub async fn delete_user(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
     Path(access_key): Path<String>,
     Query(query): Query<AclQuery>,
 ) -> Result<Json<ApiResponse<AclMutationResult>>, DashboardError> {
-    Ok(Json(ApiResponse::success(
-        service::delete_user(&state, &access_key, query).await?,
-    )))
+    let result = service::delete_user(&state, &access_key, query).await?;
+    audit
+        .record_success(None, Some(state.published().environment.environment_id))
+        .await;
+    Ok(Json(ApiResponse::success(result)))
 }
 
 pub async fn list_policies(
@@ -69,29 +83,38 @@ pub async fn list_policies(
 
 pub async fn create_policy(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
     Json(payload): Json<AclPolicyRequest>,
 ) -> Result<Json<ApiResponse<AclMutationResult>>, DashboardError> {
-    Ok(Json(ApiResponse::success(
-        service::create_policy(&state, payload).await?,
-    )))
+    let result = service::create_policy(&state, payload).await?;
+    audit
+        .record_success(None, Some(state.published().environment.environment_id))
+        .await;
+    Ok(Json(ApiResponse::success(result)))
 }
 
 pub async fn update_policy(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
     Path(policy_name): Path<String>,
     Json(payload): Json<AclPolicyRequest>,
 ) -> Result<Json<ApiResponse<AclMutationResult>>, DashboardError> {
-    Ok(Json(ApiResponse::success(
-        service::update_policy(&state, &policy_name, payload).await?,
-    )))
+    let result = service::update_policy(&state, &policy_name, payload).await?;
+    audit
+        .record_success(Some(&policy_name), Some(state.published().environment.environment_id))
+        .await;
+    Ok(Json(ApiResponse::success(result)))
 }
 
 pub async fn delete_policy(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
     Path(policy_name): Path<String>,
     Query(query): Query<AclQuery>,
 ) -> Result<Json<ApiResponse<AclMutationResult>>, DashboardError> {
-    Ok(Json(ApiResponse::success(
-        service::delete_policy(&state, &policy_name, query).await?,
-    )))
+    let result = service::delete_policy(&state, &policy_name, query).await?;
+    audit
+        .record_success(Some(&policy_name), Some(state.published().environment.environment_id))
+        .await;
+    Ok(Json(ApiResponse::success(result)))
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/audit_api.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/audit_api.rs
@@ -1,0 +1,200 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Safe, administrator-only session and audit history projections.
+
+use crate::error::DashboardError;
+use crate::middleware::require_administrator;
+use crate::model::ApiResponse;
+use crate::model::AuditAction;
+use crate::model::AuditEventView;
+use crate::model::AuditOutcome;
+use crate::model::AuthenticatedActor;
+use crate::model::SessionListPage;
+use crate::persistence::audit_repository::AuditCursor;
+use crate::persistence::audit_repository::AuditQuery;
+use crate::service;
+use crate::state::AppState;
+use axum::Json;
+use axum::extract::Extension;
+use axum::extract::Query;
+use axum::extract::State;
+use serde::Deserialize;
+use serde::Serialize;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+const DEFAULT_AUDIT_PAGE_SIZE: usize = 50;
+const DEFAULT_AUDIT_WINDOW_MS: i64 = 24 * 60 * 60 * 1_000;
+const MAX_AUDIT_WINDOW_MS: i64 = 31 * 24 * 60 * 60 * 1_000;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionListRequest {
+    pub username: Option<String>,
+    pub cursor: Option<String>,
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RevokeAllRequest {
+    pub username: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditListRequest {
+    pub start_ms: Option<i64>,
+    pub end_ms: Option<i64>,
+    pub actor: Option<String>,
+    pub action: Option<String>,
+    pub outcome: Option<String>,
+    pub environment_id: Option<String>,
+    pub cursor: Option<String>,
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditListPage {
+    pub events: Vec<AuditEventView>,
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RevokeAllResult {
+    pub revoked: u64,
+}
+
+pub async fn list_sessions(
+    State(state): State<AppState>,
+    Extension(actor): Extension<AuthenticatedActor>,
+    Query(request): Query<SessionListRequest>,
+) -> Result<Json<ApiResponse<SessionListPage>>, DashboardError> {
+    require_administrator(&actor)?;
+    let limit = request.limit.unwrap_or(DEFAULT_AUDIT_PAGE_SIZE);
+    if limit == 0 || limit > 200 {
+        return Err(DashboardError::Validation("session page limit is invalid".to_string()));
+    }
+    Ok(Json(ApiResponse::success(
+        service::list_sessions(&state, &actor, request.username, request.cursor, limit).await?,
+    )))
+}
+
+pub async fn revoke_all_sessions(
+    State(state): State<AppState>,
+    Extension(actor): Extension<AuthenticatedActor>,
+    Json(request): Json<RevokeAllRequest>,
+) -> Result<Json<ApiResponse<RevokeAllResult>>, DashboardError> {
+    require_administrator(&actor)?;
+    let revoked = service::revoke_all_sessions(&state, &actor, request.username).await?;
+    Ok(Json(ApiResponse::success(RevokeAllResult { revoked })))
+}
+
+pub async fn list_events(
+    State(state): State<AppState>,
+    Extension(actor): Extension<AuthenticatedActor>,
+    Query(request): Query<AuditListRequest>,
+) -> Result<Json<ApiResponse<AuditListPage>>, DashboardError> {
+    require_administrator(&actor)?;
+    let now = now_millis();
+    let end_ms = request.end_ms.unwrap_or(now);
+    let start_ms = request
+        .start_ms
+        .unwrap_or_else(|| end_ms.saturating_sub(DEFAULT_AUDIT_WINDOW_MS));
+    if start_ms < 0 || end_ms < start_ms || end_ms.saturating_sub(start_ms) > MAX_AUDIT_WINDOW_MS {
+        return Err(DashboardError::Validation("audit time range is invalid".to_string()));
+    }
+    let limit = request.limit.unwrap_or(DEFAULT_AUDIT_PAGE_SIZE);
+    if limit == 0 || limit > 200 {
+        return Err(DashboardError::Validation("audit page limit is invalid".to_string()));
+    }
+    let action = request
+        .action
+        .as_deref()
+        .map(AuditAction::parse)
+        .transpose_option("audit action is invalid")?;
+    let outcome = request
+        .outcome
+        .as_deref()
+        .map(AuditOutcome::parse)
+        .transpose_option("audit outcome is invalid")?;
+    let page = state
+        .persistence
+        .query_audit_events(AuditQuery {
+            start_ms,
+            end_ms,
+            actor: bounded_filter(request.actor, "audit actor is invalid")?,
+            action,
+            outcome,
+            environment_id: bounded_filter(request.environment_id, "audit environment is invalid")?,
+            cursor: request.cursor.as_deref().map(parse_audit_cursor).transpose()?,
+            limit,
+        })
+        .await?;
+    Ok(Json(ApiResponse::success(AuditListPage {
+        events: page.events.into_iter().map(Into::into).collect(),
+        next_cursor: page
+            .next_cursor
+            .map(|next| format!("{},{}", next.created_at_ms, next.event_id)),
+    })))
+}
+
+fn bounded_filter(value: Option<String>, message: &'static str) -> Result<Option<String>, DashboardError> {
+    if value
+        .as_ref()
+        .is_some_and(|value| value.is_empty() || value.len() > 128)
+    {
+        return Err(DashboardError::Validation(message.to_string()));
+    }
+    Ok(value)
+}
+
+fn parse_audit_cursor(value: &str) -> Result<AuditCursor, DashboardError> {
+    let (created_at_ms, event_id) = value
+        .split_once(',')
+        .ok_or_else(|| DashboardError::Validation("audit cursor is invalid".to_string()))?;
+    if event_id.len() != 36 || uuid::Uuid::parse_str(event_id).is_err() {
+        return Err(DashboardError::Validation("audit cursor is invalid".to_string()));
+    }
+    Ok(AuditCursor {
+        created_at_ms: created_at_ms
+            .parse()
+            .map_err(|_| DashboardError::Validation("audit cursor is invalid".to_string()))?,
+        event_id: event_id.to_string(),
+    })
+}
+
+trait AuditFilterExt<T> {
+    fn transpose_option(self, message: &'static str) -> Result<Option<T>, DashboardError>;
+}
+
+impl<T> AuditFilterExt<T> for Option<Option<T>> {
+    fn transpose_option(self, message: &'static str) -> Result<Option<T>, DashboardError> {
+        match self {
+            None => Ok(None),
+            Some(Some(value)) => Ok(Some(value)),
+            Some(None) => Err(DashboardError::Validation(message.to_string())),
+        }
+    }
+}
+
+fn now_millis() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as i64)
+        .unwrap_or_default()
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/auth_api.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/auth_api.rs
@@ -11,26 +11,79 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 use crate::error::DashboardError;
 use crate::model::ApiResponse;
+use crate::model::AuthenticatedActor;
 use crate::model::LoginRequest;
-use crate::model::SessionView;
+use crate::model::SessionAuthenticationFailure;
 use crate::service;
 use crate::state::AppState;
 use axum::Json;
+use axum::extract::Extension;
 use axum::extract::State;
+use axum::http::HeaderValue;
+use axum::http::header::SET_COOKIE;
+use axum::response::IntoResponse;
+use axum::response::Response;
 
-pub async fn session(State(state): State<AppState>) -> Result<Json<ApiResponse<SessionView>>, DashboardError> {
-    Ok(Json(ApiResponse::success(service::session(&state).await?)))
+pub async fn session(
+    State(state): State<AppState>,
+    actor: Option<Extension<AuthenticatedActor>>,
+    failure: Option<Extension<SessionAuthenticationFailure>>,
+) -> Result<Response, DashboardError> {
+    let mut session = service::session_view(&state, actor.as_ref().map(|actor| &actor.0)).await?;
+    let stale_credential = failure.is_some();
+    if let Some(failure) = failure {
+        session.auth_reason = Some(failure.0.code().to_string());
+    }
+    let mut response = Json(ApiResponse::success(session)).into_response();
+    if stale_credential {
+        response
+            .headers_mut()
+            .append(SET_COOKIE, clear_session_cookie(state.auth_state.cookie_secure())?);
+    }
+    Ok(response)
 }
 
 pub async fn login(
     State(state): State<AppState>,
     Json(request): Json<LoginRequest>,
-) -> Result<Json<ApiResponse<SessionView>>, DashboardError> {
-    Ok(Json(ApiResponse::success(service::login(&state, request).await?)))
+) -> Result<Response, DashboardError> {
+    let session = service::login(&state, request).await?;
+    let mut response = Json(ApiResponse::success(session.clone())).into_response();
+    if let Some(token) = session.session_id {
+        response
+            .headers_mut()
+            .append(SET_COOKIE, session_cookie(&token, state.auth_state.cookie_secure())?);
+    }
+    Ok(response)
 }
 
-pub async fn logout(State(state): State<AppState>) -> Result<Json<ApiResponse<SessionView>>, DashboardError> {
-    Ok(Json(ApiResponse::success(service::logout(&state).await?)))
+pub async fn logout(
+    State(state): State<AppState>,
+    Extension(actor): Extension<AuthenticatedActor>,
+) -> Result<Response, DashboardError> {
+    let session = service::logout(&state, &actor).await?;
+    let mut response = Json(ApiResponse::success(session)).into_response();
+    response
+        .headers_mut()
+        .append(SET_COOKIE, clear_session_cookie(state.auth_state.cookie_secure())?);
+    Ok(response)
+}
+
+fn session_cookie(token: &str, secure: bool) -> Result<HeaderValue, DashboardError> {
+    let secure = if secure { "; Secure" } else { "" };
+    HeaderValue::from_str(&format!(
+        "dashboard_session={token}; Path=/; HttpOnly; SameSite=Strict{secure}"
+    ))
+    .map_err(|_| DashboardError::Internal("Could not create session cookie".to_string()))
+}
+
+fn clear_session_cookie(secure: bool) -> Result<HeaderValue, DashboardError> {
+    let secure = if secure { "; Secure" } else { "" };
+    HeaderValue::from_str(&format!(
+        "dashboard_session=; Path=/; HttpOnly; SameSite=Strict; Max-Age=0{secure}"
+    ))
+    .map_err(|_| DashboardError::Internal("Could not clear session cookie".to_string()))
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/broker_api.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/broker_api.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use crate::error::DashboardError;
+use crate::middleware::AuditTerminalFactSink;
 use crate::model::ApiResponse;
 use crate::model::BrokerConfigUpdateRequest;
 use crate::model::BrokerConfigView;
@@ -21,6 +22,7 @@ use crate::model::MutationResult;
 use crate::service;
 use crate::state::AppState;
 use axum::Json;
+use axum::extract::Extension;
 use axum::extract::Path;
 use axum::extract::State;
 
@@ -48,10 +50,13 @@ pub async fn broker_config(
 
 pub async fn update_broker_config(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
     Path(broker_name): Path<String>,
     Json(request): Json<BrokerConfigUpdateRequest>,
 ) -> Result<Json<ApiResponse<MutationResult>>, DashboardError> {
-    Ok(Json(ApiResponse::success(
-        service::update_broker_config(&state, &broker_name, request).await?,
-    )))
+    let result = service::update_broker_config(&state, &broker_name, request).await?;
+    audit
+        .record_success(Some(&broker_name), Some(state.published().environment.environment_id))
+        .await;
+    Ok(Json(ApiResponse::success(result)))
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/config_api.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/config_api.rs
@@ -12,8 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use crate::error::DashboardError;
+use crate::middleware::AuditTerminalFactSink;
+use crate::middleware::successful_mutation_audit_event;
 use crate::model::AddressRequest;
 use crate::model::ApiResponse;
+use crate::model::AuditAction;
+use crate::model::AuditResourceType;
+use crate::model::AuthenticatedActor;
 use crate::model::BoolSettingRequest;
 use crate::model::ConfigMutationResult;
 use crate::model::DashboardConfigView;
@@ -31,6 +36,7 @@ use crate::service::switch_nameserver as switch_nameserver_service;
 use crate::service::switch_proxy as switch_proxy_service;
 use crate::state::AppState;
 use axum::Json;
+use axum::extract::Extension;
 use axum::extract::Path;
 use axum::extract::Query;
 use axum::extract::State;
@@ -51,79 +57,215 @@ pub async fn get_nameserver_availability(
 
 pub async fn replace_nameservers(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
+    Extension(actor): Extension<AuthenticatedActor>,
     Json(request): Json<NameserverListRequest>,
 ) -> Result<Json<ApiResponse<ConfigMutationResult>>, DashboardError> {
-    Ok(Json(ApiResponse::success(
-        crate::service::replace_nameservers(&state, request).await?,
-    )))
+    let resource_name = request.current_namesrv.clone();
+    let atomic_audit = config_audit(
+        &state,
+        &actor,
+        AuditAction::ConfigNameserverReplace,
+        AuditResourceType::Nameserver,
+        resource_name.as_deref(),
+    );
+    let result = crate::service::replace_nameservers(&state, request, Some(atomic_audit)).await?;
+    audit
+        .record_persisted_success(resource_name.as_deref(), Some(result.config.environment_id.clone()))
+        .await;
+    Ok(Json(ApiResponse::success(result)))
 }
 
 pub async fn add_nameserver(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
+    Extension(actor): Extension<AuthenticatedActor>,
     Json(request): Json<AddressRequest>,
 ) -> Result<Json<ApiResponse<ConfigMutationResult>>, DashboardError> {
-    Ok(Json(ApiResponse::success(
-        crate::service::add_nameserver(&state, request).await?,
-    )))
+    let resource_name = request.address.clone();
+    let atomic_audit = config_audit(
+        &state,
+        &actor,
+        AuditAction::ConfigNameserverAdd,
+        AuditResourceType::Nameserver,
+        Some(&resource_name),
+    );
+    let result = crate::service::add_nameserver(&state, request, Some(atomic_audit)).await?;
+    audit
+        .record_persisted_success(Some(&resource_name), Some(result.config.environment_id.clone()))
+        .await;
+    Ok(Json(ApiResponse::success(result)))
 }
 
 pub async fn switch_nameserver(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
+    Extension(actor): Extension<AuthenticatedActor>,
     Json(request): Json<EndpointRequest>,
 ) -> Result<Json<ApiResponse<ConfigMutationResult>>, DashboardError> {
-    Ok(Json(ApiResponse::success(
-        switch_nameserver_service(&state, request).await?,
-    )))
+    let resource_name = request.endpoint_id.0.clone();
+    let atomic_audit = config_audit(
+        &state,
+        &actor,
+        AuditAction::ConfigNameserverSwitch,
+        AuditResourceType::Nameserver,
+        Some(&resource_name),
+    );
+    let result = switch_nameserver_service(&state, request, Some(atomic_audit)).await?;
+    audit
+        .record_persisted_success(Some(&resource_name), Some(result.config.environment_id.clone()))
+        .await;
+    Ok(Json(ApiResponse::success(result)))
 }
 
 pub async fn delete_nameserver(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
+    Extension(actor): Extension<AuthenticatedActor>,
     Path(endpoint_id): Path<EndpointId>,
     Query(expected_revision): Query<ExpectedRevision>,
 ) -> Result<Json<ApiResponse<ConfigMutationResult>>, DashboardError> {
-    Ok(Json(ApiResponse::success(
-        delete_nameserver_service(&state, &endpoint_id, expected_revision.expected_revision).await?,
-    )))
+    let atomic_audit = config_audit(
+        &state,
+        &actor,
+        AuditAction::ConfigNameserverDelete,
+        AuditResourceType::Nameserver,
+        Some(&endpoint_id.0),
+    );
+    let result = delete_nameserver_service(
+        &state,
+        &endpoint_id,
+        expected_revision.expected_revision,
+        Some(atomic_audit),
+    )
+    .await?;
+    audit
+        .record_persisted_success(Some(&endpoint_id.0), Some(result.config.environment_id.clone()))
+        .await;
+    Ok(Json(ApiResponse::success(result)))
 }
 
 pub async fn set_vip_channel(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
+    Extension(actor): Extension<AuthenticatedActor>,
     Json(request): Json<BoolSettingRequest>,
 ) -> Result<Json<ApiResponse<ConfigMutationResult>>, DashboardError> {
-    Ok(Json(ApiResponse::success(
-        set_vip_channel_service(&state, request).await?,
-    )))
+    let atomic_audit = config_audit(
+        &state,
+        &actor,
+        AuditAction::ConfigVipSet,
+        AuditResourceType::Environment,
+        None,
+    );
+    let result = set_vip_channel_service(&state, request, Some(atomic_audit)).await?;
+    audit
+        .record_persisted_success(None, Some(result.config.environment_id.clone()))
+        .await;
+    Ok(Json(ApiResponse::success(result)))
 }
 
 pub async fn set_tls(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
+    Extension(actor): Extension<AuthenticatedActor>,
     Json(request): Json<BoolSettingRequest>,
 ) -> Result<Json<ApiResponse<ConfigMutationResult>>, DashboardError> {
-    Ok(Json(ApiResponse::success(set_tls_service(&state, request).await?)))
+    let atomic_audit = config_audit(
+        &state,
+        &actor,
+        AuditAction::ConfigTlsSet,
+        AuditResourceType::Environment,
+        None,
+    );
+    let result = set_tls_service(&state, request, Some(atomic_audit)).await?;
+    audit
+        .record_persisted_success(None, Some(result.config.environment_id.clone()))
+        .await;
+    Ok(Json(ApiResponse::success(result)))
 }
 
 pub async fn add_proxy(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
+    Extension(actor): Extension<AuthenticatedActor>,
     Json(request): Json<AddressRequest>,
 ) -> Result<Json<ApiResponse<ConfigMutationResult>>, DashboardError> {
-    Ok(Json(ApiResponse::success(
-        crate::service::add_proxy(&state, request).await?,
-    )))
+    let resource_name = request.address.clone();
+    let atomic_audit = config_audit(
+        &state,
+        &actor,
+        AuditAction::ConfigProxyAdd,
+        AuditResourceType::Proxy,
+        Some(&resource_name),
+    );
+    let result = crate::service::add_proxy(&state, request, Some(atomic_audit)).await?;
+    audit
+        .record_persisted_success(Some(&resource_name), Some(result.config.environment_id.clone()))
+        .await;
+    Ok(Json(ApiResponse::success(result)))
 }
 
 pub async fn switch_proxy(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
+    Extension(actor): Extension<AuthenticatedActor>,
     Json(request): Json<EndpointRequest>,
 ) -> Result<Json<ApiResponse<ConfigMutationResult>>, DashboardError> {
-    Ok(Json(ApiResponse::success(switch_proxy_service(&state, request).await?)))
+    let resource_name = request.endpoint_id.0.clone();
+    let atomic_audit = config_audit(
+        &state,
+        &actor,
+        AuditAction::ConfigProxySwitch,
+        AuditResourceType::Proxy,
+        Some(&resource_name),
+    );
+    let result = switch_proxy_service(&state, request, Some(atomic_audit)).await?;
+    audit
+        .record_persisted_success(Some(&resource_name), Some(result.config.environment_id.clone()))
+        .await;
+    Ok(Json(ApiResponse::success(result)))
 }
 
 pub async fn delete_proxy(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
+    Extension(actor): Extension<AuthenticatedActor>,
     Path(endpoint_id): Path<EndpointId>,
     Query(expected_revision): Query<ExpectedRevision>,
 ) -> Result<Json<ApiResponse<ConfigMutationResult>>, DashboardError> {
-    Ok(Json(ApiResponse::success(
-        delete_proxy_service(&state, &endpoint_id, expected_revision.expected_revision).await?,
-    )))
+    let atomic_audit = config_audit(
+        &state,
+        &actor,
+        AuditAction::ConfigProxyDelete,
+        AuditResourceType::Proxy,
+        Some(&endpoint_id.0),
+    );
+    let result = delete_proxy_service(
+        &state,
+        &endpoint_id,
+        expected_revision.expected_revision,
+        Some(atomic_audit),
+    )
+    .await?;
+    audit
+        .record_persisted_success(Some(&endpoint_id.0), Some(result.config.environment_id.clone()))
+        .await;
+    Ok(Json(ApiResponse::success(result)))
+}
+
+fn config_audit(
+    state: &AppState,
+    actor: &AuthenticatedActor,
+    action: AuditAction,
+    resource_type: AuditResourceType,
+    resource_name: Option<&str>,
+) -> crate::model::AuditEvent {
+    successful_mutation_audit_event(
+        actor,
+        action,
+        resource_type,
+        resource_name,
+        Some(state.published().environment.environment_id),
+    )
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/consumer_api.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/consumer_api.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use crate::error::DashboardError;
+use crate::middleware::AuditTerminalFactSink;
 use crate::model::ApiResponse;
 use crate::model::ConsumerBrokerListView;
 use crate::model::ConsumerConfigView;
@@ -30,6 +31,7 @@ use crate::model::MutationResult;
 use crate::service;
 use crate::state::AppState;
 use axum::Json;
+use axum::extract::Extension;
 use axum::extract::Path;
 use axum::extract::Query;
 use axum::extract::State;
@@ -114,6 +116,7 @@ pub async fn consumer_brokers(
 
 pub async fn create_consumer(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
     Json(request): Json<ConsumerUpsertView>,
 ) -> Result<Json<ApiResponse<ConsumerOperationResult>>, DashboardError> {
     let group = request
@@ -122,37 +125,50 @@ pub async fn create_consumer(
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
         .ok_or_else(|| DashboardError::Validation("Consumer group is required".to_string()))?;
-    Ok(Json(ApiResponse::success(
-        service::create_consumer(&state, &group, request).await?,
-    )))
+    let result = service::create_consumer(&state, &group, request).await?;
+    record_consumer_operation(&audit, &state, &result).await;
+    Ok(Json(ApiResponse::success(result)))
 }
 
 pub async fn update_consumer(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
     Path(group): Path<String>,
     Json(request): Json<ConsumerUpsertView>,
 ) -> Result<Json<ApiResponse<ConsumerOperationResult>>, DashboardError> {
-    Ok(Json(ApiResponse::success(
-        service::update_consumer(&state, &group, request).await?,
-    )))
+    let result = service::update_consumer(&state, &group, request).await?;
+    record_consumer_operation(&audit, &state, &result).await;
+    Ok(Json(ApiResponse::success(result)))
 }
 
 pub async fn delete_consumer(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
     Path(group): Path<String>,
     Json(request): Json<ConsumerDeleteView>,
 ) -> Result<Json<ApiResponse<ConsumerOperationResult>>, DashboardError> {
-    Ok(Json(ApiResponse::success(
-        service::delete_consumer(&state, &group, request).await?,
-    )))
+    let result = service::delete_consumer(&state, &group, request).await?;
+    record_consumer_operation(&audit, &state, &result).await;
+    Ok(Json(ApiResponse::success(result)))
 }
 
 pub async fn reset_offset(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
     Path(group): Path<String>,
     Json(request): Json<ConsumerResetOffsetRequest>,
 ) -> Result<Json<ApiResponse<MutationResult>>, DashboardError> {
-    Ok(Json(ApiResponse::success(
-        service::reset_consumer_offset(&state, &group, request).await?,
-    )))
+    let result = service::reset_consumer_offset(&state, &group, request).await?;
+    let environment_id = Some(state.published().environment.environment_id);
+    audit.record_success(Some(&group), environment_id).await;
+    Ok(Json(ApiResponse::success(result)))
+}
+
+async fn record_consumer_operation(audit: &AuditTerminalFactSink, state: &AppState, result: &ConsumerOperationResult) {
+    let environment_id = Some(state.published().environment.environment_id);
+    if result.success {
+        audit.record_success(Some(&result.consumer_group), environment_id).await;
+    } else {
+        audit.record_failed(Some(&result.consumer_group), environment_id).await;
+    }
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/health_api.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/health_api.rs
@@ -21,7 +21,14 @@ use axum::extract::State;
 use axum::http::StatusCode;
 
 pub async fn health(State(state): State<AppState>) -> (StatusCode, Json<ApiResponse<HealthStatus>>) {
-    readiness_response(readiness_status(&state.persistence, state.history_runtime.health().await).await)
+    readiness_response(
+        readiness_status(
+            &state.persistence,
+            state.history_runtime.health().await,
+            state.session_audit_cleanup_runtime.health().await,
+        )
+        .await,
+    )
 }
 
 pub async fn live() -> Json<ApiResponse<HealthStatus>> {
@@ -29,7 +36,14 @@ pub async fn live() -> Json<ApiResponse<HealthStatus>> {
 }
 
 pub async fn ready(State(state): State<AppState>) -> (StatusCode, Json<ApiResponse<HealthStatus>>) {
-    readiness_response(readiness_status(&state.persistence, state.history_runtime.health().await).await)
+    readiness_response(
+        readiness_status(
+            &state.persistence,
+            state.history_runtime.health().await,
+            state.session_audit_cleanup_runtime.health().await,
+        )
+        .await,
+    )
 }
 
 fn readiness_response(status: HealthStatus) -> (StatusCode, Json<ApiResponse<HealthStatus>>) {
@@ -72,6 +86,7 @@ mod tests {
                 idle_connections: None,
             }),
             history: None,
+            session_audit_cleanup: None,
         });
 
         assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/message_api.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/message_api.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use crate::error::DashboardError;
+use crate::middleware::AuditTerminalFactSink;
 use crate::model::ApiResponse;
 use crate::model::DlqBatchResendRequest;
 use crate::model::DlqExportView;
@@ -25,6 +26,7 @@ use crate::model::MessageTraceView;
 use crate::service;
 use crate::state::AppState;
 use axum::Json;
+use axum::extract::Extension;
 use axum::extract::Path;
 use axum::extract::Query;
 use axum::extract::State;
@@ -83,12 +85,18 @@ pub async fn message_trace(
 
 pub async fn resend_message(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
     Path(message_id): Path<String>,
     Json(request): Json<MessageResendRequest>,
 ) -> Result<Json<ApiResponse<MessageResendResult>>, DashboardError> {
-    Ok(Json(ApiResponse::success(
-        service::resend_message(&state, &message_id, request).await?,
-    )))
+    let result = service::resend_message(&state, &message_id, request).await?;
+    let environment_id = Some(state.published().environment.environment_id);
+    if result.success {
+        audit.record_success(Some(&message_id), environment_id).await;
+    } else {
+        audit.record_failed(Some(&message_id), environment_id).await;
+    }
+    Ok(Json(ApiResponse::success(result)))
 }
 
 pub async fn query_dlq_messages(
@@ -102,18 +110,29 @@ pub async fn query_dlq_messages(
 
 pub async fn resend_dlq_message(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
     Json(payload): Json<DlqBatchResendRequest>,
 ) -> Result<Json<ApiResponse<Vec<DlqMessageResendResult>>>, DashboardError> {
-    Ok(Json(ApiResponse::success(
-        service::resend_dlq_messages(&state, payload).await?,
-    )))
+    let result = service::resend_dlq_messages(&state, payload).await?;
+    let succeeded = !result.is_empty() && result.iter().all(|entry| entry.success);
+    let environment_id = Some(state.published().environment.environment_id);
+    if succeeded {
+        audit.record_success(None, environment_id).await;
+    } else {
+        audit.record_failed(None, environment_id).await;
+    }
+    Ok(Json(ApiResponse::success(result)))
 }
 
 pub async fn export_dlq_messages(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
     Query(query): Query<DlqMessageQuery>,
 ) -> Result<Json<ApiResponse<DlqExportView>>, DashboardError> {
-    Ok(Json(ApiResponse::success(
-        service::export_dlq_messages(&state, query).await?,
-    )))
+    let resource_name = query.consumer_group.clone();
+    let result = service::export_dlq_messages(&state, query).await?;
+    audit
+        .record_success(Some(&resource_name), Some(state.published().environment.environment_id))
+        .await;
+    Ok(Json(ApiResponse::success(result)))
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/monitor_api.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/monitor_api.rs
@@ -12,7 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use crate::error::DashboardError;
+use crate::middleware::AuditTerminalFactSink;
+use crate::middleware::successful_mutation_audit_event;
 use crate::model::ApiResponse;
+use crate::model::AuditAction;
+use crate::model::AuditResourceType;
+use crate::model::AuthenticatedActor;
 use crate::model::ConsumerMonitorMutationResult;
 use crate::model::ConsumerMonitorUpsertRequest;
 use crate::model::ConsumerMonitorView;
@@ -21,6 +26,7 @@ use crate::model::MonitorEnvironmentQuery;
 use crate::service;
 use crate::state::AppState;
 use axum::Json;
+use axum::extract::Extension;
 use axum::extract::Path;
 use axum::extract::Query;
 use axum::extract::State;
@@ -36,20 +42,53 @@ pub async fn list_consumer_monitors(
 
 pub async fn create_consumer_monitor(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
+    Extension(actor): Extension<AuthenticatedActor>,
     Json(payload): Json<ConsumerMonitorUpsertRequest>,
 ) -> Result<Json<ApiResponse<ConsumerMonitorMutationResult>>, DashboardError> {
-    Ok(Json(ApiResponse::success(
-        service::create_or_update_consumer_monitor(&state, payload).await?,
-    )))
+    let resource_name = payload.consumer_group.clone();
+    let environment_id = Some(payload.environment_id.clone());
+    let atomic_audit = successful_mutation_audit_event(
+        &actor,
+        AuditAction::MonitorUpsert,
+        AuditResourceType::Monitor,
+        Some(&resource_name),
+        environment_id.clone(),
+    );
+    let result = service::create_or_update_consumer_monitor(&state, payload, Some(atomic_audit)).await?;
+    audit
+        .record_persisted_success(Some(&resource_name), environment_id)
+        .await;
+    Ok(Json(ApiResponse::success(result)))
 }
 
 pub async fn delete_consumer_monitor(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
+    Extension(actor): Extension<AuthenticatedActor>,
     Path(consumer_group): Path<String>,
     Query(query): Query<MonitorDeleteQuery>,
 ) -> Result<Json<ApiResponse<ConsumerMonitorMutationResult>>, DashboardError> {
-    Ok(Json(ApiResponse::success(
-        service::delete_consumer_monitor(&state, &query.environment_id, &consumer_group, query.expected_revision)
-            .await?,
-    )))
+    let environment_id = Some(query.environment_id.clone());
+    let atomic_audit = successful_mutation_audit_event(
+        &actor,
+        AuditAction::MonitorDelete,
+        AuditResourceType::Monitor,
+        Some(&consumer_group),
+        environment_id.clone(),
+    );
+    let result = service::delete_consumer_monitor(
+        &state,
+        &query.environment_id,
+        &consumer_group,
+        query.expected_revision,
+        Some(atomic_audit),
+    )
+    .await?;
+    if result.message.ends_with("deleted") {
+        audit
+            .record_persisted_success(Some(&consumer_group), environment_id)
+            .await;
+    }
+    Ok(Json(ApiResponse::success(result)))
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/router.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/router.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use crate::api::acl_api;
+use crate::api::audit_api;
 use crate::api::auth_api;
 use crate::api::broker_api;
 use crate::api::config_api;
@@ -22,10 +23,16 @@ use crate::api::message_api;
 use crate::api::monitor_api;
 use crate::api::producer_api;
 use crate::api::topic_api;
+use crate::middleware::audit_mutation;
 use crate::middleware::http_trace_layer;
+use crate::middleware::optional_auth;
 use crate::middleware::require_auth;
 use crate::state::AppState;
 use axum::Router;
+use axum::http::HeaderValue;
+use axum::http::header::AUTHORIZATION;
+use axum::http::header::CONTENT_TYPE;
+use axum::http::header::HeaderName;
 use axum::middleware;
 use axum::routing::delete;
 use axum::routing::get;
@@ -150,17 +157,219 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/config/proxies", post(config_api::add_proxy))
         .route("/api/config/proxies/current", put(config_api::switch_proxy))
         .route("/api/config/proxies/{endpoint_id}", delete(config_api::delete_proxy))
+        // Authentication is outermost so the audit middleware receives the
+        // repository-validated actor extension, never a client claim.
+        .route_layer(middleware::from_fn_with_state(state.clone(), audit_mutation))
         .route_layer(middleware::from_fn_with_state(state.clone(), require_auth));
 
-    Router::new()
+    let session_status_route = Router::new()
+        .route("/api/auth/session", get(auth_api::session))
+        .layer(middleware::from_fn_with_state(state.clone(), optional_auth));
+    let secured_auth_routes = Router::new()
+        .route("/api/auth/logout", post(auth_api::logout))
+        .layer(middleware::from_fn_with_state(state.clone(), require_auth));
+    let auth_routes = session_status_route.merge(secured_auth_routes);
+
+    let admin_session_audit_routes = Router::new()
+        .route("/api/auth/sessions", get(audit_api::list_sessions))
+        .route("/api/auth/sessions/revoke-all", post(audit_api::revoke_all_sessions))
+        .route("/api/audit/events", get(audit_api::list_events))
+        .layer(middleware::from_fn_with_state(state.clone(), require_auth));
+
+    let router = Router::new()
         .route("/api/health", get(health_api::health))
         .route("/api/health/live", get(health_api::live))
         .route("/api/health/ready", get(health_api::ready))
-        .route("/api/auth/session", get(auth_api::session))
         .route("/api/auth/login", post(auth_api::login))
-        .route("/api/auth/logout", post(auth_api::logout))
+        .merge(auth_routes)
+        .merge(admin_session_audit_routes)
         .merge(protected_routes)
-        .layer(CorsLayer::permissive())
         .layer(http_trace_layer())
-        .with_state(state)
+        .with_state(state.clone());
+
+    let Some(origin) = state.auth_state.allowed_origin() else {
+        return router;
+    };
+    router.layer(cors_layer(origin))
+}
+
+fn cors_layer(origin: HeaderValue) -> CorsLayer {
+    CorsLayer::new()
+        .allow_origin(origin)
+        .allow_credentials(true)
+        .allow_methods([
+            axum::http::Method::GET,
+            axum::http::Method::POST,
+            axum::http::Method::PUT,
+            axum::http::Method::DELETE,
+        ])
+        .allow_headers([
+            AUTHORIZATION,
+            CONTENT_TYPE,
+            HeaderName::from_static("x-dashboard-session"),
+        ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_router;
+    use super::cors_layer;
+    use crate::config::AppConfig;
+    use crate::config::AuthConfig;
+    use crate::config::ServerConfig;
+    use crate::config::SqlPoolConfig;
+    use crate::config::StorageConfig;
+    use crate::model::DashboardConfigView;
+    use crate::model::LoginRequest;
+    use crate::model::StorageBackend;
+    use crate::service;
+    use crate::state::AppState;
+    use axum::Router;
+    use axum::body::Body;
+    use axum::body::to_bytes;
+    use axum::http::HeaderValue;
+    use axum::http::Request;
+    use axum::http::StatusCode;
+    use axum::http::header::AUTHORIZATION;
+    use axum::routing::get;
+    use rocketmq_admin_core::client_adapter::ClientRuntime;
+    use rocketmq_admin_core::client_adapter::ClientRuntimeConfig;
+    use rocketmq_runtime::RuntimeConfig;
+    use rocketmq_runtime::RuntimeOwner;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    fn test_config(data_path: PathBuf) -> AppConfig {
+        AppConfig {
+            server: ServerConfig {
+                host: "127.0.0.1".to_string(),
+                port: 0,
+            },
+            storage: StorageConfig {
+                backend: StorageBackend::File,
+                data_path,
+                database_url: None,
+                pool: SqlPoolConfig::default(),
+            },
+            auth: AuthConfig {
+                login_required: true,
+                username: "admin".to_string(),
+                password: "test-password".to_string(),
+                cookie_secure: false,
+                ..AuthConfig::default()
+            },
+            dashboard_history_interval_secs: 0,
+            dashboard_history_retention_days: 30,
+            dashboard_history_retention_batch_size: 500,
+            dashboard_history_lease_ttl_secs: 30,
+            initial_config: DashboardConfigView::default(),
+            admin_credentials: None,
+        }
+    }
+
+    async fn test_state(owner: &RuntimeOwner, data_path: PathBuf) -> (AppState, Arc<ClientRuntime>) {
+        let client_runtime = ClientRuntime::try_new(
+            owner.root_context().component("router-auth-test-admin-client"),
+            ClientRuntimeConfig::default(),
+            rocketmq_observability::TelemetryHandle::noop(),
+        )
+        .expect("client runtime");
+        let state = AppState::try_new_without_environment_convergence(test_config(data_path), client_runtime.clone())
+            .await
+            .expect("app state");
+        (state, client_runtime)
+    }
+
+    #[tokio::test]
+    async fn exact_origin_uses_credentialed_preflight_without_panicking() {
+        let app = Router::new()
+            .route("/api/ping", get(|| async { "ok" }))
+            .layer(cors_layer(HeaderValue::from_static("https://console.example")));
+        let request = Request::builder()
+            .method("OPTIONS")
+            .uri("/api/ping")
+            .header("origin", "https://console.example")
+            .header("access-control-request-method", "POST")
+            .body(Body::empty())
+            .expect("valid preflight request");
+
+        let response = app.oneshot(request).await.expect("cors layer response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get("access-control-allow-origin")
+                .and_then(|value| value.to_str().ok()),
+            Some("https://console.example")
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get("access-control-allow-credentials")
+                .and_then(|value| value.to_str().ok()),
+            Some("true")
+        );
+    }
+
+    #[test]
+    fn session_status_propagates_ambiguous_credentials_and_accepts_identical_duplicates() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let owner = RuntimeOwner::new(RuntimeConfig::default()).expect("runtime owner");
+        owner.block_on(async {
+            let (state, client_runtime) = test_state(&owner, directory.path().join("dashboard")).await;
+            let session = service::login(
+                &state,
+                LoginRequest {
+                    username: "admin".to_string(),
+                    password: "test-password".to_string(),
+                },
+            )
+            .await
+            .expect("login");
+            let token = session.session_id.expect("session token");
+            let app = build_router(state.clone());
+
+            let identical_request = Request::builder()
+                .uri("/api/auth/session")
+                .header("x-dashboard-session", &token)
+                .header(AUTHORIZATION, format!("Bearer {token}"))
+                .header("cookie", format!("dashboard_session={token}"))
+                .body(Body::empty())
+                .expect("identical credential request");
+            let identical_response = app.clone().oneshot(identical_request).await.expect("session response");
+            assert_eq!(identical_response.status(), StatusCode::OK);
+            let identical_body = to_bytes(identical_response.into_body(), 4_096)
+                .await
+                .expect("session body");
+            let identical_json: serde_json::Value = serde_json::from_slice(&identical_body).expect("session json");
+            assert_eq!(identical_json["data"]["authenticated"], true);
+
+            for uri in ["/api/auth/session", "/api/dashboard/overview"] {
+                let request = Request::builder()
+                    .uri(uri)
+                    .header("x-dashboard-session", "header-secret")
+                    .header(AUTHORIZATION, "Bearer bearer-secret")
+                    .header("cookie", "dashboard_session=cookie-secret")
+                    .body(Body::empty())
+                    .expect("conflicting credential request");
+                let response = app.clone().oneshot(request).await.expect("error response");
+                assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+                let body = to_bytes(response.into_body(), 4_096).await.expect("error body");
+                let json: serde_json::Value = serde_json::from_slice(&body).expect("error json");
+                assert_eq!(json["code"], "AUTH_TOKEN_AMBIGUOUS");
+                assert_eq!(json["message"], "Ambiguous session credentials");
+                let text = String::from_utf8(body.to_vec()).expect("utf-8 error body");
+                assert!(!text.contains("header-secret"));
+                assert!(!text.contains("bearer-secret"));
+                assert!(!text.contains("cookie-secret"));
+            }
+
+            drop(app);
+            drop(state);
+            client_runtime.shutdown().await.log_if_unhealthy();
+        });
+        owner.shutdown_runtime_blocking().expect("runtime shutdown");
+    }
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/topic_api.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/api/topic_api.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use crate::error::DashboardError;
+use crate::middleware::AuditTerminalFactSink;
 use crate::model::ApiResponse;
 use crate::model::TopicConfigView;
 use crate::model::TopicConsumersView;
@@ -29,6 +30,7 @@ use crate::model::TopicTestMessageRequest;
 use crate::service;
 use crate::state::AppState;
 use axum::Json;
+use axum::extract::Extension;
 use axum::extract::Path;
 use axum::extract::Query;
 use axum::extract::State;
@@ -53,68 +55,95 @@ pub async fn get_topic(
 
 pub async fn create_topic(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
     Json(request): Json<TopicMutationRequest>,
 ) -> Result<Json<ApiResponse<TopicOperationResult>>, DashboardError> {
-    Ok(Json(ApiResponse::success(
-        service::create_topic(&state, request).await?,
-    )))
+    let result = service::create_topic(&state, request).await?;
+    record_topic_operation(&audit, &state, &result).await;
+    Ok(Json(ApiResponse::success(result)))
 }
 
 pub async fn update_topic(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
     Path(topic): Path<String>,
     Json(mut request): Json<TopicMutationRequest>,
 ) -> Result<Json<ApiResponse<TopicOperationResult>>, DashboardError> {
     request.topic = topic;
-    Ok(Json(ApiResponse::success(
-        service::create_or_update_topic(&state, request).await?,
-    )))
+    let result = service::create_or_update_topic(&state, request).await?;
+    record_topic_operation(&audit, &state, &result).await;
+    Ok(Json(ApiResponse::success(result)))
 }
 
 pub async fn delete_topic(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
     Path(topic): Path<String>,
 ) -> Result<Json<ApiResponse<TopicOperationResult>>, DashboardError> {
-    Ok(Json(ApiResponse::success(service::delete_topic(&state, &topic).await?)))
+    let result = service::delete_topic(&state, &topic).await?;
+    record_topic_operation(&audit, &state, &result).await;
+    Ok(Json(ApiResponse::success(result)))
 }
 
 pub async fn send_topic_test_message(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
     Path(topic): Path<String>,
     Json(request): Json<TopicTestMessageRequest>,
 ) -> Result<Json<ApiResponse<TopicSendResultView>>, DashboardError> {
-    Ok(Json(ApiResponse::success(
-        service::send_topic_test_message(&state, &topic, request).await?,
-    )))
+    let result = service::send_topic_test_message(&state, &topic, request).await?;
+    record_terminal_outcome(&audit, &state, &result.topic, result.success).await;
+    Ok(Json(ApiResponse::success(result)))
 }
 
 pub async fn reset_topic_consumer_offset(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
     Path(topic): Path<String>,
     Json(request): Json<TopicResetOffsetRequest>,
 ) -> Result<Json<ApiResponse<TopicOffsetResult>>, DashboardError> {
-    Ok(Json(ApiResponse::success(
-        service::reset_topic_consumer_offset(&state, &topic, request).await?,
-    )))
+    let result = service::reset_topic_consumer_offset(&state, &topic, request).await?;
+    record_terminal_outcome(&audit, &state, &result.topic, result.success).await;
+    Ok(Json(ApiResponse::success(result)))
 }
 
 pub async fn skip_topic_consumer_offset(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
     Path(topic): Path<String>,
     Json(request): Json<TopicSkipOffsetRequest>,
 ) -> Result<Json<ApiResponse<TopicOffsetResult>>, DashboardError> {
-    Ok(Json(ApiResponse::success(
-        service::skip_topic_consumer_offset(&state, &topic, request).await?,
-    )))
+    let result = service::skip_topic_consumer_offset(&state, &topic, request).await?;
+    record_terminal_outcome(&audit, &state, &result.topic, result.success).await;
+    Ok(Json(ApiResponse::success(result)))
 }
 
 pub async fn delete_topic_from_broker(
     State(state): State<AppState>,
+    Extension(audit): Extension<AuditTerminalFactSink>,
     Path((topic, broker_name)): Path<(String, String)>,
 ) -> Result<Json<ApiResponse<TopicOperationResult>>, DashboardError> {
-    Ok(Json(ApiResponse::success(
-        service::delete_topic_from_broker(&state, &topic, &broker_name).await?,
-    )))
+    let result = service::delete_topic_from_broker(&state, &topic, &broker_name).await?;
+    record_topic_operation(&audit, &state, &result).await;
+    Ok(Json(ApiResponse::success(result)))
+}
+
+async fn record_topic_operation(audit: &AuditTerminalFactSink, state: &AppState, result: &TopicOperationResult) {
+    record_terminal_outcome(audit, state, &result.topic, result.success).await;
+}
+
+async fn record_terminal_outcome(
+    audit: &AuditTerminalFactSink,
+    state: &AppState,
+    resource_name: &str,
+    succeeded: bool,
+) {
+    let environment_id = Some(state.published().environment.environment_id);
+    if succeeded {
+        audit.record_success(Some(resource_name), environment_id).await;
+    } else {
+        audit.record_failed(Some(resource_name), environment_id).await;
+    }
 }
 
 pub async fn topic_route(

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/config/app_config.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/config/app_config.rs
@@ -14,6 +14,8 @@
 use crate::error::DashboardError;
 use crate::model::DashboardConfigView;
 use crate::model::StorageBackend;
+use axum::http::HeaderValue;
+use axum::http::Uri;
 use rocketmq_admin_core::core::security::AdminCredentials;
 use rocketmq_error::REDACTED;
 use std::env;
@@ -223,6 +225,34 @@ pub struct AuthConfig {
     pub login_required: bool,
     pub username: String,
     pub password: String,
+    pub session_ttl_secs: u64,
+    pub session_retention_days: u32,
+    pub audit_retention_days: u32,
+    pub cleanup_interval_secs: u64,
+    pub cleanup_batch_size: u32,
+    pub max_active_sessions: u32,
+    pub cookie_secure: bool,
+    /// Exact origin allowed for credentialed browser requests. `None` means
+    /// CORS is disabled rather than falling back to an unsafe wildcard.
+    pub allowed_origin: Option<String>,
+}
+
+impl Default for AuthConfig {
+    fn default() -> Self {
+        Self {
+            login_required: false,
+            username: "admin".to_string(),
+            password: "rocketmq".to_string(),
+            session_ttl_secs: 28_800,
+            session_retention_days: 7,
+            audit_retention_days: 180,
+            cleanup_interval_secs: 3_600,
+            cleanup_batch_size: 1_000,
+            max_active_sessions: 32,
+            cookie_secure: true,
+            allowed_origin: None,
+        }
+    }
 }
 
 impl fmt::Debug for AuthConfig {
@@ -232,8 +262,66 @@ impl fmt::Debug for AuthConfig {
             .field("login_required", &self.login_required)
             .field("username", &self.username)
             .field("password", &REDACTED)
+            .field("session_ttl_secs", &self.session_ttl_secs)
+            .field("session_retention_days", &self.session_retention_days)
+            .field("audit_retention_days", &self.audit_retention_days)
+            .field("cleanup_interval_secs", &self.cleanup_interval_secs)
+            .field("cleanup_batch_size", &self.cleanup_batch_size)
+            .field("max_active_sessions", &self.max_active_sessions)
+            .field("cookie_secure", &self.cookie_secure)
+            .field("allowed_origin", &self.allowed_origin)
             .finish()
     }
+}
+
+impl AuthConfig {
+    /// Validates and materializes the sole credentialed browser origin before
+    /// the router is constructed. CORS must never attempt to interpret a
+    /// wildcard, an opaque origin, or a URL with request-specific components.
+    pub fn cors_origin(&self) -> Result<Option<HeaderValue>, DashboardError> {
+        self.allowed_origin.as_deref().map(validate_cors_origin).transpose()
+    }
+}
+
+fn validate_cors_origin(origin: &str) -> Result<HeaderValue, DashboardError> {
+    const ERROR: &str = "DASHBOARD_WEB_CORS_ORIGIN must be one exact http:// or https:// origin";
+    if origin == "*" || origin.eq_ignore_ascii_case("null") || origin.contains(',') {
+        return Err(DashboardError::Config(ERROR.to_string()));
+    }
+
+    let uri = origin
+        .parse::<Uri>()
+        .map_err(|_| DashboardError::Config(ERROR.to_string()))?;
+    let Some(scheme) = uri.scheme_str().filter(|scheme| matches!(*scheme, "http" | "https")) else {
+        return Err(DashboardError::Config(ERROR.to_string()));
+    };
+    let Some(authority) = uri.authority() else {
+        return Err(DashboardError::Config(ERROR.to_string()));
+    };
+    let supplied_port = authority.as_str().strip_prefix('[').map_or_else(
+        || authority.as_str().rsplit_once(':').map(|(_, port)| port),
+        |bracketed| {
+            bracketed
+                .split_once(']')
+                .and_then(|(_, remainder)| remainder.strip_prefix(':'))
+        },
+    );
+    let port_is_valid = supplied_port.is_none_or(|port| !port.is_empty() && port.parse::<u16>().is_ok());
+    let bracketed_host_is_valid = authority.as_str().strip_prefix('[').is_none_or(|bracketed| {
+        bracketed
+            .split_once(']')
+            .is_some_and(|(host, _)| host.parse::<std::net::Ipv6Addr>().is_ok())
+    });
+    if authority.as_str().is_empty()
+        || authority.host().is_empty()
+        || !port_is_valid
+        || !bracketed_host_is_valid
+        || authority.as_str().contains('@')
+        || origin != format!("{scheme}://{authority}")
+    {
+        return Err(DashboardError::Config(ERROR.to_string()));
+    }
+    HeaderValue::from_str(origin).map_err(|_| DashboardError::Config(ERROR.to_string()))
 }
 
 impl AppConfig {
@@ -264,6 +352,41 @@ impl AppConfig {
                 login_required: parse_bool_env("DASHBOARD_WEB_LOGIN_REQUIRED", false),
                 username: env::var("DASHBOARD_WEB_USERNAME").unwrap_or_else(|_| "admin".to_string()),
                 password: env::var("DASHBOARD_WEB_PASSWORD").unwrap_or_else(|_| "rocketmq".to_string()),
+                session_ttl_secs: positive_u64(
+                    "DASHBOARD_WEB_SESSION_TTL_SECS",
+                    parse_u64_env("DASHBOARD_WEB_SESSION_TTL_SECS", 28_800)?,
+                    2_592_000,
+                )?,
+                session_retention_days: positive_u32(
+                    "DASHBOARD_WEB_SESSION_RETENTION_DAYS",
+                    parse_u32_env("DASHBOARD_WEB_SESSION_RETENTION_DAYS", 7)?,
+                    36_500,
+                )?,
+                audit_retention_days: positive_u32(
+                    "DASHBOARD_WEB_AUDIT_RETENTION_DAYS",
+                    parse_u32_env("DASHBOARD_WEB_AUDIT_RETENTION_DAYS", 180)?,
+                    36_500,
+                )?,
+                cleanup_interval_secs: positive_u64(
+                    "DASHBOARD_WEB_SESSION_AUDIT_CLEANUP_INTERVAL_SECS",
+                    parse_u64_env("DASHBOARD_WEB_SESSION_AUDIT_CLEANUP_INTERVAL_SECS", 3_600)?,
+                    86_400,
+                )?,
+                cleanup_batch_size: positive_u32(
+                    "DASHBOARD_WEB_SESSION_AUDIT_CLEANUP_BATCH_SIZE",
+                    parse_u32_env("DASHBOARD_WEB_SESSION_AUDIT_CLEANUP_BATCH_SIZE", 1_000)?,
+                    1_000,
+                )?,
+                max_active_sessions: positive_u32(
+                    "DASHBOARD_WEB_MAX_ACTIVE_SESSIONS",
+                    parse_u32_env("DASHBOARD_WEB_MAX_ACTIVE_SESSIONS", 32)?,
+                    32,
+                )?,
+                cookie_secure: parse_bool_env("DASHBOARD_WEB_SESSION_COOKIE_SECURE", true),
+                allowed_origin: env::var("DASHBOARD_WEB_CORS_ORIGIN")
+                    .ok()
+                    .map(|value| value.trim().to_string())
+                    .filter(|value| !value.is_empty()),
             },
             dashboard_history_interval_secs: parse_u64_env("DASHBOARD_WEB_HISTORY_INTERVAL_SECS", 60)?,
             dashboard_history_retention_days: positive_u32(
@@ -419,10 +542,55 @@ mod tests {
             login_required: true,
             username: "admin".to_string(),
             password: "dashboard-secret".to_string(),
+            ..AuthConfig::default()
         };
         let debug = format!("{config:?}");
         assert!(debug.contains("<redacted>"));
         assert!(!debug.contains("dashboard-secret"));
+    }
+
+    #[test]
+    fn cors_origin_requires_one_exact_http_or_https_origin() {
+        for origin in [
+            "http://console.example",
+            "https://console.example:8443",
+            "http://[::1]:8080",
+        ] {
+            let config = AuthConfig {
+                allowed_origin: Some(origin.to_string()),
+                ..AuthConfig::default()
+            };
+            assert_eq!(
+                config
+                    .cors_origin()
+                    .expect("valid exact origin")
+                    .as_ref()
+                    .and_then(|value| value.to_str().ok()),
+                Some(origin)
+            );
+        }
+
+        for origin in [
+            "*",
+            "null",
+            "https://console.example/path",
+            "https://console.example/",
+            "https://user@console.example",
+            "https://console.example,https://other.example",
+            "https://:8443",
+            "https://console.example:not-a-port",
+            "https://console.example:65536",
+            "https://[::1",
+            "https://[not-an-ipv6]:8443",
+            "ftp://console.example",
+            "console.example",
+        ] {
+            let config = AuthConfig {
+                allowed_origin: Some(origin.to_string()),
+                ..AuthConfig::default()
+            };
+            assert!(config.cors_origin().is_err(), "{origin} must be rejected");
+        }
     }
 
     #[test]
@@ -442,6 +610,7 @@ mod tests {
                 login_required: true,
                 username: "admin".to_string(),
                 password: "dashboard-secret".to_string(),
+                ..AuthConfig::default()
             },
             dashboard_history_interval_secs: 60,
             dashboard_history_retention_days: 30,

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/error/dashboard_error.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/error/dashboard_error.rs
@@ -47,6 +47,13 @@ pub enum DashboardError {
     NotFound(String),
     #[error("{0}")]
     Auth(String),
+    /// More than one supported request credential was supplied with different
+    /// values. Keep this response value-free so session tokens never cross the
+    /// HTTP error boundary.
+    #[error("Ambiguous session credentials")]
+    AuthTokenAmbiguous,
+    #[error("{0}")]
+    Forbidden(String),
     #[error("{0}")]
     NotImplemented(String),
     #[error("{0}")]
@@ -114,6 +121,8 @@ impl DashboardError {
             Self::Admin(error) => Cow::Owned(error.code().unwrap_or("ADMIN_ERROR").to_string()),
             Self::NotFound(_) => Cow::Borrowed("NOT_FOUND"),
             Self::Auth(_) => Cow::Borrowed("AUTH_ERROR"),
+            Self::AuthTokenAmbiguous => Cow::Borrowed("AUTH_TOKEN_AMBIGUOUS"),
+            Self::Forbidden(_) => Cow::Borrowed("FORBIDDEN"),
             Self::NotImplemented(_) => Cow::Borrowed("NOT_IMPLEMENTED"),
             Self::Internal(_) | Self::InternalSource { .. } => Cow::Borrowed("INTERNAL_ERROR"),
             Self::Storage(error) => Cow::Borrowed(error.stable_code()),
@@ -133,6 +142,8 @@ impl DashboardError {
                 .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
             Self::NotFound(_) => StatusCode::NOT_FOUND,
             Self::Auth(_) => StatusCode::UNAUTHORIZED,
+            Self::AuthTokenAmbiguous => StatusCode::UNAUTHORIZED,
+            Self::Forbidden(_) => StatusCode::FORBIDDEN,
             Self::NotImplemented(_) => StatusCode::NOT_IMPLEMENTED,
             Self::Internal(_) | Self::InternalSource { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             Self::Storage(PersistenceError::InvalidConfig(_)) => StatusCode::BAD_REQUEST,
@@ -153,8 +164,10 @@ impl DashboardError {
             | Self::Config(message)
             | Self::NotFound(message)
             | Self::Auth(message)
+            | Self::Forbidden(message)
             | Self::NotImplemented(message)
             | Self::Internal(message) => message.clone(),
+            Self::AuthTokenAmbiguous => "Ambiguous session credentials".to_string(),
             Self::ConfigSource { message, .. } | Self::InternalSource { message, .. } => (*message).to_string(),
             Self::RocketMq(error) => metadata_io_response_message(error)
                 .map(str::to_string)
@@ -382,6 +395,16 @@ mod tests {
         assert!(!body.message.contains('/'));
     }
 
+    #[tokio::test]
+    async fn ambiguous_session_credentials_are_a_typed_redacted_401_response() {
+        let (status, body) = failure_response(DashboardError::AuthTokenAmbiguous).await;
+
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(body.code, "AUTH_TOKEN_AMBIGUOUS");
+        assert_eq!(body.message, "Ambiguous session credentials");
+        assert!(!body.message.contains("token"));
+    }
+
     #[test]
     fn local_error_codes_are_stable() {
         let cases = [
@@ -404,6 +427,11 @@ mod tests {
                 DashboardError::Auth("denied".to_string()),
                 "AUTH_ERROR",
                 StatusCode::UNAUTHORIZED,
+            ),
+            (
+                DashboardError::Forbidden("denied".to_string()),
+                "FORBIDDEN",
+                StatusCode::FORBIDDEN,
             ),
             (
                 DashboardError::NotImplemented("todo".to_string()),

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/middleware.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/middleware.rs
@@ -11,8 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+pub mod audit_layer;
 pub mod auth_layer;
 pub mod trace_layer;
 
+pub use audit_layer::*;
 pub use auth_layer::*;
 pub use trace_layer::*;

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/middleware/audit_layer.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/middleware/audit_layer.rs
@@ -1,0 +1,541 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::model::AuditAction;
+use crate::model::AuditEvent;
+use crate::model::AuditOutcome;
+use crate::model::AuditResourceType;
+use crate::model::AuthenticatedActor;
+use crate::service::redact_audit_value;
+use crate::state::AppState;
+use axum::body::Body;
+use axum::body::to_bytes;
+use axum::extract::MatchedPath;
+use axum::extract::Request;
+use axum::extract::State;
+use axum::http::HeaderValue;
+use axum::http::Method;
+use axum::middleware::Next;
+use axum::response::IntoResponse;
+use axum::response::Response;
+use serde_json::Value;
+use std::sync::Arc;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+use tokio::sync::Mutex;
+
+/// A handler/service-produced terminal fact. It carries only the narrow,
+/// action-specific public identifier and domain outcome needed for audit; it
+/// is deliberately incapable of accepting a request body or header map.
+#[derive(Debug, Clone)]
+pub struct AuditTerminalFact {
+    pub resource_name: Option<String>,
+    pub environment_id: Option<crate::model::EnvironmentId>,
+    pub outcome: AuditOutcome,
+    pub already_persisted: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct AuditTerminalFactSink(Arc<Mutex<Option<AuditTerminalFact>>>);
+
+impl AuditTerminalFactSink {
+    pub async fn record_success(
+        &self,
+        resource_name: Option<&str>,
+        environment_id: Option<crate::model::EnvironmentId>,
+    ) {
+        self.record(resource_name, environment_id, AuditOutcome::Succeeded)
+            .await;
+    }
+
+    /// Marks a successful operation whose persistence repository committed
+    /// the matching audit event in the same storage transaction. The generic
+    /// middleware must not append a duplicate terminal event afterward.
+    pub async fn record_persisted_success(
+        &self,
+        resource_name: Option<&str>,
+        environment_id: Option<crate::model::EnvironmentId>,
+    ) {
+        let resource_name = resource_name
+            .filter(|value| is_safe_resource_segment(value))
+            .map(str::to_string);
+        *self.0.lock().await = Some(AuditTerminalFact {
+            resource_name,
+            environment_id,
+            outcome: AuditOutcome::Succeeded,
+            already_persisted: true,
+        });
+    }
+
+    pub async fn record_rejected(
+        &self,
+        resource_name: Option<&str>,
+        environment_id: Option<crate::model::EnvironmentId>,
+    ) {
+        self.record(resource_name, environment_id, AuditOutcome::Rejected).await;
+    }
+
+    pub async fn record_failed(
+        &self,
+        resource_name: Option<&str>,
+        environment_id: Option<crate::model::EnvironmentId>,
+    ) {
+        self.record(resource_name, environment_id, AuditOutcome::Failed).await;
+    }
+
+    async fn record(
+        &self,
+        resource_name: Option<&str>,
+        environment_id: Option<crate::model::EnvironmentId>,
+        outcome: AuditOutcome,
+    ) {
+        let resource_name = resource_name
+            .filter(|value| is_safe_resource_segment(value))
+            .map(str::to_string);
+        *self.0.lock().await = Some(AuditTerminalFact {
+            resource_name,
+            environment_id,
+            outcome,
+            already_persisted: false,
+        });
+    }
+
+    async fn take(&self) -> Option<AuditTerminalFact> {
+        self.0.lock().await.take()
+    }
+}
+
+/// Runs a catalogued mutation and its terminal audit inside the application
+/// service task group. Once admitted, disconnecting HTTP clients can only
+/// drop their response receiver; they cannot cancel the RocketMQ mutation or
+/// split its terminal audit from the response decision.
+pub async fn audit_mutation(State(state): State<AppState>, mut request: Request, next: Next) -> Response {
+    let operation = request
+        .extensions()
+        .get::<MatchedPath>()
+        .and_then(|path| mutation_for(request.method(), path.as_str()));
+    let actor = request.extensions().get::<AuthenticatedActor>().cloned();
+    let resource_name = operation.and_then(|(action, _)| safe_resource_name(action, request.uri().path()));
+    let (Some((action, resource_type)), Some(actor)) = (operation, actor) else {
+        return next.run(request).await;
+    };
+    let environment_id = state.published().environment.environment_id;
+    let fact_sink = AuditTerminalFactSink::default();
+    request.extensions_mut().insert(fact_sink.clone());
+    match state
+        .run_persisted_mutation("dashboard-audit-mutation", move |state| async move {
+            let response = next.run(request).await;
+            let fallback_outcome = match response.status().as_u16() {
+                200..=299 => AuditOutcome::Succeeded,
+                400..=499 => AuditOutcome::Rejected,
+                _ => AuditOutcome::Failed,
+            };
+            let fact = fact_sink.take().await;
+            if fact.as_ref().is_some_and(|fact| fact.already_persisted) {
+                return Ok(response);
+            }
+            let event = AuditEvent {
+                event_id: uuid::Uuid::now_v7().to_string(),
+                request_id: actor.request_id,
+                actor: actor.actor,
+                action,
+                resource_type,
+                resource_name: fact
+                    .as_ref()
+                    .and_then(|fact| fact.resource_name.clone())
+                    .or(resource_name),
+                environment_id: fact
+                    .as_ref()
+                    .and_then(|fact| fact.environment_id.clone())
+                    .or(Some(environment_id)),
+                outcome: fact.map_or(fallback_outcome, |fact| fact.outcome),
+                detail: Some(redact_audit_value(serde_json::json!({"operation": action.code()}))),
+                created_at_ms: now_millis(),
+            };
+            if state.persistence.append_audit_event(event).await.is_err() && response.status().is_success() {
+                return Ok(applied_audit_failed_response(response).await);
+            }
+            Ok(response)
+        })
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => error.into_response(),
+    }
+}
+
+/// Creates the narrow successful-event projection that a repository can
+/// commit atomically with a configuration or monitor mutation.
+pub fn successful_mutation_audit_event(
+    actor: &AuthenticatedActor,
+    action: AuditAction,
+    resource_type: AuditResourceType,
+    resource_name: Option<&str>,
+    environment_id: Option<crate::model::EnvironmentId>,
+) -> AuditEvent {
+    AuditEvent {
+        event_id: uuid::Uuid::now_v7().to_string(),
+        request_id: actor.request_id.clone(),
+        actor: actor.actor.clone(),
+        action,
+        resource_type,
+        resource_name: resource_name
+            .filter(|value| is_safe_resource_segment(value))
+            .map(str::to_string),
+        environment_id,
+        outcome: AuditOutcome::Succeeded,
+        detail: Some(redact_audit_value(serde_json::json!({"operation": action.code()}))),
+        created_at_ms: now_millis(),
+    }
+}
+
+fn safe_resource_name(action: AuditAction, path: &str) -> Option<String> {
+    let segments = path
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>();
+    let candidate = match action {
+        AuditAction::ConfigNameserverDelete | AuditAction::ConfigProxyDelete => segments.last().copied(),
+        AuditAction::MonitorDelete => segments.get(3).copied(),
+        AuditAction::TopicUpdate
+        | AuditAction::TopicDelete
+        | AuditAction::TopicDeleteFromBroker
+        | AuditAction::TopicTestMessageSend
+        | AuditAction::TopicConsumerOffsetReset
+        | AuditAction::TopicConsumerOffsetSkip => segments.get(2).copied(),
+        AuditAction::ConsumerUpdate | AuditAction::ConsumerDelete | AuditAction::ConsumerOffsetReset => {
+            segments.get(2).copied()
+        }
+        AuditAction::BrokerConfigUpdate | AuditAction::MessageResend => segments.get(2).copied(),
+        // Access keys are credentials, so user mutations are attributable by
+        // actor/action only. Request bodies are never examined here either.
+        AuditAction::AclUserCreate | AuditAction::AclUserUpdate | AuditAction::AclUserDelete => None,
+        AuditAction::AclPolicyUpdate | AuditAction::AclPolicyDelete => segments.get(3).copied(),
+        _ => None,
+    };
+    candidate
+        .filter(|value| is_safe_resource_segment(value))
+        .map(str::to_string)
+}
+
+fn is_safe_resource_segment(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 128
+        && value.is_ascii()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-' | b':' | b'@'))
+}
+
+async fn applied_audit_failed_response(response: Response) -> Response {
+    const WARNING: &str = "Mutation was applied, but its audit event could not be persisted";
+    const MAX_AUDIT_WARNING_BODY_BYTES: usize = 1_048_576;
+    let status = response.status();
+    let (mut parts, body) = response.into_parts();
+    parts
+        .headers
+        .insert("x-dashboard-audit", HeaderValue::from_static("failed"));
+    let body = to_bytes(body, MAX_AUDIT_WARNING_BODY_BYTES)
+        .await
+        .ok()
+        .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok())
+        .and_then(|mut value| {
+            let object = value.as_object_mut()?;
+            object.insert("success".to_string(), Value::Bool(true));
+            object.insert("code".to_string(), Value::String("APPLIED_AUDIT_FAILED".to_string()));
+            object.insert("message".to_string(), Value::String(WARNING.to_string()));
+            object.insert("applied".to_string(), Value::Bool(true));
+            object.insert("auditFailed".to_string(), Value::Bool(true));
+            serde_json::to_vec(&value).ok()
+        })
+        .unwrap_or_else(|| {
+            br#"{"success":true,"code":"APPLIED_AUDIT_FAILED","message":"Mutation was applied, but its audit event could not be persisted","applied":true,"auditFailed":true}"#.to_vec()
+        });
+    parts.status = status;
+    Response::from_parts(parts, Body::from(body))
+}
+
+fn mutation_for(method: &Method, path: &str) -> Option<(AuditAction, AuditResourceType)> {
+    let operation = match (method, path) {
+        (&Method::PUT, "/api/config/nameservers") => {
+            (AuditAction::ConfigNameserverReplace, AuditResourceType::Nameserver)
+        }
+        (&Method::POST, "/api/config/nameservers") => (AuditAction::ConfigNameserverAdd, AuditResourceType::Nameserver),
+        (&Method::PUT, "/api/config/nameservers/current") => {
+            (AuditAction::ConfigNameserverSwitch, AuditResourceType::Nameserver)
+        }
+        (&Method::DELETE, "/api/config/nameservers/{endpoint_id}") => {
+            (AuditAction::ConfigNameserverDelete, AuditResourceType::Nameserver)
+        }
+        (&Method::PUT, "/api/config/vip-channel") => (AuditAction::ConfigVipSet, AuditResourceType::Environment),
+        (&Method::PUT, "/api/config/tls") => (AuditAction::ConfigTlsSet, AuditResourceType::Environment),
+        (&Method::POST, "/api/config/proxies") => (AuditAction::ConfigProxyAdd, AuditResourceType::Proxy),
+        (&Method::PUT, "/api/config/proxies/current") => (AuditAction::ConfigProxySwitch, AuditResourceType::Proxy),
+        (&Method::DELETE, "/api/config/proxies/{endpoint_id}") => {
+            (AuditAction::ConfigProxyDelete, AuditResourceType::Proxy)
+        }
+        (&Method::POST, "/api/monitors/consumers") => (AuditAction::MonitorUpsert, AuditResourceType::Monitor),
+        (&Method::DELETE, "/api/monitors/consumers/{consumer_group}") => {
+            (AuditAction::MonitorDelete, AuditResourceType::Monitor)
+        }
+        (&Method::POST, "/api/topics") => (AuditAction::TopicCreate, AuditResourceType::Topic),
+        (&Method::PUT, "/api/topics/{topic}") => (AuditAction::TopicUpdate, AuditResourceType::Topic),
+        (&Method::DELETE, "/api/topics/{topic}") => (AuditAction::TopicDelete, AuditResourceType::Topic),
+        (&Method::DELETE, "/api/topics/{topic}/brokers/{broker}") => {
+            (AuditAction::TopicDeleteFromBroker, AuditResourceType::Topic)
+        }
+        (&Method::POST, "/api/topics/{topic}/test-message") => {
+            (AuditAction::TopicTestMessageSend, AuditResourceType::Topic)
+        }
+        (&Method::POST, "/api/topics/{topic}/consumer-offset/reset") => {
+            (AuditAction::TopicConsumerOffsetReset, AuditResourceType::Topic)
+        }
+        (&Method::POST, "/api/topics/{topic}/consumer-offset/skip") => {
+            (AuditAction::TopicConsumerOffsetSkip, AuditResourceType::Topic)
+        }
+        (&Method::POST, "/api/consumers") => (AuditAction::ConsumerCreate, AuditResourceType::Consumer),
+        (&Method::PUT, "/api/consumers/{group}") => (AuditAction::ConsumerUpdate, AuditResourceType::Consumer),
+        (&Method::DELETE, "/api/consumers/{group}") => (AuditAction::ConsumerDelete, AuditResourceType::Consumer),
+        (&Method::POST, "/api/consumers/{group}/reset-offset") => {
+            (AuditAction::ConsumerOffsetReset, AuditResourceType::Consumer)
+        }
+        (&Method::PUT, "/api/brokers/{broker_name}/config") => {
+            (AuditAction::BrokerConfigUpdate, AuditResourceType::Broker)
+        }
+        (&Method::POST, "/api/messages/{message_id}/resend") => {
+            (AuditAction::MessageResend, AuditResourceType::Message)
+        }
+        (&Method::POST, "/api/messages/dlq/resend") => (AuditAction::MessageDlqResend, AuditResourceType::Message),
+        (&Method::POST, "/api/acl/users") => (AuditAction::AclUserCreate, AuditResourceType::AclUser),
+        (&Method::PUT, "/api/acl/users/{access_key}") => (AuditAction::AclUserUpdate, AuditResourceType::AclUser),
+        (&Method::DELETE, "/api/acl/users/{access_key}") => (AuditAction::AclUserDelete, AuditResourceType::AclUser),
+        (&Method::POST, "/api/acl/policies") => (AuditAction::AclPolicyCreate, AuditResourceType::AclPolicy),
+        (&Method::PUT, "/api/acl/policies/{policy_name}") => {
+            (AuditAction::AclPolicyUpdate, AuditResourceType::AclPolicy)
+        }
+        (&Method::DELETE, "/api/acl/policies/{policy_name}") => {
+            (AuditAction::AclPolicyDelete, AuditResourceType::AclPolicy)
+        }
+        (&Method::GET, "/api/messages/dlq/export") => (AuditAction::DlqExport, AuditResourceType::Dlq),
+        _ => return None,
+    };
+    Some(operation)
+}
+
+fn now_millis() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as i64)
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AuditTerminalFactSink;
+    use super::applied_audit_failed_response;
+    use super::mutation_for;
+    use crate::model::AuditAction;
+    use crate::model::AuditOutcome;
+    use axum::body::Body;
+    use axum::body::to_bytes;
+    use axum::http::Method;
+    use axum::http::Response;
+
+    #[test]
+    fn mutation_catalog_covers_each_expected_route() {
+        let cases = [
+            (
+                Method::PUT,
+                "/api/config/nameservers",
+                AuditAction::ConfigNameserverReplace,
+            ),
+            (
+                Method::POST,
+                "/api/config/nameservers",
+                AuditAction::ConfigNameserverAdd,
+            ),
+            (
+                Method::PUT,
+                "/api/config/nameservers/current",
+                AuditAction::ConfigNameserverSwitch,
+            ),
+            (
+                Method::DELETE,
+                "/api/config/nameservers/{endpoint_id}",
+                AuditAction::ConfigNameserverDelete,
+            ),
+            (Method::PUT, "/api/config/vip-channel", AuditAction::ConfigVipSet),
+            (Method::PUT, "/api/config/tls", AuditAction::ConfigTlsSet),
+            (Method::POST, "/api/config/proxies", AuditAction::ConfigProxyAdd),
+            (
+                Method::PUT,
+                "/api/config/proxies/current",
+                AuditAction::ConfigProxySwitch,
+            ),
+            (
+                Method::DELETE,
+                "/api/config/proxies/{endpoint_id}",
+                AuditAction::ConfigProxyDelete,
+            ),
+            (Method::POST, "/api/monitors/consumers", AuditAction::MonitorUpsert),
+            (
+                Method::DELETE,
+                "/api/monitors/consumers/{consumer_group}",
+                AuditAction::MonitorDelete,
+            ),
+            (Method::POST, "/api/topics", AuditAction::TopicCreate),
+            (Method::PUT, "/api/topics/{topic}", AuditAction::TopicUpdate),
+            (Method::DELETE, "/api/topics/{topic}", AuditAction::TopicDelete),
+            (
+                Method::DELETE,
+                "/api/topics/{topic}/brokers/{broker}",
+                AuditAction::TopicDeleteFromBroker,
+            ),
+            (
+                Method::POST,
+                "/api/topics/{topic}/test-message",
+                AuditAction::TopicTestMessageSend,
+            ),
+            (
+                Method::POST,
+                "/api/topics/{topic}/consumer-offset/reset",
+                AuditAction::TopicConsumerOffsetReset,
+            ),
+            (
+                Method::POST,
+                "/api/topics/{topic}/consumer-offset/skip",
+                AuditAction::TopicConsumerOffsetSkip,
+            ),
+            (Method::POST, "/api/consumers", AuditAction::ConsumerCreate),
+            (Method::PUT, "/api/consumers/{group}", AuditAction::ConsumerUpdate),
+            (Method::DELETE, "/api/consumers/{group}", AuditAction::ConsumerDelete),
+            (
+                Method::POST,
+                "/api/consumers/{group}/reset-offset",
+                AuditAction::ConsumerOffsetReset,
+            ),
+            (
+                Method::PUT,
+                "/api/brokers/{broker_name}/config",
+                AuditAction::BrokerConfigUpdate,
+            ),
+            (
+                Method::POST,
+                "/api/messages/{message_id}/resend",
+                AuditAction::MessageResend,
+            ),
+            (Method::POST, "/api/messages/dlq/resend", AuditAction::MessageDlqResend),
+            (Method::POST, "/api/acl/users", AuditAction::AclUserCreate),
+            (Method::PUT, "/api/acl/users/{access_key}", AuditAction::AclUserUpdate),
+            (
+                Method::DELETE,
+                "/api/acl/users/{access_key}",
+                AuditAction::AclUserDelete,
+            ),
+            (Method::POST, "/api/acl/policies", AuditAction::AclPolicyCreate),
+            (
+                Method::PUT,
+                "/api/acl/policies/{policy_name}",
+                AuditAction::AclPolicyUpdate,
+            ),
+            (
+                Method::DELETE,
+                "/api/acl/policies/{policy_name}",
+                AuditAction::AclPolicyDelete,
+            ),
+            (Method::GET, "/api/messages/dlq/export", AuditAction::DlqExport),
+        ];
+        assert_eq!(cases.len(), 32);
+        for (method, path, expected_action) in cases {
+            assert_eq!(
+                mutation_for(&method, path).map(|operation| operation.0),
+                Some(expected_action)
+            );
+        }
+        assert!(mutation_for(&Method::GET, "/api/topics").is_none());
+    }
+
+    #[tokio::test]
+    async fn applied_audit_failure_response_has_a_stable_non_retryable_body() {
+        let response = Response::new(Body::from(r#"{"success":true,"data":{"revoked":33}}"#));
+        let response = applied_audit_failed_response(response).await;
+        assert_eq!(response.status(), 200);
+        assert_eq!(
+            response
+                .headers()
+                .get("x-dashboard-audit")
+                .and_then(|value| value.to_str().ok()),
+            Some("failed")
+        );
+        let body = to_bytes(response.into_body(), 1_024).await.expect("read response body");
+        let value: serde_json::Value = serde_json::from_slice(&body).expect("parse response body");
+        assert_eq!(value["success"], true);
+        assert_eq!(value["code"], "APPLIED_AUDIT_FAILED");
+        assert_eq!(
+            value["message"],
+            "Mutation was applied, but its audit event could not be persisted"
+        );
+        assert_eq!(value["applied"], true);
+        assert_eq!(value["auditFailed"], true);
+        assert_eq!(value["data"]["revoked"], 33);
+    }
+
+    #[tokio::test]
+    async fn applied_audit_failure_uses_the_stable_body_when_original_body_is_too_large() {
+        let response = Response::new(Body::from(vec![b'x'; 1_048_577]));
+        let response = applied_audit_failed_response(response).await;
+        let body = to_bytes(response.into_body(), 1_024)
+            .await
+            .expect("read fallback response body");
+        let value: serde_json::Value = serde_json::from_slice(&body).expect("parse fallback response body");
+
+        assert_eq!(value["success"], true);
+        assert_eq!(value["code"], "APPLIED_AUDIT_FAILED");
+        assert_eq!(value["applied"], true);
+        assert_eq!(value["auditFailed"], true);
+        assert!(value.get("data").is_none());
+    }
+
+    #[tokio::test]
+    async fn applied_audit_failure_uses_the_stable_body_when_body_collection_fails() {
+        let response = Response::new(Body::from_stream(futures_util::stream::once(async {
+            Err::<axum::body::Bytes, std::io::Error>(std::io::Error::other("body read failed"))
+        })));
+        let response = applied_audit_failed_response(response).await;
+        let body = to_bytes(response.into_body(), 1_024)
+            .await
+            .expect("read fallback response body");
+        let value: serde_json::Value = serde_json::from_slice(&body).expect("parse fallback response body");
+
+        assert_eq!(value["success"], true);
+        assert_eq!(value["code"], "APPLIED_AUDIT_FAILED");
+        assert_eq!(value["applied"], true);
+        assert_eq!(value["auditFailed"], true);
+        assert!(value.get("data").is_none());
+    }
+
+    #[tokio::test]
+    async fn typed_terminal_fact_retains_only_a_safe_public_resource_name() {
+        let facts = AuditTerminalFactSink::default();
+        facts.record_success(Some("orders-1"), None).await;
+        let fact = facts.take().await.expect("recorded fact");
+        assert_eq!(fact.resource_name.as_deref(), Some("orders-1"));
+        assert_eq!(fact.outcome, AuditOutcome::Succeeded);
+
+        facts.record_failed(Some("contains space"), None).await;
+        let fact = facts.take().await.expect("recorded fact");
+        assert_eq!(fact.resource_name, None);
+        assert_eq!(fact.outcome, AuditOutcome::Failed);
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/middleware/auth_layer.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/middleware/auth_layer.rs
@@ -11,69 +11,198 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 use crate::error::DashboardError;
+use crate::model::AuthenticatedActor;
+use crate::model::SessionAuthenticationFailure;
+use crate::service::authenticate;
+use crate::service::authenticate_session_token;
 use crate::state::AppState;
 use axum::extract::Request;
 use axum::extract::State;
 use axum::http::HeaderMap;
 use axum::http::header::AUTHORIZATION;
+use axum::http::header::COOKIE;
 use axum::middleware::Next;
 use axum::response::IntoResponse;
 use axum::response::Response;
 
 const DASHBOARD_SESSION_HEADER: &str = "x-dashboard-session";
+const DASHBOARD_SESSION_COOKIE: &str = "dashboard_session";
+const MAX_SESSION_TOKEN_BYTES: usize = 128;
 
-pub async fn require_auth(State(state): State<AppState>, request: Request, next: Next) -> Response {
-    let session_id = session_id_from_headers(request.headers());
-    if state.auth_state.is_authorized(session_id.as_deref()).await {
-        return next.run(request).await;
+/// Validates every supported credential source on every protected request.
+/// Multiple identical values are accepted for proxies that duplicate headers;
+/// conflicting values are rejected rather than silently selecting precedence.
+pub async fn require_auth(State(state): State<AppState>, mut request: Request, next: Next) -> Response {
+    let token = match session_token_from_headers(request.headers()) {
+        Ok(token) => token,
+        Err(error) => return error.into_response(),
+    };
+    let actor = match authenticate(&state, token.as_deref()).await {
+        Ok(actor) => actor,
+        Err(error) => return error.into_response(),
+    };
+    request.extensions_mut().insert(actor);
+    next.run(request).await
+}
+
+/// The session status endpoint uses the same parser and persistent validation,
+/// but can report `authenticated=false` when no credential is supplied.
+pub async fn optional_auth(State(state): State<AppState>, mut request: Request, next: Next) -> Response {
+    let token = match session_token_from_headers(request.headers()) {
+        Ok(token) => token,
+        // Credential conflicts are a security failure, not an unauthenticated
+        // session-status result. Keep the typed public error intact so callers
+        // can distinguish it without learning either supplied credential.
+        Err(DashboardError::AuthTokenAmbiguous) => {
+            return DashboardError::AuthTokenAmbiguous.into_response();
+        }
+        Err(_) => {
+            request.extensions_mut().insert(SessionAuthenticationFailure::Invalid);
+            return next.run(request).await;
+        }
+    };
+    if token.is_some() || !state.auth_state.login_required() {
+        match authenticate_session_token(&state, token.as_deref()).await {
+            Ok(Ok(actor)) => {
+                request.extensions_mut().insert(actor);
+            }
+            Ok(Err(reason)) => {
+                request.extensions_mut().insert(reason);
+            }
+            Err(error) => return error.into_response(),
+        }
     }
-
-    DashboardError::Auth("Authentication required".to_string()).into_response()
+    next.run(request).await
 }
 
-fn session_id_from_headers(headers: &HeaderMap) -> Option<String> {
-    headers
-        .get(DASHBOARD_SESSION_HEADER)
-        .and_then(|value| value.to_str().ok())
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned)
-        .or_else(|| bearer_token_from_headers(headers))
+pub fn require_administrator(actor: &AuthenticatedActor) -> Result<(), DashboardError> {
+    if actor.actor.is_administrator() {
+        Ok(())
+    } else {
+        Err(DashboardError::Forbidden(
+            "Administrator permission is required".to_string(),
+        ))
+    }
 }
 
-fn bearer_token_from_headers(headers: &HeaderMap) -> Option<String> {
+fn session_token_from_headers(headers: &HeaderMap) -> Result<Option<String>, DashboardError> {
+    let mut values = header_values(headers, DASHBOARD_SESSION_HEADER)?;
+    values.extend(bearer_values(headers)?);
+    values.extend(cookie_values(headers)?);
+    let Some(first) = values.first() else {
+        return Ok(None);
+    };
+    if values.iter().any(|value| value != first) {
+        return Err(DashboardError::AuthTokenAmbiguous);
+    }
+    Ok(Some(first.clone()))
+}
+
+fn header_values(headers: &HeaderMap, name: &str) -> Result<Vec<String>, DashboardError> {
     headers
-        .get(AUTHORIZATION)
-        .and_then(|value| value.to_str().ok())
-        .and_then(|value| value.strip_prefix("Bearer "))
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned)
+        .get_all(name)
+        .iter()
+        .map(|value| {
+            let value = value
+                .to_str()
+                .map_err(|_| DashboardError::Auth("Invalid session credential".to_string()))?;
+            validate_token(value.trim())
+        })
+        .collect()
+}
+
+fn bearer_values(headers: &HeaderMap) -> Result<Vec<String>, DashboardError> {
+    headers
+        .get_all(AUTHORIZATION)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .filter_map(|value| value.strip_prefix("Bearer "))
+        .map(|value| validate_token(value.trim()))
+        .collect()
+}
+
+fn cookie_values(headers: &HeaderMap) -> Result<Vec<String>, DashboardError> {
+    let mut values = Vec::new();
+    for header in headers.get_all(COOKIE) {
+        let value = header
+            .to_str()
+            .map_err(|_| DashboardError::Auth("Invalid session credential".to_string()))?;
+        for pair in value.split(';') {
+            let Some((name, token)) = pair.trim().split_once('=') else {
+                continue;
+            };
+            if name == DASHBOARD_SESSION_COOKIE {
+                values.push(validate_token(token.trim())?);
+            }
+        }
+    }
+    Ok(values)
+}
+
+fn validate_token(token: &str) -> Result<String, DashboardError> {
+    if token.is_empty()
+        || token.len() > MAX_SESSION_TOKEN_BYTES
+        || !token.is_ascii()
+        || token
+            .bytes()
+            .any(|byte| byte.is_ascii_control() || byte.is_ascii_whitespace())
+    {
+        return Err(DashboardError::Auth("Invalid session credential".to_string()));
+    }
+    Ok(token.to_string())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::bearer_token_from_headers;
-    use super::session_id_from_headers;
+    use super::session_token_from_headers;
+    use crate::error::DashboardError;
     use axum::http::HeaderMap;
     use axum::http::HeaderValue;
     use axum::http::header::AUTHORIZATION;
 
     #[test]
-    fn session_header_takes_precedence_over_bearer_token() {
+    fn accepts_identical_sources_and_rejects_conflicts_without_exposing_credentials() {
         let mut headers = HeaderMap::new();
         headers.insert("x-dashboard-session", HeaderValue::from_static("session-a"));
-        headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer session-b"));
+        headers.append("x-dashboard-session", HeaderValue::from_static("session-a"));
+        headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer session-a"));
+        headers.insert("cookie", HeaderValue::from_static("dashboard_session=session-a"));
+        assert_eq!(
+            session_token_from_headers(&headers).expect("same credentials"),
+            Some("session-a".to_string())
+        );
 
-        assert_eq!(session_id_from_headers(&headers).as_deref(), Some("session-a"));
-    }
-
-    #[test]
-    fn bearer_token_is_trimmed() {
-        let mut headers = HeaderMap::new();
-        headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer session-a "));
-
-        assert_eq!(bearer_token_from_headers(&headers).as_deref(), Some("session-a"));
+        for (header, bearer, cookie) in [
+            (Some("session-a"), Some("session-b"), None),
+            (Some("session-a"), None, Some("session-b")),
+            (None, Some("session-a"), Some("session-b")),
+        ] {
+            let mut headers = HeaderMap::new();
+            if let Some(value) = header {
+                headers.insert(
+                    "x-dashboard-session",
+                    HeaderValue::from_str(value).expect("header credential"),
+                );
+            }
+            if let Some(value) = bearer {
+                headers.insert(
+                    AUTHORIZATION,
+                    HeaderValue::from_str(&format!("Bearer {value}")).expect("bearer credential"),
+                );
+            }
+            if let Some(value) = cookie {
+                headers.insert(
+                    "cookie",
+                    HeaderValue::from_str(&format!("dashboard_session={value}")).expect("cookie credential"),
+                );
+            }
+            let error = session_token_from_headers(&headers).expect_err("conflicting credentials must fail");
+            assert!(matches!(error, DashboardError::AuthTokenAmbiguous));
+            assert_eq!(error.code(), "AUTH_TOKEN_AMBIGUOUS");
+            assert_eq!(error.status_code(), axum::http::StatusCode::UNAUTHORIZED);
+            assert!(!error.to_string().contains("session-b"));
+        }
     }
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/model.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/model.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 pub mod acl_model;
 pub mod api_response;
+pub mod audit_model;
 pub mod auth_model;
 pub mod broker_model;
 pub mod config_model;
@@ -26,6 +27,7 @@ pub mod topic_model;
 
 pub use acl_model::*;
 pub use api_response::*;
+pub use audit_model::*;
 pub use auth_model::*;
 pub use broker_model::*;
 pub use config_model::*;

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/model/audit_model.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/model/audit_model.rs
@@ -1,0 +1,363 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::model::EnvironmentId;
+use crate::model::StorageBackend;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::Value;
+
+/// The actor category recorded in a dashboard audit event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditActorKind {
+    Admin,
+    LocalOperator,
+    System,
+}
+
+impl AuditActorKind {
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::Admin => "admin",
+            Self::LocalOperator => "local_operator",
+            Self::System => "system",
+        }
+    }
+
+    pub fn parse(code: &str) -> Option<Self> {
+        match code {
+            "admin" => Some(Self::Admin),
+            "local_operator" => Some(Self::LocalOperator),
+            "system" => Some(Self::System),
+            _ => None,
+        }
+    }
+}
+
+/// A bounded, non-secret identity attached to a request and audit event.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditActor {
+    pub kind: AuditActorKind,
+    pub username: Option<String>,
+}
+
+impl AuditActor {
+    pub fn admin(username: impl Into<String>) -> Self {
+        Self {
+            kind: AuditActorKind::Admin,
+            username: Some(username.into()),
+        }
+    }
+
+    pub const fn local_operator() -> Self {
+        Self {
+            kind: AuditActorKind::LocalOperator,
+            username: None,
+        }
+    }
+
+    pub const fn system() -> Self {
+        Self {
+            kind: AuditActorKind::System,
+            username: None,
+        }
+    }
+
+    pub const fn is_administrator(&self) -> bool {
+        matches!(self.kind, AuditActorKind::Admin | AuditActorKind::LocalOperator)
+    }
+
+    pub fn stable_name(&self) -> &str {
+        self.username.as_deref().unwrap_or_else(|| self.kind.code())
+    }
+}
+
+/// Stable operation names accepted by the audit repository. Keeping this
+/// finite prevents a handler from accidentally persisting an arbitrary URL,
+/// header, or client-controlled string as an action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditAction {
+    SessionCreate,
+    SessionRevokeCurrent,
+    SessionRevokeAll,
+    ConfigNameserverReplace,
+    ConfigNameserverAdd,
+    ConfigNameserverSwitch,
+    ConfigNameserverDelete,
+    ConfigVipSet,
+    ConfigTlsSet,
+    ConfigProxyAdd,
+    ConfigProxySwitch,
+    ConfigProxyDelete,
+    MonitorUpsert,
+    MonitorDelete,
+    TopicCreate,
+    TopicUpdate,
+    TopicDelete,
+    TopicDeleteFromBroker,
+    TopicTestMessageSend,
+    TopicConsumerOffsetReset,
+    TopicConsumerOffsetSkip,
+    ConsumerCreate,
+    ConsumerUpdate,
+    ConsumerDelete,
+    ConsumerOffsetReset,
+    BrokerConfigUpdate,
+    MessageResend,
+    MessageDlqResend,
+    AclUserCreate,
+    AclUserUpdate,
+    AclUserDelete,
+    AclPolicyCreate,
+    AclPolicyUpdate,
+    AclPolicyDelete,
+    DlqExport,
+}
+
+impl AuditAction {
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::SessionCreate => "session.create",
+            Self::SessionRevokeCurrent => "session.revoke_current",
+            Self::SessionRevokeAll => "session.revoke_all",
+            Self::ConfigNameserverReplace => "config.nameservers.replace",
+            Self::ConfigNameserverAdd => "config.nameservers.add",
+            Self::ConfigNameserverSwitch => "config.nameservers.switch",
+            Self::ConfigNameserverDelete => "config.nameservers.delete",
+            Self::ConfigVipSet => "config.vip.set",
+            Self::ConfigTlsSet => "config.tls.set",
+            Self::ConfigProxyAdd => "config.proxies.add",
+            Self::ConfigProxySwitch => "config.proxies.switch",
+            Self::ConfigProxyDelete => "config.proxies.delete",
+            Self::MonitorUpsert => "monitor.upsert",
+            Self::MonitorDelete => "monitor.delete",
+            Self::TopicCreate => "topic.create",
+            Self::TopicUpdate => "topic.update",
+            Self::TopicDelete => "topic.delete",
+            Self::TopicDeleteFromBroker => "topic.delete_from_broker",
+            Self::TopicTestMessageSend => "topic.test_message.send",
+            Self::TopicConsumerOffsetReset => "topic.consumer_offset.reset",
+            Self::TopicConsumerOffsetSkip => "topic.consumer_offset.skip",
+            Self::ConsumerCreate => "consumer.create",
+            Self::ConsumerUpdate => "consumer.update",
+            Self::ConsumerDelete => "consumer.delete",
+            Self::ConsumerOffsetReset => "consumer.offset.reset",
+            Self::BrokerConfigUpdate => "broker.config.update",
+            Self::MessageResend => "message.resend",
+            Self::MessageDlqResend => "message.dlq.resend",
+            Self::AclUserCreate => "acl.user.create",
+            Self::AclUserUpdate => "acl.user.update",
+            Self::AclUserDelete => "acl.user.delete",
+            Self::AclPolicyCreate => "acl.policy.create",
+            Self::AclPolicyUpdate => "acl.policy.update",
+            Self::AclPolicyDelete => "acl.policy.delete",
+            Self::DlqExport => "dlq.export",
+        }
+    }
+
+    pub fn parse(code: &str) -> Option<Self> {
+        [
+            Self::SessionCreate,
+            Self::SessionRevokeCurrent,
+            Self::SessionRevokeAll,
+            Self::ConfigNameserverReplace,
+            Self::ConfigNameserverAdd,
+            Self::ConfigNameserverSwitch,
+            Self::ConfigNameserverDelete,
+            Self::ConfigVipSet,
+            Self::ConfigTlsSet,
+            Self::ConfigProxyAdd,
+            Self::ConfigProxySwitch,
+            Self::ConfigProxyDelete,
+            Self::MonitorUpsert,
+            Self::MonitorDelete,
+            Self::TopicCreate,
+            Self::TopicUpdate,
+            Self::TopicDelete,
+            Self::TopicDeleteFromBroker,
+            Self::TopicTestMessageSend,
+            Self::TopicConsumerOffsetReset,
+            Self::TopicConsumerOffsetSkip,
+            Self::ConsumerCreate,
+            Self::ConsumerUpdate,
+            Self::ConsumerDelete,
+            Self::ConsumerOffsetReset,
+            Self::BrokerConfigUpdate,
+            Self::MessageResend,
+            Self::MessageDlqResend,
+            Self::AclUserCreate,
+            Self::AclUserUpdate,
+            Self::AclUserDelete,
+            Self::AclPolicyCreate,
+            Self::AclPolicyUpdate,
+            Self::AclPolicyDelete,
+            Self::DlqExport,
+        ]
+        .into_iter()
+        .find(|action| action.code() == code)
+    }
+}
+
+/// Audited resource categories. Resource values are validated and truncated
+/// by the service before they cross the persistence boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditResourceType {
+    Session,
+    Environment,
+    Nameserver,
+    Proxy,
+    Monitor,
+    Topic,
+    Consumer,
+    Broker,
+    Message,
+    AclUser,
+    AclPolicy,
+    Dlq,
+}
+
+impl AuditResourceType {
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::Session => "session",
+            Self::Environment => "environment",
+            Self::Nameserver => "nameserver",
+            Self::Proxy => "proxy",
+            Self::Monitor => "monitor",
+            Self::Topic => "topic",
+            Self::Consumer => "consumer",
+            Self::Broker => "broker",
+            Self::Message => "message",
+            Self::AclUser => "acl_user",
+            Self::AclPolicy => "acl_policy",
+            Self::Dlq => "dlq",
+        }
+    }
+
+    pub fn parse(code: &str) -> Option<Self> {
+        [
+            Self::Session,
+            Self::Environment,
+            Self::Nameserver,
+            Self::Proxy,
+            Self::Monitor,
+            Self::Topic,
+            Self::Consumer,
+            Self::Broker,
+            Self::Message,
+            Self::AclUser,
+            Self::AclPolicy,
+            Self::Dlq,
+        ]
+        .into_iter()
+        .find(|resource| resource.code() == code)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditOutcome {
+    Succeeded,
+    Rejected,
+    Failed,
+}
+
+impl AuditOutcome {
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::Succeeded => "succeeded",
+            Self::Rejected => "rejected",
+            Self::Failed => "failed",
+        }
+    }
+
+    pub fn parse(code: &str) -> Option<Self> {
+        match code {
+            "succeeded" => Some(Self::Succeeded),
+            "rejected" => Some(Self::Rejected),
+            "failed" => Some(Self::Failed),
+            _ => None,
+        }
+    }
+}
+
+/// Domain event persisted by all storage engines. It intentionally contains
+/// only a safe, redacted detail projection, never a request DTO or error.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditEvent {
+    pub event_id: String,
+    pub request_id: String,
+    pub actor: AuditActor,
+    pub action: AuditAction,
+    pub resource_type: AuditResourceType,
+    pub resource_name: Option<String>,
+    pub environment_id: Option<EnvironmentId>,
+    pub outcome: AuditOutcome,
+    pub detail: Option<Value>,
+    pub created_at_ms: i64,
+}
+
+/// A public audit projection. It is deliberately separate from `AuditEvent`
+/// so storage-only implementation details cannot become API fields by
+/// accident.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditEventView {
+    pub event_id: String,
+    pub request_id: String,
+    pub actor: String,
+    pub actor_kind: AuditActorKind,
+    pub action: AuditAction,
+    pub resource_type: AuditResourceType,
+    pub resource_name: Option<String>,
+    pub environment_id: Option<String>,
+    pub outcome: AuditOutcome,
+    pub detail: Option<Value>,
+    pub created_at_ms: i64,
+}
+
+/// Safe operational state of the lifecycle-owned session/audit retention
+/// worker. It intentionally contains no lease holder identity or error text.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionAuditCleanupHealth {
+    pub backend: StorageBackend,
+    pub connectivity: String,
+    pub role: String,
+    pub last_cleanup_at_ms: Option<i64>,
+    pub recent_error: Option<String>,
+}
+
+impl From<AuditEvent> for AuditEventView {
+    fn from(event: AuditEvent) -> Self {
+        Self {
+            event_id: event.event_id,
+            request_id: event.request_id,
+            actor: event.actor.stable_name().to_string(),
+            actor_kind: event.actor.kind,
+            action: event.action,
+            resource_type: event.resource_type,
+            resource_name: event.resource_name,
+            environment_id: event.environment_id.map(|id| id.0),
+            outcome: event.outcome,
+            detail: event.detail,
+            created_at_ms: event.created_at_ms,
+        }
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/model/auth_model.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/model/auth_model.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 use std::fmt;
 
+use crate::model::AuditActor;
 use rocketmq_error::REDACTED;
 use serde::Deserialize;
 use serde::Serialize;
@@ -42,6 +43,135 @@ pub struct SessionView {
     pub username: Option<String>,
     pub session_id: Option<String>,
     pub login_time: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auth_reason: Option<String>,
+}
+
+/// A non-secret reason a supplied credential no longer establishes a
+/// dashboard session. It is returned only by the session-status endpoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionAuthenticationFailure {
+    Invalid,
+    Expired,
+    Revoked,
+}
+
+impl SessionAuthenticationFailure {
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::Invalid => "invalid",
+            Self::Expired => "expired",
+            Self::Revoked => "revoked",
+        }
+    }
+}
+
+/// A fixed-size SHA-256 token digest. The corresponding plaintext session
+/// token is never serialised or written to disk.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SessionTokenHash(pub [u8; 32]);
+
+impl SessionTokenHash {
+    pub const fn bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    pub fn lower_hex(&self) -> String {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let mut encoded = String::with_capacity(64);
+        for byte in self.0 {
+            encoded.push(HEX[usize::from(byte >> 4)] as char);
+            encoded.push(HEX[usize::from(byte & 0x0f)] as char);
+        }
+        encoded
+    }
+}
+
+impl fmt::Debug for SessionTokenHash {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("SessionTokenHash(<redacted>)")
+    }
+}
+
+/// Storage record used by the session repository. This type is intentionally
+/// separate from `SessionView`, which is safe to return to the browser.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SessionRecord {
+    /// Non-secret public identifier used for session administration cursors.
+    /// The digest remains storage-only and is never exposed in an API cursor.
+    pub session_id: String,
+    pub token_hash: SessionTokenHash,
+    pub username: String,
+    pub created_at_ms: i64,
+    pub expires_at_ms: i64,
+    pub last_seen_at_ms: i64,
+    pub revoked_at_ms: Option<i64>,
+}
+
+impl fmt::Debug for SessionRecord {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SessionRecord")
+            .field("session_id", &self.session_id)
+            .field("token_hash", &REDACTED)
+            .field("username", &self.username)
+            .field("created_at_ms", &self.created_at_ms)
+            .field("expires_at_ms", &self.expires_at_ms)
+            .field("last_seen_at_ms", &self.last_seen_at_ms)
+            .field("revoked_at_ms", &self.revoked_at_ms)
+            .finish()
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct NewSession {
+    pub session_id: String,
+    pub token_hash: SessionTokenHash,
+    pub username: String,
+    pub created_at_ms: i64,
+    pub expires_at_ms: i64,
+}
+
+impl fmt::Debug for NewSession {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("NewSession")
+            .field("session_id", &self.session_id)
+            .field("token_hash", &REDACTED)
+            .field("username", &self.username)
+            .field("created_at_ms", &self.created_at_ms)
+            .field("expires_at_ms", &self.expires_at_ms)
+            .finish()
+    }
+}
+
+/// Request-scoped identity installed by the authentication middleware.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthenticatedActor {
+    pub actor: AuditActor,
+    pub request_id: String,
+    pub session_hash: Option<SessionTokenHash>,
+}
+
+/// Safe administrator session projection. No token or token derivative is
+/// returned; identifiers are only used for keyset pagination.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionListItem {
+    pub session_id: String,
+    pub username: String,
+    pub created_at_ms: i64,
+    pub expires_at_ms: i64,
+    pub last_seen_at_ms: i64,
+    pub revoked_at_ms: Option<i64>,
+    pub current: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionListPage {
+    pub items: Vec<SessionListItem>,
+    pub next_cursor: Option<String>,
 }
 
 impl fmt::Debug for SessionView {
@@ -53,6 +183,7 @@ impl fmt::Debug for SessionView {
             .field("username", &self.username)
             .field("session_id", &self.session_id.as_ref().map(|_| REDACTED))
             .field("login_time", &self.login_time)
+            .field("auth_reason", &self.auth_reason)
             .finish()
     }
 }
@@ -73,6 +204,7 @@ mod tests {
             username: Some("admin".to_string()),
             session_id: Some("dashboard-session-token".to_string()),
             login_time: Some(1),
+            auth_reason: None,
         };
 
         let login_debug = format!("{login:?}");

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/model/health_model.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/model/health_model.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use crate::model::DashboardHistoryHealth;
+use crate::model::SessionAuditCleanupHealth;
 use crate::persistence::StorageHealth;
 use serde::Deserialize;
 use serde::Serialize;
@@ -24,4 +25,6 @@ pub struct HealthStatus {
     pub storage: Option<StorageHealth>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub history: Option<DashboardHistoryHealth>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_audit_cleanup: Option<SessionAuditCleanupHealth>,
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+pub mod audit_repository;
 pub mod backend;
 pub mod environment_repository;
 pub mod error;
@@ -19,6 +20,7 @@ pub mod history_repository;
 pub mod lease_repository;
 pub mod migration;
 pub mod monitor_repository;
+pub mod session_repository;
 pub mod sql_store;
 
 #[cfg(test)]
@@ -27,6 +29,10 @@ mod contract_tests;
 #[cfg(test)]
 #[path = "persistence/history_capacity_tests.rs"]
 mod history_capacity_tests;
+
+#[cfg(test)]
+#[path = "persistence/session_audit_docker_tests.rs"]
+mod session_audit_docker_tests;
 
 use crate::config::StorageConfig;
 use crate::model::StorageBackend;

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/audit_file_store.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/audit_file_store.rs
@@ -1,0 +1,630 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::FileMutationOutcome;
+use super::FilePersistence;
+use super::OpenOptions;
+use super::PersistenceError;
+use super::Utc;
+use crate::model::AuditEvent;
+use crate::persistence::audit_repository::AuditCursor;
+use crate::persistence::audit_repository::AuditPage;
+use crate::persistence::audit_repository::AuditQuery;
+use serde::Deserialize;
+use serde::Serialize;
+use std::io::BufRead;
+use std::io::BufReader;
+use std::io::Write;
+use std::path::Path;
+
+const AUDIT_REWRITE_MARKER_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AuditRewriteTransaction {
+    format_version: u32,
+    target: String,
+    backup: String,
+}
+
+impl FilePersistence {
+    pub(crate) async fn append_audit_event(&self, event: AuditEvent) -> Result<(), PersistenceError> {
+        let write_guard = self.write_guard().await;
+        self.ensure_available()?;
+        let root = self.root.clone();
+        self.dispatch_file_mutation(write_guard, "dashboard-file-audit-append", move || {
+            let day = chrono::DateTime::from_timestamp_millis(event.created_at_ms)
+                .unwrap_or_else(Utc::now)
+                .format("%Y-%m-%d")
+                .to_string();
+            let directory = root.join("audit");
+            std::fs::create_dir_all(&directory).map_err(PersistenceError::Io)?;
+            let path = directory.join(format!("{day}.jsonl"));
+            let existed = path.exists();
+            super::truncate_incomplete_tail(&path)?;
+            let original_length = if existed {
+                std::fs::metadata(&path).map_err(PersistenceError::Io)?.len()
+            } else {
+                0
+            };
+            let mut file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)
+                .map_err(PersistenceError::Io)?;
+            serde_json::to_writer(&mut file, &event).map_err(PersistenceError::Serialization)?;
+            file.write_all(b"\n").map_err(PersistenceError::Io)?;
+            file.flush().map_err(PersistenceError::Io)?;
+            file.sync_data().map_err(PersistenceError::Io)?;
+            Ok(FileMutationOutcome {
+                value: (),
+                finalize: Box::new(|| Ok(())),
+                cleanup: Box::new(|| Ok(())),
+                rollback: Box::new(move || super::rollback_jsonl_append(path, original_length, existed)),
+            })
+        })
+        .await?;
+        self.record_write();
+        Ok(())
+    }
+
+    pub(crate) async fn query_audit_events(&self, query: AuditQuery) -> Result<AuditPage, PersistenceError> {
+        // Opening a JSONL audit journal repairs only a torn final append. A
+        // completed middle line remains a fail-closed corruption error.
+        let write_guard = self.write_guard().await;
+        self.ensure_available()?;
+        let root = self.root.clone();
+        self.dispatch_file_mutation(write_guard, "dashboard-file-audit-query-recovery", move || {
+            recover_audit_tails(&root)?;
+            let page = query_audit_events(&root, query)?;
+            Ok(FileMutationOutcome {
+                value: page,
+                finalize: Box::new(|| Ok(())),
+                cleanup: Box::new(|| Ok(())),
+                rollback: Box::new(|| Ok(())),
+            })
+        })
+        .await
+    }
+
+    pub(crate) async fn delete_audit_before(&self, cutoff_ms: i64, limit: usize) -> Result<u64, PersistenceError> {
+        let write_guard = self.write_guard().await;
+        self.ensure_available()?;
+        let root = self.root.clone();
+        let deleted = self
+            .dispatch_file_mutation(write_guard, "dashboard-file-audit-cleanup", move || {
+                let deleted = delete_audit_before(&root, cutoff_ms, limit)?;
+                Ok(FileMutationOutcome {
+                    value: deleted,
+                    finalize: Box::new(|| Ok(())),
+                    cleanup: Box::new(|| Ok(())),
+                    rollback: Box::new(|| Ok(())),
+                })
+            })
+            .await?;
+        if deleted > 0 {
+            self.record_write();
+        }
+        Ok(deleted)
+    }
+}
+
+fn query_audit_events(root: &std::path::Path, query: AuditQuery) -> Result<AuditPage, PersistenceError> {
+    let directory = root.join("audit");
+    if !directory.exists() {
+        return Ok(AuditPage {
+            events: Vec::new(),
+            next_cursor: None,
+        });
+    }
+    let mut events = Vec::with_capacity(query.limit.saturating_add(1));
+    for entry in std::fs::read_dir(directory).map_err(PersistenceError::Io)? {
+        let entry = entry.map_err(PersistenceError::Io)?;
+        if entry.path().extension().is_none_or(|extension| extension != "jsonl") {
+            continue;
+        }
+        let file = std::fs::File::open(entry.path()).map_err(PersistenceError::Io)?;
+        for line in BufReader::new(file).lines() {
+            let line = line.map_err(PersistenceError::Io)?;
+            if line.is_empty() {
+                return Err(PersistenceError::CorruptedData);
+            }
+            let event: AuditEvent = serde_json::from_str(&line).map_err(|_| PersistenceError::CorruptedData)?;
+            if matches_audit_query(&event, &query) && is_after_audit_cursor(&event, query.cursor.as_ref()) {
+                insert_descending_bounded(&mut events, event, query.limit.saturating_add(1));
+            }
+        }
+    }
+    let has_more = events.len() > query.limit;
+    events.truncate(query.limit);
+    let next_cursor = if has_more {
+        events.last().map(|event| AuditCursor {
+            created_at_ms: event.created_at_ms,
+            event_id: event.event_id.clone(),
+        })
+    } else {
+        None
+    };
+    Ok(AuditPage { events, next_cursor })
+}
+
+fn recover_audit_tails(root: &std::path::Path) -> Result<(), PersistenceError> {
+    let directory = root.join("audit");
+    if !directory.exists() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(directory).map_err(PersistenceError::Io)? {
+        let path = entry.map_err(PersistenceError::Io)?.path();
+        if path.extension().is_some_and(|extension| extension == "jsonl") {
+            super::truncate_incomplete_tail(&path)?;
+        }
+    }
+    Ok(())
+}
+
+fn is_after_audit_cursor(event: &AuditEvent, cursor: Option<&AuditCursor>) -> bool {
+    cursor.is_none_or(|cursor| {
+        event.created_at_ms < cursor.created_at_ms
+            || (event.created_at_ms == cursor.created_at_ms && event.event_id < cursor.event_id)
+    })
+}
+
+fn insert_descending_bounded(events: &mut Vec<AuditEvent>, event: AuditEvent, maximum: usize) {
+    let index = events.partition_point(|current| {
+        current.created_at_ms > event.created_at_ms
+            || (current.created_at_ms == event.created_at_ms && current.event_id > event.event_id)
+    });
+    if index < maximum {
+        events.insert(index, event);
+        if events.len() > maximum {
+            events.pop();
+        }
+    }
+}
+
+fn matches_audit_query(event: &AuditEvent, query: &AuditQuery) -> bool {
+    event.created_at_ms >= query.start_ms
+        && event.created_at_ms <= query.end_ms
+        && query
+            .actor
+            .as_deref()
+            .is_none_or(|actor| event.actor.stable_name() == actor)
+        && query.action.is_none_or(|action| event.action == action)
+        && query.outcome.is_none_or(|outcome| event.outcome == outcome)
+        && query.environment_id.as_deref().is_none_or(|id| {
+            event
+                .environment_id
+                .as_ref()
+                .is_some_and(|environment| environment.0 == id)
+        })
+}
+
+fn delete_audit_before(root: &std::path::Path, cutoff_ms: i64, limit: usize) -> Result<u64, PersistenceError> {
+    let directory = root.join("audit");
+    if !directory.exists() {
+        return Ok(0);
+    }
+    let mut deleted = 0;
+    let mut paths = std::fs::read_dir(directory)
+        .map_err(PersistenceError::Io)?
+        .map(|entry| entry.map(|entry| entry.path()).map_err(PersistenceError::Io))
+        .collect::<Result<Vec<_>, _>>()?;
+    paths.sort();
+    for path in paths {
+        if deleted as usize >= limit {
+            break;
+        }
+        if path.extension().is_none_or(|extension| extension != "jsonl") {
+            continue;
+        }
+        // Stream and rewrite at most the requested number of expired records.
+        // A day may straddle the retention cutoff, or contain more records
+        // than one maintenance batch; skipping such a file would permanently
+        // block retention behind the same oldest day.
+        super::truncate_incomplete_tail(&path)?;
+        let file = std::fs::File::open(&path).map_err(PersistenceError::Io)?;
+        let temporary = path.with_file_name(format!(
+            ".{}.cleanup.{}.tmp",
+            path.file_name().and_then(|name| name.to_str()).unwrap_or("audit"),
+            Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        let mut rewritten = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&temporary)
+            .map_err(PersistenceError::Io)?;
+        let mut removed_from_file = 0_usize;
+        {
+            let mut reader = BufReader::new(file);
+            loop {
+                let mut line = String::new();
+                let read = reader.read_line(&mut line).map_err(PersistenceError::Io)?;
+                if read == 0 {
+                    break;
+                }
+                if !line.ends_with('\n') {
+                    return Err(PersistenceError::CorruptedData);
+                }
+                let line = line.trim_end_matches(['\r', '\n']);
+                if line.is_empty() {
+                    let _ = std::fs::remove_file(&temporary);
+                    return Err(PersistenceError::CorruptedData);
+                }
+                let event: AuditEvent = serde_json::from_str(line).map_err(|_| PersistenceError::CorruptedData)?;
+                if event.created_at_ms < cutoff_ms && deleted as usize + removed_from_file < limit {
+                    removed_from_file += 1;
+                    continue;
+                }
+                rewritten.write_all(line.as_bytes()).map_err(PersistenceError::Io)?;
+                rewritten.write_all(b"\n").map_err(PersistenceError::Io)?;
+            }
+            drop(reader);
+        }
+        if removed_from_file > 0 {
+            rewritten.flush().map_err(PersistenceError::Io)?;
+            rewritten.sync_all().map_err(PersistenceError::Io)?;
+            drop(rewritten);
+            let remaining = std::fs::metadata(&temporary).map_err(PersistenceError::Io)?.len();
+            replace_jsonl_file(root, &path, &temporary, remaining == 0)?;
+            deleted += removed_from_file as u64;
+        } else {
+            drop(rewritten);
+            std::fs::remove_file(&temporary).map_err(PersistenceError::Io)?;
+        }
+        if deleted as usize >= limit {
+            break;
+        }
+    }
+    Ok(deleted)
+}
+
+fn replace_jsonl_file(root: &Path, path: &Path, temporary: &Path, remove_target: bool) -> Result<(), PersistenceError> {
+    // Rewrites are journaled even on platforms where rename is atomic. The
+    // marker plus an exact backup gives the Windows truncate/copy fallback a
+    // recovery decision without relying on a hash, checksum, or custom
+    // framing format.
+    let transaction_id = format!(
+        "{:020}-{}",
+        Utc::now().timestamp_nanos_opt().unwrap_or_default(),
+        std::process::id()
+    );
+    let target = audit_relative_path(root, path)?;
+    let backup = format!(
+        "audit/.{}.rewrite-backup-{}",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .ok_or(PersistenceError::CorruptedData)?,
+        transaction_id
+    );
+    let backup_path = root.join(&backup);
+    std::fs::copy(path, &backup_path).map_err(PersistenceError::Io)?;
+    let backup_file = std::fs::OpenOptions::new()
+        .write(true)
+        .open(&backup_path)
+        .map_err(PersistenceError::Io)?;
+    backup_file.sync_all().map_err(PersistenceError::Io)?;
+    let transactions = root.join("transactions");
+    std::fs::create_dir_all(&transactions).map_err(PersistenceError::Io)?;
+    let prepared = transactions.join(format!("{transaction_id}.audit-rewrite.prepared.json"));
+    let committed = transactions.join(format!("{transaction_id}.audit-rewrite.committed.json"));
+    let marker = AuditRewriteTransaction {
+        format_version: AUDIT_REWRITE_MARKER_VERSION,
+        target,
+        backup,
+    };
+    super::write_json_new_file(&prepared, &marker)?;
+
+    if remove_target {
+        std::fs::remove_file(path).map_err(PersistenceError::Io)?;
+        std::fs::remove_file(temporary).map_err(PersistenceError::Io)?;
+    } else if let Err(rename_error) = std::fs::rename(temporary, path) {
+        // Windows cannot replace an existing file with rename. The prepared
+        // marker owns a synced copy of the old journal, so an interruption
+        // during this overwrite is restored on reopen.
+        let mut source = std::fs::File::open(temporary).map_err(PersistenceError::Io)?;
+        let mut target_file = OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(path)
+            .map_err(PersistenceError::Io)?;
+        std::io::copy(&mut source, &mut target_file).map_err(PersistenceError::Io)?;
+        target_file.flush().map_err(PersistenceError::Io)?;
+        target_file.sync_all().map_err(PersistenceError::Io)?;
+        drop(target_file);
+        drop(source);
+        std::fs::remove_file(temporary).map_err(|_| PersistenceError::Io(rename_error))?;
+    }
+    super::write_json_new_file(&committed, &marker)?;
+    cleanup_audit_rewrite_transaction(Some(&prepared), &committed, &backup_path)
+}
+
+pub(crate) fn recover_audit_rewrite_transactions(root: &Path) -> Result<(), PersistenceError> {
+    let directory = root.join("transactions");
+    if !directory.exists() {
+        return Ok(());
+    }
+    let mut prepared = std::collections::BTreeMap::new();
+    let mut committed = std::collections::BTreeMap::new();
+    for entry in std::fs::read_dir(&directory).map_err(PersistenceError::Io)? {
+        let path = entry.map_err(PersistenceError::Io)?.path();
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if let Some(id) = name.strip_suffix(".audit-rewrite.prepared.json") {
+            prepared.insert(id.to_string(), path);
+        } else if let Some(id) = name.strip_suffix(".audit-rewrite.committed.json") {
+            committed.insert(id.to_string(), path);
+        }
+    }
+    for (id, marker_path) in committed {
+        let marker = read_audit_rewrite_transaction(root, &marker_path)?;
+        let prepared_path = prepared.remove(&id);
+        cleanup_audit_rewrite_transaction(prepared_path.as_deref(), &marker_path, &root.join(marker.backup))?;
+    }
+    for marker_path in prepared.into_values() {
+        let marker = read_audit_rewrite_transaction(root, &marker_path)?;
+        let target = root.join(marker.target);
+        let backup = root.join(marker.backup);
+        if backup.exists() {
+            restore_audit_rewrite_backup(&backup, &target)?;
+        }
+        super::remove_file_if_exists(Some(&backup))?;
+        super::remove_file_if_exists(Some(&marker_path))?;
+    }
+    Ok(())
+}
+
+fn cleanup_audit_rewrite_transaction(
+    prepared: Option<&Path>,
+    committed: &Path,
+    backup: &Path,
+) -> Result<(), PersistenceError> {
+    super::remove_file_if_exists(Some(backup))?;
+    super::remove_file_if_exists(prepared)?;
+    super::remove_file_if_exists(Some(committed))
+}
+
+fn restore_audit_rewrite_backup(backup: &Path, target: &Path) -> Result<(), PersistenceError> {
+    let temporary = target.with_file_name(format!(
+        ".{}.restore.tmp",
+        target
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or(PersistenceError::CorruptedData)?
+    ));
+    std::fs::copy(backup, &temporary).map_err(PersistenceError::Io)?;
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .open(&temporary)
+        .map_err(PersistenceError::Io)?;
+    file.sync_all().map_err(PersistenceError::Io)?;
+    drop(file);
+    if target.exists() {
+        let mut source = std::fs::File::open(&temporary).map_err(PersistenceError::Io)?;
+        let mut target_file = OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(target)
+            .map_err(PersistenceError::Io)?;
+        std::io::copy(&mut source, &mut target_file).map_err(PersistenceError::Io)?;
+        target_file.sync_all().map_err(PersistenceError::Io)?;
+        drop(target_file);
+        drop(source);
+        std::fs::remove_file(&temporary).map_err(PersistenceError::Io)?;
+    } else {
+        std::fs::rename(&temporary, target).map_err(PersistenceError::Io)?;
+    }
+    Ok(())
+}
+
+fn read_audit_rewrite_transaction(root: &Path, path: &Path) -> Result<AuditRewriteTransaction, PersistenceError> {
+    let marker: AuditRewriteTransaction =
+        serde_json::from_reader(std::fs::File::open(path).map_err(PersistenceError::Io)?)
+            .map_err(|_| PersistenceError::CorruptedData)?;
+    if marker.format_version != AUDIT_REWRITE_MARKER_VERSION
+        || audit_relative_path(root, &root.join(&marker.target))? != marker.target
+        || audit_backup_relative_path(root, &root.join(&marker.backup))? != marker.backup
+    {
+        return Err(PersistenceError::CorruptedData);
+    }
+    Ok(marker)
+}
+
+fn audit_relative_path(root: &Path, path: &Path) -> Result<String, PersistenceError> {
+    let relative = path.strip_prefix(root).map_err(|_| PersistenceError::CorruptedData)?;
+    let parent = relative.parent();
+    if parent != Some(Path::new("audit"))
+        || relative.extension().is_none_or(|extension| extension != "jsonl")
+        || relative
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_none_or(|name| name.contains('/') || name.contains('\\'))
+    {
+        return Err(PersistenceError::CorruptedData);
+    }
+    relative
+        .to_str()
+        .map(str::to_string)
+        .ok_or(PersistenceError::CorruptedData)
+}
+
+fn audit_backup_relative_path(root: &Path, path: &Path) -> Result<String, PersistenceError> {
+    let relative = path.strip_prefix(root).map_err(|_| PersistenceError::CorruptedData)?;
+    let file_name = relative
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or(PersistenceError::CorruptedData)?;
+    if relative.parent() != Some(Path::new("audit"))
+        || !file_name.starts_with('.')
+        || !file_name.contains(".rewrite-backup-")
+        || file_name.contains('/')
+        || file_name.contains('\\')
+    {
+        return Err(PersistenceError::CorruptedData);
+    }
+    relative
+        .to_str()
+        .map(str::to_string)
+        .ok_or(PersistenceError::CorruptedData)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::AuditAction;
+    use crate::model::AuditActor;
+    use crate::model::AuditOutcome;
+    use crate::model::AuditResourceType;
+
+    fn event(created_at_ms: i64) -> AuditEvent {
+        AuditEvent {
+            event_id: uuid::Uuid::now_v7().to_string(),
+            request_id: uuid::Uuid::now_v7().to_string(),
+            actor: AuditActor::admin("operator"),
+            action: AuditAction::TopicCreate,
+            resource_type: AuditResourceType::Topic,
+            resource_name: Some("orders".to_string()),
+            environment_id: None,
+            outcome: AuditOutcome::Succeeded,
+            detail: None,
+            created_at_ms,
+        }
+    }
+
+    #[test]
+    fn retention_rewrites_a_boundary_day_in_successive_bounded_batches() {
+        let directory = tempfile::tempdir().expect("temporary storage");
+        let root = directory.path();
+        let path = root.join("audit").join("2023-11-14.jsonl");
+        std::fs::create_dir_all(path.parent().expect("audit parent")).expect("create audit parent");
+        let mut file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&path)
+            .expect("open audit file");
+        for created_at_ms in [1_i64, 2, 3, 100] {
+            serde_json::to_writer(&mut file, &event(created_at_ms)).expect("write audit event");
+            file.write_all(b"\n").expect("write separator");
+        }
+        file.sync_all().expect("sync audit file");
+        drop(file);
+
+        assert_eq!(delete_audit_before(root, 10, 2).expect("first retention"), 2);
+        assert_eq!(delete_audit_before(root, 10, 2).expect("second retention"), 1);
+        let page = query_audit_events(
+            root,
+            AuditQuery {
+                start_ms: 0,
+                end_ms: 200,
+                actor: None,
+                action: None,
+                outcome: None,
+                environment_id: None,
+                cursor: None,
+                limit: 10,
+            },
+        )
+        .expect("query retained events");
+        assert_eq!(page.events.len(), 1);
+        assert_eq!(page.events[0].created_at_ms, 100);
+    }
+
+    #[test]
+    fn audit_open_recovers_only_an_incomplete_final_line() {
+        let directory = tempfile::tempdir().expect("temporary storage");
+        let root = directory.path();
+        let path = root.join("audit").join("2023-11-14.jsonl");
+        std::fs::create_dir_all(path.parent().expect("audit parent")).expect("create audit parent");
+        let mut file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&path)
+            .expect("open audit file");
+        serde_json::to_writer(&mut file, &event(10)).expect("write complete event");
+        file.write_all(b"\n{\"eventId\":").expect("write torn tail");
+        file.sync_all().expect("sync audit file");
+
+        recover_audit_tails(root).expect("recover torn final append");
+        let page = query_audit_events(
+            root,
+            AuditQuery {
+                start_ms: 0,
+                end_ms: 100,
+                actor: None,
+                action: None,
+                outcome: None,
+                environment_id: None,
+                cursor: None,
+                limit: 10,
+            },
+        )
+        .expect("query recovered journal");
+        assert_eq!(page.events.len(), 1);
+    }
+
+    #[test]
+    fn prepared_audit_rewrite_recovers_the_original_journal_after_interruption() {
+        let directory = tempfile::tempdir().expect("temporary storage");
+        let root = directory.path();
+        let target = root.join("audit").join("2023-11-14.jsonl");
+        let backup = root.join("audit").join(".2023-11-14.jsonl.rewrite-backup-prepared");
+        let transactions = root.join("transactions");
+        std::fs::create_dir_all(target.parent().expect("audit parent")).expect("create audit directory");
+        std::fs::create_dir_all(&transactions).expect("create transaction directory");
+        std::fs::write(&target, b"rewritten\n").expect("write interrupted journal");
+        std::fs::write(&backup, b"original\n").expect("write backup journal");
+        let marker = AuditRewriteTransaction {
+            format_version: AUDIT_REWRITE_MARKER_VERSION,
+            target: "audit/2023-11-14.jsonl".to_string(),
+            backup: "audit/.2023-11-14.jsonl.rewrite-backup-prepared".to_string(),
+        };
+        let prepared = transactions.join("prepared.audit-rewrite.prepared.json");
+        super::super::write_json_new_file(&prepared, &marker).expect("write prepared marker");
+
+        recover_audit_rewrite_transactions(root).expect("recover prepared rewrite");
+
+        assert_eq!(std::fs::read(&target).expect("read restored journal"), b"original\n");
+        assert!(!backup.exists());
+        assert!(!prepared.exists());
+    }
+
+    #[test]
+    fn committed_audit_rewrite_preserves_the_new_journal_and_cleans_markers() {
+        let directory = tempfile::tempdir().expect("temporary storage");
+        let root = directory.path();
+        let target = root.join("audit").join("2023-11-14.jsonl");
+        let backup = root.join("audit").join(".2023-11-14.jsonl.rewrite-backup-committed");
+        let transactions = root.join("transactions");
+        std::fs::create_dir_all(target.parent().expect("audit parent")).expect("create audit directory");
+        std::fs::create_dir_all(&transactions).expect("create transaction directory");
+        std::fs::write(&target, b"rewritten\n").expect("write committed journal");
+        std::fs::write(&backup, b"original\n").expect("write backup journal");
+        let marker = AuditRewriteTransaction {
+            format_version: AUDIT_REWRITE_MARKER_VERSION,
+            target: "audit/2023-11-14.jsonl".to_string(),
+            backup: "audit/.2023-11-14.jsonl.rewrite-backup-committed".to_string(),
+        };
+        let prepared = transactions.join("committed.audit-rewrite.prepared.json");
+        let committed = transactions.join("committed.audit-rewrite.committed.json");
+        super::super::write_json_new_file(&prepared, &marker).expect("write prepared marker");
+        super::super::write_json_new_file(&committed, &marker).expect("write committed marker");
+
+        recover_audit_rewrite_transactions(root).expect("recover committed rewrite");
+
+        assert_eq!(std::fs::read(&target).expect("read committed journal"), b"rewritten\n");
+        assert!(!backup.exists());
+        assert!(!prepared.exists());
+        assert!(!committed.exists());
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/audit_repository.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/audit_repository.rs
@@ -1,0 +1,108 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::model::AuditAction;
+use crate::model::AuditEvent;
+use crate::model::AuditOutcome;
+use crate::persistence::DashboardPersistence;
+use crate::persistence::backend::PersistenceBackend;
+use crate::persistence::error::PersistenceError;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditCursor {
+    pub created_at_ms: i64,
+    pub event_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditQuery {
+    pub start_ms: i64,
+    pub end_ms: i64,
+    pub actor: Option<String>,
+    pub action: Option<AuditAction>,
+    pub outcome: Option<AuditOutcome>,
+    pub environment_id: Option<String>,
+    pub cursor: Option<AuditCursor>,
+    pub limit: usize,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AuditPage {
+    pub events: Vec<AuditEvent>,
+    pub next_cursor: Option<AuditCursor>,
+}
+
+/// Repository boundary for tamper-evident operational history. Events are
+/// append-only from the dashboard API; no delete API is exposed.
+#[allow(async_fn_in_trait)]
+pub trait AuditRepository {
+    async fn append_audit_event(&self, event: AuditEvent) -> Result<(), PersistenceError>;
+    async fn query_audit_events(&self, query: AuditQuery) -> Result<AuditPage, PersistenceError>;
+    async fn delete_audit_before(&self, cutoff_ms: i64, limit: usize) -> Result<u64, PersistenceError>;
+}
+
+impl DashboardPersistence {
+    pub async fn append_audit_event(&self, event: AuditEvent) -> Result<(), PersistenceError> {
+        match &self.backend {
+            PersistenceBackend::File(store) => store.append_audit_event(event).await,
+            PersistenceBackend::Sql(store) => store.append_audit_event(event).await,
+        }
+    }
+
+    pub async fn query_audit_events(&self, query: AuditQuery) -> Result<AuditPage, PersistenceError> {
+        validate_query(&query)?;
+        match &self.backend {
+            PersistenceBackend::File(store) => store.query_audit_events(query).await,
+            PersistenceBackend::Sql(store) => store.query_audit_events(query).await,
+        }
+    }
+
+    pub async fn delete_audit_before(&self, cutoff_ms: i64, limit: usize) -> Result<u64, PersistenceError> {
+        if limit == 0 || limit > 1_000 {
+            return Err(PersistenceError::InvalidConfig(
+                "audit cleanup batch must be between 1 and 1000".to_string(),
+            ));
+        }
+        match &self.backend {
+            PersistenceBackend::File(store) => store.delete_audit_before(cutoff_ms, limit).await,
+            PersistenceBackend::Sql(store) => store.delete_audit_before(cutoff_ms, limit).await,
+        }
+    }
+}
+
+impl AuditRepository for DashboardPersistence {
+    async fn append_audit_event(&self, event: AuditEvent) -> Result<(), PersistenceError> {
+        Self::append_audit_event(self, event).await
+    }
+
+    async fn query_audit_events(&self, query: AuditQuery) -> Result<AuditPage, PersistenceError> {
+        Self::query_audit_events(self, query).await
+    }
+
+    async fn delete_audit_before(&self, cutoff_ms: i64, limit: usize) -> Result<u64, PersistenceError> {
+        Self::delete_audit_before(self, cutoff_ms, limit).await
+    }
+}
+
+fn validate_query(query: &AuditQuery) -> Result<(), PersistenceError> {
+    if query.start_ms < 0 || query.end_ms < query.start_ms || query.limit == 0 || query.limit > 200 {
+        return Err(PersistenceError::InvalidConfig("audit query is invalid".to_string()));
+    }
+    if let Some(cursor) = &query.cursor
+        && (cursor.event_id.is_empty() || cursor.event_id.len() > 36)
+    {
+        return Err(PersistenceError::InvalidConfig("audit cursor is invalid".to_string()));
+    }
+    Ok(())
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/audit_sql_store.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/audit_sql_store.rs
@@ -1,0 +1,650 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::DatabasePool;
+use super::PersistenceError;
+use super::SqlPersistence;
+use super::map_query_error;
+use crate::model::AuditAction;
+use crate::model::AuditActor;
+use crate::model::AuditActorKind;
+use crate::model::AuditEvent;
+use crate::model::AuditOutcome;
+use crate::model::AuditResourceType;
+use crate::model::EnvironmentId;
+use crate::persistence::audit_repository::AuditCursor;
+use crate::persistence::audit_repository::AuditPage;
+use crate::persistence::audit_repository::AuditQuery;
+use sqlx::MySql;
+use sqlx::Postgres;
+use sqlx::Row;
+use sqlx::Sqlite;
+use sqlx::Transaction;
+use sqlx::mysql::MySqlRow;
+
+impl SqlPersistence {
+    pub(crate) async fn append_audit_event(&self, event: AuditEvent) -> Result<(), PersistenceError> {
+        let detail = event
+            .detail
+            .map(|value| serde_json::to_string(&value))
+            .transpose()
+            .map_err(PersistenceError::Serialization)?;
+        match &self.pool {
+            DatabasePool::Sqlite(pool) => {
+                sqlx::query("INSERT INTO dashboard_audit_event (event_id, request_id, actor_kind, actor_username, action, resource_type, resource_name, environment_id, outcome, detail_json, created_at_ms) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+                    .bind(event.event_id).bind(event.request_id).bind(event.actor.kind.code()).bind(event.actor.username)
+                    .bind(event.action.code()).bind(event.resource_type.code()).bind(event.resource_name)
+                    .bind(event.environment_id.map(|id| id.0)).bind(event.outcome.code()).bind(detail).bind(event.created_at_ms)
+                    .execute(pool).await.map_err(map_query_error)?;
+            }
+            DatabasePool::MySql(pool) => {
+                sqlx::query("INSERT INTO dashboard_audit_event (event_id, request_id, actor_kind, actor_username, action, resource_type, resource_name, environment_id, outcome, detail_json, created_at_ms) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+                    .bind(event.event_id).bind(event.request_id).bind(event.actor.kind.code()).bind(event.actor.username)
+                    .bind(event.action.code()).bind(event.resource_type.code()).bind(event.resource_name)
+                    .bind(event.environment_id.map(|id| id.0)).bind(event.outcome.code()).bind(detail).bind(event.created_at_ms)
+                    .execute(pool).await.map_err(map_query_error)?;
+            }
+            DatabasePool::Postgres(pool) => {
+                sqlx::query("INSERT INTO dashboard_audit_event (event_id, request_id, actor_kind, actor_username, action, resource_type, resource_name, environment_id, outcome, detail_json, created_at_ms) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)")
+                    .bind(event.event_id).bind(event.request_id).bind(event.actor.kind.code()).bind(event.actor.username)
+                    .bind(event.action.code()).bind(event.resource_type.code()).bind(event.resource_name)
+                    .bind(event.environment_id.map(|id| id.0)).bind(event.outcome.code()).bind(detail).bind(event.created_at_ms)
+                    .execute(pool).await.map_err(map_query_error)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn query_audit_events(&self, query: AuditQuery) -> Result<AuditPage, PersistenceError> {
+        match &self.pool {
+            DatabasePool::Sqlite(pool) => query_sqlite(pool, query).await,
+            DatabasePool::MySql(pool) => query_mysql(pool, query).await,
+            DatabasePool::Postgres(pool) => query_postgres(pool, query).await,
+        }
+    }
+
+    pub(crate) async fn delete_audit_before(&self, cutoff_ms: i64, limit: usize) -> Result<u64, PersistenceError> {
+        match &self.pool {
+            DatabasePool::Sqlite(pool) => {
+                let result = sqlx::query("DELETE FROM dashboard_audit_event WHERE event_id IN (SELECT event_id FROM dashboard_audit_event WHERE created_at_ms < ? ORDER BY created_at_ms, event_id LIMIT ?)")
+                    .bind(cutoff_ms)
+                    .bind(limit as i64)
+                    .execute(pool)
+                    .await
+                    .map_err(map_query_error)?;
+                Ok(result.rows_affected())
+            }
+            DatabasePool::MySql(pool) => {
+                // MySQL does not permit selecting from a table being deleted
+                // without an additional derived-table level.
+                let result = sqlx::query("DELETE FROM dashboard_audit_event WHERE event_id IN (SELECT event_id FROM (SELECT event_id FROM dashboard_audit_event WHERE created_at_ms < ? ORDER BY created_at_ms, event_id LIMIT ?) AS cleanup_rows)")
+                    .bind(cutoff_ms)
+                    .bind(limit as i64)
+                    .execute(pool)
+                    .await
+                    .map_err(map_query_error)?;
+                Ok(result.rows_affected())
+            }
+            DatabasePool::Postgres(pool) => {
+                let result = sqlx::query("DELETE FROM dashboard_audit_event WHERE event_id IN (SELECT event_id FROM dashboard_audit_event WHERE created_at_ms < $1 ORDER BY created_at_ms, event_id LIMIT $2)")
+                    .bind(cutoff_ms)
+                    .bind(limit as i64)
+                    .execute(pool)
+                    .await
+                    .map_err(map_query_error)?;
+                Ok(result.rows_affected())
+            }
+        }
+    }
+}
+
+/// Inserts a safe, already-built audit event on the same SQLite transaction
+/// as the local aggregate mutation. Keeping this helper database-specific
+/// avoids widening the persistence facade to a dynamic executor.
+pub(super) async fn append_sqlite_audit_event_in_transaction(
+    transaction: &mut Transaction<'_, Sqlite>,
+    event: &AuditEvent,
+) -> Result<(), PersistenceError> {
+    let detail = audit_detail(event)?;
+    sqlx::query("INSERT INTO dashboard_audit_event (event_id, request_id, actor_kind, actor_username, action, resource_type, resource_name, environment_id, outcome, detail_json, created_at_ms) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+        .bind(&event.event_id)
+        .bind(&event.request_id)
+        .bind(event.actor.kind.code())
+        .bind(event.actor.username.as_deref())
+        .bind(event.action.code())
+        .bind(event.resource_type.code())
+        .bind(event.resource_name.as_deref())
+        .bind(event.environment_id.as_ref().map(|id| id.0.as_str()))
+        .bind(event.outcome.code())
+        .bind(detail)
+        .bind(event.created_at_ms)
+        .execute(&mut **transaction)
+        .await
+        .map_err(map_query_error)?;
+    Ok(())
+}
+
+/// Inserts a safe, already-built audit event on the same MySQL transaction
+/// as the local aggregate mutation.
+pub(super) async fn append_mysql_audit_event_in_transaction(
+    transaction: &mut Transaction<'_, MySql>,
+    event: &AuditEvent,
+) -> Result<(), PersistenceError> {
+    let detail = audit_detail(event)?;
+    sqlx::query("INSERT INTO dashboard_audit_event (event_id, request_id, actor_kind, actor_username, action, resource_type, resource_name, environment_id, outcome, detail_json, created_at_ms) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+        .bind(&event.event_id)
+        .bind(&event.request_id)
+        .bind(event.actor.kind.code())
+        .bind(event.actor.username.as_deref())
+        .bind(event.action.code())
+        .bind(event.resource_type.code())
+        .bind(event.resource_name.as_deref())
+        .bind(event.environment_id.as_ref().map(|id| id.0.as_str()))
+        .bind(event.outcome.code())
+        .bind(detail)
+        .bind(event.created_at_ms)
+        .execute(&mut **transaction)
+        .await
+        .map_err(map_query_error)?;
+    Ok(())
+}
+
+/// Inserts a safe, already-built audit event on the same PostgreSQL
+/// transaction as the local aggregate mutation.
+pub(super) async fn append_postgres_audit_event_in_transaction(
+    transaction: &mut Transaction<'_, Postgres>,
+    event: &AuditEvent,
+) -> Result<(), PersistenceError> {
+    let detail = audit_detail(event)?;
+    sqlx::query("INSERT INTO dashboard_audit_event (event_id, request_id, actor_kind, actor_username, action, resource_type, resource_name, environment_id, outcome, detail_json, created_at_ms) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)")
+        .bind(&event.event_id)
+        .bind(&event.request_id)
+        .bind(event.actor.kind.code())
+        .bind(event.actor.username.as_deref())
+        .bind(event.action.code())
+        .bind(event.resource_type.code())
+        .bind(event.resource_name.as_deref())
+        .bind(event.environment_id.as_ref().map(|id| id.0.as_str()))
+        .bind(event.outcome.code())
+        .bind(detail)
+        .bind(event.created_at_ms)
+        .execute(&mut **transaction)
+        .await
+        .map_err(map_query_error)?;
+    Ok(())
+}
+
+fn audit_detail(event: &AuditEvent) -> Result<Option<String>, PersistenceError> {
+    event
+        .detail
+        .as_ref()
+        .map(serde_json::to_string)
+        .transpose()
+        .map_err(PersistenceError::Serialization)
+}
+
+async fn query_sqlite(pool: &super::SqlitePool, query: AuditQuery) -> Result<AuditPage, PersistenceError> {
+    let bindings = AuditQueryBindings::from_query(&query);
+    let rows = sqlx::query(SQLITE_AUDIT_QUERY)
+        .bind(bindings.start_ms)
+        .bind(bindings.end_ms)
+        .bind(&bindings.actor)
+        .bind(&bindings.actor)
+        .bind(&bindings.action)
+        .bind(&bindings.action)
+        .bind(&bindings.outcome)
+        .bind(&bindings.outcome)
+        .bind(&bindings.environment_id)
+        .bind(&bindings.environment_id)
+        .bind(bindings.cursor_created_at_ms)
+        .bind(bindings.cursor_created_at_ms)
+        .bind(bindings.cursor_created_at_ms)
+        .bind(&bindings.cursor_event_id)
+        .bind(bindings.limit_plus_one)
+        .fetch_all(pool)
+        .await
+        .map_err(map_query_error)?;
+    audit_page_from_rows(rows, query.limit)
+}
+
+async fn query_mysql(pool: &super::MySqlPool, query: AuditQuery) -> Result<AuditPage, PersistenceError> {
+    let bindings = AuditQueryBindings::from_query(&query);
+    let rows = sqlx::query(MYSQL_AUDIT_QUERY)
+        .bind(bindings.start_ms)
+        .bind(bindings.end_ms)
+        .bind(&bindings.actor)
+        .bind(&bindings.actor)
+        .bind(&bindings.action)
+        .bind(&bindings.action)
+        .bind(&bindings.outcome)
+        .bind(&bindings.outcome)
+        .bind(&bindings.environment_id)
+        .bind(&bindings.environment_id)
+        .bind(bindings.cursor_created_at_ms)
+        .bind(bindings.cursor_created_at_ms)
+        .bind(bindings.cursor_created_at_ms)
+        .bind(&bindings.cursor_event_id)
+        .bind(bindings.limit_plus_one)
+        .fetch_all(pool)
+        .await
+        .map_err(map_query_error)?;
+    mysql_audit_page_from_rows(rows, query.limit)
+}
+
+async fn query_postgres(pool: &super::PgPool, query: AuditQuery) -> Result<AuditPage, PersistenceError> {
+    let bindings = AuditQueryBindings::from_query(&query);
+    let rows = sqlx::query(POSTGRES_AUDIT_QUERY)
+        .bind(bindings.start_ms)
+        .bind(bindings.end_ms)
+        .bind(&bindings.actor)
+        .bind(&bindings.action)
+        .bind(&bindings.outcome)
+        .bind(&bindings.environment_id)
+        .bind(bindings.cursor_created_at_ms)
+        .bind(&bindings.cursor_event_id)
+        .bind(bindings.limit_plus_one)
+        .fetch_all(pool)
+        .await
+        .map_err(map_query_error)?;
+    audit_page_from_rows(rows, query.limit)
+}
+
+const SQLITE_AUDIT_QUERY: &str = concat!(
+    "SELECT event_id, request_id, actor_kind, actor_username, action, resource_type, resource_name, environment_id, outcome, detail_json, created_at_ms FROM dashboard_audit_event",
+    " WHERE created_at_ms >= ? AND created_at_ms <= ?",
+    " AND (? IS NULL OR COALESCE(actor_username, actor_kind) = ?)",
+    " AND (? IS NULL OR action = ?)",
+    " AND (? IS NULL OR outcome = ?)",
+    " AND (? IS NULL OR environment_id = ?)",
+    " AND (? IS NULL OR created_at_ms < ? OR (created_at_ms = ? AND event_id < ?))",
+    " ORDER BY created_at_ms DESC, event_id DESC LIMIT ?"
+);
+const MYSQL_AUDIT_QUERY: &str = concat!(
+    "SELECT event_id, request_id, actor_kind, actor_username, action, resource_type, resource_name, environment_id, outcome, detail_json, created_at_ms FROM dashboard_audit_event",
+    " WHERE created_at_ms >= ? AND created_at_ms <= ?",
+    " AND (? IS NULL OR COALESCE(actor_username, CAST(actor_kind AS BINARY)) = CAST(? AS BINARY))",
+    " AND (? IS NULL OR action = ?)",
+    " AND (? IS NULL OR outcome = ?)",
+    " AND (? IS NULL OR environment_id = ?)",
+    " AND (? IS NULL OR created_at_ms < ? OR (created_at_ms = ? AND event_id < ?))",
+    " ORDER BY created_at_ms DESC, event_id DESC LIMIT ?"
+);
+const POSTGRES_AUDIT_QUERY: &str = concat!(
+    "SELECT event_id, request_id, actor_kind, actor_username, action, resource_type, resource_name, environment_id, outcome, detail_json, created_at_ms FROM dashboard_audit_event",
+    " WHERE created_at_ms >= $1 AND created_at_ms <= $2",
+    " AND ($3::text IS NULL OR COALESCE(actor_username, actor_kind) = $3)",
+    " AND ($4::text IS NULL OR action = $4)",
+    " AND ($5::text IS NULL OR outcome = $5)",
+    " AND ($6::text IS NULL OR environment_id = $6)",
+    " AND ($7::bigint IS NULL OR created_at_ms < $7 OR (created_at_ms = $7 AND event_id < $8))",
+    " ORDER BY created_at_ms DESC, event_id DESC LIMIT $9"
+);
+
+struct AuditQueryBindings {
+    start_ms: i64,
+    end_ms: i64,
+    actor: Option<String>,
+    action: Option<String>,
+    outcome: Option<String>,
+    environment_id: Option<String>,
+    cursor_created_at_ms: Option<i64>,
+    cursor_event_id: Option<String>,
+    limit_plus_one: i64,
+}
+
+fn mysql_audit_page_from_rows(rows: Vec<MySqlRow>, limit: usize) -> Result<AuditPage, PersistenceError> {
+    let mut events = rows
+        .into_iter()
+        .map(mysql_audit_event_from_row)
+        .collect::<Result<Vec<_>, _>>()?;
+    let has_more = events.len() > limit;
+    events.truncate(limit);
+    let next_cursor = has_more
+        .then(|| {
+            events.last().map(|event| AuditCursor {
+                created_at_ms: event.created_at_ms,
+                event_id: event.event_id.clone(),
+            })
+        })
+        .flatten();
+    Ok(AuditPage { events, next_cursor })
+}
+
+fn mysql_audit_event_from_row(row: MySqlRow) -> Result<AuditEvent, PersistenceError> {
+    let actor_kind =
+        AuditActorKind::parse(&mysql_string(&row, "actor_kind")?).ok_or(PersistenceError::CorruptedData)?;
+    let action = AuditAction::parse(&mysql_string(&row, "action")?).ok_or(PersistenceError::CorruptedData)?;
+    let resource_type =
+        AuditResourceType::parse(&mysql_string(&row, "resource_type")?).ok_or(PersistenceError::CorruptedData)?;
+    let outcome = AuditOutcome::parse(&mysql_string(&row, "outcome")?).ok_or(PersistenceError::CorruptedData)?;
+    let detail = row
+        .try_get::<Option<String>, _>("detail_json")
+        .map_err(|_| PersistenceError::CorruptedData)?
+        .map(|encoded| serde_json::from_str(&encoded).map_err(|_| PersistenceError::CorruptedData))
+        .transpose()?;
+    Ok(AuditEvent {
+        event_id: mysql_string(&row, "event_id")?,
+        request_id: mysql_string(&row, "request_id")?,
+        actor: AuditActor {
+            kind: actor_kind,
+            username: mysql_optional_utf8(&row, "actor_username")?,
+        },
+        action,
+        resource_type,
+        resource_name: mysql_optional_utf8(&row, "resource_name")?,
+        environment_id: mysql_optional_utf8(&row, "environment_id")?.map(EnvironmentId),
+        outcome,
+        detail,
+        created_at_ms: row
+            .try_get("created_at_ms")
+            .map_err(|_| PersistenceError::CorruptedData)?,
+    })
+}
+
+fn mysql_string(row: &MySqlRow, column: &str) -> Result<String, PersistenceError> {
+    String::from_utf8(
+        row.try_get::<Vec<u8>, _>(column)
+            .map_err(|_| PersistenceError::CorruptedData)?,
+    )
+    .map_err(|_| PersistenceError::CorruptedData)
+}
+
+fn mysql_optional_utf8(row: &MySqlRow, column: &str) -> Result<Option<String>, PersistenceError> {
+    row.try_get::<Option<Vec<u8>>, _>(column)
+        .map_err(|_| PersistenceError::CorruptedData)?
+        .map(|bytes| String::from_utf8(bytes).map_err(|_| PersistenceError::CorruptedData))
+        .transpose()
+}
+
+impl AuditQueryBindings {
+    fn from_query(query: &AuditQuery) -> Self {
+        Self {
+            start_ms: query.start_ms,
+            end_ms: query.end_ms,
+            actor: query.actor.clone(),
+            action: query.action.map(|value| value.code().to_string()),
+            outcome: query.outcome.map(|value| value.code().to_string()),
+            environment_id: query.environment_id.clone(),
+            cursor_created_at_ms: query.cursor.as_ref().map(|cursor| cursor.created_at_ms),
+            cursor_event_id: query.cursor.as_ref().map(|cursor| cursor.event_id.clone()),
+            limit_plus_one: (query.limit + 1) as i64,
+        }
+    }
+}
+
+fn audit_page_from_rows<R>(rows: Vec<R>, limit: usize) -> Result<AuditPage, PersistenceError>
+where
+    R: super::Row,
+    for<'r> &'r str: sqlx::ColumnIndex<R>,
+    for<'r> String: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
+    for<'r> Option<String>: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
+    for<'r> i64: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
+{
+    let mut events = rows
+        .into_iter()
+        .map(audit_event_from_row)
+        .collect::<Result<Vec<_>, _>>()?;
+    let has_more = events.len() > limit;
+    events.truncate(limit);
+    let next_cursor = has_more
+        .then(|| {
+            events.last().map(|event| AuditCursor {
+                created_at_ms: event.created_at_ms,
+                event_id: event.event_id.clone(),
+            })
+        })
+        .flatten();
+    Ok(AuditPage { events, next_cursor })
+}
+
+fn audit_event_from_row<R>(row: R) -> Result<AuditEvent, PersistenceError>
+where
+    R: super::Row,
+    for<'r> &'r str: sqlx::ColumnIndex<R>,
+    for<'r> String: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
+    for<'r> Option<String>: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
+    for<'r> i64: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
+{
+    let actor_kind = AuditActorKind::parse(
+        &row.try_get::<String, _>("actor_kind")
+            .map_err(|_| PersistenceError::CorruptedData)?,
+    )
+    .ok_or(PersistenceError::CorruptedData)?;
+    let action = AuditAction::parse(
+        &row.try_get::<String, _>("action")
+            .map_err(|_| PersistenceError::CorruptedData)?,
+    )
+    .ok_or(PersistenceError::CorruptedData)?;
+    let resource_type = AuditResourceType::parse(
+        &row.try_get::<String, _>("resource_type")
+            .map_err(|_| PersistenceError::CorruptedData)?,
+    )
+    .ok_or(PersistenceError::CorruptedData)?;
+    let outcome = AuditOutcome::parse(
+        &row.try_get::<String, _>("outcome")
+            .map_err(|_| PersistenceError::CorruptedData)?,
+    )
+    .ok_or(PersistenceError::CorruptedData)?;
+    let detail = row
+        .try_get::<Option<String>, _>("detail_json")
+        .map_err(|_| PersistenceError::CorruptedData)?
+        .map(|encoded| serde_json::from_str(&encoded).map_err(|_| PersistenceError::CorruptedData))
+        .transpose()?;
+    Ok(AuditEvent {
+        event_id: row.try_get("event_id").map_err(|_| PersistenceError::CorruptedData)?,
+        request_id: row.try_get("request_id").map_err(|_| PersistenceError::CorruptedData)?,
+        actor: AuditActor {
+            kind: actor_kind,
+            username: row
+                .try_get("actor_username")
+                .map_err(|_| PersistenceError::CorruptedData)?,
+        },
+        action,
+        resource_type,
+        resource_name: row
+            .try_get("resource_name")
+            .map_err(|_| PersistenceError::CorruptedData)?,
+        environment_id: row
+            .try_get::<Option<String>, _>("environment_id")
+            .map_err(|_| PersistenceError::CorruptedData)?
+            .map(EnvironmentId),
+        outcome,
+        detail,
+        created_at_ms: row
+            .try_get("created_at_ms")
+            .map_err(|_| PersistenceError::CorruptedData)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::NewSession;
+    use crate::model::SessionTokenHash;
+    use crate::model::StorageBackend;
+    use crate::persistence::migration;
+    use serde_json::json;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn store() -> SqlPersistence {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("open SQLite storage");
+        let schema_version = migration::migrate_sqlite(&pool).await.expect("migrate SQLite storage");
+        SqlPersistence {
+            pool: DatabasePool::Sqlite(pool),
+            backend: StorageBackend::Sqlite,
+            schema_version,
+        }
+    }
+
+    fn event(id: &str, created_at_ms: i64) -> AuditEvent {
+        AuditEvent {
+            event_id: id.to_string(),
+            request_id: uuid::Uuid::now_v7().to_string(),
+            actor: AuditActor::admin("operator"),
+            action: AuditAction::TopicCreate,
+            resource_type: AuditResourceType::Topic,
+            resource_name: Some("orders".to_string()),
+            environment_id: None,
+            outcome: AuditOutcome::Succeeded,
+            detail: Some(json!({"target":"orders"})),
+            created_at_ms,
+        }
+    }
+
+    #[tokio::test]
+    async fn sqlite_audit_query_uses_descending_stable_keyset_pagination() {
+        let store = store().await;
+        let first = uuid::Uuid::now_v7().to_string();
+        let second = uuid::Uuid::now_v7().to_string();
+        let third = uuid::Uuid::now_v7().to_string();
+        store
+            .append_audit_event(event(&first, 100))
+            .await
+            .expect("append first");
+        store
+            .append_audit_event(event(&second, 100))
+            .await
+            .expect("append second");
+        store.append_audit_event(event(&third, 99)).await.expect("append third");
+
+        let first_page = store
+            .query_audit_events(AuditQuery {
+                start_ms: 0,
+                end_ms: 100,
+                actor: None,
+                action: None,
+                outcome: None,
+                environment_id: None,
+                cursor: None,
+                limit: 2,
+            })
+            .await
+            .expect("query first page");
+        assert_eq!(first_page.events.len(), 2);
+        let cursor = first_page.next_cursor.expect("next cursor");
+        store
+            .append_audit_event(event(&uuid::Uuid::now_v7().to_string(), 101))
+            .await
+            .expect("append newer event");
+        let second_page = store
+            .query_audit_events(AuditQuery {
+                start_ms: 0,
+                end_ms: 101,
+                actor: None,
+                action: None,
+                outcome: None,
+                environment_id: None,
+                cursor: Some(cursor),
+                limit: 2,
+            })
+            .await
+            .expect("query second page");
+        assert_eq!(second_page.events.len(), 1);
+        assert_eq!(second_page.events[0].event_id, third);
+    }
+
+    #[tokio::test]
+    async fn sqlite_session_audit_transaction_rolls_back_when_the_audit_insert_fails() {
+        let store = store().await;
+        let duplicate = uuid::Uuid::now_v7().to_string();
+        store
+            .append_audit_event(event(&duplicate, 1))
+            .await
+            .expect("seed audit event");
+        let hash = SessionTokenHash([7; 32]);
+        let result = store
+            .create_session_with_audit(
+                NewSession {
+                    session_id: uuid::Uuid::now_v7().to_string(),
+                    token_hash: hash,
+                    username: "operator".to_string(),
+                    created_at_ms: 2,
+                    expires_at_ms: 3,
+                },
+                event(&duplicate, 2),
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(store.find_session(&hash).await.expect("read session").is_none());
+    }
+
+    #[tokio::test]
+    async fn sqlite_capped_session_create_leaves_no_extra_session_or_audit_event() {
+        let store = store().await;
+        let first_hash = SessionTokenHash([8; 32]);
+        store
+            .create_session_with_audit_capped(
+                NewSession {
+                    session_id: uuid::Uuid::now_v7().to_string(),
+                    token_hash: first_hash,
+                    username: "operator".to_string(),
+                    created_at_ms: 1,
+                    expires_at_ms: 1_000,
+                },
+                event(&uuid::Uuid::now_v7().to_string(), 1),
+                1,
+                2,
+            )
+            .await
+            .expect("create first capped session");
+        assert!(
+            store
+                .find_session(&first_hash)
+                .await
+                .expect("read first session")
+                .is_some()
+        );
+        let second_hash = SessionTokenHash([9; 32]);
+        let rejected = store
+            .create_session_with_audit_capped(
+                NewSession {
+                    session_id: uuid::Uuid::now_v7().to_string(),
+                    token_hash: second_hash,
+                    username: "operator".to_string(),
+                    created_at_ms: 2,
+                    expires_at_ms: 1_000,
+                },
+                event(&uuid::Uuid::now_v7().to_string(), 2),
+                1,
+                2,
+            )
+            .await;
+        assert!(matches!(rejected, Err(PersistenceError::Conflict)));
+        assert!(
+            store
+                .find_session(&second_hash)
+                .await
+                .expect("read second session")
+                .is_none()
+        );
+        let events = store
+            .query_audit_events(AuditQuery {
+                start_ms: 0,
+                end_ms: 10,
+                actor: None,
+                action: None,
+                outcome: None,
+                environment_id: None,
+                cursor: None,
+                limit: 10,
+            })
+            .await
+            .expect("query audit events");
+        assert_eq!(events.events.len(), 1);
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/environment_repository.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/environment_repository.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use crate::model::AuditEvent;
 use crate::model::DashboardEnvironment;
 use crate::model::EndpointType;
 use crate::model::EnvironmentId;
@@ -92,6 +93,30 @@ impl DashboardPersistence {
         match &self.backend {
             PersistenceBackend::File(store) => store.update_environment(expected_revision, candidate).await,
             PersistenceBackend::Sql(store) => store.update_environment(expected_revision, candidate).await,
+        }
+    }
+
+    /// Persists an environment revision and its terminal successful audit event
+    /// as one storage decision. Callers must publish the returned aggregate
+    /// only after this method succeeds.
+    pub async fn update_environment_with_audit(
+        &self,
+        expected_revision: Revision,
+        mut candidate: DashboardEnvironment,
+        audit: AuditEvent,
+    ) -> Result<DashboardEnvironment, PersistenceError> {
+        sort_environment_endpoints(&mut candidate);
+        match &self.backend {
+            PersistenceBackend::File(store) => {
+                store
+                    .update_environment_with_audit(expected_revision, candidate, audit)
+                    .await
+            }
+            PersistenceBackend::Sql(store) => {
+                store
+                    .update_environment_with_audit(expected_revision, candidate, audit)
+                    .await
+            }
         }
     }
 
@@ -283,6 +308,49 @@ impl FilePersistence {
             &collection,
             current.revision,
             to_value(&candidate).map_err(PersistenceError::Serialization)?,
+        )
+        .await?;
+        Ok(candidate)
+    }
+
+    pub(crate) async fn update_environment_with_audit(
+        &self,
+        expected_revision: Revision,
+        mut candidate: DashboardEnvironment,
+        audit: AuditEvent,
+    ) -> Result<DashboardEnvironment, PersistenceError> {
+        candidate.validate().map_err(PersistenceError::InvalidConfig)?;
+        validate_environment_identity(&candidate)?;
+        let write_guard = self.write_guard().await;
+        if self
+            .list_environments_locked()
+            .await?
+            .iter()
+            .any(|existing| existing.environment_id != candidate.environment_id && existing.name == candidate.name)
+        {
+            return Err(PersistenceError::Conflict);
+        }
+        let collection = collection_for_environment(&candidate);
+        let current = self
+            .load_latest_snapshot(&collection)
+            .await?
+            .ok_or(PersistenceError::NotFound)?;
+        let current_environment =
+            decode_file_environment_snapshot(current.payload)?.ok_or(PersistenceError::NotFound)?;
+        if current_environment.environment_id != candidate.environment_id
+            || current_environment.revision != expected_revision
+        {
+            return Err(PersistenceError::Conflict);
+        }
+        candidate.revision = Revision(expected_revision.0.checked_add(1).ok_or(PersistenceError::Conflict)?);
+        self.publish_snapshot_transaction_with_audit_locked(
+            write_guard,
+            vec![FileSnapshotTransactionWrite {
+                collection,
+                expected_revision: current.revision,
+                payload: to_value(&candidate).map_err(PersistenceError::Serialization)?,
+            }],
+            audit,
         )
         .await?;
         Ok(candidate)

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/file_store.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/file_store.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use crate::config::StorageConfig;
+use crate::model::AuditEvent;
 use crate::persistence::StorageHealth;
 use crate::persistence::StorageMode;
 use crate::persistence::StorageStatus;
@@ -42,8 +43,12 @@ use tokio::sync::RwLock;
 use tokio::sync::RwLockReadGuard;
 use tokio::sync::oneshot;
 
+#[path = "audit_file_store.rs"]
+mod audit_file_store;
 #[path = "history_file_store.rs"]
 mod history_file_store;
+#[path = "session_file_store.rs"]
+mod session_file_store;
 
 const FORMAT_VERSION: u32 = 1;
 const MIN_AVAILABLE_BYTES: u64 = 64 * 1024 * 1024;
@@ -74,6 +79,10 @@ impl FileDirectoryLock {
             return Err(PersistenceError::LockUnavailable);
         }
         recover_incomplete_snapshot_transactions(root)?;
+        session_file_store::recover_session_audit_transactions(root)?;
+        session_file_store::recover_session_touch_transactions(root)?;
+        session_file_store::recover_session_cleanup_transactions(root)?;
+        audit_file_store::recover_audit_rewrite_transactions(root)?;
         history_file_store::recover_history_file_operations(root)?;
         initialize_manifest(root)?;
         Ok(Self { _file: file })
@@ -110,12 +119,24 @@ pub(crate) struct FileSnapshotTransactionWrite {
 struct FileSnapshotTransaction {
     format_version: u32,
     writes: Vec<FileSnapshotTransactionRecord>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    audit: Option<FileSnapshotAuditAppend>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct FileSnapshotTransactionRecord {
     collection: String,
     revision: u64,
+}
+
+/// The only journal rollback data persisted with a snapshot aggregate. The
+/// append payload itself is already durable in the journal; no checksum or
+/// token-derived identifier is stored in the marker.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct FileSnapshotAuditAppend {
+    relative_path: String,
+    existed: bool,
+    original_length: u64,
 }
 
 /// The result sent by an admitted storage-I/O task. A task-timeout is not a
@@ -366,6 +387,7 @@ impl FilePersistence {
                     payload,
                 }],
                 None,
+                None,
             )?;
             mutation_blocker.wait_after_mutation();
             Ok(FileMutationOutcome {
@@ -480,6 +502,7 @@ impl FilePersistence {
                         payload,
                     }],
                     None,
+                    None,
                 )?;
                 mutation_blocker.wait_after_mutation();
                 Ok(FileMutationOutcome {
@@ -515,6 +538,53 @@ impl FilePersistence {
     ) -> Result<(), PersistenceError> {
         self.publish_snapshot_transaction_locked_with_failure(write_guard, writes, None, None)
             .await
+    }
+
+    /// Publishes related snapshots and one already-safe audit event behind the
+    /// same prepared/committed decision marker. The caller must retain the
+    /// returned request ownership through `dispatch_file_mutation`; a request
+    /// cancellation can therefore only observe the old aggregate or the
+    /// committed aggregate plus its journal entry.
+    pub(crate) async fn publish_snapshot_transaction_with_audit_locked(
+        &self,
+        write_guard: OwnedRwLockWriteGuard<()>,
+        writes: Vec<FileSnapshotTransactionWrite>,
+        audit: AuditEvent,
+    ) -> Result<(), PersistenceError> {
+        self.ensure_available()?;
+        if writes.is_empty() {
+            return Err(PersistenceError::InvalidConfig(
+                "snapshot audit transaction requires at least one write".to_string(),
+            ));
+        }
+        let root = self.root.clone();
+        let mutation_blocker = self.mutation_blocker.clone();
+        self.dispatch_file_mutation(
+            write_guard,
+            "dashboard-file-storage-publish-snapshot-audit-transaction",
+            move || {
+                let encoded = serde_json::to_vec(&audit).map_err(PersistenceError::Serialization)?;
+                let audit_append = prepare_snapshot_audit_append(&root, audit.created_at_ms)?;
+                let prepared = prepare_transaction_writes_with_audit(&root, &writes, audit_append.clone())?;
+                append_snapshot_audit(&root, &audit_append, &encoded)?;
+                mutation_blocker.wait_after_mutation();
+                Ok(FileMutationOutcome {
+                    value: (),
+                    finalize: Box::new({
+                        let prepared = prepared.clone();
+                        move || prepared.finalize()
+                    }),
+                    cleanup: Box::new({
+                        let prepared = prepared.clone();
+                        move || prepared.cleanup()
+                    }),
+                    rollback: Box::new(move || prepared.rollback(None)),
+                })
+            },
+        )
+        .await?;
+        self.record_write();
+        Ok(())
     }
 
     #[cfg(test)]
@@ -887,6 +957,10 @@ impl FilePersistence {
         let root = self.root.clone();
         self.run_recovery_operation_owned("dashboard-file-storage-recover-file-operations", move || {
             recover_incomplete_snapshot_transactions(&root)?;
+            session_file_store::recover_session_audit_transactions(&root)?;
+            session_file_store::recover_session_touch_transactions(&root)?;
+            session_file_store::recover_session_cleanup_transactions(&root)?;
+            audit_file_store::recover_audit_rewrite_transactions(&root)?;
             history_file_store::recover_history_file_operations(&root)
         })
         .await
@@ -1009,7 +1083,22 @@ fn recover_incomplete_snapshot_transactions(root: &Path) -> Result<(), Persisten
         let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
             return Err(PersistenceError::CorruptedData);
         };
-        if let Some(transaction_id) = name.strip_suffix(".prepared.json") {
+        if name.ends_with(".session-audit.prepared.json")
+            || name.ends_with(".session-audit.committed.json")
+            || name.ends_with(".session-touch.prepared.json")
+            || name.ends_with(".session-touch.committed.json")
+            || name.ends_with(".session-touch-stage.json")
+            || name.ends_with(".session-touch-backup.json")
+            || name.ends_with(".session-cleanup.prepared.json")
+            || name.ends_with(".session-cleanup.committed.json")
+            || name.ends_with(".audit-rewrite.prepared.json")
+            || name.ends_with(".audit-rewrite.committed.json")
+        {
+            // Session/audit markers share the transaction directory but have
+            // their own recovery grammar and must never be interpreted as a
+            // snapshot aggregate.
+            continue;
+        } else if let Some(transaction_id) = name.strip_suffix(".prepared.json") {
             prepared_markers.insert(transaction_id.to_string(), path);
         } else if let Some(transaction_id) = name.strip_suffix(".committed.json") {
             committed_markers.insert(transaction_id.to_string(), path);
@@ -1063,13 +1152,36 @@ fn prepare_transaction_writes(
             payload: write.payload.clone(),
         });
     }
-    prepare_snapshot_transaction(root, prepared_writes, fail_after_writes)
+    prepare_snapshot_transaction(root, prepared_writes, fail_after_writes, None)
+}
+
+fn prepare_transaction_writes_with_audit(
+    root: &Path,
+    writes: &[FileSnapshotTransactionWrite],
+    audit: FileSnapshotAuditAppend,
+) -> Result<PreparedSnapshotTransaction, PersistenceError> {
+    let mut prepared_writes = Vec::with_capacity(writes.len());
+    for write in writes {
+        validate_collection(&write.collection)?;
+        let directory = root.join(&write.collection).join("snapshots");
+        let current_revision = load_latest_snapshot_file(&directory)?.map_or(0, |snapshot| snapshot.revision);
+        if current_revision != write.expected_revision {
+            return Err(PersistenceError::Conflict);
+        }
+        prepared_writes.push(PreparedSnapshotWrite {
+            collection: write.collection.clone(),
+            revision: current_revision.checked_add(1).ok_or(PersistenceError::Conflict)?,
+            payload: write.payload.clone(),
+        });
+    }
+    prepare_snapshot_transaction(root, prepared_writes, None, Some(audit))
 }
 
 fn prepare_snapshot_transaction(
     root: &Path,
     writes: Vec<PreparedSnapshotWrite>,
     fail_after_writes: Option<usize>,
+    audit: Option<FileSnapshotAuditAppend>,
 ) -> Result<PreparedSnapshotTransaction, PersistenceError> {
     if writes.is_empty() {
         return Err(PersistenceError::InvalidConfig(
@@ -1110,6 +1222,7 @@ fn prepare_snapshot_transaction(
         &FileSnapshotTransaction {
             format_version: FORMAT_VERSION,
             writes: records,
+            audit,
         },
     )?;
     for (index, write) in writes.into_iter().enumerate() {
@@ -1135,6 +1248,56 @@ fn prepare_snapshot_transaction(
         prepared_marker,
         committed_marker,
     })
+}
+
+fn prepare_snapshot_audit_append(root: &Path, created_at_ms: i64) -> Result<FileSnapshotAuditAppend, PersistenceError> {
+    let day = chrono::DateTime::from_timestamp_millis(created_at_ms)
+        .unwrap_or_else(Utc::now)
+        .format("%Y-%m-%d")
+        .to_string();
+    let relative_path = format!("audit/{day}.jsonl");
+    let path = root.join(&relative_path);
+    std::fs::create_dir_all(root.join("audit")).map_err(PersistenceError::Io)?;
+    truncate_incomplete_tail(&path)?;
+    let existed = path.exists();
+    let original_length = if existed {
+        std::fs::metadata(&path).map_err(PersistenceError::Io)?.len()
+    } else {
+        0
+    };
+    Ok(FileSnapshotAuditAppend {
+        relative_path,
+        existed,
+        original_length,
+    })
+}
+
+fn append_snapshot_audit(
+    root: &Path,
+    append: &FileSnapshotAuditAppend,
+    encoded: &[u8],
+) -> Result<(), PersistenceError> {
+    let path = audit_append_path(root, append)?;
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(PersistenceError::Io)?;
+    file.write_all(encoded).map_err(PersistenceError::Io)?;
+    file.write_all(b"\n").map_err(PersistenceError::Io)?;
+    file.flush().map_err(PersistenceError::Io)?;
+    file.sync_data().map_err(PersistenceError::Io)
+}
+
+fn audit_append_path(root: &Path, append: &FileSnapshotAuditAppend) -> Result<PathBuf, PersistenceError> {
+    let path = Path::new(&append.relative_path);
+    if path.components().count() != 2
+        || path.parent() != Some(Path::new("audit"))
+        || path.extension().is_none_or(|extension| extension != "jsonl")
+    {
+        return Err(PersistenceError::CorruptedData);
+    }
+    Ok(root.join(path))
 }
 
 fn commit_prepared_snapshot_transaction(
@@ -1192,6 +1355,9 @@ fn rollback_prepared_snapshot_transaction(
     if let Some(error) = rollback_failure {
         return Err(error);
     }
+    if let Some(audit) = transaction.audit {
+        rollback_jsonl_append(audit_append_path(root, &audit)?, audit.original_length, audit.existed)?;
+    }
     remove_file_if_exists(Some(prepared_marker))
 }
 
@@ -1204,6 +1370,15 @@ fn read_snapshot_transaction(marker: &Path) -> Result<FileSnapshotTransaction, P
     }
     for write in &transaction.writes {
         validate_collection(&write.collection)?;
+    }
+    if let Some(audit) = &transaction.audit {
+        let _ = audit_append_path(
+            marker
+                .parent()
+                .and_then(Path::parent)
+                .ok_or(PersistenceError::CorruptedData)?,
+            audit,
+        )?;
     }
     Ok(transaction)
 }
@@ -1407,16 +1582,35 @@ fn truncate_incomplete_tail(path: &Path) -> Result<(), PersistenceError> {
         .write(true)
         .open(path)
         .map_err(PersistenceError::Io)?;
-    let mut bytes = Vec::new();
-    file.read_to_end(&mut bytes).map_err(PersistenceError::Io)?;
-    if !bytes.is_empty() && !bytes.ends_with(b"\n") {
-        let length = bytes
-            .iter()
-            .rposition(|byte| *byte == b'\n')
-            .map_or(0, |position| position + 1);
-        file.set_len(length as u64).map_err(PersistenceError::Io)?;
-        file.seek(SeekFrom::Start(length as u64))
-            .map_err(PersistenceError::Io)?;
+    let length = file.metadata().map_err(PersistenceError::Io)?.len();
+    if length == 0 {
+        return Ok(());
+    }
+    file.seek(SeekFrom::End(-1)).map_err(PersistenceError::Io)?;
+    let mut final_byte = [0_u8; 1];
+    file.read_exact(&mut final_byte).map_err(PersistenceError::Io)?;
+    if final_byte != [b'\n'] {
+        // Only the incomplete final record is recoverable. Locate the last
+        // complete JSONL delimiter from the end in fixed-size blocks so a
+        // large audit file is never loaded to recover one torn append.
+        const BLOCK: usize = 8 * 1024;
+        let mut end = length;
+        let mut complete_length = 0_u64;
+        while end > 0 {
+            let start = end.saturating_sub(BLOCK as u64);
+            let block_length = usize::try_from(end - start).map_err(|_| PersistenceError::CorruptedData)?;
+            let mut block = vec![0_u8; block_length];
+            file.seek(SeekFrom::Start(start)).map_err(PersistenceError::Io)?;
+            file.read_exact(&mut block).map_err(PersistenceError::Io)?;
+            if let Some(position) = block.iter().rposition(|byte| *byte == b'\n') {
+                complete_length = start + position as u64 + 1;
+                break;
+            }
+            end = start;
+        }
+        let length = complete_length;
+        file.set_len(length).map_err(PersistenceError::Io)?;
+        file.seek(SeekFrom::Start(length)).map_err(PersistenceError::Io)?;
         file.sync_data().map_err(PersistenceError::Io)?;
     }
     Ok(())
@@ -1468,8 +1662,17 @@ fn non_zero(value: i64) -> Option<i64> {
 mod tests {
     use super::*;
     use crate::config::SqlPoolConfig;
+    use crate::model::AuditAction;
+    use crate::model::AuditActor;
+    use crate::model::AuditEvent;
+    use crate::model::AuditOutcome;
+    use crate::model::AuditResourceType;
+    use crate::model::NewSession;
+    use crate::model::SessionTokenHash;
     use crate::model::StorageBackend;
     use crate::persistence::StorageStatus;
+    use crate::persistence::audit_repository::AuditQuery;
+    use crate::persistence::session_repository::SessionQuery;
     use crate::service::readiness_status_from_storage;
     use rocketmq_runtime::BlockingPoolPolicy;
     use rocketmq_runtime::RuntimeConfig;
@@ -1483,6 +1686,41 @@ mod tests {
             data_path: root,
             database_url: None,
             pool: SqlPoolConfig::default(),
+        }
+    }
+
+    fn audit_event(created_at_ms: i64) -> AuditEvent {
+        AuditEvent {
+            event_id: uuid::Uuid::now_v7().to_string(),
+            request_id: uuid::Uuid::now_v7().to_string(),
+            actor: AuditActor::admin("operator"),
+            action: AuditAction::ConfigNameserverAdd,
+            resource_type: AuditResourceType::Nameserver,
+            resource_name: Some("127.0.0.1:9876".to_string()),
+            environment_id: None,
+            outcome: AuditOutcome::Succeeded,
+            detail: None,
+            created_at_ms,
+        }
+    }
+
+    fn expired_session(token_hash: SessionTokenHash) -> NewSession {
+        NewSession {
+            session_id: uuid::Uuid::now_v7().to_string(),
+            token_hash,
+            username: "expired-session-owner".to_string(),
+            created_at_ms: 1,
+            expires_at_ms: 2,
+        }
+    }
+
+    fn active_session(token_hash: SessionTokenHash, username: &str) -> NewSession {
+        NewSession {
+            session_id: uuid::Uuid::now_v7().to_string(),
+            token_hash,
+            username: username.to_string(),
+            created_at_ms: 1,
+            expires_at_ms: 10_000,
         }
     }
 
@@ -2151,6 +2389,7 @@ mod tests {
                     payload: json!({"value": "interrupted"}),
                 }],
                 None,
+                None,
             )
             .expect("stage single intent");
             let _multi = prepare_snapshot_transaction(
@@ -2167,6 +2406,7 @@ mod tests {
                         payload: json!({"rules": []}),
                     },
                 ],
+                None,
                 None,
             )
             .expect("stage multi intent");
@@ -2204,6 +2444,729 @@ mod tests {
                     .expect("original monitors")
                     .payload,
                 json!({"rules": ["before"]})
+            );
+        });
+        owner.shutdown_runtime_blocking().expect("runtime shutdown");
+    }
+
+    #[test]
+    fn snapshot_audit_transactions_commit_or_recover_with_one_durable_decision() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let root = directory.path().join("dashboard");
+        let owner = RuntimeOwner::new(RuntimeConfig::default()).expect("runtime owner");
+        owner.block_on(async {
+            let store = FilePersistence::initialize(
+                &file_config(root.clone()),
+                owner.root_context().component("snapshot-audit-normal"),
+            )
+            .await
+            .expect("file store");
+            store
+                .write_snapshot("config", 1, json!({"value": "before"}))
+                .await
+                .expect("seed config");
+            let normal_event = audit_event(1_000);
+            let write_guard = store.write_guard().await;
+            store
+                .publish_snapshot_transaction_with_audit_locked(
+                    write_guard,
+                    vec![FileSnapshotTransactionWrite {
+                        collection: "config".to_string(),
+                        expected_revision: 1,
+                        payload: json!({"value": "normal"}),
+                    }],
+                    normal_event.clone(),
+                )
+                .await
+                .expect("commit snapshot and audit");
+            assert_eq!(
+                store
+                    .load_latest_snapshot("config")
+                    .await
+                    .expect("load normal snapshot")
+                    .expect("normal snapshot")
+                    .payload,
+                json!({"value": "normal"})
+            );
+            assert_eq!(
+                store
+                    .query_audit_events(AuditQuery {
+                        start_ms: 0,
+                        end_ms: 2_000,
+                        actor: None,
+                        action: None,
+                        outcome: None,
+                        environment_id: None,
+                        cursor: None,
+                        limit: 10,
+                    })
+                    .await
+                    .expect("query normal audit")
+                    .events,
+                vec![normal_event.clone()]
+            );
+            drop(store);
+
+            let staged = FilePersistence::initialize(
+                &file_config(root.clone()),
+                owner.root_context().component("snapshot-audit-prepared"),
+            )
+            .await
+            .expect("stage file store");
+            let prepared_event = audit_event(2_000);
+            let append =
+                prepare_snapshot_audit_append(&root, prepared_event.created_at_ms).expect("prepare audit append");
+            let prepared = prepare_transaction_writes_with_audit(
+                &root,
+                &[FileSnapshotTransactionWrite {
+                    collection: "config".to_string(),
+                    expected_revision: 2,
+                    payload: json!({"value": "prepared"}),
+                }],
+                append.clone(),
+            )
+            .expect("stage prepared transaction");
+            append_snapshot_audit(
+                &root,
+                &append,
+                &serde_json::to_vec(&prepared_event).expect("encode audit"),
+            )
+            .expect("append staged audit");
+            drop(prepared);
+            drop(staged);
+
+            let reopened = FilePersistence::initialize(
+                &file_config(root.clone()),
+                owner.root_context().component("snapshot-audit-prepared-reopen"),
+            )
+            .await
+            .expect("recover prepared transaction");
+            assert_eq!(
+                reopened
+                    .load_latest_snapshot("config")
+                    .await
+                    .expect("load recovered snapshot")
+                    .expect("normal snapshot")
+                    .payload,
+                json!({"value": "normal"})
+            );
+            assert_eq!(
+                reopened
+                    .query_audit_events(AuditQuery {
+                        start_ms: 0,
+                        end_ms: 3_000,
+                        actor: None,
+                        action: None,
+                        outcome: None,
+                        environment_id: None,
+                        cursor: None,
+                        limit: 10,
+                    })
+                    .await
+                    .expect("query recovered audit")
+                    .events,
+                vec![normal_event.clone()]
+            );
+            drop(reopened);
+
+            let committed = FilePersistence::initialize(
+                &file_config(root.clone()),
+                owner.root_context().component("snapshot-audit-committed"),
+            )
+            .await
+            .expect("committed file store");
+            let committed_event = audit_event(3_000);
+            let append =
+                prepare_snapshot_audit_append(&root, committed_event.created_at_ms).expect("prepare committed audit");
+            let committed_transaction = prepare_transaction_writes_with_audit(
+                &root,
+                &[FileSnapshotTransactionWrite {
+                    collection: "config".to_string(),
+                    expected_revision: 2,
+                    payload: json!({"value": "committed"}),
+                }],
+                append.clone(),
+            )
+            .expect("stage committed transaction");
+            append_snapshot_audit(
+                &root,
+                &append,
+                &serde_json::to_vec(&committed_event).expect("encode audit"),
+            )
+            .expect("append committed audit");
+            committed_transaction.finalize().expect("write committed decision");
+            drop(committed_transaction);
+            drop(committed);
+
+            let reopened = FilePersistence::initialize(
+                &file_config(root.clone()),
+                owner.root_context().component("snapshot-audit-committed-reopen"),
+            )
+            .await
+            .expect("recover committed transaction");
+            assert_eq!(
+                reopened
+                    .load_latest_snapshot("config")
+                    .await
+                    .expect("load committed snapshot")
+                    .expect("committed snapshot")
+                    .payload,
+                json!({"value": "committed"})
+            );
+            let events = reopened
+                .query_audit_events(AuditQuery {
+                    start_ms: 0,
+                    end_ms: 4_000,
+                    actor: None,
+                    action: None,
+                    outcome: None,
+                    environment_id: None,
+                    cursor: None,
+                    limit: 10,
+                })
+                .await
+                .expect("query committed audit")
+                .events;
+            assert_eq!(events, vec![committed_event, normal_event]);
+        });
+        owner.shutdown_runtime_blocking().expect("runtime shutdown");
+    }
+
+    #[test]
+    fn injected_prepared_snapshot_audit_failure_reopens_with_neither_side_committed() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let root = directory.path().join("dashboard");
+        let owner = RuntimeOwner::new(RuntimeConfig::default()).expect("runtime owner");
+        owner.block_on(async {
+            let store = FilePersistence::initialize(
+                &file_config(root.clone()),
+                owner.root_context().component("snapshot-audit-failure"),
+            )
+            .await
+            .expect("file store");
+            store
+                .write_snapshot("config", 1, json!({"value": "before"}))
+                .await
+                .expect("seed config");
+
+            // The failure happens only after the transaction has staged the
+            // replacement snapshot and appended the audit line. Recovery must
+            // therefore use the prepared marker to remove both artifacts.
+            let (started, release) = install_panicking_mutation_blocker(&store);
+            let failed_event = audit_event(1_000);
+            let (result, ()) = tokio::join!(
+                async {
+                    let write_guard = store.write_guard().await;
+                    store
+                        .publish_snapshot_transaction_with_audit_locked(
+                            write_guard,
+                            vec![FileSnapshotTransactionWrite {
+                                collection: "config".to_string(),
+                                expected_revision: 1,
+                                payload: json!({"value": "after"}),
+                            }],
+                            failed_event,
+                        )
+                        .await
+                },
+                async {
+                    wait_for_mutation_start(started).await;
+                    release.send(()).expect("release injected failure");
+                },
+            );
+            assert!(matches!(
+                result,
+                Err(PersistenceError::Runtime(RuntimeError::BlockingJoin { .. }))
+            ));
+            store.mutation_blocker.clear();
+            drop(store);
+
+            let reopened = FilePersistence::initialize(
+                &file_config(root),
+                owner.root_context().component("snapshot-audit-failure-reopen"),
+            )
+            .await
+            .expect("reopen prepared failure");
+            assert_eq!(
+                reopened
+                    .load_latest_snapshot("config")
+                    .await
+                    .expect("load original config")
+                    .expect("original snapshot")
+                    .payload,
+                json!({"value": "before"})
+            );
+            assert!(
+                reopened
+                    .query_audit_events(AuditQuery {
+                        start_ms: 0,
+                        end_ms: 2_000,
+                        actor: None,
+                        action: None,
+                        outcome: None,
+                        environment_id: None,
+                        cursor: None,
+                        limit: 10,
+                    })
+                    .await
+                    .expect("query recovered journal")
+                    .events
+                    .is_empty()
+            );
+        });
+        owner.shutdown_runtime_blocking().expect("runtime shutdown");
+    }
+
+    #[test]
+    fn cancelled_session_cleanup_request_keeps_the_owned_mutation_alive_until_commit() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let owner = RuntimeOwner::new(cancellation_runtime_config()).expect("runtime owner");
+        owner.block_on(async {
+            let store = FilePersistence::initialize(
+                &file_config(directory.path().join("dashboard")),
+                owner.root_context().component("cancelled-session-cleanup-file-store"),
+            )
+            .await
+            .expect("file store");
+            let token_hash = SessionTokenHash([41; 32]);
+            store
+                .create_session(expired_session(token_hash))
+                .await
+                .expect("seed expired session");
+            let (started, release) = install_mutation_blocker(&store);
+            let request_store = store.clone();
+            let request = tokio::spawn(async move { request_store.delete_sessions_before(3, 10).await });
+            wait_for_mutation_start(started).await;
+            request.abort();
+            assert!(request.await.expect_err("cancelled request").is_cancelled());
+            release.send(()).expect("release cleanup mutation");
+            store.mutation_blocker.clear();
+            let gate = tokio::time::timeout(Duration::from_secs(1), store.write_guard())
+                .await
+                .expect("owned cleanup must release its write gate");
+            drop(gate);
+            assert!(
+                store
+                    .find_session(&token_hash)
+                    .await
+                    .expect("read committed cleanup")
+                    .is_none()
+            );
+        });
+        owner.shutdown_runtime_blocking().expect("runtime shutdown");
+    }
+
+    #[test]
+    fn timed_out_session_cleanup_rolls_back_before_active_or_reopened_reads() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let root = directory.path().join("dashboard");
+        let owner = RuntimeOwner::new(timeout_runtime_config()).expect("runtime owner");
+        owner.block_on(async {
+            let store = FilePersistence::initialize(
+                &file_config(root.clone()),
+                owner.root_context().component("timeout-session-cleanup-file-store"),
+            )
+            .await
+            .expect("file store");
+            let token_hash = SessionTokenHash([42; 32]);
+            store
+                .create_session(expired_session(token_hash))
+                .await
+                .expect("seed expired session");
+            let (started, release) = install_mutation_blocker(&store);
+            let (result, ()) = tokio::join!(
+                store.delete_sessions_before(3, 10),
+                release_mutation_after_storage_timeout(started, release),
+            );
+            assert!(matches!(
+                result,
+                Err(PersistenceError::Runtime(
+                    RuntimeError::BlockingTaskTimeoutStillRunning { .. }
+                ))
+            ));
+            store.mutation_blocker.clear();
+            assert!(
+                store
+                    .find_session(&token_hash)
+                    .await
+                    .expect("read rollback result")
+                    .is_some()
+            );
+            drop(store);
+
+            let reopened = FilePersistence::initialize(
+                &file_config(root),
+                owner
+                    .root_context()
+                    .component("timeout-session-cleanup-file-store-reopen"),
+            )
+            .await
+            .expect("reopen after cleanup rollback");
+            assert!(
+                reopened
+                    .find_session(&token_hash)
+                    .await
+                    .expect("read reopened rollback result")
+                    .is_some()
+            );
+        });
+        owner.shutdown_runtime_blocking().expect("runtime shutdown");
+    }
+
+    #[test]
+    fn session_cleanup_serializes_a_concurrent_session_writer() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let owner = RuntimeOwner::new(cancellation_runtime_config()).expect("runtime owner");
+        owner.block_on(async {
+            let store = FilePersistence::initialize(
+                &file_config(directory.path().join("dashboard")),
+                owner.root_context().component("serialized-session-cleanup-file-store"),
+            )
+            .await
+            .expect("file store");
+            let expired_hash = SessionTokenHash([43; 32]);
+            let writer_hash = SessionTokenHash([44; 32]);
+            store
+                .create_session(expired_session(expired_hash))
+                .await
+                .expect("seed expired session");
+            let (started, release) = install_mutation_blocker(&store);
+            let cleanup_store = store.clone();
+            let cleanup = tokio::spawn(async move { cleanup_store.delete_sessions_before(3, 10).await });
+            wait_for_mutation_start(started).await;
+
+            let writer_store = store.clone();
+            let mut writer = tokio::spawn(async move {
+                writer_store
+                    .create_session(NewSession {
+                        session_id: uuid::Uuid::now_v7().to_string(),
+                        token_hash: writer_hash,
+                        username: "writer".to_string(),
+                        created_at_ms: 3,
+                        expires_at_ms: 10_000,
+                    })
+                    .await
+            });
+            assert!(
+                tokio::time::timeout(Duration::from_millis(50), &mut writer)
+                    .await
+                    .is_err(),
+                "the writer must wait for the cleanup decision"
+            );
+            release.send(()).expect("release cleanup mutation");
+            store.mutation_blocker.clear();
+            assert_eq!(cleanup.await.expect("join cleanup").expect("commit cleanup"), 1);
+            writer
+                .await
+                .expect("join writer")
+                .expect("writer must finish after cleanup");
+            assert!(
+                store
+                    .find_session(&writer_hash)
+                    .await
+                    .expect("read writer session")
+                    .is_some()
+            );
+        });
+        owner.shutdown_runtime_blocking().expect("runtime shutdown");
+    }
+
+    #[test]
+    fn session_touch_reopen_recovers_prepared_old_or_committed_new_decisions() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let owner = RuntimeOwner::new(RuntimeConfig::default()).expect("runtime owner");
+        owner.block_on(async {
+            for (name, token_hash, committed, expected_last_seen) in [
+                ("prepared", SessionTokenHash([51; 32]), false, 1),
+                ("committed", SessionTokenHash([52; 32]), true, 2),
+            ] {
+                let root = directory.path().join(name);
+                let store = FilePersistence::initialize(
+                    &file_config(root.clone()),
+                    owner.root_context().component("touch-reopen-stage"),
+                )
+                .await
+                .expect("stage file store");
+                store
+                    .create_session(active_session(token_hash, "touch-owner"))
+                    .await
+                    .expect("seed active session");
+                session_file_store::stage_session_touch_for_reopen_test(&root, token_hash, 2, committed)
+                    .expect("stage interrupted touch");
+                drop(store);
+
+                let reopened = FilePersistence::initialize(
+                    &file_config(root.clone()),
+                    owner.root_context().component("touch-reopen-recover"),
+                )
+                .await
+                .expect("recover interrupted touch");
+                let record = reopened
+                    .find_session(&token_hash)
+                    .await
+                    .expect("read recovered session")
+                    .expect("recovered session");
+                assert_eq!(record.last_seen_at_ms, expected_last_seen, "{name} decision");
+                assert_eq!(
+                    std::fs::read_dir(root.join("transactions"))
+                        .expect("transaction directory")
+                        .count(),
+                    0,
+                    "{name} recovery must remove every marker and sidecar"
+                );
+            }
+        });
+        owner.shutdown_runtime_blocking().expect("runtime shutdown");
+    }
+
+    #[test]
+    fn cancelled_session_touch_request_keeps_the_owned_mutation_until_commit() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let owner = RuntimeOwner::new(cancellation_runtime_config()).expect("runtime owner");
+        owner.block_on(async {
+            let store = FilePersistence::initialize(
+                &file_config(directory.path().join("dashboard")),
+                owner.root_context().component("cancelled-session-touch-file-store"),
+            )
+            .await
+            .expect("file store");
+            let token_hash = SessionTokenHash([53; 32]);
+            store
+                .create_session(active_session(token_hash, "touch-owner"))
+                .await
+                .expect("seed active session");
+            let (started, release) = install_mutation_blocker(&store);
+            let request_store = store.clone();
+            let request = tokio::spawn(async move { request_store.touch_session(&token_hash, 2).await });
+            wait_for_mutation_start(started).await;
+            request.abort();
+            assert!(request.await.expect_err("cancelled request").is_cancelled());
+            release.send(()).expect("release touch mutation");
+            store.mutation_blocker.clear();
+            let gate = tokio::time::timeout(Duration::from_secs(1), store.write_guard())
+                .await
+                .expect("owned touch must release its write gate");
+            drop(gate);
+            assert_eq!(
+                store
+                    .find_session(&token_hash)
+                    .await
+                    .expect("read committed touch")
+                    .expect("active session")
+                    .last_seen_at_ms,
+                2
+            );
+        });
+        owner.shutdown_runtime_blocking().expect("runtime shutdown");
+    }
+
+    #[test]
+    fn timed_out_session_touch_rolls_back_before_active_or_reopened_reads() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let root = directory.path().join("dashboard");
+        let owner = RuntimeOwner::new(timeout_runtime_config()).expect("runtime owner");
+        owner.block_on(async {
+            let store = FilePersistence::initialize(
+                &file_config(root.clone()),
+                owner.root_context().component("timeout-session-touch-file-store"),
+            )
+            .await
+            .expect("file store");
+            let token_hash = SessionTokenHash([54; 32]);
+            store
+                .create_session(active_session(token_hash, "touch-owner"))
+                .await
+                .expect("seed active session");
+            let (started, release) = install_mutation_blocker(&store);
+            let (result, ()) = tokio::join!(
+                store.touch_session(&token_hash, 2),
+                release_mutation_after_storage_timeout(started, release),
+            );
+            assert!(matches!(
+                result,
+                Err(PersistenceError::Runtime(
+                    RuntimeError::BlockingTaskTimeoutStillRunning { .. }
+                ))
+            ));
+            store.mutation_blocker.clear();
+            assert_eq!(
+                store
+                    .find_session(&token_hash)
+                    .await
+                    .expect("read rollback result")
+                    .expect("active session")
+                    .last_seen_at_ms,
+                1
+            );
+            drop(store);
+
+            let reopened = FilePersistence::initialize(
+                &file_config(root),
+                owner
+                    .root_context()
+                    .component("timeout-session-touch-file-store-reopen"),
+            )
+            .await
+            .expect("reopen after touch rollback");
+            assert_eq!(
+                reopened
+                    .find_session(&token_hash)
+                    .await
+                    .expect("read reopened rollback result")
+                    .expect("active session")
+                    .last_seen_at_ms,
+                1
+            );
+        });
+        owner.shutdown_runtime_blocking().expect("runtime shutdown");
+    }
+
+    #[test]
+    fn failed_session_touch_cleanup_reopens_the_committed_record_and_removes_its_marker() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let root = directory.path().join("dashboard");
+        let owner = RuntimeOwner::new(RuntimeConfig::default()).expect("runtime owner");
+        owner.block_on(async {
+            let store = FilePersistence::initialize(
+                &file_config(root.clone()),
+                owner.root_context().component("touch-cleanup-failure-file-store"),
+            )
+            .await
+            .expect("file store");
+            let token_hash = SessionTokenHash([55; 32]);
+            store
+                .create_session(active_session(token_hash, "touch-owner"))
+                .await
+                .expect("seed active session");
+            let (started, release) = install_committed_cleanup_blocker(&store, true);
+            let (result, ()) = tokio::join!(store.touch_session(&token_hash, 2), async {
+                wait_for_mutation_start(started).await;
+                release.send(()).expect("release cleanup hook");
+            },);
+            assert!(result.expect("committed touch"));
+            store.clear_test_committed_cleanup_blocker();
+            assert_eq!(store.storage_health().await.status, StorageStatus::Available);
+            assert!(
+                std::fs::read_dir(root.join("transactions"))
+                    .expect("transaction directory")
+                    .next()
+                    .is_some(),
+                "failed cleanup must retain a committed touch marker"
+            );
+            drop(store);
+
+            let reopened = FilePersistence::initialize(
+                &file_config(root.clone()),
+                owner
+                    .root_context()
+                    .component("touch-cleanup-failure-file-store-reopen"),
+            )
+            .await
+            .expect("reopen committed touch");
+            assert_eq!(
+                reopened
+                    .find_session(&token_hash)
+                    .await
+                    .expect("read committed touch")
+                    .expect("active session")
+                    .last_seen_at_ms,
+                2
+            );
+            assert_eq!(
+                std::fs::read_dir(root.join("transactions"))
+                    .expect("transaction directory")
+                    .count(),
+                0
+            );
+        });
+        owner.shutdown_runtime_blocking().expect("runtime shutdown");
+    }
+
+    #[test]
+    fn session_touch_serializes_cleanup_listing_and_login_cap_scan() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let owner = RuntimeOwner::new(cancellation_runtime_config()).expect("runtime owner");
+        owner.block_on(async {
+            let store = FilePersistence::initialize(
+                &file_config(directory.path().join("dashboard")),
+                owner.root_context().component("serialized-session-touch-file-store"),
+            )
+            .await
+            .expect("file store");
+            let touched_hash = SessionTokenHash([56; 32]);
+            let expired_hash = SessionTokenHash([57; 32]);
+            let login_hash = SessionTokenHash([58; 32]);
+            store
+                .create_session(active_session(touched_hash, "touch-owner"))
+                .await
+                .expect("seed touched session");
+            store
+                .create_session(expired_session(expired_hash))
+                .await
+                .expect("seed expired session");
+            let (started, release) = install_mutation_blocker(&store);
+            let touch_store = store.clone();
+            let touch = tokio::spawn(async move { touch_store.touch_session(&touched_hash, 2).await });
+            wait_for_mutation_start(started).await;
+
+            let list_store = store.clone();
+            let mut listing = tokio::spawn(async move {
+                list_store
+                    .list_sessions(SessionQuery {
+                        username: None,
+                        cursor: None,
+                        limit: 50,
+                    })
+                    .await
+            });
+            let cleanup_store = store.clone();
+            let cleanup = tokio::spawn(async move { cleanup_store.delete_sessions_before(3, 10).await });
+            let login_store = store.clone();
+            let login = tokio::spawn(async move {
+                login_store
+                    .create_session_with_audit_capped(active_session(login_hash, "login-owner"), audit_event(3), 32, 3)
+                    .await
+            });
+            assert!(
+                tokio::time::timeout(Duration::from_millis(50), &mut listing)
+                    .await
+                    .is_err(),
+                "listing must wait for the touch commit decision"
+            );
+            release.send(()).expect("release touch mutation");
+            store.mutation_blocker.clear();
+            assert!(touch.await.expect("join touch").expect("commit touch"));
+            listing
+                .await
+                .expect("join listing")
+                .expect("listing after touch decision");
+            assert_eq!(cleanup.await.expect("join cleanup").expect("commit cleanup"), 1);
+            login
+                .await
+                .expect("join login-cap scan")
+                .expect("login-cap scan after touch decision");
+            assert_eq!(
+                store
+                    .find_session(&touched_hash)
+                    .await
+                    .expect("read touched session")
+                    .expect("touched session")
+                    .last_seen_at_ms,
+                2
+            );
+            assert!(
+                store
+                    .find_session(&expired_hash)
+                    .await
+                    .expect("read cleaned session")
+                    .is_none()
+            );
+            assert!(
+                store
+                    .find_session(&login_hash)
+                    .await
+                    .expect("read capped-login session")
+                    .is_some()
             );
         });
         owner.shutdown_runtime_blocking().expect("runtime shutdown");

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/lease_repository.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/lease_repository.rs
@@ -19,7 +19,7 @@ use crate::persistence::error::PersistenceError;
 
 /// Opaque authority granted by the SQL task lease. The holder identity is
 /// never serialized or exposed through a dashboard API.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct HistoryLease {
     pub(crate) environment_id: EnvironmentId,
     pub(crate) name: String,
@@ -28,7 +28,22 @@ pub struct HistoryLease {
     pub(crate) expires_at_ms: i64,
 }
 
+impl std::fmt::Debug for HistoryLease {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("HistoryLease")
+            .field("environment_id", &self.environment_id)
+            .field("name", &self.name)
+            .field("holder_id", &"<redacted>")
+            .field("fencing_token", &"<redacted>")
+            .field("expires_at_ms", &self.expires_at_ms)
+            .finish()
+    }
+}
+
 impl HistoryLease {
+    const SESSION_AUDIT_CLEANUP_ENVIRONMENT: &'static str = "session-audit-cleanup";
+    const SESSION_AUDIT_CLEANUP_NAME: &'static str = "dashboard-session-audit-cleanup";
     pub(crate) fn new(
         environment_id: EnvironmentId,
         holder_id: String,
@@ -45,7 +60,14 @@ impl HistoryLease {
     }
 
     pub(crate) fn name_for(environment_id: &EnvironmentId) -> String {
+        if environment_id.0 == Self::SESSION_AUDIT_CLEANUP_ENVIRONMENT {
+            return Self::SESSION_AUDIT_CLEANUP_NAME.to_string();
+        }
         format!("dashboard-history:{}", environment_id.0)
+    }
+
+    pub(crate) fn session_audit_cleanup_environment() -> EnvironmentId {
+        EnvironmentId(Self::SESSION_AUDIT_CLEANUP_ENVIRONMENT.to_string())
     }
 
     pub fn environment_id(&self) -> &EnvironmentId {
@@ -95,6 +117,21 @@ impl DashboardPersistence {
             self.storage_backend(),
             StorageBackend::Sqlite | StorageBackend::MySql | StorageBackend::Postgres
         )
+    }
+
+    /// SQLite is single-node by deployment contract. Only MySQL and
+    /// PostgreSQL need a durable fenced leader for cleanup.
+    pub fn session_audit_cleanup_uses_sql_lease(&self) -> bool {
+        matches!(self.storage_backend(), StorageBackend::MySql | StorageBackend::Postgres)
+    }
+
+    pub async fn acquire_session_audit_cleanup_lease(
+        &self,
+        holder_id: &str,
+        ttl_ms: i64,
+    ) -> Result<Option<HistoryLease>, PersistenceError> {
+        let environment_id = HistoryLease::session_audit_cleanup_environment();
+        self.acquire_history_lease(&environment_id, holder_id, ttl_ms).await
     }
 }
 

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/migration.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/migration.rs
@@ -21,12 +21,15 @@ use sqlx::{MySqlConnection, PgConnection, SqliteConnection};
 const SQLITE_INITIAL: &str = include_str!("../../migrations/sqlite/0001_initial.sql");
 const SQLITE_PHASE_TWO: &str = include_str!("../../migrations/sqlite/0002_environment_endpoint_constraints.sql");
 const SQLITE_PHASE_THREE: &str = include_str!("../../migrations/sqlite/0003_history_retention.sql");
+const SQLITE_PHASE_FOUR: &str = include_str!("../../migrations/sqlite/0004_session_audit.sql");
 const MYSQL_INITIAL: &str = include_str!("../../migrations/mysql/0001_initial.sql");
 const MYSQL_PHASE_TWO: &str = include_str!("../../migrations/mysql/0002_environment_endpoint_constraints.sql");
 const MYSQL_PHASE_THREE: &str = include_str!("../../migrations/mysql/0003_history_retention.sql");
+const MYSQL_PHASE_FOUR: &str = include_str!("../../migrations/mysql/0004_session_audit.sql");
 const POSTGRES_INITIAL: &str = include_str!("../../migrations/postgres/0001_initial.sql");
 const POSTGRES_PHASE_TWO: &str = include_str!("../../migrations/postgres/0002_environment_endpoint_constraints.sql");
 const POSTGRES_PHASE_THREE: &str = include_str!("../../migrations/postgres/0003_history_retention.sql");
+const POSTGRES_PHASE_FOUR: &str = include_str!("../../migrations/postgres/0004_session_audit.sql");
 const MYSQL_MIGRATION_LOCK: &str = "rocketmq_dashboard_schema_migration";
 const POSTGRES_MIGRATION_LOCK: i64 = 7_246_920_002;
 
@@ -101,6 +104,15 @@ async fn migrate_sqlite_locked(connection: &mut SqliteConnection) -> Result<i64,
     }
     if version < 3 {
         for statement in statements(SQLITE_PHASE_THREE) {
+            sqlx::query(statement)
+                .execute(&mut *connection)
+                .await
+                .map_err(|_| PersistenceError::MigrationFailed)?;
+        }
+    }
+    if version < 4 {
+        ensure_session_audit_empty_sqlite(connection).await?;
+        for statement in statements(SQLITE_PHASE_FOUR) {
             sqlx::query(statement)
                 .execute(&mut *connection)
                 .await
@@ -194,6 +206,15 @@ async fn migrate_mysql_locked(connection: &mut MySqlConnection) -> Result<i64, P
                 .map_err(|_| PersistenceError::MigrationFailed)?;
         }
     }
+    if version < 4 {
+        ensure_session_audit_empty_mysql(connection).await?;
+        for statement in statements(MYSQL_PHASE_FOUR) {
+            sqlx::query(statement)
+                .execute(&mut *connection)
+                .await
+                .map_err(|_| PersistenceError::MigrationFailed)?;
+        }
+    }
     schema_version_mysql_connection(connection).await
 }
 
@@ -239,8 +260,60 @@ async fn migrate_postgres_locked(connection: &mut PgConnection) -> Result<i64, P
                 .map_err(|_| PersistenceError::MigrationFailed)?;
         }
     }
+    if version < 4 {
+        ensure_session_audit_empty_postgres(&mut transaction).await?;
+        for statement in statements(POSTGRES_PHASE_FOUR) {
+            sqlx::query(statement)
+                .execute(&mut *transaction)
+                .await
+                .map_err(|_| PersistenceError::MigrationFailed)?;
+        }
+    }
     transaction.commit().await.map_err(map_query_error)?;
     schema_version_postgres_connection(connection).await
+}
+
+async fn ensure_session_audit_empty_sqlite(connection: &mut SqliteConnection) -> Result<(), PersistenceError> {
+    ensure_session_audit_empty(
+        sqlx::query_scalar(
+            "SELECT (SELECT COUNT(*) FROM dashboard_session) + (SELECT COUNT(*) FROM dashboard_audit_event)",
+        )
+        .fetch_one(&mut *connection)
+        .await
+        .map_err(map_query_error)?,
+    )
+}
+
+async fn ensure_session_audit_empty_mysql(connection: &mut MySqlConnection) -> Result<(), PersistenceError> {
+    ensure_session_audit_empty(
+        sqlx::query_scalar(
+            "SELECT (SELECT COUNT(*) FROM dashboard_session) + (SELECT COUNT(*) FROM dashboard_audit_event)",
+        )
+        .fetch_one(&mut *connection)
+        .await
+        .map_err(map_query_error)?,
+    )
+}
+
+async fn ensure_session_audit_empty_postgres(
+    transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+) -> Result<(), PersistenceError> {
+    ensure_session_audit_empty(
+        sqlx::query_scalar(
+            "SELECT (SELECT COUNT(*) FROM dashboard_session) + (SELECT COUNT(*) FROM dashboard_audit_event)",
+        )
+        .fetch_one(&mut **transaction)
+        .await
+        .map_err(map_query_error)?,
+    )
+}
+
+fn ensure_session_audit_empty(count: i64) -> Result<(), PersistenceError> {
+    if count == 0 {
+        Ok(())
+    } else {
+        Err(PersistenceError::UnsupportedLayout)
+    }
 }
 
 async fn sqlite_column_exists(connection: &mut SqliteConnection, column: &str) -> Result<bool, PersistenceError> {
@@ -401,7 +474,7 @@ mod tests {
             .await
             .expect("simulate the first phase-two DDL");
 
-        assert_eq!(migrate_sqlite(&pool).await.expect("resume migration"), 3);
+        assert_eq!(migrate_sqlite(&pool).await.expect("resume migration"), 4);
         let enabled_column: i64 = sqlx::query_scalar(
             "SELECT COUNT(*) FROM pragma_table_info('dashboard_endpoint') WHERE name = 'is_enabled'",
         )
@@ -435,8 +508,8 @@ mod tests {
         apply_sqlite_initial(&first).await;
 
         let (first_version, second_version) = tokio::join!(migrate_sqlite(&first), migrate_sqlite(&second));
-        assert_eq!(first_version.expect("first migration"), 3);
-        assert_eq!(second_version.expect("second migration"), 3);
+        assert_eq!(first_version.expect("first migration"), 4);
+        assert_eq!(second_version.expect("second migration"), 4);
     }
 
     #[tokio::test]
@@ -449,7 +522,7 @@ mod tests {
             .connect(&url)
             .await
             .expect("connect MySQL storage test database");
-        assert_eq!(migrate_mysql(&pool).await.expect("prepare migration"), 3);
+        assert_eq!(migrate_mysql(&pool).await.expect("prepare migration"), 4);
 
         // Leave the first phase-two DDL in place, then roll the remaining
         // schema changes back to emulate a connection loss between DDLs.
@@ -483,7 +556,7 @@ mod tests {
             .expect("release migration lock after partial DDL setup");
         assert_eq!(released, 1, "migration setup must release the advisory lock");
 
-        assert_eq!(migrate_mysql(&pool).await.expect("resume migration"), 3);
+        assert_eq!(migrate_mysql(&pool).await.expect("resume migration"), 4);
         let active_index: i64 = sqlx::query_scalar(
             "SELECT COUNT(DISTINCT index_name) FROM information_schema.statistics \
              WHERE table_schema = DATABASE() AND table_name = 'dashboard_endpoint' \
@@ -507,8 +580,8 @@ mod tests {
             .expect("connect MySQL storage test database");
 
         let (first, second) = tokio::join!(migrate_mysql(&pool), migrate_mysql(&pool));
-        assert_eq!(first.expect("first concurrent migration"), 3);
-        assert_eq!(second.expect("second concurrent migration"), 3);
+        assert_eq!(first.expect("first concurrent migration"), 4);
+        assert_eq!(second.expect("second concurrent migration"), 4);
     }
 
     #[tokio::test]
@@ -521,7 +594,7 @@ mod tests {
             .connect(&url)
             .await
             .expect("connect MySQL storage test database");
-        assert_eq!(migrate_mysql(&pool).await.expect("prepare migration"), 3);
+        assert_eq!(migrate_mysql(&pool).await.expect("prepare migration"), 4);
         let suffix = chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default();
         let environment_id = format!("mbf-{suffix}");
         let endpoint_id = format!("mbe-{suffix}");
@@ -547,7 +620,7 @@ mod tests {
             .execute(&pool)
             .await
             .expect("remove MySQL phase-two marker");
-        assert_eq!(migrate_mysql(&pool).await.expect("rerun MySQL phase two"), 3);
+        assert_eq!(migrate_mysql(&pool).await.expect("rerun MySQL phase two"), 4);
         let role: String = sqlx::query_scalar("SELECT role FROM dashboard_endpoint WHERE endpoint_id = ?")
             .bind(&endpoint_id)
             .fetch_one(&pool)
@@ -567,8 +640,8 @@ mod tests {
             .await
             .expect("connect PostgreSQL storage test database");
         let (first, second) = tokio::join!(migrate_postgres(&pool), migrate_postgres(&pool));
-        assert_eq!(first.expect("first PostgreSQL migration"), 3);
-        assert_eq!(second.expect("second PostgreSQL migration"), 3);
+        assert_eq!(first.expect("first PostgreSQL migration"), 4);
+        assert_eq!(second.expect("second PostgreSQL migration"), 4);
     }
 
     #[tokio::test]
@@ -581,7 +654,7 @@ mod tests {
             .connect(&url)
             .await
             .expect("connect PostgreSQL storage test database");
-        assert_eq!(migrate_postgres(&pool).await.expect("prepare migration"), 3);
+        assert_eq!(migrate_postgres(&pool).await.expect("prepare migration"), 4);
         let suffix = chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default();
         let environment_id = format!("pbf-{suffix}");
         let endpoint_id = format!("pbe-{suffix}");
@@ -607,7 +680,7 @@ mod tests {
             .execute(&pool)
             .await
             .expect("remove PostgreSQL phase-two marker");
-        assert_eq!(migrate_postgres(&pool).await.expect("rerun PostgreSQL phase two"), 3);
+        assert_eq!(migrate_postgres(&pool).await.expect("rerun PostgreSQL phase two"), 4);
         let role: String = sqlx::query_scalar("SELECT role FROM dashboard_endpoint WHERE endpoint_id = $1")
             .bind(&endpoint_id)
             .fetch_one(&pool)

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/monitor_repository.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/monitor_repository.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use crate::model::AuditEvent;
 use crate::model::ConsumerMonitorRule;
 use crate::model::EnvironmentId;
 use crate::persistence::DashboardPersistence;
@@ -65,6 +66,26 @@ impl DashboardPersistence {
         }
     }
 
+    pub async fn upsert_monitor_rule_with_audit(
+        &self,
+        rule: ConsumerMonitorRule,
+        expected_revision: Revision,
+        audit: AuditEvent,
+    ) -> Result<ConsumerMonitorRule, PersistenceError> {
+        match &self.backend {
+            PersistenceBackend::File(store) => {
+                store
+                    .upsert_monitor_rule_with_audit(rule, expected_revision, audit)
+                    .await
+            }
+            PersistenceBackend::Sql(store) => {
+                store
+                    .upsert_monitor_rule_with_audit(rule, expected_revision, audit)
+                    .await
+            }
+        }
+    }
+
     pub async fn delete_monitor_rule(
         &self,
         environment_id: &EnvironmentId,
@@ -80,6 +101,27 @@ impl DashboardPersistence {
             PersistenceBackend::Sql(store) => {
                 store
                     .delete_monitor_rule(environment_id, consumer_group, expected_revision)
+                    .await
+            }
+        }
+    }
+
+    pub async fn delete_monitor_rule_with_audit(
+        &self,
+        environment_id: &EnvironmentId,
+        consumer_group: &str,
+        expected_revision: Revision,
+        audit: AuditEvent,
+    ) -> Result<bool, PersistenceError> {
+        match &self.backend {
+            PersistenceBackend::File(store) => {
+                store
+                    .delete_monitor_rule_with_audit(environment_id, consumer_group, expected_revision, audit)
+                    .await
+            }
+            PersistenceBackend::Sql(store) => {
+                store
+                    .delete_monitor_rule_with_audit(environment_id, consumer_group, expected_revision, audit)
                     .await
             }
         }
@@ -188,6 +230,60 @@ impl FilePersistence {
         Ok(rule)
     }
 
+    pub(crate) async fn upsert_monitor_rule_with_audit(
+        &self,
+        mut rule: ConsumerMonitorRule,
+        expected_revision: Revision,
+        audit: AuditEvent,
+    ) -> Result<ConsumerMonitorRule, PersistenceError> {
+        rule.validate().map_err(PersistenceError::InvalidConfig)?;
+        let write_guard = self.write_guard().await;
+        self.load_environment_locked(&rule.environment_id).await?;
+        let collection = monitor_collection(&rule.environment_id);
+        let current = self.load_latest_snapshot(&collection).await?;
+        let snapshot_revision = current.as_ref().map_or(0, |snapshot| snapshot.revision);
+        let mut snapshot: FileMonitorSnapshot = current
+            .map(|snapshot| serde_json::from_value(snapshot.payload).map_err(|_| PersistenceError::CorruptedData))
+            .transpose()?
+            .unwrap_or_default();
+        let now_ms = Utc::now().timestamp_millis();
+        if let Some(existing) = snapshot
+            .rules
+            .iter_mut()
+            .find(|existing| existing.consumer_group == rule.consumer_group)
+        {
+            if expected_revision != existing.revision {
+                return Err(PersistenceError::Conflict);
+            }
+            rule.revision = Revision(existing.revision.0.checked_add(1).ok_or(PersistenceError::Conflict)?);
+            rule.created_at_ms = existing.created_at_ms;
+            rule.updated_at_ms = now_ms;
+            *existing = rule.clone();
+        } else {
+            if expected_revision != Revision(0) {
+                return Err(PersistenceError::Conflict);
+            }
+            rule.revision = Revision(1);
+            rule.created_at_ms = now_ms;
+            rule.updated_at_ms = now_ms;
+            snapshot.rules.push(rule.clone());
+        }
+        snapshot
+            .rules
+            .sort_by(|left, right| left.consumer_group.cmp(&right.consumer_group));
+        self.publish_snapshot_transaction_with_audit_locked(
+            write_guard,
+            vec![crate::persistence::file_store::FileSnapshotTransactionWrite {
+                collection,
+                expected_revision: snapshot_revision,
+                payload: to_value(snapshot).map_err(PersistenceError::Serialization)?,
+            }],
+            audit,
+        )
+        .await?;
+        Ok(rule)
+    }
+
     pub(crate) async fn delete_monitor_rule(
         &self,
         environment_id: &EnvironmentId,
@@ -220,6 +316,47 @@ impl FilePersistence {
             &collection,
             current.revision,
             to_value(snapshot).map_err(PersistenceError::Serialization)?,
+        )
+        .await?;
+        Ok(true)
+    }
+
+    pub(crate) async fn delete_monitor_rule_with_audit(
+        &self,
+        environment_id: &EnvironmentId,
+        consumer_group: &str,
+        expected_revision: Revision,
+        audit: AuditEvent,
+    ) -> Result<bool, PersistenceError> {
+        let group = consumer_group.trim();
+        if group.is_empty() {
+            return Err(PersistenceError::InvalidConfig(
+                "consumer group is required".to_string(),
+            ));
+        }
+        let write_guard = self.write_guard().await;
+        self.load_environment_locked(environment_id).await?;
+        let collection = monitor_collection(environment_id);
+        let Some(current) = self.load_latest_snapshot(&collection).await? else {
+            return Ok(false);
+        };
+        let mut snapshot: FileMonitorSnapshot =
+            serde_json::from_value(current.payload).map_err(|_| PersistenceError::CorruptedData)?;
+        let Some(index) = snapshot.rules.iter().position(|rule| rule.consumer_group == group) else {
+            return Ok(false);
+        };
+        if snapshot.rules[index].revision != expected_revision {
+            return Err(PersistenceError::Conflict);
+        }
+        snapshot.rules.remove(index);
+        self.publish_snapshot_transaction_with_audit_locked(
+            write_guard,
+            vec![crate::persistence::file_store::FileSnapshotTransactionWrite {
+                collection,
+                expected_revision: current.revision,
+                payload: to_value(snapshot).map_err(PersistenceError::Serialization)?,
+            }],
+            audit,
         )
         .await?;
         Ok(true)

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/session_audit_docker_tests.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/session_audit_docker_tests.rs
@@ -1,0 +1,438 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::config::SqlPoolConfig;
+use crate::config::StorageConfig;
+use crate::model::AuditAction;
+use crate::model::AuditActor;
+use crate::model::AuditEvent;
+use crate::model::AuditOutcome;
+use crate::model::AuditResourceType;
+use crate::model::ConsumerMonitorRule;
+use crate::model::DashboardConfigView;
+use crate::model::DashboardEnvironment;
+use crate::model::NewSession;
+use crate::model::SessionTokenHash;
+use crate::model::StorageBackend;
+use crate::persistence::DashboardPersistence;
+use crate::persistence::Revision;
+use crate::persistence::audit_repository::AuditQuery;
+use crate::persistence::session_repository::SessionQuery;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+
+#[test]
+#[ignore = "requires fresh docker-compose.storage-test.yml volumes"]
+fn docker_session_audit_contracts_cover_file_sqlite_mysql_and_postgres() {
+    let owner = RuntimeOwner::new(RuntimeConfig::default()).expect("runtime owner");
+    owner.block_on(async {
+        let configs = [
+            StorageConfig {
+                backend: StorageBackend::File,
+                data_path: std::env::var("ROCKETMQ_DASHBOARD_STORAGE_TEST_FILE_PATH")
+                    .expect("ROCKETMQ_DASHBOARD_STORAGE_TEST_FILE_PATH")
+                    .into(),
+                database_url: None,
+                pool: SqlPoolConfig::default(),
+            },
+            StorageConfig {
+                backend: StorageBackend::Sqlite,
+                data_path: std::env::var("ROCKETMQ_DASHBOARD_STORAGE_TEST_SQLITE_PATH")
+                    .expect("ROCKETMQ_DASHBOARD_STORAGE_TEST_SQLITE_PATH")
+                    .into(),
+                database_url: None,
+                pool: SqlPoolConfig::default(),
+            },
+            StorageConfig {
+                backend: StorageBackend::MySql,
+                data_path: "unused".into(),
+                database_url: Some(
+                    std::env::var("ROCKETMQ_DASHBOARD_STORAGE_TEST_MYSQL_URL")
+                        .expect("ROCKETMQ_DASHBOARD_STORAGE_TEST_MYSQL_URL"),
+                ),
+                pool: SqlPoolConfig::default(),
+            },
+            StorageConfig {
+                backend: StorageBackend::Postgres,
+                data_path: "unused".into(),
+                database_url: Some(
+                    std::env::var("ROCKETMQ_DASHBOARD_STORAGE_TEST_POSTGRES_URL")
+                        .expect("ROCKETMQ_DASHBOARD_STORAGE_TEST_POSTGRES_URL"),
+                ),
+                pool: SqlPoolConfig::default(),
+            },
+        ];
+        for (index, config) in configs.into_iter().enumerate() {
+            run_contract(&owner, config, index as u8).await;
+        }
+    });
+    owner.shutdown_runtime_blocking().expect("runtime shutdown");
+}
+
+async fn run_contract(owner: &RuntimeOwner, config: StorageConfig, discriminator: u8) {
+    let hash = SessionTokenHash([discriminator.saturating_add(1); 32]);
+    let username = format!("storage-contract-{discriminator}");
+    let store = DashboardPersistence::initialize(
+        &config,
+        owner.root_context().component("session-audit-storage-contract"),
+    )
+    .await
+    .expect("initialize storage backend");
+    let create = audit_event(AuditAction::SessionCreate, &username, 1);
+    store
+        .create_session_with_audit(
+            NewSession {
+                session_id: uuid::Uuid::now_v7().to_string(),
+                token_hash: hash,
+                username: username.clone(),
+                created_at_ms: 1,
+                expires_at_ms: 10_000,
+            },
+            create,
+        )
+        .await
+        .expect("create session with audit");
+    assert!(
+        store
+            .find_session(&hash)
+            .await
+            .unwrap_or_else(|error| panic!("find session for {:?}: {error:?}", config.backend))
+            .is_some()
+    );
+    store
+        .revoke_session_with_audit(&hash, 2, audit_event(AuditAction::SessionRevokeCurrent, &username, 2))
+        .await
+        .expect("revoke session with audit");
+    assert!(
+        store
+            .find_session(&hash)
+            .await
+            .expect("find revoked session")
+            .is_some_and(|session| session.revoked_at_ms == Some(2))
+    );
+    let page = store
+        .query_audit_events(AuditQuery {
+            start_ms: 0,
+            end_ms: 10,
+            actor: Some(username.clone()),
+            action: None,
+            outcome: None,
+            environment_id: None,
+            cursor: None,
+            limit: 10,
+        })
+        .await
+        .expect("query audit history");
+    assert_eq!(page.events.len(), 2);
+
+    // The public list is capped at 200 records, but cleanup and revoke-all
+    // must retain their complete semantic scope across a larger account.
+    // This also proves the File transaction marker no longer inherits the
+    // former 32-transition limit.
+    for index in 10_u8..250 {
+        store
+            .create_session(NewSession {
+                session_id: uuid::Uuid::now_v7().to_string(),
+                token_hash: SessionTokenHash([index; 32]),
+                username: username.clone(),
+                created_at_ms: 1,
+                expires_at_ms: if index < 43 { 10_000 } else { 2 },
+            })
+            .await
+            .unwrap_or_else(|error| panic!("seed session {index} for {:?}: {error:?}", config.backend));
+    }
+    let first_page = store
+        .list_sessions(SessionQuery {
+            username: Some(username.clone()),
+            cursor: None,
+            limit: 200,
+        })
+        .await
+        .expect("first 200-session page");
+    assert_eq!(first_page.records.len(), 200);
+    let second_page = store
+        .list_sessions(SessionQuery {
+            username: Some(username.clone()),
+            cursor: first_page.next_cursor,
+            limit: 200,
+        })
+        .await
+        .expect("remaining session page");
+    assert_eq!(first_page.records.len() + second_page.records.len(), 241);
+    assert_eq!(
+        store
+            .delete_sessions_before(3, 500)
+            .await
+            .expect("delete more than 32 expired sessions"),
+        208
+    );
+    assert_eq!(
+        store
+            .revoke_all_sessions_with_audit(&username, 3, audit_event(AuditAction::SessionRevokeAll, &username, 3),)
+            .await
+            .expect("revoke more than 32 active sessions"),
+        33
+    );
+    let revoke_all_page = store
+        .query_audit_events(AuditQuery {
+            start_ms: 0,
+            end_ms: 10,
+            actor: Some(username.clone()),
+            action: Some(AuditAction::SessionRevokeAll),
+            outcome: Some(AuditOutcome::Succeeded),
+            environment_id: None,
+            cursor: None,
+            limit: 10,
+        })
+        .await
+        .expect("query revoke-all audit");
+    assert_eq!(revoke_all_page.events.len(), 1);
+
+    // Configuration and monitor mutations must publish their durable state
+    // and successful audit event together for every storage backend. The
+    // mutable application configuration is intentionally not involved here:
+    // repository success is the publish boundary exercised by the services.
+    let mut environment = DashboardEnvironment::bootstrap(&DashboardConfigView::default(), 10);
+    environment.environment_id = crate::model::EnvironmentId::new();
+    environment.name = format!("audit-contract-environment-{discriminator}");
+    let environment = store
+        .create_environment(environment)
+        .await
+        .expect("create environment for atomic configuration audit");
+    let mut updated_environment = environment.clone();
+    updated_environment.use_tls = !updated_environment.use_tls;
+    updated_environment.updated_at_ms = 11;
+    let updated_environment = store
+        .update_environment_with_audit(
+            environment.revision,
+            updated_environment,
+            resource_audit_event(
+                AuditAction::ConfigTlsSet,
+                AuditResourceType::Environment,
+                &username,
+                Some(environment.environment_id.clone()),
+                11,
+            ),
+        )
+        .await
+        .expect("update environment and append audit in one transaction");
+    assert_eq!(
+        store
+            .load_environment(&environment.environment_id)
+            .await
+            .expect("load atomically updated environment"),
+        updated_environment
+    );
+    assert_eq!(
+        store
+            .query_audit_events(AuditQuery {
+                start_ms: 0,
+                end_ms: 20,
+                actor: Some(username.clone()),
+                action: Some(AuditAction::ConfigTlsSet),
+                outcome: Some(AuditOutcome::Succeeded),
+                environment_id: Some(environment.environment_id.0.clone()),
+                cursor: None,
+                limit: 10,
+            })
+            .await
+            .expect("query configuration audit")
+            .events
+            .len(),
+        1
+    );
+
+    let monitor_group = format!("audit-contract-monitor-{discriminator}");
+    let monitor = store
+        .upsert_monitor_rule_with_audit(
+            ConsumerMonitorRule {
+                environment_id: environment.environment_id.clone(),
+                consumer_group: monitor_group.clone(),
+                min_count: 1,
+                max_diff_total: 10,
+                revision: Revision(0),
+                created_at_ms: 0,
+                updated_at_ms: 0,
+            },
+            Revision(0),
+            resource_audit_event(
+                AuditAction::MonitorUpsert,
+                AuditResourceType::Monitor,
+                &username,
+                Some(environment.environment_id.clone()),
+                12,
+            ),
+        )
+        .await
+        .expect("upsert monitor and append audit in one transaction");
+    assert_eq!(
+        store
+            .list_monitor_rules(&environment.environment_id)
+            .await
+            .expect("list atomically created monitor"),
+        vec![monitor.clone()]
+    );
+    assert!(
+        store
+            .delete_monitor_rule_with_audit(
+                &environment.environment_id,
+                &monitor_group,
+                monitor.revision,
+                resource_audit_event(
+                    AuditAction::MonitorDelete,
+                    AuditResourceType::Monitor,
+                    &username,
+                    Some(environment.environment_id.clone()),
+                    13,
+                ),
+            )
+            .await
+            .expect("delete monitor and append audit in one transaction")
+    );
+    assert!(
+        store
+            .list_monitor_rules(&environment.environment_id)
+            .await
+            .expect("list atomically deleted monitor")
+            .is_empty()
+    );
+    for action in [AuditAction::MonitorUpsert, AuditAction::MonitorDelete] {
+        assert_eq!(
+            store
+                .query_audit_events(AuditQuery {
+                    start_ms: 0,
+                    end_ms: 20,
+                    actor: Some(username.clone()),
+                    action: Some(action),
+                    outcome: Some(AuditOutcome::Succeeded),
+                    environment_id: Some(environment.environment_id.0.clone()),
+                    cursor: None,
+                    limit: 10,
+                })
+                .await
+                .expect("query monitor audit")
+                .events
+                .len(),
+            1
+        );
+    }
+
+    // A duplicate primary key makes the audit insert fail after the SQL
+    // transaction has staged its aggregate write. File storage uses the
+    // prepared-marker interruption test below instead: a journal is
+    // append-only there and intentionally does not reject duplicate IDs.
+    // Exercise this failure mode for SQLite, MySQL, and Postgres so each
+    // backend proves that neither configuration nor monitor state escapes
+    // without its successful audit event.
+    if !matches!(config.backend, StorageBackend::File) {
+        let duplicate_configuration_audit = resource_audit_event(
+            AuditAction::ConfigTlsSet,
+            AuditResourceType::Environment,
+            &username,
+            Some(environment.environment_id.clone()),
+            14,
+        );
+        store
+            .append_audit_event(duplicate_configuration_audit.clone())
+            .await
+            .expect("seed duplicate configuration audit id");
+        let mut rejected_environment = updated_environment.clone();
+        rejected_environment.use_tls = !rejected_environment.use_tls;
+        rejected_environment.updated_at_ms = 14;
+        assert!(
+            store
+                .update_environment_with_audit(
+                    updated_environment.revision,
+                    rejected_environment,
+                    duplicate_configuration_audit,
+                )
+                .await
+                .is_err(),
+            "duplicate configuration audit must roll back {:?} environment state",
+            config.backend
+        );
+        assert_eq!(
+            store
+                .load_environment(&environment.environment_id)
+                .await
+                .expect("configuration audit failure must retain prior environment"),
+            updated_environment
+        );
+
+        let rejected_monitor_group = format!("audit-contract-rejected-monitor-{discriminator}");
+        let duplicate_monitor_audit = resource_audit_event(
+            AuditAction::MonitorUpsert,
+            AuditResourceType::Monitor,
+            &username,
+            Some(environment.environment_id.clone()),
+            15,
+        );
+        store
+            .append_audit_event(duplicate_monitor_audit.clone())
+            .await
+            .expect("seed duplicate monitor audit id");
+        assert!(
+            store
+                .upsert_monitor_rule_with_audit(
+                    ConsumerMonitorRule {
+                        environment_id: environment.environment_id.clone(),
+                        consumer_group: rejected_monitor_group,
+                        min_count: 1,
+                        max_diff_total: 10,
+                        revision: Revision(0),
+                        created_at_ms: 0,
+                        updated_at_ms: 0,
+                    },
+                    Revision(0),
+                    duplicate_monitor_audit,
+                )
+                .await
+                .is_err(),
+            "duplicate monitor audit must roll back {:?} monitor state",
+            config.backend
+        );
+        assert!(
+            store
+                .list_monitor_rules(&environment.environment_id)
+                .await
+                .expect("monitor audit failure must retain prior rules")
+                .is_empty()
+        );
+    }
+}
+
+fn audit_event(action: AuditAction, username: &str, created_at_ms: i64) -> AuditEvent {
+    resource_audit_event(action, AuditResourceType::Session, username, None, created_at_ms)
+}
+
+fn resource_audit_event(
+    action: AuditAction,
+    resource_type: AuditResourceType,
+    username: &str,
+    environment_id: Option<crate::model::EnvironmentId>,
+    created_at_ms: i64,
+) -> AuditEvent {
+    AuditEvent {
+        event_id: uuid::Uuid::now_v7().to_string(),
+        request_id: uuid::Uuid::now_v7().to_string(),
+        actor: AuditActor::admin(username),
+        action,
+        resource_type,
+        resource_name: Some(username.to_string()),
+        environment_id,
+        outcome: AuditOutcome::Succeeded,
+        detail: None,
+        created_at_ms,
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/session_file_store.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/session_file_store.rs
@@ -1,0 +1,1659 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::FileMutationOutcome;
+use super::FilePersistence;
+use super::OpenOptions;
+use super::PersistenceError;
+use super::Utc;
+use super::rollback_jsonl_append;
+use super::write_json_new_file;
+use crate::model::AuditEvent;
+use crate::model::NewSession;
+use crate::model::SessionRecord;
+use crate::model::SessionTokenHash;
+use crate::persistence::session_repository::SessionCursor;
+use crate::persistence::session_repository::SessionPage;
+use crate::persistence::session_repository::SessionQuery;
+use serde::Deserialize;
+use serde::Serialize;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FileSessionRecord {
+    session_id: String,
+    username: String,
+    created_at_ms: i64,
+    expires_at_ms: i64,
+    last_seen_at_ms: i64,
+    revoked_at_ms: Option<i64>,
+}
+
+impl FileSessionRecord {
+    fn from_new(session: NewSession) -> Self {
+        Self {
+            session_id: session.session_id,
+            username: session.username,
+            created_at_ms: session.created_at_ms,
+            expires_at_ms: session.expires_at_ms,
+            last_seen_at_ms: session.created_at_ms,
+            revoked_at_ms: None,
+        }
+    }
+
+    fn into_record(self, token_hash: SessionTokenHash) -> SessionRecord {
+        SessionRecord {
+            session_id: self.session_id,
+            token_hash,
+            username: self.username,
+            created_at_ms: self.created_at_ms,
+            expires_at_ms: self.expires_at_ms,
+            last_seen_at_ms: self.last_seen_at_ms,
+            revoked_at_ms: self.revoked_at_ms,
+        }
+    }
+}
+
+impl FilePersistence {
+    pub(crate) async fn create_session_with_audit(
+        &self,
+        session: NewSession,
+        audit: AuditEvent,
+    ) -> Result<(), PersistenceError> {
+        self.create_session_with_audit_capped(session, audit, usize::MAX, 0)
+            .await
+    }
+
+    pub(crate) async fn create_session_with_audit_capped(
+        &self,
+        session: NewSession,
+        audit: AuditEvent,
+        max_active_sessions: usize,
+        now_ms: i64,
+    ) -> Result<(), PersistenceError> {
+        let token_hash = session.token_hash;
+        let username = session.username.clone();
+        let record = FileSessionRecord::from_new(session);
+        self.run_session_audit_mutation("dashboard-file-session-create-audit", move |root| {
+            let active = active_path(root, &token_hash);
+            let revoked = revoked_path(root, &token_hash);
+            if active.exists() || revoked.exists() {
+                return Err(PersistenceError::Conflict);
+            }
+            if max_active_sessions != usize::MAX
+                && active_session_count(root, &username, now_ms)? >= max_active_sessions
+            {
+                return Err(PersistenceError::Conflict);
+            }
+            let prepared = prepare_session_audit_transaction(
+                root,
+                vec![SessionAuditStagedWrite::create(token_hash, record)],
+                &audit,
+            )?;
+            publish_session_audit_transaction(&prepared, root, &audit)?;
+            Ok(((), Some(prepared)))
+        })
+        .await?;
+        Ok(())
+    }
+
+    pub(crate) async fn create_session(&self, session: NewSession) -> Result<(), PersistenceError> {
+        let token_hash = session.token_hash;
+        let record = FileSessionRecord::from_new(session);
+        let write_guard = self.write_guard().await;
+        self.ensure_available()?;
+        let root = self.root.clone();
+        self.dispatch_file_mutation(write_guard, "dashboard-file-session-create", move || {
+            let path = active_path(&root, &token_hash);
+            write_json_new_file(&path, &record)?;
+            Ok(FileMutationOutcome {
+                value: (),
+                finalize: Box::new(|| Ok(())),
+                cleanup: Box::new(|| Ok(())),
+                rollback: Box::new(move || remove_session_file(&path)),
+            })
+        })
+        .await?;
+        self.record_write();
+        Ok(())
+    }
+
+    pub(crate) async fn find_session(
+        &self,
+        token_hash: &SessionTokenHash,
+    ) -> Result<Option<SessionRecord>, PersistenceError> {
+        let _read_guard = self.read_guard().await;
+        self.ensure_available()?;
+        let root = self.root.clone();
+        let token_hash = *token_hash;
+        self.service_context
+            .storage_io()
+            .spawn_io("dashboard-file-session-find", move || load_session(&root, token_hash))
+            .await
+            .map_err(PersistenceError::Runtime)?
+    }
+
+    pub(crate) async fn touch_session(
+        &self,
+        token_hash: &SessionTokenHash,
+        observed_at_ms: i64,
+    ) -> Result<bool, PersistenceError> {
+        let write_guard = self.write_guard().await;
+        self.ensure_available()?;
+        let root = self.root.clone();
+        let token_hash = *token_hash;
+        let mutation_blocker = self.mutation_blocker.clone();
+        let changed = self
+            .dispatch_file_mutation(write_guard, "dashboard-file-session-touch", move || {
+                let active = active_path(&root, &token_hash);
+                if !active.exists() {
+                    return Ok(FileMutationOutcome {
+                        value: false,
+                        finalize: Box::new(|| Ok(())),
+                        cleanup: Box::new(|| Ok(())),
+                        rollback: Box::new(|| Ok(())),
+                    });
+                }
+                let mut record: FileSessionRecord = read_session_file(&active)?;
+                if record.revoked_at_ms.is_some() || record.last_seen_at_ms >= observed_at_ms {
+                    return Ok(FileMutationOutcome {
+                        value: false,
+                        finalize: Box::new(|| Ok(())),
+                        cleanup: Box::new(|| Ok(())),
+                        rollback: Box::new(|| Ok(())),
+                    });
+                }
+                record.last_seen_at_ms = observed_at_ms;
+                let prepared = prepare_session_touch_transaction(&root, token_hash, &record)?;
+                publish_session_touch_transaction(&prepared)?;
+                mutation_blocker.wait_after_mutation();
+                Ok(FileMutationOutcome {
+                    value: true,
+                    finalize: Box::new({
+                        let prepared = prepared.clone();
+                        move || prepared.finalize()
+                    }),
+                    cleanup: Box::new({
+                        let prepared = prepared.clone();
+                        let cleanup_blocker = mutation_blocker.clone();
+                        move || {
+                            cleanup_blocker.wait_after_committed_cleanup()?;
+                            prepared.cleanup()
+                        }
+                    }),
+                    rollback: Box::new(move || prepared.rollback()),
+                })
+            })
+            .await?;
+        if changed {
+            self.record_write();
+        }
+        Ok(changed)
+    }
+
+    pub(crate) async fn revoke_session(
+        &self,
+        token_hash: &SessionTokenHash,
+        revoked_at_ms: i64,
+    ) -> Result<bool, PersistenceError> {
+        let write_guard = self.write_guard().await;
+        self.ensure_available()?;
+        let root = self.root.clone();
+        let token_hash = *token_hash;
+        let changed = self
+            .dispatch_file_mutation(write_guard, "dashboard-file-session-revoke", move || {
+                let active = active_path(&root, &token_hash);
+                if !active.exists() {
+                    return Ok(FileMutationOutcome {
+                        value: false,
+                        finalize: Box::new(|| Ok(())),
+                        cleanup: Box::new(|| Ok(())),
+                        rollback: Box::new(|| Ok(())),
+                    });
+                }
+                let mut record: FileSessionRecord = read_session_file(&active)?;
+                if record.revoked_at_ms.is_some() {
+                    return Ok(FileMutationOutcome {
+                        value: false,
+                        finalize: Box::new(|| Ok(())),
+                        cleanup: Box::new(|| Ok(())),
+                        rollback: Box::new(|| Ok(())),
+                    });
+                }
+                record.revoked_at_ms = Some(revoked_at_ms);
+                let revoked = revoked_path(&root, &token_hash);
+                write_json_new_file(&revoked, &record)?;
+                std::fs::remove_file(&active).map_err(PersistenceError::Io)?;
+                Ok(FileMutationOutcome {
+                    value: true,
+                    finalize: Box::new(|| Ok(())),
+                    cleanup: Box::new(|| Ok(())),
+                    rollback: Box::new(move || {
+                        if revoked.exists() {
+                            std::fs::rename(&revoked, &active).map_err(PersistenceError::Io)?;
+                        }
+                        Ok(())
+                    }),
+                })
+            })
+            .await?;
+        if changed {
+            self.record_write();
+        }
+        Ok(changed)
+    }
+
+    pub(crate) async fn revoke_session_with_audit(
+        &self,
+        token_hash: &SessionTokenHash,
+        revoked_at_ms: i64,
+        audit: AuditEvent,
+    ) -> Result<bool, PersistenceError> {
+        let token_hash = *token_hash;
+        self.run_session_audit_mutation("dashboard-file-session-revoke-audit", move |root| {
+            let active = active_path(root, &token_hash);
+            if !active.exists() {
+                return Ok((false, None));
+            }
+            let record: FileSessionRecord = read_session_file(&active)?;
+            if record.revoked_at_ms.is_some() || revoked_path(root, &token_hash).exists() {
+                return Err(PersistenceError::CorruptedData);
+            }
+            let prepared = prepare_session_audit_transaction(
+                root,
+                vec![SessionAuditStagedWrite::revoke(token_hash, record, revoked_at_ms)],
+                &audit,
+            )?;
+            publish_session_audit_transaction(&prepared, root, &audit)?;
+            Ok((true, Some(prepared)))
+        })
+        .await
+    }
+
+    pub(crate) async fn revoke_all_sessions(
+        &self,
+        username: &str,
+        revoked_at_ms: i64,
+    ) -> Result<u64, PersistenceError> {
+        let mut revoked = 0;
+        let mut cursor = None;
+        loop {
+            let page = self
+                .list_sessions(SessionQuery {
+                    username: Some(username.to_string()),
+                    cursor,
+                    limit: 200,
+                })
+                .await?;
+            for record in page.records {
+                if record.revoked_at_ms.is_none()
+                    && record.expires_at_ms > revoked_at_ms
+                    && self.revoke_session(&record.token_hash, revoked_at_ms).await?
+                {
+                    revoked += 1;
+                }
+            }
+            let Some(next_cursor) = page.next_cursor else {
+                break;
+            };
+            cursor = Some(next_cursor);
+        }
+        Ok(revoked)
+    }
+
+    pub(crate) async fn revoke_all_sessions_with_audit(
+        &self,
+        username: &str,
+        revoked_at_ms: i64,
+        audit: AuditEvent,
+    ) -> Result<u64, PersistenceError> {
+        let username = username.to_string();
+        self.run_session_audit_mutation("dashboard-file-session-revoke-all-audit", move |root| {
+            let directory = root.join("sessions").join("active");
+            let mut writes = Vec::new();
+            if directory.exists() {
+                for entry in std::fs::read_dir(directory).map_err(PersistenceError::Io)? {
+                    let entry = entry.map_err(PersistenceError::Io)?;
+                    let hash = parse_hash(&entry.path()).ok_or(PersistenceError::CorruptedData)?;
+                    let record: FileSessionRecord = read_session_file(&entry.path())?;
+                    if record.username == username
+                        && record.revoked_at_ms.is_none()
+                        && record.expires_at_ms > revoked_at_ms
+                    {
+                        if revoked_path(root, &hash).exists() {
+                            return Err(PersistenceError::CorruptedData);
+                        }
+                        writes.push(SessionAuditStagedWrite::revoke(hash, record, revoked_at_ms));
+                    }
+                }
+            }
+            let count = writes.len() as u64;
+            let prepared = prepare_session_audit_transaction(root, writes, &audit)?;
+            publish_session_audit_transaction(&prepared, root, &audit)?;
+            Ok((count, Some(prepared)))
+        })
+        .await
+    }
+
+    pub(crate) async fn list_sessions(&self, query: SessionQuery) -> Result<SessionPage, PersistenceError> {
+        let _read_guard = self.read_guard().await;
+        self.ensure_available()?;
+        let root = self.root.clone();
+        self.service_context
+            .storage_io()
+            .spawn_io("dashboard-file-session-list", move || list_sessions(&root, query))
+            .await
+            .map_err(PersistenceError::Runtime)?
+    }
+
+    pub(crate) async fn delete_sessions_before(&self, cutoff_ms: i64, limit: usize) -> Result<u64, PersistenceError> {
+        let write_guard = self.write_guard().await;
+        self.ensure_available()?;
+        let root = self.root.clone();
+        let mutation_blocker = self.mutation_blocker.clone();
+        let deleted = self
+            .dispatch_file_mutation(write_guard, "dashboard-file-session-cleanup", move || {
+                let Some(prepared) = prepare_session_cleanup_transaction(&root, cutoff_ms, limit)? else {
+                    return Ok(FileMutationOutcome {
+                        value: 0,
+                        finalize: Box::new(|| Ok(())),
+                        cleanup: Box::new(|| Ok(())),
+                        rollback: Box::new(|| Ok(())),
+                    });
+                };
+                let deleted = prepared.delete_staged_sessions()?;
+                mutation_blocker.wait_after_mutation();
+                Ok(FileMutationOutcome {
+                    value: deleted,
+                    finalize: Box::new({
+                        let prepared = prepared.clone();
+                        move || prepared.finalize()
+                    }),
+                    cleanup: Box::new({
+                        let prepared = prepared.clone();
+                        move || prepared.cleanup()
+                    }),
+                    rollback: Box::new(move || prepared.rollback()),
+                })
+            })
+            .await?;
+        if deleted > 0 {
+            self.record_write();
+        }
+        Ok(deleted)
+    }
+
+    /// Publishes the session transition and its one audit append under one
+    /// durable decision marker. The marker is retained until the committed
+    /// decision is fsynced, so request cancellation cannot leave the two
+    /// files with an unknowable relationship.
+    async fn run_session_audit_mutation<T, F>(&self, name: &'static str, operation: F) -> Result<T, PersistenceError>
+    where
+        T: Send + 'static,
+        F: FnOnce(&Path) -> Result<(T, Option<PreparedSessionAuditTransaction>), PersistenceError> + Send + 'static,
+    {
+        let write_guard = self.write_guard().await;
+        self.ensure_available()?;
+        let root = self.root.clone();
+        let value = self
+            .dispatch_file_mutation(write_guard, name, move || {
+                let (value, prepared) = operation(&root)?;
+                let Some(prepared) = prepared else {
+                    return Ok(FileMutationOutcome {
+                        value,
+                        finalize: Box::new(|| Ok(())),
+                        cleanup: Box::new(|| Ok(())),
+                        rollback: Box::new(|| Ok(())),
+                    });
+                };
+                Ok(FileMutationOutcome {
+                    value,
+                    finalize: Box::new({
+                        let prepared = prepared.clone();
+                        move || prepared.finalize()
+                    }),
+                    cleanup: Box::new({
+                        let prepared = prepared.clone();
+                        move || prepared.cleanup()
+                    }),
+                    rollback: Box::new(move || prepared.rollback()),
+                })
+            })
+            .await?;
+        self.record_write();
+        Ok(value)
+    }
+}
+
+fn active_session_count(root: &Path, username: &str, now_ms: i64) -> Result<usize, PersistenceError> {
+    let directory = root.join("sessions").join("active");
+    if !directory.exists() {
+        return Ok(0);
+    }
+    let mut count = 0;
+    for entry in std::fs::read_dir(directory).map_err(PersistenceError::Io)? {
+        let entry = entry.map_err(PersistenceError::Io)?;
+        let _hash = parse_hash(&entry.path()).ok_or(PersistenceError::CorruptedData)?;
+        let record: FileSessionRecord = read_session_file(&entry.path())?;
+        if record.username == username && record.revoked_at_ms.is_none() && record.expires_at_ms > now_ms {
+            count += 1;
+        }
+    }
+    Ok(count)
+}
+
+const SESSION_AUDIT_MARKER_VERSION: u32 = 1;
+const SESSION_TOUCH_MARKER_VERSION: u32 = 1;
+// One revoke-all decision can legitimately cover more than a single list
+// page. Keep the marker bounded, but above the public 200-record page cap.
+const MAX_SESSION_AUDIT_WRITES: usize = 1_000;
+const SESSION_CLEANUP_MARKER_VERSION: u32 = 1;
+const MAX_SESSION_CLEANUP_WRITES: usize = 1_000;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum SessionAuditOperation {
+    Create,
+    Revoke,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SessionAuditWrite {
+    hash_hex: String,
+    operation: SessionAuditOperation,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AuditAppendRollback {
+    path: String,
+    original_length: u64,
+    existed: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SessionAuditTransaction {
+    format_version: u32,
+    writes: Vec<SessionAuditWrite>,
+    audit: AuditAppendRollback,
+}
+
+/// The touch marker only names the hashed session target. Its exact stage and
+/// hard-link backup paths are derived from the durable transaction ID, so a
+/// prepared recovery can restore the old record without trusting temporary
+/// filenames left by an interrupted request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SessionTouchTransaction {
+    format_version: u32,
+    hash_hex: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum SessionCleanupLocation {
+    Active,
+    Revoked,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SessionCleanupWrite {
+    hash_hex: String,
+    location: SessionCleanupLocation,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SessionCleanupTransaction {
+    format_version: u32,
+    writes: Vec<SessionCleanupWrite>,
+}
+
+#[derive(Debug)]
+struct SessionAuditStagedWrite {
+    hash: SessionTokenHash,
+    operation: SessionAuditOperation,
+    record: FileSessionRecord,
+}
+
+impl SessionAuditStagedWrite {
+    fn create(hash: SessionTokenHash, record: FileSessionRecord) -> Self {
+        Self {
+            hash,
+            operation: SessionAuditOperation::Create,
+            record,
+        }
+    }
+
+    fn revoke(hash: SessionTokenHash, mut record: FileSessionRecord, revoked_at_ms: i64) -> Self {
+        record.revoked_at_ms = Some(revoked_at_ms);
+        Self {
+            hash,
+            operation: SessionAuditOperation::Revoke,
+            record,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PreparedSessionAuditTransaction {
+    root: PathBuf,
+    transaction_id: String,
+    prepared_marker: PathBuf,
+    committed_marker: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+struct PreparedSessionCleanupTransaction {
+    root: PathBuf,
+    transaction_id: String,
+    prepared_marker: PathBuf,
+    committed_marker: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+struct PreparedSessionTouchTransaction {
+    root: PathBuf,
+    transaction_id: String,
+    prepared_marker: PathBuf,
+    committed_marker: PathBuf,
+}
+
+impl PreparedSessionAuditTransaction {
+    fn finalize(&self) -> Result<(), PersistenceError> {
+        let transaction = read_session_audit_transaction(&self.prepared_marker)?;
+        write_json_new_file(&self.committed_marker, &transaction)
+    }
+
+    fn cleanup(&self) -> Result<(), PersistenceError> {
+        cleanup_session_audit_transaction(
+            &self.root,
+            &self.transaction_id,
+            &self.prepared_marker,
+            &self.committed_marker,
+        )
+    }
+
+    fn rollback(&self) -> Result<(), PersistenceError> {
+        rollback_session_audit_transaction(
+            &self.root,
+            &self.transaction_id,
+            &self.prepared_marker,
+            &self.committed_marker,
+        )
+    }
+}
+
+impl PreparedSessionCleanupTransaction {
+    fn delete_staged_sessions(&self) -> Result<u64, PersistenceError> {
+        let transaction = read_session_cleanup_transaction(&self.prepared_marker)?;
+        for write in &transaction.writes {
+            remove_file_if_exists(&session_cleanup_target(&self.root, write)?)?;
+        }
+        Ok(transaction.writes.len() as u64)
+    }
+
+    fn finalize(&self) -> Result<(), PersistenceError> {
+        let transaction = read_session_cleanup_transaction(&self.prepared_marker)?;
+        write_json_new_file(&self.committed_marker, &transaction)
+    }
+
+    fn cleanup(&self) -> Result<(), PersistenceError> {
+        cleanup_session_cleanup_transaction(
+            &self.root,
+            &self.transaction_id,
+            &self.prepared_marker,
+            &self.committed_marker,
+        )
+    }
+
+    fn rollback(&self) -> Result<(), PersistenceError> {
+        rollback_session_cleanup_transaction(
+            &self.root,
+            &self.transaction_id,
+            &self.prepared_marker,
+            &self.committed_marker,
+        )
+    }
+}
+
+impl PreparedSessionTouchTransaction {
+    fn finalize(&self) -> Result<(), PersistenceError> {
+        let transaction = read_session_touch_transaction(&self.prepared_marker)?;
+        write_json_new_file(&self.committed_marker, &transaction)
+    }
+
+    fn cleanup(&self) -> Result<(), PersistenceError> {
+        cleanup_session_touch_transaction(
+            &self.root,
+            &self.transaction_id,
+            &self.prepared_marker,
+            &self.committed_marker,
+        )
+    }
+
+    fn rollback(&self) -> Result<(), PersistenceError> {
+        rollback_session_touch_transaction(
+            &self.root,
+            &self.transaction_id,
+            &self.prepared_marker,
+            &self.committed_marker,
+        )
+    }
+}
+
+/// Recovers a touch as an old-or-new decision. A prepared marker always
+/// restores the exact hard-link backup; a committed marker keeps the newly
+/// observed timestamp and removes only recovery metadata.
+pub(crate) fn recover_session_touch_transactions(root: &Path) -> Result<(), PersistenceError> {
+    let directory = root.join("transactions");
+    if !directory.exists() {
+        return Ok(());
+    }
+    let mut prepared = std::collections::BTreeMap::new();
+    let mut committed = std::collections::BTreeMap::new();
+    for entry in std::fs::read_dir(&directory).map_err(PersistenceError::Io)? {
+        let entry = entry.map_err(PersistenceError::Io)?;
+        if !entry.file_type().map_err(PersistenceError::Io)?.is_file() {
+            continue;
+        }
+        let path = entry.path();
+        let name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or(PersistenceError::CorruptedData)?;
+        if let Some(id) = name.strip_suffix(".session-touch.prepared.json") {
+            prepared.insert(id.to_string(), path);
+        } else if let Some(id) = name.strip_suffix(".session-touch.committed.json") {
+            committed.insert(id.to_string(), path);
+        }
+    }
+    for (id, committed_marker) in committed {
+        let _transaction = read_session_touch_transaction(&committed_marker)?;
+        let prepared_marker = prepared
+            .remove(&id)
+            .unwrap_or_else(|| session_touch_marker_path(&directory, &id, "prepared"));
+        cleanup_session_touch_transaction(root, &id, &prepared_marker, &committed_marker)?;
+    }
+    for (id, prepared_marker) in prepared {
+        let committed_marker = session_touch_marker_path(&directory, &id, "committed");
+        rollback_session_touch_transaction(root, &id, &prepared_marker, &committed_marker)?;
+    }
+    Ok(())
+}
+
+/// Recovers only `*.session-audit.*.json` markers. Snapshot recovery calls
+/// this separately because a session target is a mutable record rather than
+/// an immutable revision snapshot.
+pub(crate) fn recover_session_audit_transactions(root: &Path) -> Result<(), PersistenceError> {
+    let directory = root.join("transactions");
+    if !directory.exists() {
+        return Ok(());
+    }
+    let mut prepared = std::collections::BTreeMap::new();
+    let mut committed = std::collections::BTreeMap::new();
+    for entry in std::fs::read_dir(&directory).map_err(PersistenceError::Io)? {
+        let entry = entry.map_err(PersistenceError::Io)?;
+        if !entry.file_type().map_err(PersistenceError::Io)?.is_file() {
+            continue;
+        }
+        let path = entry.path();
+        let name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or(PersistenceError::CorruptedData)?;
+        if let Some(id) = name.strip_suffix(".session-audit.prepared.json") {
+            prepared.insert(id.to_string(), path);
+        } else if let Some(id) = name.strip_suffix(".session-audit.committed.json") {
+            committed.insert(id.to_string(), path);
+        }
+    }
+    for (id, committed_marker) in committed {
+        let _transaction = read_session_audit_transaction(&committed_marker)?;
+        let prepared_marker = prepared
+            .remove(&id)
+            .unwrap_or_else(|| marker_path(&directory, &id, "prepared"));
+        cleanup_session_audit_transaction(root, &id, &prepared_marker, &committed_marker)?;
+    }
+    for (id, prepared_marker) in prepared {
+        let committed_marker = marker_path(&directory, &id, "committed");
+        rollback_session_audit_transaction(root, &id, &prepared_marker, &committed_marker)?;
+    }
+    Ok(())
+}
+
+/// Recovers the bounded deletion batches used by session retention. A
+/// prepared marker restores its hard-link backups, while a committed marker
+/// only removes now-obsolete recovery metadata.
+pub(crate) fn recover_session_cleanup_transactions(root: &Path) -> Result<(), PersistenceError> {
+    let directory = root.join("transactions");
+    if !directory.exists() {
+        return Ok(());
+    }
+    let mut prepared = std::collections::BTreeMap::new();
+    let mut committed = std::collections::BTreeMap::new();
+    for entry in std::fs::read_dir(&directory).map_err(PersistenceError::Io)? {
+        let entry = entry.map_err(PersistenceError::Io)?;
+        if !entry.file_type().map_err(PersistenceError::Io)?.is_file() {
+            continue;
+        }
+        let path = entry.path();
+        let name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or(PersistenceError::CorruptedData)?;
+        if let Some(id) = name.strip_suffix(".session-cleanup.prepared.json") {
+            prepared.insert(id.to_string(), path);
+        } else if let Some(id) = name.strip_suffix(".session-cleanup.committed.json") {
+            committed.insert(id.to_string(), path);
+        }
+    }
+    for (id, committed_marker) in committed {
+        let _transaction = read_session_cleanup_transaction(&committed_marker)?;
+        let prepared_marker = prepared
+            .remove(&id)
+            .unwrap_or_else(|| session_cleanup_marker_path(&directory, &id, "prepared"));
+        cleanup_session_cleanup_transaction(root, &id, &prepared_marker, &committed_marker)?;
+    }
+    for (id, prepared_marker) in prepared {
+        let committed_marker = session_cleanup_marker_path(&directory, &id, "committed");
+        rollback_session_cleanup_transaction(root, &id, &prepared_marker, &committed_marker)?;
+    }
+    Ok(())
+}
+
+fn prepare_session_cleanup_transaction(
+    root: &Path,
+    cutoff_ms: i64,
+    limit: usize,
+) -> Result<Option<PreparedSessionCleanupTransaction>, PersistenceError> {
+    let transaction_id = Uuid::now_v7().to_string();
+    let directory = root.join("transactions");
+    std::fs::create_dir_all(&directory).map_err(PersistenceError::Io)?;
+    let prepared_marker = session_cleanup_marker_path(&directory, &transaction_id, "prepared");
+    let committed_marker = session_cleanup_marker_path(&directory, &transaction_id, "committed");
+    let mut writes = Vec::new();
+    for (location, session_directory) in [
+        (SessionCleanupLocation::Active, root.join("sessions").join("active")),
+        (SessionCleanupLocation::Revoked, root.join("sessions").join("revoked")),
+    ] {
+        if !session_directory.exists() {
+            continue;
+        }
+        for entry in std::fs::read_dir(session_directory).map_err(PersistenceError::Io)? {
+            if writes.len() >= limit {
+                break;
+            }
+            let entry = entry.map_err(PersistenceError::Io)?;
+            let hash = parse_hash(&entry.path()).ok_or(PersistenceError::CorruptedData)?;
+            let record: FileSessionRecord = read_session_file(&entry.path())?;
+            if record.revoked_at_ms.unwrap_or(record.expires_at_ms) < cutoff_ms {
+                writes.push(SessionCleanupWrite {
+                    hash_hex: hash.lower_hex(),
+                    location,
+                });
+            }
+        }
+        if writes.len() >= limit {
+            break;
+        }
+    }
+    if writes.is_empty() {
+        return Ok(None);
+    }
+    if writes.len() > MAX_SESSION_CLEANUP_WRITES {
+        return Err(PersistenceError::InvalidConfig(
+            "session cleanup batch exceeds the recoverable marker limit".to_string(),
+        ));
+    }
+    let transaction = SessionCleanupTransaction {
+        format_version: SESSION_CLEANUP_MARKER_VERSION,
+        writes,
+    };
+    // Write the decision grammar before any original can disappear. Missing
+    // backups are harmless while an original is still present; a missing
+    // original requires its matching backup during rollback.
+    write_json_new_file(&prepared_marker, &transaction)?;
+    for write in &transaction.writes {
+        let source = session_cleanup_target(root, write)?;
+        let backup = session_cleanup_backup_path(&directory, &transaction_id, write)?;
+        std::fs::hard_link(source, backup).map_err(PersistenceError::Io)?;
+    }
+    Ok(Some(PreparedSessionCleanupTransaction {
+        root: root.to_path_buf(),
+        transaction_id,
+        prepared_marker,
+        committed_marker,
+    }))
+}
+
+fn prepare_session_audit_transaction(
+    root: &Path,
+    writes: Vec<SessionAuditStagedWrite>,
+    audit: &AuditEvent,
+) -> Result<PreparedSessionAuditTransaction, PersistenceError> {
+    if writes.len() > MAX_SESSION_AUDIT_WRITES {
+        return Err(PersistenceError::Conflict);
+    }
+    let transaction_id = Uuid::now_v7().to_string();
+    let directory = root.join("transactions");
+    std::fs::create_dir_all(&directory).map_err(PersistenceError::Io)?;
+    let prepared_marker = marker_path(&directory, &transaction_id, "prepared");
+    let committed_marker = marker_path(&directory, &transaction_id, "committed");
+
+    let audit_path = audit_path(root, audit.created_at_ms)?;
+    std::fs::create_dir_all(audit_path.parent().ok_or(PersistenceError::CorruptedData)?)
+        .map_err(PersistenceError::Io)?;
+    super::truncate_incomplete_tail(&audit_path)?;
+    let existed = audit_path.exists();
+    let original_length = if existed {
+        std::fs::metadata(&audit_path).map_err(PersistenceError::Io)?.len()
+    } else {
+        0
+    };
+    let mut marker_writes = Vec::with_capacity(writes.len());
+    for staged in writes {
+        let hash_hex = staged.hash.lower_hex();
+        let staged_path = staged_path(&directory, &transaction_id, &hash_hex);
+        write_json_new_file(&staged_path, &staged.record)?;
+        if matches!(staged.operation, SessionAuditOperation::Revoke) {
+            let active = active_path(root, &staged.hash);
+            let backup = backup_path(&directory, &transaction_id, &hash_hex);
+            std::fs::hard_link(active, backup).map_err(PersistenceError::Io)?;
+        }
+        marker_writes.push(SessionAuditWrite {
+            hash_hex,
+            operation: staged.operation,
+        });
+    }
+    write_json_new_file(
+        &prepared_marker,
+        &SessionAuditTransaction {
+            format_version: SESSION_AUDIT_MARKER_VERSION,
+            writes: marker_writes,
+            audit: AuditAppendRollback {
+                path: audit_path
+                    .strip_prefix(root)
+                    .map_err(|_| PersistenceError::CorruptedData)?
+                    .to_string_lossy()
+                    .replace('\\', "/"),
+                original_length,
+                existed,
+            },
+        },
+    )?;
+    // The payload is staged before the intent marker. The event itself is not
+    // serialized into a marker, so its safe detail projection is not
+    // duplicated outside the JSONL append.
+    Ok(PreparedSessionAuditTransaction {
+        root: root.to_path_buf(),
+        transaction_id,
+        prepared_marker,
+        committed_marker,
+    })
+}
+
+fn publish_session_audit_transaction(
+    prepared: &PreparedSessionAuditTransaction,
+    root: &Path,
+    audit: &AuditEvent,
+) -> Result<(), PersistenceError> {
+    let transaction = read_session_audit_transaction(&prepared.prepared_marker)?;
+    let directory = root.join("transactions");
+    for write in &transaction.writes {
+        let hash = hash_from_lower_hex(&write.hash_hex)?;
+        let stage = staged_path(&directory, &prepared.transaction_id, &write.hash_hex);
+        let target = match write.operation {
+            SessionAuditOperation::Create => active_path(root, &hash),
+            SessionAuditOperation::Revoke => revoked_path(root, &hash),
+        };
+        std::fs::create_dir_all(target.parent().ok_or(PersistenceError::CorruptedData)?)
+            .map_err(PersistenceError::Io)?;
+        std::fs::hard_link(stage, target).map_err(|error| {
+            if error.kind() == std::io::ErrorKind::AlreadyExists {
+                PersistenceError::Conflict
+            } else {
+                PersistenceError::Io(error)
+            }
+        })?;
+    }
+    let audit_path = root.join(&transaction.audit.path);
+    // The marker is durable before the append can become visible. For
+    // revocations we keep active records in place while JSONL is synced; the
+    // prepared-marker rollback can therefore restore either side of every
+    // crash point.
+    write_session_audit_event(
+        &audit_path,
+        audit,
+        transaction.audit.original_length,
+        transaction.audit.existed,
+    )?;
+    for write in &transaction.writes {
+        if matches!(write.operation, SessionAuditOperation::Revoke) {
+            let hash = hash_from_lower_hex(&write.hash_hex)?;
+            std::fs::remove_file(active_path(root, &hash)).map_err(PersistenceError::Io)?;
+        }
+    }
+    Ok(())
+}
+
+fn write_session_audit_event(
+    path: &Path,
+    audit: &AuditEvent,
+    original_length: u64,
+    existed: bool,
+) -> Result<(), PersistenceError> {
+    if path.exists() != existed
+        || (existed && std::fs::metadata(path).map_err(PersistenceError::Io)?.len() != original_length)
+    {
+        return Err(PersistenceError::Conflict);
+    }
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(PersistenceError::Io)?;
+    serde_json::to_writer(&mut file, audit).map_err(PersistenceError::Serialization)?;
+    file.write_all(b"\n").map_err(PersistenceError::Io)?;
+    file.flush().map_err(PersistenceError::Io)?;
+    file.sync_data().map_err(PersistenceError::Io)
+}
+
+fn rollback_session_audit_transaction(
+    root: &Path,
+    transaction_id: &str,
+    prepared_marker: &Path,
+    committed_marker: &Path,
+) -> Result<(), PersistenceError> {
+    if committed_marker.exists() {
+        return Err(PersistenceError::Conflict);
+    }
+    let transaction = read_session_audit_transaction(prepared_marker)?;
+    let directory = root.join("transactions");
+    for write in transaction.writes.iter().rev() {
+        let hash = hash_from_lower_hex(&write.hash_hex)?;
+        match write.operation {
+            SessionAuditOperation::Create => remove_file_if_exists(&active_path(root, &hash))?,
+            SessionAuditOperation::Revoke => {
+                remove_file_if_exists(&revoked_path(root, &hash))?;
+                let active = active_path(root, &hash);
+                if !active.exists() {
+                    std::fs::hard_link(backup_path(&directory, transaction_id, &write.hash_hex), active)
+                        .map_err(PersistenceError::Io)?;
+                }
+            }
+        }
+    }
+    rollback_jsonl_append(
+        root.join(&transaction.audit.path),
+        transaction.audit.original_length,
+        transaction.audit.existed,
+    )?;
+    cleanup_session_audit_transaction(root, transaction_id, prepared_marker, committed_marker)
+}
+
+fn cleanup_session_audit_transaction(
+    root: &Path,
+    transaction_id: &str,
+    prepared_marker: &Path,
+    committed_marker: &Path,
+) -> Result<(), PersistenceError> {
+    let transaction = if prepared_marker.exists() {
+        Some(read_session_audit_transaction(prepared_marker)?)
+    } else if committed_marker.exists() {
+        Some(read_session_audit_transaction(committed_marker)?)
+    } else {
+        None
+    };
+    if let Some(transaction) = transaction {
+        let directory = root.join("transactions");
+        for write in transaction.writes {
+            remove_file_if_exists(&staged_path(&directory, transaction_id, &write.hash_hex))?;
+            remove_file_if_exists(&backup_path(&directory, transaction_id, &write.hash_hex))?;
+        }
+    }
+    remove_file_if_exists(prepared_marker)?;
+    remove_file_if_exists(committed_marker)
+}
+
+fn read_session_audit_transaction(path: &Path) -> Result<SessionAuditTransaction, PersistenceError> {
+    let transaction: SessionAuditTransaction = serde_json::from_reader(File::open(path).map_err(PersistenceError::Io)?)
+        .map_err(|_| PersistenceError::CorruptedData)?;
+    if transaction.format_version != SESSION_AUDIT_MARKER_VERSION || transaction.writes.len() > MAX_SESSION_AUDIT_WRITES
+    {
+        return Err(PersistenceError::CorruptedData);
+    }
+    if transaction.audit.original_length > 0 && !transaction.audit.existed {
+        return Err(PersistenceError::CorruptedData);
+    }
+    if !is_audit_relative_path(&transaction.audit.path) {
+        return Err(PersistenceError::CorruptedData);
+    }
+    for write in &transaction.writes {
+        let _ = hash_from_lower_hex(&write.hash_hex)?;
+    }
+    Ok(transaction)
+}
+
+fn marker_path(directory: &Path, transaction_id: &str, decision: &str) -> PathBuf {
+    directory.join(format!("{transaction_id}.session-audit.{decision}.json"))
+}
+
+fn staged_path(directory: &Path, transaction_id: &str, hash_hex: &str) -> PathBuf {
+    directory.join(format!("{transaction_id}.{hash_hex}.session-stage.json"))
+}
+
+fn backup_path(directory: &Path, transaction_id: &str, hash_hex: &str) -> PathBuf {
+    directory.join(format!("{transaction_id}.{hash_hex}.session-backup.json"))
+}
+
+fn session_cleanup_marker_path(directory: &Path, transaction_id: &str, decision: &str) -> PathBuf {
+    directory.join(format!("{transaction_id}.session-cleanup.{decision}.json"))
+}
+
+fn session_touch_marker_path(directory: &Path, transaction_id: &str, decision: &str) -> PathBuf {
+    directory.join(format!("{transaction_id}.session-touch.{decision}.json"))
+}
+
+fn session_touch_staged_path(directory: &Path, transaction_id: &str, hash_hex: &str) -> PathBuf {
+    directory.join(format!("{transaction_id}.{hash_hex}.session-touch-stage.json"))
+}
+
+fn session_touch_backup_path(directory: &Path, transaction_id: &str, hash_hex: &str) -> PathBuf {
+    directory.join(format!("{transaction_id}.{hash_hex}.session-touch-backup.json"))
+}
+
+#[cfg(test)]
+pub(super) fn stage_session_touch_for_reopen_test(
+    root: &Path,
+    hash: SessionTokenHash,
+    observed_at_ms: i64,
+    committed: bool,
+) -> Result<(), PersistenceError> {
+    let active = active_path(root, &hash);
+    let mut record: FileSessionRecord = read_session_file(&active)?;
+    record.last_seen_at_ms = observed_at_ms;
+    let prepared = prepare_session_touch_transaction(root, hash, &record)?;
+    publish_session_touch_transaction(&prepared)?;
+    if committed {
+        prepared.finalize()?;
+    }
+    Ok(())
+}
+
+fn prepare_session_touch_transaction(
+    root: &Path,
+    hash: SessionTokenHash,
+    record: &FileSessionRecord,
+) -> Result<PreparedSessionTouchTransaction, PersistenceError> {
+    let transaction_id = Uuid::now_v7().to_string();
+    let hash_hex = hash.lower_hex();
+    let directory = root.join("transactions");
+    std::fs::create_dir_all(&directory).map_err(PersistenceError::Io)?;
+    let prepared_marker = session_touch_marker_path(&directory, &transaction_id, "prepared");
+    let committed_marker = session_touch_marker_path(&directory, &transaction_id, "committed");
+    // The durable intent exists before any sidecar. This is what lets startup
+    // distinguish a pre-publication failure from an old-or-new publication.
+    write_json_new_file(
+        &prepared_marker,
+        &SessionTouchTransaction {
+            format_version: SESSION_TOUCH_MARKER_VERSION,
+            hash_hex: hash_hex.clone(),
+        },
+    )?;
+    let active = active_path(root, &hash);
+    let backup = session_touch_backup_path(&directory, &transaction_id, &hash_hex);
+    std::fs::hard_link(&active, &backup).map_err(PersistenceError::Io)?;
+    write_json_new_file(
+        &session_touch_staged_path(&directory, &transaction_id, &hash_hex),
+        record,
+    )?;
+    Ok(PreparedSessionTouchTransaction {
+        root: root.to_path_buf(),
+        transaction_id,
+        prepared_marker,
+        committed_marker,
+    })
+}
+
+fn publish_session_touch_transaction(prepared: &PreparedSessionTouchTransaction) -> Result<(), PersistenceError> {
+    let transaction = read_session_touch_transaction(&prepared.prepared_marker)?;
+    let hash = hash_from_lower_hex(&transaction.hash_hex)?;
+    let directory = prepared.root.join("transactions");
+    let active = active_path(&prepared.root, &hash);
+    let backup = session_touch_backup_path(&directory, &prepared.transaction_id, &transaction.hash_hex);
+    let stage = session_touch_staged_path(&directory, &prepared.transaction_id, &transaction.hash_hex);
+    if !backup.exists() || !stage.exists() {
+        return Err(PersistenceError::CorruptedData);
+    }
+    std::fs::remove_file(&active).map_err(PersistenceError::Io)?;
+    std::fs::hard_link(stage, active).map_err(PersistenceError::Io)
+}
+
+fn rollback_session_touch_transaction(
+    root: &Path,
+    transaction_id: &str,
+    prepared_marker: &Path,
+    committed_marker: &Path,
+) -> Result<(), PersistenceError> {
+    if committed_marker.exists() {
+        return Err(PersistenceError::Conflict);
+    }
+    let transaction = read_session_touch_transaction(prepared_marker)?;
+    let hash = hash_from_lower_hex(&transaction.hash_hex)?;
+    let directory = root.join("transactions");
+    let active = active_path(root, &hash);
+    let backup = session_touch_backup_path(&directory, transaction_id, &transaction.hash_hex);
+    if backup.exists() {
+        remove_session_file(&active)?;
+        std::fs::hard_link(&backup, &active).map_err(PersistenceError::Io)?;
+    } else if !active.exists() {
+        return Err(PersistenceError::CorruptedData);
+    }
+    cleanup_session_touch_transaction(root, transaction_id, prepared_marker, committed_marker)
+}
+
+fn cleanup_session_touch_transaction(
+    root: &Path,
+    transaction_id: &str,
+    prepared_marker: &Path,
+    committed_marker: &Path,
+) -> Result<(), PersistenceError> {
+    let transaction = if prepared_marker.exists() {
+        Some(read_session_touch_transaction(prepared_marker)?)
+    } else if committed_marker.exists() {
+        Some(read_session_touch_transaction(committed_marker)?)
+    } else {
+        None
+    };
+    if let Some(transaction) = transaction {
+        let directory = root.join("transactions");
+        remove_file_if_exists(&session_touch_staged_path(
+            &directory,
+            transaction_id,
+            &transaction.hash_hex,
+        ))?;
+        remove_file_if_exists(&session_touch_backup_path(
+            &directory,
+            transaction_id,
+            &transaction.hash_hex,
+        ))?;
+    }
+    remove_file_if_exists(prepared_marker)?;
+    remove_file_if_exists(committed_marker)
+}
+
+fn read_session_touch_transaction(path: &Path) -> Result<SessionTouchTransaction, PersistenceError> {
+    let transaction: SessionTouchTransaction = serde_json::from_reader(File::open(path).map_err(PersistenceError::Io)?)
+        .map_err(|_| PersistenceError::CorruptedData)?;
+    if transaction.format_version != SESSION_TOUCH_MARKER_VERSION {
+        return Err(PersistenceError::CorruptedData);
+    }
+    let _hash = hash_from_lower_hex(&transaction.hash_hex)?;
+    Ok(transaction)
+}
+
+fn session_cleanup_target(root: &Path, write: &SessionCleanupWrite) -> Result<PathBuf, PersistenceError> {
+    let hash = hash_from_lower_hex(&write.hash_hex)?;
+    Ok(match write.location {
+        SessionCleanupLocation::Active => active_path(root, &hash),
+        SessionCleanupLocation::Revoked => revoked_path(root, &hash),
+    })
+}
+
+fn session_cleanup_backup_path(
+    directory: &Path,
+    transaction_id: &str,
+    write: &SessionCleanupWrite,
+) -> Result<PathBuf, PersistenceError> {
+    let location = match write.location {
+        SessionCleanupLocation::Active => "active",
+        SessionCleanupLocation::Revoked => "revoked",
+    };
+    let _hash = hash_from_lower_hex(&write.hash_hex)?;
+    Ok(directory.join(format!(
+        "{transaction_id}.{}.{}.session-cleanup-backup.json",
+        write.hash_hex, location
+    )))
+}
+
+fn rollback_session_cleanup_transaction(
+    root: &Path,
+    transaction_id: &str,
+    prepared_marker: &Path,
+    committed_marker: &Path,
+) -> Result<(), PersistenceError> {
+    if committed_marker.exists() {
+        return Err(PersistenceError::Conflict);
+    }
+    let transaction = read_session_cleanup_transaction(prepared_marker)?;
+    let directory = root.join("transactions");
+    for write in transaction.writes.iter().rev() {
+        let target = session_cleanup_target(root, write)?;
+        let backup = session_cleanup_backup_path(&directory, transaction_id, write)?;
+        if !target.exists() {
+            std::fs::hard_link(backup, target).map_err(PersistenceError::Io)?;
+        }
+    }
+    cleanup_session_cleanup_transaction(root, transaction_id, prepared_marker, committed_marker)
+}
+
+fn cleanup_session_cleanup_transaction(
+    root: &Path,
+    transaction_id: &str,
+    prepared_marker: &Path,
+    committed_marker: &Path,
+) -> Result<(), PersistenceError> {
+    let transaction = if prepared_marker.exists() {
+        Some(read_session_cleanup_transaction(prepared_marker)?)
+    } else if committed_marker.exists() {
+        Some(read_session_cleanup_transaction(committed_marker)?)
+    } else {
+        None
+    };
+    if let Some(transaction) = transaction {
+        let directory = root.join("transactions");
+        for write in &transaction.writes {
+            remove_file_if_exists(&session_cleanup_backup_path(&directory, transaction_id, write)?)?;
+        }
+    }
+    remove_file_if_exists(prepared_marker)?;
+    remove_file_if_exists(committed_marker)
+}
+
+fn read_session_cleanup_transaction(path: &Path) -> Result<SessionCleanupTransaction, PersistenceError> {
+    let transaction: SessionCleanupTransaction =
+        serde_json::from_reader(File::open(path).map_err(PersistenceError::Io)?)
+            .map_err(|_| PersistenceError::CorruptedData)?;
+    if transaction.format_version != SESSION_CLEANUP_MARKER_VERSION
+        || transaction.writes.is_empty()
+        || transaction.writes.len() > MAX_SESSION_CLEANUP_WRITES
+    {
+        return Err(PersistenceError::CorruptedData);
+    }
+    for write in &transaction.writes {
+        let _hash = hash_from_lower_hex(&write.hash_hex)?;
+    }
+    Ok(transaction)
+}
+
+fn audit_path(root: &Path, created_at_ms: i64) -> Result<PathBuf, PersistenceError> {
+    let day = chrono::DateTime::from_timestamp_millis(created_at_ms)
+        .ok_or_else(|| PersistenceError::InvalidConfig("audit timestamp is invalid".to_string()))?
+        .with_timezone(&Utc)
+        .format("%Y-%m-%d");
+    Ok(root.join("audit").join(format!("{day}.jsonl")))
+}
+
+fn is_audit_relative_path(path: &str) -> bool {
+    let path = Path::new(path);
+    path.components().count() == 2
+        && path.parent().is_some_and(|parent| parent == Path::new("audit"))
+        && path.extension().is_some_and(|extension| extension == "jsonl")
+}
+
+fn hash_from_lower_hex(value: &str) -> Result<SessionTokenHash, PersistenceError> {
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return Err(PersistenceError::CorruptedData);
+    }
+    let mut bytes = [0_u8; 32];
+    for (index, pair) in value.as_bytes().chunks_exact(2).enumerate() {
+        bytes[index] = (hex_value(pair[0]).ok_or(PersistenceError::CorruptedData)? << 4)
+            | hex_value(pair[1]).ok_or(PersistenceError::CorruptedData)?;
+    }
+    Ok(SessionTokenHash(bytes))
+}
+
+fn remove_file_if_exists(path: &Path) -> Result<(), PersistenceError> {
+    if path.exists() {
+        std::fs::remove_file(path).map_err(PersistenceError::Io)?;
+    }
+    Ok(())
+}
+
+fn active_path(root: &Path, hash: &SessionTokenHash) -> PathBuf {
+    root.join("sessions")
+        .join("active")
+        .join(format!("{}.json", hash.lower_hex()))
+}
+
+fn revoked_path(root: &Path, hash: &SessionTokenHash) -> PathBuf {
+    root.join("sessions")
+        .join("revoked")
+        .join(format!("{}.json", hash.lower_hex()))
+}
+
+fn load_session(root: &Path, token_hash: SessionTokenHash) -> Result<Option<SessionRecord>, PersistenceError> {
+    let active = active_path(root, &token_hash);
+    let revoked = revoked_path(root, &token_hash);
+    let path = if active.exists() { active } else { revoked };
+    if !path.exists() {
+        return Ok(None);
+    }
+    read_session_file::<FileSessionRecord>(&path).map(|record| Some(record.into_record(token_hash)))
+}
+
+fn list_sessions(root: &Path, query: SessionQuery) -> Result<SessionPage, PersistenceError> {
+    let mut records = Vec::new();
+    for directory in [
+        root.join("sessions").join("active"),
+        root.join("sessions").join("revoked"),
+    ] {
+        if !directory.exists() {
+            continue;
+        }
+        for entry in std::fs::read_dir(directory).map_err(PersistenceError::Io)? {
+            let entry = entry.map_err(PersistenceError::Io)?;
+            let Some(hash) = parse_hash(entry.path().as_path()) else {
+                return Err(PersistenceError::CorruptedData);
+            };
+            let record = read_session_file::<FileSessionRecord>(&entry.path())?.into_record(hash);
+            if query
+                .username
+                .as_deref()
+                .is_none_or(|username| username == record.username)
+            {
+                records.push(record);
+            }
+        }
+    }
+    records.sort_by(|left, right| {
+        right
+            .created_at_ms
+            .cmp(&left.created_at_ms)
+            .then_with(|| right.session_id.cmp(&left.session_id))
+    });
+    if let Some(cursor) = query.cursor {
+        records.retain(|record| {
+            record.created_at_ms < cursor.created_at_ms
+                || (record.created_at_ms == cursor.created_at_ms && record.session_id < cursor.session_id)
+        });
+    }
+    let has_more = records.len() > query.limit;
+    records.truncate(query.limit);
+    let next_cursor = if has_more {
+        records.last().map(|last| SessionCursor {
+            created_at_ms: last.created_at_ms,
+            session_id: last.session_id.clone(),
+        })
+    } else {
+        None
+    };
+    Ok(SessionPage { records, next_cursor })
+}
+
+fn parse_hash(path: &Path) -> Option<SessionTokenHash> {
+    let name = path.file_stem()?.to_str()?;
+    if path.extension().is_none_or(|extension| extension != "json")
+        || name.len() != 64
+        || !name
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return None;
+    }
+    let mut bytes = [0; 32];
+    for (index, pair) in name.as_bytes().chunks_exact(2).enumerate() {
+        bytes[index] = (hex_value(pair[0])? << 4) | hex_value(pair[1])?;
+    }
+    Some(SessionTokenHash(bytes))
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        _ => None,
+    }
+}
+
+fn remove_session_file(path: &Path) -> Result<(), PersistenceError> {
+    if path.exists() {
+        std::fs::remove_file(path).map_err(PersistenceError::Io)?;
+    }
+    Ok(())
+}
+
+fn read_session_file<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<T, PersistenceError> {
+    serde_json::from_reader(File::open(path).map_err(PersistenceError::Io)?)
+        .map_err(|_| PersistenceError::CorruptedData)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::AuditAction;
+    use crate::model::AuditActor;
+    use crate::model::AuditOutcome;
+    use crate::model::AuditResourceType;
+
+    fn event() -> AuditEvent {
+        AuditEvent {
+            event_id: uuid::Uuid::now_v7().to_string(),
+            request_id: uuid::Uuid::now_v7().to_string(),
+            actor: AuditActor::admin("operator"),
+            action: AuditAction::SessionRevokeCurrent,
+            resource_type: AuditResourceType::Session,
+            resource_name: Some("operator".to_string()),
+            environment_id: None,
+            outcome: AuditOutcome::Succeeded,
+            detail: None,
+            created_at_ms: 1_700_000_000_000,
+        }
+    }
+
+    fn active_record() -> FileSessionRecord {
+        FileSessionRecord {
+            session_id: uuid::Uuid::now_v7().to_string(),
+            username: "operator".to_string(),
+            created_at_ms: 1,
+            expires_at_ms: 2,
+            last_seen_at_ms: 1,
+            revoked_at_ms: None,
+        }
+    }
+
+    #[test]
+    fn prepared_revoke_marker_rolls_back_session_and_audit_tail_after_a_crash() {
+        let directory = tempfile::tempdir().expect("temporary storage");
+        let root = directory.path();
+        let hash = SessionTokenHash([3; 32]);
+        write_json_new_file(&active_path(root, &hash), &active_record()).expect("seed active session");
+        let audit = event();
+        let prepared = prepare_session_audit_transaction(
+            root,
+            vec![SessionAuditStagedWrite::revoke(hash, active_record(), 3)],
+            &audit,
+        )
+        .expect("prepare marker");
+        publish_session_audit_transaction(&prepared, root, &audit).expect("publish session and audit");
+
+        recover_session_audit_transactions(root).expect("recover prepared transaction");
+
+        assert!(active_path(root, &hash).exists());
+        assert!(!revoked_path(root, &hash).exists());
+        assert!(!audit_path(root, audit.created_at_ms).expect("audit path").exists());
+    }
+
+    #[test]
+    fn committed_revoke_marker_keeps_the_published_session_and_audit_after_a_crash() {
+        let directory = tempfile::tempdir().expect("temporary storage");
+        let root = directory.path();
+        let hash = SessionTokenHash([4; 32]);
+        write_json_new_file(&active_path(root, &hash), &active_record()).expect("seed active session");
+        let audit = event();
+        let prepared = prepare_session_audit_transaction(
+            root,
+            vec![SessionAuditStagedWrite::revoke(hash, active_record(), 3)],
+            &audit,
+        )
+        .expect("prepare marker");
+        publish_session_audit_transaction(&prepared, root, &audit).expect("publish session and audit");
+        prepared.finalize().expect("commit decision");
+
+        recover_session_audit_transactions(root).expect("recover committed transaction");
+
+        assert!(!active_path(root, &hash).exists());
+        assert!(revoked_path(root, &hash).exists());
+        assert!(audit_path(root, audit.created_at_ms).expect("audit path").exists());
+    }
+
+    #[test]
+    fn prepared_create_marker_removes_the_new_session_and_audit_after_a_crash() {
+        let directory = tempfile::tempdir().expect("temporary storage");
+        let root = directory.path();
+        let hash = SessionTokenHash([5; 32]);
+        let audit = event();
+        let prepared = prepare_session_audit_transaction(
+            root,
+            vec![SessionAuditStagedWrite::create(hash, active_record())],
+            &audit,
+        )
+        .expect("prepare marker");
+        publish_session_audit_transaction(&prepared, root, &audit).expect("publish session and audit");
+
+        recover_session_audit_transactions(root).expect("recover prepared create");
+
+        assert!(!active_path(root, &hash).exists());
+        assert!(!audit_path(root, audit.created_at_ms).expect("audit path").exists());
+    }
+
+    #[test]
+    fn committed_revoke_all_marker_keeps_every_active_transition_after_a_crash() {
+        let directory = tempfile::tempdir().expect("temporary storage");
+        let root = directory.path();
+        let first = SessionTokenHash([6; 32]);
+        let second = SessionTokenHash([7; 32]);
+        write_json_new_file(&active_path(root, &first), &active_record()).expect("seed first active session");
+        write_json_new_file(&active_path(root, &second), &active_record()).expect("seed second active session");
+        let audit = event();
+        let prepared = prepare_session_audit_transaction(
+            root,
+            vec![
+                SessionAuditStagedWrite::revoke(first, active_record(), 3),
+                SessionAuditStagedWrite::revoke(second, active_record(), 3),
+            ],
+            &audit,
+        )
+        .expect("prepare revoke all marker");
+        publish_session_audit_transaction(&prepared, root, &audit).expect("publish transitions");
+        prepared.finalize().expect("commit decision");
+
+        recover_session_audit_transactions(root).expect("recover committed revoke all");
+
+        assert!(!active_path(root, &first).exists());
+        assert!(!active_path(root, &second).exists());
+        assert!(revoked_path(root, &first).exists());
+        assert!(revoked_path(root, &second).exists());
+    }
+
+    #[test]
+    fn prepared_session_cleanup_restores_expired_records_after_a_crash() {
+        let directory = tempfile::tempdir().expect("temporary storage");
+        let root = directory.path();
+        let hash = SessionTokenHash([8; 32]);
+        write_json_new_file(&active_path(root, &hash), &active_record()).expect("seed expired session");
+        let prepared = prepare_session_cleanup_transaction(root, 3, 10)
+            .expect("prepare cleanup")
+            .expect("expired cleanup record");
+        assert_eq!(prepared.delete_staged_sessions().expect("delete staged session"), 1);
+        assert!(!active_path(root, &hash).exists());
+
+        recover_session_cleanup_transactions(root).expect("recover prepared cleanup");
+
+        assert!(active_path(root, &hash).exists());
+        assert!(!prepared.prepared_marker.exists());
+    }
+
+    #[test]
+    fn committed_session_cleanup_keeps_expired_records_deleted_after_a_crash() {
+        let directory = tempfile::tempdir().expect("temporary storage");
+        let root = directory.path();
+        let hash = SessionTokenHash([9; 32]);
+        write_json_new_file(&active_path(root, &hash), &active_record()).expect("seed expired session");
+        let prepared = prepare_session_cleanup_transaction(root, 3, 10)
+            .expect("prepare cleanup")
+            .expect("expired cleanup record");
+        assert_eq!(prepared.delete_staged_sessions().expect("delete staged session"), 1);
+        prepared.finalize().expect("commit cleanup");
+
+        recover_session_cleanup_transactions(root).expect("recover committed cleanup");
+
+        assert!(!active_path(root, &hash).exists());
+        assert!(!prepared.prepared_marker.exists());
+        assert!(!prepared.committed_marker.exists());
+    }
+
+    #[test]
+    fn prepared_touch_marker_restores_the_exact_prior_record_without_sidecars_after_recovery() {
+        let directory = tempfile::tempdir().expect("temporary storage");
+        let root = directory.path();
+        let hash = SessionTokenHash([10; 32]);
+        let before = active_record();
+        write_json_new_file(&active_path(root, &hash), &before).expect("seed active session");
+        let mut after = before.clone();
+        after.last_seen_at_ms = 2;
+        let prepared = prepare_session_touch_transaction(root, hash, &after).expect("prepare touch");
+        publish_session_touch_transaction(&prepared).expect("publish touch");
+
+        recover_session_touch_transactions(root).expect("recover prepared touch");
+
+        let recovered: FileSessionRecord = read_session_file(&active_path(root, &hash)).expect("restored record");
+        assert_eq!(recovered.session_id, before.session_id);
+        assert_eq!(recovered.last_seen_at_ms, before.last_seen_at_ms);
+        assert!(!prepared.prepared_marker.exists());
+        assert!(!prepared.committed_marker.exists());
+        let remaining = std::fs::read_dir(root.join("transactions"))
+            .expect("transaction directory")
+            .count();
+        assert_eq!(remaining, 0);
+    }
+
+    #[test]
+    fn committed_touch_marker_keeps_the_new_record_without_sidecars_after_recovery() {
+        let directory = tempfile::tempdir().expect("temporary storage");
+        let root = directory.path();
+        let hash = SessionTokenHash([11; 32]);
+        let before = active_record();
+        write_json_new_file(&active_path(root, &hash), &before).expect("seed active session");
+        let mut after = before;
+        after.last_seen_at_ms = 2;
+        let prepared = prepare_session_touch_transaction(root, hash, &after).expect("prepare touch");
+        publish_session_touch_transaction(&prepared).expect("publish touch");
+        prepared.finalize().expect("commit touch");
+
+        recover_session_touch_transactions(root).expect("recover committed touch");
+
+        let recovered: FileSessionRecord = read_session_file(&active_path(root, &hash)).expect("committed record");
+        assert_eq!(recovered.last_seen_at_ms, 2);
+        assert!(!prepared.prepared_marker.exists());
+        assert!(!prepared.committed_marker.exists());
+        let remaining = std::fs::read_dir(root.join("transactions"))
+            .expect("transaction directory")
+            .count();
+        assert_eq!(remaining, 0);
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/session_repository.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/session_repository.rs
@@ -1,0 +1,305 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::model::AuditEvent;
+use crate::model::NewSession;
+use crate::model::SessionRecord;
+use crate::model::SessionTokenHash;
+use crate::persistence::DashboardPersistence;
+use crate::persistence::backend::PersistenceBackend;
+use crate::persistence::error::PersistenceError;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionCursor {
+    pub created_at_ms: i64,
+    pub session_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionQuery {
+    pub username: Option<String>,
+    pub cursor: Option<SessionCursor>,
+    pub limit: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionPage {
+    pub records: Vec<SessionRecord>,
+    pub next_cursor: Option<SessionCursor>,
+}
+
+/// Repository contract for persisted sessions. All implementations store only
+/// the 32-byte digest, never the login token supplied by the browser.
+#[allow(async_fn_in_trait)]
+pub trait SessionRepository {
+    async fn create_session(&self, session: NewSession) -> Result<(), PersistenceError>;
+    async fn find_session(&self, token_hash: &SessionTokenHash) -> Result<Option<SessionRecord>, PersistenceError>;
+    async fn revoke_session(&self, token_hash: &SessionTokenHash, revoked_at_ms: i64)
+    -> Result<bool, PersistenceError>;
+    async fn revoke_all_sessions(&self, username: &str, revoked_at_ms: i64) -> Result<u64, PersistenceError>;
+    async fn list_sessions(&self, query: SessionQuery) -> Result<SessionPage, PersistenceError>;
+    async fn delete_sessions_before(&self, cutoff_ms: i64, limit: usize) -> Result<u64, PersistenceError>;
+    async fn create_session_with_audit(&self, session: NewSession, audit: AuditEvent) -> Result<(), PersistenceError>;
+    async fn revoke_session_with_audit(
+        &self,
+        token_hash: &SessionTokenHash,
+        revoked_at_ms: i64,
+        audit: AuditEvent,
+    ) -> Result<bool, PersistenceError>;
+    async fn revoke_all_sessions_with_audit(
+        &self,
+        username: &str,
+        revoked_at_ms: i64,
+        audit: AuditEvent,
+    ) -> Result<u64, PersistenceError>;
+}
+
+impl DashboardPersistence {
+    pub async fn create_session(&self, session: NewSession) -> Result<(), PersistenceError> {
+        validate_new_session(&session)?;
+        match &self.backend {
+            PersistenceBackend::File(store) => store.create_session(session).await,
+            PersistenceBackend::Sql(store) => store.create_session(session).await,
+        }
+    }
+
+    pub async fn create_session_with_audit(
+        &self,
+        session: NewSession,
+        audit: AuditEvent,
+    ) -> Result<(), PersistenceError> {
+        validate_new_session(&session)?;
+        match &self.backend {
+            PersistenceBackend::File(store) => store.create_session_with_audit(session, audit).await,
+            PersistenceBackend::Sql(store) => store.create_session_with_audit(session, audit).await,
+        }
+    }
+
+    /// Atomically enforces the per-user active-session limit while creating
+    /// the durable session and its successful-login audit event.
+    pub async fn create_session_with_audit_capped(
+        &self,
+        session: NewSession,
+        audit: AuditEvent,
+        max_active_sessions: usize,
+        now_ms: i64,
+    ) -> Result<(), PersistenceError> {
+        validate_new_session(&session)?;
+        if max_active_sessions == 0 || max_active_sessions > 32 {
+            return Err(PersistenceError::InvalidConfig(
+                "maximum active sessions must be between 1 and 32".to_string(),
+            ));
+        }
+        match &self.backend {
+            PersistenceBackend::File(store) => {
+                store
+                    .create_session_with_audit_capped(session, audit, max_active_sessions, now_ms)
+                    .await
+            }
+            PersistenceBackend::Sql(store) => {
+                store
+                    .create_session_with_audit_capped(session, audit, max_active_sessions, now_ms)
+                    .await
+            }
+        }
+    }
+
+    pub async fn find_session(&self, token_hash: &SessionTokenHash) -> Result<Option<SessionRecord>, PersistenceError> {
+        match &self.backend {
+            PersistenceBackend::File(store) => store.find_session(token_hash).await,
+            PersistenceBackend::Sql(store) => store.find_session(token_hash).await,
+        }
+    }
+
+    /// Records a successful authentication observation without extending the
+    /// immutable session expiry. A missing or revoked record is not touched.
+    pub async fn touch_session(
+        &self,
+        token_hash: &SessionTokenHash,
+        observed_at_ms: i64,
+    ) -> Result<bool, PersistenceError> {
+        match &self.backend {
+            PersistenceBackend::File(store) => store.touch_session(token_hash, observed_at_ms).await,
+            PersistenceBackend::Sql(store) => store.touch_session(token_hash, observed_at_ms).await,
+        }
+    }
+
+    pub async fn revoke_session(
+        &self,
+        token_hash: &SessionTokenHash,
+        revoked_at_ms: i64,
+    ) -> Result<bool, PersistenceError> {
+        match &self.backend {
+            PersistenceBackend::File(store) => store.revoke_session(token_hash, revoked_at_ms).await,
+            PersistenceBackend::Sql(store) => store.revoke_session(token_hash, revoked_at_ms).await,
+        }
+    }
+
+    pub async fn revoke_session_with_audit(
+        &self,
+        token_hash: &SessionTokenHash,
+        revoked_at_ms: i64,
+        audit: AuditEvent,
+    ) -> Result<bool, PersistenceError> {
+        match &self.backend {
+            PersistenceBackend::File(store) => store.revoke_session_with_audit(token_hash, revoked_at_ms, audit).await,
+            PersistenceBackend::Sql(store) => store.revoke_session_with_audit(token_hash, revoked_at_ms, audit).await,
+        }
+    }
+
+    pub async fn revoke_all_sessions(&self, username: &str, revoked_at_ms: i64) -> Result<u64, PersistenceError> {
+        validate_username(username)?;
+        match &self.backend {
+            PersistenceBackend::File(store) => store.revoke_all_sessions(username, revoked_at_ms).await,
+            PersistenceBackend::Sql(store) => store.revoke_all_sessions(username, revoked_at_ms).await,
+        }
+    }
+
+    pub async fn revoke_all_sessions_with_audit(
+        &self,
+        username: &str,
+        revoked_at_ms: i64,
+        audit: AuditEvent,
+    ) -> Result<u64, PersistenceError> {
+        validate_username(username)?;
+        match &self.backend {
+            PersistenceBackend::File(store) => {
+                store
+                    .revoke_all_sessions_with_audit(username, revoked_at_ms, audit)
+                    .await
+            }
+            PersistenceBackend::Sql(store) => {
+                store
+                    .revoke_all_sessions_with_audit(username, revoked_at_ms, audit)
+                    .await
+            }
+        }
+    }
+
+    pub async fn list_sessions(&self, query: SessionQuery) -> Result<SessionPage, PersistenceError> {
+        validate_session_query(&query)?;
+        match &self.backend {
+            PersistenceBackend::File(store) => store.list_sessions(query).await,
+            PersistenceBackend::Sql(store) => store.list_sessions(query).await,
+        }
+    }
+
+    pub async fn delete_sessions_before(&self, cutoff_ms: i64, limit: usize) -> Result<u64, PersistenceError> {
+        if limit == 0 || limit > 1_000 {
+            return Err(PersistenceError::InvalidConfig(
+                "session cleanup batch must be between 1 and 1000".to_string(),
+            ));
+        }
+        match &self.backend {
+            PersistenceBackend::File(store) => store.delete_sessions_before(cutoff_ms, limit).await,
+            PersistenceBackend::Sql(store) => store.delete_sessions_before(cutoff_ms, limit).await,
+        }
+    }
+}
+
+impl SessionRepository for DashboardPersistence {
+    async fn create_session(&self, session: NewSession) -> Result<(), PersistenceError> {
+        Self::create_session(self, session).await
+    }
+
+    async fn find_session(&self, token_hash: &SessionTokenHash) -> Result<Option<SessionRecord>, PersistenceError> {
+        Self::find_session(self, token_hash).await
+    }
+
+    async fn revoke_session(
+        &self,
+        token_hash: &SessionTokenHash,
+        revoked_at_ms: i64,
+    ) -> Result<bool, PersistenceError> {
+        Self::revoke_session(self, token_hash, revoked_at_ms).await
+    }
+
+    async fn revoke_all_sessions(&self, username: &str, revoked_at_ms: i64) -> Result<u64, PersistenceError> {
+        Self::revoke_all_sessions(self, username, revoked_at_ms).await
+    }
+
+    async fn list_sessions(&self, query: SessionQuery) -> Result<SessionPage, PersistenceError> {
+        Self::list_sessions(self, query).await
+    }
+
+    async fn delete_sessions_before(&self, cutoff_ms: i64, limit: usize) -> Result<u64, PersistenceError> {
+        Self::delete_sessions_before(self, cutoff_ms, limit).await
+    }
+
+    async fn create_session_with_audit(&self, session: NewSession, audit: AuditEvent) -> Result<(), PersistenceError> {
+        Self::create_session_with_audit(self, session, audit).await
+    }
+
+    async fn revoke_session_with_audit(
+        &self,
+        token_hash: &SessionTokenHash,
+        revoked_at_ms: i64,
+        audit: AuditEvent,
+    ) -> Result<bool, PersistenceError> {
+        Self::revoke_session_with_audit(self, token_hash, revoked_at_ms, audit).await
+    }
+
+    async fn revoke_all_sessions_with_audit(
+        &self,
+        username: &str,
+        revoked_at_ms: i64,
+        audit: AuditEvent,
+    ) -> Result<u64, PersistenceError> {
+        Self::revoke_all_sessions_with_audit(self, username, revoked_at_ms, audit).await
+    }
+}
+
+pub(crate) fn validate_new_session(session: &NewSession) -> Result<(), PersistenceError> {
+    validate_username(&session.username)?;
+    if uuid::Uuid::parse_str(&session.session_id).is_err() {
+        return Err(PersistenceError::InvalidConfig(
+            "session identifier is invalid".to_string(),
+        ));
+    }
+    if session.created_at_ms < 0 || session.expires_at_ms <= session.created_at_ms {
+        return Err(PersistenceError::InvalidConfig(
+            "session timestamps are invalid".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_username(username: &str) -> Result<(), PersistenceError> {
+    if username.is_empty() || username.len() > 128 || username.chars().any(char::is_control) {
+        return Err(PersistenceError::InvalidConfig(
+            "session username is invalid".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_session_query(query: &SessionQuery) -> Result<(), PersistenceError> {
+    if query.limit == 0 || query.limit > 200 {
+        return Err(PersistenceError::InvalidConfig(
+            "session page size must be between 1 and 200".to_string(),
+        ));
+    }
+    if let Some(username) = &query.username {
+        validate_username(username)?;
+    }
+    if let Some(cursor) = &query.cursor
+        && uuid::Uuid::parse_str(&cursor.session_id).is_err()
+    {
+        return Err(PersistenceError::InvalidConfig("session cursor is invalid".to_string()));
+    }
+    Ok(())
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/session_sql_store.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/session_sql_store.rs
@@ -1,0 +1,702 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::DatabasePool;
+use super::MySqlPool;
+use super::PersistenceError;
+use super::PgPool;
+use super::Row;
+use super::SqlPersistence;
+use super::SqlitePool;
+use super::map_query_error;
+use crate::model::AuditEvent;
+use crate::model::NewSession;
+use crate::model::SessionRecord;
+use crate::model::SessionTokenHash;
+use crate::persistence::session_repository::SessionCursor;
+use crate::persistence::session_repository::SessionPage;
+use crate::persistence::session_repository::SessionQuery;
+use sqlx::mysql::MySqlRow;
+
+impl SqlPersistence {
+    pub(crate) async fn create_session_with_audit(
+        &self,
+        session: NewSession,
+        audit: AuditEvent,
+    ) -> Result<(), PersistenceError> {
+        self.create_session_with_audit_capped(session, audit, usize::MAX, 0)
+            .await
+    }
+
+    pub(crate) async fn create_session_with_audit_capped(
+        &self,
+        session: NewSession,
+        audit: AuditEvent,
+        max_active_sessions: usize,
+        now_ms: i64,
+    ) -> Result<(), PersistenceError> {
+        match &self.pool {
+            DatabasePool::Sqlite(pool) => {
+                let mut transaction = pool.begin().await.map_err(map_query_error)?;
+                enforce_session_cap_sqlite(&mut transaction, &session.username, now_ms, max_active_sessions).await?;
+                sqlx::query("INSERT INTO dashboard_session (session_id, token_hash, username, created_at_ms, expires_at_ms, last_seen_at_ms, revoked_at_ms) VALUES (?, ?, ?, ?, ?, ?, NULL)")
+                    .bind(&session.session_id).bind(session.token_hash.bytes().to_vec()).bind(&session.username).bind(session.created_at_ms).bind(session.expires_at_ms).bind(session.created_at_ms)
+                    .execute(&mut *transaction).await.map_err(map_query_error)?;
+                insert_audit_sqlite(&mut transaction, audit).await?;
+                transaction.commit().await.map_err(map_query_error)?;
+            }
+            DatabasePool::MySql(pool) => {
+                let mut transaction = pool.begin().await.map_err(map_query_error)?;
+                enforce_session_cap_mysql(&mut transaction, &session.username, now_ms, max_active_sessions).await?;
+                sqlx::query("INSERT INTO dashboard_session (session_id, token_hash, username, created_at_ms, expires_at_ms, last_seen_at_ms, revoked_at_ms) VALUES (?, ?, ?, ?, ?, ?, NULL)")
+                    .bind(&session.session_id).bind(session.token_hash.bytes().to_vec()).bind(&session.username).bind(session.created_at_ms).bind(session.expires_at_ms).bind(session.created_at_ms)
+                    .execute(&mut *transaction).await.map_err(map_query_error)?;
+                insert_audit_mysql(&mut transaction, audit).await?;
+                transaction.commit().await.map_err(map_query_error)?;
+            }
+            DatabasePool::Postgres(pool) => {
+                let mut transaction = pool.begin().await.map_err(map_query_error)?;
+                enforce_session_cap_postgres(&mut transaction, &session.username, now_ms, max_active_sessions).await?;
+                sqlx::query("INSERT INTO dashboard_session (session_id, token_hash, username, created_at_ms, expires_at_ms, last_seen_at_ms, revoked_at_ms) VALUES ($1, $2, $3, $4, $5, $6, NULL)")
+                    .bind(&session.session_id).bind(session.token_hash.bytes().to_vec()).bind(&session.username).bind(session.created_at_ms).bind(session.expires_at_ms).bind(session.created_at_ms)
+                    .execute(&mut *transaction).await.map_err(map_query_error)?;
+                insert_audit_postgres(&mut transaction, audit).await?;
+                transaction.commit().await.map_err(map_query_error)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn create_session(&self, session: NewSession) -> Result<(), PersistenceError> {
+        match &self.pool {
+            DatabasePool::Sqlite(pool) => {
+                sqlx::query(
+                    "INSERT INTO dashboard_session (session_id, token_hash, username, created_at_ms, expires_at_ms, last_seen_at_ms, revoked_at_ms) VALUES (?, ?, ?, ?, ?, ?, NULL)",
+                )
+                .bind(session.session_id)
+                .bind(session.token_hash.bytes().to_vec())
+                .bind(session.username)
+                .bind(session.created_at_ms)
+                .bind(session.expires_at_ms)
+                .bind(session.created_at_ms)
+                .execute(pool)
+                .await
+                .map_err(map_query_error)?;
+            }
+            DatabasePool::MySql(pool) => {
+                sqlx::query(
+                    "INSERT INTO dashboard_session (session_id, token_hash, username, created_at_ms, expires_at_ms, last_seen_at_ms, revoked_at_ms) VALUES (?, ?, ?, ?, ?, ?, NULL)",
+                )
+                .bind(session.session_id)
+                .bind(session.token_hash.bytes().to_vec())
+                .bind(session.username)
+                .bind(session.created_at_ms)
+                .bind(session.expires_at_ms)
+                .bind(session.created_at_ms)
+                .execute(pool)
+                .await
+                .map_err(map_query_error)?;
+            }
+            DatabasePool::Postgres(pool) => {
+                sqlx::query(
+                    "INSERT INTO dashboard_session (session_id, token_hash, username, created_at_ms, expires_at_ms, last_seen_at_ms, revoked_at_ms) VALUES ($1, $2, $3, $4, $5, $6, NULL)",
+                )
+                .bind(session.session_id)
+                .bind(session.token_hash.bytes().to_vec())
+                .bind(session.username)
+                .bind(session.created_at_ms)
+                .bind(session.expires_at_ms)
+                .bind(session.created_at_ms)
+                .execute(pool)
+                .await
+                .map_err(map_query_error)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn find_session(
+        &self,
+        token_hash: &SessionTokenHash,
+    ) -> Result<Option<SessionRecord>, PersistenceError> {
+        match &self.pool {
+            DatabasePool::Sqlite(pool) => find_sqlite(pool, token_hash).await,
+            DatabasePool::MySql(pool) => find_mysql(pool, token_hash).await,
+            DatabasePool::Postgres(pool) => find_postgres(pool, token_hash).await,
+        }
+    }
+
+    pub(crate) async fn touch_session(
+        &self,
+        token_hash: &SessionTokenHash,
+        observed_at_ms: i64,
+    ) -> Result<bool, PersistenceError> {
+        let affected = match &self.pool {
+            DatabasePool::Sqlite(pool) => sqlx::query(
+                "UPDATE dashboard_session SET last_seen_at_ms = CASE WHEN last_seen_at_ms < ? THEN ? ELSE last_seen_at_ms END WHERE token_hash = ? AND revoked_at_ms IS NULL",
+            )
+            .bind(observed_at_ms).bind(observed_at_ms).bind(token_hash.bytes().to_vec()).execute(pool).await.map_err(map_query_error)?.rows_affected(),
+            DatabasePool::MySql(pool) => sqlx::query(
+                "UPDATE dashboard_session SET last_seen_at_ms = CASE WHEN last_seen_at_ms < ? THEN ? ELSE last_seen_at_ms END WHERE token_hash = ? AND revoked_at_ms IS NULL",
+            )
+            .bind(observed_at_ms).bind(observed_at_ms).bind(token_hash.bytes().to_vec()).execute(pool).await.map_err(map_query_error)?.rows_affected(),
+            DatabasePool::Postgres(pool) => sqlx::query(
+                "UPDATE dashboard_session SET last_seen_at_ms = GREATEST(last_seen_at_ms, $1) WHERE token_hash = $2 AND revoked_at_ms IS NULL",
+            )
+            .bind(observed_at_ms).bind(token_hash.bytes().to_vec()).execute(pool).await.map_err(map_query_error)?.rows_affected(),
+        };
+        Ok(affected > 0)
+    }
+
+    pub(crate) async fn revoke_session(
+        &self,
+        token_hash: &SessionTokenHash,
+        revoked_at_ms: i64,
+    ) -> Result<bool, PersistenceError> {
+        let affected = match &self.pool {
+            DatabasePool::Sqlite(pool) => sqlx::query(
+                "UPDATE dashboard_session SET revoked_at_ms = ? WHERE token_hash = ? AND revoked_at_ms IS NULL",
+            )
+            .bind(revoked_at_ms)
+            .bind(token_hash.bytes().to_vec())
+            .execute(pool)
+            .await
+            .map_err(map_query_error)?
+            .rows_affected(),
+            DatabasePool::MySql(pool) => sqlx::query(
+                "UPDATE dashboard_session SET revoked_at_ms = ? WHERE token_hash = ? AND revoked_at_ms IS NULL",
+            )
+            .bind(revoked_at_ms)
+            .bind(token_hash.bytes().to_vec())
+            .execute(pool)
+            .await
+            .map_err(map_query_error)?
+            .rows_affected(),
+            DatabasePool::Postgres(pool) => sqlx::query(
+                "UPDATE dashboard_session SET revoked_at_ms = $1 WHERE token_hash = $2 AND revoked_at_ms IS NULL",
+            )
+            .bind(revoked_at_ms)
+            .bind(token_hash.bytes().to_vec())
+            .execute(pool)
+            .await
+            .map_err(map_query_error)?
+            .rows_affected(),
+        };
+        Ok(affected > 0)
+    }
+
+    pub(crate) async fn revoke_session_with_audit(
+        &self,
+        token_hash: &SessionTokenHash,
+        revoked_at_ms: i64,
+        audit: AuditEvent,
+    ) -> Result<bool, PersistenceError> {
+        let changed = match &self.pool {
+            DatabasePool::Sqlite(pool) => {
+                let mut transaction = pool.begin().await.map_err(map_query_error)?;
+                let changed = sqlx::query(
+                    "UPDATE dashboard_session SET revoked_at_ms = ? WHERE token_hash = ? AND revoked_at_ms IS NULL",
+                )
+                .bind(revoked_at_ms)
+                .bind(token_hash.bytes().to_vec())
+                .execute(&mut *transaction)
+                .await
+                .map_err(map_query_error)?
+                .rows_affected()
+                    > 0;
+                if changed {
+                    insert_audit_sqlite(&mut transaction, audit).await?;
+                }
+                transaction.commit().await.map_err(map_query_error)?;
+                changed
+            }
+            DatabasePool::MySql(pool) => {
+                let mut transaction = pool.begin().await.map_err(map_query_error)?;
+                let changed = sqlx::query(
+                    "UPDATE dashboard_session SET revoked_at_ms = ? WHERE token_hash = ? AND revoked_at_ms IS NULL",
+                )
+                .bind(revoked_at_ms)
+                .bind(token_hash.bytes().to_vec())
+                .execute(&mut *transaction)
+                .await
+                .map_err(map_query_error)?
+                .rows_affected()
+                    > 0;
+                if changed {
+                    insert_audit_mysql(&mut transaction, audit).await?;
+                }
+                transaction.commit().await.map_err(map_query_error)?;
+                changed
+            }
+            DatabasePool::Postgres(pool) => {
+                let mut transaction = pool.begin().await.map_err(map_query_error)?;
+                let changed = sqlx::query(
+                    "UPDATE dashboard_session SET revoked_at_ms = $1 WHERE token_hash = $2 AND revoked_at_ms IS NULL",
+                )
+                .bind(revoked_at_ms)
+                .bind(token_hash.bytes().to_vec())
+                .execute(&mut *transaction)
+                .await
+                .map_err(map_query_error)?
+                .rows_affected()
+                    > 0;
+                if changed {
+                    insert_audit_postgres(&mut transaction, audit).await?;
+                }
+                transaction.commit().await.map_err(map_query_error)?;
+                changed
+            }
+        };
+        Ok(changed)
+    }
+
+    pub(crate) async fn revoke_all_sessions(
+        &self,
+        username: &str,
+        revoked_at_ms: i64,
+    ) -> Result<u64, PersistenceError> {
+        let affected = match &self.pool {
+            DatabasePool::Sqlite(pool) => sqlx::query(
+                "UPDATE dashboard_session SET revoked_at_ms = ? WHERE username = ? AND revoked_at_ms IS NULL AND expires_at_ms > ?",
+            )
+            .bind(revoked_at_ms)
+            .bind(username)
+            .bind(revoked_at_ms)
+            .execute(pool)
+            .await
+            .map_err(map_query_error)?
+            .rows_affected(),
+            DatabasePool::MySql(pool) => sqlx::query(
+                "UPDATE dashboard_session SET revoked_at_ms = ? WHERE username = ? AND revoked_at_ms IS NULL AND expires_at_ms > ?",
+            )
+            .bind(revoked_at_ms)
+            .bind(username)
+            .bind(revoked_at_ms)
+            .execute(pool)
+            .await
+            .map_err(map_query_error)?
+            .rows_affected(),
+            DatabasePool::Postgres(pool) => sqlx::query(
+                "UPDATE dashboard_session SET revoked_at_ms = $1 WHERE username = $2 AND revoked_at_ms IS NULL AND expires_at_ms > $3",
+            )
+            .bind(revoked_at_ms)
+            .bind(username)
+            .bind(revoked_at_ms)
+            .execute(pool)
+            .await
+            .map_err(map_query_error)?
+            .rows_affected(),
+        };
+        Ok(affected)
+    }
+
+    pub(crate) async fn revoke_all_sessions_with_audit(
+        &self,
+        username: &str,
+        revoked_at_ms: i64,
+        audit: AuditEvent,
+    ) -> Result<u64, PersistenceError> {
+        let affected = match &self.pool {
+            DatabasePool::Sqlite(pool) => {
+                let mut transaction = pool.begin().await.map_err(map_query_error)?;
+                let affected = sqlx::query(
+                    "UPDATE dashboard_session SET revoked_at_ms = ? WHERE username = ? AND revoked_at_ms IS NULL AND expires_at_ms > ?",
+                )
+                .bind(revoked_at_ms)
+                .bind(username)
+                .bind(revoked_at_ms)
+                .execute(&mut *transaction)
+                .await
+                .map_err(map_query_error)?
+                .rows_affected();
+                insert_audit_sqlite(&mut transaction, audit).await?;
+                transaction.commit().await.map_err(map_query_error)?;
+                affected
+            }
+            DatabasePool::MySql(pool) => {
+                let mut transaction = pool.begin().await.map_err(map_query_error)?;
+                let affected = sqlx::query(
+                    "UPDATE dashboard_session SET revoked_at_ms = ? WHERE username = ? AND revoked_at_ms IS NULL AND expires_at_ms > ?",
+                )
+                .bind(revoked_at_ms)
+                .bind(username)
+                .bind(revoked_at_ms)
+                .execute(&mut *transaction)
+                .await
+                .map_err(map_query_error)?
+                .rows_affected();
+                insert_audit_mysql(&mut transaction, audit).await?;
+                transaction.commit().await.map_err(map_query_error)?;
+                affected
+            }
+            DatabasePool::Postgres(pool) => {
+                let mut transaction = pool.begin().await.map_err(map_query_error)?;
+                let affected = sqlx::query(
+                    "UPDATE dashboard_session SET revoked_at_ms = $1 WHERE username = $2 AND revoked_at_ms IS NULL AND expires_at_ms > $3",
+                )
+                .bind(revoked_at_ms)
+                .bind(username)
+                .bind(revoked_at_ms)
+                .execute(&mut *transaction)
+                .await
+                .map_err(map_query_error)?
+                .rows_affected();
+                insert_audit_postgres(&mut transaction, audit).await?;
+                transaction.commit().await.map_err(map_query_error)?;
+                affected
+            }
+        };
+        Ok(affected)
+    }
+
+    pub(crate) async fn list_sessions(&self, query: SessionQuery) -> Result<SessionPage, PersistenceError> {
+        match &self.pool {
+            DatabasePool::Sqlite(pool) => list_sqlite(pool, query).await,
+            DatabasePool::MySql(pool) => list_mysql(pool, query).await,
+            DatabasePool::Postgres(pool) => list_postgres(pool, query).await,
+        }
+    }
+
+    pub(crate) async fn delete_sessions_before(&self, cutoff_ms: i64, limit: usize) -> Result<u64, PersistenceError> {
+        // All engines use a bounded key selection before deletion. This keeps
+        // cleanup from turning a normal maintenance tick into an unbounded
+        // transaction.
+        match &self.pool {
+            DatabasePool::Sqlite(pool) => delete_before_sqlite(pool, cutoff_ms, limit).await,
+            DatabasePool::MySql(pool) => delete_before_mysql(pool, cutoff_ms, limit).await,
+            DatabasePool::Postgres(pool) => delete_before_postgres(pool, cutoff_ms, limit).await,
+        }
+    }
+}
+
+async fn enforce_session_cap_sqlite(
+    transaction: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    username: &str,
+    now_ms: i64,
+    max_active_sessions: usize,
+) -> Result<(), PersistenceError> {
+    if max_active_sessions == usize::MAX {
+        return Ok(());
+    }
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM dashboard_session WHERE username = ? AND revoked_at_ms IS NULL AND expires_at_ms > ?",
+    )
+    .bind(username)
+    .bind(now_ms)
+    .fetch_one(&mut **transaction)
+    .await
+    .map_err(map_query_error)?;
+    (count < max_active_sessions as i64)
+        .then_some(())
+        .ok_or(PersistenceError::Conflict)
+}
+
+async fn enforce_session_cap_mysql(
+    transaction: &mut sqlx::Transaction<'_, sqlx::MySql>,
+    username: &str,
+    now_ms: i64,
+    max_active_sessions: usize,
+) -> Result<(), PersistenceError> {
+    if max_active_sessions == usize::MAX {
+        return Ok(());
+    }
+    // The username/active index makes this a next-key range lock, including
+    // the empty range, until the create-and-audit transaction commits.
+    let records = sqlx::query(
+        "SELECT token_hash FROM dashboard_session WHERE username = ? AND revoked_at_ms IS NULL AND expires_at_ms > ? FOR UPDATE",
+    )
+    .bind(username)
+    .bind(now_ms)
+    .fetch_all(&mut **transaction)
+    .await
+    .map_err(map_query_error)?;
+    (records.len() < max_active_sessions)
+        .then_some(())
+        .ok_or(PersistenceError::Conflict)
+}
+
+async fn enforce_session_cap_postgres(
+    transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    username: &str,
+    now_ms: i64,
+    max_active_sessions: usize,
+) -> Result<(), PersistenceError> {
+    if max_active_sessions == usize::MAX {
+        return Ok(());
+    }
+    // PostgreSQL predicate locks alone do not protect an empty range at the
+    // normal isolation level. A transaction-scoped advisory lock serializes
+    // this user's create path without exposing a token-derived identifier.
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtext($1))")
+        .bind(username)
+        .execute(&mut **transaction)
+        .await
+        .map_err(map_query_error)?;
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM dashboard_session WHERE username = $1 AND revoked_at_ms IS NULL AND expires_at_ms > $2",
+    )
+    .bind(username)
+    .bind(now_ms)
+    .fetch_one(&mut **transaction)
+    .await
+    .map_err(map_query_error)?;
+    (count < max_active_sessions as i64)
+        .then_some(())
+        .ok_or(PersistenceError::Conflict)
+}
+
+async fn find_sqlite(
+    pool: &SqlitePool,
+    token_hash: &SessionTokenHash,
+) -> Result<Option<SessionRecord>, PersistenceError> {
+    sqlx::query("SELECT session_id, token_hash, username, created_at_ms, expires_at_ms, last_seen_at_ms, revoked_at_ms FROM dashboard_session WHERE token_hash = ?")
+        .bind(token_hash.bytes().to_vec())
+        .fetch_optional(pool)
+        .await
+        .map_err(map_query_error)?
+        .map(session_from_row)
+        .transpose()
+}
+
+async fn find_mysql(
+    pool: &MySqlPool,
+    token_hash: &SessionTokenHash,
+) -> Result<Option<SessionRecord>, PersistenceError> {
+    sqlx::query("SELECT CAST(session_id AS BINARY) AS session_id, token_hash, username, created_at_ms, expires_at_ms, last_seen_at_ms, revoked_at_ms FROM dashboard_session WHERE token_hash = ?")
+        .bind(token_hash.bytes().to_vec())
+        .fetch_optional(pool)
+        .await
+        .map_err(map_query_error)?
+        .map(session_from_mysql_row)
+        .transpose()
+}
+
+async fn find_postgres(
+    pool: &PgPool,
+    token_hash: &SessionTokenHash,
+) -> Result<Option<SessionRecord>, PersistenceError> {
+    sqlx::query("SELECT session_id, token_hash, username, created_at_ms, expires_at_ms, last_seen_at_ms, revoked_at_ms FROM dashboard_session WHERE token_hash = $1")
+        .bind(token_hash.bytes().to_vec())
+        .fetch_optional(pool)
+        .await
+        .map_err(map_query_error)?
+        .map(session_from_row)
+        .transpose()
+}
+
+async fn list_sqlite(pool: &SqlitePool, query: SessionQuery) -> Result<SessionPage, PersistenceError> {
+    let rows = sqlx::query("SELECT session_id, token_hash, username, created_at_ms, expires_at_ms, last_seen_at_ms, revoked_at_ms FROM dashboard_session WHERE (? IS NULL OR username = ?) AND (? IS NULL OR created_at_ms < ? OR (created_at_ms = ? AND session_id < ?)) ORDER BY created_at_ms DESC, session_id DESC LIMIT ?")
+        .bind(query.username.clone()).bind(query.username.clone())
+        .bind(query.cursor.as_ref().map(|cursor| cursor.created_at_ms)).bind(query.cursor.as_ref().map(|cursor| cursor.created_at_ms)).bind(query.cursor.as_ref().map(|cursor| cursor.created_at_ms)).bind(query.cursor.as_ref().map(|cursor| cursor.session_id.clone()))
+        .bind((query.limit + 1) as i64)
+        .fetch_all(pool)
+        .await
+        .map_err(map_query_error)?;
+    page_from_rows(rows, query)
+}
+
+async fn list_mysql(pool: &MySqlPool, query: SessionQuery) -> Result<SessionPage, PersistenceError> {
+    let rows = sqlx::query("SELECT CAST(session_id AS BINARY) AS session_id, token_hash, username, created_at_ms, expires_at_ms, last_seen_at_ms, revoked_at_ms FROM dashboard_session WHERE (? IS NULL OR username = ?) AND (? IS NULL OR created_at_ms < ? OR (created_at_ms = ? AND session_id < ?)) ORDER BY created_at_ms DESC, session_id DESC LIMIT ?")
+        .bind(query.username.clone()).bind(query.username.clone())
+        .bind(query.cursor.as_ref().map(|cursor| cursor.created_at_ms)).bind(query.cursor.as_ref().map(|cursor| cursor.created_at_ms)).bind(query.cursor.as_ref().map(|cursor| cursor.created_at_ms)).bind(query.cursor.as_ref().map(|cursor| cursor.session_id.clone()))
+        .bind((query.limit + 1) as i64)
+        .fetch_all(pool)
+        .await
+        .map_err(map_query_error)?;
+    mysql_page_from_rows(rows, query)
+}
+
+async fn list_postgres(pool: &PgPool, query: SessionQuery) -> Result<SessionPage, PersistenceError> {
+    let rows = sqlx::query("SELECT session_id, token_hash, username, created_at_ms, expires_at_ms, last_seen_at_ms, revoked_at_ms FROM dashboard_session WHERE ($1::text IS NULL OR username = $2) AND ($3::bigint IS NULL OR created_at_ms < $4 OR (created_at_ms = $5 AND session_id < $6)) ORDER BY created_at_ms DESC, session_id DESC LIMIT $7")
+        .bind(query.username.clone()).bind(query.username.clone())
+        .bind(query.cursor.as_ref().map(|cursor| cursor.created_at_ms)).bind(query.cursor.as_ref().map(|cursor| cursor.created_at_ms)).bind(query.cursor.as_ref().map(|cursor| cursor.created_at_ms)).bind(query.cursor.as_ref().map(|cursor| cursor.session_id.clone()))
+        .bind((query.limit + 1) as i64)
+        .fetch_all(pool)
+        .await
+        .map_err(map_query_error)?;
+    page_from_rows(rows, query)
+}
+
+fn page_from_rows<R: Row>(rows: Vec<R>, query: SessionQuery) -> Result<SessionPage, PersistenceError>
+where
+    for<'r> &'r str: sqlx::ColumnIndex<R>,
+    for<'r> Vec<u8>: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
+    for<'r> String: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
+    for<'r> i64: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
+    for<'r> Option<i64>: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
+{
+    let mut records = rows.into_iter().map(session_from_row).collect::<Result<Vec<_>, _>>()?;
+    let has_more = records.len() > query.limit;
+    records.truncate(query.limit);
+    let next_cursor = if has_more {
+        records.last().map(|record| SessionCursor {
+            created_at_ms: record.created_at_ms,
+            session_id: record.session_id.clone(),
+        })
+    } else {
+        None
+    };
+    Ok(SessionPage { records, next_cursor })
+}
+
+fn session_from_row<R: Row>(row: R) -> Result<SessionRecord, PersistenceError>
+where
+    for<'r> &'r str: sqlx::ColumnIndex<R>,
+    for<'r> Vec<u8>: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
+    for<'r> String: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
+    for<'r> i64: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
+    for<'r> Option<i64>: sqlx::Decode<'r, R::Database> + sqlx::Type<R::Database>,
+{
+    let bytes: Vec<u8> = row.try_get("token_hash").map_err(|_| PersistenceError::CorruptedData)?;
+    let token_hash = bytes_to_hash(bytes)?;
+    Ok(SessionRecord {
+        session_id: row.try_get("session_id").map_err(|_| PersistenceError::CorruptedData)?,
+        token_hash,
+        username: row.try_get("username").map_err(|_| PersistenceError::CorruptedData)?,
+        created_at_ms: row
+            .try_get("created_at_ms")
+            .map_err(|_| PersistenceError::CorruptedData)?,
+        expires_at_ms: row
+            .try_get("expires_at_ms")
+            .map_err(|_| PersistenceError::CorruptedData)?,
+        last_seen_at_ms: row
+            .try_get("last_seen_at_ms")
+            .map_err(|_| PersistenceError::CorruptedData)?,
+        revoked_at_ms: row
+            .try_get("revoked_at_ms")
+            .map_err(|_| PersistenceError::CorruptedData)?,
+    })
+}
+
+fn mysql_page_from_rows(rows: Vec<MySqlRow>, query: SessionQuery) -> Result<SessionPage, PersistenceError> {
+    let mut records = rows
+        .into_iter()
+        .map(session_from_mysql_row)
+        .collect::<Result<Vec<_>, _>>()?;
+    let has_more = records.len() > query.limit;
+    records.truncate(query.limit);
+    let next_cursor = has_more
+        .then(|| {
+            records.last().map(|record| SessionCursor {
+                created_at_ms: record.created_at_ms,
+                session_id: record.session_id.clone(),
+            })
+        })
+        .flatten();
+    Ok(SessionPage { records, next_cursor })
+}
+
+fn session_from_mysql_row(row: MySqlRow) -> Result<SessionRecord, PersistenceError> {
+    let bytes: Vec<u8> = row.try_get("token_hash").map_err(|_| PersistenceError::CorruptedData)?;
+    let username = String::from_utf8(
+        row.try_get::<Vec<u8>, _>("username")
+            .map_err(|_| PersistenceError::CorruptedData)?,
+    )
+    .map_err(|_| PersistenceError::CorruptedData)?;
+    Ok(SessionRecord {
+        session_id: String::from_utf8(
+            row.try_get::<Vec<u8>, _>("session_id")
+                .map_err(|_| PersistenceError::CorruptedData)?,
+        )
+        .map_err(|_| PersistenceError::CorruptedData)?,
+        token_hash: bytes_to_hash(bytes)?,
+        username,
+        created_at_ms: row
+            .try_get("created_at_ms")
+            .map_err(|_| PersistenceError::CorruptedData)?,
+        expires_at_ms: row
+            .try_get("expires_at_ms")
+            .map_err(|_| PersistenceError::CorruptedData)?,
+        last_seen_at_ms: row
+            .try_get("last_seen_at_ms")
+            .map_err(|_| PersistenceError::CorruptedData)?,
+        revoked_at_ms: row
+            .try_get("revoked_at_ms")
+            .map_err(|_| PersistenceError::CorruptedData)?,
+    })
+}
+
+fn bytes_to_hash(bytes: Vec<u8>) -> Result<SessionTokenHash, PersistenceError> {
+    let bytes: [u8; 32] = bytes.try_into().map_err(|_| PersistenceError::CorruptedData)?;
+    Ok(SessionTokenHash(bytes))
+}
+
+async fn insert_audit_sqlite(
+    transaction: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    event: AuditEvent,
+) -> Result<(), PersistenceError> {
+    let detail = event
+        .detail
+        .map(|value| serde_json::to_string(&value))
+        .transpose()
+        .map_err(PersistenceError::Serialization)?;
+    sqlx::query("INSERT INTO dashboard_audit_event (event_id, request_id, actor_kind, actor_username, action, resource_type, resource_name, environment_id, outcome, detail_json, created_at_ms) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+        .bind(event.event_id).bind(event.request_id).bind(event.actor.kind.code().to_string()).bind(event.actor.username)
+        .bind(event.action.code().to_string()).bind(event.resource_type.code().to_string()).bind(event.resource_name)
+        .bind(event.environment_id.map(|id| id.0)).bind(event.outcome.code().to_string()).bind(detail).bind(event.created_at_ms)
+        .execute(&mut **transaction).await.map_err(map_query_error)?;
+    Ok(())
+}
+
+async fn insert_audit_mysql(
+    transaction: &mut sqlx::Transaction<'_, sqlx::MySql>,
+    event: AuditEvent,
+) -> Result<(), PersistenceError> {
+    let detail = event
+        .detail
+        .map(|value| serde_json::to_string(&value))
+        .transpose()
+        .map_err(PersistenceError::Serialization)?;
+    sqlx::query("INSERT INTO dashboard_audit_event (event_id, request_id, actor_kind, actor_username, action, resource_type, resource_name, environment_id, outcome, detail_json, created_at_ms) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+        .bind(event.event_id).bind(event.request_id).bind(event.actor.kind.code().to_string()).bind(event.actor.username)
+        .bind(event.action.code().to_string()).bind(event.resource_type.code().to_string()).bind(event.resource_name)
+        .bind(event.environment_id.map(|id| id.0)).bind(event.outcome.code().to_string()).bind(detail).bind(event.created_at_ms)
+        .execute(&mut **transaction).await.map_err(map_query_error)?;
+    Ok(())
+}
+
+async fn insert_audit_postgres(
+    transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    event: AuditEvent,
+) -> Result<(), PersistenceError> {
+    let detail = event
+        .detail
+        .map(|value| serde_json::to_string(&value))
+        .transpose()
+        .map_err(PersistenceError::Serialization)?;
+    sqlx::query("INSERT INTO dashboard_audit_event (event_id, request_id, actor_kind, actor_username, action, resource_type, resource_name, environment_id, outcome, detail_json, created_at_ms) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)")
+        .bind(event.event_id).bind(event.request_id).bind(event.actor.kind.code().to_string()).bind(event.actor.username)
+        .bind(event.action.code().to_string()).bind(event.resource_type.code().to_string()).bind(event.resource_name)
+        .bind(event.environment_id.map(|id| id.0)).bind(event.outcome.code().to_string()).bind(detail).bind(event.created_at_ms)
+        .execute(&mut **transaction).await.map_err(map_query_error)?;
+    Ok(())
+}
+
+async fn delete_before_sqlite(pool: &SqlitePool, cutoff: i64, limit: usize) -> Result<u64, PersistenceError> {
+    let result = sqlx::query("DELETE FROM dashboard_session WHERE token_hash IN (SELECT token_hash FROM dashboard_session WHERE COALESCE(revoked_at_ms, expires_at_ms) < ? ORDER BY COALESCE(revoked_at_ms, expires_at_ms) LIMIT ?)")
+        .bind(cutoff).bind(limit as i64).execute(pool).await.map_err(map_query_error)?;
+    Ok(result.rows_affected())
+}
+
+async fn delete_before_mysql(pool: &MySqlPool, cutoff: i64, limit: usize) -> Result<u64, PersistenceError> {
+    let result = sqlx::query("DELETE FROM dashboard_session WHERE token_hash IN (SELECT token_hash FROM (SELECT token_hash FROM dashboard_session WHERE COALESCE(revoked_at_ms, expires_at_ms) < ? ORDER BY COALESCE(revoked_at_ms, expires_at_ms) LIMIT ?) AS cleanup_rows)")
+        .bind(cutoff).bind(limit as i64).execute(pool).await.map_err(map_query_error)?;
+    Ok(result.rows_affected())
+}
+
+async fn delete_before_postgres(pool: &PgPool, cutoff: i64, limit: usize) -> Result<u64, PersistenceError> {
+    let result = sqlx::query("DELETE FROM dashboard_session WHERE token_hash IN (SELECT token_hash FROM dashboard_session WHERE COALESCE(revoked_at_ms, expires_at_ms) < $1 ORDER BY COALESCE(revoked_at_ms, expires_at_ms) LIMIT $2)")
+        .bind(cutoff).bind(limit as i64).execute(pool).await.map_err(map_query_error)?;
+    Ok(result.rows_affected())
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/sql_store.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/persistence/sql_store.rs
@@ -45,6 +45,8 @@ use std::path::PathBuf;
 use std::time::Duration;
 use tokio::time::timeout;
 
+#[path = "audit_sql_store.rs"]
+mod audit_sql_store;
 #[path = "history_lease_store.rs"]
 mod history_lease_store;
 #[path = "history_sql_store.rs"]
@@ -52,6 +54,8 @@ mod history_sql_store;
 #[cfg(test)]
 #[path = "history_sql_store_docker_tests.rs"]
 mod history_sql_store_docker_tests;
+#[path = "session_sql_store.rs"]
+mod session_sql_store;
 
 pub enum DatabasePool {
     Sqlite(SqlitePool),
@@ -391,6 +395,38 @@ impl SqlPersistence {
         Ok(candidate)
     }
 
+    pub(crate) async fn update_environment_with_audit(
+        &self,
+        expected_revision: Revision,
+        mut candidate: DashboardEnvironment,
+        audit: crate::model::AuditEvent,
+    ) -> Result<DashboardEnvironment, PersistenceError> {
+        candidate.validate().map_err(PersistenceError::InvalidConfig)?;
+        validate_environment_identity(&candidate)?;
+        candidate.revision = Revision(expected_revision.0.checked_add(1).ok_or(PersistenceError::Conflict)?);
+        match &self.pool {
+            DatabasePool::Sqlite(pool) => {
+                let mut transaction = pool.begin().await.map_err(map_query_error)?;
+                crate::update_environment_in_transaction!(transaction, expected_revision, &candidate);
+                audit_sql_store::append_sqlite_audit_event_in_transaction(&mut transaction, &audit).await?;
+                transaction.commit().await.map_err(map_query_error)?;
+            }
+            DatabasePool::MySql(pool) => {
+                let mut transaction = pool.begin().await.map_err(map_query_error)?;
+                crate::update_environment_in_transaction!(transaction, expected_revision, &candidate);
+                audit_sql_store::append_mysql_audit_event_in_transaction(&mut transaction, &audit).await?;
+                transaction.commit().await.map_err(map_query_error)?;
+            }
+            DatabasePool::Postgres(pool) => {
+                let mut transaction = pool.begin().await.map_err(map_query_error)?;
+                crate::update_environment_in_transaction!(transaction, expected_revision, &candidate);
+                audit_sql_store::append_postgres_audit_event_in_transaction(&mut transaction, &audit).await?;
+                transaction.commit().await.map_err(map_query_error)?;
+            }
+        }
+        Ok(candidate)
+    }
+
     pub(crate) async fn delete_environment(
         &self,
         environment_id: &EnvironmentId,
@@ -435,6 +471,38 @@ impl SqlPersistence {
         }
     }
 
+    pub(crate) async fn upsert_monitor_rule_with_audit(
+        &self,
+        rule: ConsumerMonitorRule,
+        expected_revision: Revision,
+        audit: crate::model::AuditEvent,
+    ) -> Result<ConsumerMonitorRule, PersistenceError> {
+        rule.validate().map_err(PersistenceError::InvalidConfig)?;
+        match &self.pool {
+            DatabasePool::Sqlite(pool) => {
+                let mut transaction = pool.begin_with("BEGIN IMMEDIATE").await.map_err(map_query_error)?;
+                let saved = crate::upsert_monitor_rule_in_transaction!(transaction, rule, expected_revision)?;
+                audit_sql_store::append_sqlite_audit_event_in_transaction(&mut transaction, &audit).await?;
+                transaction.commit().await.map_err(map_query_error)?;
+                Ok(saved)
+            }
+            DatabasePool::MySql(pool) => {
+                let mut transaction = pool.begin().await.map_err(map_query_error)?;
+                let saved = crate::upsert_monitor_rule_in_transaction!(transaction, rule, expected_revision)?;
+                audit_sql_store::append_mysql_audit_event_in_transaction(&mut transaction, &audit).await?;
+                transaction.commit().await.map_err(map_query_error)?;
+                Ok(saved)
+            }
+            DatabasePool::Postgres(pool) => {
+                let mut transaction = pool.begin().await.map_err(map_query_error)?;
+                let saved = crate::upsert_monitor_rule_in_transaction!(transaction, rule, expected_revision)?;
+                audit_sql_store::append_postgres_audit_event_in_transaction(&mut transaction, &audit).await?;
+                transaction.commit().await.map_err(map_query_error)?;
+                Ok(saved)
+            }
+        }
+    }
+
     pub(crate) async fn delete_monitor_rule(
         &self,
         environment_id: &EnvironmentId,
@@ -455,6 +523,64 @@ impl SqlPersistence {
             }
             DatabasePool::Postgres(pool) => {
                 crate::delete_monitor_rule_in_pool!(pool, environment_id, consumer_group, expected_revision)
+            }
+        }
+    }
+
+    pub(crate) async fn delete_monitor_rule_with_audit(
+        &self,
+        environment_id: &EnvironmentId,
+        consumer_group: &str,
+        expected_revision: Revision,
+        audit: crate::model::AuditEvent,
+    ) -> Result<bool, PersistenceError> {
+        if consumer_group.trim().is_empty() {
+            return Err(PersistenceError::InvalidConfig(
+                "consumer group is required".to_string(),
+            ));
+        }
+        match &self.pool {
+            DatabasePool::Sqlite(pool) => {
+                let mut transaction = pool.begin().await.map_err(map_query_error)?;
+                let removed = crate::delete_monitor_rule_in_transaction!(
+                    transaction,
+                    environment_id,
+                    consumer_group,
+                    expected_revision
+                )?;
+                if removed {
+                    audit_sql_store::append_sqlite_audit_event_in_transaction(&mut transaction, &audit).await?;
+                }
+                transaction.commit().await.map_err(map_query_error)?;
+                Ok(removed)
+            }
+            DatabasePool::MySql(pool) => {
+                let mut transaction = pool.begin().await.map_err(map_query_error)?;
+                let removed = crate::delete_monitor_rule_in_transaction!(
+                    transaction,
+                    environment_id,
+                    consumer_group,
+                    expected_revision
+                )?;
+                if removed {
+                    audit_sql_store::append_mysql_audit_event_in_transaction(&mut transaction, &audit).await?;
+                }
+                transaction.commit().await.map_err(map_query_error)?;
+                Ok(removed)
+            }
+            DatabasePool::Postgres(pool) => {
+                let mut transaction = pool.begin().await.map_err(map_query_error)?;
+                let removed = crate::delete_monitor_rule_in_transaction!(
+                    transaction,
+                    environment_id,
+                    consumer_group,
+                    expected_revision
+                )?;
+                if removed {
+                    audit_sql_store::append_postgres_audit_event_in_transaction(&mut transaction, &audit).await?;
+                }
+                transaction.commit().await.map_err(map_query_error)?;
+                Ok(removed)
             }
         }
     }
@@ -903,6 +1029,14 @@ macro_rules! insert_environment_in_pool {
 macro_rules! update_environment_in_pool {
     ($pool:expr, $expected_revision:expr, $environment:expr) => {{
         let mut transaction = $pool.begin().await.map_err(map_query_error)?;
+        $crate::update_environment_in_transaction!(transaction, $expected_revision, $environment);
+        transaction.commit().await.map_err(map_query_error)
+    }};
+}
+
+#[macro_export]
+macro_rules! update_environment_in_transaction {
+    ($transaction:ident, $expected_revision:expr, $environment:expr) => {{
         let mut update = QueryBuilder::new("UPDATE dashboard_environment SET name = ");
         update.push_bind(&$environment.name);
         update.push(", use_vip_channel = ");
@@ -919,7 +1053,7 @@ macro_rules! update_environment_in_pool {
         update.push_bind(revision_to_database($expected_revision)?);
         if update
             .build()
-            .execute(&mut *transaction)
+            .execute(&mut *$transaction)
             .await
             .map_err(map_query_error)?
             .rows_affected()
@@ -931,11 +1065,10 @@ macro_rules! update_environment_in_pool {
         delete.push_bind(&$environment.environment_id.0);
         delete
             .build()
-            .execute(&mut *transaction)
+            .execute(&mut *$transaction)
             .await
             .map_err(map_query_error)?;
-        $crate::insert_endpoints_in_transaction!(transaction, $environment);
-        transaction.commit().await.map_err(map_query_error)
+        $crate::insert_endpoints_in_transaction!($transaction, $environment);
     }};
 }
 
@@ -979,7 +1112,10 @@ macro_rules! delete_environment_in_pool {
 macro_rules! upsert_monitor_rule_in_pool {
     ($pool:expr, $rule:expr, $expected_revision:expr) => {{
         let mut transaction = $pool.begin().await.map_err(map_query_error)?;
-        $crate::upsert_monitor_rule_in_transaction!(transaction, $rule, $expected_revision)
+        let result = $crate::upsert_monitor_rule_in_transaction!(transaction, $rule, $expected_revision);
+        let result = result?;
+        transaction.commit().await.map_err(map_query_error)?;
+        Ok(result)
     }};
 }
 
@@ -1057,7 +1193,6 @@ macro_rules! upsert_monitor_rule_in_transaction {
             separated.push_unseparated(")");
             insert.build().execute(&mut *$transaction).await.map_err(map_query_error)?;
         }
-        $transaction.commit().await.map_err(map_query_error)?;
         Ok(persisted)
     }};
 }
@@ -1072,18 +1207,36 @@ async fn upsert_monitor_rule_in_sqlite_transaction(
     expected_revision: Revision,
 ) -> Result<ConsumerMonitorRule, PersistenceError> {
     let mut transaction = pool.begin_with("BEGIN IMMEDIATE").await.map_err(map_query_error)?;
-    crate::upsert_monitor_rule_in_transaction!(transaction, rule, expected_revision)
+    let result = crate::upsert_monitor_rule_in_transaction!(transaction, rule, expected_revision);
+    let result = result?;
+    transaction.commit().await.map_err(map_query_error)?;
+    Ok(result)
 }
 
 #[macro_export]
 macro_rules! delete_monitor_rule_in_pool {
     ($pool:expr, $environment_id:expr, $consumer_group:expr, $expected_revision:expr) => {{
         let mut transaction = $pool.begin().await.map_err(map_query_error)?;
+        let result = $crate::delete_monitor_rule_in_transaction!(
+            transaction,
+            $environment_id,
+            $consumer_group,
+            $expected_revision
+        );
+        let result = result?;
+        transaction.commit().await.map_err(map_query_error)?;
+        Ok(result)
+    }};
+}
+
+#[macro_export]
+macro_rules! delete_monitor_rule_in_transaction {
+    ($transaction:ident, $environment_id:expr, $consumer_group:expr, $expected_revision:expr) => {{
         let mut environment = QueryBuilder::new("SELECT 1 FROM dashboard_environment WHERE environment_id = ");
         environment.push_bind(&$environment_id.0);
         if environment
             .build()
-            .fetch_optional(&mut *transaction)
+            .fetch_optional(&mut *$transaction)
             .await
             .map_err(map_query_error)?
             .is_none()
@@ -1098,19 +1251,18 @@ macro_rules! delete_monitor_rule_in_pool {
         delete.push_bind(revision_to_database($expected_revision)?);
         let deleted = delete
             .build()
-            .execute(&mut *transaction)
+            .execute(&mut *$transaction)
             .await
             .map_err(map_query_error)?
             .rows_affected();
         if deleted == 1 {
-            transaction.commit().await.map_err(map_query_error)?;
             Ok(true)
         } else {
             let mut owner = QueryBuilder::new("SELECT 1 FROM dashboard_environment WHERE environment_id = ");
             owner.push_bind(&$environment_id.0);
             if owner
                 .build()
-                .fetch_optional(&mut *transaction)
+                .fetch_optional(&mut *$transaction)
                 .await
                 .map_err(map_query_error)?
                 .is_none()
@@ -1123,14 +1275,13 @@ macro_rules! delete_monitor_rule_in_pool {
             exists.push_bind($consumer_group);
             let found = exists
                 .build()
-                .fetch_optional(&mut *transaction)
+                .fetch_optional(&mut *$transaction)
                 .await
                 .map_err(map_query_error)?
                 .is_some();
             if found {
                 Err(PersistenceError::Conflict)
             } else {
-                transaction.commit().await.map_err(map_query_error)?;
                 Ok(false)
             }
         }
@@ -1189,7 +1340,7 @@ mod tests {
             let first = SqlPersistence::initialize(&config, owner.root_context().component("sqlite-first"))
                 .await
                 .expect("first SQLite initialization");
-            assert_eq!(first.schema_version(), 3);
+            assert_eq!(first.schema_version(), 4);
             let health = first.storage_health().await;
             assert!(matches!(health.status, StorageStatus::Available));
             assert!(health.pool_size.is_some());
@@ -1199,7 +1350,7 @@ mod tests {
             let second = SqlPersistence::initialize(&config, owner.root_context().component("sqlite-second"))
                 .await
                 .expect("second SQLite initialization");
-            assert_eq!(second.schema_version(), 3);
+            assert_eq!(second.schema_version(), 4);
         });
         assert!(database_path.exists());
         owner.shutdown_runtime_blocking().expect("runtime shutdown");
@@ -1377,7 +1528,7 @@ mod tests {
                 SqlPersistence::initialize(&config, owner.root_context().component("docker-storage-test-first"))
                     .await
                     .expect("first storage initialization");
-            assert_eq!(first.schema_version(), 3);
+            assert_eq!(first.schema_version(), 4);
             assert_eq!(first.storage_health().await.status, StorageStatus::Available);
             assert_schema_metadata(&first).await;
             drop(first);
@@ -1385,7 +1536,7 @@ mod tests {
                 SqlPersistence::initialize(&config, owner.root_context().component("docker-storage-test-second"))
                     .await
                     .expect("second storage initialization");
-            assert_eq!(second.schema_version(), 3);
+            assert_eq!(second.schema_version(), 4);
             assert_eq!(second.storage_health().await.status, StorageStatus::Available);
         });
         if config.backend == StorageBackend::Sqlite {

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 pub mod acl_service;
+pub mod audit_service;
 pub mod auth_service;
 pub mod broker_service;
 pub mod config_service;
@@ -21,9 +22,11 @@ pub mod health_service;
 pub mod message_service;
 pub mod monitor_service;
 pub mod producer_service;
+pub mod session_audit_cleanup;
 pub mod topic_service;
 
 pub use acl_service::*;
+pub use audit_service::*;
 pub use auth_service::*;
 pub use broker_service::*;
 pub use config_service::*;
@@ -33,4 +36,5 @@ pub use health_service::*;
 pub use message_service::*;
 pub use monitor_service::*;
 pub use producer_service::*;
+pub use session_audit_cleanup::*;
 pub use topic_service::*;

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/audit_service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/audit_service.rs
@@ -1,0 +1,144 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde_json::Map;
+use serde_json::Value;
+
+const MAX_DEPTH: usize = 12;
+const MAX_NODES: usize = 1_024;
+const MAX_STRING_BYTES: usize = 4_096;
+const MAX_CONTAINER_ENTRIES: usize = 128;
+const MAX_RECORD_BYTES: usize = 64 * 1_024;
+
+/// Redacts an allowlisted audit detail projection recursively. It normalises
+/// key separators and case so nested `database-url`, `database_url`, and
+/// `databaseUrl` receive the same protection.
+pub fn redact_audit_value(value: Value) -> Value {
+    let mut remaining = MAX_NODES;
+    let redacted = redact(value, 0, &mut remaining);
+    if serde_json::to_vec(&redacted)
+        .map(|encoded| encoded.len() > MAX_RECORD_BYTES)
+        .unwrap_or(true)
+    {
+        Value::String("<truncated>".to_string())
+    } else {
+        redacted
+    }
+}
+
+fn redact(value: Value, depth: usize, remaining: &mut usize) -> Value {
+    if *remaining == 0 || depth >= MAX_DEPTH {
+        return Value::String("<truncated>".to_string());
+    }
+    *remaining -= 1;
+    match value {
+        Value::Object(object) => {
+            let truncated = object.len() > MAX_CONTAINER_ENTRIES;
+            let mut redacted = object
+                .into_iter()
+                .take(MAX_CONTAINER_ENTRIES)
+                .map(|(key, value)| {
+                    if sensitive_key(&key) {
+                        (key, Value::String("<redacted>".to_string()))
+                    } else {
+                        (key, redact(value, depth + 1, remaining))
+                    }
+                })
+                .collect::<Map<_, _>>();
+            if truncated {
+                redacted.insert("<truncated>".to_string(), Value::String("<truncated>".to_string()));
+            }
+            Value::Object(redacted)
+        }
+        Value::Array(values) => {
+            let truncated = values.len() > MAX_CONTAINER_ENTRIES;
+            let mut redacted = values
+                .into_iter()
+                .take(MAX_CONTAINER_ENTRIES)
+                .map(|value| redact(value, depth + 1, remaining))
+                .collect::<Vec<_>>();
+            if truncated {
+                redacted.push(Value::String("<truncated>".to_string()));
+            }
+            Value::Array(redacted)
+        }
+        Value::String(value) if value.len() > MAX_STRING_BYTES => {
+            let mut end = MAX_STRING_BYTES;
+            while !value.is_char_boundary(end) {
+                end -= 1;
+            }
+            Value::String(format!("{}<truncated>", &value[..end]))
+        }
+        value => value,
+    }
+}
+
+fn sensitive_key(key: &str) -> bool {
+    let normalized = key
+        .bytes()
+        .filter(u8::is_ascii_alphanumeric)
+        .map(char::from)
+        .collect::<String>()
+        .to_ascii_lowercase();
+    [
+        "password",
+        "passwd",
+        "pwd",
+        "secret",
+        "token",
+        "authorization",
+        "cookie",
+        "accesskey",
+        "databaseurl",
+        "connectionstring",
+        "privatekey",
+        "tlskey",
+        "clientkey",
+        "credential",
+    ]
+    .iter()
+    .any(|needle| normalized.contains(needle))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::redact_audit_value;
+    use serde_json::json;
+
+    #[test]
+    fn recursively_redacts_normalized_secret_keys() {
+        let redacted = redact_audit_value(json!({
+            "database-url": "mysql://secret",
+            "nested": [{"TLS_Key": "private"}],
+            "safe": "visible"
+        }));
+        assert_eq!(redacted["database-url"], "<redacted>");
+        assert_eq!(redacted["nested"][0]["TLS_Key"], "<redacted>");
+        assert_eq!(redacted["safe"], "visible");
+    }
+
+    #[test]
+    fn truncates_utf8_and_container_values_without_panicking() {
+        let redacted = redact_audit_value(json!({
+            "text": "界".repeat(2_000),
+            "values": (0..256).collect::<Vec<_>>(),
+        }));
+        assert!(
+            redacted["text"]
+                .as_str()
+                .is_some_and(|value| value.ends_with("<truncated>"))
+        );
+        assert_eq!(redacted["values"].as_array().map(Vec::len), Some(129));
+    }
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/auth_service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/auth_service.rs
@@ -11,102 +11,345 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 use crate::config::AuthConfig;
 use crate::error::DashboardError;
+use crate::model::AuditAction;
+use crate::model::AuditActor;
+use crate::model::AuditEvent;
+use crate::model::AuditOutcome;
+use crate::model::AuditResourceType;
+use crate::model::AuthenticatedActor;
 use crate::model::LoginRequest;
+use crate::model::NewSession;
+use crate::model::SessionAuthenticationFailure;
+use crate::model::SessionListItem;
+use crate::model::SessionListPage;
+use crate::model::SessionTokenHash;
 use crate::model::SessionView;
+use crate::persistence::session_repository::SessionCursor;
+use crate::persistence::session_repository::SessionQuery;
 use crate::state::AppState;
+use axum::http::HeaderValue;
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use sha2::Digest;
+use sha2::Sha256;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
-use tokio::sync::RwLock;
 
-#[derive(Debug)]
+/// Authentication configuration and operations. The durable repository is the
+/// sole session authority; this type deliberately does not cache sessions.
+#[derive(Clone)]
 pub struct AuthState {
-    config: AuthConfig,
-    session: RwLock<Option<SessionView>>,
+    pub(crate) config: AuthConfig,
+    allowed_origin: Option<HeaderValue>,
 }
 
 impl AuthState {
-    pub fn new(config: AuthConfig) -> Self {
-        Self {
-            config,
-            session: RwLock::new(None),
-        }
+    pub fn new(config: AuthConfig) -> Result<Self, DashboardError> {
+        let allowed_origin = config.cors_origin()?;
+        Ok(Self { config, allowed_origin })
     }
 
-    async fn current_session(&self) -> SessionView {
-        if !self.config.login_required {
-            return SessionView {
-                login_required: false,
-                authenticated: true,
-                username: None,
-                session_id: None,
-                login_time: None,
-            };
-        }
+    pub const fn login_required(&self) -> bool {
+        self.config.login_required
+    }
 
-        self.session.read().await.clone().unwrap_or(SessionView {
+    pub const fn cookie_secure(&self) -> bool {
+        self.config.cookie_secure
+    }
+
+    pub fn allowed_origin(&self) -> Option<HeaderValue> {
+        self.allowed_origin.clone()
+    }
+
+    fn local_actor(&self) -> AuthenticatedActor {
+        AuthenticatedActor {
+            actor: AuditActor::local_operator(),
+            request_id: uuid::Uuid::now_v7().to_string(),
+            session_hash: None,
+        }
+    }
+}
+
+pub async fn authenticate(state: &AppState, token: Option<&str>) -> Result<AuthenticatedActor, DashboardError> {
+    match authenticate_session_token(state, token).await? {
+        Ok(actor) => Ok(actor),
+        Err(_) => Err(authentication_required()),
+    }
+}
+
+/// Performs the persistent session lookup without flattening an ordinary
+/// invalid, expired, or revoked credential into a storage failure. The
+/// session-status middleware uses this to clear a stale HttpOnly cookie while
+/// keeping actual repository failures fail-closed.
+pub async fn authenticate_session_token(
+    state: &AppState,
+    token: Option<&str>,
+) -> Result<Result<AuthenticatedActor, SessionAuthenticationFailure>, DashboardError> {
+    if !state.auth_state.login_required() {
+        return Ok(Ok(state.auth_state.local_actor()));
+    }
+    let Some(token) = token else {
+        return Ok(Err(SessionAuthenticationFailure::Invalid));
+    };
+    let token_hash = token_hash(token);
+    let record = state.persistence.find_session(&token_hash).await?;
+    let Some(record) = record else {
+        return Ok(Err(SessionAuthenticationFailure::Invalid));
+    };
+    let now = now_millis();
+    if record.revoked_at_ms.is_some() {
+        return Ok(Err(SessionAuthenticationFailure::Revoked));
+    }
+    if now >= record.expires_at_ms {
+        return Ok(Err(SessionAuthenticationFailure::Expired));
+    }
+    // A successful persistent lookup is also the only point at which the
+    // operational last-seen timestamp advances; it never refreshes expiry.
+    let _ = state.persistence.touch_session(&token_hash, now).await?;
+    Ok(Ok(AuthenticatedActor {
+        actor: AuditActor::admin(record.username),
+        request_id: uuid::Uuid::now_v7().to_string(),
+        session_hash: Some(token_hash),
+    }))
+}
+
+pub async fn session_view(state: &AppState, actor: Option<&AuthenticatedActor>) -> Result<SessionView, DashboardError> {
+    if !state.auth_state.login_required() {
+        return Ok(SessionView {
+            login_required: false,
+            authenticated: true,
+            username: None,
+            session_id: None,
+            login_time: None,
+            auth_reason: None,
+        });
+    }
+    let Some(actor) = actor else {
+        return Ok(SessionView {
             login_required: true,
             authenticated: false,
             username: None,
             session_id: None,
             login_time: None,
-        })
-    }
-
-    pub async fn is_authorized(&self, session_id: Option<&str>) -> bool {
-        if !self.config.login_required {
-            return true;
-        }
-
-        let Some(session_id) = session_id else {
-            return false;
-        };
-        self.session
-            .read()
-            .await
-            .as_ref()
-            .filter(|session| session.authenticated)
-            .and_then(|session| session.session_id.as_deref())
-            .is_some_and(|current_session_id| current_session_id == session_id)
-    }
-
-    async fn login(&self, request: LoginRequest) -> Result<SessionView, DashboardError> {
-        if !self.config.login_required {
-            return Ok(self.current_session().await);
-        }
-        if request.username != self.config.username || request.password != self.config.password {
-            return Err(DashboardError::Auth("Invalid username or password".to_string()));
-        }
-
-        let now = now_millis();
-        let session = SessionView {
-            login_required: true,
-            authenticated: true,
-            username: Some(request.username),
-            session_id: Some(format!("dashboard-web-{}-{now}", std::process::id())),
-            login_time: Some(now),
-        };
-        *self.session.write().await = Some(session.clone());
-        Ok(session)
-    }
-
-    async fn logout(&self) -> SessionView {
-        *self.session.write().await = None;
-        self.current_session().await
-    }
-}
-
-pub async fn session(state: &AppState) -> Result<SessionView, DashboardError> {
-    Ok(state.auth_state.current_session().await)
+            auth_reason: None,
+        });
+    };
+    let login_time = if let Some(hash) = actor.session_hash {
+        state
+            .persistence
+            .find_session(&hash)
+            .await?
+            .map(|session| session.created_at_ms)
+    } else {
+        None
+    };
+    Ok(SessionView {
+        login_required: true,
+        authenticated: true,
+        username: actor.actor.username.clone(),
+        // Only the successful login response returns a token. Session reads
+        // must never replay a credential to a caller or log it through DTOs.
+        session_id: None,
+        login_time,
+        auth_reason: None,
+    })
 }
 
 pub async fn login(state: &AppState, request: LoginRequest) -> Result<SessionView, DashboardError> {
-    state.auth_state.login(request).await
+    if !state.auth_state.login_required() {
+        return session_view(state, Some(&state.auth_state.local_actor())).await;
+    }
+    if request.username != state.auth_state.config.username || request.password != state.auth_state.config.password {
+        return Err(DashboardError::Auth("Invalid username or password".to_string()));
+    }
+
+    let now = now_millis();
+    let token = generate_token()?;
+    let expires_at_ms = now
+        .checked_add(
+            i64::try_from(state.auth_state.config.session_ttl_secs)
+                .map_err(|_| DashboardError::Config("session TTL is too large".to_string()))?
+                .saturating_mul(1_000),
+        )
+        .ok_or_else(|| DashboardError::Config("session expiry is invalid".to_string()))?;
+    state
+        .persistence
+        .create_session_with_audit_capped(
+            NewSession {
+                session_id: uuid::Uuid::now_v7().to_string(),
+                token_hash: token_hash(&token),
+                username: request.username.clone(),
+                created_at_ms: now,
+                expires_at_ms,
+            },
+            AuditEvent {
+                event_id: uuid::Uuid::now_v7().to_string(),
+                request_id: uuid::Uuid::now_v7().to_string(),
+                actor: AuditActor::admin(request.username.clone()),
+                action: AuditAction::SessionCreate,
+                resource_type: AuditResourceType::Session,
+                resource_name: Some(request.username.clone()),
+                environment_id: None,
+                outcome: AuditOutcome::Succeeded,
+                detail: None,
+                created_at_ms: now,
+            },
+            state.auth_state.config.max_active_sessions as usize,
+            now,
+        )
+        .await
+        .map_err(|error| {
+            if matches!(error, crate::persistence::error::PersistenceError::Conflict) {
+                DashboardError::Auth("Maximum active sessions reached".to_string())
+            } else {
+                error.into()
+            }
+        })?;
+    Ok(SessionView {
+        login_required: true,
+        authenticated: true,
+        username: Some(request.username),
+        // Compatibility for existing header clients. This is the only DTO
+        // path that contains the newly generated plaintext token.
+        session_id: Some(token),
+        login_time: Some(now),
+        auth_reason: None,
+    })
 }
 
-pub async fn logout(state: &AppState) -> Result<SessionView, DashboardError> {
-    Ok(state.auth_state.logout().await)
+pub async fn logout(state: &AppState, actor: &AuthenticatedActor) -> Result<SessionView, DashboardError> {
+    if let Some(hash) = actor.session_hash {
+        let now = now_millis();
+        state
+            .persistence
+            .revoke_session_with_audit(
+                &hash,
+                now,
+                AuditEvent {
+                    event_id: uuid::Uuid::now_v7().to_string(),
+                    request_id: actor.request_id.clone(),
+                    actor: actor.actor.clone(),
+                    action: AuditAction::SessionRevokeCurrent,
+                    resource_type: AuditResourceType::Session,
+                    resource_name: actor.actor.username.clone(),
+                    environment_id: None,
+                    outcome: AuditOutcome::Succeeded,
+                    detail: None,
+                    created_at_ms: now,
+                },
+            )
+            .await?;
+    }
+    Ok(SessionView {
+        login_required: state.auth_state.login_required(),
+        authenticated: !state.auth_state.login_required(),
+        username: None,
+        session_id: None,
+        login_time: None,
+        auth_reason: None,
+    })
+}
+
+pub async fn list_sessions(
+    state: &AppState,
+    actor: &AuthenticatedActor,
+    username: Option<String>,
+    cursor: Option<String>,
+    limit: usize,
+) -> Result<SessionListPage, DashboardError> {
+    let page = state
+        .persistence
+        .list_sessions(SessionQuery {
+            username,
+            cursor: cursor.as_deref().map(parse_session_cursor).transpose()?,
+            limit,
+        })
+        .await?;
+    Ok(SessionListPage {
+        items: page
+            .records
+            .into_iter()
+            .map(|record| SessionListItem {
+                session_id: record.session_id,
+                current: actor.session_hash.is_some_and(|current| current == record.token_hash),
+                username: record.username,
+                created_at_ms: record.created_at_ms,
+                expires_at_ms: record.expires_at_ms,
+                last_seen_at_ms: record.last_seen_at_ms,
+                revoked_at_ms: record.revoked_at_ms,
+            })
+            .collect(),
+        next_cursor: page
+            .next_cursor
+            .map(|next| format!("{},{}", next.created_at_ms, next.session_id)),
+    })
+}
+
+pub async fn revoke_all_sessions(
+    state: &AppState,
+    actor: &AuthenticatedActor,
+    username: String,
+) -> Result<u64, DashboardError> {
+    if username.is_empty() || username.len() > 128 {
+        return Err(DashboardError::Validation("username is invalid".to_string()));
+    }
+    let now = now_millis();
+    state
+        .persistence
+        .revoke_all_sessions_with_audit(
+            &username,
+            now,
+            AuditEvent {
+                event_id: uuid::Uuid::now_v7().to_string(),
+                request_id: actor.request_id.clone(),
+                actor: actor.actor.clone(),
+                action: AuditAction::SessionRevokeAll,
+                resource_type: AuditResourceType::Session,
+                resource_name: Some(username.clone()),
+                environment_id: None,
+                outcome: AuditOutcome::Succeeded,
+                detail: None,
+                created_at_ms: now,
+            },
+        )
+        .await
+        .map_err(Into::into)
+}
+
+fn parse_session_cursor(value: &str) -> Result<SessionCursor, DashboardError> {
+    let (created_at_ms, session_id) = value
+        .split_once(',')
+        .ok_or_else(|| DashboardError::Validation("session cursor is invalid".to_string()))?;
+    if uuid::Uuid::parse_str(session_id).is_err() {
+        return Err(DashboardError::Validation("session cursor is invalid".to_string()));
+    }
+    Ok(SessionCursor {
+        created_at_ms: created_at_ms
+            .parse()
+            .map_err(|_| DashboardError::Validation("session cursor is invalid".to_string()))?,
+        session_id: session_id.to_string(),
+    })
+}
+
+pub fn token_hash(token: &str) -> SessionTokenHash {
+    let digest = Sha256::digest(token.as_bytes());
+    let mut hash = [0; 32];
+    hash.copy_from_slice(&digest);
+    SessionTokenHash(hash)
+}
+
+fn generate_token() -> Result<String, DashboardError> {
+    let mut bytes = [0_u8; 32];
+    getrandom::fill(&mut bytes)
+        .map_err(|_| DashboardError::Internal("Could not generate session token".to_string()))?;
+    Ok(URL_SAFE_NO_PAD.encode(bytes))
+}
+
+fn authentication_required() -> DashboardError {
+    DashboardError::Auth("Authentication required".to_string())
 }
 
 fn now_millis() -> i64 {
@@ -118,29 +361,13 @@ fn now_millis() -> i64 {
 
 #[cfg(test)]
 mod tests {
-    use super::AuthState;
-    use crate::config::AuthConfig;
-    use crate::model::LoginRequest;
+    use super::token_hash;
 
-    #[tokio::test]
-    async fn auth_state_validates_session_id() {
-        let state = AuthState::new(AuthConfig {
-            login_required: true,
-            username: "admin".to_string(),
-            password: "rocketmq".to_string(),
-        });
-
-        assert!(!state.is_authorized(None).await);
-        let session = state
-            .login(LoginRequest {
-                username: "admin".to_string(),
-                password: "rocketmq".to_string(),
-            })
-            .await
-            .expect("login");
-        let session_id = session.session_id.expect("session id");
-
-        assert!(state.is_authorized(Some(&session_id)).await);
-        assert!(!state.is_authorized(Some("invalid")).await);
+    #[test]
+    fn token_hash_is_fixed_width_and_does_not_retain_plaintext() {
+        let token = "a plaintext token which must never be persisted";
+        let hash = token_hash(token);
+        assert_eq!(hash.bytes().len(), 32);
+        assert_ne!(hash.lower_hex(), token);
     }
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/config_service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/config_service.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use crate::error::DashboardError;
+use crate::model::AuditEvent;
 use crate::model::{
     AddressRequest, BoolSettingRequest, ConfigMutationResult, DashboardConfigView, DashboardEnvironment, Endpoint,
     EndpointId, EndpointRequest, EndpointRole, EndpointType, NameserverAvailabilityStatus, NameserverAvailabilityView,
@@ -63,6 +64,7 @@ async fn check_nameserver_endpoint(address: String) -> NameserverEndpointAvailab
 pub async fn replace_nameservers(
     state: &AppState,
     request: NameserverListRequest,
+    audit: Option<AuditEvent>,
 ) -> Result<ConfigMutationResult, DashboardError> {
     let addresses = normalize_address_list(&request.namesrv_addr_list, "NameServer")?;
     let active = request
@@ -78,7 +80,7 @@ pub async fn replace_nameservers(
             "Current NameServer must exist in the NameServer list".to_string(),
         ));
     }
-    persist_environment(state, request.expected_revision, move |environment| {
+    persist_environment(state, request.expected_revision, audit, move |environment| {
         replace_endpoints(environment, EndpointType::Nameserver, addresses, active);
         Ok(())
     })
@@ -89,9 +91,13 @@ pub async fn replace_nameservers(
     })
 }
 
-pub async fn add_nameserver(state: &AppState, request: AddressRequest) -> Result<ConfigMutationResult, DashboardError> {
+pub async fn add_nameserver(
+    state: &AppState,
+    request: AddressRequest,
+    audit: Option<AuditEvent>,
+) -> Result<ConfigMutationResult, DashboardError> {
     let address = normalize_address(&request.address, "NameServer")?;
-    persist_environment(state, request.expected_revision, move |environment| {
+    persist_environment(state, request.expected_revision, audit, move |environment| {
         add_endpoint(environment, EndpointType::Nameserver, address);
         Ok(())
     })
@@ -105,8 +111,9 @@ pub async fn add_nameserver(state: &AppState, request: AddressRequest) -> Result
 pub async fn set_vip_channel(
     state: &AppState,
     request: BoolSettingRequest,
+    audit: Option<AuditEvent>,
 ) -> Result<ConfigMutationResult, DashboardError> {
-    persist_environment(state, request.expected_revision, move |environment| {
+    persist_environment(state, request.expected_revision, audit, move |environment| {
         environment.use_vip_channel = request.enabled;
         Ok(())
     })
@@ -117,8 +124,12 @@ pub async fn set_vip_channel(
     })
 }
 
-pub async fn set_tls(state: &AppState, request: BoolSettingRequest) -> Result<ConfigMutationResult, DashboardError> {
-    persist_environment(state, request.expected_revision, move |environment| {
+pub async fn set_tls(
+    state: &AppState,
+    request: BoolSettingRequest,
+    audit: Option<AuditEvent>,
+) -> Result<ConfigMutationResult, DashboardError> {
+    persist_environment(state, request.expected_revision, audit, move |environment| {
         environment.use_tls = request.enabled;
         Ok(())
     })
@@ -129,9 +140,13 @@ pub async fn set_tls(state: &AppState, request: BoolSettingRequest) -> Result<Co
     })
 }
 
-pub async fn add_proxy(state: &AppState, request: AddressRequest) -> Result<ConfigMutationResult, DashboardError> {
+pub async fn add_proxy(
+    state: &AppState,
+    request: AddressRequest,
+    audit: Option<AuditEvent>,
+) -> Result<ConfigMutationResult, DashboardError> {
     let address = normalize_address(&request.address, "Proxy")?;
-    persist_environment(state, request.expected_revision, move |environment| {
+    persist_environment(state, request.expected_revision, audit, move |environment| {
         add_endpoint(environment, EndpointType::Proxy, address);
         Ok(())
     })
@@ -142,17 +157,31 @@ pub async fn add_proxy(state: &AppState, request: AddressRequest) -> Result<Conf
     })
 }
 
-pub async fn switch_proxy(state: &AppState, request: EndpointRequest) -> Result<ConfigMutationResult, DashboardError> {
-    switch_endpoint(state, request, EndpointType::Proxy, "Proxy", "Current Proxy switched").await
+pub async fn switch_proxy(
+    state: &AppState,
+    request: EndpointRequest,
+    audit: Option<AuditEvent>,
+) -> Result<ConfigMutationResult, DashboardError> {
+    switch_endpoint(
+        state,
+        request,
+        audit,
+        EndpointType::Proxy,
+        "Proxy",
+        "Current Proxy switched",
+    )
+    .await
 }
 
 pub async fn switch_nameserver(
     state: &AppState,
     request: EndpointRequest,
+    audit: Option<AuditEvent>,
 ) -> Result<ConfigMutationResult, DashboardError> {
     switch_endpoint(
         state,
         request,
+        audit,
         EndpointType::Nameserver,
         "NameServer",
         "Current NameServer switched",
@@ -163,11 +192,12 @@ pub async fn switch_nameserver(
 async fn switch_endpoint(
     state: &AppState,
     request: EndpointRequest,
+    audit: Option<AuditEvent>,
     endpoint_type: EndpointType,
     label: &'static str,
     message: &'static str,
 ) -> Result<ConfigMutationResult, DashboardError> {
-    persist_environment(state, request.expected_revision, move |environment| {
+    persist_environment(state, request.expected_revision, audit, move |environment| {
         let mut found = false;
         let now_ms = Utc::now().timestamp_millis();
         for endpoint in &mut environment.endpoints {
@@ -197,11 +227,13 @@ pub async fn delete_proxy(
     state: &AppState,
     endpoint_id: &EndpointId,
     expected_revision: Revision,
+    audit: Option<AuditEvent>,
 ) -> Result<ConfigMutationResult, DashboardError> {
     delete_endpoint(
         state,
         endpoint_id,
         expected_revision,
+        audit,
         EndpointType::Proxy,
         "Proxy",
         "Proxy deleted",
@@ -213,11 +245,13 @@ pub async fn delete_nameserver(
     state: &AppState,
     endpoint_id: &EndpointId,
     expected_revision: Revision,
+    audit: Option<AuditEvent>,
 ) -> Result<ConfigMutationResult, DashboardError> {
     delete_endpoint(
         state,
         endpoint_id,
         expected_revision,
+        audit,
         EndpointType::Nameserver,
         "NameServer",
         "NameServer deleted",
@@ -229,12 +263,13 @@ async fn delete_endpoint(
     state: &AppState,
     endpoint_id: &EndpointId,
     expected_revision: Revision,
+    audit: Option<AuditEvent>,
     endpoint_type: EndpointType,
     label: &'static str,
     message: &'static str,
 ) -> Result<ConfigMutationResult, DashboardError> {
     let endpoint_id = endpoint_id.clone();
-    persist_environment(state, expected_revision, move |environment| {
+    persist_environment(state, expected_revision, audit, move |environment| {
         let previous_len = environment.endpoints.len();
         environment
             .endpoints
@@ -255,6 +290,7 @@ async fn delete_endpoint(
 async fn persist_environment<F>(
     state: &AppState,
     expected_revision: Revision,
+    audit: Option<AuditEvent>,
     operation: F,
 ) -> Result<DashboardConfigView, DashboardError>
 where
@@ -262,7 +298,7 @@ where
 {
     state
         .run_persisted_mutation("dashboard-config-candidate-persist-publish", move |state| async move {
-            persist_environment_owned(&state, expected_revision, operation).await
+            persist_environment_owned(&state, expected_revision, audit, operation).await
         })
         .await
 }
@@ -270,6 +306,7 @@ where
 async fn persist_environment_owned<F>(
     state: &AppState,
     expected_revision: Revision,
+    audit: Option<AuditEvent>,
     operation: F,
 ) -> Result<DashboardConfigView, DashboardError>
 where
@@ -283,7 +320,16 @@ where
     }
     operation(&mut candidate)?;
     candidate.updated_at_ms = Utc::now().timestamp_millis();
-    let persisted = match state.persistence.update_environment(expected_revision, candidate).await {
+    let persisted = match audit {
+        Some(audit) => {
+            state
+                .persistence
+                .update_environment_with_audit(expected_revision, candidate, audit)
+                .await
+        }
+        None => state.persistence.update_environment(expected_revision, candidate).await,
+    };
+    let persisted = match persisted {
         Ok(environment) => environment,
         Err(PersistenceError::Conflict) => {
             // Reconcile before reporting the stable conflict so a following

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/health_service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/health_service.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 use crate::model::DashboardHistoryHealth;
 use crate::model::HealthStatus;
+use crate::model::SessionAuditCleanupHealth;
 use crate::persistence::DashboardPersistence;
 use crate::persistence::StorageHealth;
 use crate::persistence::StorageStatus;
@@ -22,12 +23,21 @@ pub fn liveness_status() -> HealthStatus {
         status: "UP".to_string(),
         storage: None,
         history: None,
+        session_audit_cleanup: None,
     }
 }
 
-pub async fn readiness_status(persistence: &DashboardPersistence, history: DashboardHistoryHealth) -> HealthStatus {
+pub async fn readiness_status(
+    persistence: &DashboardPersistence,
+    history: DashboardHistoryHealth,
+    session_audit_cleanup: SessionAuditCleanupHealth,
+) -> HealthStatus {
     let mut status = readiness_status_from_storage(persistence.storage_health().await);
     status.history = Some(history);
+    if session_audit_cleanup.connectivity != "available" {
+        status.status = "DOWN".to_string();
+    }
+    status.session_audit_cleanup = Some(session_audit_cleanup);
     status
 }
 
@@ -40,6 +50,7 @@ pub fn readiness_status_from_storage(storage: StorageHealth) -> HealthStatus {
         },
         storage: Some(storage),
         history: None,
+        session_audit_cleanup: None,
     }
 }
 

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/monitor_service.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/monitor_service.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 use crate::error::DashboardError;
 use crate::model::{
-    ConsumerMonitorMutationResult, ConsumerMonitorRule, ConsumerMonitorUpsertRequest, ConsumerMonitorView,
+    AuditEvent, ConsumerMonitorMutationResult, ConsumerMonitorRule, ConsumerMonitorUpsertRequest, ConsumerMonitorView,
     EnvironmentId,
 };
 use crate::persistence::Revision;
@@ -34,6 +34,7 @@ pub async fn list_consumer_monitors(
 pub async fn create_or_update_consumer_monitor(
     state: &AppState,
     request: ConsumerMonitorUpsertRequest,
+    audit: Option<AuditEvent>,
 ) -> Result<ConsumerMonitorMutationResult, DashboardError> {
     let rule = ConsumerMonitorRule {
         environment_id: request.environment_id,
@@ -47,7 +48,15 @@ pub async fn create_or_update_consumer_monitor(
     let expected_revision = request.expected_revision;
     state
         .run_persisted_mutation("dashboard-monitor-candidate-persist", move |state| async move {
-            let saved = state.persistence.upsert_monitor_rule(rule, expected_revision).await?;
+            let saved = match audit {
+                Some(audit) => {
+                    state
+                        .persistence
+                        .upsert_monitor_rule_with_audit(rule, expected_revision, audit)
+                        .await?
+                }
+                None => state.persistence.upsert_monitor_rule(rule, expected_revision).await?,
+            };
             let item = ConsumerMonitorView::from(saved);
             Ok(ConsumerMonitorMutationResult {
                 message: format!("Consumer monitor {} saved", item.consumer_group),
@@ -62,15 +71,26 @@ pub async fn delete_consumer_monitor(
     environment_id: &EnvironmentId,
     consumer_group: &str,
     expected_revision: Revision,
+    audit: Option<AuditEvent>,
 ) -> Result<ConsumerMonitorMutationResult, DashboardError> {
     let environment_id = environment_id.clone();
     let consumer_group = consumer_group.to_string();
     state
         .run_persisted_mutation("dashboard-monitor-delete", move |state| async move {
-            let removed = state
-                .persistence
-                .delete_monitor_rule(&environment_id, &consumer_group, expected_revision)
-                .await?;
+            let removed = match audit {
+                Some(audit) => {
+                    state
+                        .persistence
+                        .delete_monitor_rule_with_audit(&environment_id, &consumer_group, expected_revision, audit)
+                        .await?
+                }
+                None => {
+                    state
+                        .persistence
+                        .delete_monitor_rule(&environment_id, &consumer_group, expected_revision)
+                        .await?
+                }
+            };
             Ok(ConsumerMonitorMutationResult {
                 message: if removed {
                     format!("Consumer monitor {consumer_group} deleted")

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/session_audit_cleanup.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/service/session_audit_cleanup.rs
@@ -1,0 +1,136 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::config::AuthConfig;
+use crate::error::DashboardError;
+use crate::model::SessionAuditCleanupHealth;
+use crate::persistence::DashboardPersistence;
+use chrono::Utc;
+use rocketmq_runtime::ChildServiceContext;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tokio::time::MissedTickBehavior;
+
+#[derive(Debug, Clone)]
+pub struct SessionAuditCleanupRuntime {
+    state: Arc<RwLock<SessionAuditCleanupHealth>>,
+}
+
+impl SessionAuditCleanupRuntime {
+    pub fn new(persistence: &DashboardPersistence) -> Self {
+        Self {
+            state: Arc::new(RwLock::new(SessionAuditCleanupHealth {
+                backend: persistence.storage_backend(),
+                connectivity: "available".to_string(),
+                role: "standby".to_string(),
+                last_cleanup_at_ms: None,
+                recent_error: None,
+            })),
+        }
+    }
+
+    pub async fn health(&self) -> SessionAuditCleanupHealth {
+        self.state.read().await.clone()
+    }
+
+    async fn leader(&self) {
+        let mut state = self.state.write().await;
+        state.connectivity = "available".to_string();
+        state.role = "leader".to_string();
+        state.recent_error = None;
+    }
+
+    async fn standby(&self) {
+        let mut state = self.state.write().await;
+        state.connectivity = "available".to_string();
+        state.role = "standby".to_string();
+    }
+
+    async fn success(&self) {
+        let mut state = self.state.write().await;
+        state.connectivity = "available".to_string();
+        state.last_cleanup_at_ms = Some(Utc::now().timestamp_millis());
+        state.recent_error = None;
+    }
+
+    async fn unavailable(&self) {
+        let mut state = self.state.write().await;
+        state.connectivity = "unavailable".to_string();
+        state.recent_error = Some("session and audit cleanup is unavailable".to_string());
+    }
+}
+
+/// Starts the owned bounded retention loop. MySQL and PostgreSQL acquire a
+/// dedicated fenced task lease before a batch; File and mounted SQLite are
+/// single-node stores and use their process/instance coordination instead.
+pub fn start_session_audit_cleanup(
+    service_context: ChildServiceContext,
+    persistence: Arc<DashboardPersistence>,
+    config: AuthConfig,
+    runtime: SessionAuditCleanupRuntime,
+) -> Result<(), DashboardError> {
+    let cancellation = service_context.task_group().cancellation_token();
+    service_context
+        .spawn_service("dashboard-session-audit-cleanup", async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(config.cleanup_interval_secs));
+            interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+            let holder_id = uuid::Uuid::now_v7().to_string();
+            let lease_ttl_ms = i64::try_from(config.cleanup_interval_secs)
+                .ok()
+                .and_then(|seconds| seconds.checked_mul(1_000))
+                .map(|ttl| ttl.clamp(30_000, 3_600_000))
+                .unwrap_or(30_000);
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = cancellation.cancelled() => break,
+                    _ = interval.tick() => {
+                        let lease = if persistence.session_audit_cleanup_uses_sql_lease() {
+                            match persistence.acquire_session_audit_cleanup_lease(&holder_id, lease_ttl_ms).await {
+                                Ok(Some(lease)) => Some(lease),
+                                Ok(None) => {
+                                    runtime.standby().await;
+                                    continue;
+                                }
+                                Err(_) => {
+                                    runtime.unavailable().await;
+                                    continue;
+                                }
+                            }
+                        } else {
+                            None
+                        };
+                        runtime.leader().await;
+                        let now = Utc::now().timestamp_millis();
+                        let session_cutoff = now.saturating_sub(i64::from(config.session_retention_days) * 86_400_000);
+                        let audit_cutoff = now.saturating_sub(i64::from(config.audit_retention_days) * 86_400_000);
+                        let result = async {
+                            persistence.delete_sessions_before(session_cutoff, config.cleanup_batch_size as usize).await?;
+                            persistence.delete_audit_before(audit_cutoff, config.cleanup_batch_size as usize).await
+                        }.await;
+                        match result {
+                            Ok(_) => runtime.success().await,
+                            Err(_) => runtime.unavailable().await,
+                        }
+                        if let Some(lease) = lease {
+                            let _ = persistence.release_history_lease(&lease).await;
+                        }
+                    }
+                }
+            }
+            runtime.standby().await;
+        })
+        .map_err(|error| DashboardError::internal_source("Could not start session and audit cleanup", error))?;
+    Ok(())
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/state/app_state.rs
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/backend/src/state/app_state.rs
@@ -24,7 +24,9 @@ use crate::persistence::error::PersistenceError;
 use crate::service::AuthState;
 use crate::service::DashboardHistoryRuntime;
 use crate::service::HistoryCollectorConfig;
+use crate::service::SessionAuditCleanupRuntime;
 use crate::service::start_dashboard_history_collector;
+use crate::service::start_session_audit_cleanup;
 use rocketmq_admin_core::client_adapter::ClientRuntime;
 use rocketmq_dashboard_common::DashboardAdminFacade;
 use std::future::Future;
@@ -60,6 +62,7 @@ pub struct AppState {
     persisted_mutation_context: rocketmq_runtime::ChildServiceContext,
     pub auth_state: Arc<AuthState>,
     pub history_runtime: DashboardHistoryRuntime,
+    pub session_audit_cleanup_runtime: SessionAuditCleanupRuntime,
     pub published_environment: Arc<std::sync::RwLock<PublishedEnvironment>>,
     pub admin_client: DashboardAdminClient,
     #[cfg(test)]
@@ -91,7 +94,8 @@ impl AppState {
                 .await?,
         );
         ensure_persistence_ready(persistence.storage_health().await)?;
-        let auth_state = Arc::new(AuthState::new(config.auth));
+        let session_audit_config = config.auth.clone();
+        let auth_state = Arc::new(AuthState::new(config.auth)?);
         let environment = load_or_create_default_environment(&persistence, &config.initial_config).await?;
         let history_environment_id = environment.environment_id.clone();
         let published_environment = Arc::new(std::sync::RwLock::new(PublishedEnvironment::from_environment(
@@ -121,6 +125,13 @@ impl AppState {
                 history_runtime.clone(),
             )?;
         }
+        let session_audit_cleanup_runtime = SessionAuditCleanupRuntime::new(&persistence);
+        start_session_audit_cleanup(
+            client_runtime.component("dashboard-session-audit-cleanup"),
+            persistence.clone(),
+            session_audit_config,
+            session_audit_cleanup_runtime.clone(),
+        )?;
 
         let state = Self {
             persistence,
@@ -129,6 +140,7 @@ impl AppState {
             persisted_mutation_context,
             auth_state,
             history_runtime,
+            session_audit_cleanup_runtime,
             published_environment,
             admin_client,
             #[cfg(test)]
@@ -397,6 +409,7 @@ mod tests {
                 login_required: false,
                 username: "admin".to_string(),
                 password: "test-password".to_string(),
+                ..AuthConfig::default()
             },
             dashboard_history_interval_secs: 0,
             dashboard_history_retention_days: 30,
@@ -470,6 +483,7 @@ mod tests {
                         address: "127.0.0.2:8080".to_string(),
                         expected_revision: initial.revision,
                     },
+                    None,
                 )
                 .await
             });
@@ -534,6 +548,7 @@ mod tests {
                         max_diff_total: 0,
                         expected_revision: Revision(0),
                     },
+                    None,
                 )
                 .await
             });

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/App.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import AppLayout from './layouts/AppLayout';
 import { ConsumerQueryScopeProvider } from './pages/consumers/ConsumerQueryScopeProvider';
 
 const AclPage = lazy(() => import('./pages/AclPage'));
+const AuditPage = lazy(() => import('./pages/AuditPage'));
 const BrokerDetailPage = lazy(() => import('./pages/BrokerDetailPage'));
 const BrokerListPage = lazy(() => import('./pages/BrokerListPage'));
 const ConfigPage = lazy(() => import('./pages/ConfigPage'));
@@ -18,6 +19,7 @@ const MessageTracePage = lazy(() => import('./pages/MessageTracePage'));
 const MonitorPage = lazy(() => import('./pages/MonitorPage'));
 const ProducerListPage = lazy(() => import('./pages/ProducerListPage'));
 const ProxyPage = lazy(() => import('./pages/ProxyPage'));
+const SessionAdminPage = lazy(() => import('./pages/SessionAdminPage'));
 const TopicDetailPage = lazy(() => import('./pages/TopicDetailPage'));
 const TopicListPage = lazy(() => import('./pages/TopicListPage'));
 
@@ -49,7 +51,9 @@ export default function App() {
                   <Route path="/dlq" element={<Navigate to="/messages/dlq" replace />} />
                   <Route path="/message-trace" element={<MessageTracePage />} />
                   <Route path="/acl" element={<AclPage />} />
+                  <Route path="/audit" element={<AuditPage />} />
                   <Route path="/monitors" element={<MonitorPage />} />
+                  <Route path="/sessions" element={<SessionAdminPage />} />
                   <Route path="/config" element={<ConfigPage />} />
                   <Route path="*" element={<Navigate to="/dashboard" replace />} />
                 </Routes>

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/api/audit_api.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/api/audit_api.ts
@@ -1,0 +1,20 @@
+import { apiClient } from './client';
+import type { AuditEventPage, AuditEventQuery, SessionListPage } from '../types/audit';
+
+function queryString(query: object) {
+  const parameters = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    if ((typeof value === 'string' || typeof value === 'number') && value !== '') parameters.set(key, String(value));
+  }
+  const encoded = parameters.toString();
+  return encoded ? `?${encoded}` : '';
+}
+
+export const auditApi = {
+  listSessions: (query: { username?: string; cursor?: string; limit?: number } = {}) =>
+    apiClient.get<SessionListPage>(`/api/auth/sessions${queryString(query)}`),
+  revokeAllSessions: (username: string) =>
+    apiClient.post<{ revoked: number }>('/api/auth/sessions/revoke-all', { username }),
+  listEvents: (query: AuditEventQuery = {}) =>
+    apiClient.get<AuditEventPage>(`/api/audit/events${queryString(query)}`)
+};

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/api/auth_api.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/api/auth_api.ts
@@ -5,9 +5,10 @@ export const authApi = {
   session: () => apiClient.get<SessionView>('/api/auth/session'),
   login: async (request: LoginRequest) => {
     const session = await apiClient.post<SessionView>('/api/auth/login', request);
-    if (session.sessionId) {
-      authSessionStore.set(session.sessionId);
-    }
+    // New sessions are carried by the HttpOnly cookie. Clear a stale legacy
+    // header credential so it cannot conflict with that cookie on the next
+    // protected request.
+    authSessionStore.clear();
     return session;
   },
   logout: async () => {

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/api/client.test.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/api/client.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { authApi } from './auth_api';
+import { ApiClientError, apiClient, authSessionStore, handleAppliedAuditFailure } from './client';
+
+function apiResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' }
+  });
+}
+
+describe('dashboard API client terminal mutation and session handling', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    authSessionStore.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    authSessionStore.clear();
+  });
+
+  it.each([
+    { success: true, code: 'APPLIED_AUDIT_FAILED', message: 'Applied without audit.' },
+    { success: true, code: 'APPLIED_AUDIT_FAILED', message: 'Applied with audit fallback.', data: { changed: true } }
+  ])('treats APPLIED_AUDIT_FAILED as terminal before data validation', async (body) => {
+    const warning = vi.fn();
+    window.addEventListener('rocketmq-audit-warning', warning, { once: true });
+    vi.mocked(fetch).mockResolvedValueOnce(apiResponse(body));
+
+    await expect(apiClient.post('/api/mutation', { changed: true })).rejects.toMatchObject({
+      code: 'APPLIED_AUDIT_FAILED',
+      mutationApplied: true
+    } satisfies Partial<ApiClientError>);
+    expect(warning).toHaveBeenCalledOnce();
+  });
+
+  it('clears a stale header credential after cookie login so later requests do not conflict', async () => {
+    authSessionStore.set('legacy-stale-token');
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(apiResponse({ success: true, code: 'OK', message: 'success', data: { authenticated: true } }))
+      .mockResolvedValueOnce(apiResponse({ success: true, code: 'OK', message: 'success', data: { configured: true } }));
+
+    await authApi.login({ username: 'operator', password: 'password' });
+    expect(authSessionStore.get()).toBeNull();
+    await apiClient.get('/api/config');
+
+    const protectedRequest = vi.mocked(fetch).mock.calls[1][1];
+    expect(new Headers(protectedRequest?.headers).has('x-dashboard-session')).toBe(false);
+  });
+
+  it('clears the legacy credential for an unauthenticated response even without JSON', async () => {
+    authSessionStore.set('expired-token');
+    vi.mocked(fetch).mockResolvedValueOnce(new Response('', { status: 401, statusText: 'Unauthorized' }));
+
+    await expect(apiClient.get('/api/config')).rejects.toMatchObject({ code: '401' });
+    expect(authSessionStore.get()).toBeNull();
+  });
+
+  it('settles an applied audit failure once without giving mutation UIs a retry path', async () => {
+    const onApplied = vi.fn();
+    const refresh = vi.fn().mockResolvedValue(undefined);
+    const handled = await handleAppliedAuditFailure(
+      new ApiClientError('APPLIED_AUDIT_FAILED', 'Mutation applied.', { mutationApplied: true }),
+      { onApplied, refresh }
+    );
+
+    expect(handled).toBe(true);
+    expect(onApplied).toHaveBeenCalledTimes(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
+    await expect(handleAppliedAuditFailure(new Error('ordinary failure'), { onApplied, refresh })).resolves.toBe(false);
+    expect(onApplied).toHaveBeenCalledTimes(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/api/client.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/api/client.ts
@@ -2,6 +2,7 @@ import type { ApiResponse } from '../types/api';
 
 const apiBaseUrl = import.meta.env.VITE_API_BASE_URL ?? '';
 const sessionStorageKey = 'rocketmq-dashboard-web-session';
+export const appliedAuditFailedCode = 'APPLIED_AUDIT_FAILED';
 
 export const authSessionStore = {
   get: () => window.localStorage.getItem(sessionStorageKey),
@@ -11,11 +12,49 @@ export const authSessionStore = {
 
 export class ApiClientError extends Error {
   readonly code: string;
+  readonly mutationApplied: boolean;
 
-  constructor(code: string, message: string) {
+  constructor(code: string, message: string, options: { mutationApplied?: boolean } = {}) {
     super(message);
     this.code = code;
+    this.mutationApplied = options.mutationApplied ?? false;
   }
+}
+
+export function isAppliedAuditFailure(error: unknown): error is ApiClientError {
+  // The error code is the protocol contract. `mutationApplied` is an
+  // additional local signal for callers that need it, but a UI must never
+  // expose a retry merely because an adapter reconstructed this typed error.
+  return error instanceof ApiClientError && error.code === appliedAuditFailedCode;
+}
+
+/**
+ * Settles a mutation that committed remotely but whose audit event could not
+ * be recorded. The mutation must remain terminal: close or disable its UI
+ * synchronously, then fetch authoritative state exactly once without
+ * resubmitting the original request.
+ */
+export async function handleAppliedAuditFailure(
+  error: unknown,
+  options: {
+    onApplied: () => void;
+    refresh?: () => Promise<unknown> | void;
+  }
+): Promise<boolean> {
+  if (!isAppliedAuditFailure(error)) return false;
+  options.onApplied();
+  try {
+    await options.refresh?.();
+  } catch {
+    // The global audit warning is already retained by the API client. A
+    // refresh failure must not turn this terminal mutation into a retry.
+  }
+  return true;
+}
+
+function notifyAuthenticationExpired() {
+  authSessionStore.clear();
+  window.dispatchEvent(new Event('rocketmq-auth-expired'));
 }
 
 function emptyResponseMessage(path: string, response: Response) {
@@ -38,6 +77,7 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const sessionId = authSessionStore.get();
   const response = await fetch(`${apiBaseUrl}${path}`, {
     ...init,
+    credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
       ...(sessionId ? { 'x-dashboard-session': sessionId } : {}),
@@ -45,6 +85,10 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     }
   });
   const responseText = await response.text();
+  // An HTTP 401 is authoritative even when an intermediary has stripped or
+  // replaced the JSON body. Do not retain a legacy header credential that
+  // would conflict with a fresh HttpOnly session on the next request.
+  if (response.status === 401) notifyAuthenticationExpired();
   if (responseText.trim() === '') {
     throw new ApiClientError(response.ok ? 'EMPTY_RESPONSE' : String(response.status), emptyResponseMessage(path, response));
   }
@@ -56,9 +100,19 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     throw new ApiClientError(response.ok ? 'INVALID_JSON' : String(response.status), invalidJsonMessage(path, response));
   }
 
+  // This terminal result is intentionally handled before generic success and
+  // data checks. The backend has applied the mutation, so exposing response
+  // data (or an empty-response retry) could cause a second mutation.
+  if (payload.code === appliedAuditFailedCode) {
+    window.dispatchEvent(new CustomEvent('rocketmq-audit-warning', { detail: payload.message }));
+    throw new ApiClientError(appliedAuditFailedCode, payload.message || 'The mutation was applied, but audit persistence failed.', {
+      mutationApplied: true
+    });
+  }
+
   if (!response.ok || !payload.success) {
-    if (payload.code === 'AUTH_ERROR') {
-      authSessionStore.clear();
+    if (response.status === 401 || payload.code === 'AUTH_ERROR' || payload.code === 'AUTH_TOKEN_AMBIGUOUS') {
+      notifyAuthenticationExpired();
     }
     throw new ApiClientError(payload.code || String(response.status), payload.message || response.statusText);
   }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/ConsumerDeleteDialog.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/ConsumerDeleteDialog.test.tsx
@@ -1,9 +1,22 @@
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { consumerApi } from '../api/consumer_api';
+import { ApiClientError } from '../api/client';
 import type { ConsumerGroupListItem, ConsumerOperationResult } from '../types/consumer';
+import { ConsumerQueryScopeProvider } from '../pages/consumers/ConsumerQueryScopeProvider';
 import ConsumerDeleteDialog from './ConsumerDeleteDialog';
+import { resetConsumerMutationLocksForTests } from './consumerMutationLock';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
 
 vi.mock('../api/consumer_api', () => ({
   consumerApi: {
@@ -42,6 +55,7 @@ const successResult: ConsumerOperationResult = {
 
 describe('ConsumerDeleteDialog', () => {
   beforeEach(() => {
+    resetConsumerMutationLocksForTests();
     vi.clearAllMocks();
     vi.mocked(consumerApi.brokers).mockResolvedValue({
       items: [
@@ -51,18 +65,24 @@ describe('ConsumerDeleteDialog', () => {
     });
   });
 
+  afterEach(() => {
+    resetConsumerMutationLocksForTests();
+  });
+
   it('requires exact group confirmation and full success before closing', async () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
     const onSucceeded = vi.fn();
     vi.mocked(consumerApi.delete).mockResolvedValue(successResult);
     render(
-      <ConsumerDeleteDialog
-        open
-        consumer={consumer}
-        onOpenChange={onOpenChange}
-        onSucceeded={onSucceeded}
-      />
+      <ConsumerQueryScopeProvider>
+        <ConsumerDeleteDialog
+          open
+          consumer={consumer}
+          onOpenChange={onOpenChange}
+          onSucceeded={onSucceeded}
+        />
+      </ConsumerQueryScopeProvider>
     );
 
     const dialog = screen.getByRole('dialog', { name: 'Delete consumer group' });
@@ -91,12 +111,14 @@ describe('ConsumerDeleteDialog', () => {
       ]
     });
     render(
-      <ConsumerDeleteDialog
-        open
-        consumer={consumer}
-        onOpenChange={onOpenChange}
-        onSucceeded={onSucceeded}
-      />
+      <ConsumerQueryScopeProvider>
+        <ConsumerDeleteDialog
+          open
+          consumer={consumer}
+          onOpenChange={onOpenChange}
+          onSucceeded={onSucceeded}
+        />
+      </ConsumerQueryScopeProvider>
     );
 
     const dialog = screen.getByRole('dialog', { name: 'Delete consumer group' });
@@ -107,5 +129,55 @@ describe('ConsumerDeleteDialog', () => {
     expect(await within(dialog).findByText((content) => content.includes('unavailable'))).toBeInTheDocument();
     expect(onOpenChange).not.toHaveBeenCalledWith(false);
     expect(onSucceeded).not.toHaveBeenCalled();
+  });
+
+  it('retains a delete lock across close and reopen until the original applied request settles', async () => {
+    const user = userEvent.setup();
+    const pendingDelete = deferred<ConsumerOperationResult>();
+    const pendingRefresh = deferred<void>();
+    const onOpenChange = vi.fn();
+    const onAppliedAuditFailure = vi.fn(() => pendingRefresh.promise);
+    const auditWarning = vi.fn();
+    window.addEventListener('rocketmq-audit-warning', auditWarning);
+    vi.mocked(consumerApi.delete).mockImplementationOnce(() => pendingDelete.promise);
+    const renderDialog = (mounted: boolean) => (
+      <ConsumerQueryScopeProvider>
+        {mounted ? <ConsumerDeleteDialog open consumer={consumer} onOpenChange={onOpenChange} onSucceeded={vi.fn()} onAppliedAuditFailure={onAppliedAuditFailure} /> : null}
+      </ConsumerQueryScopeProvider>
+    );
+    const { rerender } = render(renderDialog(true));
+
+    let dialog = screen.getByRole('dialog', { name: 'Delete consumer group' });
+    await user.click(await within(dialog).findByRole('checkbox', { name: 'broker-a' }));
+    await user.type(within(dialog).getByLabelText('Confirm consumer group'), 'orders-consumer');
+    await user.click(within(dialog).getByRole('button', { name: 'Delete consumer group' }));
+    await waitFor(() => expect(consumerApi.delete).toHaveBeenCalledTimes(1));
+
+    expect(within(dialog).getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    expect(within(dialog).getByRole('button', { name: 'Close dialog' })).toBeDisabled();
+    fireEvent.keyDown(dialog, { key: 'Escape' });
+    fireEvent.pointerDown(document.querySelector('.ui-overlay')!);
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    rerender(renderDialog(false));
+    rerender(renderDialog(true));
+    dialog = screen.getByRole('dialog', { name: 'Delete consumer group' });
+    await user.click(await within(dialog).findByRole('checkbox', { name: 'broker-a' }));
+    await user.type(within(dialog).getByLabelText('Confirm consumer group'), 'orders-consumer');
+    expect(within(dialog).getByRole('button', { name: 'Delete consumer group' })).toBeDisabled();
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent('rocketmq-audit-warning', { detail: 'Consumer deletion was applied.' }));
+      pendingDelete.reject(new ApiClientError('APPLIED_AUDIT_FAILED', 'Consumer deletion was applied.', { mutationApplied: true }));
+    });
+    await waitFor(() => expect(onAppliedAuditFailure).toHaveBeenCalledTimes(1));
+    expect(auditWarning).toHaveBeenCalledTimes(1);
+    expect(consumerApi.delete).toHaveBeenCalledTimes(1);
+    expect(within(screen.getByRole('dialog', { name: 'Delete consumer group' })).getByRole('button', { name: 'Delete consumer group' })).toBeDisabled();
+    expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument();
+
+    await act(async () => pendingRefresh.resolve());
+    await waitFor(() => expect(within(screen.getByRole('dialog', { name: 'Delete consumer group' })).getByRole('button', { name: 'Delete consumer group' })).toBeEnabled());
+    window.removeEventListener('rocketmq-audit-warning', auditWarning);
   });
 });

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/ConsumerDeleteDialog.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/ConsumerDeleteDialog.tsx
@@ -1,6 +1,21 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { consumerApi } from '../api/consumer_api';
-import type { ConsumerGroupListItem, ConsumerOperationResult } from '../types/consumer';
+import { handleAppliedAuditFailure, isAppliedAuditFailure } from '../api/client';
+import { useConsumerQueryScope } from '../pages/consumers/ConsumerQueryScopeProvider';
+import type {
+  ConsumerGroupListItem,
+  ConsumerOperationIdentity,
+  ConsumerOperationResult,
+  ConsumerQueryScope
+} from '../types/consumer';
+import {
+  beginConsumerMutation,
+  consumerMutationKey,
+  finishConsumerMutation,
+  isConsumerMutationLocked,
+  markConsumerMutationApplied,
+  useConsumerMutationLocked
+} from './consumerMutationLock';
 import { Button } from './ui/Button';
 import {
   Dialog,
@@ -15,44 +30,142 @@ import { Input } from './ui/Input';
 interface ConsumerDeleteDialogProps {
   open: boolean;
   consumer: ConsumerGroupListItem | null;
+  operationIdentity?: ConsumerOperationIdentity | null;
   onOpenChange: (open: boolean) => void;
   onSucceeded: (result: ConsumerOperationResult) => void;
+  onAppliedAuditFailure?: (identity: ConsumerOperationIdentity) => Promise<void> | void;
+}
+
+function scopeKey(scope: ConsumerQueryScope) {
+  return `${scope.mode}:${scope.proxyAddress ?? ''}`;
+}
+
+function sameIdentity(left: ConsumerOperationIdentity, right: ConsumerOperationIdentity) {
+  return left.group === right.group
+    && left.scopeKey === right.scopeKey
+    && left.generation === right.generation;
 }
 
 export default function ConsumerDeleteDialog({
   open,
   consumer,
+  operationIdentity,
   onOpenChange,
-  onSucceeded
+  onSucceeded,
+  onAppliedAuditFailure
 }: ConsumerDeleteDialogProps) {
+  const { scope } = useConsumerQueryScope();
+  const currentScopeKey = scopeKey(scope);
   const group = consumer?.rawGroupName ?? '';
   const [brokers, setBrokers] = useState<string[]>([]);
   const [selected, setSelected] = useState<string[]>([]);
   const [confirmation, setConfirmation] = useState('');
   const [loading, setLoading] = useState(false);
+  const [ready, setReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<ConsumerOperationResult | null>(null);
+  const mutationLockKey = consumerMutationKey('delete', group, currentScopeKey);
+  const mutationLocked = useConsumerMutationLocked(mutationLockKey);
+  const committedOperationRef = useRef<{
+    guardKey: string;
+    requestGeneration: number;
+    open: boolean;
+    scopeKey: string;
+    targetGroup: string;
+    identity: ConsumerOperationIdentity | null;
+  }>({ guardKey: '', requestGeneration: 0, open: false, scopeKey: currentScopeKey, targetGroup: '', identity: null });
+  const guardKey = [
+    String(open),
+    group,
+    currentScopeKey,
+    operationIdentity?.group ?? '',
+    operationIdentity?.scopeKey ?? '',
+    String(operationIdentity?.generation ?? '')
+  ].join('\u0000');
 
-  useEffect(() => {
-    if (!open || !consumer) return;
+  const committedOperation = committedOperationRef.current;
+  const activeOperation = committedOperation.guardKey === guardKey
+    ? committedOperation
+    : {
+      guardKey,
+      requestGeneration: committedOperation.requestGeneration + 1,
+      open,
+      scopeKey: currentScopeKey,
+      targetGroup: group,
+      identity: operationIdentity ?? null
+    };
+
+  useLayoutEffect(() => {
+    committedOperationRef.current = activeOperation;
+    setBrokers([]);
     setSelected([]);
     setConfirmation('');
     setError(null);
     setResult(null);
+    setLoading(false);
+    setReady(false);
+    return () => {
+      if (committedOperationRef.current.guardKey === activeOperation.guardKey
+        && committedOperationRef.current.requestGeneration === activeOperation.requestGeneration) {
+        committedOperationRef.current = {
+          guardKey: '',
+          requestGeneration: activeOperation.requestGeneration + 1,
+          open: false,
+          scopeKey: currentScopeKey,
+          targetGroup: '',
+          identity: null
+        };
+      }
+    };
+  }, [activeOperation]);
+
+  const isCurrentOperation = (identity: ConsumerOperationIdentity, requestGeneration: number, submittedTarget: string) => {
+    const current = committedOperationRef.current;
+    return requestGeneration === current.requestGeneration
+      && current.open
+      && current.scopeKey === identity.scopeKey
+      && current.targetGroup === submittedTarget
+      && current.targetGroup === group
+      && current.targetGroup === identity.group
+      && (!current.identity || sameIdentity(current.identity, identity));
+  };
+
+  const requestOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && isConsumerMutationLocked(mutationLockKey)) return;
+    onOpenChange(nextOpen);
+  };
+
+  const preventLockedDismiss = (event: { preventDefault: () => void }) => {
+    if (isConsumerMutationLocked(mutationLockKey)) event.preventDefault();
+  };
+
+  useEffect(() => {
+    if (!open || !group) return;
+    const requestGeneration = activeOperation.requestGeneration;
+    const identity = activeOperation.identity ?? {
+      group: activeOperation.targetGroup,
+      scopeKey: currentScopeKey,
+      generation: requestGeneration
+    };
+    const operationTarget = activeOperation.targetGroup;
+    if (!isCurrentOperation(identity, requestGeneration, operationTarget)) return;
     let cancelled = false;
     consumerApi
       .brokers(group)
       .then((result) => {
-        if (cancelled) return;
+        if (cancelled || !isCurrentOperation(identity, requestGeneration, operationTarget)) return;
         setBrokers(result.items.map((item) => item.brokerName).sort());
+        if (!cancelled && isCurrentOperation(identity, requestGeneration, operationTarget)) setReady(true);
       })
       .catch((reason: unknown) => {
-        if (!cancelled) setError(reason instanceof Error ? reason.message : String(reason));
+        if (!cancelled && isCurrentOperation(identity, requestGeneration, operationTarget)) {
+          setError(reason instanceof Error ? reason.message : String(reason));
+        }
       });
     return () => {
       cancelled = true;
     };
-  }, [open, consumer, group]);
+  }, [open, group, currentScopeKey, operationIdentity, activeOperation]);
 
   const toggle = (brokerName: string, checked: boolean) => {
     setSelected((current) => checked
@@ -69,26 +182,65 @@ export default function ConsumerDeleteDialog({
       setError(`Type the exact group name "${group}" to confirm.`);
       return;
     }
+    const operation = committedOperationRef.current;
+    const requestGeneration = operation.requestGeneration;
+    const identity = operation.identity ?? {
+      group,
+      scopeKey: currentScopeKey,
+      generation: requestGeneration
+    };
+    if (!isCurrentOperation(identity, requestGeneration, group)) return;
+    const ticket = beginConsumerMutation('delete', group, currentScopeKey);
+    if (!ticket) return;
     setLoading(true);
     setError(null);
     try {
       const result = await consumerApi.delete(group, { brokerNames: selected });
+      if (!isCurrentOperation(identity, requestGeneration, group)) return;
       setResult(result);
       const allSucceeded = result.success && result.targets.every((target) => target.success);
       if (allSucceeded) {
+        if (!isCurrentOperation(identity, requestGeneration, group)) return;
         onSucceeded(result);
+        if (!isCurrentOperation(identity, requestGeneration, group)) return;
         onOpenChange(false);
       }
     } catch (reason) {
-      setError(reason instanceof Error ? reason.message : String(reason));
+      if (isAppliedAuditFailure(reason)) {
+        if (markConsumerMutationApplied(ticket)) {
+          await handleAppliedAuditFailure(reason, {
+            onApplied: () => {
+              if (!isCurrentOperation(identity, requestGeneration, group)) return;
+              setError(null);
+              if (!isCurrentOperation(identity, requestGeneration, group)) return;
+              setResult(null);
+              if (!isCurrentOperation(identity, requestGeneration, group)) return;
+              onOpenChange(false);
+            },
+            refresh: async () => {
+              await onAppliedAuditFailure?.(identity);
+            }
+          });
+        }
+        return;
+      }
+      if (isCurrentOperation(identity, requestGeneration, group)) {
+        setError(reason instanceof Error ? reason.message : String(reason));
+      }
     } finally {
-      setLoading(false);
+      finishConsumerMutation(ticket);
+      if (isCurrentOperation(identity, requestGeneration, group)) setLoading(false);
     }
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+    <Dialog open={open} onOpenChange={requestOpenChange}>
+      <DialogContent
+        closeDisabled={mutationLocked}
+        onEscapeKeyDown={preventLockedDismiss}
+        onPointerDownOutside={preventLockedDismiss}
+        onInteractOutside={preventLockedDismiss}
+      >
         <DialogHeader>
           <DialogTitle>Delete consumer group</DialogTitle>
           <DialogDescription>
@@ -130,8 +282,8 @@ export default function ConsumerDeleteDialog({
         {error ? <div className="inline-validation" role="alert">{error}</div> : null}
 
         <DialogFooter>
-          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
-          <Button type="button" variant="destructive" disabled={loading || selected.length === 0 || confirmation.trim() !== group} onClick={() => void submit()}>
+          <Button type="button" variant="outline" disabled={mutationLocked} onClick={() => requestOpenChange(false)}>Cancel</Button>
+          <Button type="button" variant="destructive" disabled={mutationLocked || loading || !ready || selected.length === 0 || confirmation.trim() !== group} onClick={() => void submit()}>
             {loading ? 'Deleting' : 'Delete consumer group'}
           </Button>
         </DialogFooter>

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/ConsumerMutationDialog.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/ConsumerMutationDialog.test.tsx
@@ -1,11 +1,23 @@
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { brokerApi } from '../api/broker_api';
 import { consumerApi } from '../api/consumer_api';
+import { ApiClientError } from '../api/client';
 import type { ConsumerGroupListItem, ConsumerOperationResult } from '../types/consumer';
 import { ConsumerQueryScopeProvider } from '../pages/consumers/ConsumerQueryScopeProvider';
 import ConsumerMutationDialog from './ConsumerMutationDialog';
+import { resetConsumerMutationLocksForTests } from './consumerMutationLock';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
 
 vi.mock('../api/broker_api', () => ({
   brokerApi: { list: vi.fn() }
@@ -46,6 +58,7 @@ const successResult: ConsumerOperationResult = {
 
 describe('ConsumerMutationDialog', () => {
   beforeEach(() => {
+    resetConsumerMutationLocksForTests();
     vi.clearAllMocks();
     vi.mocked(brokerApi.list).mockResolvedValue({
       items: [{ clusterName: 'DefaultCluster', brokerName: 'broker-a', brokerId: 0, address: '127.0.0.1:10911', role: 'MASTER', version: 'V5_3_0', produceTps: 0, consumeTps: 0 }],
@@ -60,13 +73,14 @@ describe('ConsumerMutationDialog', () => {
 
     const dialog = screen.getByRole('dialog', { name: 'Create consumer group' });
     const save = within(dialog).getByRole('button', { name: 'Create group' });
-    expect(save).toBeEnabled();
+    await waitFor(() => expect(save).toBeEnabled());
     await user.click(save);
     expect(await within(dialog).findByRole('alert')).toHaveTextContent('Consumer group is required.');
     expect(consumerApi.create).not.toHaveBeenCalled();
 
     await user.type(within(dialog).getByLabelText('Consumer group'), 'orders-consumer');
     await user.click(await within(dialog).findByRole('checkbox', { name: 'broker-a' }));
+    await waitFor(() => expect(save).toBeEnabled());
     await user.click(save);
     expect(consumerApi.create).toHaveBeenCalled();
   });
@@ -118,5 +132,172 @@ describe('ConsumerMutationDialog', () => {
     await waitFor(() => expect(within(dialog).getByRole('checkbox', { name: 'broker-a' })).toBeChecked());
     expect(within(dialog).getByLabelText('Retry queue nums')).toHaveValue(4);
     expect(within(dialog).getByLabelText('Consume timeout minutes')).toHaveValue(20);
+  });
+
+  afterEach(() => {
+    resetConsumerMutationLocksForTests();
+  });
+
+  it('closes and refreshes once instead of retrying after an applied audit failure', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const onAppliedAuditFailure = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(consumerApi.create).mockRejectedValueOnce(
+      new ApiClientError('APPLIED_AUDIT_FAILED', 'Consumer mutation applied.', { mutationApplied: true })
+    );
+    render(<ConsumerQueryScopeProvider><ConsumerMutationDialog open mode="create" onOpenChange={onOpenChange} onSucceeded={vi.fn()} onAppliedAuditFailure={onAppliedAuditFailure} /></ConsumerQueryScopeProvider>);
+
+    const dialog = screen.getByRole('dialog', { name: 'Create consumer group' });
+    await user.type(within(dialog).getByLabelText('Consumer group'), 'orders-consumer');
+    await user.click(await within(dialog).findByRole('checkbox', { name: 'broker-a' }));
+    await user.click(within(dialog).getByRole('button', { name: 'Create group' }));
+
+    await waitFor(() => expect(consumerApi.create).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+    expect(onAppliedAuditFailure).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the immutable create target locked across remount and discards its stale applied callback', async () => {
+    const user = userEvent.setup();
+    const pendingCreate = deferred<ConsumerOperationResult>();
+    const onOpenChange = vi.fn();
+    const onSucceeded = vi.fn();
+    const onAppliedAuditFailure = vi.fn();
+    const auditWarning = vi.fn();
+    window.addEventListener('rocketmq-audit-warning', auditWarning);
+    vi.mocked(consumerApi.create).mockImplementationOnce(() => pendingCreate.promise);
+    const renderDialog = (mounted: boolean) => (
+      <ConsumerQueryScopeProvider>
+        {mounted ? (
+          <ConsumerMutationDialog
+            open
+            mode="create"
+            onOpenChange={onOpenChange}
+            onSucceeded={onSucceeded}
+            onAppliedAuditFailure={onAppliedAuditFailure}
+          />
+        ) : null}
+      </ConsumerQueryScopeProvider>
+    );
+    const { rerender } = render(renderDialog(true));
+
+    let dialog = screen.getByRole('dialog', { name: 'Create consumer group' });
+    await user.type(within(dialog).getByLabelText('Consumer group'), 'orders-consumer');
+    await user.click(await within(dialog).findByRole('checkbox', { name: 'broker-a' }));
+    await user.click(within(dialog).getByRole('button', { name: 'Create group' }));
+    await waitFor(() => expect(consumerApi.create).toHaveBeenCalledTimes(1));
+
+    expect(within(dialog).getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    expect(within(dialog).getByRole('button', { name: 'Close dialog' })).toBeDisabled();
+    fireEvent.keyDown(dialog, { key: 'Escape' });
+    fireEvent.pointerDown(document.querySelector('.ui-overlay')!);
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    rerender(renderDialog(false));
+    rerender(renderDialog(true));
+    dialog = screen.getByRole('dialog', { name: 'Create consumer group' });
+    const remountedGroup = within(dialog).getByLabelText('Consumer group');
+    expect(remountedGroup).toBeDisabled();
+    await user.type(remountedGroup, 'inventory-consumer');
+    expect(remountedGroup).toHaveValue('');
+    expect(within(dialog).getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    expect(within(dialog).getByRole('button', { name: 'Close dialog' })).toBeDisabled();
+    fireEvent.keyDown(dialog, { key: 'Escape' });
+    fireEvent.pointerDown(document.querySelector('.ui-overlay')!);
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(within(dialog).getByRole('button', { name: 'Create group' })).toBeDisabled();
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent('rocketmq-audit-warning', { detail: 'Consumer create was applied.' }));
+      pendingCreate.reject(new ApiClientError('APPLIED_AUDIT_FAILED', 'Consumer create was applied.', { mutationApplied: true }));
+    });
+    await waitFor(() => expect(within(screen.getByRole('dialog', { name: 'Create consumer group' })).getByRole('button', { name: 'Create group' })).toBeEnabled());
+    expect(onAppliedAuditFailure).not.toHaveBeenCalled();
+    expect(auditWarning).toHaveBeenCalledTimes(1);
+    expect(consumerApi.create).toHaveBeenCalledTimes(1);
+    expect(onSucceeded).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument();
+    window.removeEventListener('rocketmq-audit-warning', auditWarning);
+  });
+
+  it('releases a remounted create target only after the original successful request finally settles', async () => {
+    const user = userEvent.setup();
+    const pendingCreate = deferred<ConsumerOperationResult>();
+    const onOpenChange = vi.fn();
+    const onSucceeded = vi.fn();
+    vi.mocked(consumerApi.create).mockImplementationOnce(() => pendingCreate.promise);
+    const renderDialog = (mounted: boolean) => (
+      <ConsumerQueryScopeProvider>
+        {mounted ? <ConsumerMutationDialog open mode="create" onOpenChange={onOpenChange} onSucceeded={onSucceeded} /> : null}
+      </ConsumerQueryScopeProvider>
+    );
+    const { rerender } = render(renderDialog(true));
+
+    const originalDialog = screen.getByRole('dialog', { name: 'Create consumer group' });
+    await user.type(within(originalDialog).getByLabelText('Consumer group'), 'orders-consumer');
+    await user.click(await within(originalDialog).findByRole('checkbox', { name: 'broker-a' }));
+    await user.click(within(originalDialog).getByRole('button', { name: 'Create group' }));
+    await waitFor(() => expect(consumerApi.create).toHaveBeenCalledTimes(1));
+    expect(consumerApi.create).toHaveBeenCalledWith(expect.objectContaining({ consumerGroup: 'orders-consumer' }));
+
+    rerender(renderDialog(false));
+    rerender(renderDialog(true));
+    const remountedDialog = screen.getByRole('dialog', { name: 'Create consumer group' });
+    const groupInput = within(remountedDialog).getByLabelText('Consumer group');
+    expect(groupInput).toBeDisabled();
+    await user.type(groupInput, 'inventory-consumer');
+    expect(groupInput).toHaveValue('');
+    fireEvent.keyDown(remountedDialog, { key: 'Escape' });
+    fireEvent.pointerDown(document.querySelector('.ui-overlay')!);
+    expect(within(remountedDialog).getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    await act(async () => pendingCreate.resolve(successResult));
+    await waitFor(() => expect(within(screen.getByRole('dialog', { name: 'Create consumer group' })).getByLabelText('Consumer group')).toBeEnabled());
+    expect(consumerApi.create).toHaveBeenCalledTimes(1);
+    expect(onSucceeded).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('retains an edit lock across close and reopen while its applied refresh is still authoritative', async () => {
+    const user = userEvent.setup();
+    const pendingUpdate = deferred<ConsumerOperationResult>();
+    const pendingRefresh = deferred<void>();
+    const onAppliedAuditFailure = vi.fn(() => pendingRefresh.promise);
+    vi.mocked(consumerApi.config).mockResolvedValue({
+      group: consumer.rawGroupName,
+      effective: {
+        consumeEnable: true, consumeFromMinEnable: true, consumeBroadcastEnable: false, consumeMessageOrderly: false,
+        retryQueueNums: 1, retryMaxTimes: 16, brokerId: 0, whichBrokerWhenConsumeSlowly: 1,
+        notifyConsumerIdsChangedEnable: true, groupSysFlag: 0, consumeTimeoutMinute: 15, groupRetryPolicyJson: '{}'
+      },
+      inconsistentFields: [],
+      targets: [{ brokerName: 'broker-a', brokerAddress: '127.0.0.1:10911', config: null, subscriptionTopics: [], attributes: [] }],
+      queryScope: { mode: 'nameServer' }
+    });
+    vi.mocked(consumerApi.update).mockImplementationOnce(() => pendingUpdate.promise);
+    const renderDialog = (mounted: boolean) => (
+      <ConsumerQueryScopeProvider>
+        {mounted ? <ConsumerMutationDialog open mode="edit" consumer={consumer} onOpenChange={vi.fn()} onSucceeded={vi.fn()} onAppliedAuditFailure={onAppliedAuditFailure} /> : null}
+      </ConsumerQueryScopeProvider>
+    );
+    const { rerender } = render(renderDialog(true));
+    let dialog = screen.getByRole('dialog', { name: 'Edit orders-consumer' });
+    await waitFor(() => expect(within(dialog).getByRole('button', { name: 'Update group' })).toBeEnabled());
+    await user.click(await within(dialog).findByRole('checkbox', { name: 'broker-a' }));
+    await user.click(within(dialog).getByRole('button', { name: 'Update group' }));
+    await waitFor(() => expect(consumerApi.update).toHaveBeenCalledTimes(1));
+
+    rerender(renderDialog(false));
+    rerender(renderDialog(true));
+    dialog = screen.getByRole('dialog', { name: 'Edit orders-consumer' });
+    await waitFor(() => expect(within(dialog).getByRole('button', { name: 'Update group' })).toBeDisabled());
+    await act(async () => pendingUpdate.reject(new ApiClientError('APPLIED_AUDIT_FAILED', 'Consumer edit was applied.', { mutationApplied: true })));
+    await waitFor(() => expect(onAppliedAuditFailure).toHaveBeenCalledTimes(1));
+    expect(consumerApi.update).toHaveBeenCalledTimes(1);
+    expect(within(screen.getByRole('dialog', { name: 'Edit orders-consumer' })).getByRole('button', { name: 'Update group' })).toBeDisabled();
+
+    await act(async () => pendingRefresh.resolve());
+    await waitFor(() => expect(within(screen.getByRole('dialog', { name: 'Edit orders-consumer' })).getByRole('button', { name: 'Update group' })).toBeEnabled());
   });
 });

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/ConsumerMutationDialog.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/ConsumerMutationDialog.tsx
@@ -1,8 +1,25 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { brokerApi } from '../api/broker_api';
+import { handleAppliedAuditFailure, isAppliedAuditFailure } from '../api/client';
 import { consumerApi } from '../api/consumer_api';
 import { useConsumerQueryScope } from '../pages/consumers/ConsumerQueryScopeProvider';
-import type { ConsumerGroupListItem, ConsumerOperationResult, ConsumerUpsertRequest } from '../types/consumer';
+import type {
+  ConsumerGroupListItem,
+  ConsumerOperationIdentity,
+  ConsumerOperationResult,
+  ConsumerQueryScope,
+  ConsumerUpsertRequest
+} from '../types/consumer';
+import {
+  beginConsumerMutation,
+  completeConsumerMutation,
+  consumerMutationKey,
+  finishConsumerMutation,
+  isConsumerMutationLocked,
+  markConsumerMutationApplied,
+  useConsumerMutationInFlight,
+  useConsumerMutationLocked
+} from './consumerMutationLock';
 import { Button } from './ui/Button';
 import {
   Dialog,
@@ -19,8 +36,10 @@ interface ConsumerMutationDialogProps {
   open: boolean;
   mode: 'create' | 'edit';
   consumer?: ConsumerGroupListItem | null;
+  operationIdentity?: ConsumerOperationIdentity | null;
   onOpenChange: (open: boolean) => void;
   onSucceeded: (result: ConsumerOperationResult) => void;
+  onAppliedAuditFailure?: (identity: ConsumerOperationIdentity) => Promise<void> | void;
 }
 
 const defaultForm = (): Omit<ConsumerUpsertRequest, 'consumerGroup'> => ({
@@ -39,35 +58,140 @@ const defaultForm = (): Omit<ConsumerUpsertRequest, 'consumerGroup'> => ({
   consumeTimeoutMinute: 15
 });
 
+function scopeKey(scope: ConsumerQueryScope) {
+  return `${scope.mode}:${scope.proxyAddress ?? ''}`;
+}
+
+function sameIdentity(left: ConsumerOperationIdentity, right: ConsumerOperationIdentity) {
+  return left.group === right.group
+    && left.scopeKey === right.scopeKey
+    && left.generation === right.generation;
+}
+
 export default function ConsumerMutationDialog({
   open,
   mode,
   consumer,
+  operationIdentity,
   onOpenChange,
-  onSucceeded
+  onSucceeded,
+  onAppliedAuditFailure
 }: ConsumerMutationDialogProps) {
   const { scope } = useConsumerQueryScope();
+  const currentScopeKey = scopeKey(scope);
+  const consumerGroup = consumer?.rawGroupName ?? '';
+  const targetGroup = mode === 'edit' ? consumerGroup : null;
   const [group, setGroup] = useState(consumer?.rawGroupName ?? '');
   const [form, setForm] = useState(defaultForm());
   const [brokers, setBrokers] = useState<string[]>([]);
+  const [ready, setReady] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const mutationKind = mode === 'create' ? 'create' : 'update';
+  const mutationTarget = mode === 'create' ? group.trim() : consumerGroup;
+  const mutationLockKey = consumerMutationKey(mutationKind, mutationTarget, currentScopeKey);
+  const scopedCreateTicket = useConsumerMutationInFlight('create', currentScopeKey);
+  const matchingMutationLocked = useConsumerMutationLocked(mutationLockKey);
+  const activeTicketRef = useRef<ReturnType<typeof beginConsumerMutation>>(null);
+  const activeTicket = mode === 'create' ? scopedCreateTicket : activeTicketRef.current;
+  const mutationLocked = mode === 'create'
+    ? scopedCreateTicket !== null
+    : matchingMutationLocked;
+  const committedOperationRef = useRef<{
+    guardKey: string;
+    requestGeneration: number;
+    open: boolean;
+    scopeKey: string;
+    targetGroup: string | null;
+    identity: ConsumerOperationIdentity | null;
+  }>({ guardKey: '', requestGeneration: 0, open: false, scopeKey: currentScopeKey, targetGroup: null, identity: null });
+  const guardKey = [
+    String(open),
+    targetGroup ?? '',
+    currentScopeKey,
+    operationIdentity?.group ?? '',
+    operationIdentity?.scopeKey ?? '',
+    String(operationIdentity?.generation ?? '')
+  ].join('\u0000');
+
+  const committedOperation = committedOperationRef.current;
+  const activeOperation = committedOperation.guardKey === guardKey
+    ? committedOperation
+    : {
+      guardKey,
+      requestGeneration: committedOperation.requestGeneration + 1,
+      open,
+      scopeKey: currentScopeKey,
+      targetGroup,
+      identity: operationIdentity ?? null
+    };
+
+  useLayoutEffect(() => {
+    committedOperationRef.current = activeOperation;
+    setGroup(consumerGroup);
+    setForm(defaultForm());
+    setBrokers([]);
+    setError(null);
+    setLoading(false);
+    setReady(false);
+    return () => {
+      if (committedOperationRef.current.guardKey === activeOperation.guardKey
+        && committedOperationRef.current.requestGeneration === activeOperation.requestGeneration) {
+        committedOperationRef.current = {
+          guardKey: '',
+          requestGeneration: activeOperation.requestGeneration + 1,
+          open: false,
+          scopeKey: currentScopeKey,
+          targetGroup: null,
+          identity: null
+        };
+      }
+    };
+  }, [activeOperation]);
+
+  const isCurrentOperation = (identity: ConsumerOperationIdentity, requestGeneration: number, submittedTarget: string) => {
+    const current = committedOperationRef.current;
+    const immutableTarget = activeTicketRef.current?.targetGroup ?? current.targetGroup;
+    return requestGeneration === current.requestGeneration
+      && current.open
+      && current.scopeKey === identity.scopeKey
+      && (!current.targetGroup || current.targetGroup === consumerGroup)
+      && (!current.identity || sameIdentity(current.identity, identity))
+      && (!immutableTarget || (
+        immutableTarget === submittedTarget
+        && immutableTarget === identity.group
+      ));
+  };
+
+  const requestOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && (activeTicket || isConsumerMutationLocked(mutationLockKey))) return;
+    onOpenChange(nextOpen);
+  };
+
+  const preventLockedDismiss = (event: { preventDefault: () => void }) => {
+    if (activeTicket || isConsumerMutationLocked(mutationLockKey)) event.preventDefault();
+  };
 
   useEffect(() => {
     if (!open) return;
-    setGroup(consumer?.rawGroupName ?? '');
-    setForm(defaultForm());
-    setError(null);
+    const requestGeneration = activeOperation.requestGeneration;
+    const identity = activeOperation.identity ?? {
+      group: targetGroup ?? consumerGroup,
+      scopeKey: currentScopeKey,
+      generation: requestGeneration
+    };
+    const operationTarget = activeOperation.targetGroup ?? identity.group;
+    if (!isCurrentOperation(identity, requestGeneration, operationTarget)) return;
     let cancelled = false;
     void (async () => {
       try {
         const result = await brokerApi.list();
-        if (cancelled) return;
+        if (cancelled || !isCurrentOperation(identity, requestGeneration, operationTarget)) return;
         const names = Array.from(new Set(result.items.map((broker) => broker.brokerName))).sort();
         setBrokers(names);
-        if (mode === 'edit' && consumer) {
-          const config = await consumerApi.config(consumer.rawGroupName, scope);
-          if (cancelled) return;
+        if (mode === 'edit' && consumerGroup) {
+          const config = await consumerApi.config(consumerGroup, scope);
+          if (cancelled || !isCurrentOperation(identity, requestGeneration, operationTarget)) return;
           const effective = config.effective;
           if (effective) {
             setForm({
@@ -89,14 +213,17 @@ export default function ConsumerMutationDialog({
             });
           }
         }
+        if (!cancelled && isCurrentOperation(identity, requestGeneration, operationTarget)) setReady(true);
       } catch (reason) {
-        if (!cancelled) setError(reason instanceof Error ? reason.message : String(reason));
+        if (!cancelled && isCurrentOperation(identity, requestGeneration, operationTarget)) {
+          setError(reason instanceof Error ? reason.message : String(reason));
+        }
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, [open, consumer]);
+  }, [open, consumerGroup, mode, currentScopeKey, operationIdentity, activeOperation]);
 
   const submit = async () => {
     if (mode === 'create' && !group.trim()) {
@@ -107,22 +234,64 @@ export default function ConsumerMutationDialog({
       setError('Select at least one broker target.');
       return;
     }
+    const submittedGroup = mode === 'create' ? group.trim() : consumerGroup || group;
+    const operation = committedOperationRef.current;
+    const requestGeneration = operation.requestGeneration;
+    const identity = operation.identity ?? {
+      group: submittedGroup,
+      scopeKey: currentScopeKey,
+      generation: requestGeneration
+    };
+    if (!isCurrentOperation(identity, requestGeneration, submittedGroup)) return;
+    const ticket = beginConsumerMutation(mutationKind, submittedGroup, currentScopeKey);
+    if (!ticket) return;
+    activeTicketRef.current = ticket;
     setLoading(true);
     setError(null);
     try {
       const payload: ConsumerUpsertRequest = {
-        ...(mode === 'create' ? { consumerGroup: group.trim() } : {}),
+        ...(mode === 'create' ? { consumerGroup: submittedGroup } : {}),
         ...form
       };
       const result = mode === 'create'
         ? await consumerApi.create(payload)
-        : await consumerApi.update(group, payload);
+        : await consumerApi.update(submittedGroup, payload);
+      if (mutationKind === 'create') completeConsumerMutation(ticket);
+      if (!isCurrentOperation(identity, requestGeneration, submittedGroup)) return;
       onSucceeded(result);
+      if (!isCurrentOperation(identity, requestGeneration, submittedGroup)) return;
       onOpenChange(false);
     } catch (reason) {
-      setError(reason instanceof Error ? reason.message : String(reason));
+      if (isAppliedAuditFailure(reason)) {
+        if (markConsumerMutationApplied(ticket)) {
+          if (mutationKind === 'create') completeConsumerMutation(ticket);
+          await handleAppliedAuditFailure(reason, {
+            onApplied: () => {
+              if (!isCurrentOperation(identity, requestGeneration, submittedGroup)) return;
+              setError(null);
+              if (!isCurrentOperation(identity, requestGeneration, submittedGroup)) return;
+              onOpenChange(false);
+            },
+            refresh: async () => {
+              // The list page owns create invalidation by ticket scope. A
+              // detached dialog must not invoke a stale callback that could
+              // read or write a newer route. Standalone/current consumers of
+              // this component may still provide their local refresh hook.
+              if (mutationKind !== 'create' || isCurrentOperation(identity, requestGeneration, submittedGroup)) {
+                await onAppliedAuditFailure?.(identity);
+              }
+            }
+          });
+        }
+        return;
+      }
+      if (isCurrentOperation(identity, requestGeneration, submittedGroup)) {
+        setError(reason instanceof Error ? reason.message : String(reason));
+      }
     } finally {
-      setLoading(false);
+      finishConsumerMutation(ticket);
+      if (activeTicketRef.current?.sequence === ticket.sequence) activeTicketRef.current = null;
+      if (isCurrentOperation(identity, requestGeneration, submittedGroup)) setLoading(false);
     }
   };
 
@@ -136,8 +305,13 @@ export default function ConsumerMutationDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+    <Dialog open={open} onOpenChange={requestOpenChange}>
+      <DialogContent
+        closeDisabled={mutationLocked}
+        onEscapeKeyDown={preventLockedDismiss}
+        onPointerDownOutside={preventLockedDismiss}
+        onInteractOutside={preventLockedDismiss}
+      >
         <DialogHeader>
           <DialogTitle>{mode === 'create' ? 'Create consumer group' : `Edit ${consumer?.rawGroupName ?? group}`}</DialogTitle>
           <DialogDescription>
@@ -149,7 +323,7 @@ export default function ConsumerMutationDialog({
           {mode === 'create' ? (
             <div className="field">
               <Label htmlFor="consumer-mutation-group">Consumer group</Label>
-              <Input id="consumer-mutation-group" value={group} onChange={(event) => setGroup(event.target.value)} />
+              <Input id="consumer-mutation-group" value={group} disabled={mutationLocked} onChange={(event) => setGroup(event.target.value)} />
             </div>
           ) : null}
 
@@ -188,8 +362,8 @@ export default function ConsumerMutationDialog({
         {error ? <div className="inline-validation" role="alert">{error}</div> : null}
 
         <DialogFooter>
-          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
-          <Button type="button" disabled={loading} onClick={() => void submit()}>
+          <Button type="button" variant="outline" disabled={mutationLocked} onClick={() => requestOpenChange(false)}>Cancel</Button>
+          <Button type="button" disabled={mutationLocked || loading || (mode === 'edit' && !ready)} onClick={() => void submit()}>
             {loading ? 'Saving' : mode === 'create' ? 'Create group' : 'Update group'}
           </Button>
         </DialogFooter>

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/TopicDeleteDialog.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/TopicDeleteDialog.tsx
@@ -1,6 +1,7 @@
 import { Trash2 } from 'lucide-react';
 import { useEffect, useId, useRef, useState, type FormEvent } from 'react';
 import { topicApi } from '../api/topic_api';
+import { handleAppliedAuditFailure } from '../api/client';
 import type { TopicInfo, TopicOperationResult } from '../types/topic';
 import {
   AlertDialog,
@@ -22,6 +23,7 @@ export interface TopicDeleteDialogProps {
   onOpenChange: (open: boolean) => void;
   onResult?: (result: TopicOperationResult) => void;
   onSucceeded: (result: TopicOperationResult) => void;
+  onAppliedAuditFailure?: () => Promise<void> | void;
 }
 
 interface DeleteSnapshot {
@@ -38,7 +40,8 @@ export default function TopicDeleteDialog({
   brokerName,
   onOpenChange,
   onResult,
-  onSucceeded
+  onSucceeded,
+  onAppliedAuditFailure
 }: TopicDeleteDialogProps) {
   const topicName = topic?.topic ?? '';
   const [selectedBroker, setSelectedBroker] = useState(() => initialBroker(topic, brokerName));
@@ -135,6 +138,14 @@ export default function TopicDeleteDialog({
       }
     } catch (requestError) {
       if (!isCurrentPresentation(snapshot)) return;
+      if (await handleAppliedAuditFailure(requestError, {
+        onApplied: () => {
+          invalidateAndClose();
+          setError(null);
+          setResult(null);
+        },
+        refresh: onAppliedAuditFailure
+      })) return;
       setError(requestError instanceof Error ? requestError.message : 'Unable to delete the topic.');
     } finally {
       if (pendingRef.current === requestId) {

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/TopicMutationDialog.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/TopicMutationDialog.test.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react';
 import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
+import { ApiClientError } from '../api/client';
 import { deferred } from '../test/deferred';
 import type {
   TopicConfigView,
@@ -118,6 +119,25 @@ describe('TopicMutationDialog', () => {
       messageType: 'FIFO'
     }));
     expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('closes and refreshes once instead of retrying after an applied audit failure', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const onAppliedAuditFailure = vi.fn().mockResolvedValue(undefined);
+    const onSubmit = vi.fn().mockRejectedValue(
+      new ApiClientError('APPLIED_AUDIT_FAILED', 'Topic mutation applied.', { mutationApplied: true })
+    );
+    render(<TopicMutationDialog {...defaultProps} onOpenChange={onOpenChange} onSubmit={onSubmit} onAppliedAuditFailure={onAppliedAuditFailure} />);
+
+    await user.type(screen.getByRole('textbox', { name: 'Topic name' }), 'inventory-events');
+    await user.click(screen.getByRole('checkbox', { name: 'DefaultCluster' }));
+    const confirmation = await openConfirmation(user);
+    await user.click(within(confirmation).getByRole('button', { name: 'Create topic' }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+    expect(onAppliedAuditFailure).toHaveBeenCalledTimes(1);
   });
 
   it('builds permission bits from Read, Write, and Inherit and requires Read or Write', async () => {

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/TopicMutationDialog.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/TopicMutationDialog.tsx
@@ -1,5 +1,6 @@
 import { Save } from 'lucide-react';
 import { useEffect, useId, useMemo, useRef, useState, type FormEvent } from 'react';
+import { handleAppliedAuditFailure } from '../api/client';
 import type {
   TopicConfigView,
   TopicMutationRequest,
@@ -30,6 +31,7 @@ interface TopicMutationDialogProps {
   onRetryConfig?: () => void;
   onOpenChange: (open: boolean) => void;
   onSubmit: (request: TopicMutationRequest) => Promise<TopicOperationResult>;
+  onAppliedAuditFailure?: () => Promise<void> | void;
 }
 
 interface TopicFormState {
@@ -59,7 +61,8 @@ export default function TopicMutationDialog(props: TopicMutationDialogProps) {
   const {
     open,
     onOpenChange,
-    onSubmit
+    onSubmit,
+    onAppliedAuditFailure
   } = props;
   const mode = props.mode;
   const targets = props.targets;
@@ -198,6 +201,15 @@ export default function TopicMutationDialog(props: TopicMutationDialogProps) {
       }
     } catch (requestError) {
       if (!isCurrentPresentation(requestId, submittedMode, submittedTopic)) return;
+
+      if (await handleAppliedAuditFailure(requestError, {
+        onApplied: () => {
+          closeDialog();
+          setError(null);
+          setResult(null);
+        },
+        refresh: onAppliedAuditFailure
+      })) return;
 
       setConfirmation(null);
       setError(requestError instanceof Error ? requestError.message : 'Unable to save the topic.');

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/TopicResetOffsetDialog.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/TopicResetOffsetDialog.tsx
@@ -1,6 +1,7 @@
 import { RotateCcw } from 'lucide-react';
 import { useEffect, useId, useRef, useState, type FormEvent } from 'react';
 import { topicApi } from '../api/topic_api';
+import { handleAppliedAuditFailure } from '../api/client';
 import type { TopicOffsetResult, TopicResetOffsetRequest } from '../types/topic';
 import {
   AlertDialog,
@@ -20,6 +21,7 @@ interface TopicResetOffsetDialogProps {
   consumerGroup: string;
   onOpenChange: (open: boolean) => void;
   onSucceeded: (result: TopicOffsetResult) => void;
+  onAppliedAuditFailure?: () => Promise<void> | void;
 }
 
 interface ResetConfirmation {
@@ -44,7 +46,8 @@ export default function TopicResetOffsetDialog({
   topic,
   consumerGroup,
   onOpenChange,
-  onSucceeded
+  onSucceeded,
+  onAppliedAuditFailure
 }: TopicResetOffsetDialogProps) {
   const [resetTime, setResetTime] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -142,6 +145,15 @@ export default function TopicResetOffsetDialog({
       focusReview();
     } catch (requestError) {
       if (!isCurrentPresentation(snapshot)) return;
+
+      if (await handleAppliedAuditFailure(requestError, {
+        onApplied: () => {
+          invalidateAndClose();
+          setError(null);
+          setResult(null);
+        },
+        refresh: onAppliedAuditFailure
+      })) return;
 
       setConfirmation(null);
       setError(requestError instanceof Error ? requestError.message : 'Unable to reset the consumer offset.');

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/TopicSendMessageDialog.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/TopicSendMessageDialog.tsx
@@ -1,6 +1,7 @@
 import { Send } from 'lucide-react';
 import { useEffect, useId, useRef, useState, type FormEvent } from 'react';
 import { topicApi } from '../api/topic_api';
+import { handleAppliedAuditFailure } from '../api/client';
 import type { TopicSendResultView, TopicTestMessageRequest } from '../types/topic';
 import {
   AlertDialog,
@@ -19,6 +20,7 @@ interface TopicSendMessageDialogProps {
   topic: string;
   onOpenChange: (open: boolean) => void;
   onSucceeded: (result: TopicSendResultView) => void;
+  onAppliedAuditFailure?: () => Promise<void> | void;
 }
 
 interface SendForm {
@@ -40,7 +42,8 @@ export default function TopicSendMessageDialog({
   open,
   topic,
   onOpenChange,
-  onSucceeded
+  onSucceeded,
+  onAppliedAuditFailure
 }: TopicSendMessageDialogProps) {
   const [form, setForm] = useState<SendForm>(emptyForm);
   const [error, setError] = useState<string | null>(null);
@@ -137,6 +140,15 @@ export default function TopicSendMessageDialog({
       focusReview();
     } catch (requestError) {
       if (!isCurrentPresentation(snapshot)) return;
+
+      if (await handleAppliedAuditFailure(requestError, {
+        onApplied: () => {
+          invalidateAndClose();
+          setError(null);
+          setResult(null);
+        },
+        refresh: onAppliedAuditFailure
+      })) return;
 
       setConfirmation(null);
       setError(requestError instanceof Error ? requestError.message : 'Unable to send the test message.');

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/TopicSkipBacklogDialog.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/TopicSkipBacklogDialog.tsx
@@ -1,6 +1,7 @@
 import { SkipForward } from 'lucide-react';
 import { useEffect, useId, useRef, useState, type FormEvent } from 'react';
 import { topicApi } from '../api/topic_api';
+import { handleAppliedAuditFailure } from '../api/client';
 import type { TopicOffsetResult, TopicSkipOffsetRequest } from '../types/topic';
 import { Button } from './ui/Button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from './ui/Dialog';
@@ -13,6 +14,7 @@ interface TopicSkipBacklogDialogProps {
   consumerGroup: string;
   onOpenChange: (open: boolean) => void;
   onSucceeded: (result: TopicOffsetResult) => void;
+  onAppliedAuditFailure?: () => Promise<void> | void;
 }
 
 interface SkipSnapshot {
@@ -27,7 +29,8 @@ export default function TopicSkipBacklogDialog({
   topic,
   consumerGroup,
   onOpenChange,
-  onSucceeded
+  onSucceeded,
+  onAppliedAuditFailure
 }: TopicSkipBacklogDialogProps) {
   const [confirmationText, setConfirmationText] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -109,6 +112,15 @@ export default function TopicSkipBacklogDialog({
       focusAction();
     } catch (requestError) {
       if (!isCurrentPresentation(snapshot)) return;
+
+      if (await handleAppliedAuditFailure(requestError, {
+        onApplied: () => {
+          invalidateAndClose();
+          setError(null);
+          setResult(null);
+        },
+        refresh: onAppliedAuditFailure
+      })) return;
 
       setError(requestError instanceof Error ? requestError.message : 'Unable to skip accumulated messages.');
       focusAction();

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/consumerMutationLock.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/consumerMutationLock.ts
@@ -1,0 +1,156 @@
+import { useSyncExternalStore } from 'react';
+
+export type ConsumerMutationKind = 'create' | 'update' | 'delete';
+
+export interface ConsumerMutationLockTicket {
+  key: string;
+  sequence: number;
+  kind: ConsumerMutationKind;
+  targetGroup: string;
+  scopeKey: string;
+}
+
+interface ConsumerMutationLock {
+  ticket: ConsumerMutationLockTicket;
+  appliedHandled: boolean;
+  terminalHandled: boolean;
+}
+
+const locks = new Map<string, ConsumerMutationLock>();
+const listeners = new Map<string, Set<() => void>>();
+const allListeners = new Set<() => void>();
+const terminalRevisions = new Map<string, number>();
+const terminalListeners = new Map<string, Set<() => void>>();
+let nextSequence = 0;
+
+export function consumerMutationKey(kind: ConsumerMutationKind, targetGroup: string, scopeKey: string) {
+  return `${kind}\u0000${targetGroup}\u0000${scopeKey}`;
+}
+
+export function isConsumerMutationLocked(key: string) {
+  return locks.has(key);
+}
+
+export function beginConsumerMutation(
+  kind: ConsumerMutationKind,
+  targetGroup: string,
+  scopeKey: string
+): ConsumerMutationLockTicket | null {
+  const key = consumerMutationKey(kind, targetGroup, scopeKey);
+  if (locks.has(key)) return null;
+  const ticket = { key, sequence: ++nextSequence, kind, targetGroup, scopeKey };
+  locks.set(key, { ticket, appliedHandled: false, terminalHandled: false });
+  notify(key);
+  return ticket;
+}
+
+export function markConsumerMutationApplied(ticket: ConsumerMutationLockTicket) {
+  const lock = locks.get(ticket.key);
+  if (!lock || lock.ticket.sequence !== ticket.sequence || lock.appliedHandled) return false;
+  lock.appliedHandled = true;
+  return true;
+}
+
+export function finishConsumerMutation(ticket: ConsumerMutationLockTicket) {
+  const lock = locks.get(ticket.key);
+  if (!lock || lock.ticket.sequence !== ticket.sequence) return;
+  locks.delete(ticket.key);
+  notify(ticket.key);
+}
+
+/**
+ * Records the one terminal, authoritative invalidation for a submitted
+ * consumer operation. The ticket, not a mounted dialog, owns this state so
+ * a completion that arrives after route or scope changes cannot refresh the
+ * newly visible scope.
+ */
+export function completeConsumerMutation(ticket: ConsumerMutationLockTicket) {
+  const lock = locks.get(ticket.key);
+  if (!lock || lock.ticket.sequence !== ticket.sequence || lock.terminalHandled) return false;
+  lock.terminalHandled = true;
+  terminalRevisions.set(ticket.scopeKey, (terminalRevisions.get(ticket.scopeKey) ?? 0) + 1);
+  terminalListeners.get(ticket.scopeKey)?.forEach((listener) => listener());
+  return true;
+}
+
+export function useConsumerMutationLocked(key: string) {
+  return useSyncExternalStore(
+    (listener) => subscribe(key, listener),
+    () => isConsumerMutationLocked(key),
+    () => false
+  );
+}
+
+/**
+ * Returns the immutable operation ticket currently in flight for a create
+ * scope. A remounted create dialog has no local draft identity yet, so it
+ * must discover the original ticket by scope rather than by its mutable form.
+ */
+export function useConsumerMutationInFlight(kind: ConsumerMutationKind, scopeKey: string) {
+  return useSyncExternalStore(
+    subscribeAll,
+    () => findConsumerMutationInFlight(kind, scopeKey),
+    () => null
+  );
+}
+
+/**
+ * A scope-local revision advances once for every terminal mutation owned by
+ * that scope. A mounted list consumes it immediately; an inactive scope sees
+ * it on remount and refreshes its own data without touching another scope.
+ */
+export function useConsumerMutationScopeRevision(scopeKey: string) {
+  return useSyncExternalStore(
+    (listener) => subscribeTerminal(scopeKey, listener),
+    () => terminalRevisions.get(scopeKey) ?? 0,
+    () => 0
+  );
+}
+
+function findConsumerMutationInFlight(kind: ConsumerMutationKind, scopeKey: string) {
+  for (const lock of locks.values()) {
+    if (lock.ticket.kind === kind && lock.ticket.scopeKey === scopeKey) return lock.ticket;
+  }
+  return null;
+}
+
+function subscribe(key: string, listener: () => void) {
+  const keyListeners = listeners.get(key) ?? new Set<() => void>();
+  keyListeners.add(listener);
+  listeners.set(key, keyListeners);
+  return () => {
+    keyListeners.delete(listener);
+    if (keyListeners.size === 0) listeners.delete(key);
+  };
+}
+
+function notify(key: string) {
+  listeners.get(key)?.forEach((listener) => listener());
+  allListeners.forEach((listener) => listener());
+}
+
+function subscribeAll(listener: () => void) {
+  allListeners.add(listener);
+  return () => {
+    allListeners.delete(listener);
+  };
+}
+
+function subscribeTerminal(scopeKey: string, listener: () => void) {
+  const scopeListeners = terminalListeners.get(scopeKey) ?? new Set<() => void>();
+  scopeListeners.add(listener);
+  terminalListeners.set(scopeKey, scopeListeners);
+  return () => {
+    scopeListeners.delete(listener);
+    if (scopeListeners.size === 0) terminalListeners.delete(scopeKey);
+  };
+}
+
+export function resetConsumerMutationLocksForTests() {
+  locks.clear();
+  listeners.clear();
+  allListeners.clear();
+  terminalRevisions.clear();
+  terminalListeners.clear();
+  nextSequence = 0;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/ui/Dialog.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/components/ui/Dialog.tsx
@@ -7,13 +7,24 @@ export const Dialog = DialogPrimitive.Root;
 export const DialogTrigger = DialogPrimitive.Trigger;
 export const DialogClose = DialogPrimitive.Close;
 
-export const DialogContent = forwardRef<ElementRef<typeof DialogPrimitive.Content>, ComponentPropsWithoutRef<typeof DialogPrimitive.Content>>(
-  ({ className, children, ...props }, ref) => (
+interface DialogContentProps extends ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
+  closeDisabled?: boolean;
+}
+
+export const DialogContent = forwardRef<ElementRef<typeof DialogPrimitive.Content>, DialogContentProps>(
+  ({ className, children, closeDisabled = false, ...props }, ref) => (
     <DialogPrimitive.Portal>
       <DialogPrimitive.Overlay className="ui-overlay" />
       <DialogPrimitive.Content ref={ref} className={cn('ui-dialog-content', className)} {...props}>
         {children}
-        <DialogPrimitive.Close className="ui-overlay-close" aria-label="Close dialog">
+        <DialogPrimitive.Close
+          className="ui-overlay-close"
+          aria-label="Close dialog"
+          disabled={closeDisabled}
+          onClick={(event) => {
+            if (closeDisabled) event.preventDefault();
+          }}
+        >
           <X size={16} aria-hidden="true" />
         </DialogPrimitive.Close>
       </DialogPrimitive.Content>

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/layouts/AppLayout.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/layouts/AppLayout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Sheet, SheetContent, SheetDescription, SheetTitle } from '../components/ui/Sheet';
 import Sidebar from './Sidebar';
 import Header from './Header';
@@ -10,11 +11,28 @@ interface AppLayoutProps {
 
 export default function AppLayout({ children }: AppLayoutProps) {
   const [mobileNavigationOpen, setMobileNavigationOpen] = useState(false);
+  const [auditWarning, setAuditWarning] = useState<string | null>(null);
   const navigationTriggerRef = useRef<HTMLButtonElement>(null);
   const restoreNavigationFocusRef = useRef(false);
+  const navigate = useNavigate();
 
   useEffect(() => {
     document.documentElement.dataset.theme = 'dark';
+  }, []);
+
+  useEffect(() => {
+    const onSessionExpired = () => navigate('/login', { replace: true });
+    window.addEventListener('rocketmq-auth-expired', onSessionExpired);
+    return () => window.removeEventListener('rocketmq-auth-expired', onSessionExpired);
+  }, [navigate]);
+
+  useEffect(() => {
+    const onAuditWarning = (event: Event) => {
+      const warning = event as CustomEvent<string>;
+      setAuditWarning(warning.detail || 'The change was applied, but its audit event could not be persisted.');
+    };
+    window.addEventListener('rocketmq-audit-warning', onAuditWarning);
+    return () => window.removeEventListener('rocketmq-audit-warning', onAuditWarning);
   }, []);
 
   useEffect(() => {
@@ -42,7 +60,10 @@ export default function AppLayout({ children }: AppLayoutProps) {
             setMobileNavigationOpen(true);
           }}
         />
-        <main className="content">{children}</main>
+        <main className="content">
+          {auditWarning ? <div className="audit-warning" role="status">{auditWarning}</div> : null}
+          {children}
+        </main>
       </div>
       <Sheet open={mobileNavigationOpen} onOpenChange={setMobileNavigationOpen}>
         <SheetContent

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/layouts/Header.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/layouts/Header.tsx
@@ -23,7 +23,9 @@ const pageLabels = [
   ['/producers', 'Producer', 'Messaging'],
   ['/messages', 'Message', 'Messaging'],
   ['/acl', 'ACL Management', 'Governance'],
+  ['/audit', 'Audit', 'Governance'],
   ['/monitors', 'Monitor', 'Governance'],
+  ['/sessions', 'Sessions', 'Governance'],
   ['/config', 'OPS', 'Operate'],
   ['/proxy', 'Proxy', 'Operate']
 ] as const;

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/layouts/Sidebar.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/layouts/Sidebar.tsx
@@ -9,6 +9,7 @@ import {
   Send,
   Settings,
   ShieldCheck,
+  ScrollText,
   Siren,
   Split,
   TimerReset,
@@ -56,7 +57,9 @@ const navGroups: NavGroup[] = [
     label: 'Governance',
     items: [
       { to: '/acl', label: 'ACL Management', icon: ShieldCheck },
-      { to: '/monitors', label: 'Monitor', icon: Bell }
+      { to: '/monitors', label: 'Monitor', icon: Bell },
+      { to: '/sessions', label: 'Sessions', icon: ShieldCheck },
+      { to: '/audit', label: 'Audit', icon: ScrollText }
     ]
   }
 ];

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/AclPage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/AclPage.test.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
 import { aclApi } from '../api/acl_api';
 import { brokerApi } from '../api/broker_api';
+import { ApiClientError } from '../api/client';
 import { renderAtRoute } from '../test/render';
 import AclPage from './AclPage';
 
@@ -163,6 +164,23 @@ describe('AclPage', () => {
     await waitFor(() => expect(aclApi.deleteUser).toHaveBeenCalledTimes(1));
     expect(screen.getByRole('button', { name: 'Modify ACL user locked-user' })).toBeDisabled();
     await act(async () => { resolveDelete(); });
+  });
+
+  it('treats an applied audit failure as terminal for ACL deletion and refreshes once', async () => {
+    const user = userEvent.setup();
+    vi.mocked(aclApi.listUsers).mockResolvedValue([{ brokerName: 'broker-a', brokerAddr: '10.0.0.1:10911', username: 'terminal-user', password: 'secret' }]);
+    vi.mocked(aclApi.deleteUser).mockRejectedValueOnce(
+      new ApiClientError('APPLIED_AUDIT_FAILED', 'ACL deletion applied.', { mutationApplied: true })
+    );
+    renderAtRoute(<AclPage />, '/acl');
+    await user.click(await screen.findByRole('button', { name: 'Confirm' }));
+    await screen.findByText('terminal-user');
+    await user.click(screen.getByRole('button', { name: 'Delete ACL user terminal-user' }));
+    await user.click(within(screen.getByRole('alertdialog')).getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(aclApi.deleteUser).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(aclApi.listUsers).toHaveBeenCalledTimes(2));
+    expect(screen.getByText('ACL user deletion was applied. Refreshing authoritative records.')).toBeInTheDocument();
   });
 
   it('clears stale delete feedback when changing tabs or opening a new dialog', async () => {

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/AclPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/AclPage.tsx
@@ -2,6 +2,7 @@ import { Eye, EyeOff, FileKey2, Plus, RefreshCw, Search, UserCheck, UserPlus, Us
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { aclApi } from '../api/acl_api';
 import { brokerApi } from '../api/broker_api';
+import { handleAppliedAuditFailure } from '../api/client';
 import ErrorState from '../components/ErrorState';
 import LoadingState from '../components/LoadingState';
 import PageHeader from '../components/PageHeader';
@@ -191,7 +192,16 @@ export default function AclPage() {
       setUserDialog(undefined);
       setNotice({ tone: 'success', message: username ? 'ACL user updated.' : 'ACL user created.' });
       void loadAclRecords(scope);
-    } catch {
+    } catch (error) {
+      if (await handleAppliedAuditFailure(error, {
+        onApplied: () => {
+          if (!mounted.current || interaction !== interactionGeneration.current) return;
+          setUserDialog(undefined);
+          setUserSaveError(null);
+          setNotice({ tone: 'warning', message: 'ACL user change was applied. Refreshing authoritative records.' });
+        },
+        refresh: () => scope ? loadAclRecords(scope) : undefined
+      })) return;
       if (mounted.current && interaction === interactionGeneration.current) {
         setUserSaveError('Unable to save the ACL user. Verify the request and try again.');
       }
@@ -216,7 +226,15 @@ export default function AclPage() {
       setPolicyDeleteError(null);
       setNotice({ tone: 'success', message: 'ACL user deleted.' });
       void loadAclRecords(scope);
-    } catch {
+    } catch (error) {
+      if (await handleAppliedAuditFailure(error, {
+        onApplied: () => {
+          if (!mounted.current || interaction !== interactionGeneration.current) return;
+          setUserDeleteError(null);
+          setNotice({ tone: 'warning', message: 'ACL user deletion was applied. Refreshing authoritative records.' });
+        },
+        refresh: () => scope ? loadAclRecords(scope) : undefined
+      })) return;
       if (mounted.current && interaction === interactionGeneration.current) setUserDeleteError('Unable to delete the ACL user.');
     } finally {
       mutationInFlight.current = false;
@@ -240,7 +258,16 @@ export default function AclPage() {
       setPolicyDialog(undefined);
       setNotice({ tone: 'success', message: subject ? 'ACL policy updated.' : 'ACL policy created.' });
       void loadAclRecords(scope);
-    } catch {
+    } catch (error) {
+      if (await handleAppliedAuditFailure(error, {
+        onApplied: () => {
+          if (!mounted.current || interaction !== interactionGeneration.current) return;
+          setPolicyDialog(undefined);
+          setPolicySaveError(null);
+          setNotice({ tone: 'warning', message: 'ACL policy change was applied. Refreshing authoritative records.' });
+        },
+        refresh: () => scope ? loadAclRecords(scope) : undefined
+      })) return;
       if (mounted.current && interaction === interactionGeneration.current) {
         setPolicySaveError('Unable to save the ACL policy. Verify the request and try again.');
       }
@@ -265,7 +292,15 @@ export default function AclPage() {
       setPolicyDeleteError(null);
       setNotice({ tone: 'success', message: 'ACL policy deleted.' });
       void loadAclRecords(scope);
-    } catch {
+    } catch (error) {
+      if (await handleAppliedAuditFailure(error, {
+        onApplied: () => {
+          if (!mounted.current || interaction !== interactionGeneration.current) return;
+          setPolicyDeleteError(null);
+          setNotice({ tone: 'warning', message: 'ACL policy deletion was applied. Refreshing authoritative records.' });
+        },
+        refresh: () => scope ? loadAclRecords(scope) : undefined
+      })) return;
       if (mounted.current && interaction === interactionGeneration.current) setPolicyDeleteError('Unable to delete the ACL policy.');
     } finally {
       mutationInFlight.current = false;

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/AuditPage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/AuditPage.test.tsx
@@ -1,0 +1,53 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { auditApi } from '../api/audit_api';
+import { ApiClientError } from '../api/client';
+import { renderAtRoute } from '../test/render';
+import type { AuditEventPage } from '../types/audit';
+import AuditPage from './AuditPage';
+
+vi.mock('../api/audit_api', () => ({ auditApi: { listEvents: vi.fn() } }));
+
+const page: AuditEventPage = {
+  events: [{
+    eventId: 'event-1', requestId: 'request-1', actor: 'operator', actorKind: 'admin',
+    action: 'config.tls.set', resourceType: 'environment', resourceName: 'default',
+    outcome: 'succeeded', detail: { operation: 'config.tls.set' }, createdAtMs: Date.now()
+  }],
+  nextCursor: 'next-page'
+};
+
+describe('AuditPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(auditApi.listEvents).mockResolvedValue(page);
+  });
+
+  it('sends filters and navigates keyset pages without exposing unfiltered request state', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<AuditPage />, '/audit');
+    await screen.findByText('config.tls.set');
+    await user.type(screen.getByLabelText('Actor'), 'operator');
+    await user.type(screen.getByLabelText('Action code'), 'config.tls.set');
+    await user.selectOptions(screen.getByLabelText('Outcome'), 'succeeded');
+    await user.click(screen.getByRole('button', { name: 'Filter' }));
+    await waitFor(() => expect(auditApi.listEvents).toHaveBeenLastCalledWith(expect.objectContaining({
+      actor: 'operator', action: 'config.tls.set', outcome: 'succeeded', cursor: undefined, limit: 50
+    })));
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(auditApi.listEvents).toHaveBeenLastCalledWith(expect.objectContaining({ cursor: 'next-page' })));
+  });
+
+  it('labels storage outages and retries the query without any mutation retry path', async () => {
+    const user = userEvent.setup();
+    vi.mocked(auditApi.listEvents)
+      .mockRejectedValueOnce(new ApiClientError('STORAGE_UNAVAILABLE', 'Storage unavailable'))
+      .mockResolvedValueOnce({ events: [] });
+    renderAtRoute(<AuditPage />, '/audit');
+    expect(await screen.findByRole('alert')).toHaveTextContent('Storage unavailable Retry when storage is available.');
+    await user.click(screen.getByRole('button', { name: 'Retry audit' }));
+    await screen.findByText('No audit events match these filters');
+    expect(screen.queryByRole('button', { name: /retry.*mutation/i })).not.toBeInTheDocument();
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/AuditPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/AuditPage.tsx
@@ -1,0 +1,117 @@
+import { Filter } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { auditApi } from '../api/audit_api';
+import { ApiClientError } from '../api/client';
+import EmptyState from '../components/EmptyState';
+import ErrorState from '../components/ErrorState';
+import LoadingState from '../components/LoadingState';
+import PageHeader from '../components/PageHeader';
+import RefreshButton from '../components/RefreshButton';
+import { Button } from '../components/ui/Button';
+import { Input } from '../components/ui/Input';
+import type { AuditEventPage, AuditOutcome } from '../types/audit';
+
+const pageSize = 50;
+
+export default function AuditPage() {
+  const [actor, setActor] = useState('');
+  const [action, setAction] = useState('');
+  const [outcome, setOutcome] = useState<AuditOutcome | ''>('');
+  const [environmentId, setEnvironmentId] = useState('');
+  const [start, setStart] = useState('');
+  const [end, setEnd] = useState('');
+  const [page, setPage] = useState<AuditEventPage>({ events: [] });
+  const [cursorHistory, setCursorHistory] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async (cursor?: string, resetHistory = false) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await auditApi.listEvents({
+        actor: actor.trim() || undefined,
+        action: action.trim() || undefined,
+        outcome: outcome || undefined,
+        environmentId: environmentId.trim() || undefined,
+        startMs: localDateTimeToMillis(start),
+        endMs: localDateTimeToMillis(end),
+        cursor,
+        limit: pageSize
+      });
+      setPage(next);
+      if (resetHistory) setCursorHistory([]);
+    } catch (cause) {
+      setError(errorMessage(cause, 'Unable to load audit events.'));
+    } finally {
+      setLoading(false);
+    }
+  }, [action, actor, end, environmentId, outcome, start]);
+
+  useEffect(() => { void load(undefined, true); }, [load]);
+
+  return (
+    <>
+      <PageHeader title="Audit" description="Append-only operational history. Read access is not audited." actions={<RefreshButton onRefresh={() => void load(undefined, true)} />} />
+      <section className="table-shell audit-admin-shell">
+        <div className="audit-filter-row">
+          <Input value={actor} placeholder="Actor" aria-label="Actor" onChange={(event) => setActor(event.target.value)} />
+          <Input value={action} placeholder="Action code" aria-label="Action code" onChange={(event) => setAction(event.target.value)} />
+          <Input value={environmentId} placeholder="Environment ID" aria-label="Environment ID" onChange={(event) => setEnvironmentId(event.target.value)} />
+          <Input type="datetime-local" value={start} aria-label="Start time" onChange={(event) => setStart(event.target.value)} />
+          <Input type="datetime-local" value={end} aria-label="End time" onChange={(event) => setEnd(event.target.value)} />
+          <select value={outcome} aria-label="Outcome" onChange={(event) => setOutcome(event.target.value as AuditOutcome | '')}>
+            <option value="">All outcomes</option><option value="succeeded">Succeeded</option><option value="rejected">Rejected</option><option value="failed">Failed</option>
+          </select>
+          <Button type="button" variant="secondary" onClick={() => void load(undefined, true)}><Filter size={15} aria-hidden="true" /> Filter</Button>
+        </div>
+        {loading ? <LoadingState label="Loading audit events" /> : null}
+        {!loading && error ? <ErrorState message={error} onRetry={() => void load(undefined, true)} retryLabel="Retry audit" /> : null}
+        {!loading && !error ? (
+          <>
+            <div className="table-scroll"><table>
+              <thead><tr><th>Time</th><th>Actor</th><th>Action</th><th>Resource</th><th>Outcome</th><th>Detail</th></tr></thead>
+              <tbody>{page.events.map((event) => (
+                <tr key={event.eventId}>
+                  <td>{formatTime(event.createdAtMs)}</td><td>{event.actor}</td><td><code>{event.action}</code></td>
+                  <td>{event.resourceName ?? event.resourceType}</td><td><span className={`audit-outcome audit-outcome-${event.outcome}`}>{event.outcome}</span></td>
+                  <td><code className="audit-detail">{safeJson(event.detail)}</code></td>
+                </tr>
+              ))}</tbody>
+            </table></div>
+            {page.events.length === 0 ? <EmptyState title="No audit events match these filters" /> : null}
+            <div className="table-footer"><span>{page.events.length} events</span><div className="pagination">
+              <Button type="button" variant="secondary" disabled={cursorHistory.length === 0} onClick={() => {
+                const previous = cursorHistory.slice(0, -1); setCursorHistory(previous); void load(previous[previous.length - 1]);
+              }}>Previous</Button>
+              <Button type="button" variant="secondary" disabled={!page.nextCursor} onClick={() => {
+                if (!page.nextCursor) return; setCursorHistory((history) => [...history, page.nextCursor!]); void load(page.nextCursor);
+              }}>Next</Button>
+            </div></div>
+          </>
+        ) : null}
+      </section>
+    </>
+  );
+}
+
+function safeJson(value: unknown) {
+  if (value === null || value === undefined) return '—';
+  try { return JSON.stringify(value); } catch { return '—'; }
+}
+
+function formatTime(value: number) {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? 'Unknown' : date.toLocaleString();
+}
+
+function localDateTimeToMillis(value: string) {
+  if (!value) return undefined;
+  const milliseconds = new Date(value).getTime();
+  return Number.isFinite(milliseconds) ? milliseconds : undefined;
+}
+
+function errorMessage(error: unknown, fallback: string) {
+  if (error instanceof ApiClientError && error.code === 'STORAGE_UNAVAILABLE') return `${error.message} Retry when storage is available.`;
+  return error instanceof Error ? error.message : fallback;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConfigPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConfigPage.tsx
@@ -1,7 +1,7 @@
 import { AlertTriangle, RefreshCw } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { configApi } from '../api/config_api';
-import { ApiClientError } from '../api/client';
+import { ApiClientError, handleAppliedAuditFailure } from '../api/client';
 import ErrorState from '../components/ErrorState';
 import LoadingState from '../components/LoadingState';
 import PageHeader from '../components/PageHeader';
@@ -98,6 +98,17 @@ export default function ConfigPage() {
       window.dispatchEvent(new CustomEvent('rocketmq-config-updated'));
       void checkNameserverAvailability();
     } catch (requestError) {
+      if (await handleAppliedAuditFailure(requestError, {
+        onApplied: () => {
+          setNameserverToRemove(null);
+          setNotice({ tone: 'warning', message: 'Configuration change was applied. Refreshing authoritative settings.' });
+        },
+        refresh: async () => {
+          const authoritative = await configApi.getConfig();
+          applyConfig(authoritative);
+          await checkNameserverAvailability();
+        }
+      })) return;
       setNotice({ tone: 'danger', message: mutationErrorMessage(requestError, 'Configuration update failed.') });
       if (requestError instanceof ApiClientError && requestError.code === 'STORAGE_CONFLICT') {
         load(true);

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConsumerDetailPage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConsumerDetailPage.test.tsx
@@ -1,20 +1,241 @@
-import { screen } from '@testing-library/react';
-import { Route, Routes } from 'react-router-dom';
-import { vi } from 'vitest';
+import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { Suspense, startTransition, useLayoutEffect, useRef } from 'react';
+import { flushSync } from 'react-dom';
+import { Route, Routes, useNavigate, useParams } from 'react-router-dom';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, vi } from 'vitest';
+import { ApiClientError } from '../api/client';
+import { brokerApi } from '../api/broker_api';
 import { configApi } from '../api/config_api';
 import { consumerApi } from '../api/consumer_api';
+import type { ConsumerSummaryView } from '../types/consumer';
 import { renderAtRoute } from '../test/render';
-import { ConsumerQueryScopeProvider } from './consumers/ConsumerQueryScopeProvider';
+import { ConsumerQueryScopeProvider, useConsumerQueryScope } from './consumers/ConsumerQueryScopeProvider';
 import ConsumerDetailPage from './ConsumerDetailPage';
+import { resetConsumerMutationLocksForTests } from '../components/consumerMutationLock';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function ConsumerGroupSwitch() {
+  const navigate = useNavigate();
+  return <button type="button" onClick={() => navigate('/consumers/inventory-service')}>Open inventory group</button>;
+}
+
+function ConsumerABASwitch() {
+  const navigate = useNavigate();
+  return (
+    <>
+      <button type="button" onClick={() => navigate('/consumers/inventory-service')}>Switch to inventory group</button>
+      <button type="button" onClick={() => navigate('/consumers/order-service')}>Switch to order group</button>
+    </>
+  );
+}
+
+function ConsumerScopeSwitch() {
+  const { setMode } = useConsumerQueryScope();
+  return <button type="button" onClick={() => setMode('proxy')}>Use proxy scope</button>;
+}
+
+function CommitWindowGroupSwitch({ onCommitted }: { onCommitted: () => void }) {
+  const navigate = useNavigate();
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        flushSync(() => navigate('/consumers/inventory-service'));
+        onCommitted();
+      }}
+    >
+      Commit inventory group
+    </button>
+  );
+}
+
+function CommitWindowScopeSwitch({ onCommitted }: { onCommitted: () => void }) {
+  const { setMode } = useConsumerQueryScope();
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        flushSync(() => setMode('proxy'));
+        onCommitted();
+      }}
+    >
+      Commit proxy scope
+    </button>
+  );
+}
+
+function CommitWindowUnmountSwitch({ onCommitted }: { onCommitted: () => void }) {
+  const navigate = useNavigate();
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        flushSync(() => navigate('/consumers'));
+        onCommitted();
+      }}
+    >
+      Commit consumer list
+    </button>
+  );
+}
+
+function LayoutGroupSwitch() {
+  const navigate = useNavigate();
+  return (
+    <button type="button" onClick={() => flushSync(() => navigate('/consumers/inventory-service'))}>
+      Commit layout inventory group
+    </button>
+  );
+}
+
+function LayoutScopeSwitch() {
+  const { setMode } = useConsumerQueryScope();
+  return (
+    <button type="button" onClick={() => flushSync(() => setMode('proxy'))}>
+      Commit layout proxy scope
+    </button>
+  );
+}
+
+function LayoutIdentityObserver({
+  group: expectedGroup,
+  scopeMode,
+  onSettled
+}: {
+  group: string;
+  scopeMode: 'nameServer' | 'proxy';
+  onSettled: (controls: { editDisabled: boolean; deleteDisabled: boolean }) => void;
+}) {
+  const { group } = useParams();
+  const { scope } = useConsumerQueryScope();
+  const settledIdentityRef = useRef('');
+
+  useLayoutEffect(() => {
+    if (group !== expectedGroup || scope.mode !== scopeMode) return;
+    const identityKey = `${group}|${scope.mode}|${scope.proxyAddress ?? ''}`;
+    if (settledIdentityRef.current === identityKey) return;
+    settledIdentityRef.current = identityKey;
+    const controls = Array.from(document.querySelectorAll('button'));
+    const edit = controls.find((button) => button.textContent === 'Edit configuration');
+    const remove = controls.find((button) => button.textContent === 'Delete group');
+    onSettled({
+      editDisabled: edit instanceof HTMLButtonElement && edit.disabled,
+      deleteDisabled: remove instanceof HTMLButtonElement && remove.disabled
+    });
+  }, [group, scope.mode, scope.proxyAddress, expectedGroup, scopeMode, onSettled]);
+
+  return null;
+}
+
+function ConcurrentTransitionSwitch() {
+  const navigate = useNavigate();
+  return (
+    <>
+      <button type="button" onClick={() => startTransition(() => navigate('/consumers/inventory-service'))}>
+        Start suspended inventory transition
+      </button>
+      <button type="button" onClick={() => flushSync(() => navigate('/consumers/order-service'))}>
+        Cancel suspended transition
+      </button>
+    </>
+  );
+}
+
+function SuspendInventoryAfterDetail({ suspension, onInventoryRender }: {
+  suspension: Promise<void>;
+  onInventoryRender: () => void;
+}) {
+  const { group } = useParams();
+  if (group === 'inventory-service') {
+    onInventoryRender();
+    throw suspension;
+  }
+  return null;
+}
+
+function ConcurrentConsumerWorkspace({ suspension, onInventoryRender }: {
+  suspension: Promise<void>;
+  onInventoryRender: () => void;
+}) {
+  return (
+    <>
+      <ConcurrentTransitionSwitch />
+      <Suspense fallback={<p>Inventory transition pending</p>}>
+        <Routes>
+          <Route
+            path="/consumers/:group"
+            element={<><ConsumerDetailPage /><SuspendInventoryAfterDetail suspension={suspension} onInventoryRender={onInventoryRender} /></>}
+          />
+          <Route path="/consumers" element={<h1>Consumer list</h1>} />
+        </Routes>
+      </Suspense>
+    </>
+  );
+}
 
 vi.mock('../api/consumer_api', () => ({
-  consumerApi: { summary: vi.fn(), progress: vi.fn(), resetOffset: vi.fn() }
+  consumerApi: {
+    summary: vi.fn(), progress: vi.fn(), resetOffset: vi.fn(), brokers: vi.fn(), delete: vi.fn(), config: vi.fn(), update: vi.fn()
+  }
 }));
 vi.mock('../api/config_api', () => ({ configApi: { getConfig: vi.fn() } }));
+vi.mock('../api/broker_api', () => ({ brokerApi: { list: vi.fn() } }));
+
+const consumerConfig = {
+  group: 'order-service',
+  effective: {
+    consumeEnable: true,
+    consumeFromMinEnable: true,
+    consumeBroadcastEnable: false,
+    consumeMessageOrderly: false,
+    retryQueueNums: 1,
+    retryMaxTimes: 16,
+    brokerId: 0,
+    whichBrokerWhenConsumeSlowly: 1,
+    notifyConsumerIdsChangedEnable: true,
+    groupSysFlag: 0,
+    consumeTimeoutMinute: 15,
+    groupRetryPolicyJson: '{}'
+  },
+  inconsistentFields: [],
+  targets: [{
+    brokerName: 'broker-a',
+    brokerAddress: '127.0.0.1:10911',
+    config: {
+      consumeEnable: true,
+      consumeFromMinEnable: true,
+      consumeBroadcastEnable: false,
+      consumeMessageOrderly: false,
+      retryQueueNums: 1,
+      retryMaxTimes: 16,
+      brokerId: 0,
+      whichBrokerWhenConsumeSlowly: 1,
+      notifyConsumerIdsChangedEnable: true,
+      groupSysFlag: 0,
+      consumeTimeoutMinute: 15,
+      groupRetryPolicyJson: '{}'
+    },
+    subscriptionTopics: [],
+    attributes: []
+  }],
+  queryScope: { mode: 'nameServer' as const }
+};
 
 describe('ConsumerDetailPage', () => {
   beforeEach(() => {
+    resetConsumerMutationLocksForTests();
     vi.clearAllMocks();
+    window.localStorage.clear();
     vi.mocked(configApi.getConfig).mockResolvedValue({
       environmentId: 'environment-default',
       environmentName: 'Default',
@@ -52,6 +273,14 @@ describe('ConsumerDetailPage', () => {
       topics: [],
       queryScope: { mode: 'nameServer' }
     });
+    vi.mocked(consumerApi.brokers).mockResolvedValue({
+      items: [{ brokerName: 'broker-a', brokerAddress: '127.0.0.1:10911' }]
+    });
+    vi.mocked(consumerApi.config).mockResolvedValue(consumerConfig);
+    vi.mocked(brokerApi.list).mockResolvedValue({
+      items: [{ clusterName: 'DefaultCluster', brokerName: 'broker-a', brokerId: 0, address: '127.0.0.1:10911', role: 'MASTER', version: 'V5_3_0', produceTps: 0, consumeTps: 0 }],
+      total: 1
+    });
   });
 
   it('resolves the group and renders the workspace on a direct route', async () => {
@@ -82,5 +311,1023 @@ describe('ConsumerDetailPage', () => {
 
     expect(await screen.findByRole('heading', { name: 'order-service' })).toBeInTheDocument();
     expect(await screen.findByRole('tab', { name: 'Progress' })).toBeInTheDocument();
+  });
+
+  afterEach(() => {
+    resetConsumerMutationLocksForTests();
+  });
+
+  it('invalidates destructive controls and navigates away when an applied delete is authoritatively absent', async () => {
+    const user = userEvent.setup();
+    vi.mocked(consumerApi.delete).mockRejectedValueOnce(
+      new ApiClientError('APPLIED_AUDIT_FAILED', 'Consumer deletion was applied.', { mutationApplied: true })
+    );
+    renderAtRoute(
+      <ConsumerQueryScopeProvider>
+        <Routes>
+          <Route path="/consumers/:group" element={<ConsumerDetailPage />} />
+          <Route path="/consumers" element={<h1>Consumer list</h1>} />
+        </Routes>
+      </ConsumerQueryScopeProvider>,
+      '/consumers/order-service'
+    );
+    await screen.findByRole('heading', { name: 'order-service' });
+    await waitFor(() => expect(consumerApi.summary).toHaveBeenCalled());
+    vi.clearAllMocks();
+    vi.mocked(consumerApi.brokers).mockResolvedValue({
+      items: [{ brokerName: 'broker-a', brokerAddress: '127.0.0.1:10911' }]
+    });
+    vi.mocked(consumerApi.summary).mockRejectedValueOnce(new ApiClientError('NOT_FOUND', 'Consumer group was not found.'));
+
+    await user.click(screen.getByRole('button', { name: 'Delete group' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Delete consumer group' });
+    await user.click(await within(dialog).findByRole('checkbox', { name: 'broker-a' }));
+    await user.type(within(dialog).getByLabelText('Confirm consumer group'), 'order-service');
+    await user.click(within(dialog).getByRole('button', { name: 'Delete consumer group' }));
+
+    await waitFor(() => expect(consumerApi.delete).toHaveBeenCalledTimes(1));
+    expect(await screen.findByRole('heading', { name: 'Consumer list' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Delete group' })).not.toBeInTheDocument();
+  });
+
+  it('closes an applied configuration edit and displays the one authoritative summary and config refresh without a retry', async () => {
+    const user = userEvent.setup();
+    const refreshedSummary = {
+      group: 'order-service',
+      displayGroupName: 'order-service',
+      category: 'NORMAL',
+      connectionCount: 9,
+      consumeTps: 2,
+      diffTotal: 4,
+      messageModel: 'MESSAGE_MODEL_CLUSTERING',
+      consumeType: 'CONSUME_PASSIVELY',
+      version: null,
+      versionDesc: '',
+      brokerNames: [],
+      brokerAddresses: [],
+      updateTimestamp: 1,
+      queryScope: { mode: 'nameServer' as const }
+    };
+    renderAtRoute(
+      <ConsumerQueryScopeProvider>
+        <Routes><Route path="/consumers/:group" element={<ConsumerDetailPage />} /></Routes>
+      </ConsumerQueryScopeProvider>,
+      '/consumers/order-service'
+    );
+    await screen.findByRole('heading', { name: 'order-service' });
+    await user.click(screen.getByRole('button', { name: 'Edit configuration' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Edit order-service' });
+    await waitFor(() => expect(within(dialog).getByRole('checkbox', { name: 'broker-a' })).toBeChecked());
+    vi.clearAllMocks();
+    vi.mocked(consumerApi.update).mockRejectedValueOnce(
+      new ApiClientError('APPLIED_AUDIT_FAILED', 'Consumer configuration was applied.', { mutationApplied: true })
+    );
+    vi.mocked(consumerApi.summary).mockResolvedValueOnce(refreshedSummary);
+    vi.mocked(consumerApi.config).mockResolvedValueOnce(consumerConfig);
+
+    await user.click(within(dialog).getByRole('button', { name: 'Update group' }));
+
+    await waitFor(() => expect(consumerApi.update).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(consumerApi.summary).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(consumerApi.config).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole('dialog', { name: 'Edit order-service' })).not.toBeInTheDocument();
+    expect(await screen.findByRole('group', { name: 'Connections: 9' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Retry update' })).not.toBeInTheDocument();
+  });
+
+  it('keeps edit controls disabled when the authoritative applied-edit refresh fails', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(
+      <ConsumerQueryScopeProvider>
+        <Routes><Route path="/consumers/:group" element={<ConsumerDetailPage />} /></Routes>
+      </ConsumerQueryScopeProvider>,
+      '/consumers/order-service'
+    );
+    await screen.findByRole('heading', { name: 'order-service' });
+    await user.click(screen.getByRole('button', { name: 'Edit configuration' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Edit order-service' });
+    await waitFor(() => expect(within(dialog).getByRole('checkbox', { name: 'broker-a' })).toBeChecked());
+    vi.clearAllMocks();
+    vi.mocked(consumerApi.update).mockRejectedValueOnce(
+      new ApiClientError('APPLIED_AUDIT_FAILED', 'Consumer configuration was applied.', { mutationApplied: true })
+    );
+    vi.mocked(consumerApi.summary).mockRejectedValueOnce(new Error('authoritative summary unavailable'));
+
+    await user.click(within(dialog).getByRole('button', { name: 'Update group' }));
+
+    await waitFor(() => expect(consumerApi.update).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Edit order-service' })).not.toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'Edit configuration' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Delete group' })).toBeDisabled();
+  });
+
+  it('drops a stale applied-edit refresh after the route changes to another consumer group', async () => {
+    const user = userEvent.setup();
+    const staleSummary = deferred<Awaited<ReturnType<typeof consumerApi.summary>>>();
+    const staleConfig = deferred<Awaited<ReturnType<typeof consumerApi.config>>>();
+    const inventorySummary = {
+      group: 'inventory-service',
+      displayGroupName: 'inventory-service',
+      category: 'NORMAL',
+      connectionCount: 17,
+      consumeTps: 4,
+      diffTotal: 2,
+      messageModel: 'MESSAGE_MODEL_CLUSTERING',
+      consumeType: 'CONSUME_PASSIVELY',
+      version: null,
+      versionDesc: '',
+      brokerNames: [],
+      brokerAddresses: [],
+      updateTimestamp: 2,
+      queryScope: { mode: 'nameServer' as const }
+    };
+    renderAtRoute(
+      <ConsumerQueryScopeProvider>
+        <Routes>
+          <Route path="/consumers/:group" element={<><ConsumerGroupSwitch /><ConsumerDetailPage /></>} />
+          <Route path="/consumers" element={<h1>Consumer list</h1>} />
+        </Routes>
+      </ConsumerQueryScopeProvider>,
+      '/consumers/order-service'
+    );
+    await screen.findByRole('heading', { name: 'order-service' });
+    await user.click(screen.getByRole('button', { name: 'Edit configuration' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Edit order-service' });
+    await waitFor(() => expect(within(dialog).getByRole('checkbox', { name: 'broker-a' })).toBeChecked());
+    vi.clearAllMocks();
+    vi.mocked(consumerApi.update).mockRejectedValueOnce(
+      new ApiClientError('APPLIED_AUDIT_FAILED', 'Consumer configuration was applied.', { mutationApplied: true })
+    );
+    vi.mocked(consumerApi.summary).mockImplementation((requestedGroup) => (
+      requestedGroup === 'order-service' ? staleSummary.promise : Promise.resolve(inventorySummary)
+    ));
+    vi.mocked(consumerApi.progress).mockImplementation((requestedGroup) => Promise.resolve({
+      group: requestedGroup,
+      topicCount: 0,
+      totalDiff: requestedGroup === 'inventory-service' ? 2 : 12,
+      topics: [],
+      queryScope: { mode: 'nameServer' as const }
+    }));
+    vi.mocked(consumerApi.config).mockImplementation((requestedGroup) => (
+      requestedGroup === 'order-service' ? staleConfig.promise : Promise.resolve({ ...consumerConfig, group: requestedGroup })
+    ));
+
+    await user.click(within(dialog).getByRole('button', { name: 'Update group' }));
+    await waitFor(() => expect(consumerApi.update).toHaveBeenCalledTimes(1));
+    await user.click(screen.getByRole('button', { name: 'Open inventory group' }));
+    await waitFor(() => expect(screen.getByRole('group', { name: 'Connections: 17' })).toBeInTheDocument());
+
+    await act(async () => {
+      staleSummary.resolve({
+        group: 'order-service',
+        displayGroupName: 'order-service',
+        category: 'NORMAL',
+        connectionCount: 99,
+        consumeTps: 99,
+        diffTotal: 99,
+        messageModel: 'MESSAGE_MODEL_CLUSTERING',
+        consumeType: 'CONSUME_PASSIVELY',
+        version: null,
+        versionDesc: '',
+        brokerNames: [],
+        brokerAddresses: [],
+        updateTimestamp: 3,
+        queryScope: { mode: 'nameServer' }
+      });
+      staleConfig.resolve(consumerConfig);
+    });
+
+    expect(screen.getByRole('heading', { name: 'inventory-service' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Consumer list' })).not.toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Connections: 17' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Edit configuration' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Delete group' })).toBeEnabled();
+    expect(consumerApi.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('discards a stale applied-delete NotFound after the consumer scope changes', async () => {
+    const user = userEvent.setup();
+    const staleSummary = deferred<Awaited<ReturnType<typeof consumerApi.summary>>>();
+    vi.mocked(configApi.getConfig).mockResolvedValue({
+      environmentId: 'environment-default',
+      environmentName: 'Default',
+      revision: 1,
+      endpoints: [
+        { endpointId: 'nameserver-1', endpointType: 'nameserver', address: '127.0.0.1:9876', role: 'primary', isEnabled: true, isActive: true, sortOrder: 0 },
+        { endpointId: 'proxy-1', endpointType: 'proxy', address: 'proxy-a:8081', role: 'primary', isEnabled: true, isActive: true, sortOrder: 1 }
+      ],
+      currentNamesrv: '127.0.0.1:9876',
+      namesrvAddrList: ['127.0.0.1:9876'],
+      useVIPChannel: false,
+      useTLS: false,
+      currentProxyAddr: 'proxy-a:8081',
+      proxyAddrList: ['proxy-a:8081'],
+      storageBackend: 'sqlite',
+      storageMode: 'singleNode'
+    });
+    renderAtRoute(
+      <ConsumerQueryScopeProvider>
+        <ConsumerScopeSwitch />
+        <Routes>
+          <Route path="/consumers/:group" element={<ConsumerDetailPage />} />
+          <Route path="/consumers" element={<h1>Consumer list</h1>} />
+        </Routes>
+      </ConsumerQueryScopeProvider>,
+      '/consumers/order-service'
+    );
+    await screen.findByRole('heading', { name: 'order-service' });
+    await user.click(screen.getByRole('button', { name: 'Delete group' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Delete consumer group' });
+    await user.click(await within(dialog).findByRole('checkbox', { name: 'broker-a' }));
+    await user.type(within(dialog).getByLabelText('Confirm consumer group'), 'order-service');
+    vi.clearAllMocks();
+    vi.mocked(consumerApi.delete).mockRejectedValueOnce(
+      new ApiClientError('APPLIED_AUDIT_FAILED', 'Consumer deletion was applied.', { mutationApplied: true })
+    );
+    vi.mocked(consumerApi.summary).mockImplementation((_group, requestedScope) => (
+      requestedScope.mode === 'nameServer'
+        ? staleSummary.promise
+        : Promise.resolve({
+          group: 'order-service',
+          displayGroupName: 'order-service',
+          category: 'NORMAL',
+          connectionCount: 28,
+          consumeTps: 1,
+          diffTotal: 3,
+          messageModel: 'MESSAGE_MODEL_CLUSTERING',
+          consumeType: 'CONSUME_PASSIVELY',
+          version: null,
+          versionDesc: '',
+          brokerNames: [],
+          brokerAddresses: [],
+          updateTimestamp: 4,
+          queryScope: { mode: 'proxy' as const, proxyAddress: 'proxy-a:8081' }
+        })
+    ));
+    vi.mocked(consumerApi.progress).mockResolvedValue({
+      group: 'order-service', topicCount: 0, totalDiff: 3, topics: [], queryScope: { mode: 'proxy', proxyAddress: 'proxy-a:8081' }
+    });
+
+    await user.click(within(dialog).getByRole('button', { name: 'Delete consumer group' }));
+    await waitFor(() => expect(consumerApi.delete).toHaveBeenCalledTimes(1));
+    await user.click(screen.getByRole('button', { name: 'Use proxy scope' }));
+    await waitFor(() => expect(screen.getByRole('group', { name: 'Connections: 28' })).toBeInTheDocument());
+
+    await act(async () => {
+      staleSummary.reject(new ApiClientError('NOT_FOUND', 'Consumer group was not found.'));
+    });
+
+    expect(screen.getByRole('heading', { name: 'order-service' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Consumer list' })).not.toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Connections: 28' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Edit configuration' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Delete group' })).toBeEnabled();
+    expect(consumerApi.delete).toHaveBeenCalledTimes(1);
+  });
+
+  it('unmounts the old edit dialog when a successful edit settles in the commit-before-passive window', async () => {
+    const user = userEvent.setup();
+    const pendingUpdate = deferred<Awaited<ReturnType<typeof consumerApi.update>>>();
+    const inventorySummary = {
+      group: 'inventory-service',
+      displayGroupName: 'inventory-service',
+      category: 'NORMAL',
+      connectionCount: 37,
+      consumeTps: 5,
+      diffTotal: 1,
+      messageModel: 'MESSAGE_MODEL_CLUSTERING',
+      consumeType: 'CONSUME_PASSIVELY',
+      version: null,
+      versionDesc: '',
+      brokerNames: [],
+      brokerAddresses: [],
+      updateTimestamp: 6,
+      queryScope: { mode: 'nameServer' as const }
+    };
+    renderAtRoute(
+      <ConsumerQueryScopeProvider>
+        <Routes>
+          <Route
+            path="/consumers/:group"
+            element={<><CommitWindowGroupSwitch onCommitted={() => {
+              pendingUpdate.resolve({
+                operation: 'UPDATE',
+                consumerGroup: 'order-service',
+                success: true,
+                targetCount: 1,
+                message: 'saved',
+                targets: [{ target: 'broker-a', kind: 'BROKER', success: true, message: 'saved' }]
+              });
+            }} /><ConsumerDetailPage /></>}
+          />
+          <Route path="/consumers" element={<h1>Consumer list</h1>} />
+        </Routes>
+      </ConsumerQueryScopeProvider>,
+      '/consumers/order-service'
+    );
+    await screen.findByRole('heading', { name: 'order-service' });
+    await user.click(screen.getByRole('button', { name: 'Edit configuration' }));
+    const orderDialog = await screen.findByRole('dialog', { name: 'Edit order-service' });
+    await waitFor(() => expect(within(orderDialog).getByRole('checkbox', { name: 'broker-a' })).toBeChecked());
+    vi.clearAllMocks();
+    vi.mocked(consumerApi.update).mockImplementationOnce(() => pendingUpdate.promise);
+    vi.mocked(consumerApi.summary).mockResolvedValue(inventorySummary);
+    vi.mocked(consumerApi.config).mockResolvedValue({ ...consumerConfig, group: 'inventory-service' });
+    vi.mocked(brokerApi.list).mockResolvedValue({
+      items: [{ clusterName: 'DefaultCluster', brokerName: 'broker-a', brokerId: 0, address: '127.0.0.1:10911', role: 'MASTER', version: 'V5_3_0', produceTps: 0, consumeTps: 0 }],
+      total: 1
+    });
+
+    await user.click(within(orderDialog).getByRole('button', { name: 'Update group' }));
+    await waitFor(() => expect(consumerApi.update).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByText('Commit inventory group'));
+
+    await screen.findByRole('heading', { name: 'inventory-service', hidden: true });
+    expect(screen.queryByRole('dialog', { name: 'Edit inventory-service' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Consumer list', hidden: true })).not.toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Connections: 37', hidden: true })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Edit configuration', hidden: true })).toBeEnabled());
+    expect(consumerApi.update).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(consumerApi.summary).mock.calls).not.toContainEqual(['order-service', { mode: 'nameServer' }]);
+    expect(consumerApi.config).not.toHaveBeenCalled();
+  });
+
+  it('unmounts the old edit dialog when an applied edit settles in the commit-before-passive window', async () => {
+    const user = userEvent.setup();
+    const pendingUpdate = deferred<Awaited<ReturnType<typeof consumerApi.update>>>();
+    const auditWarning = vi.fn();
+    const inventorySummary = {
+      group: 'inventory-service',
+      displayGroupName: 'inventory-service',
+      category: 'NORMAL',
+      connectionCount: 41,
+      consumeTps: 6,
+      diffTotal: 2,
+      messageModel: 'MESSAGE_MODEL_CLUSTERING',
+      consumeType: 'CONSUME_PASSIVELY',
+      version: null,
+      versionDesc: '',
+      brokerNames: [],
+      brokerAddresses: [],
+      updateTimestamp: 6,
+      queryScope: { mode: 'nameServer' as const }
+    };
+    window.addEventListener('rocketmq-audit-warning', auditWarning);
+    renderAtRoute(
+      <ConsumerQueryScopeProvider>
+        <Routes>
+          <Route
+            path="/consumers/:group"
+            element={<><CommitWindowGroupSwitch onCommitted={() => {
+              window.dispatchEvent(new CustomEvent('rocketmq-audit-warning', { detail: 'Consumer edit was applied.' }));
+              pendingUpdate.reject(new ApiClientError('APPLIED_AUDIT_FAILED', 'Consumer edit was applied.', { mutationApplied: true }));
+            }} /><ConsumerDetailPage /></>}
+          />
+          <Route path="/consumers" element={<h1>Consumer list</h1>} />
+        </Routes>
+      </ConsumerQueryScopeProvider>,
+      '/consumers/order-service'
+    );
+    await screen.findByRole('heading', { name: 'order-service' });
+    await user.click(screen.getByRole('button', { name: 'Edit configuration' }));
+    const orderDialog = await screen.findByRole('dialog', { name: 'Edit order-service' });
+    await waitFor(() => expect(within(orderDialog).getByRole('checkbox', { name: 'broker-a' })).toBeChecked());
+    vi.clearAllMocks();
+    vi.mocked(consumerApi.update).mockImplementationOnce(() => pendingUpdate.promise);
+    vi.mocked(consumerApi.summary).mockResolvedValue(inventorySummary);
+    vi.mocked(consumerApi.config).mockResolvedValue({ ...consumerConfig, group: 'inventory-service' });
+    vi.mocked(brokerApi.list).mockResolvedValue({
+      items: [{ clusterName: 'DefaultCluster', brokerName: 'broker-a', brokerId: 0, address: '127.0.0.1:10911', role: 'MASTER', version: 'V5_3_0', produceTps: 0, consumeTps: 0 }],
+      total: 1
+    });
+
+    await user.click(within(orderDialog).getByRole('button', { name: 'Update group' }));
+    await waitFor(() => expect(consumerApi.update).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByText('Commit inventory group'));
+    await screen.findByRole('heading', { name: 'inventory-service', hidden: true });
+    await waitFor(() => expect(auditWarning).toHaveBeenCalledTimes(1));
+
+    expect(auditWarning).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('heading', { name: 'inventory-service', hidden: true })).toBeInTheDocument();
+    expect(screen.queryByRole('dialog', { name: 'Edit inventory-service' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Consumer list', hidden: true })).not.toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Connections: 41', hidden: true })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Edit configuration', hidden: true })).toBeEnabled());
+    expect(vi.mocked(consumerApi.summary).mock.calls).toContainEqual(['order-service', { mode: 'nameServer' }]);
+    expect(consumerApi.config).toHaveBeenCalledWith('order-service', { mode: 'nameServer' });
+    expect(consumerApi.update).toHaveBeenCalledTimes(1);
+    window.removeEventListener('rocketmq-audit-warning', auditWarning);
+  });
+
+  it('unmounts the old delete dialog when an applied delete settles in the commit-before-passive window', async () => {
+    const user = userEvent.setup();
+    const pendingDelete = deferred<Awaited<ReturnType<typeof consumerApi.delete>>>();
+    const auditWarning = vi.fn();
+    vi.mocked(configApi.getConfig).mockResolvedValue({
+      environmentId: 'environment-default',
+      environmentName: 'Default',
+      revision: 1,
+      endpoints: [
+        { endpointId: 'nameserver-1', endpointType: 'nameserver', address: '127.0.0.1:9876', role: 'primary', isEnabled: true, isActive: true, sortOrder: 0 },
+        { endpointId: 'proxy-1', endpointType: 'proxy', address: 'proxy-a:8081', role: 'primary', isEnabled: true, isActive: true, sortOrder: 1 }
+      ],
+      currentNamesrv: '127.0.0.1:9876',
+      namesrvAddrList: ['127.0.0.1:9876'],
+      useVIPChannel: false,
+      useTLS: false,
+      currentProxyAddr: 'proxy-a:8081',
+      proxyAddrList: ['proxy-a:8081'],
+      storageBackend: 'sqlite',
+      storageMode: 'singleNode'
+    });
+    window.addEventListener('rocketmq-audit-warning', auditWarning);
+    renderAtRoute(
+      <ConsumerQueryScopeProvider>
+        <CommitWindowScopeSwitch onCommitted={() => {
+          window.dispatchEvent(new CustomEvent('rocketmq-audit-warning', { detail: 'Consumer deletion was applied.' }));
+          pendingDelete.reject(new ApiClientError('APPLIED_AUDIT_FAILED', 'Consumer deletion was applied.', { mutationApplied: true }));
+        }} />
+        <Routes>
+          <Route path="/consumers/:group" element={<ConsumerDetailPage />} />
+          <Route path="/consumers" element={<h1>Consumer list</h1>} />
+        </Routes>
+      </ConsumerQueryScopeProvider>,
+      '/consumers/order-service'
+    );
+    await screen.findByRole('heading', { name: 'order-service' });
+    await user.click(screen.getByRole('button', { name: 'Delete group' }));
+    const nameServerDialog = await screen.findByRole('dialog', { name: 'Delete consumer group' });
+    await user.click(await within(nameServerDialog).findByRole('checkbox', { name: 'broker-a' }));
+    await user.type(within(nameServerDialog).getByLabelText('Confirm consumer group'), 'order-service');
+    vi.clearAllMocks();
+    vi.mocked(consumerApi.delete).mockImplementationOnce(() => pendingDelete.promise);
+    vi.mocked(consumerApi.summary).mockResolvedValue({
+      group: 'order-service',
+      displayGroupName: 'order-service',
+      category: 'NORMAL',
+      connectionCount: 28,
+      consumeTps: 1,
+      diffTotal: 3,
+      messageModel: 'MESSAGE_MODEL_CLUSTERING',
+      consumeType: 'CONSUME_PASSIVELY',
+      version: null,
+      versionDesc: '',
+      brokerNames: [],
+      brokerAddresses: [],
+      updateTimestamp: 7,
+      queryScope: { mode: 'proxy' as const, proxyAddress: 'proxy-a:8081' }
+    });
+
+    await user.click(within(nameServerDialog).getByRole('button', { name: 'Delete consumer group' }));
+    await waitFor(() => expect(consumerApi.delete).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByText('Commit proxy scope'));
+    await waitFor(() => expect(screen.getByRole('group', { name: 'Connections: 28', hidden: true })).toBeInTheDocument());
+    await waitFor(() => expect(auditWarning).toHaveBeenCalledTimes(1));
+
+    expect(auditWarning).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('heading', { name: 'order-service', hidden: true })).toBeInTheDocument();
+    expect(screen.queryByRole('dialog', { name: 'Delete consumer group' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Consumer list', hidden: true })).not.toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Connections: 28', hidden: true })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Delete group', hidden: true })).toBeEnabled());
+    expect(vi.mocked(consumerApi.summary).mock.calls).toContainEqual(['order-service', { mode: 'nameServer' }]);
+    expect(consumerApi.delete).toHaveBeenCalledTimes(1);
+    window.removeEventListener('rocketmq-audit-warning', auditWarning);
+  });
+
+  it('unmounts the old delete dialog when a stale NotFound settles in the commit-before-passive window', async () => {
+    const user = userEvent.setup();
+    const pendingDelete = deferred<Awaited<ReturnType<typeof consumerApi.delete>>>();
+    const inventorySummary = {
+      group: 'inventory-service',
+      displayGroupName: 'inventory-service',
+      category: 'NORMAL',
+      connectionCount: 32,
+      consumeTps: 2,
+      diffTotal: 1,
+      messageModel: 'MESSAGE_MODEL_CLUSTERING',
+      consumeType: 'CONSUME_PASSIVELY',
+      version: null,
+      versionDesc: '',
+      brokerNames: [],
+      brokerAddresses: [],
+      updateTimestamp: 8,
+      queryScope: { mode: 'nameServer' as const }
+    };
+    renderAtRoute(
+      <ConsumerQueryScopeProvider>
+        <Routes>
+          <Route
+            path="/consumers/:group"
+            element={<><CommitWindowGroupSwitch onCommitted={() => {
+              pendingDelete.reject(new ApiClientError('NOT_FOUND', 'Consumer group was not found.'));
+            }} /><ConsumerDetailPage /></>}
+          />
+          <Route path="/consumers" element={<h1>Consumer list</h1>} />
+        </Routes>
+      </ConsumerQueryScopeProvider>,
+      '/consumers/order-service'
+    );
+    await screen.findByRole('heading', { name: 'order-service' });
+    await user.click(screen.getByRole('button', { name: 'Delete group' }));
+    const orderDialog = await screen.findByRole('dialog', { name: 'Delete consumer group' });
+    await user.click(await within(orderDialog).findByRole('checkbox', { name: 'broker-a' }));
+    await user.type(within(orderDialog).getByLabelText('Confirm consumer group'), 'order-service');
+    vi.clearAllMocks();
+    vi.mocked(consumerApi.delete).mockImplementationOnce(() => pendingDelete.promise);
+    vi.mocked(consumerApi.summary).mockResolvedValue(inventorySummary);
+    vi.mocked(consumerApi.brokers).mockResolvedValue({ items: [{ brokerName: 'broker-a', brokerAddress: '127.0.0.1:10911' }] });
+
+    await user.click(within(orderDialog).getByRole('button', { name: 'Delete consumer group' }));
+    await waitFor(() => expect(consumerApi.delete).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByText('Commit inventory group'));
+
+    await screen.findByRole('heading', { name: 'inventory-service', hidden: true });
+    expect(screen.queryByRole('dialog', { name: 'Delete consumer group' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Consumer list', hidden: true })).not.toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Connections: 32', hidden: true })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Edit configuration', hidden: true })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Delete group', hidden: true })).toBeEnabled();
+    expect(consumerApi.delete).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(consumerApi.summary).mock.calls).not.toContainEqual(['order-service', { mode: 'nameServer' }]);
+  });
+
+  it('disables B synchronously in a sibling layout effect while a pending A edit becomes applied', async () => {
+    const user = userEvent.setup();
+    const pendingUpdate = deferred<Awaited<ReturnType<typeof consumerApi.update>>>();
+    const inventorySummary = deferred<ConsumerSummaryView>();
+    const layoutSettled = vi.fn();
+    const auditWarning = vi.fn();
+    window.addEventListener('rocketmq-audit-warning', auditWarning);
+    renderAtRoute(
+      <ConsumerQueryScopeProvider>
+        <Routes>
+          <Route
+            path="/consumers/:group"
+            element={<><LayoutGroupSwitch /><ConsumerDetailPage /><LayoutIdentityObserver group="inventory-service" scopeMode="nameServer" onSettled={(controls) => {
+              layoutSettled(controls);
+              window.dispatchEvent(new CustomEvent('rocketmq-audit-warning', { detail: 'Consumer edit was applied.' }));
+              pendingUpdate.reject(new ApiClientError('APPLIED_AUDIT_FAILED', 'Consumer edit was applied.', { mutationApplied: true }));
+            }} /></>}
+          />
+        </Routes>
+      </ConsumerQueryScopeProvider>,
+      '/consumers/order-service'
+    );
+    await screen.findByRole('heading', { name: 'order-service' });
+    await user.click(screen.getByRole('button', { name: 'Edit configuration' }));
+    const orderDialog = await screen.findByRole('dialog', { name: 'Edit order-service' });
+    await waitFor(() => expect(within(orderDialog).getByRole('checkbox', { name: 'broker-a' })).toBeChecked());
+
+    vi.clearAllMocks();
+    vi.mocked(consumerApi.update).mockImplementationOnce(() => pendingUpdate.promise);
+    vi.mocked(consumerApi.summary).mockImplementation((requestedGroup) => {
+      if (requestedGroup === 'inventory-service') return inventorySummary.promise;
+      return Promise.reject(new Error(`unexpected stale summary read for ${requestedGroup}`));
+    });
+    vi.mocked(consumerApi.progress).mockResolvedValue({
+      group: 'inventory-service', topicCount: 0, totalDiff: 1, topics: [], queryScope: { mode: 'nameServer' }
+    });
+    vi.mocked(consumerApi.config).mockResolvedValue({ ...consumerConfig, group: 'inventory-service' });
+    vi.mocked(brokerApi.list).mockResolvedValue({
+      items: [{ clusterName: 'DefaultCluster', brokerName: 'broker-b', brokerId: 0, address: '127.0.0.2:10911', role: 'MASTER', version: 'V5_3_0', produceTps: 0, consumeTps: 0 }],
+      total: 1
+    });
+
+    await user.click(within(orderDialog).getByRole('button', { name: 'Update group' }));
+    await waitFor(() => expect(consumerApi.update).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole('button', { name: 'Commit layout inventory group', hidden: true }));
+
+    await waitFor(() => expect(layoutSettled).toHaveBeenCalledTimes(1));
+    expect(layoutSettled).toHaveBeenCalledWith({ editDisabled: true, deleteDisabled: true });
+    await waitFor(() => expect(auditWarning).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole('dialog', { name: 'Edit inventory-service' })).not.toBeInTheDocument();
+    expect(consumerApi.update).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(consumerApi.summary).mock.calls).toContainEqual(['order-service', { mode: 'nameServer' }]);
+    expect(consumerApi.config).toHaveBeenCalledWith('order-service', { mode: 'nameServer' });
+
+    await act(async () => {
+      inventorySummary.resolve({
+        group: 'inventory-service', displayGroupName: 'inventory-service', category: 'NORMAL', connectionCount: 47,
+        consumeTps: 7, diffTotal: 1, messageModel: 'MESSAGE_MODEL_CLUSTERING', consumeType: 'CONSUME_PASSIVELY',
+        version: null, versionDesc: '', brokerNames: [], brokerAddresses: [], updateTimestamp: 10,
+        queryScope: { mode: 'nameServer' }
+      });
+    });
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Edit configuration' })).toBeEnabled());
+    await user.click(screen.getByRole('button', { name: 'Edit configuration' }));
+    const inventoryDialog = await screen.findByRole('dialog', { name: 'Edit inventory-service' });
+    await waitFor(() => expect(consumerApi.config).toHaveBeenCalledTimes(2));
+    expect(within(inventoryDialog).getByRole('checkbox', { name: 'broker-b' })).not.toBeChecked();
+    expect(consumerApi.config).toHaveBeenCalledWith('inventory-service', { mode: 'nameServer' });
+    window.removeEventListener('rocketmq-audit-warning', auditWarning);
+  });
+
+  it('disables the proxy scope synchronously in a sibling layout effect while a pending NameServer delete becomes applied', async () => {
+    const user = userEvent.setup();
+    const pendingDelete = deferred<Awaited<ReturnType<typeof consumerApi.delete>>>();
+    const proxySummary = deferred<ConsumerSummaryView>();
+    const layoutSettled = vi.fn();
+    const auditWarning = vi.fn();
+    vi.mocked(configApi.getConfig).mockResolvedValue({
+      environmentId: 'environment-default', environmentName: 'Default', revision: 1,
+      endpoints: [
+        { endpointId: 'nameserver-1', endpointType: 'nameserver', address: '127.0.0.1:9876', role: 'primary', isEnabled: true, isActive: true, sortOrder: 0 },
+        { endpointId: 'proxy-1', endpointType: 'proxy', address: 'proxy-a:8081', role: 'primary', isEnabled: true, isActive: true, sortOrder: 1 }
+      ],
+      currentNamesrv: '127.0.0.1:9876', namesrvAddrList: ['127.0.0.1:9876'], useVIPChannel: false, useTLS: false,
+      currentProxyAddr: 'proxy-a:8081', proxyAddrList: ['proxy-a:8081'], storageBackend: 'sqlite', storageMode: 'singleNode'
+    });
+    window.addEventListener('rocketmq-audit-warning', auditWarning);
+    renderAtRoute(
+      <ConsumerQueryScopeProvider>
+        <LayoutScopeSwitch />
+        <Routes>
+          <Route
+            path="/consumers/:group"
+            element={<><ConsumerDetailPage /><LayoutIdentityObserver group="order-service" scopeMode="proxy" onSettled={(controls) => {
+              layoutSettled(controls);
+              window.dispatchEvent(new CustomEvent('rocketmq-audit-warning', { detail: 'Consumer deletion was applied.' }));
+              pendingDelete.reject(new ApiClientError('APPLIED_AUDIT_FAILED', 'Consumer deletion was applied.', { mutationApplied: true }));
+            }} /></>}
+          />
+        </Routes>
+      </ConsumerQueryScopeProvider>,
+      '/consumers/order-service'
+    );
+    await screen.findByRole('heading', { name: 'order-service' });
+    await user.click(screen.getByRole('button', { name: 'Delete group' }));
+    const nameServerDialog = await screen.findByRole('dialog', { name: 'Delete consumer group' });
+    await user.click(await within(nameServerDialog).findByRole('checkbox', { name: 'broker-a' }));
+    await user.type(within(nameServerDialog).getByLabelText('Confirm consumer group'), 'order-service');
+
+    vi.clearAllMocks();
+    vi.mocked(consumerApi.delete).mockImplementationOnce(() => pendingDelete.promise);
+    vi.mocked(consumerApi.summary).mockImplementation((_requestedGroup, requestedScope) => {
+      if (requestedScope.mode === 'proxy') return proxySummary.promise;
+      return Promise.reject(new Error('unexpected stale NameServer summary read'));
+    });
+    vi.mocked(consumerApi.progress).mockResolvedValue({
+      group: 'order-service', topicCount: 0, totalDiff: 2, topics: [], queryScope: { mode: 'proxy', proxyAddress: 'proxy-a:8081' }
+    });
+
+    await user.click(within(nameServerDialog).getByRole('button', { name: 'Delete consumer group' }));
+    await waitFor(() => expect(consumerApi.delete).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole('button', { name: 'Commit layout proxy scope', hidden: true }));
+
+    await waitFor(() => expect(layoutSettled).toHaveBeenCalledTimes(1));
+    expect(layoutSettled).toHaveBeenCalledWith({ editDisabled: true, deleteDisabled: true });
+    await waitFor(() => expect(auditWarning).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole('dialog', { name: 'Delete consumer group' })).not.toBeInTheDocument();
+    expect(consumerApi.delete).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(consumerApi.summary).mock.calls).toContainEqual(['order-service', { mode: 'nameServer' }]);
+
+    await act(async () => {
+      proxySummary.resolve({
+        group: 'order-service', displayGroupName: 'order-service', category: 'NORMAL', connectionCount: 53,
+        consumeTps: 9, diffTotal: 2, messageModel: 'MESSAGE_MODEL_CLUSTERING', consumeType: 'CONSUME_PASSIVELY',
+        version: null, versionDesc: '', brokerNames: [], brokerAddresses: [], updateTimestamp: 11,
+        queryScope: { mode: 'proxy', proxyAddress: 'proxy-a:8081' }
+      });
+    });
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Delete group' })).toBeEnabled());
+    expect(screen.queryByRole('dialog', { name: 'Delete consumer group' })).not.toBeInTheDocument();
+    window.removeEventListener('rocketmq-audit-warning', auditWarning);
+  });
+
+  it('drops an applied completion settled in the commit-before-passive unmount window', async () => {
+    const user = userEvent.setup();
+    const pendingUpdate = deferred<Awaited<ReturnType<typeof consumerApi.update>>>();
+    const auditWarning = vi.fn();
+    window.addEventListener('rocketmq-audit-warning', auditWarning);
+    renderAtRoute(
+      <ConsumerQueryScopeProvider>
+        <Routes>
+          <Route
+            path="/consumers/:group"
+            element={<><CommitWindowUnmountSwitch onCommitted={() => {
+              window.dispatchEvent(new CustomEvent('rocketmq-audit-warning', { detail: 'Consumer edit was applied.' }));
+              pendingUpdate.reject(new ApiClientError('APPLIED_AUDIT_FAILED', 'Consumer edit was applied.', { mutationApplied: true }));
+            }} /><ConsumerDetailPage /></>}
+          />
+          <Route path="/consumers" element={<h1>Consumer list</h1>} />
+        </Routes>
+      </ConsumerQueryScopeProvider>,
+      '/consumers/order-service'
+    );
+    await screen.findByRole('heading', { name: 'order-service' });
+    await user.click(screen.getByRole('button', { name: 'Edit configuration' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Edit order-service' });
+    await waitFor(() => expect(within(dialog).getByRole('checkbox', { name: 'broker-a' })).toBeChecked());
+    vi.clearAllMocks();
+    vi.mocked(consumerApi.update).mockImplementationOnce(() => pendingUpdate.promise);
+
+    await user.click(within(dialog).getByRole('button', { name: 'Update group' }));
+    await waitFor(() => expect(consumerApi.update).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByText('Commit consumer list'));
+
+    expect(await screen.findByRole('heading', { name: 'Consumer list' })).toBeInTheDocument();
+    await waitFor(() => expect(auditWarning).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole('dialog', { name: 'Edit order-service', hidden: true })).not.toBeInTheDocument();
+    expect(consumerApi.update).toHaveBeenCalledTimes(1);
+    expect(consumerApi.summary).toHaveBeenCalledWith('order-service', { mode: 'nameServer' });
+    expect(consumerApi.config).toHaveBeenCalledWith('order-service', { mode: 'nameServer' });
+    window.removeEventListener('rocketmq-audit-warning', auditWarning);
+  });
+
+  it('keeps a pending A edit current when a suspended B render is discarded before commit', async () => {
+    const user = userEvent.setup();
+    const suspension = deferred<void>();
+    const pendingUpdate = deferred<Awaited<ReturnType<typeof consumerApi.update>>>();
+    const inventoryRendered = vi.fn();
+    renderAtRoute(
+      <ConsumerQueryScopeProvider>
+        <ConcurrentConsumerWorkspace suspension={suspension.promise} onInventoryRender={inventoryRendered} />
+      </ConsumerQueryScopeProvider>,
+      '/consumers/order-service'
+    );
+    await screen.findByRole('heading', { name: 'order-service' });
+    await user.click(screen.getByRole('button', { name: 'Edit configuration' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Edit order-service' });
+    await waitFor(() => expect(within(dialog).getByRole('checkbox', { name: 'broker-a' })).toBeChecked());
+    vi.clearAllMocks();
+    vi.mocked(consumerApi.update).mockImplementationOnce(() => pendingUpdate.promise);
+
+    await user.click(within(dialog).getByRole('button', { name: 'Update group' }));
+    await waitFor(() => expect(consumerApi.update).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole('button', { name: 'Start suspended inventory transition', hidden: true }));
+    await waitFor(() => expect(inventoryRendered).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel suspended transition', hidden: true }));
+
+    await act(async () => {
+      pendingUpdate.resolve({
+        operation: 'UPDATE',
+        consumerGroup: 'order-service',
+        success: true,
+        targetCount: 1,
+        message: 'saved',
+        targets: [{ target: 'broker-a', kind: 'BROKER', success: true, message: 'saved' }]
+      });
+      suspension.resolve();
+    });
+
+    expect(screen.getByRole('heading', { name: 'order-service' })).toBeInTheDocument();
+    expect(screen.queryByRole('dialog', { name: 'Edit order-service' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Edit configuration' })).toBeDisabled();
+    expect(consumerApi.update).toHaveBeenCalledTimes(1);
+    expect(consumerApi.summary).not.toHaveBeenCalled();
+    expect(consumerApi.config).not.toHaveBeenCalled();
+  });
+
+  it('runs the A terminal applied refresh once after a suspended B render is discarded', async () => {
+    const user = userEvent.setup();
+    const suspension = deferred<void>();
+    const pendingUpdate = deferred<Awaited<ReturnType<typeof consumerApi.update>>>();
+    const inventoryRendered = vi.fn();
+    const auditWarning = vi.fn();
+    const appliedSummary = {
+      group: 'order-service',
+      displayGroupName: 'order-service',
+      category: 'NORMAL',
+      connectionCount: 19,
+      consumeTps: 1,
+      diffTotal: 2,
+      messageModel: 'MESSAGE_MODEL_CLUSTERING',
+      consumeType: 'CONSUME_PASSIVELY',
+      version: null,
+      versionDesc: '',
+      brokerNames: [],
+      brokerAddresses: [],
+      updateTimestamp: 9,
+      queryScope: { mode: 'nameServer' as const }
+    };
+    window.addEventListener('rocketmq-audit-warning', auditWarning);
+    renderAtRoute(
+      <ConsumerQueryScopeProvider>
+        <ConcurrentConsumerWorkspace suspension={suspension.promise} onInventoryRender={inventoryRendered} />
+      </ConsumerQueryScopeProvider>,
+      '/consumers/order-service'
+    );
+    await screen.findByRole('heading', { name: 'order-service' });
+    await user.click(screen.getByRole('button', { name: 'Edit configuration' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Edit order-service' });
+    await waitFor(() => expect(within(dialog).getByRole('checkbox', { name: 'broker-a' })).toBeChecked());
+    await waitFor(() => expect(consumerApi.config).toHaveBeenCalledTimes(1));
+    await act(async () => undefined);
+    vi.clearAllMocks();
+    vi.mocked(consumerApi.update).mockImplementationOnce(() => pendingUpdate.promise);
+    vi.mocked(consumerApi.summary).mockResolvedValueOnce(appliedSummary);
+    vi.mocked(consumerApi.config).mockResolvedValueOnce(consumerConfig);
+
+    await user.click(within(dialog).getByRole('button', { name: 'Update group' }));
+    await waitFor(() => expect(consumerApi.update).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole('button', { name: 'Start suspended inventory transition', hidden: true }));
+    await waitFor(() => expect(inventoryRendered).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel suspended transition', hidden: true }));
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent('rocketmq-audit-warning', { detail: 'Consumer edit was applied.' }));
+      pendingUpdate.reject(new ApiClientError('APPLIED_AUDIT_FAILED', 'Consumer edit was applied.', { mutationApplied: true }));
+      suspension.resolve();
+    });
+
+    await waitFor(() => expect(consumerApi.summary).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(consumerApi.config).toHaveBeenCalledTimes(1));
+    expect(auditWarning).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('dialog', { name: 'Edit order-service' })).not.toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Connections: 19' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Retry update' })).not.toBeInTheDocument();
+    expect(consumerApi.update).toHaveBeenCalledTimes(1);
+    window.removeEventListener('rocketmq-audit-warning', auditWarning);
+  });
+
+  it('navigates once for A NotFound after a suspended B render is discarded', async () => {
+    const user = userEvent.setup();
+    const suspension = deferred<void>();
+    const pendingDelete = deferred<Awaited<ReturnType<typeof consumerApi.delete>>>();
+    const inventoryRendered = vi.fn();
+    renderAtRoute(
+      <ConsumerQueryScopeProvider>
+        <ConcurrentConsumerWorkspace suspension={suspension.promise} onInventoryRender={inventoryRendered} />
+      </ConsumerQueryScopeProvider>,
+      '/consumers/order-service'
+    );
+    await screen.findByRole('heading', { name: 'order-service' });
+    await user.click(screen.getByRole('button', { name: 'Delete group' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Delete consumer group' });
+    await user.click(await within(dialog).findByRole('checkbox', { name: 'broker-a' }));
+    await user.type(within(dialog).getByLabelText('Confirm consumer group'), 'order-service');
+    vi.clearAllMocks();
+    vi.mocked(consumerApi.delete).mockImplementationOnce(() => pendingDelete.promise);
+    vi.mocked(consumerApi.summary).mockRejectedValueOnce(new ApiClientError('NOT_FOUND', 'Consumer group was not found.'));
+
+    await user.click(within(dialog).getByRole('button', { name: 'Delete consumer group' }));
+    await waitFor(() => expect(consumerApi.delete).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole('button', { name: 'Start suspended inventory transition', hidden: true }));
+    await waitFor(() => expect(inventoryRendered).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel suspended transition', hidden: true }));
+
+    await act(async () => {
+      pendingDelete.reject(new ApiClientError('APPLIED_AUDIT_FAILED', 'Consumer deletion was applied.', { mutationApplied: true }));
+      suspension.resolve();
+    });
+
+    expect(await screen.findByRole('heading', { name: 'Consumer list' })).toBeInTheDocument();
+    expect(screen.queryByRole('dialog', { name: 'Delete consumer group' })).not.toBeInTheDocument();
+    expect(consumerApi.delete).toHaveBeenCalledTimes(1);
+    expect(consumerApi.summary).toHaveBeenCalledTimes(1);
+    expect(consumerApi.summary).toHaveBeenCalledWith('order-service', { mode: 'nameServer' });
+  });
+
+  it('retains an A edit lock through A-to-B-to-A until its terminal refresh settles once', async () => {
+    const user = userEvent.setup();
+    const pendingUpdate = deferred<Awaited<ReturnType<typeof consumerApi.update>>>();
+    const pendingConfig = deferred<Awaited<ReturnType<typeof consumerApi.config>>>();
+    const auditWarning = vi.fn();
+    const orderSummary = {
+      group: 'order-service', displayGroupName: 'order-service', category: 'NORMAL', connectionCount: 61,
+      consumeTps: 2, diffTotal: 3, messageModel: 'MESSAGE_MODEL_CLUSTERING', consumeType: 'CONSUME_PASSIVELY',
+      version: null, versionDesc: '', brokerNames: [], brokerAddresses: [], updateTimestamp: 12,
+      queryScope: { mode: 'nameServer' as const }
+    };
+    const inventorySummary = {
+      group: 'inventory-service', displayGroupName: 'inventory-service', category: 'NORMAL', connectionCount: 62,
+      consumeTps: 4, diffTotal: 5, messageModel: 'MESSAGE_MODEL_CLUSTERING', consumeType: 'CONSUME_PASSIVELY',
+      version: null, versionDesc: '', brokerNames: [], brokerAddresses: [], updateTimestamp: 13,
+      queryScope: { mode: 'nameServer' as const }
+    };
+    window.addEventListener('rocketmq-audit-warning', auditWarning);
+    renderAtRoute(
+      <ConsumerQueryScopeProvider>
+        <ConsumerABASwitch />
+        <Routes>
+          <Route path="/consumers/:group" element={<ConsumerDetailPage />} />
+        </Routes>
+      </ConsumerQueryScopeProvider>,
+      '/consumers/order-service'
+    );
+    await screen.findByRole('heading', { name: 'order-service' });
+    await user.click(screen.getByRole('button', { name: 'Edit configuration' }));
+    const orderDialog = await screen.findByRole('dialog', { name: 'Edit order-service' });
+    await waitFor(() => expect(within(orderDialog).getByRole('checkbox', { name: 'broker-a' })).toBeChecked());
+
+    vi.clearAllMocks();
+    vi.mocked(consumerApi.update).mockImplementationOnce(() => pendingUpdate.promise);
+    vi.mocked(consumerApi.summary).mockImplementation((requestedGroup) => Promise.resolve(
+      requestedGroup === 'inventory-service' ? inventorySummary : orderSummary
+    ));
+    vi.mocked(consumerApi.config).mockImplementation(() => pendingConfig.promise);
+    vi.mocked(consumerApi.progress).mockResolvedValue({
+      group: 'order-service', topicCount: 0, totalDiff: 0, topics: [], queryScope: { mode: 'nameServer' }
+    });
+
+    await user.click(within(orderDialog).getByRole('button', { name: 'Update group' }));
+    await waitFor(() => expect(consumerApi.update).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole('button', { name: 'Switch to inventory group', hidden: true }));
+    await screen.findByRole('heading', { name: 'inventory-service' });
+    fireEvent.click(screen.getByRole('button', { name: 'Switch to order group', hidden: true }));
+    await screen.findByRole('heading', { name: 'order-service' });
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Edit configuration' })).toBeDisabled());
+
+    const summaryCallsBeforeApplied = vi.mocked(consumerApi.summary).mock.calls.length;
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent('rocketmq-audit-warning', { detail: 'Consumer edit was applied.' }));
+      pendingUpdate.reject(new ApiClientError('APPLIED_AUDIT_FAILED', 'Consumer edit was applied.', { mutationApplied: true }));
+    });
+    await waitFor(() => expect(consumerApi.config).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(consumerApi.summary).mock.calls).toHaveLength(summaryCallsBeforeApplied + 1);
+    expect(vi.mocked(consumerApi.summary).mock.calls[vi.mocked(consumerApi.summary).mock.calls.length - 1]).toEqual(['order-service', { mode: 'nameServer' }]);
+    expect(auditWarning).toHaveBeenCalledTimes(1);
+    expect(consumerApi.update).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('button', { name: 'Edit configuration' })).toBeDisabled();
+    expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument();
+
+    await act(async () => pendingConfig.resolve(consumerConfig));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Edit configuration' })).toBeEnabled());
+    window.removeEventListener('rocketmq-audit-warning', auditWarning);
+  });
+
+  it('applies the first applied-edit refresh for a new consumer identity exactly once', async () => {
+    const user = userEvent.setup();
+    const inventorySummary = {
+      group: 'inventory-service',
+      displayGroupName: 'inventory-service',
+      category: 'NORMAL',
+      connectionCount: 23,
+      consumeTps: 3,
+      diffTotal: 1,
+      messageModel: 'MESSAGE_MODEL_CLUSTERING',
+      consumeType: 'CONSUME_PASSIVELY',
+      version: null,
+      versionDesc: '',
+      brokerNames: [],
+      brokerAddresses: [],
+      updateTimestamp: 5,
+      queryScope: { mode: 'nameServer' as const }
+    };
+    const inventoryConfig = {
+      ...consumerConfig,
+      group: 'inventory-service',
+      effective: { ...consumerConfig.effective!, retryMaxTimes: 31 },
+      targets: consumerConfig.targets.map((target) => ({
+        ...target,
+        config: target.config ? { ...target.config, retryMaxTimes: 31 } : null
+      }))
+    };
+    renderAtRoute(
+      <ConsumerQueryScopeProvider>
+        <Routes><Route path="/consumers/:group" element={<><ConsumerGroupSwitch /><ConsumerDetailPage /></>} /></Routes>
+      </ConsumerQueryScopeProvider>,
+      '/consumers/order-service'
+    );
+    await screen.findByRole('heading', { name: 'order-service' });
+    await user.click(screen.getByRole('button', { name: 'Edit configuration' }));
+    let dialog = await screen.findByRole('dialog', { name: 'Edit order-service' });
+    await waitFor(() => expect(within(dialog).getByRole('checkbox', { name: 'broker-a' })).toBeChecked());
+    vi.clearAllMocks();
+    vi.mocked(consumerApi.update).mockRejectedValueOnce(
+      new ApiClientError('APPLIED_AUDIT_FAILED', 'Consumer configuration was applied.', { mutationApplied: true })
+    );
+    vi.mocked(consumerApi.summary).mockResolvedValueOnce({
+      ...inventorySummary,
+      group: 'order-service',
+      displayGroupName: 'order-service',
+      connectionCount: 9
+    });
+    vi.mocked(consumerApi.config).mockResolvedValueOnce(consumerConfig);
+    await user.click(within(dialog).getByRole('button', { name: 'Update group' }));
+    await waitFor(() => expect(consumerApi.summary).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Edit order-service' })).not.toBeInTheDocument());
+    await waitFor(() => expect(document.body).not.toHaveAttribute('data-scroll-locked'));
+    vi.mocked(consumerApi.summary).mockResolvedValue(inventorySummary);
+    vi.mocked(consumerApi.progress).mockResolvedValue({
+      group: 'inventory-service', topicCount: 0, totalDiff: 1, topics: [], queryScope: { mode: 'nameServer' }
+    });
+    vi.mocked(consumerApi.config).mockResolvedValue(inventoryConfig);
+    vi.mocked(brokerApi.list).mockResolvedValue({
+      items: [{ clusterName: 'DefaultCluster', brokerName: 'broker-a', brokerId: 0, address: '127.0.0.1:10911', role: 'MASTER', version: 'V5_3_0', produceTps: 0, consumeTps: 0 }],
+      total: 1
+    });
+    await user.click(screen.getByRole('button', { name: 'Open inventory group' }));
+    await screen.findByRole('heading', { name: 'inventory-service' });
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Edit configuration' })).toBeEnabled());
+    await user.click(screen.getByRole('button', { name: 'Edit configuration' }));
+    dialog = await screen.findByRole('dialog', { name: 'Edit inventory-service', hidden: true });
+    await waitFor(() => expect(within(dialog).getByRole('checkbox', { name: 'broker-a' })).toBeChecked());
+    vi.clearAllMocks();
+    vi.mocked(consumerApi.update).mockRejectedValueOnce(
+      new ApiClientError('APPLIED_AUDIT_FAILED', 'Consumer configuration was applied.', { mutationApplied: true })
+    );
+    vi.mocked(consumerApi.summary).mockResolvedValueOnce(inventorySummary);
+    vi.mocked(consumerApi.config).mockResolvedValueOnce(inventoryConfig);
+
+    await user.click(within(dialog).getByRole('button', { name: 'Update group' }));
+    await waitFor(() => expect(consumerApi.update).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(consumerApi.summary).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(consumerApi.config).toHaveBeenCalledTimes(1));
+    await user.click(screen.getByRole('tab', { name: 'Configuration' }));
+
+    expect(await screen.findAllByText('31')).toHaveLength(2);
+    expect(consumerApi.config).toHaveBeenCalledTimes(1);
   });
 });

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConsumerDetailPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConsumerDetailPage.tsx
@@ -1,19 +1,34 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { consumerApi } from '../api/consumer_api';
+import { ApiClientError } from '../api/client';
 import ConsumerDeleteDialog from '../components/ConsumerDeleteDialog';
 import EntityDetailPage from '../components/EntityDetailPage';
 import ConsumerMutationDialog from '../components/ConsumerMutationDialog';
+import { consumerMutationKey, useConsumerMutationLocked } from '../components/consumerMutationLock';
 import { Button } from '../components/ui/Button';
-import type { ConsumerGroupListItem, ConsumerSummaryView } from '../types/consumer';
+import type { ConsumerGroupListItem, ConsumerOperationIdentity, ConsumerSummaryView } from '../types/consumer';
 import { useConsumerQueryScope } from './consumers/ConsumerQueryScopeProvider';
 import ConsumerDetailContent from './consumers/ConsumerDetailContent';
+
+function consumerScopeKey(mode: string, proxyAddress: string | undefined) {
+  return `${mode}:${proxyAddress ?? ''}`;
+}
+
+function sameIdentity(left: ConsumerOperationIdentity, right: ConsumerOperationIdentity) {
+  return left.group === right.group
+    && left.scopeKey === right.scopeKey
+    && left.generation === right.generation;
+}
 
 export default function ConsumerDetailPage() {
   const { group = '' } = useParams();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { scope } = useConsumerQueryScope();
+  const scopeKey = consumerScopeKey(scope.mode, scope.proxyAddress);
+  const editMutationLocked = useConsumerMutationLocked(consumerMutationKey('update', group, scopeKey));
+  const deleteMutationLocked = useConsumerMutationLocked(consumerMutationKey('delete', group, scopeKey));
   const tabParam = searchParams.get('tab');
   const initialTab = tabParam === 'clients' || tabParam === 'progress' || tabParam === 'config' || tabParam === 'reset' || tabParam === 'overview'
     ? tabParam
@@ -21,30 +36,124 @@ export default function ConsumerDetailPage() {
   const [summary, setSummary] = useState<ConsumerSummaryView | null>(null);
   const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const [mutationControlsDisabled, setMutationControlsDisabled] = useState(false);
+  const [authoritativeDetail, setAuthoritativeDetail] = useState<{
+    identityKey: string;
+    revision: number;
+    summary: ConsumerSummaryView;
+    config: Awaited<ReturnType<typeof consumerApi.config>>;
+  } | null>(null);
+  const committedIdentityRef = useRef<ConsumerOperationIdentity | null>(null);
+  const authoritativeRevisionRef = useRef(0);
+
+  // Render only derives a candidate. A concurrent render may be discarded,
+  // therefore the layout effect is the sole publisher of committed identity.
+  const committedIdentity = committedIdentityRef.current;
+  const activeIdentity: ConsumerOperationIdentity = committedIdentity
+    && committedIdentity.group === group
+    && committedIdentity.scopeKey === scopeKey
+    ? committedIdentity
+    : {
+      group,
+      scopeKey,
+      generation: (committedIdentity?.generation ?? 0) + 1
+    };
+
+  const isCurrentIdentity = (identity: ConsumerOperationIdentity) => {
+    const current = committedIdentityRef.current;
+    return current?.group === identity.group
+      && current.scopeKey === identity.scopeKey
+      && current.generation === identity.generation;
+  };
+
+  useLayoutEffect(() => {
+    committedIdentityRef.current = activeIdentity;
+    setEditOpen(false);
+    setDeleteOpen(false);
+    return () => {
+      if (committedIdentityRef.current && sameIdentity(committedIdentityRef.current, activeIdentity)) {
+        committedIdentityRef.current = {
+          ...activeIdentity,
+          generation: activeIdentity.generation + 1
+        };
+      }
+    };
+  }, [activeIdentity]);
 
   useEffect(() => {
-    let cancelled = false;
+    const identity = activeIdentity;
     setSummary(null);
+    setMutationControlsDisabled(false);
+    setAuthoritativeDetail(null);
     consumerApi.summary(group, scope)
-      .then((result) => { if (!cancelled) setSummary(result); })
-      .catch(() => { if (!cancelled) setSummary(null); });
-    return () => { cancelled = true; };
-  }, [group, scope.mode, scope.proxyAddress]);
+      .then((result) => { if (isCurrentIdentity(identity)) setSummary(result); })
+      .catch(() => { if (isCurrentIdentity(identity)) setSummary(null); });
+  }, [activeIdentity, scope]);
 
-  const listItem: ConsumerGroupListItem | null = summary ? {
-    displayGroupName: summary.displayGroupName,
-    rawGroupName: summary.group,
-    category: summary.category,
-    connectionCount: summary.connectionCount,
-    consumeTps: summary.consumeTps,
-    diffTotal: summary.diffTotal,
-    messageModel: summary.messageModel,
-    consumeType: summary.consumeType,
-    version: summary.version,
-    versionDesc: summary.versionDesc,
-    brokerNames: summary.brokerNames,
-    brokerAddresses: summary.brokerAddresses,
-    updateTimestamp: summary.updateTimestamp
+  const refreshAppliedEdit = async (identity: ConsumerOperationIdentity) => {
+    // Clear the old detail before the request so the destructive controls
+    // cannot reuse a stale configuration while the authoritative read is in
+    // flight. A failed refresh intentionally leaves the controls disabled.
+    const appliedScope = scope;
+    if (isCurrentIdentity(identity)) setMutationControlsDisabled(true);
+    if (isCurrentIdentity(identity)) setSummary(null);
+    if (isCurrentIdentity(identity)) setEditOpen(false);
+    const [nextSummary, nextConfig] = await Promise.all([
+      consumerApi.summary(identity.group, appliedScope),
+      consumerApi.config(identity.group, appliedScope)
+    ]);
+    if (!isCurrentIdentity(identity)) return;
+    setSummary(nextSummary);
+    if (!isCurrentIdentity(identity)) return;
+    setAuthoritativeDetail({
+      identityKey: `${identity.group}|${identity.scopeKey}`,
+      revision: ++authoritativeRevisionRef.current,
+      summary: nextSummary,
+      config: nextConfig
+    });
+    if (isCurrentIdentity(identity)) setMutationControlsDisabled(false);
+  };
+
+  const refreshAppliedDelete = async (identity: ConsumerOperationIdentity) => {
+    const appliedScope = scope;
+    if (isCurrentIdentity(identity)) setMutationControlsDisabled(true);
+    if (isCurrentIdentity(identity)) setSummary(null);
+    if (isCurrentIdentity(identity)) setDeleteOpen(false);
+    try {
+      const nextSummary = await consumerApi.summary(identity.group, appliedScope);
+      if (!isCurrentIdentity(identity)) return;
+      setSummary(nextSummary);
+      if (isCurrentIdentity(identity)) setMutationControlsDisabled(false);
+    } catch (error) {
+      if (isCurrentIdentity(identity) && error instanceof ApiClientError && error.code === 'NOT_FOUND') {
+        navigate('/consumers', { replace: true });
+      }
+      throw error;
+    }
+  };
+
+  const summaryScopeKey = summary
+    ? consumerScopeKey(summary.queryScope.mode, summary.queryScope.proxyAddress)
+    : null;
+  const currentSummary = summary
+    && summary.group === group
+    && summaryScopeKey === scopeKey
+    ? summary
+    : null;
+  const listItem: ConsumerGroupListItem | null = currentSummary ? {
+    displayGroupName: currentSummary.displayGroupName,
+    rawGroupName: currentSummary.group,
+    category: currentSummary.category,
+    connectionCount: currentSummary.connectionCount,
+    consumeTps: currentSummary.consumeTps,
+    diffTotal: currentSummary.diffTotal,
+    messageModel: currentSummary.messageModel,
+    consumeType: currentSummary.consumeType,
+    version: currentSummary.version,
+    versionDesc: currentSummary.versionDesc,
+    brokerNames: currentSummary.brokerNames,
+    brokerAddresses: currentSummary.brokerAddresses,
+    updateTimestamp: currentSummary.updateTimestamp
   } : null;
 
   return (
@@ -55,25 +164,33 @@ export default function ConsumerDetailPage() {
       backTo="/consumers"
       backLabel="Back to groups"
       actions={<>
-        <Button type="button" variant="outline" size="sm" disabled={!listItem} onClick={() => setEditOpen(true)}>Edit configuration</Button>
-        <Button type="button" variant="destructive" size="sm" disabled={!listItem} onClick={() => setDeleteOpen(true)}>Delete group</Button>
+        <Button type="button" variant="outline" size="sm" disabled={!listItem || mutationControlsDisabled || editMutationLocked} onClick={() => setEditOpen(true)}>Edit configuration</Button>
+        <Button type="button" variant="destructive" size="sm" disabled={!listItem || mutationControlsDisabled || deleteMutationLocked} onClick={() => setDeleteOpen(true)}>Delete group</Button>
       </>}
     >
-      <ConsumerDetailContent group={group} initialTab={initialTab} />
+      <ConsumerDetailContent group={group} initialTab={initialTab} authoritativeDetail={authoritativeDetail} />
 
-      <ConsumerMutationDialog
-        open={editOpen}
-        mode="edit"
-        consumer={listItem}
-        onOpenChange={setEditOpen}
-        onSucceeded={() => { setEditOpen(false); setSummary(null); }}
-      />
-      <ConsumerDeleteDialog
-        open={deleteOpen}
-        consumer={listItem}
-        onOpenChange={setDeleteOpen}
-        onSucceeded={() => navigate('/consumers')}
-      />
+      {listItem ? (
+        <>
+          <ConsumerMutationDialog
+            open={editOpen}
+            mode="edit"
+            consumer={listItem}
+            operationIdentity={activeIdentity}
+            onOpenChange={setEditOpen}
+            onSucceeded={() => { setEditOpen(false); setSummary(null); }}
+            onAppliedAuditFailure={refreshAppliedEdit}
+          />
+          <ConsumerDeleteDialog
+            open={deleteOpen}
+            consumer={listItem}
+            operationIdentity={activeIdentity}
+            onOpenChange={setDeleteOpen}
+            onSucceeded={() => navigate('/consumers')}
+            onAppliedAuditFailure={refreshAppliedDelete}
+          />
+        </>
+      ) : null}
     </EntityDetailPage>
   );
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConsumerListPage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConsumerListPage.test.tsx
@@ -1,14 +1,19 @@
-import { screen, waitFor } from '@testing-library/react';
+import { act, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { vi } from 'vitest';
+import { useState } from 'react';
+import { afterEach, vi } from 'vitest';
 import { configApi } from '../api/config_api';
 import { consumerApi } from '../api/consumer_api';
+import { brokerApi } from '../api/broker_api';
+import { ApiClientError } from '../api/client';
 import { renderAtRoute } from '../test/render';
 import type { ConsumerGroupListItem } from '../types/consumer';
-import { ConsumerQueryScopeProvider } from './consumers/ConsumerQueryScopeProvider';
+import { ConsumerQueryScopeProvider, useConsumerQueryScope } from './consumers/ConsumerQueryScopeProvider';
 import ConsumerListPage from './ConsumerListPage';
+import { resetConsumerMutationLocksForTests } from '../components/consumerMutationLock';
 
-vi.mock('../api/consumer_api', () => ({ consumerApi: { list: vi.fn() } }));
+vi.mock('../api/consumer_api', () => ({ consumerApi: { list: vi.fn(), create: vi.fn(), update: vi.fn(), config: vi.fn() } }));
+vi.mock('../api/broker_api', () => ({ brokerApi: { list: vi.fn() } }));
 vi.mock('../api/config_api', () => ({ configApi: { getConfig: vi.fn() } }));
 
 const consumer = (overrides: Partial<ConsumerGroupListItem> = {}): ConsumerGroupListItem => ({
@@ -30,25 +35,71 @@ const consumer = (overrides: Partial<ConsumerGroupListItem> = {}): ConsumerGroup
 
 function renderPage() {
   return renderAtRoute(
-    <ConsumerQueryScopeProvider><ConsumerListPage /></ConsumerQueryScopeProvider>,
+    <MountableConsumerListPage />,
     '/consumers'
   );
 }
 
+let setScopeMode: ReturnType<typeof useConsumerQueryScope>['setMode'];
+let setListMounted: (mounted: boolean) => void;
+
+function MountableConsumerListPage() {
+  const [mounted, setMounted] = useState(true);
+  setListMounted = setMounted;
+  return (
+    <ConsumerQueryScopeProvider>
+      <ScopeControls />
+      {mounted ? <ConsumerListPage /> : null}
+    </ConsumerQueryScopeProvider>
+  );
+}
+
+function ScopeControls() {
+  const { setMode } = useConsumerQueryScope();
+  setScopeMode = setMode;
+  return null;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function listView(name: string, mode: 'nameServer' | 'proxy') {
+  return {
+    items: [consumer({ rawGroupName: name, displayGroupName: name })],
+    total: 1,
+    queryScope: mode === 'proxy' ? { mode, proxyAddress: '127.0.0.1:8080' } : { mode },
+    capabilities: { connections: true, progress: true, configuration: true, runningInfo: true, jstack: true }
+  };
+}
+
 describe('ConsumerListPage', () => {
+  afterEach(() => {
+    resetConsumerMutationLocksForTests();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(configApi.getConfig).mockResolvedValue({
       environmentId: 'environment-default',
       environmentName: 'Default',
       revision: 1,
-      endpoints: [{ endpointId: 'nameserver-1', endpointType: 'nameserver', address: '127.0.0.1:9876', role: 'primary', isEnabled: true, isActive: true, sortOrder: 0 }],
+      endpoints: [
+        { endpointId: 'nameserver-1', endpointType: 'nameserver', address: '127.0.0.1:9876', role: 'primary', isEnabled: true, isActive: true, sortOrder: 0 },
+        { endpointId: 'proxy-1', endpointType: 'proxy', address: '127.0.0.1:8080', role: 'primary', isEnabled: true, isActive: true, sortOrder: 1 }
+      ],
       currentNamesrv: '127.0.0.1:9876',
       namesrvAddrList: ['127.0.0.1:9876'],
       useVIPChannel: false,
       useTLS: false,
-      currentProxyAddr: null,
-      proxyAddrList: [],
+      currentProxyAddr: '127.0.0.1:8080',
+      proxyAddrList: ['127.0.0.1:8080'],
       storageBackend: 'sqlite',
       storageMode: 'singleNode'
     });
@@ -62,6 +113,10 @@ describe('ConsumerListPage', () => {
       total: 11,
       queryScope: { mode: 'nameServer' },
       capabilities: { connections: true, progress: true, configuration: true, runningInfo: true, jstack: true }
+    });
+    vi.mocked(brokerApi.list).mockResolvedValue({
+      items: [{ clusterName: 'DefaultCluster', brokerName: 'broker-a', brokerId: 0, address: '127.0.0.1:10911', role: 'MASTER', version: 'V5_3_0', produceTps: 0, consumeTps: 0 }],
+      total: 1
     });
   });
 
@@ -100,5 +155,83 @@ describe('ConsumerListPage', () => {
     expect(await screen.findByText('consumer service unavailable')).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Retry' }));
     expect(await screen.findByRole('heading', { name: 'Consumer groups' })).toBeInTheDocument();
+  });
+
+  it('keeps an inactive create completion dirty until its original scope returns', async () => {
+    const user = userEvent.setup();
+    const pendingCreate = deferred<{
+      operation: 'CREATE'; consumerGroup: string; success: boolean; targetCount: number; message: string; targets: [];
+    }>();
+    const nameServerRefresh = deferred<ReturnType<typeof listView>>();
+    let nameServerReads = 0;
+    vi.mocked(consumerApi.list).mockImplementation((scope) => {
+      if (scope?.mode === 'proxy') return Promise.resolve(listView('proxy-only', 'proxy'));
+      nameServerReads += 1;
+      return nameServerReads === 1
+        ? Promise.resolve(listView('name-server-only', 'nameServer'))
+        : nameServerRefresh.promise;
+    });
+    vi.mocked(consumerApi.create).mockImplementationOnce(() => pendingCreate.promise);
+    renderPage();
+
+    expect(await screen.findByText('name-server-only')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Create group' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Create consumer group' });
+    await user.type(screen.getByLabelText('Consumer group'), 'created-in-a');
+    await user.click(await screen.findByRole('checkbox', { name: 'broker-a' }));
+    await user.click(within(dialog).getByRole('button', { name: 'Create group' }));
+    await waitFor(() => expect(consumerApi.create).toHaveBeenCalledTimes(1));
+
+    await act(async () => setListMounted(false));
+    await act(async () => setScopeMode('proxy'));
+    await act(async () => setListMounted(true));
+    expect(await screen.findByText('proxy-only')).toBeInTheDocument();
+    await act(async () => pendingCreate.resolve({ operation: 'CREATE', consumerGroup: 'created-in-a', success: true, targetCount: 1, message: 'created', targets: [] }));
+    expect(screen.getByText('proxy-only')).toBeInTheDocument();
+    expect(nameServerReads).toBe(1);
+
+    await act(async () => setScopeMode('nameServer'));
+    await waitFor(() => expect(nameServerReads).toBe(2));
+    await act(async () => nameServerRefresh.resolve(listView('refreshed-a', 'nameServer')));
+    expect(await screen.findByText('refreshed-a')).toBeInTheDocument();
+    expect(consumerApi.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let an applied NameServer create refresh the visible proxy scope', async () => {
+    const user = userEvent.setup();
+    const pendingCreate = deferred<never>();
+    const auditWarning = vi.fn();
+    window.addEventListener('rocketmq-audit-warning', auditWarning);
+    vi.mocked(consumerApi.list).mockImplementation((scope) => Promise.resolve(
+      scope?.mode === 'proxy' ? listView('proxy-only', 'proxy') : listView('name-server-only', 'nameServer')
+    ));
+    vi.mocked(consumerApi.create).mockImplementationOnce(() => pendingCreate.promise);
+    renderPage();
+
+    expect(await screen.findByText('name-server-only')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Create group' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Create consumer group' });
+    await user.type(screen.getByLabelText('Consumer group'), 'applied-in-a');
+    await user.click(await screen.findByRole('checkbox', { name: 'broker-a' }));
+    await user.click(within(dialog).getByRole('button', { name: 'Create group' }));
+    await waitFor(() => expect(consumerApi.create).toHaveBeenCalledTimes(1));
+
+    await act(async () => setScopeMode('proxy'));
+    expect(await screen.findByText('proxy-only')).toBeInTheDocument();
+    const readsBeforeTerminal = vi.mocked(consumerApi.list).mock.calls.length;
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent('rocketmq-audit-warning', { detail: 'Mutation applied.' }));
+      pendingCreate.reject(new ApiClientError('APPLIED_AUDIT_FAILED', 'Mutation applied.', { mutationApplied: true }));
+    });
+    await waitFor(() => expect(auditWarning).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(consumerApi.list).mock.calls).toHaveLength(readsBeforeTerminal);
+    expect(screen.getByText('proxy-only')).toBeInTheDocument();
+    await act(async () => setScopeMode('nameServer'));
+    await waitFor(() => expect(
+      vi.mocked(consumerApi.list).mock.calls.filter(([scope]) => scope?.mode === 'nameServer')
+    ).toHaveLength(2));
+    expect(await screen.findByText('name-server-only')).toBeInTheDocument();
+    expect(consumerApi.create).toHaveBeenCalledTimes(1);
+    window.removeEventListener('rocketmq-audit-warning', auditWarning);
   });
 });

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConsumerListPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ConsumerListPage.tsx
@@ -1,9 +1,10 @@
 import { Activity, ListRestart, MoreHorizontal, Pencil, Plus, RotateCcw, Trash2, Users } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { consumerApi } from '../api/consumer_api';
 import ConsumerDeleteDialog from '../components/ConsumerDeleteDialog';
 import ConsumerMutationDialog from '../components/ConsumerMutationDialog';
+import { useConsumerMutationScopeRevision } from '../components/consumerMutationLock';
 import AppDataTable, { type AppDataTableColumn } from '../components/AppDataTable';
 import ErrorState from '../components/ErrorState';
 import LoadingState from '../components/LoadingState';
@@ -41,6 +42,10 @@ import {
 
 const PAGE_SIZE = 10;
 
+function consumerScopeKey(scope: { mode: string; proxyAddress?: string }) {
+  return `${scope.mode}:${scope.proxyAddress ?? ''}`;
+}
+
 const SORT_OPTIONS: Array<{ key: ConsumerSortKey; label: string }> = [
   { key: 'rawGroupName', label: 'Group' },
   { key: 'connectionCount', label: 'Connections' },
@@ -52,6 +57,8 @@ const SORT_OPTIONS: Array<{ key: ConsumerSortKey; label: string }> = [
 
 export default function ConsumerListPage() {
   const { scope, revision } = useConsumerQueryScope();
+  const scopeKey = consumerScopeKey(scope);
+  const terminalRevision = useConsumerMutationScopeRevision(scopeKey);
   const [data, setData] = useState<ConsumerGroupListView | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -64,8 +71,32 @@ export default function ConsumerListPage() {
   const [mutationConsumer, setMutationConsumer] = useState<ConsumerGroupListItem | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<ConsumerGroupListItem | null>(null);
   const requestToken = useRef(0);
+  const committedScopeRef = useRef({ key: '', generation: 0 });
 
-  const load = async (isRefresh: boolean) => {
+  const isCurrentScope = (requestScope: { key: string; generation: number }) => {
+    const current = committedScopeRef.current;
+    return current.key === requestScope.key && current.generation === requestScope.generation;
+  };
+
+  // A candidate can be rendered and discarded in concurrent React. Only the
+  // layout effect publishes the current scope used by asynchronous reads.
+  useLayoutEffect(() => {
+    const current = committedScopeRef.current;
+    if (current.key === scopeKey) return;
+    committedScopeRef.current = { key: scopeKey, generation: current.generation + 1 };
+    requestToken.current += 1;
+    setData(null);
+    setInitialError(null);
+    setRefreshError(null);
+    setLoading(true);
+  }, [scopeKey]);
+
+  const load = async (
+    isRefresh: boolean,
+    requestScope = committedScopeRef.current,
+    requestScopeValue = scope
+  ) => {
+    if (requestScope.key !== consumerScopeKey(requestScopeValue) || !isCurrentScope(requestScope)) return;
     const token = ++requestToken.current;
     if (isRefresh) {
       setRefreshing(true);
@@ -75,16 +106,16 @@ export default function ConsumerListPage() {
       setInitialError(null);
     }
     try {
-      const next = await consumerApi.list(scope);
-      if (token !== requestToken.current) return;
+      const next = await consumerApi.list(requestScopeValue);
+      if (token !== requestToken.current || !isCurrentScope(requestScope)) return;
       setData(next);
     } catch (error) {
-      if (token !== requestToken.current) return;
+      if (token !== requestToken.current || !isCurrentScope(requestScope)) return;
       const message = error instanceof Error ? error.message : String(error);
       if (isRefresh) setRefreshError(message);
       else setInitialError(message);
     } finally {
-      if (token === requestToken.current) {
+      if (token === requestToken.current && isCurrentScope(requestScope)) {
         setLoading(false);
         setRefreshing(false);
       }
@@ -92,13 +123,11 @@ export default function ConsumerListPage() {
   };
 
   useEffect(() => {
-    requestToken.current += 1;
+    const requestScope = committedScopeRef.current;
+    if (requestScope.key !== scopeKey) return;
     setPage(1);
-    void load(false);
-    return () => {
-      requestToken.current += 1;
-    };
-  }, [scope.mode, scope.proxyAddress, revision]);
+    void load(false, requestScope, scope);
+  }, [scopeKey, revision, terminalRevision]);
 
   const consumers = data?.items ?? [];
   const metrics = useMemo(() => getConsumerMetrics(consumers), [consumers]);
@@ -369,7 +398,9 @@ export default function ConsumerListPage() {
         mode={mutationMode ?? 'create'}
         consumer={mutationConsumer}
         onOpenChange={(open) => { if (!open) { setMutationMode(null); setMutationConsumer(null); } }}
-        onSucceeded={() => void load(false)}
+        onSucceeded={() => {
+          if (mutationMode !== 'create') void load(false);
+        }}
       />
 
       <ConsumerDeleteDialog
@@ -377,6 +408,7 @@ export default function ConsumerListPage() {
         consumer={deleteTarget}
         onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}
         onSucceeded={() => void load(false)}
+        onAppliedAuditFailure={() => load(false)}
       />
     </div>
   );

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/DlqMessagePage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/DlqMessagePage.test.tsx
@@ -4,6 +4,7 @@ import { StrictMode } from 'react';
 import { vi } from 'vitest';
 import { consumerApi } from '../api/consumer_api';
 import { dlqApi } from '../api/dlq_api';
+import { ApiClientError } from '../api/client';
 import { renderAtRoute } from '../test/render';
 import type { MessageView } from '../types/message';
 import DlqMessagePage from './DlqMessagePage';
@@ -147,6 +148,24 @@ describe('DlqMessagePage', () => {
 
     await waitFor(() => expect(dlqApi.list).toHaveBeenNthCalledWith(3, expect.objectContaining({ pageNum: 2 })));
     expect(await screen.findByText('DLQ-021')).toBeInTheDocument();
+  });
+
+  it('treats an applied audit failure as terminal, clears the submitted batch, and refetches once', async () => {
+    const user = userEvent.setup();
+    vi.mocked(dlqApi.resend).mockRejectedValueOnce(
+      new ApiClientError('APPLIED_AUDIT_FAILED', 'Batch resend was applied.', { mutationApplied: true })
+    );
+    renderAtRoute(<DlqMessagePage />, '/messages/dlq');
+    await screen.findByRole('heading', { name: 'Dead-letter messages' });
+    await user.click(screen.getByRole('button', { name: 'Search DLQ messages' }));
+    await user.click(await screen.findByRole('checkbox', { name: 'Select DLQ-001' }));
+    await user.click(screen.getByRole('button', { name: 'Review selected resend' }));
+    await user.click(within(screen.getByRole('alertdialog', { name: 'Resend selected DLQ messages?' })).getByRole('button', { name: 'Confirm resend' }));
+
+    await waitFor(() => expect(dlqApi.resend).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByText('0 selected')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'Review selected resend' })).toBeDisabled();
+    await waitFor(() => expect(dlqApi.list).toHaveBeenCalledTimes(2));
   });
 
   it('shows every exact-ID match as one non-paginated result set', async () => {
@@ -410,6 +429,23 @@ describe('DlqMessagePage', () => {
     expect(await screen.findByText('export backend unavailable')).toBeInTheDocument();
     expect(screen.getByText('DLQ-001')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Retry export' })).toBeInTheDocument();
+  });
+
+  it('treats an applied audit failure during export as terminal without offering a retry', async () => {
+    const user = userEvent.setup();
+    vi.mocked(dlqApi.export).mockRejectedValueOnce(
+      new ApiClientError('APPLIED_AUDIT_FAILED', 'Export was applied.', { mutationApplied: true })
+    );
+
+    renderAtRoute(<DlqMessagePage />, '/messages/dlq');
+    await screen.findByRole('heading', { name: 'Dead-letter messages' });
+    await user.click(screen.getByRole('button', { name: 'Search DLQ messages' }));
+    await user.click(screen.getByRole('button', { name: 'Export current query' }));
+
+    await waitFor(() => expect(dlqApi.export).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText(/export was applied, but its audit record could not be stored/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Retry export' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Export current query' })).toBeDisabled();
   });
 
   it('unlocks batch resend after completion under React StrictMode', async () => {

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/DlqMessagePage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/DlqMessagePage.tsx
@@ -2,6 +2,7 @@ import { Download, RotateCcw, Search, ShieldAlert } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { consumerApi } from '../api/consumer_api';
 import { dlqApi } from '../api/dlq_api';
+import { handleAppliedAuditFailure } from '../api/client';
 import AppDataTable, { type AppDataTableColumn } from '../components/AppDataTable';
 import EntitySheet from '../components/EntitySheet';
 import MetricCard from '../components/MetricCard';
@@ -45,8 +46,10 @@ export default function DlqMessagePage() {
   const [resending, setResending] = useState(false);
   const [resendResults, setResendResults] = useState<DlqMessageResendResult[]>([]);
   const [resendError, setResendError] = useState<string | null>(null);
+  const [resendTerminal, setResendTerminal] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
+  const [exportTerminal, setExportTerminal] = useState(false);
   const [groupsLoading, setGroupsLoading] = useState(false);
   const [groupsError, setGroupsError] = useState<string | null>(null);
   const requestRef = useRef(0);
@@ -110,8 +113,10 @@ export default function DlqMessagePage() {
     resendRequestRef.current += 1;
     exportRequestRef.current += 1;
     setExporting(false);
+    setExportTerminal(false);
     setResendResults([]);
     setResendError(null);
+    setResendTerminal(false);
     setExportError(null);
     const requestId = ++requestRef.current;
     if (requestPage === 1) setExhaustedAfterPage(null);
@@ -161,6 +166,7 @@ export default function DlqMessagePage() {
     exportRequestRef.current += 1;
     setLoading(false);
     setExporting(false);
+    setExportTerminal(false);
     setRows([]);
     setTotal(0);
     setPage(1);
@@ -171,6 +177,7 @@ export default function DlqMessagePage() {
     setResendResults([]);
     setQueryError(null);
     setResendError(null);
+    setResendTerminal(false);
     setExportError(null);
   };
 
@@ -186,6 +193,7 @@ export default function DlqMessagePage() {
     setResending(true);
     setResendResults([]);
     setResendError(null);
+    setResendTerminal(false);
     try {
       const results = await dlqApi.resend({
         messages: selectedTargets.map((target) => ({
@@ -197,6 +205,16 @@ export default function DlqMessagePage() {
       });
       if (resendRequestRef.current === requestId) setResendResults(results);
     } catch (requestError) {
+      if (await handleAppliedAuditFailure(requestError, {
+        onApplied: () => {
+          setSelectedIds(new Set());
+          setSelected(null);
+          setResendResults([]);
+          setResendTerminal(true);
+          setResendError('Selected DLQ resends were applied. Refreshing authoritative results.');
+        },
+        refresh: () => query(page)
+      })) return;
       if (resendRequestRef.current === requestId) {
         setResendError(requestError instanceof Error ? requestError.message : String(requestError));
       }
@@ -207,6 +225,7 @@ export default function DlqMessagePage() {
   };
 
   const exportCurrentQuery = async () => {
+    if (exportTerminal) return;
     const issue = validateQuery(consumerGroup, begin, end);
     if (issue) {
       setValidation(issue);
@@ -225,6 +244,13 @@ export default function DlqMessagePage() {
       anchor.click();
       URL.revokeObjectURL(url);
     } catch (requestError) {
+      if (exportRequestRef.current !== requestId) return;
+      if (await handleAppliedAuditFailure(requestError, {
+        onApplied: () => {
+          setExportTerminal(true);
+          setExportError('The export was applied, but its audit record could not be stored. Re-query before requesting another export.');
+        }
+      })) return;
       if (exportRequestRef.current === requestId) {
         setExportError(requestError instanceof Error ? requestError.message : String(requestError));
       }
@@ -247,6 +273,7 @@ export default function DlqMessagePage() {
             resendRequestRef.current += 1;
             setResendResults([]);
             setResendError(null);
+            setResendTerminal(false);
             setSelectedIds((current) => toggleMessageSelection(current, rowId, event.target.checked));
           }}
         />
@@ -304,7 +331,7 @@ export default function DlqMessagePage() {
           <div><CardTitle>Dead-letter queue</CardTitle><CardDescription>Message bodies are available only from the detail sheet.</CardDescription></div>
           <div className="dlq-action-bar">
             <span>{selectedTargets.length} selected</span>
-            <Button type="button" variant="outline" loading={exporting} onClick={() => void exportCurrentQuery()}><Download size={15} aria-hidden="true" /> Export current query</Button>
+            <Button type="button" variant="outline" disabled={exportTerminal} loading={exporting} onClick={() => void exportCurrentQuery()}><Download size={15} aria-hidden="true" /> Export current query</Button>
             <AlertDialog>
               <AlertDialogTrigger asChild><Button type="button" variant="destructive" disabled={selectedTargets.length === 0 || resending}><RotateCcw size={15} aria-hidden="true" /> Review selected resend</Button></AlertDialogTrigger>
               <AlertDialogContent>
@@ -316,11 +343,11 @@ export default function DlqMessagePage() {
           </div>
         </CardHeader>
         <CardContent>
-          {resendError ? <div className="notice notice-danger" role="alert">{resendError}. Review the selected batch again to retry.</div> : null}
+          {resendError ? <div className={`notice ${resendTerminal ? 'notice-warning' : 'notice-danger'}`} role="alert">{resendError}{resendTerminal ? '' : '. Review the selected batch again to retry.'}</div> : null}
           {exportError ? (
-            <div className="notice notice-danger message-discovery-notice" role="alert">
+            <div className={`notice ${exportTerminal ? 'notice-warning' : 'notice-danger'} message-discovery-notice`} role="alert">
               <span>{exportError}</span>
-              <Button type="button" variant="outline" size="sm" onClick={() => void exportCurrentQuery()}>Retry export</Button>
+              {!exportTerminal ? <Button type="button" variant="outline" size="sm" onClick={() => void exportCurrentQuery()}>Retry export</Button> : null}
             </div>
           ) : null}
           {resendResults.length > 0 ? (

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/LoginPage.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/LoginPage.css
@@ -65,6 +65,12 @@
   font-size: 16px;
 }
 
+.login-session-notice {
+  margin: 0 0 14px;
+  color: var(--warning);
+  font-size: 13px;
+}
+
 .login-session-note svg {
   flex: 0 0 auto;
   color: var(--info);

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/LoginPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/LoginPage.tsx
@@ -20,15 +20,19 @@ export default function LoginPage() {
   const [checking, setChecking] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [sessionError, setSessionError] = useState<string | null>(null);
+  const [sessionNotice, setSessionNotice] = useState<string | null>(null);
   const [credentialError, setCredentialError] = useState<string | null>(null);
 
   const checkSession = async () => {
     setChecking(true);
     setSessionError(null);
+    setSessionNotice(null);
     try {
       const session = await authApi.session();
       if (!session.loginRequired || session.authenticated) {
         navigate('/dashboard', { replace: true });
+      } else if (session.authReason) {
+        setSessionNotice(sessionReason(session.authReason));
       }
     } catch {
       setSessionError('Unable to load auth session.');
@@ -101,6 +105,7 @@ export default function LoginPage() {
           <LogIn size={18} aria-hidden="true" />
           Authentication is required for this dashboard.
         </p>
+        {sessionNotice ? <p className="login-session-notice" role="status">{sessionNotice}</p> : null}
         <Card className="login-card">
           <CardHeader>
             <CardTitle>Sign in to RocketMQ Operations</CardTitle>
@@ -144,4 +149,12 @@ export default function LoginPage() {
       <p className="login-footer">RocketMQ Dashboard Web</p>
     </main>
   );
+}
+
+function sessionReason(reason: NonNullable<import('../types/auth').SessionView['authReason']>) {
+  switch (reason) {
+    case 'expired': return 'Your dashboard session expired. Sign in again to continue.';
+    case 'revoked': return 'Your dashboard session was revoked. Sign in again to continue.';
+    default: return 'Your previous dashboard session is no longer valid. Sign in again to continue.';
+  }
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/MessageQueryPage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/MessageQueryPage.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { StrictMode } from 'react';
 import { vi } from 'vitest';
 import { messageApi } from '../api/message_api';
+import { ApiClientError } from '../api/client';
 import { topicApi } from '../api/topic_api';
 import { renderAtRoute } from '../test/render';
 import type { MessageView } from '../types/message';
@@ -277,5 +278,25 @@ describe('MessageQueryPage', () => {
     resolveResend({ message: 'Direct consume returned CR_SUCCESS', success: true, consumeResult: 'CR_SUCCESS' });
 
     await waitFor(() => expect(within(dialog).getByRole('button', { name: 'Review resend' })).toBeEnabled());
+  });
+
+  it('treats an applied audit failure as terminal, clears the selected message, and refetches once', async () => {
+    const user = userEvent.setup();
+    vi.mocked(messageApi.resend).mockRejectedValueOnce(
+      new ApiClientError('APPLIED_AUDIT_FAILED', 'Resend was applied.', { mutationApplied: true })
+    );
+    renderAtRoute(<MessageQueryPage />, '/messages');
+    await screen.findByRole('heading', { name: 'Message search' });
+    await user.click(screen.getByRole('button', { name: 'Search messages' }));
+    await user.click(await screen.findByRole('row', { name: /MSG-001/ }));
+    const dialog = await screen.findByRole('dialog', { name: 'Message detail' });
+    await user.type(within(dialog).getByRole('textbox', { name: 'Consumer group' }), 'order-service');
+    await user.click(within(dialog).getByRole('button', { name: 'Review resend' }));
+    await user.click(within(screen.getByRole('alertdialog', { name: 'Resend message?' })).getByRole('button', { name: 'Confirm resend' }));
+
+    await waitFor(() => expect(messageApi.resend).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Message detail' })).not.toBeInTheDocument());
+    await waitFor(() => expect(messageApi.list).toHaveBeenCalledTimes(2));
+    expect(screen.queryByRole('button', { name: 'Confirm resend' })).not.toBeInTheDocument();
   });
 });

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/MessageQueryPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/MessageQueryPage.tsx
@@ -1,6 +1,7 @@
 import { Clock3, DatabaseZap, Hash, Search, Send } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { messageApi } from '../api/message_api';
+import { handleAppliedAuditFailure } from '../api/client';
 import { topicApi } from '../api/topic_api';
 import AppDataTable, { type AppDataTableColumn } from '../components/AppDataTable';
 import EntitySheet from '../components/EntitySheet';
@@ -45,7 +46,7 @@ export default function MessageQueryPage() {
   const [consumerGroup, setConsumerGroup] = useState('');
   const [clientId, setClientId] = useState('');
   const [resending, setResending] = useState(false);
-  const [resendNotice, setResendNotice] = useState<{ tone: 'success' | 'danger'; message: string } | null>(null);
+  const [resendNotice, setResendNotice] = useState<{ tone: 'success' | 'warning' | 'danger'; message: string } | null>(null);
   const [topicsLoading, setTopicsLoading] = useState(false);
   const [topicsError, setTopicsError] = useState<string | null>(null);
   const requestRef = useRef(0);
@@ -204,6 +205,15 @@ export default function MessageQueryPage() {
         message: result.remark ? `${result.consumeResult}: ${result.remark}` : result.message
       });
     } catch (requestError) {
+      if (await handleAppliedAuditFailure(requestError, {
+        onApplied: () => {
+          setSelected(null);
+          setConsumerGroup('');
+          setClientId('');
+          setResendNotice({ tone: 'warning', message: 'Message resend was applied. Refreshing authoritative results.' });
+        },
+        refresh: searchMessages
+      })) return;
       if (resendRequestRef.current === requestId) {
         setResendNotice({ tone: 'danger', message: requestError instanceof Error ? requestError.message : String(requestError) });
       }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/MonitorPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/MonitorPage.tsx
@@ -1,7 +1,7 @@
 import { Pencil, Plus, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { configApi } from '../api/config_api';
-import { ApiClientError } from '../api/client';
+import { ApiClientError, handleAppliedAuditFailure } from '../api/client';
 import { monitorApi } from '../api/monitor_api';
 import DataTable, { type DataTableColumn } from '../components/DataTable';
 import ErrorState from '../components/ErrorState';
@@ -91,6 +91,13 @@ export default function MonitorPage() {
       setDeleteTarget(null);
       void load();
     } catch (error) {
+      if (await handleAppliedAuditFailure(error, {
+        onApplied: () => {
+          setDeleteTarget(null);
+          setMutationError(null);
+        },
+        refresh: load
+      })) return;
       if (mounted.current) {
         setDeleteTarget(null);
         let retryRule: ConsumerMonitorView | null = rule;
@@ -186,6 +193,7 @@ export default function MonitorPage() {
           if (authoritative) setSelectedRule(authoritative);
           return authoritative;
         }}
+        onAppliedAuditFailure={load}
       />
 
       <AlertDialog open={Boolean(deleteTarget)} onOpenChange={(open) => {

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ProxyPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/ProxyPage.tsx
@@ -1,7 +1,7 @@
 import { CheckCircle2, Plus, RefreshCw, Route, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { configApi } from '../api/config_api';
-import { ApiClientError } from '../api/client';
+import { ApiClientError, handleAppliedAuditFailure } from '../api/client';
 import ConfirmDialog from '../components/ConfirmDialog';
 import EmptyState from '../components/EmptyState';
 import ErrorState from '../components/ErrorState';
@@ -76,6 +76,15 @@ export default function ProxyPage() {
       applyMutation(await request());
       onSuccess?.();
     } catch (requestError) {
+      if (await handleAppliedAuditFailure(requestError, {
+        onApplied: () => {
+          setAddDialogOpen(false);
+          setAddError(null);
+          setRetryProxyMutation(null);
+          setNotice({ tone: 'warning', message: 'Proxy configuration change was applied. Refreshing authoritative settings.' });
+        },
+        refresh: load
+      })) return;
       if (requestError instanceof ApiClientError && requestError.code === 'STORAGE_CONFLICT' && onConflict) {
         try {
           await onConflict(requestError);

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/SessionAdminPage.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/SessionAdminPage.test.tsx
@@ -1,0 +1,87 @@
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { auditApi } from '../api/audit_api';
+import { ApiClientError } from '../api/client';
+import { renderAtRoute } from '../test/render';
+import type { SessionListPage } from '../types/audit';
+import SessionAdminPage from './SessionAdminPage';
+
+vi.mock('../api/audit_api', () => ({
+  auditApi: { listSessions: vi.fn(), revokeAllSessions: vi.fn() }
+}));
+
+const now = Date.now();
+const firstPage: SessionListPage = {
+  items: [
+    { sessionId: 'active', username: 'operator', createdAtMs: now - 3_000, expiresAtMs: now + 60_000, lastSeenAtMs: now, current: true },
+    { sessionId: 'revoked', username: 'operator', createdAtMs: now - 4_000, expiresAtMs: now + 60_000, lastSeenAtMs: now, revokedAtMs: now - 1_000, current: false },
+    { sessionId: 'expired', username: 'operator', createdAtMs: now - 5_000, expiresAtMs: now - 1_000, lastSeenAtMs: now - 2_000, current: false }
+  ],
+  nextCursor: 'next-page'
+};
+
+describe('SessionAdminPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(auditApi.listSessions).mockResolvedValue(firstPage);
+    vi.mocked(auditApi.revokeAllSessions).mockResolvedValue({ revoked: 2 });
+  });
+
+  it('applies an exact username filter, renders terminal state, and follows keyset pagination', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<SessionAdminPage />, '/sessions');
+    await screen.findByText('Active');
+    expect(screen.getByText(/^Revoked /)).toBeInTheDocument();
+    expect(screen.getByText('Expired')).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText('Exact username'), 'operator');
+    await user.click(screen.getByRole('button', { name: 'Filter' }));
+    await waitFor(() => expect(auditApi.listSessions).toHaveBeenLastCalledWith({ username: 'operator', cursor: undefined, limit: 50 }));
+
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    await waitFor(() => expect(auditApi.listSessions).toHaveBeenLastCalledWith({ username: 'operator', cursor: 'next-page', limit: 50 }));
+  });
+
+  it('requires confirmation before revoke-all and refreshes without a second mutation', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<SessionAdminPage />, '/sessions');
+    await screen.findByText('Active');
+    await user.type(screen.getByLabelText('Exact username'), 'operator');
+    await user.click(screen.getByRole('button', { name: 'Revoke all' }));
+    const dialog = screen.getByRole('alertdialog', { name: 'Revoke all sessions?' });
+    expect(dialog).toHaveTextContent('operator');
+    await user.click(screen.getByRole('button', { name: 'Revoke all' }));
+    await waitFor(() => expect(auditApi.revokeAllSessions).toHaveBeenCalledWith('operator'));
+    expect(auditApi.revokeAllSessions).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(auditApi.listSessions).toHaveBeenCalledTimes(2));
+  });
+
+  it('reports storage unavailability and retries only the session list', async () => {
+    const user = userEvent.setup();
+    vi.mocked(auditApi.listSessions)
+      .mockRejectedValueOnce(new ApiClientError('STORAGE_UNAVAILABLE', 'Storage unavailable'))
+      .mockResolvedValueOnce({ items: [] });
+    renderAtRoute(<SessionAdminPage />, '/sessions');
+    expect(await screen.findByRole('alert')).toHaveTextContent('Storage unavailable Retry when storage is available.');
+    await user.click(screen.getByRole('button', { name: 'Retry sessions' }));
+    await screen.findByText('No sessions match this filter');
+    expect(auditApi.revokeAllSessions).not.toHaveBeenCalled();
+  });
+
+  it('does not offer a second revoke after the backend applied it without an audit receipt', async () => {
+    const user = userEvent.setup();
+    vi.mocked(auditApi.revokeAllSessions).mockRejectedValueOnce(
+      new ApiClientError('APPLIED_AUDIT_FAILED', 'Sessions were revoked, but audit persistence failed.')
+    );
+    renderAtRoute(<SessionAdminPage />, '/sessions');
+    await screen.findByText('Active');
+    await user.type(screen.getByLabelText('Exact username'), 'operator');
+    await user.click(screen.getByRole('button', { name: 'Revoke all' }));
+    await user.click(within(screen.getByRole('alertdialog', { name: 'Revoke all sessions?' })).getByRole('button', { name: 'Revoke all' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Sessions were revoked, but audit persistence failed.');
+    expect(screen.queryByRole('button', { name: 'Retry revoke' })).not.toBeInTheDocument();
+    expect(auditApi.revokeAllSessions).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(auditApi.listSessions).toHaveBeenCalledTimes(2));
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/SessionAdminPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/SessionAdminPage.tsx
@@ -1,0 +1,179 @@
+import { LogOut, ShieldCheck } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { auditApi } from '../api/audit_api';
+import { ApiClientError, isAppliedAuditFailure } from '../api/client';
+import ConfirmDialog from '../components/ConfirmDialog';
+import EmptyState from '../components/EmptyState';
+import ErrorState from '../components/ErrorState';
+import LoadingState from '../components/LoadingState';
+import PageHeader from '../components/PageHeader';
+import RefreshButton from '../components/RefreshButton';
+import { Button } from '../components/ui/Button';
+import { Input } from '../components/ui/Input';
+import type { SessionListPage } from '../types/audit';
+
+const pageSize = 50;
+
+interface RevokeErrorState {
+  message: string;
+  retryable: boolean;
+}
+
+export default function SessionAdminPage() {
+  const [username, setUsername] = useState('');
+  const [appliedUsername, setAppliedUsername] = useState('');
+  const [page, setPage] = useState<SessionListPage>({ items: [] });
+  const [cursorHistory, setCursorHistory] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [revoking, setRevoking] = useState(false);
+  const [revokeError, setRevokeError] = useState<RevokeErrorState | null>(null);
+
+  const load = useCallback(async (exactUsername: string, cursor?: string, resetHistory = false) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await auditApi.listSessions({ username: exactUsername || undefined, cursor, limit: pageSize });
+      setPage(next);
+      if (resetHistory) setCursorHistory([]);
+    } catch (cause) {
+      setError(errorMessage(cause, 'Unable to load active sessions.'));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void load(appliedUsername, undefined, true); }, [appliedUsername, load]);
+
+  const revokeAll = async () => {
+    const exactUsername = username.trim();
+    if (!exactUsername) return;
+    setRevoking(true);
+    setRevokeError(null);
+    try {
+      await auditApi.revokeAllSessions(exactUsername);
+      await load(appliedUsername, undefined, true);
+    } catch (cause) {
+      if (isAppliedAuditFailure(cause)) {
+        // The business mutation is durable. Reload authoritative state but
+        // retain the terminal warning instead of offering a second revoke.
+        await load(appliedUsername, undefined, true);
+      }
+      setRevokeError({
+        message: errorMessage(cause, 'Unable to revoke sessions.'),
+        // The backend has already applied the mutation. Retrying would create
+        // another revoke-all audit decision rather than repairing its audit.
+        retryable: !isAppliedAuditFailure(cause)
+      });
+    } finally {
+      setRevoking(false);
+    }
+  };
+
+  const next = () => {
+    if (!page.nextCursor) return;
+    setCursorHistory((history) => [...history, page.nextCursor!]);
+    void load(appliedUsername, page.nextCursor);
+  };
+  const previous = () => {
+    if (cursorHistory.length === 0) return;
+    const previousHistory = cursorHistory.slice(0, -1);
+    const cursor = previousHistory[previousHistory.length - 1];
+    setCursorHistory(previousHistory);
+    void load(appliedUsername, cursor);
+  };
+
+  return (
+    <>
+      <PageHeader
+        title="Sessions"
+        description="Review active and revoked dashboard sign-ins. Session credentials are never shown."
+        actions={<RefreshButton onRefresh={() => void load(appliedUsername, undefined, true)} />}
+      />
+      <section className="table-shell audit-admin-shell">
+        <div className="audit-filter-row">
+          <Input value={username} placeholder="Exact username" aria-label="Exact username" onChange={(event) => setUsername(event.target.value)} />
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => {
+              const nextUsername = username.trim();
+              if (nextUsername === appliedUsername) {
+                void load(nextUsername, undefined, true);
+              } else {
+                setAppliedUsername(nextUsername);
+              }
+            }}
+          >
+            Filter
+          </Button>
+          <ConfirmDialog
+            title="Revoke all sessions?"
+            description={username.trim()
+              ? `Revoke every active session for ${username.trim()}. The current session is included when it belongs to this user.`
+              : 'Enter the exact username before revoking sessions.'}
+            confirmLabel={revoking ? 'Revoking' : 'Revoke all'}
+            onConfirm={() => { void revokeAll(); }}
+          >
+            <Button type="button" variant="destructive" disabled={!username.trim() || revoking}>
+              <LogOut size={15} aria-hidden="true" /> Revoke all
+            </Button>
+          </ConfirmDialog>
+        </div>
+        {revokeError ? (
+          <ErrorState
+            message={revokeError.message}
+            onRetry={revokeError.retryable ? () => void revokeAll() : undefined}
+            retryLabel="Retry revoke"
+          />
+        ) : null}
+        {loading ? <LoadingState label="Loading dashboard sessions" /> : null}
+        {!loading && error ? <ErrorState message={error} onRetry={() => void load(appliedUsername, undefined, true)} retryLabel="Retry sessions" /> : null}
+        {!loading && !error ? (
+          <>
+            <div className="table-scroll">
+              <table>
+                <thead><tr><th>User</th><th>Created</th><th>Expires</th><th>Last seen</th><th>Status</th></tr></thead>
+                <tbody>
+                  {page.items.map((session) => (
+                    <tr key={session.sessionId}>
+                      <td><div className="audit-actor"><ShieldCheck size={14} aria-hidden="true" /> {session.username}{session.current ? ' (current)' : ''}</div></td>
+                      <td>{formatTime(session.createdAtMs)}</td>
+                      <td>{formatTime(session.expiresAtMs)}</td>
+                      <td>{formatTime(session.lastSeenAtMs)}</td>
+                      <td>{sessionStatus(session)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            {page.items.length === 0 ? <EmptyState title="No sessions match this filter" /> : null}
+            <div className="table-footer">
+              <span>{page.items.length} sessions</span>
+              <div className="pagination">
+                <Button type="button" variant="secondary" disabled={cursorHistory.length === 0} onClick={previous}>Previous</Button>
+                <Button type="button" variant="secondary" disabled={!page.nextCursor} onClick={next}>Next</Button>
+              </div>
+            </div>
+          </>
+        ) : null}
+      </section>
+    </>
+  );
+}
+
+function formatTime(value: number) {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? 'Unknown' : date.toLocaleString();
+}
+
+function sessionStatus(session: SessionListPage['items'][number]) {
+  if (session.revokedAtMs) return `Revoked ${formatTime(session.revokedAtMs)}`;
+  if (Date.now() >= session.expiresAtMs) return 'Expired';
+  return 'Active';
+}
+
+function errorMessage(error: unknown, fallback: string) {
+  if (error instanceof ApiClientError && error.code === 'STORAGE_UNAVAILABLE') return `${error.message} Retry when storage is available.`;
+  return error instanceof Error ? error.message : fallback;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/TopicListPage.applied-audit.test.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/TopicListPage.applied-audit.test.tsx
@@ -1,0 +1,140 @@
+import type { ReactNode } from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { topicApi } from '../api/topic_api';
+import { renderAtRoute } from '../test/render';
+import TopicListPage from './TopicListPage';
+
+type TerminalDialogProps = {
+  open: boolean;
+  mode?: string;
+  onOpenChange?: (open: boolean) => void;
+  onAppliedAuditFailure?: () => Promise<void> | void;
+};
+
+async function settleApplied(props: TerminalDialogProps) {
+  props.onOpenChange?.(false);
+  await props.onAppliedAuditFailure?.();
+}
+
+vi.mock('../api/topic_api', () => ({ topicApi: { list: vi.fn() } }));
+vi.mock('../components/TopicMutationDialog', () => ({
+  default: (props: TerminalDialogProps) => props.open ? (
+    <button type="button" onClick={() => void settleApplied(props)}>Applied {props.mode}</button>
+  ) : null
+}));
+vi.mock('../components/TopicResetOffsetDialog', () => ({
+  default: (props: TerminalDialogProps) => props.open ? (
+    <button type="button" onClick={() => void settleApplied(props)}>Applied reset</button>
+  ) : null
+}));
+vi.mock('../components/TopicSkipBacklogDialog', () => ({
+  default: (props: TerminalDialogProps) => props.open ? (
+    <button type="button" onClick={() => void settleApplied(props)}>Applied skip</button>
+  ) : null
+}));
+vi.mock('../components/TopicDeleteDialog', () => ({
+  default: (props: TerminalDialogProps) => props.open ? (
+    <button type="button" onClick={() => void settleApplied(props)}>Applied delete</button>
+  ) : null
+}));
+vi.mock('../components/TopicSendMessageDialog', () => ({
+  default: (props: TerminalDialogProps) => props.open ? (
+    <button type="button" onClick={() => void settleApplied(props)}>Applied send</button>
+  ) : null
+}));
+vi.mock('./topics/TopicConsumerActionDialog', () => ({
+  default: ({ open, onSelect }: {
+    open: boolean;
+    onSelect: (consumerGroup: string) => void;
+  }) => open ? (
+    <button type="button" onClick={() => onSelect('orders-consumer')}>Choose consumer</button>
+  ) : null
+}));
+vi.mock('../components/EntitySheet', () => ({
+  default: ({ open, actions, children }: { open: boolean; actions?: ReactNode; children?: ReactNode }) => open ? (
+    <section aria-label="Topic detail">{actions}{children}</section>
+  ) : null
+}));
+vi.mock('./topics/TopicDetailContent', () => ({
+  default: ({ resourceRevisions }: { resourceRevisions: { route: number; stats: number; consumers: number; config: number } }) => (
+    <output data-testid="topic-revisions">{JSON.stringify(resourceRevisions)}</output>
+  )
+}));
+
+const catalog = {
+  items: [{
+    topic: 'orders',
+    brokerName: 'broker-a',
+    brokers: ['broker-a'],
+    clusters: ['DefaultCluster'],
+    readQueueCount: 4,
+    writeQueueCount: 4,
+    perm: 6,
+    category: 'NORMAL',
+    messageType: 'NORMAL',
+    order: false,
+    systemTopic: false
+  }],
+  total: 1,
+  targets: [{ clusterName: 'DefaultCluster', brokerNames: ['broker-a'] }]
+};
+
+async function openAction(user: ReturnType<typeof userEvent.setup>, label: string) {
+  await user.click(screen.getByRole('button', { name: 'Actions for orders' }));
+  await user.click(screen.getByRole('menuitem', { name: label }));
+}
+
+async function expectCatalogRefresh() {
+  await waitFor(() => expect(topicApi.list).toHaveBeenCalledTimes(1));
+}
+
+describe('TopicListPage applied audit failure refreshes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(topicApi.list).mockResolvedValue(catalog);
+  });
+
+  it('closes each terminal dialog and refreshes the exact catalog/detail resources once', async () => {
+    const user = userEvent.setup();
+    renderAtRoute(<TopicListPage />, '/topics');
+    await screen.findByRole('heading', { name: 'Topics' });
+    await user.click(screen.getByText('orders'));
+    await screen.findByTestId('topic-revisions');
+
+    vi.clearAllMocks();
+    await openAction(user, 'Edit configuration');
+    await user.click(screen.getByRole('button', { name: 'Applied edit' }));
+    await expectCatalogRefresh();
+    expect(screen.getByTestId('topic-revisions')).toHaveTextContent('"config":1');
+    expect(screen.queryByRole('button', { name: 'Applied edit' })).not.toBeInTheDocument();
+
+    vi.clearAllMocks();
+    await openAction(user, 'Reset consumer offset');
+    await user.click(screen.getByRole('button', { name: 'Choose consumer' }));
+    await user.click(screen.getByRole('button', { name: 'Applied reset' }));
+    await expectCatalogRefresh();
+    expect(screen.getByTestId('topic-revisions')).toHaveTextContent('"stats":1');
+    expect(screen.getByTestId('topic-revisions')).toHaveTextContent('"consumers":1');
+    expect(screen.queryByRole('button', { name: 'Applied reset' })).not.toBeInTheDocument();
+
+    vi.clearAllMocks();
+    await openAction(user, 'Skip accumulated messages');
+    await user.click(screen.getByRole('button', { name: 'Choose consumer' }));
+    await user.click(screen.getByRole('button', { name: 'Applied skip' }));
+    await expectCatalogRefresh();
+    expect(screen.getByTestId('topic-revisions')).toHaveTextContent('"stats":2');
+    expect(screen.getByTestId('topic-revisions')).toHaveTextContent('"consumers":2');
+    expect(screen.queryByRole('button', { name: 'Applied skip' })).not.toBeInTheDocument();
+
+    vi.clearAllMocks();
+    await openAction(user, 'Delete from broker');
+    await user.click(screen.getByRole('button', { name: 'Applied delete' }));
+    await expectCatalogRefresh();
+    expect(screen.getByTestId('topic-revisions')).toHaveTextContent('"route":1');
+    expect(screen.getByTestId('topic-revisions')).toHaveTextContent('"stats":3');
+    expect(screen.getByTestId('topic-revisions')).toHaveTextContent('"config":2');
+    expect(screen.queryByRole('button', { name: 'Applied delete' })).not.toBeInTheDocument();
+  });
+});

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/TopicListPage.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/TopicListPage.tsx
@@ -218,6 +218,11 @@ export default function TopicListPage() {
     });
   };
 
+  const refreshAppliedTopicResources = async (...resources: Array<keyof typeof detailRevisions>) => {
+    refreshDetailResources(...resources);
+    await load();
+  };
+
   const openDetails = (topic: TopicInfo, origin?: HTMLElement) => {
     if (origin) detailTriggerRef.current = origin;
     selectedTopicRef.current = topic;
@@ -485,6 +490,7 @@ export default function TopicListPage() {
         targets={data?.targets ?? []}
         onOpenChange={changeCreateOpen}
         onSubmit={saveCreate}
+        onAppliedAuditFailure={load}
       />
       <TopicMutationDialog
         open={Boolean(editAction)}
@@ -496,6 +502,7 @@ export default function TopicListPage() {
         onRetryConfig={retryEditConfig}
         onOpenChange={(open) => { if (!open) closeAction(); }}
         onSubmit={saveEdit}
+        onAppliedAuditFailure={() => refreshAppliedTopicResources('config')}
       />
       <EntitySheet
         open={selectedTopic !== null}
@@ -556,6 +563,7 @@ export default function TopicListPage() {
         topic={sendAction?.topic.topic ?? ''}
         onOpenChange={(open) => { if (!open) closeAction(); }}
         onSucceeded={() => undefined}
+        onAppliedAuditFailure={() => refreshAppliedTopicResources('stats')}
       />
       <TopicResetOffsetDialog
         open={Boolean(consumerAction?.kind === 'reset' && consumerAction.consumerGroup)}
@@ -563,6 +571,7 @@ export default function TopicListPage() {
         consumerGroup={consumerAction?.consumerGroup ?? ''}
         onOpenChange={(open) => { if (!open) closeAction(); }}
         onSucceeded={(result) => refreshOffsetResources(result.topic)}
+        onAppliedAuditFailure={() => refreshAppliedTopicResources('stats', 'consumers')}
       />
       <TopicSkipBacklogDialog
         open={Boolean(consumerAction?.kind === 'skip' && consumerAction.consumerGroup)}
@@ -570,6 +579,7 @@ export default function TopicListPage() {
         consumerGroup={consumerAction?.consumerGroup ?? ''}
         onOpenChange={(open) => { if (!open) closeAction(); }}
         onSucceeded={(result) => refreshOffsetResources(result.topic)}
+        onAppliedAuditFailure={() => refreshAppliedTopicResources('stats', 'consumers')}
       />
       <TopicDeleteDialog
         open={Boolean(deleteAction)}
@@ -579,6 +589,12 @@ export default function TopicListPage() {
         onOpenChange={(open) => { if (!open) closeAction(); }}
         onResult={handleDeleteResult}
         onSucceeded={handleDeleteSucceeded}
+        onAppliedAuditFailure={() => {
+          const resources = deleteAction?.kind === 'delete-broker'
+            ? ['route', 'stats', 'config'] as const
+            : [] as const;
+          return refreshAppliedTopicResources(...resources);
+        }}
       />
     </div>
   );

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/brokers/BrokerDetailContent.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/brokers/BrokerDetailContent.tsx
@@ -1,6 +1,7 @@
 import { AlertTriangle, CheckCircle2, Pencil, Save, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { brokerApi } from '../../api/broker_api';
+import { handleAppliedAuditFailure } from '../../api/client';
 import ErrorState from '../../components/ErrorState';
 import KeyValueTable from '../../components/KeyValueTable';
 import LoadingState from '../../components/LoadingState';
@@ -166,6 +167,16 @@ export default function BrokerDetailContent({ brokerName, broker, initialTab = '
       setSaveMessage('Configuration updated.');
     } catch (requestError) {
       if (requestId !== saveRequestRef.current || brokerNameRef.current !== requestBroker) return;
+      if (await handleAppliedAuditFailure(requestError, {
+        onApplied: () => {
+          setEditing(false);
+          setConfirmOpen(false);
+          setPendingEntries(null);
+          setSaveError(null);
+          setSaveMessage('Configuration change was applied. Refreshing authoritative values.');
+        },
+        refresh: loadConfig
+      })) return;
       setSaveError(requestError instanceof Error ? requestError.message : String(requestError));
       setConfirmOpen(false);
     } finally {

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/ConsumerDetailContent.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/consumers/ConsumerDetailContent.tsx
@@ -1,6 +1,7 @@
 import { ListChecks, Network, RadioTower, RotateCcw, Settings2, Users } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { consumerApi } from '../../api/consumer_api';
+import { handleAppliedAuditFailure } from '../../api/client';
 import AppDataTable, { type AppDataTableColumn } from '../../components/AppDataTable';
 import ErrorState from '../../components/ErrorState';
 import LoadingState from '../../components/LoadingState';
@@ -37,6 +38,12 @@ import { normalizeConsumerValue } from './consumer-model';
 interface ConsumerDetailContentProps {
   group: string;
   initialTab?: 'overview' | 'clients' | 'progress' | 'config' | 'reset';
+  authoritativeDetail?: {
+    identityKey: string;
+    revision: number;
+    summary: ConsumerSummaryView;
+    config: ConsumerConfigView;
+  } | null;
 }
 
 const connectionColumns: AppDataTableColumn<ConsumerConnectionItem>[] = [
@@ -69,8 +76,14 @@ const queueColumns: AppDataTableColumn<ConsumerProgressQueue>[] = [
   { id: 'lastConsume', header: 'Last consume time', width: '180px', cell: (row) => formatTimestamp(row.lastTimestamp) }
 ];
 
-export default function ConsumerDetailContent({ group, initialTab = 'overview' }: ConsumerDetailContentProps) {
+export default function ConsumerDetailContent({
+  group,
+  initialTab = 'overview',
+  authoritativeDetail = null
+}: ConsumerDetailContentProps) {
   const { scope, revision } = useConsumerQueryScope();
+  const scopeKey = `${scope.mode}:${scope.proxyAddress ?? ''}`;
+  const identityKey = `${group}|${scopeKey}`;
   const [activeTab, setActiveTab] = useState(initialTab);
   const [summary, setSummary] = useState<ConsumerSummaryView | null>(null);
   const [progress, setProgress] = useState<ConsumerProgressView | null>(null);
@@ -90,8 +103,10 @@ export default function ConsumerDetailContent({ group, initialTab = 'overview' }
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [resetting, setResetting] = useState(false);
   const requestToken = useRef(0);
+  const configRequestToken = useRef(0);
   const resetOperationToken = useRef(0);
   const currentGroupRef = useRef(group);
+  const appliedCursorRef = useRef<{ identityKey: string; revision: number } | null>(null);
 
   const load = async () => {
     const token = ++requestToken.current;
@@ -128,14 +143,19 @@ export default function ConsumerDetailContent({ group, initialTab = 'overview' }
   };
 
   const loadConfig = async () => {
+    const token = ++configRequestToken.current;
     setConfigLoading(true);
     setConfigError(null);
     try {
-      setConfig(await consumerApi.config(group, scope));
+      const nextConfig = await consumerApi.config(group, scope);
+      if (token !== configRequestToken.current) return;
+      setConfig(nextConfig);
     } catch (requestError) {
-      setConfigError(requestError instanceof Error ? requestError.message : String(requestError));
+      if (token === configRequestToken.current) {
+        setConfigError(requestError instanceof Error ? requestError.message : String(requestError));
+      }
     } finally {
-      setConfigLoading(false);
+      if (token === configRequestToken.current) setConfigLoading(false);
     }
   };
 
@@ -155,12 +175,29 @@ export default function ConsumerDetailContent({ group, initialTab = 'overview' }
     setNotice(null);
     setConfirmOpen(false);
     setResetting(false);
+    appliedCursorRef.current = null;
     void load();
     return () => {
       requestToken.current += 1;
+      configRequestToken.current += 1;
       resetOperationToken.current += 1;
     };
   }, [group, initialTab, scope.mode, scope.proxyAddress, revision]);
+
+  useEffect(() => {
+    if (!authoritativeDetail || authoritativeDetail.identityKey !== identityKey) return;
+    const cursor = appliedCursorRef.current;
+    if (cursor?.identityKey === identityKey && cursor.revision === authoritativeDetail.revision) return;
+    appliedCursorRef.current = { identityKey, revision: authoritativeDetail.revision };
+    requestToken.current += 1;
+    configRequestToken.current += 1;
+    setSummary(authoritativeDetail.summary);
+    setConfig(authoritativeDetail.config);
+    setLoading(false);
+    setError(null);
+    setConfigLoading(false);
+    setConfigError(null);
+  }, [authoritativeDetail, identityKey]);
 
   useEffect(() => {
     if (activeTab === 'clients' && !connections) void loadClients();
@@ -220,6 +257,14 @@ export default function ConsumerDetailContent({ group, initialTab = 'overview' }
       await load();
     } catch (requestError) {
       if (operationToken !== resetOperationToken.current || currentGroupRef.current !== operationGroup) return;
+      if (await handleAppliedAuditFailure(requestError, {
+        onApplied: () => {
+          setConfirmOpen(false);
+          setValidationError(null);
+          setNotice(`Offset reset was applied for ${operationGroup}. Refreshing authoritative progress.`);
+        },
+        refresh: load
+      })) return;
       setConfirmOpen(false);
       setValidationError(requestError instanceof Error ? requestError.message : 'Unable to reset offsets.');
     } finally {

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/monitor/MonitorDialog.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/pages/monitor/MonitorDialog.tsx
@@ -1,6 +1,6 @@
 import { Save } from 'lucide-react';
 import { useEffect, useId, useRef, useState } from 'react';
-import { ApiClientError } from '../../api/client';
+import { ApiClientError, handleAppliedAuditFailure } from '../../api/client';
 import { Button } from '../../components/ui/Button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../../components/ui/Dialog';
 import { Input } from '../../components/ui/Input';
@@ -15,6 +15,7 @@ interface MonitorDialogProps {
   onOpenChange: (open: boolean) => void;
   onSubmit: (request: ConsumerMonitorUpsertRequest) => Promise<void>;
   onConflict?: (consumerGroup: string) => Promise<ConsumerMonitorView | null>;
+  onAppliedAuditFailure?: () => Promise<void> | void;
 }
 
 const emptyDraft: ConsumerMonitorDraft = {
@@ -23,7 +24,7 @@ const emptyDraft: ConsumerMonitorDraft = {
   maxDiffTotal: '1000'
 };
 
-export default function MonitorDialog({ open, environmentId, rule, onOpenChange, onSubmit, onConflict }: MonitorDialogProps) {
+export default function MonitorDialog({ open, environmentId, rule, onOpenChange, onSubmit, onConflict, onAppliedAuditFailure }: MonitorDialogProps) {
   const [draft, setDraft] = useState<ConsumerMonitorDraft>(emptyDraft);
   const [validationErrors, setValidationErrors] = useState<Partial<Record<keyof ConsumerMonitorDraft, string>>>({});
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -84,6 +85,13 @@ export default function MonitorDialog({ open, environmentId, rule, onOpenChange,
       if (generation === requestGeneration.current) onOpenChange(false);
     } catch (error) {
       if (generation === requestGeneration.current) {
+        if (await handleAppliedAuditFailure(error, {
+          onApplied: () => {
+            setSubmitError(null);
+            onOpenChange(false);
+          },
+          refresh: onAppliedAuditFailure
+        })) return;
         if (error instanceof ApiClientError && error.code === 'STORAGE_CONFLICT') {
           // Set this before awaiting the parent refresh: a concurrent create
           // can synchronously select the authoritative row and otherwise

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/router/index.tsx
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/router/index.tsx
@@ -13,7 +13,9 @@ export const canonicalRoutePatterns = [
   '/messages/dlq',
   '/message-trace',
   '/acl',
+  '/audit',
   '/monitors',
+  '/sessions',
   '/config'
 ] as const;
 
@@ -38,7 +40,9 @@ export const routes = [
   '/dlq',
   '/message-trace',
   '/acl',
+  '/audit',
   '/monitors',
+  '/sessions',
   '/login',
   '/config'
 ];

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/pages.css
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/styles/pages.css
@@ -1326,6 +1326,57 @@
   }
 }
 
+.audit-admin-shell {
+  display: grid;
+  gap: 16px;
+}
+
+.audit-filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.audit-filter-row .ui-input,
+.audit-filter-row select {
+  min-width: 160px;
+}
+
+.audit-actor {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.audit-outcome {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: capitalize;
+}
+
+.audit-outcome-succeeded { color: var(--success); }
+.audit-outcome-rejected { color: var(--warning); }
+.audit-outcome-failed { color: var(--destructive); }
+
+.audit-detail {
+  display: inline-block;
+  max-width: 260px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: bottom;
+  white-space: nowrap;
+}
+
+.audit-warning {
+  margin-bottom: 14px;
+  padding: 10px 12px;
+  border: 1px solid color-mix(in srgb, var(--warning) 42%, var(--border));
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--warning) 9%, var(--card));
+  color: var(--warning);
+}
+
 /* Message operations */
 .settings-workspace {
   display: grid;

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/types/audit.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/types/audit.ts
@@ -1,0 +1,46 @@
+export type AuditOutcome = 'succeeded' | 'rejected' | 'failed';
+
+export interface SessionListItem {
+  sessionId: string;
+  username: string;
+  createdAtMs: number;
+  expiresAtMs: number;
+  lastSeenAtMs: number;
+  revokedAtMs?: number | null;
+  current: boolean;
+}
+
+export interface SessionListPage {
+  items: SessionListItem[];
+  nextCursor?: string | null;
+}
+
+export interface AuditEvent {
+  eventId: string;
+  requestId: string;
+  actor: string;
+  actorKind: 'admin' | 'local_operator' | 'system';
+  action: string;
+  resourceType: string;
+  resourceName?: string | null;
+  environmentId?: string | null;
+  outcome: AuditOutcome;
+  detail?: unknown;
+  createdAtMs: number;
+}
+
+export interface AuditEventPage {
+  events: AuditEvent[];
+  nextCursor?: string | null;
+}
+
+export interface AuditEventQuery {
+  startMs?: number;
+  endMs?: number;
+  actor?: string;
+  action?: string;
+  outcome?: AuditOutcome;
+  environmentId?: string;
+  cursor?: string;
+  limit?: number;
+}

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/types/auth.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/types/auth.ts
@@ -9,4 +9,5 @@ export interface SessionView {
   username?: string | null;
   sessionId?: string | null;
   loginTime?: number | null;
+  authReason?: 'invalid' | 'expired' | 'revoked' | null;
 }

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/types/consumer.ts
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/src/types/consumer.ts
@@ -5,6 +5,17 @@ export interface ConsumerQueryScope {
   proxyAddress?: string;
 }
 
+/**
+ * Identifies the consumer workspace that owned a mutation when it started.
+ * The generation is supplied by the route owner so a delayed completion
+ * cannot refresh or close a newer group or query scope.
+ */
+export interface ConsumerOperationIdentity {
+  group: string;
+  scopeKey: string;
+  generation: number;
+}
+
 export interface ConsumerQuery {
   mode: ConsumerQueryMode;
   proxyAddress?: string;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9686

### Brief Description

- Persist multi-session authentication and management audit events through the File, SQLite, MySQL, and PostgreSQL storage backends.
- Add atomic session and audit repository operations, retention cleanup, crash recovery, strict credential and CORS handling, and redacted audit contracts.
- Add session administration and audit views, cookie-first authentication, and terminal handling for applied mutations whose audit write fails.
- Prevent duplicate consumer mutations across dialog, route, scope, remount, and concurrent-render transitions by using durable identity-keyed operation ownership.

### How Did You Test This Change?

- `cargo fmt -- --check`: passed.
- `cargo clippy --all-targets --all-features -- -D warnings`: passed.
- `cargo test --all-targets --all-features`: 169 passed, 0 failed, 22 Docker-only tests ignored.
- Fresh Docker File, SQLite, MySQL 8.4, and PostgreSQL 15 matrix with `--include-ignored`: 189 passed, 0 failed; dedicated containers, network, and volumes were removed afterward.
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`: passed.
- `npm ci`: passed.
- `npm test -- --run --reporter=dot --silent`: 57 files and 400 tests passed.
- `npm run build`: passed.
- `git diff --check`: passed.
- Error-hygiene checks passed for the dashboard scope; the repository-wide guard still reports only pre-existing findings outside the changed paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added administrator pages for viewing audit events and managing active sessions, including filtering, pagination, and bulk session revocation.
  * Added persistent session management with secure cookies, expiration, revocation, and clearer authentication-status messages.
  * Added audit tracking for configuration, topic, consumer, broker, messaging, ACL, and monitoring changes.
  * Added cleanup health reporting and retention handling for sessions and audit records.
  * Restricted CORS to configured origins and rejected conflicting authentication credentials.

* **Bug Fixes**
  * Improved mutation handling to prevent duplicate submissions and stale updates.
  * Added warnings and authoritative refreshes when changes succeed but audit persistence fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->