### PR TITLE
[ISSUE #9786]🚀Add exhaustive V2 handler outcomes and inline response state

### DIFF
--- a/rocketmq-transport/src/dispatch.rs
+++ b/rocketmq-transport/src/dispatch.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod authorized_dispatcher;
+mod handler_outcome;
 mod remoting_request;
 mod request_context;
 mod request_control;
@@ -26,6 +27,17 @@ pub use authorized_dispatcher::AuthorizedCommandDispatcher;
 pub use authorized_dispatcher::AuthorizedDispatchBoundary;
 pub use authorized_dispatcher::DispatchError;
 pub use authorized_dispatcher::DispatchOutcome;
+pub use handler_outcome::DeferredRegistration;
+pub use handler_outcome::HandlerOutcome;
+#[allow(
+    unused_imports,
+    reason = "DSP-02 exposes the private inline handler contract to later dispatcher wiring"
+)]
+pub(crate) use handler_outcome::HandlerOutcomeContractError;
+pub(crate) use handler_outcome::InlineResponseSlot;
+pub use handler_outcome::ProtocolNoResponse;
+pub use handler_outcome::ProtocolNoResponseError;
+pub use handler_outcome::ProtocolNoResponseReason;
 pub use remoting_request::IngressRequestView;
 pub use remoting_request::RemotingRequest;
 pub use request_context::RequestContext;

--- a/rocketmq-transport/src/dispatch/handler_outcome.rs
+++ b/rocketmq-transport/src/dispatch/handler_outcome.rs
@@ -1,0 +1,782 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Exhaustive V2 handler outcomes and inline response-contract state.
+
+use std::fmt;
+
+use rocketmq_error::RocketMQError;
+
+use super::OriginalRequestIdentity;
+use super::RequestId;
+use super::ResponsePlan;
+
+/// The one terminal contract outcome returned by a V2 request handler.
+///
+/// Each variant owns an affine capability or response payload. A handler must
+/// either return a standard response plan, prove that trusted deferred storage
+/// owns the response lifecycle, or return a request-bound protocol marker.
+/// There is deliberately no direct-write bypass variant.
+///
+/// ```
+/// use rocketmq_transport::api::v2::HandlerOutcome;
+///
+/// fn inspect(outcome: HandlerOutcome) {
+///     match outcome {
+///         HandlerOutcome::Reply(plan) => {
+///             let _ = plan.response_code();
+///         }
+///         HandlerOutcome::Deferred(registration) => {
+///             let _ = registration.request_id();
+///         }
+///         HandlerOutcome::NoReply(marker) => {
+///             let _ = marker.reason();
+///         }
+///     }
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::HandlerOutcome;
+///
+/// fn outcomes_are_affine(outcome: &HandlerOutcome) {
+///     let _: HandlerOutcome = outcome.clone();
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::HandlerOutcome;
+///
+/// fn no_direct_write_bypass_exists() -> HandlerOutcome {
+///     HandlerOutcome::AlreadyWritten
+/// }
+/// ```
+#[must_use]
+#[derive(Debug)]
+pub enum HandlerOutcome {
+    /// Return one owned response plan through canonical response binding and delivery.
+    Reply(ResponsePlan),
+    /// Complete the inline contract with a sealed deferred-registry proof.
+    Deferred(DeferredRegistration),
+    /// Complete the request without a direct response where protocol policy permits it.
+    NoReply(ProtocolNoResponse),
+}
+
+/// Proof that trusted deferred storage accepted one request's response lifecycle.
+///
+/// The fields and seal are private, and this stage intentionally provides no
+/// production constructor. Deferred registry integration will create this
+/// proof only after it owns the responder, resume data, and wait permit.
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::{DeferredRegistration, RequestId};
+///
+/// fn cannot_forge(request_id: RequestId) -> DeferredRegistration {
+///     DeferredRegistration { request_id }
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::DeferredRegistration;
+///
+/// fn registrations_are_affine(registration: &DeferredRegistration) {
+///     let _: DeferredRegistration = registration.clone();
+/// }
+/// ```
+#[must_use]
+pub struct DeferredRegistration {
+    request_id: RequestId,
+    seal: DeferredRegistrationSeal,
+}
+
+#[cfg(not(test))]
+struct DeferredRegistrationSeal;
+
+#[cfg(test)]
+struct DeferredRegistrationSeal {
+    drop_probe: Option<std::sync::Arc<std::sync::atomic::AtomicUsize>>,
+}
+
+#[cfg(test)]
+impl Drop for DeferredRegistrationSeal {
+    fn drop(&mut self) {
+        if let Some(probe) = &self.drop_probe {
+            probe.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+}
+
+impl DeferredRegistration {
+    /// Returns the exact request accepted by trusted deferred storage.
+    #[must_use]
+    pub const fn request_id(&self) -> RequestId {
+        self.request_id
+    }
+
+    #[cfg(test)]
+    fn for_test(request_id: RequestId) -> Self {
+        Self {
+            request_id,
+            seal: DeferredRegistrationSeal { drop_probe: None },
+        }
+    }
+
+    #[cfg(test)]
+    fn with_drop_probe(request_id: RequestId, drop_probe: std::sync::Arc<std::sync::atomic::AtomicUsize>) -> Self {
+        Self {
+            request_id,
+            seal: DeferredRegistrationSeal {
+                drop_probe: Some(drop_probe),
+            },
+        }
+    }
+}
+
+impl fmt::Debug for DeferredRegistration {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let _ = &self.seal;
+        formatter
+            .debug_struct("DeferredRegistration")
+            .field("request_id", &self.request_id)
+            .field("sealed", &true)
+            .finish()
+    }
+}
+
+/// Closed protocol reason for completing a request without a direct response.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProtocolNoResponseReason {
+    /// The peer-requested callback was handled without a direct response frame.
+    CallbackHandled,
+    /// The peer-requested notification was handled without a direct response frame.
+    NotificationHandled,
+}
+
+impl ProtocolNoResponseReason {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::CallbackHandled => "callback_handled",
+            Self::NotificationHandled => "notification_handled",
+        }
+    }
+}
+
+/// Failure to create a protocol no-response marker for an inbound request.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum ProtocolNoResponseError {
+    /// One-way handling is an ingress property and cannot be claimed as a handler outcome.
+    #[error("protocol no-response is unavailable for one-way requests")]
+    OneWayRequest,
+    /// The original request code does not permit the requested closed reason.
+    #[error("protocol no-response reason {reason:?} is unsupported for request code {request_code}")]
+    Unsupported {
+        /// Original raw request code captured at ingress.
+        request_code: i32,
+        /// Closed reason rejected by the audited protocol policy.
+        reason: ProtocolNoResponseReason,
+    },
+}
+
+impl From<ProtocolNoResponseError> for RocketMQError {
+    fn from(error: ProtocolNoResponseError) -> Self {
+        match error {
+            ProtocolNoResponseError::OneWayRequest => {
+                Self::illegal_argument("protocol_no_response: category=one_way_request")
+            }
+            ProtocolNoResponseError::Unsupported { request_code, reason } => Self::illegal_argument(format!(
+                "protocol_no_response: category=unsupported, request_code={request_code}, reason={}",
+                reason.as_str()
+            )),
+        }
+    }
+}
+
+/// Request-bound proof that the protocol permits no direct response frame.
+///
+/// Construct markers with [`crate::api::v2::RemotingRequest::protocol_no_response`].
+/// The marker is affine so it cannot complete multiple handler contracts.
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::ProtocolNoResponse;
+///
+/// fn markers_are_affine(marker: &ProtocolNoResponse) {
+///     let _: ProtocolNoResponse = marker.clone();
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use rocketmq_transport::api::v2::{ProtocolNoResponse, ProtocolNoResponseReason, RequestId};
+///
+/// fn cannot_forge(request_id: RequestId) -> ProtocolNoResponse {
+///     ProtocolNoResponse {
+///         request_id,
+///         original_code: 39,
+///         reason: ProtocolNoResponseReason::CallbackHandled,
+///     }
+/// }
+/// ```
+#[must_use]
+pub struct ProtocolNoResponse {
+    request_id: RequestId,
+    original_code: i32,
+    reason: ProtocolNoResponseReason,
+}
+
+impl ProtocolNoResponse {
+    pub(super) fn from_original(
+        original: OriginalRequestIdentity,
+        reason: ProtocolNoResponseReason,
+    ) -> Result<Self, ProtocolNoResponseError> {
+        validate_protocol_no_response(original, reason)?;
+        Ok(Self {
+            request_id: original.request_id(),
+            original_code: original.original_code(),
+            reason,
+        })
+    }
+
+    /// Returns the exact ingress request identity bound to this marker.
+    #[must_use]
+    pub const fn request_id(&self) -> RequestId {
+        self.request_id
+    }
+
+    /// Returns the original raw request code captured at ingress.
+    #[must_use]
+    pub const fn original_code(&self) -> i32 {
+        self.original_code
+    }
+
+    /// Returns the closed protocol reason represented by this marker.
+    #[must_use]
+    pub const fn reason(&self) -> ProtocolNoResponseReason {
+        self.reason
+    }
+}
+
+impl fmt::Debug for ProtocolNoResponse {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProtocolNoResponse")
+            .field("request_id", &self.request_id)
+            .field("original_code", &self.original_code)
+            .field("reason", &self.reason)
+            .finish()
+    }
+}
+
+fn validate_protocol_no_response(
+    original: OriginalRequestIdentity,
+    reason: ProtocolNoResponseReason,
+) -> Result<(), ProtocolNoResponseError> {
+    if original.is_one_way() {
+        return Err(ProtocolNoResponseError::OneWayRequest);
+    }
+    if protocol_no_response_allowed(original.original_code(), reason) {
+        Ok(())
+    } else {
+        Err(ProtocolNoResponseError::Unsupported {
+            request_code: original.original_code(),
+            reason,
+        })
+    }
+}
+
+fn protocol_no_response_allowed(request_code: i32, reason: ProtocolNoResponseReason) -> bool {
+    matches!(
+        (request_code, reason),
+        (39 | 220, ProtocolNoResponseReason::CallbackHandled)
+            | (40 | 200_073, ProtocolNoResponseReason::NotificationHandled)
+    )
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum InlineResponseState {
+    Open,
+    OpenWithDeferred,
+    DeferredTaken,
+    Completed,
+}
+
+/// Allocation-free handler-contract state owned by one request stack frame.
+pub(crate) struct InlineResponseSlot {
+    state: InlineResponseState,
+}
+
+impl Default for InlineResponseSlot {
+    fn default() -> Self {
+        Self::disabled()
+    }
+}
+
+impl InlineResponseSlot {
+    pub(crate) const fn disabled() -> Self {
+        Self {
+            state: InlineResponseState::Open,
+        }
+    }
+
+    pub(crate) const fn deferred_capable() -> Self {
+        Self {
+            state: InlineResponseState::OpenWithDeferred,
+        }
+    }
+
+    pub(crate) const fn has_deferred_capability(&self) -> bool {
+        matches!(self.state, InlineResponseState::OpenWithDeferred)
+    }
+
+    pub(crate) fn mark_deferred_taken(
+        &mut self,
+        original: OriginalRequestIdentity,
+    ) -> Result<(), HandlerOutcomeContractError> {
+        if original.is_one_way() {
+            return Err(HandlerOutcomeContractError::DeferredUnavailable);
+        }
+        match self.state {
+            InlineResponseState::Open => Err(HandlerOutcomeContractError::DeferredUnavailable),
+            InlineResponseState::OpenWithDeferred => {
+                self.state = InlineResponseState::DeferredTaken;
+                Ok(())
+            }
+            InlineResponseState::DeferredTaken => Err(HandlerOutcomeContractError::DeferredAlreadyTaken),
+            InlineResponseState::Completed => Err(HandlerOutcomeContractError::OutcomeAlreadyCompleted),
+        }
+    }
+
+    pub(crate) fn resolve(
+        &mut self,
+        original: OriginalRequestIdentity,
+        outcome: HandlerOutcome,
+    ) -> Result<HandlerOutcome, HandlerOutcomeContractError> {
+        let state = std::mem::replace(&mut self.state, InlineResponseState::Completed);
+        match state {
+            InlineResponseState::Open | InlineResponseState::OpenWithDeferred => match outcome {
+                outcome @ HandlerOutcome::Reply(_) => Ok(outcome),
+                HandlerOutcome::Deferred(_) => Err(HandlerOutcomeContractError::DeferredResponderNotTaken),
+                HandlerOutcome::NoReply(marker) => {
+                    validate_marker(&marker, original)?;
+                    Ok(HandlerOutcome::NoReply(marker))
+                }
+            },
+            InlineResponseState::DeferredTaken => match outcome {
+                HandlerOutcome::Reply(_) => Err(HandlerOutcomeContractError::ReplyAfterDeferredTaken),
+                HandlerOutcome::Deferred(registration) => {
+                    if registration.request_id() != original.request_id() {
+                        return Err(HandlerOutcomeContractError::DeferredRegistrationRequestMismatch {
+                            expected: original.request_id(),
+                            actual: registration.request_id(),
+                        });
+                    }
+                    Ok(HandlerOutcome::Deferred(registration))
+                }
+                HandlerOutcome::NoReply(_) => Err(HandlerOutcomeContractError::NoReplyAfterDeferredTaken),
+            },
+            InlineResponseState::Completed => Err(HandlerOutcomeContractError::OutcomeAlreadyCompleted),
+        }
+    }
+}
+
+fn validate_marker(
+    marker: &ProtocolNoResponse,
+    original: OriginalRequestIdentity,
+) -> Result<(), HandlerOutcomeContractError> {
+    if marker.request_id != original.request_id() || marker.original_code != original.original_code() {
+        return Err(HandlerOutcomeContractError::NoResponseIdentityMismatch);
+    }
+    if original.is_one_way() || !protocol_no_response_allowed(original.original_code(), marker.reason) {
+        return Err(HandlerOutcomeContractError::NoResponsePolicyMismatch {
+            request_code: original.original_code(),
+            reason: marker.reason,
+        });
+    }
+    Ok(())
+}
+
+/// Failure while consuming one affine handler outcome against inline request state.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub(crate) enum HandlerOutcomeContractError {
+    #[error("deferred response capability is unavailable")]
+    DeferredUnavailable,
+    #[error("the deferred responder was already taken")]
+    DeferredAlreadyTaken,
+    #[error("the handler outcome was already completed")]
+    OutcomeAlreadyCompleted,
+    #[error("a deferred registration was supplied before a responder was taken")]
+    DeferredResponderNotTaken,
+    #[error("a reply was supplied after the deferred responder was taken")]
+    ReplyAfterDeferredTaken,
+    #[error("a no-response marker was supplied after the deferred responder was taken")]
+    NoReplyAfterDeferredTaken,
+    #[error("the deferred registration belongs to request {actual:?}, not {expected:?}")]
+    DeferredRegistrationRequestMismatch { expected: RequestId, actual: RequestId },
+    #[error("the protocol no-response marker does not match the original request identity")]
+    NoResponseIdentityMismatch,
+    #[error("protocol no-response reason {reason:?} is invalid for request code {request_code}")]
+    NoResponsePolicyMismatch {
+        request_code: i32,
+        reason: ProtocolNoResponseReason,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::io::Write;
+    use std::sync::atomic::AtomicU64;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
+
+    use bytes::Bytes;
+    use rocketmq_protocol::code::request_code::RequestCode;
+    use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+
+    use super::*;
+    use crate::dispatch::ResponseBody;
+    use crate::file_region::FileRegion;
+    use crate::file_region::FileRegionLease;
+    use crate::file_region::FileRegionSequence;
+
+    fn identity(owner: u64, code: RequestCode) -> OriginalRequestIdentity {
+        identity_from_counter(owner, code, &AtomicU64::new(1))
+    }
+
+    fn identity_from_counter(owner: u64, code: RequestCode, sequence: &AtomicU64) -> OriginalRequestIdentity {
+        let command = RemotingCommand::create_remoting_command(code.to_i32()).set_opaque(owner as i32);
+        OriginalRequestIdentity::capture(owner, sequence, &command).expect("test identity should allocate")
+    }
+
+    fn response_head(code: i32) -> RemotingCommand {
+        RemotingCommand::create_response_command_with_code(code)
+    }
+
+    struct CountingLease {
+        file: File,
+        accesses: Arc<AtomicUsize>,
+        drops: Arc<AtomicUsize>,
+    }
+
+    impl FileRegionLease for CountingLease {
+        fn file(&self) -> &File {
+            self.accesses.fetch_add(1, Ordering::SeqCst);
+            &self.file
+        }
+    }
+
+    impl Drop for CountingLease {
+        fn drop(&mut self) {
+            self.drops.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    fn counting_file_plan(
+        response_code: i32,
+    ) -> (ResponsePlan, Arc<CountingLease>, Arc<AtomicUsize>, Arc<AtomicUsize>) {
+        let mut file = tempfile::tempfile().expect("temporary file");
+        file.write_all(b"file-body").expect("write file body");
+        let accesses = Arc::new(AtomicUsize::new(0));
+        let drops = Arc::new(AtomicUsize::new(0));
+        let lease = Arc::new(CountingLease {
+            file,
+            accesses: Arc::clone(&accesses),
+            drops: Arc::clone(&drops),
+        });
+        let region = FileRegion::try_new(lease.clone(), 0, 9).expect("file region");
+        let regions = FileRegionSequence::single(region);
+        let plan = ResponsePlan::file_regions(response_head(response_code), regions).expect("file plan");
+        (plan, lease, accesses, drops)
+    }
+
+    #[test]
+    fn inline_slot_is_stack_only_and_tracks_the_four_closed_states() {
+        assert_eq!(
+            std::mem::size_of::<InlineResponseSlot>(),
+            std::mem::size_of::<InlineResponseState>()
+        );
+        assert!(!std::mem::needs_drop::<InlineResponseSlot>());
+
+        let original = identity(11, RequestCode::CheckTransactionState);
+        let mut disabled = InlineResponseSlot::disabled();
+        assert!(!disabled.has_deferred_capability());
+        assert_eq!(
+            disabled.mark_deferred_taken(original),
+            Err(HandlerOutcomeContractError::DeferredUnavailable)
+        );
+
+        let mut capable = InlineResponseSlot::deferred_capable();
+        assert!(capable.has_deferred_capability());
+        assert_eq!(capable.mark_deferred_taken(original), Ok(()));
+        assert!(!capable.has_deferred_capability());
+        assert_eq!(
+            capable.mark_deferred_taken(original),
+            Err(HandlerOutcomeContractError::DeferredAlreadyTaken)
+        );
+        let registration = DeferredRegistration::for_test(original.request_id());
+        assert!(matches!(
+            capable.resolve(original, HandlerOutcome::Deferred(registration)),
+            Ok(HandlerOutcome::Deferred(_))
+        ));
+        assert_eq!(
+            capable.mark_deferred_taken(original),
+            Err(HandlerOutcomeContractError::OutcomeAlreadyCompleted)
+        );
+    }
+
+    #[test]
+    fn reply_moves_segment_and_file_owners_without_copy_or_file_access() {
+        let original = identity(12, RequestCode::CheckTransactionState);
+        let first = Bytes::from_static(b"first");
+        let second = Bytes::from_static(b"second");
+        let first_ptr = first.as_ptr();
+        let second_ptr = second.as_ptr();
+        let plan = ResponsePlan::segments(response_head(7), vec![first, second]).expect("segment plan");
+        let ResponseBody::Segments(before) = plan.test_body() else {
+            panic!("segments should retain their representation");
+        };
+        let allocation = before.as_ptr();
+        let mut slot = InlineResponseSlot::disabled();
+        let HandlerOutcome::Reply(plan) = slot
+            .resolve(original, HandlerOutcome::Reply(plan))
+            .expect("open reply should resolve")
+        else {
+            panic!("reply should remain a reply");
+        };
+        let ResponseBody::Segments(after) = plan.test_body() else {
+            panic!("segments should retain their representation");
+        };
+        assert_eq!(after.as_ptr(), allocation);
+        assert_eq!(after[0].as_ptr(), first_ptr);
+        assert_eq!(after[1].as_ptr(), second_ptr);
+
+        let (plan, lease, accesses, drops) = counting_file_plan(8);
+        let ResponseBody::FileRegions(before) = plan.test_body() else {
+            panic!("file plan representation");
+        };
+        let allocation = before.regions().as_ptr();
+        assert_eq!(accesses.load(Ordering::SeqCst), 1);
+        let mut slot = InlineResponseSlot::disabled();
+        let HandlerOutcome::Reply(plan) = slot
+            .resolve(original, HandlerOutcome::Reply(plan))
+            .expect("file reply should resolve")
+        else {
+            panic!("reply should remain a reply");
+        };
+        let ResponseBody::FileRegions(after) = plan.test_body() else {
+            panic!("file plan representation");
+        };
+        assert_eq!(after.regions().as_ptr(), allocation);
+        assert_eq!(accesses.load(Ordering::SeqCst), 1);
+        drop(plan);
+        assert_eq!(Arc::strong_count(&lease), 1);
+        drop(lease);
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn legal_no_reply_is_revalidated_and_cross_request_or_policy_markers_fail_closed() {
+        let first = identity(21, RequestCode::CheckTransactionState);
+        let second = identity(22, RequestCode::CheckTransactionState);
+        let marker =
+            ProtocolNoResponse::from_original(first, ProtocolNoResponseReason::CallbackHandled).expect("legal marker");
+        let mut cross_request = InlineResponseSlot::disabled();
+        assert!(matches!(
+            cross_request.resolve(second, HandlerOutcome::NoReply(marker)),
+            Err(HandlerOutcomeContractError::NoResponseIdentityMismatch)
+        ));
+        assert!(matches!(
+            cross_request.resolve(
+                second,
+                HandlerOutcome::Reply(ResponsePlan::command(response_head(9)).expect("reply"))
+            ),
+            Err(HandlerOutcomeContractError::OutcomeAlreadyCompleted)
+        ));
+
+        let invalid = ProtocolNoResponse {
+            request_id: first.request_id(),
+            original_code: first.original_code(),
+            reason: ProtocolNoResponseReason::NotificationHandled,
+        };
+        let mut policy = InlineResponseSlot::disabled();
+        assert!(matches!(
+            policy.resolve(first, HandlerOutcome::NoReply(invalid)),
+            Err(HandlerOutcomeContractError::NoResponsePolicyMismatch { .. })
+        ));
+
+        let legal =
+            ProtocolNoResponse::from_original(first, ProtocolNoResponseReason::CallbackHandled).expect("legal marker");
+        let mut accepted = InlineResponseSlot::disabled();
+        assert!(matches!(
+            accepted.resolve(first, HandlerOutcome::NoReply(legal)),
+            Ok(HandlerOutcome::NoReply(_))
+        ));
+    }
+
+    #[test]
+    fn no_reply_revalidation_rejects_four_cross_requests_and_every_identity_component() {
+        let legal = [
+            (
+                RequestCode::CheckTransactionState,
+                ProtocolNoResponseReason::CallbackHandled,
+            ),
+            (
+                RequestCode::ResetConsumerClientOffset,
+                ProtocolNoResponseReason::CallbackHandled,
+            ),
+            (
+                RequestCode::NotifyConsumerIdsChanged,
+                ProtocolNoResponseReason::NotificationHandled,
+            ),
+            (
+                RequestCode::NotifyUnsubscribeLite,
+                ProtocolNoResponseReason::NotificationHandled,
+            ),
+        ];
+        for (index, (code, reason)) in legal.into_iter().enumerate() {
+            let source = identity(51 + index as u64, code);
+            let other_owner = identity(61 + index as u64, code);
+            let marker = ProtocolNoResponse::from_original(source, reason).expect("legal marker");
+            let mut slot = InlineResponseSlot::disabled();
+            assert!(matches!(
+                slot.resolve(other_owner, HandlerOutcome::NoReply(marker)),
+                Err(HandlerOutcomeContractError::NoResponseIdentityMismatch)
+            ));
+        }
+
+        let sequence = AtomicU64::new(1);
+        let first = identity_from_counter(71, RequestCode::CheckTransactionState, &sequence);
+        let second = identity_from_counter(71, RequestCode::CheckTransactionState, &sequence);
+        let marker =
+            ProtocolNoResponse::from_original(first, ProtocolNoResponseReason::CallbackHandled).expect("legal marker");
+        let mut same_owner = InlineResponseSlot::disabled();
+        assert!(matches!(
+            same_owner.resolve(second, HandlerOutcome::NoReply(marker)),
+            Err(HandlerOutcomeContractError::NoResponseIdentityMismatch)
+        ));
+
+        let wrong_code = ProtocolNoResponse {
+            request_id: first.request_id(),
+            original_code: RequestCode::NotifyConsumerIdsChanged.to_i32(),
+            reason: ProtocolNoResponseReason::CallbackHandled,
+        };
+        let mut raw_code = InlineResponseSlot::disabled();
+        assert!(matches!(
+            raw_code.resolve(first, HandlerOutcome::NoReply(wrong_code)),
+            Err(HandlerOutcomeContractError::NoResponseIdentityMismatch)
+        ));
+
+        let mut command = RemotingCommand::create_remoting_command(RequestCode::CheckTransactionState.to_i32());
+        command.mark_oneway_rpc_ref();
+        let one_way = OriginalRequestIdentity::capture(72, &AtomicU64::new(1), &command)
+            .expect("one-way identity should allocate");
+        let forged = ProtocolNoResponse {
+            request_id: one_way.request_id(),
+            original_code: one_way.original_code(),
+            reason: ProtocolNoResponseReason::CallbackHandled,
+        };
+        let mut one_way_slot = InlineResponseSlot::disabled();
+        assert!(matches!(
+            one_way_slot.resolve(one_way, HandlerOutcome::NoReply(forged)),
+            Err(HandlerOutcomeContractError::NoResponsePolicyMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn deferred_proofs_require_take_match_identity_and_drop_once_on_failure() {
+        let first = identity(31, RequestCode::ResetConsumerClientOffset);
+        let second = identity(32, RequestCode::ResetConsumerClientOffset);
+        let drops = Arc::new(AtomicUsize::new(0));
+        let registration = DeferredRegistration::with_drop_probe(first.request_id(), Arc::clone(&drops));
+        let mut untaken = InlineResponseSlot::deferred_capable();
+        assert!(matches!(
+            untaken.resolve(first, HandlerOutcome::Deferred(registration)),
+            Err(HandlerOutcomeContractError::DeferredResponderNotTaken)
+        ));
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+
+        let registration = DeferredRegistration::with_drop_probe(first.request_id(), Arc::clone(&drops));
+        let mut mismatch = InlineResponseSlot::deferred_capable();
+        mismatch.mark_deferred_taken(second).expect("take deferred responder");
+        assert!(matches!(
+            mismatch.resolve(second, HandlerOutcome::Deferred(registration)),
+            Err(HandlerOutcomeContractError::DeferredRegistrationRequestMismatch { .. })
+        ));
+        assert_eq!(drops.load(Ordering::SeqCst), 2);
+
+        let sequence = AtomicU64::new(1);
+        let first = identity_from_counter(33, RequestCode::ResetConsumerClientOffset, &sequence);
+        let second = identity_from_counter(33, RequestCode::ResetConsumerClientOffset, &sequence);
+        let registration = DeferredRegistration::with_drop_probe(first.request_id(), Arc::clone(&drops));
+        let mut same_owner = InlineResponseSlot::deferred_capable();
+        same_owner.mark_deferred_taken(second).expect("take deferred responder");
+        assert!(matches!(
+            same_owner.resolve(second, HandlerOutcome::Deferred(registration)),
+            Err(HandlerOutcomeContractError::DeferredRegistrationRequestMismatch { .. })
+        ));
+        assert_eq!(drops.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn reply_and_no_reply_after_defer_drop_payloads_and_complete_the_slot() {
+        let original = identity(41, RequestCode::CheckTransactionState);
+        let (plan, lease, accesses, drops) = counting_file_plan(10);
+        drop(lease);
+        let mut slot = InlineResponseSlot::deferred_capable();
+        slot.mark_deferred_taken(original).expect("take deferred responder");
+        assert!(matches!(
+            slot.resolve(original, HandlerOutcome::Reply(plan)),
+            Err(HandlerOutcomeContractError::ReplyAfterDeferredTaken)
+        ));
+        assert_eq!(accesses.load(Ordering::SeqCst), 1);
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+        assert!(matches!(
+            slot.resolve(
+                original,
+                HandlerOutcome::NoReply(
+                    ProtocolNoResponse::from_original(original, ProtocolNoResponseReason::CallbackHandled)
+                        .expect("legal marker")
+                )
+            ),
+            Err(HandlerOutcomeContractError::OutcomeAlreadyCompleted)
+        ));
+
+        let mut no_reply = InlineResponseSlot::deferred_capable();
+        no_reply.mark_deferred_taken(original).expect("take deferred responder");
+        assert!(matches!(
+            no_reply.resolve(
+                original,
+                HandlerOutcome::NoReply(
+                    ProtocolNoResponse::from_original(original, ProtocolNoResponseReason::CallbackHandled)
+                        .expect("legal marker")
+                )
+            ),
+            Err(HandlerOutcomeContractError::NoReplyAfterDeferredTaken)
+        ));
+    }
+
+    #[test]
+    fn closed_error_mapping_contains_only_stable_contract_fields() {
+        let mapped = RocketMQError::from(ProtocolNoResponseError::Unsupported {
+            request_code: -91,
+            reason: ProtocolNoResponseReason::NotificationHandled,
+        });
+        let display = mapped.to_string();
+        assert!(display.contains("protocol_no_response"));
+        assert!(display.contains("request_code=-91"));
+        assert!(display.contains("notification_handled"));
+        assert!(!display.contains("body"));
+        assert!(!display.contains("peer"));
+        assert!(!display.contains("principal"));
+    }
+}

--- a/rocketmq-transport/src/dispatch/remoting_request.rs
+++ b/rocketmq-transport/src/dispatch/remoting_request.rs
@@ -21,7 +21,13 @@ use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 
 use super::request_control::LazyExtensions;
 use super::AuthenticationState;
+use super::HandlerOutcome;
+use super::HandlerOutcomeContractError;
+use super::InlineResponseSlot;
 use super::OriginalRequestIdentity;
+use super::ProtocolNoResponse;
+use super::ProtocolNoResponseError;
+use super::ProtocolNoResponseReason;
 use super::RequestControlView;
 use super::RequestMeta;
 use super::RequestOrigin;
@@ -108,11 +114,7 @@ pub struct RemotingRequest {
     session: SessionView,
     control: RequestControlView,
     extensions: LazyExtensions,
-    #[allow(
-        dead_code,
-        reason = "REQ-06 reserves the inert deferred slot for later DEF lifecycle work"
-    )]
-    deferred: DeferredSlot,
+    inline_response: InlineResponseSlot,
     command: RemotingCommand,
 }
 
@@ -152,6 +154,35 @@ impl RemotingRequest {
     #[must_use]
     pub const fn control(&self) -> &RequestControlView {
         &self.control
+    }
+
+    /// Creates an affine no-response marker from immutable ingress identity.
+    ///
+    /// The mutable processor command is deliberately not consulted. Only the
+    /// audited original request code/reason pairs can create a marker.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProtocolNoResponseError::OneWayRequest`] for every original
+    /// one-way request. Returns [`ProtocolNoResponseError::Unsupported`] when
+    /// the original raw request code and supplied reason are not allowlisted.
+    ///
+    /// ```
+    /// use rocketmq_error::RocketMQResult;
+    /// use rocketmq_transport::api::v2::{
+    ///     HandlerOutcome, ProtocolNoResponseReason, RemotingRequest,
+    /// };
+    ///
+    /// fn callback_outcome(request: &RemotingRequest) -> RocketMQResult<HandlerOutcome> {
+    ///     let marker = request.protocol_no_response(ProtocolNoResponseReason::CallbackHandled)?;
+    ///     Ok(HandlerOutcome::NoReply(marker))
+    /// }
+    /// ```
+    pub fn protocol_no_response(
+        &self,
+        reason: ProtocolNoResponseReason,
+    ) -> Result<ProtocolNoResponse, ProtocolNoResponseError> {
+        ProtocolNoResponse::from_original(self.original, reason)
     }
 
     /// Returns the owned command as it currently stands.
@@ -200,10 +231,29 @@ impl RemotingRequest {
 
     #[allow(
         dead_code,
-        reason = "REQ-06 tests the inert deferred slot before later DEF lifecycle work"
+        reason = "DSP-02 preserves the deferred-capability builder regression before dispatcher wiring"
     )]
     pub(crate) const fn has_reserved_deferred_response(&self) -> bool {
-        self.deferred.is_reserved()
+        self.inline_response.has_deferred_capability()
+    }
+
+    #[allow(
+        dead_code,
+        reason = "DSP-02 exposes inline deferred transition to later dispatcher wiring"
+    )]
+    pub(crate) fn mark_deferred_response_taken(&mut self) -> Result<(), HandlerOutcomeContractError> {
+        self.inline_response.mark_deferred_taken(self.original)
+    }
+
+    #[allow(
+        dead_code,
+        reason = "DSP-02 exposes terminal outcome validation to later dispatcher wiring"
+    )]
+    pub(crate) fn resolve_handler_outcome(
+        &mut self,
+        outcome: HandlerOutcome,
+    ) -> Result<HandlerOutcome, HandlerOutcomeContractError> {
+        self.inline_response.resolve(self.original, outcome)
     }
 }
 
@@ -244,28 +294,8 @@ impl<'a> IngressRequestView<'a> {
     }
 }
 
-#[derive(Default)]
-#[allow(
-    dead_code,
-    reason = "REQ-06 reserves this crate-private placeholder before later DEF lifecycle work"
-)]
-pub(crate) struct DeferredSlot {
-    reserved: bool,
-}
-
-#[allow(
-    dead_code,
-    reason = "REQ-06 reserves inert deferred-state operations before later DEF lifecycle work"
-)]
-impl DeferredSlot {
-    pub(crate) const fn reserved() -> Self {
-        Self { reserved: true }
-    }
-
-    pub(crate) const fn is_reserved(&self) -> bool {
-        self.reserved
-    }
-}
+/// Compatibility name retained only for the private extension-type denylist.
+pub(crate) type DeferredSlot = InlineResponseSlot;
 
 #[cfg(test)]
 mod tests;

--- a/rocketmq-transport/src/dispatch/remoting_request/builder.rs
+++ b/rocketmq-transport/src/dispatch/remoting_request/builder.rs
@@ -17,9 +17,9 @@ use std::time::Instant;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_runtime::TaskGroup;
 
-use super::DeferredSlot;
 use super::IngressRequestView;
 use super::RemotingRequest;
+use crate::dispatch::InlineResponseSlot;
 use crate::dispatch::OriginalRequestIdentity;
 use crate::dispatch::RequestContext;
 use crate::dispatch::RequestControlView;
@@ -129,7 +129,7 @@ pub(crate) struct RemotingRequestBuilder {
     received_at: Instant,
     context: RequestContext,
     lifecycle: RequestLifecycleProvenance,
-    deferred: DeferredSlot,
+    inline_response: InlineResponseSlot,
     command: RemotingCommand,
 }
 
@@ -150,13 +150,13 @@ impl RemotingRequestBuilder {
             received_at,
             context,
             lifecycle,
-            deferred: DeferredSlot::default(),
+            inline_response: InlineResponseSlot::disabled(),
             command,
         }
     }
 
     pub(crate) fn reserve_deferred_response(mut self) -> Self {
-        self.deferred = DeferredSlot::reserved();
+        self.inline_response = InlineResponseSlot::deferred_capable();
         self
     }
 
@@ -209,7 +209,7 @@ impl RemotingRequestBuilder {
             }
         }
 
-        if self.original.is_one_way() && self.deferred.is_reserved() {
+        if self.original.is_one_way() && self.inline_response.has_deferred_capability() {
             return Err(RemotingRequestBuildError::OneWayDeferredResponse);
         }
 
@@ -221,7 +221,7 @@ impl RemotingRequestBuilder {
             session: self.lifecycle.session,
             control,
             extensions: Default::default(),
-            deferred: self.deferred,
+            inline_response: self.inline_response,
             command: self.command,
         })
     }

--- a/rocketmq-transport/src/dispatch/remoting_request/tests.rs
+++ b/rocketmq-transport/src/dispatch/remoting_request/tests.rs
@@ -18,6 +18,7 @@ use std::time::Instant;
 
 use bytes::Bytes;
 use cheetah_string::CheetahString;
+use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::LanguageCode;
 use rocketmq_runtime::RuntimeContext;
@@ -95,8 +96,18 @@ fn network_fixture(
     deadline: Option<crate::deadline::RequestDeadline>,
     one_way: bool,
 ) -> (Fixture, NetworkSessionHarness) {
+    network_fixture_with_code(parent_task_group, owner, deadline, one_way, 17)
+}
+
+fn network_fixture_with_code(
+    parent_task_group: &TaskGroup,
+    owner: u64,
+    deadline: Option<crate::deadline::RequestDeadline>,
+    one_way: bool,
+    request_code: i32,
+) -> (Fixture, NetworkSessionHarness) {
     let peer_address = address("198.51.100.44:43123");
-    let mut command = RemotingCommand::create_remoting_command(17)
+    let mut command = RemotingCommand::create_remoting_command(request_code)
         .set_opaque(91)
         .set_language(LanguageCode::JAVA)
         .set_version(123)
@@ -525,7 +536,7 @@ async fn request_extensions_reject_reserved_request_model_types() {
         Err(value) => value,
         Ok(_) => panic!("deferred slots must remain reserved extension types"),
     };
-    assert!(!returned.is_reserved());
+    assert!(!returned.has_deferred_capability());
     assert!(request.extension::<DeferredSlot>().is_none());
 
     shutdown(runtime).await;
@@ -546,6 +557,109 @@ async fn one_way_requests_cannot_reserve_deferred_response_state() {
         .build()
         .expect("non-one-way request may retain the inert deferred slot");
     assert!(request.has_reserved_deferred_response());
+
+    shutdown(runtime).await;
+}
+
+#[tokio::test]
+async fn protocol_no_response_factory_accepts_only_the_four_frozen_raw_code_reason_pairs() {
+    let runtime = RuntimeContext::from_current("remoting-request-protocol-no-response-allowlist");
+    let legal = [
+        (
+            RequestCode::CheckTransactionState.to_i32(),
+            ProtocolNoResponseReason::CallbackHandled,
+        ),
+        (
+            RequestCode::ResetConsumerClientOffset.to_i32(),
+            ProtocolNoResponseReason::CallbackHandled,
+        ),
+        (
+            RequestCode::NotifyConsumerIdsChanged.to_i32(),
+            ProtocolNoResponseReason::NotificationHandled,
+        ),
+        (
+            RequestCode::NotifyUnsubscribeLite.to_i32(),
+            ProtocolNoResponseReason::NotificationHandled,
+        ),
+    ];
+
+    for (index, (request_code, reason)) in legal.into_iter().enumerate() {
+        let owner = 121 + index as u64;
+        let (fixture, _session) = network_fixture_with_code(runtime.root_group(), owner, None, false, request_code);
+        let request = build(fixture).expect("legal no-response request should build");
+        let marker = request
+            .protocol_no_response(reason)
+            .expect("frozen code/reason pair should be accepted");
+
+        assert_eq!(marker.request_id(), request.original_identity().request_id());
+        assert_eq!(marker.original_code(), request_code);
+        assert_eq!(marker.reason(), reason);
+    }
+
+    shutdown(runtime).await;
+}
+
+#[tokio::test]
+async fn protocol_no_response_factory_rejects_known_mismatches_unknown_codes_and_one_way_first() {
+    let runtime = RuntimeContext::from_current("remoting-request-protocol-no-response-rejections");
+    let rejected = [
+        (
+            RequestCode::CheckTransactionState.to_i32(),
+            ProtocolNoResponseReason::NotificationHandled,
+        ),
+        (
+            RequestCode::NotifyConsumerIdsChanged.to_i32(),
+            ProtocolNoResponseReason::CallbackHandled,
+        ),
+        (-91_337, ProtocolNoResponseReason::CallbackHandled),
+        (-91_337, ProtocolNoResponseReason::NotificationHandled),
+    ];
+
+    for (index, (request_code, reason)) in rejected.into_iter().enumerate() {
+        let (fixture, _session) =
+            network_fixture_with_code(runtime.root_group(), 131 + index as u64, None, false, request_code);
+        let request = build(fixture).expect("ordinary request should build");
+        assert!(matches!(
+            request.protocol_no_response(reason),
+            Err(ProtocolNoResponseError::Unsupported {
+                request_code: actual_code,
+                reason: actual_reason,
+            }) if actual_code == request_code && actual_reason == reason
+        ));
+    }
+
+    let one_way_code = RequestCode::CheckTransactionState.to_i32();
+    let (fixture, _session) = network_fixture_with_code(runtime.root_group(), 139, None, true, one_way_code);
+    let request = build(fixture).expect("one-way request without deferred capability should build");
+    assert!(matches!(
+        request.protocol_no_response(ProtocolNoResponseReason::CallbackHandled),
+        Err(ProtocolNoResponseError::OneWayRequest)
+    ));
+    assert!(matches!(
+        request.protocol_no_response(ProtocolNoResponseReason::NotificationHandled),
+        Err(ProtocolNoResponseError::OneWayRequest)
+    ));
+
+    shutdown(runtime).await;
+}
+
+#[tokio::test]
+async fn protocol_no_response_factory_uses_immutable_original_code_and_one_way_flag() {
+    let runtime = RuntimeContext::from_current("remoting-request-protocol-no-response-original-identity");
+    let original_code = RequestCode::ResetConsumerClientOffset.to_i32();
+    let (fixture, _session) = network_fixture_with_code(runtime.root_group(), 141, None, false, original_code);
+    let mut request = build(fixture).expect("ordinary request should build");
+    let original = request.original_identity();
+
+    request.command_mut().set_code_ref(-77_777);
+    request.command_mut().mark_oneway_rpc_ref();
+    let marker = request
+        .protocol_no_response(ProtocolNoResponseReason::CallbackHandled)
+        .expect("mutable command changes cannot alter ingress policy");
+
+    assert_eq!(marker.request_id(), original.request_id());
+    assert_eq!(marker.original_code(), original_code);
+    assert_eq!(marker.reason(), ProtocolNoResponseReason::CallbackHandled);
 
     shutdown(runtime).await;
 }

--- a/rocketmq-transport/src/public_api_v2.rs
+++ b/rocketmq-transport/src/public_api_v2.rs
@@ -21,9 +21,14 @@
 
 pub use crate::deadline::RequestDeadline;
 pub use crate::dispatch::AuthenticationState;
+pub use crate::dispatch::DeferredRegistration;
 pub use crate::dispatch::EmbeddedCaller;
+pub use crate::dispatch::HandlerOutcome;
 pub use crate::dispatch::IngressRequestView;
 pub use crate::dispatch::OriginalRequestIdentity;
+pub use crate::dispatch::ProtocolNoResponse;
+pub use crate::dispatch::ProtocolNoResponseError;
+pub use crate::dispatch::ProtocolNoResponseReason;
 pub use crate::dispatch::RemotingRequest;
 pub use crate::dispatch::RequestControlView;
 pub use crate::dispatch::RequestId;

--- a/rocketmq-transport/tests/public_api_contract.rs
+++ b/rocketmq-transport/tests/public_api_contract.rs
@@ -674,7 +674,15 @@ fn validate_public_api_v2_boundary(boundary: &PublicBoundary) -> Result<(), Stri
         },
         PublicUse {
             module_path: String::new(),
+            use_tree: "crate::dispatch::DeferredRegistration".to_owned(),
+        },
+        PublicUse {
+            module_path: String::new(),
             use_tree: "crate::dispatch::EmbeddedCaller".to_owned(),
+        },
+        PublicUse {
+            module_path: String::new(),
+            use_tree: "crate::dispatch::HandlerOutcome".to_owned(),
         },
         PublicUse {
             module_path: String::new(),
@@ -683,6 +691,18 @@ fn validate_public_api_v2_boundary(boundary: &PublicBoundary) -> Result<(), Stri
         PublicUse {
             module_path: String::new(),
             use_tree: "crate::dispatch::OriginalRequestIdentity".to_owned(),
+        },
+        PublicUse {
+            module_path: String::new(),
+            use_tree: "crate::dispatch::ProtocolNoResponse".to_owned(),
+        },
+        PublicUse {
+            module_path: String::new(),
+            use_tree: "crate::dispatch::ProtocolNoResponseError".to_owned(),
+        },
+        PublicUse {
+            module_path: String::new(),
+            use_tree: "crate::dispatch::ProtocolNoResponseReason".to_owned(),
         },
         PublicUse {
             module_path: String::new(),
@@ -747,7 +767,7 @@ fn validate_public_api_v2_boundary(boundary: &PublicBoundary) -> Result<(), Stri
     Ok(())
 }
 
-const CURATED_V2_REEXPORTS: &str = "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::IngressRequestView; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::RemotingRequest; pub use crate::dispatch::RequestControlView; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestMeta; pub use crate::dispatch::RequestOrigin; pub use crate::dispatch::ResponseBodyKind; pub use crate::dispatch::ResponsePlan; pub use crate::dispatch::ResponsePlanError; pub use crate::file_region::FileRegion; pub use crate::file_region::FileRegionSequence; pub use crate::session_view::ProxyInfoSnapshot; pub use crate::session_view::SessionId; pub use crate::session_view::SessionStateView; pub use crate::session_view::SessionView;";
+const CURATED_V2_REEXPORTS: &str = "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::DeferredRegistration; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::HandlerOutcome; pub use crate::dispatch::IngressRequestView; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::ProtocolNoResponse; pub use crate::dispatch::ProtocolNoResponseError; pub use crate::dispatch::ProtocolNoResponseReason; pub use crate::dispatch::RemotingRequest; pub use crate::dispatch::RequestControlView; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestMeta; pub use crate::dispatch::RequestOrigin; pub use crate::dispatch::ResponseBodyKind; pub use crate::dispatch::ResponsePlan; pub use crate::dispatch::ResponsePlanError; pub use crate::file_region::FileRegion; pub use crate::file_region::FileRegionSequence; pub use crate::session_view::ProxyInfoSnapshot; pub use crate::session_view::SessionId; pub use crate::session_view::SessionStateView; pub use crate::session_view::SessionView;";
 
 #[test]
 fn lib_rs_exposes_only_the_curated_versioned_boundary() {

--- a/rocketmq-transport/tests/public_api_v2.rs
+++ b/rocketmq-transport/tests/public_api_v2.rs
@@ -17,16 +17,22 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use cheetah_string::CheetahString;
+use rocketmq_error::RocketMQError;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_security_api::Principal;
 use rocketmq_transport::api::v1::RequestDeadline as V1RequestDeadline;
 use rocketmq_transport::api::v1::RequestId as V1RequestId;
 use rocketmq_transport::api::v2::AuthenticationState;
+use rocketmq_transport::api::v2::DeferredRegistration;
 use rocketmq_transport::api::v2::EmbeddedCaller;
 use rocketmq_transport::api::v2::FileRegion;
 use rocketmq_transport::api::v2::FileRegionSequence;
+use rocketmq_transport::api::v2::HandlerOutcome;
 use rocketmq_transport::api::v2::IngressRequestView;
 use rocketmq_transport::api::v2::OriginalRequestIdentity;
+use rocketmq_transport::api::v2::ProtocolNoResponse;
+use rocketmq_transport::api::v2::ProtocolNoResponseError;
+use rocketmq_transport::api::v2::ProtocolNoResponseReason;
 use rocketmq_transport::api::v2::ProxyInfoSnapshot;
 use rocketmq_transport::api::v2::RemotingRequest;
 use rocketmq_transport::api::v2::RequestControlView;
@@ -103,6 +109,8 @@ fn assert_file_region_dto_contract(_: Option<FileRegion>, _: Option<FileRegionSe
 
 fn assert_error_contract<T: std::error::Error>() {}
 
+fn assert_debug_contract<T: std::fmt::Debug>() {}
+
 fn assert_response_plan_contract(plan: Option<ResponsePlan>) {
     if let Some(plan) = plan {
         let _: i32 = plan.response_code();
@@ -121,6 +129,38 @@ fn assert_response_plan_contract(plan: Option<ResponsePlan>) {
     let _ = ResponseBodyKind::Segments;
     let _ = ResponseBodyKind::FileRegions;
     assert_error_contract::<ResponsePlanError>();
+}
+
+fn consume_handler_outcome_exhaustively(outcome: HandlerOutcome) -> Option<V2RequestId> {
+    match outcome {
+        HandlerOutcome::Reply(plan) => {
+            let _: i32 = plan.response_code();
+            None
+        }
+        HandlerOutcome::Deferred(registration) => Some(registration.request_id()),
+        HandlerOutcome::NoReply(marker) => {
+            let _: i32 = marker.original_code();
+            let _: ProtocolNoResponseReason = marker.reason();
+            Some(marker.request_id())
+        }
+    }
+}
+
+fn assert_handler_outcome_contract(registration: Option<DeferredRegistration>, marker: Option<ProtocolNoResponse>) {
+    if let Some(registration) = registration {
+        let _: V2RequestId = registration.request_id();
+        let _: String = format!("{registration:?}");
+    }
+    if let Some(marker) = marker {
+        let _: V2RequestId = marker.request_id();
+        let _: i32 = marker.original_code();
+        let _: ProtocolNoResponseReason = marker.reason();
+    }
+
+    let _: fn(&RemotingRequest, ProtocolNoResponseReason) -> Result<ProtocolNoResponse, ProtocolNoResponseError> =
+        RemotingRequest::protocol_no_response;
+    assert_error_contract::<ProtocolNoResponseError>();
+    let _: RocketMQError = ProtocolNoResponseError::OneWayRequest.into();
 }
 
 fn assert_session_view_contract(view: SessionView) {
@@ -221,4 +261,23 @@ fn v2_exposes_the_request_aggregate_and_ingress_view_without_legacy_reexports() 
 fn v2_exposes_only_response_plan_metadata_and_file_region_construction_dtos() {
     assert_response_plan_contract(None);
     assert_file_region_dto_contract(None, None);
+}
+
+#[test]
+fn v2_exposes_exactly_three_exhaustive_affine_handler_outcomes() {
+    assert_debug_contract::<HandlerOutcome>();
+    assert_debug_contract::<DeferredRegistration>();
+    assert_debug_contract::<ProtocolNoResponse>();
+    let plan = ResponsePlan::command(RemotingCommand::create_response_command_with_code(0))
+        .expect("public reply plan should construct");
+    assert_eq!(consume_handler_outcome_exhaustively(HandlerOutcome::Reply(plan)), None);
+    assert_handler_outcome_contract(None, None);
+
+    let _ = ProtocolNoResponseReason::CallbackHandled;
+    let _ = ProtocolNoResponseReason::NotificationHandled;
+    let unsupported = ProtocolNoResponseError::Unsupported {
+        request_code: -91,
+        reason: ProtocolNoResponseReason::CallbackHandled,
+    };
+    assert!(unsupported.to_string().contains("-91"));
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9786

### Brief Description

Add the final exhaustive V2 handler outcome algebra and an allocation-free inline response state machine.

`HandlerOutcome` now distinguishes an owned reply, a sealed deferred-registration proof, and a request-bound protocol no-response marker without exposing any direct-write bypass. Deferred and no-response proofs are affine and cannot be forged by public code. Protocol no-response policy uses immutable ingress identity, rejects original one-way requests, and accepts only the audited raw request-code/reason pairs.

`RemotingRequest` now owns a private stack-only inline state machine that makes reply, deferred, and no-response outcomes mutually exclusive. Every outcome resolution attempt is terminal, including validation failures, so callers cannot retry with a different outcome. The response plan remains owned and unmodified; segments and file-region leases pass through without encoding, concatenation, or file access.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-transport -- --check`
- Handler-outcome focused tests: 7 passed
- Remoting-request focused tests: 15 passed
- V2 public API tests: 8 passed
- Public API contract tests: 18 passed
- All-features V1 processor contract tests: 6 passed
- `cargo check -p rocketmq-transport --all-targets --all-features`
- `cargo test -p rocketmq-transport`
- `cargo test -p rocketmq-transport --all-features`
- `cargo test -p rocketmq-transport --doc --all-features` (63 passed, 16 ignored)
- `cargo doc -p rocketmq-transport --no-deps --all-features`
- `cargo clippy -p rocketmq-transport --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `git diff --check origin/main`

The error-hygiene guard reports only the 18 findings already present on `origin/main`; none of its reported paths are changed by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public handler outcome API supporting replies, deferred responses, and protocol-approved no-response results.
  * Added validation for request types, response reasons, request identity, and deferred-response capability.
  * Exposed structured errors and response-reason details through the public API.

* **Bug Fixes**
  * Improved handling of invalid response decisions, mismatched requests, unsupported scenarios, and one-way requests.

* **Tests**
  * Added comprehensive coverage for outcome transitions, validation, error conversion, and public API compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->