### PR TITLE
[ISSUE #9757]✨Return typed completion from V1 response writes

### DIFF
--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -605,15 +605,33 @@ where
         opaque: i32,
     ) {
         match response_result {
-            Ok(Some(response)) => ctx.write_response(response.set_opaque(opaque)).await,
+            Ok(Some(response)) => {
+                if let Err(error) = ctx.try_write_response(response.set_opaque(opaque)).await {
+                    warn!(
+                        kind = error.kind().as_str(),
+                        progress = error.write_progress().map_or("none", |progress| progress.as_str()),
+                        retryable = error.retryable(),
+                        "detached fast failure response write failed; not retrying"
+                    );
+                }
+            }
             Ok(None) => {}
             Err(_error) => {
-                ctx.write_response(system_error_response(
-                    command_factory,
-                    opaque,
-                    "fast failure response channel closed before detached request completed",
-                ))
-                .await;
+                if let Err(error) = ctx
+                    .try_write_response(system_error_response(
+                        command_factory,
+                        opaque,
+                        "fast failure response channel closed before detached request completed",
+                    ))
+                    .await
+                {
+                    warn!(
+                        kind = error.kind().as_str(),
+                        progress = error.write_progress().map_or("none", |progress| progress.as_str()),
+                        retryable = error.retryable(),
+                        "detached fast failure response write failed; not retrying"
+                    );
+                }
             }
         }
     }

--- a/rocketmq-broker/src/processor/pull_message_processor.rs
+++ b/rocketmq-broker/src/processor/pull_message_processor.rs
@@ -1150,7 +1150,14 @@ where
 
             if let Ok(Some(response)) = response {
                 let command = response.set_opaque(opaque).mark_response_type();
-                ctx.write_response(command).await;
+                if let Err(error) = ctx.try_write_response(command).await {
+                    error!(
+                        kind = error.kind().as_str(),
+                        progress = error.write_progress().map_or("none", |progress| progress.as_str()),
+                        retryable = error.retryable(),
+                        "long polling wakeup response write failed; not retrying"
+                    );
+                }
             }
         };
         spawn_wakeup_pull_task(self.wakeup_task_group.get(), task);
@@ -1739,7 +1746,6 @@ mod tests {
 
         assert!(!processor.contains(concat!("WAKEUP_WRITE_", "LOCK_SHARDS")));
         assert!(!processor.contains("wakeup_write_locks"));
-        assert!(processor.contains("ctx.write_response(command).await"));
         for source in [processor, result_handler] {
             assert!(!source.contains(concat!("Broker", "RuntimeInner")));
             assert!(!source.contains(concat!("Arc", "Mut")));

--- a/rocketmq-broker/src/processor/send_message_processor.rs
+++ b/rocketmq-broker/src/processor/send_message_processor.rs
@@ -83,7 +83,10 @@ use rocketmq_transport::api::v1::Channel;
 use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use rocketmq_transport::api::v1::RejectRequestResponse;
 use rocketmq_transport::api::v1::RequestProcessor;
+use rocketmq_transport::api::v1::ResponseError;
+use rocketmq_transport::api::v1::ResponseReceipt;
 use tracing::debug;
+use tracing::error;
 use tracing::info;
 use tracing::warn;
 use tracing::Instrument;
@@ -560,14 +563,9 @@ where
                 MessageType::NormalMsg,
             )
             .await;
-        send_message_callback(&mut send_message_context, &mut response);
-        if result.1 {
-            Ok(None)
-        } else if result.0.is_some() {
-            Ok(result.0)
-        } else {
-            Ok(Some(response))
-        }
+        finish_send_message_response(result, response, |response| {
+            send_message_callback(&mut send_message_context, response);
+        })
     }
 
     async fn send_message<F>(
@@ -728,14 +726,38 @@ where
                 MessageType::NormalMsg,
             )
             .await;
-        send_message_callback(&mut send_message_context, &mut response);
-        if result.1 {
-            Ok(None)
-        } else if result.0.is_some() {
-            Ok(result.0)
-        } else {
-            Ok(Some(response))
-        }
+        finish_send_message_response(result, response, |response| {
+            send_message_callback(&mut send_message_context, response);
+        })
+    }
+}
+
+async fn complete_direct_send_message_response(
+    response_write: impl Future<Output = Result<ResponseReceipt, ResponseError>>,
+) -> (Option<RemotingCommand>, bool) {
+    if let Err(error) = response_write.await {
+        error!(
+            kind = error.kind().as_str(),
+            progress = error.write_progress().map_or("none", |progress| progress.as_str()),
+            retryable = error.retryable(),
+            "send message response write failed; not retrying"
+        );
+    }
+    (None, true)
+}
+
+fn finish_send_message_response(
+    result: (Option<RemotingCommand>, bool),
+    mut response: RemotingCommand,
+    send_message_callback: impl FnOnce(&mut RemotingCommand),
+) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+    send_message_callback(&mut response);
+    if result.1 {
+        Ok(None)
+    } else if result.0.is_some() {
+        Ok(result.0)
+    } else {
+        Ok(Some(response))
     }
 }
 
@@ -1044,8 +1066,7 @@ where
             }
 
             response.set_opaque_mut(request.opaque());
-            ctx.write_response_ref(response).await;
-            (None, true)
+            complete_direct_send_message_response(ctx.try_write_response_ref(response)).await
         } else {
             if has_send_message_hook {
                 let request_body_len = request.body().as_ref().map_or(0, |body| body.len() as i32);
@@ -1988,6 +2009,11 @@ fn no_retry_queue_response(command_factory: &RemotingCommandFactory) -> Remoting
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
     use std::collections::HashMap;
     use std::future::Future;
 
@@ -2010,6 +2036,9 @@ mod tests {
     use rocketmq_store::StoreHealthError;
     use rocketmq_store::StoreHealthSnapshot;
     use rocketmq_store::SyncFlushRuntimeInfo;
+    use rocketmq_transport::api::v1::ResponseError;
+    use rocketmq_transport::api::v1::ResponseReceipt;
+    use rocketmq_transport::test_support::LocalRequestHarness;
 
     use crate::mqtrace::send_message_context::SendMessageContext;
     use crate::mqtrace::send_message_hook::SendMessageHook;
@@ -2018,6 +2047,8 @@ mod tests {
     use super::add_send_response_metadata;
     use super::append_message_with_store;
     use super::broker_send_permission_denied;
+    use super::complete_direct_send_message_response;
+    use super::finish_send_message_response;
     use super::has_registered_send_message_hooks;
     use super::has_valid_compaction_key;
     use super::map_put_status_to_response;
@@ -2169,6 +2200,48 @@ mod tests {
 
         let hooks: Vec<Box<dyn SendMessageHook>> = vec![Box::new(NoopSendMessageHook)];
         assert!(has_registered_send_message_hooks(&hooks));
+    }
+
+    #[tokio::test]
+    async fn direct_send_response_failure_does_not_enable_central_fallback() {
+        let harness = LocalRequestHarness::new(crate::test_task_group("send-message-direct-write-failure"))
+            .await
+            .expect("local transport harness should start");
+        let context = harness.context();
+        context.connection_ref().close();
+        let attempts = AtomicUsize::new(0);
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let mut response = RemotingCommand::create_success_response_command().set_body(b"direct".to_vec());
+
+        let direct_result = {
+            let write_events = Arc::clone(&events);
+            let response_write = async {
+                attempts.fetch_add(1, Ordering::Relaxed);
+                write_events.lock().expect("write event lock").push("write");
+                let error = context
+                    .try_write_response_ref(&mut response)
+                    .await
+                    .expect_err("closed session should reject the direct response write");
+                assert!(matches!(error, ResponseError::SessionClosed));
+                Err::<ResponseReceipt, ResponseError>(error)
+            };
+            complete_direct_send_message_response(response_write).await
+        };
+
+        assert_eq!(attempts.load(Ordering::Relaxed), 1);
+        assert!(direct_result.0.is_none());
+        assert!(direct_result.1);
+        assert!(response.body().is_none(), "the single direct write consumed the body");
+        let callback_events = Arc::clone(&events);
+        let outer = finish_send_message_response(direct_result, response, move |_| {
+            callback_events.lock().expect("callback event lock").push("callback");
+        })
+        .expect("direct write failure remains a successful processor outcome");
+        assert!(
+            outer.is_none(),
+            "a failed direct write must not produce a central fallback response"
+        );
+        assert_eq!(events.lock().expect("event lock").as_slice(), ["write", "callback"]);
     }
 
     #[test]

--- a/rocketmq-transport/src/connection.rs
+++ b/rocketmq-transport/src/connection.rs
@@ -1040,6 +1040,28 @@ impl Connection {
         .map_err(SendFailure::into_response)
     }
 
+    /// Sends a borrowed server response through the canonical writer with a
+    /// stage-aware completion error.
+    pub(crate) async fn send_response_ref(&mut self, command: &mut RemotingCommand) -> Result<(), ResponseError> {
+        let class = self
+            .response_class()
+            .unwrap_or_else(|| AdmissionClass::for_request_code(command.code()));
+        let frame = self
+            .limits
+            .encode_command(command.clone())
+            .map_err(|source| ResponseError::Encode { source })?;
+        let _ = command.take_body();
+        self.send_payload_inner(
+            OutboundPayload::Frame(frame),
+            class,
+            None,
+            None,
+            "transport-session-writer".to_string(),
+        )
+        .await
+        .map_err(SendFailure::into_response)
+    }
+
     /// Sends a `RemotingCommand` to the peer (consumes command).
     ///
     /// Encodes the command into immutable prefix/header/body segments, then flushes it to the

--- a/rocketmq-transport/src/connection/issue_9754_tests.rs
+++ b/rocketmq-transport/src/connection/issue_9754_tests.rs
@@ -242,7 +242,12 @@ async fn typed_response_encode_failure_is_not_started_and_keeps_direct_writer_he
         .send_response(RemotingCommand::create_remoting_command(1).set_body(vec![1]))
         .await
         .expect_err("body above the zero-byte profile must fail encoding");
-    assert!(matches!(error, ResponseError::Encode { .. }));
+    let ResponseError::Encode { source } = &error else {
+        panic!("oversized response must retain the typed encoding failure")
+    };
+    assert_eq!(error.write_progress(), Some(WriteProgress::NotStarted));
+    let _ = source.kind();
+    assert!(Error::source(&error).is_some());
     assert_eq!(connection.state(), ConnectionState::Healthy);
 
     connection
@@ -512,6 +517,36 @@ async fn typed_response_write_and_flush_failures_are_possibly_partial_with_a_typ
             assert_eq!(writes.load(Ordering::Acquire), 2);
         }
     }
+}
+
+#[tokio::test]
+async fn typed_borrowed_response_late_transport_failure_preserves_source_after_body_take() {
+    let writes = Arc::new(AtomicUsize::new(0));
+    let mut connection = Connection::new_with_plaintext_stream(FailingResponseTransport {
+        writes: Arc::clone(&writes),
+        phase: DirectFailurePhase::PartialThenError,
+    });
+    let mut command = RemotingCommand::create_remoting_command(7).set_body(b"borrowed-body".to_vec());
+
+    let error = connection
+        .send_response_ref(&mut command)
+        .await
+        .expect_err("injected late transport failure");
+
+    assert!(
+        command.body().is_none(),
+        "borrowed response body must be taken before the late write failure"
+    );
+    let ResponseError::Transport { progress, source } = &error else {
+        panic!("late transport failure must retain typed response completion")
+    };
+    assert_eq!(*progress, WriteProgress::PossiblyPartial);
+    let RocketMQError::Shared(shared) = source else {
+        panic!("late transport failure must preserve the writer source")
+    };
+    assert!(matches!(shared.as_error(), RocketMQError::IO(_)));
+    assert!(Error::source(&error).is_some());
+    assert_eq!(writes.load(Ordering::Acquire), 2);
 }
 
 #[tokio::test]

--- a/rocketmq-transport/src/dispatch/response.rs
+++ b/rocketmq-transport/src/dispatch/response.rs
@@ -16,8 +16,33 @@
 
 use std::error::Error;
 use std::fmt;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 
 use rocketmq_error::RocketMQError;
+
+// V1 response writes have no request owner. Keep their receipts in a reserved,
+// process-local namespace rather than deriving an identity from protocol opaque values.
+const LEGACY_V1_RESPONSE_OWNER_ID: u64 = u64::MAX;
+static LEGACY_V1_RESPONSE_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+
+fn reserve_legacy_v1_request_id(sequence: &AtomicU64) -> Result<RequestId, ResponseError> {
+    let sequence = sequence
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |sequence| {
+            if sequence == 0 {
+                None
+            } else {
+                sequence.checked_add(1)
+            }
+        })
+        .map_err(|_| ResponseError::AlreadyCompleted {
+            state: ResponseTerminalState::Closed,
+        })?;
+    Ok(RequestId {
+        owner_id: LEGACY_V1_RESPONSE_OWNER_ID,
+        sequence,
+    })
+}
 
 /// Opaque process-local identity for one response owner.
 ///
@@ -297,6 +322,18 @@ pub struct ResponseReceipt {
 }
 
 impl ResponseReceipt {
+    /// Reserves a synthetic V1 receipt before local completion starts.
+    ///
+    /// The fixed V1 namespace is process-local and intentionally has no request ownership. Its
+    /// sequence never wraps: after exhaustion, the legacy owner remains permanently closed and
+    /// this returns `AlreadyCompleted(Closed)` before any write begins.
+    pub(crate) fn legacy_v1(disposition: ResponseDisposition) -> Result<Self, ResponseError> {
+        Ok(Self {
+            request_id: reserve_legacy_v1_request_id(&LEGACY_V1_RESPONSE_SEQUENCE)?,
+            disposition,
+        })
+    }
+
     /// Returns the response owner that produced this receipt.
     #[must_use]
     pub const fn request_id(&self) -> RequestId {
@@ -566,5 +603,51 @@ mod tests {
 
         assert_eq!(receipt.request_id(), request_id);
         assert_eq!(receipt.disposition(), ResponseDisposition::InProcessAccepted);
+    }
+
+    #[test]
+    fn legacy_v1_receipts_use_a_reserved_owner_and_distinct_sequences() {
+        let first = ResponseReceipt::legacy_v1(ResponseDisposition::TransportWritten)
+            .expect("V1 receipt identity should be available");
+        let second = ResponseReceipt::legacy_v1(ResponseDisposition::TransportWritten)
+            .expect("V1 receipt identity should be available");
+
+        assert_eq!(first.request_id().owner_id(), LEGACY_V1_RESPONSE_OWNER_ID);
+        assert_eq!(second.request_id().owner_id(), LEGACY_V1_RESPONSE_OWNER_ID);
+        assert_ne!(first.request_id(), second.request_id());
+        assert!(second.request_id().sequence() > first.request_id().sequence());
+    }
+
+    #[test]
+    fn legacy_v1_receipt_ids_stop_before_maximum_sequence_wraps() {
+        let sequence = AtomicU64::new(u64::MAX - 1);
+
+        let final_id = reserve_legacy_v1_request_id(&sequence).expect("final safe sequence should be issued");
+        let error = reserve_legacy_v1_request_id(&sequence).expect_err("exhausted V1 owner must stay closed");
+
+        assert_eq!(final_id.owner_id(), LEGACY_V1_RESPONSE_OWNER_ID);
+        assert_eq!(final_id.sequence(), u64::MAX - 1);
+        assert_eq!(sequence.load(Ordering::Relaxed), u64::MAX);
+        assert!(matches!(
+            error,
+            ResponseError::AlreadyCompleted {
+                state: ResponseTerminalState::Closed
+            }
+        ));
+    }
+
+    #[test]
+    fn legacy_v1_receipt_ids_reject_a_wrapped_sequence_cursor() {
+        let sequence = AtomicU64::new(0);
+
+        let error = reserve_legacy_v1_request_id(&sequence).expect_err("wrapped V1 owner must stay closed");
+
+        assert!(matches!(
+            error,
+            ResponseError::AlreadyCompleted {
+                state: ResponseTerminalState::Closed
+            }
+        ));
+        assert_eq!(sequence.load(Ordering::Relaxed), 0);
     }
 }

--- a/rocketmq-transport/src/dispatch/response_sink.rs
+++ b/rocketmq-transport/src/dispatch/response_sink.rs
@@ -24,6 +24,10 @@ use tokio_util::sync::CancellationToken;
 use crate::codec::remoting_command_codec::FrameLimits;
 use crate::codec::remoting_command_codec::RemotingCommandCodec;
 use crate::deadline::RequestDeadline;
+use crate::dispatch::ResponseDisposition;
+use crate::dispatch::ResponseError;
+use crate::dispatch::ResponseReceipt;
+use crate::dispatch::ResponseTerminalState;
 use crate::server::SessionHandle;
 
 /// Typed failure produced by a response output capability.
@@ -52,6 +56,7 @@ pub enum ResponseSinkError {
 struct LocalResponseState {
     sender: Option<oneshot::Sender<Result<RemotingCommand, ResponseSinkError>>>,
     encoded: BytesMut,
+    terminal_state: Option<ResponseTerminalState>,
 }
 
 #[derive(Clone)]
@@ -64,13 +69,49 @@ pub struct LocalResponseSink {
 
 impl LocalResponseSink {
     fn complete(&self, result: Result<RemotingCommand, ResponseSinkError>) -> Result<(), ResponseSinkError> {
-        let sender = self
-            .state
-            .lock()
-            .sender
-            .take()
-            .ok_or(ResponseSinkError::AlreadyCompleted)?;
-        sender.send(result).map_err(|_| ResponseSinkError::ReceiverDropped)
+        let mut state = self.state.lock();
+        let sender = state.sender.take().ok_or(ResponseSinkError::AlreadyCompleted)?;
+        let terminal_state = if result.is_ok() {
+            ResponseTerminalState::Completed
+        } else {
+            ResponseTerminalState::Failed {
+                progress: crate::dispatch::WriteProgress::NotStarted,
+            }
+        };
+        match sender.send(result) {
+            Ok(()) => {
+                state.terminal_state = Some(terminal_state);
+                Ok(())
+            }
+            Err(_) => {
+                state.terminal_state = Some(ResponseTerminalState::Closed);
+                Err(ResponseSinkError::ReceiverDropped)
+            }
+        }
+    }
+
+    fn complete_legacy_v1(
+        &self,
+        command: RemotingCommand,
+        receipt: ResponseReceipt,
+    ) -> Result<ResponseReceipt, ResponseError> {
+        let mut state = self.state.lock();
+        let Some(sender) = state.sender.take() else {
+            return Err(ResponseError::AlreadyCompleted {
+                state: state.terminal_state.unwrap_or(ResponseTerminalState::Closed),
+            });
+        };
+
+        match sender.send(Ok(command)) {
+            Ok(()) => {
+                state.terminal_state = Some(ResponseTerminalState::Completed);
+                Ok(receipt)
+            }
+            Err(_) => {
+                state.terminal_state = Some(ResponseTerminalState::Closed);
+                Err(ResponseError::SessionClosed)
+            }
+        }
     }
 
     fn send_bytes(&self, bytes: Bytes) -> Result<(), ResponseSinkError> {
@@ -91,8 +132,16 @@ impl LocalResponseSink {
             ));
         }
         let sender = state.sender.take().ok_or(ResponseSinkError::AlreadyCompleted)?;
-        drop(state);
-        sender.send(Ok(command)).map_err(|_| ResponseSinkError::ReceiverDropped)
+        match sender.send(Ok(command)) {
+            Ok(()) => {
+                state.terminal_state = Some(ResponseTerminalState::Completed);
+                Ok(())
+            }
+            Err(_) => {
+                state.terminal_state = Some(ResponseTerminalState::Closed);
+                Err(ResponseSinkError::ReceiverDropped)
+            }
+        }
     }
 }
 
@@ -114,6 +163,7 @@ impl ResponseSink {
             state: Arc::new(parking_lot::Mutex::new(LocalResponseState {
                 sender: Some(sender),
                 encoded: BytesMut::new(),
+                terminal_state: None,
             })),
         };
         (Self::Local(sink), LocalResponseReceiver { receiver })
@@ -123,6 +173,25 @@ impl ResponseSink {
     #[must_use]
     pub const fn is_local(&self) -> bool {
         matches!(self, Self::Local(_))
+    }
+
+    pub(crate) fn reserve_legacy_v1_receipt(&self) -> Result<ResponseReceipt, ResponseError> {
+        let disposition = match self {
+            Self::Network(_) => ResponseDisposition::TransportWritten,
+            Self::Local(_) => ResponseDisposition::InProcessAccepted,
+        };
+        ResponseReceipt::legacy_v1(disposition)
+    }
+
+    pub(crate) async fn complete_legacy_v1_reserved(
+        &self,
+        command: RemotingCommand,
+        receipt: ResponseReceipt,
+    ) -> Result<ResponseReceipt, ResponseError> {
+        match self {
+            Self::Network(session) => session.connection().send_response(command).await.map(|()| receipt),
+            Self::Local(sink) => sink.complete_legacy_v1(command, receipt),
+        }
     }
 
     /// Delivers one materialized response.
@@ -210,5 +279,204 @@ impl LocalResponseReceiver {
             }
         };
         result.map_err(|_| ResponseSinkError::ReceiverDropped)?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+    use std::net::SocketAddr;
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use rocketmq_runtime::RuntimeContext;
+    use tokio::io::DuplexStream;
+    use tokio::sync::oneshot;
+
+    use super::*;
+    use crate::admission::AdmissionController;
+    use crate::admission::AdmissionLimits;
+    use crate::connection::Connection;
+    use crate::net::channel::ChannelInner;
+    use crate::security::TransportSecurity;
+    use crate::server::run_connected_session;
+    use crate::server::ConnectionHandler;
+
+    struct CaptureSession {
+        sender: std::sync::Mutex<Option<oneshot::Sender<SessionHandle>>>,
+    }
+
+    impl ConnectionHandler for CaptureSession {
+        fn connected(&self, session: SessionHandle) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+            Box::pin(async move {
+                if let Some(sender) = self.sender.lock().expect("capture session lock").take() {
+                    let _ = sender.send(session);
+                }
+            })
+        }
+
+        fn command(
+            &self,
+            _session: SessionHandle,
+            _command: RemotingCommand,
+        ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+            Box::pin(async {})
+        }
+    }
+
+    async fn connected_network_sink(
+        name: &'static str,
+    ) -> (RuntimeContext, ResponseSink, DuplexStream, tokio::task::JoinHandle<()>) {
+        let runtime = RuntimeContext::from_current(name);
+        let service = runtime.service_context(name);
+        let (transport, peer) = tokio::io::duplex(4096);
+        let (session_tx, session_rx) = oneshot::channel();
+        let handler = Arc::new(CaptureSession {
+            sender: std::sync::Mutex::new(Some(session_tx)),
+        });
+        let local_addr: SocketAddr = "127.0.0.1:19011".parse().expect("local address");
+        let remote_addr: SocketAddr = "127.0.0.1:19012".parse().expect("remote address");
+        let runner = tokio::spawn(run_connected_session(
+            Connection::new_with_plaintext_stream(transport),
+            local_addr,
+            remote_addr,
+            service.task_group().clone(),
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+            Arc::new(TransportSecurity::development_insecure_loopback(None, None)),
+            None,
+            Duration::from_secs(30),
+            handler,
+        ));
+        let session = session_rx.await.expect("capture connected session");
+
+        (runtime, ResponseSink::Network(Arc::new(session)), peer, runner)
+    }
+
+    fn legacy_v1_receipt(sink: &ResponseSink) -> ResponseReceipt {
+        sink.reserve_legacy_v1_receipt()
+            .expect("V1 receipt identity should be available")
+    }
+
+    #[tokio::test]
+    async fn network_sink_reservation_and_local_channel_adapter_write_transport_receipts() {
+        let (runtime, sink, peer, runner) = connected_network_sink("response-sink-network-receipt-test").await;
+
+        assert_eq!(
+            legacy_v1_receipt(&sink).disposition(),
+            ResponseDisposition::TransportWritten
+        );
+
+        let channel = ChannelInner::new_local(
+            sink,
+            runtime
+                .service_context("response-sink-network-channel")
+                .task_group()
+                .clone(),
+        );
+        let owned_receipt = channel
+            .send_response(RemotingCommand::create_remoting_command(1).set_opaque(71))
+            .await
+            .expect("network response should write one owned frame");
+        let mut borrowed = RemotingCommand::create_remoting_command(2)
+            .set_opaque(72)
+            .set_body(b"borrowed network body".to_vec());
+        let borrowed_receipt = channel
+            .send_response_ref(&mut borrowed)
+            .await
+            .expect("network response should write one borrowed frame");
+
+        assert_eq!(owned_receipt.disposition(), ResponseDisposition::TransportWritten);
+        assert_eq!(borrowed_receipt.disposition(), ResponseDisposition::TransportWritten);
+        assert!(
+            borrowed.body().is_none(),
+            "borrowed response body should be consumed after handoff"
+        );
+
+        let mut peer = Connection::new_with_plaintext_stream(peer);
+        let owned = peer
+            .receive_command()
+            .await
+            .expect("network peer should receive owned response")
+            .expect("owned response frame should decode");
+        let borrowed = peer
+            .receive_command()
+            .await
+            .expect("network peer should receive borrowed response")
+            .expect("borrowed response frame should decode");
+        assert_eq!(owned.opaque(), 71);
+        assert_eq!(borrowed.opaque(), 72);
+        assert_eq!(
+            borrowed.body().map(bytes::Bytes::as_ref),
+            Some(&b"borrowed network body"[..])
+        );
+
+        drop(channel);
+        drop(peer);
+        runner
+            .await
+            .expect("connected session runner should stop after peer closes");
+    }
+
+    #[tokio::test]
+    async fn legacy_v1_local_completion_returns_an_in_process_receipt() {
+        let (sink, receiver) = ResponseSink::local();
+        let command = RemotingCommand::create_remoting_command(1).set_opaque(77);
+
+        let receipt = sink
+            .complete_legacy_v1_reserved(command, legacy_v1_receipt(&sink))
+            .await
+            .expect("local response completion should hand off the command");
+
+        assert_eq!(receipt.disposition(), ResponseDisposition::InProcessAccepted);
+        let cancellation = CancellationToken::new();
+        let received = receiver
+            .receive(&cancellation, None)
+            .await
+            .expect("local response receiver should receive the command");
+        assert_eq!(received.opaque(), 77);
+    }
+
+    #[tokio::test]
+    async fn legacy_v1_local_completion_reports_receiver_drop_and_prior_terminal_state() {
+        let (sink, receiver) = ResponseSink::local();
+        drop(receiver);
+
+        let error = sink
+            .complete_legacy_v1_reserved(RemotingCommand::create_remoting_command(1), legacy_v1_receipt(&sink))
+            .await
+            .expect_err("dropped receiver should close the local response session");
+        assert!(matches!(error, ResponseError::SessionClosed));
+
+        let duplicate = sink
+            .complete_legacy_v1_reserved(RemotingCommand::create_remoting_command(2), legacy_v1_receipt(&sink))
+            .await
+            .expect_err("closed local response sink should reject a second completion");
+        assert!(matches!(
+            duplicate,
+            ResponseError::AlreadyCompleted {
+                state: ResponseTerminalState::Closed
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn legacy_v1_local_completion_reports_completed_for_duplicates() {
+        let (sink, _receiver) = ResponseSink::local();
+
+        sink.complete_legacy_v1_reserved(RemotingCommand::create_remoting_command(1), legacy_v1_receipt(&sink))
+            .await
+            .expect("first completion should succeed");
+        let duplicate = sink
+            .complete_legacy_v1_reserved(RemotingCommand::create_remoting_command(2), legacy_v1_receipt(&sink))
+            .await
+            .expect_err("second completion should be rejected");
+
+        assert!(matches!(
+            duplicate,
+            ResponseError::AlreadyCompleted {
+                state: ResponseTerminalState::Completed
+            }
+        ));
     }
 }

--- a/rocketmq-transport/src/net/channel.rs
+++ b/rocketmq-transport/src/net/channel.rs
@@ -43,6 +43,9 @@ use crate::base::pending_request_table::PendingRequestToken;
 use crate::connection::Connection;
 use crate::connection::ConnectionStateHandle;
 use crate::deadline::RequestDeadline;
+use crate::dispatch::ResponseDisposition;
+use crate::dispatch::ResponseError;
+use crate::dispatch::ResponseReceipt;
 use crate::dispatch::ResponseSink;
 use crate::file_region::FileRegion;
 use crate::file_region::FileRegionSequence;
@@ -268,6 +271,17 @@ impl Channel {
 
     pub(crate) fn pending_request_owner(&self) -> Option<&PendingRequestOwner> {
         self.inner.pending_request_owner()
+    }
+
+    pub(crate) async fn send_response(&self, command: RemotingCommand) -> Result<ResponseReceipt, ResponseError> {
+        self.inner.send_response(command).await
+    }
+
+    pub(crate) async fn send_response_ref(
+        &self,
+        command: &mut RemotingCommand,
+    ) -> Result<ResponseReceipt, ResponseError> {
+        self.inner.send_response_ref(command).await
     }
 
     /// Sends a command through the serialized connection writer.
@@ -820,6 +834,20 @@ impl ChannelInner {
         }
     }
 
+    pub(crate) async fn send_response(&self, command: RemotingCommand) -> Result<ResponseReceipt, ResponseError> {
+        match &self.connection {
+            ChannelIo::Network(connection) => {
+                let receipt = ResponseReceipt::legacy_v1(ResponseDisposition::TransportWritten)?;
+                connection.lock().await.send_response(command).await?;
+                Ok(receipt)
+            }
+            ChannelIo::Local(response) => {
+                let receipt = response.reserve_legacy_v1_receipt()?;
+                response.complete_legacy_v1_reserved(command, receipt).await
+            }
+        }
+    }
+
     /// Sends one network command with a leased external file body.
     pub async fn send_file_region_command(
         &self,
@@ -893,6 +921,25 @@ impl ChannelInner {
                 let owned = command.clone();
                 let _ = command.take_body();
                 response.send(owned).await.map_err(response_sink_error)
+            }
+        }
+    }
+
+    pub(crate) async fn send_response_ref(
+        &self,
+        command: &mut RemotingCommand,
+    ) -> Result<ResponseReceipt, ResponseError> {
+        match &self.connection {
+            ChannelIo::Network(connection) => {
+                let receipt = ResponseReceipt::legacy_v1(ResponseDisposition::TransportWritten)?;
+                connection.lock().await.send_response_ref(command).await?;
+                Ok(receipt)
+            }
+            ChannelIo::Local(response) => {
+                let receipt = response.reserve_legacy_v1_receipt()?;
+                let owned = command.clone();
+                let _ = command.take_body();
+                response.complete_legacy_v1_reserved(owned, receipt).await
             }
         }
     }

--- a/rocketmq-transport/src/runtime/connection_handler_context.rs
+++ b/rocketmq-transport/src/runtime/connection_handler_context.rs
@@ -18,6 +18,8 @@ use std::sync::Arc;
 use tracing::error;
 
 use crate::connection::ConnectionStateHandle;
+use crate::dispatch::ResponseError;
+use crate::dispatch::ResponseReceipt;
 use crate::net::channel::Channel;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 
@@ -90,10 +92,46 @@ impl ConnectionHandlerContextWrapper {
 
     // === Response Writing ===
 
+    /// Writes a response and reports its local completion disposition.
+    ///
+    /// A successful receipt confirms only local completion: a network receipt means the canonical
+    /// writer wrote and flushed the frame, while an embedded receipt means the response was handed
+    /// to its in-process receiver. Neither outcome confirms peer receipt or business completion.
+    /// The receipt uses a synthetic process-local V1 identifier; it is not derived from the
+    /// protocol opaque value and does not provide request ownership or at-most-once allocation.
+    /// V1 contexts have no request deadline capability, so this method does not synthesize a
+    /// `DeadlineExceeded` failure.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed failure that preserves the write stage and, for encoding or transport
+    /// failures, the source error for programmatic inspection.
+    pub async fn try_write_response(&self, cmd: RemotingCommand) -> Result<ResponseReceipt, ResponseError> {
+        self.channel.send_response(cmd).await
+    }
+
+    /// Writes a borrowed response and reports its local completion disposition.
+    ///
+    /// A successful receipt confirms only local completion: a network receipt means the canonical
+    /// writer wrote and flushed the frame, while an embedded receipt means the response was handed
+    /// to its in-process receiver. Neither outcome confirms peer receipt or business completion.
+    /// The receipt uses a synthetic process-local V1 identifier; it is not derived from the
+    /// protocol opaque value and does not provide request ownership or at-most-once allocation.
+    /// The command body may be consumed after encoding and before a later error is returned.
+    /// V1 contexts have no request deadline capability, so this method does not synthesize a
+    /// `DeadlineExceeded` failure.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed failure that preserves the write stage and, for encoding or transport
+    /// failures, the source error for programmatic inspection.
+    pub async fn try_write_response_ref(&self, cmd: &mut RemotingCommand) -> Result<ResponseReceipt, ResponseError> {
+        self.channel.send_response_ref(cmd).await
+    }
+
     /// Sends a response command back to the client (consumes command).
     ///
-    /// This is the primary method for responding to requests. Errors are
-    /// logged but not propagated to allow handlers to continue processing.
+    /// This compatibility facade logs typed local completion failures but does not propagate them.
     ///
     /// # Arguments
     ///
@@ -101,8 +139,8 @@ impl ConnectionHandlerContextWrapper {
     ///
     /// # Behavior
     ///
-    /// - **Success**: Command encoded and sent
-    /// - **Error**: Logged at ERROR level, method returns normally
+    /// - **Success**: Command completed at the local writer or embedded handoff boundary
+    /// - **Error**: One redacted structured failure is logged and the method returns normally
     ///
     /// # Example
     ///
@@ -114,10 +152,15 @@ impl ConnectionHandlerContextWrapper {
     /// }
     /// ```
     pub async fn write_response(&self, cmd: RemotingCommand) {
-        match self.channel.send_command(cmd).await {
+        match self.try_write_response(cmd).await {
             Ok(_) => {}
             Err(error) => {
-                error!("failed to send response: {}", error);
+                error!(
+                    kind = error.kind().as_str(),
+                    progress = error.write_progress().map_or("none", |progress| progress.as_str()),
+                    retryable = error.retryable(),
+                    "response write failed"
+                );
             }
         }
     }
@@ -125,7 +168,7 @@ impl ConnectionHandlerContextWrapper {
     /// Sends a response command back to the client (borrows command).
     ///
     /// Similar to `write_response`, but borrows the command instead of consuming it.
-    /// Use when the caller needs to retain ownership of the command.
+    /// Use when the caller needs to retain ownership of the command after any body consumption.
     ///
     /// # Arguments
     ///
@@ -133,17 +176,22 @@ impl ConnectionHandlerContextWrapper {
     ///
     /// # Behavior
     ///
-    /// - **Success**: Command encoded and sent
-    /// - **Error**: Logged at ERROR level, method returns normally
+    /// - **Success**: Command completed at the local writer or embedded handoff boundary
+    /// - **Error**: One redacted structured failure is logged and the method returns normally
     ///
     /// # Note
     ///
     /// The command's body may be consumed during sending (`take_body()`).
     pub async fn write_response_ref(&self, cmd: &mut RemotingCommand) {
-        match self.channel.send_command_ref(cmd).await {
+        match self.try_write_response_ref(cmd).await {
             Ok(_) => {}
             Err(error) => {
-                error!("failed to send response: {}", error);
+                error!(
+                    kind = error.kind().as_str(),
+                    progress = error.write_progress().map_or("none", |progress| progress.as_str()),
+                    retryable = error.retryable(),
+                    "response write failed"
+                );
             }
         }
     }
@@ -207,15 +255,37 @@ impl AsRef<ConnectionHandlerContextWrapper> for ConnectionHandlerContextWrapper 
 
 #[cfg(test)]
 mod tests {
+    use std::net::SocketAddr;
     use std::time::Duration;
 
     use tokio::net::TcpListener;
     use tokio::net::TcpStream;
+    use tokio_util::sync::CancellationToken;
 
     use super::*;
     use crate::base::pending_request_table::PendingRequestTable;
     use crate::connection::Connection;
+    use crate::dispatch::LocalResponseReceiver;
+    use crate::dispatch::ResponseDisposition;
+    use crate::dispatch::ResponseSink;
     use crate::net::channel::ChannelInner;
+
+    fn embedded_context(
+        runtime: &rocketmq_runtime::RuntimeContext,
+        name: &'static str,
+    ) -> (ConnectionHandlerContext, LocalResponseReceiver) {
+        let (sink, receiver) = ResponseSink::local();
+        let address = SocketAddr::from(([127, 0, 0, 1], 0));
+        let channel = Channel::new(
+            Arc::new(ChannelInner::new_local(
+                sink,
+                runtime.service_context(name).task_group().clone(),
+            )),
+            address,
+            address,
+        );
+        (Arc::new(ConnectionHandlerContextWrapper::new(channel)), receiver)
+    }
 
     #[tokio::test]
     async fn cloned_contexts_share_one_serialized_channel_writer() {
@@ -240,8 +310,16 @@ mod tests {
 
         assert!(Arc::ptr_eq(&context, &context_clone));
         let first = RemotingCommand::create_remoting_command(1).set_opaque(101);
-        let second = RemotingCommand::create_remoting_command(2).set_opaque(202);
-        tokio::join!(context.write_response(first), context_clone.write_response(second));
+        let second = RemotingCommand::create_remoting_command(2).set_opaque(101);
+        let (first_receipt, second_receipt) = tokio::join!(
+            context.try_write_response(first),
+            context_clone.try_write_response(second)
+        );
+        let first_receipt = first_receipt.expect("first response should be written locally");
+        let second_receipt = second_receipt.expect("second response should be written locally");
+        assert_eq!(first_receipt.disposition(), ResponseDisposition::TransportWritten);
+        assert_eq!(second_receipt.disposition(), ResponseDisposition::TransportWritten);
+        assert_ne!(first_receipt.request_id(), second_receipt.request_id());
 
         let mut peer = Connection::new(client_stream);
         let first = tokio::time::timeout(Duration::from_secs(1), peer.receive_command())
@@ -256,11 +334,69 @@ mod tests {
             .expect("second frame should decode");
         let mut opaque_ids = [first.opaque(), second.opaque()];
         opaque_ids.sort_unstable();
-        assert_eq!(opaque_ids, [101, 202]);
+        assert_eq!(opaque_ids, [101, 101]);
 
         context.connection_ref().close();
         assert!(!context_clone.connection_ref().is_healthy());
         let report = channel.close_with_report(Duration::from_secs(1)).await;
         assert!(report.is_healthy(), "{}", report.to_json());
+    }
+
+    #[tokio::test]
+    async fn embedded_context_returns_an_in_process_receipt() {
+        let runtime = rocketmq_runtime::RuntimeContext::from_current("embedded-context-receipt-test");
+        let (context, receiver) = embedded_context(&runtime, "embedded-context-receipt");
+
+        let receipt = context
+            .try_write_response(RemotingCommand::create_remoting_command(1).set_opaque(37))
+            .await
+            .expect("embedded response handoff should succeed");
+        assert_eq!(receipt.disposition(), ResponseDisposition::InProcessAccepted);
+        let cancellation = CancellationToken::new();
+        let response = receiver
+            .receive(&cancellation, None)
+            .await
+            .expect("embedded receiver should receive the response");
+        assert_eq!(response.opaque(), 37);
+    }
+
+    #[tokio::test]
+    async fn borrowed_response_write_consumes_the_body_before_a_late_error() {
+        let runtime = rocketmq_runtime::RuntimeContext::from_current("borrowed-context-receipt-test");
+        let (context, receiver) = embedded_context(&runtime, "borrowed-context-success");
+        let mut response = RemotingCommand::create_remoting_command(1).set_body(b"body".to_vec());
+
+        let receipt = context
+            .try_write_response_ref(&mut response)
+            .await
+            .expect("embedded borrowed response handoff should succeed");
+        assert_eq!(receipt.disposition(), ResponseDisposition::InProcessAccepted);
+        assert!(response.body().is_none());
+        let cancellation = CancellationToken::new();
+        assert_eq!(
+            receiver
+                .receive(&cancellation, None)
+                .await
+                .expect("embedded receiver should receive the response")
+                .body()
+                .map(|body| body.as_ref()),
+            Some(b"body".as_slice())
+        );
+
+        let (closed_context, closed_receiver) = embedded_context(&runtime, "borrowed-context-closed");
+        drop(closed_receiver);
+        let mut late_failure = RemotingCommand::create_remoting_command(2).set_body(b"late".to_vec());
+        assert!(matches!(
+            closed_context.try_write_response_ref(&mut late_failure).await,
+            Err(ResponseError::SessionClosed)
+        ));
+        assert!(late_failure.body().is_none());
+
+        let mut compatibility = RemotingCommand::create_remoting_command(3).set_body(b"compatibility".to_vec());
+        closed_context.write_response_ref(&mut compatibility).await;
+        assert!(compatibility.body().is_none());
+        closed_context
+            .write_response(RemotingCommand::create_remoting_command(4))
+            .await;
     }
 }

--- a/rocketmq-transport/tests/public_api_v1.rs
+++ b/rocketmq-transport/tests/public_api_v1.rs
@@ -21,6 +21,7 @@ use rocketmq_runtime::ShutdownReport;
 use rocketmq_transport::api::v1::CachedConnectionState;
 use rocketmq_transport::api::v1::ClientShutdownReport;
 use rocketmq_transport::api::v1::ClientSnapshot;
+use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use rocketmq_transport::api::v1::DefaultRequestProcessor;
 use rocketmq_transport::api::v1::PendingUsage;
 use rocketmq_transport::api::v1::RemotingClient;
@@ -110,6 +111,46 @@ fn assert_versioned_response_contract(
     let _: bool = error.retryable();
 }
 
+fn assert_v1_response_context_method_signatures(context: &ConnectionHandlerContext) {
+    let command = rocketmq_protocol::protocol::remoting_command::RemotingCommand::create_remoting_command(1);
+    let write = context.try_write_response(command);
+    let _: &dyn std::future::Future<Output = Result<ResponseReceipt, ResponseError>> = &write;
+    drop(write);
+
+    let mut borrowed = rocketmq_protocol::protocol::remoting_command::RemotingCommand::create_remoting_command(2);
+    let write_ref = context.try_write_response_ref(&mut borrowed);
+    let _: &dyn std::future::Future<Output = Result<ResponseReceipt, ResponseError>> = &write_ref;
+    drop(write_ref);
+
+    let compatibility = context
+        .write_response(rocketmq_protocol::protocol::remoting_command::RemotingCommand::create_remoting_command(3));
+    let _: &dyn std::future::Future<Output = ()> = &compatibility;
+    drop(compatibility);
+
+    let mut borrowed_compatibility =
+        rocketmq_protocol::protocol::remoting_command::RemotingCommand::create_remoting_command(4);
+    let compatibility_ref = context.write_response_ref(&mut borrowed_compatibility);
+    let _: &dyn std::future::Future<Output = ()> = &compatibility_ref;
+    drop(compatibility_ref);
+
+    #[allow(
+        deprecated,
+        reason = "public API contract test intentionally freezes legacy future outputs"
+    )]
+    {
+        let write =
+            context.write(rocketmq_protocol::protocol::remoting_command::RemotingCommand::create_remoting_command(5));
+        let _: &dyn std::future::Future<Output = ()> = &write;
+        drop(write);
+
+        let mut borrowed_write =
+            rocketmq_protocol::protocol::remoting_command::RemotingCommand::create_remoting_command(6);
+        let write_ref = context.write_ref(&mut borrowed_write);
+        let _: &dyn std::future::Future<Output = ()> = &write_ref;
+        drop(write_ref);
+    }
+}
+
 async fn assert_checked_server_method_signatures() {
     let runtime = RuntimeContext::try_from_current("transport-public-api-v1-checked-signatures").unwrap();
     let config = Arc::new(ServerConfig::default());
@@ -172,6 +213,7 @@ fn prelude_reexports_the_curated_composition_root_surface() {
 #[test]
 fn versioned_api_exposes_response_contract_types_without_prelude_exports() {
     assert_versioned_response_contract(None, None, ResponseError::DeadlineExceeded);
+    let _ = assert_v1_response_context_method_signatures as fn(&ConnectionHandlerContext);
     let _: Option<ResponseTerminalState> = Some(ResponseTerminalState::Completed);
     let _: Option<ResponseDisposition> = Some(ResponseDisposition::TransportWritten);
     let _: Option<WriteProgress> = Some(WriteProgress::NotStarted);

--- a/rocketmq-transport/tests/v1_processor_contract_tests.rs
+++ b/rocketmq-transport/tests/v1_processor_contract_tests.rs
@@ -40,6 +40,7 @@ use rocketmq_transport::api::v1::RequestContext;
 use rocketmq_transport::api::v1::RequestOrdering;
 use rocketmq_transport::api::v1::RequestOrderingKey;
 use rocketmq_transport::api::v1::RequestProcessor;
+use rocketmq_transport::api::v1::ResponseDisposition;
 use rocketmq_transport::api::v1::ResponseWriteObservation;
 use rocketmq_transport::api::v1::ResponseWriteOutcome;
 use rocketmq_transport::api::v1::ServerConfig;
@@ -95,6 +96,10 @@ enum Event {
         response_code: i32,
         outcome: ResponseWriteOutcome,
     },
+    DirectWrite {
+        code: i32,
+        disposition: ResponseDisposition,
+    },
 }
 
 impl Event {
@@ -104,7 +109,8 @@ impl Event {
             | Self::Reject { code }
             | Self::Before { code, .. }
             | Self::Process { code, .. }
-            | Self::After { code, .. } => *code,
+            | Self::After { code, .. }
+            | Self::DirectWrite { code, .. } => *code,
             Self::Observe { request_code, .. } => *request_code,
         }
     }
@@ -145,12 +151,23 @@ impl RequestProcessor for ContractProcessor {
         match request.code() {
             NONE | ONEWAY_NONE => Ok(None),
             DIRECT_WRITE => {
-                ctx.write_response(
-                    RemotingCommand::create_response_command_with_code(ResponseCode::Success)
-                        .set_opaque(request.opaque())
-                        .set_body(b"direct".to_vec()),
-                )
-                .await;
+                let receipt = ctx
+                    .try_write_response(
+                        RemotingCommand::create_response_command_with_code(ResponseCode::Success)
+                            .set_opaque(request.opaque())
+                            .set_body(b"direct".to_vec()),
+                    )
+                    .await
+                    .map_err(|error| {
+                        rocketmq_error::RocketMQError::response_process_failed(
+                            "v1_processor_contract",
+                            error.to_string(),
+                        )
+                    })?;
+                self.events.push(Event::DirectWrite {
+                    code: DIRECT_WRITE,
+                    disposition: receipt.disposition(),
+                });
                 Ok(None)
             }
             _ => Ok(Some(
@@ -518,8 +535,8 @@ async fn network_oneway_and_none_results_do_not_emit_central_responses_or_observ
 #[tokio::test]
 async fn direct_context_write_followed_by_none_emits_exactly_one_processor_frame() {
     let runtime = RuntimeContext::from_current("v1-direct-write-processor-contract");
-    let fixture = fixture(&runtime, "network");
-    let responses = run_network(&fixture, vec![request(DIRECT_WRITE, 5), request(SENTINEL, 6)], 2).await;
+    let network = fixture(&runtime, "network");
+    let responses = run_network(&network, vec![request(DIRECT_WRITE, 5), request(SENTINEL, 6)], 2).await;
 
     assert_eq!(responses.len(), 2);
     assert_eq!(responses[0].opaque(), 5);
@@ -528,7 +545,29 @@ async fn direct_context_write_followed_by_none_emits_exactly_one_processor_frame
         Some(b"direct".as_slice())
     );
     assert_eq!(responses[1].opaque(), 6);
-    assert!(!fixture.events.snapshot().iter().any(|event| matches!(
+    let network_events = network.events.snapshot();
+    assert!(network_events.contains(&Event::DirectWrite {
+        code: DIRECT_WRITE,
+        disposition: ResponseDisposition::TransportWritten,
+    }));
+    assert!(!network_events.iter().any(|event| matches!(
+        event,
+        Event::Observe {
+            request_code: DIRECT_WRITE,
+            ..
+        }
+    )));
+
+    let embedded = fixture(&runtime, "embedded");
+    let response = dispatch_embedded(&embedded, request(DIRECT_WRITE, 7)).await;
+    assert_eq!(response.opaque(), 7);
+    assert_eq!(response.body().map(|body| body.as_ref()), Some(b"direct".as_slice()));
+    let embedded_events = embedded.events.snapshot();
+    assert!(embedded_events.contains(&Event::DirectWrite {
+        code: DIRECT_WRITE,
+        disposition: ResponseDisposition::InProcessAccepted,
+    }));
+    assert!(!embedded_events.iter().any(|event| matches!(
         event,
         Event::Observe {
             request_code: DIRECT_WRITE,


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9757

### Brief Description

Expose typed V1 response completion through `try_write_response` and `try_write_response_ref` while preserving the unit-returning compatibility methods. The change adds accurate network and embedded receipts, non-wrapping synthetic V1 receipt identities, typed local-sink terminal states, and redacted failure handling at all existing Broker direct-response boundaries.

The send-message direct-write path remains terminal after either success or failure, so a possibly partial write can never enable a central fallback frame. Receipt disposition is selected by the actual response sink, including the crate-internal network-sink/local-channel adapter case.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-transport -- --check`
- `cargo fmt -p rocketmq-broker -- --check`
- `cargo test -p rocketmq-transport --all-features`
- `cargo test -p rocketmq-broker --lib direct_send_response_failure_does_not_enable_central_fallback`
- `cargo doc -p rocketmq-transport --all-features --no-deps`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz`
- `git diff --check`

The full Broker library run completed 823 tests successfully with two ignored and two unrelated failures. The timer capability failure reproduces unchanged on `main`; the shutdown ordering failure passes when rerun in isolation. Error-hygiene output is also identical to the existing `main` baseline, with no finding introduced by this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response delivery reliability for message sends, pulls, and fast-failure scenarios.
  * Prevented failed direct responses from triggering duplicate fallback responses.
  * Preserved detailed error status when response delivery fails, including late transport failures.
  * Improved handling of closed connections, duplicate completions, and exhausted response sessions.

* **Tests**
  * Expanded coverage for network and in-process response delivery, failure reporting, and response lifecycle behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->