### PR TITLE
[ISSUE #9750]✨Distinguish ambiguous V1 empty response telemetry

### DIFF
--- a/rocketmq-observability/src/metrics/remoting.rs
+++ b/rocketmq-observability/src/metrics/remoting.rs
@@ -29,6 +29,7 @@ const NO_RESPONSE_CODE: i32 = -1;
 const RESULT_ONEWAY: &str = "oneway";
 const RESULT_SUCCESS: &str = "success";
 const RESULT_CANCELED: &str = "cancelled";
+const RESULT_LEGACY_AMBIGUOUS_NONE: &str = "legacy_ambiguous_none";
 const RESULT_PROCESS_REQUEST_FAILED: &str = "process_request_failed";
 const RESULT_WRITE_CHANNEL_FAILED: &str = "write_channel_failed";
 
@@ -77,6 +78,11 @@ impl RequestMetricsGuard {
     #[inline]
     pub fn complete_cancelled(&mut self) {
         self.record_rpc_latency(NO_RESPONSE_CODE, RESULT_CANCELED);
+    }
+
+    #[inline]
+    pub fn complete_legacy_ambiguous_none(&mut self) {
+        self.record_rpc_latency(NO_RESPONSE_CODE, RESULT_LEGACY_AMBIGUOUS_NONE);
     }
 
     #[inline]
@@ -417,15 +423,19 @@ mod tests {
         success.complete_response(0);
         success.complete_cancelled();
 
-        let mut process_failure = RequestMetricsGuard::start(metrics.clone(), 11, 64, true);
+        let mut legacy_ambiguous_none = RequestMetricsGuard::start(metrics.clone(), 11, 64, true);
+        legacy_ambiguous_none.complete_legacy_ambiguous_none();
+        legacy_ambiguous_none.complete_cancelled();
+
+        let mut process_failure = RequestMetricsGuard::start(metrics.clone(), 12, 32, true);
         process_failure.complete_process_request_failed(1);
         process_failure.complete_response(0);
 
-        let mut write_failure = RequestMetricsGuard::start(metrics.clone(), 12, 32, false);
+        let mut write_failure = RequestMetricsGuard::start(metrics.clone(), 13, 16, false);
         write_failure.complete_write_channel_failed(2);
         write_failure.complete_oneway();
 
-        drop(RequestMetricsGuard::start(metrics, 13, 16, false));
+        drop(RequestMetricsGuard::start(metrics, 14, 8, false));
     }
 
     #[cfg(feature = "otel-metrics")]

--- a/rocketmq-observability/src/metrics/tests/remoting_metric_isolation.rs
+++ b/rocketmq-observability/src/metrics/tests/remoting_metric_isolation.rs
@@ -157,7 +157,12 @@ fn request_guards_record_each_terminal_outcome_once_and_keep_instances_isolated(
 
     drop(RequestMetricsGuard::start(first.clone(), 11, 7, true));
 
-    let mut failure = RequestMetricsGuard::start(first, 12, 9, false);
+    let mut legacy_ambiguous_none = RequestMetricsGuard::start(first.clone(), 12, 9, false);
+    legacy_ambiguous_none.complete_legacy_ambiguous_none();
+    legacy_ambiguous_none.complete_cancelled();
+    drop(legacy_ambiguous_none);
+
+    let mut failure = RequestMetricsGuard::start(first, 13, 11, false);
     failure.complete_process_request_failed(1);
     failure.complete_response(0);
     drop(failure);
@@ -171,13 +176,13 @@ fn request_guards_record_each_terminal_outcome_once_and_keep_instances_isolated(
 
     let first_points = first_exporter.points();
     let second_points = second_exporter.points();
-    assert_eq!(metric_value(&first_points, TRANSPORT_REQUESTS_TOTAL), 3);
+    assert_eq!(metric_value(&first_points, TRANSPORT_REQUESTS_TOTAL), 4);
     assert_eq!(
         metric_value(&first_points, TRANSPORT_INBOUND_DECODED_PLAINTEXT_BYTES),
         21
     );
-    assert_eq!(metric_value(&first_points, TRANSPORT_REQUEST_LATENCY), 3);
-    assert_eq!(metric_value(&first_points, RPC_LATENCY), 3);
+    assert_eq!(metric_value(&first_points, TRANSPORT_REQUEST_LATENCY), 4);
+    assert_eq!(metric_value(&first_points, RPC_LATENCY), 4);
     assert_eq!(metric_value(&second_points, TRANSPORT_REQUESTS_TOTAL), 1);
     assert_eq!(
         metric_value(&second_points, TRANSPORT_INBOUND_DECODED_PLAINTEXT_BYTES),
@@ -190,16 +195,28 @@ fn request_guards_record_each_terminal_outcome_once_and_keep_instances_isolated(
         .iter()
         .filter(|point| point.metric == RPC_LATENCY)
         .collect::<Vec<_>>();
-    assert_eq!(first_rpc.len(), 3);
+    assert_eq!(first_rpc.len(), 4);
     assert!(first_rpc.iter().any(|point| {
         point.attributes.get("request_code") == Some(&CapturedValue::I64(10))
             && point.attributes.get("response_code") == Some(&CapturedValue::I64(0))
             && point.attributes.get("is_long_polling") == Some(&CapturedValue::Bool(false))
             && point.attributes.get("result") == Some(&CapturedValue::String("success".to_owned()))
     }));
-    assert!(first_rpc
+    assert!(first_rpc.iter().any(|point| {
+        point.attributes.get("request_code") == Some(&CapturedValue::I64(11))
+            && point.attributes.get("response_code") == Some(&CapturedValue::I64(-1))
+            && point.attributes.get("result") == Some(&CapturedValue::String("cancelled".to_owned()))
+    }));
+    let legacy_ambiguous_none = first_rpc
         .iter()
-        .any(|point| point.attributes.get("result") == Some(&CapturedValue::String("cancelled".to_owned()))));
+        .filter(|point| {
+            point.attributes.get("request_code") == Some(&CapturedValue::I64(12))
+                && point.attributes.get("response_code") == Some(&CapturedValue::I64(-1))
+                && point.attributes.get("result") == Some(&CapturedValue::String("legacy_ambiguous_none".to_owned()))
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(legacy_ambiguous_none.len(), 1);
+    assert_eq!(legacy_ambiguous_none[0].value, 1);
     assert!(first_rpc.iter().any(|point| {
         point.attributes.get("result") == Some(&CapturedValue::String("process_request_failed".to_owned()))
     }));

--- a/rocketmq-sre/config/observability/required-signals/broker.yaml
+++ b/rocketmq-sre/config/observability/required-signals/broker.yaml
@@ -53,7 +53,7 @@ signals:
     registry_reference: rocketmq_rpc_latency
     signal_type: metric
     status: queryable
-    query: sum by (request_code, response_code, result) (rate(rocketmq_rpc_latency_milliseconds_count{result!="success"}[5m]))
+    query: sum by (request_code, response_code, result) (rate(rocketmq_rpc_latency_milliseconds_count{result!="success",result!="legacy_ambiguous_none"}[5m]))
     query_resource: metrics/rocketmq_rpc_latency_milliseconds_count
     freshness_seconds: 60
     expected_attributes: [request_code, response_code, result]

--- a/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/required_signals.rs
+++ b/rocketmq-sre/crates/rocketmq-sre-connector/src/sources/required_signals.rs
@@ -577,6 +577,23 @@ mod tests {
     }
 
     #[test]
+    fn broker_request_errors_exclude_legacy_ambiguous_none() {
+        let manifest: serde_yaml::Value = serde_yaml::from_str(BROKER_MANIFEST).expect("valid broker manifest");
+        let request_errors = manifest["signals"]
+            .as_sequence()
+            .expect("broker signals are a sequence")
+            .iter()
+            .find(|signal| signal["requirement_id"].as_str() == Some("broker.request_errors"))
+            .expect("broker request errors signal");
+        const EXPECTED_QUERY: &str = concat!(
+            "sum by (request_code, response_code, result) ",
+            "(rate(rocketmq_rpc_latency_milliseconds_count{result!=\"success\",result!=\"legacy_ambiguous_none\"}[5m]))"
+        );
+
+        assert_eq!(request_errors["query"].as_str(), Some(EXPECTED_QUERY));
+    }
+
+    #[test]
     fn empty_metric_series_is_missing_and_never_fabricated_as_zero() {
         let signal = ManifestSignal {
             requirement_id: "broker.availability".to_owned(),

--- a/rocketmq-transport/Cargo.toml
+++ b/rocketmq-transport/Cargo.toml
@@ -85,6 +85,7 @@ libc = { version = "0.2.186", optional = true }
 anyhow.workspace = true
 criterion = { version = "0.8.2", features = ["async_tokio"] }
 pkcs8.workspace = true
+rocketmq-observability = { workspace = true, features = ["prometheus"] }
 serde_json.workspace = true
 tempfile = "3.27.0"
 tokio = { workspace = true, features = ["test-util"] }

--- a/rocketmq-transport/src/remoting.rs
+++ b/rocketmq-transport/src/remoting.rs
@@ -193,7 +193,7 @@ pub(crate) mod inner {
                 return Ok(());
             }
             let Some(response) = response else {
-                metrics_guard.complete_cancelled();
+                metrics_guard.complete_legacy_ambiguous_none();
                 return Ok(());
             };
             let response_code = response.code();

--- a/rocketmq-transport/src/telemetry.rs
+++ b/rocketmq-transport/src/telemetry.rs
@@ -220,9 +220,9 @@ impl TransportRequestMetricsGuard {
     }
 
     #[inline]
-    pub(crate) fn complete_cancelled(&mut self) {
+    pub(crate) fn complete_legacy_ambiguous_none(&mut self) {
         #[cfg(feature = "observability")]
-        self.inner.complete_cancelled();
+        self.inner.complete_legacy_ambiguous_none();
     }
 
     #[inline]
@@ -263,6 +263,6 @@ mod tests {
         assert!(telemetry.request_span(10, 1).is_disabled());
         let mut guard = telemetry.request_guard(10, 64, false);
         guard.complete_response(0);
-        guard.complete_cancelled();
+        guard.complete_legacy_ambiguous_none();
     }
 }

--- a/rocketmq-transport/tests/v1_processor_contract_tests.rs
+++ b/rocketmq-transport/tests/v1_processor_contract_tests.rs
@@ -19,6 +19,12 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
 
+#[cfg(feature = "observability")]
+use rocketmq_observability::init_observability_with_service_context;
+#[cfg(feature = "observability")]
+use rocketmq_observability::MetricsExporter;
+#[cfg(feature = "observability")]
+use rocketmq_observability::ObservabilityConfig;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_runtime::ChildServiceContext;
@@ -41,6 +47,12 @@ use rocketmq_transport::api::v1::TransportSecurity;
 use rocketmq_transport::api::v1::TransportServer;
 use rocketmq_transport::api::v1::TransportTelemetry;
 use rocketmq_transport::test_support::Connection;
+#[cfg(feature = "observability")]
+use tokio::io::AsyncReadExt;
+#[cfg(feature = "observability")]
+use tokio::io::AsyncWriteExt;
+#[cfg(feature = "observability")]
+use tokio::net::TcpListener;
 use tokio::net::TcpStream;
 use tokio::sync::oneshot;
 
@@ -50,6 +62,7 @@ const ONEWAY: i32 = 19_750;
 const NONE: i32 = 19_751;
 const DIRECT_WRITE: i32 = 19_752;
 const SENTINEL: i32 = 19_753;
+const ONEWAY_NONE: i32 = 19_754;
 const ORIGINAL_OPAQUE: i32 = 74;
 const MUTATED_OPAQUE: i32 = 8_074;
 const PROCESSOR_RESPONSE_OPAQUE: i32 = 9_074;
@@ -130,7 +143,7 @@ impl RequestProcessor for ContractProcessor {
             opaque: request.opaque(),
         });
         match request.code() {
-            NONE => Ok(None),
+            NONE | ONEWAY_NONE => Ok(None),
             DIRECT_WRITE => {
                 ctx.write_response(
                     RemotingCommand::create_response_command_with_code(ResponseCode::Success)
@@ -222,6 +235,10 @@ struct Fixture {
 }
 
 fn fixture(runtime: &RuntimeContext, name: &'static str) -> Fixture {
+    fixture_with_telemetry(runtime, name, TransportTelemetry::noop())
+}
+
+fn fixture_with_telemetry(runtime: &RuntimeContext, name: &'static str, telemetry: TransportTelemetry) -> Fixture {
     let service = runtime.service_context(name);
     let process_budget = service.process_budget();
     let events = EventLog::default();
@@ -236,7 +253,7 @@ fn fixture(runtime: &RuntimeContext, name: &'static str) -> Fixture {
             processor.clone(),
             vec![Arc::new(ContractHook { events: events.clone() })],
             &process_budget,
-            TransportTelemetry::noop(),
+            telemetry,
             Arc::clone(&security),
             admission,
         )
@@ -518,4 +535,112 @@ async fn direct_context_write_followed_by_none_emits_exactly_one_processor_frame
             ..
         }
     )));
+}
+
+#[cfg(feature = "observability")]
+#[tokio::test]
+async fn network_v1_none_outcomes_record_their_distinct_terminal_telemetry() {
+    let runtime = RuntimeContext::from_current("v1-none-terminal-telemetry");
+    let telemetry_service = runtime.service_context("telemetry");
+    let mut observability = ObservabilityConfig {
+        enabled: true,
+        ..ObservabilityConfig::default()
+    };
+    observability.metrics.enabled = true;
+    observability.metrics.exporter = MetricsExporter::Prometheus;
+    observability.prometheus.host = "127.0.0.1".to_owned();
+    let port_reservation = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("reserve a Prometheus port");
+    observability.prometheus.port = port_reservation
+        .local_addr()
+        .expect("reserved Prometheus port has an address")
+        .port();
+    drop(port_reservation);
+    observability.prometheus.path = "/metrics".to_owned();
+    let telemetry_runtime = init_observability_with_service_context(&observability, &telemetry_service)
+        .await
+        .expect("test telemetry runtime should initialize");
+    let fixture = fixture_with_telemetry(
+        &runtime,
+        "network",
+        TransportTelemetry::from_handle(&telemetry_runtime.handle()),
+    );
+
+    // The network adapter delegates these requests to RemotingGeneralHandler::process_message_received.
+    let responses = run_network(
+        &fixture,
+        vec![
+            request(NONE, 1),
+            request(ONEWAY_NONE, 2).mark_oneway_rpc(),
+            request(SENTINEL, 3),
+        ],
+        1,
+    )
+    .await;
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0].opaque(), 3);
+
+    let metrics = scrape_metrics(
+        telemetry_runtime
+            .prometheus_local_addr()
+            .expect("test telemetry should expose Prometheus metrics"),
+        observability.prometheus.path.as_str(),
+    )
+    .await;
+    assert_rpc_latency_count(&metrics, NONE, -1, "legacy_ambiguous_none");
+    assert_rpc_latency_count(&metrics, ONEWAY_NONE, -1, "oneway");
+
+    let report = telemetry_runtime
+        .shutdown_with_service_context(&telemetry_service, Duration::from_secs(3))
+        .await;
+    assert!(report.is_healthy(), "{}", report.to_json());
+}
+
+#[cfg(feature = "observability")]
+async fn scrape_metrics(address: SocketAddr, path: &str) -> String {
+    let mut stream = TcpStream::connect(address)
+        .await
+        .expect("connect to test Prometheus endpoint");
+    let request = format!("GET {path} HTTP/1.1\r\nHost: {address}\r\nConnection: close\r\n\r\n");
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .expect("write test Prometheus request");
+    let mut response = Vec::new();
+    stream
+        .read_to_end(&mut response)
+        .await
+        .expect("read test Prometheus response");
+    let response = String::from_utf8(response).expect("Prometheus response is UTF-8");
+    assert!(response.starts_with("HTTP/1.1 200 OK"), "{response}");
+    response
+        .split_once("\r\n\r\n")
+        .expect("Prometheus response has headers and body")
+        .1
+        .to_owned()
+}
+
+#[cfg(feature = "observability")]
+fn assert_rpc_latency_count(metrics: &str, request_code: i32, response_code: i32, result: &str) {
+    let expected_request_code = format!("request_code=\"{request_code}\"");
+    let expected_response_code = format!("response_code=\"{response_code}\"");
+    let expected_result = format!("result=\"{result}\"");
+    let matching = metrics
+        .lines()
+        .filter(|line| {
+            line.starts_with("rocketmq_rpc_latency_count{")
+                && line.contains(expected_request_code.as_str())
+                && line.contains(expected_response_code.as_str())
+                && line.contains(expected_result.as_str())
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(matching.len(), 1, "matching RPC metrics: {matching:?}");
+    assert_eq!(
+        matching[0].split_whitespace().last(),
+        Some("1"),
+        "matching RPC metric: {}",
+        matching[0]
+    );
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9750

### Brief Description

Classify a non-oneway V1 processor `Ok(None)` result as the static `legacy_ambiguous_none` telemetry outcome instead of cancellation while preserving drop-based cancellation and one-way semantics. Update the broker required-signal query so this legacy ambiguity is not counted as a request error. Add guard-level, SRE query, and real socket-backed V1 Prometheus regression coverage.

### How Did You Test This Change?

- Passed the five V1 processor contract tests with `observability,test-support`, including the real network telemetry regression.
- Passed the complete `rocketmq-transport` test suite with `observability`.
- Passed package formatting and `git diff --check`.
- Passed root workspace check and Clippy for the default, observability, OTLP metrics, Prometheus metrics, OTLP traces, OTLP logs, combined OTLP/Prometheus, and all-features configurations.
- Passed every `rocketmq-observability` unit test in each required feature configuration, metric catalog generation check, telemetry semantic guard, and all-features documentation build.
- Passed the `rocketmq-sre` locked workspace check, Clippy, documentation build, connector regression, required-signal qualification checks, source layout check, and execution dependency boundary check.
- Passed the AGENTS routing drift check required by the test dependency manifest change.
- Confirmed two unrelated baseline failures on `main`: the observability subscriber installation registry does not include an existing `rocketmq-auth` site, and the SRE control-plane semantic registry reports the existing unknown `mcp` owner. The same failures are present without this change; all affected tests introduced or exercised by this PR pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added distinct observability tracking for requests that complete without a response due to legacy ambiguous outcomes.
  * Added support for the `ONEWAY_NONE` request behavior, including network-level metrics visibility.

* **Bug Fixes**
  * Improved broker request-error metrics to exclude successful and legacy ambiguous outcomes.
  * Ensured no-response request outcomes are recorded accurately and only once.

* **Tests**
  * Added coverage validating distinct terminal results and Prometheus metric reporting for no-response scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->