### PR TITLE
[ISSUE #9771]✨Assemble the trusted V2 RemotingRequest model

### DIFF
--- a/rocketmq-transport/src/dispatch.rs
+++ b/rocketmq-transport/src/dispatch.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod authorized_dispatcher;
+mod remoting_request;
 mod request_context;
 mod request_control;
 mod request_identity;
@@ -24,6 +25,8 @@ pub use authorized_dispatcher::AuthorizedCommandDispatcher;
 pub use authorized_dispatcher::AuthorizedDispatchBoundary;
 pub use authorized_dispatcher::DispatchError;
 pub use authorized_dispatcher::DispatchOutcome;
+pub use remoting_request::IngressRequestView;
+pub use remoting_request::RemotingRequest;
 pub use request_context::RequestContext;
 pub use request_context::RequestContextError;
 pub use request_context::RequestTransport;

--- a/rocketmq-transport/src/dispatch/remoting_request.rs
+++ b/rocketmq-transport/src/dispatch/remoting_request.rs
@@ -1,0 +1,271 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The trusted V2 request aggregate and immutable ingress ordering view.
+
+use std::collections::HashMap;
+
+use cheetah_string::CheetahString;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+
+use super::request_control::LazyExtensions;
+use super::AuthenticationState;
+use super::OriginalRequestIdentity;
+use super::RequestControlView;
+use super::RequestMeta;
+use super::RequestOrigin;
+use crate::session_view::SessionView;
+
+mod builder;
+
+#[allow(
+    unused_imports,
+    reason = "REQ-06 exposes the crate-private builder to later dispatcher wiring without expanding the public API"
+)]
+pub(crate) use builder::RemotingRequestBuildError;
+#[allow(
+    unused_imports,
+    reason = "REQ-06 exposes the crate-private builder to later dispatcher wiring without expanding the public API"
+)]
+pub(crate) use builder::RemotingRequestBuilder;
+#[allow(
+    unused_imports,
+    reason = "REQ-06 exposes sealed lifecycle provenance to later dispatcher wiring without expanding the public API"
+)]
+pub(crate) use builder::RequestLifecycleProvenance;
+
+/// One trusted request with immutable ingress facts and one mutable command.
+///
+/// The request owns the [`RemotingCommand`] handed to a V2 processor. Its
+/// original identity is captured before hooks or processors can mutate that
+/// command. Ordering receives a short-lived [`IngressRequestView`] from the
+/// trusted builder before this aggregate is built; processors use
+/// [`Self::command_mut`] for command changes.
+///
+/// Instances are assembled only by the transport's trusted builder. This type
+/// is intentionally not [`Clone`]: cloning would duplicate mutable command
+/// ownership and blur response/lifecycle boundaries.
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::RemotingRequest;
+///
+/// fn cannot_clone(request: &RemotingRequest) {
+///     let _: RemotingRequest = request.clone();
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::RemotingRequest;
+///
+/// fn cannot_recover_legacy_transport_capabilities(request: &RemotingRequest) {
+///     let _ = request.channel();
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::RemotingRequest;
+///
+/// fn cannot_cancel_or_close_through_the_request(request: &RemotingRequest) {
+///     request.cancel();
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::RemotingRequest;
+///
+/// fn cannot_recover_a_pre_mutation_ingress_view(request: &RemotingRequest) {
+///     let _ = request.ingress();
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::RemotingRequestBuilder;
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::DeferredSlot;
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::RemotingCommand;
+/// ```
+pub struct RemotingRequest {
+    original: OriginalRequestIdentity,
+    meta: RequestMeta,
+    origin: RequestOrigin,
+    authentication: AuthenticationState,
+    session: SessionView,
+    control: RequestControlView,
+    extensions: LazyExtensions,
+    #[allow(
+        dead_code,
+        reason = "REQ-06 reserves the inert deferred slot for later DEF lifecycle work"
+    )]
+    deferred: DeferredSlot,
+    command: RemotingCommand,
+}
+
+impl RemotingRequest {
+    /// Returns the immutable identity captured when this request entered the
+    /// trusted transport boundary.
+    #[must_use]
+    pub const fn original_identity(&self) -> OriginalRequestIdentity {
+        self.original
+    }
+
+    /// Returns metadata captured when this request entered the transport.
+    #[must_use]
+    pub const fn meta(&self) -> &RequestMeta {
+        &self.meta
+    }
+
+    /// Returns the trusted request origin.
+    #[must_use]
+    pub const fn origin(&self) -> &RequestOrigin {
+        &self.origin
+    }
+
+    /// Returns authentication facts established by trusted ingress.
+    #[must_use]
+    pub const fn authentication(&self) -> &AuthenticationState {
+        &self.authentication
+    }
+
+    /// Returns the read-only session view for this request.
+    #[must_use]
+    pub const fn session(&self) -> &SessionView {
+        &self.session
+    }
+
+    /// Returns observer-only request deadline and cancellation state.
+    #[must_use]
+    pub const fn control(&self) -> &RequestControlView {
+        &self.control
+    }
+
+    /// Returns the owned command as it currently stands.
+    ///
+    /// This command may differ from [`Self::original_identity`] after hooks or
+    /// processors mutate it.
+    #[must_use]
+    pub const fn command(&self) -> &RemotingCommand {
+        &self.command
+    }
+
+    /// Returns the command for processor-owned mutation.
+    ///
+    /// Mutating this command cannot alter the captured original identity.
+    /// Ingress ordering has already observed its borrowed extension fields
+    /// before the builder created this request.
+    pub fn command_mut(&mut self) -> &mut RemotingCommand {
+        &mut self.command
+    }
+
+    /// Returns the request-local extension of type `T`, when one was inserted.
+    ///
+    /// This is allocation-free when no extension has previously been inserted.
+    #[must_use]
+    pub fn extension<T>(&self) -> Option<&T>
+    where
+        T: Send + Sync + 'static,
+    {
+        self.extensions.get()
+    }
+
+    /// Inserts a request-local extension, replacing an existing value of the
+    /// same type.
+    ///
+    /// # Errors
+    ///
+    /// Returns the supplied value unchanged when `T` is a reserved ingress
+    /// fact or lifecycle capability. Rejection does not allocate extension
+    /// storage.
+    pub fn try_insert_extension<T>(&mut self, value: T) -> Result<Option<T>, T>
+    where
+        T: Send + Sync + 'static,
+    {
+        self.extensions.try_insert(value)
+    }
+
+    #[allow(
+        dead_code,
+        reason = "REQ-06 tests the inert deferred slot before later DEF lifecycle work"
+    )]
+    pub(crate) const fn has_reserved_deferred_response(&self) -> bool {
+        self.deferred.is_reserved()
+    }
+}
+
+/// Immutable request facts used before processor mutation, such as ordering.
+///
+/// The trusted builder creates this view before transferring command ownership
+/// to [`RemotingRequest`]. It borrows the command's ingress extension fields
+/// directly and never contains a request body, so ordering can inspect headers
+/// without copying or retaining the payload.
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::IngressRequestView;
+///
+/// fn ingress_view_cannot_expose_the_request_body(view: IngressRequestView<'_>) {
+///     let _ = view.body();
+/// }
+/// ```
+pub struct IngressRequestView<'a> {
+    original: OriginalRequestIdentity,
+    ext_fields: Option<&'a HashMap<CheetahString, CheetahString>>,
+}
+
+impl<'a> IngressRequestView<'a> {
+    /// Returns the immutable identity captured at ingress.
+    #[must_use]
+    pub const fn original_identity(&self) -> OriginalRequestIdentity {
+        self.original
+    }
+
+    /// Returns the captured ingress extension fields, when the inbound command
+    /// carried any.
+    ///
+    /// The builder consumes itself after ordering finishes, so later processor
+    /// command mutation cannot be observed through this view.
+    #[must_use]
+    pub const fn ext_fields(&self) -> Option<&'a HashMap<CheetahString, CheetahString>> {
+        self.ext_fields
+    }
+}
+
+#[derive(Default)]
+#[allow(
+    dead_code,
+    reason = "REQ-06 reserves this crate-private placeholder before later DEF lifecycle work"
+)]
+pub(crate) struct DeferredSlot {
+    reserved: bool,
+}
+
+#[allow(
+    dead_code,
+    reason = "REQ-06 reserves inert deferred-state operations before later DEF lifecycle work"
+)]
+impl DeferredSlot {
+    pub(crate) const fn reserved() -> Self {
+        Self { reserved: true }
+    }
+
+    pub(crate) const fn is_reserved(&self) -> bool {
+        self.reserved
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/rocketmq-transport/src/dispatch/remoting_request/builder.rs
+++ b/rocketmq-transport/src/dispatch/remoting_request/builder.rs
@@ -1,0 +1,228 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Instant;
+
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_runtime::TaskGroup;
+
+use super::DeferredSlot;
+use super::IngressRequestView;
+use super::RemotingRequest;
+use crate::dispatch::OriginalRequestIdentity;
+use crate::dispatch::RequestContext;
+use crate::dispatch::RequestControlView;
+use crate::dispatch::RequestMeta;
+use crate::dispatch::RequestOrigin;
+use crate::server::SessionHandle;
+use crate::session_view::EmbeddedSessionRecord;
+use crate::session_view::SessionView;
+
+/// Trusted-only construction error for a V2 request aggregate.
+#[allow(
+    dead_code,
+    reason = "REQ-06 exposes typed build failures to later dispatcher wiring without public construction"
+)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub(crate) enum RemotingRequestBuildError {
+    #[error("response commands cannot build inbound remoting requests")]
+    ResponseCommand,
+    #[error("original request identity does not match the owned command")]
+    OriginalCommandMismatch,
+    #[error("request owner does not match the session owner")]
+    SessionOwnerMismatch,
+    #[error("network ingress requires a network session")]
+    NetworkSessionMismatch,
+    #[error("embedded ingress requires an embedded session")]
+    EmbeddedSessionMismatch,
+    #[error("network peer does not match the session effective peer")]
+    NetworkPeerMismatch,
+    #[error("embedded ingress requires an authenticated principal")]
+    MissingEmbeddedAuthentication,
+    #[error("one-way requests cannot reserve a deferred response")]
+    OneWayDeferredResponse,
+}
+
+/// Sealed lifecycle facts that bind a request to its real session and owner.
+///
+/// Network provenance is derived only from the canonical [`SessionHandle`],
+/// which supplies both the session view and its owning task group. Embedded
+/// provenance similarly binds one [`EmbeddedSessionRecord`] to the actual
+/// dispatch parent task group. The fields remain private so callers cannot
+/// combine a view from one session with state or cancellation from another.
+#[allow(
+    dead_code,
+    reason = "REQ-06 prepares sealed lifecycle provenance for later dispatcher wiring"
+)]
+pub(crate) struct RequestLifecycleProvenance {
+    session: SessionView,
+    parent_task_group: TaskGroup,
+}
+
+#[allow(
+    dead_code,
+    reason = "REQ-06 prepares sealed lifecycle provenance construction for later dispatcher wiring"
+)]
+impl RequestLifecycleProvenance {
+    /// Derives network request lifecycle facts from one canonical session.
+    pub(crate) fn from_network_session(session: &SessionHandle) -> Self {
+        Self::from_session_view(session.session_view(), session.task_group())
+    }
+
+    /// Derives embedded request lifecycle facts from the record that owns its
+    /// session publishers and the dispatch owner that will run the request.
+    pub(crate) fn from_embedded_session(session: &EmbeddedSessionRecord, parent_task_group: &TaskGroup) -> Self {
+        Self::from_session_view(session.view(), parent_task_group)
+    }
+
+    fn from_session_view(session: SessionView, parent_task_group: &TaskGroup) -> Self {
+        Self {
+            session,
+            parent_task_group: parent_task_group.clone(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn network_for_test(
+        session_id: u64,
+        local_addr: std::net::SocketAddr,
+        remote_addr: std::net::SocketAddr,
+        transport_peer_addr: std::net::SocketAddr,
+        proxy_protocol: Option<&crate::proxy_protocol::ProxyProtocolMetadata>,
+        state_rx: tokio::sync::watch::Receiver<crate::connection::ConnectionState>,
+        closed_rx: tokio::sync::watch::Receiver<bool>,
+        parent_task_group: &TaskGroup,
+    ) -> Self {
+        Self::from_session_view(
+            SessionView::network(
+                session_id,
+                local_addr,
+                remote_addr,
+                transport_peer_addr,
+                proxy_protocol,
+                state_rx,
+                closed_rx,
+            ),
+            parent_task_group,
+        )
+    }
+}
+
+/// Crate-private assembly point for trusted ingress request facts.
+#[allow(
+    dead_code,
+    reason = "REQ-06 prepares trusted assembly before later dispatcher wiring"
+)]
+pub(crate) struct RemotingRequestBuilder {
+    original: OriginalRequestIdentity,
+    received_at: Instant,
+    context: RequestContext,
+    lifecycle: RequestLifecycleProvenance,
+    deferred: DeferredSlot,
+    command: RemotingCommand,
+}
+
+#[allow(
+    dead_code,
+    reason = "REQ-06 prepares trusted assembly operations before later dispatcher wiring"
+)]
+impl RemotingRequestBuilder {
+    pub(crate) fn new(
+        original: OriginalRequestIdentity,
+        received_at: Instant,
+        context: RequestContext,
+        lifecycle: RequestLifecycleProvenance,
+        command: RemotingCommand,
+    ) -> Self {
+        Self {
+            original,
+            received_at,
+            context,
+            lifecycle,
+            deferred: DeferredSlot::default(),
+            command,
+        }
+    }
+
+    pub(crate) fn reserve_deferred_response(mut self) -> Self {
+        self.deferred = DeferredSlot::reserved();
+        self
+    }
+
+    /// Borrows immutable ingress fields while the builder still owns the
+    /// unmodified command. Ordering must finish before [`Self::build`] moves
+    /// that command into a processor-facing request.
+    #[must_use]
+    pub(crate) fn ingress_view(&self) -> IngressRequestView<'_> {
+        IngressRequestView {
+            original: self.original,
+            ext_fields: self.command.ext_fields(),
+        }
+    }
+
+    pub(crate) fn build(self) -> Result<RemotingRequest, RemotingRequestBuildError> {
+        if self.command.is_response_type() {
+            return Err(RemotingRequestBuildError::ResponseCommand);
+        }
+        if !self.original.matches_command(&self.command) {
+            return Err(RemotingRequestBuildError::OriginalCommandMismatch);
+        }
+        if self.original.request_id().owner_id() != self.lifecycle.session.id().owner_id() {
+            return Err(RemotingRequestBuildError::SessionOwnerMismatch);
+        }
+
+        let context = self.context.into_parts();
+        let meta = RequestMeta::new(self.received_at, context.deadline);
+        let control = RequestControlView::from_meta(
+            &meta,
+            self.lifecycle.session.state().clone(),
+            &self.lifecycle.parent_task_group,
+        );
+
+        match (&context.origin, &self.lifecycle.session) {
+            (RequestOrigin::Network { peer }, SessionView::Network { remote_addr, .. }) => {
+                if peer.address() != *remote_addr {
+                    return Err(RemotingRequestBuildError::NetworkPeerMismatch);
+                }
+            }
+            (RequestOrigin::Network { .. }, SessionView::Embedded { .. }) => {
+                return Err(RemotingRequestBuildError::NetworkSessionMismatch);
+            }
+            (RequestOrigin::Embedded { .. }, SessionView::Network { .. }) => {
+                return Err(RemotingRequestBuildError::EmbeddedSessionMismatch);
+            }
+            (RequestOrigin::Embedded { .. }, SessionView::Embedded { .. }) => {
+                if context.authentication.principal().is_none() {
+                    return Err(RemotingRequestBuildError::MissingEmbeddedAuthentication);
+                }
+            }
+        }
+
+        if self.original.is_one_way() && self.deferred.is_reserved() {
+            return Err(RemotingRequestBuildError::OneWayDeferredResponse);
+        }
+
+        Ok(RemotingRequest {
+            original: self.original,
+            meta,
+            origin: context.origin,
+            authentication: context.authentication,
+            session: self.lifecycle.session,
+            control,
+            extensions: Default::default(),
+            deferred: self.deferred,
+            command: self.command,
+        })
+    }
+}

--- a/rocketmq-transport/src/dispatch/remoting_request/tests.rs
+++ b/rocketmq-transport/src/dispatch/remoting_request/tests.rs
@@ -1,0 +1,551 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicU64;
+use std::time::Duration;
+use std::time::Instant;
+
+use bytes::Bytes;
+use cheetah_string::CheetahString;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::LanguageCode;
+use rocketmq_runtime::RuntimeContext;
+use rocketmq_runtime::TaskGroup;
+use rocketmq_security_api::PeerInfo;
+use rocketmq_security_api::Principal;
+use tokio::sync::watch;
+
+use super::super::AuthenticationState;
+use super::super::EmbeddedCaller;
+use super::super::RequestContext;
+use super::super::RequestOrigin;
+use super::*;
+use crate::connection::ConnectionState;
+use crate::proxy_protocol::ProxyProtocolMetadata;
+use crate::session_view::EmbeddedSessionRecord;
+use crate::session_view::SessionId;
+
+struct Fixture {
+    original: OriginalRequestIdentity,
+    received_at: Instant,
+    context: RequestContext,
+    lifecycle: RequestLifecycleProvenance,
+    command: RemotingCommand,
+}
+
+fn address(value: &str) -> std::net::SocketAddr {
+    value.parse().expect("test address must parse")
+}
+
+struct NetworkSessionHarness {
+    owner: u64,
+    local_addr: std::net::SocketAddr,
+    remote_addr: std::net::SocketAddr,
+    transport_peer_addr: std::net::SocketAddr,
+    state_tx: watch::Sender<ConnectionState>,
+    closed_tx: watch::Sender<bool>,
+}
+
+impl NetworkSessionHarness {
+    fn new(owner: u64, remote_addr: std::net::SocketAddr, transport_peer_addr: std::net::SocketAddr) -> Self {
+        let (state_tx, _) = watch::channel(ConnectionState::Healthy);
+        let (closed_tx, _) = watch::channel(false);
+        Self {
+            owner,
+            local_addr: address("192.0.2.10:10911"),
+            remote_addr,
+            transport_peer_addr,
+            state_tx,
+            closed_tx,
+        }
+    }
+
+    fn provenance(
+        &self,
+        parent_task_group: &TaskGroup,
+        proxy_protocol: Option<&ProxyProtocolMetadata>,
+    ) -> RequestLifecycleProvenance {
+        RequestLifecycleProvenance::network_for_test(
+            self.owner,
+            self.local_addr,
+            self.remote_addr,
+            self.transport_peer_addr,
+            proxy_protocol,
+            self.state_tx.subscribe(),
+            self.closed_tx.subscribe(),
+            parent_task_group,
+        )
+    }
+}
+
+fn network_fixture(
+    parent_task_group: &TaskGroup,
+    owner: u64,
+    deadline: Option<crate::deadline::RequestDeadline>,
+    one_way: bool,
+) -> (Fixture, NetworkSessionHarness) {
+    let peer_address = address("198.51.100.44:43123");
+    let mut command = RemotingCommand::create_remoting_command(17)
+        .set_opaque(91)
+        .set_language(LanguageCode::JAVA)
+        .set_version(123)
+        .set_body(Bytes::from_static(b"request-body"));
+    command.add_ext_field("tenant", "ingress-tenant");
+    if one_way {
+        command.mark_oneway_rpc_ref();
+    }
+    let original =
+        OriginalRequestIdentity::capture(owner, &AtomicU64::new(1), &command).expect("test identity must allocate");
+    let received_at = Instant::now();
+    let session = NetworkSessionHarness::new(owner, peer_address, peer_address);
+    let context = RequestContext::network(
+        PeerInfo::new(peer_address, true),
+        Some(Principal::new("network-user")),
+        deadline,
+    );
+
+    (
+        Fixture {
+            original,
+            received_at,
+            context,
+            lifecycle: session.provenance(parent_task_group, None),
+            command,
+        },
+        session,
+    )
+}
+
+fn embedded_fixture(
+    parent_task_group: &TaskGroup,
+    owner: u64,
+    deadline: Option<crate::deadline::RequestDeadline>,
+) -> (Fixture, EmbeddedSessionRecord) {
+    let mut command = RemotingCommand::create_remoting_command(18)
+        .set_opaque(92)
+        .set_language(LanguageCode::RUST)
+        .set_version(124);
+    command.add_ext_field("tenant", "embedded-tenant");
+    let original =
+        OriginalRequestIdentity::capture(owner, &AtomicU64::new(1), &command).expect("test identity must allocate");
+    let received_at = Instant::now();
+    let session = EmbeddedSessionRecord::new(owner);
+    let context = RequestContext::try_embedded_with_caller(
+        EmbeddedCaller::BrokerProxy,
+        Some(Principal::new("embedded-user")),
+        deadline,
+    )
+    .expect("embedded fixture must have a principal");
+
+    (
+        Fixture {
+            original,
+            received_at,
+            context,
+            lifecycle: RequestLifecycleProvenance::from_embedded_session(&session, parent_task_group),
+            command,
+        },
+        session,
+    )
+}
+
+fn builder(fixture: Fixture) -> RemotingRequestBuilder {
+    RemotingRequestBuilder::new(
+        fixture.original,
+        fixture.received_at,
+        fixture.context,
+        fixture.lifecycle,
+        fixture.command,
+    )
+}
+
+fn build(fixture: Fixture) -> Result<RemotingRequest, RemotingRequestBuildError> {
+    builder(fixture).build()
+}
+
+async fn shutdown(runtime: RuntimeContext) {
+    let report = runtime.shutdown_tasks(Duration::from_secs(1)).await;
+    assert!(report.is_healthy(), "{}", report.to_json());
+}
+
+#[tokio::test]
+async fn builder_assembles_a_network_request_with_one_canonical_deadline() {
+    let runtime = RuntimeContext::from_current("remoting-request-network");
+    let deadline = crate::deadline::RequestDeadline::after(Duration::from_secs(5));
+    let (fixture, _session) = network_fixture(runtime.root_group(), 41, Some(deadline), false);
+    let received_at = fixture.received_at;
+    let request = build(fixture).expect("matching trusted network facts must build a request");
+
+    assert_eq!(request.original_identity().original_code(), 17);
+    assert_eq!(request.original_identity().original_opaque(), 91);
+    assert_eq!(request.meta().received_at(), received_at);
+    assert_eq!(request.meta().deadline(), Some(deadline));
+    assert_eq!(request.control().deadline(), Some(deadline));
+    assert_eq!(request.session().id(), SessionId::from_session_owner(41));
+    assert!(matches!(request.origin(), RequestOrigin::Network { .. }));
+    assert!(matches!(request.session(), SessionView::Network { .. }));
+
+    shutdown(runtime).await;
+}
+
+#[tokio::test]
+async fn builder_assembles_an_authenticated_embedded_request() {
+    let runtime = RuntimeContext::from_current("remoting-request-embedded");
+    let (fixture, _session) = embedded_fixture(runtime.root_group(), 42, None);
+    let request = build(fixture).expect("matching authenticated embedded facts must build a request");
+
+    assert!(matches!(request.origin(), RequestOrigin::Embedded { .. }));
+    assert!(matches!(request.session(), SessionView::Embedded { .. }));
+    assert_eq!(
+        request.authentication().principal().map(Principal::id),
+        Some("embedded-user")
+    );
+
+    shutdown(runtime).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn builder_control_observes_its_session_not_a_same_deadline_decoy() {
+    let runtime = RuntimeContext::from_current("remoting-request-session-provenance");
+    let deadline = crate::deadline::RequestDeadline::after(Duration::from_secs(5));
+    let (fixture, actual_session) = network_fixture(runtime.root_group(), 46, Some(deadline), false);
+    let (_decoy_fixture, decoy_session) = network_fixture(runtime.root_group(), 47, Some(deadline), false);
+    let request = build(fixture).expect("matching trusted facts must build a request");
+
+    assert_eq!(request.meta().deadline(), Some(deadline));
+    assert_eq!(request.control().deadline(), request.meta().deadline());
+    decoy_session
+        .closed_tx
+        .send(true)
+        .expect("decoy session publisher must remain subscribed");
+    assert!(!request.control().is_cancelled());
+    assert!(
+        tokio::time::timeout(Duration::from_secs(1), request.control().cancelled())
+            .await
+            .is_err()
+    );
+
+    actual_session
+        .closed_tx
+        .send(true)
+        .expect("actual session publisher must remain subscribed");
+    request.control().cancelled().await;
+    assert!(request.control().is_cancelled());
+
+    shutdown(runtime).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn builder_control_observes_its_parent_not_a_decoy_parent() {
+    let runtime = RuntimeContext::from_current("remoting-request-parent-provenance");
+    let actual_parent = runtime
+        .service_context("remoting-request-actual-parent")
+        .task_group()
+        .clone();
+    let decoy_parent = runtime
+        .service_context("remoting-request-decoy-parent")
+        .task_group()
+        .clone();
+    let (fixture, _session) = network_fixture(&actual_parent, 48, None, false);
+    let request = build(fixture).expect("matching trusted facts must build a request");
+
+    decoy_parent.cancel();
+    assert!(!request.control().is_cancelled());
+    assert!(
+        tokio::time::timeout(Duration::from_secs(1), request.control().cancelled())
+            .await
+            .is_err()
+    );
+
+    actual_parent.cancel();
+    request.control().cancelled().await;
+    assert!(request.control().is_cancelled());
+
+    shutdown(runtime).await;
+}
+
+#[tokio::test]
+async fn builder_rejects_response_and_every_captured_command_fact_mismatch() {
+    let runtime = RuntimeContext::from_current("remoting-request-command-mismatch");
+
+    let (fixture, _session) = network_fixture(runtime.root_group(), 51, None, false);
+    let mut response = fixture.command;
+    response.mark_response_type_ref();
+    assert_eq!(
+        RemotingRequestBuilder::new(
+            fixture.original,
+            fixture.received_at,
+            fixture.context,
+            fixture.lifecycle,
+            response,
+        )
+        .build()
+        .err(),
+        Some(RemotingRequestBuildError::ResponseCommand)
+    );
+
+    let (fixture, _session) = network_fixture(runtime.root_group(), 52, None, false);
+    let mut code = fixture.command;
+    code.set_code_ref(99);
+    assert_eq!(
+        RemotingRequestBuilder::new(
+            fixture.original,
+            fixture.received_at,
+            fixture.context,
+            fixture.lifecycle,
+            code,
+        )
+        .build()
+        .err(),
+        Some(RemotingRequestBuildError::OriginalCommandMismatch)
+    );
+
+    let (fixture, _session) = network_fixture(runtime.root_group(), 53, None, false);
+    let mut opaque = fixture.command;
+    opaque.set_opaque_mut(100);
+    assert_eq!(
+        RemotingRequestBuilder::new(
+            fixture.original,
+            fixture.received_at,
+            fixture.context,
+            fixture.lifecycle,
+            opaque,
+        )
+        .build()
+        .err(),
+        Some(RemotingRequestBuildError::OriginalCommandMismatch)
+    );
+
+    let (fixture, _session) = network_fixture(runtime.root_group(), 54, None, false);
+    let mut one_way = fixture.command;
+    one_way.mark_oneway_rpc_ref();
+    assert_eq!(
+        RemotingRequestBuilder::new(
+            fixture.original,
+            fixture.received_at,
+            fixture.context,
+            fixture.lifecycle,
+            one_way,
+        )
+        .build()
+        .err(),
+        Some(RemotingRequestBuildError::OriginalCommandMismatch)
+    );
+
+    let (fixture, _session) = network_fixture(runtime.root_group(), 55, None, false);
+    let language = fixture.command.set_language(LanguageCode::RUST);
+    assert_eq!(
+        RemotingRequestBuilder::new(
+            fixture.original,
+            fixture.received_at,
+            fixture.context,
+            fixture.lifecycle,
+            language,
+        )
+        .build()
+        .err(),
+        Some(RemotingRequestBuildError::OriginalCommandMismatch)
+    );
+
+    let (fixture, _session) = network_fixture(runtime.root_group(), 56, None, false);
+    let version = fixture.command.set_version(124);
+    assert_eq!(
+        RemotingRequestBuilder::new(
+            fixture.original,
+            fixture.received_at,
+            fixture.context,
+            fixture.lifecycle,
+            version,
+        )
+        .build()
+        .err(),
+        Some(RemotingRequestBuildError::OriginalCommandMismatch)
+    );
+
+    shutdown(runtime).await;
+}
+
+#[tokio::test]
+async fn builder_rejects_owner_and_origin_session_shape_mismatches() {
+    let runtime = RuntimeContext::from_current("remoting-request-invalid-facts");
+
+    let (mut fixture, _session) = network_fixture(runtime.root_group(), 61, None, false);
+    let decoy_session = NetworkSessionHarness::new(62, address("198.51.100.44:43123"), address("198.51.100.44:43123"));
+    fixture.lifecycle = decoy_session.provenance(runtime.root_group(), None);
+    assert_eq!(
+        build(fixture).err(),
+        Some(RemotingRequestBuildError::SessionOwnerMismatch)
+    );
+
+    let (mut fixture, _session) = network_fixture(runtime.root_group(), 64, None, false);
+    let embedded = EmbeddedSessionRecord::new(64);
+    fixture.lifecycle = RequestLifecycleProvenance::from_embedded_session(&embedded, runtime.root_group());
+    assert_eq!(
+        build(fixture).err(),
+        Some(RemotingRequestBuildError::NetworkSessionMismatch)
+    );
+
+    let (mut fixture, _session) = embedded_fixture(runtime.root_group(), 65, None);
+    let network = NetworkSessionHarness::new(65, address("198.51.100.44:43123"), address("198.51.100.44:43123"));
+    fixture.lifecycle = network.provenance(runtime.root_group(), None);
+    assert_eq!(
+        build(fixture).err(),
+        Some(RemotingRequestBuildError::EmbeddedSessionMismatch)
+    );
+
+    shutdown(runtime).await;
+}
+
+#[tokio::test]
+async fn builder_uses_effective_proxy_peer_and_rejects_mismatched_network_peers() {
+    let runtime = RuntimeContext::from_current("remoting-request-effective-peer");
+    let effective_peer = address("198.51.100.44:43123");
+    let transport_peer = address("203.0.113.9:31000");
+    let metadata = ProxyProtocolMetadata {
+        transport_peer,
+        source: effective_peer,
+        destination: address("192.0.2.10:10911"),
+        tlvs: Default::default(),
+    };
+    let (mut fixture, _session) = network_fixture(runtime.root_group(), 71, None, false);
+    let proxied_session = NetworkSessionHarness::new(71, metadata.source, metadata.transport_peer);
+    fixture.lifecycle = proxied_session.provenance(runtime.root_group(), Some(&metadata));
+    assert!(
+        build(fixture).is_ok(),
+        "effective peer must be accepted even when transport peer differs"
+    );
+
+    let (mut fixture, _session) = network_fixture(runtime.root_group(), 72, None, false);
+    let mismatched_session = NetworkSessionHarness::new(72, address("198.51.100.45:43123"), transport_peer);
+    fixture.lifecycle = mismatched_session.provenance(runtime.root_group(), None);
+    assert_eq!(
+        build(fixture).err(),
+        Some(RemotingRequestBuildError::NetworkPeerMismatch)
+    );
+
+    shutdown(runtime).await;
+}
+
+#[tokio::test]
+async fn builder_rejects_embedded_requests_without_authenticated_ingress() {
+    let runtime = RuntimeContext::from_current("remoting-request-embedded-authentication");
+    let (mut fixture, _session) = embedded_fixture(runtime.root_group(), 81, None);
+    let mut parts = fixture.context.into_parts();
+    parts.authentication = AuthenticationState::Anonymous;
+    fixture.context = RequestContext::from_parts(parts);
+
+    assert_eq!(
+        build(fixture).err(),
+        Some(RemotingRequestBuildError::MissingEmbeddedAuthentication)
+    );
+
+    shutdown(runtime).await;
+}
+
+#[tokio::test]
+async fn builder_ingress_view_borrows_pre_mutation_extension_fields_without_body_copy() {
+    let runtime = RuntimeContext::from_current("remoting-request-ingress-view");
+    let (fixture, _session) = network_fixture(runtime.root_group(), 91, None, false);
+    let body_ptr = fixture.command.body().expect("fixture has a body").as_ptr();
+    let builder = builder(fixture);
+
+    {
+        let ingress = builder.ingress_view();
+        assert_eq!(ingress.original_identity().original_code(), 17);
+        assert_eq!(
+            ingress
+                .ext_fields()
+                .and_then(|fields| fields.get(&CheetahString::from_static_str("tenant"))),
+            Some(&CheetahString::from_static_str("ingress-tenant"))
+        );
+    }
+
+    let mut request = builder.build().expect("builder ownership transfers after ordering");
+    assert_eq!(
+        request.command().body().expect("request retains body").as_ptr(),
+        body_ptr
+    );
+    let original = request.original_identity();
+    request.command_mut().set_code_ref(99);
+    request.command_mut().set_opaque_mut(100);
+    request.command_mut().add_ext_field("tenant", "mutated-tenant");
+    assert_eq!(request.original_identity(), original);
+
+    shutdown(runtime).await;
+}
+
+#[tokio::test]
+async fn request_extensions_remain_lazy_replace_values_and_preserve_rejected_values() {
+    let runtime = RuntimeContext::from_current("remoting-request-extensions");
+    let (fixture, _session) = network_fixture(runtime.root_group(), 101, None, false);
+    let mut request = build(fixture).expect("matching trusted facts must build a request");
+
+    assert_eq!(request.extension::<String>(), None);
+    assert_eq!(request.try_insert_extension("first".to_owned()), Ok(None));
+    assert_eq!(request.extension::<String>(), Some(&"first".to_owned()));
+    assert_eq!(
+        request.try_insert_extension("second".to_owned()),
+        Ok(Some("first".to_owned()))
+    );
+    let deadline = crate::deadline::RequestDeadline::after(Duration::from_secs(1));
+    assert_eq!(request.try_insert_extension(deadline), Err(deadline));
+
+    shutdown(runtime).await;
+}
+
+#[tokio::test]
+async fn request_extensions_reject_reserved_request_model_types() {
+    let runtime = RuntimeContext::from_current("remoting-request-reserved-extensions");
+    let (fixture, _session) = network_fixture(runtime.root_group(), 106, None, false);
+    let mut request = build(fixture).expect("matching trusted facts must build a request");
+    let (nested_fixture, _nested_session) = network_fixture(runtime.root_group(), 107, None, false);
+    let nested = build(nested_fixture).expect("matching trusted facts must build a request");
+    let nested_identity = nested.original_identity();
+
+    let returned = match request.try_insert_extension(nested) {
+        Err(value) => value,
+        Ok(_) => panic!("request aggregates must remain reserved extension types"),
+    };
+
+    assert_eq!(returned.original_identity(), nested_identity);
+    assert!(request.extension::<RemotingRequest>().is_none());
+
+    let returned = match request.try_insert_extension(DeferredSlot::default()) {
+        Err(value) => value,
+        Ok(_) => panic!("deferred slots must remain reserved extension types"),
+    };
+    assert!(!returned.is_reserved());
+    assert!(request.extension::<DeferredSlot>().is_none());
+
+    shutdown(runtime).await;
+}
+
+#[tokio::test]
+async fn one_way_requests_cannot_reserve_deferred_response_state() {
+    let runtime = RuntimeContext::from_current("remoting-request-one-way-defer");
+    let (fixture, _session) = network_fixture(runtime.root_group(), 111, None, true);
+    assert_eq!(
+        builder(fixture).reserve_deferred_response().build().err(),
+        Some(RemotingRequestBuildError::OneWayDeferredResponse)
+    );
+
+    let (fixture, _session) = network_fixture(runtime.root_group(), 112, None, false);
+    let request = builder(fixture)
+        .reserve_deferred_response()
+        .build()
+        .expect("non-one-way request may retain the inert deferred slot");
+    assert!(request.has_reserved_deferred_response());
+
+    shutdown(runtime).await;
+}

--- a/rocketmq-transport/src/dispatch/request_context.rs
+++ b/rocketmq-transport/src/dispatch/request_context.rs
@@ -50,6 +50,17 @@ pub struct RequestContext {
     authentication: AuthenticationState,
 }
 
+/// Trusted request facts transferred from ingress into the request builder.
+#[allow(
+    dead_code,
+    reason = "REQ-06 keeps this crate-private transfer object ready for later dispatcher wiring"
+)]
+pub(crate) struct RequestContextParts {
+    pub(crate) deadline: Option<RequestDeadline>,
+    pub(crate) origin: RequestOrigin,
+    pub(crate) authentication: AuthenticationState,
+}
+
 impl RequestContext {
     /// Creates a context for a decoded network command.
     #[must_use]
@@ -154,6 +165,29 @@ impl RequestContext {
     )]
     pub(crate) const fn authentication(&self) -> &AuthenticationState {
         &self.authentication
+    }
+
+    /// Consumes the staging context after trusted ingress has finished
+    /// materializing its request facts.
+    #[allow(
+        dead_code,
+        reason = "REQ-06 consumes staging facts from later dispatcher wiring; current coverage is builder-local"
+    )]
+    pub(crate) fn into_parts(self) -> RequestContextParts {
+        RequestContextParts {
+            deadline: self.deadline,
+            origin: self.origin,
+            authentication: self.authentication,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_parts(parts: RequestContextParts) -> Self {
+        Self {
+            deadline: parts.deadline,
+            origin: parts.origin,
+            authentication: parts.authentication,
+        }
     }
 }
 

--- a/rocketmq-transport/src/dispatch/request_control.rs
+++ b/rocketmq-transport/src/dispatch/request_control.rs
@@ -28,9 +28,14 @@ use tokio_util::sync::CancellationToken;
 use crate::connection::Connection;
 use crate::connection::ConnectionStateHandle;
 use crate::deadline::RequestDeadline;
+use crate::dispatch::remoting_request::DeferredSlot;
+use crate::dispatch::remoting_request::RequestLifecycleProvenance;
+use crate::dispatch::request_context::RequestContextParts;
 use crate::dispatch::AuthenticationState;
 use crate::dispatch::EmbeddedCaller;
+use crate::dispatch::IngressRequestView;
 use crate::dispatch::OriginalRequestIdentity;
+use crate::dispatch::RemotingRequest;
 use crate::dispatch::RequestContext;
 use crate::dispatch::RequestId;
 use crate::dispatch::RequestOrigin;
@@ -211,30 +216,18 @@ impl RequestControlView {
     }
 }
 
-#[allow(
-    dead_code,
-    reason = "REQ-05 establishes the crate-private extension storage before REQ-06 owns it in RemotingRequest"
-)]
 type ExtensionValue = Box<dyn Any + Send + Sync>;
 
 /// Request-local type map that remains unallocated until its first successful insertion.
 ///
 /// Trusted ingress facts and lifecycle capabilities never belong in this map:
 /// they have dedicated read-only request fields and views instead.
-#[allow(
-    dead_code,
-    reason = "REQ-05 establishes the crate-private lazy map before REQ-06 owns it in RemotingRequest"
-)]
 #[derive(Default)]
 pub(crate) struct LazyExtensions {
     values: Option<HashMap<TypeId, ExtensionValue>>,
 }
 
 impl LazyExtensions {
-    #[allow(
-        dead_code,
-        reason = "REQ-05 establishes the crate-private accessor before REQ-06 exposes request extensions"
-    )]
     pub(crate) fn get<T>(&self) -> Option<&T>
     where
         T: Send + Sync + 'static,
@@ -247,10 +240,6 @@ impl LazyExtensions {
     /// Rejected types return their original value and leave the map absent,
     /// preserving the allocation-free request path when no eligible extension
     /// has been inserted.
-    #[allow(
-        dead_code,
-        reason = "REQ-05 establishes the crate-private insertion path before REQ-06 exposes request extensions"
-    )]
     pub(crate) fn try_insert<T>(&mut self, value: T) -> Result<Option<T>, T>
     where
         T: Send + Sync + 'static,
@@ -286,19 +275,24 @@ fn is_reserved_extension_type_id(type_id: TypeId) -> bool {
         TypeId::of::<ConnectionHandlerContextWrapper>(),
         TypeId::of::<ConnectionStateHandle>(),
         TypeId::of::<EmbeddedCaller>(),
+        TypeId::of::<IngressRequestView<'static>>(),
         TypeId::of::<OperationContext>(),
         TypeId::of::<OriginalRequestIdentity>(),
         TypeId::of::<PeerInfo>(),
         TypeId::of::<Principal>(),
         TypeId::of::<ProxyInfoSnapshot>(),
         TypeId::of::<RequestContext>(),
+        TypeId::of::<RequestContextParts>(),
         TypeId::of::<RequestControlView>(),
         TypeId::of::<RequestDeadline>(),
         TypeId::of::<RequestId>(),
         TypeId::of::<RequestMeta>(),
+        TypeId::of::<RequestLifecycleProvenance>(),
+        TypeId::of::<RemotingRequest>(),
         TypeId::of::<RequestOrigin>(),
         TypeId::of::<RequestTransport>(),
         TypeId::of::<ResponseSink>(),
+        TypeId::of::<DeferredSlot>(),
         TypeId::of::<SessionExecutor>(),
         TypeId::of::<SessionHandle>(),
         TypeId::of::<SessionId>(),
@@ -565,5 +559,12 @@ mod tests {
         assert!(is_reserved_extension_type_id(TypeId::of::<SessionExecutor>()));
         assert!(is_reserved_extension_type_id(TypeId::of::<SessionHandle>()));
         assert!(is_reserved_extension_type_id(TypeId::of::<TaskGroup>()));
+        assert!(is_reserved_extension_type_id(
+            TypeId::of::<IngressRequestView<'static>>()
+        ));
+        assert!(is_reserved_extension_type_id(TypeId::of::<RemotingRequest>()));
+        assert!(is_reserved_extension_type_id(TypeId::of::<DeferredSlot>()));
+        assert!(is_reserved_extension_type_id(TypeId::of::<RequestContextParts>()));
+        assert!(is_reserved_extension_type_id(TypeId::of::<RequestLifecycleProvenance>()));
     }
 }

--- a/rocketmq-transport/src/dispatch/request_identity.rs
+++ b/rocketmq-transport/src/dispatch/request_identity.rs
@@ -18,6 +18,7 @@ use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::LanguageCode;
 
 use super::RequestId;
 
@@ -46,8 +47,9 @@ pub(crate) fn reserve_session_owner() -> Option<u64> {
 /// Immutable wire identity captured for one inbound request.
 ///
 /// This value preserves the raw request code, protocol opaque, and one-way flag
-/// as they arrived at the trusted transport boundary. Later hook or processor
-/// mutations of the command cannot change these facts.
+/// as they arrived at the trusted transport boundary, together with the wire
+/// language and version used to decode it. Later hook or processor mutations
+/// of the command cannot change these facts.
 ///
 /// ```compile_fail
 /// use rocketmq_transport::api::v2::OriginalRequestIdentity;
@@ -62,6 +64,8 @@ pub struct OriginalRequestIdentity {
     original_code: i32,
     original_opaque: i32,
     one_way: bool,
+    original_language: LanguageCode,
+    original_version: i32,
 }
 
 impl OriginalRequestIdentity {
@@ -75,6 +79,8 @@ impl OriginalRequestIdentity {
             original_code: command.code(),
             original_opaque: command.opaque(),
             one_way: command.is_oneway_rpc(),
+            original_language: command.language(),
+            original_version: command.version(),
         })
     }
 
@@ -100,6 +106,34 @@ impl OriginalRequestIdentity {
     #[must_use]
     pub const fn is_one_way(self) -> bool {
         self.one_way
+    }
+
+    #[allow(
+        dead_code,
+        reason = "REQ-06 validates the private ingress language before dispatcher integration"
+    )]
+    pub(crate) const fn original_language(self) -> LanguageCode {
+        self.original_language
+    }
+
+    #[allow(
+        dead_code,
+        reason = "REQ-06 validates the private ingress version before dispatcher integration"
+    )]
+    pub(crate) const fn original_version(self) -> i32 {
+        self.original_version
+    }
+
+    #[allow(
+        dead_code,
+        reason = "REQ-06 validates captured command facts before dispatcher integration"
+    )]
+    pub(crate) fn matches_command(self, command: &RemotingCommand) -> bool {
+        self.original_code == command.code()
+            && self.original_opaque == command.opaque()
+            && self.one_way == command.is_oneway_rpc()
+            && self.original_language == command.language()
+            && self.original_version == command.version()
     }
 }
 
@@ -173,10 +207,15 @@ mod tests {
     #[test]
     fn capture_preserves_raw_ingress_facts_and_increases_sequence() {
         let sequence = AtomicU64::new(1);
-        let first = OriginalRequestIdentity::capture(17, &sequence, &request(-123_456, 91).mark_oneway_rpc())
-            .expect("identity should be allocated");
-        let second = OriginalRequestIdentity::capture(17, &sequence, &request(-123_456, 91))
-            .expect("identity should be allocated");
+        let first_command = request(-123_456, 91)
+            .set_language(LanguageCode::JAVA)
+            .set_version(123)
+            .mark_oneway_rpc();
+        let second_command = request(-123_456, 91);
+        let first =
+            OriginalRequestIdentity::capture(17, &sequence, &first_command).expect("identity should be allocated");
+        let second =
+            OriginalRequestIdentity::capture(17, &sequence, &second_command).expect("identity should be allocated");
 
         assert_eq!(first.request_id().owner_id(), 17);
         assert_eq!(first.request_id().sequence(), 1);
@@ -186,6 +225,8 @@ mod tests {
         assert_eq!(first.original_opaque(), 91);
         assert!(first.is_one_way());
         assert!(!second.is_one_way());
+        assert_eq!(first.original_language(), LanguageCode::JAVA);
+        assert_eq!(first.original_version(), 123);
     }
 
     #[test]

--- a/rocketmq-transport/src/lib.rs
+++ b/rocketmq-transport/src/lib.rs
@@ -85,10 +85,11 @@ pub mod api {
 
     /// Curated source API boundary for the 2.x release line.
     ///
-    /// Only immutable request timing, identity, origin, authentication, and
-    /// session facts approved for the 2.x request model are exposed here. This
-    /// narrow surface intentionally excludes legacy channels, session handles,
-    /// operation contexts, and cancellation capabilities.
+    /// The trusted mutable request aggregate and its immutable supporting
+    /// timing, identity, origin, authentication, and session views approved for
+    /// the 2.x request model are exposed here. This narrow surface intentionally
+    /// excludes legacy channels, session handles, operation contexts, and raw
+    /// cancellation authority.
     pub mod v2 {
         pub use crate::public_api_v2::*;
     }

--- a/rocketmq-transport/src/public_api_v2.rs
+++ b/rocketmq-transport/src/public_api_v2.rs
@@ -14,15 +14,17 @@
 
 //! Explicitly approved source API for the 2.x release line.
 //!
-//! This surface exposes only immutable request timing, identity, origin,
-//! authentication, and session facts approved for the 2.x request model.
-//! These facts are read-only DTOs: they do not expose legacy channels, session
-//! handles, operation contexts, or cancellation capabilities.
+//! This surface exposes the trusted mutable request aggregate and its immutable
+//! supporting timing, identity, origin, authentication, and session views
+//! approved for the 2.x request model. It does not expose legacy channels,
+//! session handles, operation contexts, or raw cancellation authority.
 
 pub use crate::deadline::RequestDeadline;
 pub use crate::dispatch::AuthenticationState;
 pub use crate::dispatch::EmbeddedCaller;
+pub use crate::dispatch::IngressRequestView;
 pub use crate::dispatch::OriginalRequestIdentity;
+pub use crate::dispatch::RemotingRequest;
 pub use crate::dispatch::RequestControlView;
 pub use crate::dispatch::RequestId;
 pub use crate::dispatch::RequestMeta;

--- a/rocketmq-transport/src/session_view.rs
+++ b/rocketmq-transport/src/session_view.rs
@@ -33,6 +33,14 @@ impl SessionId {
     pub(crate) const fn from_session_owner(owner_id: u64) -> Self {
         Self(owner_id)
     }
+
+    #[allow(
+        dead_code,
+        reason = "REQ-06 validates request/session ownership before dispatcher integration"
+    )]
+    pub(crate) const fn owner_id(self) -> u64 {
+        self.0
+    }
 }
 
 /// Read-only source and destination facts supplied by a trusted PROXY header.

--- a/rocketmq-transport/tests/public_api_contract.rs
+++ b/rocketmq-transport/tests/public_api_contract.rs
@@ -678,7 +678,15 @@ fn validate_public_api_v2_boundary(boundary: &PublicBoundary) -> Result<(), Stri
         },
         PublicUse {
             module_path: String::new(),
+            use_tree: "crate::dispatch::IngressRequestView".to_owned(),
+        },
+        PublicUse {
+            module_path: String::new(),
             use_tree: "crate::dispatch::OriginalRequestIdentity".to_owned(),
+        },
+        PublicUse {
+            module_path: String::new(),
+            use_tree: "crate::dispatch::RemotingRequest".to_owned(),
         },
         PublicUse {
             module_path: String::new(),
@@ -719,7 +727,7 @@ fn validate_public_api_v2_boundary(boundary: &PublicBoundary) -> Result<(), Stri
     Ok(())
 }
 
-const CURATED_V2_REEXPORTS: &str = "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::RequestControlView; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestMeta; pub use crate::dispatch::RequestOrigin; pub use crate::session_view::ProxyInfoSnapshot; pub use crate::session_view::SessionId; pub use crate::session_view::SessionStateView; pub use crate::session_view::SessionView;";
+const CURATED_V2_REEXPORTS: &str = "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::IngressRequestView; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::RemotingRequest; pub use crate::dispatch::RequestControlView; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestMeta; pub use crate::dispatch::RequestOrigin; pub use crate::session_view::ProxyInfoSnapshot; pub use crate::session_view::SessionId; pub use crate::session_view::SessionStateView; pub use crate::session_view::SessionView;";
 
 #[test]
 fn lib_rs_exposes_only_the_curated_versioned_boundary() {
@@ -757,7 +765,9 @@ expose_extra!();
 pub use crate::deadline::RequestDeadline;
 pub use crate::dispatch::AuthenticationState;
 pub use crate::dispatch::EmbeddedCaller;
+pub use crate::dispatch::IngressRequestView;
 pub use crate::dispatch::OriginalRequestIdentity;
+pub use crate::dispatch::RemotingRequest;
 pub use crate::dispatch::RequestControlView;
 pub use crate::dispatch::RequestId;
 pub use crate::dispatch::RequestMeta;

--- a/rocketmq-transport/tests/public_api_v2.rs
+++ b/rocketmq-transport/tests/public_api_v2.rs
@@ -15,13 +15,17 @@
 use std::future::Future;
 use std::time::Duration;
 
+use cheetah_string::CheetahString;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_security_api::Principal;
 use rocketmq_transport::api::v1::RequestDeadline as V1RequestDeadline;
 use rocketmq_transport::api::v1::RequestId as V1RequestId;
 use rocketmq_transport::api::v2::AuthenticationState;
 use rocketmq_transport::api::v2::EmbeddedCaller;
+use rocketmq_transport::api::v2::IngressRequestView;
 use rocketmq_transport::api::v2::OriginalRequestIdentity;
 use rocketmq_transport::api::v2::ProxyInfoSnapshot;
+use rocketmq_transport::api::v2::RemotingRequest;
 use rocketmq_transport::api::v2::RequestControlView;
 use rocketmq_transport::api::v2::RequestDeadline as V2RequestDeadline;
 use rocketmq_transport::api::v2::RequestId as V2RequestId;
@@ -66,6 +70,26 @@ fn assert_request_control_contract(control: Option<RequestControlView>) {
         let _: Option<V2RequestDeadline> = control.deadline();
         let _: bool = control.is_cancelled();
         std::mem::drop(cancelled(&control));
+    }
+}
+
+fn assert_ingress_view_contract(view: IngressRequestView<'_>) {
+    let _: V2RequestId = view.original_identity().request_id();
+    let _: Option<&std::collections::HashMap<CheetahString, CheetahString>> = view.ext_fields();
+}
+
+fn assert_remoting_request_contract(request: Option<RemotingRequest>) {
+    if let Some(mut request) = request {
+        let _: OriginalRequestIdentity = request.original_identity();
+        let _: &RequestMeta = request.meta();
+        let _: &RequestOrigin = request.origin();
+        let _: &AuthenticationState = request.authentication();
+        let _: &SessionView = request.session();
+        let _: &RequestControlView = request.control();
+        let _: &RemotingCommand = request.command();
+        let _: &mut RemotingCommand = request.command_mut();
+        let _: Option<&String> = request.extension::<String>();
+        let _: Result<Option<String>, String> = request.try_insert_extension("v2-extension".to_owned());
     }
 }
 
@@ -155,4 +179,10 @@ fn v2_exposes_read_only_network_and_embedded_session_views() {
 fn v2_exposes_read_only_request_metadata_and_control() {
     assert_request_meta_contract(None);
     assert_request_control_contract(None);
+}
+
+#[test]
+fn v2_exposes_the_request_aggregate_and_ingress_view_without_legacy_reexports() {
+    let _: fn(IngressRequestView<'_>) = assert_ingress_view_contract;
+    assert_remoting_request_contract(None);
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-that-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #9771

### Brief Description

Adds the trusted V2 `RemotingRequest` aggregate and its constrained builder. The builder derives immutable request metadata and observer-only control state from a sealed, single-source lifecycle provenance so callers cannot mix a session with an unrelated parent task group.

The request exposes intentional command mutation and lazy typed extensions while preserving immutable original identity, origin, authentication, session, deadline, and cancellation observations. A borrowed `IngressRequestView` supports pre-mutation policy checks without copying request bodies. The curated V2 API remains free of legacy channels, session handles, operation contexts, and raw cancellation authority.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-transport -- --check`
- `cargo test -p rocketmq-transport --all-features -- --test-threads=1`
- `cargo test -p rocketmq-transport --doc`
- `cargo doc -p rocketmq-transport --all-features --no-deps`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- Runtime ownership boundary audit with baseline enforcement
- MCP read-only dependency boundary check
- MCP `cargo check --locked`
- MCP `cargo test --locked`
- MCP `cargo test --locked --all-features`
- MCP `cargo clippy --locked --all-targets --features streamable-http -- -D warnings`
- MCP `cargo doc --locked --no-deps`
- `git diff --check`

The MCP workspace-wide formatter could not start on Windows because the generated rustfmt command exceeded the OS command-line length limit; the equivalent package-scoped `cargo fmt -p rocketmq-mcp -- --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added trusted request handling for remoting operations.
  * Added immutable ingress views for inspecting original request identity and metadata.
  * Exposed request identity, command, session, authentication, origin, control, and extension details through the v2 API.
  * Added validation to reject inconsistent request identities, sessions, origins, authentication, and invalid deferred responses.

* **Documentation**
  * Updated v2 API documentation to describe the new request interfaces.

* **Tests**
  * Added comprehensive coverage for request construction, validation, extensions, lifecycle handling, and public API boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->