### PR TITLE
[ISSUE #9776]✨Add plan-aware network and embedded response delivery

### DIFF
--- a/rocketmq-transport/src/connection.rs
+++ b/rocketmq-transport/src/connection.rs
@@ -40,8 +40,11 @@ use crate::backend::WriteBackend;
 use crate::codec::remoting_command_codec::FrameLimits;
 use crate::codec::remoting_command_codec::RemotingCommandCodec;
 use crate::codec::remoting_command_codec::SessionCommandDecoder;
+use crate::codec::PreparedResponse;
 use crate::deadline::RequestDeadline;
+use crate::dispatch::RequestControlView;
 use crate::dispatch::ResponseError;
+use crate::dispatch::ResponseTransportDropHandle;
 use crate::dispatch::WriteProgress;
 use crate::file_region::FileRegion;
 use crate::file_region::FileRegionSequence;
@@ -52,6 +55,7 @@ use crate::write_strategy::FrameWriteMode;
 use crate::write_strategy::FrameWriter;
 use crate::write_strategy::OutboundPayload;
 use crate::write_strategy::QueuedWrite;
+use crate::write_strategy::QueuedWriteCancellation;
 use crate::write_strategy::QueuedWriteProgress;
 use crate::writer_runtime::WriterLanes;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
@@ -181,6 +185,9 @@ enum SendFailure {
     SessionClosed {
         target: String,
     },
+    Cancelled {
+        target: String,
+    },
     QueueSaturated {
         target: String,
     },
@@ -200,6 +207,9 @@ impl SendFailure {
             Self::SessionClosed { target } => {
                 rocketmq_error::RocketMQError::network_connection_failed(target, "connection is closed")
             }
+            Self::Cancelled { target } => {
+                rocketmq_error::RocketMQError::network_connection_failed(target, "request was cancelled before send")
+            }
             Self::QueueSaturated { target } => rocketmq_error::RocketMQError::network_queue_full(target),
             Self::Writer {
                 target,
@@ -213,9 +223,66 @@ impl SendFailure {
         match self {
             Self::DeadlineExceeded { .. } => ResponseError::DeadlineExceeded,
             Self::SessionClosed { .. } => ResponseError::SessionClosed,
+            Self::Cancelled { .. } => ResponseError::Cancelled,
             Self::QueueSaturated { .. } => ResponseError::QueueSaturated,
             Self::Writer { failure, .. } => failure.into_response(),
         }
+    }
+}
+
+fn current_request_stop(control: &RequestControlView) -> Option<QueuedWriteCancellation> {
+    if control.parent_is_cancelled() {
+        Some(QueuedWriteCancellation::Request)
+    } else if control.session_is_closed() {
+        Some(QueuedWriteCancellation::SessionClosed)
+    } else if control.deadline().is_some_and(RequestDeadline::is_expired) {
+        Some(QueuedWriteCancellation::Deadline)
+    } else {
+        None
+    }
+}
+
+fn stop_failure(reason: QueuedWriteCancellation, target: String) -> SendFailure {
+    match reason {
+        QueuedWriteCancellation::Deadline => SendFailure::DeadlineExceeded { target },
+        QueuedWriteCancellation::Request => SendFailure::Cancelled { target },
+        QueuedWriteCancellation::SessionClosed => SendFailure::SessionClosed { target },
+    }
+}
+
+struct InFlightQueuedSendDrop {
+    handle: ResponseTransportDropHandle,
+    progress: Arc<QueuedWriteProgress>,
+    armed: bool,
+}
+
+impl InFlightQueuedSendDrop {
+    fn new(handle: ResponseTransportDropHandle, progress: Arc<QueuedWriteProgress>) -> Self {
+        handle.delegate();
+        Self {
+            handle,
+            progress,
+            armed: true,
+        }
+    }
+
+    fn complete(mut self) {
+        self.handle.resume_outer();
+        self.armed = false;
+    }
+}
+
+impl Drop for InFlightQueuedSendDrop {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let progress = if self.progress.cancel_before_start_with(QueuedWriteCancellation::Request) {
+            WriteProgress::NotStarted
+        } else {
+            WriteProgress::PossiblyPartial
+        };
+        self.handle.finish_dropped(progress);
     }
 }
 
@@ -543,8 +610,13 @@ pub struct Connection {
 
     telemetry: TransportTelemetry,
 
+    response_plan_drop: Option<ResponseTransportDropHandle>,
+
     #[cfg(test)]
     enqueue_gate: Option<(Arc<tokio::sync::Notify>, Arc<tokio::sync::Notify>)>,
+
+    #[cfg(test)]
+    enqueue_complete_signal: Option<Arc<tokio::sync::Notify>>,
 }
 
 impl Hash for Connection {
@@ -688,8 +760,11 @@ impl Connection {
             state_rx,
             connection_id: CheetahString::from_string(Uuid::new_v4().to_string()),
             telemetry: TransportTelemetry::noop(),
+            response_plan_drop: None,
             #[cfg(test)]
             enqueue_gate: None,
+            #[cfg(test)]
+            enqueue_complete_signal: None,
         }
     }
 
@@ -738,14 +813,27 @@ impl Connection {
             state_rx,
             connection_id,
             telemetry,
+            response_plan_drop: None,
             #[cfg(test)]
             enqueue_gate: None,
+            #[cfg(test)]
+            enqueue_complete_signal: None,
         }
     }
 
     #[cfg(test)]
     pub(crate) fn set_enqueue_gate(&mut self, checked: Arc<tokio::sync::Notify>, resume: Arc<tokio::sync::Notify>) {
         self.enqueue_gate = Some((checked, resume));
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_enqueue_complete_signal(&mut self, signal: Arc<tokio::sync::Notify>) {
+        self.enqueue_complete_signal = Some(signal);
+    }
+
+    pub(crate) fn with_response_plan_drop(mut self, drop_handle: Option<ResponseTransportDropHandle>) -> Self {
+        self.response_plan_drop = drop_handle;
+        self
     }
 
     #[cfg(test)]
@@ -827,7 +915,7 @@ impl Connection {
         deadline: Option<RequestDeadline>,
         target: String,
     ) -> rocketmq_error::RocketMQResult<()> {
-        self.send_payload_inner(payload, class, reservation, deadline, target)
+        self.send_payload_inner(payload, class, reservation, deadline, None, target)
             .await
             .map_err(SendFailure::into_legacy)
     }
@@ -838,8 +926,10 @@ impl Connection {
         class: AdmissionClass,
         reservation: Option<ResourcePermit>,
         deadline: Option<RequestDeadline>,
+        control: Option<&RequestControlView>,
         target: String,
     ) -> Result<(), SendFailure> {
+        let response_plan_drop = self.response_plan_drop.clone();
         let encoded_len = payload.encoded_len();
         let legacy_reason = match &self.outbound {
             ConnectionWriter::Direct(writer) => {
@@ -848,6 +938,9 @@ impl Connection {
             ConnectionWriter::Queued(_) => LegacyWriterReason::CanonicalWriter,
         };
         self.telemetry.record_outbound_attempted_plaintext_bytes(encoded_len);
+        if let Some(reason) = control.and_then(current_request_stop) {
+            return Err(stop_failure(reason, target));
+        }
         if deadline.is_some_and(RequestDeadline::is_expired) {
             return Err(SendFailure::DeadlineExceeded { target });
         }
@@ -866,7 +959,16 @@ impl Connection {
             #[cfg(test)]
             if let Some((checked, resume)) = self.enqueue_gate.as_ref() {
                 checked.notify_one();
-                if let Some(deadline) = deadline {
+                if let Some(control) = control {
+                    tokio::select! {
+                        biased;
+                        () = control.cancelled() => {
+                            let reason = current_request_stop(control).unwrap_or(QueuedWriteCancellation::Request);
+                            return Err(stop_failure(reason, target));
+                        }
+                        () = resume.notified() => {}
+                    }
+                } else if let Some(deadline) = deadline {
                     deadline
                         .timeout(resume.notified())
                         .await
@@ -885,6 +987,9 @@ impl Connection {
                 queued.writer_diagnostics.record_rejected(None);
                 SendFailure::QueueSaturated { target: target.clone() }
             })?;
+            if let Some(reason) = control.and_then(current_request_stop) {
+                return Err(stop_failure(reason, target));
+            }
             if deadline.is_some_and(RequestDeadline::is_expired) {
                 return Err(SendFailure::DeadlineExceeded { target });
             }
@@ -919,8 +1024,29 @@ impl Connection {
                     });
                 }
             }
+            let mut in_flight_drop =
+                response_plan_drop.map(|handle| InFlightQueuedSendDrop::new(handle, Arc::clone(&progress)));
+            #[cfg(test)]
+            if let Some(signal) = &self.enqueue_complete_signal {
+                signal.notify_one();
+            }
             let mut result = result;
-            let outcome = if let Some(deadline) = deadline {
+            let outcome = if let Some(control) = control {
+                tokio::select! {
+                    biased;
+                    outcome = &mut result => outcome,
+                    () = control.cancelled() => {
+                        let reason = current_request_stop(control).unwrap_or(QueuedWriteCancellation::Request);
+                        if progress.cancel_before_start_with(reason) {
+                            if let Some(drop_guard) = in_flight_drop.take() {
+                                drop_guard.complete();
+                            }
+                            return Err(stop_failure(reason, target));
+                        }
+                        result.await
+                    }
+                }
+            } else if let Some(deadline) = deadline {
                 match deadline.timeout(&mut result).await {
                     Ok(outcome) => outcome,
                     Err(_) => {
@@ -932,8 +1058,13 @@ impl Connection {
                 }
             } else {
                 result.await
-            }
-            .map_err(|_| {
+            };
+            let outcome = outcome.map_err(|_| {
+                if !progress.write_started() {
+                    if let Some(reason) = control.and_then(current_request_stop) {
+                        return stop_failure(reason, target.clone());
+                    }
+                }
                 let progress = if progress.write_started() {
                     WriteProgress::PossiblyPartial
                 } else {
@@ -944,11 +1075,22 @@ impl Connection {
                     target: target.clone(),
                     legacy_reason: LegacyWriterReason::CompletionDropped,
                 }
-            })?;
-            return outcome.map_err(|failure| SendFailure::Writer {
-                target,
-                failure,
-                legacy_reason,
+            });
+            if let Some(drop_guard) = in_flight_drop.take() {
+                drop_guard.complete();
+            }
+            let outcome = outcome?;
+            return outcome.map_err(|failure| {
+                if failure.progress() == WriteProgress::NotStarted {
+                    if let Some(reason) = control.and_then(current_request_stop) {
+                        return stop_failure(reason, target.clone());
+                    }
+                }
+                SendFailure::Writer {
+                    target,
+                    failure,
+                    legacy_reason,
+                }
             });
         }
         if self.state() == ConnectionState::Closed {
@@ -1021,6 +1163,37 @@ impl Connection {
     /// Sends a server response through the canonical writer with a stage-aware
     /// completion error. This is intentionally crate-private while the public
     /// response receipt/context API is introduced separately.
+    #[allow(
+        dead_code,
+        reason = "RSP-05 canonical prepared-response seam is invoked by later dispatcher wiring"
+    )]
+    pub(crate) async fn send_prepared_response(
+        &mut self,
+        prepared: PreparedResponse,
+        control: &RequestControlView,
+    ) -> Result<(), ResponseError> {
+        if self.queued_writer().is_none() {
+            return Err(ResponseError::SessionClosed);
+        }
+        let Some(class) = self.response_class() else {
+            return Err(ResponseError::SessionClosed);
+        };
+        let (_, payload) = prepared.into_parts();
+        self.send_payload_inner(
+            payload,
+            class,
+            None,
+            control.deadline(),
+            Some(control),
+            "transport-session-writer".to_string(),
+        )
+        .await
+        .map_err(SendFailure::into_response)
+    }
+
+    /// Sends a server response through the canonical writer with a stage-aware
+    /// completion error. This is intentionally crate-private while the public
+    /// response receipt/context API is introduced separately.
     pub(crate) async fn send_response(&mut self, command: RemotingCommand) -> Result<(), ResponseError> {
         let class = self
             .response_class()
@@ -1032,6 +1205,7 @@ impl Connection {
         self.send_payload_inner(
             OutboundPayload::Frame(frame),
             class,
+            None,
             None,
             None,
             "transport-session-writer".to_string(),
@@ -1054,6 +1228,7 @@ impl Connection {
         self.send_payload_inner(
             OutboundPayload::Frame(frame),
             class,
+            None,
             None,
             None,
             "transport-session-writer".to_string(),

--- a/rocketmq-transport/src/connection/issue_9754_tests.rs
+++ b/rocketmq-transport/src/connection/issue_9754_tests.rs
@@ -392,6 +392,7 @@ async fn actual_dropped_queued_completion_before_start_maps_to_typed_not_started
                 AdmissionClass::Data,
                 None,
                 None,
+                None,
                 "dropped-before-start-target".to_string(),
             )
             .await;
@@ -458,6 +459,7 @@ async fn actual_dropped_active_completion_maps_to_typed_possibly_partial() {
             .send_payload_inner(
                 OutboundPayload::Contiguous(Bytes::from_static(b"dropped-active")),
                 AdmissionClass::Data,
+                None,
                 None,
                 None,
                 "dropped-active-target".to_string(),
@@ -567,6 +569,7 @@ async fn explicit_sendfile_tls_preflight_preserves_legacy_reason_without_poisoni
             AdmissionClass::Data,
             None,
             None,
+            None,
             "typed-sendfile-target".to_string(),
         )
         .await
@@ -591,6 +594,7 @@ async fn explicit_sendfile_tls_preflight_preserves_legacy_reason_without_poisoni
         .send_payload_inner(
             explicit_sendfile_payload(),
             AdmissionClass::Data,
+            None,
             None,
             None,
             "legacy-sendfile-target".to_string(),
@@ -629,6 +633,7 @@ async fn direct_preflight_deadline_is_not_started_and_keeps_the_writer_healthy()
                 Some(crate::deadline::RequestDeadline::after(
                     std::time::Duration::from_millis(10),
                 )),
+                None,
                 "typed-direct-target".to_string(),
             )
             .await;
@@ -750,6 +755,7 @@ async fn queued_preflight_deadline_matches_direct_not_started_classification_wit
                 Some(crate::deadline::RequestDeadline::after(
                     std::time::Duration::from_millis(10),
                 )),
+                None,
                 "typed-queued-target".to_string(),
             )
             .await;
@@ -848,6 +854,7 @@ async fn queued_typed_transport_failure_matches_direct_possibly_partial_classifi
         .send_payload_inner(
             OutboundPayload::Contiguous(Bytes::from_static(b"queued-typed")),
             AdmissionClass::Data,
+            None,
             None,
             None,
             "typed-queued-target".to_string(),

--- a/rocketmq-transport/src/dispatch.rs
+++ b/rocketmq-transport/src/dispatch.rs
@@ -63,6 +63,13 @@ pub(crate) use response_plan::ResponseBody;
 pub use response_plan::ResponseBodyKind;
 pub use response_plan::ResponsePlan;
 pub use response_plan::ResponsePlanError;
+#[allow(
+    unused_imports,
+    reason = "RSP-05 exposes the private local handoff seam consumed by RSP-06"
+)]
+pub(crate) use response_sink::LocalResponsePlanReceiver;
 pub use response_sink::LocalResponseReceiver;
+pub(crate) use response_sink::NetworkResponsePlanContext;
 pub use response_sink::ResponseSink;
 pub use response_sink::ResponseSinkError;
+pub(crate) use response_sink::ResponseTransportDropHandle;

--- a/rocketmq-transport/src/dispatch/request_control.rs
+++ b/rocketmq-transport/src/dispatch/request_control.rs
@@ -189,6 +189,14 @@ impl RequestControlView {
             || self.parent_cancellation.is_cancelled()
     }
 
+    pub(crate) fn session_is_closed(&self) -> bool {
+        self.session.is_closed()
+    }
+
+    pub(crate) fn parent_is_cancelled(&self) -> bool {
+        self.parent_cancellation.is_cancelled()
+    }
+
     /// Waits until the deadline expires, the session closes, or the parent
     /// task group is cancelled.
     ///

--- a/rocketmq-transport/src/dispatch/response.rs
+++ b/rocketmq-transport/src/dispatch/response.rs
@@ -341,6 +341,17 @@ pub struct ResponseReceipt {
 }
 
 impl ResponseReceipt {
+    #[allow(
+        dead_code,
+        reason = "RSP-05 exact request receipts are created by later private dispatcher wiring"
+    )]
+    pub(crate) const fn new(request_id: RequestId, disposition: ResponseDisposition) -> Self {
+        Self {
+            request_id,
+            disposition,
+        }
+    }
+
     /// Reserves a synthetic V1 receipt before local completion starts.
     ///
     /// The fixed V1 namespace is process-local and intentionally has no request ownership. Its

--- a/rocketmq-transport/src/dispatch/response_plan.rs
+++ b/rocketmq-transport/src/dispatch/response_plan.rs
@@ -259,6 +259,20 @@ impl ResponsePlan {
         self.body_part_count
     }
 
+    #[allow(
+        dead_code,
+        reason = "RSP-05 local delivery rebuilds this trusted wrapper before later dispatcher wiring"
+    )]
+    pub(crate) fn from_bound_parts(head: RemotingCommand, body: ResponseBody) -> Self {
+        let (body_len, body_part_count) = body.metadata();
+        Self::new(head, body, body_len, body_part_count)
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn test_body(&self) -> &ResponseBody {
+        &self.body
+    }
+
     fn new(head: RemotingCommand, body: ResponseBody, body_len: usize, body_part_count: usize) -> Self {
         Self {
             head,
@@ -320,6 +334,16 @@ pub(crate) enum ResponseBody {
 }
 
 impl ResponseBody {
+    #[allow(dead_code, reason = "RSP-05 trusted local rewrapping preserves cached plan metadata")]
+    fn metadata(&self) -> (usize, usize) {
+        match self {
+            Self::Empty => (0, 0),
+            Self::Bytes(bytes) => (bytes.len(), 1),
+            Self::Segments(segments) => (segments.iter().map(Bytes::len).sum(), segments.len()),
+            Self::FileRegions(regions) => (regions.len() as usize, regions.regions().len()),
+        }
+    }
+
     const fn kind(&self) -> ResponseBodyKind {
         match self {
             Self::Empty => ResponseBodyKind::Empty,

--- a/rocketmq-transport/src/dispatch/response_sink.rs
+++ b/rocketmq-transport/src/dispatch/response_sink.rs
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[allow(
+    dead_code,
+    reason = "RSP-05 defines the private plan delivery seam wired by the later dispatcher stage"
+)]
+mod plan;
+
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -29,6 +35,11 @@ use crate::dispatch::ResponseError;
 use crate::dispatch::ResponseReceipt;
 use crate::dispatch::ResponseTerminalState;
 use crate::server::SessionHandle;
+
+use plan::LocalPlanSenderState;
+pub(crate) use plan::LocalResponsePlanReceiver;
+pub(crate) use plan::NetworkResponsePlanContext;
+pub(crate) use plan::ResponseTransportDropHandle;
 
 /// Typed failure produced by a response output capability.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -53,10 +64,20 @@ pub enum ResponseSinkError {
     Decode(String),
 }
 
-struct LocalResponseState {
+struct LegacyLocalResponseState {
     sender: Option<oneshot::Sender<Result<RemotingCommand, ResponseSinkError>>>,
     encoded: BytesMut,
     terminal_state: Option<ResponseTerminalState>,
+}
+
+#[derive(Clone)]
+enum LocalResponseMode {
+    Legacy(Arc<parking_lot::Mutex<LegacyLocalResponseState>>),
+    #[allow(
+        dead_code,
+        reason = "RSP-05 plan mode is constructed by the private seam wired by the later dispatcher stage"
+    )]
+    Plan(Arc<LocalPlanSenderState>),
 }
 
 #[derive(Clone)]
@@ -64,12 +85,19 @@ struct LocalResponseState {
 ///
 /// Construction remains private to [`ResponseSink::local`].
 pub struct LocalResponseSink {
-    state: Arc<parking_lot::Mutex<LocalResponseState>>,
+    mode: LocalResponseMode,
 }
 
 impl LocalResponseSink {
+    fn legacy_state(&self) -> Result<&parking_lot::Mutex<LegacyLocalResponseState>, ResponseSinkError> {
+        match &self.mode {
+            LocalResponseMode::Legacy(state) => Ok(state),
+            LocalResponseMode::Plan(_) => Err(ResponseSinkError::AlreadyCompleted),
+        }
+    }
+
     fn complete(&self, result: Result<RemotingCommand, ResponseSinkError>) -> Result<(), ResponseSinkError> {
-        let mut state = self.state.lock();
+        let mut state = self.legacy_state()?.lock();
         let sender = state.sender.take().ok_or(ResponseSinkError::AlreadyCompleted)?;
         let terminal_state = if result.is_ok() {
             ResponseTerminalState::Completed
@@ -95,7 +123,12 @@ impl LocalResponseSink {
         command: RemotingCommand,
         receipt: ResponseReceipt,
     ) -> Result<ResponseReceipt, ResponseError> {
-        let mut state = self.state.lock();
+        let mut state = self
+            .legacy_state()
+            .map_err(|_| ResponseError::AlreadyCompleted {
+                state: ResponseTerminalState::Closed,
+            })?
+            .lock();
         let Some(sender) = state.sender.take() else {
             return Err(ResponseError::AlreadyCompleted {
                 state: state.terminal_state.unwrap_or(ResponseTerminalState::Closed),
@@ -115,7 +148,7 @@ impl LocalResponseSink {
     }
 
     fn send_bytes(&self, bytes: Bytes) -> Result<(), ResponseSinkError> {
-        let mut state = self.state.lock();
+        let mut state = self.legacy_state()?.lock();
         if state.sender.is_none() {
             return Err(ResponseSinkError::AlreadyCompleted);
         }
@@ -145,6 +178,16 @@ impl LocalResponseSink {
     }
 }
 
+impl Drop for LocalResponseSink {
+    fn drop(&mut self) {
+        if let LocalResponseMode::Plan(state) = &self.mode {
+            if Arc::strong_count(state) == 1 {
+                state.close_last_sender();
+            }
+        }
+    }
+}
+
 /// Closed response output variants for network and in-process dispatch.
 #[derive(Clone)]
 pub enum ResponseSink {
@@ -160,11 +203,11 @@ impl ResponseSink {
     pub fn local() -> (Self, LocalResponseReceiver) {
         let (sender, receiver) = oneshot::channel();
         let sink = LocalResponseSink {
-            state: Arc::new(parking_lot::Mutex::new(LocalResponseState {
+            mode: LocalResponseMode::Legacy(Arc::new(parking_lot::Mutex::new(LegacyLocalResponseState {
                 sender: Some(sender),
                 encoded: BytesMut::new(),
                 terminal_state: None,
-            })),
+            }))),
         };
         (Self::Local(sink), LocalResponseReceiver { receiver })
     }

--- a/rocketmq-transport/src/dispatch/response_sink/plan.rs
+++ b/rocketmq-transport/src/dispatch/response_sink/plan.rs
@@ -1,0 +1,750 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Consuming plan-aware network and embedded response delivery.
+
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use tokio::sync::oneshot;
+
+use super::LocalResponseMode;
+use super::LocalResponseSink;
+use super::ResponseSink;
+use crate::admission::AdmissionClass;
+use crate::codec::prepare_response;
+use crate::dispatch::BoundResponsePlan;
+use crate::dispatch::RequestControlView;
+use crate::dispatch::ResponseDisposition;
+use crate::dispatch::ResponseError;
+use crate::dispatch::ResponsePlan;
+use crate::dispatch::ResponseReceipt;
+use crate::dispatch::ResponseTerminalState;
+use crate::dispatch::WriteProgress;
+use crate::server::SessionHandle;
+
+#[derive(Clone)]
+pub(crate) struct NetworkResponsePlanContext {
+    control: RequestControlView,
+    slot: Arc<ResponseCompletionSlot>,
+    transport_drop: ResponseTransportDropHandle,
+    #[cfg(test)]
+    enqueue_gate: Option<(Arc<tokio::sync::Notify>, Arc<tokio::sync::Notify>)>,
+    #[cfg(test)]
+    enqueue_complete_signal: Option<Arc<tokio::sync::Notify>>,
+}
+
+impl NetworkResponsePlanContext {
+    fn new(control: RequestControlView) -> Self {
+        let slot = Arc::new(ResponseCompletionSlot::new());
+        Self {
+            control,
+            transport_drop: ResponseTransportDropHandle::new(Arc::clone(&slot)),
+            slot,
+            #[cfg(test)]
+            enqueue_gate: None,
+            #[cfg(test)]
+            enqueue_complete_signal: None,
+        }
+    }
+
+    fn control(&self) -> &RequestControlView {
+        &self.control
+    }
+
+    fn slot(&self) -> &Arc<ResponseCompletionSlot> {
+        &self.slot
+    }
+
+    pub(crate) fn transport_drop_handle(&self) -> ResponseTransportDropHandle {
+        self.transport_drop.clone()
+    }
+
+    #[cfg(test)]
+    fn with_enqueue_gate(mut self, checked: Arc<tokio::sync::Notify>, resume: Arc<tokio::sync::Notify>) -> Self {
+        self.enqueue_gate = Some((checked, resume));
+        self
+    }
+
+    #[cfg(test)]
+    fn with_enqueue_complete_signal(mut self, signal: Arc<tokio::sync::Notify>) -> Self {
+        self.enqueue_complete_signal = Some(signal);
+        self
+    }
+}
+
+pub(super) struct LocalPlanSenderState {
+    sender: parking_lot::Mutex<Option<oneshot::Sender<Result<ResponsePlan, ResponseError>>>>,
+    sender_taken: Arc<AtomicBool>,
+    control: RequestControlView,
+    slot: Arc<ResponseCompletionSlot>,
+    #[cfg(test)]
+    handoff_gate: Option<(Arc<tokio::sync::Notify>, Arc<tokio::sync::Notify>)>,
+    #[cfg(test)]
+    handoff_attempts: Arc<std::sync::atomic::AtomicUsize>,
+}
+
+impl LocalPlanSenderState {
+    fn new(
+        sender: oneshot::Sender<Result<ResponsePlan, ResponseError>>,
+        sender_taken: Arc<AtomicBool>,
+        control: RequestControlView,
+        slot: Arc<ResponseCompletionSlot>,
+    ) -> Self {
+        Self {
+            sender: parking_lot::Mutex::new(Some(sender)),
+            sender_taken,
+            control,
+            slot,
+            #[cfg(test)]
+            handoff_gate: None,
+            #[cfg(test)]
+            handoff_attempts: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_handoff_gate(
+        mut self,
+        checked: Arc<tokio::sync::Notify>,
+        resume: Arc<tokio::sync::Notify>,
+        attempts: Arc<std::sync::atomic::AtomicUsize>,
+    ) -> Self {
+        self.handoff_gate = Some((checked, resume));
+        self.handoff_attempts = attempts;
+        self
+    }
+
+    fn take_sender(&self) -> Option<oneshot::Sender<Result<ResponsePlan, ResponseError>>> {
+        let sender = self.sender.lock().take();
+        if sender.is_some() {
+            self.sender_taken.store(true, Ordering::Release);
+        }
+        sender
+    }
+
+    pub(super) fn close_last_sender(&self) {
+        let Some(sender) = self.take_sender() else {
+            return;
+        };
+        if self.slot.close_if_open(ResponseTerminalState::Closed) {
+            let _ = sender.send(Err(ResponseError::SessionClosed));
+        }
+    }
+}
+
+/// Single owner of an exact in-process response plan handoff.
+pub(crate) struct LocalResponsePlanReceiver {
+    receiver: oneshot::Receiver<Result<ResponsePlan, ResponseError>>,
+    control: RequestControlView,
+    slot: Arc<ResponseCompletionSlot>,
+    sender_taken: Arc<AtomicBool>,
+}
+
+impl LocalResponsePlanReceiver {
+    pub(crate) async fn receive(mut self) -> Result<ResponsePlan, ResponseError> {
+        if let Some(stop) = current_stop(&self.control) {
+            self.slot.finish_external(stop);
+            return Err(stop.into_error());
+        }
+
+        let result = tokio::select! {
+            biased;
+            () = self.control.cancelled() => {
+                let stop = current_stop(&self.control).unwrap_or(ResponseStop::Cancelled);
+                self.slot.finish_external(stop);
+                return Err(stop.into_error());
+            }
+            result = &mut self.receiver => result,
+        };
+        result.map_err(|_| {
+            self.slot.finish_external(ResponseStop::SessionClosed);
+            ResponseError::SessionClosed
+        })?
+    }
+}
+
+impl Drop for LocalResponsePlanReceiver {
+    fn drop(&mut self) {
+        if !self.sender_taken.load(Ordering::Acquire) {
+            self.slot.close_from_receiver_drop();
+        }
+    }
+}
+
+impl ResponseSink {
+    pub(crate) fn network_plan(
+        session: SessionHandle,
+        admission_class: AdmissionClass,
+        control: RequestControlView,
+    ) -> Self {
+        let context = NetworkResponsePlanContext::new(control);
+        Self::Network(Arc::new(
+            session
+                .with_response_class(admission_class)
+                .with_response_plan_context(context),
+        ))
+    }
+
+    pub(crate) fn local_plan(control: RequestControlView) -> (Self, LocalResponsePlanReceiver) {
+        let (sender, receiver) = oneshot::channel();
+        let slot = Arc::new(ResponseCompletionSlot::new());
+        let sender_taken = Arc::new(AtomicBool::new(false));
+        let state = Arc::new(LocalPlanSenderState::new(
+            sender,
+            Arc::clone(&sender_taken),
+            control.clone(),
+            Arc::clone(&slot),
+        ));
+        let sink = Self::Local(LocalResponseSink {
+            mode: LocalResponseMode::Plan(state),
+        });
+        let receiver = LocalResponsePlanReceiver {
+            receiver,
+            control,
+            slot,
+            sender_taken,
+        };
+        (sink, receiver)
+    }
+
+    #[cfg(test)]
+    fn local_plan_with_handoff_gate(
+        control: RequestControlView,
+        checked: Arc<tokio::sync::Notify>,
+        resume: Arc<tokio::sync::Notify>,
+    ) -> (Self, LocalResponsePlanReceiver, Arc<std::sync::atomic::AtomicUsize>) {
+        let (sender, receiver) = oneshot::channel();
+        let slot = Arc::new(ResponseCompletionSlot::new());
+        let sender_taken = Arc::new(AtomicBool::new(false));
+        let attempts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let state = Arc::new(
+            LocalPlanSenderState::new(sender, Arc::clone(&sender_taken), control.clone(), Arc::clone(&slot))
+                .with_handoff_gate(checked, resume, Arc::clone(&attempts)),
+        );
+        let sink = Self::Local(LocalResponseSink {
+            mode: LocalResponseMode::Plan(state),
+        });
+        let receiver = LocalResponsePlanReceiver {
+            receiver,
+            control,
+            slot,
+            sender_taken,
+        };
+        (sink, receiver, attempts)
+    }
+
+    #[cfg(test)]
+    fn network_plan_with_enqueue_gate(
+        session: SessionHandle,
+        admission_class: AdmissionClass,
+        control: RequestControlView,
+        checked: Arc<tokio::sync::Notify>,
+        resume: Arc<tokio::sync::Notify>,
+    ) -> Self {
+        let context = NetworkResponsePlanContext::new(control).with_enqueue_gate(checked, resume);
+        Self::Network(Arc::new(
+            session
+                .with_response_class(admission_class)
+                .with_response_plan_context(context),
+        ))
+    }
+
+    #[cfg(test)]
+    fn network_plan_with_enqueue_observer(
+        session: SessionHandle,
+        admission_class: AdmissionClass,
+        control: RequestControlView,
+        signal: Arc<tokio::sync::Notify>,
+    ) -> Self {
+        let context = NetworkResponsePlanContext::new(control).with_enqueue_complete_signal(signal);
+        Self::Network(Arc::new(
+            session
+                .with_response_class(admission_class)
+                .with_response_plan_context(context),
+        ))
+    }
+
+    pub(crate) async fn send_plan(self, bound: BoundResponsePlan) -> Result<ResponseReceipt, ResponseError> {
+        match self {
+            Self::Network(session) => send_network_plan(session, bound).await,
+            Self::Local(sink) => send_local_plan(sink, bound).await,
+        }
+    }
+}
+
+async fn send_network_plan(
+    session: Arc<SessionHandle>,
+    bound: BoundResponsePlan,
+) -> Result<ResponseReceipt, ResponseError> {
+    let Some(context) = session.response_plan_context() else {
+        return Err(ResponseError::SessionClosed);
+    };
+    let mut claim = context.slot().claim().await?;
+    claim.observe_transport_drop(context.transport_drop_handle());
+    let request_id = bound.request_id();
+    if let Some(stop) = current_stop(context.control()) {
+        claim.finish(stop.terminal());
+        return Err(stop.into_error());
+    }
+
+    let mut connection = session.connection();
+    #[cfg(test)]
+    if let Some((checked, resume)) = &context.enqueue_gate {
+        connection.set_enqueue_gate(Arc::clone(checked), Arc::clone(resume));
+    }
+    #[cfg(test)]
+    if let Some(signal) = &context.enqueue_complete_signal {
+        connection.set_enqueue_complete_signal(Arc::clone(signal));
+    }
+    let prepared = match prepare_response(bound, connection.frame_limits()) {
+        Ok(prepared) => prepared,
+        Err(error) => {
+            claim.finish(terminal_for_error(&error));
+            return Err(error);
+        }
+    };
+    let metadata = *prepared.metadata();
+    debug_assert_eq!(metadata.request_id(), request_id);
+    if let Some(stop) = current_stop(context.control()) {
+        claim.finish(stop.terminal());
+        return Err(stop.into_error());
+    }
+
+    match connection.send_prepared_response(prepared, context.control()).await {
+        Ok(()) => {
+            claim.finish(ResponseTerminalState::Completed);
+            Ok(ResponseReceipt::new(
+                metadata.request_id(),
+                ResponseDisposition::TransportWritten,
+            ))
+        }
+        Err(error) => {
+            claim.finish(terminal_for_error(&error));
+            Err(error)
+        }
+    }
+}
+
+async fn send_local_plan(sink: LocalResponseSink, bound: BoundResponsePlan) -> Result<ResponseReceipt, ResponseError> {
+    let state = match &sink.mode {
+        LocalResponseMode::Plan(state) => Arc::clone(state),
+        LocalResponseMode::Legacy(_) => return Err(ResponseError::SessionClosed),
+    };
+    let claim = state.slot.claim().await?;
+    #[cfg(test)]
+    if let Some((checked, resume)) = &state.handoff_gate {
+        checked.notify_one();
+        resume.notified().await;
+    }
+    if let Some(stop) = current_stop(&state.control) {
+        return Err(claim.finish_stop(stop));
+    }
+
+    let (request_id, head, body) = bound.into_parts();
+    let plan = ResponsePlan::from_bound_parts(head, body);
+    claim.commit_local_handoff(&state, plan)?;
+    Ok(ResponseReceipt::new(request_id, ResponseDisposition::InProcessAccepted))
+}
+
+#[derive(Clone, Copy)]
+enum ResponseStop {
+    Cancelled,
+    SessionClosed,
+    DeadlineExceeded,
+}
+
+impl ResponseStop {
+    fn into_error(self) -> ResponseError {
+        match self {
+            Self::Cancelled => ResponseError::Cancelled,
+            Self::SessionClosed => ResponseError::SessionClosed,
+            Self::DeadlineExceeded => ResponseError::DeadlineExceeded,
+        }
+    }
+
+    fn terminal(self) -> ResponseTerminalState {
+        match self {
+            Self::Cancelled => ResponseTerminalState::Cancelled,
+            Self::SessionClosed => ResponseTerminalState::Closed,
+            Self::DeadlineExceeded => ResponseTerminalState::Failed {
+                progress: WriteProgress::NotStarted,
+            },
+        }
+    }
+}
+
+fn current_stop(control: &RequestControlView) -> Option<ResponseStop> {
+    if control.parent_is_cancelled() {
+        Some(ResponseStop::Cancelled)
+    } else if control.session_is_closed() {
+        Some(ResponseStop::SessionClosed)
+    } else if control
+        .deadline()
+        .is_some_and(crate::deadline::RequestDeadline::is_expired)
+    {
+        Some(ResponseStop::DeadlineExceeded)
+    } else {
+        None
+    }
+}
+
+fn terminal_for_error(error: &ResponseError) -> ResponseTerminalState {
+    match error {
+        ResponseError::Cancelled => ResponseTerminalState::Cancelled,
+        ResponseError::SessionClosed => ResponseTerminalState::Closed,
+        ResponseError::Transport { progress, .. } => ResponseTerminalState::Failed { progress: *progress },
+        ResponseError::DeadlineExceeded | ResponseError::QueueSaturated | ResponseError::Encode { .. } => {
+            ResponseTerminalState::Failed {
+                progress: WriteProgress::NotStarted,
+            }
+        }
+        ResponseError::AlreadyCompleted { state } => *state,
+    }
+}
+
+enum ResponseCompletionState {
+    Open,
+    Claimed,
+    Terminal {
+        state: ResponseTerminalState,
+        primary_session_closed: bool,
+        claimant_stop: Option<ResponseStop>,
+    },
+}
+
+struct ResponseCompletionSlot {
+    state: parking_lot::Mutex<ResponseCompletionState>,
+    changed: tokio::sync::Notify,
+}
+
+#[derive(Clone)]
+pub(crate) struct ResponseTransportDropHandle {
+    slot: Arc<ResponseCompletionSlot>,
+    delegated: Arc<AtomicBool>,
+}
+
+impl ResponseTransportDropHandle {
+    fn new(slot: Arc<ResponseCompletionSlot>) -> Self {
+        Self {
+            slot,
+            delegated: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    pub(crate) fn delegate(&self) {
+        self.delegated.store(true, Ordering::Release);
+    }
+
+    pub(crate) fn resume_outer(&self) {
+        self.delegated.store(false, Ordering::Release);
+    }
+
+    fn is_delegated(&self) -> bool {
+        self.delegated.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn finish_dropped(&self, progress: WriteProgress) {
+        self.slot.finish_claim(ResponseTerminalState::Failed { progress });
+    }
+}
+
+impl ResponseCompletionSlot {
+    fn new() -> Self {
+        Self {
+            state: parking_lot::Mutex::new(ResponseCompletionState::Open),
+            changed: tokio::sync::Notify::new(),
+        }
+    }
+
+    async fn claim(self: &Arc<Self>) -> Result<ResponseClaim, ResponseError> {
+        loop {
+            let changed = self.changed.notified();
+            tokio::pin!(changed);
+            changed.as_mut().enable();
+            {
+                let mut state = self.state.lock();
+                match &mut *state {
+                    ResponseCompletionState::Open => {
+                        *state = ResponseCompletionState::Claimed;
+                        return Ok(ResponseClaim {
+                            slot: Some(Arc::clone(self)),
+                            drop_state: ResponseTerminalState::Failed {
+                                progress: WriteProgress::NotStarted,
+                            },
+                            transport_drop: None,
+                        });
+                    }
+                    ResponseCompletionState::Claimed => {}
+                    ResponseCompletionState::Terminal {
+                        state,
+                        primary_session_closed,
+                        claimant_stop,
+                    } => {
+                        if claimant_stop.is_none() {
+                            if *primary_session_closed {
+                                *primary_session_closed = false;
+                                return Err(ResponseError::SessionClosed);
+                            }
+                            return Err(ResponseError::AlreadyCompleted { state: *state });
+                        }
+                    }
+                }
+            }
+            changed.await;
+        }
+    }
+
+    fn finish_claim(&self, terminal: ResponseTerminalState) {
+        let mut state = self.state.lock();
+        if matches!(*state, ResponseCompletionState::Claimed) {
+            *state = ResponseCompletionState::Terminal {
+                state: terminal,
+                primary_session_closed: false,
+                claimant_stop: None,
+            };
+            drop(state);
+            self.changed.notify_waiters();
+        }
+    }
+
+    fn finish_external(&self, stop: ResponseStop) {
+        let mut state = self.state.lock();
+        let claimant_stop = matches!(*state, ResponseCompletionState::Claimed).then_some(stop);
+        if !matches!(*state, ResponseCompletionState::Terminal { .. }) {
+            *state = ResponseCompletionState::Terminal {
+                state: stop.terminal(),
+                primary_session_closed: false,
+                claimant_stop,
+            };
+            drop(state);
+            self.changed.notify_waiters();
+        }
+    }
+
+    fn close_from_receiver_drop(&self) {
+        let mut state = self.state.lock();
+        let claimed = matches!(*state, ResponseCompletionState::Claimed);
+        if !matches!(*state, ResponseCompletionState::Terminal { .. }) {
+            *state = ResponseCompletionState::Terminal {
+                state: ResponseTerminalState::Closed,
+                primary_session_closed: !claimed,
+                claimant_stop: claimed.then_some(ResponseStop::SessionClosed),
+            };
+            drop(state);
+            self.changed.notify_waiters();
+        }
+    }
+
+    fn close_if_open(&self, terminal: ResponseTerminalState) -> bool {
+        let mut state = self.state.lock();
+        if matches!(*state, ResponseCompletionState::Open) {
+            *state = ResponseCompletionState::Terminal {
+                state: terminal,
+                primary_session_closed: false,
+                claimant_stop: None,
+            };
+            drop(state);
+            self.changed.notify_waiters();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn finish_claim_stop(&self, stop: ResponseStop) -> ResponseError {
+        let mut state = self.state.lock();
+        let (error, changed) = match &mut *state {
+            ResponseCompletionState::Claimed => {
+                *state = ResponseCompletionState::Terminal {
+                    state: stop.terminal(),
+                    primary_session_closed: false,
+                    claimant_stop: None,
+                };
+                (stop.into_error(), true)
+            }
+            ResponseCompletionState::Terminal {
+                state,
+                primary_session_closed,
+                claimant_stop,
+            } => {
+                if let Some(external_stop) = claimant_stop.take() {
+                    (external_stop.into_error(), true)
+                } else if *primary_session_closed {
+                    *primary_session_closed = false;
+                    (ResponseError::SessionClosed, true)
+                } else {
+                    (ResponseError::AlreadyCompleted { state: *state }, false)
+                }
+            }
+            ResponseCompletionState::Open => {
+                *state = ResponseCompletionState::Terminal {
+                    state: stop.terminal(),
+                    primary_session_closed: false,
+                    claimant_stop: None,
+                };
+                (stop.into_error(), true)
+            }
+        };
+        drop(state);
+        if changed {
+            self.changed.notify_waiters();
+        }
+        error
+    }
+
+    fn commit_local_handoff(
+        &self,
+        sender_state: &LocalPlanSenderState,
+        plan: ResponsePlan,
+    ) -> Result<(), ResponseError> {
+        let mut state = self.state.lock();
+        let (result, changed) = match &mut *state {
+            ResponseCompletionState::Claimed => {
+                if let Some(sender) = sender_state.take_sender() {
+                    #[cfg(test)]
+                    sender_state.handoff_attempts.fetch_add(1, Ordering::SeqCst);
+                    let result = if sender.send(Ok(plan)).is_ok() {
+                        *state = ResponseCompletionState::Terminal {
+                            state: ResponseTerminalState::Completed,
+                            primary_session_closed: false,
+                            claimant_stop: None,
+                        };
+                        Ok(())
+                    } else {
+                        *state = ResponseCompletionState::Terminal {
+                            state: ResponseTerminalState::Closed,
+                            primary_session_closed: false,
+                            claimant_stop: None,
+                        };
+                        Err(ResponseError::SessionClosed)
+                    };
+                    (result, true)
+                } else {
+                    *state = ResponseCompletionState::Terminal {
+                        state: ResponseTerminalState::Closed,
+                        primary_session_closed: false,
+                        claimant_stop: None,
+                    };
+                    (Err(ResponseError::SessionClosed), true)
+                }
+            }
+            ResponseCompletionState::Terminal {
+                state,
+                primary_session_closed,
+                claimant_stop,
+            } => {
+                if let Some(stop) = claimant_stop.take() {
+                    (Err(stop.into_error()), true)
+                } else if *primary_session_closed {
+                    *primary_session_closed = false;
+                    (Err(ResponseError::SessionClosed), true)
+                } else {
+                    (Err(ResponseError::AlreadyCompleted { state: *state }), false)
+                }
+            }
+            ResponseCompletionState::Open => {
+                *state = ResponseCompletionState::Terminal {
+                    state: ResponseTerminalState::Closed,
+                    primary_session_closed: false,
+                    claimant_stop: None,
+                };
+                (Err(ResponseError::SessionClosed), true)
+            }
+        };
+        drop(state);
+        if changed {
+            self.changed.notify_waiters();
+        }
+        result
+    }
+
+    fn abandon_claim(&self, terminal: ResponseTerminalState) {
+        let mut state = self.state.lock();
+        let changed = match &mut *state {
+            ResponseCompletionState::Claimed => {
+                *state = ResponseCompletionState::Terminal {
+                    state: terminal,
+                    primary_session_closed: false,
+                    claimant_stop: None,
+                };
+                true
+            }
+            ResponseCompletionState::Terminal { claimant_stop, .. } if claimant_stop.is_some() => {
+                *claimant_stop = None;
+                true
+            }
+            ResponseCompletionState::Open | ResponseCompletionState::Terminal { .. } => false,
+        };
+        drop(state);
+        if changed {
+            self.changed.notify_waiters();
+        }
+    }
+}
+
+struct ResponseClaim {
+    slot: Option<Arc<ResponseCompletionSlot>>,
+    drop_state: ResponseTerminalState,
+    transport_drop: Option<ResponseTransportDropHandle>,
+}
+
+impl ResponseClaim {
+    fn observe_transport_drop(&mut self, transport_drop: ResponseTransportDropHandle) {
+        self.transport_drop = Some(transport_drop);
+    }
+
+    fn finish(mut self, terminal: ResponseTerminalState) {
+        if let Some(slot) = self.slot.take() {
+            slot.finish_claim(terminal);
+        }
+    }
+
+    fn finish_stop(mut self, stop: ResponseStop) -> ResponseError {
+        self.slot
+            .take()
+            .map_or_else(|| stop.into_error(), |slot| slot.finish_claim_stop(stop))
+    }
+
+    fn commit_local_handoff(
+        mut self,
+        sender_state: &LocalPlanSenderState,
+        plan: ResponsePlan,
+    ) -> Result<(), ResponseError> {
+        self.slot.take().map_or_else(
+            || Err(ResponseError::SessionClosed),
+            |slot| slot.commit_local_handoff(sender_state, plan),
+        )
+    }
+}
+
+impl Drop for ResponseClaim {
+    fn drop(&mut self) {
+        if self
+            .transport_drop
+            .as_ref()
+            .is_some_and(ResponseTransportDropHandle::is_delegated)
+        {
+            return;
+        }
+        if let Some(slot) = self.slot.take() {
+            slot.abandon_claim(self.drop_state);
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "plan_tests/harness_tests.rs"]
+mod tests;

--- a/rocketmq-transport/src/dispatch/response_sink/plan_tests/harness_tests.rs
+++ b/rocketmq-transport/src/dispatch/response_sink/plan_tests/harness_tests.rs
@@ -1,0 +1,331 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs::File;
+use std::io::Write;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::task::Context;
+use std::task::Poll;
+use std::time::Duration;
+use std::time::Instant;
+
+use bytes::Bytes;
+use cheetah_string::CheetahString;
+use rocketmq_protocol::protocol::command_custom_header::CommandCustomHeader;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_runtime::BlockingLane;
+use rocketmq_runtime::RuntimeContext;
+use rocketmq_runtime::TaskGroup;
+use tokio::io::AsyncRead;
+use tokio::io::AsyncWrite;
+use tokio::io::ReadBuf;
+use tokio::sync::oneshot;
+
+use super::*;
+use crate::admission::AdmissionController;
+use crate::admission::AdmissionLimits;
+use crate::admission::ResourceLimit;
+use crate::codec::remoting_command_codec::FrameLimits;
+use crate::connection::Connection;
+use crate::connection::ConnectionState;
+use crate::deadline::RequestDeadline;
+use crate::dispatch::OriginalRequestIdentity;
+use crate::dispatch::RequestMeta;
+use crate::dispatch::ResponseBody;
+use crate::dispatch::ResponseBodyKind;
+use crate::file_region::FileRegion;
+use crate::file_region::FileRegionLease;
+use crate::file_region::FileRegionSequence;
+use crate::file_region::FileTransferMode;
+use crate::security::TransportSecurity;
+use crate::server::run_connected_session;
+use crate::server::ConnectionHandler;
+use crate::server::SessionHandle;
+use crate::session_view::SessionStateView;
+
+struct ControlHarness {
+    runtime: RuntimeContext,
+    parent: TaskGroup,
+    _state_tx: tokio::sync::watch::Sender<ConnectionState>,
+    closed_tx: tokio::sync::watch::Sender<bool>,
+}
+
+impl ControlHarness {
+    fn new(name: &'static str, deadline: Option<RequestDeadline>) -> (Self, RequestControlView) {
+        let runtime = RuntimeContext::from_current(name);
+        let parent = runtime.service_context(name).task_group().clone();
+        let (state_tx, state_rx) = tokio::sync::watch::channel(ConnectionState::Healthy);
+        let (closed_tx, closed_rx) = tokio::sync::watch::channel(false);
+        let control = RequestControlView::from_meta(
+            &RequestMeta::new(Instant::now(), deadline),
+            SessionStateView::from_receivers(state_rx, closed_rx),
+            &parent,
+        );
+        (
+            Self {
+                runtime,
+                parent,
+                _state_tx: state_tx,
+                closed_tx,
+            },
+            control,
+        )
+    }
+
+    async fn shutdown(self) {
+        let report = self.runtime.shutdown_tasks(Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+    }
+}
+
+fn response_head(code: i32, opaque: i32) -> RemotingCommand {
+    RemotingCommand::create_response_command_with_code(code).set_opaque(opaque)
+}
+
+fn bind(plan: ResponsePlan, owner: u64, opaque: i32) -> BoundResponsePlan {
+    let request = RemotingCommand::create_remoting_command(31).set_opaque(opaque);
+    let original = OriginalRequestIdentity::capture(owner, &AtomicU64::new(1), &request)
+        .expect("test request identity should allocate");
+    plan.bind(original).expect("ordinary request should bind")
+}
+
+struct CountingHeader {
+    encodes: Arc<AtomicUsize>,
+}
+
+impl CommandCustomHeader for CountingHeader {
+    fn to_map(&self) -> Option<std::collections::HashMap<CheetahString, CheetahString>> {
+        self.encodes.fetch_add(1, Ordering::SeqCst);
+        Some(std::collections::HashMap::new())
+    }
+}
+
+struct CountingLease {
+    file: File,
+    accesses: Arc<AtomicUsize>,
+    drops: Arc<AtomicUsize>,
+}
+
+struct FlushCountingTransport {
+    inner: tokio::io::DuplexStream,
+    flushes: Arc<AtomicUsize>,
+    fail_flush: bool,
+}
+
+impl AsyncRead for FlushCountingTransport {
+    fn poll_read(
+        mut self: std::pin::Pin<&mut Self>,
+        context: &mut Context<'_>,
+        buffer: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        std::pin::Pin::new(&mut self.inner).poll_read(context, buffer)
+    }
+}
+
+impl AsyncWrite for FlushCountingTransport {
+    fn poll_write(
+        mut self: std::pin::Pin<&mut Self>,
+        context: &mut Context<'_>,
+        buffer: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        std::pin::Pin::new(&mut self.inner).poll_write(context, buffer)
+    }
+
+    fn poll_write_vectored(
+        mut self: std::pin::Pin<&mut Self>,
+        context: &mut Context<'_>,
+        buffers: &[std::io::IoSlice<'_>],
+    ) -> Poll<std::io::Result<usize>> {
+        std::pin::Pin::new(&mut self.inner).poll_write_vectored(context, buffers)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
+    }
+
+    fn poll_flush(mut self: std::pin::Pin<&mut Self>, context: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        match std::pin::Pin::new(&mut self.inner).poll_flush(context) {
+            Poll::Ready(Ok(())) if self.fail_flush => Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "injected flush failure",
+            ))),
+            Poll::Ready(Ok(())) => {
+                self.flushes.fetch_add(1, Ordering::SeqCst);
+                Poll::Ready(Ok(()))
+            }
+            result => result,
+        }
+    }
+
+    fn poll_shutdown(mut self: std::pin::Pin<&mut Self>, context: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        std::pin::Pin::new(&mut self.inner).poll_shutdown(context)
+    }
+}
+
+struct CaptureSession {
+    sender: std::sync::Mutex<Option<oneshot::Sender<SessionHandle>>>,
+}
+
+impl ConnectionHandler for CaptureSession {
+    fn connected(
+        &self,
+        session: SessionHandle,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+        Box::pin(async move {
+            if let Some(sender) = self.sender.lock().expect("capture session lock").take() {
+                let _ = sender.send(session);
+            }
+        })
+    }
+
+    fn command(
+        &self,
+        _session: SessionHandle,
+        _command: RemotingCommand,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+        Box::pin(async {})
+    }
+}
+
+struct NetworkHarness {
+    runtime: RuntimeContext,
+    session: SessionHandle,
+    peer: Connection,
+    runner: tokio::task::JoinHandle<()>,
+    flushes: Arc<AtomicUsize>,
+}
+
+impl NetworkHarness {
+    async fn new(
+        name: &'static str,
+        limits: FrameLimits,
+        admission_limits: AdmissionLimits,
+        preflight: Option<crate::write_strategy::WritePreflightBarrier>,
+    ) -> Self {
+        Self::new_with_flush_behavior(name, limits, admission_limits, preflight, false).await
+    }
+
+    async fn new_with_flush_failure(name: &'static str) -> Self {
+        Self::new_with_flush_behavior(name, FrameLimits::default(), AdmissionLimits::default(), None, true).await
+    }
+
+    async fn new_with_flush_behavior(
+        name: &'static str,
+        limits: FrameLimits,
+        admission_limits: AdmissionLimits,
+        preflight: Option<crate::write_strategy::WritePreflightBarrier>,
+        fail_flush: bool,
+    ) -> Self {
+        let runtime = RuntimeContext::from_current(name);
+        let service = runtime.service_context(name);
+        let (transport, peer) = tokio::io::duplex(1024 * 1024);
+        let flushes = Arc::new(AtomicUsize::new(0));
+        let transport = FlushCountingTransport {
+            inner: transport,
+            flushes: Arc::clone(&flushes),
+            fail_flush,
+        };
+        let mut connection = Connection::new_with_plaintext_stream_and_limits(transport, limits).with_file_region_io(
+            runtime.blocking(BlockingLane::StorageIo).clone(),
+            FileTransferMode::Portable,
+        );
+        if let Some(preflight) = preflight {
+            connection.set_write_preflight_barrier(preflight);
+        }
+        let (session_tx, session_rx) = oneshot::channel();
+        let handler = Arc::new(CaptureSession {
+            sender: std::sync::Mutex::new(Some(session_tx)),
+        });
+        let local_addr = "127.0.0.1:19021".parse().expect("local address");
+        let remote_addr = "127.0.0.1:19022".parse().expect("remote address");
+        let runner = tokio::spawn(run_connected_session(
+            connection,
+            local_addr,
+            remote_addr,
+            service.task_group().clone(),
+            Arc::new(AdmissionController::new(admission_limits)),
+            Arc::new(TransportSecurity::development_insecure_loopback(None, None)),
+            None,
+            Duration::from_secs(30),
+            handler,
+        ));
+        let session = session_rx.await.expect("capture connected session");
+        Self {
+            runtime,
+            session,
+            peer: Connection::new_with_plaintext_stream(peer),
+            runner,
+            flushes,
+        }
+    }
+
+    fn control(&self, name: &'static str, deadline: Option<RequestDeadline>) -> (RequestControlView, TaskGroup) {
+        let parent = self
+            .runtime
+            .root_group()
+            .try_child(name)
+            .expect("request control child group");
+        let control = RequestControlView::from_meta(
+            &RequestMeta::new(Instant::now(), deadline),
+            self.session.session_view().state().clone(),
+            &parent,
+        );
+        (control, parent)
+    }
+
+    async fn receive(&mut self) -> RemotingCommand {
+        self.peer
+            .receive_command()
+            .await
+            .expect("peer should receive a frame")
+            .expect("peer should decode a frame")
+    }
+
+    async fn shutdown(self) {
+        let Self {
+            runtime,
+            session,
+            peer,
+            runner,
+            ..
+        } = self;
+        drop(session);
+        drop(peer);
+        runner.await.expect("connected session runner should stop");
+        let report = runtime.shutdown_tasks(Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+    }
+}
+
+impl FileRegionLease for CountingLease {
+    fn file(&self) -> &File {
+        self.accesses.fetch_add(1, Ordering::SeqCst);
+        &self.file
+    }
+}
+
+impl Drop for CountingLease {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[path = "local.rs"]
+mod local;
+
+#[path = "network.rs"]
+mod network;

--- a/rocketmq-transport/src/dispatch/response_sink/plan_tests/local.rs
+++ b/rocketmq-transport/src/dispatch/response_sink/plan_tests/local.rs
@@ -1,0 +1,489 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+#[tokio::test]
+async fn local_plan_hands_off_all_body_owners_without_encoding_or_copying_storage() {
+    let (harness, control) = ControlHarness::new("local-plan-four-bodies", None);
+
+    let empty = ResponsePlan::command(response_head(71, 700)).expect("empty response plan");
+    let (sink, receiver) = ResponseSink::local_plan(control.clone());
+    let receipt = sink.send_plan(bind(empty, 701, 701)).await.expect("empty plan handoff");
+    assert_eq!(receipt.request_id().owner_id(), 701);
+    assert_eq!(receipt.disposition(), ResponseDisposition::InProcessAccepted);
+    let received = receiver.receive().await.expect("receive empty plan");
+    assert_eq!(received.body_kind(), ResponseBodyKind::Empty);
+    assert_eq!(received.response_code(), 71);
+
+    let bytes = Bytes::from_static(b"local bytes");
+    let bytes_pointer = bytes.as_ptr();
+    let bytes_plan = ResponsePlan::bytes(response_head(72, 710), bytes).expect("bytes response plan");
+    let (sink, receiver) = ResponseSink::local_plan(control.clone());
+    sink.send_plan(bind(bytes_plan, 702, 702))
+        .await
+        .expect("bytes plan handoff");
+    let received = receiver.receive().await.expect("receive bytes plan");
+    let ResponseBody::Bytes(bytes) = received.test_body() else {
+        panic!("bytes owner should remain contiguous");
+    };
+    assert_eq!(bytes.as_ptr(), bytes_pointer);
+
+    let first = Bytes::from_static(b"first");
+    let second = Bytes::from_static(b"second");
+    let first_pointer = first.as_ptr();
+    let second_pointer = second.as_ptr();
+    let segments_plan =
+        ResponsePlan::segments(response_head(73, 720), vec![first, second]).expect("segments response plan");
+    let (vector_pointer, vector_capacity) = match segments_plan.test_body() {
+        ResponseBody::Segments(segments) => (segments.as_ptr(), segments.capacity()),
+        _ => panic!("segments plan should own segments"),
+    };
+    let (sink, receiver) = ResponseSink::local_plan(control.clone());
+    sink.send_plan(bind(segments_plan, 703, 703))
+        .await
+        .expect("segments plan handoff");
+    let received = receiver.receive().await.expect("receive segments plan");
+    let ResponseBody::Segments(segments) = received.test_body() else {
+        panic!("segments owner should remain segmented");
+    };
+    assert_eq!(segments.as_ptr(), vector_pointer);
+    assert_eq!(segments.capacity(), vector_capacity);
+    assert_eq!(segments[0].as_ptr(), first_pointer);
+    assert_eq!(segments[1].as_ptr(), second_pointer);
+    assert_eq!(
+        segments.iter().map(Bytes::as_ref).collect::<Vec<_>>(),
+        vec![&b"first"[..], &b"second"[..]]
+    );
+
+    let mut file = tempfile::tempfile().expect("temporary file");
+    file.write_all(b"file-body").expect("write file body");
+    let file = Arc::new(file);
+    let region = FileRegion::try_new(file.clone(), 0, 9).expect("file region");
+    let plan = ResponsePlan::file_regions(response_head(74, 730), FileRegionSequence::single(region))
+        .expect("file response plan");
+    let (sink, receiver) = ResponseSink::local_plan(control);
+    sink.send_plan(bind(plan, 704, 704)).await.expect("file plan handoff");
+    let received = receiver.receive().await.expect("receive file plan");
+    assert_eq!(received.body_kind(), ResponseBodyKind::FileRegions);
+    assert_eq!(received.body_len(), 9);
+    assert_eq!(Arc::strong_count(&file), 2);
+    drop(received);
+    assert_eq!(Arc::strong_count(&file), 1);
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn local_plan_never_invokes_the_header_encoder() {
+    let (harness, control) = ControlHarness::new("local-plan-no-encoder", None);
+    let encodes = Arc::new(AtomicUsize::new(0));
+    let head = response_head(75, 740).set_command_custom_header(CountingHeader {
+        encodes: Arc::clone(&encodes),
+    });
+    let plan = ResponsePlan::bytes(head, Bytes::from_static(b"body")).expect("response plan");
+    let (sink, receiver) = ResponseSink::local_plan(control);
+
+    sink.send_plan(bind(plan, 705, 705)).await.expect("local plan handoff");
+    assert_eq!(encodes.load(Ordering::SeqCst), 0);
+    drop(receiver.receive().await.expect("receive plan"));
+    assert_eq!(encodes.load(Ordering::SeqCst), 0);
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn local_plan_receiver_and_sender_drop_publish_closed_once() {
+    let (harness, control) = ControlHarness::new("local-plan-drop", None);
+    let (sink, receiver) = ResponseSink::local_plan(control.clone());
+    let duplicate = sink.clone();
+    drop(receiver);
+
+    assert!(matches!(
+        sink.send_plan(bind(
+            ResponsePlan::command(response_head(76, 750)).expect("response plan"),
+            706,
+            706,
+        ))
+        .await,
+        Err(ResponseError::SessionClosed)
+    ));
+    assert!(matches!(
+        duplicate
+            .send_plan(bind(
+                ResponsePlan::command(response_head(77, 751)).expect("duplicate response plan"),
+                707,
+                707,
+            ))
+            .await,
+        Err(ResponseError::AlreadyCompleted {
+            state: ResponseTerminalState::Closed
+        })
+    ));
+
+    let (sink, receiver) = ResponseSink::local_plan(control);
+    let clone = sink.clone();
+    drop(sink);
+    drop(clone);
+    assert!(matches!(receiver.receive().await, Err(ResponseError::SessionClosed)));
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn local_parent_cancellation_after_claim_prevents_handoff_and_resolves_duplicates() {
+    let (harness, control) = ControlHarness::new("local-plan-post-claim-cancel", None);
+    let checked = Arc::new(tokio::sync::Notify::new());
+    let resume = Arc::new(tokio::sync::Notify::new());
+    let (sink, receiver, handoff_attempts) =
+        ResponseSink::local_plan_with_handoff_gate(control, Arc::clone(&checked), Arc::clone(&resume));
+    let duplicate = sink.clone();
+    let final_duplicate = sink.clone();
+    let active = tokio::spawn(sink.send_plan(bind(
+        ResponsePlan::command(response_head(91, 830)).expect("active response plan"),
+        721,
+        721,
+    )));
+    checked.notified().await;
+
+    harness.parent.cancel();
+    assert!(matches!(receiver.receive().await, Err(ResponseError::Cancelled)));
+    let duplicate = tokio::spawn(duplicate.send_plan(bind(
+        ResponsePlan::command(response_head(92, 831)).expect("duplicate response plan"),
+        722,
+        722,
+    )));
+    tokio::task::yield_now().await;
+    assert!(!duplicate.is_finished(), "duplicate must wait for the active claimant");
+
+    resume.notify_one();
+    assert!(matches!(
+        active.await.expect("active task"),
+        Err(ResponseError::Cancelled)
+    ));
+    assert_eq!(handoff_attempts.load(Ordering::SeqCst), 0);
+    assert!(matches!(
+        duplicate.await.expect("duplicate task"),
+        Err(ResponseError::AlreadyCompleted {
+            state: ResponseTerminalState::Cancelled
+        })
+    ));
+    assert!(matches!(
+        final_duplicate
+            .send_plan(bind(
+                ResponsePlan::command(response_head(93, 832)).expect("final duplicate response plan"),
+                723,
+                723,
+            ))
+            .await,
+        Err(ResponseError::AlreadyCompleted {
+            state: ResponseTerminalState::Cancelled
+        })
+    ));
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn local_receiver_drop_after_claim_prevents_handoff_without_primary_close_leakage() {
+    let (harness, control) = ControlHarness::new("local-plan-post-claim-receiver-drop", None);
+    let checked = Arc::new(tokio::sync::Notify::new());
+    let resume = Arc::new(tokio::sync::Notify::new());
+    let (sink, receiver, handoff_attempts) =
+        ResponseSink::local_plan_with_handoff_gate(control, Arc::clone(&checked), Arc::clone(&resume));
+    let duplicate = sink.clone();
+    let final_duplicate = sink.clone();
+    let active = tokio::spawn(sink.send_plan(bind(
+        ResponsePlan::command(response_head(94, 840)).expect("active response plan"),
+        724,
+        724,
+    )));
+    checked.notified().await;
+
+    drop(receiver);
+    let duplicate = tokio::spawn(duplicate.send_plan(bind(
+        ResponsePlan::command(response_head(95, 841)).expect("duplicate response plan"),
+        725,
+        725,
+    )));
+    tokio::task::yield_now().await;
+    assert!(!duplicate.is_finished(), "duplicate must wait for the active claimant");
+
+    resume.notify_one();
+    assert!(matches!(
+        active.await.expect("active task"),
+        Err(ResponseError::SessionClosed)
+    ));
+    assert_eq!(handoff_attempts.load(Ordering::SeqCst), 0);
+    assert!(matches!(
+        duplicate.await.expect("duplicate task"),
+        Err(ResponseError::AlreadyCompleted {
+            state: ResponseTerminalState::Closed
+        })
+    ));
+    assert!(matches!(
+        final_duplicate
+            .send_plan(bind(
+                ResponsePlan::command(response_head(96, 842)).expect("final duplicate response plan"),
+                726,
+                726,
+            ))
+            .await,
+        Err(ResponseError::AlreadyCompleted {
+            state: ResponseTerminalState::Closed
+        })
+    ));
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn local_plan_sequential_and_concurrent_duplicates_observe_the_exact_terminal_state() {
+    let (harness, control) = ControlHarness::new("local-plan-duplicates", None);
+    let (sink, receiver) = ResponseSink::local_plan(control.clone());
+    let duplicate = sink.clone();
+    sink.send_plan(bind(
+        ResponsePlan::command(response_head(78, 760)).expect("response plan"),
+        708,
+        708,
+    ))
+    .await
+    .expect("first handoff");
+    assert!(matches!(
+        duplicate
+            .send_plan(bind(
+                ResponsePlan::command(response_head(79, 761)).expect("duplicate response plan"),
+                709,
+                709,
+            ))
+            .await,
+        Err(ResponseError::AlreadyCompleted {
+            state: ResponseTerminalState::Completed
+        })
+    ));
+    drop(receiver);
+
+    let (sink, receiver) = ResponseSink::local_plan(control);
+    let first = tokio::spawn(sink.clone().send_plan(bind(
+        ResponsePlan::command(response_head(80, 770)).expect("first response plan"),
+        710,
+        710,
+    )));
+    let second = tokio::spawn(sink.send_plan(bind(
+        ResponsePlan::command(response_head(81, 771)).expect("second response plan"),
+        711,
+        711,
+    )));
+    let first = first.await.expect("first task");
+    let second = second.await.expect("second task");
+    assert_eq!(usize::from(first.is_ok()) + usize::from(second.is_ok()), 1);
+    let duplicate = if first.is_err() { first } else { second };
+    assert!(matches!(
+        duplicate,
+        Err(ResponseError::AlreadyCompleted {
+            state: ResponseTerminalState::Completed
+        })
+    ));
+    drop(receiver);
+
+    harness.shutdown().await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn local_plan_preserves_cancel_session_deadline_priority_and_terminal_states() {
+    let deadline = RequestDeadline::after(Duration::from_secs(1));
+    let (deadline_harness, deadline_control) = ControlHarness::new("local-plan-deadline", Some(deadline));
+    tokio::time::advance(Duration::from_secs(1)).await;
+    let (sink, _receiver) = ResponseSink::local_plan(deadline_control);
+    let duplicate = sink.clone();
+    assert!(matches!(
+        sink.send_plan(bind(
+            ResponsePlan::command(response_head(82, 780)).expect("response plan"),
+            712,
+            712,
+        ))
+        .await,
+        Err(ResponseError::DeadlineExceeded)
+    ));
+    assert!(matches!(
+        duplicate
+            .send_plan(bind(
+                ResponsePlan::command(response_head(83, 781)).expect("duplicate response plan"),
+                713,
+                713,
+            ))
+            .await,
+        Err(ResponseError::AlreadyCompleted {
+            state: ResponseTerminalState::Failed {
+                progress: WriteProgress::NotStarted
+            }
+        })
+    ));
+    deadline_harness.shutdown().await;
+
+    let (cancel_harness, cancel_control) = ControlHarness::new("local-plan-cancel", None);
+    cancel_harness.parent.cancel();
+    let (sink, _receiver) = ResponseSink::local_plan(cancel_control);
+    assert!(matches!(
+        sink.send_plan(bind(
+            ResponsePlan::command(response_head(84, 790)).expect("response plan"),
+            714,
+            714,
+        ))
+        .await,
+        Err(ResponseError::Cancelled)
+    ));
+    cancel_harness.shutdown().await;
+
+    let (closed_harness, closed_control) = ControlHarness::new("local-plan-close", Some(deadline));
+    closed_harness
+        .closed_tx
+        .send(true)
+        .expect("session close publisher should remain open");
+    let (sink, _receiver) = ResponseSink::local_plan(closed_control);
+    assert!(matches!(
+        sink.send_plan(bind(
+            ResponsePlan::command(response_head(85, 800)).expect("response plan"),
+            715,
+            715,
+        ))
+        .await,
+        Err(ResponseError::SessionClosed)
+    ));
+    closed_harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn local_receiver_is_cancellation_first_without_reopening_a_completed_handoff() {
+    let (harness, control) = ControlHarness::new("local-plan-receiver-cancel", None);
+    let (sink, receiver) = ResponseSink::local_plan(control);
+    let duplicate = sink.clone();
+    sink.send_plan(bind(
+        ResponsePlan::bytes(response_head(87, 820), Bytes::from_static(b"already handed off")).expect("response plan"),
+        717,
+        717,
+    ))
+    .await
+    .expect("handoff should complete");
+    harness.parent.cancel();
+
+    assert!(matches!(receiver.receive().await, Err(ResponseError::Cancelled)));
+    assert!(matches!(
+        duplicate
+            .send_plan(bind(
+                ResponsePlan::command(response_head(88, 821)).expect("duplicate response plan"),
+                718,
+                718,
+            ))
+            .await,
+        Err(ResponseError::AlreadyCompleted {
+            state: ResponseTerminalState::Completed
+        })
+    ));
+
+    harness.shutdown().await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn local_receiver_stop_reasons_publish_their_exact_terminal_states() {
+    let deadline = RequestDeadline::after(Duration::from_secs(1));
+    let (deadline_harness, deadline_control) = ControlHarness::new("local-receiver-deadline", Some(deadline));
+    let (sink, receiver) = ResponseSink::local_plan(deadline_control);
+    tokio::time::advance(Duration::from_secs(1)).await;
+    assert!(matches!(receiver.receive().await, Err(ResponseError::DeadlineExceeded)));
+    assert!(matches!(
+        sink.send_plan(bind(
+            ResponsePlan::command(response_head(88, 821)).expect("response plan"),
+            718,
+            718,
+        ))
+        .await,
+        Err(ResponseError::AlreadyCompleted {
+            state: ResponseTerminalState::Failed {
+                progress: WriteProgress::NotStarted
+            }
+        })
+    ));
+    deadline_harness.shutdown().await;
+
+    let (cancel_harness, cancel_control) = ControlHarness::new("local-receiver-cancel", None);
+    let (sink, receiver) = ResponseSink::local_plan(cancel_control);
+    cancel_harness.parent.cancel();
+    assert!(matches!(receiver.receive().await, Err(ResponseError::Cancelled)));
+    assert!(matches!(
+        sink.send_plan(bind(
+            ResponsePlan::command(response_head(89, 822)).expect("response plan"),
+            719,
+            719,
+        ))
+        .await,
+        Err(ResponseError::AlreadyCompleted {
+            state: ResponseTerminalState::Cancelled
+        })
+    ));
+    cancel_harness.shutdown().await;
+
+    let (closed_harness, closed_control) = ControlHarness::new("local-receiver-close", None);
+    let (sink, receiver) = ResponseSink::local_plan(closed_control);
+    closed_harness
+        .closed_tx
+        .send(true)
+        .expect("session close publisher should remain open");
+    assert!(matches!(receiver.receive().await, Err(ResponseError::SessionClosed)));
+    assert!(matches!(
+        sink.send_plan(bind(
+            ResponsePlan::command(response_head(90, 823)).expect("response plan"),
+            720,
+            720,
+        ))
+        .await,
+        Err(ResponseError::AlreadyCompleted {
+            state: ResponseTerminalState::Closed
+        })
+    ));
+    closed_harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn local_file_plan_preserves_the_exact_lease_without_restatting_or_cloning() {
+    let (harness, control) = ControlHarness::new("local-plan-file-lease", None);
+    let accesses = Arc::new(AtomicUsize::new(0));
+    let drops = Arc::new(AtomicUsize::new(0));
+    let mut file = tempfile::tempfile().expect("temporary file");
+    file.write_all(b"leased body").expect("write leased body");
+    let lease = Arc::new(CountingLease {
+        file,
+        accesses: Arc::clone(&accesses),
+        drops: Arc::clone(&drops),
+    });
+    let region = FileRegion::try_new(lease.clone(), 0, 11).expect("file region");
+    let plan = ResponsePlan::file_regions(response_head(86, 810), FileRegionSequence::single(region))
+        .expect("file response plan");
+    assert_eq!(accesses.load(Ordering::SeqCst), 1);
+    assert_eq!(Arc::strong_count(&lease), 2);
+    let (sink, receiver) = ResponseSink::local_plan(control);
+
+    sink.send_plan(bind(plan, 716, 716)).await.expect("file plan handoff");
+    assert_eq!(accesses.load(Ordering::SeqCst), 1);
+    assert_eq!(Arc::strong_count(&lease), 2);
+    let received = receiver.receive().await.expect("receive file plan");
+    assert_eq!(accesses.load(Ordering::SeqCst), 1);
+    assert_eq!(Arc::strong_count(&lease), 2);
+    drop(received);
+    assert_eq!(Arc::strong_count(&lease), 1);
+    drop(lease);
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+
+    harness.shutdown().await;
+}

--- a/rocketmq-transport/src/dispatch/response_sink/plan_tests/network.rs
+++ b/rocketmq-transport/src/dispatch/response_sink/plan_tests/network.rs
@@ -1,0 +1,751 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+#[tokio::test]
+async fn network_plan_prepares_and_writes_all_four_bodies_before_issuing_receipts() {
+    let mut harness = NetworkHarness::new(
+        "network-plan-four-bodies",
+        FrameLimits::default(),
+        AdmissionLimits::default(),
+        None,
+    )
+    .await;
+    let encodes = Arc::new(AtomicUsize::new(0));
+    let plans = [
+        ResponsePlan::command(response_head(91, 900)).expect("empty response plan"),
+        ResponsePlan::bytes(
+            response_head(92, 901).set_command_custom_header(CountingHeader {
+                encodes: Arc::clone(&encodes),
+            }),
+            Bytes::from_static(b"bytes-body"),
+        )
+        .expect("bytes response plan"),
+        ResponsePlan::segments(
+            response_head(93, 902),
+            vec![Bytes::from_static(b"segment-"), Bytes::from_static(b"body")],
+        )
+        .expect("segments response plan"),
+        {
+            let mut file = tempfile::tempfile().expect("temporary file");
+            file.write_all(b"file-body").expect("write file body");
+            let region = FileRegion::try_new(Arc::new(file), 0, 9).expect("file region");
+            ResponsePlan::file_regions(response_head(94, 903), FileRegionSequence::single(region))
+                .expect("file response plan")
+        },
+    ];
+    let expected_bodies: [&[u8]; 4] = [b"", b"bytes-body", b"segment-body", b"file-body"];
+
+    for (index, (plan, expected_body)) in plans.into_iter().zip(expected_bodies).enumerate() {
+        let owner = 801 + index as u64;
+        let (control, _parent) = harness.control("network-plan-four-bodies-control", None);
+        let sink = ResponseSink::network_plan(harness.session.clone(), AdmissionClass::Data, control);
+        let flushes_before = harness.flushes.load(Ordering::SeqCst);
+        let receipt = sink
+            .send_plan(bind(plan, owner, 1_001 + index as i32))
+            .await
+            .expect("network plan should complete through writer");
+        assert_eq!(receipt.request_id().owner_id(), owner);
+        assert_eq!(receipt.disposition(), ResponseDisposition::TransportWritten);
+        assert!(harness.flushes.load(Ordering::SeqCst) > flushes_before);
+        let received = harness.receive().await;
+        assert_eq!(received.opaque(), 1_001 + index as i32);
+        assert_eq!(received.body().map(Bytes::as_ref).unwrap_or_default(), expected_body);
+    }
+    assert_eq!(encodes.load(Ordering::SeqCst), 1);
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn network_plan_flush_failure_reports_exact_progress_and_never_issues_or_retries_a_receipt() {
+    let mut harness = NetworkHarness::new_with_flush_failure("network-plan-flush-failure").await;
+    let (control, _parent) = harness.control("network-plan-flush-failure-control", None);
+    let sink = ResponseSink::network_plan(harness.session.clone(), AdmissionClass::Data, control);
+    let duplicate = sink.clone();
+
+    let error = sink
+        .send_plan(bind(
+            ResponsePlan::bytes(
+                response_head(117, 1_117),
+                Bytes::from_static(b"written-before-flush-fails"),
+            )
+            .expect("response plan"),
+            824,
+            1_117,
+        ))
+        .await
+        .expect_err("flush failure must prevent a receipt");
+    assert!(matches!(
+        error,
+        ResponseError::Transport {
+            progress: WriteProgress::PossiblyPartial,
+            ..
+        }
+    ));
+    assert!(matches!(
+        duplicate
+            .send_plan(bind(
+                ResponsePlan::command(response_head(118, 1_118)).expect("duplicate response plan"),
+                825,
+                1_118,
+            ))
+            .await,
+        Err(ResponseError::AlreadyCompleted {
+            state: ResponseTerminalState::Failed {
+                progress: WriteProgress::PossiblyPartial
+            }
+        })
+    ));
+    let received = harness.receive().await;
+    assert_eq!(received.opaque(), 1_117);
+    assert_eq!(
+        received.body().map(Bytes::as_ref),
+        Some(&b"written-before-flush-fails"[..])
+    );
+    assert_eq!(harness.flushes.load(Ordering::SeqCst), 0);
+    let second = tokio::time::timeout(Duration::from_millis(25), harness.peer.receive_command()).await;
+    assert!(
+        !matches!(second, Ok(Some(Ok(_)))),
+        "terminal duplicate must not write a second frame"
+    );
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn network_plan_rejects_pre_encode_stops_and_preserves_typed_encode_failures() {
+    let harness = NetworkHarness::new(
+        "network-plan-preflight-errors",
+        FrameLimits {
+            max_header_bytes: 0,
+            ..FrameLimits::default()
+        },
+        AdmissionLimits::default(),
+        None,
+    )
+    .await;
+    let encodes = Arc::new(AtomicUsize::new(0));
+    let (expired, _parent) = harness.control(
+        "network-plan-expired-control",
+        Some(RequestDeadline::after(Duration::ZERO)),
+    );
+    let sink = ResponseSink::network_plan(harness.session.clone(), AdmissionClass::Data, expired);
+    let plan = ResponsePlan::command(response_head(95, 910).set_command_custom_header(CountingHeader {
+        encodes: Arc::clone(&encodes),
+    }))
+    .expect("response plan");
+    assert!(matches!(
+        sink.send_plan(bind(plan, 805, 1_005)).await,
+        Err(ResponseError::DeadlineExceeded)
+    ));
+    assert_eq!(encodes.load(Ordering::SeqCst), 0);
+
+    let (control, _parent) = harness.control("network-plan-encode-control", None);
+    let sink = ResponseSink::network_plan(harness.session.clone(), AdmissionClass::Data, control);
+    let plan = ResponsePlan::command(response_head(96, 911).set_command_custom_header(CountingHeader {
+        encodes: Arc::clone(&encodes),
+    }))
+    .expect("response plan");
+    let error = sink
+        .send_plan(bind(plan, 806, 1_006))
+        .await
+        .expect_err("zero header limit should reject encoding");
+    let ResponseError::Encode { source } = error else {
+        panic!("encoding failure should preserve its typed source");
+    };
+    assert_eq!(source.kind().code().as_str(), "SERIALIZATION_FAILED");
+    assert_eq!(encodes.load(Ordering::SeqCst), 1);
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn network_plan_rechecks_control_after_encoding_without_retrying_the_encoder() {
+    let harness = NetworkHarness::new(
+        "network-plan-post-encode-stop",
+        FrameLimits::default(),
+        AdmissionLimits::default(),
+        None,
+    )
+    .await;
+    let checked = Arc::new(tokio::sync::Notify::new());
+    let resume = Arc::new(tokio::sync::Notify::new());
+    let encodes = Arc::new(AtomicUsize::new(0));
+    let (control, parent) = harness.control("network-plan-post-encode-control", None);
+    let sink = ResponseSink::network_plan_with_enqueue_gate(
+        harness.session.clone(),
+        AdmissionClass::Data,
+        control,
+        Arc::clone(&checked),
+        resume,
+    );
+    let duplicate = sink.clone();
+    let send = tokio::spawn(
+        sink.send_plan(bind(
+            ResponsePlan::command(response_head(97, 1_007).set_command_custom_header(CountingHeader {
+                encodes: Arc::clone(&encodes),
+            }))
+            .expect("response plan"),
+            807,
+            1_007,
+        )),
+    );
+    checked.notified().await;
+    let duplicate = tokio::spawn(duplicate.send_plan(bind(
+        ResponsePlan::command(response_head(98, 1_008)).expect("duplicate response plan"),
+        808,
+        1_008,
+    )));
+    tokio::task::yield_now().await;
+    assert!(
+        !duplicate.is_finished(),
+        "concurrent duplicate must wait for the claimed owner"
+    );
+    parent.cancel();
+
+    assert!(matches!(
+        send.await.expect("plan send task"),
+        Err(ResponseError::Cancelled)
+    ));
+    assert_eq!(encodes.load(Ordering::SeqCst), 1);
+    assert!(matches!(
+        duplicate.await.expect("duplicate plan task"),
+        Err(ResponseError::AlreadyCompleted {
+            state: ResponseTerminalState::Cancelled
+        })
+    ));
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn network_plan_queue_rejection_is_not_started_and_drops_a_file_lease_once() {
+    let harness = NetworkHarness::new(
+        "network-plan-queue-reject",
+        FrameLimits::default(),
+        AdmissionLimits {
+            queued: ResourceLimit { count: 64, bytes: 1 },
+            ..AdmissionLimits::default()
+        },
+        None,
+    )
+    .await;
+    let accesses = Arc::new(AtomicUsize::new(0));
+    let drops = Arc::new(AtomicUsize::new(0));
+    let mut file = tempfile::tempfile().expect("temporary file");
+    file.write_all(b"leased body").expect("write leased body");
+    let lease = Arc::new(CountingLease {
+        file,
+        accesses: Arc::clone(&accesses),
+        drops: Arc::clone(&drops),
+    });
+    let region = FileRegion::try_new(lease.clone(), 0, 11).expect("file region");
+    let plan = ResponsePlan::file_regions(response_head(99, 1_009), FileRegionSequence::single(region))
+        .expect("response plan");
+    let (control, _parent) = harness.control("network-plan-queue-reject-control", None);
+    let sink = ResponseSink::network_plan(harness.session.clone(), AdmissionClass::Data, control);
+    let duplicate = sink.clone();
+
+    assert!(matches!(
+        sink.send_plan(bind(plan, 809, 1_009)).await,
+        Err(ResponseError::QueueSaturated)
+    ));
+    assert!(matches!(
+        duplicate
+            .send_plan(bind(
+                ResponsePlan::command(response_head(100, 1_010)).expect("duplicate response plan"),
+                810,
+                1_010,
+            ))
+            .await,
+        Err(ResponseError::AlreadyCompleted {
+            state: ResponseTerminalState::Failed {
+                progress: WriteProgress::NotStarted
+            }
+        })
+    ));
+    assert_eq!(accesses.load(Ordering::SeqCst), 1);
+    assert_eq!(Arc::strong_count(&lease), 1);
+    assert_eq!(drops.load(Ordering::SeqCst), 0);
+    drop(lease);
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn network_plan_preserves_session_close_before_and_after_encoding() {
+    let pre_encode = NetworkHarness::new(
+        "network-plan-pre-encode-close",
+        FrameLimits::default(),
+        AdmissionLimits::default(),
+        None,
+    )
+    .await;
+    let encodes = Arc::new(AtomicUsize::new(0));
+    let (control, _parent) = pre_encode.control("network-plan-pre-encode-close-control", None);
+    let sink = ResponseSink::network_plan(pre_encode.session.clone(), AdmissionClass::Data, control);
+    let duplicate = sink.clone();
+    pre_encode.session.abort();
+    let plan = ResponsePlan::command(response_head(112, 1_112).set_command_custom_header(CountingHeader {
+        encodes: Arc::clone(&encodes),
+    }))
+    .expect("response plan");
+    assert!(matches!(
+        sink.send_plan(bind(plan, 819, 1_112)).await,
+        Err(ResponseError::SessionClosed)
+    ));
+    assert_eq!(encodes.load(Ordering::SeqCst), 0);
+    assert!(matches!(
+        duplicate
+            .send_plan(bind(
+                ResponsePlan::command(response_head(113, 1_113)).expect("duplicate response plan"),
+                820,
+                1_113,
+            ))
+            .await,
+        Err(ResponseError::AlreadyCompleted {
+            state: ResponseTerminalState::Closed
+        })
+    ));
+    pre_encode.shutdown().await;
+
+    let post_encode = NetworkHarness::new(
+        "network-plan-post-encode-close",
+        FrameLimits::default(),
+        AdmissionLimits::default(),
+        None,
+    )
+    .await;
+    let checked = Arc::new(tokio::sync::Notify::new());
+    let resume = Arc::new(tokio::sync::Notify::new());
+    let (control, _parent) = post_encode.control("network-plan-post-encode-close-control", None);
+    let sink = ResponseSink::network_plan_with_enqueue_gate(
+        post_encode.session.clone(),
+        AdmissionClass::Data,
+        control,
+        Arc::clone(&checked),
+        resume,
+    );
+    let plan = ResponsePlan::command(response_head(114, 1_114).set_command_custom_header(CountingHeader {
+        encodes: Arc::clone(&encodes),
+    }))
+    .expect("response plan");
+    let send = tokio::spawn(sink.send_plan(bind(plan, 821, 1_114)));
+    checked.notified().await;
+    post_encode.session.abort();
+    assert!(matches!(
+        send.await.expect("plan send task"),
+        Err(ResponseError::SessionClosed)
+    ));
+    assert_eq!(encodes.load(Ordering::SeqCst), 1);
+    post_encode.shutdown().await;
+}
+
+#[tokio::test]
+async fn dropping_a_waiting_network_send_cancels_before_start_and_writes_no_plan_bytes() {
+    let checked = Arc::new(tokio::sync::Notify::new());
+    let resume = Arc::new(tokio::sync::Notify::new());
+    let barrier = crate::write_strategy::WritePreflightBarrier::new(Arc::clone(&checked), Arc::clone(&resume));
+    let mut harness = NetworkHarness::new(
+        "network-plan-waiting-drop",
+        FrameLimits::default(),
+        AdmissionLimits::default(),
+        Some(barrier),
+    )
+    .await;
+
+    let mut blocker_connection = harness.session.connection();
+    let blocker = tokio::spawn(async move {
+        blocker_connection
+            .send_command(response_head(101, 1_101))
+            .await
+            .expect("blocker should write after the barrier resumes");
+    });
+    checked.notified().await;
+
+    let enqueued = Arc::new(tokio::sync::Notify::new());
+    let (control, _parent) = harness.control("network-plan-waiting-drop-control", None);
+    let sink = ResponseSink::network_plan_with_enqueue_observer(
+        harness.session.clone(),
+        AdmissionClass::Data,
+        control,
+        Arc::clone(&enqueued),
+    );
+    let duplicate = sink.clone();
+    let send = tokio::spawn(sink.send_plan(bind(
+        ResponsePlan::bytes(response_head(102, 1_102), Bytes::from_static(b"must-not-write")).expect("response plan"),
+        811,
+        1_102,
+    )));
+    enqueued.notified().await;
+    send.abort();
+    assert!(send.await.expect_err("aborted plan send should stop").is_cancelled());
+
+    assert!(matches!(
+        duplicate
+            .send_plan(bind(
+                ResponsePlan::command(response_head(103, 1_103)).expect("duplicate response plan"),
+                812,
+                1_103,
+            ))
+            .await,
+        Err(ResponseError::AlreadyCompleted {
+            state: ResponseTerminalState::Failed {
+                progress: WriteProgress::NotStarted
+            }
+        })
+    ));
+    resume.notify_one();
+    blocker.await.expect("blocker task should complete");
+    let received = harness.receive().await;
+    assert_eq!(received.opaque(), 1_101);
+    assert!(
+        tokio::time::timeout(Duration::from_millis(25), harness.peer.receive_command())
+            .await
+            .is_err(),
+        "cancelled waiting plan must not write a second frame"
+    );
+    assert_eq!(harness.session.writer_snapshot().deadline_expired, 0);
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn dropping_a_writer_claimed_network_send_is_terminally_possibly_partial_and_not_retried() {
+    let checked = Arc::new(tokio::sync::Notify::new());
+    let resume = Arc::new(tokio::sync::Notify::new());
+    let barrier = crate::write_strategy::WritePreflightBarrier::new(Arc::clone(&checked), Arc::clone(&resume));
+    let mut harness = NetworkHarness::new(
+        "network-plan-claimed-drop",
+        FrameLimits::default(),
+        AdmissionLimits::default(),
+        Some(barrier),
+    )
+    .await;
+
+    let enqueued = Arc::new(tokio::sync::Notify::new());
+    let (control, _parent) = harness.control("network-plan-claimed-drop-control", None);
+    let sink = ResponseSink::network_plan_with_enqueue_observer(
+        harness.session.clone(),
+        AdmissionClass::Data,
+        control,
+        Arc::clone(&enqueued),
+    );
+    let duplicate = sink.clone();
+    let send = tokio::spawn(sink.send_plan(bind(
+        ResponsePlan::bytes(response_head(104, 1_104), Bytes::from_static(b"write-once")).expect("response plan"),
+        813,
+        1_104,
+    )));
+    enqueued.notified().await;
+    checked.notified().await;
+    send.abort();
+    assert!(send.await.expect_err("aborted plan send should stop").is_cancelled());
+
+    assert!(matches!(
+        duplicate
+            .send_plan(bind(
+                ResponsePlan::command(response_head(105, 1_105)).expect("duplicate response plan"),
+                814,
+                1_105,
+            ))
+            .await,
+        Err(ResponseError::AlreadyCompleted {
+            state: ResponseTerminalState::Failed {
+                progress: WriteProgress::PossiblyPartial
+            }
+        })
+    ));
+    resume.notify_one();
+    let received = harness.receive().await;
+    assert_eq!(received.opaque(), 1_104);
+    assert_eq!(received.body().map(Bytes::as_ref), Some(&b"write-once"[..]));
+    assert!(
+        tokio::time::timeout(Duration::from_millis(25), harness.peer.receive_command())
+            .await
+            .is_err(),
+        "the terminal duplicate must not enqueue a second frame"
+    );
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn session_close_after_writer_claim_but_before_start_stays_closed_and_writes_nothing() {
+    let checked = Arc::new(tokio::sync::Notify::new());
+    let resume = Arc::new(tokio::sync::Notify::new());
+    let barrier = crate::write_strategy::WritePreflightBarrier::new(Arc::clone(&checked), Arc::clone(&resume));
+    let mut harness = NetworkHarness::new(
+        "network-plan-claimed-close",
+        FrameLimits::default(),
+        AdmissionLimits::default(),
+        Some(barrier),
+    )
+    .await;
+    let enqueued = Arc::new(tokio::sync::Notify::new());
+    let (control, _parent) = harness.control("network-plan-claimed-close-control", None);
+    let sink = ResponseSink::network_plan_with_enqueue_observer(
+        harness.session.clone(),
+        AdmissionClass::Data,
+        control,
+        Arc::clone(&enqueued),
+    );
+    let duplicate = sink.clone();
+    let send = tokio::spawn(sink.send_plan(bind(
+        ResponsePlan::bytes(response_head(115, 1_115), Bytes::from_static(b"must-not-start")).expect("response plan"),
+        822,
+        1_115,
+    )));
+    enqueued.notified().await;
+    checked.notified().await;
+    harness.session.abort();
+    assert!(matches!(
+        send.await.expect("plan send task"),
+        Err(ResponseError::SessionClosed)
+    ));
+    let duplicate_result = duplicate
+        .send_plan(bind(
+            ResponsePlan::command(response_head(116, 1_116)).expect("duplicate response plan"),
+            823,
+            1_116,
+        ))
+        .await;
+    assert!(
+        matches!(
+            duplicate_result,
+            Err(ResponseError::AlreadyCompleted {
+                state: ResponseTerminalState::Closed
+            })
+        ),
+        "unexpected duplicate result: {duplicate_result:?}"
+    );
+    resume.notify_one();
+    let observed = tokio::time::timeout(Duration::from_millis(25), harness.peer.receive_command()).await;
+    assert!(
+        !matches!(observed, Ok(Some(Ok(_)))),
+        "session close before writer start must not touch the socket"
+    );
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn session_close_after_writer_start_reports_possibly_partial_and_never_retries() {
+    let checked = Arc::new(tokio::sync::Notify::new());
+    let resume = Arc::new(tokio::sync::Notify::new());
+    let barrier = crate::write_strategy::WritePreflightBarrier::new(Arc::clone(&checked), Arc::clone(&resume));
+    let mut harness = NetworkHarness::new(
+        "network-plan-started-close",
+        FrameLimits::default(),
+        AdmissionLimits::default(),
+        Some(barrier),
+    )
+    .await;
+    let (control, _parent) = harness.control("network-plan-started-close-control", None);
+    let sink = ResponseSink::network_plan(harness.session.clone(), AdmissionClass::Data, control);
+    let duplicate = sink.clone();
+    let send = tokio::spawn(
+        sink.send_plan(bind(
+            ResponsePlan::bytes(response_head(119, 1_119), Bytes::from(vec![0x5a; 2 * 1024 * 1024]))
+                .expect("response plan"),
+            826,
+            1_119,
+        )),
+    );
+    checked.notified().await;
+    resume.notify_one();
+    while harness.session.writer_snapshot().queued_items != 0 {
+        assert!(
+            !send.is_finished(),
+            "large response must still be blocked in socket I/O"
+        );
+        tokio::task::yield_now().await;
+    }
+    assert!(
+        !send.is_finished(),
+        "large response must still be blocked in socket I/O"
+    );
+    harness.session.abort();
+
+    assert!(matches!(
+        send.await.expect("plan send task"),
+        Err(ResponseError::Transport {
+            progress: WriteProgress::PossiblyPartial,
+            ..
+        })
+    ));
+    assert!(matches!(
+        duplicate
+            .send_plan(bind(
+                ResponsePlan::command(response_head(120, 1_120)).expect("duplicate response plan"),
+                827,
+                1_120,
+            ))
+            .await,
+        Err(ResponseError::AlreadyCompleted {
+            state: ResponseTerminalState::Failed {
+                progress: WriteProgress::PossiblyPartial
+            }
+        })
+    ));
+    let observed = tokio::time::timeout(Duration::from_millis(25), harness.peer.receive_command()).await;
+    assert!(
+        !matches!(observed, Ok(Some(Ok(_)))),
+        "a partial original frame must not be followed by a retry"
+    );
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn cancelling_a_waiting_network_send_preserves_the_reason_without_deadline_diagnostics() {
+    let checked = Arc::new(tokio::sync::Notify::new());
+    let resume = Arc::new(tokio::sync::Notify::new());
+    let barrier = crate::write_strategy::WritePreflightBarrier::new(Arc::clone(&checked), Arc::clone(&resume));
+    let mut harness = NetworkHarness::new(
+        "network-plan-waiting-cancel",
+        FrameLimits::default(),
+        AdmissionLimits::default(),
+        Some(barrier),
+    )
+    .await;
+    let mut blocker_connection = harness.session.connection();
+    let blocker = tokio::spawn(async move {
+        blocker_connection
+            .send_command(response_head(106, 1_106))
+            .await
+            .expect("blocker should write after the barrier resumes");
+    });
+    checked.notified().await;
+
+    let enqueued = Arc::new(tokio::sync::Notify::new());
+    let (control, parent) = harness.control("network-plan-waiting-cancel-control", None);
+    let sink = ResponseSink::network_plan_with_enqueue_observer(
+        harness.session.clone(),
+        AdmissionClass::Data,
+        control,
+        Arc::clone(&enqueued),
+    );
+    let duplicate = sink.clone();
+    let send = tokio::spawn(sink.send_plan(bind(
+        ResponsePlan::bytes(response_head(107, 1_107), Bytes::from_static(b"cancelled")).expect("response plan"),
+        815,
+        1_107,
+    )));
+    enqueued.notified().await;
+    parent.cancel();
+    assert!(matches!(
+        send.await.expect("plan send task"),
+        Err(ResponseError::Cancelled)
+    ));
+    assert!(matches!(
+        duplicate
+            .send_plan(bind(
+                ResponsePlan::command(response_head(108, 1_108)).expect("duplicate response plan"),
+                816,
+                1_108,
+            ))
+            .await,
+        Err(ResponseError::AlreadyCompleted {
+            state: ResponseTerminalState::Cancelled
+        })
+    ));
+
+    resume.notify_one();
+    blocker.await.expect("blocker task should complete");
+    assert_eq!(harness.receive().await.opaque(), 1_106);
+    assert!(
+        tokio::time::timeout(Duration::from_millis(25), harness.peer.receive_command())
+            .await
+            .is_err(),
+        "cancelled waiting response must not reach the socket"
+    );
+    assert_eq!(harness.session.writer_snapshot().deadline_expired, 0);
+
+    harness.shutdown().await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn deadline_of_a_waiting_network_send_is_not_started_and_writes_no_plan_bytes() {
+    let checked = Arc::new(tokio::sync::Notify::new());
+    let resume = Arc::new(tokio::sync::Notify::new());
+    let barrier = crate::write_strategy::WritePreflightBarrier::new(Arc::clone(&checked), Arc::clone(&resume));
+    let mut harness = NetworkHarness::new(
+        "network-plan-waiting-deadline",
+        FrameLimits::default(),
+        AdmissionLimits::default(),
+        Some(barrier),
+    )
+    .await;
+    let mut blocker_connection = harness.session.connection();
+    let blocker = tokio::spawn(async move {
+        blocker_connection
+            .send_command(response_head(109, 1_109))
+            .await
+            .expect("blocker should write after the barrier resumes");
+    });
+    checked.notified().await;
+
+    let enqueued = Arc::new(tokio::sync::Notify::new());
+    let deadline = RequestDeadline::after(Duration::from_secs(1));
+    let (control, _parent) = harness.control("network-plan-waiting-deadline-control", Some(deadline));
+    let sink = ResponseSink::network_plan_with_enqueue_observer(
+        harness.session.clone(),
+        AdmissionClass::Data,
+        control,
+        Arc::clone(&enqueued),
+    );
+    let duplicate = sink.clone();
+    let send = tokio::spawn(sink.send_plan(bind(
+        ResponsePlan::bytes(response_head(110, 1_110), Bytes::from_static(b"expired")).expect("response plan"),
+        817,
+        1_110,
+    )));
+    enqueued.notified().await;
+    tokio::time::advance(Duration::from_secs(1)).await;
+    assert!(matches!(
+        send.await.expect("plan send task"),
+        Err(ResponseError::DeadlineExceeded)
+    ));
+    assert!(matches!(
+        duplicate
+            .send_plan(bind(
+                ResponsePlan::command(response_head(111, 1_111)).expect("duplicate response plan"),
+                818,
+                1_111,
+            ))
+            .await,
+        Err(ResponseError::AlreadyCompleted {
+            state: ResponseTerminalState::Failed {
+                progress: WriteProgress::NotStarted
+            }
+        })
+    ));
+
+    resume.notify_one();
+    blocker.await.expect("blocker task should complete");
+    assert_eq!(harness.receive().await.opaque(), 1_109);
+    assert!(
+        tokio::time::timeout(Duration::from_millis(25), harness.peer.receive_command())
+            .await
+            .is_err(),
+        "expired waiting response must not reach the socket"
+    );
+    assert_eq!(harness.session.writer_snapshot().deadline_expired, 1);
+
+    harness.shutdown().await;
+}

--- a/rocketmq-transport/src/server.rs
+++ b/rocketmq-transport/src/server.rs
@@ -61,6 +61,7 @@ use crate::connection::SessionWriterDiagnostics;
 use crate::connection::SessionWriterSnapshot;
 use crate::dispatch::reserve_session_owner;
 use crate::dispatch::AuthorizedDispatchBoundary;
+use crate::dispatch::NetworkResponsePlanContext;
 use crate::dispatch::OriginalRequestIdentity;
 use crate::dispatch::RequestContext;
 use crate::dispatch::ResponseSink;
@@ -157,6 +158,7 @@ pub struct SessionHandle {
     request_operation: OperationContext,
     response_class: Option<AdmissionClass>,
     original_request_identity: Option<OriginalRequestIdentity>,
+    response_plan_context: Option<NetworkResponsePlanContext>,
 }
 
 impl SessionHandle {
@@ -194,6 +196,11 @@ impl SessionHandle {
             self.response_class,
             self.send.lifecycle.clone(),
             self.send.telemetry.clone(),
+        )
+        .with_response_plan_drop(
+            self.response_plan_context
+                .as_ref()
+                .map(NetworkResponsePlanContext::transport_drop_handle),
         )
     }
 
@@ -246,6 +253,23 @@ impl SessionHandle {
     pub(crate) fn with_original_request_identity(mut self, identity: Option<OriginalRequestIdentity>) -> Self {
         self.original_request_identity = identity;
         self
+    }
+
+    #[allow(
+        dead_code,
+        reason = "RSP-05 private response plan context is installed by later dispatcher wiring"
+    )]
+    pub(crate) fn with_response_plan_context(mut self, context: NetworkResponsePlanContext) -> Self {
+        self.response_plan_context = Some(context);
+        self
+    }
+
+    #[allow(
+        dead_code,
+        reason = "RSP-05 private response plan context is consumed by later dispatcher wiring"
+    )]
+    pub(crate) fn response_plan_context(&self) -> Option<&NetworkResponsePlanContext> {
+        self.response_plan_context.as_ref()
     }
 
     /// Closes the session writer after all sends that already entered the lifecycle gate finish.
@@ -796,6 +820,7 @@ async fn run_framed_session_with_request_sequence<H>(
         request_operation: request_operation.clone(),
         response_class: None,
         original_request_identity: None,
+        response_plan_context: None,
     };
 
     handler.connected(session.clone()).await;

--- a/rocketmq-transport/src/write_strategy.rs
+++ b/rocketmq-transport/src/write_strategy.rs
@@ -47,7 +47,9 @@ use crate::file_region_writer::write_portable_file_region;
 const QUEUED_WRITE_WAITING: u8 = 0;
 const QUEUED_WRITE_CLAIMED: u8 = 1;
 const QUEUED_WRITE_STARTED: u8 = 2;
-const QUEUED_WRITE_CANCELLED_BEFORE_START: u8 = 3;
+const QUEUED_WRITE_CANCELLED_BY_DEADLINE: u8 = 3;
+const QUEUED_WRITE_CANCELLED_BY_REQUEST: u8 = 4;
+const QUEUED_WRITE_CANCELLED_BY_SESSION: u8 = 5;
 const AUTO_SENDFILE_MIN_BYTES: u64 = 64 * 1024;
 
 /// Test-only one-shot barrier placed immediately before the first write-progress
@@ -74,6 +76,32 @@ impl WritePreflightBarrier {
 
 pub(crate) struct QueuedWriteProgress(AtomicU8);
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum QueuedWriteCancellation {
+    Deadline,
+    Request,
+    SessionClosed,
+}
+
+impl QueuedWriteCancellation {
+    const fn state(self) -> u8 {
+        match self {
+            Self::Deadline => QUEUED_WRITE_CANCELLED_BY_DEADLINE,
+            Self::Request => QUEUED_WRITE_CANCELLED_BY_REQUEST,
+            Self::SessionClosed => QUEUED_WRITE_CANCELLED_BY_SESSION,
+        }
+    }
+
+    const fn from_state(state: u8) -> Option<Self> {
+        match state {
+            QUEUED_WRITE_CANCELLED_BY_DEADLINE => Some(Self::Deadline),
+            QUEUED_WRITE_CANCELLED_BY_REQUEST => Some(Self::Request),
+            QUEUED_WRITE_CANCELLED_BY_SESSION => Some(Self::SessionClosed),
+            _ => None,
+        }
+    }
+}
+
 impl QueuedWriteProgress {
     pub(crate) fn waiting() -> Self {
         Self(AtomicU8::new(QUEUED_WRITE_WAITING))
@@ -95,14 +123,22 @@ impl QueuedWriteProgress {
 
     /// Cancels a queued envelope before the writer owns it.
     pub(crate) fn cancel_before_start(&self) -> bool {
+        self.cancel_before_start_with(QueuedWriteCancellation::Deadline)
+    }
+
+    pub(crate) fn cancel_before_start_with(&self, reason: QueuedWriteCancellation) -> bool {
         self.0
             .compare_exchange(
                 QUEUED_WRITE_WAITING,
-                QUEUED_WRITE_CANCELLED_BEFORE_START,
+                reason.state(),
                 Ordering::AcqRel,
                 Ordering::Acquire,
             )
             .is_ok()
+    }
+
+    pub(crate) fn cancellation_reason(&self) -> Option<QueuedWriteCancellation> {
+        QueuedWriteCancellation::from_state(self.0.load(Ordering::Acquire))
     }
 
     /// Marks the precise boundary immediately before the first socket attempt.

--- a/rocketmq-transport/src/writer_runtime.rs
+++ b/rocketmq-transport/src/writer_runtime.rs
@@ -34,6 +34,7 @@ use crate::telemetry::TransportTelemetry;
 use crate::write_result::WriterFailure;
 use crate::write_strategy::OutboundPayload;
 use crate::write_strategy::QueuedWrite;
+use crate::write_strategy::QueuedWriteCancellation;
 use crate::write_strategy::WriterOperation;
 
 /// Hard bounds for one writer micro-batch.
@@ -547,10 +548,27 @@ async fn write_batch(
     for envelope in batch {
         let write = envelope.into_write();
         if !write.progress.claim_for_writer() {
-            diagnostics.finish_not_started(write.enqueued_at, write.encoded_len(), true);
-            let _ = write
-                .completion
-                .send(Err(WriterFailure::deadline_exceeded_before_send()));
+            let cancellation = write
+                .progress
+                .cancellation_reason()
+                .unwrap_or(QueuedWriteCancellation::Deadline);
+            diagnostics.finish_not_started(
+                write.enqueued_at,
+                write.encoded_len(),
+                cancellation == QueuedWriteCancellation::Deadline,
+            );
+            let failure = match cancellation {
+                QueuedWriteCancellation::Deadline => WriterFailure::deadline_exceeded_before_send(),
+                QueuedWriteCancellation::Request => WriterFailure::connection_failed(
+                    crate::dispatch::WriteProgress::NotStarted,
+                    "request was cancelled before writer start",
+                ),
+                QueuedWriteCancellation::SessionClosed => WriterFailure::connection_failed(
+                    crate::dispatch::WriteProgress::NotStarted,
+                    "session closed before writer start",
+                ),
+            };
+            let _ = write.completion.send(Err(failure));
             continue;
         }
         if write.deadline.is_some_and(RequestDeadline::is_expired) {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9776

### Brief Description

Add crate-private plan-aware network and embedded response delivery while preserving the existing public `ResponseSink` and V1 compatibility surface.

The network path prepares each bound response exactly once, retains the ingress admission class and absolute request deadline, writes through the canonical queued writer, and issues a receipt only after write and flush complete. The local path transfers the owned response plan directly without encoding, decoding, copying body storage, or reading file regions.

A shared completion slot enforces at-most-once delivery across sink clones and records exact terminal state. Queue cancellation and send-future drop are linearized so a waiting envelope is cancelled before socket I/O, while a writer-owned envelope is conservatively terminalized as possibly partial. Local receiver cancellation and drop races are atomically ordered with ownership handoff.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-transport -- --check`
- Focused plan-aware response sink tests: 22 passed
- Focused writer-runtime tests: 14 passed
- Connection lifecycle, end-to-end deadline, write strategy, TLS, file-region, and public API V1/V2/allowlist integration tests
- `cargo test -p rocketmq-transport`
- `cargo test -p rocketmq-transport --all-features`
- `cargo test -p rocketmq-transport --doc --all-features` (53 passed, 16 ignored)
- `cargo doc -p rocketmq-transport --no-deps --all-features`
- `cargo clippy -p rocketmq-transport --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `git diff --check origin/main`

The error-hygiene guard reports only the 18 findings already present on `origin/main`; none of its reported paths are changed by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable response delivery for local and network requests, including command, byte, segmented, and file-based responses.
  * Added cancellation handling that distinguishes deadlines, request cancellation, and session closure.
  * Improved response delivery behavior when connections close, tasks stop, or receivers disconnect.

* **Bug Fixes**
  * Prevented duplicate or incomplete response frames during cancellation, timeouts, and transport failures.
  * Preserved response body ownership and file resources during handoff and delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->