### PR TITLE
[ISSUE #9766]✨Add read-only V2 SessionView and stable SessionId

### DIFF
--- a/rocketmq-transport/src/dispatch/authorized_dispatcher.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher.rs
@@ -62,6 +62,7 @@ use crate::runtime::RPCHook;
 use crate::security::TransportSecurity;
 use crate::session_executor::SessionDispatchError;
 use crate::session_executor::SessionExecutor;
+use crate::session_view::EmbeddedSessionRecord;
 use crate::telemetry::TransportTelemetry;
 
 /// Result of submitting a command to the shared dispatch boundary.
@@ -320,6 +321,7 @@ where
             return Err(DispatchError::InvalidEmbeddedContext);
         }
         let (session_id, original_request_identity) = capture_embedded_request_identity(&command)?;
+        let _session_record = EmbeddedSessionRecord::new(session_id);
         let retained_bytes = materialize_and_estimate_remoting_command_retained_bytes(&mut command);
         let scope = AdmissionScope::new(IpAddr::V4(Ipv4Addr::LOCALHOST)).with_session(session_id);
         let scope = self

--- a/rocketmq-transport/src/lib.rs
+++ b/rocketmq-transport/src/lib.rs
@@ -65,6 +65,7 @@ mod runtime;
 mod security;
 mod server;
 mod session_executor;
+mod session_view;
 #[cfg(feature = "socks")]
 mod socks;
 mod telemetry;
@@ -84,9 +85,9 @@ pub mod api {
 
     /// Curated source API boundary for the 2.x release line.
     ///
-    /// Only immutable request timing, identity, origin, and authentication
-    /// facts approved for the 2.x request model are exposed here. This narrow
-    /// surface intentionally excludes legacy channels, session handles,
+    /// Only immutable request timing, identity, origin, authentication, and
+    /// session facts approved for the 2.x request model are exposed here. This
+    /// narrow surface intentionally excludes legacy channels, session handles,
     /// operation contexts, and cancellation capabilities.
     pub mod v2 {
         pub use crate::public_api_v2::*;

--- a/rocketmq-transport/src/public_api_v2.rs
+++ b/rocketmq-transport/src/public_api_v2.rs
@@ -14,10 +14,10 @@
 
 //! Explicitly approved source API for the 2.x release line.
 //!
-//! This surface exposes only immutable request timing, identity, origin, and
-//! authentication facts approved for the 2.x request model. These facts are
-//! read-only DTOs: they do not expose legacy channels, session handles,
-//! operation contexts, or cancellation capabilities.
+//! This surface exposes only immutable request timing, identity, origin,
+//! authentication, and session facts approved for the 2.x request model.
+//! These facts are read-only DTOs: they do not expose legacy channels, session
+//! handles, operation contexts, or cancellation capabilities.
 
 pub use crate::deadline::RequestDeadline;
 pub use crate::dispatch::AuthenticationState;
@@ -25,3 +25,7 @@ pub use crate::dispatch::EmbeddedCaller;
 pub use crate::dispatch::OriginalRequestIdentity;
 pub use crate::dispatch::RequestId;
 pub use crate::dispatch::RequestOrigin;
+pub use crate::session_view::ProxyInfoSnapshot;
+pub use crate::session_view::SessionId;
+pub use crate::session_view::SessionStateView;
+pub use crate::session_view::SessionView;

--- a/rocketmq-transport/src/server.rs
+++ b/rocketmq-transport/src/server.rs
@@ -70,6 +70,7 @@ use crate::proxy_protocol::ProxyProtocolConfig;
 use crate::proxy_protocol::ProxyProtocolMetadata;
 use crate::request_ordering::RequestOrdering;
 use crate::security::TransportSecurity;
+use crate::session_view::SessionView;
 use crate::telemetry::TransportTelemetry;
 use crate::tls::NegotiatedConnection;
 use crate::tls::TlsServerRuntime;
@@ -140,6 +141,8 @@ struct SessionSendHandle {
     admission: AdmissionScopeHandle,
     state_tx: tokio::sync::watch::Sender<ConnectionState>,
     state_rx: tokio::sync::watch::Receiver<ConnectionState>,
+    session_closed_tx: tokio::sync::watch::Sender<bool>,
+    session_view: SessionView,
     task_group: TaskGroup,
     reader_cancellation: CancellationToken,
     writer_operation: OperationContext,
@@ -209,11 +212,20 @@ impl SessionHandle {
         &self.request_operation
     }
 
+    #[allow(
+        dead_code,
+        reason = "REQ-04 retains the canonical session view for the REQ-06 request builder"
+    )]
+    pub(crate) fn session_view(&self) -> SessionView {
+        self.send.session_view.clone()
+    }
+
     pub(crate) fn original_request_identity(&self) -> Option<OriginalRequestIdentity> {
         self.original_request_identity
     }
 
     pub(crate) fn abort(&self) {
+        let _ = self.send.session_closed_tx.send(true);
         let _ = self.send.state_tx.send(ConnectionState::Closed);
         self.send.reader_cancellation.cancel();
         self.request_operation.cancel();
@@ -255,6 +267,7 @@ impl SessionHandle {
         match tokio::time::timeout(timeout, self.retire_inner(started)).await {
             Ok(result) => result,
             Err(_) => {
+                let _ = self.send.session_closed_tx.send(true);
                 let _ = self.send.state_tx.send(ConnectionState::Closed);
                 self.send.reader_cancellation.cancel();
                 self.request_operation.cancel();
@@ -279,6 +292,7 @@ impl SessionHandle {
         let (completion, result) = tokio::sync::oneshot::channel();
         let send_result = self.send.writer.close(completion).await;
         if send_result.is_err() {
+            let _ = self.send.session_closed_tx.send(true);
             let _ = self.send.state_tx.send(ConnectionState::Closed);
             self.send.reader_cancellation.cancel();
             self.request_operation.cancel();
@@ -295,6 +309,7 @@ impl SessionHandle {
                 "writer retirement completion dropped",
             ))
         });
+        let _ = self.send.session_closed_tx.send(true);
         let _ = self.send.state_tx.send(ConnectionState::Closed);
         self.send.reader_cancellation.cancel();
         self.request_operation.cancel();
@@ -715,6 +730,7 @@ async fn run_framed_session_with_request_sequence<H>(
         Err(_) => return,
     };
     let (state_tx, state_rx) = tokio::sync::watch::channel(ConnectionState::Healthy);
+    let (session_closed_tx, session_closed_rx) = tokio::sync::watch::channel(false);
     let lifecycle = Arc::new(SessionLifecycle::new());
     let (writer, writes) = writer_lanes(io_policy.writer_queue);
     let writer_diagnostics = Arc::new(SessionWriterDiagnostics::new(io_policy.writer_queue.total_capacity()));
@@ -744,6 +760,15 @@ async fn run_framed_session_with_request_sequence<H>(
         Ok(writer_task_id) => writer_task_id,
         Err(_) => return,
     };
+    let session_view = SessionView::network(
+        session_id,
+        local_addr,
+        remote_addr,
+        transport_peer_addr,
+        proxy_protocol.as_deref(),
+        state_rx.clone(),
+        session_closed_rx,
+    );
     let session = SessionHandle {
         send: Arc::new(SessionSendHandle {
             session_id,
@@ -759,6 +784,8 @@ async fn run_framed_session_with_request_sequence<H>(
             admission: admission_scope,
             state_tx: state_tx.clone(),
             state_rx,
+            session_closed_tx,
+            session_view,
             task_group: task_group.clone(),
             reader_cancellation: reader_cancellation.clone(),
             writer_operation,
@@ -844,6 +871,10 @@ async fn run_framed_session_with_request_sequence<H>(
             break;
         }
     }
+    // Request dispatchers may still be draining accepted work, but the reader
+    // no longer accepts frames. Publish the session-close transition now so
+    // read-only views observe shutdown without closing the response writer.
+    let _ = session.send.session_closed_tx.send(true);
     let request_deadline = task_group
         .shutdown_deadline()
         .unwrap_or_else(|| ShutdownDeadline::after(SESSION_RETIREMENT_TIMEOUT));
@@ -1388,7 +1419,10 @@ mod retirement_tests {
     use crate::config::TlsMode;
     use crate::connection::Connection;
     use crate::deadline::RequestDeadline;
+    use crate::proxy_protocol::ProxyProtocolConfig;
     use crate::security::TransportSecurity;
+    use crate::session_view::SessionId;
+    use crate::session_view::SessionView;
     use crate::tls::TlsServerRuntime;
 
     struct CaptureSession {
@@ -1411,6 +1445,12 @@ mod retirement_tests {
         entered: std::sync::Mutex<Option<oneshot::Sender<crate::dispatch::OriginalRequestIdentity>>>,
         release: Arc<Notify>,
         disconnected: std::sync::Mutex<Option<oneshot::Sender<SessionHandle>>>,
+    }
+
+    struct ReaderExitObserver {
+        connected: std::sync::Mutex<Option<oneshot::Sender<SessionHandle>>>,
+        entered: std::sync::Mutex<Option<oneshot::Sender<()>>>,
+        release: Arc<Notify>,
     }
 
     impl ConnectionHandler for CaptureSession {
@@ -1510,6 +1550,34 @@ mod retirement_tests {
                 if let Some(sender) = self.disconnected.lock().expect("sequence disconnect lock").take() {
                     let _ = sender.send(session);
                 }
+            })
+        }
+    }
+
+    impl ConnectionHandler for ReaderExitObserver {
+        fn connected(&self, session: SessionHandle) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+            Box::pin(async move {
+                if let Some(sender) = self.connected.lock().expect("reader exit connected lock").take() {
+                    let _ = sender.send(session);
+                }
+            })
+        }
+
+        fn command(
+            &self,
+            session: SessionHandle,
+            command: RemotingCommand,
+        ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+            Box::pin(async move {
+                if let Some(sender) = self.entered.lock().expect("reader exit entered lock").take() {
+                    let _ = sender.send(());
+                }
+                self.release.notified().await;
+                let mut connection = session.connection();
+                connection
+                    .send_response(RemotingCommand::create_response_command_with_code(0).set_opaque(command.opaque()))
+                    .await
+                    .expect("accepted response should still reach the canonical writer");
             })
         }
     }
@@ -1724,6 +1792,182 @@ mod retirement_tests {
         drop(second_peer);
         first_runner.await.expect("first session runner should finish");
         second_runner.await.expect("second session runner should finish");
+    }
+
+    #[tokio::test]
+    async fn canonical_network_session_view_keeps_addresses_and_shared_close_state() {
+        let runtime = RuntimeContext::from_current("transport-canonical-session-view-test");
+        let service = runtime.service_context("transport-canonical-session-view");
+        let (transport, peer) = tokio::io::duplex(1024);
+        let (connected_tx, connected_rx) = oneshot::channel();
+        let local_addr: SocketAddr = "127.0.0.1:19501".parse().expect("local address");
+        let remote_addr: SocketAddr = "127.0.0.1:19502".parse().expect("remote address");
+        let runner = tokio::spawn(super::run_connected_session(
+            Connection::new_with_plaintext_stream(transport),
+            local_addr,
+            remote_addr,
+            service.task_group().clone(),
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+            Arc::new(TransportSecurity::development_insecure_loopback(None, None)),
+            None,
+            Duration::from_secs(30),
+            Arc::new(CaptureSession {
+                sender: std::sync::Mutex::new(Some(connected_tx)),
+            }),
+        ));
+        let session = connected_rx.await.expect("network session should connect");
+        let mut first = session.session_view();
+        let mut second = first.clone();
+
+        let SessionView::Network {
+            id,
+            local_addr: actual_local,
+            remote_addr: actual_remote,
+            transport_peer_addr,
+            proxy,
+            state,
+        } = &first
+        else {
+            panic!("network session must retain a network view");
+        };
+        assert_eq!(*id, SessionId::from_session_owner(session.session_id()));
+        assert_eq!(*actual_local, local_addr);
+        assert_eq!(*actual_remote, remote_addr);
+        assert_eq!(*transport_peer_addr, remote_addr);
+        assert!(proxy.is_none());
+        assert!(state.is_healthy());
+
+        drop(peer);
+        runner.await.expect("session runner should finish");
+
+        let SessionView::Network { state, .. } = &mut first else {
+            panic!("network session view must retain its variant");
+        };
+        state.closed().await;
+        assert!(state.is_closed());
+        let SessionView::Network { state, .. } = &mut second else {
+            panic!("network session view must retain its variant");
+        };
+        state.closed().await;
+        assert!(state.is_closed());
+    }
+
+    #[tokio::test]
+    async fn listener_network_session_view_retains_trusted_proxy_and_transport_peer_addresses() {
+        let runtime = RuntimeContext::from_current("transport-session-view-proxy-listener-test");
+        let service = runtime.service_context("transport-session-view-proxy-listener");
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
+        let listener_addr = listener.local_addr().expect("listener address");
+        let tls = TlsServerRuntime::initialize_with_service_context(TlsConfig::default(), &service)
+            .await
+            .expect("initialize TLS runtime");
+        let (connected_tx, connected_rx) = oneshot::channel();
+        let proxy_config = ProxyProtocolConfig {
+            enabled: true,
+            trusted_proxies: vec!["127.0.0.0/8".parse().expect("trusted loopback CIDR")],
+            ..ProxyProtocolConfig::default()
+        };
+        let transport = TransportListener::new(
+            listener,
+            service.task_group().clone(),
+            tls,
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+            Duration::from_secs(1),
+        )
+        .try_with_proxy_protocol(proxy_config)
+        .expect("trusted proxy configuration should be valid");
+        let server = tokio::spawn(transport.run(Arc::new(CaptureSession {
+            sender: std::sync::Mutex::new(Some(connected_tx)),
+        })));
+        let mut client = TcpStream::connect(listener_addr).await.expect("connect proxy peer");
+        let transport_peer = client.local_addr().expect("client local address");
+        client
+            .write_all(b"PROXY TCP4 198.51.100.44 192.0.2.10 43123 10911\r\n\0")
+            .await
+            .expect("write trusted PROXY header and plaintext discriminator");
+        let session = tokio::time::timeout(Duration::from_secs(1), connected_rx)
+            .await
+            .expect("trusted proxy session should connect")
+            .expect("connected session capture");
+        let view = session.session_view();
+
+        let SessionView::Network {
+            local_addr,
+            remote_addr,
+            transport_peer_addr,
+            proxy,
+            ..
+        } = view
+        else {
+            panic!("listener session must retain a network view");
+        };
+        let proxy = proxy.expect("trusted PROXY header must create a snapshot");
+        let source: SocketAddr = "198.51.100.44:43123".parse().expect("PROXY source address");
+        let destination: SocketAddr = "192.0.2.10:10911".parse().expect("PROXY destination address");
+
+        assert_eq!(local_addr, destination);
+        assert_eq!(remote_addr, source);
+        assert_eq!(transport_peer_addr, transport_peer);
+        assert_eq!(proxy.source(), source);
+        assert_eq!(proxy.destination(), destination);
+        assert_ne!(transport_peer_addr, source);
+        assert_ne!(transport_peer_addr, destination);
+
+        service.task_group().cancel();
+        tokio::time::timeout(Duration::from_secs(1), server)
+            .await
+            .expect("listener should stop after owner cancellation")
+            .expect("listener task")
+            .expect("listener result");
+        let report = service.task_group().shutdown(Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+    }
+
+    #[tokio::test]
+    async fn canonical_session_view_closes_when_the_reader_stops_before_dispatch_drains() {
+        let runtime = RuntimeContext::from_current("transport-session-view-reader-exit-test");
+        let service = runtime.service_context("transport-session-view-reader-exit");
+        let (transport, peer_stream) = tokio::io::duplex(1024);
+        let (connected_tx, connected_rx) = oneshot::channel();
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let release = Arc::new(Notify::new());
+        let runner = tokio::spawn(super::run_connected_session(
+            Connection::new_with_plaintext_stream(transport),
+            "127.0.0.1:19601".parse().expect("local address"),
+            "127.0.0.1:19602".parse().expect("remote address"),
+            service.task_group().clone(),
+            Arc::new(AdmissionController::new(AdmissionLimits::default())),
+            Arc::new(TransportSecurity::development_insecure_loopback(None, None)),
+            None,
+            Duration::from_secs(30),
+            Arc::new(ReaderExitObserver {
+                connected: std::sync::Mutex::new(Some(connected_tx)),
+                entered: std::sync::Mutex::new(Some(entered_tx)),
+                release: Arc::clone(&release),
+            }),
+        ));
+        let session = connected_rx.await.expect("network session should connect");
+        let view = session.session_view();
+        let mut peer = Connection::new_with_plaintext_stream(peer_stream);
+        peer.send_command(RemotingCommand::create_remoting_command(710).set_opaque(12))
+            .await
+            .expect("request should enter the session");
+        entered_rx.await.expect("request handler should begin draining work");
+
+        peer.shutdown().await.expect("client write half should close");
+        tokio::time::timeout(Duration::from_secs(1), view.state().closed())
+            .await
+            .expect("reader exit must close the view before accepted work drains");
+        assert!(view.state().is_closed());
+
+        release.notify_one();
+        let response = tokio::time::timeout(Duration::from_secs(1), peer.receive_command())
+            .await
+            .expect("accepted response should arrive after the reader exits")
+            .expect("accepted response read should succeed")
+            .expect("accepted response should be present");
+        assert_eq!(response.opaque(), 12);
+        runner.await.expect("session runner should finish");
     }
 
     #[tokio::test]

--- a/rocketmq-transport/src/session_view.rs
+++ b/rocketmq-transport/src/session_view.rs
@@ -1,0 +1,506 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::net::SocketAddr;
+
+use tokio::sync::watch;
+
+use crate::connection::ConnectionState;
+use crate::proxy_protocol::ProxyProtocolMetadata;
+
+/// Stable process-local identity for one network or embedded session.
+///
+/// Session identifiers are allocated by the trusted transport entry boundary.
+/// They are suitable for equality and hashing within one process, but are not
+/// protocol identifiers or peer identities.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct SessionId(u64);
+
+impl SessionId {
+    /// Creates an identifier from an owner already allocated by the trusted
+    /// transport boundary.
+    pub(crate) const fn from_session_owner(owner_id: u64) -> Self {
+        Self(owner_id)
+    }
+}
+
+/// Read-only source and destination facts supplied by a trusted PROXY header.
+///
+/// The direct TCP peer remains available separately on
+/// [`SessionView::Network`]. Raw PROXY TLVs are deliberately not exposed.
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::ProxyInfoSnapshot;
+///
+/// fn cannot_read_raw_tlv_field(proxy: &ProxyInfoSnapshot) {
+///     let _ = proxy.tlvs;
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::ProxyInfoSnapshot;
+///
+/// fn cannot_read_raw_tlvs(proxy: &ProxyInfoSnapshot) {
+///     let _ = proxy.tlvs();
+/// }
+/// ```
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct ProxyInfoSnapshot {
+    source: SocketAddr,
+    destination: SocketAddr,
+}
+
+impl ProxyInfoSnapshot {
+    fn from_metadata(metadata: &ProxyProtocolMetadata) -> Self {
+        Self {
+            source: metadata.source,
+            destination: metadata.destination,
+        }
+    }
+
+    /// Returns the original client address asserted by the trusted proxy.
+    #[must_use]
+    pub const fn source(&self) -> SocketAddr {
+        self.source
+    }
+
+    /// Returns the destination address asserted by the trusted proxy.
+    #[must_use]
+    pub const fn destination(&self) -> SocketAddr {
+        self.destination
+    }
+}
+
+/// Read-only lifecycle state for one session.
+///
+/// This view observes the canonical session state without retaining a state
+/// sender, connection, writer, task group, or cancellation capability.
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::SessionStateView;
+///
+/// fn cannot_close(state: &SessionStateView) {
+///     state.close();
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::SessionStateView;
+///
+/// fn cannot_write(state: &SessionStateView) {
+///     state.write();
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::SessionStateView;
+///
+/// fn cannot_cancel(state: &SessionStateView) {
+///     state.cancel();
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::SessionStateView;
+///
+/// fn cannot_get_a_task_group(state: &SessionStateView) {
+///     let _ = state.task_group();
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::SessionStateView;
+///
+/// fn cannot_get_a_cancellation_token(state: &SessionStateView) {
+///     let _ = state.cancellation_token();
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::SessionStateView;
+///
+/// fn cannot_get_a_connection_state_handle(state: &SessionStateView) {
+///     let _ = state.connection_state_handle();
+/// }
+/// ```
+#[derive(Clone)]
+pub struct SessionStateView {
+    state_rx: watch::Receiver<ConnectionState>,
+    closed_rx: watch::Receiver<bool>,
+}
+
+impl SessionStateView {
+    pub(crate) fn from_receivers(state_rx: watch::Receiver<ConnectionState>, closed_rx: watch::Receiver<bool>) -> Self {
+        Self { state_rx, closed_rx }
+    }
+
+    /// Returns whether the session is currently accepting inbound work.
+    #[must_use]
+    pub fn is_healthy(&self) -> bool {
+        !self.is_closed() && *self.state_rx.borrow() == ConnectionState::Healthy
+    }
+
+    /// Returns whether the session has stopped accepting inbound work.
+    ///
+    /// A response writer may finish already accepted work after this becomes
+    /// `true`.
+    #[must_use]
+    pub fn is_closed(&self) -> bool {
+        self.publishers_dropped() || *self.closed_rx.borrow() || *self.state_rx.borrow() == ConnectionState::Closed
+    }
+
+    /// Waits until the session closes or its lifecycle publisher is dropped.
+    ///
+    /// This method is observational only. Dropping the lifecycle publisher
+    /// also ends the wait because no subsequent state transition is possible.
+    pub async fn closed(&self) {
+        let mut state_rx = self.state_rx.clone();
+        let mut closed_rx = self.closed_rx.clone();
+        while !self.is_closed() {
+            tokio::select! {
+                changed = state_rx.changed() => {
+                    if changed.is_err() {
+                        return;
+                    }
+                }
+                changed = closed_rx.changed() => {
+                    if changed.is_err() {
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    fn publishers_dropped(&self) -> bool {
+        self.state_rx.has_changed().is_err() || self.closed_rx.has_changed().is_err()
+    }
+}
+
+/// Immutable session metadata available to V2 request processing.
+///
+/// Network values are captured when the canonical transport session is
+/// established. Embedded sessions intentionally have no socket addresses.
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::SessionView;
+///
+/// fn cannot_close(view: &SessionView) {
+///     view.close();
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::SessionView;
+///
+/// fn cannot_write(view: &SessionView) {
+///     view.write();
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::SessionView;
+///
+/// fn cannot_cancel(view: &SessionView) {
+///     view.cancel();
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::SessionView;
+///
+/// fn cannot_get_a_task_group(view: &SessionView) {
+///     let _ = view.task_group();
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::SessionView;
+///
+/// fn cannot_get_a_cancellation_token(view: &SessionView) {
+///     let _ = view.cancellation_token();
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::SessionView;
+///
+/// fn cannot_get_a_connection(view: &SessionView) {
+///     let _ = view.connection();
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::SessionHandle;
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::Channel;
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::Connection;
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::ConnectionStateHandle;
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::OperationContext;
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::TaskGroup;
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::CancellationToken;
+/// ```
+#[derive(Clone)]
+#[non_exhaustive]
+pub enum SessionView {
+    /// Metadata for a TCP or TLS session.
+    Network {
+        /// Stable process-local session identity.
+        id: SessionId,
+        /// Address accepted by the transport listener or trusted proxy.
+        local_addr: SocketAddr,
+        /// Effective remote address after trusted PROXY source rewriting.
+        remote_addr: SocketAddr,
+        /// Direct TCP peer before trusted PROXY source rewriting.
+        transport_peer_addr: SocketAddr,
+        /// Trusted PROXY source/destination snapshot, when a header was present.
+        proxy: Option<ProxyInfoSnapshot>,
+        /// Read-only lifecycle state shared with this session's clones.
+        state: SessionStateView,
+    },
+    /// Metadata for an in-process embedded session.
+    Embedded {
+        /// Stable process-local session identity.
+        id: SessionId,
+        /// Read-only lifecycle state shared with this session's clones.
+        state: SessionStateView,
+    },
+}
+
+impl SessionView {
+    pub(crate) fn network(
+        session_id: u64,
+        local_addr: SocketAddr,
+        remote_addr: SocketAddr,
+        transport_peer_addr: SocketAddr,
+        proxy_protocol: Option<&ProxyProtocolMetadata>,
+        state_rx: watch::Receiver<ConnectionState>,
+        closed_rx: watch::Receiver<bool>,
+    ) -> Self {
+        Self::Network {
+            id: SessionId::from_session_owner(session_id),
+            local_addr,
+            remote_addr,
+            transport_peer_addr,
+            proxy: proxy_protocol.map(ProxyInfoSnapshot::from_metadata),
+            state: SessionStateView::from_receivers(state_rx, closed_rx),
+        }
+    }
+
+    /// Returns the stable process-local identity for this session.
+    #[must_use]
+    pub const fn id(&self) -> SessionId {
+        match self {
+            Self::Network { id, .. } | Self::Embedded { id, .. } => *id,
+        }
+    }
+
+    /// Returns the read-only lifecycle view for this session.
+    #[must_use]
+    pub const fn state(&self) -> &SessionStateView {
+        match self {
+            Self::Network { state, .. } | Self::Embedded { state, .. } => state,
+        }
+    }
+}
+
+/// Crate-private lifecycle owner for one embedded dispatch session.
+///
+/// The record owns the only sender for embedded session state. Views only hold
+/// receivers, so dropping this record closes every cloned embedded view without
+/// exposing a close capability to processors.
+pub(crate) struct EmbeddedSessionRecord {
+    view: SessionView,
+    state_tx: watch::Sender<ConnectionState>,
+    closed_tx: watch::Sender<bool>,
+}
+
+impl EmbeddedSessionRecord {
+    pub(crate) fn new(session_id: u64) -> Self {
+        let (state_tx, state_rx) = watch::channel(ConnectionState::Healthy);
+        let (closed_tx, closed_rx) = watch::channel(false);
+        Self {
+            view: SessionView::Embedded {
+                id: SessionId::from_session_owner(session_id),
+                state: SessionStateView::from_receivers(state_rx, closed_rx),
+            },
+            state_tx,
+            closed_tx,
+        }
+    }
+
+    #[allow(
+        dead_code,
+        reason = "REQ-04 retains the embedded view for the REQ-06 request builder"
+    )]
+    pub(crate) fn view(&self) -> SessionView {
+        self.view.clone()
+    }
+}
+
+impl Drop for EmbeddedSessionRecord {
+    fn drop(&mut self) {
+        let _ = self.state_tx.send(ConnectionState::Closed);
+        let _ = self.closed_tx.send(true);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::net::SocketAddr;
+
+    use super::*;
+
+    fn address(value: &str) -> SocketAddr {
+        value.parse().expect("test socket address must parse")
+    }
+
+    #[tokio::test]
+    async fn cloned_state_views_observe_the_same_close_transition() {
+        let (state_tx, state_rx) = watch::channel(ConnectionState::Healthy);
+        let (closed_tx, closed_rx) = watch::channel(false);
+        let first = SessionStateView::from_receivers(state_rx, closed_rx);
+        let second = first.clone();
+
+        assert!(first.is_healthy());
+        assert!(!first.is_closed());
+        state_tx
+            .send(ConnectionState::Degraded)
+            .expect("test state receiver must remain subscribed");
+        assert!(!first.is_healthy());
+        assert!(!first.is_closed());
+
+        closed_tx
+            .send(true)
+            .expect("test close receiver must remain subscribed");
+        first.closed().await;
+        second.closed().await;
+
+        assert!(first.is_closed());
+        assert!(second.is_closed());
+    }
+
+    #[tokio::test]
+    async fn cloned_state_views_treat_publisher_loss_as_closed() {
+        let (state_tx, state_rx) = watch::channel(ConnectionState::Healthy);
+        let (closed_tx, closed_rx) = watch::channel(false);
+        let first = SessionStateView::from_receivers(state_rx, closed_rx);
+        let second = first.clone();
+
+        drop(state_tx);
+        drop(closed_tx);
+        first.closed().await;
+        second.closed().await;
+
+        assert!(first.is_closed());
+        assert!(second.is_closed());
+        assert!(!first.is_healthy());
+        assert!(!second.is_healthy());
+    }
+
+    #[tokio::test]
+    async fn embedded_views_have_no_socket_addresses_and_close_with_their_record() {
+        let record = EmbeddedSessionRecord::new(41);
+        let view = record.view();
+
+        let SessionView::Embedded { id, state } = &view else {
+            panic!("embedded record must create an embedded session view");
+        };
+        assert_eq!(*id, view.id());
+        assert!(state.is_healthy());
+        drop(record);
+
+        let SessionView::Embedded { state, .. } = &view else {
+            panic!("embedded session view must retain its variant");
+        };
+        state.closed().await;
+        assert!(state.is_closed());
+    }
+
+    #[test]
+    fn network_view_keeps_proxy_source_distinct_from_the_transport_peer() {
+        let transport_peer = address("203.0.113.9:31000");
+        let metadata = ProxyProtocolMetadata {
+            transport_peer,
+            source: address("198.51.100.44:43123"),
+            destination: address("192.0.2.10:10911"),
+            tlvs: Default::default(),
+        };
+        let (_state_tx, state_rx) = watch::channel(ConnectionState::Healthy);
+        let (_closed_tx, closed_rx) = watch::channel(false);
+        let view = SessionView::network(
+            77,
+            metadata.destination,
+            metadata.source,
+            transport_peer,
+            Some(&metadata),
+            state_rx,
+            closed_rx,
+        );
+
+        let SessionView::Network {
+            id,
+            local_addr,
+            remote_addr,
+            transport_peer_addr,
+            proxy,
+            state,
+        } = view
+        else {
+            panic!("network constructor must create a network session view");
+        };
+        let proxy = proxy.expect("trusted proxy metadata must have a snapshot");
+
+        assert_eq!(local_addr, metadata.destination);
+        assert_eq!(remote_addr, metadata.source);
+        assert_eq!(transport_peer_addr, transport_peer);
+        assert_ne!(remote_addr, transport_peer_addr);
+        assert_eq!(proxy.source(), metadata.source);
+        assert_eq!(proxy.destination(), metadata.destination);
+        assert!(state.is_healthy());
+        assert_eq!(id, SessionId::from_session_owner(77));
+    }
+
+    #[test]
+    fn session_ids_are_stable_hash_keys() {
+        let ids = [
+            SessionId::from_session_owner(51),
+            SessionId::from_session_owner(52),
+            SessionId::from_session_owner(51),
+        ]
+        .into_iter()
+        .collect::<HashSet<_>>();
+
+        assert_eq!(ids.len(), 2);
+    }
+}

--- a/rocketmq-transport/tests/public_api_contract.rs
+++ b/rocketmq-transport/tests/public_api_contract.rs
@@ -688,6 +688,22 @@ fn validate_public_api_v2_boundary(boundary: &PublicBoundary) -> Result<(), Stri
             module_path: String::new(),
             use_tree: "crate::dispatch::RequestOrigin".to_owned(),
         },
+        PublicUse {
+            module_path: String::new(),
+            use_tree: "crate::session_view::ProxyInfoSnapshot".to_owned(),
+        },
+        PublicUse {
+            module_path: String::new(),
+            use_tree: "crate::session_view::SessionId".to_owned(),
+        },
+        PublicUse {
+            module_path: String::new(),
+            use_tree: "crate::session_view::SessionStateView".to_owned(),
+        },
+        PublicUse {
+            module_path: String::new(),
+            use_tree: "crate::session_view::SessionView".to_owned(),
+        },
     ];
     if boundary.uses != expected_uses {
         return Err(format!("unexpected public v2 uses: {:?}", boundary.uses));
@@ -702,22 +718,22 @@ fn lib_rs_exposes_only_the_curated_versioned_boundary() {
 }
 
 #[test]
-fn public_api_v2_exposes_exactly_the_curated_request_identity_and_ingress_fact_types() {
+fn public_api_v2_exposes_exactly_the_curated_request_and_session_fact_types() {
     let boundary =
         inspect_public_boundary(include_str!("../src/public_api_v2.rs")).expect("public_api_v2.rs must tokenize");
 
     validate_public_api_v2_boundary(&boundary)
-        .expect("public_api_v2.rs must expose only approved request identity and ingress fact types");
+        .expect("public_api_v2.rs must expose only approved request, ingress, and session fact types");
 }
 
 #[test]
 fn public_api_v2_rejects_unapproved_public_surface() {
     for source in [
-        "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestOrigin; pub use crate::net::channel::Channel;",
-        "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestOrigin; pub use rocketmq_runtime::OperationContext;",
-        "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestOrigin; pub use crate::deadline::{RequestDeadline,RequestId};",
-        "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestOrigin; pub use crate::deadline::*;",
-        "pub mod request_model {} pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestOrigin;",
+        "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestOrigin; pub use crate::session_view::ProxyInfoSnapshot; pub use crate::session_view::SessionId; pub use crate::session_view::SessionStateView; pub use crate::session_view::SessionView; pub use crate::net::channel::Channel;",
+        "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestOrigin; pub use crate::session_view::ProxyInfoSnapshot; pub use crate::session_view::SessionId; pub use crate::session_view::SessionStateView; pub use crate::session_view::SessionView; pub use rocketmq_runtime::OperationContext;",
+        "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestOrigin; pub use crate::session_view::ProxyInfoSnapshot; pub use crate::session_view::SessionId; pub use crate::session_view::SessionStateView; pub use crate::session_view::SessionView; pub use crate::deadline::{RequestDeadline,RequestId};",
+        "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestOrigin; pub use crate::session_view::ProxyInfoSnapshot; pub use crate::session_view::SessionId; pub use crate::session_view::SessionStateView; pub use crate::session_view::SessionView; pub use crate::deadline::*;",
+        "pub mod request_model {} pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestOrigin; pub use crate::session_view::ProxyInfoSnapshot; pub use crate::session_view::SessionId; pub use crate::session_view::SessionStateView; pub use crate::session_view::SessionView;",
     ] {
         let boundary = inspect_public_boundary(source).expect("adversarial V2 fixture must parse");
 
@@ -733,6 +749,10 @@ pub use crate::dispatch::EmbeddedCaller;
 pub use crate::dispatch::RequestId;
 pub use crate::dispatch::OriginalRequestIdentity;
 pub use crate::dispatch::RequestOrigin;
+pub use crate::session_view::ProxyInfoSnapshot;
+pub use crate::session_view::SessionId;
+pub use crate::session_view::SessionStateView;
+pub use crate::session_view::SessionView;
 "#;
     let error = inspect_public_boundary(source).expect_err("public V2 macro invocation must be rejected");
 
@@ -745,8 +765,8 @@ pub use crate::dispatch::RequestOrigin;
 #[test]
 fn public_api_v2_rejects_direct_public_items() {
     for source in [
-        "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestOrigin; pub type Channel = crate::net::channel::Channel;",
-        "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestOrigin; pub struct Leaked;",
+        "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestOrigin; pub use crate::session_view::ProxyInfoSnapshot; pub use crate::session_view::SessionId; pub use crate::session_view::SessionStateView; pub use crate::session_view::SessionView; pub type Channel = crate::net::channel::Channel;",
+        "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestOrigin; pub use crate::session_view::ProxyInfoSnapshot; pub use crate::session_view::SessionId; pub use crate::session_view::SessionStateView; pub use crate::session_view::SessionView; pub struct Leaked;",
     ] {
         let error = inspect_public_boundary(source).expect_err("direct public V2 item must be rejected");
 

--- a/rocketmq-transport/tests/public_api_v2.rs
+++ b/rocketmq-transport/tests/public_api_v2.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::future::Future;
 use std::time::Duration;
 
 use rocketmq_security_api::Principal;
@@ -20,9 +21,13 @@ use rocketmq_transport::api::v1::RequestId as V1RequestId;
 use rocketmq_transport::api::v2::AuthenticationState;
 use rocketmq_transport::api::v2::EmbeddedCaller;
 use rocketmq_transport::api::v2::OriginalRequestIdentity;
+use rocketmq_transport::api::v2::ProxyInfoSnapshot;
 use rocketmq_transport::api::v2::RequestDeadline as V2RequestDeadline;
 use rocketmq_transport::api::v2::RequestId as V2RequestId;
 use rocketmq_transport::api::v2::RequestOrigin;
+use rocketmq_transport::api::v2::SessionId;
+use rocketmq_transport::api::v2::SessionStateView;
+use rocketmq_transport::api::v2::SessionView;
 
 fn assert_same_deadline_type(_: &V1RequestDeadline, _: &V2RequestDeadline) {}
 
@@ -36,6 +41,42 @@ fn assert_original_identity_contract(identity: Option<OriginalRequestIdentity>) 
         let _: i32 = identity.original_code();
         let _: i32 = identity.original_opaque();
         let _: bool = identity.is_one_way();
+    }
+}
+
+fn closed<'a>(state: &'a SessionStateView) -> impl Future<Output = ()> + 'a {
+    state.closed()
+}
+
+fn assert_session_view_contract(view: SessionView) {
+    let _: SessionId = view.id();
+    let _: &SessionStateView = view.state();
+    match view {
+        SessionView::Network {
+            id,
+            local_addr,
+            remote_addr,
+            transport_peer_addr,
+            proxy,
+            state,
+            ..
+        } => {
+            let _: SessionId = id;
+            let _: std::net::SocketAddr = local_addr;
+            let _: std::net::SocketAddr = remote_addr;
+            let _: std::net::SocketAddr = transport_peer_addr;
+            let _: bool = state.is_healthy();
+            let _: bool = state.is_closed();
+            let _: Option<ProxyInfoSnapshot> = proxy;
+            std::mem::drop(closed(&state));
+        }
+        SessionView::Embedded { id, state, .. } => {
+            let _: SessionId = id;
+            let _: bool = state.is_healthy();
+            let _: bool = state.is_closed();
+            std::mem::drop(closed(&state));
+        }
+        _ => {}
     }
 }
 
@@ -82,4 +123,9 @@ fn v2_exposes_read_only_origin_and_authenticated_principal() {
     let _: fn(&AuthenticationState) -> Option<&Principal> = authenticated_principal;
     let _: fn(&AuthenticationState) -> bool = has_authenticated_principal;
     let _: fn(&RequestOrigin) -> Option<std::net::SocketAddr> = inspect_origin;
+}
+
+#[test]
+fn v2_exposes_read_only_network_and_embedded_session_views() {
+    let _: fn(SessionView) = assert_session_view_contract;
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9766

### Brief Description

Adds the read-only V2 session model required by the connection-handler-context design:

- introduces an opaque, process-local `SessionId` and explicit network/embedded `SessionView` variants;
- projects canonical addresses, the direct transport peer, and a minimal trusted PROXY source/destination snapshot without raw TLVs;
- provides cloneable health and close observation without exposing writers, close senders, cancellation tokens, task ownership, or raw connection handles;
- publishes session closure when the reader stops accepting work while preserving the canonical writer long enough to drain accepted responses;
- keeps embedded sessions free of fabricated socket addresses and uses the same owner identity as immutable request identity;
- extends the exact V2 export contract and independent compile-fail coverage for every forbidden capability.

Existing V1 APIs and behavior remain unchanged.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-transport -- --check`
- `cargo test -p rocketmq-transport --all-features`
- `cargo doc -p rocketmq-transport --all-features --no-deps`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- RocketMQ MCP locked check, read-only boundary check, default/all-feature tests, streamable-http Clippy, and Rustdoc

Coverage includes publisher loss, cloned close propagation, real trusted-PROXY listener provenance, reader-close-before-drain with a successful accepted response write, embedded shape, stable identity hashing, the exact V2 export allowlist, and independent compile-fail checks for forbidden transport/lifecycle capabilities.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added read-only session views for network and embedded connections.
  - Exposed session IDs, connection addresses, trusted proxy details, health status, and closure state through the 2.x API.
  - Added lifecycle notifications so applications can observe when sessions close.
  - Embedded sessions now receive session records before request processing.

- **Tests**
  - Added coverage for session metadata, proxy handling, lifecycle transitions, and public API compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->