### PR TITLE
[ISSUE #9764]✨Model trusted request origin and authentication state

### DIFF
--- a/rocketmq-transport/src/dispatch.rs
+++ b/rocketmq-transport/src/dispatch.rs
@@ -15,6 +15,7 @@
 mod authorized_dispatcher;
 mod request_context;
 mod request_identity;
+mod request_origin;
 mod response;
 mod response_sink;
 
@@ -27,6 +28,9 @@ pub use request_context::RequestContextError;
 pub use request_context::RequestTransport;
 pub(crate) use request_identity::reserve_session_owner;
 pub use request_identity::OriginalRequestIdentity;
+pub use request_origin::AuthenticationState;
+pub use request_origin::EmbeddedCaller;
+pub use request_origin::RequestOrigin;
 pub use response::RequestId;
 pub use response::ResponseDisposition;
 pub use response::ResponseError;

--- a/rocketmq-transport/src/dispatch/request_context.rs
+++ b/rocketmq-transport/src/dispatch/request_context.rs
@@ -14,8 +14,12 @@
 
 use rocketmq_security_api::PeerInfo;
 use rocketmq_security_api::Principal;
+use rocketmq_security_api::SecurityBootstrapProfile;
 
 use crate::deadline::RequestDeadline;
+use crate::dispatch::AuthenticationState;
+use crate::dispatch::EmbeddedCaller;
+use crate::dispatch::RequestOrigin;
 
 /// Trusted entry adapter that materialized a dispatch request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -41,21 +45,32 @@ pub enum RequestContextError {
 /// only supported constructors.
 #[derive(Debug, Clone)]
 pub struct RequestContext {
-    transport: RequestTransport,
-    peer: Option<PeerInfo>,
-    principal: Option<Principal>,
     deadline: Option<RequestDeadline>,
+    origin: RequestOrigin,
+    authentication: AuthenticationState,
 }
 
 impl RequestContext {
     /// Creates a context for a decoded network command.
     #[must_use]
     pub fn network(peer: PeerInfo, principal: Option<Principal>, deadline: Option<RequestDeadline>) -> Self {
+        Self::network_with_security_profile(peer, principal, deadline, SecurityBootstrapProfile::SecureEnforced)
+    }
+
+    /// Creates a context for a decoded network command using the security
+    /// profile selected by the trusted transport bootstrap.
+    #[must_use]
+    pub(crate) fn network_with_security_profile(
+        peer: PeerInfo,
+        principal: Option<Principal>,
+        deadline: Option<RequestDeadline>,
+        profile: SecurityBootstrapProfile,
+    ) -> Self {
+        let authentication = AuthenticationState::from_network_principal(principal, profile);
         Self {
-            transport: RequestTransport::Network,
-            peer: Some(peer),
-            principal,
             deadline,
+            origin: RequestOrigin::Network { peer },
+            authentication,
         }
     }
 
@@ -69,36 +84,199 @@ impl RequestContext {
         principal: Option<Principal>,
         deadline: Option<RequestDeadline>,
     ) -> Result<Self, RequestContextError> {
+        Self::try_embedded_with_caller(EmbeddedCaller::BrokerProxy, principal, deadline)
+    }
+
+    /// Creates a fail-closed context for an explicitly identified embedded caller.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RequestContextError::MissingEmbeddedPrincipal`] when the
+    /// composition root did not inject a trusted principal.
+    pub(crate) fn try_embedded_with_caller(
+        caller: EmbeddedCaller,
+        principal: Option<Principal>,
+        deadline: Option<RequestDeadline>,
+    ) -> Result<Self, RequestContextError> {
         let principal = principal.ok_or(RequestContextError::MissingEmbeddedPrincipal)?;
         Ok(Self {
-            transport: RequestTransport::EmbeddedProxy,
-            peer: None,
-            principal: Some(principal),
+            origin: RequestOrigin::Embedded { caller },
             deadline,
+            authentication: AuthenticationState::authenticated(principal),
         })
     }
 
     /// Returns the trusted entry type.
     #[must_use]
     pub const fn transport(&self) -> RequestTransport {
-        self.transport
+        match &self.origin {
+            RequestOrigin::Network { .. } => RequestTransport::Network,
+            RequestOrigin::Embedded { .. } => RequestTransport::EmbeddedProxy,
+        }
     }
 
     /// Returns read-only peer metadata established by the network adapter.
     #[must_use]
     pub const fn peer(&self) -> Option<&PeerInfo> {
-        self.peer.as_ref()
+        match &self.origin {
+            RequestOrigin::Network { peer } => Some(peer),
+            RequestOrigin::Embedded { .. } => None,
+        }
     }
 
     /// Returns the authenticated identity established by the adapter.
     #[must_use]
     pub const fn principal(&self) -> Option<&Principal> {
-        self.principal.as_ref()
+        self.authentication.principal()
     }
 
     /// Returns the immutable end-to-end deadline, when supplied.
     #[must_use]
     pub const fn deadline(&self) -> Option<RequestDeadline> {
         self.deadline
+    }
+
+    /// Returns the immutable origin captured by a trusted ingress adapter.
+    #[must_use]
+    #[allow(
+        dead_code,
+        reason = "REQ-03 retains this crate-internal staging accessor for the REQ-06 request builder"
+    )]
+    pub(crate) const fn origin(&self) -> &RequestOrigin {
+        &self.origin
+    }
+
+    /// Returns the immutable authentication facts established at ingress.
+    #[must_use]
+    #[allow(
+        dead_code,
+        reason = "REQ-03 retains this crate-internal staging accessor for the REQ-06 request builder"
+    )]
+    pub(crate) const fn authentication(&self) -> &AuthenticationState {
+        &self.authentication
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::SocketAddr;
+
+    use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+
+    use super::*;
+
+    fn peer(address: &str) -> PeerInfo {
+        PeerInfo::new(
+            address.parse::<SocketAddr>().expect("test peer address must parse"),
+            true,
+        )
+    }
+
+    #[test]
+    fn network_context_retains_the_trusted_peer_and_principal() {
+        let peer = peer("192.0.2.44:10911");
+        let principal = Principal::new("network-user");
+
+        let context = RequestContext::network_with_security_profile(
+            peer.clone(),
+            Some(principal.clone()),
+            None,
+            SecurityBootstrapProfile::SecureEnforced,
+        );
+
+        assert_eq!(context.peer(), Some(&peer));
+        assert_eq!(context.principal(), Some(&principal));
+        assert_eq!(context.origin(), &RequestOrigin::Network { peer: peer.clone() });
+        assert_eq!(context.authentication(), &AuthenticationState::authenticated(principal));
+    }
+
+    #[test]
+    fn network_authentication_matrix_prioritizes_the_trusted_principal() {
+        for (profile, unauthenticated) in [
+            (SecurityBootstrapProfile::SecureEnforced, AuthenticationState::Anonymous),
+            (
+                SecurityBootstrapProfile::DevelopmentInsecureLoopback,
+                AuthenticationState::SecurityDisabled,
+            ),
+        ] {
+            let without_principal =
+                RequestContext::network_with_security_profile(peer("192.0.2.45:10911"), None, None, profile);
+            assert_eq!(without_principal.authentication(), &unauthenticated);
+
+            let principal = Principal::new("network-user");
+            let with_principal = RequestContext::network_with_security_profile(
+                peer("192.0.2.46:10911"),
+                Some(principal.clone()),
+                None,
+                profile,
+            );
+            assert!(matches!(
+                with_principal.authentication(),
+                AuthenticationState::Authenticated(actual, ..) if actual == &principal
+            ));
+        }
+    }
+
+    #[test]
+    fn embedded_context_has_an_explicit_caller_without_a_network_peer() {
+        let principal = Principal::new("embedded-user");
+        let context =
+            RequestContext::try_embedded_with_caller(EmbeddedCaller::BrokerProxy, Some(principal.clone()), None)
+                .expect("trusted embedded principal must construct context");
+
+        assert_eq!(context.transport(), RequestTransport::EmbeddedProxy);
+        assert_eq!(context.peer(), None);
+        assert_eq!(
+            context.origin(),
+            &RequestOrigin::Embedded {
+                caller: EmbeddedCaller::BrokerProxy
+            }
+        );
+        assert_eq!(context.authentication(), &AuthenticationState::authenticated(principal));
+    }
+
+    #[test]
+    fn embedded_compatibility_wrapper_uses_the_broker_proxy_caller() {
+        let principal = Principal::new("embedded-user");
+        let context = RequestContext::try_embedded(Some(principal.clone()), None)
+            .expect("trusted embedded principal must construct context");
+
+        assert_eq!(
+            context.origin(),
+            &RequestOrigin::Embedded {
+                caller: EmbeddedCaller::BrokerProxy
+            }
+        );
+        assert_eq!(context.peer(), None);
+        assert_eq!(context.principal(), Some(&principal));
+        assert_eq!(context.authentication(), &AuthenticationState::authenticated(principal));
+    }
+
+    #[test]
+    fn embedded_context_without_a_principal_fails_closed() {
+        assert_eq!(
+            RequestContext::try_embedded_with_caller(EmbeddedCaller::BrokerProxy, None, None)
+                .expect_err("embedded context must require a trusted principal"),
+            RequestContextError::MissingEmbeddedPrincipal
+        );
+    }
+
+    #[test]
+    fn command_extensions_cannot_claim_origin_or_authentication_facts() {
+        let mut command = RemotingCommand::create_remoting_command(17);
+        command.add_ext_field("principal", "forged-user");
+        command.add_ext_field("origin", "embedded");
+        let peer = peer("198.51.100.7:10911");
+        let context = RequestContext::network_with_security_profile(
+            peer.clone(),
+            None,
+            None,
+            SecurityBootstrapProfile::SecureEnforced,
+        );
+
+        assert!(command.ext_fields().is_some());
+        assert_eq!(context.origin(), &RequestOrigin::Network { peer: peer.clone() });
+        assert_eq!(context.authentication(), &AuthenticationState::Anonymous);
+        assert_eq!(context.principal(), None);
     }
 }

--- a/rocketmq-transport/src/dispatch/request_origin.rs
+++ b/rocketmq-transport/src/dispatch/request_origin.rs
@@ -1,0 +1,102 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocketmq_security_api::PeerInfo;
+use rocketmq_security_api::Principal;
+use rocketmq_security_api::SecurityBootstrapProfile;
+
+/// A trusted in-process caller that submitted an embedded request.
+///
+/// This value is supplied by the transport composition root. It is not derived
+/// from command headers, extensions, or processor-provided data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum EmbeddedCaller {
+    /// The Broker-owned embedded Proxy adapter.
+    BrokerProxy,
+}
+
+/// The trusted ingress origin of a request.
+///
+/// Network requests carry the peer observed by the transport. Embedded
+/// requests identify their in-process caller and intentionally have no
+/// network peer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RequestOrigin {
+    /// A request decoded from a network session.
+    Network {
+        /// Peer metadata captured by the transport ingress.
+        peer: PeerInfo,
+    },
+    /// A request submitted by a trusted in-process adapter.
+    Embedded {
+        /// The trusted adapter that submitted the request.
+        caller: EmbeddedCaller,
+    },
+}
+
+/// Authentication facts established at transport ingress.
+///
+/// Callers outside this crate can inspect an authenticated principal, but
+/// cannot construct an authenticated state from processor or command data. Use
+/// [`Self::principal`] to distinguish an authenticated state when matching the
+/// forward-compatible enum.
+///
+/// ```compile_fail
+/// use rocketmq_security_api::Principal;
+/// use rocketmq_transport::api::v2::AuthenticationState;
+///
+/// let _ = AuthenticationState::Authenticated(Principal::new("forged"), ());
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AuthenticationState {
+    /// A principal supplied by a trusted network or embedded ingress adapter.
+    #[allow(
+        private_interfaces,
+        reason = "the private proof prevents untrusted construction while patterns can inspect the principal"
+    )]
+    Authenticated(Principal, AuthenticationProof),
+    /// Security remains enabled, but ingress did not establish a principal.
+    Anonymous,
+    /// The explicitly configured development-insecure loopback profile.
+    SecurityDisabled,
+}
+
+impl AuthenticationState {
+    pub(crate) fn from_network_principal(principal: Option<Principal>, profile: SecurityBootstrapProfile) -> Self {
+        match (principal, profile) {
+            (Some(principal), _) => Self::Authenticated(principal, AuthenticationProof),
+            (None, SecurityBootstrapProfile::DevelopmentInsecureLoopback) => Self::SecurityDisabled,
+            (None, SecurityBootstrapProfile::SecureEnforced) => Self::Anonymous,
+        }
+    }
+
+    pub(crate) fn authenticated(principal: Principal) -> Self {
+        Self::Authenticated(principal, AuthenticationProof)
+    }
+
+    /// Returns the trusted principal when ingress authenticated the request.
+    #[must_use]
+    pub const fn principal(&self) -> Option<&Principal> {
+        match self {
+            Self::Authenticated(principal, ..) => Some(principal),
+            Self::Anonymous | Self::SecurityDisabled => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct AuthenticationProof;

--- a/rocketmq-transport/src/lib.rs
+++ b/rocketmq-transport/src/lib.rs
@@ -84,8 +84,10 @@ pub mod api {
 
     /// Curated source API boundary for the 2.x release line.
     ///
-    /// Only the immutable request timing and identity values approved for the
-    /// 2.x request model are exposed here.
+    /// Only immutable request timing, identity, origin, and authentication
+    /// facts approved for the 2.x request model are exposed here. This narrow
+    /// surface intentionally excludes legacy channels, session handles,
+    /// operation contexts, and cancellation capabilities.
     pub mod v2 {
         pub use crate::public_api_v2::*;
     }

--- a/rocketmq-transport/src/public_api_v2.rs
+++ b/rocketmq-transport/src/public_api_v2.rs
@@ -14,9 +14,14 @@
 
 //! Explicitly approved source API for the 2.x release line.
 //!
-//! This surface exposes only the immutable request timing and identity values
-//! approved for the 2.x request model.
+//! This surface exposes only immutable request timing, identity, origin, and
+//! authentication facts approved for the 2.x request model. These facts are
+//! read-only DTOs: they do not expose legacy channels, session handles,
+//! operation contexts, or cancellation capabilities.
 
 pub use crate::deadline::RequestDeadline;
+pub use crate::dispatch::AuthenticationState;
+pub use crate::dispatch::EmbeddedCaller;
 pub use crate::dispatch::OriginalRequestIdentity;
 pub use crate::dispatch::RequestId;
+pub use crate::dispatch::RequestOrigin;

--- a/rocketmq-transport/src/server.rs
+++ b/rocketmq-transport/src/server.rs
@@ -810,7 +810,12 @@ async fn run_framed_session_with_request_sequence<H>(
             original_request_identity.map_or_else(|| command.code(), OriginalRequestIdentity::original_code),
         );
         let bytes = decoded.retained_frame_bytes;
-        let context = RequestContext::network(PeerInfo::new(remote_addr, peer_is_tls), principal.clone(), None);
+        let context = RequestContext::network_with_security_profile(
+            PeerInfo::new(remote_addr, peer_is_tls),
+            principal.clone(),
+            None,
+            dispatch.security_profile(),
+        );
         let ordering = handler.request_ordering(&command);
         let request_handler = handler.clone();
         let request_session = session

--- a/rocketmq-transport/tests/authorized_dispatch_conformance_tests.rs
+++ b/rocketmq-transport/tests/authorized_dispatch_conformance_tests.rs
@@ -17,6 +17,7 @@
 use std::future;
 use std::net::IpAddr;
 use std::net::Ipv4Addr;
+use std::net::SocketAddr;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -166,6 +167,23 @@ impl IngressPolicy for DenyIngressPolicy {
     }
 }
 
+struct RecordingNetworkPeerIngressPolicy {
+    peers: Arc<Mutex<Vec<Option<SocketAddr>>>>,
+}
+
+impl IngressPolicy for RecordingNetworkPeerIngressPolicy {
+    fn evaluate_ingress(
+        &self,
+        request: rocketmq_security_api::SecurityRequestView<'_>,
+    ) -> LayerEvaluation<IngressDecision> {
+        self.peers
+            .lock()
+            .expect("recording network peer ingress policy lock")
+            .push(request.peer().map(|peer| peer.address()));
+        Ok(IngressDecision::Deny)
+    }
+}
+
 struct DispatchFixture {
     service: ChildServiceContext,
     processor: ConformanceProcessor,
@@ -234,13 +252,31 @@ async fn dispatch_embedded(
 }
 
 async fn network_round_trip(fixture: &DispatchFixture, principal: &str, command: RemotingCommand) -> RemotingCommand {
+    network_round_trip_with_principal(fixture, Some(principal), command).await
+}
+
+async fn network_round_trip_with_principal(
+    fixture: &DispatchFixture,
+    principal: Option<&str>,
+    command: RemotingCommand,
+) -> RemotingCommand {
+    network_round_trip_with_principal_and_peer(fixture, principal, command)
+        .await
+        .0
+}
+
+async fn network_round_trip_with_principal_and_peer(
+    fixture: &DispatchFixture,
+    principal: Option<&str>,
+    command: RemotingCommand,
+) -> (RemotingCommand, SocketAddr) {
     let config = Arc::new(ServerConfig {
         bind_address: "127.0.0.1".to_owned(),
         listen_port: 0,
         ..ServerConfig::default()
     });
     let mut server = TransportServer::new(config, fixture.service.component("network"))
-        .with_transport_security(Arc::clone(&fixture.security), Some(Principal::new(principal)))
+        .with_transport_security(Arc::clone(&fixture.security), principal.map(Principal::new))
         .with_authorized_dispatcher(Arc::clone(&fixture.dispatcher));
     let (startup_tx, startup_rx) = oneshot::channel();
     let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
@@ -261,7 +297,11 @@ async fn network_round_trip(fixture: &DispatchFixture, principal: &str, command:
         .await
         .expect("server should report startup")
         .expect("server should bind");
-    let mut connection = Connection::new(TcpStream::connect(address).await.expect("client should connect"));
+    let stream = TcpStream::connect(address).await.expect("client should connect");
+    let peer_seen_by_server = stream
+        .local_addr()
+        .expect("connected client stream should expose its local address");
+    let mut connection = Connection::new(stream);
     connection
         .send_command(command)
         .await
@@ -278,7 +318,84 @@ async fn network_round_trip(fixture: &DispatchFixture, principal: &str, command:
         .expect("server task should not panic")
         .expect("server should report shutdown");
     assert!(report.is_healthy(), "{}", report.to_json());
-    response
+    (response, peer_seen_by_server)
+}
+
+#[tokio::test]
+async fn secure_network_dispatch_rejects_command_claimed_authentication_and_origin() {
+    let runtime = RuntimeContext::from_current("authorized-dispatch-forged-ingress-facts");
+    let fixture = dispatch_fixture(
+        &runtime,
+        "forged-ingress-facts",
+        ProcessorBehavior::Echo,
+        AdmissionLimits::default(),
+    );
+    let mut command = RemotingCommand::create_remoting_command(RequestCode::SendMessage).set_opaque(50);
+    command.add_ext_field("principal", "allowed");
+    command.add_ext_field("origin", "embedded");
+
+    let response = network_round_trip_with_principal(&fixture, None, command).await;
+
+    assert_eq!(response.code(), ResponseCode::NoPermission.to_i32());
+    assert_eq!(response.opaque(), 50);
+    assert_eq!(fixture.processor.calls.load(Ordering::SeqCst), 0);
+    let report = fixture.service.task_group().shutdown(Duration::from_secs(1)).await;
+    report.assert_no_task_leak().expect("test tasks should be owned");
+}
+
+#[tokio::test]
+async fn network_ingress_policy_receives_actual_peer_despite_forged_origin_extension() {
+    let runtime = RuntimeContext::from_current("authorized-dispatch-forged-network-origin");
+    let service = runtime.service_context("forged-network-origin");
+    let process_budget = service.process_budget();
+    let admission = Arc::new(
+        AdmissionController::try_new_with_budget(AdmissionLimits::default(), &process_budget)
+            .expect("test admission limits should be valid"),
+    );
+    let peers = Arc::new(Mutex::new(Vec::new()));
+    let security = Arc::new(
+        TransportSecurity::secure_enforced(Some(Arc::new(AllowOnlyNamedPrincipal)), None).with_ingress_policy(
+            Arc::new(RecordingNetworkPeerIngressPolicy {
+                peers: Arc::clone(&peers),
+            }),
+        ),
+    );
+    let processor = ConformanceProcessor::new(ProcessorBehavior::Echo);
+    let dispatcher = Arc::new(
+        AuthorizedCommandDispatcher::try_new(
+            processor.clone(),
+            Vec::new(),
+            &process_budget,
+            TransportTelemetry::noop(),
+            Arc::clone(&security),
+            Arc::clone(&admission),
+        )
+        .expect("test dispatcher should fit the process budget"),
+    );
+    let fixture = DispatchFixture {
+        service,
+        processor,
+        dispatcher,
+        security,
+        admission,
+    };
+    let mut command = RemotingCommand::create_remoting_command(RequestCode::SendMessage).set_opaque(51);
+    command.add_ext_field("origin", "embedded");
+
+    let (response, actual_peer) = network_round_trip_with_principal_and_peer(&fixture, None, command).await;
+
+    assert_eq!(response.code(), ResponseCode::NoPermission.to_i32());
+    assert_eq!(response.opaque(), 51);
+    assert_eq!(fixture.processor.calls.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        peers
+            .lock()
+            .expect("recording network peer ingress policy lock")
+            .as_slice(),
+        [Some(actual_peer)],
+    );
+    let report = fixture.service.task_group().shutdown(Duration::from_secs(1)).await;
+    report.assert_no_task_leak().expect("test tasks should be owned");
 }
 
 fn assert_equivalent(actual: &RemotingCommand, expected: &RemotingCommand) {

--- a/rocketmq-transport/tests/public_api_contract.rs
+++ b/rocketmq-transport/tests/public_api_contract.rs
@@ -670,11 +670,23 @@ fn validate_public_api_v2_boundary(boundary: &PublicBoundary) -> Result<(), Stri
         },
         PublicUse {
             module_path: String::new(),
+            use_tree: "crate::dispatch::AuthenticationState".to_owned(),
+        },
+        PublicUse {
+            module_path: String::new(),
+            use_tree: "crate::dispatch::EmbeddedCaller".to_owned(),
+        },
+        PublicUse {
+            module_path: String::new(),
             use_tree: "crate::dispatch::OriginalRequestIdentity".to_owned(),
         },
         PublicUse {
             module_path: String::new(),
             use_tree: "crate::dispatch::RequestId".to_owned(),
+        },
+        PublicUse {
+            module_path: String::new(),
+            use_tree: "crate::dispatch::RequestOrigin".to_owned(),
         },
     ];
     if boundary.uses != expected_uses {
@@ -690,22 +702,22 @@ fn lib_rs_exposes_only_the_curated_versioned_boundary() {
 }
 
 #[test]
-fn public_api_v2_exposes_exactly_the_curated_request_identity_types() {
+fn public_api_v2_exposes_exactly_the_curated_request_identity_and_ingress_fact_types() {
     let boundary =
         inspect_public_boundary(include_str!("../src/public_api_v2.rs")).expect("public_api_v2.rs must tokenize");
 
     validate_public_api_v2_boundary(&boundary)
-        .expect("public_api_v2.rs must expose only RequestDeadline, RequestId, and OriginalRequestIdentity");
+        .expect("public_api_v2.rs must expose only approved request identity and ingress fact types");
 }
 
 #[test]
 fn public_api_v2_rejects_unapproved_public_surface() {
     for source in [
-        "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::RequestId; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::net::channel::Channel;",
-        "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::RequestId; pub use crate::dispatch::OriginalRequestIdentity; pub use rocketmq_runtime::OperationContext;",
-        "pub use crate::deadline::{RequestDeadline,RequestId};",
-        "pub use crate::deadline::*;",
-        "pub mod request_model {} pub use crate::deadline::RequestDeadline; pub use crate::dispatch::RequestId; pub use crate::dispatch::OriginalRequestIdentity;",
+        "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestOrigin; pub use crate::net::channel::Channel;",
+        "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestOrigin; pub use rocketmq_runtime::OperationContext;",
+        "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestOrigin; pub use crate::deadline::{RequestDeadline,RequestId};",
+        "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestOrigin; pub use crate::deadline::*;",
+        "pub mod request_model {} pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestOrigin;",
     ] {
         let boundary = inspect_public_boundary(source).expect("adversarial V2 fixture must parse");
 
@@ -716,8 +728,11 @@ fn public_api_v2_rejects_unapproved_public_surface() {
 macro_rules! expose_extra { () => { pub use crate::net::channel::Channel; }; }
 expose_extra!();
 pub use crate::deadline::RequestDeadline;
+pub use crate::dispatch::AuthenticationState;
+pub use crate::dispatch::EmbeddedCaller;
 pub use crate::dispatch::RequestId;
 pub use crate::dispatch::OriginalRequestIdentity;
+pub use crate::dispatch::RequestOrigin;
 "#;
     let error = inspect_public_boundary(source).expect_err("public V2 macro invocation must be rejected");
 
@@ -730,8 +745,8 @@ pub use crate::dispatch::OriginalRequestIdentity;
 #[test]
 fn public_api_v2_rejects_direct_public_items() {
     for source in [
-        "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::RequestId; pub use crate::dispatch::OriginalRequestIdentity; pub type Channel = crate::net::channel::Channel;",
-        "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::RequestId; pub use crate::dispatch::OriginalRequestIdentity; pub struct Leaked;",
+        "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestOrigin; pub type Channel = crate::net::channel::Channel;",
+        "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestOrigin; pub struct Leaked;",
     ] {
         let error = inspect_public_boundary(source).expect_err("direct public V2 item must be rejected");
 

--- a/rocketmq-transport/tests/public_api_v1.rs
+++ b/rocketmq-transport/tests/public_api_v1.rs
@@ -18,6 +18,8 @@ use std::time::Duration;
 use rocketmq_runtime::RuntimeContext;
 use rocketmq_runtime::ShutdownDeadline;
 use rocketmq_runtime::ShutdownReport;
+use rocketmq_security_api::PeerInfo;
+use rocketmq_security_api::Principal;
 use rocketmq_transport::api::v1::CachedConnectionState;
 use rocketmq_transport::api::v1::ClientShutdownReport;
 use rocketmq_transport::api::v1::ClientSnapshot;
@@ -25,9 +27,12 @@ use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use rocketmq_transport::api::v1::DefaultRequestProcessor;
 use rocketmq_transport::api::v1::PendingUsage;
 use rocketmq_transport::api::v1::RemotingClient;
+use rocketmq_transport::api::v1::RequestContext;
+use rocketmq_transport::api::v1::RequestContextError;
 use rocketmq_transport::api::v1::RequestDeadline;
 use rocketmq_transport::api::v1::RequestId;
 use rocketmq_transport::api::v1::RequestTarget;
+use rocketmq_transport::api::v1::RequestTransport;
 use rocketmq_transport::api::v1::ResponseDisposition;
 use rocketmq_transport::api::v1::ResponseError;
 use rocketmq_transport::api::v1::ResponseErrorKind;
@@ -109,6 +114,17 @@ fn assert_versioned_response_contract(
     let _: ResponseErrorKind = error.kind();
     let _: Option<WriteProgress> = error.write_progress();
     let _: bool = error.retryable();
+}
+
+fn assert_v1_request_context_method_signatures(context: &RequestContext) {
+    let _: fn(PeerInfo, Option<Principal>, Option<RequestDeadline>) -> RequestContext = RequestContext::network;
+    let _: fn(Option<Principal>, Option<RequestDeadline>) -> Result<RequestContext, RequestContextError> =
+        RequestContext::try_embedded;
+    let _: fn(&RequestContext) -> RequestTransport = RequestContext::transport;
+    let _: for<'a> fn(&'a RequestContext) -> Option<&'a PeerInfo> = RequestContext::peer;
+    let _: for<'a> fn(&'a RequestContext) -> Option<&'a Principal> = RequestContext::principal;
+    let _: fn(&RequestContext) -> Option<RequestDeadline> = RequestContext::deadline;
+    let _ = context;
 }
 
 fn assert_v1_response_context_method_signatures(context: &ConnectionHandlerContext) {
@@ -214,6 +230,7 @@ fn prelude_reexports_the_curated_composition_root_surface() {
 fn versioned_api_exposes_response_contract_types_without_prelude_exports() {
     assert_versioned_response_contract(None, None, ResponseError::DeadlineExceeded);
     let _ = assert_v1_response_context_method_signatures as fn(&ConnectionHandlerContext);
+    let _ = assert_v1_request_context_method_signatures as fn(&RequestContext);
     let _: Option<ResponseTerminalState> = Some(ResponseTerminalState::Completed);
     let _: Option<ResponseDisposition> = Some(ResponseDisposition::TransportWritten);
     let _: Option<WriteProgress> = Some(WriteProgress::NotStarted);

--- a/rocketmq-transport/tests/public_api_v2.rs
+++ b/rocketmq-transport/tests/public_api_v2.rs
@@ -14,11 +14,15 @@
 
 use std::time::Duration;
 
+use rocketmq_security_api::Principal;
 use rocketmq_transport::api::v1::RequestDeadline as V1RequestDeadline;
 use rocketmq_transport::api::v1::RequestId as V1RequestId;
+use rocketmq_transport::api::v2::AuthenticationState;
+use rocketmq_transport::api::v2::EmbeddedCaller;
 use rocketmq_transport::api::v2::OriginalRequestIdentity;
 use rocketmq_transport::api::v2::RequestDeadline as V2RequestDeadline;
 use rocketmq_transport::api::v2::RequestId as V2RequestId;
+use rocketmq_transport::api::v2::RequestOrigin;
 
 fn assert_same_deadline_type(_: &V1RequestDeadline, _: &V2RequestDeadline) {}
 
@@ -48,4 +52,34 @@ fn v2_reuses_v1_request_id_and_exposes_read_only_original_identity() {
     let v2_value: Option<V2RequestId> = assert_same_request_id_type(v1_value);
     assert!(v2_value.is_none());
     assert_original_identity_contract(None);
+}
+
+#[test]
+fn v2_exposes_read_only_origin_and_authenticated_principal() {
+    fn authenticated_principal(state: &AuthenticationState) -> Option<&Principal> {
+        state.principal()
+    }
+
+    fn has_authenticated_principal(state: &AuthenticationState) -> bool {
+        match state {
+            AuthenticationState::Anonymous | AuthenticationState::SecurityDisabled => false,
+            AuthenticationState::Authenticated(principal, ..) => principal.id() == "v2-user",
+            _ => state.principal().is_some(),
+        }
+    }
+
+    fn inspect_origin(origin: &RequestOrigin) -> Option<std::net::SocketAddr> {
+        match origin {
+            RequestOrigin::Network { peer, .. } => Some(peer.address()),
+            RequestOrigin::Embedded { caller } => {
+                let _known_caller = matches!(caller, EmbeddedCaller::BrokerProxy);
+                None
+            }
+            _ => None,
+        }
+    }
+
+    let _: fn(&AuthenticationState) -> Option<&Principal> = authenticated_principal;
+    let _: fn(&AuthenticationState) -> bool = has_authenticated_principal;
+    let _: fn(&RequestOrigin) -> Option<std::net::SocketAddr> = inspect_origin;
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9764

### Brief Description

Add trusted V2 request-origin and authentication-state DTOs while keeping `RequestContext` as a private ingress staging boundary. Network requests now map the canonical security bootstrap profile to `Authenticated`, `Anonymous`, or `SecurityDisabled`; embedded requests carry an explicit `BrokerProxy` caller, never synthesize a network peer, and remain fail-closed without a principal. A private proof payload lets downstream code inspect authenticated principals without allowing safe Rust to fabricate authenticated state. Existing V1 constructors and getters remain source-compatible projections of the new single source of truth.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-transport -- --check`
- `cargo test -p rocketmq-transport --all-features`
- `cargo doc -p rocketmq-transport --all-features --no-deps`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- RocketMQ MCP consumer validation: locked check, read-only boundary, default/all-feature tests, streamable-http Clippy, package format, and Rustdoc
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added request origin information, distinguishing network requests from trusted embedded callers.
  - Added authentication state reporting for authenticated, anonymous, and security-disabled access.
  - Public API v2 now exposes approved request identity, origin, authentication, and timing details.

- **Security Enhancements**
  - Requests now preserve verified peer and principal information.
  - Forged authentication or origin details are rejected before processing.
  - Embedded requests without a valid principal fail safely.

- **Documentation**
  - Clarified the supported public API surface and excluded legacy capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->