### PR TITLE
[ISSUE #9777]🚀Add bounded legacy local response-plan materialization

### DIFF
--- a/rocketmq-transport/src/dispatch.rs
+++ b/rocketmq-transport/src/dispatch.rs
@@ -52,6 +52,16 @@ pub use response::WriteProgress;
 pub(crate) use response_plan::BoundResponsePlan;
 #[allow(
     unused_imports,
+    reason = "RSP-06 exposes the private legacy materialization failure to later embedded wiring"
+)]
+pub(crate) use response_plan::LegacyLocalMaterializationError;
+#[allow(
+    unused_imports,
+    reason = "RSP-06 exposes the private bounded legacy materialization profile to later embedded wiring"
+)]
+pub(crate) use response_plan::LegacyMaterializationLimits;
+#[allow(
+    unused_imports,
     reason = "later private response stages handle the RSP-03 binding failure through dispatch"
 )]
 pub(crate) use response_plan::ResponseBindingError;

--- a/rocketmq-transport/src/dispatch/response_plan.rs
+++ b/rocketmq-transport/src/dispatch/response_plan.rs
@@ -15,6 +15,11 @@
 //! Owned V2 response heads and body storage.
 
 mod binding;
+#[allow(
+    dead_code,
+    reason = "RSP-06 defines the private terminal compatibility seam wired by a later embedded adapter stage"
+)]
+mod materializer;
 
 use std::fmt;
 
@@ -25,6 +30,8 @@ use crate::file_region::FileRegionSequence;
 
 pub(crate) use binding::BoundResponsePlan;
 pub(crate) use binding::ResponseBindingError;
+pub(crate) use materializer::LegacyLocalMaterializationError;
+pub(crate) use materializer::LegacyMaterializationLimits;
 
 const MAX_RESPONSE_BODY_LEN: u64 = i32::MAX as u64 - 4;
 
@@ -143,6 +150,14 @@ const MAX_RESPONSE_BODY_LEN: u64 = i32::MAX as u64 - 4;
 ///
 /// ```compile_fail
 /// use rocketmq_transport::api::v2::BoundResponsePlan;
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::LegacyMaterializationLimits;
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::prelude::LegacyLocalMaterializationError;
 /// ```
 pub struct ResponsePlan {
     head: RemotingCommand,
@@ -266,6 +281,10 @@ impl ResponsePlan {
     pub(crate) fn from_bound_parts(head: RemotingCommand, body: ResponseBody) -> Self {
         let (body_len, body_part_count) = body.metadata();
         Self::new(head, body, body_len, body_part_count)
+    }
+
+    fn into_materialization_parts(self) -> (RemotingCommand, ResponseBody, usize, usize) {
+        (self.head, self.body, self.body_len, self.body_part_count)
     }
 
     #[cfg(test)]

--- a/rocketmq-transport/src/dispatch/response_plan/materializer.rs
+++ b/rocketmq-transport/src/dispatch/response_plan/materializer.rs
@@ -1,0 +1,437 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Bounded terminal compatibility conversion for locally delivered response plans.
+
+use std::collections::TryReserveError;
+use std::error::Error;
+use std::fmt;
+use std::io;
+
+use bytes::Bytes;
+use rocketmq_error::RocketMQError;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_runtime::BlockingExecutor;
+use rocketmq_runtime::RuntimeError;
+use rocketmq_runtime::ShutdownDeadline;
+
+use super::ResponseBody;
+use crate::codec::remoting_command_codec::FrameLimits;
+use crate::dispatch::LocalResponsePlanReceiver;
+use crate::dispatch::RequestControlView;
+use crate::dispatch::ResponseError;
+use crate::dispatch::WriteProgress;
+use crate::file_region::FileRegionSequence;
+use crate::file_region_io::read_file_region_chunk;
+use crate::file_region_io::FILE_REGION_READ_CHUNK_BYTES;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct LegacyMaterializationLimits {
+    frame_limits: FrameLimits,
+    max_materialized_body_bytes: usize,
+    max_body_parts: usize,
+}
+
+impl LegacyMaterializationLimits {
+    pub(crate) fn try_new(
+        frame_limits: FrameLimits,
+        max_materialized_body_bytes: usize,
+        max_body_parts: usize,
+    ) -> Result<Self, LegacyLocalMaterializationError> {
+        frame_limits
+            .validate()
+            .map_err(LegacyLocalMaterializationError::limits)?;
+        if max_materialized_body_bytes > frame_limits.max_body_bytes {
+            return Err(LegacyLocalMaterializationError::limits(
+                RocketMQError::illegal_argument(format!(
+                    "legacy materialized body limit {max_materialized_body_bytes} exceeds frame body limit {}",
+                    frame_limits.max_body_bytes
+                )),
+            ));
+        }
+        Ok(Self {
+            frame_limits,
+            max_materialized_body_bytes,
+            max_body_parts,
+        })
+    }
+
+    fn validate_plan(self, body_len: usize, body_part_count: usize) -> Result<(), LegacyLocalMaterializationError> {
+        if body_len > self.max_materialized_body_bytes {
+            return Err(LegacyLocalMaterializationError::limits(
+                RocketMQError::illegal_argument(format!(
+                    "legacy response body length {body_len} exceeds materialization limit {}",
+                    self.max_materialized_body_bytes
+                )),
+            ));
+        }
+        if body_part_count > self.max_body_parts {
+            return Err(LegacyLocalMaterializationError::limits(
+                RocketMQError::illegal_argument(format!(
+                    "legacy response body part count {body_part_count} exceeds materialization limit {}",
+                    self.max_body_parts
+                )),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum LegacyLocalMaterializationErrorKind {
+    Cancelled,
+    SessionClosed,
+    DeadlineExceeded,
+    Response,
+    Limits,
+    Frame,
+    Allocation,
+    Runtime,
+    FileIo,
+}
+
+impl LegacyLocalMaterializationErrorKind {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Cancelled => "cancelled",
+            Self::SessionClosed => "session_closed",
+            Self::DeadlineExceeded => "deadline_exceeded",
+            Self::Response => "response",
+            Self::Limits => "limits",
+            Self::Frame => "frame",
+            Self::Allocation => "allocation",
+            Self::Runtime => "runtime",
+            Self::FileIo => "file_io",
+        }
+    }
+}
+
+pub(crate) enum LegacyLocalMaterializationError {
+    Cancelled,
+    SessionClosed,
+    DeadlineExceeded,
+    Response { source: ResponseError },
+    Limits { source: RocketMQError },
+    Frame { source: RocketMQError },
+    Allocation { source: TryReserveError },
+    Runtime { source: RuntimeError },
+    FileIo { source: io::Error },
+}
+
+impl LegacyLocalMaterializationError {
+    fn response(source: ResponseError) -> Self {
+        match source {
+            ResponseError::Cancelled => Self::Cancelled,
+            ResponseError::SessionClosed => Self::SessionClosed,
+            ResponseError::DeadlineExceeded => Self::DeadlineExceeded,
+            source => Self::Response { source },
+        }
+    }
+
+    fn limits(source: RocketMQError) -> Self {
+        Self::Limits { source }
+    }
+
+    fn frame(source: RocketMQError) -> Self {
+        Self::Frame { source }
+    }
+
+    fn allocation(source: TryReserveError) -> Self {
+        Self::Allocation { source }
+    }
+
+    fn runtime(source: RuntimeError) -> Self {
+        Self::Runtime { source }
+    }
+
+    fn file_io(source: io::Error) -> Self {
+        Self::FileIo { source }
+    }
+
+    const fn kind(&self) -> LegacyLocalMaterializationErrorKind {
+        match self {
+            Self::Cancelled => LegacyLocalMaterializationErrorKind::Cancelled,
+            Self::SessionClosed => LegacyLocalMaterializationErrorKind::SessionClosed,
+            Self::DeadlineExceeded => LegacyLocalMaterializationErrorKind::DeadlineExceeded,
+            Self::Response { .. } => LegacyLocalMaterializationErrorKind::Response,
+            Self::Limits { .. } => LegacyLocalMaterializationErrorKind::Limits,
+            Self::Frame { .. } => LegacyLocalMaterializationErrorKind::Frame,
+            Self::Allocation { .. } => LegacyLocalMaterializationErrorKind::Allocation,
+            Self::Runtime { .. } => LegacyLocalMaterializationErrorKind::Runtime,
+            Self::FileIo { .. } => LegacyLocalMaterializationErrorKind::FileIo,
+        }
+    }
+
+    pub(crate) const fn write_progress(&self) -> WriteProgress {
+        WriteProgress::NotStarted
+    }
+
+    pub(crate) const fn retryable(&self) -> bool {
+        false
+    }
+}
+
+impl fmt::Debug for LegacyLocalMaterializationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug = formatter.debug_struct("LegacyLocalMaterializationError");
+        debug.field("kind", &self.kind().as_str());
+        debug.field("progress", &self.write_progress().as_str());
+        debug.field("retryable", &self.retryable());
+        if let Self::FileIo { source } = self {
+            debug.field("io_kind", &source.kind());
+        }
+        debug.finish()
+    }
+}
+
+impl fmt::Display for LegacyLocalMaterializationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "legacy local response materialization failed: {} (progress={}, retryable=false)",
+            self.kind().as_str(),
+            self.write_progress().as_str()
+        )?;
+        if let Self::FileIo { source } = self {
+            write!(formatter, ", io_kind={:?}", source.kind())?;
+        }
+        Ok(())
+    }
+}
+
+impl Error for LegacyLocalMaterializationError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Cancelled | Self::SessionClosed | Self::DeadlineExceeded => None,
+            Self::Response { source } => Some(source),
+            Self::Limits { source } | Self::Frame { source } => Some(source),
+            Self::Allocation { source } => Some(source),
+            Self::Runtime { source } => Some(source),
+            Self::FileIo { source } => Some(source),
+        }
+    }
+}
+
+impl LocalResponsePlanReceiver {
+    pub(crate) async fn receive_command(
+        self,
+        limits: LegacyMaterializationLimits,
+        blocking: &BlockingExecutor,
+    ) -> Result<RemotingCommand, LegacyLocalMaterializationError> {
+        let control = self.control().clone();
+        ensure_running(&control)?;
+        let plan = self
+            .receive()
+            .await
+            .map_err(LegacyLocalMaterializationError::response)?;
+        ensure_running(&control)?;
+
+        let body_len = plan.body_len();
+        let body_part_count = plan.body_part_count();
+        limits.validate_plan(body_len, body_part_count)?;
+
+        let (head, body, body_len, _) = plan.into_materialization_parts();
+        limits
+            .frame_limits
+            .encode_frame_head(head.clone(), body_len)
+            .map_err(LegacyLocalMaterializationError::frame)?;
+        ensure_running(&control)?;
+
+        match body {
+            ResponseBody::Empty => Ok(head),
+            ResponseBody::Bytes(body) => Ok(head.set_body(body)),
+            ResponseBody::Segments(segments) => materialize_segments(head, segments, body_len),
+            ResponseBody::FileRegions(regions) => {
+                materialize_file_regions(head, regions, body_len, control, blocking).await
+            }
+        }
+    }
+}
+
+fn materialize_segments(
+    head: RemotingCommand,
+    mut segments: Vec<Bytes>,
+    body_len: usize,
+) -> Result<RemotingCommand, LegacyLocalMaterializationError> {
+    if segments.len() == 1 {
+        let body = segments.pop().ok_or_else(body_length_mismatch)?;
+        if body.len() != body_len {
+            return Err(body_length_mismatch());
+        }
+        return Ok(head.set_body(body));
+    }
+
+    let mut body = allocate_body(body_len)?;
+    let mut copied = 0_usize;
+    for segment in segments {
+        copied = copied
+            .checked_add(segment.len())
+            .filter(|copied| *copied <= body_len)
+            .ok_or_else(body_length_mismatch)?;
+        body.extend_from_slice(&segment);
+    }
+    if copied != body_len || body.len() != body_len {
+        return Err(body_length_mismatch());
+    }
+    Ok(head.set_body(Bytes::from(body)))
+}
+
+async fn materialize_file_regions(
+    head: RemotingCommand,
+    regions: FileRegionSequence,
+    body_len: usize,
+    control: RequestControlView,
+    blocking: &BlockingExecutor,
+) -> Result<RemotingCommand, LegacyLocalMaterializationError> {
+    ensure_running(&control)?;
+    let operation_control = control.clone();
+    let deadline = control.deadline();
+    let operation = move || read_file_regions(regions, body_len, operation_control);
+    let execution = async {
+        match deadline {
+            Some(deadline) => {
+                blocking
+                    .spawn_io_until(
+                        "transport.legacy-local-response.materialize-file",
+                        ShutdownDeadline::at(deadline.instant().into_std()),
+                        operation,
+                    )
+                    .await
+            }
+            None => {
+                blocking
+                    .spawn_io("transport.legacy-local-response.materialize-file", operation)
+                    .await
+            }
+        }
+    };
+    tokio::pin!(execution);
+
+    let body = tokio::select! {
+        biased;
+        () = control.cancelled() => {
+            let stop = current_stop(&control).unwrap_or(MaterializationStop::Cancelled);
+            return Err(stop.into_error());
+        }
+        result = &mut execution => result.map_err(LegacyLocalMaterializationError::runtime)??,
+    };
+    ensure_running(&control)?;
+    Ok(head.set_body(body))
+}
+
+fn read_file_regions(
+    regions: FileRegionSequence,
+    body_len: usize,
+    control: RequestControlView,
+) -> Result<Bytes, LegacyLocalMaterializationError> {
+    let mut body = allocate_body(body_len)?;
+    body.resize(body_len, 0);
+    let mut destination_offset = 0_usize;
+
+    for region in regions.regions() {
+        let mut region_progress = 0_u64;
+        while region_progress < region.len() {
+            ensure_running(&control)?;
+            let remaining = region.len() - region_progress;
+            let chunk_len = usize::try_from(remaining.min(FILE_REGION_READ_CHUNK_BYTES as u64))
+                .map_err(|_| file_io_error(io::ErrorKind::InvalidInput, "file-region chunk length exceeds usize"))?;
+            let destination_end = destination_offset
+                .checked_add(chunk_len)
+                .filter(|end| *end <= body_len)
+                .ok_or_else(body_length_mismatch)?;
+            let read = read_file_region_chunk(
+                region.lease().file(),
+                &mut body[destination_offset..destination_end],
+                region.offset(),
+                region_progress,
+            )
+            .map_err(LegacyLocalMaterializationError::file_io)?;
+            if read == 0 {
+                return Err(file_io_error(
+                    io::ErrorKind::UnexpectedEof,
+                    "leased file region ended before its validated length",
+                ));
+            }
+            destination_offset = destination_offset
+                .checked_add(read)
+                .filter(|offset| *offset <= body_len)
+                .ok_or_else(body_length_mismatch)?;
+            region_progress = region_progress
+                .checked_add(read as u64)
+                .ok_or_else(|| file_io_error(io::ErrorKind::InvalidData, "file-region progress overflow"))?;
+        }
+    }
+
+    if destination_offset != body_len {
+        return Err(body_length_mismatch());
+    }
+    Ok(Bytes::from(body))
+}
+
+fn allocate_body(body_len: usize) -> Result<Vec<u8>, LegacyLocalMaterializationError> {
+    let mut body = Vec::new();
+    body.try_reserve_exact(body_len)
+        .map_err(LegacyLocalMaterializationError::allocation)?;
+    Ok(body)
+}
+
+fn body_length_mismatch() -> LegacyLocalMaterializationError {
+    LegacyLocalMaterializationError::limits(RocketMQError::illegal_argument(
+        "legacy response cached body metadata did not match its owned body",
+    ))
+}
+
+fn file_io_error(kind: io::ErrorKind, message: &'static str) -> LegacyLocalMaterializationError {
+    LegacyLocalMaterializationError::file_io(io::Error::new(kind, message))
+}
+
+fn ensure_running(control: &RequestControlView) -> Result<(), LegacyLocalMaterializationError> {
+    current_stop(control).map_or(Ok(()), |stop| Err(stop.into_error()))
+}
+
+#[derive(Clone, Copy)]
+enum MaterializationStop {
+    Cancelled,
+    SessionClosed,
+    DeadlineExceeded,
+}
+
+impl MaterializationStop {
+    fn into_error(self) -> LegacyLocalMaterializationError {
+        match self {
+            Self::Cancelled => LegacyLocalMaterializationError::Cancelled,
+            Self::SessionClosed => LegacyLocalMaterializationError::SessionClosed,
+            Self::DeadlineExceeded => LegacyLocalMaterializationError::DeadlineExceeded,
+        }
+    }
+}
+
+fn current_stop(control: &RequestControlView) -> Option<MaterializationStop> {
+    if control.parent_is_cancelled() {
+        Some(MaterializationStop::Cancelled)
+    } else if control.session_is_closed() {
+        Some(MaterializationStop::SessionClosed)
+    } else if control
+        .deadline()
+        .is_some_and(crate::deadline::RequestDeadline::is_expired)
+    {
+        Some(MaterializationStop::DeadlineExceeded)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+#[path = "materializer/materializer_tests.rs"]
+mod tests;

--- a/rocketmq-transport/src/dispatch/response_plan/materializer/materializer_tests.rs
+++ b/rocketmq-transport/src/dispatch/response_plan/materializer/materializer_tests.rs
@@ -1,0 +1,586 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error as _;
+use std::fs::File;
+use std::io::Write;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
+
+use bytes::Bytes;
+use cheetah_string::CheetahString;
+use rocketmq_protocol::protocol::command_custom_header::CommandCustomHeader;
+use rocketmq_protocol::protocol::header::message_operation_header::send_message_response_header::SendMessageResponseHeader;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::LanguageCode;
+use rocketmq_protocol::protocol::SerializeType;
+use rocketmq_runtime::BlockingLane;
+use rocketmq_runtime::BlockingPoolPolicy;
+use rocketmq_runtime::RuntimeContext;
+use rocketmq_runtime::TaskGroup;
+
+use super::*;
+use crate::connection::ConnectionState;
+use crate::deadline::RequestDeadline;
+use crate::dispatch::BoundResponsePlan;
+use crate::dispatch::OriginalRequestIdentity;
+use crate::dispatch::RequestMeta;
+use crate::dispatch::ResponsePlan;
+use crate::dispatch::ResponseSink;
+use crate::dispatch::ResponseTerminalState;
+use crate::file_region::FileRegion;
+use crate::file_region::FileRegionLease;
+use crate::file_region::FileRegionSequence;
+use crate::session_view::SessionStateView;
+
+struct ControlHarness {
+    runtime: RuntimeContext,
+    parent: TaskGroup,
+    _state_tx: tokio::sync::watch::Sender<ConnectionState>,
+    _closed_tx: tokio::sync::watch::Sender<bool>,
+}
+
+impl ControlHarness {
+    fn new(name: &'static str, deadline: Option<RequestDeadline>) -> (Self, RequestControlView) {
+        Self::with_runtime(RuntimeContext::from_current(name), name, deadline)
+    }
+
+    fn with_policy(
+        name: &'static str,
+        deadline: Option<RequestDeadline>,
+        policy: BlockingPoolPolicy,
+    ) -> (Self, RequestControlView) {
+        let runtime = RuntimeContext::try_from_current_with_blocking_policy(name, policy)
+            .expect("blocking policy should construct a test runtime");
+        Self::with_runtime(runtime, name, deadline)
+    }
+
+    fn with_runtime(
+        runtime: RuntimeContext,
+        name: &'static str,
+        deadline: Option<RequestDeadline>,
+    ) -> (Self, RequestControlView) {
+        let parent = runtime.service_context(name).task_group().clone();
+        let (state_tx, state_rx) = tokio::sync::watch::channel(ConnectionState::Healthy);
+        let (closed_tx, closed_rx) = tokio::sync::watch::channel(false);
+        let control = RequestControlView::from_meta(
+            &RequestMeta::new(Instant::now(), deadline),
+            SessionStateView::from_receivers(state_rx, closed_rx),
+            &parent,
+        );
+        (
+            Self {
+                runtime,
+                parent,
+                _state_tx: state_tx,
+                _closed_tx: closed_tx,
+            },
+            control,
+        )
+    }
+
+    fn blocking(&self) -> &BlockingExecutor {
+        self.runtime.blocking(BlockingLane::StorageIo)
+    }
+
+    async fn shutdown(self) {
+        let report = self.runtime.shutdown_tasks(Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+    }
+}
+
+fn response_head(code: i32, opaque: i32) -> RemotingCommand {
+    RemotingCommand::create_response_command_with_code(code).set_opaque(opaque)
+}
+
+fn bind(plan: ResponsePlan, owner: u64, opaque: i32) -> BoundResponsePlan {
+    let request = RemotingCommand::create_remoting_command(31).set_opaque(opaque);
+    let identity = OriginalRequestIdentity::capture(owner, &AtomicU64::new(1), &request)
+        .expect("test request identity should allocate");
+    plan.bind(identity).expect("ordinary request should bind")
+}
+
+async fn handoff(plan: ResponsePlan, control: RequestControlView) -> (LocalResponsePlanReceiver, ResponseSink) {
+    let (sink, receiver) = ResponseSink::local_plan(control);
+    let duplicate = sink.clone();
+    sink.send_plan(bind(plan, 701, 91))
+        .await
+        .expect("local response ownership handoff should complete");
+    (receiver, duplicate)
+}
+
+fn limits(max_body_bytes: usize, max_body_parts: usize) -> LegacyMaterializationLimits {
+    LegacyMaterializationLimits::try_new(FrameLimits::default(), max_body_bytes, max_body_parts)
+        .expect("test materialization limits should be valid")
+}
+
+fn expect_materialization_error(
+    result: Result<RemotingCommand, LegacyLocalMaterializationError>,
+    context: &'static str,
+) -> LegacyLocalMaterializationError {
+    match result {
+        Ok(_) => panic!("{context}"),
+        Err(error) => error,
+    }
+}
+
+struct CountingHeader {
+    encodes: Arc<AtomicUsize>,
+}
+
+impl CommandCustomHeader for CountingHeader {
+    fn to_map(&self) -> Option<std::collections::HashMap<CheetahString, CheetahString>> {
+        self.encodes.fetch_add(1, Ordering::SeqCst);
+        Some(std::collections::HashMap::new())
+    }
+}
+
+struct CountingLease {
+    file: File,
+    accesses: Arc<AtomicUsize>,
+    drops: Arc<AtomicUsize>,
+}
+
+impl FileRegionLease for CountingLease {
+    fn file(&self) -> &File {
+        self.accesses.fetch_add(1, Ordering::SeqCst);
+        &self.file
+    }
+}
+
+impl Drop for CountingLease {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+fn counting_region(
+    contents: &[u8],
+) -> (
+    FileRegionSequence,
+    Arc<CountingLease>,
+    Arc<AtomicUsize>,
+    Arc<AtomicUsize>,
+) {
+    let mut file = tempfile::tempfile().expect("temporary file");
+    file.write_all(contents).expect("write file contents");
+    let accesses = Arc::new(AtomicUsize::new(0));
+    let drops = Arc::new(AtomicUsize::new(0));
+    let lease = Arc::new(CountingLease {
+        file,
+        accesses: Arc::clone(&accesses),
+        drops: Arc::clone(&drops),
+    });
+    let region = FileRegion::try_new(lease.clone(), 0, contents.len() as u64).expect("valid file region");
+    (FileRegionSequence::single(region), lease, accesses, drops)
+}
+
+#[test]
+fn materialization_limits_are_fallible_bounded_and_have_no_implicit_default() {
+    let frame_limits = FrameLimits::default();
+    assert!(LegacyMaterializationLimits::try_new(frame_limits, frame_limits.max_body_bytes, usize::MAX).is_ok());
+    assert!(matches!(
+        LegacyMaterializationLimits::try_new(frame_limits, frame_limits.max_body_bytes + 1, 1),
+        Err(LegacyLocalMaterializationError::Limits { .. })
+    ));
+
+    let invalid_frame_limits = FrameLimits {
+        max_frame_bytes: 7,
+        ..frame_limits
+    };
+    assert!(matches!(
+        LegacyMaterializationLimits::try_new(invalid_frame_limits, 0, 0),
+        Err(LegacyLocalMaterializationError::Limits { .. })
+    ));
+}
+
+#[tokio::test]
+async fn empty_bytes_single_segment_and_multi_segment_follow_their_copy_contracts() {
+    let (harness, control) = ControlHarness::new("legacy-materializer-body-kinds", None);
+
+    let (receiver, _) = handoff(
+        ResponsePlan::command(response_head(71, 1)).expect("empty plan"),
+        control.clone(),
+    )
+    .await;
+    let empty = receiver
+        .receive_command(limits(0, 0), harness.blocking())
+        .await
+        .expect("empty command");
+    assert!(empty.body().is_none());
+
+    let bytes = Bytes::from_static(b"contiguous");
+    let bytes_pointer = bytes.as_ptr();
+    let (receiver, _) = handoff(
+        ResponsePlan::bytes(response_head(72, 2), bytes).expect("bytes plan"),
+        control.clone(),
+    )
+    .await;
+    let bytes_command = receiver
+        .receive_command(limits(10, 1), harness.blocking())
+        .await
+        .expect("bytes command");
+    assert_eq!(bytes_command.body().expect("body").as_ptr(), bytes_pointer);
+
+    let segment = Bytes::from_static(b"one-segment");
+    let segment_pointer = segment.as_ptr();
+    let (receiver, _) = handoff(
+        ResponsePlan::segments(response_head(73, 3), vec![segment]).expect("single segment plan"),
+        control.clone(),
+    )
+    .await;
+    let segment_command = receiver
+        .receive_command(limits(11, 1), harness.blocking())
+        .await
+        .expect("single segment command");
+    assert_eq!(segment_command.body().expect("body").as_ptr(), segment_pointer);
+
+    let first = Bytes::from_static(b"first");
+    let second = Bytes::from_static(b"second");
+    let first_pointer = first.as_ptr();
+    let second_pointer = second.as_ptr();
+    let (receiver, _) = handoff(
+        ResponsePlan::segments(response_head(74, 4), vec![first, second]).expect("multi segment plan"),
+        control,
+    )
+    .await;
+    let multi = receiver
+        .receive_command(limits(11, 2), harness.blocking())
+        .await
+        .expect("multi segment command");
+    let body = multi.body().expect("body");
+    assert_eq!(body.as_ref(), b"firstsecond");
+    assert_ne!(body.as_ptr(), first_pointer);
+    assert_ne!(body.as_ptr(), second_pointer);
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn cached_body_and_part_limits_are_exact_and_reject_one_over_before_encoding_or_file_access() {
+    let (harness, control) = ControlHarness::new("legacy-materializer-cached-limits", None);
+
+    let (receiver, _) = handoff(
+        ResponsePlan::bytes(response_head(75, 5), Bytes::from_static(b"exact")).expect("exact body plan"),
+        control.clone(),
+    )
+    .await;
+    assert_eq!(
+        receiver
+            .receive_command(limits(5, 1), harness.blocking())
+            .await
+            .expect("exact body limit")
+            .body()
+            .expect("body"),
+        &Bytes::from_static(b"exact")
+    );
+
+    let encodes = Arc::new(AtomicUsize::new(0));
+    let head = response_head(76, 6).set_command_custom_header(CountingHeader {
+        encodes: Arc::clone(&encodes),
+    });
+    let (regions, lease, accesses, drops) = counting_region(b"one-over");
+    assert_eq!(accesses.load(Ordering::SeqCst), 1);
+    let (receiver, duplicate) = handoff(
+        ResponsePlan::file_regions(head, regions).expect("file plan"),
+        control.clone(),
+    )
+    .await;
+    let error = expect_materialization_error(
+        receiver.receive_command(limits(7, 1), harness.blocking()).await,
+        "one-over body limit must fail",
+    );
+    assert!(matches!(error, LegacyLocalMaterializationError::Limits { .. }));
+    assert_eq!(encodes.load(Ordering::SeqCst), 0);
+    assert_eq!(accesses.load(Ordering::SeqCst), 1);
+    assert!(matches!(
+        duplicate
+            .send_plan(bind(
+                ResponsePlan::command(response_head(77, 7)).expect("duplicate plan"),
+                702,
+                92,
+            ))
+            .await,
+        Err(ResponseError::AlreadyCompleted {
+            state: ResponseTerminalState::Completed
+        })
+    ));
+    drop(lease);
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+
+    let (receiver, _) = handoff(
+        ResponsePlan::segments(
+            response_head(78, 8),
+            vec![Bytes::from_static(b"a"), Bytes::from_static(b"b")],
+        )
+        .expect("two part plan"),
+        control.clone(),
+    )
+    .await;
+    assert!(receiver.receive_command(limits(2, 2), harness.blocking()).await.is_ok());
+
+    let (receiver, _) = handoff(
+        ResponsePlan::segments(
+            response_head(79, 9),
+            vec![Bytes::from_static(b"a"), Bytes::from_static(b"b")],
+        )
+        .expect("two part plan"),
+        control,
+    )
+    .await;
+    assert!(matches!(
+        receiver.receive_command(limits(2, 1), harness.blocking()).await,
+        Err(LegacyLocalMaterializationError::Limits { .. })
+    ));
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn exact_frame_preflight_applies_to_empty_and_rejects_invalid_or_one_over_heads() {
+    let (harness, control) = ControlHarness::new("legacy-materializer-frame-preflight", None);
+    let encodes = Arc::new(AtomicUsize::new(0));
+    let counted_head = response_head(80, 10).set_command_custom_header(CountingHeader {
+        encodes: Arc::clone(&encodes),
+    });
+    let (receiver, _) = handoff(
+        ResponsePlan::command(counted_head).expect("counted empty plan"),
+        control.clone(),
+    )
+    .await;
+    assert!(receiver.receive_command(limits(0, 0), harness.blocking()).await.is_ok());
+    assert_eq!(encodes.load(Ordering::SeqCst), 1);
+
+    let head = response_head(80, 10).set_remark("exact frame head");
+    let oracle = FrameLimits::java_compatibility()
+        .encode_frame_head(head.clone(), 0)
+        .expect("oracle head")
+        .encoded_len();
+    let exact_frame_limits = FrameLimits::try_new(oracle, FrameLimits::java_compatibility().max_header_bytes, 0, 8)
+        .expect("exact frame limits");
+    let exact_limits = LegacyMaterializationLimits::try_new(exact_frame_limits, 0, 0).expect("exact limits");
+    let (receiver, _) = handoff(ResponsePlan::command(head).expect("empty plan"), control.clone()).await;
+    assert!(receiver.receive_command(exact_limits, harness.blocking()).await.is_ok());
+
+    let one_over_frame_limits =
+        FrameLimits::try_new(oracle - 1, FrameLimits::java_compatibility().max_header_bytes, 0, 8)
+            .expect("one-over frame limits");
+    let one_over_limits = LegacyMaterializationLimits::try_new(one_over_frame_limits, 0, 0).expect("one-over limits");
+    let (receiver, _) = handoff(
+        ResponsePlan::command(response_head(80, 10).set_remark("exact frame head")).expect("empty plan"),
+        control.clone(),
+    )
+    .await;
+    assert!(matches!(
+        receiver.receive_command(one_over_limits, harness.blocking()).await,
+        Err(LegacyLocalMaterializationError::Frame { .. })
+    ));
+
+    let mut invalid = ResponsePlan::command(response_head(81, 11)).expect("empty plan");
+    invalid.head = invalid.head.set_body(Bytes::from_static(b"must remain bodyless"));
+    let (receiver, _) = handoff(invalid, control).await;
+    assert!(matches!(
+        receiver.receive_command(limits(0, 0), harness.blocking()).await,
+        Err(LegacyLocalMaterializationError::Frame { .. })
+    ));
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn materialization_preserves_bound_head_metadata_and_never_decodes_frame_shaped_body_bytes() {
+    let (harness, control) = ControlHarness::new("legacy-materializer-metadata", None);
+    let typed_header = SendMessageResponseHeader::new(
+        CheetahString::from("message-id"),
+        17,
+        91,
+        Some(CheetahString::from("transaction-id")),
+        None,
+        None,
+    );
+    let mut head = response_head(-19, 999)
+        .set_language(LanguageCode::CPP)
+        .set_version(-31)
+        .set_flag(1 | (1 << 9))
+        .set_serialize_type(SerializeType::JSON)
+        .set_remark("preserved remark")
+        .set_command_custom_header(typed_header);
+    head.add_ext_field("extension-key", "extension-value");
+    let frame_shaped = Bytes::from_static(&[0, 0, 0, 2, 0x7f, 0xff]);
+    let pointer = frame_shaped.as_ptr();
+    let (receiver, _) = handoff(ResponsePlan::bytes(head, frame_shaped).expect("metadata plan"), control).await;
+
+    let command = receiver
+        .receive_command(limits(6, 1), harness.blocking())
+        .await
+        .expect("materialized command");
+    assert_eq!(command.code(), -19);
+    assert_eq!(command.opaque(), 91);
+    assert_eq!(command.language(), LanguageCode::CPP);
+    assert_eq!(command.version(), -31);
+    assert_eq!(command.flag(), 1 | (1 << 9));
+    assert_eq!(command.serialize_type(), SerializeType::JSON);
+    assert_eq!(command.remark().map(CheetahString::as_str), Some("preserved remark"));
+    assert_eq!(
+        command
+            .ext_fields()
+            .and_then(|fields| fields.get("extension-key"))
+            .map(CheetahString::as_str),
+        Some("extension-value")
+    );
+    let header = command
+        .read_custom_header_ref::<SendMessageResponseHeader>()
+        .expect("typed header must remain attached");
+    assert_eq!(header.msg_id().as_str(), "message-id");
+    assert_eq!(command.body().expect("body").as_ptr(), pointer);
+    assert_eq!(command.body().expect("body").as_ref(), &[0, 0, 0, 2, 0x7f, 0xff]);
+
+    harness.shutdown().await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn simultaneous_parent_cancellation_and_deadline_is_cancellation_first() {
+    let deadline = RequestDeadline::after(Duration::from_secs(1));
+    let (harness, control) = ControlHarness::new("legacy-materializer-stop-priority", Some(deadline));
+    let (receiver, _) = handoff(
+        ResponsePlan::command(response_head(82, 12)).expect("empty plan"),
+        control,
+    )
+    .await;
+    harness.parent.cancel();
+    tokio::time::advance(Duration::from_secs(1)).await;
+
+    assert!(matches!(
+        receiver.receive_command(limits(0, 0), harness.blocking()).await,
+        Err(LegacyLocalMaterializationError::Cancelled)
+    ));
+
+    harness.shutdown().await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn session_close_and_deadline_keep_distinct_direct_error_variants() {
+    let (closed_harness, closed_control) = ControlHarness::new(
+        "legacy-materializer-session-close",
+        Some(RequestDeadline::after(Duration::from_secs(1))),
+    );
+    let (receiver, _) = handoff(
+        ResponsePlan::command(response_head(83, 13)).expect("empty plan"),
+        closed_control,
+    )
+    .await;
+    closed_harness
+        ._closed_tx
+        .send(true)
+        .expect("session close observer should remain open");
+    assert!(matches!(
+        receiver.receive_command(limits(0, 0), closed_harness.blocking()).await,
+        Err(LegacyLocalMaterializationError::SessionClosed)
+    ));
+    closed_harness.shutdown().await;
+
+    let (deadline_harness, deadline_control) = ControlHarness::new(
+        "legacy-materializer-deadline",
+        Some(RequestDeadline::after(Duration::from_secs(1))),
+    );
+    let (receiver, _) = handoff(
+        ResponsePlan::command(response_head(84, 14)).expect("empty plan"),
+        deadline_control,
+    )
+    .await;
+    tokio::time::advance(Duration::from_secs(1)).await;
+    assert!(matches!(
+        receiver
+            .receive_command(limits(0, 0), deadline_harness.blocking())
+            .await,
+        Err(LegacyLocalMaterializationError::DeadlineExceeded)
+    ));
+    deadline_harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn ordinary_plan_receive_keeps_file_regions_lazy_and_owned() {
+    let (harness, control) = ControlHarness::new("legacy-materializer-ordinary-receive", None);
+    let (regions, lease, accesses, drops) = counting_region(b"ordinary-v2-plan");
+    assert_eq!(accesses.load(Ordering::SeqCst), 1);
+    let (receiver, _) = handoff(
+        ResponsePlan::file_regions(response_head(83, 13), regions).expect("file plan"),
+        control,
+    )
+    .await;
+
+    let plan = receiver.receive().await.expect("ordinary plan receive");
+    assert_eq!(accesses.load(Ordering::SeqCst), 1);
+    assert_eq!(plan.body_len(), 16);
+    drop(plan);
+    drop(lease);
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+
+    harness.shutdown().await;
+}
+
+#[test]
+fn errors_are_typed_redacted_not_started_and_non_retryable() {
+    let allocation = allocate_body(usize::MAX).expect_err("capacity overflow should fail deterministically");
+    assert!(matches!(allocation, LegacyLocalMaterializationError::Allocation { .. }));
+    assert_eq!(allocation.write_progress(), WriteProgress::NotStarted);
+    assert!(!allocation.retryable());
+    assert!(allocation
+        .source()
+        .and_then(|source| source.downcast_ref::<TryReserveError>())
+        .is_some());
+
+    for error in [
+        LegacyLocalMaterializationError::Cancelled,
+        LegacyLocalMaterializationError::SessionClosed,
+        LegacyLocalMaterializationError::DeadlineExceeded,
+    ] {
+        assert_eq!(error.write_progress(), WriteProgress::NotStarted);
+        assert!(!error.retryable());
+        assert!(error.source().is_none());
+    }
+
+    let errors = [
+        LegacyLocalMaterializationError::response(ResponseError::AlreadyCompleted {
+            state: ResponseTerminalState::Completed,
+        }),
+        LegacyLocalMaterializationError::limits(RocketMQError::illegal_argument("secret-limit-source")),
+        LegacyLocalMaterializationError::frame(RocketMQError::illegal_argument("secret-frame-source")),
+        LegacyLocalMaterializationError::runtime(RuntimeError::InvalidConfig("secret-runtime-source".to_owned())),
+        LegacyLocalMaterializationError::file_io(io::Error::new(io::ErrorKind::UnexpectedEof, "secret-file-source")),
+    ];
+    for error in errors {
+        assert_eq!(error.write_progress(), WriteProgress::NotStarted);
+        assert!(!error.retryable());
+        let debug = format!("{error:?}");
+        let display = error.to_string();
+        assert!(!debug.contains("secret"));
+        assert!(!display.contains("secret"));
+        assert!(error.source().is_some());
+    }
+    let file_error =
+        LegacyLocalMaterializationError::file_io(io::Error::new(io::ErrorKind::PermissionDenied, "hidden path"));
+    assert!(format!("{file_error:?}").contains("PermissionDenied"));
+    assert!(file_error.to_string().contains("PermissionDenied"));
+}
+
+#[path = "tests/executor.rs"]
+mod executor;
+
+#[path = "tests/file.rs"]
+mod file;

--- a/rocketmq-transport/src/dispatch/response_plan/materializer/tests/executor.rs
+++ b/rocketmq-transport/src/dispatch/response_plan/materializer/tests/executor.rs
@@ -1,0 +1,560 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Condvar;
+use std::sync::Mutex;
+
+use rocketmq_runtime::RuntimeError;
+
+use super::*;
+
+struct BlockingLease {
+    file: File,
+    accesses: Arc<AtomicUsize>,
+    drops: Arc<AtomicUsize>,
+    entered: Arc<tokio::sync::Notify>,
+    dropped: Arc<tokio::sync::Notify>,
+    release: Arc<(Mutex<bool>, Condvar)>,
+}
+
+impl FileRegionLease for BlockingLease {
+    fn file(&self) -> &File {
+        let access = self.accesses.fetch_add(1, Ordering::SeqCst);
+        if access > 0 {
+            self.entered.notify_one();
+            let (released, condition) = &*self.release;
+            let mut released = released.lock().expect("release lock");
+            while !*released {
+                released = condition.wait(released).expect("release wait");
+            }
+        }
+        &self.file
+    }
+}
+
+impl Drop for BlockingLease {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::SeqCst);
+        self.dropped.notify_one();
+    }
+}
+
+struct PanicAfterValidationLease {
+    file: File,
+    accesses: AtomicUsize,
+    drops: Arc<AtomicUsize>,
+}
+
+impl FileRegionLease for PanicAfterValidationLease {
+    fn file(&self) -> &File {
+        if self.accesses.fetch_add(1, Ordering::SeqCst) > 0 {
+            panic!("test-only file lease panic after validation");
+        }
+        &self.file
+    }
+}
+
+impl Drop for PanicAfterValidationLease {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+struct BlockingRegionHarness {
+    regions: FileRegionSequence,
+    accesses: Arc<AtomicUsize>,
+    drops: Arc<AtomicUsize>,
+    entered: Arc<tokio::sync::Notify>,
+    dropped: Arc<tokio::sync::Notify>,
+    release: Arc<(Mutex<bool>, Condvar)>,
+}
+
+impl BlockingRegionHarness {
+    fn new() -> Self {
+        let mut file = tempfile::tempfile().expect("temporary file");
+        file.write_all(b"blocking-file-body").expect("write file body");
+        let accesses = Arc::new(AtomicUsize::new(0));
+        let drops = Arc::new(AtomicUsize::new(0));
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let dropped = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let lease = Arc::new(BlockingLease {
+            file,
+            accesses: Arc::clone(&accesses),
+            drops: Arc::clone(&drops),
+            entered: Arc::clone(&entered),
+            dropped: Arc::clone(&dropped),
+            release: Arc::clone(&release),
+        });
+        let region = FileRegion::try_new(lease, 0, 18).expect("blocking file region");
+        Self {
+            regions: FileRegionSequence::single(region),
+            accesses,
+            drops,
+            entered,
+            dropped,
+            release,
+        }
+    }
+}
+
+fn blocking_policy(queue_timeout: Duration, task_timeout: Duration, max_queue_depth: usize) -> BlockingPoolPolicy {
+    BlockingPoolPolicy {
+        name: "legacy-materializer-blocking-test".to_owned(),
+        max_concurrency: 1,
+        max_queue_depth,
+        queue_timeout,
+        task_timeout,
+        warn_after: Duration::from_secs(60),
+    }
+}
+
+struct Occupant {
+    release: Arc<(Mutex<bool>, Condvar)>,
+    task: tokio::task::JoinHandle<Result<(), RuntimeError>>,
+}
+
+impl Occupant {
+    async fn start(blocking: BlockingExecutor) -> Self {
+        let started = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let started_wait = started.notified();
+        let operation_started = Arc::clone(&started);
+        let operation_release = Arc::clone(&release);
+        let task = tokio::spawn(async move {
+            blocking
+                .spawn_io("legacy-materializer-test-occupant", move || {
+                    operation_started.notify_one();
+                    let (released, condition) = &*operation_release;
+                    let mut released = released.lock().expect("occupant release lock");
+                    while !*released {
+                        released = condition.wait(released).expect("occupant release wait");
+                    }
+                })
+                .await
+        });
+        started_wait.await;
+        Self { release, task }
+    }
+
+    async fn release(self) {
+        let (released, condition) = &*self.release;
+        *released.lock().expect("occupant release lock") = true;
+        condition.notify_all();
+        self.task
+            .await
+            .expect("occupant task should join")
+            .expect("occupant should complete");
+    }
+}
+
+async fn wait_for_queued(blocking: &BlockingExecutor, expected: usize) {
+    for _ in 0..10_000 {
+        if blocking.snapshot().queued == expected {
+            return;
+        }
+        tokio::task::yield_now().await;
+    }
+    panic!("blocking executor did not reach queued={expected}");
+}
+
+async fn wait_for_running(blocking: &BlockingExecutor, expected: usize) {
+    for _ in 0..10_000 {
+        if blocking.blocking_still_running() == expected {
+            return;
+        }
+        tokio::task::yield_now().await;
+    }
+    panic!("blocking executor did not reach blocking_still_running={expected}");
+}
+
+async fn assert_duplicate_completed(duplicate: ResponseSink, code: i32) {
+    assert!(matches!(
+        duplicate
+            .send_plan(bind(
+                ResponsePlan::command(response_head(code, code)).expect("duplicate plan"),
+                code as u64,
+                code,
+            ))
+            .await,
+        Err(ResponseError::AlreadyCompleted {
+            state: ResponseTerminalState::Completed
+        })
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn running_parent_cancellation_returns_early_but_keeps_lease_tracked_until_closure_exit() {
+    let policy = blocking_policy(Duration::from_secs(1), Duration::from_secs(5), 4);
+    let (harness, control) = ControlHarness::with_policy("legacy-materializer-running-cancel", None, policy);
+    let file = BlockingRegionHarness::new();
+    let entered = file.entered.notified();
+    let dropped = file.dropped.notified();
+    let accesses = Arc::clone(&file.accesses);
+    let drops = Arc::clone(&file.drops);
+    let release = Arc::clone(&file.release);
+    let (receiver, duplicate) = handoff(
+        ResponsePlan::file_regions(response_head(101, 31), file.regions).expect("file plan"),
+        control,
+    )
+    .await;
+    let blocking = harness.blocking().clone();
+    let materialization = tokio::spawn(async move { receiver.receive_command(limits(18, 1), &blocking).await });
+    entered.await;
+    assert_eq!(accesses.load(Ordering::SeqCst), 2);
+
+    harness.parent.cancel();
+    assert!(matches!(
+        materialization.await.expect("materialization task"),
+        Err(LegacyLocalMaterializationError::Cancelled)
+    ));
+    assert_eq!(drops.load(Ordering::SeqCst), 0);
+    assert_eq!(harness.blocking().blocking_still_running(), 1);
+    assert_duplicate_completed(duplicate, 102).await;
+
+    let (released, condition) = &*release;
+    *released.lock().expect("release lock") = true;
+    condition.notify_all();
+    dropped.await;
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+    wait_for_running(harness.blocking(), 0).await;
+    harness.shutdown().await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn running_request_deadline_wins_over_executor_policy_and_keeps_the_closure_tracked() {
+    let request_deadline = RequestDeadline::after(Duration::from_secs(1));
+    let policy = blocking_policy(Duration::from_secs(30), Duration::from_secs(30), 4);
+    let (harness, control) = ControlHarness::with_policy(
+        "legacy-materializer-running-request-deadline",
+        Some(request_deadline),
+        policy,
+    );
+    let file = BlockingRegionHarness::new();
+    let entered = file.entered.notified();
+    let dropped = file.dropped.notified();
+    let accesses = Arc::clone(&file.accesses);
+    let drops = Arc::clone(&file.drops);
+    let release = Arc::clone(&file.release);
+    let (receiver, duplicate) = handoff(
+        ResponsePlan::file_regions(response_head(111, 38), file.regions).expect("file plan"),
+        control,
+    )
+    .await;
+    let blocking = harness.blocking().clone();
+    let materialization = tokio::spawn(async move { receiver.receive_command(limits(18, 1), &blocking).await });
+    entered.await;
+    assert_eq!(accesses.load(Ordering::SeqCst), 2);
+
+    tokio::time::advance(Duration::from_secs(1)).await;
+    assert!(request_deadline.is_expired());
+    assert!(matches!(
+        materialization.await.expect("materialization task"),
+        Err(LegacyLocalMaterializationError::DeadlineExceeded)
+    ));
+    assert_eq!(drops.load(Ordering::SeqCst), 0);
+    assert_eq!(harness.blocking().blocking_still_running(), 1);
+    assert_duplicate_completed(duplicate, 112).await;
+
+    let (released, condition) = &*release;
+    *released.lock().expect("release lock") = true;
+    condition.notify_all();
+    dropped.await;
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+    wait_for_running(harness.blocking(), 0).await;
+    harness.shutdown().await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn running_session_close_wins_when_the_request_deadline_is_also_expired() {
+    let request_deadline = RequestDeadline::after(Duration::from_secs(1));
+    let policy = blocking_policy(Duration::from_secs(30), Duration::from_secs(30), 4);
+    let (harness, control) = ControlHarness::with_policy(
+        "legacy-materializer-running-session-deadline",
+        Some(request_deadline),
+        policy,
+    );
+    let file = BlockingRegionHarness::new();
+    let entered = file.entered.notified();
+    let dropped = file.dropped.notified();
+    let drops = Arc::clone(&file.drops);
+    let release = Arc::clone(&file.release);
+    let (receiver, duplicate) = handoff(
+        ResponsePlan::file_regions(response_head(113, 39), file.regions).expect("file plan"),
+        control,
+    )
+    .await;
+    let blocking = harness.blocking().clone();
+    let materialization = tokio::spawn(async move { receiver.receive_command(limits(18, 1), &blocking).await });
+    entered.await;
+
+    harness
+        ._closed_tx
+        .send(true)
+        .expect("session close observer should remain open");
+    tokio::time::advance(Duration::from_secs(1)).await;
+    assert!(request_deadline.is_expired());
+    assert!(matches!(
+        materialization.await.expect("materialization task"),
+        Err(LegacyLocalMaterializationError::SessionClosed)
+    ));
+    assert_eq!(drops.load(Ordering::SeqCst), 0);
+    assert_eq!(harness.blocking().blocking_still_running(), 1);
+    assert_duplicate_completed(duplicate, 114).await;
+
+    let (released, condition) = &*release;
+    *released.lock().expect("release lock") = true;
+    condition.notify_all();
+    dropped.await;
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+    wait_for_running(harness.blocking(), 0).await;
+    harness.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn running_caller_future_drop_keeps_executor_tracking_and_prevents_a_second_receive() {
+    let policy = blocking_policy(Duration::from_secs(1), Duration::from_secs(5), 4);
+    let (harness, control) = ControlHarness::with_policy("legacy-materializer-running-drop", None, policy);
+    let file = BlockingRegionHarness::new();
+    let entered = file.entered.notified();
+    let dropped = file.dropped.notified();
+    let drops = Arc::clone(&file.drops);
+    let release = Arc::clone(&file.release);
+    let (receiver, duplicate) = handoff(
+        ResponsePlan::file_regions(response_head(103, 32), file.regions).expect("file plan"),
+        control,
+    )
+    .await;
+    let blocking = harness.blocking().clone();
+    let materialization = tokio::spawn(async move { receiver.receive_command(limits(18, 1), &blocking).await });
+    entered.await;
+
+    materialization.abort();
+    match materialization.await {
+        Err(error) => assert!(error.is_cancelled()),
+        Ok(_) => panic!("caller future should have been aborted"),
+    }
+    assert_eq!(drops.load(Ordering::SeqCst), 0);
+    assert_eq!(harness.blocking().blocking_still_running(), 1);
+    assert_duplicate_completed(duplicate, 104).await;
+
+    let (released, condition) = &*release;
+    *released.lock().expect("release lock") = true;
+    condition.notify_all();
+    dropped.await;
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+    wait_for_running(harness.blocking(), 0).await;
+    harness.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn queued_caller_future_drop_never_reads_the_file_and_releases_the_unstarted_lease_once() {
+    let policy = blocking_policy(Duration::from_secs(5), Duration::from_secs(5), 4);
+    let (harness, control) = ControlHarness::with_policy("legacy-materializer-queued-drop", None, policy);
+    let occupant = Occupant::start(harness.blocking().clone()).await;
+    let (regions, lease, accesses, drops) = counting_region(b"queued-drop-body");
+    let (receiver, duplicate) = handoff(
+        ResponsePlan::file_regions(response_head(105, 33), regions).expect("file plan"),
+        control,
+    )
+    .await;
+    drop(lease);
+    let blocking = harness.blocking().clone();
+    let observer = blocking.clone();
+    let materialization = tokio::spawn(async move { receiver.receive_command(limits(16, 1), &blocking).await });
+    wait_for_queued(&observer, 1).await;
+
+    materialization.abort();
+    match materialization.await {
+        Err(error) => assert!(error.is_cancelled()),
+        Ok(_) => panic!("caller future should have been aborted"),
+    }
+    assert_eq!(accesses.load(Ordering::SeqCst), 1);
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+    assert_duplicate_completed(duplicate, 106).await;
+
+    occupant.release().await;
+    harness.shutdown().await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn queued_request_deadline_drops_the_unstarted_file_operation_without_access() {
+    let request_deadline = RequestDeadline::after(Duration::from_secs(1));
+    let policy = blocking_policy(Duration::from_secs(30), Duration::from_secs(30), 4);
+    let (harness, control) = ControlHarness::with_policy(
+        "legacy-materializer-queued-request-deadline",
+        Some(request_deadline),
+        policy,
+    );
+    let occupant = Occupant::start(harness.blocking().clone()).await;
+    let body = b"queued-deadline";
+    let (regions, lease, accesses, drops) = counting_region(body);
+    let (receiver, duplicate) = handoff(
+        ResponsePlan::file_regions(response_head(115, 40), regions).expect("file plan"),
+        control,
+    )
+    .await;
+    drop(lease);
+    let blocking = harness.blocking().clone();
+    let observer = blocking.clone();
+    let materialization = tokio::spawn(async move { receiver.receive_command(limits(body.len(), 1), &blocking).await });
+    wait_for_queued(&observer, 1).await;
+
+    tokio::time::advance(Duration::from_secs(1)).await;
+    assert!(request_deadline.is_expired());
+    assert!(matches!(
+        materialization.await.expect("materialization task"),
+        Err(LegacyLocalMaterializationError::DeadlineExceeded)
+    ));
+    wait_for_queued(&observer, 0).await;
+    assert_eq!(accesses.load(Ordering::SeqCst), 1);
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+    assert_duplicate_completed(duplicate, 116).await;
+
+    occupant.release().await;
+    harness.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn executor_queue_full_and_queue_timeout_preserve_runtime_sources_without_file_reads() {
+    let full_policy = blocking_policy(Duration::from_secs(5), Duration::from_secs(5), 1);
+    let (full_harness, full_control) = ControlHarness::with_policy("legacy-materializer-queue-full", None, full_policy);
+    let full_occupant = Occupant::start(full_harness.blocking().clone()).await;
+    let queued_executor = full_harness.blocking().clone();
+    let queued = tokio::spawn(async move {
+        queued_executor
+            .spawn_io("legacy-materializer-queue-filler", || ())
+            .await
+    });
+    wait_for_queued(full_harness.blocking(), 1).await;
+    let (regions, lease, accesses, drops) = counting_region(b"queue-full-body");
+    let (receiver, _) = handoff(
+        ResponsePlan::file_regions(response_head(107, 34), regions).expect("file plan"),
+        full_control,
+    )
+    .await;
+    drop(lease);
+    let error = expect_materialization_error(
+        receiver.receive_command(limits(15, 1), full_harness.blocking()).await,
+        "full executor queue should reject",
+    );
+    assert!(matches!(
+        error,
+        LegacyLocalMaterializationError::Runtime {
+            source: RuntimeError::BlockingQueueFull { .. }
+        }
+    ));
+    assert_eq!(accesses.load(Ordering::SeqCst), 1);
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+    full_occupant.release().await;
+    queued
+        .await
+        .expect("queued filler task")
+        .expect("queued filler should complete");
+    full_harness.shutdown().await;
+
+    let timeout_policy = blocking_policy(Duration::from_millis(30), Duration::from_secs(5), 2);
+    let (timeout_harness, timeout_control) =
+        ControlHarness::with_policy("legacy-materializer-queue-timeout", None, timeout_policy);
+    let timeout_occupant = Occupant::start(timeout_harness.blocking().clone()).await;
+    let (regions, lease, accesses, drops) = counting_region(b"queue-timeout-body");
+    let (receiver, _) = handoff(
+        ResponsePlan::file_regions(response_head(108, 35), regions).expect("file plan"),
+        timeout_control,
+    )
+    .await;
+    drop(lease);
+    let error = expect_materialization_error(
+        receiver
+            .receive_command(limits(18, 1), timeout_harness.blocking())
+            .await,
+        "executor queue timeout should fail",
+    );
+    assert!(matches!(
+        error,
+        LegacyLocalMaterializationError::Runtime {
+            source: RuntimeError::BlockingQueueTimeout { .. }
+        }
+    ));
+    assert_eq!(accesses.load(Ordering::SeqCst), 1);
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+    timeout_occupant.release().await;
+    timeout_harness.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn executor_running_timeout_and_join_panic_remain_typed_and_release_leases_once() {
+    let timeout_policy = blocking_policy(Duration::from_secs(1), Duration::from_millis(30), 2);
+    let (timeout_harness, timeout_control) =
+        ControlHarness::with_policy("legacy-materializer-running-timeout", None, timeout_policy);
+    let file = BlockingRegionHarness::new();
+    let entered = file.entered.notified();
+    let dropped = file.dropped.notified();
+    let drops = Arc::clone(&file.drops);
+    let release = Arc::clone(&file.release);
+    let (receiver, _) = handoff(
+        ResponsePlan::file_regions(response_head(109, 36), file.regions).expect("file plan"),
+        timeout_control,
+    )
+    .await;
+    let blocking = timeout_harness.blocking().clone();
+    let materialization = tokio::spawn(async move { receiver.receive_command(limits(18, 1), &blocking).await });
+    entered.await;
+    let error = expect_materialization_error(
+        materialization.await.expect("materialization task"),
+        "running task timeout should fail",
+    );
+    assert!(matches!(
+        error,
+        LegacyLocalMaterializationError::Runtime {
+            source: RuntimeError::BlockingTaskTimeoutStillRunning { .. }
+        }
+    ));
+    assert_eq!(drops.load(Ordering::SeqCst), 0);
+    assert_eq!(timeout_harness.blocking().blocking_still_running(), 1);
+    let (released, condition) = &*release;
+    *released.lock().expect("release lock") = true;
+    condition.notify_all();
+    dropped.await;
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+    wait_for_running(timeout_harness.blocking(), 0).await;
+    timeout_harness.shutdown().await;
+
+    let (join_harness, join_control) = ControlHarness::new("legacy-materializer-join-panic", None);
+    let mut file = tempfile::tempfile().expect("temporary file");
+    file.write_all(b"panic-file-body").expect("write file body");
+    let drops = Arc::new(AtomicUsize::new(0));
+    let lease = Arc::new(PanicAfterValidationLease {
+        file,
+        accesses: AtomicUsize::new(0),
+        drops: Arc::clone(&drops),
+    });
+    let region = FileRegion::try_new(lease, 0, 15).expect("panic file region");
+    let (receiver, _) = handoff(
+        ResponsePlan::file_regions(response_head(110, 37), FileRegionSequence::single(region)).expect("file plan"),
+        join_control,
+    )
+    .await;
+    let error = expect_materialization_error(
+        receiver.receive_command(limits(15, 1), join_harness.blocking()).await,
+        "blocking join panic should fail",
+    );
+    assert!(matches!(
+        error,
+        LegacyLocalMaterializationError::Runtime {
+            source: RuntimeError::BlockingJoin { .. }
+        }
+    ));
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+    join_harness.shutdown().await;
+}

--- a/rocketmq-transport/src/dispatch/response_plan/materializer/tests/file.rs
+++ b/rocketmq-transport/src/dispatch/response_plan/materializer/tests/file.rs
@@ -1,0 +1,132 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+#[tokio::test]
+async fn file_regions_preserve_order_offsets_and_bounded_chunk_progress() {
+    let (harness, control) = ControlHarness::new("legacy-materializer-file-regions", None);
+    let first_len = FILE_REGION_READ_CHUNK_BYTES + 17;
+    let contents = (0..first_len + 64).map(|index| (index % 251) as u8).collect::<Vec<_>>();
+    let mut file = tempfile::tempfile().expect("temporary file");
+    file.write_all(&contents).expect("write file contents");
+    let accesses = Arc::new(AtomicUsize::new(0));
+    let drops = Arc::new(AtomicUsize::new(0));
+    let lease = Arc::new(CountingLease {
+        file,
+        accesses: Arc::clone(&accesses),
+        drops: Arc::clone(&drops),
+    });
+    let first = FileRegion::try_new(lease.clone(), 3, first_len as u64).expect("first file region");
+    let second = FileRegion::try_new(lease.clone(), 1, 29).expect("second file region");
+    let regions = FileRegionSequence::try_new(vec![first, second]).expect("file region sequence");
+    assert_eq!(accesses.load(Ordering::SeqCst), 2);
+    let expected = [&contents[3..3 + first_len], &contents[1..30]].concat();
+    let expected_len = expected.len();
+    let (receiver, _) = handoff(
+        ResponsePlan::file_regions(response_head(91, 21), regions).expect("file plan"),
+        control,
+    )
+    .await;
+
+    let command = receiver
+        .receive_command(limits(expected_len, 2), harness.blocking())
+        .await
+        .expect("file materialization");
+    assert_eq!(command.body().expect("body").as_ref(), expected);
+    assert_eq!(accesses.load(Ordering::SeqCst), 5);
+    drop(command);
+    drop(lease);
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn exact_frame_failure_precedes_file_access_and_destination_allocation() {
+    let (harness, control) = ControlHarness::new("legacy-materializer-file-preflight", None);
+    let body = b"file-preflight";
+    let (regions, lease, accesses, drops) = counting_region(body);
+    let head = response_head(92, 22).set_remark("frame preflight");
+    let encoded_len = FrameLimits::java_compatibility()
+        .encode_frame_head(head.clone(), body.len())
+        .expect("oracle frame head")
+        .encoded_len();
+    let frame_limits = FrameLimits::try_new(
+        encoded_len - 1,
+        FrameLimits::java_compatibility().max_header_bytes,
+        body.len(),
+        8,
+    )
+    .expect("one-over frame profile");
+    let materialization_limits =
+        LegacyMaterializationLimits::try_new(frame_limits, body.len(), 1).expect("materialization limits");
+    let (receiver, _) = handoff(ResponsePlan::file_regions(head, regions).expect("file plan"), control).await;
+
+    assert!(matches!(
+        receiver
+            .receive_command(materialization_limits, harness.blocking())
+            .await,
+        Err(LegacyLocalMaterializationError::Frame { .. })
+    ));
+    assert_eq!(accesses.load(Ordering::SeqCst), 1);
+    drop(lease);
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn truncation_after_region_validation_returns_typed_short_read_without_partial_command() {
+    let (harness, control) = ControlHarness::new("legacy-materializer-short-file", None);
+    let (regions, lease, accesses, drops) = counting_region(b"validated-length");
+    lease.file.set_len(4).expect("truncate leased file after validation");
+    let (receiver, _) = handoff(
+        ResponsePlan::file_regions(response_head(93, 23), regions).expect("file plan"),
+        control,
+    )
+    .await;
+
+    let error = expect_materialization_error(
+        receiver.receive_command(limits(16, 1), harness.blocking()).await,
+        "short file must fail",
+    );
+    let LegacyLocalMaterializationError::FileIo { source } = error else {
+        panic!("short file should retain its io source");
+    };
+    assert_eq!(source.kind(), io::ErrorKind::UnexpectedEof);
+    assert!(accesses.load(Ordering::SeqCst) >= 2);
+    drop(lease);
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+
+    harness.shutdown().await;
+}
+
+#[test]
+fn checked_positional_reads_handle_offsets_partial_ranges_and_overflow() {
+    let mut file = tempfile::tempfile().expect("temporary file");
+    file.write_all(b"0123456789").expect("write file contents");
+    let mut buffer = [0_u8; 4];
+
+    let read = read_file_region_chunk(&file, &mut buffer, 2, 3).expect("checked positional read");
+    assert_eq!(read, 4);
+    assert_eq!(&buffer, b"5678");
+
+    let partial = read_file_region_chunk(&file, &mut buffer, 8, 0).expect("partial positional read");
+    assert_eq!(partial, 2);
+    assert_eq!(&buffer[..partial], b"89");
+
+    let overflow = read_file_region_chunk(&file, &mut buffer, u64::MAX, 1).expect_err("offset overflow");
+    assert_eq!(overflow.kind(), io::ErrorKind::InvalidInput);
+}

--- a/rocketmq-transport/src/dispatch/response_sink/plan.rs
+++ b/rocketmq-transport/src/dispatch/response_sink/plan.rs
@@ -154,6 +154,10 @@ pub(crate) struct LocalResponsePlanReceiver {
 }
 
 impl LocalResponsePlanReceiver {
+    pub(crate) const fn control(&self) -> &RequestControlView {
+        &self.control
+    }
+
     pub(crate) async fn receive(mut self) -> Result<ResponsePlan, ResponseError> {
         if let Some(stop) = current_stop(&self.control) {
             self.slot.finish_external(stop);

--- a/rocketmq-transport/src/file_region_io.rs
+++ b/rocketmq-transport/src/file_region_io.rs
@@ -1,0 +1,75 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs::File;
+use std::io;
+
+pub(crate) const FILE_REGION_READ_CHUNK_BYTES: usize = 64 * 1024;
+
+pub(crate) fn read_file_region_chunk(
+    file: &File,
+    buffer: &mut [u8],
+    region_offset: u64,
+    progress: u64,
+) -> io::Result<usize> {
+    let offset = region_offset
+        .checked_add(progress)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "file-region read offset overflow"))?;
+    positional_read(file, buffer, offset)
+}
+
+#[cfg(unix)]
+fn positional_read(file: &File, buffer: &mut [u8], offset: u64) -> io::Result<usize> {
+    use std::os::unix::fs::FileExt;
+
+    file.read_at(buffer, offset)
+}
+
+#[cfg(windows)]
+fn positional_read(file: &File, buffer: &mut [u8], offset: u64) -> io::Result<usize> {
+    use std::os::windows::fs::FileExt;
+
+    file.seek_read(buffer, offset)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn positional_read(_file: &File, _buffer: &mut [u8], _offset: u64) -> io::Result<usize> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "portable positional file reads are not implemented for this platform",
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checked_position_rejects_offset_overflow_before_file_access() {
+        let file = tempfile::tempfile().expect("temporary file");
+        let error = read_file_region_chunk(&file, &mut [0_u8; 1], u64::MAX, 1).expect_err("overflow must be rejected");
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    #[test]
+    fn unsupported_platform_returns_a_typed_io_error() {
+        let file = tempfile::tempfile().expect("temporary file");
+        let error =
+            read_file_region_chunk(&file, &mut [0_u8; 1], 0, 0).expect_err("unsupported positional read must fail");
+
+        assert_eq!(error.kind(), io::ErrorKind::Unsupported);
+    }
+}

--- a/rocketmq-transport/src/file_region_writer.rs
+++ b/rocketmq-transport/src/file_region_writer.rs
@@ -21,8 +21,8 @@ use tokio::io::AsyncWrite;
 use tokio::io::AsyncWriteExt;
 
 use crate::file_region::FileRegion;
-
-const PORTABLE_CHUNK_BYTES: usize = 64 * 1024;
+use crate::file_region_io::read_file_region_chunk;
+use crate::file_region_io::FILE_REGION_READ_CHUNK_BYTES;
 
 static PORTABLE_BYTES: AtomicU64 = AtomicU64::new(0);
 static SENDFILE_BYTES: AtomicU64 = AtomicU64::new(0);
@@ -95,21 +95,18 @@ where
     W: AsyncWrite + Unpin,
 {
     let mut sent = 0_u64;
-    let initial_len = usize::try_from(region.len().min(PORTABLE_CHUNK_BYTES as u64))
+    let initial_len = usize::try_from(region.len().min(FILE_REGION_READ_CHUNK_BYTES as u64))
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "file-region chunk length exceeds usize"))?;
     let mut buffer = vec![0_u8; initial_len];
     while sent < region.len() {
-        let chunk_len = usize::try_from((region.len() - sent).min(PORTABLE_CHUNK_BYTES as u64))
+        let chunk_len = usize::try_from((region.len() - sent).min(FILE_REGION_READ_CHUNK_BYTES as u64))
             .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "file-region chunk length exceeds usize"))?;
         buffer.resize(chunk_len, 0);
-        let offset = region
-            .offset()
-            .checked_add(sent)
-            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "file-region read offset overflow"))?;
+        let region_offset = region.offset();
         let lease = region.lease().clone();
         let (returned_buffer, read) = blocking
             .spawn_io("transport.file-region.read", move || {
-                let read = read_at(lease.file(), &mut buffer, offset)?;
+                let read = read_file_region_chunk(lease.file(), &mut buffer, region_offset, sent)?;
                 Ok::<_, io::Error>((buffer, read))
             })
             .await
@@ -127,26 +124,4 @@ where
             .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "file-region progress overflow"))?;
     }
     Ok(sent)
-}
-
-#[cfg(unix)]
-fn read_at(file: &std::fs::File, buffer: &mut [u8], offset: u64) -> io::Result<usize> {
-    use std::os::unix::fs::FileExt;
-
-    file.read_at(buffer, offset)
-}
-
-#[cfg(windows)]
-fn read_at(file: &std::fs::File, buffer: &mut [u8], offset: u64) -> io::Result<usize> {
-    use std::os::windows::fs::FileExt;
-
-    file.seek_read(buffer, offset)
-}
-
-#[cfg(not(any(unix, windows)))]
-fn read_at(_file: &std::fs::File, _buffer: &mut [u8], _offset: u64) -> io::Result<usize> {
-    Err(io::Error::new(
-        io::ErrorKind::Unsupported,
-        "portable positional file reads are not implemented for this platform",
-    ))
 }

--- a/rocketmq-transport/src/lib.rs
+++ b/rocketmq-transport/src/lib.rs
@@ -45,6 +45,7 @@ mod dispatch;
 mod error_helpers;
 mod error_response;
 mod file_region;
+mod file_region_io;
 mod file_region_writer;
 mod hook_registry;
 #[cfg(all(target_os = "linux", feature = "linux-sendfile"))]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9777

### Brief Description

Add a crate-private, bounded terminal adapter that materializes a locally delivered `ResponsePlan` into the `RemotingCommand` required by legacy embedded callers. The ordinary V2 local path remains plan-native and performs no materialization.

The adapter validates explicit frame, byte, and body-part limits before allocation, copying, or file access. Empty, contiguous bytes, and one segment move without body copies; multiple segments use one checked allocation and one ordered copy per segment. File regions are read only through the injected `BlockingExecutor` with the original absolute request deadline and a shared checked positional-read helper.

All failures are typed, redacted, non-retryable, and report `WriteProgress::NotStarted`. Cancellation, session closure, and deadline retain their fixed priority. Blocking work owns file leases and destination storage until the real closure exits, including after caller timeout, cancellation, or future drop, and materialization never reopens the already-completed response slot.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-transport -- --check`
- Focused materializer tests: 21 passed
- Focused plan-aware response sink tests: 22 passed
- File-region integration tests: 2 passed
- File-region connection tests with `test-support`: 7 passed
- `cargo test -p rocketmq-transport` (440 unit tests plus all default integration tests and doctests)
- `cargo test -p rocketmq-transport --all-features`
- `cargo test -p rocketmq-transport --doc --all-features` (55 passed, 16 ignored)
- `cargo doc -p rocketmq-transport --no-deps --all-features`
- `cargo clippy -p rocketmq-transport --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `git diff --check origin/main`

The error-hygiene guard reports only the 18 findings already present on `origin/main`; none of its reported paths are changed by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bounded materialization for locally delivered responses, including byte and file-region content.
  * Added validation for frame size, body size, and body-part limits.
  * Added cancellation, deadline, timeout, and file I/O error handling.
  * Added portable chunked file-region reading across supported platforms.

* **Bug Fixes**
  * Improved handling of truncated files, offset overflows, partial reads, and resource cleanup.

* **Tests**
  * Added comprehensive coverage for materialization, cancellation, deadlines, file operations, limits, and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->