### PR TITLE
[ISSUE #9762]✨Capture immutable remoting request identity

### DIFF
--- a/rocketmq-transport/src/clients/client.rs
+++ b/rocketmq-transport/src/clients/client.rs
@@ -156,7 +156,9 @@ impl<PR: RequestProcessor + Sync + Clone + 'static> TransportConnectionHandler f
             else {
                 return;
             };
-            cmd_handler.process_message_received(&context, command).await;
+            cmd_handler
+                .process_message_received(&context, session.original_request_identity(), command)
+                .await;
         })
     }
 

--- a/rocketmq-transport/src/dispatch.rs
+++ b/rocketmq-transport/src/dispatch.rs
@@ -14,6 +14,7 @@
 
 mod authorized_dispatcher;
 mod request_context;
+mod request_identity;
 mod response;
 mod response_sink;
 
@@ -24,6 +25,8 @@ pub use authorized_dispatcher::DispatchOutcome;
 pub use request_context::RequestContext;
 pub use request_context::RequestContextError;
 pub use request_context::RequestTransport;
+pub(crate) use request_identity::reserve_session_owner;
+pub use request_identity::OriginalRequestIdentity;
 pub use response::RequestId;
 pub use response::ResponseDisposition;
 pub use response::ResponseError;

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher.rs
@@ -17,7 +17,6 @@ use std::net::IpAddr;
 use std::net::Ipv4Addr;
 use std::net::SocketAddr;
 use std::sync::atomic::AtomicU64;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -36,7 +35,9 @@ use rocketmq_security_api::Resource;
 use rocketmq_security_api::ResourceKind;
 use rocketmq_security_api::SecurityBootstrapProfile;
 
+use super::reserve_session_owner;
 use super::LocalResponseReceiver;
+use super::OriginalRequestIdentity;
 use super::RequestContext;
 use super::RequestTransport;
 use super::ResponseSink;
@@ -143,6 +144,7 @@ impl AuthorizedDispatchSession {
     pub(crate) async fn dispatch<F, Fut>(
         &self,
         context: RequestContext,
+        original_request_identity: Option<OriginalRequestIdentity>,
         command: RemotingCommand,
         retained_bytes: usize,
         partial_frame_permit: Option<PartialFramePermit>,
@@ -154,7 +156,10 @@ impl AuthorizedDispatchSession {
         F: FnOnce(OperationContext, RemotingCommand) -> Fut + Send + 'static,
         Fut: Future<Output = ()> + Send + 'static,
     {
-        let opaque = command.opaque();
+        let opaque =
+            original_request_identity.map_or_else(|| command.opaque(), OriginalRequestIdentity::original_opaque);
+        let request_code =
+            original_request_identity.map_or_else(|| command.code(), OriginalRequestIdentity::original_code);
         if context.deadline().is_some_and(|deadline| deadline.is_expired()) {
             response.send(deadline_response(opaque)).await?;
             return Ok(DispatchOutcome::Rejected);
@@ -163,7 +168,7 @@ impl AuthorizedDispatchSession {
             &command,
             context.peer(),
             context.principal(),
-            Resource::new(ResourceKind::Other, command.code().to_string()),
+            Resource::new(ResourceKind::Other, request_code.to_string()),
             Action::Manage,
         ) {
             response
@@ -183,7 +188,7 @@ impl AuthorizedDispatchSession {
         let processor_rejection = response.clone();
         match self.executor.try_execute(
             retained_bytes,
-            AdmissionClass::for_request_code(command.code()),
+            AdmissionClass::for_request_code(request_code),
             partial_frame_permit,
             ordering,
             move |operation| async move {
@@ -230,7 +235,6 @@ impl AuthorizedDispatchSession {
 pub struct AuthorizedCommandDispatcher<RP> {
     boundary: Arc<AuthorizedDispatchBoundary>,
     handler: Arc<RemotingGeneralHandler<RP>>,
-    next_embedded_session: AtomicU64,
 }
 
 impl<RP> AuthorizedCommandDispatcher<RP>
@@ -271,7 +275,6 @@ where
                 response_table,
                 telemetry,
             )),
-            next_embedded_session: AtomicU64::new(1),
         })
     }
 
@@ -292,9 +295,12 @@ where
     pub(crate) async fn process_network(
         &self,
         context: &crate::runtime::connection_handler_context::ConnectionHandlerContext,
+        original_request_identity: Option<OriginalRequestIdentity>,
         command: RemotingCommand,
     ) {
-        self.handler.process_message_received(context, command).await;
+        self.handler
+            .process_message_received(context, original_request_identity, command)
+            .await;
     }
 
     /// Dispatches one embedded command without creating a listener, socket
@@ -313,8 +319,8 @@ where
         if context.transport() != RequestTransport::EmbeddedProxy {
             return Err(DispatchError::InvalidEmbeddedContext);
         }
+        let (session_id, original_request_identity) = capture_embedded_request_identity(&command)?;
         let retained_bytes = materialize_and_estimate_remoting_command_retained_bytes(&mut command);
-        let session_id = self.next_embedded_session.fetch_add(1, Ordering::Relaxed).max(1);
         let scope = AdmissionScope::new(IpAddr::V4(Ipv4Addr::LOCALHOST)).with_session(session_id);
         let scope = self
             .boundary
@@ -340,13 +346,16 @@ where
         session
             .dispatch(
                 context,
+                Some(original_request_identity),
                 command,
                 retained_bytes,
                 None,
                 ordering,
                 response,
                 move |_operation, command| async move {
-                    handler.process_message_received(&handler_context, command).await;
+                    handler
+                        .process_message_received(&handler_context, Some(original_request_identity), command)
+                        .await;
                 },
             )
             .await?;
@@ -360,6 +369,32 @@ where
     }
 }
 
+fn capture_embedded_request_identity(
+    command: &RemotingCommand,
+) -> Result<(u64, OriginalRequestIdentity), DispatchError> {
+    capture_embedded_request_identity_with_owner(command, reserve_session_owner())
+}
+
+fn capture_embedded_request_identity_with_owner(
+    command: &RemotingCommand,
+    session_id: Option<u64>,
+) -> Result<(u64, OriginalRequestIdentity), DispatchError> {
+    let session_id = session_id.ok_or_else(|| {
+        DispatchError::Runtime(RuntimeError::LifecycleOperation {
+            operation: "authorized_dispatcher.reserve_embedded_session_owner",
+            message: "process-local session owner namespace exhausted".to_owned(),
+        })
+    })?;
+    let request_sequence = AtomicU64::new(1);
+    let identity = OriginalRequestIdentity::capture(session_id, &request_sequence, command).ok_or_else(|| {
+        DispatchError::Runtime(RuntimeError::LifecycleOperation {
+            operation: "authorized_dispatcher.capture_embedded_request_identity",
+            message: "embedded request identity namespace exhausted".to_owned(),
+        })
+    })?;
+    Ok((session_id, identity))
+}
+
 fn admission_response(opaque: i32, error: &AdmissionError) -> RemotingCommand {
     RemotingCommand::create_response_command_with_code_remark(ResponseCode::SystemBusy, error.to_string())
         .set_opaque(opaque)
@@ -371,4 +406,43 @@ fn deadline_response(opaque: i32) -> RemotingCommand {
         "request deadline exceeded".to_owned(),
     )
     .set_opaque(opaque)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_sessions_use_distinct_process_owners_even_with_the_same_opaque() {
+        let network_owner = reserve_session_owner().expect("test process owner should be available");
+        let command = RemotingCommand::create_remoting_command(-91_762).set_opaque(77);
+
+        let (_, first) = capture_embedded_request_identity(&command).expect("first embedded identity");
+        let (_, second) = capture_embedded_request_identity(&command).expect("second embedded identity");
+
+        assert_ne!(first.request_id().owner_id(), network_owner);
+        assert_ne!(second.request_id().owner_id(), network_owner);
+        assert_ne!(first.request_id().owner_id(), second.request_id().owner_id());
+        assert_eq!(first.request_id().sequence(), 1);
+        assert_eq!(second.request_id().sequence(), 1);
+        assert_eq!(first.original_opaque(), second.original_opaque());
+        assert_eq!(first.original_code(), -91_762);
+        assert_eq!(second.original_code(), -91_762);
+    }
+
+    #[test]
+    fn embedded_owner_exhaustion_is_a_runtime_lifecycle_failure() {
+        let command = RemotingCommand::create_remoting_command(10).set_opaque(77);
+
+        let error = capture_embedded_request_identity_with_owner(&command, None)
+            .expect_err("an exhausted process owner namespace must fail closed");
+
+        match error {
+            DispatchError::Runtime(RuntimeError::LifecycleOperation { operation, message }) => {
+                assert_eq!(operation, "authorized_dispatcher.reserve_embedded_session_owner");
+                assert_eq!(message, "process-local session owner namespace exhausted");
+            }
+            other => panic!("unexpected embedded exhaustion error: {other:?}"),
+        }
+    }
 }

--- a/rocketmq-transport/src/dispatch/request_identity.rs
+++ b/rocketmq-transport/src/dispatch/request_identity.rs
@@ -1,0 +1,202 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Immutable facts captured when a remoting request enters the transport.
+
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+
+use super::RequestId;
+
+const FIRST_ALLOCATED_ID: u64 = 1;
+const EXHAUSTED_ID: u64 = u64::MAX;
+
+static NEXT_SESSION_OWNER: AtomicU64 = AtomicU64::new(FIRST_ALLOCATED_ID);
+
+fn reserve_checked(counter: &AtomicU64) -> Option<u64> {
+    counter
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |next| match next {
+            0 | EXHAUSTED_ID => None,
+            _ => Some(next + 1),
+        })
+        .ok()
+}
+
+/// Reserves a process-local owner for one real network or embedded session.
+///
+/// Zero is never allocated, and `u64::MAX` remains reserved for synthetic V1
+/// response receipts. Once exhausted, the process-local allocator never wraps.
+pub(crate) fn reserve_session_owner() -> Option<u64> {
+    reserve_checked(&NEXT_SESSION_OWNER)
+}
+
+/// Immutable wire identity captured for one inbound request.
+///
+/// This value preserves the raw request code, protocol opaque, and one-way flag
+/// as they arrived at the trusted transport boundary. Later hook or processor
+/// mutations of the command cannot change these facts.
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::OriginalRequestIdentity;
+///
+/// fn fields_are_private(identity: OriginalRequestIdentity) {
+///     let _ = identity.original_code;
+/// }
+/// ```
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct OriginalRequestIdentity {
+    request_id: RequestId,
+    original_code: i32,
+    original_opaque: i32,
+    one_way: bool,
+}
+
+impl OriginalRequestIdentity {
+    pub(crate) fn capture(owner_id: u64, request_sequence: &AtomicU64, command: &RemotingCommand) -> Option<Self> {
+        if owner_id == 0 || owner_id == EXHAUSTED_ID {
+            return None;
+        }
+        let sequence = reserve_checked(request_sequence)?;
+        Some(Self {
+            request_id: RequestId::real(owner_id, sequence)?,
+            original_code: command.code(),
+            original_opaque: command.opaque(),
+            one_way: command.is_oneway_rpc(),
+        })
+    }
+
+    /// Returns the process-local identity allocated for this request.
+    #[must_use]
+    pub const fn request_id(self) -> RequestId {
+        self.request_id
+    }
+
+    /// Returns the raw request code captured from the inbound frame.
+    #[must_use]
+    pub const fn original_code(self) -> i32 {
+        self.original_code
+    }
+
+    /// Returns the protocol opaque captured from the inbound frame.
+    #[must_use]
+    pub const fn original_opaque(self) -> i32 {
+        self.original_opaque
+    }
+
+    /// Returns whether the inbound frame was originally marked one-way.
+    #[must_use]
+    pub const fn is_one_way(self) -> bool {
+        self.one_way
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::sync::Arc;
+    use std::thread;
+
+    use super::*;
+
+    fn request(code: i32, opaque: i32) -> RemotingCommand {
+        RemotingCommand::create_remoting_command(code).set_opaque(opaque)
+    }
+
+    #[test]
+    fn checked_allocator_is_sequential_and_excludes_reserved_values() {
+        let counter = AtomicU64::new(1);
+
+        assert_eq!(reserve_checked(&counter), Some(1));
+        assert_eq!(reserve_checked(&counter), Some(2));
+        assert_ne!(counter.load(Ordering::Relaxed), 0);
+        assert_ne!(counter.load(Ordering::Relaxed), u64::MAX);
+    }
+
+    #[test]
+    fn checked_allocator_issues_max_minus_one_then_stays_exhausted() {
+        let counter = AtomicU64::new(u64::MAX - 1);
+
+        assert_eq!(reserve_checked(&counter), Some(u64::MAX - 1));
+        assert_eq!(reserve_checked(&counter), None);
+        assert_eq!(reserve_checked(&counter), None);
+        assert_eq!(counter.load(Ordering::Relaxed), u64::MAX);
+    }
+
+    #[test]
+    fn checked_allocator_rejects_zero_without_recovery() {
+        let counter = AtomicU64::new(0);
+
+        assert_eq!(reserve_checked(&counter), None);
+        assert_eq!(reserve_checked(&counter), None);
+        assert_eq!(counter.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn concurrent_reservations_are_unique() {
+        const THREADS: usize = 8;
+        const IDS_PER_THREAD: usize = 256;
+
+        let counter = Arc::new(AtomicU64::new(1));
+        let threads = (0..THREADS)
+            .map(|_| {
+                let counter = Arc::clone(&counter);
+                thread::spawn(move || {
+                    (0..IDS_PER_THREAD)
+                        .map(|_| reserve_checked(&counter).expect("test allocator should have capacity"))
+                        .collect::<Vec<_>>()
+                })
+            })
+            .collect::<Vec<_>>();
+        let ids = threads
+            .into_iter()
+            .flat_map(|thread| thread.join().expect("allocator thread should finish"))
+            .collect::<HashSet<_>>();
+
+        assert_eq!(ids.len(), THREADS * IDS_PER_THREAD);
+        assert!(!ids.contains(&0));
+        assert!(!ids.contains(&u64::MAX));
+    }
+
+    #[test]
+    fn capture_preserves_raw_ingress_facts_and_increases_sequence() {
+        let sequence = AtomicU64::new(1);
+        let first = OriginalRequestIdentity::capture(17, &sequence, &request(-123_456, 91).mark_oneway_rpc())
+            .expect("identity should be allocated");
+        let second = OriginalRequestIdentity::capture(17, &sequence, &request(-123_456, 91))
+            .expect("identity should be allocated");
+
+        assert_eq!(first.request_id().owner_id(), 17);
+        assert_eq!(first.request_id().sequence(), 1);
+        assert_eq!(second.request_id().owner_id(), 17);
+        assert_eq!(second.request_id().sequence(), 2);
+        assert_eq!(first.original_code(), -123_456);
+        assert_eq!(first.original_opaque(), 91);
+        assert!(first.is_one_way());
+        assert!(!second.is_one_way());
+    }
+
+    #[test]
+    fn capture_rejects_reserved_owner_and_exhausted_sequence() {
+        let available = AtomicU64::new(1);
+        let exhausted = AtomicU64::new(u64::MAX);
+        let command = request(10, 20);
+
+        assert!(OriginalRequestIdentity::capture(0, &available, &command).is_none());
+        assert!(OriginalRequestIdentity::capture(u64::MAX, &available, &command).is_none());
+        assert_eq!(available.load(Ordering::Relaxed), 1);
+        assert!(OriginalRequestIdentity::capture(1, &exhausted, &command).is_none());
+    }
+}

--- a/rocketmq-transport/src/dispatch/response.rs
+++ b/rocketmq-transport/src/dispatch/response.rs
@@ -44,11 +44,20 @@ fn reserve_legacy_v1_request_id(sequence: &AtomicU64) -> Result<RequestId, Respo
     })
 }
 
-/// Opaque process-local identity for one response owner.
+/// Opaque process-local identity for one request allocation.
 ///
-/// The owner identifier distinguishes independent allocators within a process, and the sequence
-/// distinguishes requests created by that owner. The values do not identify a peer, request body,
-/// or protocol message.
+/// Real inbound requests use a process-local session owner and a sequence assigned within that
+/// session. Legacy V1 direct-write receipts use the same type with a reserved synthetic owner. The
+/// values are internal correlation data, not wire identifiers, peer identities, request bodies, or
+/// other protocol content.
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::RequestId;
+///
+/// fn fields_are_private(request_id: RequestId) {
+///     let _ = request_id.owner_id;
+/// }
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct RequestId {
     owner_id: u64,
@@ -56,13 +65,23 @@ pub struct RequestId {
 }
 
 impl RequestId {
-    /// Returns the process-local response-owner identifier.
+    /// Creates an identity in the namespace reserved for real request sessions.
+    pub(crate) const fn real(owner_id: u64, sequence: u64) -> Option<Self> {
+        if owner_id == 0 || owner_id == LEGACY_V1_RESPONSE_OWNER_ID || sequence == 0 || sequence == u64::MAX {
+            None
+        } else {
+            Some(Self { owner_id, sequence })
+        }
+    }
+
+    /// Returns the process-local request owner, including the reserved owner used by synthetic V1
+    /// direct-write receipts.
     #[must_use]
     pub const fn owner_id(self) -> u64 {
         self.owner_id
     }
 
-    /// Returns the sequence assigned by the process-local response owner.
+    /// Returns the sequence assigned within the process-local owner namespace.
     #[must_use]
     pub const fn sequence(self) -> u64 {
         self.sequence

--- a/rocketmq-transport/src/lib.rs
+++ b/rocketmq-transport/src/lib.rs
@@ -84,8 +84,8 @@ pub mod api {
 
     /// Curated source API boundary for the 2.x release line.
     ///
-    /// `RequestDeadline` is the only currently shared type; the 2.x request
-    /// model is not yet publicly exposed.
+    /// Only the immutable request timing and identity values approved for the
+    /// 2.x request model are exposed here.
     pub mod v2 {
         pub use crate::public_api_v2::*;
     }

--- a/rocketmq-transport/src/public_api_v2.rs
+++ b/rocketmq-transport/src/public_api_v2.rs
@@ -14,7 +14,9 @@
 
 //! Explicitly approved source API for the 2.x release line.
 //!
-//! [`RequestDeadline`] is currently the only shared type. The 2.x request
-//! model is not yet publicly exposed.
+//! This surface exposes only the immutable request timing and identity values
+//! approved for the 2.x request model.
 
 pub use crate::deadline::RequestDeadline;
+pub use crate::dispatch::OriginalRequestIdentity;
+pub use crate::dispatch::RequestId;

--- a/rocketmq-transport/src/remoting.rs
+++ b/rocketmq-transport/src/remoting.rs
@@ -25,6 +25,7 @@ pub(crate) mod inner {
     use tracing::Instrument;
 
     use crate::base::pending_request_table::PendingRequestTable;
+    use crate::dispatch::OriginalRequestIdentity;
     use crate::hook_registry::HookRegistry;
     use crate::hook_registry::HookSnapshot;
     use crate::runtime::connection_handler_context::ConnectionHandlerContext;
@@ -72,11 +73,24 @@ pub(crate) mod inner {
             }
         }
 
-        pub async fn process_message_received(&self, ctx: &ConnectionHandlerContext, cmd: RemotingCommand) {
+        pub async fn process_message_received(
+            &self,
+            ctx: &ConnectionHandlerContext,
+            original_request_identity: Option<OriginalRequestIdentity>,
+            cmd: RemotingCommand,
+        ) {
             match cmd.get_type() {
                 RemotingCommandType::REQUEST => {
-                    let span = self.telemetry.request_span(cmd.code(), cmd.opaque());
-                    match self.process_request_command(ctx, cmd).instrument(span).await {
+                    let Some(original_request_identity) = original_request_identity else {
+                        error!("request reached the remoting handler without an owned identity");
+                        return;
+                    };
+                    let span = self.telemetry.request_span(original_request_identity);
+                    match self
+                        .process_request_command(ctx, original_request_identity, cmd)
+                        .instrument(span)
+                        .await
+                    {
                         Ok(_) => {}
                         Err(e) => {
                             error!("process request command failed: {}", e);
@@ -92,18 +106,19 @@ pub(crate) mod inner {
         async fn process_request_command(
             &self,
             ctx: &ConnectionHandlerContext,
+            original_request_identity: OriginalRequestIdentity,
             mut cmd: RemotingCommand,
         ) -> RocketMQResult<()> {
             let request_started = Instant::now();
-            let opaque = cmd.opaque();
-            let request_code = cmd.code();
+            let opaque = original_request_identity.original_opaque();
+            let request_code = original_request_identity.original_code();
             let mut metrics_guard = self.telemetry.request_guard(
-                cmd.code(),
+                request_code,
                 cmd.body().map_or(0, |body| body.len() as u64),
-                is_long_polling_request(cmd.code()),
+                is_long_polling_request(request_code),
             );
             let mut request_processor = self.request_processor.clone();
-            let reject_request = request_processor.reject_request(cmd.code());
+            let reject_request = request_processor.reject_request(request_code);
             const REJECT_REQUEST_MSG: &str = "[REJECT REQUEST]system busy, start flow control for a while";
             if reject_request.0 {
                 let response = if let Some(response) = reject_request.1 {
@@ -139,7 +154,7 @@ pub(crate) mod inner {
                 }
                 return Ok(());
             }
-            let oneway_rpc = cmd.is_oneway_rpc();
+            let oneway_rpc = original_request_identity.is_one_way();
             let hook_snapshot = self.rpc_hooks.snapshot();
             //before handle request hooks
             let exception = self
@@ -238,7 +253,6 @@ pub(crate) mod inner {
             };
             if !completed {
                 warn!(
-                    opaque,
                     code,
                     address = %ctx.channel().remote_address(),
                     channel_id = %ctx.channel().channel_id(),

--- a/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/connection_handler.rs
+++ b/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/connection_handler.rs
@@ -139,7 +139,9 @@ impl<RP: RequestProcessor + Sync + Clone + 'static> ConnectionHandler<RP> {
                     }
                 }
                 let dispatcher = self.dispatcher.clone();
-                dispatcher.process_network(&remoting_session.context, command).await;
+                dispatcher
+                    .process_network(&remoting_session.context, session.original_request_identity(), command)
+                    .await;
             }
         }
     }

--- a/rocketmq-transport/src/server.rs
+++ b/rocketmq-transport/src/server.rs
@@ -29,6 +29,7 @@ use futures_util::StreamExt;
 use rocketmq_error::RocketMQError;
 use rocketmq_error::RocketMQResult;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::RemotingCommandType;
 use rocketmq_runtime::BlockingExecutor;
 use rocketmq_runtime::ChildServiceContext;
 use rocketmq_runtime::OperationContext;
@@ -58,7 +59,9 @@ use crate::connection::ConnectionState;
 use crate::connection::SessionLifecycle;
 use crate::connection::SessionWriterDiagnostics;
 use crate::connection::SessionWriterSnapshot;
+use crate::dispatch::reserve_session_owner;
 use crate::dispatch::AuthorizedDispatchBoundary;
+use crate::dispatch::OriginalRequestIdentity;
 use crate::dispatch::RequestContext;
 use crate::dispatch::ResponseSink;
 use crate::file_region::FileTransferMode;
@@ -125,6 +128,7 @@ pub trait SessionProcessor: Send + Sync + 'static {
 
 struct SessionSendHandle {
     session_id: u64,
+    request_sequence: AtomicU64,
     local_addr: SocketAddr,
     remote_addr: SocketAddr,
     transport_peer_addr: SocketAddr,
@@ -149,6 +153,7 @@ pub struct SessionHandle {
     send: Arc<SessionSendHandle>,
     request_operation: OperationContext,
     response_class: Option<AdmissionClass>,
+    original_request_identity: Option<OriginalRequestIdentity>,
 }
 
 impl SessionHandle {
@@ -204,6 +209,10 @@ impl SessionHandle {
         &self.request_operation
     }
 
+    pub(crate) fn original_request_identity(&self) -> Option<OriginalRequestIdentity> {
+        self.original_request_identity
+    }
+
     pub(crate) fn abort(&self) {
         let _ = self.send.state_tx.send(ConnectionState::Closed);
         self.send.reader_cancellation.cancel();
@@ -219,6 +228,11 @@ impl SessionHandle {
 
     pub(crate) fn with_operation_context(mut self, operation: OperationContext) -> Self {
         self.request_operation = operation;
+        self
+    }
+
+    pub(crate) fn with_original_request_identity(mut self, identity: Option<OriginalRequestIdentity>) -> Self {
+        self.original_request_identity = identity;
         self
     }
 
@@ -390,7 +404,6 @@ pub struct TransportListener {
     handshake_timeout: Duration,
     io_policy: SessionIoPolicy,
     principal: Option<Principal>,
-    next_session: AtomicU64,
     telemetry: TransportTelemetry,
     socket_options: SocketOptions,
     file_region_blocking: Option<BlockingExecutor>,
@@ -419,7 +432,6 @@ impl TransportListener {
             handshake_timeout,
             io_policy: SessionIoPolicy::default(),
             principal: None,
-            next_session: AtomicU64::new(1),
             telemetry: TransportTelemetry::noop(),
             socket_options: SocketOptions::default(),
             file_region_blocking: None,
@@ -523,7 +535,13 @@ impl TransportListener {
                 continue;
             }
             let local_addr = stream.local_addr()?;
-            let session_id = self.next_session.fetch_add(1, Ordering::Relaxed);
+            let Some(session_id) = reserve_session_owner() else {
+                drop(stream);
+                return Err(RocketMQError::network_connection_failed(
+                    "transport-session-owner",
+                    "process-local session owner namespace exhausted",
+                ));
+            };
             let scope = AdmissionScope::new(remote_addr.ip()).with_session(session_id);
             let Ok(connection_permit) = admission.try_acquire(
                 AdmissionResource::Connection,
@@ -642,6 +660,47 @@ async fn run_framed_session<H>(
 ) where
     H: ConnectionHandler,
 {
+    run_framed_session_with_request_sequence(
+        connection,
+        local_addr,
+        remote_addr,
+        transport_peer_addr,
+        proxy_protocol,
+        session_id,
+        scope,
+        task_group,
+        dispatch,
+        principal,
+        peer_is_tls,
+        io_policy,
+        AtomicU64::new(1),
+        #[cfg(test)]
+        None,
+        handler,
+    )
+    .await;
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_framed_session_with_request_sequence<H>(
+    connection: Connection,
+    local_addr: SocketAddr,
+    remote_addr: SocketAddr,
+    transport_peer_addr: SocketAddr,
+    proxy_protocol: Option<Arc<ProxyProtocolMetadata>>,
+    session_id: u64,
+    scope: AdmissionScope,
+    task_group: TaskGroup,
+    dispatch: Arc<AuthorizedDispatchBoundary>,
+    principal: Option<Principal>,
+    peer_is_tls: bool,
+    io_policy: SessionIoPolicy,
+    request_sequence: AtomicU64,
+    #[cfg(test)] mut request_identity_exhausted: Option<tokio::sync::oneshot::Sender<()>>,
+    handler: Arc<H>,
+) where
+    H: ConnectionHandler,
+{
     let connection_id = connection.connection_id().clone();
     let frame_limits = connection.frame_limits();
     let telemetry = connection.telemetry();
@@ -688,6 +747,7 @@ async fn run_framed_session<H>(
     let session = SessionHandle {
         send: Arc::new(SessionSendHandle {
             session_id,
+            request_sequence,
             local_addr,
             remote_addr,
             transport_peer_addr,
@@ -708,6 +768,7 @@ async fn run_framed_session<H>(
         }),
         request_operation: request_operation.clone(),
         response_class: None,
+        original_request_identity: None,
     };
 
     handler.connected(session.clone()).await;
@@ -722,22 +783,45 @@ async fn run_framed_session<H>(
             Ok(Some(Ok(decoded))) => decoded,
             Ok(Some(Err(_))) | Ok(None) | Err(_) => break,
         };
+        let command = decoded.command;
+        let original_request_identity = if command.get_type() == RemotingCommandType::REQUEST {
+            let Some(identity) = OriginalRequestIdentity::capture(session_id, &session.send.request_sequence, &command)
+            else {
+                #[cfg(test)]
+                if let Some(signal) = request_identity_exhausted.take() {
+                    let _ = signal.send(());
+                }
+                tracing::error!(
+                    reason = "sequence_exhausted",
+                    "transport session stopped accepting because request identity allocation is exhausted"
+                );
+                break;
+            };
+            Some(identity)
+        } else {
+            None
+        };
         session
             .send
             .telemetry
             .record_inbound_decoded_plaintext_bytes(decoded.retained_frame_bytes);
-        let command = decoded.command;
         let partial_frame_permit = decoded.partial_frame_permit;
-        let class = AdmissionClass::for_request_code(command.code());
+        let class = AdmissionClass::for_request_code(
+            original_request_identity.map_or_else(|| command.code(), OriginalRequestIdentity::original_code),
+        );
         let bytes = decoded.retained_frame_bytes;
         let context = RequestContext::network(PeerInfo::new(remote_addr, peer_is_tls), principal.clone(), None);
         let ordering = handler.request_ordering(&command);
         let request_handler = handler.clone();
-        let request_session = session.clone().with_response_class(class);
+        let request_session = session
+            .clone()
+            .with_response_class(class)
+            .with_original_request_identity(original_request_identity);
         let response = ResponseSink::Network(Arc::new(session.clone().with_response_class(class)));
         if executor
             .dispatch(
                 context,
+                original_request_identity,
                 command,
                 bytes,
                 partial_frame_permit,
@@ -813,7 +897,13 @@ pub async fn run_connected_session_with_io_policy<H>(
     let Ok(io_policy) = io_policy.validate() else {
         return;
     };
-    let session_id = u64::from(remote_addr.port());
+    let Some(session_id) = reserve_session_owner() else {
+        tracing::error!(
+            reason = "owner_exhausted",
+            "connected transport session rejected because request owner allocation is exhausted"
+        );
+        return;
+    };
     let scope = AdmissionScope::new(remote_addr.ip()).with_session(session_id);
     let Ok(session_group) = task_group.try_child(format!("rocketmq.transport.session.{session_id}")) else {
         return;
@@ -890,7 +980,6 @@ pub struct SessionTransportServer {
     dispatch: Arc<AuthorizedDispatchBoundary>,
     tls: TlsServerRuntime,
     started: AtomicBool,
-    next_session: AtomicU64,
     active_sessions: AtomicUsize,
     principal: Option<Principal>,
     telemetry: TransportTelemetry,
@@ -939,6 +1028,9 @@ impl ConnectionHandler for ProcessorSessionHandler {
         let processor = self.processor.clone();
         let request_timeout = self.request_timeout;
         Box::pin(async move {
+            let original_opaque = session
+                .original_request_identity()
+                .map(OriginalRequestIdentity::original_opaque);
             let response = match tokio::time::timeout(request_timeout, processor.process(request)).await {
                 Ok(Ok(response)) => response,
                 Ok(Err(error)) => {
@@ -960,6 +1052,11 @@ impl ConnectionHandler for ProcessorSessionHandler {
                     session.abort();
                     return;
                 }
+            };
+            let response = if let Some(original_opaque) = original_opaque {
+                response.set_opaque(original_opaque)
+            } else {
+                response
             };
             let mut connection = session.connection();
             let _ = connection.send_response(response).await;
@@ -1090,7 +1187,6 @@ impl SessionTransportServer {
             dispatch: Arc::new(AuthorizedDispatchBoundary::new(security, admission)),
             tls,
             started: AtomicBool::new(false),
-            next_session: AtomicU64::new(1),
             active_sessions: AtomicUsize::new(0),
             principal,
             telemetry,
@@ -1130,7 +1226,14 @@ impl SessionTransportServer {
                     tracing::warn!(%remote_addr, %error, "rejected transport socket with invalid required options");
                     continue;
                 }
-                let session_id = server.next_session.fetch_add(1, Ordering::Relaxed);
+                let Some(session_id) = reserve_session_owner() else {
+                    drop(stream);
+                    tracing::error!(
+                        reason = "owner_exhausted",
+                        "transport server stopped accepting because request owner allocation is exhausted"
+                    );
+                    break;
+                };
                 let scope = AdmissionScope::new(remote_addr.ip()).with_session(session_id);
                 let Ok(connection_permit) = server.dispatch.admission_controller().try_acquire(
                     AdmissionResource::Connection,
@@ -1252,12 +1355,16 @@ mod retirement_tests {
     use std::future::Future;
     use std::net::SocketAddr;
     use std::pin::Pin;
+    use std::sync::atomic::AtomicU64;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
     use std::sync::Arc;
     use std::time::Duration;
 
     use rocketmq_error::NetworkError;
     use rocketmq_error::RocketMQError;
     use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+    use rocketmq_protocol::protocol::RemotingCommandType;
     use rocketmq_runtime::RuntimeContext;
     use tokio::io::AsyncReadExt;
     use tokio::io::AsyncWriteExt;
@@ -1286,6 +1393,19 @@ mod retirement_tests {
     struct ObserveSessionRetirement {
         connected: std::sync::Mutex<Option<oneshot::Sender<SessionHandle>>>,
         disconnected: std::sync::Mutex<Option<oneshot::Sender<()>>>,
+    }
+
+    struct CaptureRequestIdentities {
+        connected: std::sync::Mutex<Option<oneshot::Sender<u64>>>,
+        commands:
+            tokio::sync::mpsc::UnboundedSender<(RemotingCommandType, Option<crate::dispatch::OriginalRequestIdentity>)>,
+    }
+
+    struct SequenceExhaustionLifecycle {
+        calls: AtomicUsize,
+        entered: std::sync::Mutex<Option<oneshot::Sender<crate::dispatch::OriginalRequestIdentity>>>,
+        release: Arc<Notify>,
+        disconnected: std::sync::Mutex<Option<oneshot::Sender<SessionHandle>>>,
     }
 
     impl ConnectionHandler for CaptureSession {
@@ -1330,6 +1450,275 @@ mod retirement_tests {
                 }
             })
         }
+    }
+
+    impl ConnectionHandler for CaptureRequestIdentities {
+        fn connected(&self, session: SessionHandle) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+            Box::pin(async move {
+                if let Some(sender) = self.connected.lock().expect("connected identity lock").take() {
+                    let _ = sender.send(session.session_id());
+                }
+            })
+        }
+
+        fn command(
+            &self,
+            session: SessionHandle,
+            command: RemotingCommand,
+        ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+            Box::pin(async move {
+                let _ = self
+                    .commands
+                    .send((command.get_type(), session.original_request_identity()));
+            })
+        }
+    }
+
+    impl ConnectionHandler for SequenceExhaustionLifecycle {
+        fn connected(&self, _session: SessionHandle) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+            Box::pin(async {})
+        }
+
+        fn command(
+            &self,
+            session: SessionHandle,
+            command: RemotingCommand,
+        ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+            Box::pin(async move {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                let identity = session
+                    .original_request_identity()
+                    .expect("accepted request must carry its identity");
+                if let Some(sender) = self.entered.lock().expect("sequence entry lock").take() {
+                    let _ = sender.send(identity);
+                }
+                self.release.notified().await;
+                let mut connection = session.connection();
+                let _ = connection
+                    .send_response(RemotingCommand::create_response_command_with_code(0).set_opaque(command.opaque()))
+                    .await;
+            })
+        }
+
+        fn disconnected(&self, session: SessionHandle) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+            Box::pin(async move {
+                if let Some(sender) = self.disconnected.lock().expect("sequence disconnect lock").take() {
+                    let _ = sender.send(session);
+                }
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn request_frames_share_session_owner_and_response_frames_do_not_consume_sequence() {
+        let runtime = RuntimeContext::from_current("transport-request-identity-sequence-test");
+        let service = runtime.service_context("transport-request-identity-sequence");
+        let (transport, peer_stream) = tokio::io::duplex(4096);
+        let (connected_tx, connected_rx) = oneshot::channel();
+        let (commands_tx, mut commands_rx) = tokio::sync::mpsc::unbounded_channel();
+        let handler = Arc::new(CaptureRequestIdentities {
+            connected: std::sync::Mutex::new(Some(connected_tx)),
+            commands: commands_tx,
+        });
+        let runner = tokio::spawn(super::run_connected_session(
+            Connection::new_with_plaintext_stream(transport),
+            "127.0.0.1:19101".parse().expect("local address"),
+            "127.0.0.1:19102".parse().expect("remote address"),
+            service.task_group().clone(),
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+            Arc::new(TransportSecurity::development_insecure_loopback(None, None)),
+            None,
+            Duration::from_secs(30),
+            handler,
+        ));
+        let owner_id = connected_rx.await.expect("connected session owner");
+        let mut peer = Connection::new_with_plaintext_stream(peer_stream);
+        peer.send_command(RemotingCommand::create_response_command_with_code(0).set_opaque(33))
+            .await
+            .expect("response frame should be sent");
+        peer.send_command(RemotingCommand::create_remoting_command(991).set_opaque(44))
+            .await
+            .expect("first request frame should be sent");
+        peer.send_command(RemotingCommand::create_remoting_command(992).set_opaque(44))
+            .await
+            .expect("second request frame should be sent");
+
+        let mut response_identity = None;
+        let mut request_identities = Vec::new();
+        for _ in 0..3 {
+            let (command_type, identity) = tokio::time::timeout(Duration::from_secs(1), commands_rx.recv())
+                .await
+                .expect("command should be dispatched")
+                .expect("identity observer should remain open");
+            match command_type {
+                RemotingCommandType::REQUEST => {
+                    request_identities.push(identity.expect("request frame must carry identity"));
+                }
+                RemotingCommandType::RESPONSE => response_identity = Some(identity),
+            }
+        }
+        request_identities.sort_unstable_by_key(|identity| identity.request_id().sequence());
+
+        assert_eq!(response_identity, Some(None));
+        assert_eq!(request_identities.len(), 2);
+        assert!(request_identities
+            .iter()
+            .all(|identity| identity.request_id().owner_id() == owner_id));
+        assert_eq!(request_identities[0].request_id().sequence(), 1);
+        assert_eq!(request_identities[1].request_id().sequence(), 2);
+        assert_eq!(request_identities[0].original_opaque(), 44);
+        assert_eq!(request_identities[1].original_opaque(), 44);
+
+        drop(peer);
+        runner.await.expect("session runner should finish");
+    }
+
+    #[tokio::test]
+    async fn sequence_exhaustion_drains_accepted_work_and_retires_without_dispatching_the_exhausted_request() {
+        let runtime = RuntimeContext::from_current("transport-request-sequence-exhaustion-test");
+        let service = runtime.service_context("transport-request-sequence-exhaustion");
+        let (transport, peer_stream) = tokio::io::duplex(4096);
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let (exhausted_tx, exhausted_rx) = oneshot::channel();
+        let (disconnected_tx, disconnected_rx) = oneshot::channel();
+        let release = Arc::new(Notify::new());
+        let handler = Arc::new(SequenceExhaustionLifecycle {
+            calls: AtomicUsize::new(0),
+            entered: std::sync::Mutex::new(Some(entered_tx)),
+            release: Arc::clone(&release),
+            disconnected: std::sync::Mutex::new(Some(disconnected_tx)),
+        });
+        let session_id = crate::dispatch::reserve_session_owner().expect("test process owner should be available");
+        let local_addr: SocketAddr = "127.0.0.1:19401".parse().expect("local address");
+        let remote_addr: SocketAddr = "127.0.0.1:19402".parse().expect("remote address");
+        let admission = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+        let security = Arc::new(TransportSecurity::development_insecure_loopback(None, None));
+        let dispatch = Arc::new(crate::dispatch::AuthorizedDispatchBoundary::new(
+            Arc::clone(&security),
+            Arc::clone(&admission),
+        ));
+        let scope = crate::admission::AdmissionScope::new(remote_addr.ip()).with_session(session_id);
+        let session_group = service
+            .task_group()
+            .try_child("transport-request-sequence-exhaustion-session")
+            .expect("test session group should be created");
+        let runner_handler = Arc::clone(&handler);
+        let mut runner = tokio::spawn(super::run_framed_session_with_request_sequence(
+            Connection::new_with_plaintext_stream(transport),
+            local_addr,
+            remote_addr,
+            remote_addr,
+            None,
+            session_id,
+            scope,
+            session_group,
+            dispatch,
+            None,
+            false,
+            super::SessionIoPolicy {
+                idle_timeout: Duration::from_secs(30),
+                ..super::SessionIoPolicy::default()
+            },
+            AtomicU64::new(u64::MAX - 1),
+            Some(exhausted_tx),
+            runner_handler,
+        ));
+        let mut peer = Connection::new_with_plaintext_stream(peer_stream);
+        peer.send_command(RemotingCommand::create_remoting_command(701).set_opaque(11))
+            .await
+            .expect("last allocatable request should be sent");
+        let identity = tokio::time::timeout(Duration::from_secs(1), entered_rx)
+            .await
+            .expect("last allocatable request should enter the handler")
+            .expect("handler should report the accepted identity");
+        assert_eq!(identity.request_id().sequence(), u64::MAX - 1);
+
+        peer.send_command(RemotingCommand::create_remoting_command(702).set_opaque(22))
+            .await
+            .expect("exhausted request frame should reach the session");
+        tokio::time::timeout(Duration::from_secs(1), exhausted_rx)
+            .await
+            .expect("session should detect request sequence exhaustion")
+            .expect("exhaustion signal should remain open");
+        assert_eq!(handler.calls.load(Ordering::SeqCst), 1);
+        assert!(!runner.is_finished(), "accepted work must drain before retirement");
+
+        release.notify_one();
+        let response = tokio::time::timeout(Duration::from_secs(1), peer.receive_command())
+            .await
+            .expect("accepted request should complete while the session drains")
+            .expect("accepted response read should succeed")
+            .expect("accepted request should emit one response");
+        assert_eq!(response.opaque(), 11);
+        let disconnected_session = tokio::time::timeout(Duration::from_secs(1), disconnected_rx)
+            .await
+            .expect("sequence exhaustion should run disconnected")
+            .expect("disconnected signal should remain open");
+        tokio::time::timeout(Duration::from_secs(1), &mut runner)
+            .await
+            .expect("sequence-exhausted session should retire")
+            .expect("session runner should not panic");
+        assert_eq!(handler.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            disconnected_session.connection().state(),
+            crate::connection::ConnectionState::Closed
+        );
+        assert!(
+            peer.receive_command().await.is_none(),
+            "exhausted request must not receive a response"
+        );
+
+        let report = service.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+    }
+
+    #[tokio::test]
+    async fn independently_connected_sessions_receive_distinct_process_owners() {
+        let runtime = RuntimeContext::from_current("transport-distinct-session-owner-test");
+        let service = runtime.service_context("transport-distinct-session-owner");
+        let (first_transport, first_peer) = tokio::io::duplex(1024);
+        let (second_transport, second_peer) = tokio::io::duplex(1024);
+        let (first_tx, first_rx) = oneshot::channel();
+        let (second_tx, second_rx) = oneshot::channel();
+        let admission = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+        let security = Arc::new(TransportSecurity::development_insecure_loopback(None, None));
+        let first_runner = tokio::spawn(super::run_connected_session(
+            Connection::new_with_plaintext_stream(first_transport),
+            "127.0.0.1:19201".parse().expect("first local address"),
+            "127.0.0.1:19202".parse().expect("first remote address"),
+            service.task_group().clone(),
+            Arc::clone(&admission),
+            Arc::clone(&security),
+            None,
+            Duration::from_secs(30),
+            Arc::new(CaptureSession {
+                sender: std::sync::Mutex::new(Some(first_tx)),
+            }),
+        ));
+        let second_runner = tokio::spawn(super::run_connected_session(
+            Connection::new_with_plaintext_stream(second_transport),
+            "127.0.0.1:19301".parse().expect("second local address"),
+            "127.0.0.1:19302".parse().expect("second remote address"),
+            service.task_group().clone(),
+            admission,
+            security,
+            None,
+            Duration::from_secs(30),
+            Arc::new(CaptureSession {
+                sender: std::sync::Mutex::new(Some(second_tx)),
+            }),
+        ));
+        let first_session = first_rx.await.expect("first session should connect");
+        let second_session = second_rx.await.expect("second session should connect");
+
+        assert_ne!(first_session.session_id(), second_session.session_id());
+        assert!(!matches!(first_session.session_id(), 0 | u64::MAX));
+        assert!(!matches!(second_session.session_id(), 0 | u64::MAX));
+
+        drop(first_peer);
+        drop(second_peer);
+        first_runner.await.expect("first session runner should finish");
+        second_runner.await.expect("second session runner should finish");
     }
 
     #[tokio::test]

--- a/rocketmq-transport/src/telemetry.rs
+++ b/rocketmq-transport/src/telemetry.rs
@@ -12,6 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(any(test, feature = "observability", feature = "observability-traces"))]
+#[inline]
+fn request_identity_span(identity: crate::dispatch::OriginalRequestIdentity) -> tracing::Span {
+    tracing::info_span!(
+        "RocketMQ REMOTING REQUEST",
+        rocketmq.request.code = identity.original_code(),
+        rocketmq.request.owner_id = identity.request_id().owner_id(),
+        rocketmq.request.sequence = identity.request_id().sequence(),
+    )
+}
+
 /// Cloneable metrics and tracing capability for one transport composition.
 ///
 /// A no-op value is explicit and never consults process-global OpenTelemetry state.
@@ -46,21 +57,17 @@ impl TransportTelemetry {
     }
 
     #[inline]
-    pub(crate) fn request_span(&self, request_code: i32, request_opaque: i32) -> tracing::Span {
+    pub(crate) fn request_span(&self, identity: crate::dispatch::OriginalRequestIdentity) -> tracing::Span {
         #[cfg(any(feature = "observability", feature = "observability-traces"))]
         if self
             .handle
             .as_ref()
             .is_some_and(|handle| handle.is_active() && handle.trace_policy().enabled)
         {
-            return tracing::info_span!(
-                "RocketMQ REMOTING REQUEST",
-                rocketmq.request.code = request_code,
-                rocketmq.request.opaque = request_opaque,
-            );
+            return request_identity_span(identity);
         }
 
-        let _ = (request_code, request_opaque);
+        let _ = identity;
         tracing::Span::none()
     }
 
@@ -246,9 +253,70 @@ impl TransportRequestMetricsGuard {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+    use std::fmt;
+    use std::sync::atomic::AtomicU64;
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
+    use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+    use tracing::field::Field;
+    use tracing::field::Visit;
+    use tracing::span::Attributes;
+    use tracing::span::Id;
+    use tracing::span::Record;
+    use tracing::Event;
+    use tracing::Metadata;
+    use tracing::Subscriber;
+
+    use super::request_identity_span;
     use super::TransportGoAwayOutcome;
     use super::TransportNameServerFailoverReason;
     use super::TransportTelemetry;
+
+    struct FieldCapture<'a> {
+        fields: &'a mut BTreeMap<String, String>,
+    }
+
+    impl Visit for FieldCapture<'_> {
+        fn record_i64(&mut self, field: &Field, value: i64) {
+            self.fields.insert(field.name().to_owned(), value.to_string());
+        }
+
+        fn record_u64(&mut self, field: &Field, value: u64) {
+            self.fields.insert(field.name().to_owned(), value.to_string());
+        }
+
+        fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+            self.fields.insert(field.name().to_owned(), format!("{value:?}"));
+        }
+    }
+
+    struct SpanCapture {
+        fields: Arc<Mutex<BTreeMap<String, String>>>,
+    }
+
+    impl Subscriber for SpanCapture {
+        fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+            true
+        }
+
+        fn new_span(&self, attributes: &Attributes<'_>) -> Id {
+            let mut fields = self.fields.lock().expect("span field capture lock");
+            attributes.record(&mut FieldCapture { fields: &mut fields });
+            Id::from_u64(1)
+        }
+
+        fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+        fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+        fn event(&self, _event: &Event<'_>) {}
+
+        fn enter(&self, _span: &Id) {}
+
+        fn exit(&self, _span: &Id) {}
+    }
 
     #[test]
     fn noop_transport_telemetry_covers_request_and_network_paths() {
@@ -260,9 +328,41 @@ mod tests {
         telemetry.record_lifecycle_listener_latency(std::time::Duration::from_millis(1), "connected");
         telemetry.record_nameserver_failover(TransportNameServerFailoverReason::ConnectFailure);
         telemetry.record_go_away(TransportGoAwayOutcome::Received);
-        assert!(telemetry.request_span(10, 1).is_disabled());
+        let identity = crate::dispatch::OriginalRequestIdentity::capture(
+            1,
+            &AtomicU64::new(1),
+            &RemotingCommand::create_remoting_command(10).set_opaque(1),
+        )
+        .expect("test request identity should be allocated");
+        assert!(telemetry.request_span(identity).is_disabled());
         let mut guard = telemetry.request_guard(10, 64, false);
         guard.complete_response(0);
         guard.complete_legacy_ambiguous_none();
+    }
+
+    #[test]
+    fn request_span_records_only_original_low_cardinality_identity_fields() {
+        let identity = crate::dispatch::OriginalRequestIdentity::capture(
+            73,
+            &AtomicU64::new(41),
+            &RemotingCommand::create_remoting_command(-91_764).set_opaque(889),
+        )
+        .expect("test request identity should be allocated");
+        let fields = Arc::new(Mutex::new(BTreeMap::new()));
+        let subscriber = SpanCapture {
+            fields: Arc::clone(&fields),
+        };
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = request_identity_span(identity);
+            assert!(!span.is_disabled());
+        });
+
+        let fields = fields.lock().expect("captured request span fields");
+        assert_eq!(fields.get("rocketmq.request.code").map(String::as_str), Some("-91764"));
+        assert_eq!(fields.get("rocketmq.request.owner_id").map(String::as_str), Some("73"));
+        assert_eq!(fields.get("rocketmq.request.sequence").map(String::as_str), Some("41"));
+        assert_eq!(fields.len(), 3, "request span fields: {fields:?}");
+        assert!(fields.keys().all(|field| !field.contains("opaque")));
     }
 }

--- a/rocketmq-transport/tests/authorized_dispatch_conformance_tests.rs
+++ b/rocketmq-transport/tests/authorized_dispatch_conformance_tests.rs
@@ -20,6 +20,7 @@ use std::net::Ipv4Addr;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::time::Duration;
 
 use rocketmq_error::RocketMQError;
@@ -128,6 +129,20 @@ impl RequestPolicy for AllowOnlyNamedPrincipal {
 
 struct CountingLegacyPolicy {
     calls: Arc<AtomicUsize>,
+}
+
+struct RecordingResourcePolicy {
+    requests: Arc<Mutex<Vec<(i32, String)>>>,
+}
+
+impl RequestPolicy for RecordingResourcePolicy {
+    fn evaluate_authenticated(&self, context: AuthenticatedRequestContext<'_>) -> Decision {
+        self.requests
+            .lock()
+            .expect("recording resource policy lock")
+            .push((context.request().code(), context.resource().name().to_owned()));
+        Decision::Allow
+    }
 }
 
 impl RequestPolicy for CountingLegacyPolicy {
@@ -291,6 +306,7 @@ async fn network_and_embedded_adapters_share_authorized_dispatch_semantics() {
     );
     let network = network_round_trip(&valid, "allowed", request).await;
     assert_equivalent(&embedded, &network);
+    assert_eq!(embedded.opaque(), 41);
     assert_eq!(valid.processor.calls.load(Ordering::SeqCst), 2);
 
     assert_eq!(
@@ -303,6 +319,7 @@ async fn network_and_embedded_adapters_share_authorized_dispatch_semantics() {
     let network_denied = network_round_trip(&denied, "denied", denied_request).await;
     assert_equivalent(&embedded_denied, &network_denied);
     assert_eq!(embedded_denied.code(), ResponseCode::NoPermission.to_i32());
+    assert_eq!(embedded_denied.opaque(), 42);
     assert_eq!(denied.processor.calls.load(Ordering::SeqCst), 0);
 
     let malformed = dispatch_fixture(
@@ -316,6 +333,7 @@ async fn network_and_embedded_adapters_share_authorized_dispatch_semantics() {
     let network_malformed = network_round_trip(&malformed, "allowed", malformed_request).await;
     assert_equivalent(&embedded_malformed, &network_malformed);
     assert_eq!(embedded_malformed.code(), ResponseCode::SystemError.to_i32());
+    assert_eq!(embedded_malformed.opaque(), 43);
 
     let handler_error = dispatch_fixture(
         &runtime,
@@ -328,6 +346,7 @@ async fn network_and_embedded_adapters_share_authorized_dispatch_semantics() {
     let network_error = network_round_trip(&handler_error, "allowed", error_request).await;
     assert_equivalent(&embedded_error, &network_error);
     assert_eq!(embedded_error.code(), ResponseCode::SystemError.to_i32());
+    assert_eq!(embedded_error.opaque(), 44);
 
     let deadline = dispatch_fixture(
         &runtime,
@@ -343,6 +362,7 @@ async fn network_and_embedded_adapters_share_authorized_dispatch_semantics() {
     )
     .await;
     assert_eq!(deadline_response.code(), ResponseCode::SystemError.to_i32());
+    assert_eq!(deadline_response.opaque(), 45);
     assert_eq!(deadline.processor.calls.load(Ordering::SeqCst), 0);
 
     let limits = AdmissionLimits {
@@ -368,6 +388,7 @@ async fn network_and_embedded_adapters_share_authorized_dispatch_semantics() {
     let network_overloaded = network_round_trip(&overloaded, "allowed", overloaded_request).await;
     assert_equivalent(&embedded_overloaded, &network_overloaded);
     assert_eq!(embedded_overloaded.code(), ResponseCode::SystemBusy.to_i32());
+    assert_eq!(embedded_overloaded.opaque(), 46);
     assert_eq!(overloaded.processor.calls.load(Ordering::SeqCst), 0);
 
     let cancelled = dispatch_fixture(
@@ -444,9 +465,67 @@ async fn configured_ingress_deny_short_circuits_legacy_policy_and_handler() {
         .expect("ingress denial should produce a response");
 
     assert_eq!(response.code(), ResponseCode::NoPermission.to_i32());
+    assert_eq!(response.opaque(), 48);
     assert_eq!(ingress_calls.load(Ordering::SeqCst), 1);
     assert_eq!(legacy_calls.load(Ordering::SeqCst), 0);
     assert_eq!(processor.calls.load(Ordering::SeqCst), 0);
     let report = service.task_group().shutdown(Duration::from_secs(1)).await;
+    report.assert_no_task_leak().expect("test tasks should be owned");
+}
+
+#[tokio::test]
+async fn unknown_raw_code_is_preserved_in_the_authorization_resource() {
+    const UNKNOWN_RAW_CODE: i32 = -91_763;
+
+    let runtime = RuntimeContext::from_current("authorized-dispatch-unknown-resource");
+    let service = runtime.service_context("unknown-resource");
+    let process_budget = service.process_budget();
+    let admission = Arc::new(
+        AdmissionController::try_new_with_budget(AdmissionLimits::default(), &process_budget)
+            .expect("test admission limits should be valid"),
+    );
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let security = Arc::new(TransportSecurity::secure_enforced(
+        Some(Arc::new(RecordingResourcePolicy {
+            requests: Arc::clone(&requests),
+        })),
+        None,
+    ));
+    let processor = ConformanceProcessor::new(ProcessorBehavior::Echo);
+    let dispatcher = Arc::new(
+        AuthorizedCommandDispatcher::try_new(
+            processor.clone(),
+            Vec::new(),
+            &process_budget,
+            TransportTelemetry::noop(),
+            Arc::clone(&security),
+            Arc::clone(&admission),
+        )
+        .expect("test dispatcher should fit the process budget"),
+    );
+    let fixture = DispatchFixture {
+        service,
+        processor,
+        dispatcher,
+        security,
+        admission,
+    };
+    let command = RemotingCommand::create_remoting_command(UNKNOWN_RAW_CODE).set_opaque(49);
+
+    let embedded = dispatch_embedded(&fixture, "allowed", None, command.clone()).await;
+    let network = network_round_trip(&fixture, "allowed", command).await;
+
+    assert_eq!(embedded.code(), ResponseCode::Success.to_i32());
+    assert_eq!(network.code(), embedded.code());
+    assert_eq!(network.opaque(), embedded.opaque());
+    assert_eq!(
+        requests.lock().expect("recorded authorization requests").as_slice(),
+        [
+            (UNKNOWN_RAW_CODE, UNKNOWN_RAW_CODE.to_string()),
+            (UNKNOWN_RAW_CODE, UNKNOWN_RAW_CODE.to_string()),
+        ]
+    );
+    assert_eq!(fixture.processor.calls.load(Ordering::SeqCst), 2);
+    let report = fixture.service.task_group().shutdown(Duration::from_secs(1)).await;
     report.assert_no_task_leak().expect("test tasks should be owned");
 }

--- a/rocketmq-transport/tests/client_server_lifecycle.rs
+++ b/rocketmq-transport/tests/client_server_lifecycle.rs
@@ -458,7 +458,7 @@ async fn hung_processor_and_send_failure_complete_without_leaking_pending_or_tas
 }
 
 #[tokio::test]
-async fn wrong_response_opaque_is_rejected_and_cannot_complete_the_request() {
+async fn low_level_processor_response_is_rebound_to_the_original_opaque() {
     let runtime = RuntimeContext::from_current("transport-wrong-opaque-test");
     let admission = Arc::new(AdmissionController::new(AdmissionLimits::default()));
     let server = SessionTransportServer::bind(
@@ -481,10 +481,8 @@ async fn wrong_response_opaque_is_rejected_and_cannot_complete_the_request() {
         )
         .await;
 
-    assert!(
-        result.is_err(),
-        "a mismatched response opaque must not complete the request"
-    );
+    let response = result.expect("transport must bind the processor response to the request opaque");
+    assert_eq!(response.code(), ResponseCode::Success.to_i32());
     assert_eq!(client.pending_usage().count, 0);
     let _ = server
         .shutdown_until(ShutdownDeadline::after(Duration::from_secs(1)))

--- a/rocketmq-transport/tests/public_api_contract.rs
+++ b/rocketmq-transport/tests/public_api_contract.rs
@@ -663,10 +663,20 @@ fn validate_public_api_v2_boundary(boundary: &PublicBoundary) -> Result<(), Stri
     if !boundary.modules.is_empty() {
         return Err(format!("unexpected public v2 modules: {:?}", boundary.modules));
     }
-    let expected_uses = [PublicUse {
-        module_path: String::new(),
-        use_tree: "crate::deadline::RequestDeadline".to_owned(),
-    }];
+    let expected_uses = [
+        PublicUse {
+            module_path: String::new(),
+            use_tree: "crate::deadline::RequestDeadline".to_owned(),
+        },
+        PublicUse {
+            module_path: String::new(),
+            use_tree: "crate::dispatch::OriginalRequestIdentity".to_owned(),
+        },
+        PublicUse {
+            module_path: String::new(),
+            use_tree: "crate::dispatch::RequestId".to_owned(),
+        },
+    ];
     if boundary.uses != expected_uses {
         return Err(format!("unexpected public v2 uses: {:?}", boundary.uses));
     }
@@ -680,21 +690,22 @@ fn lib_rs_exposes_only_the_curated_versioned_boundary() {
 }
 
 #[test]
-fn public_api_v2_exposes_only_the_curated_request_deadline() {
+fn public_api_v2_exposes_exactly_the_curated_request_identity_types() {
     let boundary =
         inspect_public_boundary(include_str!("../src/public_api_v2.rs")).expect("public_api_v2.rs must tokenize");
 
-    validate_public_api_v2_boundary(&boundary).expect("public_api_v2.rs must expose only RequestDeadline");
+    validate_public_api_v2_boundary(&boundary)
+        .expect("public_api_v2.rs must expose only RequestDeadline, RequestId, and OriginalRequestIdentity");
 }
 
 #[test]
 fn public_api_v2_rejects_unapproved_public_surface() {
     for source in [
-        "pub use crate::deadline::RequestDeadline; pub use crate::net::channel::Channel;",
-        "pub use crate::deadline::RequestDeadline; pub use rocketmq_runtime::OperationContext;",
+        "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::RequestId; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::net::channel::Channel;",
+        "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::RequestId; pub use crate::dispatch::OriginalRequestIdentity; pub use rocketmq_runtime::OperationContext;",
         "pub use crate::deadline::{RequestDeadline,RequestId};",
         "pub use crate::deadline::*;",
-        "pub mod request_model {} pub use crate::deadline::RequestDeadline;",
+        "pub mod request_model {} pub use crate::deadline::RequestDeadline; pub use crate::dispatch::RequestId; pub use crate::dispatch::OriginalRequestIdentity;",
     ] {
         let boundary = inspect_public_boundary(source).expect("adversarial V2 fixture must parse");
 
@@ -705,6 +716,8 @@ fn public_api_v2_rejects_unapproved_public_surface() {
 macro_rules! expose_extra { () => { pub use crate::net::channel::Channel; }; }
 expose_extra!();
 pub use crate::deadline::RequestDeadline;
+pub use crate::dispatch::RequestId;
+pub use crate::dispatch::OriginalRequestIdentity;
 "#;
     let error = inspect_public_boundary(source).expect_err("public V2 macro invocation must be rejected");
 
@@ -717,8 +730,8 @@ pub use crate::deadline::RequestDeadline;
 #[test]
 fn public_api_v2_rejects_direct_public_items() {
     for source in [
-        "pub use crate::deadline::RequestDeadline; pub type Channel = crate::net::channel::Channel;",
-        "pub use crate::deadline::RequestDeadline; pub struct Leaked;",
+        "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::RequestId; pub use crate::dispatch::OriginalRequestIdentity; pub type Channel = crate::net::channel::Channel;",
+        "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::RequestId; pub use crate::dispatch::OriginalRequestIdentity; pub struct Leaked;",
     ] {
         let error = inspect_public_boundary(source).expect_err("direct public V2 item must be rejected");
 

--- a/rocketmq-transport/tests/public_api_v2.rs
+++ b/rocketmq-transport/tests/public_api_v2.rs
@@ -15,13 +15,37 @@
 use std::time::Duration;
 
 use rocketmq_transport::api::v1::RequestDeadline as V1RequestDeadline;
+use rocketmq_transport::api::v1::RequestId as V1RequestId;
+use rocketmq_transport::api::v2::OriginalRequestIdentity;
 use rocketmq_transport::api::v2::RequestDeadline as V2RequestDeadline;
+use rocketmq_transport::api::v2::RequestId as V2RequestId;
 
-fn assert_same_type(_: &V1RequestDeadline, _: &V2RequestDeadline) {}
+fn assert_same_deadline_type(_: &V1RequestDeadline, _: &V2RequestDeadline) {}
+
+fn assert_same_request_id_type(value: Option<V1RequestId>) -> Option<V2RequestId> {
+    value
+}
+
+fn assert_original_identity_contract(identity: Option<OriginalRequestIdentity>) {
+    if let Some(identity) = identity {
+        let _: V2RequestId = identity.request_id();
+        let _: i32 = identity.original_code();
+        let _: i32 = identity.original_opaque();
+        let _: bool = identity.is_one_way();
+    }
+}
 
 #[test]
 fn v2_exposes_the_v1_request_deadline_type() {
     let deadline = V2RequestDeadline::after(Duration::from_secs(1));
 
-    assert_same_type(&deadline, &deadline);
+    assert_same_deadline_type(&deadline, &deadline);
+}
+
+#[test]
+fn v2_reuses_v1_request_id_and_exposes_read_only_original_identity() {
+    let v1_value: Option<V1RequestId> = None;
+    let v2_value: Option<V2RequestId> = assert_same_request_id_type(v1_value);
+    assert!(v2_value.is_none());
+    assert_original_identity_contract(None);
 }

--- a/rocketmq-transport/tests/v1_processor_contract_tests.rs
+++ b/rocketmq-transport/tests/v1_processor_contract_tests.rs
@@ -64,9 +64,14 @@ const NONE: i32 = 19_751;
 const DIRECT_WRITE: i32 = 19_752;
 const SENTINEL: i32 = 19_753;
 const ONEWAY_NONE: i32 = 19_754;
+const UNKNOWN_PROCESSOR_ERROR: i32 = -91_762;
 const ORIGINAL_OPAQUE: i32 = 74;
+const MUTATED_CODE: i32 = 29_749;
 const MUTATED_OPAQUE: i32 = 8_074;
+const PROCESSOR_MUTATED_CODE: i32 = 39_749;
+const PROCESSOR_MUTATED_OPAQUE: i32 = 18_074;
 const PROCESSOR_RESPONSE_OPAQUE: i32 = 9_074;
+const AFTER_HOOK_RESPONSE_OPAQUE: i32 = 10_074;
 const ORDERING_KEY: RequestOrderingKey = RequestOrderingKey::new(9748);
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -148,8 +153,16 @@ impl RequestProcessor for ContractProcessor {
             code: request.code(),
             opaque: request.opaque(),
         });
+        if request.code() == MUTATED_CODE {
+            request.set_code_mut(PROCESSOR_MUTATED_CODE);
+            request.set_opaque_mut(PROCESSOR_MUTATED_OPAQUE);
+        }
         match request.code() {
             NONE | ONEWAY_NONE => Ok(None),
+            UNKNOWN_PROCESSOR_ERROR => Err(rocketmq_error::RocketMQError::response_process_failed(
+                "v1_processor_contract",
+                "unknown raw request code test failure",
+            )),
             DIRECT_WRITE => {
                 let receipt = ctx
                     .try_write_response(
@@ -223,7 +236,11 @@ impl RPCHook for ContractHook {
             opaque: request.opaque(),
         });
         if request.code() == STANDARD {
+            request.set_code_mut(MUTATED_CODE);
             request.set_opaque_mut(MUTATED_OPAQUE);
+            request.mark_oneway_rpc_ref();
+        } else if request.code() == ONEWAY {
+            *request = RemotingCommand::create_remoting_command(ONEWAY).set_opaque(request.opaque());
         }
         Ok(())
     }
@@ -239,6 +256,9 @@ impl RPCHook for ContractHook {
             request_opaque: request.opaque(),
             response_opaque: response.opaque(),
         });
+        if request.code() == PROCESSOR_MUTATED_CODE {
+            response.set_opaque_mut(AFTER_HOOK_RESPONSE_OPAQUE);
+        }
         Ok(())
     }
 }
@@ -406,17 +426,37 @@ async fn standard_dispatch_preserves_v1_ordering_and_opaque_for_embedded_and_net
     assert_eq!(embedded_response.opaque(), ORIGINAL_OPAQUE);
     assert_eq!(
         embedded.events.snapshot(),
-        successful_response_events(STANDARD, ORIGINAL_OPAQUE, MUTATED_OPAQUE)
+        vec![
+            Event::Ordering {
+                code: STANDARD,
+                opaque: ORIGINAL_OPAQUE,
+            },
+            Event::Before {
+                code: STANDARD,
+                opaque: ORIGINAL_OPAQUE,
+            },
+            Event::Process {
+                code: MUTATED_CODE,
+                opaque: MUTATED_OPAQUE,
+            },
+            Event::After {
+                code: PROCESSOR_MUTATED_CODE,
+                request_opaque: PROCESSOR_MUTATED_OPAQUE,
+                response_opaque: PROCESSOR_RESPONSE_OPAQUE,
+            },
+            Event::Observe {
+                request_code: STANDARD,
+                response_code: ResponseCode::Success.to_i32(),
+                outcome: ResponseWriteOutcome::Sent,
+            },
+        ]
     );
 
     let network = fixture(&runtime, "network");
     let responses = run_network(&network, vec![request(STANDARD, ORIGINAL_OPAQUE)], 1).await;
     assert_eq!(responses.len(), 1);
     assert_eq!(responses[0].opaque(), ORIGINAL_OPAQUE);
-    assert_eq!(
-        network.events.snapshot(),
-        successful_response_events(STANDARD, ORIGINAL_OPAQUE, MUTATED_OPAQUE)
-    );
+    assert_eq!(network.events.snapshot(), embedded.events.snapshot());
 }
 
 #[tokio::test]
@@ -445,6 +485,32 @@ async fn reject_short_circuits_hooks_and_processor_for_embedded_and_network_adap
     assert_eq!(responses.len(), 1);
     assert_eq!(responses[0].opaque(), ORIGINAL_OPAQUE);
     assert_eq!(network.events.snapshot(), expected);
+}
+
+#[tokio::test]
+async fn unknown_raw_code_is_preserved_for_processor_error_observation_and_response_binding() {
+    let runtime = RuntimeContext::from_current("v1-unknown-code-processor-error-contract");
+
+    let embedded = fixture(&runtime, "embedded");
+    let embedded_response = dispatch_embedded(&embedded, request(UNKNOWN_PROCESSOR_ERROR, ORIGINAL_OPAQUE)).await;
+    assert_eq!(embedded_response.code(), ResponseCode::SystemError.to_i32());
+    assert_eq!(embedded_response.opaque(), ORIGINAL_OPAQUE);
+    assert!(embedded.events.snapshot().contains(&Event::Observe {
+        request_code: UNKNOWN_PROCESSOR_ERROR,
+        response_code: ResponseCode::SystemError.to_i32(),
+        outcome: ResponseWriteOutcome::Sent,
+    }));
+
+    let network = fixture(&runtime, "network");
+    let responses = run_network(&network, vec![request(UNKNOWN_PROCESSOR_ERROR, ORIGINAL_OPAQUE)], 1).await;
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0].code(), ResponseCode::SystemError.to_i32());
+    assert_eq!(responses[0].opaque(), ORIGINAL_OPAQUE);
+    assert!(network.events.snapshot().contains(&Event::Observe {
+        request_code: UNKNOWN_PROCESSOR_ERROR,
+        response_code: ResponseCode::SystemError.to_i32(),
+        outcome: ResponseWriteOutcome::Sent,
+    }));
 }
 
 #[tokio::test]
@@ -613,12 +679,14 @@ async fn network_v1_none_outcomes_record_their_distinct_terminal_telemetry() {
             request(NONE, 1),
             request(ONEWAY_NONE, 2).mark_oneway_rpc(),
             request(SENTINEL, 3),
+            request(STANDARD, 4),
         ],
-        1,
+        2,
     )
     .await;
-    assert_eq!(responses.len(), 1);
+    assert_eq!(responses.len(), 2);
     assert_eq!(responses[0].opaque(), 3);
+    assert_eq!(responses[1].opaque(), 4);
 
     let metrics = scrape_metrics(
         telemetry_runtime
@@ -629,6 +697,24 @@ async fn network_v1_none_outcomes_record_their_distinct_terminal_telemetry() {
     .await;
     assert_rpc_latency_count(&metrics, NONE, -1, "legacy_ambiguous_none");
     assert_rpc_latency_count(&metrics, ONEWAY_NONE, -1, "oneway");
+    assert_rpc_latency_count(&metrics, STANDARD, ResponseCode::Success.to_i32(), "success");
+    assert!(
+        !metrics.contains(&format!("request_code=\"{MUTATED_CODE}\"")),
+        "mutated request code must not become a metric label"
+    );
+    assert!(
+        !metrics.contains(&format!("request_code=\"{PROCESSOR_MUTATED_CODE}\"")),
+        "processor-mutated request code must not become a metric label"
+    );
+    for forbidden_identity_field in ["owner_id", "sequence", "request_id"] {
+        assert!(
+            metrics
+                .lines()
+                .filter(|line| line.starts_with("rocketmq_rpc_"))
+                .all(|line| !line.contains(forbidden_identity_field)),
+            "request identity must not become an RPC metric label or field: {forbidden_identity_field}"
+        );
+    }
 
     let report = telemetry_runtime
         .shutdown_with_service_context(&telemetry_service, Duration::from_secs(3))


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9762

### Brief Description

Capture immutable remoting request identity immediately after decode and propagate it through network and embedded dispatch. The change reuses the V1 `RequestId` type in the curated V2 API, assigns checked process-wide session owners and per-session sequences, preserves raw request code, opaque, and one-way facts across processor mutation, and binds all centralized responses to the original opaque. It also records only low-cardinality identity fields in spans, keeps identity out of metric labels, and permanently retires a session when its request sequence is exhausted.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-transport -- --check`
- `cargo test -p rocketmq-transport --all-features`
- `cargo doc -p rocketmq-transport --all-features --no-deps`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `python scripts/error_architecture_guard.py` (same 18 pre-existing findings as `origin/main`; no new findings)
- RocketMQ MCP consumer validation: locked check, read-only boundary, default/all-feature tests, streamable-http Clippy, package format, and Rustdoc
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public request identity information to the 2.x transport API, including request IDs, original codes, opaque values, and one-way status.
  * Preserved original request details across embedded and network processing, authorization, and responses.
* **Bug Fixes**
  * Responses now correctly reconnect with their originating requests, even when request data is modified during processing.
  * Improved handling of unknown or invalid requests and exhausted session capacity.
* **Observability**
  * Updated request tracing to use stable identity fields without exposing opaque values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->