### PR TITLE
[ISSUE #9733]✨Track compatibility re-exports in the API freeze

### DIFF
--- a/scripts/public-api-reexport-surfaces.json
+++ b/scripts/public-api-reexport-surfaces.json
@@ -1,0 +1,43 @@
+{
+  "profiles": {
+    "rocketmq-auth:default": {
+      "item_paths": [
+        "rocketmq_auth::MaintenanceAuthorizationContext",
+        "rocketmq_auth::MaintenanceAuthorizationError",
+        "rocketmq_auth::MaintenanceAuthorizationGrant",
+        "rocketmq_auth::MaintenanceAuthorizer",
+        "rocketmq_auth::MaintenanceCapability",
+        "rocketmq_auth::MaintenancePolicy",
+        "rocketmq_auth::MaintenancePrincipalBinding",
+        "rocketmq_auth::MaintenanceRequestClass",
+        "rocketmq_auth::MaintenanceResourceBudget",
+        "rocketmq_auth::MaintenanceRole",
+        "rocketmq_auth::MaintenanceRoleGrant",
+        "rocketmq_auth::MAINTENANCE_POLICY_SCHEMA_VERSION",
+        "rocketmq_auth::SecurityPrincipal",
+        "rocketmq_auth::SecurityResource"
+      ],
+      "package": "rocketmq-auth"
+    },
+    "rocketmq-filter:default": {
+      "item_paths": [
+        "rocketmq_filter::filter::FilterFactory",
+        "rocketmq_filter::filter::Filter",
+        "rocketmq_filter::filter::FilterError",
+        "rocketmq_filter::filter::FilterSpi",
+        "rocketmq_filter::filter::SqlFilter",
+        "rocketmq_filter::filter::FilterCompileError",
+        "rocketmq_filter::filter::FilterCompileErrorKind",
+        "rocketmq_filter::filter::FilterCompileSource",
+        "rocketmq_filter::filter::FilterCompileStage",
+        "rocketmq_filter::filter::Filter::compile",
+        "rocketmq_filter::filter::Filter::try_compile",
+        "rocketmq_filter::filter::Filter::of_type",
+        "rocketmq_filter::filter::FilterError::new",
+        "rocketmq_filter::filter::FilterError::message"
+      ],
+      "package": "rocketmq-filter"
+    }
+  },
+  "schema_version": 1
+}

--- a/scripts/public_api_snapshot.py
+++ b/scripts/public_api_snapshot.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
 import json
 import re
 import shutil
@@ -33,8 +34,10 @@ import m09_compatibility_matrix
 ROOT = Path(__file__).resolve().parents[1]
 PUBLIC_API_INTENT = ROOT / "scripts" / "public-api-intent.json"
 DEFAULT_FREEZE_POLICY = ROOT / "scripts" / "public-api-freeze-policy.json"
+DEFAULT_REEXPORT_SURFACE_INVENTORY = ROOT / "scripts" / "public-api-reexport-surfaces.json"
 SCHEMA_VERSION = 3
 IDENTITY = "structural"
+REEXPORT_SURFACE_INVENTORY_SCHEMA_VERSION = 1
 LIB_KINDS = {"lib", "rlib", "proc-macro"}
 RUSTDOC_TOOLCHAIN = "nightly-2026-07-05"
 STRUCTURAL_ITEM_FIELDS = (
@@ -385,7 +388,483 @@ def _record(
     }
 
 
-def semantic_public_items(package: str, document: dict[str, Any]) -> list[dict[str, str]]:
+def _normalized_reexport_selection(selected_reexport_paths: Iterable[str]) -> set[str]:
+    selected = list(selected_reexport_paths)
+    if any(not isinstance(item_path, str) or not item_path for item_path in selected):
+        raise SnapshotError("selected re-export paths must be non-empty strings")
+    if any("*" in item_path for item_path in selected):
+        raise SnapshotError("selected re-export paths must be exact paths, not wildcards")
+    if len(selected) != len(set(selected)):
+        raise SnapshotError("selected re-export paths must not contain duplicates")
+    return set(selected)
+
+
+def _public_reexport_record(
+    package: str,
+    item_path: str,
+    use_item: dict[str, Any],
+    *,
+    alias_kind: str,
+    target_path: str,
+    target_kind: str,
+    target_signature: Any,
+) -> dict[str, str]:
+    return {
+        "package": package,
+        "module": item_path.rsplit("::", 1)[0] if "::" in item_path else "",
+        "item_path": item_path,
+        "kind": "reexport",
+        "visibility": "public",
+        "signature": json.dumps(
+            {
+                "alias_kind": alias_kind,
+                "target_kind": target_kind,
+                "target_path": target_path,
+                "target_signature": target_signature,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+        "feature": _item_feature(use_item),
+    }
+
+
+def _rustdoc_paths(document: dict[str, Any]) -> dict[str, tuple[str, str]]:
+    paths = document.get("paths", {})
+    if not isinstance(paths, dict):
+        return {}
+    result: dict[str, tuple[str, str]] = {}
+    for item_id, path_record in paths.items():
+        if not isinstance(path_record, dict):
+            continue
+        path = path_record.get("path")
+        kind = path_record.get("kind")
+        if (
+            not isinstance(path, list)
+            or not path
+            or any(not isinstance(part, str) or not part for part in path)
+            or not isinstance(kind, str)
+            or not kind
+        ):
+            continue
+        result[str(item_id)] = ("::".join(path), kind)
+    return result
+
+
+@dataclass(frozen=True)
+class _ReexportTarget:
+    """The canonical rustdoc target behind a public export binding."""
+
+    path: str
+    kind: str
+    item_id: str
+    item: dict[str, Any] | None
+
+    def identity(self) -> tuple[str, str, str]:
+        return self.path, self.kind, self.item_id
+
+
+@dataclass(frozen=True)
+class _ReexportBinding:
+    """A named public binding within a semantic rustdoc module."""
+
+    target: _ReexportTarget
+    alias_kind: str
+    source_item: dict[str, Any]
+    origin: str
+
+
+def _collect_selected_reexports(
+    package: str,
+    document: dict[str, Any],
+    records: dict[str, dict[str, str]],
+    selected_reexport_paths: set[str],
+) -> None:
+    """Collect selected public re-export aliases from rustdoc's semantic module graph."""
+
+    index = document.get("index", {})
+    if not isinstance(index, dict):
+        raise SnapshotError(f"rustdoc index for {package} must be an object")
+    paths = _rustdoc_paths(document)
+    root_id = str(document.get("root", ""))
+    root = _item_by_id(index, root_id)
+    root_path = paths.get(root_id, ("", ""))[0]
+    if root is None or not root_path:
+        raise SnapshotError(f"rustdoc root for selected re-exports is missing for {package}")
+    root_kind, root_value = _item_kind_and_value(root)
+    if root_kind != "module" or not isinstance(root_value, dict):
+        raise SnapshotError(f"rustdoc root for selected re-exports is not a module for {package}")
+
+    def resolve_target(item_id: Any) -> _ReexportTarget | None:
+        current_id = str(item_id)
+        visited: set[str] = set()
+        while current_id not in visited:
+            visited.add(current_id)
+            target_item = _item_by_id(index, current_id)
+            target_path = paths.get(current_id)
+            if target_item is not None:
+                target_kind, target_value = _item_kind_and_value(target_item)
+                if target_kind == "use" and isinstance(target_value, dict):
+                    nested_id = target_value.get("id")
+                    if nested_id is None:
+                        return None
+                    current_id = str(nested_id)
+                    continue
+                if target_path is not None:
+                    return _ReexportTarget(
+                        path=target_path[0],
+                        kind=target_path[1],
+                        item_id=current_id,
+                        item=target_item,
+                    )
+                return None
+            if target_path is not None:
+                return _ReexportTarget(
+                    path=target_path[0],
+                    kind=target_path[1],
+                    item_id=current_id,
+                    item=None,
+                )
+            return None
+        return None
+
+    def binding_sort_key(binding: _ReexportBinding) -> tuple[str, str, str, str]:
+        return (
+            binding.target.path,
+            binding.target.kind,
+            binding.alias_kind,
+            _item_feature(binding.source_item),
+        )
+
+    def add_explicit_binding(
+        bindings: dict[str, _ReexportBinding],
+        name: str,
+        binding: _ReexportBinding,
+        module_path: str,
+    ) -> None:
+        previous = bindings.get(name)
+        if previous is None:
+            bindings[name] = binding
+            return
+        if previous.target.identity() != binding.target.identity():
+            raise SnapshotError(f"conflicting explicit public bindings for {module_path}::{name}")
+        if binding_sort_key(binding) < binding_sort_key(previous):
+            bindings[name] = binding
+
+    def public_bindings(
+        module_id: Any,
+        module_stack: set[str],
+    ) -> dict[str, _ReexportBinding]:
+        module_key = str(module_id)
+        if module_key in module_stack:
+            return {}
+        module = _item_by_id(index, module_key)
+        if module is None:
+            return {}
+        module_kind, module_value = _item_kind_and_value(module)
+        if module_kind != "module" or not isinstance(module_value, dict):
+            return {}
+        module_path = paths.get(module_key, (f"<module:{module_key}>", "module"))[0]
+        next_stack = {*module_stack, module_key}
+        explicit: dict[str, _ReexportBinding] = {}
+        glob_sources: list[tuple[_ReexportTarget, dict[str, Any]]] = []
+        for child_id in _reference_list(module_value.get("items")):
+            child = _item_by_id(index, child_id)
+            if child is None or child.get("visibility") != "public":
+                continue
+            child_kind, child_value = _item_kind_and_value(child)
+            if child_kind == "use" and isinstance(child_value, dict):
+                target_id = child_value.get("id")
+                if target_id is None:
+                    continue
+                if child_value.get("is_glob"):
+                    target = resolve_target(target_id)
+                    if target is not None and target.kind == "module":
+                        glob_sources.append((target, child))
+                    continue
+                name = child_value.get("name")
+                target = resolve_target(target_id)
+                if isinstance(name, str) and name and target is not None:
+                    canonical_name = target.path.rsplit("::", 1)[-1]
+                    add_explicit_binding(
+                        explicit,
+                        name,
+                        _ReexportBinding(
+                            target=target,
+                            alias_kind="plain" if name == canonical_name else "renamed",
+                            source_item=child,
+                            origin="named",
+                        ),
+                        module_path,
+                    )
+                continue
+            name = child.get("name")
+            target = resolve_target(child_id)
+            if isinstance(name, str) and name and target is not None:
+                add_explicit_binding(
+                    explicit,
+                    name,
+                    _ReexportBinding(
+                        target=target,
+                        alias_kind="direct",
+                        source_item=child,
+                        origin="direct",
+                    ),
+                    module_path,
+                )
+
+        globbed: dict[str, list[_ReexportBinding]] = {}
+        for target, source_item in glob_sources:
+            for name, binding in public_bindings(target.item_id, next_stack).items():
+                if name in explicit:
+                    continue
+                globbed.setdefault(name, []).append(
+                    _ReexportBinding(
+                        target=binding.target,
+                        alias_kind="glob",
+                        source_item=source_item,
+                        origin="glob",
+                    )
+                )
+        resolved = dict(explicit)
+        for name, bindings in globbed.items():
+            identities = {binding.target.identity() for binding in bindings}
+            if len(identities) != 1:
+                raise SnapshotError(f"ambiguous public glob bindings for {module_path}::{name}")
+            resolved[name] = min(bindings, key=binding_sort_key)
+        return {name: resolved[name] for name in sorted(resolved)}
+
+    def targets_at_path(canonical_path: str) -> list[_ReexportTarget]:
+        targets = [
+            _ReexportTarget(
+                path=path,
+                kind=kind,
+                item_id=item_id,
+                item=_item_by_id(index, item_id),
+            )
+            for item_id, (path, kind) in paths.items()
+            if path == canonical_path
+        ]
+        return sorted(targets, key=lambda target: (target.kind, target.item_id))
+
+    def unique_target_at_path(
+        canonical_path: str,
+        *,
+        context: str,
+    ) -> _ReexportTarget | None:
+        targets = targets_at_path(canonical_path)
+        if len(targets) > 1:
+            raise SnapshotError(f"ambiguous rustdoc targets for {context}: {canonical_path}")
+        return targets[0] if targets else None
+
+    def public_external_glob_sources(module_id: Any) -> list[tuple[_ReexportTarget, dict[str, Any]]]:
+        module = _item_by_id(index, str(module_id))
+        if module is None:
+            return []
+        module_kind, module_value = _item_kind_and_value(module)
+        if module_kind != "module" or not isinstance(module_value, dict):
+            return []
+        result: list[tuple[_ReexportTarget, dict[str, Any]]] = []
+        for child_id in _reference_list(module_value.get("items")):
+            child = _item_by_id(index, child_id)
+            if child is None or child.get("visibility") != "public":
+                continue
+            child_kind, child_value = _item_kind_and_value(child)
+            if child_kind != "use" or not isinstance(child_value, dict) or not child_value.get("is_glob"):
+                continue
+            target_id = child_value.get("id")
+            if target_id is None:
+                continue
+            target = resolve_target(target_id)
+            if target is not None and target.kind == "module" and target.item is None:
+                result.append((target, child))
+        return result
+
+    matched: set[str] = set()
+
+    def add_associated(
+        target: _ReexportTarget,
+        alias_path: str,
+        alias_kind: str,
+        source_item: dict[str, Any],
+    ) -> None:
+        if target.item is None:
+            return
+        _, target_value = _item_kind_and_value(target.item)
+        direct_ids = _direct_associated_ids(target.kind, target_value)
+        inherent_ids = _inherent_associated_ids(target.kind, target_value, index)
+        for position, child_id in enumerate((*direct_ids, *inherent_ids)):
+            child = _item_by_id(index, child_id)
+            if child is None:
+                continue
+            relationship_kind = target.kind if position < len(direct_ids) else "impl"
+            if not _is_public_associated(relationship_kind, child):
+                continue
+            child_name = child.get("name")
+            if not isinstance(child_name, str) or not child_name:
+                continue
+            child_alias_path = f"{alias_path}::{child_name}"
+            if child_alias_path not in selected_reexport_paths:
+                continue
+            child_kind, _ = _item_kind_and_value(child)
+            child_target_path = paths.get(str(child_id), (f"{target.path}::{child_name}", child_kind))[0]
+            matched.add(child_alias_path)
+            records.setdefault(
+                child_alias_path,
+                _public_reexport_record(
+                    package,
+                    child_alias_path,
+                    source_item,
+                    alias_kind=f"{alias_kind}-associated",
+                    target_path=child_target_path,
+                    target_kind=child_kind,
+                    target_signature=_semantic_value(_item_kind_and_value(child)[1], index),
+                ),
+            )
+
+    def add_target(
+        alias_path: str,
+        alias_kind: str,
+        source_item: dict[str, Any],
+        target: _ReexportTarget,
+    ) -> None:
+        if alias_path in selected_reexport_paths:
+            target_signature = None
+            if target.item is not None:
+                target_signature = _semantic_value(_item_kind_and_value(target.item)[1], index)
+            matched.add(alias_path)
+            records.setdefault(
+                alias_path,
+                _public_reexport_record(
+                    package,
+                    alias_path,
+                    source_item,
+                    alias_kind=alias_kind,
+                    target_path=target.path,
+                    target_kind=target.kind,
+                    target_signature=target_signature,
+                ),
+            )
+        add_associated(target, alias_path, alias_kind, source_item)
+
+    def add_external_module_descendants(
+        target: _ReexportTarget,
+        alias_path: str,
+        alias_kind: str,
+        source_item: dict[str, Any],
+    ) -> None:
+        """Map exact selected descendants of an external module through its public alias."""
+
+        prefix = f"{alias_path}::"
+        for selected_path in sorted(path for path in selected_reexport_paths if path.startswith(prefix)):
+            suffix = selected_path.removeprefix(prefix)
+            descendant = unique_target_at_path(
+                f"{target.path}::{suffix}",
+                context=selected_path,
+            )
+            if descendant is not None:
+                add_target(
+                    selected_path,
+                    f"{alias_kind}-external-descendant",
+                    source_item,
+                    descendant,
+                )
+
+    def add_external_glob_descendants(
+        module_id: Any,
+        public_path: str,
+        bindings: dict[str, _ReexportBinding],
+    ) -> None:
+        """Resolve selected descendants of external glob modules from rustdoc path entries only."""
+
+        sources = public_external_glob_sources(module_id)
+        if not sources:
+            return
+        module_path = paths.get(str(module_id), (f"<module:{module_id}>", "module"))[0]
+        prefix = f"{public_path}::"
+        selected_by_name: dict[str, list[tuple[str, str]]] = {}
+        for selected_path in selected_reexport_paths:
+            if not selected_path.startswith(prefix):
+                continue
+            suffix = selected_path.removeprefix(prefix)
+            name, _, _ = suffix.partition("::")
+            if name and name not in bindings:
+                selected_by_name.setdefault(name, []).append((selected_path, suffix))
+        for name, selected_paths in sorted(selected_by_name.items()):
+            candidates: list[tuple[_ReexportTarget, _ReexportTarget, dict[str, Any]]] = []
+            for source_target, source_item in sources:
+                target = unique_target_at_path(
+                    f"{source_target.path}::{name}",
+                    context=f"{module_path}::{name}",
+                )
+                if target is not None:
+                    candidates.append((target, source_target, source_item))
+            identities = {target.identity() for target, _, _ in candidates}
+            if len(identities) > 1:
+                raise SnapshotError(f"ambiguous public glob bindings for {module_path}::{name}")
+            if not candidates:
+                continue
+            _, source_target, source_item = min(candidates, key=lambda entry: entry[1].item_id)
+            for selected_path, suffix in sorted(selected_paths):
+                descendant = unique_target_at_path(
+                    f"{source_target.path}::{suffix}",
+                    context=selected_path,
+                )
+                if descendant is None:
+                    continue
+                add_target(
+                    selected_path,
+                    "glob-external-descendant",
+                    source_item,
+                    descendant,
+                )
+
+    def walk_public_alias(
+        module_id: Any,
+        public_path: str,
+        module_stack: set[str],
+        through_module_alias: bool,
+    ) -> None:
+        module_key = str(module_id)
+        if module_key in module_stack:
+            return
+        bindings = public_bindings(module_key, module_stack)
+        for name, binding in bindings.items():
+            alias_path = f"{public_path}::{name}"
+            alias_kind = binding.alias_kind
+            if binding.origin == "direct" and through_module_alias:
+                alias_kind = "module-descendant"
+            add_target(alias_path, alias_kind, binding.source_item, binding.target)
+            if binding.target.kind == "module" and binding.target.item is not None:
+                walk_public_alias(
+                    binding.target.item_id,
+                    alias_path,
+                    {*module_stack, module_key},
+                    through_module_alias or binding.origin != "direct",
+                )
+            elif binding.target.kind == "module":
+                add_external_module_descendants(
+                    binding.target,
+                    alias_path,
+                    alias_kind,
+                    binding.source_item,
+                )
+        add_external_glob_descendants(module_key, public_path, bindings)
+
+    walk_public_alias(root_id, root_path, set(), False)
+    missing = sorted(selected_reexport_paths - matched)
+    if missing:
+        raise SnapshotError(
+            f"selected public re-export paths were not found for {package}: {', '.join(missing)}"
+        )
+
+
+def semantic_public_items(
+    package: str,
+    document: dict[str, Any],
+    *,
+    selected_reexport_paths: Iterable[str] = (),
+) -> list[dict[str, str]]:
     """Build stable, readable API records from rustdoc's public API graph."""
 
     index = document.get("index", {})
@@ -474,6 +953,9 @@ def semantic_public_items(package: str, document: dict[str, Any]) -> list[dict[s
 
         if root_kind == "module" and root_path is not None:
             add_public_proc_macros(root_id, root_path, root_value)
+    selected = _normalized_reexport_selection(selected_reexport_paths)
+    if selected:
+        _collect_selected_reexports(package, document, records, selected)
     return sorted(
         records.values(),
         key=lambda item: tuple(item[field] for field in STRUCTURAL_ITEM_FIELDS),
@@ -506,7 +988,12 @@ def _rustdoc_command(profile: dict[str, Any]) -> list[str]:
     return command
 
 
-def snapshot_profile(profile: dict[str, Any], *, refresh: bool = True) -> dict[str, Any]:
+def snapshot_profile(
+    profile: dict[str, Any],
+    *,
+    refresh: bool = True,
+    selected_reexport_paths: Iterable[str] = (),
+) -> dict[str, Any]:
     cache_path = _profile_cache_path(profile["id"])
     if refresh:
         run(_rustdoc_command(profile))
@@ -524,7 +1011,11 @@ def snapshot_profile(profile: dict[str, Any], *, refresh: bool = True) -> dict[s
     result.update(
         {
             "crate_version": document.get("crate_version"),
-            "public_api": semantic_public_items(profile["package"], document),
+            "public_api": semantic_public_items(
+                profile["package"],
+                document,
+                selected_reexport_paths=selected_reexport_paths,
+            ),
         }
     )
     return result
@@ -573,11 +1064,63 @@ def load_freeze_policy(path: Path = DEFAULT_FREEZE_POLICY) -> dict[str, Any]:
     return policy
 
 
+def load_reexport_surface_inventory(
+    profiles: Iterable[dict[str, Any]],
+    path: Path = DEFAULT_REEXPORT_SURFACE_INVENTORY,
+) -> dict[str, tuple[str, ...]]:
+    """Load exact re-export paths selected for compatibility-surface tracking."""
+
+    try:
+        inventory = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise SnapshotError(f"cannot read public API re-export inventory {path}: {error}") from error
+    if not isinstance(inventory, dict) or set(inventory) != {"schema_version", "profiles"}:
+        raise SnapshotError("public API re-export inventory must contain only schema_version and profiles")
+    if inventory.get("schema_version") != REEXPORT_SURFACE_INVENTORY_SCHEMA_VERSION:
+        raise SnapshotError(
+            "public API re-export inventory schema_version must be "
+            f"{REEXPORT_SURFACE_INVENTORY_SCHEMA_VERSION}"
+        )
+    selections = inventory.get("profiles")
+    if not isinstance(selections, dict):
+        raise SnapshotError("public API re-export inventory profiles must be an object")
+    known_profiles = {profile.get("id"): profile for profile in profiles}
+    result: dict[str, tuple[str, ...]] = {}
+    for profile_id, selection in selections.items():
+        if not isinstance(profile_id, str) or profile_id not in known_profiles:
+            raise SnapshotError(f"public API re-export inventory has unknown profile: {profile_id!r}")
+        if not isinstance(selection, dict) or set(selection) != {"package", "item_paths"}:
+            raise SnapshotError(
+                f"public API re-export inventory selection {profile_id} must contain only package and item_paths"
+            )
+        profile = known_profiles[profile_id]
+        if selection.get("package") != profile.get("package"):
+            raise SnapshotError(
+                f"public API re-export inventory selection {profile_id} has the wrong package"
+            )
+        item_paths = selection.get("item_paths")
+        if not isinstance(item_paths, list) or not item_paths:
+            raise SnapshotError(
+                f"public API re-export inventory selection {profile_id} must have non-empty item_paths"
+            )
+        normalized = _normalized_reexport_selection(item_paths)
+        target = profile.get("target")
+        if not isinstance(target, str) or any(
+            not item_path.startswith(f"{target}::") for item_path in normalized
+        ):
+            raise SnapshotError(
+                f"public API re-export inventory selection {profile_id} has an item path outside its target"
+            )
+        result[profile_id] = tuple(sorted(normalized))
+    return result
+
+
 def generate_snapshot(
     *,
     refresh: bool = True,
     scope: str = "core-release",
     freeze_policy_path: Path = DEFAULT_FREEZE_POLICY,
+    reexport_surface_inventory_path: Path = DEFAULT_REEXPORT_SURFACE_INVENTORY,
 ) -> dict[str, Any]:
     metadata = workspace_metadata()
     targets = workspace_library_targets(scope=scope, metadata=metadata)
@@ -588,13 +1131,21 @@ def generate_snapshot(
     )
     if not refresh:
         validate_existing_artifacts(profiles)
+    reexport_selections = load_reexport_surface_inventory(
+        profiles,
+        reexport_surface_inventory_path,
+    )
     profile_snapshots: dict[str, dict[str, Any]] = {}
     for index, profile in enumerate(profiles, start=1):
         print(
             f"PUBLIC_API_SNAPSHOT_PROFILE {index}/{len(profiles)} {profile['id']}",
             flush=True,
         )
-        profile_snapshots[profile["id"]] = snapshot_profile(profile, refresh=refresh)
+        profile_snapshots[profile["id"]] = snapshot_profile(
+            profile,
+            refresh=refresh,
+            selected_reexport_paths=reexport_selections.get(profile["id"], ()),
+        )
 
     packages: dict[str, dict[str, Any]] = {}
     for package, target in targets:
@@ -754,7 +1305,35 @@ def _validate_frozen_contracts(baseline: dict[str, Any]) -> None:
             )
 
 
-def validate_baseline_contract(baseline: dict[str, Any]) -> None:
+def _validate_reexport_surface_inventory_coverage(
+    baseline: dict[str, Any],
+    reexport_surface_inventory_path: Path,
+) -> None:
+    profiles = baseline["profiles"]
+    profile_specs = [
+        {
+            "id": profile_id,
+            "package": profile.get("package"),
+            "target": profile.get("target"),
+        }
+        for profile_id, profile in profiles.items()
+        if isinstance(profile, dict)
+    ]
+    selections = load_reexport_surface_inventory(profile_specs, reexport_surface_inventory_path)
+    for profile_id, item_paths in selections.items():
+        available = {item["item_path"] for item in profiles[profile_id]["public_api"]}
+        missing = sorted(set(item_paths) - available)
+        if missing:
+            raise SnapshotError(
+                f"public API re-export inventory paths are absent from {profile_id}: {', '.join(missing)}"
+            )
+
+
+def validate_baseline_contract(
+    baseline: dict[str, Any],
+    *,
+    reexport_surface_inventory_path: Path | None = None,
+) -> None:
     if baseline.get("schema_version") != SCHEMA_VERSION:
         raise SnapshotError(f"baseline schema_version must be {SCHEMA_VERSION}")
     if baseline.get("identity") != IDENTITY:
@@ -771,6 +1350,8 @@ def validate_baseline_contract(baseline: dict[str, Any]) -> None:
     _validate_profiles(baseline)
     _validate_decisions(baseline.get("compatibility_decisions"))
     _validate_frozen_contracts(baseline)
+    if reexport_surface_inventory_path is not None:
+        _validate_reexport_surface_inventory_coverage(baseline, reexport_surface_inventory_path)
 
 
 def _approval_for(
@@ -1014,6 +1595,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--identity", choices=(IDENTITY,), default=IDENTITY)
     parser.add_argument("--freeze-policy", type=Path, default=DEFAULT_FREEZE_POLICY)
     parser.add_argument(
+        "--reexport-surface-inventory",
+        type=Path,
+        default=DEFAULT_REEXPORT_SURFACE_INVENTORY,
+    )
+    parser.add_argument(
         "--from-existing",
         action="store_true",
         help="assemble from per-profile rustdoc JSON cached after the current HEAD",
@@ -1024,16 +1610,24 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     try:
+        reexport_surface_inventory_path = args.reexport_surface_inventory.resolve()
         baseline: dict[str, Any] | None = None
         if args.check:
             baseline = json.loads(args.check.read_text(encoding="utf-8"))
-            validate_baseline_contract(baseline)
+            validate_baseline_contract(
+                baseline,
+                reexport_surface_inventory_path=reexport_surface_inventory_path,
+            )
         candidate = generate_snapshot(
             refresh=not args.from_existing,
             scope=args.scope,
             freeze_policy_path=args.freeze_policy.resolve(),
+            reexport_surface_inventory_path=reexport_surface_inventory_path,
         )
-        validate_baseline_contract(candidate)
+        validate_baseline_contract(
+            candidate,
+            reexport_surface_inventory_path=reexport_surface_inventory_path,
+        )
         if args.write_baseline:
             write_json(args.write_baseline, candidate)
             print(

--- a/scripts/stable_surface_guard.py
+++ b/scripts/stable_surface_guard.py
@@ -33,6 +33,7 @@ import public_api_snapshot
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_POLICY = ROOT / "scripts" / "stable-surface-policy.json"
 DEFAULT_API_BASELINE = ROOT / "scripts" / "public-api-snapshot-baseline.json"
+DEFAULT_API_REEXPORT_INVENTORY = public_api_snapshot.DEFAULT_REEXPORT_SURFACE_INVENTORY
 FEATURE_ATTRIBUTE_RE = re.compile(r"#!\s*\[\s*feature\s*\((?P<body>.*?)\)\s*\]", re.DOTALL)
 FEATURE_START_RE = re.compile(r"#!\s*\[\s*feature\b")
 FEATURE_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
@@ -135,6 +136,27 @@ def scan_features(root: Path, *, scope: str = "all") -> set[NightlyFeature]:
     return findings
 
 
+def resolve_api_contract_inputs(
+    api_baseline: Path | None,
+    api_reexport_inventory: Path | None,
+    *,
+    mode: str,
+    scope: str,
+) -> tuple[Path | None, Path | None]:
+    """Resolve API freeze inputs without allowing the production contract to bypass its inventory."""
+
+    if api_baseline is None and api_reexport_inventory is not None:
+        raise InputError("--api-reexport-inventory requires --api-baseline")
+    baseline = api_baseline.resolve() if api_baseline is not None else None
+    inventory = api_reexport_inventory.resolve() if api_reexport_inventory is not None else None
+    default_baseline = DEFAULT_API_BASELINE.resolve()
+    if baseline is None and mode == "target" and scope == "core-release":
+        baseline = default_baseline
+    if baseline == default_baseline and inventory is None:
+        inventory = DEFAULT_API_REEXPORT_INVENTORY.resolve()
+    return baseline, inventory
+
+
 def validate(
     root: Path,
     policy_path: Path,
@@ -142,9 +164,12 @@ def validate(
     *,
     scope: str = "all",
     api_baseline: Path | None = None,
+    api_reexport_inventory: Path | None = None,
 ) -> str:
     if not root.is_dir():
         raise InputError(f"root does not exist: {root}")
+    if api_baseline is None and api_reexport_inventory is not None:
+        raise InputError("api_reexport_inventory requires api_baseline")
     policy = load_policy(policy_path)
     allowed = policy_features(policy)
     if scope != "all":
@@ -171,7 +196,10 @@ def validate(
     if api_baseline is not None:
         try:
             baseline = json.loads(api_baseline.read_text(encoding="utf-8"))
-            public_api_snapshot.validate_baseline_contract(baseline)
+            public_api_snapshot.validate_baseline_contract(
+                baseline,
+                reexport_surface_inventory_path=api_reexport_inventory,
+            )
         except (OSError, json.JSONDecodeError, public_api_snapshot.SnapshotError) as error:
             raise InputError(f"invalid public API freeze: {error}") from error
         api_status = "verified"
@@ -186,6 +214,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--root", type=Path, default=ROOT)
     parser.add_argument("--policy", type=Path, default=DEFAULT_POLICY)
     parser.add_argument("--api-baseline", type=Path)
+    parser.add_argument("--api-reexport-inventory", type=Path)
     parser.add_argument("--mode", choices=("baseline", "target"), default="baseline")
     parser.add_argument(
         "--scope",
@@ -197,16 +226,20 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    api_baseline = args.api_baseline
-    if api_baseline is None and args.mode == "target" and args.scope == "core-release":
-        api_baseline = DEFAULT_API_BASELINE
     try:
+        api_baseline, api_reexport_inventory = resolve_api_contract_inputs(
+            args.api_baseline,
+            args.api_reexport_inventory,
+            mode=args.mode,
+            scope=args.scope,
+        )
         message = validate(
             args.root.resolve(),
             args.policy.resolve(),
             args.mode,
             scope=args.scope,
-            api_baseline=api_baseline.resolve() if api_baseline is not None else None,
+            api_baseline=api_baseline,
+            api_reexport_inventory=api_reexport_inventory,
         )
     except InputError as error:
         print(f"STABLE_SURFACE_GUARD_ERROR: {error}", file=sys.stderr)

--- a/scripts/tests/test_public_api_snapshot.py
+++ b/scripts/tests/test_public_api_snapshot.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 import copy
 import json
+from pathlib import Path
+import tempfile
 from types import SimpleNamespace
 import unittest
 
@@ -195,6 +197,389 @@ def rustdoc_proc_macro_fixture(*, include_v3_path: bool = False) -> dict[str, ob
             "kind": "proc_macro",
         }
     return {"crate_version": "1.0.0", "root": root_id, "paths": paths, "index": index}
+
+
+def rustdoc_reexport_fixture() -> dict[str, object]:
+    def item(name: str | None, visibility: str, kind: str, value: object) -> dict[str, object]:
+        return {
+            "id": name,
+            "crate_id": 0,
+            "name": name,
+            "visibility": visibility,
+            "attrs": [],
+            "inner": {kind: value},
+        }
+
+    index: dict[str, object] = {
+        "root": item(
+            "demo",
+            "public",
+            "module",
+            {
+                "is_crate": True,
+                "is_stripped": False,
+                "items": ["api", "private", "alias-a-use", "alias-b-use", "root-api-glob"],
+            },
+        ),
+        "api": item(
+            "api",
+            "public",
+            "module",
+            {
+                "is_crate": False,
+                "is_stripped": False,
+                "items": [
+                    "plain-use",
+                    "renamed-use",
+                    "external-use",
+                    "glob-use",
+                    "trait-use",
+                    "error-use",
+                    "existing-use",
+                    "private-use",
+                    "child",
+                ],
+            },
+        ),
+        "child": item(
+            "Child",
+            "public",
+            "module",
+            {"is_crate": False, "is_stripped": False, "items": ["child-thing"]},
+        ),
+        "child-thing": item(
+            "ChildThing",
+            "public",
+            "struct",
+            {"kind": "unit", "generics": {"params": [], "where_predicates": []}, "impls": []},
+        ),
+        "private": item(
+            "private",
+            "default",
+            "module",
+            {"is_crate": False, "is_stripped": False, "items": ["hidden-use"]},
+        ),
+        "source": item(
+            "source",
+            "public",
+            "module",
+            {
+                "is_crate": False,
+                "is_stripped": False,
+                "items": ["glob-thing", "nested-glob", "cycle-glob"],
+            },
+        ),
+        "nested": item(
+            "nested",
+            "public",
+            "module",
+            {"is_crate": False, "is_stripped": False, "items": ["nested-thing"]},
+        ),
+        "cycle-a": item(
+            "cycle_a",
+            "public",
+            "module",
+            {"is_crate": False, "is_stripped": False, "items": ["cycle-a-glob"]},
+        ),
+        "cycle-b": item(
+            "cycle_b",
+            "public",
+            "module",
+            {"is_crate": False, "is_stripped": False, "items": ["cycle-b-glob", "cycle-thing"]},
+        ),
+        "thing": item(
+            "Thing",
+            "public",
+            "struct",
+            {"kind": "unit", "generics": {"params": [], "where_predicates": []}, "impls": []},
+        ),
+        "glob-thing": item(
+            "GlobThing",
+            "public",
+            "struct",
+            {"kind": "unit", "generics": {"params": [], "where_predicates": []}, "impls": []},
+        ),
+        "nested-thing": item(
+            "NestedThing",
+            "public",
+            "struct",
+            {"kind": "unit", "generics": {"params": [], "where_predicates": []}, "impls": []},
+        ),
+        "cycle-thing": item(
+            "CycleThing",
+            "public",
+            "struct",
+            {"kind": "unit", "generics": {"params": [], "where_predicates": []}, "impls": []},
+        ),
+        "trait": item(
+            "Trait",
+            "public",
+            "trait",
+            {
+                "is_auto": False,
+                "is_unsafe": False,
+                "is_dyn_compatible": True,
+                "items": ["compile", "try-compile"],
+                "generics": {"params": [], "where_predicates": []},
+                "bounds": [],
+                "implementations": [],
+            },
+        ),
+        "error": item(
+            "Error",
+            "public",
+            "struct",
+            {
+                "kind": {"plain": {"fields": [], "has_stripped_fields": False}},
+                "generics": {"params": [], "where_predicates": []},
+                "impls": ["error-impl"],
+            },
+        ),
+        "compile": item(
+            "compile",
+            "default",
+            "function",
+            {
+                "sig": {"inputs": [], "output": {"primitive": "bool"}, "is_c_variadic": False},
+                "generics": {"params": [], "where_predicates": []},
+                "header": {"is_const": False, "is_unsafe": False, "is_async": False, "abi": "Rust"},
+                "has_body": False,
+            },
+        ),
+        "try-compile": item(
+            "try_compile",
+            "default",
+            "function",
+            {
+                "sig": {"inputs": [], "output": {"primitive": "bool"}, "is_c_variadic": False},
+                "generics": {"params": [], "where_predicates": []},
+                "header": {"is_const": False, "is_unsafe": False, "is_async": False, "abi": "Rust"},
+                "has_body": True,
+            },
+        ),
+        "error-impl": item(
+            None,
+            "default",
+            "impl",
+            {
+                "trait": None,
+                "is_synthetic": False,
+                "items": ["error-new", "error-message"],
+            },
+        ),
+        "error-new": item(
+            "new",
+            "public",
+            "function",
+            {
+                "sig": {"inputs": [], "output": {"generic": "Self"}, "is_c_variadic": False},
+                "generics": {"params": [], "where_predicates": []},
+                "header": {"is_const": False, "is_unsafe": False, "is_async": False, "abi": "Rust"},
+                "has_body": True,
+            },
+        ),
+        "error-message": item(
+            "message",
+            "public",
+            "function",
+            {
+                "sig": {"inputs": [], "output": {"primitive": "str"}, "is_c_variadic": False},
+                "generics": {"params": [], "where_predicates": []},
+                "header": {"is_const": False, "is_unsafe": False, "is_async": False, "abi": "Rust"},
+                "has_body": True,
+            },
+        ),
+        "existing": item(
+            "Existing",
+            "public",
+            "struct",
+            {"kind": "unit", "generics": {"params": [], "where_predicates": []}, "impls": []},
+        ),
+    }
+    for use_id, visibility, name, target_id, is_glob in (
+        ("plain-use", "public", "Thing", "thing", False),
+        ("renamed-use", "public", "RenamedThing", "thing", False),
+        ("external-use", "public", "ExternalThing", "external", False),
+        ("glob-use", "public", None, "source", True),
+        ("trait-use", "public", "Trait", "trait", False),
+        ("error-use", "public", "Error", "error", False),
+        ("existing-use", "public", "Existing", "thing", False),
+        ("private-use", "default", "PrivateImport", "thing", False),
+        ("hidden-use", "public", "HiddenImport", "thing", False),
+        ("nested-glob", "public", None, "nested", True),
+        ("cycle-glob", "public", None, "cycle-a", True),
+        ("cycle-a-glob", "public", None, "cycle-b", True),
+        ("cycle-b-glob", "public", None, "cycle-a", True),
+        ("alias-a-use", "public", "AliasA", "api", False),
+        ("alias-b-use", "public", "AliasB", "api", False),
+        ("root-api-glob", "public", None, "api", True),
+    ):
+        index[use_id] = item(
+            None,
+            visibility,
+            "use",
+            {"source": "semantic-only", "name": name, "id": target_id, "is_glob": is_glob},
+        )
+    paths = {
+        "root": {"crate_id": 0, "path": ["demo"], "kind": "module"},
+        "api": {"crate_id": 0, "path": ["demo", "api"], "kind": "module"},
+        "child": {"crate_id": 0, "path": ["demo", "api", "Child"], "kind": "module"},
+        "child-thing": {"crate_id": 0, "path": ["demo", "api", "Child", "ChildThing"], "kind": "struct"},
+        "private": {"crate_id": 0, "path": ["demo", "private"], "kind": "module"},
+        "source": {"crate_id": 0, "path": ["demo", "api", "source"], "kind": "module"},
+        "nested": {"crate_id": 0, "path": ["demo", "api", "source", "nested"], "kind": "module"},
+        "cycle-a": {"crate_id": 0, "path": ["demo", "api", "source", "cycle_a"], "kind": "module"},
+        "cycle-b": {"crate_id": 0, "path": ["demo", "api", "source", "cycle_b"], "kind": "module"},
+        "thing": {"crate_id": 0, "path": ["demo", "hidden", "Thing"], "kind": "struct"},
+        "glob-thing": {"crate_id": 0, "path": ["demo", "api", "source", "GlobThing"], "kind": "struct"},
+        "nested-thing": {"crate_id": 0, "path": ["demo", "api", "source", "nested", "NestedThing"], "kind": "struct"},
+        "cycle-thing": {"crate_id": 0, "path": ["demo", "api", "source", "cycle_b", "CycleThing"], "kind": "struct"},
+        "trait": {"crate_id": 0, "path": ["demo", "hidden", "Trait"], "kind": "trait"},
+        "error": {"crate_id": 0, "path": ["demo", "hidden", "Error"], "kind": "struct"},
+        "existing": {"crate_id": 0, "path": ["demo", "api", "Existing"], "kind": "struct"},
+        "external": {"crate_id": 4, "path": ["external_crate", "ExternalThing"], "kind": "struct"},
+    }
+    return {"crate_version": "1.0.0", "root": "root", "paths": paths, "index": index}
+
+
+def rustdoc_binding_resolution_fixture(
+    *,
+    explicit_after_glob: bool = False,
+    glob_target_ids: tuple[str, ...] = ("glob-thing",),
+    include_explicit: bool = True,
+) -> dict[str, object]:
+    """A minimal semantic fixture for module bindings and Rust shadowing rules."""
+
+    def item(name: str | None, kind: str, value: object) -> dict[str, object]:
+        return {
+            "id": name,
+            "crate_id": 0,
+            "name": name,
+            "visibility": "public",
+            "attrs": [],
+            "inner": {kind: value},
+        }
+
+    def unit_struct(name: str) -> dict[str, object]:
+        return item(
+            name,
+            "struct",
+            {"kind": "unit", "generics": {"params": [], "where_predicates": []}, "impls": []},
+        )
+
+    index: dict[str, object] = {
+        "root": item("demo", "module", {"is_crate": True, "is_stripped": False, "items": ["api"]}),
+        "api": item("api", "module", {"is_crate": False, "is_stripped": False, "items": []}),
+        "explicit-thing": unit_struct("Thing"),
+        "glob-thing": unit_struct("Thing"),
+        "shared-thing": unit_struct("Thing"),
+        "same-path-a": unit_struct("Thing"),
+        "same-path-b": item(
+            "Thing",
+            "struct",
+            {
+                "kind": "unit",
+                "generics": {
+                    "params": [{"name": "T", "kind": {"type": {"bounds": []}}}],
+                    "where_predicates": [],
+                },
+                "impls": [],
+            },
+        ),
+    }
+    api_items: list[str] = []
+    glob_items: list[str] = []
+    for position, target_id in enumerate(glob_target_ids):
+        source_id = f"glob-source-{position}"
+        source_use_id = f"glob-source-{position}-thing"
+        glob_use_id = f"glob-use-{position}"
+        index[source_id] = item(
+            f"glob_source_{position}",
+            "module",
+            {"is_crate": False, "is_stripped": False, "items": [source_use_id]},
+        )
+        index[source_use_id] = item(
+            None,
+            "use",
+            {"source": "semantic-only", "name": "Thing", "id": target_id, "is_glob": False},
+        )
+        index[glob_use_id] = item(
+            None,
+            "use",
+            {"source": "semantic-only", "name": None, "id": source_id, "is_glob": True},
+        )
+        glob_items.append(glob_use_id)
+    if include_explicit:
+        index["explicit-use"] = item(
+            None,
+            "use",
+            {"source": "semantic-only", "name": "Thing", "id": "explicit-thing", "is_glob": False},
+        )
+        if explicit_after_glob:
+            api_items.extend([*glob_items, "explicit-use"])
+        else:
+            api_items.extend(["explicit-use", *glob_items])
+    else:
+        api_items.extend(glob_items)
+    index["api"]["inner"]["module"]["items"] = api_items
+
+    paths: dict[str, object] = {
+        "root": {"crate_id": 0, "path": ["demo"], "kind": "module"},
+        "api": {"crate_id": 0, "path": ["demo", "api"], "kind": "module"},
+        "explicit-thing": {"crate_id": 0, "path": ["demo", "hidden", "explicit", "Thing"], "kind": "struct"},
+        "glob-thing": {"crate_id": 0, "path": ["demo", "hidden", "glob", "Thing"], "kind": "struct"},
+        "shared-thing": {"crate_id": 0, "path": ["demo", "hidden", "shared", "Thing"], "kind": "struct"},
+        "same-path-a": {"crate_id": 0, "path": ["demo", "hidden", "same", "Thing"], "kind": "struct"},
+        "same-path-b": {"crate_id": 0, "path": ["demo", "hidden", "same", "Thing"], "kind": "struct"},
+    }
+    for position in range(len(glob_target_ids)):
+        paths[f"glob-source-{position}"] = {
+            "crate_id": 0,
+            "path": ["demo", "hidden", f"glob_source_{position}"],
+            "kind": "module",
+        }
+    return {"crate_version": "1.0.0", "root": "root", "paths": paths, "index": index}
+
+
+def rustdoc_external_module_reexport_fixture() -> dict[str, object]:
+    def item(name: str | None, kind: str, value: object) -> dict[str, object]:
+        return {
+            "id": name,
+            "crate_id": 0,
+            "name": name,
+            "visibility": "public",
+            "attrs": [],
+            "inner": {kind: value},
+        }
+
+    index = {
+        "root": item(
+            "demo",
+            "module",
+            {"is_crate": True, "is_stripped": False, "items": ["alias-use", "glob-use"]},
+        ),
+        "alias-use": item(
+            None,
+            "use",
+            {"source": "external_crate::api", "name": "Alias", "id": "external-api", "is_glob": False},
+        ),
+        "glob-use": item(
+            None,
+            "use",
+            {"source": "external_crate::api", "name": None, "id": "external-api", "is_glob": True},
+        ),
+    }
+    paths = {
+        "root": {"crate_id": 0, "path": ["demo"], "kind": "module"},
+        "external-api": {"crate_id": 4, "path": ["external_crate", "api"], "kind": "module"},
+        "external-child": {"crate_id": 4, "path": ["external_crate", "api", "Child"], "kind": "module"},
+        "external-thing": {
+            "crate_id": 4,
+            "path": ["external_crate", "api", "Child", "Thing"],
+            "kind": "struct",
+        },
+    }
+    return {"crate_version": "1.0.0", "root": "root", "paths": paths, "index": index}
 
 
 class PublicApiSnapshotTests(unittest.TestCase):
@@ -652,6 +1037,402 @@ class PublicApiSnapshotTests(unittest.TestCase):
             "compatibility_decisions": [],
             "frozen_contracts": [],
         }
+
+
+class PublicApiReexportTests(unittest.TestCase):
+    SELECTED_PATHS = (
+        "demo::api::Thing",
+        "demo::api::RenamedThing",
+        "demo::api::ExternalThing",
+        "demo::api::GlobThing",
+        "demo::api::NestedThing",
+        "demo::api::CycleThing",
+        "demo::api::Trait",
+        "demo::api::Trait::compile",
+        "demo::api::Trait::try_compile",
+        "demo::api::Error",
+        "demo::api::Error::new",
+        "demo::api::Error::message",
+        "demo::api::Existing",
+    )
+
+    @staticmethod
+    def _selected_records(document: dict[str, object] | None = None) -> dict[str, dict[str, str]]:
+        records = snapshot.semantic_public_items(
+            "rocketmq-model",
+            document or rustdoc_reexport_fixture(),
+            selected_reexport_paths=PublicApiReexportTests.SELECTED_PATHS,
+        )
+        return {record["item_path"]: record for record in records}
+
+    @staticmethod
+    def _snapshot(records: list[dict[str, str]]) -> dict[str, object]:
+        baseline = PublicApiSnapshotTests.structural_snapshot()
+        baseline["profiles"]["rocketmq-model:default"]["public_api"] = records
+        return baseline
+
+    def test_reexport_collection_is_opt_in_and_private_edges_do_not_leak(self) -> None:
+        records = snapshot.semantic_public_items("rocketmq-model", rustdoc_reexport_fixture())
+        paths = {record["item_path"] for record in records}
+
+        self.assertNotIn("demo::api::Thing", paths)
+        self.assertNotIn("demo::api::PrivateImport", paths)
+        self.assertNotIn("demo::private::HiddenImport", paths)
+
+    def test_selected_reexports_cover_plain_rename_glob_nested_cycle_and_external_targets(self) -> None:
+        records = self._selected_records()
+
+        self.assertEqual(set(self.SELECTED_PATHS), set(self.SELECTED_PATHS) & set(records))
+        self.assertEqual("reexport", records["demo::api::Thing"]["kind"])
+        self.assertEqual("plain", json.loads(records["demo::api::Thing"]["signature"])["alias_kind"])
+        self.assertEqual("renamed", json.loads(records["demo::api::RenamedThing"]["signature"])["alias_kind"])
+        self.assertEqual("glob", json.loads(records["demo::api::GlobThing"]["signature"])["alias_kind"])
+        self.assertIn("demo::api::NestedThing", records)
+        self.assertIn("demo::api::CycleThing", records)
+        external_signature = json.loads(records["demo::api::ExternalThing"]["signature"])
+        self.assertEqual("external_crate::ExternalThing", external_signature["target_path"])
+        self.assertIsNone(external_signature["target_signature"])
+
+    def test_module_reexport_aliases_each_expose_their_public_descendants(self) -> None:
+        selected = (
+            "demo::AliasA::Child::ChildThing",
+            "demo::AliasB::Child::ChildThing",
+        )
+        records = {
+            record["item_path"]: record
+            for record in snapshot.semantic_public_items(
+                "rocketmq-model",
+                rustdoc_reexport_fixture(),
+                selected_reexport_paths=selected,
+            )
+        }
+
+        self.assertEqual(set(selected), set(selected) & set(records))
+        for item_path in selected:
+            signature = json.loads(records[item_path]["signature"])
+            self.assertEqual("module-descendant", signature["alias_kind"])
+            self.assertEqual("demo::api::Child::ChildThing", signature["target_path"])
+
+    def test_glob_exported_child_module_exposes_its_public_subtree(self) -> None:
+        item_path = "demo::Child::ChildThing"
+        records = {
+            record["item_path"]: record
+            for record in snapshot.semantic_public_items(
+                "rocketmq-model",
+                rustdoc_reexport_fixture(),
+                selected_reexport_paths=(item_path,),
+            )
+        }
+
+        signature = json.loads(records[item_path]["signature"])
+        self.assertEqual("module-descendant", signature["alias_kind"])
+        self.assertEqual("demo::api::Child::ChildThing", signature["target_path"])
+
+    def test_explicit_binding_shadows_glob_regardless_of_rustdoc_item_order(self) -> None:
+        item_path = "demo::api::Thing"
+        for explicit_after_glob in (False, True):
+            with self.subTest(explicit_after_glob=explicit_after_glob):
+                records = {
+                    record["item_path"]: record
+                    for record in snapshot.semantic_public_items(
+                        "rocketmq-model",
+                        rustdoc_binding_resolution_fixture(
+                            explicit_after_glob=explicit_after_glob,
+                        ),
+                        selected_reexport_paths=(item_path,),
+                    )
+                }
+                signature = json.loads(records[item_path]["signature"])
+                self.assertEqual("plain", signature["alias_kind"])
+                self.assertEqual("demo::hidden::explicit::Thing", signature["target_path"])
+
+    def test_glob_bindings_with_the_same_target_dedupe_but_conflicts_fail_closed(self) -> None:
+        item_path = "demo::api::Thing"
+        records = {
+            record["item_path"]: record
+            for record in snapshot.semantic_public_items(
+                "rocketmq-model",
+                rustdoc_binding_resolution_fixture(
+                    glob_target_ids=("shared-thing", "shared-thing"),
+                    include_explicit=False,
+                ),
+                selected_reexport_paths=(item_path,),
+            )
+        }
+        self.assertEqual("glob", json.loads(records[item_path]["signature"])["alias_kind"])
+        self.assertEqual("demo::hidden::shared::Thing", json.loads(records[item_path]["signature"])["target_path"])
+
+        with self.assertRaisesRegex(snapshot.SnapshotError, "ambiguous public glob bindings"):
+            snapshot.semantic_public_items(
+                "rocketmq-model",
+                rustdoc_binding_resolution_fixture(
+                    glob_target_ids=("glob-thing", "shared-thing"),
+                    include_explicit=False,
+                ),
+                selected_reexport_paths=(item_path,),
+            )
+
+        with self.assertRaisesRegex(snapshot.SnapshotError, "ambiguous public glob bindings"):
+            snapshot.semantic_public_items(
+                "rocketmq-model",
+                rustdoc_binding_resolution_fixture(
+                    glob_target_ids=("same-path-a", "same-path-b"),
+                    include_explicit=False,
+                ),
+                selected_reexport_paths=(item_path,),
+            )
+
+    def test_external_module_alias_and_glob_subtrees_use_rustdoc_paths_only(self) -> None:
+        alias_path = "demo::Alias::Child::Thing"
+        glob_path = "demo::Child::Thing"
+        records = {
+            record["item_path"]: record
+            for record in snapshot.semantic_public_items(
+                "rocketmq-model",
+                rustdoc_external_module_reexport_fixture(),
+                selected_reexport_paths=(alias_path, glob_path),
+            )
+        }
+
+        alias_signature = json.loads(records[alias_path]["signature"])
+        glob_signature = json.loads(records[glob_path]["signature"])
+        self.assertEqual("renamed-external-descendant", alias_signature["alias_kind"])
+        self.assertEqual("glob-external-descendant", glob_signature["alias_kind"])
+        self.assertEqual("external_crate::api::Child::Thing", alias_signature["target_path"])
+        self.assertEqual("external_crate::api::Child::Thing", glob_signature["target_path"])
+        self.assertIsNone(alias_signature["target_signature"])
+        self.assertIsNone(glob_signature["target_signature"])
+
+    def test_external_module_alias_target_drift_changes_the_public_facade_signature(self) -> None:
+        item_path = "demo::Alias::Child::Thing"
+        before = {
+            record["item_path"]: record
+            for record in snapshot.semantic_public_items(
+                "rocketmq-model",
+                rustdoc_external_module_reexport_fixture(),
+                selected_reexport_paths=(item_path,),
+            )
+        }[item_path]
+        changed_document = rustdoc_external_module_reexport_fixture()
+        changed_document["paths"]["external-api"]["path"] = ["external_crate", "renamed_api"]
+        changed_document["paths"]["external-child"]["path"] = [
+            "external_crate",
+            "renamed_api",
+            "Child",
+        ]
+        changed_document["paths"]["external-thing"]["path"] = [
+            "external_crate",
+            "renamed_api",
+            "Child",
+            "Thing",
+        ]
+        after = {
+            record["item_path"]: record
+            for record in snapshot.semantic_public_items(
+                "rocketmq-model",
+                changed_document,
+                selected_reexport_paths=(item_path,),
+            )
+        }[item_path]
+
+        differences = snapshot.compare_snapshots(self._snapshot([before]), self._snapshot([after]))
+
+        self.assertEqual(1, len(differences))
+        self.assertEqual("item-changed", differences[0]["kind"])
+        self.assertEqual(["signature"], differences[0]["changed_fields"])
+        self.assertFalse(differences[0]["allowed"])
+
+    def test_selected_associated_items_use_the_public_alias_parent_and_target_semantics(self) -> None:
+        records = self._selected_records()
+        try_compile = json.loads(records["demo::api::Trait::try_compile"]["signature"])
+        error_new = json.loads(records["demo::api::Error::new"]["signature"])
+
+        self.assertEqual("plain-associated", try_compile["alias_kind"])
+        self.assertEqual("demo::hidden::Trait::try_compile", try_compile["target_path"])
+        self.assertEqual("function", try_compile["target_kind"])
+        self.assertEqual({"primitive": "bool"}, try_compile["target_signature"]["sig"]["output"])
+        self.assertEqual("demo::hidden::Error::new", error_new["target_path"])
+        self.assertEqual("function", records["demo::hidden::Trait::try_compile"]["kind"])
+        self.assertEqual("reexport", records["demo::api::Trait::try_compile"]["kind"])
+
+    def test_existing_canonical_path_wins_dedupe_over_selected_reexport(self) -> None:
+        records = self._selected_records()
+
+        self.assertEqual("struct", records["demo::api::Existing"]["kind"])
+        self.assertEqual(
+            1,
+            sum(record["item_path"] == "demo::api::Existing" for record in records.values()),
+        )
+
+    def test_associated_target_signature_drift_is_a_breaking_public_facade_change(self) -> None:
+        before = self._selected_records()["demo::api::Trait::try_compile"]
+        changed_document = rustdoc_reexport_fixture()
+        changed_document["index"]["try-compile"]["inner"]["function"]["sig"]["output"] = {
+            "primitive": "str"
+        }
+        after = self._selected_records(changed_document)["demo::api::Trait::try_compile"]
+        baseline = self._snapshot([before])
+        candidate = self._snapshot([after])
+
+        differences = snapshot.compare_snapshots(baseline, candidate)
+
+        self.assertEqual(1, len(differences))
+        self.assertEqual("item-changed", differences[0]["kind"])
+        self.assertEqual("demo::api::Trait::try_compile", differences[0]["item_path"])
+        self.assertEqual(["signature"], differences[0]["changed_fields"])
+        self.assertFalse(differences[0]["allowed"])
+
+    def test_alias_retarget_is_a_breaking_public_facade_change(self) -> None:
+        before = self._selected_records()["demo::api::Thing"]
+        changed_document = rustdoc_reexport_fixture()
+        changed_document["paths"]["thing"]["path"] = ["demo", "other", "Thing"]
+        after = self._selected_records(changed_document)["demo::api::Thing"]
+        baseline = self._snapshot([before])
+        candidate = self._snapshot([after])
+
+        differences = snapshot.compare_snapshots(baseline, candidate)
+
+        self.assertEqual(1, len(differences))
+        self.assertEqual("item-changed", differences[0]["kind"])
+        self.assertEqual("demo::api::Thing", differences[0]["item_path"])
+        self.assertEqual(["signature"], differences[0]["changed_fields"])
+        self.assertFalse(differences[0]["allowed"])
+
+    def test_selected_reexport_removal_requires_an_exact_approval(self) -> None:
+        record = self._selected_records()["demo::api::Trait::try_compile"]
+        baseline = self._snapshot([record])
+        candidate = self._snapshot([])
+
+        unapproved = snapshot.compare_snapshots(baseline, candidate)
+        self.assertEqual("item-removed", unapproved[0]["kind"])
+        self.assertFalse(unapproved[0]["allowed"])
+
+        decision = {
+            "id": "API-POST-REEXPORT-001",
+            "classification": "approved-break",
+            "applies_to": "post-freeze",
+            "profile_id": "rocketmq-model:default",
+            "package": "rocketmq-model",
+            "item_path": "demo::api::Trait::try_compile",
+            "change": "removed",
+            "replacement": "demo::api::Trait::try_compile_v2",
+            "reason": "Synthetic exact-match approval test.",
+            "approved_by": "release-approver",
+            "approved_on": "2026-08-25",
+        }
+        baseline["compatibility_decisions"] = [decision]
+        candidate["compatibility_decisions"] = copy.deepcopy(baseline["compatibility_decisions"])
+
+        approved = snapshot.compare_snapshots(baseline, candidate)
+        self.assertEqual("approved-break", approved[0]["classification"])
+        self.assertTrue(approved[0]["allowed"])
+
+    def test_reexport_mismatched_approvals_do_not_allow_removal_or_signature_changes(self) -> None:
+        record = self._selected_records()["demo::api::Trait::try_compile"]
+        for field, value in (
+            ("profile_id", "rocketmq-filter:default"),
+            ("package", "rocketmq-filter"),
+            ("item_path", "demo::api::Trait::compile"),
+            ("change", "signature"),
+            ("change", "any"),
+        ):
+            with self.subTest(removal_field=field, removal_value=value):
+                baseline = self._snapshot([record])
+                candidate = self._snapshot([])
+                decision = {
+                    "id": "API-POST-REEXPORT-MISMATCH",
+                    "classification": "approved-break",
+                    "applies_to": "post-freeze",
+                    "profile_id": "rocketmq-model:default",
+                    "package": "rocketmq-model",
+                    "item_path": "demo::api::Trait::try_compile",
+                    "change": "removed",
+                    "replacement": "demo::api::Trait::try_compile_v2",
+                    "reason": "Synthetic re-export mismatch test.",
+                    "approved_by": "release-approver",
+                    "approved_on": "2026-08-25",
+                }
+                decision[field] = value
+                baseline["compatibility_decisions"] = [decision]
+                candidate["compatibility_decisions"] = copy.deepcopy(baseline["compatibility_decisions"])
+
+                difference = snapshot.compare_snapshots(baseline, candidate)[0]
+                self.assertEqual("item-removed", difference["kind"])
+                self.assertFalse(difference["allowed"])
+
+        before = self._selected_records()["demo::api::Thing"]
+        changed_document = rustdoc_reexport_fixture()
+        changed_document["paths"]["thing"]["path"] = ["demo", "other", "Thing"]
+        after = self._selected_records(changed_document)["demo::api::Thing"]
+        baseline = self._snapshot([before])
+        candidate = self._snapshot([after])
+        decision = {
+            "id": "API-POST-REEXPORT-ANY",
+            "classification": "approved-break",
+            "applies_to": "post-freeze",
+            "profile_id": "rocketmq-model:default",
+            "package": "rocketmq-model",
+            "item_path": "demo::api::Thing",
+            "change": "any",
+            "replacement": "demo::api::ThingV2",
+            "reason": "Wildcard approvals are not accepted.",
+            "approved_by": "release-approver",
+            "approved_on": "2026-08-25",
+        }
+        baseline["compatibility_decisions"] = [decision]
+        candidate["compatibility_decisions"] = copy.deepcopy(baseline["compatibility_decisions"])
+
+        difference = snapshot.compare_snapshots(baseline, candidate)[0]
+        self.assertEqual("item-changed", difference["kind"])
+        self.assertFalse(difference["allowed"])
+
+    def test_selection_and_inventory_fail_closed(self) -> None:
+        profiles = [
+            {"id": "demo:default", "package": "demo-package", "target": "demo"},
+        ]
+        valid = {
+            "schema_version": 1,
+            "profiles": {
+                "demo:default": {
+                    "package": "demo-package",
+                    "item_paths": ["demo::api::Thing"],
+                }
+            },
+        }
+        invalid_documents = (
+            {"schema_version": 1, "profiles": {"unknown:default": valid["profiles"]["demo:default"]}},
+            {"schema_version": 1, "profiles": {"demo:default": {"package": "wrong", "item_paths": ["demo::api::Thing"]}}},
+            {"schema_version": 1, "profiles": {"demo:default": {"package": "demo-package"}}},
+            {"schema_version": 1, "profiles": {"demo:default": {"package": "demo-package", "item_paths": []}}},
+            {"schema_version": 1, "profiles": {"demo:default": {"package": "demo-package", "item_paths": ["demo::api::Thing", "demo::api::Thing"]}}},
+            {"schema_version": 1, "profiles": {"demo:default": {"package": "demo-package", "item_paths": ["demo::api::*"]}}},
+            {"schema_version": 1, "profiles": {"demo:default": {"package": "demo-package", "item_paths": ["other::Thing"]}}},
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            inventory_path = Path(directory) / "inventory.json"
+            inventory_path.write_text(json.dumps(valid), encoding="utf-8")
+            self.assertEqual(
+                {"demo:default": ("demo::api::Thing",)},
+                snapshot.load_reexport_surface_inventory(profiles, inventory_path),
+            )
+            for invalid in invalid_documents:
+                with self.subTest(invalid=invalid):
+                    inventory_path.write_text(json.dumps(invalid), encoding="utf-8")
+                    with self.assertRaises(snapshot.SnapshotError):
+                        snapshot.load_reexport_surface_inventory(profiles, inventory_path)
+
+        with self.assertRaises(snapshot.SnapshotError):
+            snapshot.semantic_public_items(
+                "rocketmq-model",
+                rustdoc_reexport_fixture(),
+                selected_reexport_paths=("demo::api::Thing", "demo::api::Thing"),
+            )
+        with self.assertRaises(snapshot.SnapshotError):
+            snapshot.semantic_public_items(
+                "rocketmq-model",
+                rustdoc_reexport_fixture(),
+                selected_reexport_paths=("demo::api::Missing",),
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_stable_surface_guard.py
+++ b/scripts/tests/test_stable_surface_guard.py
@@ -24,6 +24,8 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 GUARD = REPO_ROOT / "scripts" / "stable_surface_guard.py"
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+import stable_surface_guard as stable_guard
 
 
 class StableSurfaceGuardTests(unittest.TestCase):
@@ -69,7 +71,9 @@ class StableSurfaceGuardTests(unittest.TestCase):
         self,
         *,
         mode: str = "baseline",
+        scope: str = "all",
         api_baseline: Path | None = None,
+        api_reexport_inventory: Path | None = None,
     ) -> subprocess.CompletedProcess[str]:
         command = [
             sys.executable,
@@ -80,9 +84,13 @@ class StableSurfaceGuardTests(unittest.TestCase):
             str(self.policy),
             "--mode",
             mode,
+            "--scope",
+            scope,
         ]
         if api_baseline is not None:
             command.extend(("--api-baseline", str(api_baseline)))
+        if api_reexport_inventory is not None:
+            command.extend(("--api-reexport-inventory", str(api_reexport_inventory)))
         return subprocess.run(
             command,
             check=False,
@@ -160,6 +168,123 @@ class StableSurfaceGuardTests(unittest.TestCase):
 
         self.assertEqual(0, result.returncode, result.stderr)
         self.assertIn("api_freeze=verified", result.stdout)
+
+    def test_explicit_default_baseline_resolves_the_default_reexport_inventory(self) -> None:
+        baseline, inventory = stable_guard.resolve_api_contract_inputs(
+            stable_guard.DEFAULT_API_BASELINE,
+            None,
+            mode="baseline",
+            scope="all",
+        )
+
+        self.assertEqual(stable_guard.DEFAULT_API_BASELINE.resolve(), baseline)
+        self.assertEqual(stable_guard.DEFAULT_API_REEXPORT_INVENTORY.resolve(), inventory)
+
+    def test_inventory_without_a_baseline_is_rejected(self) -> None:
+        with self.assertRaisesRegex(stable_guard.InputError, "requires --api-baseline"):
+            stable_guard.resolve_api_contract_inputs(
+                None,
+                self.policy,
+                mode="baseline",
+                scope="all",
+            )
+        with self.assertRaisesRegex(stable_guard.InputError, "requires api_baseline"):
+            stable_guard.validate(
+                self.root,
+                self.policy,
+                "baseline",
+                api_reexport_inventory=self.policy,
+            )
+
+        empty_inventory = self.root / "empty-api-reexport-inventory.json"
+        empty_inventory.write_text("{}", encoding="utf-8")
+        for inventory in (empty_inventory, stable_guard.DEFAULT_API_REEXPORT_INVENTORY):
+            with self.subTest(inventory=inventory):
+                result = self.run_guard_with_api(
+                    mode="target",
+                    scope="core-release",
+                    api_reexport_inventory=inventory,
+                )
+
+                self.assertNotEqual(0, result.returncode)
+                self.assertIn("requires --api-baseline", result.stderr)
+
+    def test_target_mode_accepts_an_explicit_reexport_inventory_for_a_custom_baseline(self) -> None:
+        self.source.write_text("pub fn value() {}\n", encoding="utf-8")
+        self.write_policy([])
+        baseline = self.root / "api-baseline.json"
+        baseline.write_text(json.dumps(self.api_freeze_fixture()), encoding="utf-8")
+        inventory = self.root / "api-reexport-inventory.json"
+        inventory.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "profiles": {
+                        "rocketmq-store:default": {
+                            "package": "rocketmq-store",
+                            "item_paths": ["rocketmq_store::MappedFileBuilder"],
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = self.run_guard_with_api(
+            mode="target",
+            api_baseline=baseline,
+            api_reexport_inventory=inventory,
+        )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("api_freeze=verified", result.stdout)
+
+    def test_target_mode_rejects_missing_or_unknown_explicit_reexport_inventory_selection(self) -> None:
+        self.source.write_text("pub fn value() {}\n", encoding="utf-8")
+        self.write_policy([])
+        baseline = self.root / "api-baseline.json"
+        baseline.write_text(json.dumps(self.api_freeze_fixture()), encoding="utf-8")
+        invalid_inventories = (
+            (
+                "missing",
+                {
+                    "schema_version": 1,
+                    "profiles": {
+                        "rocketmq-store:default": {
+                            "package": "rocketmq-store",
+                            "item_paths": ["rocketmq_store::Missing"],
+                        }
+                    },
+                },
+                "paths are absent",
+            ),
+            (
+                "unknown",
+                {
+                    "schema_version": 1,
+                    "profiles": {
+                        "rocketmq-unknown:default": {
+                            "package": "rocketmq-store",
+                            "item_paths": ["rocketmq_store::MappedFileBuilder"],
+                        }
+                    },
+                },
+                "unknown profile",
+            ),
+        )
+        for name, value, expected in invalid_inventories:
+            with self.subTest(name=name):
+                inventory = self.root / f"{name}-inventory.json"
+                inventory.write_text(json.dumps(value), encoding="utf-8")
+
+                result = self.run_guard_with_api(
+                    mode="target",
+                    api_baseline=baseline,
+                    api_reexport_inventory=inventory,
+                )
+
+                self.assertNotEqual(0, result.returncode)
+                self.assertIn(expected, result.stderr)
 
     @staticmethod
     def api_freeze_fixture() -> dict[str, object]:


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9733

### Brief Description

Track the exact compatibility re-export surfaces selected for the `rocketmq-auth` and `rocketmq-filter` default profiles in the structural public API snapshot. The collector follows semantic Rustdoc import data across public modules, aliases, globs, and selected associated items while keeping unrelated workspace re-exports outside the frozen baseline. This adds 28 snapshot records without approvals or Rust API, signature, or behavior changes.

### How Did You Test This Change?

- Ran the public API snapshot, stable surface guard, and M09 compatibility unit suites: 52 tests passed.
- Verified implicit and explicit default baseline checks, inventory-only rejection, and custom baseline/inventory behavior.
- Compared all 50 existing Rustdoc profiles and confirmed the pre-existing blocked set is unchanged and all 28 selected records have zero differences.
- Ran the workspace Clippy gate and `git diff --check` successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for tracking and validating selected public API re-exports.
  - Added approved public exports for authentication, maintenance authorization, filtering, and SQL filtering capabilities.
  - Added configurable API inventory support for release validation.

- **Bug Fixes**
  - Improved detection of missing, ambiguous, duplicate, or mismatched public API exports.

- **Tests**
  - Expanded coverage for aliases, nested modules, external exports, associated methods, and validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->