### PR TITLE
[ISSUE #9754]✨Return stage-aware canonical writer failures

### DIFF
--- a/rocketmq-transport/src/connection.rs
+++ b/rocketmq-transport/src/connection.rs
@@ -41,10 +41,13 @@ use crate::codec::remoting_command_codec::FrameLimits;
 use crate::codec::remoting_command_codec::RemotingCommandCodec;
 use crate::codec::remoting_command_codec::SessionCommandDecoder;
 use crate::deadline::RequestDeadline;
+use crate::dispatch::ResponseError;
+use crate::dispatch::WriteProgress;
 use crate::file_region::FileRegion;
 use crate::file_region::FileRegionSequence;
 use crate::file_region::FileTransferMode;
 use crate::telemetry::TransportTelemetry;
+use crate::write_result::WriterFailure;
 use crate::write_strategy::FrameWriteMode;
 use crate::write_strategy::FrameWriter;
 use crate::write_strategy::OutboundPayload;
@@ -137,6 +140,83 @@ pub(crate) type ConnectionFrameWriter = FrameWriter<WriteBackend>;
 enum ConnectionWriter {
     Direct(ConnectionFrameWriter),
     Queued(QueuedConnection),
+}
+
+/// Static legacy reason selected from the caller's operation rather than an
+/// I/O source. The writer completion remains source-preserving for typed
+/// response fan-out, while each legacy caller reconstructs its historic text.
+#[derive(Clone, Copy)]
+enum LegacyWriterReason {
+    CanonicalWriter,
+    ExplicitSendfile,
+    CompletionDropped,
+}
+
+impl LegacyWriterReason {
+    const fn for_direct_payload(payload: &OutboundPayload, file_transfer_mode: FileTransferMode) -> Self {
+        if matches!(payload, OutboundPayload::FileFrame { .. })
+            && matches!(file_transfer_mode, FileTransferMode::Sendfile)
+        {
+            Self::ExplicitSendfile
+        } else {
+            Self::CanonicalWriter
+        }
+    }
+
+    const fn as_static_reason(self) -> &'static str {
+        match self {
+            Self::CanonicalWriter => "canonical writer failure",
+            Self::ExplicitSendfile => "sendfile mode requires an eligible file and plaintext TCP connection",
+            Self::CompletionDropped => "writer completion dropped",
+        }
+    }
+}
+
+/// Private send mechanics shared by legacy `RocketMQResult` facades and the
+/// server's typed response completion path.
+enum SendFailure {
+    DeadlineExceeded {
+        target: String,
+    },
+    SessionClosed {
+        target: String,
+    },
+    QueueSaturated {
+        target: String,
+    },
+    Writer {
+        target: String,
+        failure: WriterFailure,
+        legacy_reason: LegacyWriterReason,
+    },
+}
+
+impl SendFailure {
+    fn into_legacy(self) -> rocketmq_error::RocketMQError {
+        match self {
+            Self::DeadlineExceeded { target } => {
+                rocketmq_error::RocketMQError::network_deadline_exceeded_before_send(target)
+            }
+            Self::SessionClosed { target } => {
+                rocketmq_error::RocketMQError::network_connection_failed(target, "connection is closed")
+            }
+            Self::QueueSaturated { target } => rocketmq_error::RocketMQError::network_queue_full(target),
+            Self::Writer {
+                target,
+                failure,
+                legacy_reason,
+            } => failure.into_legacy_for_target(target, legacy_reason.as_static_reason()),
+        }
+    }
+
+    fn into_response(self) -> ResponseError {
+        match self {
+            Self::DeadlineExceeded { .. } => ResponseError::DeadlineExceeded,
+            Self::SessionClosed { .. } => ResponseError::SessionClosed,
+            Self::QueueSaturated { .. } => ResponseError::QueueSaturated,
+            Self::Writer { failure, .. } => failure.into_response(),
+        }
+    }
 }
 
 static TRANSPORT_ENCODED_BYTES_WRITTEN: AtomicU64 = AtomicU64::new(0);
@@ -245,7 +325,11 @@ impl SessionWriterDiagnostics {
     }
 
     pub(crate) fn finish_write(&self, started_at: Instant, succeeded: bool, deadline_expired: bool) {
-        let write_latency = duration_millis(started_at.elapsed());
+        self.finish_write_at(started_at, Instant::now(), succeeded, deadline_expired);
+    }
+
+    fn finish_write_at(&self, started_at: Instant, finished_at: Instant, succeeded: bool, deadline_expired: bool) {
+        let write_latency = duration_millis(finished_at.saturating_duration_since(started_at));
         self.last_write_latency_millis.store(write_latency, Ordering::Relaxed);
         self.max_write_latency_millis
             .fetch_max(write_latency, Ordering::Relaxed);
@@ -254,6 +338,22 @@ impl SessionWriterDiagnostics {
         } else {
             self.failed.fetch_add(1, Ordering::Relaxed);
         }
+        if deadline_expired {
+            self.deadline_expired.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Completes an accepted envelope that never reached a socket attempt.
+    ///
+    /// This deliberately does not call `start_write`: poisoned-drain and
+    /// deterministic preflight paths must not look like writer activity in the
+    /// queue diagnostics.
+    pub(crate) fn finish_not_started(&self, enqueued_at: Option<Instant>, bytes: usize, deadline_expired: bool) {
+        if enqueued_at.is_some() {
+            self.queued_items.fetch_sub(1, Ordering::AcqRel);
+            self.queued_bytes.fetch_sub(bytes, Ordering::AcqRel);
+        }
+        self.failed.fetch_add(1, Ordering::Relaxed);
         if deadline_expired {
             self.deadline_expired.fetch_add(1, Ordering::Relaxed);
         }
@@ -648,6 +748,13 @@ impl Connection {
         self.enqueue_gate = Some((checked, resume));
     }
 
+    #[cfg(test)]
+    pub(crate) fn set_write_preflight_barrier(&mut self, barrier: crate::write_strategy::WritePreflightBarrier) {
+        if let ConnectionWriter::Direct(writer) = &mut self.outbound {
+            writer.set_write_preflight_barrier(barrier);
+        }
+    }
+
     pub(crate) fn into_session_io(
         self,
         admission: AdmissionScopeHandle,
@@ -720,36 +827,50 @@ impl Connection {
         deadline: Option<RequestDeadline>,
         target: String,
     ) -> rocketmq_error::RocketMQResult<()> {
+        self.send_payload_inner(payload, class, reservation, deadline, target)
+            .await
+            .map_err(SendFailure::into_legacy)
+    }
+
+    async fn send_payload_inner(
+        &mut self,
+        payload: OutboundPayload,
+        class: AdmissionClass,
+        reservation: Option<ResourcePermit>,
+        deadline: Option<RequestDeadline>,
+        target: String,
+    ) -> Result<(), SendFailure> {
         let encoded_len = payload.encoded_len();
+        let legacy_reason = match &self.outbound {
+            ConnectionWriter::Direct(writer) => {
+                LegacyWriterReason::for_direct_payload(&payload, writer.file_transfer_mode())
+            }
+            ConnectionWriter::Queued(_) => LegacyWriterReason::CanonicalWriter,
+        };
         self.telemetry.record_outbound_attempted_plaintext_bytes(encoded_len);
-        if let Some(deadline) = deadline {
-            deadline.ensure_before_send(target.clone())?;
+        if deadline.is_some_and(RequestDeadline::is_expired) {
+            return Err(SendFailure::DeadlineExceeded { target });
         }
         if let Some(queued) = self.queued_writer() {
             let _send_lease = match queued.lifecycle.begin_send() {
                 Some(lease) => lease,
                 None => {
                     queued.writer_diagnostics.record_rejected(None);
-                    return Err(rocketmq_error::RocketMQError::network_connection_failed(
-                        target,
-                        "connection writer is retiring",
-                    ));
+                    return Err(SendFailure::SessionClosed { target });
                 }
             };
             if self.state() == ConnectionState::Closed {
                 queued.writer_diagnostics.record_rejected(None);
-                return Err(rocketmq_error::RocketMQError::network_connection_failed(
-                    target,
-                    "connection is closed",
-                ));
+                return Err(SendFailure::SessionClosed { target });
             }
             #[cfg(test)]
             if let Some((checked, resume)) = self.enqueue_gate.as_ref() {
                 checked.notify_one();
                 if let Some(deadline) = deadline {
-                    deadline.timeout(resume.notified()).await.map_err(|_| {
-                        rocketmq_error::RocketMQError::network_deadline_exceeded_before_send(target.clone())
-                    })?;
+                    deadline
+                        .timeout(resume.notified())
+                        .await
+                        .map_err(|_| SendFailure::DeadlineExceeded { target: target.clone() })?;
                 } else {
                     resume.notified().await;
                 }
@@ -762,13 +883,13 @@ impl Connection {
             }
             .map_err(|_| {
                 queued.writer_diagnostics.record_rejected(None);
-                rocketmq_error::RocketMQError::network_queue_full(target.clone())
+                SendFailure::QueueSaturated { target: target.clone() }
             })?;
-            if let Some(deadline) = deadline {
-                deadline.ensure_before_send(target.clone())?;
+            if deadline.is_some_and(RequestDeadline::is_expired) {
+                return Err(SendFailure::DeadlineExceeded { target });
             }
             let (completion, result) = oneshot::channel();
-            let progress = deadline.map(|_| Arc::new(QueuedWriteProgress::waiting()));
+            let progress = Arc::new(QueuedWriteProgress::waiting());
             let enqueued_at = queued.writer_diagnostics.prepare_enqueue(encoded_len);
             match queued.writer.try_send(
                 class,
@@ -790,59 +911,91 @@ impl Connection {
                     queued.writer_diagnostics.record_rejected(Some(encoded_len));
                     return Err(match error {
                         crate::writer_runtime::WriterEnqueueError::Full => {
-                            rocketmq_error::RocketMQError::network_queue_full(target.clone())
+                            SendFailure::QueueSaturated { target: target.clone() }
                         }
                         crate::writer_runtime::WriterEnqueueError::Closed => {
-                            rocketmq_error::RocketMQError::network_connection_failed(
-                                target.clone(),
-                                "writer queue closed",
-                            )
+                            SendFailure::SessionClosed { target: target.clone() }
                         }
                     });
                 }
             }
+            let mut result = result;
             let outcome = if let Some(deadline) = deadline {
-                deadline.timeout(result).await.map_err(|_| {
-                    if progress.as_ref().is_some_and(|progress| !progress.write_started()) {
-                        rocketmq_error::RocketMQError::network_deadline_exceeded_before_send(target.clone())
-                    } else {
-                        rocketmq_error::RocketMQError::network_write_timeout(target.clone(), deadline.budget_millis())
+                match deadline.timeout(&mut result).await {
+                    Ok(outcome) => outcome,
+                    Err(_) => {
+                        if progress.cancel_before_start() {
+                            return Err(SendFailure::DeadlineExceeded { target });
+                        }
+                        result.await
                     }
-                })?
+                }
             } else {
                 result.await
             }
             .map_err(|_| {
-                rocketmq_error::RocketMQError::network_connection_failed(target.clone(), "writer completion dropped")
+                let progress = if progress.write_started() {
+                    WriteProgress::PossiblyPartial
+                } else {
+                    WriteProgress::NotStarted
+                };
+                SendFailure::Writer {
+                    failure: WriterFailure::completion_dropped(progress),
+                    target: target.clone(),
+                    legacy_reason: LegacyWriterReason::CompletionDropped,
+                }
             })?;
-            return outcome;
+            return outcome.map_err(|failure| SendFailure::Writer {
+                target,
+                failure,
+                legacy_reason,
+            });
         }
         if self.state() == ConnectionState::Closed {
-            return Err(rocketmq_error::RocketMQError::network_connection_failed(
-                target,
-                "connection is closed",
-            ));
+            return Err(SendFailure::SessionClosed { target });
         }
         self.telemetry.record_outbound_accepted_plaintext_bytes(encoded_len);
         let writer = match &mut self.outbound {
             ConnectionWriter::Direct(writer) => writer,
             ConnectionWriter::Queued(_) => unreachable!("queued writer returned above"),
         };
+        let write_started = Arc::new(AtomicBool::new(false));
+        let write_started_marker = Arc::clone(&write_started);
+        let mut mark_write_started = move || write_started_marker.store(true, Ordering::Release);
         let send_result = if let Some(deadline) = deadline {
-            match deadline.timeout(payload.write_to(writer)).await {
-                Ok(result) => result,
-                Err(_) => {
-                    let _ = self.state_tx.send(ConnectionState::Degraded);
-                    let _ = writer.shutdown().await;
-                    let _ = self.state_tx.send(ConnectionState::Closed);
-                    return Err(rocketmq_error::RocketMQError::network_write_timeout(
-                        target,
-                        deadline.budget_millis(),
-                    ));
-                }
+            match deadline
+                .timeout(writer.write_transport_payloads_with_start(&[&payload], 64, &mut mark_write_started))
+                .await
+            {
+                Ok(Ok(())) => Ok(()),
+                Ok(Err(error)) => Err(WriterFailure::from_io(
+                    if write_started.load(Ordering::Acquire) {
+                        WriteProgress::PossiblyPartial
+                    } else {
+                        WriteProgress::NotStarted
+                    },
+                    error,
+                )),
+                Err(_) => Err(if write_started.load(Ordering::Acquire) {
+                    WriterFailure::write_timeout(deadline.budget_millis())
+                } else {
+                    WriterFailure::deadline_exceeded_before_send()
+                }),
             }
         } else {
-            payload.write_to(writer).await
+            writer
+                .write_transport_payloads_with_start(&[&payload], 64, &mut mark_write_started)
+                .await
+                .map_err(|error| {
+                    WriterFailure::from_io(
+                        if write_started.load(Ordering::Acquire) {
+                            WriteProgress::PossiblyPartial
+                        } else {
+                            WriteProgress::NotStarted
+                        },
+                        error,
+                    )
+                })
         };
         match send_result {
             Ok(()) => {
@@ -850,16 +1003,41 @@ impl Connection {
                 self.telemetry.record_outbound_written_plaintext_bytes(encoded_len);
                 Ok(())
             }
-            Err(error) => {
-                let _ = self.state_tx.send(ConnectionState::Degraded);
-                let _ = writer.shutdown().await;
-                let _ = self.state_tx.send(ConnectionState::Closed);
-                Err(rocketmq_error::RocketMQError::network_connection_failed(
+            Err(failure) => {
+                if failure.progress() == WriteProgress::PossiblyPartial || writer.is_poisoned() {
+                    let _ = self.state_tx.send(ConnectionState::Degraded);
+                    let _ = writer.shutdown().await;
+                    let _ = self.state_tx.send(ConnectionState::Closed);
+                }
+                Err(SendFailure::Writer {
                     target,
-                    error.to_string(),
-                ))
+                    failure,
+                    legacy_reason,
+                })
             }
         }
+    }
+
+    /// Sends a server response through the canonical writer with a stage-aware
+    /// completion error. This is intentionally crate-private while the public
+    /// response receipt/context API is introduced separately.
+    pub(crate) async fn send_response(&mut self, command: RemotingCommand) -> Result<(), ResponseError> {
+        let class = self
+            .response_class()
+            .unwrap_or_else(|| AdmissionClass::for_request_code(command.code()));
+        let frame = self
+            .limits
+            .encode_command(command)
+            .map_err(|source| ResponseError::Encode { source })?;
+        self.send_payload_inner(
+            OutboundPayload::Frame(frame),
+            class,
+            None,
+            None,
+            "transport-session-writer".to_string(),
+        )
+        .await
+        .map_err(SendFailure::into_response)
     }
 
     /// Sends a `RemotingCommand` to the peer (consumes command).
@@ -1377,7 +1555,11 @@ impl Connection {
 }
 
 #[cfg(test)]
-mod session_lifecycle_tests {
+#[path = "connection/issue_9754_tests.rs"]
+mod session_lifecycle_tests;
+
+#[cfg(test)]
+mod lifecycle_regression_tests {
     use std::sync::Arc;
 
     use super::SessionLifecycle;
@@ -1412,7 +1594,7 @@ mod session_lifecycle_tests {
     fn queued_send_path_does_not_restore_a_lock_guard_across_network_await() {
         let source = include_str!("connection.rs").replace("\r\n", "\n");
         let production = source
-            .split("#[cfg(test)]\nmod session_lifecycle_tests")
+            .split("#[cfg(test)]\n#[path = \"connection/issue_9754_tests.rs\"]")
             .next()
             .expect("production connection source");
 

--- a/rocketmq-transport/src/connection/issue_9754_tests.rs
+++ b/rocketmq-transport/src/connection/issue_9754_tests.rs
@@ -1,0 +1,887 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::io;
+use std::io::IoSlice;
+use std::io::Write as _;
+use std::num::NonZeroUsize;
+use std::pin::Pin;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::task::Context;
+use std::task::Poll;
+
+use bytes::Bytes;
+use cheetah_string::CheetahString;
+use rocketmq_error::NetworkError;
+use rocketmq_error::RocketMQError;
+use rocketmq_protocol::protocol::encoded_frame::EncodedFrameHead;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use tokio::io::AsyncRead;
+use tokio::io::AsyncWrite;
+use tokio::io::ReadBuf;
+use tokio_util::sync::CancellationToken;
+
+use super::Connection;
+use super::ConnectionState;
+use super::FrameLimits;
+use super::SessionLifecycle;
+use crate::admission::AdmissionClass;
+use crate::admission::AdmissionController;
+use crate::admission::AdmissionLimits;
+use crate::admission::AdmissionResource;
+use crate::admission::AdmissionScope;
+use crate::admission::ResourceLimit;
+use crate::dispatch::ResponseError;
+use crate::dispatch::WriteProgress;
+use crate::file_region::FileRegion;
+use crate::file_region::FileRegionSequence;
+use crate::file_region::FileTransferMode;
+use crate::telemetry::TransportTelemetry;
+use crate::write_strategy::OutboundPayload;
+use crate::write_strategy::QueuedWrite;
+use crate::write_strategy::QueuedWriteProgress;
+use crate::writer_runtime::run_session_writer;
+use crate::writer_runtime::writer_lanes;
+use crate::writer_runtime::WriterQueueConfig;
+
+fn explicit_sendfile_payload() -> OutboundPayload {
+    let mut file = tempfile::tempfile().expect("temporary file");
+    file.write_all(&[0x5a]).expect("write leased byte");
+    let body = FileRegionSequence::single(FileRegion::try_new(Arc::new(file), 0, 1).expect("leased file region"));
+    let head = EncodedFrameHead::from_command_and_body_len(RemotingCommand::create_remoting_command(97), 1)
+        .expect("file frame head");
+    OutboundPayload::FileFrame { head, body }
+}
+
+#[derive(Clone, Copy)]
+enum DirectFailurePhase {
+    FirstWrite,
+    PartialThenError,
+    Flush,
+}
+
+struct FailingResponseTransport {
+    writes: Arc<AtomicUsize>,
+    phase: DirectFailurePhase,
+}
+
+impl AsyncRead for FailingResponseTransport {
+    fn poll_read(self: Pin<&mut Self>, _: &mut Context<'_>, _: &mut ReadBuf<'_>) -> Poll<io::Result<()>> {
+        Poll::Pending
+    }
+}
+
+impl AsyncWrite for FailingResponseTransport {
+    fn poll_write(self: Pin<&mut Self>, _: &mut Context<'_>, buffer: &[u8]) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        let attempt = this.writes.fetch_add(1, Ordering::AcqRel);
+        match this.phase {
+            DirectFailurePhase::FirstWrite => Poll::Ready(Err(io::Error::other("injected direct write failure"))),
+            DirectFailurePhase::PartialThenError if attempt == 0 => Poll::Ready(Ok(1)),
+            DirectFailurePhase::PartialThenError => {
+                Poll::Ready(Err(io::Error::other("injected partial write failure")))
+            }
+            DirectFailurePhase::Flush => Poll::Ready(Ok(buffer.len())),
+        }
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+        buffers: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        let attempt = this.writes.fetch_add(1, Ordering::AcqRel);
+        match this.phase {
+            DirectFailurePhase::FirstWrite => Poll::Ready(Err(io::Error::other("injected direct write failure"))),
+            DirectFailurePhase::PartialThenError if attempt == 0 => Poll::Ready(Ok(1)),
+            DirectFailurePhase::PartialThenError => {
+                Poll::Ready(Err(io::Error::other("injected partial write failure")))
+            }
+            DirectFailurePhase::Flush => Poll::Ready(Ok(buffers.iter().map(|buffer| buffer.len()).sum())),
+        }
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match self.get_mut().phase {
+            DirectFailurePhase::FirstWrite => Poll::Ready(Ok(())),
+            DirectFailurePhase::PartialThenError => Poll::Ready(Ok(())),
+            DirectFailurePhase::Flush => Poll::Ready(Err(io::Error::other("injected direct flush failure"))),
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+struct CountingTransport {
+    writes: Arc<AtomicUsize>,
+    flushes: Arc<AtomicUsize>,
+}
+
+impl AsyncRead for CountingTransport {
+    fn poll_read(self: Pin<&mut Self>, _: &mut Context<'_>, _: &mut ReadBuf<'_>) -> Poll<io::Result<()>> {
+        Poll::Pending
+    }
+}
+
+impl AsyncWrite for CountingTransport {
+    fn poll_write(self: Pin<&mut Self>, _: &mut Context<'_>, buffer: &[u8]) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        this.writes.fetch_add(1, Ordering::AcqRel);
+        Poll::Ready(Ok(buffer.len()))
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+        buffers: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        this.writes.fetch_add(1, Ordering::AcqRel);
+        Poll::Ready(Ok(buffers.iter().map(|buffer| buffer.len()).sum()))
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.get_mut().flushes.fetch_add(1, Ordering::AcqRel);
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+struct PendingWriteTransport {
+    writes: Arc<AtomicUsize>,
+    entered: Arc<tokio::sync::Notify>,
+}
+
+impl AsyncRead for PendingWriteTransport {
+    fn poll_read(self: Pin<&mut Self>, _: &mut Context<'_>, _: &mut ReadBuf<'_>) -> Poll<io::Result<()>> {
+        Poll::Pending
+    }
+}
+
+impl AsyncWrite for PendingWriteTransport {
+    fn poll_write(self: Pin<&mut Self>, _: &mut Context<'_>, _: &[u8]) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        this.writes.fetch_add(1, Ordering::AcqRel);
+        this.entered.notify_one();
+        Poll::Pending
+    }
+
+    fn poll_write_vectored(self: Pin<&mut Self>, _: &mut Context<'_>, _: &[IoSlice<'_>]) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        this.writes.fetch_add(1, Ordering::AcqRel);
+        this.entered.notify_one();
+        Poll::Pending
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+#[test]
+fn writer_diagnostics_use_the_retained_start_instant_for_latency() {
+    let diagnostics = super::SessionWriterDiagnostics::new(1);
+    let started_at = std::time::Instant::now();
+    let finished_at = started_at
+        .checked_add(std::time::Duration::from_millis(17))
+        .expect("small duration remains representable");
+
+    diagnostics.finish_write_at(started_at, finished_at, true, false);
+
+    let snapshot = diagnostics.snapshot();
+    assert_eq!(snapshot.last_write_latency_millis, 17);
+    assert_eq!(snapshot.max_write_latency_millis, 17);
+    assert_eq!(snapshot.completed, 1);
+}
+
+#[tokio::test]
+async fn typed_response_encode_failure_is_not_started_and_keeps_direct_writer_healthy() {
+    let limits = FrameLimits::try_new(1024, 1024, 0, 8).expect("valid test limits");
+    let (transport, peer_transport) = tokio::io::duplex(4096);
+    let mut connection = Connection::new_with_plaintext_stream_and_limits(transport, limits);
+
+    let error = connection
+        .send_response(RemotingCommand::create_remoting_command(1).set_body(vec![1]))
+        .await
+        .expect_err("body above the zero-byte profile must fail encoding");
+    assert!(matches!(error, ResponseError::Encode { .. }));
+    assert_eq!(connection.state(), ConnectionState::Healthy);
+
+    connection
+        .send_response(RemotingCommand::create_remoting_command(2))
+        .await
+        .expect("a deterministic preflight failure must not poison the writer");
+    let mut peer = Connection::new_with_plaintext_stream_and_limits(peer_transport, limits);
+    let response = peer
+        .receive_command()
+        .await
+        .expect("peer response result")
+        .expect("peer response command");
+    assert_eq!(response.code(), 2);
+}
+
+#[tokio::test]
+async fn typed_response_queue_saturation_is_not_started() {
+    let controller = AdmissionController::new(AdmissionLimits::default());
+    let admission = controller
+        .prepare_scope(AdmissionScope::new("127.0.0.1".parse().expect("loopback")))
+        .expect("prepare scope");
+    let config = WriterQueueConfig {
+        data_capacity: NonZeroUsize::new(1).expect("non-zero"),
+        ..WriterQueueConfig::default()
+    };
+    let (lanes, receivers) = writer_lanes(config);
+    let permit = admission
+        .try_acquire(AdmissionResource::Queued, 1, AdmissionClass::Data)
+        .expect("reserve blocker");
+    let (completion, _completion_result) = tokio::sync::oneshot::channel();
+    lanes
+        .try_send(
+            AdmissionClass::Data,
+            QueuedWrite::data(
+                OutboundPayload::Contiguous(Bytes::from_static(b"x")),
+                completion,
+                permit,
+                None,
+                "queued-blocker".to_string(),
+                Arc::new(QueuedWriteProgress::waiting()),
+                std::time::Instant::now(),
+            ),
+        )
+        .expect("fill data lane");
+    let diagnostics = Arc::new(super::SessionWriterDiagnostics::new(config.total_capacity()));
+    let (state_tx, state_rx) = tokio::sync::watch::channel(ConnectionState::Healthy);
+    let mut connection = Connection::new_queued(
+        lanes.clone(),
+        diagnostics,
+        admission,
+        state_tx,
+        state_rx,
+        CheetahString::from_string("typed-response-queue-test".to_string()),
+        FrameLimits::default(),
+        Some(AdmissionClass::Data),
+        Arc::new(SessionLifecycle::new()),
+        TransportTelemetry::noop(),
+    );
+    let error = connection
+        .send_response(RemotingCommand::create_remoting_command(7))
+        .await
+        .expect_err("a full data lane must reject the typed response");
+
+    assert!(matches!(&error, ResponseError::QueueSaturated));
+    assert_eq!(error.write_progress(), Some(WriteProgress::NotStarted));
+    drop(connection);
+    drop(lanes);
+    drop(receivers);
+    assert_eq!(controller.snapshot().queued.current_count, 0);
+}
+
+#[tokio::test]
+async fn typed_response_admission_saturation_is_not_started_before_lane_enqueue() {
+    let limits = AdmissionLimits {
+        queued: ResourceLimit { count: 1, bytes: 1024 },
+        ..AdmissionLimits::default()
+    };
+    let controller = AdmissionController::new(limits);
+    let admission = controller
+        .prepare_scope(AdmissionScope::new("127.0.0.1".parse().expect("loopback")))
+        .expect("prepare scope");
+    let blocker = admission
+        .try_acquire(AdmissionResource::Queued, 1, AdmissionClass::Data)
+        .expect("consume the admission budget without filling the lane");
+    let config = WriterQueueConfig::default();
+    let (lanes, receivers) = writer_lanes(config);
+    let diagnostics = Arc::new(super::SessionWriterDiagnostics::new(config.total_capacity()));
+    let (state_tx, state_rx) = tokio::sync::watch::channel(ConnectionState::Healthy);
+    let mut connection = Connection::new_queued(
+        lanes.clone(),
+        diagnostics,
+        admission,
+        state_tx,
+        state_rx,
+        CheetahString::from_string("typed-response-admission-test".to_string()),
+        FrameLimits::default(),
+        Some(AdmissionClass::Data),
+        Arc::new(SessionLifecycle::new()),
+        TransportTelemetry::noop(),
+    );
+
+    let error = connection
+        .send_response(RemotingCommand::create_remoting_command(7))
+        .await
+        .expect_err("admission exhaustion must reject before lane enqueue");
+    assert!(matches!(&error, ResponseError::QueueSaturated));
+    assert_eq!(error.write_progress(), Some(WriteProgress::NotStarted));
+    drop(connection);
+    drop(lanes);
+    drop(receivers);
+    drop(blocker);
+    assert_eq!(controller.snapshot().queued.current_count, 0);
+}
+
+#[tokio::test]
+async fn actual_dropped_queued_completion_before_start_maps_to_typed_not_started() {
+    let controller = AdmissionController::new(AdmissionLimits::default());
+    let admission = controller
+        .prepare_scope(AdmissionScope::new("127.0.0.1".parse().expect("loopback")))
+        .expect("prepare scope");
+    let config = WriterQueueConfig::default();
+    let diagnostics = Arc::new(super::SessionWriterDiagnostics::new(config.total_capacity()));
+    let (lanes, mut receivers) = writer_lanes(config);
+    let (state_tx, state_rx) = tokio::sync::watch::channel(ConnectionState::Healthy);
+    let connection = Connection::new_queued(
+        lanes.clone(),
+        diagnostics,
+        admission,
+        state_tx,
+        state_rx,
+        CheetahString::from_string("dropped-before-start-test".to_string()),
+        FrameLimits::default(),
+        Some(AdmissionClass::Data),
+        Arc::new(SessionLifecycle::new()),
+        TransportTelemetry::noop(),
+    );
+    let send = tokio::spawn(async move {
+        let mut connection = connection;
+        let outcome = connection
+            .send_payload_inner(
+                OutboundPayload::Contiguous(Bytes::from_static(b"dropped-before-start")),
+                AdmissionClass::Data,
+                None,
+                None,
+                "dropped-before-start-target".to_string(),
+            )
+            .await;
+        (connection, outcome)
+    });
+
+    receivers.drop_next_write_for_test().await;
+    let (connection, outcome) = send.await.expect("queued send task");
+    let response = outcome
+        .expect_err("dropped completion must fail the waiting caller")
+        .into_response();
+    assert!(matches!(
+        response,
+        ResponseError::Transport {
+            progress: WriteProgress::NotStarted,
+            ..
+        }
+    ));
+    drop(connection);
+    drop(lanes);
+    assert_eq!(controller.snapshot().queued.current_count, 0);
+}
+
+#[tokio::test]
+async fn actual_dropped_active_completion_maps_to_typed_possibly_partial() {
+    let controller = AdmissionController::new(AdmissionLimits::default());
+    let admission = controller
+        .prepare_scope(AdmissionScope::new("127.0.0.1".parse().expect("loopback")))
+        .expect("prepare scope");
+    let writes = Arc::new(AtomicUsize::new(0));
+    let entered = Arc::new(tokio::sync::Notify::new());
+    let physical_connection = Connection::new_with_plaintext_stream(PendingWriteTransport {
+        writes: Arc::clone(&writes),
+        entered: Arc::clone(&entered),
+    });
+    let (frame_writer, _reader) = physical_connection.into_session_io(admission.clone());
+    let config = WriterQueueConfig::default();
+    let diagnostics = Arc::new(super::SessionWriterDiagnostics::new(config.total_capacity()));
+    let (lanes, receivers) = writer_lanes(config);
+    let (state_tx, state_rx) = tokio::sync::watch::channel(ConnectionState::Healthy);
+    let connection = Connection::new_queued(
+        lanes,
+        Arc::clone(&diagnostics),
+        admission,
+        state_tx.clone(),
+        state_rx,
+        CheetahString::from_string("dropped-active-test".to_string()),
+        FrameLimits::default(),
+        Some(AdmissionClass::Data),
+        Arc::new(SessionLifecycle::new()),
+        TransportTelemetry::noop(),
+    );
+    let writer = tokio::spawn(run_session_writer(
+        frame_writer,
+        receivers,
+        diagnostics,
+        state_tx,
+        CancellationToken::new(),
+        TransportTelemetry::noop(),
+    ));
+    let send = tokio::spawn(async move {
+        let mut connection = connection;
+        let outcome = connection
+            .send_payload_inner(
+                OutboundPayload::Contiguous(Bytes::from_static(b"dropped-active")),
+                AdmissionClass::Data,
+                None,
+                None,
+                "dropped-active-target".to_string(),
+            )
+            .await;
+        (connection, outcome)
+    });
+
+    entered.notified().await;
+    writer.abort();
+    assert!(writer.await.expect_err("aborted writer task").is_cancelled());
+    let (connection, outcome) = send.await.expect("queued send task");
+    let response = outcome
+        .expect_err("dropped active completion must fail the waiting caller")
+        .into_response();
+    assert!(matches!(
+        response,
+        ResponseError::Transport {
+            progress: WriteProgress::PossiblyPartial,
+            ..
+        }
+    ));
+    assert_eq!(writes.load(Ordering::Acquire), 1);
+    drop(connection);
+    assert_eq!(controller.snapshot().queued.current_count, 0);
+}
+
+#[tokio::test]
+async fn typed_response_write_and_flush_failures_are_possibly_partial_with_a_typed_source() {
+    for phase in [
+        DirectFailurePhase::FirstWrite,
+        DirectFailurePhase::PartialThenError,
+        DirectFailurePhase::Flush,
+    ] {
+        let writes = Arc::new(AtomicUsize::new(0));
+        let mut connection = Connection::new_with_plaintext_stream(FailingResponseTransport {
+            writes: Arc::clone(&writes),
+            phase,
+        });
+        let error = connection
+            .send_response(RemotingCommand::create_remoting_command(7))
+            .await
+            .expect_err("injected transport failure");
+
+        let ResponseError::Transport { progress, source } = &error else {
+            panic!("transport failures must preserve typed response completion")
+        };
+        assert_eq!(*progress, WriteProgress::PossiblyPartial);
+        let RocketMQError::Shared(shared) = source else {
+            panic!("writer completion must preserve the shared typed source")
+        };
+        assert!(matches!(shared.as_error(), RocketMQError::IO(_)));
+        assert!(Error::source(&error).is_some());
+        assert_eq!(connection.state(), ConnectionState::Closed);
+        assert!(writes.load(Ordering::Acquire) >= 1);
+        if matches!(phase, DirectFailurePhase::PartialThenError) {
+            assert_eq!(writes.load(Ordering::Acquire), 2);
+        }
+    }
+}
+
+#[tokio::test]
+async fn explicit_sendfile_tls_preflight_preserves_legacy_reason_without_poisoning_typed_send() {
+    let owner = RuntimeOwner::new(RuntimeConfig::default()).expect("runtime owner");
+    let blocking = owner
+        .root_context()
+        .component("typed-sendfile-preflight-test")
+        .storage_io()
+        .clone();
+    let (transport, _peer) = tokio::io::duplex(4096);
+    let mut connection =
+        Connection::new_with_tls_stream(transport).with_file_region_io(blocking.clone(), FileTransferMode::Sendfile);
+
+    let typed = connection
+        .send_payload_inner(
+            explicit_sendfile_payload(),
+            AdmissionClass::Data,
+            None,
+            None,
+            "typed-sendfile-target".to_string(),
+        )
+        .await
+        .expect_err("TLS sendfile preflight must fail");
+    assert!(matches!(
+        typed.into_response(),
+        ResponseError::Transport {
+            progress: WriteProgress::NotStarted,
+            ..
+        }
+    ));
+    assert_eq!(connection.state(), ConnectionState::Healthy);
+    connection
+        .send_command(RemotingCommand::create_remoting_command(98))
+        .await
+        .expect("preflight rejection must leave typed writer healthy");
+
+    let (transport, _peer) = tokio::io::duplex(4096);
+    let mut legacy_connection =
+        Connection::new_with_tls_stream(transport).with_file_region_io(blocking, FileTransferMode::Sendfile);
+    let legacy = legacy_connection
+        .send_payload_inner(
+            explicit_sendfile_payload(),
+            AdmissionClass::Data,
+            None,
+            None,
+            "legacy-sendfile-target".to_string(),
+        )
+        .await
+        .expect_err("TLS sendfile preflight must fail")
+        .into_legacy();
+    assert!(matches!(
+        legacy,
+        RocketMQError::Network(NetworkError::ConnectionFailed { addr, reason })
+            if addr == "legacy-sendfile-target" && reason.contains("sendfile")
+    ));
+    assert_eq!(legacy_connection.state(), ConnectionState::Healthy);
+}
+
+#[tokio::test(start_paused = true)]
+async fn direct_preflight_deadline_is_not_started_and_keeps_the_writer_healthy() {
+    let writes = Arc::new(AtomicUsize::new(0));
+    let flushes = Arc::new(AtomicUsize::new(0));
+    let checked = Arc::new(tokio::sync::Notify::new());
+    let resume = Arc::new(tokio::sync::Notify::new());
+    let mut connection = Connection::new_with_plaintext_stream(CountingTransport {
+        writes: Arc::clone(&writes),
+        flushes: Arc::clone(&flushes),
+    });
+    connection.set_write_preflight_barrier(crate::write_strategy::WritePreflightBarrier::new(
+        Arc::clone(&checked),
+        Arc::clone(&resume),
+    ));
+    let send = tokio::spawn(async move {
+        let outcome = connection
+            .send_payload_inner(
+                OutboundPayload::Contiguous(Bytes::from_static(b"typed")),
+                AdmissionClass::Data,
+                None,
+                Some(crate::deadline::RequestDeadline::after(
+                    std::time::Duration::from_millis(10),
+                )),
+                "typed-direct-target".to_string(),
+            )
+            .await;
+        (connection, outcome)
+    });
+
+    checked.notified().await;
+    tokio::time::advance(std::time::Duration::from_millis(10)).await;
+    tokio::task::yield_now().await;
+    resume.notify_one();
+    let (mut connection, outcome) = send.await.expect("direct send task");
+    let response = outcome.expect_err("preflight deadline must fail").into_response();
+
+    assert!(matches!(
+        response,
+        ResponseError::Transport {
+            progress: WriteProgress::NotStarted,
+            ..
+        }
+    ));
+    assert_eq!(writes.load(Ordering::Acquire), 0);
+    assert_eq!(flushes.load(Ordering::Acquire), 0);
+    assert_eq!(connection.state(), ConnectionState::Healthy);
+    connection
+        .send_command(RemotingCommand::create_remoting_command(11))
+        .await
+        .expect("healthy direct writer must remain usable");
+    assert!(writes.load(Ordering::Acquire) > 0);
+    assert!(flushes.load(Ordering::Acquire) > 0);
+
+    let writes = Arc::new(AtomicUsize::new(0));
+    let flushes = Arc::new(AtomicUsize::new(0));
+    let checked = Arc::new(tokio::sync::Notify::new());
+    let resume = Arc::new(tokio::sync::Notify::new());
+    let mut legacy_connection = Connection::new_with_plaintext_stream(CountingTransport {
+        writes: Arc::clone(&writes),
+        flushes: Arc::clone(&flushes),
+    });
+    legacy_connection.set_write_preflight_barrier(crate::write_strategy::WritePreflightBarrier::new(
+        Arc::clone(&checked),
+        Arc::clone(&resume),
+    ));
+    let legacy_send = tokio::spawn(async move {
+        let result = legacy_connection
+            .send_command_with_deadline(
+                RemotingCommand::create_remoting_command(10),
+                crate::deadline::RequestDeadline::after(std::time::Duration::from_millis(10)),
+                "legacy-direct-target",
+            )
+            .await;
+        (legacy_connection, result)
+    });
+
+    checked.notified().await;
+    tokio::time::advance(std::time::Duration::from_millis(10)).await;
+    tokio::task::yield_now().await;
+    resume.notify_one();
+    let (legacy_connection, result) = legacy_send.await.expect("legacy direct send task");
+    assert!(matches!(
+        result,
+        Err(RocketMQError::Network(NetworkError::DeadlineExceededBeforeSend { addr }))
+            if addr == "legacy-direct-target"
+    ));
+    assert_eq!(writes.load(Ordering::Acquire), 0);
+    assert_eq!(flushes.load(Ordering::Acquire), 0);
+    assert_eq!(legacy_connection.state(), ConnectionState::Healthy);
+}
+
+#[tokio::test(start_paused = true)]
+async fn queued_preflight_deadline_matches_direct_not_started_classification_without_socket_io() {
+    let controller = AdmissionController::new(AdmissionLimits::default());
+    let admission = controller
+        .prepare_scope(AdmissionScope::new("127.0.0.1".parse().expect("loopback")))
+        .expect("prepare scope");
+    let writes = Arc::new(AtomicUsize::new(0));
+    let flushes = Arc::new(AtomicUsize::new(0));
+    let checked = Arc::new(tokio::sync::Notify::new());
+    let resume = Arc::new(tokio::sync::Notify::new());
+    let mut physical_connection = Connection::new_with_plaintext_stream(CountingTransport {
+        writes: Arc::clone(&writes),
+        flushes: Arc::clone(&flushes),
+    });
+    physical_connection.set_write_preflight_barrier(crate::write_strategy::WritePreflightBarrier::new(
+        Arc::clone(&checked),
+        Arc::clone(&resume),
+    ));
+    let (frame_writer, _reader) = physical_connection.into_session_io(admission.clone());
+    let config = WriterQueueConfig::default();
+    let diagnostics = Arc::new(super::SessionWriterDiagnostics::new(config.total_capacity()));
+    let (lanes, receivers) = writer_lanes(config);
+    let (state_tx, state_rx) = tokio::sync::watch::channel(ConnectionState::Healthy);
+    let queued_connection = Connection::new_queued(
+        lanes,
+        Arc::clone(&diagnostics),
+        admission,
+        state_tx.clone(),
+        state_rx,
+        CheetahString::from_string("queued-preflight-test".to_string()),
+        FrameLimits::default(),
+        Some(AdmissionClass::Data),
+        Arc::new(SessionLifecycle::new()),
+        TransportTelemetry::noop(),
+    );
+    let writer = tokio::spawn(run_session_writer(
+        frame_writer,
+        receivers,
+        diagnostics,
+        state_tx,
+        CancellationToken::new(),
+        TransportTelemetry::noop(),
+    ));
+    let send = tokio::spawn(async move {
+        let mut connection = queued_connection;
+        let outcome = connection
+            .send_payload_inner(
+                OutboundPayload::Contiguous(Bytes::from_static(b"queued")),
+                AdmissionClass::Data,
+                None,
+                Some(crate::deadline::RequestDeadline::after(
+                    std::time::Duration::from_millis(10),
+                )),
+                "typed-queued-target".to_string(),
+            )
+            .await;
+        (connection, outcome)
+    });
+
+    checked.notified().await;
+    tokio::time::advance(std::time::Duration::from_millis(10)).await;
+    tokio::task::yield_now().await;
+    resume.notify_one();
+    let (mut queued_connection, outcome) = send.await.expect("queued send task");
+    let response = outcome
+        .expect_err("queued preflight deadline must fail")
+        .into_response();
+
+    assert!(matches!(
+        response,
+        ResponseError::Transport {
+            progress: WriteProgress::NotStarted,
+            ..
+        }
+    ));
+    assert_eq!(writes.load(Ordering::Acquire), 0);
+    assert_eq!(flushes.load(Ordering::Acquire), 0);
+    assert_eq!(queued_connection.state(), ConnectionState::Healthy);
+    queued_connection
+        .send_command(RemotingCommand::create_remoting_command(12))
+        .await
+        .expect("healthy queued writer must remain usable");
+    assert!(writes.load(Ordering::Acquire) > 0);
+    assert!(flushes.load(Ordering::Acquire) > 0);
+    drop(queued_connection);
+    writer.await.expect("writer must exit after queue handles drop");
+}
+
+#[tokio::test]
+async fn direct_legacy_facade_retains_the_callers_target_and_network_failure_shape() {
+    let writes = Arc::new(AtomicUsize::new(0));
+    let mut connection = Connection::new_with_plaintext_stream(FailingResponseTransport {
+        writes,
+        phase: DirectFailurePhase::FirstWrite,
+    });
+    let error = connection
+        .send_command_with_deadline(
+            RemotingCommand::create_remoting_command(8),
+            crate::deadline::RequestDeadline::after(std::time::Duration::from_secs(1)),
+            "direct-caller-target",
+        )
+        .await
+        .expect_err("injected direct write failure");
+
+    assert!(matches!(
+        error,
+        RocketMQError::Network(NetworkError::ConnectionFailed { addr, reason })
+            if addr == "direct-caller-target" && reason == "canonical writer failure"
+    ));
+}
+
+#[tokio::test]
+async fn queued_typed_transport_failure_matches_direct_possibly_partial_classification() {
+    let controller = AdmissionController::new(AdmissionLimits::default());
+    let admission = controller
+        .prepare_scope(AdmissionScope::new("127.0.0.1".parse().expect("loopback")))
+        .expect("prepare scope");
+    let physical_connection = Connection::new_with_plaintext_stream(FailingResponseTransport {
+        writes: Arc::new(AtomicUsize::new(0)),
+        phase: DirectFailurePhase::PartialThenError,
+    });
+    let (frame_writer, _reader) = physical_connection.into_session_io(admission.clone());
+    let config = WriterQueueConfig::default();
+    let diagnostics = Arc::new(super::SessionWriterDiagnostics::new(config.total_capacity()));
+    let (lanes, receivers) = writer_lanes(config);
+    let (state_tx, state_rx) = tokio::sync::watch::channel(ConnectionState::Healthy);
+    let mut connection = Connection::new_queued(
+        lanes,
+        Arc::clone(&diagnostics),
+        admission,
+        state_tx.clone(),
+        state_rx,
+        CheetahString::from_string("queued-typed-failure-test".to_string()),
+        FrameLimits::default(),
+        Some(AdmissionClass::Data),
+        Arc::new(SessionLifecycle::new()),
+        TransportTelemetry::noop(),
+    );
+    let writer = tokio::spawn(run_session_writer(
+        frame_writer,
+        receivers,
+        diagnostics,
+        state_tx,
+        CancellationToken::new(),
+        TransportTelemetry::noop(),
+    ));
+
+    let response = connection
+        .send_payload_inner(
+            OutboundPayload::Contiguous(Bytes::from_static(b"queued-typed")),
+            AdmissionClass::Data,
+            None,
+            None,
+            "typed-queued-target".to_string(),
+        )
+        .await
+        .expect_err("partial queued write must fail")
+        .into_response();
+    writer.await.expect("poisoned writer task must exit");
+
+    assert!(matches!(
+        response,
+        ResponseError::Transport {
+            progress: WriteProgress::PossiblyPartial,
+            ..
+        }
+    ));
+    assert_eq!(connection.state(), ConnectionState::Closed);
+}
+
+#[tokio::test]
+async fn queued_legacy_facade_reprojects_the_shared_writer_source_for_its_caller_target() {
+    let controller = AdmissionController::new(AdmissionLimits::default());
+    let admission = controller
+        .prepare_scope(AdmissionScope::new("127.0.0.1".parse().expect("loopback")))
+        .expect("prepare scope");
+    let writes = Arc::new(AtomicUsize::new(0));
+    let physical_connection = Connection::new_with_plaintext_stream(FailingResponseTransport {
+        writes,
+        phase: DirectFailurePhase::FirstWrite,
+    });
+    let (frame_writer, _reader) = physical_connection.into_session_io(admission.clone());
+    let config = WriterQueueConfig::default();
+    let diagnostics = Arc::new(super::SessionWriterDiagnostics::new(config.total_capacity()));
+    let (lanes, receivers) = writer_lanes(config);
+    let (state_tx, state_rx) = tokio::sync::watch::channel(ConnectionState::Healthy);
+    let mut queued_connection = Connection::new_queued(
+        lanes,
+        Arc::clone(&diagnostics),
+        admission,
+        state_tx.clone(),
+        state_rx,
+        CheetahString::from_string("queued-legacy-test".to_string()),
+        FrameLimits::default(),
+        Some(AdmissionClass::Data),
+        Arc::new(SessionLifecycle::new()),
+        TransportTelemetry::noop(),
+    );
+    let writer = tokio::spawn(run_session_writer(
+        frame_writer,
+        receivers,
+        diagnostics,
+        state_tx,
+        CancellationToken::new(),
+        TransportTelemetry::noop(),
+    ));
+
+    let error = queued_connection
+        .send_command_with_deadline(
+            RemotingCommand::create_remoting_command(9),
+            crate::deadline::RequestDeadline::after(std::time::Duration::from_secs(1)),
+            "queued-caller-target",
+        )
+        .await
+        .expect_err("injected queued write failure");
+    writer.await.expect("writer task must exit after poisoning");
+
+    assert!(matches!(
+        error,
+        RocketMQError::Network(NetworkError::ConnectionFailed { addr, reason })
+            if addr == "queued-caller-target" && reason == "canonical writer failure"
+    ));
+}

--- a/rocketmq-transport/src/lib.rs
+++ b/rocketmq-transport/src/lib.rs
@@ -70,6 +70,7 @@ mod telemetry;
 #[cfg(any(test, feature = "test-support"))]
 pub mod test_support;
 mod tls;
+mod write_result;
 mod write_strategy;
 mod writer_runtime;
 

--- a/rocketmq-transport/src/server.rs
+++ b/rocketmq-transport/src/server.rs
@@ -962,7 +962,7 @@ impl ConnectionHandler for ProcessorSessionHandler {
                 }
             };
             let mut connection = session.connection();
-            let _ = connection.send_command(response).await;
+            let _ = connection.send_response(response).await;
         })
     }
 }

--- a/rocketmq-transport/src/write_result.rs
+++ b/rocketmq-transport/src/write_result.rs
@@ -1,0 +1,251 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Crate-private canonical writer completion.
+
+use std::io;
+use std::sync::Arc;
+
+use rocketmq_error::RocketMQError;
+use rocketmq_error::SharedRocketMQError;
+
+use crate::dispatch::ResponseError;
+use crate::dispatch::WriteProgress;
+
+/// Result returned by the sole session-writer owner.
+pub(crate) type WriterResult = Result<(), WriterFailure>;
+
+/// A terminal canonical-writer failure and the write progress it can prove.
+///
+/// The source is shared because one failed micro-batch completes every member
+/// with the same immutable error snapshot. Converting it to either legacy or
+/// response-facing errors retains that shared snapshot instead of formatting it
+/// into a new string error. Legacy public facades use a separate projection so
+/// their historic target and network-error shape remain intact per caller.
+#[derive(Clone, Debug)]
+pub(crate) struct WriterFailure {
+    progress: WriteProgress,
+    source: SharedRocketMQError,
+    legacy: LegacyWriterFailure,
+}
+
+#[derive(Clone, Debug)]
+enum LegacyWriterFailure {
+    ConnectionFailed,
+    DeadlineExceededBeforeSend,
+    WriteTimeout { timeout_millis: u64 },
+}
+
+impl WriterFailure {
+    /// Captures a socket failure once without formatting its source. The legacy
+    /// facade receives a stable compatibility reason while typed callers retain
+    /// the original shared error chain.
+    pub(crate) fn from_io(progress: WriteProgress, error: io::Error) -> Self {
+        Self {
+            progress,
+            source: SharedRocketMQError::new(RocketMQError::from(error)),
+            legacy: LegacyWriterFailure::ConnectionFailed,
+        }
+    }
+
+    pub(crate) fn connection_failed(progress: WriteProgress, reason: impl Into<Arc<str>>) -> Self {
+        let reason = reason.into();
+        Self {
+            progress,
+            source: SharedRocketMQError::new(RocketMQError::network_connection_failed(
+                "transport-session-writer",
+                reason.as_ref(),
+            )),
+            legacy: LegacyWriterFailure::ConnectionFailed,
+        }
+    }
+
+    pub(crate) fn deadline_exceeded_before_send() -> Self {
+        Self {
+            progress: WriteProgress::NotStarted,
+            source: SharedRocketMQError::new(RocketMQError::network_deadline_exceeded_before_send(
+                "transport-session-writer",
+            )),
+            legacy: LegacyWriterFailure::DeadlineExceededBeforeSend,
+        }
+    }
+
+    pub(crate) fn write_timeout(timeout_millis: u64) -> Self {
+        Self {
+            progress: WriteProgress::PossiblyPartial,
+            source: SharedRocketMQError::new(RocketMQError::network_write_timeout(
+                "transport-session-writer",
+                timeout_millis,
+            )),
+            legacy: LegacyWriterFailure::WriteTimeout { timeout_millis },
+        }
+    }
+
+    pub(crate) fn completion_dropped(progress: WriteProgress) -> Self {
+        Self::connection_failed(progress, Arc::<str>::from("writer completion dropped"))
+    }
+
+    pub(crate) const fn progress(&self) -> WriteProgress {
+        self.progress
+    }
+
+    /// Returns the immutable canonical cause shared by every completion in a
+    /// failed writer micro-batch.
+    #[cfg(test)]
+    pub(crate) fn source(&self) -> &SharedRocketMQError {
+        &self.source
+    }
+
+    pub(crate) fn into_response(self) -> ResponseError {
+        ResponseError::Transport {
+            progress: self.progress,
+            source: self.source.into_error(),
+        }
+    }
+
+    pub(crate) fn into_legacy_for_target(
+        self,
+        target: String,
+        connection_failed_reason: &'static str,
+    ) -> RocketMQError {
+        match self.legacy {
+            LegacyWriterFailure::ConnectionFailed => {
+                RocketMQError::network_connection_failed(target, connection_failed_reason)
+            }
+            LegacyWriterFailure::DeadlineExceededBeforeSend => {
+                RocketMQError::network_deadline_exceeded_before_send(target)
+            }
+            LegacyWriterFailure::WriteTimeout { timeout_millis } => {
+                RocketMQError::network_write_timeout(target, timeout_millis)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error;
+    use std::fmt;
+    use std::io;
+
+    use rocketmq_error::NetworkError;
+    use rocketmq_error::RocketMQError;
+
+    use super::WriterFailure;
+    use crate::dispatch::ResponseError;
+    use crate::dispatch::WriteProgress;
+
+    #[derive(Debug)]
+    struct PanicDisplay;
+
+    impl fmt::Display for PanicDisplay {
+        fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+            panic!("canonical writer failures must not format their source")
+        }
+    }
+
+    impl Error for PanicDisplay {}
+
+    #[test]
+    fn response_conversion_retains_the_shared_typed_source_chain_and_identity() {
+        let failure = WriterFailure::from_io(WriteProgress::PossiblyPartial, io::Error::other(PanicDisplay));
+        let response = failure.clone().into_response();
+        let second_response = failure.into_response();
+
+        assert!(matches!(
+            &response,
+            ResponseError::Transport {
+                progress: WriteProgress::PossiblyPartial,
+                ..
+            }
+        ));
+        let ResponseError::Transport { source, .. } = &response else {
+            panic!("writer failure must become a transport response error")
+        };
+        let ResponseError::Transport {
+            source: second_source, ..
+        } = &second_response
+        else {
+            panic!("writer failure must become a transport response error")
+        };
+        let RocketMQError::Shared(shared) = source else {
+            panic!("response completion must retain a shared typed source")
+        };
+        let RocketMQError::Shared(second_shared) = second_source else {
+            panic!("response completion must retain a shared typed source")
+        };
+        assert!(std::ptr::eq(shared.as_error(), second_shared.as_error()));
+        let RocketMQError::IO(io_error) = shared.as_error() else {
+            panic!("writer I/O failure must retain the original typed error")
+        };
+        assert!(io_error.get_ref().is_some_and(|source| source.is::<PanicDisplay>()));
+        assert!(Error::source(&response).is_some());
+    }
+
+    #[test]
+    fn legacy_projection_preserves_each_callers_network_target_and_timeout_shape() {
+        let source = WriterFailure::from_io(WriteProgress::PossiblyPartial, io::Error::other(PanicDisplay));
+        let direct = source
+            .clone()
+            .into_legacy_for_target("direct-target".to_string(), "canonical writer failure");
+        let queued = source.into_legacy_for_target("queued-target".to_string(), "canonical writer failure");
+
+        assert!(matches!(
+            direct,
+            RocketMQError::Network(NetworkError::ConnectionFailed { addr, reason })
+                if addr == "direct-target" && reason == "canonical writer failure"
+        ));
+        assert!(matches!(
+            queued,
+            RocketMQError::Network(NetworkError::ConnectionFailed { addr, reason })
+                if addr == "queued-target" && reason == "canonical writer failure"
+        ));
+        assert!(matches!(
+            WriterFailure::from_io(WriteProgress::NotStarted, io::Error::other(PanicDisplay)).into_legacy_for_target(
+                "sendfile-target".to_string(),
+                "sendfile mode requires an eligible file and plaintext TCP connection",
+            ),
+            RocketMQError::Network(NetworkError::ConnectionFailed { addr, reason })
+                if addr == "sendfile-target" && reason.contains("sendfile")
+        ));
+        assert!(matches!(
+            WriterFailure::completion_dropped(WriteProgress::NotStarted)
+                .into_legacy_for_target("dropped-target".to_string(), "writer completion dropped"),
+            RocketMQError::Network(NetworkError::ConnectionFailed { addr, reason })
+                if addr == "dropped-target" && reason == "writer completion dropped"
+        ));
+        assert!(matches!(
+            WriterFailure::deadline_exceeded_before_send()
+                .into_legacy_for_target("deadline-target".to_string(), "unused connection reason"),
+            RocketMQError::Network(NetworkError::DeadlineExceededBeforeSend { addr }) if addr == "deadline-target"
+        ));
+        assert!(matches!(
+            WriterFailure::write_timeout(37)
+                .into_legacy_for_target("timeout-target".to_string(), "unused connection reason"),
+            RocketMQError::Network(NetworkError::WriteTimeout { addr, timeout_ms: 37 }) if addr == "timeout-target"
+        ));
+    }
+
+    #[test]
+    fn completion_drop_preserves_the_observed_write_progress() {
+        assert_eq!(
+            WriterFailure::completion_dropped(WriteProgress::NotStarted).progress(),
+            WriteProgress::NotStarted
+        );
+        assert_eq!(
+            WriterFailure::completion_dropped(WriteProgress::PossiblyPartial).progress(),
+            WriteProgress::PossiblyPartial
+        );
+    }
+}

--- a/rocketmq-transport/src/write_strategy.rs
+++ b/rocketmq-transport/src/write_strategy.rs
@@ -45,8 +45,32 @@ use crate::file_region_writer::record_sendfile_bytes;
 use crate::file_region_writer::write_portable_file_region;
 
 const QUEUED_WRITE_WAITING: u8 = 0;
-const QUEUED_WRITE_STARTED: u8 = 1;
+const QUEUED_WRITE_CLAIMED: u8 = 1;
+const QUEUED_WRITE_STARTED: u8 = 2;
+const QUEUED_WRITE_CANCELLED_BEFORE_START: u8 = 3;
 const AUTO_SENDFILE_MIN_BYTES: u64 = 64 * 1024;
+
+/// Test-only one-shot barrier placed immediately before the first write-progress
+/// transition. It makes deadline/preflight races deterministic without adding a
+/// production field or branch.
+#[cfg(test)]
+#[derive(Clone)]
+pub(crate) struct WritePreflightBarrier {
+    checked: Arc<tokio::sync::Notify>,
+    resume: Arc<tokio::sync::Notify>,
+}
+
+#[cfg(test)]
+impl WritePreflightBarrier {
+    pub(crate) fn new(checked: Arc<tokio::sync::Notify>, resume: Arc<tokio::sync::Notify>) -> Self {
+        Self { checked, resume }
+    }
+
+    async fn wait(&self) {
+        self.checked.notify_one();
+        self.resume.notified().await;
+    }
+}
 
 pub(crate) struct QueuedWriteProgress(AtomicU8);
 
@@ -55,8 +79,40 @@ impl QueuedWriteProgress {
         Self(AtomicU8::new(QUEUED_WRITE_WAITING))
     }
 
+    /// Claims a queued envelope for the sole writer. A caller whose deadline
+    /// wins `cancel_before_start` prevents this transition and therefore any
+    /// later socket attempt for the envelope.
+    pub(crate) fn claim_for_writer(&self) -> bool {
+        self.0
+            .compare_exchange(
+                QUEUED_WRITE_WAITING,
+                QUEUED_WRITE_CLAIMED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    /// Cancels a queued envelope before the writer owns it.
+    pub(crate) fn cancel_before_start(&self) -> bool {
+        self.0
+            .compare_exchange(
+                QUEUED_WRITE_WAITING,
+                QUEUED_WRITE_CANCELLED_BEFORE_START,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    /// Marks the precise boundary immediately before the first socket attempt.
     pub(crate) fn start_write(&self) {
-        self.0.store(QUEUED_WRITE_STARTED, Ordering::Release);
+        let _ = self.0.compare_exchange(
+            QUEUED_WRITE_CLAIMED,
+            QUEUED_WRITE_STARTED,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        );
     }
 
     pub(crate) fn write_started(&self) -> bool {
@@ -66,22 +122,23 @@ impl QueuedWriteProgress {
 
 pub(crate) struct QueuedWrite {
     pub(crate) operation: WriterOperation,
-    pub(crate) completion: oneshot::Sender<rocketmq_error::RocketMQResult<()>>,
+    pub(crate) completion: oneshot::Sender<crate::write_result::WriterResult>,
     pub(crate) permit: Option<AdmissionPermit>,
     pub(crate) deadline: Option<RequestDeadline>,
+    #[allow(dead_code, reason = "queue-policy tests retain this opaque fixture identifier")]
     pub(crate) target: String,
-    pub(crate) progress: Option<Arc<QueuedWriteProgress>>,
+    pub(crate) progress: Arc<QueuedWriteProgress>,
     pub(crate) enqueued_at: Option<Instant>,
 }
 
 impl QueuedWrite {
     pub(crate) fn data(
         payload: OutboundPayload,
-        completion: oneshot::Sender<rocketmq_error::RocketMQResult<()>>,
+        completion: oneshot::Sender<crate::write_result::WriterResult>,
         permit: AdmissionPermit,
         deadline: Option<RequestDeadline>,
         target: String,
-        progress: Option<Arc<QueuedWriteProgress>>,
+        progress: Arc<QueuedWriteProgress>,
         enqueued_at: Instant,
     ) -> Self {
         Self {
@@ -142,10 +199,6 @@ impl OutboundPayload {
             Self::Contiguous(bytes) => bytes.len(),
         }
     }
-
-    pub(crate) async fn write_to(&self, writer: &mut FrameWriter<WriteBackend>) -> io::Result<()> {
-        writer.write_transport_payloads(&[self], 64).await
-    }
 }
 
 /// Socket-write representation selected after TCP/TLS negotiation.
@@ -188,6 +241,8 @@ pub struct FrameWriter<W> {
     poisoned: bool,
     file_region_blocking: Option<BlockingExecutor>,
     file_transfer_mode: FileTransferMode,
+    #[cfg(test)]
+    preflight_barrier: Option<WritePreflightBarrier>,
 }
 
 struct WriteCancellationGuard<'a> {
@@ -234,6 +289,8 @@ where
             poisoned: false,
             file_region_blocking: None,
             file_transfer_mode: FileTransferMode::Auto,
+            #[cfg(test)]
+            preflight_barrier: None,
         })
     }
 
@@ -247,6 +304,8 @@ where
             poisoned: false,
             file_region_blocking: None,
             file_transfer_mode: FileTransferMode::Auto,
+            #[cfg(test)]
+            preflight_barrier: None,
         }
     }
 
@@ -262,6 +321,13 @@ where
     #[must_use]
     pub const fn is_poisoned(&self) -> bool {
         self.poisoned
+    }
+
+    /// Returns the configured external-file transfer policy without performing I/O.
+    #[inline]
+    #[must_use]
+    pub(crate) const fn file_transfer_mode(&self) -> FileTransferMode {
+        self.file_transfer_mode
     }
 
     /// Returns ownership of the underlying I/O object.
@@ -281,6 +347,18 @@ where
     pub(crate) fn configure_file_region_io(&mut self, blocking: BlockingExecutor, mode: FileTransferMode) {
         self.file_region_blocking = Some(blocking);
         self.file_transfer_mode = mode;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_write_preflight_barrier(&mut self, barrier: WritePreflightBarrier) {
+        self.preflight_barrier = Some(barrier);
+    }
+
+    #[cfg(test)]
+    async fn wait_write_preflight_barrier(&mut self) {
+        if let Some(barrier) = self.preflight_barrier.take() {
+            barrier.wait().await;
+        }
     }
 
     /// Writes and flushes one immutable RocketMQ frame.
@@ -326,7 +404,12 @@ where
     ///
     /// Returns the first validation, write, or flush error and poisons the writer
     /// when socket progress may have occurred.
-    pub(crate) async fn write_payloads(&mut self, payloads: &[&OutboundPayload], max_iov: usize) -> io::Result<()> {
+    async fn write_payloads_with_start(
+        &mut self,
+        payloads: &[&OutboundPayload],
+        max_iov: usize,
+        on_start: &mut (dyn FnMut() + Send),
+    ) -> io::Result<()> {
         self.ensure_healthy()?;
         if payloads.is_empty() {
             return Ok(());
@@ -338,17 +421,46 @@ where
         let payload_bytes = payloads
             .iter()
             .fold(0usize, |total, payload| total.saturating_add(payload.encoded_len()));
+
+        // Resolve every deterministic strategy error before the write-progress
+        // boundary. In particular, a file payload belongs to the file writer
+        // and must not poison a healthy generic frame writer.
+        let vectored_segments = match mode {
+            FrameWriteMode::PlainVectored | FrameWriteMode::TlsVectored { .. } => Some(payload_segments(payloads)?),
+            FrameWriteMode::TlsAuto {
+                coalesce_below_bytes, ..
+            } if payload_bytes > coalesce_below_bytes => Some(payload_segments(payloads)?),
+            FrameWriteMode::TlsCoalesced { .. } | FrameWriteMode::TlsAuto { .. } => {
+                if payloads
+                    .iter()
+                    .any(|payload| matches!(payload, OutboundPayload::FileFrame { .. }))
+                {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "file-backed frames require the transport file writer",
+                    ));
+                }
+                None
+            }
+        };
+
+        // The callback is the canonical write-progress boundary. It runs after
+        // validation/coalescing selection but immediately before the first
+        // possible socket write or flush attempt.
+        #[cfg(test)]
+        self.wait_write_preflight_barrier().await;
+        on_start();
         let mut cancellation = WriteCancellationGuard::new(&mut self.poisoned);
         match mode {
             FrameWriteMode::PlainVectored | FrameWriteMode::TlsVectored { .. } => {
-                let segments = payload_segments(payloads)?;
-                write_vectored_segments(&mut self.io, &segments, max_iov.max(1)).await?;
+                let segments = vectored_segments.as_deref().expect("vectored preflight segments");
+                write_vectored_segments(&mut self.io, segments, max_iov.max(1)).await?;
             }
             FrameWriteMode::TlsAuto {
                 coalesce_below_bytes, ..
             } if payload_bytes > coalesce_below_bytes => {
-                let segments = payload_segments(payloads)?;
-                write_vectored_segments(&mut self.io, &segments, max_iov.max(1)).await?;
+                let segments = vectored_segments.as_deref().expect("vectored preflight segments");
+                write_vectored_segments(&mut self.io, segments, max_iov.max(1)).await?;
             }
             FrameWriteMode::TlsCoalesced { .. } | FrameWriteMode::TlsAuto { .. } => {
                 for payload in payloads {
@@ -432,16 +544,19 @@ enum SelectedFileTransfer {
 }
 
 impl FrameWriter<WriteBackend> {
-    pub(crate) async fn write_transport_payloads(
+    /// Writes transport payloads and calls `on_start` immediately before the
+    /// first potentially observable socket operation.
+    pub(crate) async fn write_transport_payloads_with_start(
         &mut self,
         payloads: &[&OutboundPayload],
         max_iov: usize,
+        on_start: &mut (dyn FnMut() + Send),
     ) -> io::Result<()> {
         if !payloads
             .iter()
             .any(|payload| matches!(payload, OutboundPayload::FileFrame { .. }))
         {
-            return self.write_payloads(payloads, max_iov).await;
+            return self.write_payloads_with_start(payloads, max_iov, on_start).await;
         }
 
         let mut buffered = Vec::new();
@@ -449,25 +564,26 @@ impl FrameWriter<WriteBackend> {
             match payload {
                 OutboundPayload::FileFrame { head, body } => {
                     if !buffered.is_empty() {
-                        self.write_payloads(&buffered, max_iov).await?;
+                        self.write_payloads_with_start(&buffered, max_iov, on_start).await?;
                         buffered.clear();
                     }
-                    self.write_file_frame(head, body, max_iov).await?;
+                    self.write_file_frame_with_start(head, body, max_iov, on_start).await?;
                 }
                 _ => buffered.push(*payload),
             }
         }
         if !buffered.is_empty() {
-            self.write_payloads(&buffered, max_iov).await?;
+            self.write_payloads_with_start(&buffered, max_iov, on_start).await?;
         }
         Ok(())
     }
 
-    async fn write_file_frame(
+    async fn write_file_frame_with_start(
         &mut self,
         head: &EncodedFrameHead,
         body: &FileRegionSequence,
         max_iov: usize,
+        on_start: &mut (dyn FnMut() + Send),
     ) -> io::Result<()> {
         self.ensure_healthy()?;
         let body_len = usize::try_from(body.len())
@@ -508,6 +624,9 @@ impl FrameWriter<WriteBackend> {
                 }
             }
         }
+        #[cfg(test)]
+        self.wait_write_preflight_barrier().await;
+        on_start();
         let mut cancellation = WriteCancellationGuard::new(&mut self.poisoned);
         if let Err(error) = write_vectored_segments(&mut self.io, &head.segments(), max_iov.max(1)).await {
             record_head_failure();
@@ -630,7 +749,12 @@ async fn probe_native_file_region(blocking: Option<BlockingExecutor>, body: &Fil
             crate::linux::sendfile::probe_file_region(&region)
         })
         .await
-        .map_err(|error| io::Error::other(error.to_string()))?
+        .map_err(preserve_preflight_task_error)?
+}
+
+#[cfg(any(all(target_os = "linux", feature = "linux-sendfile"), test))]
+fn preserve_preflight_task_error(error: impl std::error::Error + Send + Sync + 'static) -> io::Error {
+    io::Error::other(error)
 }
 
 fn native_file_region_eligible(body: &FileRegion) -> bool {
@@ -857,6 +981,8 @@ fn advance_segments(
 
 #[cfg(test)]
 mod file_frame_tests {
+    use std::error::Error;
+    use std::fmt;
     use std::io::Write;
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering;
@@ -869,6 +995,17 @@ mod file_frame_tests {
     use crate::file_region::FileRegion;
     use crate::file_region::FileRegionLease;
     use crate::file_region::FileRegionSequence;
+
+    #[derive(Debug)]
+    struct PanicDisplay;
+
+    impl fmt::Display for PanicDisplay {
+        fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+            panic!("preflight source must not be formatted")
+        }
+    }
+
+    impl Error for PanicDisplay {}
 
     struct DropLease {
         file: std::fs::File,
@@ -918,5 +1055,12 @@ mod file_frame_tests {
             1,
             "lease should release with the queue item"
         );
+    }
+
+    #[test]
+    fn preflight_task_error_preserves_the_typed_source_without_display() {
+        let error = super::preserve_preflight_task_error(PanicDisplay);
+
+        assert!(error.get_ref().is_some_and(|source| source.is::<PanicDisplay>()));
     }
 }

--- a/rocketmq-transport/src/writer_runtime.rs
+++ b/rocketmq-transport/src/writer_runtime.rs
@@ -17,6 +17,7 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
+use std::time::Instant;
 
 use rocketmq_error::RocketMQError;
 use tokio::sync::mpsc;
@@ -30,6 +31,7 @@ use crate::connection::SessionWriterDiagnostics;
 use crate::connection::SessionWriterSnapshot;
 use crate::deadline::RequestDeadline;
 use crate::telemetry::TransportTelemetry;
+use crate::write_result::WriterFailure;
 use crate::write_strategy::OutboundPayload;
 use crate::write_strategy::QueuedWrite;
 use crate::write_strategy::WriterOperation;
@@ -368,6 +370,14 @@ impl WriterReceivers {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) async fn drop_next_write_for_test(&mut self) {
+        match self.recv().await {
+            WriterEvent::Write(envelope) => drop(envelope),
+            WriterEvent::Close(_) | WriterEvent::Closed => panic!("expected queued writer envelope"),
+        }
+    }
+
     fn collect_ready(&mut self, batch: &mut Vec<LaneEnvelope>) {
         while batch.len() < self.config.batch.max_items.get() {
             let Some(next) = self.take_ready() else {
@@ -427,33 +437,29 @@ impl WriterReceivers {
         self.data.close();
     }
 
-    fn fail_remaining(&mut self, diagnostics: &SessionWriterDiagnostics, message: &'static str) {
+    fn fail_remaining(&mut self, diagnostics: &SessionWriterDiagnostics, failure: &WriterFailure) {
         if let Some(envelope) = self.deferred.take() {
-            fail_envelope(envelope, diagnostics, message);
+            fail_envelope(envelope, diagnostics, failure);
         }
         while let Ok(envelope) = self.control.try_recv() {
-            fail_envelope(envelope, diagnostics, message);
+            fail_envelope(envelope, diagnostics, failure);
         }
         while let Ok(envelope) = self.data.try_recv() {
-            fail_envelope(envelope, diagnostics, message);
+            fail_envelope(envelope, diagnostics, failure);
         }
         while let Ok(close) = self.close.try_recv() {
             let _ = close.completion.send(Err(RocketMQError::network_connection_failed(
                 "transport-session-writer",
-                message,
+                "connection writer is poisoned by a previous frame failure",
             )));
         }
     }
 }
 
-fn fail_envelope(envelope: LaneEnvelope, diagnostics: &SessionWriterDiagnostics, message: &'static str) {
+fn fail_envelope(envelope: LaneEnvelope, diagnostics: &SessionWriterDiagnostics, failure: &WriterFailure) {
     let write = envelope.into_write();
-    let started_at = diagnostics.start_write(write.enqueued_at, write.encoded_len());
-    diagnostics.finish_write(started_at, false, false);
-    let target = write.target.clone();
-    let _ = write
-        .completion
-        .send(Err(RocketMQError::network_connection_failed(target, message)));
+    diagnostics.finish_not_started(write.enqueued_at, write.encoded_len(), false);
+    let _ = write.completion.send(Err(failure.clone()));
 }
 
 /// Runs the sole socket writer owner until graceful close, cancellation, or a poisoned write.
@@ -484,23 +490,27 @@ pub(crate) async fn run_session_writer(
                 let mut batch = Vec::with_capacity(receivers.config.batch.max_items.get());
                 batch.push(first);
                 let close_during_batch = receivers.collect_batch(&mut batch).await;
-                if !write_batch(&mut frame_writer, &diagnostics, &telemetry, receivers.config, batch).await {
-                    let _ = state.send(ConnectionState::Degraded);
-                    receivers.close_business_lanes();
-                    let _ = frame_writer.shutdown().await;
-                    receivers.fail_remaining(
-                        &diagnostics,
-                        "connection writer is poisoned by a previous frame failure",
-                    );
-                    if let Some(close) = closing.take() {
-                        let _ = close.completion.send(Err(RocketMQError::network_connection_failed(
-                            "transport-session-writer",
-                            "connection writer failed during retirement",
-                        )));
+                match write_batch(&mut frame_writer, &diagnostics, &telemetry, receivers.config, batch).await {
+                    BatchWriteDisposition::Continue => {}
+                    BatchWriteDisposition::Poisoned => {
+                        let _ = state.send(ConnectionState::Degraded);
+                        receivers.close_business_lanes();
+                        let _ = frame_writer.shutdown().await;
+                        let drained = WriterFailure::connection_failed(
+                            crate::dispatch::WriteProgress::NotStarted,
+                            "connection writer is poisoned by a previous frame failure",
+                        );
+                        receivers.fail_remaining(&diagnostics, &drained);
+                        if let Some(close) = closing.take() {
+                            let _ = close.completion.send(Err(RocketMQError::network_connection_failed(
+                                "transport-session-writer",
+                                "connection writer failed during retirement",
+                            )));
+                        }
+                        let _ = state.send(ConnectionState::Closed);
+                        reader_shutdown.cancel();
+                        break;
                     }
-                    let _ = state.send(ConnectionState::Closed);
-                    reader_shutdown.cancel();
-                    break;
                 }
                 if let Some(close) = close_during_batch {
                     receivers.close_business_lanes();
@@ -521,36 +531,44 @@ pub(crate) async fn run_session_writer(
     }
 }
 
+enum BatchWriteDisposition {
+    Continue,
+    Poisoned,
+}
+
 async fn write_batch(
     frame_writer: &mut ConnectionFrameWriter,
     diagnostics: &SessionWriterDiagnostics,
     telemetry: &TransportTelemetry,
     config: WriterQueueConfig,
     batch: Vec<LaneEnvelope>,
-) -> bool {
+) -> BatchWriteDisposition {
     let mut ready = Vec::with_capacity(batch.len());
     for envelope in batch {
         let write = envelope.into_write();
-        let started_at = diagnostics.start_write(write.enqueued_at, write.encoded_len());
-        if write.deadline.is_some_and(RequestDeadline::is_expired) {
-            diagnostics.finish_write(started_at, false, true);
+        if !write.progress.claim_for_writer() {
+            diagnostics.finish_not_started(write.enqueued_at, write.encoded_len(), true);
             let _ = write
                 .completion
-                .send(Err(RocketMQError::network_deadline_exceeded_before_send(write.target)));
+                .send(Err(WriterFailure::deadline_exceeded_before_send()));
             continue;
         }
-        if let Some(progress) = write.progress.as_ref() {
-            progress.start_write();
+        if write.deadline.is_some_and(RequestDeadline::is_expired) {
+            diagnostics.finish_not_started(write.enqueued_at, write.encoded_len(), true);
+            let _ = write
+                .completion
+                .send(Err(WriterFailure::deadline_exceeded_before_send()));
+            continue;
         }
-        ready.push((write, started_at));
+        ready.push(write);
     }
     if ready.is_empty() {
-        return true;
+        return BatchWriteDisposition::Continue;
     }
     let stall_deadline = RequestDeadline::after(config.max_write_stall);
     let write_deadline = ready
         .iter()
-        .filter_map(|(write, _)| write.deadline)
+        .filter_map(|write| write.deadline)
         .fold(stall_deadline, |earliest, next| {
             if next.instant() < earliest.instant() {
                 next
@@ -560,51 +578,109 @@ async fn write_batch(
         });
     let payloads = ready
         .iter()
-        .map(|(write, _)| match &write.operation {
+        .map(|write| match &write.operation {
             WriterOperation::Send(payload) => payload,
         })
         .collect::<Vec<&OutboundPayload>>();
-    let result = match write_deadline
-        .timeout(frame_writer.write_transport_payloads(&payloads, config.batch.max_iov.get()))
-        .await
-    {
-        Ok(result) => result.map_err(|error| error.to_string()),
-        Err(_) => Err(format!(
-            "writer exceeded its {} ms absolute deadline",
-            write_deadline.budget_millis()
-        )),
+    let start_data = ready
+        .iter()
+        .map(|write| ActiveWriteStart {
+            progress: &write.progress,
+            enqueued_at: write.enqueued_at,
+            encoded_len: write.encoded_len(),
+        })
+        .collect::<Vec<_>>();
+    let mut started_at = vec![None; ready.len()];
+    let mut write_started = false;
+    let result = {
+        let mut mark_started = || {
+            if write_started {
+                return;
+            }
+            write_started = true;
+            for (start, started_at) in start_data.iter().zip(started_at.iter_mut()) {
+                start.progress.start_write();
+                *started_at = Some(diagnostics.start_write(start.enqueued_at, start.encoded_len));
+            }
+        };
+        match write_deadline
+            .timeout(frame_writer.write_transport_payloads_with_start(
+                &payloads,
+                config.batch.max_iov.get(),
+                &mut mark_started,
+            ))
+            .await
+        {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(error)) => Err(if write_started {
+                WriterFailure::from_io(crate::dispatch::WriteProgress::PossiblyPartial, error)
+            } else {
+                WriterFailure::from_io(crate::dispatch::WriteProgress::NotStarted, error)
+            }),
+            Err(_) => Err(if write_started {
+                WriterFailure::write_timeout(write_deadline.budget_millis())
+            } else {
+                WriterFailure::deadline_exceeded_before_send()
+            }),
+        }
     };
+    drop(start_data);
     let succeeded = result.is_ok();
     if succeeded {
         let written_bytes = ready
             .iter()
-            .fold(0usize, |total, (write, _)| total.saturating_add(write.encoded_len()));
+            .fold(0usize, |total, write| total.saturating_add(write.encoded_len()));
         telemetry.record_outbound_written_plaintext_bytes(written_bytes);
     }
-    for (write, started_at) in ready {
+    for (write, started_at) in ready.into_iter().zip(started_at) {
         let encoded_len = write.encoded_len();
-        diagnostics.finish_write(started_at, succeeded, !succeeded && write_deadline.is_expired());
+        if let Some(started_at) = started_at {
+            diagnostics.finish_write(started_at, succeeded, !succeeded && write_deadline.is_expired());
+        } else {
+            diagnostics.finish_not_started(
+                write.enqueued_at,
+                encoded_len,
+                !succeeded && write_deadline.is_expired(),
+            );
+        }
         drop(write.permit);
         let completion = match &result {
             Ok(()) => {
                 record_transport_write(encoded_len);
                 Ok(())
             }
-            Err(message) => Err(RocketMQError::network_connection_failed(
-                write.target.clone(),
-                message.clone(),
-            )),
+            Err(failure) => Err(failure.clone()),
         };
         let _ = write.completion.send(completion);
     }
-    succeeded && !frame_writer.is_poisoned()
+    if result
+        .as_ref()
+        .err()
+        .is_some_and(|failure| failure.progress() == crate::dispatch::WriteProgress::PossiblyPartial)
+        || frame_writer.is_poisoned()
+    {
+        BatchWriteDisposition::Poisoned
+    } else {
+        BatchWriteDisposition::Continue
+    }
+}
+
+struct ActiveWriteStart<'a> {
+    progress: &'a crate::write_strategy::QueuedWriteProgress,
+    enqueued_at: Option<Instant>,
+    encoded_len: usize,
 }
 
 #[cfg(test)]
-mod tests {
+#[path = "writer_runtime/issue_9754_tests.rs"]
+mod tests;
+
+#[cfg(test)]
+mod queue_regression_tests {
     use std::num::NonZeroUsize;
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering;
+    use std::sync::Arc;
     use std::time::Duration;
     use std::time::Instant;
 
@@ -624,6 +700,7 @@ mod tests {
     use crate::admission::AdmissionScope;
     use crate::write_strategy::OutboundPayload;
     use crate::write_strategy::QueuedWrite;
+    use crate::write_strategy::QueuedWriteProgress;
 
     fn queued_write(target: &'static str, bytes: usize) -> QueuedWrite {
         let admission = AdmissionController::new(AdmissionLimits::default());
@@ -640,7 +717,7 @@ mod tests {
             permit,
             None,
             target.to_string(),
-            None,
+            Arc::new(QueuedWriteProgress::waiting()),
             Instant::now(),
         )
     }

--- a/rocketmq-transport/src/writer_runtime/issue_9754_tests.rs
+++ b/rocketmq-transport/src/writer_runtime/issue_9754_tests.rs
@@ -1,0 +1,536 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io;
+use std::io::IoSlice;
+use std::io::Write as _;
+use std::num::NonZeroUsize;
+use std::pin::Pin;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::task::Context;
+use std::task::Poll;
+use std::time::Duration;
+use std::time::Instant;
+
+use bytes::Bytes;
+use rocketmq_protocol::protocol::encoded_frame::EncodedFrameHead;
+use rocketmq_protocol::protocol::RemotingCommand;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use tokio::io::AsyncRead;
+use tokio::io::AsyncWrite;
+use tokio::io::ReadBuf;
+use tokio::sync::oneshot;
+use tokio::sync::watch;
+use tokio_util::sync::CancellationToken;
+
+use super::run_session_writer;
+use super::writer_lanes;
+use super::MicroBatchConfig;
+use super::WriterEvent;
+use super::WriterQueueConfig;
+use crate::admission::AdmissionClass;
+use crate::admission::AdmissionController;
+use crate::admission::AdmissionLimits;
+use crate::admission::AdmissionResource;
+use crate::admission::AdmissionScope;
+use crate::connection::Connection;
+use crate::connection::ConnectionState;
+use crate::connection::SessionWriterDiagnostics;
+use crate::dispatch::WriteProgress;
+use crate::file_region::FileRegion;
+use crate::file_region::FileRegionLease;
+use crate::file_region::FileRegionSequence;
+use crate::file_region::FileTransferMode;
+use crate::telemetry::TransportTelemetry;
+use crate::write_result::WriterFailure;
+use crate::write_strategy::OutboundPayload;
+use crate::write_strategy::QueuedWrite;
+use crate::write_strategy::QueuedWriteProgress;
+
+struct DropLease {
+    file: std::fs::File,
+    drops: Arc<AtomicUsize>,
+}
+
+impl FileRegionLease for DropLease {
+    fn file(&self) -> &std::fs::File {
+        &self.file
+    }
+}
+
+impl Drop for DropLease {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+fn queued_write_with_completion(
+    admission: &crate::admission::AdmissionScopeHandle,
+    target: &'static str,
+    bytes: usize,
+    progress: Arc<QueuedWriteProgress>,
+) -> (QueuedWrite, oneshot::Receiver<crate::write_result::WriterResult>) {
+    let permit = admission
+        .try_acquire(AdmissionResource::Queued, bytes, AdmissionClass::Data)
+        .expect("queue admission");
+    let (completion, result) = oneshot::channel();
+    (
+        QueuedWrite::data(
+            OutboundPayload::Contiguous(Bytes::from(vec![0x5a; bytes])),
+            completion,
+            permit,
+            None,
+            target.to_string(),
+            progress,
+            Instant::now(),
+        ),
+        result,
+    )
+}
+
+fn queued_file_write_with_completion(
+    admission: &crate::admission::AdmissionScopeHandle,
+    target: &'static str,
+) -> (
+    QueuedWrite,
+    oneshot::Receiver<crate::write_result::WriterResult>,
+    Arc<AtomicUsize>,
+) {
+    let mut file = tempfile::tempfile().expect("temporary file");
+    file.write_all(&[0x5a; 16]).expect("write file body");
+    let drops = Arc::new(AtomicUsize::new(0));
+    let lease = Arc::new(DropLease {
+        file,
+        drops: Arc::clone(&drops),
+    });
+    let region = FileRegion::try_new(lease.clone(), 0, 16).expect("leased file region");
+    let head = EncodedFrameHead::from_command_and_body_len(
+        RemotingCommand::create_remoting_command(91),
+        region.len() as usize,
+    )
+    .expect("file frame head");
+    let payload = OutboundPayload::FileFrame {
+        head,
+        body: FileRegionSequence::single(region),
+    };
+    let permit = admission
+        .try_acquire(AdmissionResource::Queued, payload.encoded_len(), AdmissionClass::Data)
+        .expect("queue admission");
+    let (completion, result) = oneshot::channel();
+    let write = QueuedWrite::data(
+        payload,
+        completion,
+        permit,
+        None,
+        target.to_string(),
+        Arc::new(QueuedWriteProgress::waiting()),
+        Instant::now(),
+    );
+    drop(lease);
+    (write, result, drops)
+}
+
+#[derive(Clone, Copy)]
+enum WriteFailurePhase {
+    FirstWrite,
+    Flush,
+}
+
+struct FailingTransport {
+    attempts: Arc<AtomicUsize>,
+    flushes: Arc<AtomicUsize>,
+    phase: WriteFailurePhase,
+}
+
+struct PendingTransport {
+    attempts: Arc<AtomicUsize>,
+    entered: Arc<tokio::sync::Notify>,
+}
+
+impl AsyncRead for PendingTransport {
+    fn poll_read(self: Pin<&mut Self>, _: &mut Context<'_>, _: &mut ReadBuf<'_>) -> Poll<io::Result<()>> {
+        Poll::Pending
+    }
+}
+
+impl AsyncWrite for PendingTransport {
+    fn poll_write(self: Pin<&mut Self>, _: &mut Context<'_>, _: &[u8]) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        this.attempts.fetch_add(1, Ordering::AcqRel);
+        this.entered.notify_one();
+        Poll::Pending
+    }
+
+    fn poll_write_vectored(self: Pin<&mut Self>, _: &mut Context<'_>, _: &[IoSlice<'_>]) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        this.attempts.fetch_add(1, Ordering::AcqRel);
+        this.entered.notify_one();
+        Poll::Pending
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl AsyncRead for FailingTransport {
+    fn poll_read(self: Pin<&mut Self>, _: &mut Context<'_>, _: &mut ReadBuf<'_>) -> Poll<io::Result<()>> {
+        Poll::Pending
+    }
+}
+
+impl AsyncWrite for FailingTransport {
+    fn poll_write(self: Pin<&mut Self>, _: &mut Context<'_>, buffer: &[u8]) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        this.attempts.fetch_add(1, Ordering::AcqRel);
+        match this.phase {
+            WriteFailurePhase::FirstWrite => Poll::Ready(Err(io::Error::other("injected first write failure"))),
+            WriteFailurePhase::Flush => Poll::Ready(Ok(buffer.len())),
+        }
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+        buffers: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        this.attempts.fetch_add(1, Ordering::AcqRel);
+        match this.phase {
+            WriteFailurePhase::FirstWrite => Poll::Ready(Err(io::Error::other("injected first write failure"))),
+            WriteFailurePhase::Flush => Poll::Ready(Ok(buffers.iter().map(|buffer| buffer.len()).sum())),
+        }
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        this.flushes.fetch_add(1, Ordering::AcqRel);
+        match this.phase {
+            WriteFailurePhase::FirstWrite => Poll::Ready(Ok(())),
+            WriteFailurePhase::Flush => Poll::Ready(Err(io::Error::other("injected flush failure"))),
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+fn queue_config() -> WriterQueueConfig {
+    WriterQueueConfig {
+        data_capacity: NonZeroUsize::new(4).expect("non-zero"),
+        control_capacity: NonZeroUsize::new(4).expect("non-zero"),
+        data_max_bytes: NonZeroUsize::new(256).expect("non-zero"),
+        control_max_bytes: NonZeroUsize::new(256).expect("non-zero"),
+        control_burst: NonZeroUsize::new(2).expect("non-zero"),
+        max_write_stall: Duration::from_secs(1),
+        batch: MicroBatchConfig {
+            max_items: NonZeroUsize::new(3).expect("non-zero"),
+            max_bytes: NonZeroUsize::new(128).expect("non-zero"),
+            max_delay: Duration::ZERO,
+            max_iov: NonZeroUsize::new(8).expect("non-zero"),
+        },
+    }
+}
+
+#[test]
+fn queued_deadline_cancellation_cannot_race_a_later_writer_claim() {
+    let progress = QueuedWriteProgress::waiting();
+    assert!(progress.cancel_before_start());
+    assert!(!progress.claim_for_writer());
+    assert!(!progress.write_started());
+
+    let progress = QueuedWriteProgress::waiting();
+    assert!(progress.claim_for_writer());
+    assert!(!progress.cancel_before_start());
+    progress.start_write();
+    assert!(progress.write_started());
+}
+
+#[tokio::test]
+async fn active_batch_failure_shares_source_and_drains_followers_without_a_second_socket_attempt() {
+    let controller = AdmissionController::new(AdmissionLimits::default());
+    let admission = controller
+        .prepare_scope(AdmissionScope::new("127.0.0.1".parse().expect("loopback")))
+        .expect("prepare scope");
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let flushes = Arc::new(AtomicUsize::new(0));
+    let connection = Connection::new_with_plaintext_stream(FailingTransport {
+        attempts: Arc::clone(&attempts),
+        flushes,
+        phase: WriteFailurePhase::FirstWrite,
+    });
+    let (frame_writer, _reader) = connection.into_session_io(admission.clone());
+    let mut config = queue_config();
+    config.batch.max_items = NonZeroUsize::new(2).expect("non-zero");
+    let (lanes, receivers) = writer_lanes(config);
+    let (first, first_completion) =
+        queued_write_with_completion(&admission, "first-target", 16, Arc::new(QueuedWriteProgress::waiting()));
+    let (second, second_completion) = queued_write_with_completion(
+        &admission,
+        "second-target",
+        16,
+        Arc::new(QueuedWriteProgress::waiting()),
+    );
+    let (follower, follower_completion) = queued_write_with_completion(
+        &admission,
+        "follower-target",
+        16,
+        Arc::new(QueuedWriteProgress::waiting()),
+    );
+    lanes.try_send(AdmissionClass::Data, first).expect("first queued write");
+    lanes
+        .try_send(AdmissionClass::Data, second)
+        .expect("second queued write");
+    lanes
+        .try_send(AdmissionClass::Data, follower)
+        .expect("follower queued write");
+    drop(lanes);
+
+    let diagnostics = Arc::new(SessionWriterDiagnostics::new(config.total_capacity()));
+    let (state, _) = watch::channel(ConnectionState::Healthy);
+    run_session_writer(
+        frame_writer,
+        receivers,
+        Arc::clone(&diagnostics),
+        state,
+        CancellationToken::new(),
+        TransportTelemetry::noop(),
+    )
+    .await;
+
+    let first = first_completion
+        .await
+        .expect("first completion")
+        .expect_err("first write must fail");
+    let second = second_completion
+        .await
+        .expect("second completion")
+        .expect_err("second write must fail");
+    let follower = follower_completion
+        .await
+        .expect("follower completion")
+        .expect_err("poison-drained follower must fail");
+
+    assert_eq!(first.progress(), WriteProgress::PossiblyPartial);
+    assert_eq!(second.progress(), WriteProgress::PossiblyPartial);
+    assert_eq!(follower.progress(), WriteProgress::NotStarted);
+    assert!(std::ptr::eq(first.source().as_error(), second.source().as_error()));
+    assert_eq!(attempts.load(Ordering::Acquire), 1);
+    assert_eq!(controller.snapshot().queued.current_count, 0);
+    assert_eq!(controller.snapshot().queued.current_bytes, 0);
+    assert_eq!(diagnostics.snapshot().failed, 3);
+}
+
+#[tokio::test]
+async fn active_file_failure_and_poison_drain_release_each_file_lease_once() {
+    let owner = RuntimeOwner::new(RuntimeConfig::default()).expect("runtime owner");
+    let blocking = owner
+        .root_context()
+        .component("writer-file-lease-test")
+        .storage_io()
+        .clone();
+    let controller = AdmissionController::new(AdmissionLimits::default());
+    let admission = controller
+        .prepare_scope(AdmissionScope::new("127.0.0.1".parse().expect("loopback")))
+        .expect("prepare scope");
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let connection = Connection::new_with_plaintext_stream(FailingTransport {
+        attempts: Arc::clone(&attempts),
+        flushes: Arc::new(AtomicUsize::new(0)),
+        phase: WriteFailurePhase::FirstWrite,
+    })
+    .with_file_region_io(blocking, FileTransferMode::Portable);
+    let (frame_writer, _reader) = connection.into_session_io(admission.clone());
+    let mut config = queue_config();
+    config.batch.max_items = NonZeroUsize::new(1).expect("non-zero");
+    config.data_max_bytes = NonZeroUsize::new(1024).expect("non-zero");
+    let (lanes, receivers) = writer_lanes(config);
+    let (active, active_completion, active_drops) = queued_file_write_with_completion(&admission, "active-file");
+    let (follower, follower_completion, follower_drops) =
+        queued_file_write_with_completion(&admission, "follower-file");
+    lanes
+        .try_send(AdmissionClass::Data, active)
+        .expect("active file queued");
+    lanes
+        .try_send(AdmissionClass::Data, follower)
+        .expect("follower file queued");
+    drop(lanes);
+    let diagnostics = Arc::new(SessionWriterDiagnostics::new(config.total_capacity()));
+    let (state, _) = watch::channel(ConnectionState::Healthy);
+    run_session_writer(
+        frame_writer,
+        receivers,
+        diagnostics,
+        state,
+        CancellationToken::new(),
+        TransportTelemetry::noop(),
+    )
+    .await;
+
+    assert_eq!(
+        active_completion
+            .await
+            .expect("active completion")
+            .expect_err("active file head write must fail")
+            .progress(),
+        WriteProgress::PossiblyPartial
+    );
+    assert_eq!(
+        follower_completion
+            .await
+            .expect("follower completion")
+            .expect_err("poison-drained file write must fail")
+            .progress(),
+        WriteProgress::NotStarted
+    );
+    assert_eq!(attempts.load(Ordering::Acquire), 1);
+    assert_eq!(active_drops.load(Ordering::SeqCst), 1);
+    assert_eq!(follower_drops.load(Ordering::SeqCst), 1);
+    assert_eq!(controller.snapshot().queued.current_count, 0);
+}
+
+#[tokio::test]
+async fn queued_cancellation_wins_before_writer_start_and_never_touches_the_socket() {
+    let controller = AdmissionController::new(AdmissionLimits::default());
+    let admission = controller
+        .prepare_scope(AdmissionScope::new("127.0.0.1".parse().expect("loopback")))
+        .expect("prepare scope");
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let flushes = Arc::new(AtomicUsize::new(0));
+    let connection = Connection::new_with_plaintext_stream(FailingTransport {
+        attempts: Arc::clone(&attempts),
+        flushes,
+        phase: WriteFailurePhase::Flush,
+    });
+    let (frame_writer, _reader) = connection.into_session_io(admission.clone());
+    let config = queue_config();
+    let (lanes, receivers) = writer_lanes(config);
+    let progress = Arc::new(QueuedWriteProgress::waiting());
+    let (write, completion) = queued_write_with_completion(&admission, "deadline-target", 16, Arc::clone(&progress));
+    lanes.try_send(AdmissionClass::Data, write).expect("queued write");
+    assert!(progress.cancel_before_start());
+    drop(lanes);
+
+    let diagnostics = Arc::new(SessionWriterDiagnostics::new(config.total_capacity()));
+    let (state, _) = watch::channel(ConnectionState::Healthy);
+    run_session_writer(
+        frame_writer,
+        receivers,
+        Arc::clone(&diagnostics),
+        state,
+        CancellationToken::new(),
+        TransportTelemetry::noop(),
+    )
+    .await;
+
+    let failure = completion
+        .await
+        .expect("deadline completion")
+        .expect_err("cancelled queued write must fail");
+    assert_eq!(failure.progress(), WriteProgress::NotStarted);
+    assert_eq!(attempts.load(Ordering::Acquire), 0);
+    assert_eq!(controller.snapshot().queued.current_count, 0);
+    assert_eq!(diagnostics.snapshot().failed, 1);
+    assert_eq!(diagnostics.snapshot().deadline_expired, 1);
+}
+
+#[tokio::test]
+async fn dropped_completion_before_writer_start_is_not_started_and_releases_its_permit() {
+    let controller = AdmissionController::new(AdmissionLimits::default());
+    let admission = controller
+        .prepare_scope(AdmissionScope::new("127.0.0.1".parse().expect("loopback")))
+        .expect("prepare scope");
+    let config = queue_config();
+    let (lanes, mut receivers) = writer_lanes(config);
+    let progress = Arc::new(QueuedWriteProgress::waiting());
+    let (write, completion) =
+        queued_write_with_completion(&admission, "dropped-before-start", 16, Arc::clone(&progress));
+    drop(completion);
+    lanes.try_send(AdmissionClass::Data, write).expect("queued write");
+    drop(lanes);
+
+    let WriterEvent::Write(envelope) = receivers.recv().await else {
+        panic!("queued envelope")
+    };
+    drop(envelope);
+
+    assert!(!progress.write_started());
+    assert_eq!(
+        WriterFailure::completion_dropped(WriteProgress::NotStarted).progress(),
+        WriteProgress::NotStarted
+    );
+    assert_eq!(controller.snapshot().queued.current_count, 0);
+    assert_eq!(controller.snapshot().queued.current_bytes, 0);
+}
+
+#[tokio::test]
+async fn dropped_active_completion_is_possibly_partial_and_releases_its_permit() {
+    let controller = AdmissionController::new(AdmissionLimits::default());
+    let admission = controller
+        .prepare_scope(AdmissionScope::new("127.0.0.1".parse().expect("loopback")))
+        .expect("prepare scope");
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let entered = Arc::new(tokio::sync::Notify::new());
+    let connection = Connection::new_with_plaintext_stream(PendingTransport {
+        attempts: Arc::clone(&attempts),
+        entered: Arc::clone(&entered),
+    });
+    let (frame_writer, _reader) = connection.into_session_io(admission.clone());
+    let config = queue_config();
+    let (lanes, receivers) = writer_lanes(config);
+    let progress = Arc::new(QueuedWriteProgress::waiting());
+    let (write, completion) =
+        queued_write_with_completion(&admission, "dropped-after-start", 16, Arc::clone(&progress));
+    lanes.try_send(AdmissionClass::Data, write).expect("queued write");
+    drop(lanes);
+    let diagnostics = Arc::new(SessionWriterDiagnostics::new(config.total_capacity()));
+    let (state, _) = watch::channel(ConnectionState::Healthy);
+    let writer = tokio::spawn(run_session_writer(
+        frame_writer,
+        receivers,
+        diagnostics,
+        state,
+        CancellationToken::new(),
+        TransportTelemetry::noop(),
+    ));
+
+    entered.notified().await;
+    writer.abort();
+    assert!(writer.await.expect_err("aborted writer task").is_cancelled());
+    assert!(completion.await.is_err());
+    assert!(progress.write_started());
+    assert_eq!(
+        WriterFailure::completion_dropped(WriteProgress::PossiblyPartial).progress(),
+        WriteProgress::PossiblyPartial
+    );
+    assert_eq!(attempts.load(Ordering::Acquire), 1);
+    assert_eq!(controller.snapshot().queued.current_count, 0);
+    assert_eq!(controller.snapshot().queued.current_bytes, 0);
+}

--- a/rocketmq-transport/tests/file_region_connection.rs
+++ b/rocketmq-transport/tests/file_region_connection.rs
@@ -18,6 +18,8 @@ use std::io::Write;
 use std::sync::Arc;
 use std::time::Duration;
 
+use rocketmq_error::NetworkError;
+use rocketmq_error::RocketMQError;
 use rocketmq_protocol::protocol::RemotingCommand;
 use rocketmq_runtime::RuntimeConfig;
 use rocketmq_runtime::RuntimeOwner;
@@ -197,7 +199,7 @@ fn explicit_sendfile_on_tls_fails_before_writing_the_head() {
     let before = file_transfer_snapshot();
 
     owner.block_on(async move {
-        let (client, mut server) = tokio::io::duplex(1024);
+        let (client, server) = tokio::io::duplex(1024);
         let mut sender =
             Connection::new_with_tls_stream(client).with_file_region_io(blocking, FileTransferMode::Sendfile);
         let error = sender
@@ -208,15 +210,26 @@ fn explicit_sendfile_on_tls_fails_before_writing_the_head() {
             )
             .await
             .expect_err("sendfile must never bypass a TLS stream");
-        assert!(error.to_string().contains("sendfile"));
+        assert!(matches!(
+            error,
+            RocketMQError::Network(NetworkError::ConnectionFailed { addr, reason })
+                if addr == "transport-file-region-writer" && reason.contains("sendfile")
+        ));
+        assert_eq!(sender.state(), ConnectionState::Healthy);
 
-        let mut byte = [0_u8; 1];
-        let read = tokio::time::timeout(Duration::from_millis(50), server.read(&mut byte))
-            .await
-            .expect("closed sender should wake the peer")
-            .expect("peer read should succeed");
-        assert_eq!(read, 0, "unsupported sendfile must not emit a frame head");
-        assert_eq!(sender.state(), ConnectionState::Closed);
+        let mut receiver = Connection::new_with_plaintext_stream(server);
+        let (sent, received) = tokio::join!(
+            sender.send_command(RemotingCommand::create_remoting_command(325)),
+            receiver.receive_command()
+        );
+        sent.expect("preflight sendfile rejection must leave the writer usable");
+        assert_eq!(
+            received
+                .expect("peer response")
+                .expect("decoded follow-up command")
+                .code(),
+            325
+        );
     });
 
     assert!(file_transfer_snapshot().selection_failures > before.selection_failures);

--- a/rocketmq-transport/tests/write_strategy.rs
+++ b/rocketmq-transport/tests/write_strategy.rs
@@ -652,7 +652,7 @@ async fn partial_failure_closes_session_and_fails_every_already_queued_frame() {
         first.1.expect_err("first queued frame should fail"),
         second.1.expect_err("second queued frame should fail"),
     ];
-    assert!(errors.iter().all(|error| error.contains("injected connection failure")));
+    assert!(errors.iter().all(|error| error.contains("canonical writer failure")));
     assert!(control.failure_poll.load(Ordering::Acquire) >= 2);
     assert_eq!(
         control.write_polls.load(Ordering::Acquire),


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9754

### Brief Description

- Return a crate-private canonical writer completion that preserves a shared typed source and reports `NotStarted` or `PossiblyPartial` from the actual socket-I/O boundary.
- Replace the queued waiting/started race with an atomic claim/cancel/start handshake, so a before-start deadline guarantees that the frame cannot be written later.
- Fan out one typed failure to active micro-batch members, fail poison-drained followers as not started, close poisoned sessions, and release every admission permit and file lease exactly once.
- Add a typed internal response send path while preserving all public `Connection::send_*` signatures, legacy network error shapes, caller targets, and operation-specific compatibility reasons.
- Keep deterministic preflight failures non-poisoning and preserve accurate queue/write diagnostics without adding per-message synchronization.
- Add focused fault-injection coverage for encode/admission/lane failures, queued cancellation, first/partial/flush failures, active batch fan-out, poison drain, completion drops, file leases, diagnostics, direct/queued parity, and sendfile compatibility.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-transport -- --check`
- `cargo test -p rocketmq-transport --no-fail-fast`
- `cargo test -p rocketmq-transport --all-features --no-fail-fast`
- `cargo clippy -p rocketmq-transport --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo doc -p rocketmq-transport --no-deps --all-features`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `git diff --check`
- `.\scripts\check-error-hygiene.ps1` reports the same pre-existing source-stringification and redaction findings on this branch and `main`; this change adds no finding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved send failure reporting with clearer, stage-aware errors.
  * Correctly distinguishes expired, timed-out, cancelled, partial, and failed writes.
  * Preserves healthy connections when no socket data was sent.
  * Prevents queued operations from hanging when completions are dropped.
  * Ensures failed writes are cleaned up and pending operations are completed consistently.

* **Tests**
  * Added extensive coverage for deadlines, cancellation, partial writes, TLS transfers, connection health, and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->