### PR TITLE
[ISSUE #9724]📝Document RocketMQRuntime migration before 2.0 removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **docs(runtime):** Document `RocketMQRuntime` as a deprecated 1.x compatibility API with removal intended only for a future 2.0 source-compatibility boundary, subject to the full release cycle, a 2.0 breaking window, and exact reviewed post-freeze repository-owner approval for every affected frozen public item; this change grants no removal approval and existing public APIs remain available ([#9724](https://github.com/mxsm/rocketmq-rust/issues/9724)).
 - **fix(namesrv):** Exclude the lifecycle handle from shutdown-report tracing instrumentation ([#9169](https://github.com/mxsm/rocketmq-rust/issues/9169))
 - **refactor(error):** Preserve typed header, JSON, and authorization sources through Controller maintenance handling while retaining the existing error kinds and redacted boundary projections.
 - **fix(controller):** Route online consensus membership changes through `apply_membership_change`, which requires a maintenance authorization grant, optimistic membership version, idempotency key, quorum checks, and audit facts. Direct public `add_learner` and `change_membership` mutation methods are no longer exposed; embedders must migrate online changes to the authorized boundary.

--- a/rocketmq-doc/en/release/1.0/api-migration.md
+++ b/rocketmq-doc/en/release/1.0/api-migration.md
@@ -69,6 +69,99 @@ Request processors are fixed when a client is built. Replace the deprecated
 Applications own the runtime and pass an `Arc<ClientRuntime>` to producers and
 consumers. Client APIs do not create hidden Tokio runtimes.
 
+### `RocketMQRuntime` legacy runtime boundary
+
+`RocketMQRuntime` remains a public, deprecated compatibility API throughout
+the 1.x line. This guide does not remove it, change any of its public methods,
+or announce a 2.0 release. Its removal is only intended for a future 2.0
+source-compatibility boundary, after downstream applications have migrated to
+the explicit ownership and shutdown APIs below. Any future removal remains
+subject to the full release cycle, a 2.0 breaking window, and an exact,
+reviewed post-freeze repository-owner approval record for every affected frozen
+public item (package, profile, item path, and change kind). This change creates
+no approval record and does not authorize a removal.
+
+| Legacy 1.x API | Migration target | Required ownership or policy decision |
+|---|---|---|
+| `RocketMQRuntime::new_multi(threads, name)` | `RuntimeOwner::new(RuntimeConfig { .. })?` | Put the worker count and thread name in `RuntimeConfig`; propagate its typed `RuntimeResult` instead of relying on an infallible constructor. |
+| `get_handle()` | `RuntimeOwner::root_context().component(...)` or a child derived from `RuntimeContext` | Pass `ChildServiceContext` (or a narrower capability) to a library. Do not replace this call with a raw Tokio handle. |
+| `get_runtime()` | `RuntimeOwner::block_on(...)` at an owned synchronous entrypoint, or context-owned task operations | Keep the Tokio runtime private to its owner. Libraries receive a context and use its task group, blocking lanes, and diagnostics rather than a raw runtime reference. |
+| `schedule_at_fixed_rate(task, initial_delay, period)` (`Fn`) | `ScheduledTaskGroup::schedule_fixed_rate_no_overlap` | Set `config.initial_delay = initial_delay.unwrap_or(Duration::ZERO)`. The legacy callback was serial, so preserve that non-overlap policy explicitly; a tick is skipped while an async run is active. Choose `schedule_fixed_rate` only when overlapping runs are intentional and reentrant. |
+| `schedule_at_fixed_rate_mut(task, initial_delay, period)` (`FnMut`) | `ScheduledTaskGroup::schedule_fixed_delay` | Set `config.initial_delay = initial_delay.unwrap_or(Duration::ZERO)`. This accepts mutable callback state while keeping runs serial. If fixed-rate cadence is required, make the callback state safe for the chosen explicit no-overlap or allow-overlap policy. |
+| `shutdown()` | `RuntimeOwner::shutdown_background(self)` | Cancels tracked RocketMQ work, returns an immediate `ShutdownReport`, and asks Tokio to finish runtime shutdown in the background. |
+| `shutdown_timeout(timeout)` at a synchronous runtime-owning boundary | `RuntimeOwner::shutdown_runtime_blocking_with_timeout(timeout)?` | Shuts down tracked work and then the owned Tokio runtime within the timeout. It returns typed errors, including `RuntimeError::InsideTokioRuntime` when called from Tokio. |
+| async shutdown that must retain the host Tokio runtime | `RuntimeOwner::shutdown_tasks().await` or `RuntimeContext::shutdown_tasks(timeout).await` | Shuts down only tracked RocketMQ work and returns `ShutdownReport`; it does not close the owned or host Tokio runtime. |
+
+For a process entrypoint that owns Tokio, construct one owner from typed
+configuration and derive child service contexts from it:
+
+```rust,ignore
+use rocketmq_runtime::{RuntimeConfig, RuntimeOwner};
+
+let owner = RuntimeOwner::new(RuntimeConfig {
+    worker_threads: threads,
+    thread_name: service_name.to_owned(),
+    ..RuntimeConfig::default()
+})?;
+let service = owner.root_context().component("consumer");
+```
+
+Code that is already executing inside an application-owned Tokio runtime may
+use `RuntimeContext::try_from_current("migration")?` as a migration or test
+harness and derive a `ChildServiceContext` from it. Production composition
+roots use `RuntimeOwner`; neither form grants libraries raw Tokio runtime
+access.
+
+Make the periodic-work policy visible at the call site. The no-overlap choice
+below is the closest replacement for the legacy `Fn` callback. It keeps a
+fixed cadence, skips a tick if the prior run is active, and lets shutdown track
+both the driver and any run it owns.
+
+```rust,ignore
+use std::time::Duration;
+
+use rocketmq_runtime::ScheduledTaskConfig;
+
+let scheduled = service.scheduled_tasks("consumer-maintenance");
+let mut config = ScheduledTaskConfig::fixed_rate_no_overlap(
+    "consumer-maintenance.refresh",
+    period,
+);
+config.initial_delay = initial_delay.unwrap_or(Duration::ZERO);
+scheduled.schedule_fixed_rate_no_overlap(config, || async {
+    refresh_routes().await;
+})?;
+```
+
+For stateful legacy `FnMut` callbacks, use fixed delay unless a different
+overlap policy has been deliberately designed and documented:
+
+```rust,ignore
+let mut generation = 0_u64;
+let mut config = ScheduledTaskConfig::fixed_delay(
+    "consumer-maintenance.persist",
+    period,
+);
+config.initial_delay = initial_delay.unwrap_or(Duration::ZERO);
+scheduled.schedule_fixed_delay(config, move || {
+    generation += 1;
+    async move {
+        persist_generation(generation).await;
+    }
+})?;
+```
+
+At shutdown, choose the matching ownership boundary and make the report part
+of the application's lifecycle result. `shutdown_background` is the immediate
+compatibility path, `shutdown_tasks` closes only tracked RocketMQ work, and
+`shutdown_runtime_blocking_with_timeout` is for synchronous process teardown
+only; the latter returns a typed error if invoked from inside Tokio.
+
+```rust,ignore
+let report = owner.shutdown_runtime_blocking_with_timeout(timeout)?;
+report.assert_no_task_leak().map_err(|message| anyhow::anyhow!(message))?;
+```
+
 ### Mapped buffer reads
 
 The former `MappedBuffer::read_zero_copy` name was inaccurate because the

--- a/rocketmq-runtime/README-zh_cn.md
+++ b/rocketmq-runtime/README-zh_cn.md
@@ -14,8 +14,8 @@ Tokio runtime、如何追踪长期任务、如何调度周期任务、如何隔�
 
 RocketMQ Rust 只使用 Tokio 作为异步 runtime。runtime 所有权和任务生命周期必须显式：
 
-- 应用入口使用 `RuntimeOwner`，或在已有 Tokio runtime 中绑定 `RuntimeContext`。
-- broker、namesrv、proxy、controller 和 admin 工具入口从 owner 派生组件级 `ServiceContext`。
+- 应用入口使用 `RuntimeOwner`；迁移和测试 harness 可在已有 Tokio runtime 中绑定 `RuntimeContext`。
+- broker、namesrv、proxy、controller 和 admin 工具入口从 owner 派生组件级 `ChildServiceContext`。
 - 长期服务任务通过 `TaskGroup` 注册和关闭。
 - 周期任务通过 `ScheduledTaskGroup` 管理。
 - 文件 IO、RocksDB、DNS、压缩等短时阻塞工作通过 `BlockingExecutor` 执行。
@@ -25,13 +25,13 @@ RocketMQ Rust 只使用 Tokio 作为异步 runtime。runtime 所有权和任务�
 ```mermaid
 flowchart TD
     Entry["应用入口"] --> Owner["RuntimeOwner"]
-    Entry --> Current["RuntimeContext::from_current"]
-    Owner --> Context["RuntimeContext"]
-    Current --> Context
-    Context --> Root["根 TaskGroup"]
-    Context --> Blocking["BlockingExecutor"]
-    Context --> Diagnostics["RuntimeDiagnostics"]
-    Context --> Service["ServiceContext"]
+    Entry --> Current["RuntimeContext（迁移/测试）"]
+    Owner --> Root["RootServiceContext"]
+    Root --> GroupRoot["根 TaskGroup"]
+    Root --> Blocking["BlockingExecutor"]
+    Root --> Diagnostics["RuntimeDiagnostics"]
+    Root --> Service["ChildServiceContext"]
+    Current --> Service
     Service --> Group["服务 TaskGroup"]
     Group --> Scheduled["ScheduledTaskGroup"]
     Group --> Workers["service / worker / IO tasks"]
@@ -45,14 +45,14 @@ flowchart TD
 | 类型 | 作用 |
 | --- | --- |
 | `RuntimeConfig` | 配置 Tokio worker 线程数、blocking 线程上限、线程名、可选 worker stack、keep-alive、关闭超时、IO/time driver 和 blocking policy。 |
-| `RuntimeOwner` | 持有专用 Tokio 多线程 runtime，并暴露 `RuntimeContext`；关闭时区分任务关闭和 runtime 释放。 |
-| `RuntimeContext` | 绑定当前 runtime handle、根 `TaskGroup`、`BlockingExecutor` 和 diagnostics；可来自 owned runtime 或当前 Tokio runtime。 |
-| `ServiceContext` | 组件级运行时视图，包含 runtime handle、服务 `TaskGroup`、blocking executor 和 diagnostics。 |
+| `RuntimeOwner` | 持有专用 Tokio 多线程 runtime，并暴露根 service context；关闭时区分任务关闭和 runtime 释放。 |
+| `RuntimeContext` | 当前 Tokio runtime 的迁移和测试 harness。生产 composition root 使用 `RuntimeOwner`；库接收 `ChildServiceContext`。 |
+| `ChildServiceContext` | 组件级运行时视图，包含 runtime handle、服务 `TaskGroup`、blocking executor 和 diagnostics。 |
 | `TaskGroup` | 结构化任务作用域，支持任务元数据、取消、关闭、abort、child group 和健康报告。 |
 | `ScheduledTaskGroup` | 在 `TaskGroup` 下运行 fixed-delay / fixed-rate 周期任务，并记录调度指标。 |
 | `BlockingExecutor` | 有界 `spawn_blocking` 网关，提供排队超时、任务超时和仍在运行任务的 reaper 跟踪。 |
 | `ShutdownReport` | 可序列化的关闭证据，记录任务完成、取消、abort、泄漏、panic、timeout、detached task 和 blocking task。 |
-| `RocketMQRuntime` | 旧兼容 wrapper。新代码应使用 `RuntimeOwner`、`RuntimeContext` 或 `ServiceContext`。 |
+| `RocketMQRuntime` | 旧兼容 wrapper。生产 composition root 使用 `RuntimeOwner`，库接收 `ChildServiceContext`；`RuntimeContext` 仅用于迁移和测试 harness。 |
 
 ## 使用方式
 
@@ -63,7 +63,7 @@ use rocketmq_runtime::{RuntimeConfig, RuntimeOwner};
 
 fn main() -> rocketmq_runtime::RuntimeResult<()> {
     let owner = RuntimeOwner::new(RuntimeConfig::broker_default())?;
-    let broker = owner.context().service_context("broker");
+    let broker = owner.root_context().component("broker");
 
     broker.spawn_service("heartbeat", async move {
         // tracked service loop
@@ -75,8 +75,8 @@ fn main() -> rocketmq_runtime::RuntimeResult<()> {
 }
 ```
 
-组件运行在已有 Tokio runtime 内时使用 `RuntimeContext::from_current`。这种 context
-可以关闭 RocketMQ 自己登记的任务，但不会拥有或关闭宿主 Tokio runtime。
+仅在迁移或测试 harness 已运行于 `#[tokio::main]` 或测试 runtime 中时使用
+`RuntimeContext::try_from_current`。这种 context 可以关闭 RocketMQ 自己登记的任务，但不会拥有或关闭宿主 Tokio runtime。
 
 ## 工作区接入状态
 
@@ -104,6 +104,14 @@ Standalone dashboard 应用保留宿主 runtime 边界：Tauri/Web backend、GPU
 - dedicated OS threads：用于不适合 Tokio blocking pool 的长期循环，必须提供 stop signal 和 bounded join。
 
 新增代码不得扩大未分类 legacy runtime、raw `tokio::spawn` 或隐藏 runtime owner 的使用范围。
+
+`RocketMQRuntime` 及其全部 public method 在 1.x 中仍然可用，但已弃用。其移除仅意图在未来的
+2.0 source-compatibility boundary 执行；目前尚未移除，本 crate 也没有声称已经发布 2.0。任何未来
+移除仍须经过完整发布周期、2.0 breaking window，并对每个受影响的 frozen public item 获得精确、经
+reviewed post-freeze 的 repository-owner approval。本次变更不创建 approval record，也不授予移除批准。请将构造迁移到
+`RuntimeOwner::new(RuntimeConfig { .. })?`，向库注入 `ChildServiceContext` 而非暴露 raw Tokio
+runtime 或 handle，将周期回调迁移到具有明确 overlap policy 的 `ScheduledTaskGroup`，并消费 owner
+shutdown API 返回的 `ShutdownReport`。逐方法迁移说明见 [1.0 API migration guide](../rocketmq-doc/en/release/1.0/api-migration.md)。
 
 ## 关闭语义
 

--- a/rocketmq-runtime/README.md
+++ b/rocketmq-runtime/README.md
@@ -21,11 +21,11 @@ shutdown can be verified.
 RocketMQ Rust uses Tokio as the only async runtime. Runtime ownership and task
 lifecycle are explicit:
 
-- application entrypoints create a `RuntimeOwner` or bind a `RuntimeContext`
-  to the current Tokio runtime;
+- application entrypoints create a `RuntimeOwner`; migration and test harnesses
+  may bind a `RuntimeContext` to the current Tokio runtime;
 - broker, namesrv, proxy, controller, and admin tool entrypoints derive their
-  component `ServiceContext` from the runtime owner;
-- every service receives a `ServiceContext`;
+  component `ChildServiceContext` from the runtime owner;
+- every service receives a `ChildServiceContext`;
 - every long-running task is spawned through a `TaskGroup`;
 - every periodic task is registered through a `ScheduledTaskGroup`;
 - blocking work goes through `BlockingExecutor` unless it is a dedicated
@@ -35,13 +35,13 @@ lifecycle are explicit:
 ```mermaid
 flowchart TD
     Entry["Application entrypoint"] --> Owner["RuntimeOwner"]
-    Entry --> Current["RuntimeContext::from_current"]
-    Owner --> Context["RuntimeContext"]
-    Current --> Context
-    Context --> Root["Root TaskGroup"]
-    Context --> Blocking["BlockingExecutor"]
-    Context --> Diagnostics["RuntimeDiagnostics"]
-    Context --> Service["ServiceContext"]
+    Entry --> Current["RuntimeContext (migration/test)"]
+    Owner --> Root["RootServiceContext"]
+    Root --> GroupRoot["Root TaskGroup"]
+    Root --> Blocking["BlockingExecutor"]
+    Root --> Diagnostics["RuntimeDiagnostics"]
+    Root --> Service["ChildServiceContext"]
+    Current --> Service
     Service --> Group["Service TaskGroup"]
     Group --> Scheduled["ScheduledTaskGroup"]
     Group --> Workers["service / worker / IO tasks"]
@@ -55,15 +55,15 @@ flowchart TD
 | Type | Responsibility |
 | --- | --- |
 | `RuntimeConfig` | Configures Tokio worker threads, blocking-thread limit, thread name, optional worker stack size, keep-alive, shutdown timeout, IO/time drivers, and blocking policy. |
-| `RuntimeOwner` | Owns a dedicated Tokio multi-thread runtime and exposes `RuntimeContext`. It separates async task shutdown from blocking runtime shutdown. |
-| `RuntimeContext` | Binds runtime handle, root `TaskGroup`, `BlockingExecutor`, and diagnostics. It can be created from an owned runtime or the current Tokio runtime. |
+| `RuntimeOwner` | Owns a dedicated Tokio multi-thread runtime and exposes a root service context. It separates async task shutdown from blocking runtime shutdown. |
+| `RuntimeContext` | Migration and test harness for a current Tokio runtime. Production composition roots use `RuntimeOwner`; libraries receive `ChildServiceContext`. |
 | `RuntimeHandle` | Lightweight wrapper around `tokio::runtime::Handle`; it is handle access, not lifecycle ownership. |
-| `ServiceContext` | Per-service view containing runtime handle, service task group, blocking executor, and diagnostics. |
+| `ChildServiceContext` | Per-service view containing runtime handle, service task group, blocking executor, and diagnostics. |
 | `TaskGroup` | Structured task scope with task metadata, cancellation, shutdown, abort, child groups, and health reporting. |
 | `ScheduledTaskGroup` | Runs fixed-delay and fixed-rate jobs under a task group and records schedule metrics. |
 | `BlockingExecutor` | Bounded `spawn_blocking` gateway with queue timeout, task timeout, and still-running reaper tracking. |
 | `ShutdownReport` | Serializable shutdown evidence for task completion, cancellation, aborts, leaks, panics, timeouts, detached tasks, and blocking tasks. |
-| `RocketMQRuntime` | Legacy compatibility wrapper. New code should prefer `RuntimeOwner` or `RuntimeContext`. |
+| `RocketMQRuntime` | Legacy compatibility wrapper. Production composition roots use `RuntimeOwner`; libraries receive `ChildServiceContext`; `RuntimeContext` is only a migration and test harness. |
 
 ## Runtime Ownership
 
@@ -74,7 +74,7 @@ use rocketmq_runtime::{RuntimeConfig, RuntimeOwner};
 
 fn main() -> rocketmq_runtime::RuntimeResult<()> {
     let owner = RuntimeOwner::new(RuntimeConfig::broker_default())?;
-    let broker = owner.context().service_context("broker");
+    let broker = owner.root_context().component("broker");
 
     broker.spawn_service("heartbeat", async move {
         // tracked service loop
@@ -86,19 +86,32 @@ fn main() -> rocketmq_runtime::RuntimeResult<()> {
 }
 ```
 
-Use `RuntimeContext::from_current` in applications that already run inside
-`#[tokio::main]` or a test runtime. A context created from the current runtime
-can shut down tracked RocketMQ tasks, but it does not own or close the Tokio
-runtime itself.
+Use `RuntimeContext::try_from_current` only in migration or test harnesses
+that already run inside `#[tokio::main]` or a test runtime. It can shut down
+tracked RocketMQ tasks, but it does not own or close the host Tokio runtime.
 
 ### Legacy Compatibility Boundary
 
 `RocketMQRuntime` is retained only for legacy synchronous APIs that still need
-to pass around an owned Tokio runtime. New code should use `RuntimeOwner` for
-owned runtime lifecycle and `RuntimeContext` / `ServiceContext` for borrowed
-runtime integration. Runtime audit classifies remaining `RocketMQRuntime`
-references as either runtime primitives or explicit compatibility adapters so
-new unclassified legacy runtime use cannot grow unnoticed.
+to pass around an owned Tokio runtime. Production composition roots use
+`RuntimeOwner`, libraries receive `ChildServiceContext`, and `RuntimeContext`
+is only a migration and test harness. Runtime audit classifies remaining
+`RocketMQRuntime` references as either runtime primitives or explicit
+compatibility adapters so new unclassified legacy runtime use cannot grow
+unnoticed.
+
+`RocketMQRuntime` and all of its public methods remain available, deprecated
+1.x API. Its removal is intended only for a future 2.0 source-compatibility
+boundary; it has not happened, and this crate does not claim a 2.0 release.
+Any future removal remains subject to the full release cycle, a 2.0 breaking
+window, and exact, reviewed post-freeze repository-owner approval for every
+affected frozen public item. This change creates no approval record and does
+not authorize a removal.
+Migrate construction to `RuntimeOwner::new(RuntimeConfig { .. })?`, inject a
+`ChildServiceContext` instead of exposing a raw Tokio runtime or handle, move
+periodic callbacks to `ScheduledTaskGroup` with an explicit overlap policy,
+and consume the `ShutdownReport` returned by the owner shutdown APIs. The
+full per-method migration is in the [1.0 API migration guide](../rocketmq-doc/en/release/1.0/api-migration.md).
 
 `RuntimeOwner` intentionally separates two phases:
 
@@ -199,7 +212,7 @@ New RocketMQ code should follow these rules:
 
 - do not create ad hoc Tokio runtimes inside business crates;
 - do not call raw `tokio::spawn` for long-running service work;
-- derive a `ServiceContext` and spawn through its `TaskGroup`;
+- derive a `ChildServiceContext` and spawn through its `TaskGroup`;
 - wrap periodic loops in `ScheduledTaskGroup`;
 - route file IO, RocksDB calls, DNS resolution, and other short blocking work
   through `BlockingExecutor`;

--- a/rocketmq-runtime/tests/runtime_migration_fixture.rs
+++ b/rocketmq-runtime/tests/runtime_migration_fixture.rs
@@ -1,0 +1,69 @@
+// Copyright 2023 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use rocketmq_runtime::ChildServiceContext;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use rocketmq_runtime::ScheduleMode;
+use rocketmq_runtime::ScheduledTaskConfig;
+use rocketmq_runtime::ShutdownReport;
+use tokio::sync::Notify;
+
+fn migrated_initial_delay(initial_delay: Option<Duration>) -> Duration {
+    initial_delay.unwrap_or(Duration::ZERO)
+}
+
+#[test]
+fn migration_fixture_owns_scheduled_child_work_and_reports_shutdown() {
+    let owner = RuntimeOwner::new(RuntimeConfig::for_parallelism("runtime-migration-fixture", 1))
+        .expect("runtime owner should start");
+    let service: ChildServiceContext = owner.root_context().component("migration-fixture");
+    let scheduled = service.scheduled_tasks("migration-fixture-schedules");
+    let runs = Arc::new(AtomicUsize::new(0));
+    let completed = Arc::new(Notify::new());
+    let mut config = ScheduledTaskConfig::fixed_rate_no_overlap("migration-fixture.refresh", Duration::from_secs(60));
+    config.initial_delay = migrated_initial_delay(Some(Duration::ZERO));
+    assert_eq!(config.initial_delay, Duration::ZERO);
+
+    scheduled
+        .schedule_fixed_rate_no_overlap(config, {
+            let runs = Arc::clone(&runs);
+            let completed = Arc::clone(&completed);
+            move || {
+                let runs = Arc::clone(&runs);
+                let completed = Arc::clone(&completed);
+                async move {
+                    runs.fetch_add(1, Ordering::SeqCst);
+                    completed.notify_one();
+                }
+            }
+        })
+        .expect("scheduled task should register");
+
+    let report: ShutdownReport = owner.block_on(async {
+        completed.notified().await;
+        owner.shutdown_tasks().await
+    });
+
+    assert_eq!(runs.load(Ordering::SeqCst), 1);
+    let snapshot = scheduled.snapshot();
+    assert_eq!(snapshot.len(), 1);
+    assert_eq!(snapshot[0].mode, ScheduleMode::FixedRateNoOverlap);
+    assert!(report.is_healthy(), "{}", report.to_json());
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9724

### Brief Description

- Documents the method-by-method migration from deprecated 1.x `RocketMQRuntime` APIs to `RuntimeOwner`, `ChildServiceContext`, `ScheduledTaskGroup`, and typed shutdown reporting.
- Keeps the 2.0 removal as a future intent subject to the release-cycle, breaking-window, and per-item approval gates; this PR does not change or remove the public compatibility API.
- Aligns the English and Chinese runtime guides, records the migration notice in the Unreleased changelog, and adds an executable lifecycle migration fixture.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-runtime -- --check` - passed.
- `cargo test --locked -p rocketmq-runtime --test runtime_migration_fixture` - passed.
- `cargo test --locked -p rocketmq-runtime --all-features` - passed.
- `cargo doc --locked -p rocketmq-runtime --no-deps` - passed.
- `cargo clippy --locked --workspace --no-deps --all-targets --all-features -- -D warnings` - passed.
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` - passed.
- `git diff --check` - passed.
- `python scripts/architecture_documentation_guard.py --check` - reports 55 pre-existing test-inventory findings; the guard, inventory, and reported test files are unchanged by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added migration guidance for the runtime ownership model, including `RuntimeOwner`, root contexts, child contexts, and migration-only runtime contexts.
  - Documented scheduling and shutdown migration paths with practical examples.
  - Clarified that `RocketMQRuntime` remains available but deprecated throughout the 1.x compatibility line, with removal deferred to a future 2.0 boundary.
  - Updated English and Chinese runtime documentation, diagrams, examples, and compatibility guidance.

- **Tests**
  - Added coverage validating scheduled task ownership, execution, and healthy shutdown reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->