### PR TITLE
[ISSUE #9775]✨Add one-pass encoding for structured response payloads

### DIFF
--- a/rocketmq-transport/src/codec.rs
+++ b/rocketmq-transport/src/codec.rs
@@ -13,4 +13,11 @@
 // limitations under the License.
 
 pub mod remoting_command_codec;
+mod response_preparation;
 mod trusted_encoded_frame;
+
+#[allow(
+    unused_imports,
+    reason = "the later private response sink consumes the RSP-04 preparation capability"
+)]
+pub(crate) use response_preparation::{prepare_response, PreparedResponse, PreparedResponseMetadata};

--- a/rocketmq-transport/src/codec/remoting_command_codec.rs
+++ b/rocketmq-transport/src/codec/remoting_command_codec.rs
@@ -245,7 +245,7 @@ impl FrameLimits {
         Ok(frame)
     }
 
-    pub(crate) fn encode_file_frame_head(
+    pub(crate) fn encode_frame_head(
         self,
         command: RemotingCommand,
         body_len: usize,

--- a/rocketmq-transport/src/codec/response_preparation.rs
+++ b/rocketmq-transport/src/codec/response_preparation.rs
@@ -1,0 +1,727 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! One-pass preparation of bound structured responses.
+
+use rocketmq_error::SerializationError;
+
+use super::remoting_command_codec::FrameLimits;
+use crate::dispatch::BoundResponsePlan;
+use crate::dispatch::RequestId;
+use crate::dispatch::ResponseBody;
+use crate::dispatch::ResponseBodyKind;
+use crate::dispatch::ResponseError;
+use crate::write_strategy::OutboundPayload;
+use crate::write_strategy::PreparedStructuredResponseBody;
+use crate::write_strategy::StructuredResponseFrame;
+
+#[allow(
+    dead_code,
+    reason = "the later private response sink owns this prepared RSP-04 value"
+)]
+pub(crate) struct PreparedResponse {
+    metadata: PreparedResponseMetadata,
+    payload: OutboundPayload,
+}
+
+#[allow(
+    dead_code,
+    reason = "the later private response sink consumes prepared metadata and payload ownership"
+)]
+impl PreparedResponse {
+    pub(crate) const fn metadata(&self) -> &PreparedResponseMetadata {
+        &self.metadata
+    }
+
+    pub(crate) fn into_parts(self) -> (PreparedResponseMetadata, OutboundPayload) {
+        (self.metadata, self.payload)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[allow(
+    dead_code,
+    reason = "the later private response sink uses this RSP-04 admission and completion metadata"
+)]
+pub(crate) struct PreparedResponseMetadata {
+    request_id: RequestId,
+    response_code: i32,
+    body_kind: ResponseBodyKind,
+    body_len: usize,
+    body_part_count: usize,
+    encoded_len: usize,
+    opaque_was_corrected: bool,
+}
+
+#[allow(
+    dead_code,
+    reason = "the later private response sink reads prepared response metadata"
+)]
+impl PreparedResponseMetadata {
+    pub(crate) const fn request_id(self) -> RequestId {
+        self.request_id
+    }
+
+    pub(crate) const fn response_code(self) -> i32 {
+        self.response_code
+    }
+
+    pub(crate) const fn body_kind(self) -> ResponseBodyKind {
+        self.body_kind
+    }
+
+    pub(crate) const fn body_len(self) -> usize {
+        self.body_len
+    }
+
+    pub(crate) const fn body_part_count(self) -> usize {
+        self.body_part_count
+    }
+
+    pub(crate) const fn encoded_len(self) -> usize {
+        self.encoded_len
+    }
+
+    pub(crate) const fn opaque_was_corrected(self) -> bool {
+        self.opaque_was_corrected
+    }
+}
+
+#[allow(
+    dead_code,
+    reason = "the later private response sink invokes this RSP-04 preparation seam"
+)]
+pub(crate) fn prepare_response(
+    bound: BoundResponsePlan,
+    limits: FrameLimits,
+) -> Result<PreparedResponse, ResponseError> {
+    let opaque_was_corrected = bound.opaque_was_corrected();
+    let (request_id, head, body) = bound.into_parts();
+    let response_code = head.code();
+    let (body_kind, body_len, body_part_count, body) = prepare_body(body).map_err(encode_error)?;
+    let head = limits.encode_frame_head(head, body_len).map_err(encode_error)?;
+    let encoded_len = head.encoded_len();
+    let payload = match body {
+        PreparedBody::Structured(body) => {
+            StructuredResponseFrame::new(head, body).map(OutboundPayload::StructuredFrame)
+        }
+        PreparedBody::FileRegions(body) => Ok(OutboundPayload::FileFrame { head, body }),
+    }
+    .map_err(encode_error)?;
+
+    Ok(PreparedResponse {
+        metadata: PreparedResponseMetadata {
+            request_id,
+            response_code,
+            body_kind,
+            body_len,
+            body_part_count,
+            encoded_len,
+            opaque_was_corrected,
+        },
+        payload,
+    })
+}
+
+#[allow(
+    dead_code,
+    reason = "the later private response preparation seam computes body metadata before encoding"
+)]
+fn prepare_body(body: ResponseBody) -> rocketmq_error::RocketMQResult<(ResponseBodyKind, usize, usize, PreparedBody)> {
+    match body {
+        ResponseBody::Empty => {
+            let body = PreparedStructuredResponseBody::empty()?;
+            Ok((
+                ResponseBodyKind::Empty,
+                body.body_len(),
+                0,
+                PreparedBody::Structured(body),
+            ))
+        }
+        ResponseBody::Bytes(bytes) => {
+            let body = PreparedStructuredResponseBody::bytes(bytes)?;
+            Ok((
+                ResponseBodyKind::Bytes,
+                body.body_len(),
+                1,
+                PreparedBody::Structured(body),
+            ))
+        }
+        ResponseBody::Segments(segments) => {
+            let body_part_count = segments.len();
+            let body = PreparedStructuredResponseBody::segments(segments)?;
+            Ok((
+                ResponseBodyKind::Segments,
+                body.body_len(),
+                body_part_count,
+                PreparedBody::Structured(body),
+            ))
+        }
+        ResponseBody::FileRegions(regions) => {
+            let body_len = usize::try_from(regions.len()).map_err(|_| {
+                SerializationError::encode_failed(
+                    "structured-response-frame",
+                    "file-region response body length is not representable as usize",
+                )
+            })?;
+            let body_part_count = regions.regions().len();
+            Ok((
+                ResponseBodyKind::FileRegions,
+                body_len,
+                body_part_count,
+                PreparedBody::FileRegions(regions),
+            ))
+        }
+    }
+}
+
+enum PreparedBody {
+    Structured(PreparedStructuredResponseBody),
+    FileRegions(crate::file_region::FileRegionSequence),
+}
+
+#[allow(
+    dead_code,
+    reason = "the later private response preparation seam retains typed encoding failures"
+)]
+fn encode_error(source: rocketmq_error::RocketMQError) -> ResponseError {
+    ResponseError::Encode { source }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::fs::File;
+    use std::io::Write;
+    use std::sync::atomic::AtomicU64;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
+
+    use bytes::Bytes;
+    use cheetah_string::CheetahString;
+    use rocketmq_protocol::protocol::command_custom_header::CommandCustomHeader;
+    use rocketmq_protocol::protocol::encoded_frame::EncodedFrame;
+    use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+    use rocketmq_protocol::protocol::SerializeType;
+
+    use super::*;
+    use crate::dispatch::OriginalRequestIdentity;
+    use crate::dispatch::ResponsePlan;
+    use crate::file_region::FileRegion;
+    use crate::file_region::FileRegionLease;
+    use crate::file_region::FileRegionSequence;
+
+    fn bind(plan: ResponsePlan, owner_id: u64, original_opaque: i32) -> BoundResponsePlan {
+        let sequence = AtomicU64::new(1);
+        let request = RemotingCommand::create_remoting_command(41).set_opaque(original_opaque);
+        let original = OriginalRequestIdentity::capture(owner_id, &sequence, &request)
+            .expect("test request identity should be allocated");
+        plan.bind(original).expect("ordinary requests should bind")
+    }
+
+    fn response_head(code: i32, opaque: i32, serialize_type: SerializeType) -> RemotingCommand {
+        RemotingCommand::create_response_command_with_code(code)
+            .set_opaque(opaque)
+            .set_serialize_type(serialize_type)
+            .set_remark("prepared-response")
+    }
+
+    fn structured_wire(payload: &OutboundPayload) -> Vec<u8> {
+        let OutboundPayload::StructuredFrame(frame) = payload else {
+            panic!("expected an in-memory structured frame");
+        };
+        frame
+            .test_segments()
+            .into_iter()
+            .flat_map(|segment| segment.iter().copied())
+            .collect()
+    }
+
+    #[test]
+    fn all_body_kinds_report_exact_metadata_and_retain_the_bound_identity() {
+        let cases = [
+            (
+                ResponsePlan::command(response_head(71, -1, SerializeType::JSON)).expect("empty plan"),
+                ResponseBodyKind::Empty,
+                0,
+                0,
+            ),
+            (
+                ResponsePlan::bytes(response_head(72, -1, SerializeType::JSON), Bytes::from_static(b"bytes"))
+                    .expect("bytes plan"),
+                ResponseBodyKind::Bytes,
+                5,
+                1,
+            ),
+            (
+                ResponsePlan::segments(
+                    response_head(73, -1, SerializeType::JSON),
+                    vec![Bytes::from_static(b"left"), Bytes::from_static(b"right")],
+                )
+                .expect("segments plan"),
+                ResponseBodyKind::Segments,
+                9,
+                2,
+            ),
+        ];
+
+        for (index, (plan, kind, body_len, body_part_count)) in cases.into_iter().enumerate() {
+            let prepared = prepare_response(
+                bind(plan, 100 + index as u64, 900 + index as i32),
+                FrameLimits::default(),
+            )
+            .expect("response should prepare");
+            let metadata = *prepared.metadata();
+            assert_eq!(metadata.request_id().owner_id(), 100 + index as u64);
+            assert_eq!(metadata.response_code(), 71 + index as i32);
+            assert_eq!(metadata.body_kind(), kind);
+            assert_eq!(metadata.body_len(), body_len);
+            assert_eq!(metadata.body_part_count(), body_part_count);
+            assert!(metadata.opaque_was_corrected());
+            let copied = metadata;
+            assert_eq!(copied, metadata, "metadata remains copyable");
+
+            let (parts_metadata, payload) = prepared.into_parts();
+            assert_eq!(parts_metadata, metadata);
+            assert_eq!(payload.encoded_len(), metadata.encoded_len());
+            assert_eq!(structured_wire(&payload).len(), metadata.encoded_len());
+        }
+
+        let mut file = tempfile::tempfile().expect("temporary file");
+        file.write_all(b"file-body").expect("write file body");
+        let sequence =
+            FileRegionSequence::single(FileRegion::try_new(Arc::new(file), 0, 9).expect("valid file region"));
+        let prepared = prepare_response(
+            bind(
+                ResponsePlan::file_regions(response_head(74, 903, SerializeType::JSON), sequence).expect("file plan"),
+                103,
+                903,
+            ),
+            FrameLimits::default(),
+        )
+        .expect("file response should prepare");
+        let metadata = *prepared.metadata();
+        assert_eq!(metadata.request_id().owner_id(), 103);
+        assert_eq!(metadata.response_code(), 74);
+        assert_eq!(metadata.body_kind(), ResponseBodyKind::FileRegions);
+        assert_eq!(metadata.body_len(), 9);
+        assert_eq!(metadata.body_part_count(), 1);
+        assert!(!metadata.opaque_was_corrected());
+        let (_, payload) = prepared.into_parts();
+        assert!(matches!(payload, OutboundPayload::FileFrame { .. }));
+        assert_eq!(payload.encoded_len(), metadata.encoded_len());
+    }
+
+    #[test]
+    fn json_and_rocketmq_frames_match_the_canonical_wire_oracle() {
+        for serialize_type in [SerializeType::JSON, SerializeType::ROCKETMQ] {
+            let body = Bytes::from_static(b"canonical structured body");
+            let head = response_head(81, -77, serialize_type);
+            let expected = EncodedFrame::from_command(head.clone().set_opaque(377).set_body(body.clone()))
+                .expect("canonical command should encode")
+                .into_bytes();
+            let plan = ResponsePlan::bytes(head, body).expect("valid response plan");
+            let prepared =
+                prepare_response(bind(plan, 201, 377), FrameLimits::default()).expect("response should prepare");
+            let metadata = *prepared.metadata();
+            let (_, payload) = prepared.into_parts();
+            let actual = structured_wire(&payload);
+
+            assert_eq!(actual.as_slice(), expected.as_ref(), "{serialize_type:?}");
+            assert_eq!(actual.len(), metadata.encoded_len());
+            assert_eq!(payload.encoded_len(), metadata.encoded_len());
+        }
+    }
+
+    #[test]
+    fn preparation_moves_bytes_segment_buffers_and_the_segment_vector_allocation() {
+        let bytes = Bytes::from_static(b"same bytes allocation");
+        let bytes_pointer = bytes.as_ptr();
+        let prepared = prepare_response(
+            bind(
+                ResponsePlan::bytes(response_head(82, 9, SerializeType::JSON), bytes).expect("bytes plan"),
+                202,
+                9,
+            ),
+            FrameLimits::default(),
+        )
+        .expect("bytes response should prepare");
+        let (_, payload) = prepared.into_parts();
+        let OutboundPayload::StructuredFrame(frame) = payload else {
+            panic!("expected structured frame");
+        };
+        let wire_segments = frame.test_segments();
+        assert_eq!(wire_segments.last().expect("body segment").as_ptr(), bytes_pointer);
+
+        let first = Bytes::from_static(b"first");
+        let second = Bytes::from_static(b"second");
+        let first_pointer = first.as_ptr();
+        let second_pointer = second.as_ptr();
+        let mut input = Vec::with_capacity(4);
+        input.push(first);
+        input.push(second);
+        let vector_pointer = input.as_ptr();
+        let prepared = prepare_response(
+            bind(
+                ResponsePlan::segments(response_head(83, 10, SerializeType::JSON), input).expect("segments plan"),
+                203,
+                10,
+            ),
+            FrameLimits::default(),
+        )
+        .expect("segmented response should prepare");
+        let (_, payload) = prepared.into_parts();
+        let OutboundPayload::StructuredFrame(frame) = payload else {
+            panic!("expected structured frame");
+        };
+        let segments = frame.test_body_segments().expect("segmented body storage");
+        assert_eq!(segments.as_ptr(), vector_pointer);
+        assert_eq!(segments[0].as_ptr(), first_pointer);
+        assert_eq!(segments[1].as_ptr(), second_pointer);
+        assert_eq!(segments[0].as_ref(), b"first");
+        assert_eq!(segments[1].as_ref(), b"second");
+    }
+
+    struct CountingHeader {
+        encodes: Arc<AtomicUsize>,
+    }
+
+    impl CommandCustomHeader for CountingHeader {
+        fn to_map(&self) -> Option<HashMap<CheetahString, CheetahString>> {
+            self.encodes.fetch_add(1, Ordering::SeqCst);
+            Some(HashMap::from([(
+                CheetahString::from_static_str("counted"),
+                CheetahString::from_static_str("once"),
+            )]))
+        }
+    }
+
+    fn counting_plan(encodes: Arc<AtomicUsize>, body: Bytes, serialize_type: SerializeType) -> ResponsePlan {
+        ResponsePlan::bytes(
+            RemotingCommand::create_response_command_with_code(84)
+                .set_opaque(11)
+                .set_serialize_type(serialize_type)
+                .set_command_custom_header(CountingHeader { encodes }),
+            body,
+        )
+        .expect("counting response plan")
+    }
+
+    #[test]
+    fn encoder_runs_exactly_once_and_limit_failures_never_retry() {
+        for serialize_type in [SerializeType::JSON, SerializeType::ROCKETMQ] {
+            let success_count = Arc::new(AtomicUsize::new(0));
+            prepare_response(
+                bind(
+                    counting_plan(Arc::clone(&success_count), Bytes::from_static(b"body"), serialize_type),
+                    204,
+                    11,
+                ),
+                FrameLimits::default(),
+            )
+            .expect("response should prepare");
+            assert_eq!(success_count.load(Ordering::SeqCst), 1, "{serialize_type:?}");
+        }
+
+        let lower_bound_count = Arc::new(AtomicUsize::new(0));
+        let limits = FrameLimits {
+            max_body_bytes: 3,
+            ..FrameLimits::default()
+        };
+        let Err(error) = prepare_response(
+            bind(
+                counting_plan(
+                    Arc::clone(&lower_bound_count),
+                    Bytes::from_static(b"body"),
+                    SerializeType::JSON,
+                ),
+                205,
+                11,
+            ),
+            limits,
+        ) else {
+            panic!("known body overflow should fail before serialization");
+        };
+        assert!(matches!(error, ResponseError::Encode { .. }));
+        assert_eq!(lower_bound_count.load(Ordering::SeqCst), 0);
+
+        let post_encode_count = Arc::new(AtomicUsize::new(0));
+        let limits = FrameLimits {
+            max_header_bytes: 0,
+            ..FrameLimits::default()
+        };
+        let Err(error) = prepare_response(
+            bind(
+                counting_plan(
+                    Arc::clone(&post_encode_count),
+                    Bytes::from_static(b"body"),
+                    SerializeType::JSON,
+                ),
+                206,
+                11,
+            ),
+            limits,
+        ) else {
+            panic!("exact header overflow should fail after one serialization");
+        };
+        assert!(matches!(error, ResponseError::Encode { .. }));
+        assert_eq!(post_encode_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn exact_configured_limits_pass_and_one_byte_smaller_limits_fail_at_the_expected_stage() {
+        let body = Bytes::from_static(b"limit-body");
+        let baseline = prepare_response(
+            bind(
+                ResponsePlan::bytes(response_head(85, 12, SerializeType::JSON), body.clone()).expect("baseline plan"),
+                207,
+                12,
+            ),
+            FrameLimits::default(),
+        )
+        .expect("baseline response should prepare");
+        let metadata = *baseline.metadata();
+        let (_, payload) = baseline.into_parts();
+        let OutboundPayload::StructuredFrame(frame) = payload else {
+            panic!("expected structured frame");
+        };
+        let header_len = frame.test_segments()[1].len();
+        let exact = FrameLimits {
+            max_frame_bytes: metadata.encoded_len(),
+            max_header_bytes: header_len,
+            max_body_bytes: body.len(),
+            initial_read_bytes: 8,
+        };
+        let prepared = prepare_response(
+            bind(
+                ResponsePlan::bytes(response_head(85, 12, SerializeType::JSON), body.clone()).expect("exact plan"),
+                208,
+                12,
+            ),
+            exact,
+        )
+        .expect("exact limits should pass");
+        assert_eq!(prepared.metadata().encoded_len(), metadata.encoded_len());
+
+        for limits in [
+            FrameLimits {
+                max_frame_bytes: metadata.encoded_len() - 1,
+                ..exact
+            },
+            FrameLimits {
+                max_header_bytes: header_len - 1,
+                ..exact
+            },
+            FrameLimits {
+                max_body_bytes: body.len() - 1,
+                ..exact
+            },
+        ] {
+            let Err(error) = prepare_response(
+                bind(
+                    ResponsePlan::bytes(response_head(85, 12, SerializeType::JSON), body.clone())
+                        .expect("one-over plan"),
+                    209,
+                    12,
+                ),
+                limits,
+            ) else {
+                panic!("one-byte excess should fail");
+            };
+            assert!(matches!(error, ResponseError::Encode { .. }));
+        }
+    }
+
+    #[test]
+    fn frame_profiles_accept_exact_protocol_ceilings_and_reject_one_over() {
+        assert!(FrameLimits::try_new(i32::MAX as usize + 4, 0x00ff_ffff, i32::MAX as usize - 4, 8).is_ok());
+        assert!(FrameLimits::try_new(i32::MAX as usize + 5, 0x00ff_ffff, i32::MAX as usize - 4, 8).is_err());
+        assert!(FrameLimits::try_new(i32::MAX as usize + 4, 0x0100_0000, i32::MAX as usize - 4, 8).is_err());
+    }
+
+    #[test]
+    fn preparation_accepts_the_exact_24_bit_header_and_rejects_one_byte_over() {
+        const MAX_HEADER_BYTES: usize = 0x00ff_ffff;
+        let base = response_head(88, 15, SerializeType::JSON).set_remark("");
+        let base_head =
+            rocketmq_protocol::protocol::encoded_frame::EncodedFrameHead::from_command_and_body_len(base.clone(), 0)
+                .expect("base response head");
+        let base_header_len = base_head.segments()[1].len();
+        let exact_remark_len = MAX_HEADER_BYTES - base_header_len;
+        let limits = FrameLimits {
+            max_frame_bytes: i32::MAX as usize + 4,
+            max_header_bytes: MAX_HEADER_BYTES,
+            max_body_bytes: 0,
+            initial_read_bytes: 8,
+        };
+
+        let exact = response_head(88, 15, SerializeType::JSON).set_remark("a".repeat(exact_remark_len));
+        let prepared = prepare_response(
+            bind(ResponsePlan::command(exact).expect("exact header plan"), 212, 15),
+            limits,
+        )
+        .expect("24-bit header ceiling should encode");
+        let (_, payload) = prepared.into_parts();
+        let OutboundPayload::StructuredFrame(frame) = payload else {
+            panic!("expected structured frame");
+        };
+        assert_eq!(frame.test_segments()[1].len(), MAX_HEADER_BYTES);
+        drop(frame);
+
+        let over = response_head(88, 15, SerializeType::JSON).set_remark("a".repeat(exact_remark_len + 1));
+        let Err(error) = prepare_response(
+            bind(ResponsePlan::command(over).expect("one-over header plan"), 213, 15),
+            limits,
+        ) else {
+            panic!("header above the 24-bit field must fail");
+        };
+        assert!(matches!(error, ResponseError::Encode { .. }));
+    }
+
+    #[test]
+    fn preparation_accepts_the_exact_signed_frame_length_and_rejects_one_byte_over() {
+        let head = response_head(89, 16, SerializeType::JSON).set_remark("");
+        let base_head =
+            rocketmq_protocol::protocol::encoded_frame::EncodedFrameHead::from_command_and_body_len(head.clone(), 0)
+                .expect("base response head");
+        let header_len = base_head.segments()[1].len();
+        let exact_body_len = i32::MAX as usize - 4 - header_len;
+        let file = Arc::new(tempfile::tempfile().expect("temporary sparse file"));
+        file.set_len((exact_body_len + 1) as u64)
+            .expect("extend sparse file to signed boundary");
+        let limits = FrameLimits {
+            max_frame_bytes: i32::MAX as usize + 4,
+            max_header_bytes: 0x00ff_ffff,
+            max_body_bytes: i32::MAX as usize - 4,
+            initial_read_bytes: 8,
+        };
+
+        let exact_region = FileRegion::try_new(file.clone(), 0, exact_body_len as u64).expect("exact file region");
+        let prepared = prepare_response(
+            bind(
+                ResponsePlan::file_regions(head.clone(), FileRegionSequence::single(exact_region))
+                    .expect("exact signed frame plan"),
+                214,
+                16,
+            ),
+            limits,
+        )
+        .expect("signed i32 payload ceiling should encode");
+        assert_eq!(prepared.metadata().encoded_len(), i32::MAX as usize + 4);
+        drop(prepared);
+
+        let over_region = FileRegion::try_new(file, 0, (exact_body_len + 1) as u64).expect("one-over file region");
+        let Err(error) = prepare_response(
+            bind(
+                ResponsePlan::file_regions(head, FileRegionSequence::single(over_region))
+                    .expect("one-over signed frame plan"),
+                215,
+                16,
+            ),
+            limits,
+        ) else {
+            panic!("frame above the signed i32 payload limit must fail");
+        };
+        assert!(matches!(error, ResponseError::Encode { .. }));
+    }
+
+    struct CountingLease {
+        file: File,
+        file_accesses: Arc<AtomicUsize>,
+        drops: Arc<AtomicUsize>,
+    }
+
+    impl FileRegionLease for CountingLease {
+        fn file(&self) -> &File {
+            self.file_accesses.fetch_add(1, Ordering::SeqCst);
+            &self.file
+        }
+    }
+
+    impl Drop for CountingLease {
+        fn drop(&mut self) {
+            self.drops.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    fn counting_file_sequence(
+        file_accesses: &Arc<AtomicUsize>,
+        drops: &Arc<AtomicUsize>,
+    ) -> (Arc<CountingLease>, FileRegionSequence) {
+        let mut file = tempfile::tempfile().expect("temporary file");
+        file.write_all(b"leased-body").expect("write leased body");
+        let lease = Arc::new(CountingLease {
+            file,
+            file_accesses: Arc::clone(file_accesses),
+            drops: Arc::clone(drops),
+        });
+        let first = FileRegion::try_new(lease.clone(), 0, 6).expect("first region");
+        let second = FileRegion::try_new(lease.clone(), 6, 5).expect("second region");
+        let sequence = FileRegionSequence::try_new(vec![first, second]).expect("region sequence");
+        (lease, sequence)
+    }
+
+    #[test]
+    fn file_preparation_uses_cached_metadata_without_clone_or_restat_and_releases_on_drop() {
+        let file_accesses = Arc::new(AtomicUsize::new(0));
+        let drops = Arc::new(AtomicUsize::new(0));
+        let (lease, sequence) = counting_file_sequence(&file_accesses, &drops);
+        assert_eq!(file_accesses.load(Ordering::SeqCst), 2);
+        assert_eq!(Arc::strong_count(&lease), 3);
+        let prepared = prepare_response(
+            bind(
+                ResponsePlan::file_regions(response_head(86, 13, SerializeType::JSON), sequence)
+                    .expect("file response plan"),
+                210,
+                13,
+            ),
+            FrameLimits::default(),
+        )
+        .expect("file response should prepare");
+        assert_eq!(file_accesses.load(Ordering::SeqCst), 2);
+        assert_eq!(Arc::strong_count(&lease), 3, "preparation must not clone file leases");
+        drop(prepared);
+        assert_eq!(Arc::strong_count(&lease), 1);
+        assert_eq!(drops.load(Ordering::SeqCst), 0);
+        drop(lease);
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn file_preparation_failure_releases_the_moved_lease_without_restatting() {
+        let file_accesses = Arc::new(AtomicUsize::new(0));
+        let drops = Arc::new(AtomicUsize::new(0));
+        let (lease, sequence) = counting_file_sequence(&file_accesses, &drops);
+        let Err(error) = prepare_response(
+            bind(
+                ResponsePlan::file_regions(response_head(87, 14, SerializeType::JSON), sequence)
+                    .expect("file response plan"),
+                211,
+                14,
+            ),
+            FrameLimits {
+                max_body_bytes: 10,
+                ..FrameLimits::default()
+            },
+        ) else {
+            panic!("body lower bound should reject preparation");
+        };
+        assert!(matches!(error, ResponseError::Encode { .. }));
+        assert_eq!(file_accesses.load(Ordering::SeqCst), 2);
+        assert_eq!(Arc::strong_count(&lease), 1);
+        drop(lease);
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+    }
+}

--- a/rocketmq-transport/src/connection.rs
+++ b/rocketmq-transport/src/connection.rs
@@ -1196,7 +1196,7 @@ impl Connection {
         let body_len = usize::try_from(body.len()).map_err(|_| {
             rocketmq_error::RocketMQError::illegal_argument("file region sequence length exceeds this platform's usize")
         })?;
-        let head = self.limits.encode_file_frame_head(command_without_body, body_len)?;
+        let head = self.limits.encode_frame_head(command_without_body, body_len)?;
         if let Some(deadline) = deadline {
             deadline.ensure_before_send(target.clone())?;
         }

--- a/rocketmq-transport/src/write_strategy.rs
+++ b/rocketmq-transport/src/write_strategy.rs
@@ -163,8 +163,142 @@ pub(crate) enum WriterOperation {
     Send(OutboundPayload),
 }
 
+pub(crate) struct StructuredResponseFrame {
+    head: EncodedFrameHead,
+    body: PreparedStructuredResponseBody,
+}
+
+#[allow(
+    dead_code,
+    reason = "the later private response sink constructs this RSP-04 in-memory frame"
+)]
+enum StructuredResponseBody {
+    Empty,
+    Bytes(Bytes),
+    Segments(Vec<Bytes>),
+}
+
+pub(crate) struct PreparedStructuredResponseBody {
+    body: StructuredResponseBody,
+    checked_len: usize,
+}
+
+impl PreparedStructuredResponseBody {
+    pub(crate) fn empty() -> rocketmq_error::RocketMQResult<Self> {
+        Ok(Self {
+            body: StructuredResponseBody::Empty,
+            checked_len: 0,
+        })
+    }
+
+    pub(crate) fn bytes(body: Bytes) -> rocketmq_error::RocketMQResult<Self> {
+        let checked_len = body.len();
+        Ok(Self {
+            body: StructuredResponseBody::Bytes(body),
+            checked_len,
+        })
+    }
+
+    pub(crate) fn segments(body: Vec<Bytes>) -> rocketmq_error::RocketMQResult<Self> {
+        let checked_len = body.iter().try_fold(0_usize, |total, segment| {
+            total.checked_add(segment.len()).ok_or_else(|| {
+                SerializationError::encode_failed("structured-response-frame", "structured body length overflow")
+            })
+        })?;
+        Ok(Self {
+            body: StructuredResponseBody::Segments(body),
+            checked_len,
+        })
+    }
+
+    pub(crate) const fn body_len(&self) -> usize {
+        self.checked_len
+    }
+}
+
+impl StructuredResponseFrame {
+    #[allow(
+        dead_code,
+        reason = "the later private response sink constructs structured frames through checked variants"
+    )]
+    pub(crate) fn new(
+        head: EncodedFrameHead,
+        body: PreparedStructuredResponseBody,
+    ) -> rocketmq_error::RocketMQResult<Self> {
+        let frame = Self { head, body };
+        frame.validate_body_len()?;
+        Ok(frame)
+    }
+
+    fn validate_body_len(&self) -> rocketmq_error::RocketMQResult<()> {
+        let actual = self.body.checked_len;
+        if actual != self.head.body_len() {
+            return Err(SerializationError::encode_failed(
+                "structured-response-frame",
+                format!(
+                    "structured body length {actual} does not match encoded frame head body length {}",
+                    self.head.body_len()
+                ),
+            )
+            .into());
+        }
+        Ok(())
+    }
+
+    fn encoded_len(&self) -> usize {
+        self.head.encoded_len()
+    }
+
+    fn extend_segments<'a>(&'a self, segments: &mut Vec<&'a [u8]>) {
+        segments.extend(self.head.segments());
+        match &self.body.body {
+            StructuredResponseBody::Empty => {}
+            StructuredResponseBody::Bytes(bytes) => segments.push(bytes.as_ref()),
+            StructuredResponseBody::Segments(body_segments) => {
+                segments.extend(body_segments.iter().map(Bytes::as_ref));
+            }
+        }
+    }
+
+    fn copy_to(&self, destination: &mut BytesMut) {
+        destination.reserve(self.encoded_len());
+        for segment in self.head.segments() {
+            destination.extend_from_slice(segment);
+        }
+        match &self.body.body {
+            StructuredResponseBody::Empty => {}
+            StructuredResponseBody::Bytes(bytes) => destination.extend_from_slice(bytes),
+            StructuredResponseBody::Segments(segments) => {
+                for segment in segments {
+                    destination.extend_from_slice(segment);
+                }
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_segments(&self) -> Vec<&[u8]> {
+        let mut segments = Vec::new();
+        self.extend_segments(&mut segments);
+        segments
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_body_segments(&self) -> Option<&[Bytes]> {
+        match &self.body.body {
+            StructuredResponseBody::Segments(segments) => Some(segments),
+            _ => None,
+        }
+    }
+}
+
 pub(crate) enum OutboundPayload {
     Frame(EncodedFrame),
+    #[allow(
+        dead_code,
+        reason = "the later private response sink enqueues the RSP-04 structured frame"
+    )]
+    StructuredFrame(StructuredResponseFrame),
     FileFrame {
         head: EncodedFrameHead,
         body: FileRegionSequence,
@@ -193,6 +327,7 @@ impl OutboundPayload {
     pub(crate) fn encoded_len(&self) -> usize {
         match self {
             Self::Frame(frame) => frame.encoded_len(),
+            Self::StructuredFrame(frame) => frame.encoded_len(),
             Self::FileFrame { head, .. } => head.encoded_len(),
             Self::Batch { encoded_len, .. } => *encoded_len,
             Self::FrameSegments { encoded_len, .. } => *encoded_len,
@@ -415,6 +550,7 @@ where
             return Ok(());
         }
         let mode = self.mode;
+        validate_structured_payloads(payloads)?;
         if let Some(max_plaintext_frame_bytes) = tls_plaintext_bound(mode) {
             validate_tls_payloads(payloads, max_plaintext_frame_bytes)?;
         }
@@ -789,6 +925,13 @@ fn validate_tls_payloads(payloads: &[&OutboundPayload], max_plaintext_frame_byte
     for payload in payloads {
         match payload {
             OutboundPayload::Frame(frame) => validate_tls_frame(frame, max_plaintext_frame_bytes)?,
+            OutboundPayload::StructuredFrame(frame) if frame.encoded_len() > max_plaintext_frame_bytes => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "structured response frame exceeds TLS plaintext bound",
+                ));
+            }
+            OutboundPayload::StructuredFrame(_) => {}
             OutboundPayload::FileFrame { head, .. } if head.encoded_len() > max_plaintext_frame_bytes => {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
@@ -834,11 +977,23 @@ fn validate_tls_frame(frame: &EncodedFrame, max_plaintext_frame_bytes: usize) ->
     }
 }
 
+fn validate_structured_payloads(payloads: &[&OutboundPayload]) -> io::Result<()> {
+    for payload in payloads {
+        if let OutboundPayload::StructuredFrame(frame) = payload {
+            frame
+                .validate_body_len()
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))?;
+        }
+    }
+    Ok(())
+}
+
 fn payload_segments<'a>(payloads: &'a [&'a OutboundPayload]) -> io::Result<Vec<&'a [u8]>> {
     let mut segments = Vec::new();
     for payload in payloads {
         match payload {
             OutboundPayload::Frame(frame) => segments.extend(frame.segments()),
+            OutboundPayload::StructuredFrame(frame) => frame.extend_segments(&mut segments),
             OutboundPayload::FileFrame { .. } => {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
@@ -866,6 +1021,11 @@ where
 {
     match payload {
         OutboundPayload::Frame(frame) => {
+            buffer.clear();
+            frame.copy_to(buffer);
+            write_contiguous(io, buffer.as_ref()).await
+        }
+        OutboundPayload::StructuredFrame(frame) => {
             buffer.clear();
             frame.copy_to(buffer);
             write_contiguous(io, buffer.as_ref()).await
@@ -1062,5 +1222,236 @@ mod file_frame_tests {
         let error = super::preserve_preflight_task_error(PanicDisplay);
 
         assert!(error.get_ref().is_some_and(|source| source.is::<PanicDisplay>()));
+    }
+}
+
+#[cfg(test)]
+mod structured_response_tests {
+    use std::io;
+    use std::io::IoSlice;
+    use std::pin::Pin;
+    use std::task::Context;
+    use std::task::Poll;
+
+    use bytes::Bytes;
+    use rocketmq_protocol::protocol::encoded_frame::EncodedFrameHead;
+    use rocketmq_protocol::protocol::RemotingCommand;
+    use tokio::io::AsyncWrite;
+
+    use super::FrameWriteMode;
+    use super::FrameWriter;
+    use super::OutboundPayload;
+    use super::PreparedStructuredResponseBody;
+    use super::StructuredResponseBody;
+    use super::StructuredResponseFrame;
+
+    #[derive(Default)]
+    struct RecordingIo {
+        output: Vec<u8>,
+        vectored_widths: Vec<usize>,
+        flushes: usize,
+    }
+
+    impl AsyncWrite for RecordingIo {
+        fn poll_write(mut self: Pin<&mut Self>, _context: &mut Context<'_>, buffer: &[u8]) -> Poll<io::Result<usize>> {
+            self.output.extend_from_slice(buffer);
+            Poll::Ready(Ok(buffer.len()))
+        }
+
+        fn poll_write_vectored(
+            mut self: Pin<&mut Self>,
+            _context: &mut Context<'_>,
+            buffers: &[IoSlice<'_>],
+        ) -> Poll<io::Result<usize>> {
+            self.vectored_widths.push(buffers.len());
+            let mut written = 0;
+            for buffer in buffers {
+                self.output.extend_from_slice(buffer);
+                written += buffer.len();
+            }
+            Poll::Ready(Ok(written))
+        }
+
+        fn is_write_vectored(&self) -> bool {
+            true
+        }
+
+        fn poll_flush(mut self: Pin<&mut Self>, _context: &mut Context<'_>) -> Poll<io::Result<()>> {
+            self.flushes += 1;
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _context: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    fn structured_segments() -> (OutboundPayload, Vec<u8>, usize) {
+        let body = vec![
+            Bytes::from_static(b"first"),
+            Bytes::from_static(b"-second"),
+            Bytes::from_static(b"-third"),
+        ];
+        let body_len = body.iter().map(Bytes::len).sum::<usize>();
+        let owner = PreparedStructuredResponseBody::segments(body).expect("checked structured body");
+        let head = EncodedFrameHead::from_command_and_body_len(
+            RemotingCommand::create_response_command_with_code(901).set_opaque(37),
+            body_len,
+        )
+        .expect("encoded response head");
+        let encoded_len = head.encoded_len();
+        let frame = StructuredResponseFrame::new(head, owner).expect("matching structured frame");
+        let expected = frame
+            .test_segments()
+            .into_iter()
+            .flat_map(|segment| segment.iter().copied())
+            .collect();
+        (OutboundPayload::StructuredFrame(frame), expected, encoded_len)
+    }
+
+    async fn write_payload(
+        payload: &OutboundPayload,
+        mode: FrameWriteMode,
+        max_iov: usize,
+    ) -> (io::Result<()>, RecordingIo, bool, bool) {
+        let mut writer = FrameWriter::new(RecordingIo::default(), mode).expect("recording writer");
+        let mut started = false;
+        let result = writer
+            .write_payloads_with_start(&[payload], max_iov, &mut || started = true)
+            .await;
+        let poisoned = writer.is_poisoned();
+        (result, writer.into_inner(), started, poisoned)
+    }
+
+    #[tokio::test]
+    async fn plaintext_preserves_segment_order_with_single_and_normal_iov_windows() {
+        for (max_iov, expected_widths) in [(1, vec![1, 1, 1, 1, 1]), (3, vec![3, 2])] {
+            let (payload, expected, encoded_len) = structured_segments();
+            let (result, io, started, poisoned) = write_payload(&payload, FrameWriteMode::PlainVectored, max_iov).await;
+
+            result.expect("plaintext structured write");
+            assert!(started);
+            assert!(!poisoned);
+            assert_eq!(io.output, expected);
+            assert_eq!(io.output.len(), encoded_len);
+            assert_eq!(io.vectored_widths, expected_widths);
+            assert_eq!(io.flushes, 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn tls_vectored_coalesced_and_auto_modes_receive_identical_complete_plaintext() {
+        let (baseline, expected, encoded_len) = structured_segments();
+        let modes = [
+            FrameWriteMode::TlsVectored {
+                max_plaintext_frame_bytes: encoded_len,
+            },
+            FrameWriteMode::TlsCoalesced {
+                max_plaintext_frame_bytes: encoded_len,
+            },
+            FrameWriteMode::TlsAuto {
+                max_plaintext_frame_bytes: encoded_len,
+                coalesce_below_bytes: encoded_len,
+            },
+            FrameWriteMode::TlsAuto {
+                max_plaintext_frame_bytes: encoded_len,
+                coalesce_below_bytes: 0,
+            },
+        ];
+
+        for mode in modes {
+            let (result, io, started, poisoned) = write_payload(&baseline, mode, 2).await;
+            result.expect("bounded TLS structured write");
+            assert!(started);
+            assert!(!poisoned);
+            assert_eq!(io.output, expected, "{mode:?}");
+            assert_eq!(io.output.len(), encoded_len);
+            assert_eq!(io.flushes, 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn every_tls_mode_rejects_an_oversized_complete_frame_before_progress() {
+        let (payload, _, encoded_len) = structured_segments();
+        let modes = [
+            FrameWriteMode::TlsVectored {
+                max_plaintext_frame_bytes: encoded_len - 1,
+            },
+            FrameWriteMode::TlsCoalesced {
+                max_plaintext_frame_bytes: encoded_len - 1,
+            },
+            FrameWriteMode::TlsAuto {
+                max_plaintext_frame_bytes: encoded_len - 1,
+                coalesce_below_bytes: encoded_len,
+            },
+        ];
+
+        for mode in modes {
+            let (result, io, started, poisoned) = write_payload(&payload, mode, 8).await;
+            assert_eq!(
+                result.expect_err("oversized TLS plaintext").kind(),
+                io::ErrorKind::InvalidInput
+            );
+            assert!(!started, "{mode:?}");
+            assert!(!poisoned, "{mode:?}");
+            assert!(io.output.is_empty(), "{mode:?}");
+            assert_eq!(io.flushes, 0, "{mode:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn a_mismatched_structured_head_is_rejected_before_progress() {
+        let head =
+            EncodedFrameHead::from_command_and_body_len(RemotingCommand::create_response_command_with_code(902), 7)
+                .expect("encoded response head");
+        let malformed = StructuredResponseFrame {
+            head,
+            body: PreparedStructuredResponseBody {
+                body: StructuredResponseBody::Bytes(Bytes::from_static(b"six!!!")),
+                checked_len: 6,
+            },
+        };
+        let payload = OutboundPayload::StructuredFrame(malformed);
+
+        let (result, io, started, poisoned) = write_payload(&payload, FrameWriteMode::PlainVectored, 8).await;
+        assert_eq!(
+            result.expect_err("mismatched body length").kind(),
+            io::ErrorKind::InvalidInput
+        );
+        assert!(!started);
+        assert!(!poisoned);
+        assert!(io.output.is_empty());
+        assert_eq!(io.flushes, 0);
+    }
+
+    #[tokio::test]
+    async fn legacy_complete_frame_segments_keep_their_existing_write_shape() {
+        let payload = OutboundPayload::FrameSegments {
+            segments: vec![
+                Bytes::from_static(b"legacy-prefix"),
+                Bytes::from_static(b"legacy-header"),
+                Bytes::from_static(b"legacy-body"),
+            ],
+            encoded_len: 37,
+        };
+        let (result, io, started, poisoned) = write_payload(&payload, FrameWriteMode::PlainVectored, 2).await;
+
+        result.expect("legacy segmented payload");
+        assert!(started);
+        assert!(!poisoned);
+        assert_eq!(io.output, b"legacy-prefixlegacy-headerlegacy-body");
+        assert_eq!(io.vectored_widths, [2, 1]);
+    }
+
+    #[test]
+    fn structured_encoded_len_counts_the_body_exactly_once() {
+        let (payload, expected, encoded_len) = structured_segments();
+        let announced_payload = i32::from_be_bytes(expected[..4].try_into().expect("frame prefix"));
+
+        assert_eq!(payload.encoded_len(), encoded_len);
+        assert_eq!(payload.encoded_len(), expected.len());
+        assert_eq!(announced_payload as usize + 4, expected.len());
+        assert!(matches!(payload, OutboundPayload::StructuredFrame(_)));
+        assert!(!matches!(payload, OutboundPayload::FrameSegments { .. }));
     }
 }

--- a/rocketmq-transport/src/writer_runtime/issue_9754_tests.rs
+++ b/rocketmq-transport/src/writer_runtime/issue_9754_tests.rs
@@ -161,6 +161,44 @@ struct PendingTransport {
     entered: Arc<tokio::sync::Notify>,
 }
 
+struct SuccessfulTransport {
+    attempts: Arc<AtomicUsize>,
+}
+
+impl AsyncRead for SuccessfulTransport {
+    fn poll_read(self: Pin<&mut Self>, _: &mut Context<'_>, _: &mut ReadBuf<'_>) -> Poll<io::Result<()>> {
+        Poll::Pending
+    }
+}
+
+impl AsyncWrite for SuccessfulTransport {
+    fn poll_write(self: Pin<&mut Self>, _: &mut Context<'_>, buffer: &[u8]) -> Poll<io::Result<usize>> {
+        self.attempts.fetch_add(1, Ordering::AcqRel);
+        Poll::Ready(Ok(buffer.len()))
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+        buffers: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        self.attempts.fetch_add(1, Ordering::AcqRel);
+        Poll::Ready(Ok(buffers.iter().map(|buffer| buffer.len()).sum()))
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
 impl AsyncRead for PendingTransport {
     fn poll_read(self: Pin<&mut Self>, _: &mut Context<'_>, _: &mut ReadBuf<'_>) -> Poll<io::Result<()>> {
         Poll::Pending
@@ -414,6 +452,120 @@ async fn active_file_failure_and_poison_drain_release_each_file_lease_once() {
     assert_eq!(active_drops.load(Ordering::SeqCst), 1);
     assert_eq!(follower_drops.load(Ordering::SeqCst), 1);
     assert_eq!(controller.snapshot().queued.current_count, 0);
+}
+
+#[tokio::test]
+async fn successful_file_write_releases_its_lease_once_after_completion() {
+    let owner = RuntimeOwner::new(RuntimeConfig::default()).expect("runtime owner");
+    let blocking = owner
+        .root_context()
+        .component("writer-file-success-test")
+        .storage_io()
+        .clone();
+    let controller = AdmissionController::new(AdmissionLimits::default());
+    let admission = controller
+        .prepare_scope(AdmissionScope::new("127.0.0.1".parse().expect("loopback")))
+        .expect("prepare scope");
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let connection = Connection::new_with_plaintext_stream(SuccessfulTransport {
+        attempts: Arc::clone(&attempts),
+    })
+    .with_file_region_io(blocking, FileTransferMode::Portable);
+    let (frame_writer, _reader) = connection.into_session_io(admission.clone());
+    let mut config = queue_config();
+    config.batch.max_items = NonZeroUsize::new(1).expect("non-zero");
+    config.data_max_bytes = NonZeroUsize::new(1024).expect("non-zero");
+    let (lanes, receivers) = writer_lanes(config);
+    let (write, completion, drops) = queued_file_write_with_completion(&admission, "successful-file");
+    lanes
+        .try_send(AdmissionClass::Data, write)
+        .expect("successful file queued");
+    drop(lanes);
+    let diagnostics = Arc::new(SessionWriterDiagnostics::new(config.total_capacity()));
+    let (state, _) = watch::channel(ConnectionState::Healthy);
+    run_session_writer(
+        frame_writer,
+        receivers,
+        diagnostics,
+        state,
+        CancellationToken::new(),
+        TransportTelemetry::noop(),
+    )
+    .await;
+
+    completion.await.expect("file completion").expect("file write succeeds");
+    assert!(
+        attempts.load(Ordering::Acquire) >= 2,
+        "head and body must both be written"
+    );
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+    assert_eq!(controller.snapshot().queued.current_count, 0);
+}
+
+#[tokio::test]
+async fn queued_file_cancellation_releases_its_lease_before_socket_progress() {
+    let controller = AdmissionController::new(AdmissionLimits::default());
+    let admission = controller
+        .prepare_scope(AdmissionScope::new("127.0.0.1".parse().expect("loopback")))
+        .expect("prepare scope");
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let connection = Connection::new_with_plaintext_stream(FailingTransport {
+        attempts: Arc::clone(&attempts),
+        flushes: Arc::new(AtomicUsize::new(0)),
+        phase: WriteFailurePhase::Flush,
+    });
+    let (frame_writer, _reader) = connection.into_session_io(admission.clone());
+    let mut config = queue_config();
+    config.data_max_bytes = NonZeroUsize::new(1024).expect("non-zero");
+    let (lanes, receivers) = writer_lanes(config);
+    let (write, completion, drops) = queued_file_write_with_completion(&admission, "cancelled-file");
+    let progress = Arc::clone(&write.progress);
+    lanes.try_send(AdmissionClass::Data, write).expect("file queued");
+    assert!(progress.cancel_before_start());
+    drop(lanes);
+    let diagnostics = Arc::new(SessionWriterDiagnostics::new(config.total_capacity()));
+    let (state, _) = watch::channel(ConnectionState::Healthy);
+    run_session_writer(
+        frame_writer,
+        receivers,
+        diagnostics,
+        state,
+        CancellationToken::new(),
+        TransportTelemetry::noop(),
+    )
+    .await;
+
+    let failure = completion
+        .await
+        .expect("cancelled file completion")
+        .expect_err("cancelled file must fail");
+    assert_eq!(failure.progress(), WriteProgress::NotStarted);
+    assert_eq!(attempts.load(Ordering::Acquire), 0);
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn dropping_a_queued_file_envelope_releases_its_lease_once() {
+    let controller = AdmissionController::new(AdmissionLimits::default());
+    let admission = controller
+        .prepare_scope(AdmissionScope::new("127.0.0.1".parse().expect("loopback")))
+        .expect("prepare scope");
+    let mut config = queue_config();
+    config.data_max_bytes = NonZeroUsize::new(1024).expect("non-zero");
+    let (lanes, mut receivers) = writer_lanes(config);
+    let (write, completion, drops) = queued_file_write_with_completion(&admission, "dropped-file");
+    drop(completion);
+    lanes.try_send(AdmissionClass::Data, write).expect("file queued");
+    drop(lanes);
+
+    let WriterEvent::Write(envelope) = receivers.recv().await else {
+        panic!("queued file envelope")
+    };
+    drop(envelope);
+
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+    assert_eq!(controller.snapshot().queued.current_count, 0);
+    assert_eq!(controller.snapshot().queued.current_bytes, 0);
 }
 
 #[tokio::test]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9775

### Brief Description

- Add a crate-private one-pass preparation seam for bound structured responses with exact metadata and typed encoding errors.
- Introduce a dedicated structured outbound frame for empty, `Bytes`, and body-only segments while preserving the existing file-region writer path.
- Extend plaintext and TLS writers with exact complete-frame accounting, ownership-preserving vectored writes, and causal lifecycle coverage.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-transport -- --check`
- focused response preparation, structured writer, and writer-runtime file lease tests
- `cargo test -p rocketmq-transport`
- `cargo test -p rocketmq-transport --all-features`
- `cargo test -p rocketmq-transport --doc --all-features`
- `cargo doc -p rocketmq-transport --no-deps --all-features`
- `cargo clippy -p rocketmq-transport --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `git diff --check origin/main`

`check-error-hygiene.ps1` reported only 18 pre-existing findings outside this diff; no new finding was introduced by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved RocketMQ response handling for structured data and file-based payloads.
  * Added support for segmented response bodies and efficient frame transmission.
  * Added response metadata, including request identifiers, body details, encoded sizes, and correction status.
  * Added validation for response sizes and malformed payloads.

* **Bug Fixes**
  * Improved cleanup of file resources when writes complete, are cancelled, or queued messages are dropped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->