### PR TITLE
[ISSUE #9739]🐛Prevent Windows async stack overflows

### DIFF
--- a/rocketmq-broker/src/topic/topic_queue_mapping_clean_service.rs
+++ b/rocketmq-broker/src/topic/topic_queue_mapping_clean_service.rs
@@ -14,6 +14,8 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -49,6 +51,9 @@ const INITIAL_DELAY: Duration = Duration::from_secs(5 * 60);
 const CLEAN_INTERVAL: Duration = Duration::from_secs(5 * 60);
 const TOPIC_SCAN_YIELD_DELAY: Duration = Duration::from_millis(10);
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
+// Erase the scan future before it enters generic scheduler layers so Windows startup stacks stay bounded.
+type CleanTaskFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
 
 #[derive(Default)]
 struct CleanServiceLifecycle {
@@ -144,11 +149,11 @@ impl TopicQueueMappingCleanService {
 
         if let Err(error) = scheduled_tasks.schedule_fixed_delay(config, move || {
             let this = this.clone();
-            async move {
+            Box::pin(async move {
                 if let Err(err) = this.run_once().await {
                     warn!("TopicQueueMappingCleanService scan failed: {}", err);
                 }
-            }
+            }) as CleanTaskFuture
         }) {
             self.inner.running.store(false, Ordering::Release);
             warn!(?error, "failed to spawn TopicQueueMappingCleanService scan task");

--- a/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_lite_pull_consumer_impl.rs
@@ -1314,7 +1314,7 @@ impl DefaultLitePullConsumerImpl {
                     )));
                 }
 
-                if let Err(error) = client_instance.start().await {
+                if let Err(error) = Box::pin(client_instance.start()).await {
                     client_instance
                         .unregister_consumer(&consumer_config.consumer_group)
                         .await;

--- a/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
+++ b/rocketmq-client/src/consumer/consumer_impl/default_mq_push_consumer_impl.rs
@@ -610,7 +610,7 @@ impl DefaultMQPushConsumerImpl {
                         FAQUrl::suggest_todo(FAQUrl::GROUP_NAME_DUPLICATE_URL)
                     )));
                 }
-                if let Err(error) = client_instance.start().await {
+                if let Err(error) = Box::pin(client_instance.start()).await {
                     client_instance
                         .unregister_consumer(consumer_config.consumer_group.as_str())
                         .await;

--- a/rocketmq-client/src/factory/mq_client_instance.rs
+++ b/rocketmq-client/src/factory/mq_client_instance.rs
@@ -610,7 +610,9 @@ impl MQClientInstance {
         let Some(producer_impl) = default_producer.default_mqproducer_impl.as_mut() else {
             return Err(mq_client_err!("default producer impl is None"));
         };
-        producer_impl.start_with_factory(false).await
+        // A user producer starts this internal producer through the same factory future. Erase the nested
+        // lifecycle future here so the combined startup chain stays within the default Windows main stack.
+        Box::pin(producer_impl.start_with_factory(false)).await
     }
 
     async fn shutdown_default_producer(&self) -> rocketmq_error::RocketMQResult<()> {

--- a/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl/lifecycle.rs
+++ b/rocketmq-client/src/producer/producer_impl/default_mq_producer_impl/lifecycle.rs
@@ -763,7 +763,7 @@ impl MQProducerInner for DefaultMQProducerImpl {
 #[allow(unused_assignments)]
 impl DefaultMQProducerImpl {
     pub async fn start(&self) -> rocketmq_error::RocketMQResult<()> {
-        self.start_with_factory(true).await
+        Box::pin(self.start_with_factory(true)).await
     }
 
     #[inline]
@@ -894,7 +894,7 @@ impl DefaultMQProducerImpl {
 
     /// Shutdown the producer gracefully
     pub async fn shutdown(&self) -> rocketmq_error::RocketMQResult<()> {
-        self.shutdown_with_factory(true).await
+        Box::pin(self.shutdown_with_factory(true)).await
     }
 
     pub(super) async fn shutdown_producer_tasks(&self) {

--- a/rocketmq-client/tests/windows_consumer_process_startup.rs
+++ b/rocketmq-client/tests/windows_consumer_process_startup.rs
@@ -30,6 +30,7 @@ use rocketmq_client_rust::ClientRuntime;
 use rocketmq_client_rust::ClientRuntimeConfig;
 use rocketmq_client_rust::ConsumeConcurrentlyContext;
 use rocketmq_client_rust::ConsumeConcurrentlyStatus;
+use rocketmq_client_rust::DefaultMQProducer;
 use rocketmq_client_rust::DefaultMQPushConsumer;
 use rocketmq_client_rust::MQPushConsumer;
 use rocketmq_client_rust::MessageListenerConcurrently;
@@ -45,18 +46,21 @@ use rocketmq_transport::api::v1::ServerConfig;
 use tokio::sync::oneshot;
 
 const CHILD_MODE_ENV: &str = "ROCKETMQ_CLIENT_STACK_TEST_CHILD";
+const PRODUCER_CHILD_MODE_ENV: &str = "ROCKETMQ_CLIENT_PRODUCER_STACK_TEST_CHILD";
 const NAMESRV_ADDR_ENV: &str = "ROCKETMQ_CLIENT_STACK_TEST_NAMESRV_ADDR";
 const STARTUP_MARKER: &str = "CLIENT_STACK_STARTUP_OK";
 const SHUTDOWN_MARKER: &str = "CLIENT_STACK_SHUTDOWN_OK";
+const PRODUCER_STARTUP_MARKER: &str = "CLIENT_PRODUCER_STACK_STARTUP_OK";
+const PRODUCER_SHUTDOWN_MARKER: &str = "CLIENT_PRODUCER_STACK_SHUTDOWN_OK";
 const WINDOWS_MAIN_STACK_SIZE: usize = 1024 * 1024;
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 
-struct ConsumerProcess {
+struct ClientProcess {
     child: Option<Child>,
 }
 
-impl ConsumerProcess {
+impl ClientProcess {
     fn new(child: Child) -> Self {
         Self { child: Some(child) }
     }
@@ -82,7 +86,7 @@ impl ConsumerProcess {
     }
 }
 
-impl Drop for ConsumerProcess {
+impl Drop for ClientProcess {
     fn drop(&mut self) {
         let Some(mut child) = self.child.take() else {
             return;
@@ -189,6 +193,36 @@ fn run_consumer_child() {
     thread.join().expect("consumer startup thread should not panic");
 }
 
+fn run_producer_child() {
+    let namesrv_addr = std::env::var(NAMESRV_ADDR_ENV).expect("child NameServer address should be present");
+    let thread = std::thread::Builder::new()
+        .name("rocketmq-client-producer-stack-probe".to_owned())
+        .stack_size(WINDOWS_MAIN_STACK_SIZE)
+        .spawn(move || {
+            let owner = RuntimeOwner::new(RuntimeConfig {
+                worker_threads: 2,
+                thread_name: "rocketmq-client-producer-stack-test".to_owned(),
+                ..RuntimeConfig::default()
+            })
+            .expect("create producer client process runtime");
+            let client_runtime = ClientRuntime::try_new(
+                owner.root_context().component("client"),
+                ClientRuntimeConfig::default(),
+                TelemetryHandle::noop(),
+            )
+            .expect("create producer client runtime");
+            owner.block_on(run_producer_startup(Arc::clone(&client_runtime), namesrv_addr));
+            let report = owner.block_on(client_runtime.shutdown());
+            assert!(report.is_healthy(), "{}", report.to_json());
+            owner
+                .shutdown_runtime_blocking()
+                .expect("producer process runtime should stop cleanly");
+        })
+        .expect("start 1 MiB producer startup thread");
+
+    thread.join().expect("producer startup thread should not panic");
+}
+
 async fn run_consumer_startup(client_runtime: Arc<ClientRuntime>, namesrv_addr: String) {
     let mut consumer = DefaultMQPushConsumer::builder(client_runtime)
         .consumer_group(format!("windows_stack_test_{}", std::process::id()))
@@ -210,61 +244,76 @@ async fn run_consumer_startup(client_runtime: Arc<ClientRuntime>, namesrv_addr: 
     std::io::stdout().flush().expect("flush shutdown marker");
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn windows_consumer_starts_without_stack_overflow() {
-    if std::env::var_os(CHILD_MODE_ENV).is_some() {
-        run_consumer_child();
-        return;
-    }
+async fn run_producer_startup(client_runtime: Arc<ClientRuntime>, namesrv_addr: String) {
+    let mut producer = DefaultMQProducer::builder(client_runtime)
+        .producer_group(format!("windows_producer_stack_test_{}", std::process::id()))
+        .name_server_addr(namesrv_addr)
+        .build();
+    producer.start().await.expect("start test producer");
 
+    println!("{PRODUCER_STARTUP_MARKER}");
+    std::io::stdout().flush().expect("flush producer startup marker");
+
+    producer.shutdown().await;
+    println!("{PRODUCER_SHUTDOWN_MARKER}");
+    std::io::stdout().flush().expect("flush producer shutdown marker");
+}
+
+async fn assert_client_process_startup(
+    child_mode_env: &'static str,
+    test_name: &'static str,
+    startup_marker: &'static str,
+    shutdown_marker: &'static str,
+    client_kind: &'static str,
+) {
     let root = tempfile::tempdir().expect("create client process root");
     let namesrv_port = available_port();
     let namesrv_addr = format!("127.0.0.1:{namesrv_port}");
     let (namesrv_shutdown, namesrv_handle) = start_namesrv(root.path(), namesrv_port).await;
     let child = Command::new(std::env::current_exe().expect("resolve client stack test executable"))
         .arg("--exact")
-        .arg("windows_consumer_starts_without_stack_overflow")
+        .arg(test_name)
         .arg("--nocapture")
-        .env(CHILD_MODE_ENV, "1")
+        .env(child_mode_env, "1")
         .env(NAMESRV_ADDR_ENV, &namesrv_addr)
         .env("RUST_LOG", "warn")
         .env_remove("NAMESRV_ADDR")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .expect("start consumer process");
-    let mut consumer = ConsumerProcess::new(child);
+        .unwrap_or_else(|error| panic!("start {client_kind} process: {error}"));
+    let mut client = ClientProcess::new(child);
 
     let deadline = Instant::now() + STARTUP_TIMEOUT;
     let output = loop {
-        if consumer
+        if client
             .child_mut()
             .try_wait()
-            .expect("inspect consumer startup status")
+            .expect("inspect client startup status")
             .is_some()
         {
-            break consumer.wait_with_output();
+            break client.wait_with_output();
         }
         if Instant::now() >= deadline {
-            let output = consumer.terminate_with_output();
-            panic!("Consumer startup timed out:\n{}", process_output(&output));
+            let output = client.terminate_with_output();
+            panic!("{client_kind} startup timed out:\n{}", process_output(&output));
         }
         tokio::time::sleep(POLL_INTERVAL).await;
     };
 
     assert!(
         output.status.success(),
-        "Consumer exited before startup completed:\n{}",
+        "{client_kind} exited before startup completed:\n{}",
         process_output(&output)
     );
     assert!(
-        String::from_utf8_lossy(&output.stdout).contains(STARTUP_MARKER),
-        "Consumer did not emit startup marker:\n{}",
+        String::from_utf8_lossy(&output.stdout).contains(startup_marker),
+        "{client_kind} did not emit startup marker:\n{}",
         process_output(&output)
     );
     assert!(
-        String::from_utf8_lossy(&output.stdout).contains(SHUTDOWN_MARKER),
-        "Consumer did not complete clean shutdown:\n{}",
+        String::from_utf8_lossy(&output.stdout).contains(shutdown_marker),
+        "{client_kind} did not complete clean shutdown:\n{}",
         process_output(&output)
     );
 
@@ -273,4 +322,38 @@ async fn windows_consumer_starts_without_stack_overflow() {
         .await
         .expect("NameServer shutdown should be bounded")
         .expect("NameServer task should not panic");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn windows_consumer_starts_without_stack_overflow() {
+    if std::env::var_os(CHILD_MODE_ENV).is_some() {
+        run_consumer_child();
+        return;
+    }
+
+    assert_client_process_startup(
+        CHILD_MODE_ENV,
+        "windows_consumer_starts_without_stack_overflow",
+        STARTUP_MARKER,
+        SHUTDOWN_MARKER,
+        "Consumer",
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn windows_producer_starts_without_stack_overflow() {
+    if std::env::var_os(PRODUCER_CHILD_MODE_ENV).is_some() {
+        run_producer_child();
+        return;
+    }
+
+    assert_client_process_startup(
+        PRODUCER_CHILD_MODE_ENV,
+        "windows_producer_starts_without_stack_overflow",
+        PRODUCER_STARTUP_MARKER,
+        PRODUCER_SHUTDOWN_MARKER,
+        "Producer",
+    )
+    .await;
 }

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/sources.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/sources.rs
@@ -269,7 +269,9 @@ where
         }
 
         let started_at = Instant::now();
-        let result = self.query_uncached(source, &query, operation, &session).await;
+        // Source dispatch combines several large async implementations. Keep that state on the heap so
+        // callers do not embed the complete dispatch future in their thread stack.
+        let result = Box::pin(self.query_uncached(source, &query, operation, &session)).await;
         let mut output = match result {
             Ok(output) => {
                 self.record_success(source, output.freshness_seconds).await;


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9739

### Brief Description

This change prevents the remaining observed Windows stack overflows caused by large concrete async futures crossing scheduler, lifecycle, and dispatch boundaries by value.

- Heap-erases the Broker `TopicQueueMappingCleanService` scan future before generic scheduled-task layers.
- Boxes nested Producer, `MQClientInstance`, Push Consumer, and LitePull Consumer lifecycle futures so their combined startup state stays off the default Windows main stack.
- Extends the Windows client process regression to start and shut down a real producer with a 1 MiB stack while preserving the consumer scenario.
- Boxes the RocketMQ SRE Connector source-dispatch future, which combines several large async source implementations.
- Preserves task ownership, cancellation, shutdown, query-security, and error-mapping semantics.

### How Did You Test This Change?

Passed:

- `cargo test -p rocketmq-broker --test broker_process_startup windows_broker_reaches_readiness_without_main_stack_overflow -- --exact --nocapture`
- `cargo test --quiet -p rocketmq-broker topic::topic_queue_mapping_clean_service::tests::` (7 passed)
- `cargo test -p rocketmq-client-rust --test windows_consumer_process_startup -- --nocapture` (2 passed)
- `cargo test --quiet -p rocketmq-client-rust --lib default_mq_producer_impl` (49 passed)
- Push Consumer module tests (26 passed)
- LitePull Consumer module tests (48 passed)
- `cargo test --quiet -p rocketmq-client-rust --test target_recursion_limit_contract`
- `cargo test --locked -p rocketmq-sre-connector --all-features --lib` (99 passed)
- Package-scoped format checks for `rocketmq-broker`, `rocketmq-client-rust`, and all SRE workspace packages
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings` from `rocketmq-sre/`
- `cargo check --locked --workspace` and `cargo doc --locked --workspace --no-deps` from `rocketmq-sre/`
- SRE source-layout and execution-dependency boundary checks
- `scripts/runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`
- `git diff --check`

Known unrelated validation findings:

- The full SRE workspace test gate reaches the fixed Connector tests but still fails three existing Control Plane capability-document tests because the semantic registry reports `unknown=["mcp"]`.
- The standalone `rocketmq-example` package format check passes, while its Clippy build is blocked by an existing lock/path dependency mismatch that lacks current `rocketmq-error` and `rocketmq-security-api` exports.
- `cargo fmt --all -- --check` in `rocketmq-example/` hits Windows error 206 due to the generated rustfmt command-line length; the package-scoped format check passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup and shutdown reliability for producers and consumers, particularly on Windows.
  * Reduced the risk of stack overflows during client initialization and lifecycle operations.
  * Improved reliability when processing uncached evidence queries.

* **Tests**
  * Expanded Windows startup coverage to validate both consumer and producer workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->