### PR TITLE
[ISSUE #9711]♻️Reduce RequestHeaderCodec to a frozen compatibility adapter

### DIFF
--- a/rocketmq-macros/README-zh_cn.md
+++ b/rocketmq-macros/README-zh_cn.md
@@ -11,11 +11,11 @@ RocketMQ-Rust 协议类型和 Remoting Header 使用的过程宏。
 | 宏 | 状态 | 用途 |
 | --- | --- | --- |
 | `RequestHeaderCodecV3` | 推荐 | 生成类型化 map/source codec、wire schema、校验、键解析、兼容适配器，以及经过审查的可选直接编码。 |
-| `RequestHeaderCodecV2` | 已废弃 | 在兼容窗口内保留加固后的 V2 wire 契约；生产 Header 禁止新增使用。 |
-| `RequestHeaderCodec` | 已废弃 | 仅为下游源码兼容保留最早版本的 Request Header derive。 |
+| `RequestHeaderCodecV2` | 已废弃 | 加固 V2 wire 契约的冻结兼容适配器；生产 Header 禁止新增使用。 |
+| `RequestHeaderCodec` | 已废弃 | 保留最早 Request Header quirks 的冻结兼容适配器，仅用于下游源码兼容。 |
 | `RemotingSerializable` | 工具 | 为类型生成 Remoting 序列化辅助实现。 |
 
-仓库中登记的全部生产请求头和响应头都已使用 V3。旧 derive 至少保留一个发布窗口，只会在未来的破坏性版本中删除。
+仓库中登记的全部生产请求头和响应头都已使用 V3。所有新增 request-header 代码必须使用 V3；V1 和 V2 仅是冻结的兼容适配器。旧 derive 至少保留一个发布窗口，只会在未来的破坏性版本中删除。
 
 ## 快速开始
 
@@ -82,7 +82,7 @@ struct SendMessageRequestHeader {
 
 回退按 Header 和命令生效，不改变 wire 契约，也不会在每条消息上增加全局开关或环境变量查询。
 
-## 从 V2 迁移
+## 迁移旧 Header
 
 V2 元数据不会被静默解释成 V3。必须对照固定 Java schema 审核后显式转换：
 
@@ -96,6 +96,8 @@ V2 元数据不会被静默解释成 V3。必须对照固定 Java schema 审核�
 | 对应 Java `int`/`long` 的无符号字段 | `range = "i32"` / `range = "i64"` |
 
 V2 只应用于尚未完成迁移的既有下游模型。RocketMQ-Rust 新增生产 Header 必须使用 V3，并进入 checked-in schema inventory，否则 migration guard 会拒绝。
+
+V1（`RequestHeaderCodec`）为源码兼容而冻结，包括其历史解析和 decode quirks。不要将其用于新代码；现有 V1 Header 应直接迁移到显式的 V3 model。
 
 ## 重命名 Protocol 依赖
 
@@ -117,9 +119,10 @@ struct Header {
 | 路径 | 用途 |
 | --- | --- |
 | [`src/lib.rs`](src/lib.rs) | 公开 derive 入口和共享解析辅助函数。 |
-| [`src/request_header_codec_v3/`](src/request_header_codec_v3/) | V3 元数据、语义模型、校验和代码生成。 |
-| [`src/request_header_codec_v2/`](src/request_header_codec_v2/) | 兼容窗口内保留的 V2 实现。 |
-| [`src/request_header_custom.rs`](src/request_header_custom.rs) | 已废弃的最早版本 derive 实现。 |
+| [`src/request_header_codec_v3/`](src/request_header_codec_v3/) | canonical V3 元数据、语义模型、profile 校验和代码生成。 |
+| [`src/request_header_codec_v3/legacy_v1.rs`](src/request_header_codec_v3/legacy_v1.rs) 与 [`legacy_v2.rs`](src/request_header_codec_v3/legacy_v2.rs) | 基于 canonical model 的冻结 V1/V2 语法适配器和兼容代码生成。 |
+| [`src/request_header_codec_v2/`](src/request_header_codec_v2/) | 已废弃的 V2 public syntax parser 和 adapter。 |
+| [`src/request_header_custom.rs`](src/request_header_custom.rs) | 已废弃的 V1 parse/wrapper entry，转发到冻结兼容适配器。 |
 | [`src/remoting_serializable.rs`](src/remoting_serializable.rs) | Remoting 序列化 derive。 |
 
 Cargo 构建不会访问 Java checkout。Java schema、golden frame、迁移状态和性能证据由仓库中的 `scripts/request-header-codec` 资产治理。
@@ -130,6 +133,8 @@ Cargo 构建不会访问 Java checkout。Java schema、golden frame、迁移状�
 python scripts/request-header-codec/migrate.py check
 python scripts/request-header-codec/compare_header_schema.py
 cargo test -p rocketmq-macros --lib
+cargo test -p rocketmq-protocol --test request_header_codec_v1_ui
+cargo test -p rocketmq-protocol --test request_header_codec_v1_wire_snapshot
 cargo test -p rocketmq-protocol --test request_header_codec_v3_ui
 cargo test -p rocketmq-protocol --test request_header_codec_v2_ui
 cargo test -p rocketmq-protocol --test request_header_codec_v2_wire_snapshot

--- a/rocketmq-macros/README.md
+++ b/rocketmq-macros/README.md
@@ -12,12 +12,13 @@ or remoting crates instead of depending on it directly.
 | Macro | Status | Purpose |
 | --- | --- | --- |
 | `RequestHeaderCodecV3` | Recommended | Generates typed map/source codecs, wire schema, validation, key resolution, compatibility adapters, and optional reviewed direct encoding. |
-| `RequestHeaderCodecV2` | Deprecated | Preserves the hardened V2 wire contract during the compatibility window. No production header may newly adopt it. |
-| `RequestHeaderCodec` | Deprecated | Preserves the original request-header derive for downstream source compatibility. |
+| `RequestHeaderCodecV2` | Deprecated | Frozen compatibility adapter for the hardened V2 wire contract. No production header may newly adopt it. |
+| `RequestHeaderCodec` | Deprecated | Frozen compatibility adapter that preserves the original request-header quirks for downstream source compatibility. |
 | `RemotingSerializable` | Utility | Implements the remoting serialization helper for a type. |
 
-All registered production request and response headers use V3. Legacy derives remain callable for at least one
-release window and will only be removed in a future breaking release.
+All registered production request and response headers use V3. All new request-header code must use V3; V1 and V2
+are frozen compatibility adapters only. Legacy derives remain callable for at least one release window and will only
+be removed in a future breaking release.
 
 ## Quick start
 
@@ -92,7 +93,7 @@ schema resolves collisions and the map path remains authoritative.
 This fallback is per header and per command. It does not change the wire contract, and it avoids adding a global
 branch or environment lookup to every message.
 
-## Migrating from V2
+## Migrating legacy headers
 
 V2 metadata is not silently reinterpreted. Review it against the fixed Java schema and convert it explicitly:
 
@@ -107,6 +108,9 @@ V2 metadata is not silently reinterpreted. Review it against the fixed Java sche
 
 Keep V2 only while migrating an existing downstream model. New RocketMQ-Rust production headers are rejected by
 the migration guard unless they use V3 and are registered in the checked-in schema inventory.
+
+V1 (`RequestHeaderCodec`) is frozen for source compatibility, including its historical parsing and decode quirks.
+Do not use it for new code; migrate existing V1 headers directly to the explicit V3 model.
 
 ## Renamed protocol dependency
 
@@ -128,9 +132,10 @@ The standalone `tests/fixtures/renamed-consumer` project verifies both the V3 pa
 | Path | Purpose |
 | --- | --- |
 | [`src/lib.rs`](src/lib.rs) | Public derive entry points and shared parsing helpers. |
-| [`src/request_header_codec_v3/`](src/request_header_codec_v3/) | V3 metadata, semantic model, validation, and code generation. |
-| [`src/request_header_codec_v2/`](src/request_header_codec_v2/) | Deprecated V2 implementation retained during the compatibility window. |
-| [`src/request_header_custom.rs`](src/request_header_custom.rs) | Deprecated original derive implementation. |
+| [`src/request_header_codec_v3/`](src/request_header_codec_v3/) | Canonical V3 metadata, semantic model, profile validation, and code generation. |
+| [`src/request_header_codec_v3/legacy_v1.rs`](src/request_header_codec_v3/legacy_v1.rs) and [`legacy_v2.rs`](src/request_header_codec_v3/legacy_v2.rs) | Frozen V1/V2 syntax adapters and compatibility code generation over the canonical model. |
+| [`src/request_header_codec_v2/`](src/request_header_codec_v2/) | Deprecated V2 public syntax parser and adapter. |
+| [`src/request_header_custom.rs`](src/request_header_custom.rs) | Deprecated V1 parse/wrapper entry forwarding to the frozen compatibility adapter. |
 | [`src/remoting_serializable.rs`](src/remoting_serializable.rs) | Remoting serialization derive. |
 
 No Java checkout is accessed during Cargo builds. Java schemas, golden frames, migration state, and performance
@@ -142,6 +147,8 @@ evidence are governed by the repository's `scripts/request-header-codec` assets.
 python scripts/request-header-codec/migrate.py check
 python scripts/request-header-codec/compare_header_schema.py
 cargo test -p rocketmq-macros --lib
+cargo test -p rocketmq-protocol --test request_header_codec_v1_ui
+cargo test -p rocketmq-protocol --test request_header_codec_v1_wire_snapshot
 cargo test -p rocketmq-protocol --test request_header_codec_v3_ui
 cargo test -p rocketmq-protocol --test request_header_codec_v2_ui
 cargo test -p rocketmq-protocol --test request_header_codec_v2_wire_snapshot

--- a/rocketmq-macros/src/request_header_codec_v3.rs
+++ b/rocketmq-macros/src/request_header_codec_v3.rs
@@ -18,6 +18,7 @@ mod codegen;
 mod codegen_map;
 mod codegen_schema;
 mod codegen_shim;
+pub(crate) mod legacy_v1;
 pub(crate) mod legacy_v2;
 mod model;
 mod validate;

--- a/rocketmq-macros/src/request_header_codec_v3/codegen.rs
+++ b/rocketmq-macros/src/request_header_codec_v3/codegen.rs
@@ -26,6 +26,7 @@ pub(super) fn generate(model: &HeaderModel) -> TokenStream {
     match &model.profile {
         CodecProfile::V3 => {}
         CodecProfile::LegacyV2 { .. } => return super::legacy_v2::codegen::generate(model),
+        CodecProfile::LegacyV1 => return super::legacy_v1::codegen::generate(model),
     }
 
     let ident = &model.ident;

--- a/rocketmq-macros/src/request_header_codec_v3/legacy_v1.rs
+++ b/rocketmq-macros/src/request_header_codec_v3/legacy_v1.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The RocketMQ Rust Authors
+// Copyright 2026 The RocketMQ Rust Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,10 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use proc_macro::TokenStream;
-use syn::{parse_macro_input, DeriveInput};
+mod adapter;
+pub(super) mod codegen;
 
-pub(super) fn request_header_codec_inner(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as DeriveInput);
-    crate::request_header_codec_v3::legacy_v1::expand(input).into()
+use proc_macro2::TokenStream;
+use syn::DeriveInput;
+
+pub(crate) fn expand(input: DeriveInput) -> TokenStream {
+    let Some(model) = adapter::adapt(input) else {
+        return TokenStream::new();
+    };
+    match super::validate::validate(&model) {
+        Ok(()) => super::codegen::generate(&model),
+        Err(error) => error.into_compile_error(),
+    }
 }

--- a/rocketmq-macros/src/request_header_codec_v3/legacy_v1/adapter.rs
+++ b/rocketmq-macros/src/request_header_codec_v3/legacy_v1/adapter.rs
@@ -1,0 +1,97 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use syn::spanned::Spanned;
+use syn::{Data, DeriveInput, Fields, LitStr};
+
+use super::super::model::{
+    AliasConflict, CodecProfile, FieldModel, HeaderModel, LegacyShim, LookupPlan, MissingPolicy, ValueKind, WireName,
+};
+use crate::{has_serde_flatten_attribute, is_option_type, is_struct_type, snake_to_camel_case};
+
+pub(super) fn adapt(input: DeriveInput) -> Option<HeaderModel> {
+    let fields = match input.data {
+        Data::Struct(value) => match value.fields {
+            Fields::Named(fields) => fields.named,
+            Fields::Unnamed(_) | Fields::Unit => return None,
+        },
+        Data::Enum(_) | Data::Union(_) => return None,
+    };
+
+    let fields = fields
+        .into_iter()
+        .enumerate()
+        .filter_map(|(source_order, field)| adapt_field(field, source_order))
+        .collect();
+
+    Some(HeaderModel {
+        ident: input.ident,
+        generics: input.generics,
+        type_id: LitStr::new("legacy::V1", proc_macro2::Span::call_site()),
+        java_class: None,
+        validate_path: None,
+        lookup: LookupPlan::Auto,
+        legacy_shim: LegacyShim::Manual,
+        protocol_path: syn::parse_quote!(crate),
+        fast: false,
+        fields,
+        profile: CodecProfile::LegacyV1,
+    })
+}
+
+fn adapt_field(field: syn::Field, source_order: usize) -> Option<FieldModel> {
+    let span = field.span();
+    let ident = field.ident.clone()?;
+    let legacy_struct_type = is_struct_type(&field.ty);
+    let legacy_serde_flatten = has_serde_flatten_attribute(&field);
+    let required = field
+        .attrs
+        .iter()
+        .any(|attr| attr.path().get_ident().is_some_and(|ident| ident == "required"));
+    let option_inner = is_option_type(&field.ty).cloned();
+    let flattened = legacy_struct_type && legacy_serde_flatten;
+    let missing = if flattened {
+        None
+    } else if required {
+        Some(MissingPolicy::Required)
+    } else if option_inner.is_some() {
+        Some(MissingPolicy::Optional)
+    } else {
+        Some(MissingPolicy::Default)
+    };
+
+    Some(FieldModel {
+        key: WireName {
+            value: snake_to_camel_case(&format!("{ident}")),
+            span: ident.span(),
+        },
+        ident,
+        ty: field.ty,
+        option_inner,
+        aliases: Vec::new(),
+        alias_conflict: AliasConflict::PreferCanonical,
+        missing,
+        default_semantic: None,
+        flattened,
+        flatten_presence: None,
+        java_type: None,
+        range: None,
+        binary_order: None,
+        source_order: u16::try_from(source_order).unwrap_or(u16::MAX),
+        kind: ValueKind::Unsupported,
+        legacy_required: required,
+        legacy_v2_default_declared: false,
+        span,
+    })
+}

--- a/rocketmq-macros/src/request_header_codec_v3/legacy_v1/codegen.rs
+++ b/rocketmq-macros/src/request_header_codec_v3/legacy_v1/codegen.rs
@@ -1,0 +1,240 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+
+use super::super::model::{FieldModel, HeaderModel};
+use crate::get_type_name;
+
+pub(crate) fn generate(model: &HeaderModel) -> TokenStream {
+    let struct_name = &model.ident;
+    let static_fields = model.fields.iter().map(gen_static_field);
+    let to_maps = model.fields.iter().map(gen_to_map);
+    let from_map = model.fields.iter().map(gen_from_map);
+
+    quote! {
+        impl #struct_name {
+            #(#static_fields)*
+        }
+
+        impl crate::protocol::command_custom_header::CommandCustomHeader for #struct_name {
+            fn to_map(&self) -> Option<std::collections::HashMap<cheetah_string::CheetahString, cheetah_string::CheetahString>> {
+                let mut map = std::collections::HashMap::new();
+                #(#to_maps)*
+                Some(map)
+            }
+        }
+
+        impl crate::protocol::command_custom_header::FromMap for #struct_name {
+
+            type Error = rocketmq_error::RocketMQError;
+
+            type Target = Self;
+
+            fn from(map: &std::collections::HashMap<cheetah_string::CheetahString, cheetah_string::CheetahString>) -> Result<Self::Target, Self::Error> {
+                Ok(#struct_name {
+                    #(#from_map)*
+                })
+            }
+        }
+    }
+}
+
+fn gen_static_field(field: &FieldModel) -> TokenStream {
+    let static_name = static_name(field);
+    let camel_case_name = &field.key.value;
+    quote! {
+        const #static_name: &'static str = #camel_case_name;
+    }
+}
+
+fn gen_to_map(field: &FieldModel) -> TokenStream {
+    let field_name = &field.ident;
+    let static_name = static_name(field);
+    match (legacy_value_kind(field), field.option_inner.is_some(), field.flattened) {
+        (_, true, true) => quote! {
+            if let Some(ref value) = self.#field_name {
+                if let Some(value) = value.to_map() {
+                    map.extend(value);
+                }
+            }
+        },
+        (LegacyValueKind::CheetahString, true, false) => quote! {
+            if let Some(ref value) = self.#field_name {
+                map.insert(
+                    cheetah_string::CheetahString::from_static_str(Self::#static_name),
+                    value.clone()
+                );
+            }
+        },
+        (LegacyValueKind::String, true, false) => quote! {
+            if let Some(ref value) = self.#field_name {
+                map.insert(
+                    cheetah_string::CheetahString::from_static_str(Self::#static_name),
+                    cheetah_string::CheetahString::from_string(value.clone())
+                );
+            }
+        },
+        (LegacyValueKind::Primitive, true, false) => quote! {
+            if let Some(ref value) = self.#field_name {
+                map.insert(
+                    cheetah_string::CheetahString::from_static_str(Self::#static_name),
+                    cheetah_string::CheetahString::from_string(value.to_string())
+                );
+            }
+        },
+        (_, false, true) => quote! {
+            if let Some(value) = self.#field_name.to_map() {
+                map.extend(value);
+            }
+        },
+        (LegacyValueKind::CheetahString, false, false) => quote! {
+            map.insert(
+                cheetah_string::CheetahString::from_static_str(Self::#static_name),
+                self.#field_name.clone()
+            );
+        },
+        (LegacyValueKind::String, false, false) => quote! {
+            map.insert(
+                cheetah_string::CheetahString::from_static_str(Self::#static_name),
+                cheetah_string::CheetahString::from_string(self.#field_name.clone())
+            );
+        },
+        (LegacyValueKind::Primitive, false, false) => quote! {
+            map.insert(
+                cheetah_string::CheetahString::from_static_str(Self::#static_name),
+                cheetah_string::CheetahString::from_string(self.#field_name.to_string())
+            );
+        },
+    }
+}
+
+fn gen_from_map(field: &FieldModel) -> TokenStream {
+    let field_name = &field.ident;
+    let static_name = static_name(field);
+    let required = field.legacy_required;
+    let type_name = legacy_value_kind(field);
+
+    match (field.option_inner.as_ref(), type_name, field.flattened, required) {
+        (Some(_), LegacyValueKind::CheetahString, false, true) => quote! {
+            #field_name: Some(
+                map.get(&cheetah_string::CheetahString::from_static_str(Self::#static_name))
+                    .cloned()
+                    .ok_or(rocketmq_error::RocketMQError::request_header_error(
+                        format!("Missing {} field", Self::#static_name),
+                    ))?
+            ),
+        },
+        (Some(_), LegacyValueKind::String, false, true) => quote! {
+            Some(
+                map.get(&cheetah_string::CheetahString::from_static_str(Self::#static_name))
+                    .cloned()
+                    .ok_or(rocketmq_error::RocketMQError::request_header_error(
+                        format!("Missing {} field", Self::#static_name),
+                    ))?
+                    .to_string()
+            )
+        },
+        (Some(_), LegacyValueKind::CheetahString | LegacyValueKind::String, false, false) => quote! {
+            #field_name: map.get(&cheetah_string::CheetahString::from_static_str(Self::#static_name)).cloned(),
+        },
+        (Some(type_), _, true, _) => quote! {
+            #field_name: Some(<#type_ as crate::protocol::command_custom_header::FromMap>::from(map)?),
+        },
+        (Some(type_), LegacyValueKind::Primitive, false, true) => quote! {
+            #field_name: Some(
+                map.get(&cheetah_string::CheetahString::from_static_str(Self::#static_name))
+                    .ok_or(rocketmq_error::RocketMQError::request_header_error(
+                        format!("Missing {} field", Self::#static_name),
+                    ))?
+                    .parse::<#type_>()
+                    .map_err(|_| rocketmq_error::RocketMQError::request_header_error(
+                        format!("Parse {} field error", Self::#static_name)
+                    ))?
+            ),
+        },
+        (Some(type_), LegacyValueKind::Primitive, false, false) => quote! {
+            #field_name: map.get(&cheetah_string::CheetahString::from_static_str(Self::#static_name))
+                .and_then(|s| s.parse::<#type_>().ok()),
+        },
+        (None, LegacyValueKind::CheetahString, false, true) => quote! {
+            #field_name: map.get(&cheetah_string::CheetahString::from_static_str(Self::#static_name))
+                .cloned()
+                .ok_or(rocketmq_error::RocketMQError::request_header_error(
+                    format!("Missing {} field", Self::#static_name),
+                ))?,
+        },
+        (None, LegacyValueKind::String, false, true) => quote! {
+            #field_name: map.get(&cheetah_string::CheetahString::from_static_str(Self::#static_name))
+                .cloned()
+                .ok_or(rocketmq_error::RocketMQError::request_header_error(
+                    format!("Missing {} field", Self::#static_name),
+                ))?
+                .to_string(),
+        },
+        (None, LegacyValueKind::CheetahString | LegacyValueKind::String, false, false) => quote! {
+            #field_name: map.get(&cheetah_string::CheetahString::from_static_str(Self::#static_name))
+                .cloned()
+                .unwrap_or_default(),
+        },
+        (None, _, true, _) => {
+            let type_ = &field.ty;
+            quote! {
+                #field_name: <#type_ as crate::protocol::command_custom_header::FromMap>::from(map)?,
+            }
+        }
+        (None, LegacyValueKind::Primitive, false, true) => {
+            let type_ = &field.ty;
+            quote! {
+                #field_name: map.get(&cheetah_string::CheetahString::from_static_str(Self::#static_name))
+                    .ok_or(rocketmq_error::RocketMQError::request_header_error(
+                        format!("Missing {} field", Self::#static_name),
+                    ))?
+                    .parse::<#type_>()
+                    .map_err(|_| rocketmq_error::RocketMQError::request_header_error(
+                        format!("Parse {} field error", Self::#static_name)
+                    ))?,
+            }
+        }
+        (None, LegacyValueKind::Primitive, false, false) => {
+            let type_ = &field.ty;
+            quote! {
+                #field_name: map.get(&cheetah_string::CheetahString::from_static_str(Self::#static_name))
+                    .and_then(|s| s.parse::<#type_>().ok())
+                    .unwrap_or_default(),
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum LegacyValueKind {
+    CheetahString,
+    String,
+    Primitive,
+}
+
+fn legacy_value_kind(field: &FieldModel) -> LegacyValueKind {
+    let type_ = field.option_inner.as_ref().unwrap_or(&field.ty);
+    match get_type_name(type_).as_str() {
+        "CheetahString" => LegacyValueKind::CheetahString,
+        "String" => LegacyValueKind::String,
+        _ => LegacyValueKind::Primitive,
+    }
+}
+
+fn static_name(field: &FieldModel) -> syn::Ident {
+    syn::Ident::new(&field.ident.to_string().to_ascii_uppercase(), field.ident.span())
+}

--- a/rocketmq-macros/src/request_header_codec_v3/legacy_v2/codegen.rs
+++ b/rocketmq-macros/src/request_header_codec_v3/legacy_v2/codegen.rs
@@ -29,7 +29,7 @@ pub(crate) fn generate(model: &HeaderModel) -> TokenStream {
     } = model;
     let validation_method = match &model.profile {
         CodecProfile::LegacyV2 { validation_method } => validation_method.as_ref(),
-        CodecProfile::V3 => return TokenStream::new(),
+        CodecProfile::V3 | CodecProfile::LegacyV1 => return TokenStream::new(),
     };
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let command_trait = command_custom_header_trait(protocol_path);

--- a/rocketmq-macros/src/request_header_codec_v3/model.rs
+++ b/rocketmq-macros/src/request_header_codec_v3/model.rs
@@ -61,6 +61,7 @@ pub(super) struct FieldModel {
 pub(super) enum CodecProfile {
     V3,
     LegacyV2 { validation_method: Option<Ident> },
+    LegacyV1,
 }
 
 #[derive(Clone)]

--- a/rocketmq-macros/src/request_header_codec_v3/validate.rs
+++ b/rocketmq-macros/src/request_header_codec_v3/validate.rs
@@ -28,6 +28,7 @@ pub(super) fn validate(model: &HeaderModel) -> syn::Result<()> {
     match &model.profile {
         CodecProfile::V3 => {}
         CodecProfile::LegacyV2 { .. } => return super::legacy_v2::validate::validate(model),
+        CodecProfile::LegacyV1 => return Ok(()),
     }
 
     let mut errors = None;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9711

### Brief Description

- Route the legacy `RequestHeaderCodec` parser through the canonical `HeaderModel` and `FieldModel` using an explicit `LegacyV1` profile.
- Keep legacy-only code generation in a narrow compatibility emitter while preserving the frozen V1 wire mapping, parsing quirks, diagnostics, and silent no-op behavior for unsupported derive inputs.
- Document V1 and V2 as frozen adapters and require V3 for new request-header code in both macro migration guides.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-macros -- --check`
- `cargo fmt -p rocketmq-protocol -- --check`
- `cargo test --locked -p rocketmq-macros`
- `cargo test --locked -p rocketmq-protocol`
- V1, V2, and V3 UI, wire, typed-map, and registry tests with `--features simd`
- `cargo check --locked --offline --manifest-path rocketmq-macros/tests/fixtures/renamed-consumer/Cargo.toml`
- Request-header migration, schema comparison, unit, hygiene, lint-debt, architecture-debt, and metric-catalog checks
- `cargo doc --locked -p rocketmq-macros -p rocketmq-protocol --no-deps`
- `cargo clippy --locked --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check` and `cargo clippy --all-targets -- -D warnings` in `rocketmq-example`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` in `fuzz`

The required `cargo fmt --all -- --check` command in `rocketmq-example` reproduces the clean-main Windows path-length error (`os error 206`); the package-only format check above passes.
