### PR TITLE
[ISSUE #9702]♻️Remove production test interception and bound lifecycle callbacks

### DIFF
--- a/rocketmq-transport/src/base/channel_event_listener.rs
+++ b/rocketmq-transport/src/base/channel_event_listener.rs
@@ -16,10 +16,15 @@ use crate::net::channel::Channel;
 
 /// Receives connection lifecycle notifications from the remoting event dispatcher.
 ///
-/// Callbacks execute serially on a Tokio service task and therefore must return promptly. A
-/// callback that needs blocking I/O should hand that work to the application's injected blocking
-/// executor instead of blocking this dispatcher. Slow callbacks are measured and logged by the
-/// transport runtime.
+/// The transport runtime runs callbacks on its injected, bounded blocking executor and applies a
+/// private callback deadline. A callback that exceeds that deadline is not cancelled because a
+/// synchronous closure cannot be forcefully stopped; the executor continues to track it until it
+/// returns and it continues to occupy its permit.
+///
+/// The event dispatcher proceeds after a callback deadline expires. Consequently, callbacks
+/// scheduled after a timed-out callback can overlap it and can complete in a different order than
+/// their lifecycle events. Implementations must therefore be thread-safe and should return
+/// promptly.
 pub trait ChannelEventListener: Sync + Send {
     fn on_channel_connect(&self, remote_addr: &str, channel: &Channel);
 

--- a/rocketmq-transport/src/remoting_server/rocketmq_tokio_server.rs
+++ b/rocketmq-transport/src/remoting_server/rocketmq_tokio_server.rs
@@ -164,5 +164,5 @@ pub struct TransportServer<RP> {
     _phantom_data: std::marker::PhantomData<RP>,
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(doctest)))]
 mod tests;

--- a/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/capabilities.rs
+++ b/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/capabilities.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(all(test, not(doctest)))]
 use super::connection_handler::SessionCommandInterceptor;
 use super::lifecycle_events::LifecycleEventConfig;
 use super::lifecycle_events::LifecycleEventPublisher;
@@ -43,6 +44,7 @@ pub(super) struct RemotingServerRunCapabilities {
     pub(super) transport_security: Option<Arc<TransportSecurity>>,
     pub(super) transport_principal: Option<Principal>,
     pub(super) admission: Option<Arc<AdmissionController>>,
+    #[cfg(all(test, not(doctest)))]
     pub(super) command_interceptor: Arc<dyn SessionCommandInterceptor>,
     pub(super) telemetry: TransportTelemetry,
     pub(super) lifecycle_event_config: LifecycleEventConfig,

--- a/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/connection_handler.rs
+++ b/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/connection_handler.rs
@@ -33,14 +33,9 @@ pub(super) type TestDeferredResponse = Box<
 pub(super) type TestRequestHook =
     Arc<dyn Fn(i32, i32, Channel, TaskGroup, TestDeferredResponse) -> TestRequestHookResult + Send + Sync>;
 
+#[cfg(all(test, not(doctest)))]
 pub(super) trait SessionCommandInterceptor: Send + Sync + 'static {
     fn intercept(&self, code: i32, opaque: i32, channel: Channel, request_executor_group: TaskGroup) -> bool;
-}
-
-impl SessionCommandInterceptor for () {
-    fn intercept(&self, _code: i32, _opaque: i32, _channel: Channel, _request_executor_group: TaskGroup) -> bool {
-        false
-    }
 }
 
 pub(super) struct ConnectionHandler<RP> {
@@ -51,6 +46,7 @@ pub(super) struct ConnectionHandler<RP> {
     pub(super) sessions: dashmap::DashMap<u64, RemotingSession<ConnectionHandlerContext>>,
 }
 
+#[cfg(all(test, not(doctest)))]
 pub(super) struct InterceptingConnectionHandler<RP> {
     pub(super) inner: ConnectionHandler<RP>,
     pub(super) command_interceptor: Arc<dyn SessionCommandInterceptor>,
@@ -71,7 +67,7 @@ impl<RP: RequestProcessor + Sync + Clone + 'static> ConnectionHandler<RP> {
         &self,
         session: crate::server::SessionHandle,
         action: RemotingSessionAction,
-        command_interceptor: Option<&dyn SessionCommandInterceptor>,
+        #[cfg(all(test, not(doctest)))] command_interceptor: Option<&dyn SessionCommandInterceptor>,
     ) {
         let channel_id = match &action {
             RemotingSessionAction::Connect => format!("transport-session-{}", session.session_id()),
@@ -131,12 +127,13 @@ impl<RP: RequestProcessor + Sync + Clone + 'static> ConnectionHandler<RP> {
                 }
             }
             RemotingSessionAction::Command(command) => {
+                #[cfg(all(test, not(doctest)))]
                 if let Some(command_interceptor) = command_interceptor {
                     if command_interceptor.intercept(
                         command.code(),
                         command.opaque(),
                         remoting_session.context.channel().clone(),
-                        session.request_executor_group().clone(),
+                        session.task_group().clone(),
                     ) {
                         return;
                     }
@@ -151,7 +148,13 @@ impl<RP: RequestProcessor + Sync + Clone + 'static> ConnectionHandler<RP> {
 impl<RP: RequestProcessor + Sync + Clone + 'static> TransportConnectionHandler for ConnectionHandler<RP> {
     fn connected(&self, session: crate::server::SessionHandle) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(async move {
-            self.run(session, RemotingSessionAction::Connect, None).await;
+            self.run(
+                session,
+                RemotingSessionAction::Connect,
+                #[cfg(all(test, not(doctest)))]
+                None,
+            )
+            .await;
         })
     }
 
@@ -168,7 +171,13 @@ impl<RP: RequestProcessor + Sync + Clone + 'static> TransportConnectionHandler f
         command: rocketmq_protocol::protocol::remoting_command::RemotingCommand,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(async move {
-            self.run(session, RemotingSessionAction::Command(command), None).await;
+            self.run(
+                session,
+                RemotingSessionAction::Command(command),
+                #[cfg(all(test, not(doctest)))]
+                None,
+            )
+            .await;
         })
     }
 
@@ -208,6 +217,7 @@ impl<RP: RequestProcessor + Sync + Clone + 'static> TransportConnectionHandler f
     }
 }
 
+#[cfg(all(test, not(doctest)))]
 impl<RP: RequestProcessor + Sync + Clone + 'static> TransportConnectionHandler for InterceptingConnectionHandler<RP> {
     fn connected(&self, session: crate::server::SessionHandle) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         self.inner.connected(session)

--- a/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/connection_listener.rs
+++ b/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/connection_listener.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use super::connection_handler::ConnectionHandler;
+#[cfg(all(test, not(doctest)))]
 use super::connection_handler::InterceptingConnectionHandler;
+#[cfg(all(test, not(doctest)))]
 use super::connection_handler::SessionCommandInterceptor;
 use super::lifecycle_events::LifecycleEventPublisher;
 use super::*;
@@ -76,6 +78,7 @@ pub(super) struct ConnectionListener<RP> {
     pub(super) proxy_protocol: ProxyProtocolConfig,
 
     pub(super) transport_principal: Option<Principal>,
+    #[cfg(all(test, not(doctest)))]
     pub(super) command_interceptor: Arc<dyn SessionCommandInterceptor>,
     pub(super) telemetry: TransportTelemetry,
     pub(super) lifecycle_dispatcher_task: Option<TaskId>,
@@ -126,17 +129,25 @@ impl<RP: RequestProcessor + Sync + 'static + Clone> ConnectionListener<RP> {
         .try_with_frame_limits(self.frame_limits)?
         .try_with_proxy_protocol(self.proxy_protocol.clone())?
         .with_telemetry(self.telemetry.clone());
-        transport
-            .run(Arc::new(InterceptingConnectionHandler {
-                inner: ConnectionHandler {
-                    shutdown_complete_tx: self.shutdown_complete_tx.clone(),
-                    conn_disconnect_notify: self.conn_disconnect_notify.clone(),
-                    dispatcher: self.dispatcher.clone(),
-                    event_publisher,
-                    sessions: dashmap::DashMap::new(),
-                },
-                command_interceptor: self.command_interceptor.clone(),
-            }))
-            .await
+        #[cfg(all(test, not(doctest)))]
+        let connection_handler = Arc::new(InterceptingConnectionHandler {
+            inner: ConnectionHandler {
+                shutdown_complete_tx: self.shutdown_complete_tx.clone(),
+                conn_disconnect_notify: self.conn_disconnect_notify.clone(),
+                dispatcher: self.dispatcher.clone(),
+                event_publisher,
+                sessions: dashmap::DashMap::new(),
+            },
+            command_interceptor: self.command_interceptor.clone(),
+        });
+        #[cfg(not(all(test, not(doctest))))]
+        let connection_handler = Arc::new(ConnectionHandler {
+            shutdown_complete_tx: self.shutdown_complete_tx.clone(),
+            conn_disconnect_notify: self.conn_disconnect_notify.clone(),
+            dispatcher: self.dispatcher.clone(),
+            event_publisher,
+            sessions: dashmap::DashMap::new(),
+        });
+        transport.run(connection_handler).await
     }
 }

--- a/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/launch.rs
+++ b/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/launch.rs
@@ -17,6 +17,7 @@ use rocketmq_security_api::SecurityBootstrapProfile;
 use super::capabilities::PreparedServer;
 use super::capabilities::RemotingServerRunCapabilities;
 use super::capabilities::ServerSecurityState;
+#[cfg(all(test, not(doctest)))]
 use super::connection_handler::SessionCommandInterceptor;
 use super::connection_listener::ConnectionListener;
 use super::lifecycle_events::run_lifecycle_event_dispatcher;
@@ -392,8 +393,6 @@ impl<RP: RequestProcessor + Sync + 'static + Clone> TransportServer<RP> {
         let rpc_hooks = self.rpc_hooks.take().unwrap_or_default();
         #[cfg(all(test, not(doctest)))]
         let command_interceptor: Arc<dyn SessionCommandInterceptor> = Arc::new(self.test_request_hook.clone());
-        #[cfg(not(test))]
-        let command_interceptor: Arc<dyn SessionCommandInterceptor> = Arc::new(());
         let capabilities = RemotingServerRunCapabilities {
             tls_runtime,
             task_group: remoting_context.task_group().clone(),
@@ -404,6 +403,7 @@ impl<RP: RequestProcessor + Sync + 'static + Clone> TransportServer<RP> {
             transport_security: self.transport_security.clone(),
             transport_principal: self.transport_principal.clone(),
             admission: self.admission.clone(),
+            #[cfg(all(test, not(doctest)))]
             command_interceptor,
             telemetry: self.telemetry.clone(),
             lifecycle_event_config,
@@ -415,6 +415,7 @@ impl<RP: RequestProcessor + Sync + 'static + Clone> TransportServer<RP> {
             channel_event_listener,
             self.authorized_dispatcher.clone(),
             capabilities,
+            remoting_context.metadata_io().clone(),
         ) {
             Ok(prepared) => Ok(prepared),
             Err(error) => {
@@ -445,6 +446,7 @@ fn prepare_capabilities<RP: RequestProcessor + Sync + 'static + Clone>(
     channel_event_listener: Option<Arc<dyn ChannelEventListener>>,
     authorized_dispatcher: Option<Arc<AuthorizedCommandDispatcher<RP>>>,
     capabilities: RemotingServerRunCapabilities,
+    lifecycle_listener_blocking: BlockingExecutor,
 ) -> Result<PreparedServer<RP>, ServerStartError> {
     let RemotingServerRunCapabilities {
         tls_runtime,
@@ -456,6 +458,7 @@ fn prepare_capabilities<RP: RequestProcessor + Sync + 'static + Clone>(
         transport_security,
         transport_principal,
         admission,
+        #[cfg(all(test, not(doctest)))]
         command_interceptor,
         telemetry,
         lifecycle_event_config,
@@ -524,6 +527,7 @@ fn prepare_capabilities<RP: RequestProcessor + Sync + 'static + Clone>(
         &task_group,
         lifecycle_event_config,
         lifecycle_shutdown.clone(),
+        lifecycle_listener_blocking,
         telemetry.clone(),
     )?;
     info!(?security_state, "remoting server startup capabilities prepared");
@@ -539,6 +543,7 @@ fn prepare_capabilities<RP: RequestProcessor + Sync + 'static + Clone>(
             transport_security: None,
             transport_principal,
             admission: None,
+            #[cfg(all(test, not(doctest)))]
             command_interceptor,
             telemetry,
             lifecycle_event_config,
@@ -563,6 +568,7 @@ fn prepare_lifecycle_event_dispatcher(
     task_group: &TaskGroup,
     lifecycle_event_config: LifecycleEventConfig,
     lifecycle_shutdown: CancellationToken,
+    lifecycle_listener_blocking: BlockingExecutor,
     telemetry: TransportTelemetry,
 ) -> Result<(Option<LifecycleEventPublisher>, Option<TaskId>), ServerStartError> {
     let Some(listener) = channel_event_listener else {
@@ -583,6 +589,7 @@ fn prepare_lifecycle_event_dispatcher(
                 listener,
                 lifecycle_shutdown,
                 lifecycle_event_config,
+                lifecycle_listener_blocking,
                 telemetry,
             ),
         )
@@ -621,6 +628,7 @@ async fn serve_prepared<RP: RequestProcessor + Sync + 'static + Clone>(
         transport_security: _,
         transport_principal,
         admission: _,
+        #[cfg(all(test, not(doctest)))]
         command_interceptor,
         telemetry,
         lifecycle_event_config: _,
@@ -640,6 +648,7 @@ async fn serve_prepared<RP: RequestProcessor + Sync + 'static + Clone>(
         frame_limits,
         proxy_protocol,
         transport_principal,
+        #[cfg(all(test, not(doctest)))]
         command_interceptor,
         telemetry,
         lifecycle_dispatcher_task,

--- a/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/lifecycle_events.rs
+++ b/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/lifecycle_events.rs
@@ -19,7 +19,7 @@ pub(super) struct LifecycleEventConfig {
     pub(super) queue_capacity: usize,
     pub(super) publish_timeout: Duration,
     pub(super) drain_timeout: Duration,
-    pub(super) listener_warn_threshold: Duration,
+    pub(super) listener_callback_budget: Duration,
 }
 
 impl Default for LifecycleEventConfig {
@@ -28,7 +28,7 @@ impl Default for LifecycleEventConfig {
             queue_capacity: 1024,
             publish_timeout: Duration::from_millis(10),
             drain_timeout: Duration::from_millis(250),
-            listener_warn_threshold: Duration::from_millis(50),
+            listener_callback_budget: Duration::from_millis(50),
         }
     }
 }
@@ -38,7 +38,10 @@ impl LifecycleEventConfig {
         validate_positive_config("channelEventQueueCapacity", self.queue_capacity)?;
         validate_duration_config("channelEventPublishTimeoutMillis", self.publish_timeout)?;
         validate_duration_config("channelEventDrainTimeoutMillis", self.drain_timeout)?;
-        validate_duration_config("channelEventListenerWarnMillis", self.listener_warn_threshold)?;
+        validate_duration_config(
+            "channelEventListenerCallbackBudgetMillis",
+            self.listener_callback_budget,
+        )?;
         Ok(self)
     }
 }
@@ -145,6 +148,7 @@ pub(super) async fn run_lifecycle_event_dispatcher(
     listener: Arc<dyn ChannelEventListener>,
     cancellation: CancellationToken,
     config: LifecycleEventConfig,
+    listener_blocking: BlockingExecutor,
     telemetry: TransportTelemetry,
 ) {
     loop {
@@ -153,11 +157,12 @@ pub(super) async fn run_lifecycle_event_dispatcher(
             _ = cancellation.cancelled() => break,
             event = receiver.recv() => match event {
                 Some(event) => dispatch_lifecycle_event(
-                    listener.as_ref(),
+                    Arc::clone(&listener),
                     event,
-                    config.listener_warn_threshold,
+                    ShutdownDeadline::after(config.listener_callback_budget),
+                    &listener_blocking,
                     &telemetry,
-                ),
+                ).await,
                 None => {
                     info!("Remoting lifecycle event dispatcher closed");
                     return;
@@ -171,7 +176,18 @@ pub(super) async fn run_lifecycle_event_dispatcher(
         let Ok(event) = receiver.try_recv() else {
             break;
         };
-        dispatch_lifecycle_event(listener.as_ref(), event, config.listener_warn_threshold, &telemetry);
+        let callback_deadline = Instant::now()
+            .checked_add(config.listener_callback_budget)
+            .unwrap_or(drain_deadline)
+            .min(drain_deadline);
+        dispatch_lifecycle_event(
+            Arc::clone(&listener),
+            event,
+            ShutdownDeadline::at(callback_deadline),
+            &listener_blocking,
+            &telemetry,
+        )
+        .await;
     }
 
     let dropped = receiver.len();
@@ -185,29 +201,55 @@ pub(super) async fn run_lifecycle_event_dispatcher(
     info!("Remoting lifecycle event dispatcher terminated");
 }
 
-fn dispatch_lifecycle_event(
-    listener: &dyn ChannelEventListener,
+async fn dispatch_lifecycle_event(
+    listener: Arc<dyn ChannelEventListener>,
     event: TokioEvent,
-    listener_warn_threshold: Duration,
+    deadline: ShutdownDeadline,
+    listener_blocking: &BlockingExecutor,
     telemetry: &TransportTelemetry,
 ) {
     let event_name = lifecycle_event_name(event.type_());
-    let addr = event.remote_addr().to_string();
-    let started = Instant::now();
-    match event.type_() {
-        ConnectionNetEvent::CONNECTED(_) => listener.on_channel_connect(&addr, event.channel()),
-        ConnectionNetEvent::DISCONNECTED => listener.on_channel_close(&addr, event.channel()),
-        ConnectionNetEvent::EXCEPTION => listener.on_channel_exception(&addr, event.channel()),
-        ConnectionNetEvent::IDLE => listener.on_channel_idle(&addr, event.channel()),
-    }
-    let elapsed = started.elapsed();
-    telemetry.record_lifecycle_event(event_name, "delivered");
-    telemetry.record_lifecycle_listener_latency(elapsed, event_name);
-    if elapsed >= listener_warn_threshold {
+    let wait_started = Instant::now();
+    let callback_telemetry = telemetry.clone();
+    let outcome = listener_blocking
+        .spawn_io_until("rocketmq.remoting.lifecycle_listener", deadline, move || {
+            let callback_started = Instant::now();
+            let addr = event.remote_addr().to_string();
+            match event.type_() {
+                ConnectionNetEvent::CONNECTED(_) => listener.on_channel_connect(&addr, event.channel()),
+                ConnectionNetEvent::DISCONNECTED => listener.on_channel_close(&addr, event.channel()),
+                ConnectionNetEvent::EXCEPTION => listener.on_channel_exception(&addr, event.channel()),
+                ConnectionNetEvent::IDLE => listener.on_channel_idle(&addr, event.channel()),
+            }
+            callback_telemetry.record_lifecycle_listener_latency(callback_started.elapsed(), event_name);
+        })
+        .await;
+    let wait_elapsed = wait_started.elapsed();
+    let outcome_label = match outcome {
+        Ok(()) => "delivered",
+        Err(rocketmq_runtime::RuntimeError::BlockingTaskTimeoutStillRunning { .. }) => "callback_timeout_still_running",
+        Err(
+            rocketmq_runtime::RuntimeError::BlockingQueueTimeout { .. }
+            | rocketmq_runtime::RuntimeError::BlockingQueueFull { .. },
+        ) => "executor_deadline_or_rejected",
+        Err(rocketmq_runtime::RuntimeError::BlockingJoin { .. }) => "callback_join_failure",
+        Err(error) => {
+            warn!(
+                event = event_name,
+                elapsed_ms = wait_elapsed.as_millis(),
+                cause = %error,
+                "Remoting lifecycle listener executor failed"
+            );
+            "executor_failure"
+        }
+    };
+    telemetry.record_lifecycle_event(event_name, outcome_label);
+    if outcome_label != "delivered" {
         warn!(
             event = event_name,
-            elapsed_ms = elapsed.as_millis(),
-            "Slow remoting lifecycle listener callback"
+            outcome = outcome_label,
+            elapsed_ms = wait_elapsed.as_millis(),
+            "Remoting lifecycle listener callback was not delivered within its deadline"
         );
     }
 }

--- a/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/tests.rs
+++ b/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/tests.rs
@@ -33,9 +33,13 @@ use crate::request_processor::default_request_processor::DefaultRequestProcessor
 use crate::runtime::config::client_config::TransportClientConfig;
 
 use self::runtime_test_support::test_service_context;
+#[cfg(all(test, not(doctest)))]
 use super::connection_handler::SessionCommandInterceptor;
+#[cfg(all(test, not(doctest)))]
 use super::connection_handler::TestDeferredResponse;
+#[cfg(all(test, not(doctest)))]
 use super::connection_handler::TestRequestHook;
+#[cfg(all(test, not(doctest)))]
 use super::connection_handler::TestRequestHookResult;
 use super::launch::run_with_report;
 use super::launch::run_with_report_with_service_context;
@@ -55,6 +59,7 @@ mod runtime_test_support {
     }
 }
 
+#[cfg(all(test, not(doctest)))]
 impl SessionCommandInterceptor for Option<TestRequestHook> {
     fn intercept(&self, code: i32, opaque: i32, channel: Channel, request_executor_group: TaskGroup) -> bool {
         let Some(hook) = self.as_ref() else {
@@ -80,6 +85,7 @@ struct ConnectSignalListener {
 
 struct SlowLifecycleListener {
     first_delivery: std::sync::Mutex<Option<oneshot::Sender<()>>>,
+    disconnected_delivery: std::sync::Mutex<Option<oneshot::Sender<()>>>,
     release: Arc<(std::sync::Mutex<bool>, std::sync::Condvar)>,
     deliveries: std::sync::atomic::AtomicUsize,
 }
@@ -143,7 +149,7 @@ async fn lifecycle_event_queue_reports_closed_dispatcher() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn capacity_one_slow_listener_makes_overload_explicit_and_drains_queued_event() {
+async fn timed_out_lifecycle_listener_allows_later_callback_before_release() {
     let context = RuntimeContext::from_current("remoting-lifecycle-overload-test");
     let service = context.service_context("remoting-lifecycle-overload");
     let task_group = service.task_group().clone();
@@ -154,8 +160,10 @@ async fn capacity_one_slow_listener_makes_overload_explicit_and_drains_queued_ev
     let remote_addr = harness.remote_address();
     let release = Arc::new((std::sync::Mutex::new(false), std::sync::Condvar::new()));
     let (first_delivery_tx, first_delivery_rx) = oneshot::channel();
+    let (disconnected_delivery_tx, disconnected_delivery_rx) = oneshot::channel();
     let listener = Arc::new(SlowLifecycleListener {
         first_delivery: std::sync::Mutex::new(Some(first_delivery_tx)),
+        disconnected_delivery: std::sync::Mutex::new(Some(disconnected_delivery_tx)),
         release: Arc::clone(&release),
         deliveries: std::sync::atomic::AtomicUsize::new(0),
     });
@@ -165,7 +173,7 @@ async fn capacity_one_slow_listener_makes_overload_explicit_and_drains_queued_ev
         queue_capacity: 1,
         publish_timeout: Duration::from_millis(5),
         drain_timeout: Duration::from_millis(100),
-        listener_warn_threshold: Duration::from_millis(1),
+        listener_callback_budget: Duration::from_millis(1),
     };
     let telemetry = TransportTelemetry::noop();
     task_group
@@ -176,6 +184,7 @@ async fn capacity_one_slow_listener_makes_overload_explicit_and_drains_queued_ev
                 listener.clone(),
                 cancellation.clone(),
                 config,
+                service.metadata_io().clone(),
                 telemetry.clone(),
             ),
         )
@@ -210,16 +219,10 @@ async fn capacity_one_slow_listener_makes_overload_explicit_and_drains_queued_ev
             .await,
         LifecycleEventPublishOutcome::Queued
     );
-    assert_eq!(
-        publisher
-            .publish(TokioEvent::new(
-                ConnectionNetEvent::DISCONNECTED,
-                remote_addr,
-                channel.clone(),
-            ))
-            .await,
-        LifecycleEventPublishOutcome::DeadlineExpired
-    );
+    tokio::time::timeout(Duration::from_secs(1), disconnected_delivery_rx)
+        .await
+        .expect("disconnected callback should run after the first callback deadline")
+        .expect("disconnected callback should be delivered before release");
 
     {
         let (released, condition) = release.as_ref();
@@ -227,12 +230,12 @@ async fn capacity_one_slow_listener_makes_overload_explicit_and_drains_queued_ev
         condition.notify_all();
     }
     tokio::time::timeout(Duration::from_secs(1), async {
-        while listener.deliveries.load(std::sync::atomic::Ordering::Acquire) < 2 {
+        while service.metadata_io().snapshot().blocking_still_running != 0 {
             tokio::task::yield_now().await;
         }
     })
     .await
-    .expect("queued lifecycle event should be delivered");
+    .expect("timed-out lifecycle callback should leave the blocking executor after release");
 
     let channel_report = channel.close_with_report(Duration::from_secs(1)).await;
     assert!(channel_report.is_healthy(), "{}", channel_report.to_json());
@@ -294,6 +297,14 @@ impl ChannelEventListener for SlowLifecycleListener {
 
     fn on_channel_close(&self, _remote_addr: &str, _channel: &Channel) {
         self.deliveries.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+        if let Some(sender) = self
+            .disconnected_delivery
+            .lock()
+            .expect("disconnect delivery lock")
+            .take()
+        {
+            let _ = sender.send(());
+        }
     }
 
     fn on_channel_exception(&self, _remote_addr: &str, _channel: &Channel) {}

--- a/rocketmq-transport/src/server.rs
+++ b/rocketmq-transport/src/server.rs
@@ -200,10 +200,6 @@ impl SessionHandle {
         snapshot
     }
 
-    pub(crate) fn request_executor_group(&self) -> &TaskGroup {
-        &self.send.task_group
-    }
-
     pub fn operation_context(&self) -> &OperationContext {
         &self.request_operation
     }

--- a/rocketmq-transport/tests/client_server_lifecycle.rs
+++ b/rocketmq-transport/tests/client_server_lifecycle.rs
@@ -44,15 +44,20 @@ use rocketmq_transport::api::v1::AdmissionController;
 use rocketmq_transport::api::v1::AdmissionLimits;
 use rocketmq_transport::api::v1::AdmissionResource;
 use rocketmq_transport::api::v1::AdmissionScope;
+use rocketmq_transport::api::v1::Channel;
+use rocketmq_transport::api::v1::ChannelEventListener;
+use rocketmq_transport::api::v1::DefaultRequestProcessor;
 use rocketmq_transport::api::v1::FrameLimits;
 use rocketmq_transport::api::v1::OneShotTransportClient;
 use rocketmq_transport::api::v1::RequestDeadline;
 use rocketmq_transport::api::v1::ResourceLimit;
+use rocketmq_transport::api::v1::ServerConfig;
 use rocketmq_transport::api::v1::TlsClientConfig;
 use rocketmq_transport::api::v1::TlsConfig;
 use rocketmq_transport::api::v1::TlsMode;
 use rocketmq_transport::api::v1::TlsServerRuntime;
 use rocketmq_transport::api::v1::TransportSecurity;
+use rocketmq_transport::api::v1::TransportServer;
 #[cfg(feature = "tls")]
 use rocketmq_transport::test_support::transport_io_snapshot;
 use rocketmq_transport::test_support::Connection;
@@ -62,6 +67,10 @@ use rocketmq_transport::test_support::SessionProcessor as RequestProcessor;
 use rocketmq_transport::test_support::SessionTransportServer;
 use rocketmq_transport::test_support::SessionTransportServerConfig;
 use rocketmq_transport::test_support::TransportListener;
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpListener;
+use tokio::net::TcpStream;
+use tokio::sync::oneshot;
 
 struct EchoProcessor;
 
@@ -122,6 +131,12 @@ struct ControlledProcessor {
     calls: AtomicUsize,
 }
 
+struct BlockingLifecycleListener {
+    connected: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+    disconnected: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+    release: Arc<(std::sync::Mutex<bool>, std::sync::Condvar)>,
+}
+
 struct AllowAuthenticated;
 
 impl RequestPolicy for AllowAuthenticated {
@@ -139,6 +154,31 @@ impl OutboundSigner for MarkerSigner {
             Secret::new(CheetahString::from_static_str("signed")),
         )]))
     }
+}
+
+impl ChannelEventListener for BlockingLifecycleListener {
+    fn on_channel_connect(&self, _remote_addr: &str, _channel: &Channel) {
+        if let Some(sender) = self.connected.lock().expect("connected callback lock").take() {
+            let _ = sender.send(());
+        }
+        let (released, condition) = self.release.as_ref();
+        let mut released = released.lock().expect("lifecycle callback release lock");
+        while !*released {
+            released = condition.wait(released).expect("lifecycle callback release wait");
+        }
+    }
+
+    fn on_channel_close(&self, _remote_addr: &str, _channel: &Channel) {
+        if let Some(sender) = self.disconnected.lock().expect("disconnected callback lock").take() {
+            let _ = sender.send(());
+        }
+    }
+
+    fn on_channel_exception(&self, _remote_addr: &str, _channel: &Channel) {}
+
+    fn on_channel_idle(&self, _remote_addr: &str, _channel: &Channel) {}
+
+    fn on_channel_active(&self, _remote_addr: &str, _channel: &Channel) {}
 }
 
 struct SignatureProcessor;
@@ -263,6 +303,79 @@ impl RequestProcessor for ControlledProcessor {
             Ok(RemotingCommand::create_response_command_with_code(ResponseCode::Success).set_opaque(request.opaque()))
         })
     }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn production_lifecycle_dispatcher_advances_after_callback_deadline() {
+    let runtime = RuntimeContext::from_current("transport-production-lifecycle-deadline-test");
+    let service = runtime.service_context("transport-production-lifecycle-deadline-server");
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("test listener should bind");
+    let address = listener.local_addr().expect("test listener address");
+    let (connected_tx, connected_rx) = oneshot::channel();
+    let (disconnected_tx, disconnected_rx) = oneshot::channel();
+    let release = Arc::new((std::sync::Mutex::new(false), std::sync::Condvar::new()));
+    let lifecycle_listener = Arc::new(BlockingLifecycleListener {
+        connected: std::sync::Mutex::new(Some(connected_tx)),
+        disconnected: std::sync::Mutex::new(Some(disconnected_tx)),
+        release: Arc::clone(&release),
+    });
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let mut server =
+        TransportServer::<DefaultRequestProcessor>::new(Arc::new(ServerConfig::default()), service.clone());
+    let server_task = tokio::spawn(async move {
+        server
+            .try_serve_bound_listener_until(
+                listener,
+                DefaultRequestProcessor,
+                None,
+                Some(lifecycle_listener),
+                async {
+                    let _ = shutdown_rx.await;
+                },
+            )
+            .await
+    });
+
+    let mut client = TcpStream::connect(address).await.expect("client should connect");
+    client
+        .write_all(&[0])
+        .await
+        .expect("client should send plaintext detection byte");
+    tokio::time::timeout(Duration::from_secs(1), connected_rx)
+        .await
+        .expect("connected callback should start")
+        .expect("connected callback signal");
+    drop(client);
+    tokio::time::timeout(Duration::from_secs(1), disconnected_rx)
+        .await
+        .expect("disconnected callback should run before the connected callback is released")
+        .expect("disconnected callback signal");
+
+    {
+        let (released, condition) = release.as_ref();
+        *released.lock().expect("lifecycle callback release lock") = true;
+        condition.notify_all();
+    }
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while service.metadata_io().snapshot().blocking_still_running != 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("timed-out lifecycle callback should leave the blocking executor after release");
+
+    let _ = shutdown_tx.send(());
+    let report = tokio::time::timeout(Duration::from_secs(3), server_task)
+        .await
+        .expect("server should stop")
+        .expect("server task should not panic")
+        .expect("server should return a shutdown report");
+    assert!(report.is_healthy(), "{}", report.to_json());
+    assert_eq!(service.metadata_io().snapshot().blocking_still_running, 0);
+    let root_report = runtime.shutdown_tasks(Duration::from_secs(1)).await;
+    root_report.assert_no_task_leak().expect("runtime should converge");
 }
 
 #[tokio::test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9702

### Brief Description

- Routes production remoting sessions directly through `ConnectionHandler` and keeps command interception in the unit-test-only wrapper.
- Runs synchronous lifecycle listener callbacks on the injected bounded metadata blocking executor with an absolute callback deadline and explicit delivery outcomes.
- Documents timeout non-cancellation, permit ownership, and possible callback overlap or completion reordering.
- Adds deterministic unit and production-path integration coverage proving that a blocked `CONNECTED` callback does not prevent a later `DISCONNECTED` callback.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-transport -- --check` passed.
- `cargo check -p rocketmq-transport --no-default-features` passed.
- `cargo check -p rocketmq-transport --all-features` passed.
- `cargo test -p rocketmq-transport --lib rocketmq_tokio_server` passed with 24 tests.
- `cargo test -p rocketmq-transport --features test-support --test client_server_lifecycle` passed with 14 tests.
- `cargo test -p rocketmq-transport --test public_api_contract --test public_api_v1` passed with 18 tests.
- `cargo test -p rocketmq-transport --no-default-features --lib` passed with 231 tests.
- `cargo test -p rocketmq-transport --all-features` passed, including 247 unit tests, all integration targets, and doctests.
- `cargo doc -p rocketmq-transport --no-deps --all-features` passed with one pre-existing private-link warning in `rocketmq-transport/src/tls.rs`.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` passed.
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` passed.
- Core-release stable-surface, Rust-hygiene, lint-debt, and architecture-debt guards passed.
- Core-release maintainability, public-API-intent, and telemetry-semantic guards reported only findings reproduced unchanged on `origin/main` at `ad55e7ad8b0e8890ff6bdbd22cfde75d283b00d6`.
- `cargo test -p rocketmq-broker client_housekeeping_service` passed with 3 tests.
- `cargo test -p rocketmq-namesrv duplicate_channel_destroy` passed with 2 tests.
- `cargo test -p rocketmq-controller default_broker_heartbeat_manager` passed with 5 tests and 3 pre-marked ignored tests.
- `git diff --check` passed.
