### PR TITLE
[ISSUE #9769]🐛Controller tests reuse one port for remoting and Raft

### DIFF
--- a/rocketmq-controller/src/controller/controller_manager.rs
+++ b/rocketmq-controller/src/controller/controller_manager.rs
@@ -1937,9 +1937,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_leadership_watch_enables_scheduling_for_openraft_leader() {
-        let port = 9883;
+        let (remoting_addr, raft_addr) = reserve_controller_addresses();
         let config = ControllerConfig::default()
-            .with_node_info(1, format!("127.0.0.1:{port}").parse::<SocketAddr>().unwrap())
+            .with_node_info(1, remoting_addr)
+            .with_raft_peers(vec![crate::config::RaftPeer { id: 1, addr: raft_addr }])
             .with_heartbeat_interval_ms(100)
             .with_election_timeout_ms(300)
             .with_storage_backend(crate::config::StorageBackendType::Memory);
@@ -1957,7 +1958,7 @@ mod tests {
             1,
             Node {
                 node_id: 1,
-                rpc_addr: format!("127.0.0.1:{port}"),
+                rpc_addr: raft_addr.to_string(),
             },
         );
         manager
@@ -2094,9 +2095,10 @@ mod tests {
 
     #[tokio::test]
     async fn inactive_slave_does_not_elect_but_inactive_master_does() {
-        let port = 9886;
+        let (remoting_addr, raft_addr) = reserve_controller_addresses();
         let config = ControllerConfig::default()
-            .with_node_info(1, format!("127.0.0.1:{port}").parse::<SocketAddr>().unwrap())
+            .with_node_info(1, remoting_addr)
+            .with_raft_peers(vec![crate::config::RaftPeer { id: 1, addr: raft_addr }])
             .with_heartbeat_interval_ms(100)
             .with_election_timeout_ms(300)
             .with_storage_backend(crate::config::StorageBackendType::Memory)
@@ -2115,7 +2117,7 @@ mod tests {
             1,
             Node {
                 node_id: 1,
-                rpc_addr: format!("127.0.0.1:{port}"),
+                rpc_addr: raft_addr.to_string(),
             },
         );
         manager
@@ -2279,9 +2281,10 @@ mod tests {
 
     #[tokio::test]
     async fn processor_successful_manual_election_records_role_change_notification() {
-        let port = 9887;
+        let (remoting_addr, raft_addr) = reserve_controller_addresses();
         let config = ControllerConfig::default()
-            .with_node_info(1, format!("127.0.0.1:{port}").parse::<SocketAddr>().unwrap())
+            .with_node_info(1, remoting_addr)
+            .with_raft_peers(vec![crate::config::RaftPeer { id: 1, addr: raft_addr }])
             .with_heartbeat_interval_ms(100)
             .with_election_timeout_ms(300)
             .with_storage_backend(crate::config::StorageBackendType::Memory)
@@ -2300,7 +2303,7 @@ mod tests {
             1,
             Node {
                 node_id: 1,
-                rpc_addr: format!("127.0.0.1:{port}"),
+                rpc_addr: raft_addr.to_string(),
             },
         );
         manager

--- a/rocketmq-controller/tests/controller_request_processor_contract_test.rs
+++ b/rocketmq-controller/tests/controller_request_processor_contract_test.rs
@@ -10,6 +10,7 @@ use rocketmq_controller::ControllerConfig;
 use rocketmq_controller::ControllerManager;
 use rocketmq_controller::ControllerRequestProcessor;
 use rocketmq_controller::Node;
+use rocketmq_controller::RaftPeer;
 use rocketmq_controller::StorageBackendType;
 use rocketmq_error::ErrorKind;
 use rocketmq_error::RocketMQResult;
@@ -66,9 +67,10 @@ struct ReplicaSeed {
 
 impl ProcessorHarness {
     async fn new() -> Self {
-        let listen_addr = reserve_socket_addr();
+        let (remoting_addr, raft_addr) = reserve_controller_addresses();
         let config = ControllerConfig::default()
-            .with_node_info(1, listen_addr)
+            .with_node_info(1, remoting_addr)
+            .with_raft_peers(vec![RaftPeer { id: 1, addr: raft_addr }])
             .with_storage_backend(StorageBackendType::Memory)
             .with_heartbeat_interval_ms(100)
             .with_election_timeout_ms(300);
@@ -90,7 +92,7 @@ impl ProcessorHarness {
             1,
             Node {
                 node_id: 1,
-                rpc_addr: listen_addr.to_string(),
+                rpc_addr: raft_addr.to_string(),
             },
         );
         manager
@@ -288,11 +290,15 @@ impl ProcessorHarness {
     }
 }
 
-fn reserve_socket_addr() -> SocketAddr {
-    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind random port");
-    let addr = listener.local_addr().expect("read listener addr");
-    drop(listener);
-    addr
+fn reserve_controller_addresses() -> (SocketAddr, SocketAddr) {
+    let remoting = std::net::TcpListener::bind("127.0.0.1:0").expect("reserve remoting address");
+    let raft = std::net::TcpListener::bind("127.0.0.1:0").expect("reserve raft address");
+    let addresses = (
+        remoting.local_addr().expect("remoting address"),
+        raft.local_addr().expect("raft address"),
+    );
+    drop((remoting, raft));
+    addresses
 }
 
 async fn create_test_channel() -> Channel {


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #9769 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved controller integration and contract test reliability by dynamically reserving network addresses.
  * Added separate address configuration for remoting and Raft communication in test environments.
  * Updated cluster initialization checks to use the configured Raft endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->