### PR TITLE
[ISSUE #9755]📝Correct stale and machine-specific AGENTS.md guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,8 +52,8 @@
 - Treat `rust-version` as the MSRV and `rust-toolchain.toml` as the repository toolchain selection. Changes
   to either must keep root and standalone manifests, `.clippy.toml`, and CI aligned.
 - Do not normalize editions across projects. The root workspace defaults to Rust 2021;
-  `rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/` explicitly uses Rust 2024. Follow each of the five
-  standalone Cargo projects' local edition and toolchain rules; `fuzz/` intentionally remains Rust 2021.
+  `rocketmq-tools/rocketmq-admin/rocketmq-admin-cli/` explicitly uses Rust 2024. Follow each standalone Cargo
+  project's local edition and toolchain rules; `fuzz/` intentionally remains Rust 2021.
 - Keep Cargo features additive and explicit. Preserve documented default behavior, gate optional dependencies
   with their owning feature, and validate the exact changed feature combinations.
 - Treat public crate APIs, request/response codes and headers, Serde field names/defaults, and persisted record

--- a/rocketmq-dashboard/rocketmq-dashboard-web/frontend/AGENTS.md
+++ b/rocketmq-dashboard/rocketmq-dashboard-web/frontend/AGENTS.md
@@ -20,11 +20,7 @@ This file applies to `rocketmq-dashboard/rocketmq-dashboard-web/frontend/`.
 - Do not show internal migration/API parity hints in the product UI.
 
 ## Java Dashboard parity
-- When matching behavior, inspect the local Java frontend at:
-
-```text
-D:\Github\Java\rocketmq-dashboard\frontend-new
-```
+- When matching behavior, inspect the upstream [RocketMQ Dashboard frontend](https://github.com/apache/rocketmq-dashboard/tree/master/frontend-new).
 
 - Preserve Java Dashboard operational flows where practical: Topic, Consumer, Producer, Broker/Cluster, Message, DLQMessage, MessageTrace, Proxy, OPS, and ACL.
 - Do not copy the old Java visual style directly.


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #9755 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Rust project guidance to clarify standalone Cargo project conventions while retaining the Rust 2021 fuzzing exception.
  * Replaced a machine-specific local path with a publicly accessible upstream RocketMQ Dashboard frontend reference for parity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->