### PR TITLE
[ISSUE #9722]♻️Enforce fail-closed layered authorization pipeline

### DIFF
--- a/rocketmq-auth/src/layered_authorization.rs
+++ b/rocketmq-auth/src/layered_authorization.rs
@@ -1,0 +1,150 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Adapters from the legacy authorization model to layered decisions.
+
+use rocketmq_runtime::MetadataIoError;
+use rocketmq_security_api::DetailedDecision;
+use rocketmq_security_api::LayerEvaluation;
+use rocketmq_security_api::LayerFailureKind;
+
+use crate::authorization::enums::decision::Decision as PolicyDecision;
+use crate::authorization::provider::AuthorizationError;
+
+/// Projects a legacy policy decision into the detailed authorization contract.
+///
+/// The legacy policy decision remains binary. In particular, an ACL or policy
+/// `Deny` can never become a layered `Abstain`.
+#[must_use]
+pub const fn project_policy_decision(decision: PolicyDecision) -> DetailedDecision {
+    match decision {
+        PolicyDecision::Allow => DetailedDecision::Allow,
+        PolicyDecision::Deny => DetailedDecision::Deny,
+    }
+}
+
+/// Classifies a legacy authorization failure for the fail-closed layered contract.
+///
+/// This classification carries no underlying error text. Callers must use the
+/// fixed denial output from `rocketmq-security-api` rather than returning the
+/// source error to a peer.
+#[must_use]
+pub const fn project_authorization_error(error: &AuthorizationError) -> LayerFailureKind {
+    match error {
+        AuthorizationError::ConfigurationError(_)
+        | AuthorizationError::NotInitialized(_)
+        | AuthorizationError::StorageReadFailed { .. }
+        | AuthorizationError::StorageLockFailed(_)
+        | AuthorizationError::MetadataIo(
+            MetadataIoError::InvalidConfig(_) | MetadataIoError::Closed | MetadataIoError::WorkerStopped { .. },
+        ) => LayerFailureKind::Unavailable,
+        AuthorizationError::MetadataIo(MetadataIoError::DeadlineExceeded { .. }) => LayerFailureKind::Timeout,
+        AuthorizationError::PermissionDenied { .. }
+        | AuthorizationError::PolicyEvaluationFailed(_)
+        | AuthorizationError::SubjectNotFound(_)
+        | AuthorizationError::ResourceNotFound(_)
+        | AuthorizationError::ProviderRuntimeFailed(_)
+        | AuthorizationError::StorageWriteFailed { .. }
+        | AuthorizationError::MetadataIo(
+            MetadataIoError::QueueFull { .. }
+            | MetadataIoError::ByteLimitExceeded { .. }
+            | MetadataIoError::ResourcePathConflict { .. }
+            | MetadataIoError::WorkerFailed { .. }
+            | MetadataIoError::Io { .. },
+        )
+        | AuthorizationError::SerializationFailed { .. }
+        | AuthorizationError::InvalidContext(_) => LayerFailureKind::Error,
+    }
+}
+
+/// Projects a legacy authorization operation into a detailed layer result.
+///
+/// A successful operation allows the request. A legacy permission denial is a
+/// detailed denial. Every other error remains a layer failure and is never
+/// converted to `Abstain`.
+pub fn project_authorization_result(result: Result<(), AuthorizationError>) -> LayerEvaluation<DetailedDecision> {
+    match result {
+        Ok(()) => Ok(DetailedDecision::Allow),
+        Err(error @ AuthorizationError::PermissionDenied { .. }) => {
+            let _ = error;
+            Ok(DetailedDecision::Deny)
+        }
+        Err(error) => Err(project_authorization_error(&error)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn policy_decisions_remain_binary() {
+        assert_eq!(project_policy_decision(PolicyDecision::Allow), DetailedDecision::Allow);
+        assert_eq!(project_policy_decision(PolicyDecision::Deny), DetailedDecision::Deny);
+    }
+
+    #[test]
+    fn permission_denial_is_not_an_abstention() {
+        let result = project_authorization_result(Err(AuthorizationError::PermissionDenied {
+            subject: "alice".to_owned(),
+            resource: "topic:orders".to_owned(),
+            reason: "not granted".to_owned(),
+        }));
+
+        assert_eq!(result, Ok(DetailedDecision::Deny));
+    }
+
+    #[test]
+    fn unavailable_and_operational_errors_never_abstain() {
+        assert_eq!(
+            project_authorization_result(Err(AuthorizationError::NotInitialized("not ready".to_owned()))),
+            Err(LayerFailureKind::Unavailable)
+        );
+        assert_eq!(
+            project_authorization_result(Err(AuthorizationError::PolicyEvaluationFailed("failed".to_owned()))),
+            Err(LayerFailureKind::Error)
+        );
+    }
+
+    #[test]
+    fn metadata_io_errors_keep_timeout_unavailable_and_error_distinct() {
+        assert_eq!(
+            project_authorization_error(&AuthorizationError::MetadataIo(MetadataIoError::DeadlineExceeded {
+                operation: "persist",
+            })),
+            LayerFailureKind::Timeout
+        );
+        assert_eq!(
+            project_authorization_error(&AuthorizationError::MetadataIo(MetadataIoError::InvalidConfig(
+                "metadata path",
+            ))),
+            LayerFailureKind::Unavailable
+        );
+        assert_eq!(
+            project_authorization_error(&AuthorizationError::MetadataIo(MetadataIoError::Closed)),
+            LayerFailureKind::Unavailable
+        );
+        assert_eq!(
+            project_authorization_error(&AuthorizationError::MetadataIo(MetadataIoError::WorkerStopped {
+                resource: std::sync::Arc::<str>::from("authorization"),
+                generation: rocketmq_runtime::MetadataGeneration::new(1),
+            })),
+            LayerFailureKind::Unavailable
+        );
+        assert_eq!(
+            project_authorization_error(&AuthorizationError::MetadataIo(MetadataIoError::QueueFull { limit: 1 })),
+            LayerFailureKind::Error
+        );
+    }
+}

--- a/rocketmq-auth/src/lib.rs
+++ b/rocketmq-auth/src/lib.rs
@@ -18,6 +18,7 @@ mod authorization;
 mod bootstrap;
 mod config;
 mod credential_rotation;
+mod layered_authorization;
 mod maintenance;
 mod migration;
 mod permission;
@@ -121,6 +122,9 @@ pub use credential_rotation::CredentialVerification;
 pub use credential_rotation::CredentialVerificationSource;
 pub use credential_rotation::RetiringCredentialSnapshot;
 pub use credential_rotation::ValidatedCredential;
+pub use layered_authorization::project_authorization_error;
+pub use layered_authorization::project_authorization_result;
+pub use layered_authorization::project_policy_decision;
 pub use maintenance::LoadedMaintenancePolicy;
 #[deprecated(
     since = "1.1.0",

--- a/rocketmq-auth/src/runtime.rs
+++ b/rocketmq-auth/src/runtime.rs
@@ -17,6 +17,10 @@ use rocketmq_runtime::ScheduledTaskConfig;
 use rocketmq_runtime::ScheduledTaskGroup;
 use rocketmq_runtime::ScheduledTaskSnapshot;
 use rocketmq_runtime::ShutdownReport;
+use rocketmq_security_api::DetailedDecision;
+use rocketmq_security_api::LayerEvaluation;
+use rocketmq_security_api::LayerFailureKind;
+use rocketmq_security_api::LayerRequirement;
 use rocketmq_security_api::ResourcePattern;
 use rocketmq_security_api::ResourceType;
 use rocketmq_transport::api::v1::Channel;
@@ -54,6 +58,8 @@ use crate::migration::alc::acl_config::AclConfig;
 use crate::migration::alc::plain_access_config::PlainAccessConfig;
 use crate::migration::alc::plain_permission_manager::PlainPermissionManager;
 use crate::permission::Permission;
+use crate::project_authorization_error;
+use crate::project_authorization_result;
 use crate::AuthMetrics;
 use crate::AuthMetricsSnapshot;
 
@@ -403,6 +409,20 @@ impl AuthRuntime {
         self.config.authentication_enabled || self.config.authorization_enabled
     }
 
+    /// Returns whether this runtime requires a detailed authorization result.
+    ///
+    /// Disabled authorization is an explicit compatibility boundary and is the
+    /// only configuration state represented by `Optional` here. Authentication
+    /// failures and authorization failures remain fail-closed layer failures.
+    #[must_use]
+    pub const fn detailed_authorization_requirement(&self) -> LayerRequirement {
+        if self.config.authorization_enabled {
+            LayerRequirement::Required
+        } else {
+            LayerRequirement::Optional
+        }
+    }
+
     pub async fn reload_acl_file(&self) -> RocketMQResult<usize> {
         Ok(load_configured_acl_file(
             &self.provider_registry,
@@ -498,6 +518,35 @@ impl AuthRuntime {
             .await?;
         self.authorization_service
             .authorize_remoting(channel_context, command)
+            .await
+    }
+
+    /// Evaluates authentication and detailed authorization for a remoting request.
+    ///
+    /// The global ACL whitelist remains an allow decision. When authorization is
+    /// disabled, the authorization service returns `Abstain`; callers must resolve
+    /// that value through the explicitly selected layer requirement. Errors never
+    /// become an abstention and deliberately carry no request or credential data.
+    pub async fn evaluate_remoting_detailed(
+        &self,
+        channel_context: &(dyn std::any::Any + Send + Sync),
+        command: &RemotingCommand,
+    ) -> LayerEvaluation<DetailedDecision> {
+        let source_ip = source_ip_from_channel_context(channel_context);
+        let channel_id = channel_id_from_channel_context(channel_context);
+        let is_whitelisted = self
+            .is_acl_white_remote_address(access_key_from_command(command), source_ip.as_deref())
+            .map_err(|_| LayerFailureKind::Error)?;
+        if is_whitelisted {
+            return Ok(DetailedDecision::Allow);
+        }
+
+        self.authentication_service
+            .authenticate_remoting(command, channel_id.as_deref())
+            .await
+            .map_err(|_| LayerFailureKind::Error)?;
+        self.authorization_service
+            .authorize_remoting_detailed(channel_context, command)
             .await
     }
 
@@ -646,6 +695,47 @@ impl AuthorizationService {
         }
 
         Ok(())
+    }
+
+    /// Evaluates remoting authorization using the layered detailed contract.
+    ///
+    /// This adapter leaves the legacy `authorize_remoting` API unchanged. A
+    /// disabled authorization service explicitly abstains; policy denials remain
+    /// denials, while provider and context errors retain a fail-closed failure kind.
+    pub async fn authorize_remoting_detailed(
+        &self,
+        channel_context: &(dyn std::any::Any + Send + Sync),
+        command: &RemotingCommand,
+    ) -> LayerEvaluation<DetailedDecision> {
+        if !self.config.authorization_enabled {
+            return Ok(DetailedDecision::Abstain);
+        }
+        if self.whitelist.contains(&command.code().to_string()) {
+            self.metrics.record_whitelist_check(true);
+            return Ok(DetailedDecision::Allow);
+        }
+
+        let contexts = self
+            .provider
+            .new_contexts_from_remoting_command(channel_context, command)
+            .map_err(|error| {
+                self.metrics.record_authorization_result(false);
+                project_authorization_error(&error)
+            })?;
+
+        for context in contexts {
+            match project_authorization_result(self.provider.authorize(&context).await) {
+                Ok(DetailedDecision::Allow) => {}
+                Ok(DetailedDecision::Deny | DetailedDecision::Abstain) => {
+                    return Ok(DetailedDecision::Deny);
+                }
+                Err(failure) => {
+                    return Err(failure);
+                }
+            }
+        }
+
+        Ok(DetailedDecision::Allow)
     }
 }
 
@@ -1347,6 +1437,57 @@ accounts:
         let command = send_message_command("topic-a", "alice", &signature);
 
         runtime.check_remoting(&(), &command).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn detailed_authorization_records_each_provider_decision_once() {
+        let runtime = AuthRuntimeBuilder::new(AuthConfig {
+            authentication_enabled: true,
+            authorization_enabled: true,
+            ..AuthConfig::default()
+        })
+        .build()
+        .await
+        .expect("test auth runtime should initialize");
+
+        let authn_provider = runtime.provider_registry().authentication_metadata_provider();
+        let mut user = User::of_with_type("alice", "secret", UserType::Normal);
+        user.set_user_status(UserStatus::Enable);
+        authn_provider
+            .create_user(user)
+            .await
+            .expect("test user should be stored");
+
+        let authz_provider = runtime.provider_registry().authorization_metadata_provider();
+        authz_provider
+            .create_acl(Acl::of(
+                "alice",
+                SubjectType::User,
+                Policy::of(
+                    vec![Resource::of_topic("topic-a")],
+                    vec![Action::Pub],
+                    None,
+                    Decision::Allow,
+                ),
+            ))
+            .await
+            .expect("test ACL should be stored");
+
+        let command = send_message_command(
+            "topic-a",
+            "alice",
+            &acl_signer::cal_signature("alicetopic-a".as_bytes(), "secret")
+                .expect("test signature should be generated"),
+        );
+        assert_eq!(
+            runtime.evaluate_remoting_detailed(&(), &command).await,
+            Ok(DetailedDecision::Allow)
+        );
+
+        let snapshot = runtime.metrics_snapshot();
+        assert_eq!(snapshot.authorization_successes, 1);
+        assert_eq!(snapshot.authorization_failures, 0);
+        runtime.shutdown().await.expect("test auth runtime should shut down");
     }
 
     #[tokio::test]

--- a/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
+++ b/rocketmq-namesrv/src/bin/namesrv_bootstrap_server.rs
@@ -17,7 +17,6 @@
 use std::net::IpAddr;
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use anyhow::bail;
 use anyhow::Context;
@@ -41,7 +40,7 @@ use rocketmq_namesrv::bootstrap::Builder;
 use rocketmq_namesrv::config::is_tls_config_key;
 use rocketmq_namesrv::config::DEFAULT_NAMESRV_LISTEN_PORT;
 use rocketmq_namesrv::parse_command_and_config_file;
-use rocketmq_namesrv::security::NameServerTransportPolicy;
+use rocketmq_namesrv::security::build_namesrv_transport_security;
 use rocketmq_namesrv::NamesrvConfig;
 use rocketmq_protocol::protocol::remoting_command_facade::initialize_remoting_defaults;
 use rocketmq_runtime::common::parse_config_file;
@@ -52,7 +51,6 @@ use rocketmq_runtime::RuntimeOwner;
 use rocketmq_runtime::ServiceLifecycle;
 use rocketmq_runtime::ServiceLifecycleState;
 use rocketmq_runtime::ShutdownReason;
-use rocketmq_security_api::Principal;
 use rocketmq_security_api::SecurityBootstrap;
 use rocketmq_security_api::SecurityBootstrapConfig;
 use rocketmq_security_api::SecurityBootstrapError;
@@ -61,7 +59,6 @@ use rocketmq_security_api::SecurityBootstrapProfile;
 use rocketmq_transport::api::v1::ServerConfig;
 use rocketmq_transport::api::v1::TlsMode;
 use rocketmq_transport::api::v1::TransportClientConfig;
-use rocketmq_transport::api::v1::TransportSecurity;
 use serde::Deserialize;
 use tracing::info;
 
@@ -213,7 +210,7 @@ async fn run(service_context: ChildServiceContext, lifecycle: ServiceLifecycle) 
         telemetry_guard.subscriber_install_status(),
     );
     log_security_bootstrap(validated_security);
-    let (transport_security, transport_principal) = build_namesrv_transport_security(validated_security);
+    let transport_security = build_namesrv_transport_security(validated_security);
 
     if let Err(error) = lifecycle.start(&service_context).await {
         lifecycle.mark_failed();
@@ -262,7 +259,7 @@ async fn run(service_context: ChildServiceContext, lifecycle: ServiceLifecycle) 
         .set_name_server_config(namesrv_config)
         .set_server_config(server_config)
         .set_tokio_client_config(tokio_client_config)
-        .set_transport_security(transport_security, transport_principal);
+        .set_transport_security(transport_security, None);
     #[cfg(feature = "embedded-controller")]
     let builder = builder.set_controller_config_opt(controller_config);
     #[cfg(not(feature = "embedded-controller"))]
@@ -339,15 +336,8 @@ fn validate_namesrv_security(
     let has_public_listener = listeners.iter().any(|listener| !listener.ip().is_loopback());
     let outcome = match security_bootstrap.validate(&listeners) {
         Ok(outcome) => outcome,
-        Err(SecurityBootstrapError::DevelopmentListenerNotLoopback)
-            if namesrv_config.allow_insecure_public_listener =>
-        {
-            security_bootstrap.validate(&[]).map_err(anyhow::Error::from)?
-        }
         Err(SecurityBootstrapError::DevelopmentListenerNotLoopback) => {
-            bail!(
-                "allowInsecurePublicListener is required for a non-loopback NameServer listener in the development-insecure profile"
-            );
+            bail!("development-insecure NameServer listeners must be loopback-only");
         }
         Err(error) => return Err(error.into()),
     };
@@ -383,26 +373,6 @@ fn validate_namesrv_security(
     }
 
     Ok(outcome)
-}
-
-fn build_namesrv_transport_security(outcome: SecurityBootstrapOutcome) -> (Arc<TransportSecurity>, Option<Principal>) {
-    match outcome {
-        SecurityBootstrapOutcome::Validated(validated)
-            if validated.profile() == SecurityBootstrapProfile::SecureEnforced =>
-        {
-            (
-                Arc::new(TransportSecurity::secure_enforced(
-                    Some(Arc::new(NameServerTransportPolicy)),
-                    None,
-                )),
-                Some(Principal::new("namesrv.protocol-authorization")),
-            )
-        }
-        SecurityBootstrapOutcome::Disabled | SecurityBootstrapOutcome::Validated(_) => (
-            Arc::new(TransportSecurity::development_insecure_loopback(None, None)),
-            None,
-        ),
-    }
 }
 
 fn log_security_bootstrap(outcome: SecurityBootstrapOutcome) {
@@ -1026,6 +996,8 @@ struct Args {
 
 #[cfg(test)]
 mod tests {
+    use rocketmq_protocol::code::request_code::RequestCode;
+
     use super::*;
 
     fn secure_bootstrap(root: &std::path::Path) -> SecurityBootstrap {
@@ -1166,10 +1138,36 @@ mod tests {
         )
         .expect_err("a public file Prometheus listener must fail closed");
         let message = error.to_string();
-        assert!(message.contains("allowInsecurePublicListener"));
         assert!(message.contains("development-insecure"));
+        assert!(message.contains("loopback-only"));
+        assert!(!message.contains("allowInsecurePublicListener"));
         assert!(!message.contains("0.0.0.0"));
         assert!(!message.contains("5557"));
+    }
+
+    #[test]
+    fn development_security_rejects_public_listener_even_with_migration_opt_in() {
+        let security = rocketmq_security_api::SecurityBootstrap::Enabled(SecurityBootstrapConfig::new(
+            SecurityBootstrapProfile::DevelopmentInsecureLoopback,
+        ));
+        let namesrv = NamesrvConfig {
+            allow_insecure_public_listener: true,
+            ..NamesrvConfig::default()
+        };
+        let server = ServerConfig {
+            bind_address: "0.0.0.0".to_string(),
+            listen_port: 9876,
+            ..ServerConfig::default()
+        };
+
+        let error = validate_namesrv_security(&security, &namesrv, &server, None, None, None)
+            .expect_err("development profile must not fabricate validation for public listeners");
+        let message = error.to_string();
+        assert!(message.contains("development-insecure"));
+        assert!(message.contains("loopback-only"));
+        assert!(!message.contains("allowInsecurePublicListener"));
+        assert!(!message.contains("0.0.0.0"));
+        assert!(!message.contains("9876"));
     }
 
     #[test]
@@ -1205,6 +1203,103 @@ mod tests {
             SecurityBootstrapOutcome::Validated(validated)
                 if validated.profile() == SecurityBootstrapProfile::SecureEnforced
         ));
+    }
+
+    #[test]
+    fn validated_bootstrap_installs_only_the_coarse_ingress_projection() {
+        let root = tempfile::tempdir().expect("temporary security root");
+        let security = secure_bootstrap(root.path());
+        let mut namesrv = NamesrvConfig::default();
+        namesrv.auth_config.authentication_enabled = true;
+        namesrv.auth_config.authorization_enabled = true;
+        namesrv.auth_config.auth_config_path = root.path().join("auth").to_string_lossy().as_ref().into();
+        namesrv.auth_config.acl_file = root.path().join("material.pem").to_string_lossy().as_ref().into();
+        let mut server = ServerConfig {
+            bind_address: "0.0.0.0".to_string(),
+            listen_port: 9876,
+            ..ServerConfig::default()
+        };
+        server.tls_config.enable = true;
+        server.tls_config.server.mode = TlsMode::Enforcing;
+        let outcome = validate_namesrv_security(&security, &namesrv, &server, None, None, None)
+            .expect("secure bootstrap should validate before installing transport security");
+        assert!(matches!(
+            outcome,
+            SecurityBootstrapOutcome::Validated(validated)
+                if validated.profile() == SecurityBootstrapProfile::SecureEnforced && validated.listener_count() == 1
+        ));
+        let transport_security = build_namesrv_transport_security(outcome);
+        assert!(transport_security.is_secure_enforced());
+        assert_eq!(
+            transport_security.authorize_ingress(
+                &rocketmq_protocol::protocol::remoting_command::RemotingCommand::create_remoting_command(
+                    RequestCode::GetRouteinfoByTopic,
+                ),
+                None,
+            ),
+            Ok(rocketmq_security_api::IngressDecision::AllowToContinue)
+        );
+        assert_eq!(
+            transport_security.authorize_ingress(
+                &rocketmq_protocol::protocol::remoting_command::RemotingCommand::create_remoting_command(
+                    RequestCode::SendMessage,
+                ),
+                None,
+            ),
+            Ok(rocketmq_security_api::IngressDecision::Deny)
+        );
+
+        let development_bootstrap = SecurityBootstrap::Enabled(SecurityBootstrapConfig::new(
+            SecurityBootstrapProfile::DevelopmentInsecureLoopback,
+        ));
+        let development_server = ServerConfig {
+            bind_address: "127.0.0.1".to_string(),
+            listen_port: 9876,
+            ..ServerConfig::default()
+        };
+        let development_outcome = validate_namesrv_security(
+            &development_bootstrap,
+            &NamesrvConfig::default(),
+            &development_server,
+            None,
+            None,
+            None,
+        )
+        .expect("development bootstrap should validate its loopback listener");
+        assert!(matches!(
+            development_outcome,
+            SecurityBootstrapOutcome::Validated(validated)
+                if validated.profile() == SecurityBootstrapProfile::DevelopmentInsecureLoopback
+                    && validated.listener_count() == 1
+        ));
+        let development = build_namesrv_transport_security(development_outcome);
+        assert!(!development.is_secure_enforced());
+        assert_eq!(
+            development.authorize_ingress(
+                &rocketmq_protocol::protocol::remoting_command::RemotingCommand::create_remoting_command(
+                    RequestCode::GetRouteinfoByTopic,
+                ),
+                None,
+            ),
+            Ok(rocketmq_security_api::IngressDecision::AllowToContinue)
+        );
+
+        let disabled_namesrv = NamesrvConfig {
+            allow_insecure_public_listener: true,
+            ..NamesrvConfig::default()
+        };
+        let disabled_outcome = validate_namesrv_security(
+            &SecurityBootstrap::Disabled,
+            &disabled_namesrv,
+            &ServerConfig::default(),
+            None,
+            None,
+            None,
+        )
+        .expect("explicit Disabled migration mode should select compatibility transport");
+        assert_eq!(disabled_outcome, SecurityBootstrapOutcome::Disabled);
+        let disabled = build_namesrv_transport_security(disabled_outcome);
+        assert!(!disabled.is_secure_enforced());
     }
 
     #[test]

--- a/rocketmq-namesrv/src/bootstrap.rs
+++ b/rocketmq-namesrv/src/bootstrap.rs
@@ -57,6 +57,7 @@ use rocketmq_runtime::ShutdownDeadline;
 use rocketmq_runtime::ShutdownReason;
 use rocketmq_runtime::ShutdownReport;
 use rocketmq_runtime::TaskGroup;
+use rocketmq_security_api::LayerRequirement;
 use rocketmq_security_api::Principal;
 use rocketmq_transport::api::v1::ChannelEventListener;
 #[cfg(test)]
@@ -1022,6 +1023,11 @@ impl NameServerRuntime {
         let default_request_processor =
             crate::processor::default_request_processor::DefaultRequestProcessor::new(runtime_handle.clone());
 
+        let auth_runtime = self.inner.auth_runtime();
+        let detailed_requirement = namesrv_detailed_authorization_requirement(
+            self.inner.transport_security.as_deref(),
+            auth_runtime.as_deref(),
+        );
         let mut name_server_request_processor = NameServerRequestProcessor::new_with_in_flight_tracker(
             self.inner.in_flight_request_tracker(),
             self.inner.namesrv_metrics(),
@@ -1029,7 +1035,8 @@ impl NameServerRuntime {
         )
         .with_runtime_handle(runtime_handle)
         .with_workload_admission(Arc::clone(&self.inner.workload_admission))
-        .with_auth_runtime(self.inner.auth_runtime());
+        .with_auth_runtime(auth_runtime)
+        .with_detailed_authorization_requirement(detailed_requirement);
 
         // Register topic route query processor
         name_server_request_processor.register_processor(RequestCode::GetRouteinfoByTopic, route_request_processor);
@@ -1041,6 +1048,18 @@ impl NameServerRuntime {
 
         debug!("Request processor pipeline configured");
         name_server_request_processor
+    }
+}
+
+fn namesrv_detailed_authorization_requirement(
+    transport_security: Option<&TransportSecurity>,
+    auth_runtime: Option<&AuthRuntime>,
+) -> LayerRequirement {
+    match transport_security {
+        Some(security) if security.is_secure_enforced() => LayerRequirement::Required,
+        _ => auth_runtime
+            .map(AuthRuntime::detailed_authorization_requirement)
+            .unwrap_or(LayerRequirement::Optional),
     }
 }
 
@@ -1888,6 +1907,7 @@ mod tests {
     use std::time::Duration;
 
     use cheetah_string::CheetahString;
+    use rocketmq_auth::AuthConfig;
     #[cfg(feature = "embedded-controller")]
     use rocketmq_controller::Controller;
     #[cfg(feature = "embedded-controller")]
@@ -1941,17 +1961,46 @@ mod tests {
     #[cfg(feature = "embedded-controller")]
     use rocketmq_protocol::protocol::SerializeType;
     use rocketmq_runtime::RuntimeContext;
+    use rocketmq_security_api::Principal;
+    use rocketmq_security_api::SecurityBootstrap;
+    use rocketmq_security_api::SecurityBootstrapConfig;
+    use rocketmq_security_api::SecurityBootstrapOutcome;
+    use rocketmq_security_api::SecurityBootstrapProfile;
+    use rocketmq_transport::api::v1::AdmissionController;
+    use rocketmq_transport::api::v1::AdmissionLimits;
+    use rocketmq_transport::api::v1::AuthorizedCommandDispatcher;
     use rocketmq_transport::api::v1::ConnectionState;
     use rocketmq_transport::api::v1::RPCHook;
+    use rocketmq_transport::api::v1::RequestContext;
     use rocketmq_transport::api::v1::RequestProcessor;
     use rocketmq_transport::api::v1::ServerConfig;
     use rocketmq_transport::api::v1::TlsMode;
+    use rocketmq_transport::api::v1::TransportTelemetry;
     use rocketmq_transport::test_support::LocalRequestHarness;
     use tokio::net::TcpStream as TokioTcpStream;
     use tokio::sync::oneshot;
     use tokio::time::sleep;
 
     use super::*;
+
+    #[test]
+    fn secure_transport_forces_required_detailed_authorization() {
+        let secure = TransportSecurity::secure_enforced(None, None);
+        let development = TransportSecurity::development_insecure_loopback(None, None);
+
+        assert_eq!(
+            namesrv_detailed_authorization_requirement(Some(&secure), None),
+            LayerRequirement::Required
+        );
+        assert_eq!(
+            namesrv_detailed_authorization_requirement(Some(&development), None),
+            LayerRequirement::Optional
+        );
+        assert_eq!(
+            namesrv_detailed_authorization_requirement(None, None),
+            LayerRequirement::Optional
+        );
+    }
 
     fn test_task_group(name: &'static str) -> rocketmq_runtime::TaskGroup {
         RuntimeContext::from_current(name)
@@ -1983,6 +2032,225 @@ mod tests {
 
     fn build_default_bootstrap() -> NameServerBootstrap {
         build_bootstrap_with_config(NamesrvConfig::default())
+    }
+
+    struct LayeredDispatchFixture {
+        service: ChildServiceContext,
+        dispatcher: Arc<AuthorizedCommandDispatcher<NameServerRequestProcessor>>,
+        auth_runtime: Option<Arc<AuthRuntime>>,
+        bootstrap: NameServerBootstrap,
+    }
+
+    async fn layered_dispatch_fixture(
+        runtime: &RuntimeContext,
+        name: &'static str,
+        security_outcome: SecurityBootstrapOutcome,
+        namesrv_config: NamesrvConfig,
+    ) -> LayeredDispatchFixture {
+        let service = runtime.service_context(name);
+        let transport_security = crate::security::build_namesrv_transport_security(security_outcome);
+        let bootstrap = Builder::new(service.clone(), TelemetryHandle::noop())
+            .set_name_server_config(namesrv_config)
+            .set_transport_security(Arc::clone(&transport_security), None)
+            .build();
+        bootstrap
+            .name_server_runtime
+            .initialize_auth_runtime()
+            .await
+            .expect("test NameServer auth runtime should initialize");
+        let processor = bootstrap.name_server_runtime.init_processors();
+        let process_budget = service.process_budget();
+        let admission = Arc::new(
+            AdmissionController::try_new_with_budget(AdmissionLimits::default(), &process_budget)
+                .expect("test admission limits should be valid"),
+        );
+        let dispatcher = Arc::new(
+            AuthorizedCommandDispatcher::try_new(
+                processor,
+                Vec::new(),
+                &process_budget,
+                TransportTelemetry::noop(),
+                transport_security,
+                admission,
+            )
+            .expect("test dispatcher should fit the process budget"),
+        );
+
+        LayeredDispatchFixture {
+            service,
+            dispatcher,
+            auth_runtime: bootstrap.name_server_runtime.inner.auth_runtime(),
+            bootstrap,
+        }
+    }
+
+    fn layered_route_request(opaque: i32) -> RemotingCommand {
+        let mut request = RemotingCommand::create_request_command(
+            RequestCode::GetRouteinfoByTopic,
+            GetRouteInfoRequestHeader::new(CheetahString::from_static_str("layered-dispatch-topic"), Some(true)),
+        )
+        .set_opaque(opaque);
+        request.make_custom_header_to_net();
+        request
+    }
+
+    async fn dispatch_layered_request(fixture: &LayeredDispatchFixture, request: RemotingCommand) -> RemotingCommand {
+        fixture
+            .dispatcher
+            .dispatch_embedded(
+                fixture.service.task_group(),
+                RequestContext::try_embedded(Some(Principal::new("namesrv-layered-test")), None)
+                    .expect("test embedded identity should be accepted"),
+                request,
+            )
+            .await
+            .expect("layered dispatch should return a response")
+    }
+
+    async fn shutdown_layered_dispatch_fixture(fixture: LayeredDispatchFixture) {
+        if let Some(auth_runtime) = fixture.auth_runtime {
+            auth_runtime
+                .shutdown()
+                .await
+                .expect("test auth runtime should shut down");
+        }
+        let report = fixture.service.task_group().shutdown(Duration::from_secs(1)).await;
+        report
+            .assert_no_task_leak()
+            .expect("layered dispatch tasks should be owned");
+        drop(fixture.bootstrap);
+    }
+
+    fn test_security_outcome(bootstrap: SecurityBootstrap, listener: SocketAddr) -> SecurityBootstrapOutcome {
+        bootstrap
+            .validate(&[listener])
+            .expect("test security bootstrap should validate its listener")
+    }
+
+    fn secure_test_security_outcome() -> SecurityBootstrapOutcome {
+        let root = tempfile::tempdir().expect("temporary security root");
+        let material = root.path().join("material.pem");
+        std::fs::write(&material, "test-material").expect("security material should be written");
+        let outcome = test_security_outcome(
+            SecurityBootstrap::Enabled(
+                SecurityBootstrapConfig::new(SecurityBootstrapProfile::SecureEnforced)
+                    .with_trust_anchor(&material)
+                    .with_tls_identity(&material, &material)
+                    .with_secret_provider(rocketmq_security_api::MOUNTED_FILES_SECRET_PROVIDER)
+                    .with_admin_identity(&material)
+                    .with_request_policy(&material),
+            ),
+            SocketAddr::from(([0, 0, 0, 0], 9876)),
+        );
+        assert!(matches!(
+            outcome,
+            SecurityBootstrapOutcome::Validated(validated)
+                if validated.profile() == SecurityBootstrapProfile::SecureEnforced && validated.listener_count() == 1
+        ));
+        outcome
+    }
+
+    fn development_test_security_outcome() -> SecurityBootstrapOutcome {
+        let outcome = test_security_outcome(
+            SecurityBootstrap::Enabled(SecurityBootstrapConfig::new(
+                SecurityBootstrapProfile::DevelopmentInsecureLoopback,
+            )),
+            SocketAddr::from(([127, 0, 0, 1], 9876)),
+        );
+        assert!(matches!(
+            outcome,
+            SecurityBootstrapOutcome::Validated(validated)
+                if validated.profile() == SecurityBootstrapProfile::DevelopmentInsecureLoopback
+                    && validated.listener_count() == 1
+        ));
+        outcome
+    }
+
+    #[tokio::test]
+    async fn layered_dispatch_uses_production_ingress_and_detailed_authorization_pipeline() {
+        let runtime = RuntimeContext::from_current("namesrv-layered-dispatch-test");
+
+        let secure_without_auth = layered_dispatch_fixture(
+            &runtime,
+            "secure-without-auth",
+            secure_test_security_outcome(),
+            NamesrvConfig::default(),
+        )
+        .await;
+        let coarse_denied = dispatch_layered_request(
+            &secure_without_auth,
+            RemotingCommand::create_remoting_command(RequestCode::SendMessage).set_opaque(0x7101),
+        )
+        .await;
+        assert_eq!(ResponseCode::from(coarse_denied.code()), ResponseCode::NoPermission);
+        assert_eq!(
+            coarse_denied.remark().map(CheetahString::as_str),
+            Some(rocketmq_security_api::LAYERED_AUTHORIZATION_DENIED_REASON)
+        );
+
+        let required_abstention = dispatch_layered_request(&secure_without_auth, layered_route_request(0x7102)).await;
+        assert_eq!(
+            ResponseCode::from(required_abstention.code()),
+            ResponseCode::NoPermission
+        );
+        assert_ne!(
+            required_abstention.remark().map(CheetahString::as_str),
+            Some(rocketmq_security_api::LAYERED_AUTHORIZATION_DENIED_REASON),
+            "a known request must have passed coarse ingress and been rejected by required detailed authorization"
+        );
+        shutdown_layered_dispatch_fixture(secure_without_auth).await;
+
+        let route_code = RequestCode::GetRouteinfoByTopic.to_i32().to_string();
+        let secure_with_whitelist = layered_dispatch_fixture(
+            &runtime,
+            "secure-with-whitelist",
+            secure_test_security_outcome(),
+            NamesrvConfig {
+                auth_config: AuthConfig {
+                    authentication_enabled: true,
+                    authorization_enabled: true,
+                    authentication_whitelist: CheetahString::from_string(route_code.clone()),
+                    authorization_whitelist: CheetahString::from_string(route_code),
+                    ..AuthConfig::default()
+                },
+                ..NamesrvConfig::default()
+            },
+        )
+        .await;
+        let whitelisted = dispatch_layered_request(&secure_with_whitelist, layered_route_request(0x7103)).await;
+        assert_eq!(ResponseCode::from(whitelisted.code()), ResponseCode::TopicNotExist);
+        shutdown_layered_dispatch_fixture(secure_with_whitelist).await;
+
+        let disabled = layered_dispatch_fixture(
+            &runtime,
+            "disabled-compatibility",
+            test_security_outcome(SecurityBootstrap::Disabled, SocketAddr::from(([0, 0, 0, 0], 9876))),
+            NamesrvConfig {
+                allow_insecure_public_listener: true,
+                ..NamesrvConfig::default()
+            },
+        )
+        .await;
+        let optional_abstention = dispatch_layered_request(&disabled, layered_route_request(0x7104)).await;
+        assert_eq!(
+            ResponseCode::from(optional_abstention.code()),
+            ResponseCode::TopicNotExist
+        );
+        shutdown_layered_dispatch_fixture(disabled).await;
+
+        let development = layered_dispatch_fixture(
+            &runtime,
+            "development-loopback",
+            development_test_security_outcome(),
+            NamesrvConfig::default(),
+        )
+        .await;
+        let development_response = dispatch_layered_request(&development, layered_route_request(0x7105)).await;
+        assert_eq!(
+            ResponseCode::from(development_response.code()),
+            ResponseCode::TopicNotExist
+        );
+        shutdown_layered_dispatch_fixture(development).await;
     }
 
     struct PartiallyStartedRouteLookup {

--- a/rocketmq-namesrv/src/config.rs
+++ b/rocketmq-namesrv/src/config.rs
@@ -899,7 +899,7 @@ impl Default for NamesrvConfig {
             need_wait_for_service: false,
             wait_seconds_for_service: 45,
             delete_topic_with_broker_registration: false,
-            allow_insecure_public_listener: true,
+            allow_insecure_public_listener: false,
             auth_config: AuthConfig::default(),
             config_black_list: "configBlackList;configStorePath;kvConfigPath".to_string(),
         }

--- a/rocketmq-namesrv/src/processor.rs
+++ b/rocketmq-namesrv/src/processor.rs
@@ -27,6 +27,10 @@ use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
 use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
+use rocketmq_security_api::combine_layered_authorization;
+use rocketmq_security_api::DetailedDecision;
+use rocketmq_security_api::IngressDecision;
+use rocketmq_security_api::LayerRequirement;
 use rocketmq_transport::api::v1::Channel;
 use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use rocketmq_transport::api::v1::RejectRequestResponse;
@@ -105,6 +109,7 @@ pub struct NameServerRequestProcessor {
     default_request_processor: Option<NameServerRequestProcessorWrapper>,
     in_flight_requests: Option<Arc<InFlightRequestTracker>>,
     auth_runtime: Option<Arc<AuthRuntime>>,
+    detailed_authorization_requirement: Option<LayerRequirement>,
     runtime_handle: Option<NameServerRuntimeHandle>,
     workload_admission: Option<Arc<NameServerWorkloadAdmission>>,
     metrics: NameServerMetrics,
@@ -124,6 +129,7 @@ impl NameServerRequestProcessor {
             default_request_processor: None,
             in_flight_requests: None,
             auth_runtime: None,
+            detailed_authorization_requirement: None,
             runtime_handle: None,
             workload_admission: None,
             metrics: NameServerMetrics::noop(),
@@ -141,6 +147,7 @@ impl NameServerRequestProcessor {
             default_request_processor: None,
             in_flight_requests: Some(in_flight_requests),
             auth_runtime: None,
+            detailed_authorization_requirement: None,
             runtime_handle: None,
             workload_admission: None,
             metrics,
@@ -158,6 +165,11 @@ impl NameServerRequestProcessor {
 
     pub(crate) fn with_auth_runtime(mut self, auth_runtime: Option<Arc<AuthRuntime>>) -> Self {
         self.auth_runtime = auth_runtime;
+        self
+    }
+
+    pub(crate) fn with_detailed_authorization_requirement(mut self, requirement: LayerRequirement) -> Self {
+        self.detailed_authorization_requirement = Some(requirement);
         self
     }
 
@@ -198,29 +210,40 @@ impl RequestProcessor for NameServerRequestProcessor {
             }
         };
         let metric_class = metric_workload_class(WorkloadAdmissionClass::from(request_class));
-        if let Some(auth_runtime) = &self.auth_runtime {
-            if auth_runtime.check_remoting(&ctx, request).await.is_err() {
-                tracing::warn!(
-                    remote_endpoint = %ctx.remote_address(),
-                    request_class = request_class.as_str(),
-                    reason_code = "protocol-auth-denied",
-                    "NameServer request denied"
-                );
-                let error =
-                    RocketMQError::authentication_failed("NameServer request authentication or authorization failed");
-                self.metrics.record_security_event(NameServerSecurityEvent::AuthDenied);
-                self.metrics.record_request(
-                    metric_class,
-                    NameServerRequestOutcome::Rejected,
-                    request_started.elapsed(),
-                    0,
-                );
-                return Ok(Some(self.command_factory.command_from_error_with_remark_and_opaque(
-                    &error,
-                    error.to_string(),
-                    request.opaque(),
-                )));
-            }
+        let detailed_requirement = self.detailed_authorization_requirement.unwrap_or_else(|| {
+            self.auth_runtime
+                .as_ref()
+                .map(|auth_runtime| auth_runtime.detailed_authorization_requirement())
+                .unwrap_or(LayerRequirement::Optional)
+        });
+        let detailed = match &self.auth_runtime {
+            Some(auth_runtime) => auth_runtime.evaluate_remoting_detailed(&ctx, request).await,
+            None => Ok(DetailedDecision::Abstain),
+        };
+        if matches!(
+            combine_layered_authorization(Ok(IngressDecision::AllowToContinue), detailed_requirement, || detailed,),
+            rocketmq_security_api::Decision::Deny { .. }
+        ) {
+            tracing::warn!(
+                remote_endpoint = %ctx.remote_address(),
+                request_class = request_class.as_str(),
+                reason_code = "protocol-auth-denied",
+                "NameServer request denied"
+            );
+            let error =
+                RocketMQError::authentication_failed("NameServer request authentication or authorization failed");
+            self.metrics.record_security_event(NameServerSecurityEvent::AuthDenied);
+            self.metrics.record_request(
+                metric_class,
+                NameServerRequestOutcome::Rejected,
+                request_started.elapsed(),
+                0,
+            );
+            return Ok(Some(self.command_factory.command_from_error_with_remark_and_opaque(
+                &error,
+                error.to_string(),
+                request.opaque(),
+            )));
         }
         let admission_class = WorkloadAdmissionClass::from(request_class);
         let admission_config = self
@@ -406,15 +429,69 @@ mod tests {
     use std::net::SocketAddr;
     use std::time::Duration;
 
+    use cheetah_string::CheetahString;
     use rocketmq_auth::AuthConfig;
     use rocketmq_auth::AuthRuntimeBuilder;
     use rocketmq_protocol::code::response_code::ResponseCode;
+    use rocketmq_protocol::protocol::header::client_request_header::GetRouteInfoRequestHeader;
     use rocketmq_runtime::RuntimeContext;
     use rocketmq_transport::api::v1::ConnectionHandlerContextWrapper;
     use rocketmq_transport::test_support::Connection;
     use rocketmq_transport::test_support::TestChannelBuilder;
 
     use super::*;
+
+    fn route_request(opaque: i32) -> RemotingCommand {
+        let mut request = RemotingCommand::create_request_command(
+            RequestCode::GetRouteinfoByTopic,
+            GetRouteInfoRequestHeader::new(CheetahString::from_static_str("layered-auth-topic"), Some(true)),
+        )
+        .set_opaque(opaque);
+        request.make_custom_header_to_net();
+        request
+    }
+
+    fn route_processor(
+        bootstrap: &crate::bootstrap::NameServerBootstrap,
+        auth_runtime: Option<Arc<AuthRuntime>>,
+        requirement: LayerRequirement,
+    ) -> NameServerRequestProcessor {
+        let runtime_handle = NameServerRuntimeHandle::new(&bootstrap.runtime_inner());
+        let mut processor = NameServerRequestProcessor::new()
+            .with_auth_runtime(auth_runtime)
+            .with_detailed_authorization_requirement(requirement);
+        processor.register_processor(
+            RequestCode::GetRouteinfoByTopic,
+            NameServerRequestProcessorWrapper::ClientRequestProcessor(Arc::new(ClientRequestProcessor::new(
+                runtime_handle,
+            ))),
+        );
+        processor
+    }
+
+    fn test_channel_context(
+        runtime: &RuntimeContext,
+        name: &'static str,
+    ) -> (
+        rocketmq_runtime::ChildServiceContext,
+        Channel,
+        Arc<ConnectionHandlerContextWrapper>,
+    ) {
+        let channel_service = runtime.service_context(name);
+        let (transport, _peer) = tokio::io::duplex(4096);
+        let channel = TestChannelBuilder::new(
+            Connection::new_with_plaintext_stream(transport),
+            channel_service.task_group().clone(),
+        )
+        .addresses(
+            SocketAddr::from(([127, 0, 0, 1], 9876)),
+            SocketAddr::from(([127, 0, 0, 1], 10911)),
+        )
+        .build()
+        .expect("test channel should initialize");
+        let context = Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        (channel_service, channel, context)
+    }
 
     #[test]
     fn cloned_nameserver_processors_share_the_dispatch_table() {
@@ -495,5 +572,143 @@ mod tests {
         auth_runtime.shutdown().await.expect("auth runtime should shut down");
         let report = channel_service.task_group().shutdown(Duration::from_secs(1)).await;
         report.assert_no_task_leak().expect("channel tasks should be owned");
+    }
+
+    #[tokio::test]
+    async fn required_abstention_denies_before_the_route_handler() {
+        let runtime = RuntimeContext::from_current("namesrv-required-abstain-test");
+        let bootstrap = crate::bootstrap::Builder::new(
+            runtime.service_context("namesrv-bootstrap"),
+            rocketmq_observability::TelemetryHandle::noop(),
+        )
+        .build();
+        let mut processor = route_processor(&bootstrap, None, LayerRequirement::Required);
+        let (channel_service, channel, context) = test_channel_context(&runtime, "namesrv-channel");
+        let mut request = route_request(0x5a5b);
+
+        let response = processor
+            .process_request(channel, context, &mut request)
+            .await
+            .expect("required abstention should produce a response")
+            .expect("required abstention should return a command");
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::NoPermission);
+        assert_eq!(response.opaque(), 0x5a5b);
+        let report = channel_service.task_group().shutdown(Duration::from_secs(1)).await;
+        report.assert_no_task_leak().expect("channel tasks should be owned");
+    }
+
+    #[tokio::test]
+    async fn optional_abstention_allows_the_route_handler_to_run() {
+        let runtime = RuntimeContext::from_current("namesrv-optional-abstain-test");
+        let bootstrap = crate::bootstrap::Builder::new(
+            runtime.service_context("namesrv-bootstrap"),
+            rocketmq_observability::TelemetryHandle::noop(),
+        )
+        .build();
+        let mut processor = route_processor(&bootstrap, None, LayerRequirement::Optional);
+        let (channel_service, channel, context) = test_channel_context(&runtime, "namesrv-channel");
+        let mut request = route_request(0x5a5c);
+
+        let response = processor
+            .process_request(channel, context, &mut request)
+            .await
+            .expect("optional abstention should reach the route handler")
+            .expect("route handler should return a command");
+
+        assert_ne!(ResponseCode::from(response.code()), ResponseCode::NoPermission);
+        assert_ne!(
+            ResponseCode::from(response.code()),
+            ResponseCode::RequestCodeNotSupported
+        );
+        let report = channel_service.task_group().shutdown(Duration::from_secs(1)).await;
+        report.assert_no_task_leak().expect("channel tasks should be owned");
+    }
+
+    #[tokio::test]
+    async fn auth_whitelists_allow_the_route_handler_but_detailed_denial_blocks_it() {
+        let runtime = RuntimeContext::from_current("namesrv-layered-auth-handler-test");
+        let route_code = RequestCode::GetRouteinfoByTopic.to_i32().to_string();
+        let whitelisted_runtime = Arc::new(
+            AuthRuntimeBuilder::new(
+                AuthConfig {
+                    authentication_enabled: true,
+                    authorization_enabled: true,
+                    authentication_whitelist: CheetahString::from_string(route_code.clone()),
+                    authorization_whitelist: CheetahString::from_string(route_code),
+                    ..AuthConfig::default()
+                },
+                runtime.service_context("namesrv-whitelist-auth"),
+            )
+            .build()
+            .await
+            .expect("whitelisted auth runtime should initialize"),
+        );
+        let bootstrap = crate::bootstrap::Builder::new(
+            runtime.service_context("namesrv-bootstrap"),
+            rocketmq_observability::TelemetryHandle::noop(),
+        )
+        .build();
+        let mut allowed_processor = route_processor(
+            &bootstrap,
+            Some(Arc::clone(&whitelisted_runtime)),
+            LayerRequirement::Required,
+        );
+        let (channel_service, channel, context) = test_channel_context(&runtime, "namesrv-allowed-channel");
+        let mut allowed_request = route_request(0x5a5d);
+        let allowed = allowed_processor
+            .process_request(channel, context, &mut allowed_request)
+            .await
+            .expect("whitelisted authorization should reach the route handler")
+            .expect("route handler should return a command");
+        assert_eq!(ResponseCode::from(allowed.code()), ResponseCode::TopicNotExist);
+
+        let denying_runtime = Arc::new(
+            AuthRuntimeBuilder::new(
+                AuthConfig {
+                    authentication_enabled: true,
+                    authorization_enabled: true,
+                    ..AuthConfig::default()
+                },
+                runtime.service_context("namesrv-denying-auth"),
+            )
+            .build()
+            .await
+            .expect("denying auth runtime should initialize"),
+        );
+        let mut denied_processor = route_processor(
+            &bootstrap,
+            Some(Arc::clone(&denying_runtime)),
+            LayerRequirement::Required,
+        );
+        let (denied_channel_service, denied_channel, denied_context) =
+            test_channel_context(&runtime, "namesrv-denied-channel");
+        let mut denied_request = route_request(0x5a5e);
+        let denied = denied_processor
+            .process_request(denied_channel, denied_context, &mut denied_request)
+            .await
+            .expect("detailed denial should produce a response")
+            .expect("detailed denial should return a command");
+        assert_eq!(ResponseCode::from(denied.code()), ResponseCode::NoPermission);
+
+        whitelisted_runtime
+            .shutdown()
+            .await
+            .expect("whitelisted auth runtime should shut down");
+        denying_runtime
+            .shutdown()
+            .await
+            .expect("denying auth runtime should shut down");
+        let report = channel_service.task_group().shutdown(Duration::from_secs(1)).await;
+        report
+            .assert_no_task_leak()
+            .expect("allowed channel tasks should be owned");
+        let report = denied_channel_service
+            .task_group()
+            .shutdown(Duration::from_secs(1))
+            .await;
+        report
+            .assert_no_task_leak()
+            .expect("denied channel tasks should be owned");
     }
 }

--- a/rocketmq-namesrv/src/security.rs
+++ b/rocketmq-namesrv/src/security.rs
@@ -12,10 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_security_api::AuthenticatedRequestContext;
 use rocketmq_security_api::Decision;
+use rocketmq_security_api::IngressDecision;
+use rocketmq_security_api::IngressPolicy;
+use rocketmq_security_api::LayerEvaluation;
 use rocketmq_security_api::RequestPolicy;
+use rocketmq_security_api::SecurityBootstrapOutcome;
+use rocketmq_security_api::SecurityBootstrapProfile;
+use rocketmq_transport::api::v1::TransportSecurity;
 
 /// Low-cardinality authorization classes for every NameServer request.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -86,6 +94,44 @@ pub const fn classify_namesrv_request(code: RequestCode) -> Option<NameServerReq
 /// transport dispatcher.
 #[doc(hidden)]
 pub struct NameServerTransportPolicy;
+
+/// Builds the NameServer transport boundary selected by a validated bootstrap outcome.
+///
+/// A [`SecurityBootstrapOutcome::Disabled`] result selects the legacy
+/// development-compatible transport behavior. It is an explicit migration
+/// choice, not a validated loopback-listener proof. A validated development
+/// outcome has already proved every supplied listener is loopback-only.
+///
+/// This is hidden from the public documentation because the bootstrap binary is
+/// the only production composition root. It remains public so that binary and
+/// library targets use the exact same outcome-to-transport projection.
+#[doc(hidden)]
+#[must_use]
+pub fn build_namesrv_transport_security(outcome: SecurityBootstrapOutcome) -> Arc<TransportSecurity> {
+    match outcome {
+        SecurityBootstrapOutcome::Disabled => Arc::new(TransportSecurity::development_insecure_loopback(None, None)),
+        SecurityBootstrapOutcome::Validated(validated) => match validated.profile() {
+            SecurityBootstrapProfile::SecureEnforced => Arc::new(
+                TransportSecurity::secure_enforced(None, None).with_ingress_policy(Arc::new(NameServerTransportPolicy)),
+            ),
+            SecurityBootstrapProfile::DevelopmentInsecureLoopback => {
+                Arc::new(TransportSecurity::development_insecure_loopback(None, None))
+            }
+        },
+    }
+}
+
+impl IngressPolicy for NameServerTransportPolicy {
+    fn evaluate_ingress(
+        &self,
+        request: rocketmq_security_api::SecurityRequestView<'_>,
+    ) -> LayerEvaluation<IngressDecision> {
+        match classify_namesrv_request(RequestCode::from(request.code())) {
+            Some(_) => Ok(IngressDecision::AllowToContinue),
+            None => Ok(IngressDecision::Deny),
+        }
+    }
+}
 
 impl RequestPolicy for NameServerTransportPolicy {
     fn evaluate_authenticated(&self, context: AuthenticatedRequestContext<'_>) -> Decision {

--- a/rocketmq-security-api/src/layered_authorization.rs
+++ b/rocketmq-security-api/src/layered_authorization.rs
@@ -1,0 +1,202 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Runtime-neutral contracts for staged authorization.
+
+use crate::Decision;
+use crate::SecurityRequestView;
+
+/// Stable, non-sensitive reason used when the layered pipeline rejects a request.
+///
+/// Layer implementations must not substitute credential, signature, token, header,
+/// or body data into this value.
+pub const LAYERED_AUTHORIZATION_DENIED_REASON: &str = "authorization denied";
+
+/// The coarse ingress decision made before authentication or detailed policy evaluation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IngressDecision {
+    /// The request may continue to authentication and detailed authorization.
+    AllowToContinue,
+    /// The request must be rejected before evaluating a detailed layer.
+    Deny,
+}
+
+/// The result of a detailed authorization policy evaluation.
+///
+/// `Abstain` is intentionally local to the layered contract. It is not a
+/// variant of the legacy public [`Decision`] type and is resolved only by
+/// [`combine_layered_authorization`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DetailedDecision {
+    /// The detailed policy allows the request.
+    Allow,
+    /// The detailed policy denies the request.
+    Deny,
+    /// The detailed policy is deliberately not installed or enabled.
+    Abstain,
+}
+
+/// A fail-closed category for a layer that could not return a decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LayerFailureKind {
+    /// The layer or its required dependency is not available.
+    Unavailable,
+    /// The layer returned an operational or policy-evaluation error.
+    Error,
+    /// The layer exceeded its configured deadline.
+    Timeout,
+}
+
+/// Whether a detailed authorization decision is required for a request path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LayerRequirement {
+    /// A detailed decision must be present; `Abstain` is a denial.
+    Required,
+    /// An explicit compatibility boundary permits `Abstain`.
+    ///
+    /// This variant is only for a deliberately disabled compatibility layer. It
+    /// must not be used to convert an unavailable layer or any other failure
+    /// into an allow.
+    Optional,
+}
+
+/// The result returned by one authorization layer.
+///
+/// Every [`Err`] value is denied by [`combine_layered_authorization`].
+pub type LayerEvaluation<T> = Result<T, LayerFailureKind>;
+
+/// A coarse ingress policy that can inspect a request without authenticating it.
+///
+/// Implementations classify only the ingress surface. Authentication and
+/// resource-level authorization remain the responsibility of later layers.
+pub trait IngressPolicy: Send + Sync {
+    /// Evaluates whether the request may proceed to the detailed layer.
+    fn evaluate_ingress(&self, request: SecurityRequestView<'_>) -> LayerEvaluation<IngressDecision>;
+}
+
+/// Combines coarse ingress and detailed authorization under fail-closed semantics.
+///
+/// A coarse deny is sticky and does not invoke `detailed`. An ingress failure, a
+/// detailed failure, or a detailed deny always produces the fixed public denial.
+/// A detailed abstention is allowed only at an explicit [`LayerRequirement::Optional`]
+/// compatibility boundary; required authorization fails closed.
+pub fn combine_layered_authorization<F>(
+    ingress: LayerEvaluation<IngressDecision>,
+    requirement: LayerRequirement,
+    detailed: F,
+) -> Decision
+where
+    F: FnOnce() -> LayerEvaluation<DetailedDecision>,
+{
+    match ingress {
+        Ok(IngressDecision::AllowToContinue) => match detailed() {
+            Ok(DetailedDecision::Allow) => Decision::Allow,
+            Ok(DetailedDecision::Abstain) if requirement == LayerRequirement::Optional => Decision::Allow,
+            Ok(DetailedDecision::Deny | DetailedDecision::Abstain) | Err(_) => layered_deny(),
+        },
+        Ok(IngressDecision::Deny) | Err(_) => layered_deny(),
+    }
+}
+
+fn layered_deny() -> Decision {
+    Decision::deny(LAYERED_AUTHORIZATION_DENIED_REASON)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::*;
+
+    fn is_allow(decision: Decision) -> bool {
+        matches!(decision, Decision::Allow)
+    }
+
+    #[test]
+    fn complete_truth_table_is_fail_closed() {
+        for ingress in [IngressDecision::AllowToContinue, IngressDecision::Deny] {
+            for requirement in [LayerRequirement::Required, LayerRequirement::Optional] {
+                for detailed in [
+                    DetailedDecision::Allow,
+                    DetailedDecision::Deny,
+                    DetailedDecision::Abstain,
+                ] {
+                    let detailed_called = Cell::new(false);
+                    let result = combine_layered_authorization(Ok(ingress), requirement, || {
+                        detailed_called.set(true);
+                        Ok(detailed)
+                    });
+                    let expected_allow = matches!(
+                        (ingress, requirement, detailed),
+                        (IngressDecision::AllowToContinue, _, DetailedDecision::Allow)
+                            | (
+                                IngressDecision::AllowToContinue,
+                                LayerRequirement::Optional,
+                                DetailedDecision::Abstain
+                            )
+                    );
+
+                    assert_eq!(is_allow(result), expected_allow);
+                    assert_eq!(detailed_called.get(), ingress == IngressDecision::AllowToContinue);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn coarse_deny_is_sticky_and_skips_detailed_evaluation() {
+        let detailed_called = Cell::new(false);
+        let result = combine_layered_authorization(Ok(IngressDecision::Deny), LayerRequirement::Optional, || {
+            detailed_called.set(true);
+            Ok(DetailedDecision::Allow)
+        });
+
+        assert!(matches!(result, Decision::Deny { .. }));
+        assert!(!detailed_called.get());
+    }
+
+    #[test]
+    fn every_layer_failure_is_denied() {
+        for failure in [
+            LayerFailureKind::Unavailable,
+            LayerFailureKind::Error,
+            LayerFailureKind::Timeout,
+        ] {
+            assert!(matches!(
+                combine_layered_authorization(Err(failure), LayerRequirement::Optional, || {
+                    Ok(DetailedDecision::Allow)
+                }),
+                Decision::Deny { .. }
+            ));
+            assert!(matches!(
+                combine_layered_authorization(
+                    Ok(IngressDecision::AllowToContinue),
+                    LayerRequirement::Optional,
+                    || Err(failure),
+                ),
+                Decision::Deny { .. }
+            ));
+        }
+    }
+
+    #[test]
+    fn denial_reason_is_fixed_and_redaction_safe() {
+        let result =
+            combine_layered_authorization(Ok(IngressDecision::AllowToContinue), LayerRequirement::Required, || {
+                Ok(DetailedDecision::Deny)
+            });
+
+        assert_eq!(result, Decision::deny(LAYERED_AUTHORIZATION_DENIED_REASON));
+    }
+}

--- a/rocketmq-security-api/src/lib.rs
+++ b/rocketmq-security-api/src/lib.rs
@@ -16,6 +16,8 @@
 
 //! Runtime-neutral security contracts.
 
+/// Layered ingress and detailed authorization contracts.
+pub mod layered_authorization;
 pub mod maintenance;
 /// Resource pattern types and operations.
 pub mod resource_pattern;
@@ -24,6 +26,14 @@ pub mod resource_type;
 pub mod secret_provider;
 pub mod secure_deployment;
 
+pub use layered_authorization::combine_layered_authorization;
+pub use layered_authorization::DetailedDecision;
+pub use layered_authorization::IngressDecision;
+pub use layered_authorization::IngressPolicy;
+pub use layered_authorization::LayerEvaluation;
+pub use layered_authorization::LayerFailureKind;
+pub use layered_authorization::LayerRequirement;
+pub use layered_authorization::LAYERED_AUTHORIZATION_DENIED_REASON;
 pub use maintenance::MaintenanceAuthorizationContext;
 pub use maintenance::MaintenanceAuthorizationError;
 pub use maintenance::MaintenanceAuthorizationGrant;

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher.rs
@@ -159,7 +159,7 @@ impl AuthorizedDispatchSession {
             response.send(deadline_response(opaque)).await?;
             return Ok(DispatchOutcome::Rejected);
         }
-        if let Decision::Deny { reason } = self.boundary.security.authorize(
+        if let Decision::Deny { reason } = self.boundary.security.authorize_for_dispatch(
             &command,
             context.peer(),
             context.principal(),

--- a/rocketmq-transport/src/security.rs
+++ b/rocketmq-transport/src/security.rs
@@ -21,6 +21,10 @@ use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_security_api::evaluate_request;
 use rocketmq_security_api::Action;
 use rocketmq_security_api::Decision;
+use rocketmq_security_api::IngressDecision;
+use rocketmq_security_api::IngressPolicy;
+use rocketmq_security_api::LayerEvaluation;
+use rocketmq_security_api::LayerFailureKind;
 use rocketmq_security_api::OutboundSigner;
 use rocketmq_security_api::PeerInfo;
 use rocketmq_security_api::Principal;
@@ -30,6 +34,7 @@ use rocketmq_security_api::Resource;
 use rocketmq_security_api::SecurityBootstrapProfile;
 use rocketmq_security_api::SecurityRequestView;
 use rocketmq_security_api::SigningError;
+use rocketmq_security_api::LAYERED_AUTHORIZATION_DENIED_REASON;
 
 fn empty_fields() -> &'static HashMap<CheetahString, CheetahString> {
     static EMPTY: OnceLock<HashMap<CheetahString, CheetahString>> = OnceLock::new();
@@ -54,6 +59,7 @@ pub fn request_view<'a>(command: &'a RemotingCommand, peer: Option<&'a PeerInfo>
 /// Injected transport ports; provider implementations remain in composition crates.
 pub struct TransportSecurity {
     profile: SecurityBootstrapProfile,
+    ingress_policy: Option<Arc<dyn IngressPolicy>>,
     policy: Option<Arc<dyn RequestPolicy>>,
     signer: Option<Arc<dyn OutboundSigner>>,
 }
@@ -65,6 +71,12 @@ impl TransportSecurity {
         self.profile
     }
 
+    /// Returns whether this adapter was constructed for a secure-enforced process.
+    #[must_use]
+    pub const fn is_secure_enforced(&self) -> bool {
+        matches!(self.profile, SecurityBootstrapProfile::SecureEnforced)
+    }
+
     /// Creates an explicitly insecure transport adapter for loopback-only development.
     ///
     /// The listener address restriction is enforced by the process security bootstrap before bind.
@@ -74,6 +86,7 @@ impl TransportSecurity {
     ) -> Self {
         Self {
             profile: SecurityBootstrapProfile::DevelopmentInsecureLoopback,
+            ingress_policy: None,
             policy,
             signer,
         }
@@ -83,8 +96,39 @@ impl TransportSecurity {
     pub fn secure_enforced(policy: Option<Arc<dyn RequestPolicy>>, signer: Option<Arc<dyn OutboundSigner>>) -> Self {
         Self {
             profile: SecurityBootstrapProfile::SecureEnforced,
+            ingress_policy: None,
             policy,
             signer,
+        }
+    }
+
+    /// Installs a coarse ingress policy for the transport dispatch boundary.
+    ///
+    /// When configured, this policy is evaluated before a request reaches the
+    /// service processor. The legacy `RequestPolicy` remains available only as
+    /// the compatibility fallback when no ingress policy has been installed.
+    #[must_use]
+    pub fn with_ingress_policy(mut self, ingress_policy: Arc<dyn IngressPolicy>) -> Self {
+        self.ingress_policy = Some(ingress_policy);
+        self
+    }
+
+    /// Projects a request onto the coarse ingress continuation contract.
+    ///
+    /// This method does not authenticate or evaluate detailed resource policy.
+    /// A missing secure ingress policy is unavailable and must be resolved as a
+    /// fail-closed denial by the caller.
+    pub fn authorize_ingress(
+        &self,
+        command: &RemotingCommand,
+        peer: Option<&PeerInfo>,
+    ) -> LayerEvaluation<IngressDecision> {
+        match &self.ingress_policy {
+            Some(policy) => policy.evaluate_ingress(request_view(command, peer)),
+            None => match self.profile {
+                SecurityBootstrapProfile::DevelopmentInsecureLoopback => Ok(IngressDecision::AllowToContinue),
+                SecurityBootstrapProfile::SecureEnforced => Err(LayerFailureKind::Unavailable),
+            },
         }
     }
 
@@ -104,6 +148,23 @@ impl TransportSecurity {
         };
         let context = RequestContext::new(request_view(command, peer), principal, resource, action);
         evaluate_request(policy.as_ref(), &context)
+    }
+
+    pub(crate) fn authorize_for_dispatch(
+        &self,
+        command: &RemotingCommand,
+        peer: Option<&PeerInfo>,
+        principal: Option<&Principal>,
+        resource: Resource,
+        action: Action,
+    ) -> Decision {
+        if self.ingress_policy.is_some() {
+            return match self.authorize_ingress(command, peer) {
+                Ok(IngressDecision::AllowToContinue) => Decision::Allow,
+                Ok(IngressDecision::Deny) | Err(_) => Decision::deny(LAYERED_AUTHORIZATION_DENIED_REASON),
+            };
+        }
+        self.authorize(command, peer, principal, resource, action)
     }
 
     pub fn sign(&self, command: &mut RemotingCommand, peer: Option<&PeerInfo>) -> Result<(), SigningError> {

--- a/rocketmq-transport/tests/authorized_dispatch_conformance_tests.rs
+++ b/rocketmq-transport/tests/authorized_dispatch_conformance_tests.rs
@@ -31,6 +31,9 @@ use rocketmq_runtime::ChildServiceContext;
 use rocketmq_runtime::RuntimeContext;
 use rocketmq_security_api::AuthenticatedRequestContext;
 use rocketmq_security_api::Decision;
+use rocketmq_security_api::IngressDecision;
+use rocketmq_security_api::IngressPolicy;
+use rocketmq_security_api::LayerEvaluation;
 use rocketmq_security_api::Principal;
 use rocketmq_security_api::RequestPolicy;
 use rocketmq_transport::api::v1::AdmissionClass;
@@ -120,6 +123,31 @@ impl RequestPolicy for AllowOnlyNamedPrincipal {
         } else {
             Decision::deny("principal is not authorized")
         }
+    }
+}
+
+struct CountingLegacyPolicy {
+    calls: Arc<AtomicUsize>,
+}
+
+impl RequestPolicy for CountingLegacyPolicy {
+    fn evaluate_authenticated(&self, _context: AuthenticatedRequestContext<'_>) -> Decision {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Decision::Allow
+    }
+}
+
+struct DenyIngressPolicy {
+    calls: Arc<AtomicUsize>,
+}
+
+impl IngressPolicy for DenyIngressPolicy {
+    fn evaluate_ingress(
+        &self,
+        _request: rocketmq_security_api::SecurityRequestView<'_>,
+    ) -> LayerEvaluation<IngressDecision> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(IngressDecision::Deny)
     }
 }
 
@@ -369,4 +397,56 @@ async fn network_and_embedded_adapters_share_authorized_dispatch_semantics() {
         Err(error) => error,
     };
     assert!(matches!(error, DispatchError::Response(ResponseSinkError::Cancelled)));
+}
+
+#[tokio::test]
+async fn configured_ingress_deny_short_circuits_legacy_policy_and_handler() {
+    let runtime = RuntimeContext::from_current("authorized-dispatch-ingress-short-circuit");
+    let service = runtime.service_context("ingress-short-circuit");
+    let process_budget = service.process_budget();
+    let admission = Arc::new(
+        AdmissionController::try_new_with_budget(AdmissionLimits::default(), &process_budget)
+            .expect("test admission limits should be valid"),
+    );
+    let ingress_calls = Arc::new(AtomicUsize::new(0));
+    let legacy_calls = Arc::new(AtomicUsize::new(0));
+    let security = Arc::new(
+        TransportSecurity::secure_enforced(
+            Some(Arc::new(CountingLegacyPolicy {
+                calls: Arc::clone(&legacy_calls),
+            })),
+            None,
+        )
+        .with_ingress_policy(Arc::new(DenyIngressPolicy {
+            calls: Arc::clone(&ingress_calls),
+        })),
+    );
+    let processor = ConformanceProcessor::new(ProcessorBehavior::Echo);
+    let dispatcher = Arc::new(
+        AuthorizedCommandDispatcher::try_new(
+            processor.clone(),
+            Vec::new(),
+            &process_budget,
+            TransportTelemetry::noop(),
+            security,
+            admission,
+        )
+        .expect("test dispatcher should fit the process budget"),
+    );
+
+    let response = dispatcher
+        .dispatch_embedded(
+            service.task_group(),
+            embedded_context("allowed", None),
+            RemotingCommand::create_remoting_command(RequestCode::SendMessage).set_opaque(48),
+        )
+        .await
+        .expect("ingress denial should produce a response");
+
+    assert_eq!(response.code(), ResponseCode::NoPermission.to_i32());
+    assert_eq!(ingress_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(legacy_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(processor.calls.load(Ordering::SeqCst), 0);
+    let report = service.task_group().shutdown(Duration::from_secs(1)).await;
+    report.assert_no_task_leak().expect("test tasks should be owned");
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9722

### Brief Description

- Add runtime-neutral ingress, detailed, failure, and requirement decisions with one fail-closed composition contract while keeping the legacy final decision binary.
- Project authentication and authorization outcomes into the layered contract without changing the frozen first-success authorization handler chain.
- Preserve the transport legacy policy fallback while making configured ingress policy a coarse continuation gate that short-circuits denial before the handler.
- Wire validated NameServer bootstrap outcomes through coarse ingress, authentication, detailed authorization, and the real request handler for secure, disabled compatibility, and loopback development modes.
- Make insecure public NameServer listeners opt-in, preserve whitelists, use fixed denial output, and cover the production composition with embedded dispatcher tests.

### How Did You Test This Change?

- Passed package-scoped format checks for `rocketmq-security-api`, `rocketmq-auth`, `rocketmq-transport`, and `rocketmq-namesrv`.
- Passed full package tests for all four affected packages, including 348 auth library tests, 264 NameServer library tests, 12 NameServer bootstrap binary tests, integration tests, and doctests.
- Passed `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`.
- Passed `./scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` and the stable-surface guard.
- Architecture dependency, public API intent, and error hygiene checks produced only findings reproduced unchanged on the base commit; affected core error mappings passed.
- Passed the MCP read-only boundary, locked check, default and all-feature tests, streamable HTTP Clippy, and documentation build.
- `cargo fmt --all -- --check` in the standalone MCP workspace is blocked by Windows `os error 206` on both this branch and the unchanged base; all affected root packages passed their required scoped format checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added layered authorization for NameServer requests, combining transport-level and detailed permission checks.
  - Added clearer handling for authorization failures, including unavailable services, timeouts, and operational errors.
  - Added ingress controls that reject unsupported or unauthorized request types before dispatch.

- **Security Enhancements**
  - Secure-enforced listeners now fail closed when ingress authorization is unavailable.
  - Development-insecure listeners are restricted to loopback addresses.
  - Insecure public listeners are disabled by default; they require explicit configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->