### PR TITLE
[ISSUE #9772]✨Add the owned V2 ResponsePlan model

### DIFF
--- a/rocketmq-transport/src/dispatch.rs
+++ b/rocketmq-transport/src/dispatch.rs
@@ -19,6 +19,7 @@ mod request_control;
 mod request_identity;
 mod request_origin;
 mod response;
+mod response_plan;
 mod response_sink;
 
 pub use authorized_dispatcher::AuthorizedCommandDispatcher;
@@ -44,6 +45,9 @@ pub use response::ResponseErrorKind;
 pub use response::ResponseReceipt;
 pub use response::ResponseTerminalState;
 pub use response::WriteProgress;
+pub use response_plan::ResponseBodyKind;
+pub use response_plan::ResponsePlan;
+pub use response_plan::ResponsePlanError;
 pub use response_sink::LocalResponseReceiver;
 pub use response_sink::ResponseSink;
 pub use response_sink::ResponseSinkError;

--- a/rocketmq-transport/src/dispatch/response_plan.rs
+++ b/rocketmq-transport/src/dispatch/response_plan.rs
@@ -1,0 +1,577 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Owned V2 response heads and body storage.
+
+use std::fmt;
+
+use bytes::Bytes;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+
+use crate::file_region::FileRegionSequence;
+
+const MAX_RESPONSE_BODY_LEN: u64 = i32::MAX as u64 - 4;
+
+/// A validated response head and exactly one owned response body.
+///
+/// The head never carries a body. Instead, the plan owns either no body,
+/// contiguous bytes, body-only segments, or a validated file-region sequence.
+/// This keeps response metadata available to processors and later dispatch
+/// stages without exposing response storage, an encoder, or file handles.
+///
+/// Instances are intentionally not [`Clone`]. Cloning could duplicate mutable
+/// response ownership or file-region leases.
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::ResponsePlan;
+///
+/// fn cannot_clone(plan: &ResponsePlan) {
+///     let _: ResponsePlan = plan.clone();
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::ResponsePlan;
+///
+/// fn cannot_construct_with_fields() {
+///     let _ = ResponsePlan {
+///         head: panic!(),
+///         body: panic!(),
+///         body_len: 0,
+///         body_part_count: 0,
+///     };
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::ResponsePlan;
+///
+/// fn cannot_read_the_body(plan: &ResponsePlan) {
+///     let _ = plan.body();
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::ResponsePlan;
+///
+/// fn cannot_read_the_head(plan: &ResponsePlan) {
+///     let _ = plan.head();
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::ResponsePlan;
+///
+/// fn cannot_read_contiguous_body_bytes(plan: &ResponsePlan) {
+///     let _ = plan.bytes();
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::ResponsePlan;
+///
+/// fn cannot_read_body_segments(plan: &ResponsePlan) {
+///     let _ = plan.segments();
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::ResponsePlan;
+///
+/// fn cannot_read_file_regions(plan: &ResponsePlan) {
+///     let _ = plan.file_regions();
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::ResponseBody;
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::FileRegionLease;
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::ResponsePlan;
+///
+/// fn cannot_encode_an_arbitrary_complete_frame(plan: ResponsePlan) {
+///     let _ = plan.into_bytes();
+/// }
+/// ```
+pub struct ResponsePlan {
+    head: RemotingCommand,
+    body: ResponseBody,
+    body_len: usize,
+    body_part_count: usize,
+}
+
+impl ResponsePlan {
+    /// Creates a response with an empty body.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ResponsePlanError`] when `head` already owns a body, is a
+    /// request command, or is marked one-way.
+    pub fn command(head: RemotingCommand) -> Result<Self, ResponsePlanError> {
+        Self::validate_head(&head)?;
+        Ok(Self::new(head, ResponseBody::Empty, 0, 0))
+    }
+
+    /// Creates a response with one contiguous body allocation.
+    ///
+    /// Empty input is normalized to [`ResponseBodyKind::Empty`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ResponsePlanError`] when the head is invalid or the body
+    /// exceeds the protocol's absolute representable length.
+    pub fn bytes(head: RemotingCommand, body: Bytes) -> Result<Self, ResponsePlanError> {
+        Self::validate_head(&head)?;
+        let body_len = checked_body_len([body.len() as u64])?;
+        if body.is_empty() {
+            return Ok(Self::new(head, ResponseBody::Empty, 0, 0));
+        }
+        Ok(Self::new(head, ResponseBody::Bytes(body), body_len, 1))
+    }
+
+    /// Creates a response from ordered body-only byte segments.
+    ///
+    /// Empty segments are discarded. The remaining segment bytes are accepted
+    /// as body data without interpreting bytes that resemble a frame prefix.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ResponsePlanError`] when the head is invalid, segment lengths
+    /// overflow, or the aggregate body exceeds the protocol's absolute limit.
+    pub fn segments(head: RemotingCommand, body_segments: Vec<Bytes>) -> Result<Self, ResponsePlanError> {
+        Self::validate_head(&head)?;
+        let body_segments = body_segments
+            .into_iter()
+            .filter(|segment| !segment.is_empty())
+            .collect::<Vec<_>>();
+        let body_len = checked_body_len(body_segments.iter().map(|segment| segment.len() as u64))?;
+        let body_part_count = body_segments.len();
+        if body_segments.is_empty() {
+            return Ok(Self::new(head, ResponseBody::Empty, 0, 0));
+        }
+        Ok(Self::new(
+            head,
+            ResponseBody::Segments(body_segments),
+            body_len,
+            body_part_count,
+        ))
+    }
+
+    /// Creates a response with validated, leased external file regions.
+    ///
+    /// This constructor retains the supplied sequence by value and uses its
+    /// cached aggregate length. It does not re-stat the source files.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ResponsePlanError`] when the head is invalid, the sequence
+    /// length overflows, or the aggregate body exceeds the protocol's absolute
+    /// limit.
+    pub fn file_regions(head: RemotingCommand, regions: FileRegionSequence) -> Result<Self, ResponsePlanError> {
+        Self::validate_head(&head)?;
+        let body_len = checked_body_len([regions.len()])?;
+        let body_part_count = regions.regions().len();
+        Ok(Self::new(
+            head,
+            ResponseBody::FileRegions(regions),
+            body_len,
+            body_part_count,
+        ))
+    }
+
+    /// Returns the response code from the validated head.
+    #[must_use]
+    pub fn response_code(&self) -> i32 {
+        self.head.code()
+    }
+
+    /// Returns the storage category of the owned response body.
+    #[must_use]
+    pub const fn body_kind(&self) -> ResponseBodyKind {
+        self.body.kind()
+    }
+
+    /// Returns the validated aggregate body length in bytes.
+    #[must_use]
+    pub const fn body_len(&self) -> usize {
+        self.body_len
+    }
+
+    /// Returns the number of contiguous body allocations, segments, or file
+    /// regions retained by this plan.
+    ///
+    /// Empty plans contain zero parts, contiguous byte plans contain one part,
+    /// and segmented or file-region plans contain their respective number of
+    /// retained body parts.
+    #[must_use]
+    pub const fn body_part_count(&self) -> usize {
+        self.body_part_count
+    }
+
+    fn new(head: RemotingCommand, body: ResponseBody, body_len: usize, body_part_count: usize) -> Self {
+        Self {
+            head,
+            body,
+            body_len,
+            body_part_count,
+        }
+    }
+
+    fn validate_head(head: &RemotingCommand) -> Result<(), ResponsePlanError> {
+        if head.body().is_some() {
+            return Err(ResponsePlanError::HeadHasBody);
+        }
+        if !head.is_response_type() {
+            return Err(ResponsePlanError::RequestHead);
+        }
+        if head.is_oneway_rpc() {
+            return Err(ResponsePlanError::OneWayHead);
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for ResponsePlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ResponsePlan")
+            .field("response_code", &self.response_code())
+            .field("body_kind", &self.body_kind())
+            .field("body_len", &self.body_len())
+            .field("body_part_count", &self.body_part_count())
+            .finish()
+    }
+}
+
+/// Metadata category for the one body owner in a [`ResponsePlan`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum ResponseBodyKind {
+    /// The plan has no body owner.
+    Empty,
+    /// The plan owns one contiguous [`Bytes`] value.
+    Bytes,
+    /// The plan owns ordered body-only [`Bytes`] segments.
+    Segments,
+    /// The plan owns an ordered sequence of validated file regions.
+    FileRegions,
+}
+
+/// Internal storage owned by a [`ResponsePlan`].
+///
+/// This type remains crate-private so V2 processors can choose an explicit
+/// constructor without recovering the stored bytes, file leases, or an
+/// arbitrary encoded frame.
+pub(crate) enum ResponseBody {
+    Empty,
+    Bytes(Bytes),
+    Segments(Vec<Bytes>),
+    FileRegions(FileRegionSequence),
+}
+
+impl ResponseBody {
+    const fn kind(&self) -> ResponseBodyKind {
+        match self {
+            Self::Empty => ResponseBodyKind::Empty,
+            Self::Bytes(bytes) => {
+                debug_assert!(!bytes.is_empty());
+                ResponseBodyKind::Bytes
+            }
+            Self::Segments(segments) => {
+                debug_assert!(!segments.is_empty());
+                ResponseBodyKind::Segments
+            }
+            Self::FileRegions(regions) => {
+                debug_assert!(!regions.is_empty());
+                ResponseBodyKind::FileRegions
+            }
+        }
+    }
+}
+
+/// Failure returned while constructing a [`ResponsePlan`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum ResponsePlanError {
+    /// The supplied response head already owns a body, including an empty one.
+    #[error("response plan head must not already own a body")]
+    HeadHasBody,
+    /// The supplied head is a request command rather than a response command.
+    #[error("response plan head must be a response command")]
+    RequestHead,
+    /// The supplied response head is marked one-way.
+    #[error("response plan head must not be one-way")]
+    OneWayHead,
+    /// Adding body part lengths exceeded the protocol's length representation.
+    #[error("response plan body length overflowed u64")]
+    BodyLengthOverflow,
+    /// The body exceeds the absolute RocketMQ frame body ceiling.
+    #[error("response plan body length {actual} exceeds the maximum {MAX_RESPONSE_BODY_LEN}")]
+    BodyTooLarge {
+        /// Aggregate byte length supplied to the constructor.
+        actual: u64,
+    },
+    /// The wire-representable body length does not fit this platform's address space.
+    #[error("response plan body length {actual} is not representable as usize")]
+    BodyLengthNotRepresentable {
+        /// Aggregate byte length supplied to the constructor.
+        actual: u64,
+    },
+}
+
+fn checked_body_len<I>(lengths: I) -> Result<usize, ResponsePlanError>
+where
+    I: IntoIterator<Item = u64>,
+{
+    let mut body_len = 0_u64;
+    for len in lengths {
+        body_len = body_len.checked_add(len).ok_or(ResponsePlanError::BodyLengthOverflow)?;
+    }
+    if body_len > MAX_RESPONSE_BODY_LEN {
+        return Err(ResponsePlanError::BodyTooLarge { actual: body_len });
+    }
+    usize::try_from(body_len).map_err(|_| ResponsePlanError::BodyLengthNotRepresentable { actual: body_len })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::io::Write;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::file_region::FileRegion;
+    use crate::file_region::FileRegionLease;
+
+    fn response_head() -> RemotingCommand {
+        RemotingCommand::create_response_command_with_code(7)
+    }
+
+    fn assert_metadata(plan: &ResponsePlan, kind: ResponseBodyKind, body_len: usize, body_part_count: usize) {
+        assert_eq!(plan.response_code(), 7);
+        assert_eq!(plan.body_kind(), kind);
+        assert_eq!(plan.body_len(), body_len);
+        assert_eq!(plan.body_part_count(), body_part_count);
+    }
+
+    #[test]
+    fn constructors_keep_exactly_one_normalized_body_owner() {
+        let empty = ResponsePlan::command(response_head()).expect("valid empty response");
+        assert_metadata(&empty, ResponseBodyKind::Empty, 0, 0);
+
+        let bytes = ResponsePlan::bytes(response_head(), Bytes::from_static(b"bytes")).expect("valid bytes response");
+        assert_metadata(&bytes, ResponseBodyKind::Bytes, 5, 1);
+
+        let segments = ResponsePlan::segments(
+            response_head(),
+            vec![
+                Bytes::new(),
+                Bytes::from_static(b"left"),
+                Bytes::new(),
+                Bytes::from_static(b"right"),
+            ],
+        )
+        .expect("valid segmented response");
+        assert_metadata(&segments, ResponseBodyKind::Segments, 9, 2);
+    }
+
+    #[test]
+    fn segments_discard_empty_values_without_moving_non_empty_backing_storage() {
+        let left = Bytes::from_static(b"left");
+        let right = Bytes::from_static(b"right");
+        let left_ptr = left.as_ptr();
+        let right_ptr = right.as_ptr();
+
+        let plan = ResponsePlan::segments(response_head(), vec![Bytes::new(), left, Bytes::new(), right])
+            .expect("valid segmented response");
+
+        let ResponseBody::Segments(segments) = &plan.body else {
+            panic!("non-empty segments must retain their segmented body owner");
+        };
+        assert_eq!(segments.len(), 2);
+        assert_eq!(segments[0].as_ptr(), left_ptr);
+        assert_eq!(segments[1].as_ptr(), right_ptr);
+    }
+
+    #[test]
+    fn empty_bytes_and_segments_normalize_to_empty() {
+        let bytes = ResponsePlan::bytes(response_head(), Bytes::new()).expect("empty bytes normalize");
+        assert_metadata(&bytes, ResponseBodyKind::Empty, 0, 0);
+
+        let segments = ResponsePlan::segments(response_head(), vec![Bytes::new(), Bytes::new()])
+            .expect("empty segments normalize");
+        assert_metadata(&segments, ResponseBodyKind::Empty, 0, 0);
+    }
+
+    #[test]
+    fn segments_accept_payloads_that_resemble_frame_prefixes() {
+        let plan = ResponsePlan::segments(response_head(), vec![Bytes::from_static(&[0, 0, 0, 2, 0x7f, 0xff])])
+            .expect("body-only segments do not parse frame contents");
+
+        assert_metadata(&plan, ResponseBodyKind::Segments, 6, 1);
+    }
+
+    #[test]
+    fn constructors_reject_invalid_response_heads() {
+        let head_with_empty_body = response_head().set_body(Bytes::new());
+        assert!(matches!(
+            ResponsePlan::command(head_with_empty_body),
+            Err(ResponsePlanError::HeadHasBody)
+        ));
+
+        let request_head = RemotingCommand::create_remoting_command(7);
+        assert!(matches!(
+            ResponsePlan::command(request_head),
+            Err(ResponsePlanError::RequestHead)
+        ));
+
+        let one_way_head = response_head().mark_oneway_rpc();
+        assert!(matches!(
+            ResponsePlan::command(one_way_head),
+            Err(ResponsePlanError::OneWayHead)
+        ));
+    }
+
+    fn file_region_sequence_with_len(len: u64) -> FileRegionSequence {
+        let file = tempfile::tempfile().expect("temporary sparse file");
+        file.set_len(len).expect("set sparse file length");
+        let region = FileRegion::try_new(Arc::new(file), 0, len).expect("validated sparse region");
+        FileRegionSequence::try_new(vec![region]).expect("validated sparse region sequence")
+    }
+
+    #[test]
+    fn every_body_constructor_validates_its_response_head() {
+        let body_head = response_head().set_body(Bytes::new());
+        assert!(matches!(
+            ResponsePlan::bytes(body_head, Bytes::from_static(b"body")),
+            Err(ResponsePlanError::HeadHasBody)
+        ));
+
+        let request_head = RemotingCommand::create_remoting_command(7);
+        assert!(matches!(
+            ResponsePlan::segments(request_head, vec![Bytes::from_static(b"segment")]),
+            Err(ResponsePlanError::RequestHead)
+        ));
+
+        let one_way_head = response_head().mark_oneway_rpc();
+        assert!(matches!(
+            ResponsePlan::file_regions(one_way_head, file_region_sequence_with_len(1)),
+            Err(ResponsePlanError::OneWayHead)
+        ));
+    }
+
+    #[test]
+    fn checked_length_rejects_overflow_and_the_absolute_protocol_ceiling() {
+        assert_eq!(
+            checked_body_len([MAX_RESPONSE_BODY_LEN]).expect("exact limit"),
+            usize::try_from(MAX_RESPONSE_BODY_LEN).expect("protocol ceiling fits usize")
+        );
+        assert_eq!(
+            checked_body_len([MAX_RESPONSE_BODY_LEN + 1]),
+            Err(ResponsePlanError::BodyTooLarge {
+                actual: MAX_RESPONSE_BODY_LEN + 1,
+            })
+        );
+        assert_eq!(
+            checked_body_len([u64::MAX, 1]),
+            Err(ResponsePlanError::BodyLengthOverflow)
+        );
+    }
+
+    #[test]
+    fn file_region_constructor_enforces_the_absolute_body_ceiling_without_writing_the_sparse_file() {
+        let body_len = MAX_RESPONSE_BODY_LEN + 1;
+        let regions = file_region_sequence_with_len(body_len);
+
+        assert!(matches!(
+            ResponsePlan::file_regions(response_head(), regions),
+            Err(ResponsePlanError::BodyTooLarge { actual }) if actual == body_len
+        ));
+    }
+
+    #[test]
+    fn debug_uses_metadata_without_head_body_or_file_details() {
+        let mut head = response_head().set_remark("response-remark-secret");
+        head.add_ext_field("response-ext-key-secret", "response-ext-value-secret");
+        let bytes =
+            ResponsePlan::bytes(head, Bytes::from_static(b"response-body-secret")).expect("valid bytes response");
+        let debug = format!("{bytes:?}");
+
+        assert!(debug.contains("ResponsePlan"));
+        assert!(debug.contains("body_kind: Bytes"));
+        assert!(!debug.contains("response-remark-secret"));
+        assert!(!debug.contains("response-ext-key-secret"));
+        assert!(!debug.contains("response-ext-value-secret"));
+        assert!(!debug.contains("response-body-secret"));
+        assert!(!debug.contains("head:"));
+        assert!(!debug.contains("body:"));
+    }
+
+    struct CountingLease {
+        file: File,
+        drops: Arc<AtomicUsize>,
+        file_accesses: Arc<AtomicUsize>,
+    }
+
+    impl Drop for CountingLease {
+        fn drop(&mut self) {
+            self.drops.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    impl FileRegionLease for CountingLease {
+        fn file(&self) -> &File {
+            self.file_accesses.fetch_add(1, Ordering::SeqCst);
+            &self.file
+        }
+    }
+
+    #[test]
+    fn file_regions_retain_the_validated_lease_without_restatting_or_extra_clones() {
+        let drops = Arc::new(AtomicUsize::new(0));
+        let file_accesses = Arc::new(AtomicUsize::new(0));
+        let mut file = tempfile::tempfile().expect("temporary file");
+        file.write_all(b"leased body").expect("write leased body");
+        let lease = Arc::new(CountingLease {
+            file,
+            drops: drops.clone(),
+            file_accesses: file_accesses.clone(),
+        });
+        let region = FileRegion::try_new(lease.clone(), 0, 11).expect("validated region");
+        assert_eq!(file_accesses.load(Ordering::SeqCst), 1);
+        let regions = FileRegionSequence::try_new(vec![region]).expect("validated region sequence");
+
+        assert_eq!(Arc::strong_count(&lease), 2);
+        let plan = ResponsePlan::file_regions(response_head(), regions).expect("valid file-region response");
+        assert_eq!(file_accesses.load(Ordering::SeqCst), 1);
+        assert_metadata(&plan, ResponseBodyKind::FileRegions, 11, 1);
+        assert_eq!(Arc::strong_count(&lease), 2);
+        let debug = format!("{plan:?}");
+        assert!(!debug.contains("FileRegion {"));
+        assert!(!debug.contains("offset"));
+        assert!(!debug.contains("lease"));
+        assert_eq!(file_accesses.load(Ordering::SeqCst), 1);
+
+        drop(plan);
+        assert_eq!(Arc::strong_count(&lease), 1);
+        assert_eq!(drops.load(Ordering::SeqCst), 0);
+        drop(lease);
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+    }
+}

--- a/rocketmq-transport/src/lib.rs
+++ b/rocketmq-transport/src/lib.rs
@@ -85,11 +85,12 @@ pub mod api {
 
     /// Curated source API boundary for the 2.x release line.
     ///
-    /// The trusted mutable request aggregate and its immutable supporting
-    /// timing, identity, origin, authentication, and session views approved for
-    /// the 2.x request model are exposed here. This narrow surface intentionally
-    /// excludes legacy channels, session handles, operation contexts, and raw
-    /// cancellation authority.
+    /// This surface exposes the trusted mutable request aggregate, immutable
+    /// ingress facts, and an owned [`ResponsePlan`](crate::api::v2::ResponsePlan).
+    /// A response plan provides only response metadata; raw body storage,
+    /// complete-frame encoders, response sinks, and raw file leases remain
+    /// private to the transport. Legacy channels, session handles, operation
+    /// contexts, and other legacy transport authority are also excluded.
     pub mod v2 {
         pub use crate::public_api_v2::*;
     }

--- a/rocketmq-transport/src/public_api_v2.rs
+++ b/rocketmq-transport/src/public_api_v2.rs
@@ -14,10 +14,10 @@
 
 //! Explicitly approved source API for the 2.x release line.
 //!
-//! This surface exposes the trusted mutable request aggregate and its immutable
-//! supporting timing, identity, origin, authentication, and session views
-//! approved for the 2.x request model. It does not expose legacy channels,
-//! session handles, operation contexts, or raw cancellation authority.
+//! This surface exposes the trusted mutable request aggregate, immutable
+//! ingress facts, and owned V2 response plan approved for the 2.x request
+//! model. It does not expose legacy channels, session handles, operation
+//! contexts, raw cancellation authority, response bodies, or encoded frames.
 
 pub use crate::deadline::RequestDeadline;
 pub use crate::dispatch::AuthenticationState;
@@ -29,6 +29,11 @@ pub use crate::dispatch::RequestControlView;
 pub use crate::dispatch::RequestId;
 pub use crate::dispatch::RequestMeta;
 pub use crate::dispatch::RequestOrigin;
+pub use crate::dispatch::ResponseBodyKind;
+pub use crate::dispatch::ResponsePlan;
+pub use crate::dispatch::ResponsePlanError;
+pub use crate::file_region::FileRegion;
+pub use crate::file_region::FileRegionSequence;
 pub use crate::session_view::ProxyInfoSnapshot;
 pub use crate::session_view::SessionId;
 pub use crate::session_view::SessionStateView;

--- a/rocketmq-transport/tests/public_api_contract.rs
+++ b/rocketmq-transport/tests/public_api_contract.rs
@@ -706,6 +706,26 @@ fn validate_public_api_v2_boundary(boundary: &PublicBoundary) -> Result<(), Stri
         },
         PublicUse {
             module_path: String::new(),
+            use_tree: "crate::dispatch::ResponseBodyKind".to_owned(),
+        },
+        PublicUse {
+            module_path: String::new(),
+            use_tree: "crate::dispatch::ResponsePlan".to_owned(),
+        },
+        PublicUse {
+            module_path: String::new(),
+            use_tree: "crate::dispatch::ResponsePlanError".to_owned(),
+        },
+        PublicUse {
+            module_path: String::new(),
+            use_tree: "crate::file_region::FileRegion".to_owned(),
+        },
+        PublicUse {
+            module_path: String::new(),
+            use_tree: "crate::file_region::FileRegionSequence".to_owned(),
+        },
+        PublicUse {
+            module_path: String::new(),
             use_tree: "crate::session_view::ProxyInfoSnapshot".to_owned(),
         },
         PublicUse {
@@ -727,7 +747,7 @@ fn validate_public_api_v2_boundary(boundary: &PublicBoundary) -> Result<(), Stri
     Ok(())
 }
 
-const CURATED_V2_REEXPORTS: &str = "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::IngressRequestView; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::RemotingRequest; pub use crate::dispatch::RequestControlView; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestMeta; pub use crate::dispatch::RequestOrigin; pub use crate::session_view::ProxyInfoSnapshot; pub use crate::session_view::SessionId; pub use crate::session_view::SessionStateView; pub use crate::session_view::SessionView;";
+const CURATED_V2_REEXPORTS: &str = "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::IngressRequestView; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::RemotingRequest; pub use crate::dispatch::RequestControlView; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestMeta; pub use crate::dispatch::RequestOrigin; pub use crate::dispatch::ResponseBodyKind; pub use crate::dispatch::ResponsePlan; pub use crate::dispatch::ResponsePlanError; pub use crate::file_region::FileRegion; pub use crate::file_region::FileRegionSequence; pub use crate::session_view::ProxyInfoSnapshot; pub use crate::session_view::SessionId; pub use crate::session_view::SessionStateView; pub use crate::session_view::SessionView;";
 
 #[test]
 fn lib_rs_exposes_only_the_curated_versioned_boundary() {
@@ -736,7 +756,7 @@ fn lib_rs_exposes_only_the_curated_versioned_boundary() {
 }
 
 #[test]
-fn public_api_v2_exposes_exactly_the_curated_request_and_session_fact_types() {
+fn public_api_v2_exposes_exactly_the_curated_request_session_and_response_types() {
     let boundary =
         inspect_public_boundary(include_str!("../src/public_api_v2.rs")).expect("public_api_v2.rs must tokenize");
 

--- a/rocketmq-transport/tests/public_api_v2.rs
+++ b/rocketmq-transport/tests/public_api_v2.rs
@@ -15,6 +15,7 @@
 use std::future::Future;
 use std::time::Duration;
 
+use bytes::Bytes;
 use cheetah_string::CheetahString;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_security_api::Principal;
@@ -22,6 +23,8 @@ use rocketmq_transport::api::v1::RequestDeadline as V1RequestDeadline;
 use rocketmq_transport::api::v1::RequestId as V1RequestId;
 use rocketmq_transport::api::v2::AuthenticationState;
 use rocketmq_transport::api::v2::EmbeddedCaller;
+use rocketmq_transport::api::v2::FileRegion;
+use rocketmq_transport::api::v2::FileRegionSequence;
 use rocketmq_transport::api::v2::IngressRequestView;
 use rocketmq_transport::api::v2::OriginalRequestIdentity;
 use rocketmq_transport::api::v2::ProxyInfoSnapshot;
@@ -31,6 +34,9 @@ use rocketmq_transport::api::v2::RequestDeadline as V2RequestDeadline;
 use rocketmq_transport::api::v2::RequestId as V2RequestId;
 use rocketmq_transport::api::v2::RequestMeta;
 use rocketmq_transport::api::v2::RequestOrigin;
+use rocketmq_transport::api::v2::ResponseBodyKind;
+use rocketmq_transport::api::v2::ResponsePlan;
+use rocketmq_transport::api::v2::ResponsePlanError;
 use rocketmq_transport::api::v2::SessionId;
 use rocketmq_transport::api::v2::SessionStateView;
 use rocketmq_transport::api::v2::SessionView;
@@ -91,6 +97,30 @@ fn assert_remoting_request_contract(request: Option<RemotingRequest>) {
         let _: Option<&String> = request.extension::<String>();
         let _: Result<Option<String>, String> = request.try_insert_extension("v2-extension".to_owned());
     }
+}
+
+fn assert_file_region_dto_contract(_: Option<FileRegion>, _: Option<FileRegionSequence>) {}
+
+fn assert_error_contract<T: std::error::Error>() {}
+
+fn assert_response_plan_contract(plan: Option<ResponsePlan>) {
+    if let Some(plan) = plan {
+        let _: i32 = plan.response_code();
+        let _: ResponseBodyKind = plan.body_kind();
+        let _: usize = plan.body_len();
+        let _: usize = plan.body_part_count();
+    }
+
+    let _: fn(RemotingCommand) -> Result<ResponsePlan, ResponsePlanError> = ResponsePlan::command;
+    let _: fn(RemotingCommand, Bytes) -> Result<ResponsePlan, ResponsePlanError> = ResponsePlan::bytes;
+    let _: fn(RemotingCommand, Vec<Bytes>) -> Result<ResponsePlan, ResponsePlanError> = ResponsePlan::segments;
+    let _: fn(RemotingCommand, FileRegionSequence) -> Result<ResponsePlan, ResponsePlanError> =
+        ResponsePlan::file_regions;
+    let _ = ResponseBodyKind::Empty;
+    let _ = ResponseBodyKind::Bytes;
+    let _ = ResponseBodyKind::Segments;
+    let _ = ResponseBodyKind::FileRegions;
+    assert_error_contract::<ResponsePlanError>();
 }
 
 fn assert_session_view_contract(view: SessionView) {
@@ -185,4 +215,10 @@ fn v2_exposes_read_only_request_metadata_and_control() {
 fn v2_exposes_the_request_aggregate_and_ingress_view_without_legacy_reexports() {
     let _: fn(IngressRequestView<'_>) = assert_ingress_view_contract;
     assert_remoting_request_contract(None);
+}
+
+#[test]
+fn v2_exposes_only_response_plan_metadata_and_file_region_construction_dtos() {
+    assert_response_plan_contract(None);
+    assert_file_region_dto_contract(None, None);
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and link this pull request to that issue using keywords to ensure automatic closure. -->

- Fixes #9772

### Brief Description

Adds the owned, non-`Clone` V2 `ResponsePlan` model for empty, contiguous bytes, body-only segments, and validated file-region sequences. Constructors enforce response-only heads, reject one-way or pre-populated heads, use checked protocol-length arithmetic, normalize empty byte/segment bodies, and retain body allocations and file leases without encoding, coalescing, or re-statting them.

The public V2 surface exposes only response metadata and the DTOs needed to construct file-region plans. Raw response storage, file leases, encoded-frame capabilities, encoders, sinks, and legacy transport authority remain private. Compile-fail contracts freeze those boundaries.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-transport -- --check`
- Focused response-plan and public API contract tests
- `cargo test -p rocketmq-transport --all-features`
- `cargo test -p rocketmq-transport --doc`
- `cargo doc -p rocketmq-transport --all-features --no-deps`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- Standalone `rocketmq-example` Clippy and package-scoped format check
- MCP read-only dependency boundary check
- MCP `cargo check --locked`
- MCP `cargo test --locked`
- MCP `cargo test --locked --all-features`
- MCP `cargo clippy --locked --all-targets --features streamable-http -- -D warnings`
- MCP `cargo doc --locked --no-deps`
- `git diff --check`

The repository error-architecture guard still reports existing findings in unchanged store, broker, and endpoint-state files. None of those files are in this PR, and the new response-plan module produces no guard finding.

On Windows, the standalone `cargo fmt --all -- --check` commands for the example and MCP projects exceed the OS command-line length limit because they expand all path dependencies. The equivalent package-scoped format checks passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a public response-planning API for constructing validated responses.
  - Supports empty bodies, contiguous bytes, segmented payloads, and file regions.
  - Exposes response metadata including status code, body type, length, and part count.
  - Added structured errors for invalid response headers and body-size limits.
  - Added public file-region types for file-backed responses.

- **Documentation**
  - Updated API documentation to clarify response metadata visibility and body-storage boundaries.

- **Tests**
  - Added coverage for response validation, payload normalization, API exports, limits, and metadata privacy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->