### PR TITLE
[ISSUE #9790]🚀Implement the V2 authorized dispatcher execution flow

### DIFF
--- a/rocketmq-transport/src/admission.rs
+++ b/rocketmq-transport/src/admission.rs
@@ -451,9 +451,14 @@ struct PreparedScopeBudgets {
 pub(crate) struct AdmissionScopeHandle {
     budgets: Arc<PreparedScopeBudgets>,
     observer: Option<tokio::sync::mpsc::Sender<AdmissionEvent>>,
+    session_id: Option<u64>,
 }
 
 impl AdmissionScopeHandle {
+    pub(crate) const fn session_id(&self) -> Option<u64> {
+        self.session_id
+    }
+
     fn budget(&self, resource: AdmissionResource) -> ResourceBudget {
         match resource {
             AdmissionResource::Connection => self.budgets.connection.clone(),
@@ -669,6 +674,7 @@ impl AdmissionController {
     }
 
     pub(crate) fn prepare_scope(&self, scope: AdmissionScope) -> Result<AdmissionScopeHandle, AdmissionError> {
+        let session_id = scope.session;
         Ok(AdmissionScopeHandle {
             budgets: Arc::new(PreparedScopeBudgets {
                 connection: self.scoped_budget(AdmissionResource::Connection, scope)?,
@@ -679,6 +685,7 @@ impl AdmissionController {
                 processor: self.scoped_budget(AdmissionResource::Processor, scope)?,
             }),
             observer: self.observer.clone(),
+            session_id,
         })
     }
 

--- a/rocketmq-transport/src/dispatch.rs
+++ b/rocketmq-transport/src/dispatch.rs
@@ -24,7 +24,17 @@ mod response_plan;
 mod response_sink;
 
 pub use authorized_dispatcher::AuthorizedCommandDispatcher;
+#[allow(
+    unused_imports,
+    reason = "DSP-03 exposes the private V2 dispatcher core to later coexistence routing"
+)]
+pub(crate) use authorized_dispatcher::AuthorizedCommandDispatcherV2;
 pub use authorized_dispatcher::AuthorizedDispatchBoundary;
+#[allow(
+    unused_imports,
+    reason = "DSP-03 exposes the private V2 dispatcher failure to later coexistence routing"
+)]
+pub(crate) use authorized_dispatcher::AuthorizedDispatchV2Error;
 pub use authorized_dispatcher::DispatchError;
 pub use authorized_dispatcher::DispatchOutcome;
 pub use handler_outcome::DeferredRegistration;

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher.rs
@@ -65,6 +65,11 @@ use crate::session_executor::SessionExecutor;
 use crate::session_view::EmbeddedSessionRecord;
 use crate::telemetry::TransportTelemetry;
 
+mod v2;
+
+pub(crate) use v2::AuthorizedCommandDispatcherV2;
+pub(crate) use v2::AuthorizedDispatchV2Error;
+
 /// Result of submitting a command to the shared dispatch boundary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DispatchOutcome {
@@ -127,6 +132,7 @@ impl AuthorizedDispatchBoundary {
     ) -> Result<AuthorizedDispatchSession, RuntimeError> {
         Ok(AuthorizedDispatchSession {
             boundary: Arc::clone(self),
+            session_id: scope.session_id(),
             executor: SessionExecutor::try_new(task_group, scope)?,
         })
     }
@@ -134,6 +140,11 @@ impl AuthorizedDispatchBoundary {
 
 pub(crate) struct AuthorizedDispatchSession {
     boundary: Arc<AuthorizedDispatchBoundary>,
+    #[allow(
+        dead_code,
+        reason = "DSP-03 validates the canonical session owner before later coexistence routing wires V2"
+    )]
+    session_id: Option<u64>,
     executor: SessionExecutor,
 }
 

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher/v2.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher/v2.rs
@@ -1,0 +1,571 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Private V2 dispatch from trusted network ingress to terminal response delivery.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use rocketmq_error::RocketMQError;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_security_api::Action;
+use rocketmq_security_api::Decision;
+use rocketmq_security_api::Resource;
+use rocketmq_security_api::ResourceKind;
+
+use super::admission_response;
+use super::deadline_response;
+use super::AuthorizedDispatchSession;
+use super::DispatchOutcome;
+use crate::admission::AdmissionClass;
+use crate::admission::AdmissionError;
+use crate::admission::FullPolicy;
+use crate::admission::PartialFramePermit;
+use crate::dispatch::remoting_request::RemotingRequestBuildError;
+use crate::dispatch::remoting_request::RemotingRequestBuilder;
+use crate::dispatch::remoting_request::RequestLifecycleProvenance;
+use crate::dispatch::HandlerOutcome;
+use crate::dispatch::HandlerOutcomeContractError;
+use crate::dispatch::OriginalRequestIdentity;
+use crate::dispatch::RemotingRequest;
+use crate::dispatch::RequestContext;
+use crate::dispatch::RequestTransport;
+use crate::dispatch::ResponseBindingError;
+use crate::dispatch::ResponseErrorKind;
+use crate::dispatch::ResponsePlan;
+use crate::dispatch::ResponsePlanError;
+use crate::dispatch::ResponseSink;
+use crate::dispatch::WriteProgress;
+use crate::hook_registry::HookRegistry;
+use crate::hook_registry::HookSnapshot;
+use crate::remoting::inner::run_after_rpc_hooks;
+use crate::remoting::inner::run_before_rpc_hooks;
+use crate::runtime::processor_v2::RejectRequestDecision;
+use crate::runtime::processor_v2::RequestProcessorV2;
+use crate::runtime::processor_v2::ResponseWriteObservationV2;
+use crate::runtime::processor_v2::ResponseWritePath;
+use crate::runtime::RPCHook;
+use crate::server::SessionHandle;
+use crate::session_executor::SessionDispatchError;
+
+/// Stable private failure from scheduling or executing one V2 dispatch.
+#[derive(Debug, thiserror::Error)]
+#[allow(
+    dead_code,
+    reason = "DSP-03 defines the private dispatcher failure consumed by later coexistence routing"
+)]
+pub(crate) enum AuthorizedDispatchV2Error {
+    #[error("V2 dispatch requires a network request context")]
+    InvalidNetworkContext,
+    #[error("V2 dispatch requires the canonical ingress request identity")]
+    MissingOriginalIdentity,
+    #[error("the canonical ingress identity no longer matches the request command")]
+    OriginalIdentityMismatch,
+    #[error("the authorized dispatch session does not own the canonical network session")]
+    SessionMismatch,
+    #[error("authorized V2 dispatch session is closing: {0}")]
+    Closing(String),
+    #[error("authorized V2 dispatch admission failed: {0}")]
+    Admission(#[source] AdmissionError),
+    #[error("V2 boundary response failed")]
+    BoundaryResponse(#[source] RocketMQError),
+    #[error(transparent)]
+    RequestBuild(#[from] RemotingRequestBuildError),
+    #[error(transparent)]
+    ResponsePlan(#[from] ResponsePlanError),
+    #[error(transparent)]
+    ResponseBinding(#[from] ResponseBindingError),
+    #[error(transparent)]
+    HandlerContract(#[from] HandlerOutcomeContractError),
+    #[error("one-way requests cannot complete with {outcome}")]
+    OneWayOutcome { outcome: &'static str },
+    #[error("V2 response delivery failed: {kind:?}, progress={progress:?}")]
+    Response {
+        kind: ResponseErrorKind,
+        progress: Option<WriteProgress>,
+    },
+}
+
+impl AuthorizedDispatchV2Error {
+    const fn category(&self) -> &'static str {
+        match self {
+            Self::InvalidNetworkContext => "invalid_network_context",
+            Self::MissingOriginalIdentity => "missing_original_identity",
+            Self::OriginalIdentityMismatch => "original_identity_mismatch",
+            Self::SessionMismatch => "session_mismatch",
+            Self::Closing(_) => "closing",
+            Self::Admission(_) => "admission",
+            Self::BoundaryResponse(_) => "boundary_response",
+            Self::RequestBuild(_) => "request_build",
+            Self::ResponsePlan(_) => "response_plan",
+            Self::ResponseBinding(_) => "response_binding",
+            Self::HandlerContract(_) => "handler_contract",
+            Self::OneWayOutcome { .. } => "one_way_outcome",
+            Self::Response { .. } => "response",
+        }
+    }
+}
+
+/// Network-only V2 processor boundary.
+#[allow(
+    dead_code,
+    reason = "DSP-03 defines the private dispatcher core wired by the later coexistence stage"
+)]
+pub(crate) struct AuthorizedCommandDispatcherV2<P> {
+    processor: P,
+    rpc_hooks: HookRegistry,
+    #[cfg(test)]
+    reported_failures: std::sync::Mutex<Vec<&'static str>>,
+}
+
+struct HandlerCandidate {
+    outcome: HandlerOutcome,
+    failure: Option<HandlerFailureOrigin>,
+}
+
+impl HandlerCandidate {
+    const fn success(outcome: HandlerOutcome) -> Self {
+        Self { outcome, failure: None }
+    }
+
+    const fn failure(outcome: HandlerOutcome, failure: HandlerFailureOrigin) -> Self {
+        Self {
+            outcome,
+            failure: Some(failure),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum HandlerFailureOrigin {
+    BeforeHook,
+    ProcessorError,
+    Deadline,
+    AfterHook,
+    ProcessorErrorAfterHookError,
+}
+
+impl HandlerFailureOrigin {
+    const fn category(self) -> &'static str {
+        match self {
+            Self::BeforeHook => "before_hook",
+            Self::ProcessorError => "processor_error",
+            Self::Deadline => "deadline",
+            Self::AfterHook => "after_hook",
+            Self::ProcessorErrorAfterHookError => "processor_error_after_hook_error",
+        }
+    }
+
+    const fn after_hook_error(self) -> Self {
+        match self {
+            Self::ProcessorError => Self::ProcessorErrorAfterHookError,
+            Self::BeforeHook | Self::Deadline | Self::AfterHook | Self::ProcessorErrorAfterHookError => Self::AfterHook,
+        }
+    }
+}
+
+impl<P> AuthorizedCommandDispatcherV2<P>
+where
+    P: RequestProcessorV2 + Clone + Sync + 'static,
+{
+    #[allow(
+        dead_code,
+        reason = "DSP-03 construction remains private until later coexistence routing"
+    )]
+    pub(crate) fn new(processor: P, rpc_hooks: Vec<Arc<dyn RPCHook>>) -> Self {
+        Self {
+            processor,
+            rpc_hooks: HookRegistry::new(rpc_hooks),
+            #[cfg(test)]
+            reported_failures: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Admits one canonical network request into its existing session executor.
+    #[allow(
+        dead_code,
+        reason = "DSP-03 dispatch remains private until later coexistence routing"
+    )]
+    pub(crate) async fn dispatch(
+        self: &Arc<Self>,
+        authorized_session: &AuthorizedDispatchSession,
+        session: SessionHandle,
+        context: RequestContext,
+        command: RemotingCommand,
+        retained_bytes: usize,
+        partial_frame_permit: Option<PartialFramePermit>,
+    ) -> Result<DispatchOutcome, AuthorizedDispatchV2Error> {
+        if context.transport() != RequestTransport::Network {
+            return Err(AuthorizedDispatchV2Error::InvalidNetworkContext);
+        }
+        if authorized_session.session_id != Some(session.session_id()) {
+            return Err(AuthorizedDispatchV2Error::SessionMismatch);
+        }
+        let original = session
+            .original_request_identity()
+            .ok_or(AuthorizedDispatchV2Error::MissingOriginalIdentity)?;
+        if original.request_id().owner_id() != session.session_id() {
+            return Err(AuthorizedDispatchV2Error::SessionMismatch);
+        }
+        if !original.matches_command(&command) {
+            return Err(AuthorizedDispatchV2Error::OriginalIdentityMismatch);
+        }
+
+        let request_started = Instant::now();
+        let class = AdmissionClass::for_request_code(original.original_code());
+        let lifecycle = RequestLifecycleProvenance::from_network_session(&session);
+        let builder = RemotingRequestBuilder::new(original, request_started, context, lifecycle, command);
+        let ordering = self.processor.request_ordering(builder.ingress_view());
+
+        if builder.deadline().is_some_and(|deadline| deadline.is_expired()) {
+            send_boundary_response(&session, original, deadline_response(original.original_opaque())).await?;
+            return Ok(DispatchOutcome::Rejected);
+        }
+        if let Decision::Deny { reason } = authorized_session.boundary.security.authorize_for_dispatch(
+            builder.command(),
+            builder.peer(),
+            builder.principal(),
+            Resource::new(ResourceKind::Other, original.original_code().to_string()),
+            Action::Manage,
+        ) {
+            let response = RemotingCommand::create_response_command_with_code_remark(
+                rocketmq_protocol::code::response_code::ResponseCode::NoPermission,
+                reason.to_string(),
+            );
+            send_boundary_response(&session, original, response).await?;
+            return Ok(DispatchOutcome::Rejected);
+        }
+
+        let admitted_dispatcher = Arc::clone(self);
+        let admitted_session = session.clone();
+        let remote_address = session.remote_addr();
+        let rejected_session = session.clone();
+        let rejected_original = original;
+        match authorized_session.executor.try_execute(
+            retained_bytes,
+            class,
+            partial_frame_permit,
+            ordering,
+            move |_operation| async move {
+                let processor = admitted_dispatcher.processor.clone();
+                if let Err(error) = admitted_dispatcher
+                    .execute_admitted(
+                        processor,
+                        admitted_session,
+                        class,
+                        original,
+                        remote_address,
+                        request_started,
+                        builder,
+                    )
+                    .await
+                {
+                    admitted_dispatcher.report_admitted_failure(&error);
+                }
+            },
+            move |_operation, error| async move {
+                let response = admission_response(rejected_original.original_opaque(), &error);
+                if send_boundary_response(&rejected_session, rejected_original, response)
+                    .await
+                    .is_err()
+                {
+                    tracing::warn!(
+                        failure = "admission_boundary_response",
+                        "V2 admission rejection response could not be written"
+                    );
+                }
+            },
+        ) {
+            Ok(task_id) => Ok(DispatchOutcome::Accepted(task_id)),
+            Err(SessionDispatchError::Admission {
+                error,
+                retained_partial,
+            }) if error.policy() == FullPolicy::Reject => {
+                drop(retained_partial);
+                let response = admission_response(original.original_opaque(), &error);
+                send_boundary_response(&session, original, response).await?;
+                Ok(DispatchOutcome::Rejected)
+            }
+            Err(SessionDispatchError::Admission {
+                error,
+                retained_partial,
+            }) => {
+                drop(retained_partial);
+                Err(AuthorizedDispatchV2Error::Admission(error))
+            }
+            Err(SessionDispatchError::Closing(error)) => Err(AuthorizedDispatchV2Error::Closing(error.to_string())),
+        }
+    }
+
+    #[allow(
+        dead_code,
+        reason = "DSP-03 admitted execution is reached through the not-yet-wired private dispatcher"
+    )]
+    async fn execute_admitted(
+        &self,
+        mut processor: P,
+        session: SessionHandle,
+        class: AdmissionClass,
+        original: OriginalRequestIdentity,
+        remote_address: std::net::SocketAddr,
+        request_started: Instant,
+        builder: RemotingRequestBuilder,
+    ) -> Result<(), AuthorizedDispatchV2Error> {
+        let response = ResponseSink::network_plan(session, class, builder.control().clone());
+
+        if builder.deadline().is_some_and(|deadline| deadline.is_expired()) {
+            let plan = ResponsePlan::command(deadline_response(original.original_opaque()))?;
+            if original.is_one_way() {
+                drop(plan);
+                self.report_failure_category(HandlerFailureOrigin::Deadline.category());
+                return Ok(());
+            }
+            return deliver_and_observe(&processor, response, original, request_started, plan).await;
+        }
+
+        match processor.reject_request(original.original_code()) {
+            RejectRequestDecision::Proceed => {}
+            RejectRequestDecision::Reject(plan) => {
+                if original.is_one_way() {
+                    drop(plan);
+                    return Ok(());
+                }
+                return deliver_and_observe(&processor, response, original, request_started, plan).await;
+            }
+        }
+
+        let mut request = builder.build()?;
+        let hook_snapshot = self.rpc_hooks.snapshot();
+        let before_result = request.with_body_free_hook_command(|request_head| {
+            run_before_rpc_hooks(hook_snapshot.as_deref(), remote_address, request_head)
+        });
+        let candidate = match before_result {
+            Ok(()) => {
+                let processed = match request.meta().deadline() {
+                    Some(deadline) => deadline.timeout(processor.process(&mut request)).await,
+                    None => Ok(processor.process(&mut request).await),
+                };
+                match processed {
+                    Ok(Ok(outcome)) => apply_after_hook(
+                        &mut request,
+                        HandlerCandidate::success(outcome),
+                        hook_snapshot.as_deref(),
+                        remote_address,
+                    )?,
+                    Ok(Err(error)) => {
+                        let plan = crate::error_response::response_plan_from_error(&error)?;
+                        apply_after_hook(
+                            &mut request,
+                            HandlerCandidate::failure(
+                                HandlerOutcome::Reply(plan),
+                                HandlerFailureOrigin::ProcessorError,
+                            ),
+                            hook_snapshot.as_deref(),
+                            remote_address,
+                        )?
+                    }
+                    Err(_) => HandlerCandidate::failure(
+                        HandlerOutcome::Reply(ResponsePlan::command(deadline_response(original.original_opaque()))?),
+                        HandlerFailureOrigin::Deadline,
+                    ),
+                }
+            }
+            Err(error) => HandlerCandidate::failure(
+                HandlerOutcome::Reply(crate::error_response::response_plan_from_error(&error)?),
+                HandlerFailureOrigin::BeforeHook,
+            ),
+        };
+
+        let outcome = request.resolve_handler_outcome(candidate.outcome)?;
+        if original.is_one_way() {
+            return match outcome {
+                HandlerOutcome::Reply(plan) => {
+                    drop(plan);
+                    if let Some(failure) = candidate.failure {
+                        self.report_failure_category(failure.category());
+                    }
+                    Ok(())
+                }
+                HandlerOutcome::Deferred(registration) => {
+                    drop(registration);
+                    Err(AuthorizedDispatchV2Error::OneWayOutcome { outcome: "deferred" })
+                }
+                HandlerOutcome::NoReply(marker) => {
+                    drop(marker);
+                    Err(AuthorizedDispatchV2Error::OneWayOutcome { outcome: "no_reply" })
+                }
+            };
+        }
+
+        match outcome {
+            HandlerOutcome::Reply(plan) => {
+                deliver_and_observe(&processor, response, original, request_started, plan).await
+            }
+            HandlerOutcome::Deferred(registration) => {
+                drop(registration);
+                Ok(())
+            }
+            HandlerOutcome::NoReply(marker) => {
+                drop(marker);
+                Ok(())
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn register_rpc_hook(&self, hook: Arc<dyn RPCHook>) {
+        self.rpc_hooks.register(hook);
+    }
+
+    fn report_admitted_failure(&self, error: &AuthorizedDispatchV2Error) {
+        if matches!(error, AuthorizedDispatchV2Error::Response { .. }) {
+            return;
+        }
+        self.report_failure_category(error.category());
+    }
+
+    fn report_failure_category(&self, category: &'static str) {
+        #[cfg(test)]
+        self.reported_failures
+            .lock()
+            .expect("V2 failure report lock")
+            .push(category);
+        tracing::warn!(
+            failure = category,
+            "admitted V2 dispatch terminated without a response attempt"
+        );
+    }
+
+    #[cfg(test)]
+    fn reported_failure_categories(&self) -> Vec<&'static str> {
+        self.reported_failures.lock().expect("V2 failure report lock").clone()
+    }
+}
+
+#[allow(
+    dead_code,
+    reason = "DSP-03 hook application is reached through the not-yet-wired private dispatcher"
+)]
+fn apply_after_hook(
+    request: &mut RemotingRequest,
+    candidate: HandlerCandidate,
+    hook_snapshot: Option<&HookSnapshot>,
+    remote_address: std::net::SocketAddr,
+) -> Result<HandlerCandidate, AuthorizedDispatchV2Error> {
+    let HandlerCandidate { outcome, failure } = candidate;
+    let HandlerOutcome::Reply(mut plan) = outcome else {
+        return Ok(HandlerCandidate { outcome, failure });
+    };
+
+    let result = request.with_body_free_hook_request(|request_head| {
+        plan.with_body_free_hook_head(|response_head| {
+            run_after_rpc_hooks(hook_snapshot, remote_address, request_head, response_head)
+        })
+    });
+    match result {
+        Ok(()) => Ok(HandlerCandidate {
+            outcome: HandlerOutcome::Reply(plan),
+            failure,
+        }),
+        Err(error) => {
+            drop(plan);
+            let failure = failure
+                .map(HandlerFailureOrigin::after_hook_error)
+                .unwrap_or(HandlerFailureOrigin::AfterHook);
+            Ok(HandlerCandidate::failure(
+                HandlerOutcome::Reply(crate::error_response::response_plan_from_error(&error)?),
+                failure,
+            ))
+        }
+    }
+}
+
+#[allow(
+    dead_code,
+    reason = "DSP-03 delivery is reached through the not-yet-wired private dispatcher"
+)]
+async fn deliver_and_observe<P>(
+    processor: &P,
+    response: ResponseSink,
+    original: OriginalRequestIdentity,
+    request_started: Instant,
+    plan: ResponsePlan,
+) -> Result<(), AuthorizedDispatchV2Error>
+where
+    P: RequestProcessorV2,
+{
+    let response_code = plan.response_code();
+    let body_kind = plan.body_kind();
+    let bound = plan.bind(original)?;
+    let write_started = Instant::now();
+    let result = response.send_plan(bound).await;
+    let write_elapsed = write_started.elapsed();
+    let end_to_end_elapsed = request_started.elapsed();
+
+    match result {
+        Ok(receipt) => {
+            processor.observe_response_write(ResponseWriteObservationV2::from_result(
+                original.request_id(),
+                original.original_code(),
+                response_code,
+                body_kind,
+                ResponseWritePath::Inline,
+                write_elapsed,
+                end_to_end_elapsed,
+                Ok(receipt),
+            ));
+            Ok(())
+        }
+        Err(error) => {
+            let kind = error.kind();
+            let progress = error.write_progress();
+            processor.observe_response_write(ResponseWriteObservationV2::from_result(
+                original.request_id(),
+                original.original_code(),
+                response_code,
+                body_kind,
+                ResponseWritePath::Inline,
+                write_elapsed,
+                end_to_end_elapsed,
+                Err(error),
+            ));
+            Err(AuthorizedDispatchV2Error::Response { kind, progress })
+        }
+    }
+}
+
+#[allow(
+    dead_code,
+    reason = "DSP-03 boundary rejection is reached through the not-yet-wired private dispatcher"
+)]
+async fn send_boundary_response(
+    session: &SessionHandle,
+    original: OriginalRequestIdentity,
+    response: RemotingCommand,
+) -> Result<(), AuthorizedDispatchV2Error> {
+    if original.is_one_way() {
+        return Ok(());
+    }
+    session
+        .clone()
+        .with_response_class(AdmissionClass::Control)
+        .connection()
+        .send_command(response.set_opaque(original.original_opaque()))
+        .await
+        .map_err(AuthorizedDispatchV2Error::BoundaryResponse)
+}
+
+#[cfg(test)]
+#[path = "v2/tests.rs"]
+mod tests;

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests.rs
@@ -1,0 +1,22 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[path = "tests/boundary_identity.rs"]
+mod boundary_identity;
+#[path = "tests/delivery_hooks.rs"]
+mod delivery_hooks;
+#[path = "tests/harness.rs"]
+mod harness;
+#[path = "tests/outcomes_deadlines.rs"]
+mod outcomes_deadlines;

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/boundary_identity.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/boundary_identity.rs
@@ -1,0 +1,221 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::harness::*;
+#[tokio::test]
+async fn pre_admission_deadline_and_admission_rejection_never_clone_or_observe_processor() {
+    let limits = AdmissionLimits {
+        queued: crate::admission::ResourceLimit { count: 2, bytes: 1024 },
+        control_reserve: crate::admission::ResourceLimit { count: 1, bytes: 0 },
+        ..AdmissionLimits::default()
+    };
+    let mut harness = DispatchHarness::new_with_limits("dispatch-v2-pre-admission", limits).await;
+    let (processor, state) = TestProcessor::new(Behavior::Reply);
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(processor, Vec::new()));
+    let command = request(false);
+    let (session, _) = harness.request_session(&command);
+
+    let outcome = dispatcher
+        .dispatch(
+            &harness.authorized,
+            session,
+            harness.context(Some(RequestDeadline::after(Duration::ZERO))),
+            command,
+            256,
+            None,
+        )
+        .await
+        .expect("expired request produces boundary response");
+    assert_eq!(outcome, DispatchOutcome::Rejected);
+    let response = harness.receive().await;
+    assert_eq!(ResponseCode::from(response.code()), ResponseCode::SystemError);
+    assert_eq!(state.clones.load(Ordering::SeqCst), 0);
+    assert!(state.observations.lock().expect("observation lock").is_empty());
+
+    let queued = harness
+        .admission_scope
+        .try_acquire(AdmissionResource::Queued, 1, AdmissionClass::Data)
+        .expect("hold the only queued permit");
+    let command = request(false);
+    let (session, _) = harness.request_session(&command);
+    let outcome = dispatcher
+        .dispatch(&harness.authorized, session, harness.context(None), command, 256, None)
+        .await
+        .expect("queue rejection produces boundary response");
+    assert_eq!(outcome, DispatchOutcome::Rejected);
+    let response = harness.receive().await;
+    assert_eq!(ResponseCode::from(response.code()), ResponseCode::SystemBusy);
+    assert_eq!(state.clones.load(Ordering::SeqCst), 0);
+    assert_eq!(state.processes.load(Ordering::SeqCst), 0);
+    assert!(state.observations.lock().expect("observation lock").is_empty());
+    drop(queued);
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn authorization_denial_runs_after_ordering_without_clone_hook_process_or_observation() {
+    let security = Arc::new(TransportSecurity::secure_enforced(None, None));
+    let mut harness = DispatchHarness::new_with_security("dispatch-v2-auth-denial", security).await;
+    let (processor, state) = TestProcessor::new(Behavior::Reply);
+    let hook_events = Arc::new(Mutex::new(Vec::new()));
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+        processor,
+        vec![Arc::new(hook(false, false, Arc::clone(&hook_events)))],
+    ));
+    let command = request(false);
+    let (session, _) = harness.request_session(&command);
+
+    let outcome = dispatcher
+        .dispatch(&harness.authorized, session, harness.context(None), command, 256, None)
+        .await
+        .expect("authorization denial produces boundary response");
+    assert_eq!(outcome, DispatchOutcome::Rejected);
+    let response = harness.receive().await;
+
+    assert_eq!(ResponseCode::from(response.code()), ResponseCode::NoPermission);
+    assert_eq!(response.opaque(), 811);
+    assert_eq!(state.clones.load(Ordering::SeqCst), 0);
+    assert_eq!(state.processes.load(Ordering::SeqCst), 0);
+    assert_eq!(state.events.lock().expect("event lock").as_slice(), ["ordering"]);
+    assert!(state.observations.lock().expect("observation lock").is_empty());
+    assert!(hook_events.lock().expect("hook events").is_empty());
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn canonical_session_mismatch_fails_before_ordering_clone_or_response_capability_derivation() {
+    let mut first = DispatchHarness::new("dispatch-v2-owner-first").await;
+    let mut second = DispatchHarness::new("dispatch-v2-owner-second").await;
+    let (processor, state) = TestProcessor::new(Behavior::Reply);
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(processor, Vec::new()));
+    let command = request(false);
+    let (second_session, _) = second.request_session(&command);
+
+    let error = dispatcher
+        .dispatch(
+            &first.authorized,
+            second_session,
+            second.context(None),
+            command,
+            256,
+            None,
+        )
+        .await
+        .expect_err("cross-session capability splice must fail closed");
+
+    assert!(matches!(error, AuthorizedDispatchV2Error::SessionMismatch));
+    assert_eq!(state.clones.load(Ordering::SeqCst), 0);
+    assert!(state.events.lock().expect("event lock").is_empty());
+    assert!(state.observations.lock().expect("observation lock").is_empty());
+    first.assert_no_response().await;
+    second.assert_no_response().await;
+    first.shutdown().await;
+    second.shutdown().await;
+}
+
+#[tokio::test]
+async fn cross_owner_identity_splice_cannot_reach_structured_rejection() {
+    let mut first = DispatchHarness::new("dispatch-v2-identity-first-reject").await;
+    let mut second = DispatchHarness::new("dispatch-v2-identity-second-reject").await;
+    let (processor, state) = TestProcessor::new(Behavior::Reject);
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(processor, Vec::new()));
+    let command = request(false);
+    let (_, foreign_original) = second.request_session(&command);
+    let spliced_session = first
+        .session
+        .clone()
+        .with_original_request_identity(Some(foreign_original));
+
+    let error = dispatcher
+        .dispatch(
+            &first.authorized,
+            spliced_session,
+            first.context(None),
+            command,
+            256,
+            None,
+        )
+        .await
+        .expect_err("foreign request identity must fail before structured rejection");
+
+    assert!(matches!(error, AuthorizedDispatchV2Error::SessionMismatch));
+    assert_eq!(state.clones.load(Ordering::SeqCst), 0);
+    assert!(state.events.lock().expect("event lock").is_empty());
+    assert!(state.observations.lock().expect("observation lock").is_empty());
+    first.assert_no_response().await;
+    second.assert_no_response().await;
+    first.shutdown().await;
+    second.shutdown().await;
+}
+
+#[tokio::test]
+async fn cross_owner_identity_splice_cannot_queue_for_admitted_deadline_response() {
+    let mut first = DispatchHarness::new("dispatch-v2-identity-first-deadline").await;
+    let mut second = DispatchHarness::new("dispatch-v2-identity-second-deadline").await;
+    let (processor, state) = TestProcessor::new(Behavior::WaitReply);
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(processor, Vec::new()));
+
+    let predecessor = request(false);
+    let (predecessor_session, _) = first.request_session(&predecessor);
+    dispatcher
+        .dispatch(
+            &first.authorized,
+            predecessor_session,
+            first.context(None),
+            predecessor,
+            256,
+            None,
+        )
+        .await
+        .expect("submit ordered predecessor");
+    state.entered.notified().await;
+    let ordering_events_before_splice = state.events.lock().expect("event lock").len();
+
+    let spliced_command = request(false);
+    let (_, foreign_original) = second.request_session(&spliced_command);
+    let spliced_session = first
+        .session
+        .clone()
+        .with_original_request_identity(Some(foreign_original));
+    let error = dispatcher
+        .dispatch(
+            &first.authorized,
+            spliced_session,
+            first.context(Some(RequestDeadline::after(Duration::from_millis(10)))),
+            spliced_command,
+            256,
+            None,
+        )
+        .await
+        .expect_err("foreign identity must fail before entering ordered deadline queue");
+
+    assert!(matches!(error, AuthorizedDispatchV2Error::SessionMismatch));
+    assert_eq!(
+        state.events.lock().expect("event lock").len(),
+        ordering_events_before_splice
+    );
+    assert_eq!(state.clones.load(Ordering::SeqCst), 1);
+    assert!(state.observations.lock().expect("observation lock").is_empty());
+
+    state.resume.notify_one();
+    let response = first.receive().await;
+    wait_for_observation_count(&state, 1).await;
+    assert_eq!(response.code(), 71);
+    first.assert_no_response().await;
+    second.assert_no_response().await;
+    assert_eq!(state.clones.load(Ordering::SeqCst), 1);
+    assert_eq!(state.observations.lock().expect("observation lock").len(), 1);
+    first.shutdown().await;
+    second.shutdown().await;
+}

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/delivery_hooks.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/delivery_hooks.rs
@@ -1,0 +1,357 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::harness::*;
+#[tokio::test]
+async fn admitted_reply_uses_body_free_hooks_resolve_bind_writer_and_one_observation_in_order() {
+    let mut harness = DispatchHarness::new("dispatch-v2-reply").await;
+    let (processor, state) = TestProcessor::new(Behavior::Reply);
+    let hook_events = Arc::new(Mutex::new(Vec::new()));
+    let recording_hook = hook(false, false, Arc::clone(&hook_events));
+    let before_seen = Arc::clone(&recording_hook.before_body_seen);
+    let after_request_seen = Arc::clone(&recording_hook.after_request_body_seen);
+    let after_response_seen = Arc::clone(&recording_hook.after_response_body_seen);
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+        processor,
+        vec![Arc::new(recording_hook)],
+    ));
+    let command = request(false);
+    let body_pointer = command.body().expect("request body").as_ptr() as usize;
+    let (session, original) = harness.request_session(&command);
+
+    let outcome = dispatcher
+        .dispatch(&harness.authorized, session, harness.context(None), command, 256, None)
+        .await
+        .expect("dispatch submission");
+    assert!(matches!(outcome, DispatchOutcome::Accepted(_)));
+    let response = harness.receive().await;
+    wait_for_observation_count(&state, 1).await;
+
+    assert_eq!(response.opaque(), 811, "binding must restore immutable ingress opaque");
+    assert!(response.is_response_type());
+    assert_eq!(response.code(), 71);
+    assert_eq!(response.body().map(Bytes::as_ref), Some(&b"V2 response body"[..]));
+    assert_eq!(
+        response
+            .ext_fields()
+            .and_then(|fields| fields.get("hook-after"))
+            .map(cheetah_string::CheetahString::as_str),
+        Some("applied")
+    );
+    assert_eq!(state.clones.load(Ordering::SeqCst), 1);
+    assert_eq!(state.processes.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        *state.request_body_pointer.lock().expect("body pointer lock"),
+        Some(body_pointer)
+    );
+    assert_eq!(before_seen.load(Ordering::SeqCst), 0);
+    assert_eq!(after_request_seen.load(Ordering::SeqCst), 0);
+    assert_eq!(after_response_seen.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        hook_events.lock().expect("hook event lock").as_slice(),
+        ["before", "after"]
+    );
+    assert_eq!(
+        state.events.lock().expect("event lock").as_slice(),
+        ["ordering", "reject", "process", "observe"]
+    );
+    let observation = {
+        let observations = state.observations.lock().expect("observation lock");
+        assert_eq!(observations.len(), 1);
+        observations[0]
+    };
+    assert_eq!(observation.request_id(), original.request_id());
+    assert_eq!(observation.original_code(), 91);
+    assert_eq!(observation.response_code(), 71);
+    assert_eq!(observation.body_kind(), ResponseBodyKind::Bytes);
+    assert_eq!(observation.path(), ResponseWritePath::Inline);
+    assert!(matches!(
+        observation.outcome(),
+        ResponseWriteOutcomeV2::Written(receipt)
+            if receipt.request_id() == original.request_id()
+                && receipt.disposition() == ResponseDisposition::TransportWritten
+    ));
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn structured_rejection_clones_once_bypasses_hooks_and_processes_and_observes_one_write() {
+    let mut harness = DispatchHarness::new("dispatch-v2-structured-reject").await;
+    let (processor, state) = TestProcessor::new(Behavior::Reject);
+    let hook_events = Arc::new(Mutex::new(Vec::new()));
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+        processor,
+        vec![Arc::new(hook(false, false, Arc::clone(&hook_events)))],
+    ));
+    let command = request(false);
+    let (session, _) = harness.request_session(&command);
+
+    dispatcher
+        .dispatch(&harness.authorized, session, harness.context(None), command, 256, None)
+        .await
+        .expect("dispatch rejection");
+    let response = harness.receive().await;
+    wait_for_observation_count(&state, 1).await;
+
+    assert_eq!(response.code(), 73);
+    assert_eq!(response.opaque(), 811);
+    assert_eq!(response.body().map(Bytes::as_ref), Some(&b"structured rejection"[..]));
+    assert_eq!(state.clones.load(Ordering::SeqCst), 1);
+    assert_eq!(state.rejects.load(Ordering::SeqCst), 1);
+    assert_eq!(state.processes.load(Ordering::SeqCst), 0);
+    assert_eq!(state.observations.lock().expect("observation lock").len(), 1);
+    assert!(hook_events.lock().expect("hook event lock").is_empty());
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn mapped_processor_and_after_hook_errors_do_not_retry_after_or_write_twice() {
+    for (name, fail_after) in [
+        ("dispatch-v2-processor-error", false),
+        ("dispatch-v2-after-error", true),
+    ] {
+        let mut harness = DispatchHarness::new(name).await;
+        let behavior = if fail_after { Behavior::Reply } else { Behavior::Error };
+        let (processor, state) = TestProcessor::new(behavior);
+        let hook_events = Arc::new(Mutex::new(Vec::new()));
+        let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+            processor,
+            vec![Arc::new(hook(fail_after, false, Arc::clone(&hook_events)))],
+        ));
+        let command = request(false);
+        let (session, _) = harness.request_session(&command);
+
+        dispatcher
+            .dispatch(&harness.authorized, session, harness.context(None), command, 256, None)
+            .await
+            .expect("dispatch mapped error");
+        let response = harness.receive().await;
+        wait_for_observation_count(&state, 1).await;
+
+        assert_eq!(ResponseCode::from(response.code()), ResponseCode::InvalidParameter);
+        assert_eq!(response.opaque(), 811);
+        assert_eq!(
+            hook_events.lock().expect("hook event lock").as_slice(),
+            ["before", "after"]
+        );
+        assert_eq!(state.clones.load(Ordering::SeqCst), 1);
+        assert_eq!(state.processes.load(Ordering::SeqCst), 1);
+        assert_eq!(state.observations.lock().expect("observation lock").len(), 1);
+        harness.assert_no_response().await;
+        harness.shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn after_hook_oneway_mutation_fails_closed_and_maps_once_without_recursive_after() {
+    let mut harness = DispatchHarness::new("dispatch-v2-after-oneway-contract").await;
+    let (processor, state) = TestProcessor::new(Behavior::Reply);
+    let hook_events = Arc::new(Mutex::new(Vec::new()));
+    let mut recording_hook = hook(false, false, Arc::clone(&hook_events));
+    recording_hook.mark_after_oneway = true;
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+        processor,
+        vec![Arc::new(recording_hook)],
+    ));
+    let command = request(false);
+    let (session, _) = harness.request_session(&command);
+
+    dispatcher
+        .dispatch(&harness.authorized, session, harness.context(None), command, 256, None)
+        .await
+        .expect("dispatch response-head contract error");
+    let response = harness.receive().await;
+    wait_for_observation_count(&state, 1).await;
+
+    assert_eq!(ResponseCode::from(response.code()), ResponseCode::SystemError);
+    assert_eq!(response.opaque(), 811);
+    assert!(!response.is_oneway_rpc());
+    assert_eq!(
+        hook_events.lock().expect("hook event lock").as_slice(),
+        ["before", "after"]
+    );
+    assert_eq!(state.processes.load(Ordering::SeqCst), 1);
+    assert_eq!(state.observations.lock().expect("observation lock").len(), 1);
+    harness.assert_no_response().await;
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn binding_restores_response_type_after_hook_clears_it_without_losing_plan_body() {
+    let mut harness = DispatchHarness::new("dispatch-v2-after-response-type-binding").await;
+    let (processor, state) = TestProcessor::new(Behavior::Reply);
+    let hook_events = Arc::new(Mutex::new(Vec::new()));
+    let mut recording_hook = hook(false, false, Arc::clone(&hook_events));
+    recording_hook.clear_after_response_type = true;
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+        processor,
+        vec![Arc::new(recording_hook)],
+    ));
+    let command = request(false);
+    let (session, _) = harness.request_session(&command);
+
+    dispatcher
+        .dispatch(&harness.authorized, session, harness.context(None), command, 256, None)
+        .await
+        .expect("dispatch response-type binding correction");
+    let response = harness.receive().await;
+    wait_for_observation_count(&state, 1).await;
+
+    assert!(response.is_response_type());
+    assert_eq!(response.opaque(), 811);
+    assert_eq!(response.code(), 71);
+    assert_eq!(response.body().map(Bytes::as_ref), Some(&b"V2 response body"[..]));
+    assert_eq!(
+        hook_events.lock().expect("hook event lock").as_slice(),
+        ["before", "after"]
+    );
+    assert_eq!(state.processes.load(Ordering::SeqCst), 1);
+    assert_eq!(state.observations.lock().expect("observation lock").len(), 1);
+    harness.assert_no_response().await;
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn possibly_partial_flush_failure_is_observed_once_and_never_retried() {
+    let harness = DispatchHarness::new_with_flush_failure("dispatch-v2-possibly-partial").await;
+    let (processor, state) = TestProcessor::new(Behavior::Reply);
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(processor, Vec::new()));
+    let command = request(false);
+    let (session, _) = harness.request_session(&command);
+    let session_view = session.session_view();
+
+    dispatcher
+        .dispatch(&harness.authorized, session, harness.context(None), command, 256, None)
+        .await
+        .expect("dispatch flush failure request");
+    wait_for_observation_count(&state, 1).await;
+    tokio::time::timeout(Duration::from_secs(2), session_view.state().closed())
+        .await
+        .expect("writer failure must close the canonical session");
+
+    {
+        let observations = state.observations.lock().expect("observation lock");
+        assert_eq!(observations.len(), 1);
+        assert_eq!(
+            observations[0].outcome(),
+            ResponseWriteOutcomeV2::Failed {
+                kind: ResponseErrorKind::Transport,
+                progress: Some(WriteProgress::PossiblyPartial),
+            }
+        );
+    }
+    assert_eq!(state.clones.load(Ordering::SeqCst), 1);
+    assert_eq!(state.processes.load(Ordering::SeqCst), 1);
+    assert_eq!(state.observations.lock().expect("observation lock").len(), 1);
+    assert!(session_view.state().is_closed());
+    assert!(!session_view.state().is_healthy());
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn hook_body_attachment_fails_closed_before_processing_and_never_exposes_either_body() {
+    let mut harness = DispatchHarness::new("dispatch-v2-hook-body-contract").await;
+    let (processor, state) = TestProcessor::new(Behavior::Reply);
+    let hook_events = Arc::new(Mutex::new(Vec::new()));
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+        processor,
+        vec![Arc::new(hook(false, true, Arc::clone(&hook_events)))],
+    ));
+    let command = request(false);
+    let (session, _) = harness.request_session(&command);
+
+    dispatcher
+        .dispatch(&harness.authorized, session, harness.context(None), command, 256, None)
+        .await
+        .expect("dispatch hook contract error");
+    let response = harness.receive().await;
+    wait_for_observation_count(&state, 1).await;
+
+    assert_eq!(ResponseCode::from(response.code()), ResponseCode::SystemError);
+    assert_eq!(response.opaque(), 811);
+    assert_eq!(state.processes.load(Ordering::SeqCst), 0);
+    assert_eq!(state.observations.lock().expect("observation lock").len(), 1);
+    assert_eq!(hook_events.lock().expect("hook event lock").as_slice(), ["before"]);
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn after_hook_body_attachment_drops_original_plan_and_maps_one_bodyless_frame() {
+    let mut harness = DispatchHarness::new("dispatch-v2-after-body-contract").await;
+    let (processor, state) = TestProcessor::new(Behavior::Reply);
+    let hook_events = Arc::new(Mutex::new(Vec::new()));
+    let mut recording_hook = hook(false, false, Arc::clone(&hook_events));
+    recording_hook.attach_after_body = true;
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+        processor,
+        vec![Arc::new(recording_hook)],
+    ));
+    let command = request(false);
+    let (session, _) = harness.request_session(&command);
+
+    dispatcher
+        .dispatch(&harness.authorized, session, harness.context(None), command, 256, None)
+        .await
+        .expect("dispatch response-body contract error");
+    let response = harness.receive().await;
+    wait_for_observation_count(&state, 1).await;
+
+    assert_eq!(ResponseCode::from(response.code()), ResponseCode::SystemError);
+    assert_eq!(response.opaque(), 811);
+    assert!(
+        response.body().is_none(),
+        "mapped invariant response must stay bodyless"
+    );
+    assert_eq!(
+        hook_events.lock().expect("hook event lock").as_slice(),
+        ["before", "after"]
+    );
+    assert_eq!(state.processes.load(Ordering::SeqCst), 1);
+    assert_eq!(state.observations.lock().expect("observation lock").len(), 1);
+    harness.assert_no_response().await;
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn one_hook_snapshot_is_retained_across_before_process_and_after() {
+    let mut harness = DispatchHarness::new("dispatch-v2-hook-snapshot").await;
+    let (processor, state) = TestProcessor::new(Behavior::WaitReply);
+    let first_events = Arc::new(Mutex::new(Vec::new()));
+    let second_events = Arc::new(Mutex::new(Vec::new()));
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+        processor,
+        vec![Arc::new(hook(false, false, Arc::clone(&first_events)))],
+    ));
+    let command = request(false);
+    let (session, _) = harness.request_session(&command);
+
+    dispatcher
+        .dispatch(&harness.authorized, session, harness.context(None), command, 256, None)
+        .await
+        .expect("dispatch retained hook snapshot");
+    state.entered.notified().await;
+    dispatcher.register_rpc_hook(Arc::new(hook(false, false, Arc::clone(&second_events))));
+    state.resume.notify_one();
+    let _response = harness.receive().await;
+    wait_for_observation_count(&state, 1).await;
+
+    assert_eq!(
+        first_events.lock().expect("first hook events").as_slice(),
+        ["before", "after"]
+    );
+    assert!(second_events.lock().expect("second hook events").is_empty());
+    assert_eq!(state.processes.load(Ordering::SeqCst), 1);
+    assert_eq!(state.observations.lock().expect("observation lock").len(), 1);
+    harness.shutdown().await;
+}

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/harness.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/harness.rs
@@ -1,0 +1,523 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(super) use std::future::Future;
+pub(super) use std::net::IpAddr;
+pub(super) use std::net::Ipv4Addr;
+pub(super) use std::pin::Pin;
+pub(super) use std::sync::atomic::AtomicU64;
+pub(super) use std::sync::atomic::AtomicUsize;
+pub(super) use std::sync::atomic::Ordering;
+pub(super) use std::sync::Arc;
+pub(super) use std::sync::Mutex;
+pub(super) use std::task::Context;
+pub(super) use std::task::Poll;
+pub(super) use std::time::Duration;
+pub(super) use std::time::Instant;
+
+pub(super) use bytes::Bytes;
+pub(super) use rocketmq_error::RocketMQError;
+pub(super) use rocketmq_protocol::code::response_code::ResponseCode;
+pub(super) use rocketmq_runtime::RuntimeContext;
+pub(super) use rocketmq_runtime::ShutdownDeadline;
+pub(super) use rocketmq_security_api::PeerInfo;
+pub(super) use tokio::io::AsyncRead;
+pub(super) use tokio::io::AsyncWrite;
+pub(super) use tokio::io::ReadBuf;
+
+pub(super) use super::super::*;
+pub(super) use crate::admission::AdmissionController;
+pub(super) use crate::admission::AdmissionLimits;
+pub(super) use crate::admission::AdmissionResource;
+pub(super) use crate::admission::AdmissionScope;
+pub(super) use crate::connection::Connection;
+pub(super) use crate::deadline::RequestDeadline;
+pub(super) use crate::dispatch::ProtocolNoResponseReason;
+pub(super) use crate::dispatch::ResponseBodyKind;
+pub(super) use crate::dispatch::ResponseDisposition;
+pub(super) use crate::request_ordering::RequestOrdering;
+pub(super) use crate::request_ordering::RequestOrderingKey;
+pub(super) use crate::runtime::processor_v2::ResponseWriteObservationV2;
+pub(super) use crate::runtime::processor_v2::ResponseWriteOutcomeV2;
+pub(super) use crate::security::TransportSecurity;
+pub(super) use crate::server::run_connected_session;
+pub(super) use crate::server::ConnectionHandler;
+pub(super) use tokio::sync::oneshot;
+
+#[derive(Clone, Copy)]
+pub(super) enum Behavior {
+    Reply,
+    WaitReply,
+    Reject,
+    Error,
+    NoReply,
+    Deferred,
+    UnclaimedDeferred,
+    ReplyAfterDeferred,
+}
+
+#[derive(Default)]
+pub(super) struct ProcessorState {
+    pub(super) clones: AtomicUsize,
+    pub(super) rejects: AtomicUsize,
+    pub(super) processes: AtomicUsize,
+    pub(super) request_body_pointer: Mutex<Option<usize>>,
+    pub(super) events: Mutex<Vec<&'static str>>,
+    pub(super) observations: Mutex<Vec<ResponseWriteObservationV2>>,
+    pub(super) observed: tokio::sync::Notify,
+    pub(super) entered: tokio::sync::Notify,
+    pub(super) resume: tokio::sync::Notify,
+}
+
+pub(super) struct TestProcessor {
+    behavior: Behavior,
+    state: Arc<ProcessorState>,
+}
+
+impl TestProcessor {
+    pub(super) fn new(behavior: Behavior) -> (Self, Arc<ProcessorState>) {
+        let state = Arc::new(ProcessorState::default());
+        (
+            Self {
+                behavior,
+                state: Arc::clone(&state),
+            },
+            state,
+        )
+    }
+}
+
+impl Clone for TestProcessor {
+    fn clone(&self) -> Self {
+        self.state.clones.fetch_add(1, Ordering::SeqCst);
+        Self {
+            behavior: self.behavior,
+            state: Arc::clone(&self.state),
+        }
+    }
+}
+
+impl RequestProcessorV2 for TestProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        self.state.processes.fetch_add(1, Ordering::SeqCst);
+        self.state.events.lock().expect("event lock").push("process");
+        *self.state.request_body_pointer.lock().expect("body pointer lock") =
+            request.command().body().map(|body| body.as_ptr() as usize);
+        if matches!(self.behavior, Behavior::WaitReply) {
+            self.state.entered.notify_one();
+            self.state.resume.notified().await;
+        }
+        match self.behavior {
+            Behavior::Reply | Behavior::WaitReply | Behavior::Reject => Ok(HandlerOutcome::Reply(
+                ResponsePlan::bytes(
+                    RemotingCommand::create_response_command_with_code(71).set_opaque(-777),
+                    Bytes::from_static(b"V2 response body"),
+                )
+                .expect("test response plan"),
+            )),
+            Behavior::Error => Err(RocketMQError::illegal_argument("processor failure")),
+            Behavior::NoReply => Ok(HandlerOutcome::NoReply(
+                request.protocol_no_response(ProtocolNoResponseReason::CallbackHandled)?,
+            )),
+            Behavior::Deferred => {
+                request
+                    .mark_deferred_response_taken()
+                    .expect("test request reserves deferred capability");
+                Ok(HandlerOutcome::Deferred(
+                    crate::dispatch::DeferredRegistration::for_test(request.original_identity().request_id()),
+                ))
+            }
+            Behavior::UnclaimedDeferred => Ok(HandlerOutcome::Deferred(
+                crate::dispatch::DeferredRegistration::for_test(request.original_identity().request_id()),
+            )),
+            Behavior::ReplyAfterDeferred => {
+                request
+                    .mark_deferred_response_taken()
+                    .expect("test request reserves deferred capability");
+                Ok(HandlerOutcome::Reply(
+                    ResponsePlan::command(RemotingCommand::create_response_command_with_code(75))
+                        .expect("reply after deferred plan"),
+                ))
+            }
+        }
+    }
+
+    fn reject_request(&self, _code: i32) -> RejectRequestDecision {
+        self.state.rejects.fetch_add(1, Ordering::SeqCst);
+        self.state.events.lock().expect("event lock").push("reject");
+        match self.behavior {
+            Behavior::Reject => RejectRequestDecision::Reject(
+                ResponsePlan::bytes(
+                    RemotingCommand::create_response_command_with_code(73).set_opaque(-991),
+                    Bytes::from_static(b"structured rejection"),
+                )
+                .expect("test rejection plan"),
+            ),
+            Behavior::Reply
+            | Behavior::WaitReply
+            | Behavior::Error
+            | Behavior::NoReply
+            | Behavior::Deferred
+            | Behavior::UnclaimedDeferred
+            | Behavior::ReplyAfterDeferred => RejectRequestDecision::Proceed,
+        }
+    }
+
+    fn request_ordering(&self, ingress: crate::dispatch::IngressRequestView<'_>) -> RequestOrdering {
+        self.state.events.lock().expect("event lock").push("ordering");
+        assert_eq!(ingress.original_identity().original_opaque(), 811);
+        assert_eq!(
+            ingress
+                .ext_fields()
+                .and_then(|fields| fields.get("ingress"))
+                .map(cheetah_string::CheetahString::as_str),
+            Some("preserved")
+        );
+        if matches!(self.behavior, Behavior::WaitReply) {
+            RequestOrdering::Ordered(RequestOrderingKey::new(17))
+        } else {
+            RequestOrdering::Concurrent
+        }
+    }
+
+    fn observe_response_write(&self, observation: ResponseWriteObservationV2) {
+        self.state.events.lock().expect("event lock").push("observe");
+        self.state
+            .observations
+            .lock()
+            .expect("observation lock")
+            .push(observation);
+        self.state.observed.notify_one();
+    }
+}
+
+pub(super) struct RecordingHook {
+    pub(super) events: Arc<Mutex<Vec<&'static str>>>,
+    pub(super) before_body_seen: Arc<AtomicUsize>,
+    pub(super) after_request_body_seen: Arc<AtomicUsize>,
+    pub(super) after_response_body_seen: Arc<AtomicUsize>,
+    pub(super) fail_after: bool,
+    pub(super) attach_before_body: bool,
+    pub(super) attach_after_body: bool,
+    pub(super) mark_after_oneway: bool,
+    pub(super) clear_after_response_type: bool,
+}
+
+impl crate::runtime::RPCHook for RecordingHook {
+    fn do_before_request(
+        &self,
+        _remote_addr: std::net::SocketAddr,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        self.events.lock().expect("hook event lock").push("before");
+        self.before_body_seen
+            .fetch_add(usize::from(request.body().is_some()), Ordering::SeqCst);
+        request.set_opaque_mut(-81);
+        request.set_code_mut(-82);
+        request.add_ext_field("hook-before", "applied");
+        if self.attach_before_body {
+            request.set_body_mut_ref(Bytes::from_static(b"forbidden hook body"));
+        }
+        Ok(())
+    }
+
+    fn do_after_response(
+        &self,
+        _remote_addr: std::net::SocketAddr,
+        request: &RemotingCommand,
+        response: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        self.events.lock().expect("hook event lock").push("after");
+        self.after_request_body_seen
+            .fetch_add(usize::from(request.body().is_some()), Ordering::SeqCst);
+        self.after_response_body_seen
+            .fetch_add(usize::from(response.body().is_some()), Ordering::SeqCst);
+        response.set_opaque_mut(-83);
+        response.add_ext_field("hook-after", "applied");
+        if self.attach_after_body {
+            response.set_body_mut_ref(Bytes::from_static(b"forbidden response hook body"));
+        }
+        if self.clear_after_response_type {
+            let flag = response.flag() & !1;
+            let head = std::mem::replace(response, RemotingCommand::create_remoting_command(0));
+            *response = head.set_flag(flag);
+        }
+        if self.fail_after {
+            Err(RocketMQError::illegal_argument("after hook failure"))
+        } else {
+            if self.mark_after_oneway {
+                response.mark_oneway_rpc_ref();
+            }
+            Ok(())
+        }
+    }
+}
+
+struct CaptureSession {
+    sender: Mutex<Option<oneshot::Sender<SessionHandle>>>,
+}
+
+struct FlushFailingStream {
+    inner: tokio::io::DuplexStream,
+    fail_flush: bool,
+}
+
+impl AsyncRead for FlushFailingStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+        buffer: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_read(context, buffer)
+    }
+}
+
+impl AsyncWrite for FlushFailingStream {
+    fn poll_write(mut self: Pin<&mut Self>, context: &mut Context<'_>, buffer: &[u8]) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write(context, buffer)
+    }
+
+    fn poll_write_vectored(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+        buffers: &[std::io::IoSlice<'_>],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write_vectored(context, buffers)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        match Pin::new(&mut self.inner).poll_flush(context) {
+            Poll::Ready(Ok(())) if self.fail_flush => Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "injected V2 flush failure",
+            ))),
+            result => result,
+        }
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(context)
+    }
+}
+
+impl ConnectionHandler for CaptureSession {
+    fn connected(&self, session: SessionHandle) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async move {
+            if let Some(sender) = self.sender.lock().expect("capture session lock").take() {
+                let _ = sender.send(session);
+            }
+        })
+    }
+
+    fn command(
+        &self,
+        _session: SessionHandle,
+        _command: RemotingCommand,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async {})
+    }
+}
+
+pub(super) struct DispatchHarness {
+    pub(super) runtime: RuntimeContext,
+    pub(super) session: SessionHandle,
+    pub(super) authorized: AuthorizedDispatchSession,
+    pub(super) admission_scope: crate::admission::AdmissionScopeHandle,
+    pub(super) peer: Connection,
+    pub(super) runner: tokio::task::JoinHandle<()>,
+    pub(super) security_profile: rocketmq_security_api::SecurityBootstrapProfile,
+}
+
+impl DispatchHarness {
+    pub(super) async fn new(name: &'static str) -> Self {
+        Self::new_with_options(
+            name,
+            AdmissionLimits::default(),
+            false,
+            Arc::new(TransportSecurity::development_insecure_loopback(None, None)),
+        )
+        .await
+    }
+
+    pub(super) async fn new_with_limits(name: &'static str, limits: AdmissionLimits) -> Self {
+        Self::new_with_options(
+            name,
+            limits,
+            false,
+            Arc::new(TransportSecurity::development_insecure_loopback(None, None)),
+        )
+        .await
+    }
+
+    pub(super) async fn new_with_flush_failure(name: &'static str) -> Self {
+        Self::new_with_options(
+            name,
+            AdmissionLimits::default(),
+            true,
+            Arc::new(TransportSecurity::development_insecure_loopback(None, None)),
+        )
+        .await
+    }
+
+    pub(super) async fn new_with_security(name: &'static str, security: Arc<TransportSecurity>) -> Self {
+        Self::new_with_options(name, AdmissionLimits::default(), false, security).await
+    }
+
+    pub(super) async fn new_with_options(
+        name: &'static str,
+        limits: AdmissionLimits,
+        fail_flush: bool,
+        security: Arc<TransportSecurity>,
+    ) -> Self {
+        let runtime = RuntimeContext::from_current(name);
+        let service = runtime.service_context(name);
+        let admission = Arc::new(AdmissionController::new(limits));
+        let security_profile = security.profile();
+        let (transport, peer) = tokio::io::duplex(1024 * 1024);
+        let transport = FlushFailingStream {
+            inner: transport,
+            fail_flush,
+        };
+        let (session_tx, session_rx) = oneshot::channel();
+        let handler = Arc::new(CaptureSession {
+            sender: Mutex::new(Some(session_tx)),
+        });
+        let local_addr = "127.0.0.1:19131".parse().expect("local address");
+        let remote_addr = "127.0.0.1:19132".parse().expect("remote address");
+        let runner = tokio::spawn(run_connected_session(
+            Connection::new_with_plaintext_stream(transport),
+            local_addr,
+            remote_addr,
+            service.task_group().clone(),
+            Arc::clone(&admission),
+            Arc::clone(&security),
+            None,
+            Duration::from_secs(30),
+            handler,
+        ));
+        let session = session_rx.await.expect("capture canonical session");
+        let scope = AdmissionScope::new(IpAddr::V4(Ipv4Addr::LOCALHOST)).with_session(session.session_id());
+        let admission_scope = admission.prepare_scope(scope).expect("prepare dispatch scope");
+        let boundary = Arc::new(super::super::super::AuthorizedDispatchBoundary::new(
+            security, admission,
+        ));
+        let authorized = boundary
+            .session(service.task_group(), admission_scope.clone())
+            .expect("authorized dispatch session");
+        Self {
+            runtime,
+            session,
+            authorized,
+            admission_scope,
+            peer: Connection::new_with_plaintext_stream(peer),
+            runner,
+            security_profile,
+        }
+    }
+
+    pub(super) fn request_session(&self, command: &RemotingCommand) -> (SessionHandle, OriginalRequestIdentity) {
+        let original = OriginalRequestIdentity::capture(self.session.session_id(), &AtomicU64::new(1), command)
+            .expect("capture request identity");
+        (
+            self.session.clone().with_original_request_identity(Some(original)),
+            original,
+        )
+    }
+
+    pub(super) fn context(&self, deadline: Option<RequestDeadline>) -> RequestContext {
+        RequestContext::network_with_security_profile(
+            PeerInfo::new(self.session.remote_addr(), false),
+            None,
+            deadline,
+            self.security_profile,
+        )
+    }
+
+    pub(super) async fn receive(&mut self) -> RemotingCommand {
+        tokio::time::timeout(Duration::from_secs(2), self.peer.receive_command())
+            .await
+            .expect("response timeout")
+            .expect("response read")
+            .expect("response frame")
+    }
+
+    pub(super) async fn assert_no_response(&mut self) {
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), self.peer.receive_command())
+                .await
+                .is_err()
+        );
+    }
+
+    pub(super) async fn drain_requests(&self) {
+        self.authorized
+            .drain_until(ShutdownDeadline::after(Duration::from_secs(1)))
+            .await
+            .assert_no_task_leak()
+            .expect("V2 requests should drain");
+    }
+
+    pub(super) async fn shutdown(self) {
+        self.drain_requests().await;
+        drop(self.session);
+        drop(self.peer);
+        self.runner.await.expect("session runner should stop");
+        let report = self.runtime.shutdown_tasks(Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+    }
+}
+
+pub(super) async fn wait_for_observation_count(state: &ProcessorState, expected: usize) {
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let notified = state.observed.notified();
+            if state.observations.lock().expect("observation lock").len() >= expected {
+                break;
+            }
+            notified.await;
+        }
+    })
+    .await
+    .expect("response observation barrier");
+}
+
+pub(super) fn request(one_way: bool) -> RemotingCommand {
+    let mut command = RemotingCommand::create_remoting_command(91)
+        .set_opaque(811)
+        .set_body(Bytes::from_static(b"request body"));
+    command.add_ext_field("ingress", "preserved");
+    if one_way {
+        command.mark_oneway_rpc()
+    } else {
+        command
+    }
+}
+
+pub(super) fn hook(fail_after: bool, attach_before_body: bool, events: Arc<Mutex<Vec<&'static str>>>) -> RecordingHook {
+    RecordingHook {
+        events,
+        before_body_seen: Arc::new(AtomicUsize::new(0)),
+        after_request_body_seen: Arc::new(AtomicUsize::new(0)),
+        after_response_body_seen: Arc::new(AtomicUsize::new(0)),
+        fail_after,
+        attach_before_body,
+        attach_after_body: false,
+        mark_after_oneway: false,
+        clear_after_response_type: false,
+    }
+}

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/outcomes_deadlines.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/outcomes_deadlines.rs
@@ -1,0 +1,437 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::harness::*;
+#[tokio::test]
+async fn one_way_reply_and_structured_rejection_are_consumed_without_write_or_observation() {
+    for (name, behavior, expected_processes) in [
+        ("dispatch-v2-oneway-reply", Behavior::Reply, 1),
+        ("dispatch-v2-oneway-reject", Behavior::Reject, 0),
+    ] {
+        let mut harness = DispatchHarness::new(name).await;
+        let (processor, state) = TestProcessor::new(behavior);
+        let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(processor, Vec::new()));
+        let command = request(true);
+        let (session, _) = harness.request_session(&command);
+
+        dispatcher
+            .dispatch(&harness.authorized, session, harness.context(None), command, 256, None)
+            .await
+            .expect("dispatch one-way request");
+        harness.drain_requests().await;
+        harness.assert_no_response().await;
+
+        assert_eq!(state.clones.load(Ordering::SeqCst), 1);
+        assert_eq!(state.processes.load(Ordering::SeqCst), expected_processes);
+        assert!(state.observations.lock().expect("observation lock").is_empty());
+        harness.shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn one_way_processor_error_reports_fixed_category_without_write_observation() {
+    let mut harness = DispatchHarness::new("dispatch-v2-oneway-processor-error").await;
+    let (processor, state) = TestProcessor::new(Behavior::Error);
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(processor, Vec::new()));
+    let command = request(true);
+    let (session, _) = harness.request_session(&command);
+
+    dispatcher
+        .dispatch(&harness.authorized, session, harness.context(None), command, 256, None)
+        .await
+        .expect("submit one-way processor error");
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while dispatcher.reported_failure_categories().is_empty() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("one-way processor error reporter");
+    harness.drain_requests().await;
+
+    assert_eq!(dispatcher.reported_failure_categories(), ["processor_error"]);
+    assert_eq!(state.processes.load(Ordering::SeqCst), 1);
+    assert!(state.observations.lock().expect("observation lock").is_empty());
+    harness.assert_no_response().await;
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn one_way_processor_and_after_hook_errors_report_one_combined_category() {
+    let mut harness = DispatchHarness::new("dispatch-v2-oneway-combined-error").await;
+    let (processor, state) = TestProcessor::new(Behavior::Error);
+    let hook_events = Arc::new(Mutex::new(Vec::new()));
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+        processor,
+        vec![Arc::new(hook(true, false, Arc::clone(&hook_events)))],
+    ));
+    let command = request(true);
+    let (session, _) = harness.request_session(&command);
+
+    dispatcher
+        .dispatch(&harness.authorized, session, harness.context(None), command, 256, None)
+        .await
+        .expect("submit combined one-way failure");
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while dispatcher.reported_failure_categories().is_empty() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("combined one-way failure reporter");
+    harness.drain_requests().await;
+
+    assert_eq!(
+        dispatcher.reported_failure_categories(),
+        ["processor_error_after_hook_error"]
+    );
+    assert_eq!(
+        hook_events.lock().expect("hook event lock").as_slice(),
+        ["before", "after"]
+    );
+    assert_eq!(state.processes.load(Ordering::SeqCst), 1);
+    assert!(state.observations.lock().expect("observation lock").is_empty());
+    harness.assert_no_response().await;
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn queued_deadline_expiry_suppresses_original_oneway_before_binding_or_write() {
+    let mut harness = DispatchHarness::new("dispatch-v2-queued-oneway-deadline").await;
+    let (processor, state) = TestProcessor::new(Behavior::WaitReply);
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(processor, Vec::new()));
+
+    let first = request(false);
+    let (first_session, _) = harness.request_session(&first);
+    dispatcher
+        .dispatch(
+            &harness.authorized,
+            first_session,
+            harness.context(None),
+            first,
+            256,
+            None,
+        )
+        .await
+        .expect("submit ordered predecessor");
+    state.entered.notified().await;
+
+    let deadline = RequestDeadline::after(Duration::from_millis(10));
+    let second = request(true);
+    let (second_session, _) = harness.request_session(&second);
+    dispatcher
+        .dispatch(
+            &harness.authorized,
+            second_session,
+            harness.context(Some(deadline)),
+            second,
+            256,
+            None,
+        )
+        .await
+        .expect("queue ordered one-way request");
+    tokio::time::sleep(deadline.remaining()).await;
+    assert!(deadline.is_expired());
+
+    state.resume.notify_one();
+    let response = harness.receive().await;
+    assert_eq!(response.code(), 71, "only the ordered predecessor may write");
+    harness.drain_requests().await;
+    harness.assert_no_response().await;
+
+    assert_eq!(state.clones.load(Ordering::SeqCst), 2);
+    assert_eq!(state.processes.load(Ordering::SeqCst), 1);
+    assert_eq!(state.observations.lock().expect("observation lock").len(), 1);
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn direct_expired_oneway_admission_completes_without_reaching_binding() {
+    let mut harness = DispatchHarness::new("dispatch-v2-direct-oneway-deadline").await;
+    let (processor, state) = TestProcessor::new(Behavior::Reply);
+    let dispatcher = AuthorizedCommandDispatcherV2::new(TestProcessor::new(Behavior::Reply).0, Vec::new());
+    let command = request(true);
+    let (session, original) = harness.request_session(&command);
+    let builder = RemotingRequestBuilder::new(
+        original,
+        Instant::now(),
+        harness.context(Some(RequestDeadline::after(Duration::ZERO))),
+        RequestLifecycleProvenance::from_network_session(&session),
+        command,
+    );
+
+    dispatcher
+        .execute_admitted(
+            processor,
+            session.clone(),
+            AdmissionClass::Data,
+            original,
+            session.remote_addr(),
+            Instant::now(),
+            builder,
+        )
+        .await
+        .expect("expired one-way plan must be consumed before binding");
+
+    harness.assert_no_response().await;
+    assert_eq!(state.processes.load(Ordering::SeqCst), 0);
+    assert!(state.observations.lock().expect("observation lock").is_empty());
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn one_way_deferred_outcome_is_a_policy_error_without_inline_write_or_observation() {
+    let mut harness = DispatchHarness::new("dispatch-v2-oneway-deferred-policy").await;
+    let (processor, state) = TestProcessor::new(Behavior::Deferred);
+    let dispatcher = AuthorizedCommandDispatcherV2::new(TestProcessor::new(Behavior::Reply).0, Vec::new());
+    let builder_command = request(false);
+    let (session, builder_original) = harness.request_session(&builder_command);
+    let builder = RemotingRequestBuilder::new(
+        builder_original,
+        Instant::now(),
+        harness.context(None),
+        RequestLifecycleProvenance::from_network_session(&session),
+        builder_command,
+    )
+    .reserve_deferred_response();
+    // DSP-02 rejects reserving deferred capability for a one-way request.
+    // Calling the private admitted seam with a separate immutable one-way
+    // identity isolates the post-resolution policy branch defensively.
+    let one_way_command = request(true);
+    let one_way_original =
+        OriginalRequestIdentity::capture(session.session_id(), &AtomicU64::new(41), &one_way_command)
+            .expect("capture one-way policy identity");
+
+    let result = dispatcher
+        .execute_admitted(
+            processor,
+            session.clone(),
+            AdmissionClass::Data,
+            one_way_original,
+            session.remote_addr(),
+            Instant::now(),
+            builder,
+        )
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(AuthorizedDispatchV2Error::OneWayOutcome { outcome: "deferred" })
+    ));
+    harness.assert_no_response().await;
+    assert_eq!(state.processes.load(Ordering::SeqCst), 1);
+    assert!(state.observations.lock().expect("observation lock").is_empty());
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn one_way_no_reply_marker_failure_maps_resolves_and_drops_without_write() {
+    let mut harness = DispatchHarness::new("dispatch-v2-oneway-no-reply-policy").await;
+    let (processor, state) = TestProcessor::new(Behavior::NoReply);
+    let dispatcher = AuthorizedCommandDispatcherV2::new(TestProcessor::new(Behavior::Reply).0, Vec::new());
+    let mut command = request(true).set_code(39);
+    command.set_opaque_mut(811);
+    let (session, original) = harness.request_session(&command);
+    let builder = RemotingRequestBuilder::new(
+        original,
+        Instant::now(),
+        harness.context(None),
+        RequestLifecycleProvenance::from_network_session(&session),
+        command,
+    );
+
+    dispatcher
+        .execute_admitted(
+            processor,
+            session.clone(),
+            AdmissionClass::Control,
+            original,
+            session.remote_addr(),
+            Instant::now(),
+            builder,
+        )
+        .await
+        .expect("one-way marker construction error maps to a consumed reply");
+
+    harness.assert_no_response().await;
+    assert_eq!(state.processes.load(Ordering::SeqCst), 1);
+    assert!(state.observations.lock().expect("observation lock").is_empty());
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn queued_deadline_expiry_attempts_one_plan_write_and_observes_not_started() {
+    let mut harness = DispatchHarness::new("dispatch-v2-queued-deadline-observation").await;
+    let (processor, state) = TestProcessor::new(Behavior::WaitReply);
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(processor, Vec::new()));
+
+    let first = request(false);
+    let (first_session, _) = harness.request_session(&first);
+    dispatcher
+        .dispatch(
+            &harness.authorized,
+            first_session,
+            harness.context(None),
+            first,
+            256,
+            None,
+        )
+        .await
+        .expect("submit ordered predecessor");
+    state.entered.notified().await;
+
+    let deadline = RequestDeadline::after(Duration::from_millis(10));
+    let second = request(false);
+    let (second_session, _) = harness.request_session(&second);
+    dispatcher
+        .dispatch(
+            &harness.authorized,
+            second_session,
+            harness.context(Some(deadline)),
+            second,
+            256,
+            None,
+        )
+        .await
+        .expect("queue ordered deadline request");
+    tokio::time::sleep(deadline.remaining()).await;
+    assert!(deadline.is_expired());
+
+    state.resume.notify_one();
+    let response = harness.receive().await;
+    assert_eq!(response.code(), 71, "only the ordered predecessor may write");
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while state.observations.lock().expect("observation lock").len() != 2 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("queued deadline observation");
+    harness.assert_no_response().await;
+
+    {
+        let observations = state.observations.lock().expect("observation lock");
+        assert_eq!(observations.len(), 2);
+        assert!(matches!(
+            observations[1].outcome(),
+            ResponseWriteOutcomeV2::Failed {
+                kind: ResponseErrorKind::DeadlineExceeded,
+                progress: Some(WriteProgress::NotStarted),
+            }
+        ));
+    }
+    assert_eq!(state.clones.load(Ordering::SeqCst), 2);
+    assert_eq!(state.processes.load(Ordering::SeqCst), 1);
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn legal_protocol_no_response_resolves_without_inline_write_or_observation() {
+    let mut harness = DispatchHarness::new("dispatch-v2-no-reply").await;
+    let (processor, state) = TestProcessor::new(Behavior::NoReply);
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(processor, Vec::new()));
+    let mut command = request(false).set_code(39);
+    command.set_opaque_mut(811);
+    let (session, _) = harness.request_session(&command);
+
+    dispatcher
+        .dispatch(&harness.authorized, session, harness.context(None), command, 256, None)
+        .await
+        .expect("dispatch protocol no-response");
+    harness.drain_requests().await;
+    harness.assert_no_response().await;
+
+    assert_eq!(state.clones.load(Ordering::SeqCst), 1);
+    assert_eq!(state.processes.load(Ordering::SeqCst), 1);
+    assert!(state.observations.lock().expect("observation lock").is_empty());
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn deferred_transfer_and_reply_after_defer_resolve_once_without_inline_write() {
+    for (name, behavior, expected_error) in [
+        ("dispatch-v2-deferred", Behavior::Deferred, false),
+        ("dispatch-v2-reply-after-defer", Behavior::ReplyAfterDeferred, true),
+    ] {
+        let mut harness = DispatchHarness::new(name).await;
+        let (processor, state) = TestProcessor::new(behavior);
+        let dispatcher = AuthorizedCommandDispatcherV2::new(TestProcessor::new(Behavior::Reply).0, Vec::new());
+        let command = request(false);
+        let (session, original) = harness.request_session(&command);
+        let builder = RemotingRequestBuilder::new(
+            original,
+            Instant::now(),
+            harness.context(None),
+            RequestLifecycleProvenance::from_network_session(&session),
+            command,
+        )
+        .reserve_deferred_response();
+
+        let result = dispatcher
+            .execute_admitted(
+                processor,
+                session.clone(),
+                AdmissionClass::Data,
+                original,
+                session.remote_addr(),
+                Instant::now(),
+                builder,
+            )
+            .await;
+
+        if expected_error {
+            assert!(matches!(
+                result,
+                Err(AuthorizedDispatchV2Error::HandlerContract(
+                    HandlerOutcomeContractError::ReplyAfterDeferredTaken
+                ))
+            ));
+        } else {
+            result.expect("sealed deferred proof should complete without an inline write");
+        }
+        harness.assert_no_response().await;
+        assert_eq!(state.processes.load(Ordering::SeqCst), 1);
+        assert!(state.observations.lock().expect("observation lock").is_empty());
+        harness.shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn real_dispatch_reports_handler_contract_failure_with_fixed_category() {
+    let mut harness = DispatchHarness::new("dispatch-v2-handler-contract-report").await;
+    let (processor, state) = TestProcessor::new(Behavior::UnclaimedDeferred);
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(processor, Vec::new()));
+    let command = request(false);
+    let (session, _) = harness.request_session(&command);
+
+    dispatcher
+        .dispatch(&harness.authorized, session, harness.context(None), command, 256, None)
+        .await
+        .expect("submit handler-contract failure");
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while dispatcher.reported_failure_categories().is_empty() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("handler-contract reporter");
+    harness.drain_requests().await;
+
+    assert_eq!(dispatcher.reported_failure_categories(), ["handler_contract"]);
+    assert_eq!(state.clones.load(Ordering::SeqCst), 1);
+    assert_eq!(state.processes.load(Ordering::SeqCst), 1);
+    assert!(state.observations.lock().expect("observation lock").is_empty());
+    harness.assert_no_response().await;
+    harness.shutdown().await;
+}

--- a/rocketmq-transport/src/dispatch/handler_outcome.rs
+++ b/rocketmq-transport/src/dispatch/handler_outcome.rs
@@ -125,7 +125,7 @@ impl DeferredRegistration {
     }
 
     #[cfg(test)]
-    fn for_test(request_id: RequestId) -> Self {
+    pub(crate) fn for_test(request_id: RequestId) -> Self {
         Self {
             request_id,
             seal: DeferredRegistrationSeal { drop_probe: None },

--- a/rocketmq-transport/src/dispatch/remoting_request.rs
+++ b/rocketmq-transport/src/dispatch/remoting_request.rs
@@ -255,6 +255,45 @@ impl RemotingRequest {
     ) -> Result<HandlerOutcome, HandlerOutcomeContractError> {
         self.inline_response.resolve(self.original, outcome)
     }
+
+    #[allow(
+        dead_code,
+        reason = "DSP-03 body-free hook projection is consumed by the not-yet-wired private dispatcher"
+    )]
+    pub(crate) fn with_body_free_hook_command<T>(
+        &mut self,
+        apply: impl FnOnce(&mut RemotingCommand) -> rocketmq_error::RocketMQResult<T>,
+    ) -> rocketmq_error::RocketMQResult<T> {
+        let body = self.command.take_body();
+        let result = apply(&mut self.command);
+        let attached_body = self.command.take_body();
+        if let Some(body) = body {
+            self.command.set_body_mut_ref(body);
+        }
+        if attached_body.is_some() {
+            return Err(rocketmq_error::RocketMQError::invariant_violated(
+                "RPC hook attached a request body through the body-free V2 projection",
+            ));
+        }
+        result
+    }
+
+    #[allow(
+        dead_code,
+        reason = "DSP-03 body-free hook projection is consumed by the not-yet-wired private dispatcher"
+    )]
+    pub(crate) fn with_body_free_hook_request<T>(
+        &mut self,
+        apply: impl FnOnce(&RemotingCommand) -> rocketmq_error::RocketMQResult<T>,
+    ) -> rocketmq_error::RocketMQResult<T> {
+        let body = self.command.take_body();
+        let result = apply(&self.command);
+        debug_assert!(self.command.body().is_none());
+        if let Some(body) = body {
+            self.command.set_body_mut_ref(body);
+        }
+        result
+    }
 }
 
 /// Immutable request facts used before processor mutation, such as ordering.

--- a/rocketmq-transport/src/dispatch/remoting_request/builder.rs
+++ b/rocketmq-transport/src/dispatch/remoting_request/builder.rs
@@ -126,9 +126,11 @@ impl RequestLifecycleProvenance {
 )]
 pub(crate) struct RemotingRequestBuilder {
     original: OriginalRequestIdentity,
-    received_at: Instant,
-    context: RequestContext,
-    lifecycle: RequestLifecycleProvenance,
+    meta: RequestMeta,
+    origin: crate::dispatch::RequestOrigin,
+    authentication: crate::dispatch::AuthenticationState,
+    session: SessionView,
+    control: RequestControlView,
     inline_response: InlineResponseSlot,
     command: RemotingCommand,
 }
@@ -145,11 +147,17 @@ impl RemotingRequestBuilder {
         lifecycle: RequestLifecycleProvenance,
         command: RemotingCommand,
     ) -> Self {
+        let context = context.into_parts();
+        let meta = RequestMeta::new(received_at, context.deadline);
+        let control =
+            RequestControlView::from_meta(&meta, lifecycle.session.state().clone(), &lifecycle.parent_task_group);
         Self {
             original,
-            received_at,
-            context,
-            lifecycle,
+            meta,
+            origin: context.origin,
+            authentication: context.authentication,
+            session: lifecycle.session,
+            control,
             inline_response: InlineResponseSlot::disabled(),
             command,
         }
@@ -171,6 +179,29 @@ impl RemotingRequestBuilder {
         }
     }
 
+    pub(crate) const fn control(&self) -> &RequestControlView {
+        &self.control
+    }
+
+    pub(crate) const fn deadline(&self) -> Option<crate::deadline::RequestDeadline> {
+        self.meta.deadline()
+    }
+
+    pub(crate) const fn command(&self) -> &RemotingCommand {
+        &self.command
+    }
+
+    pub(crate) const fn peer(&self) -> Option<&rocketmq_security_api::PeerInfo> {
+        match &self.origin {
+            crate::dispatch::RequestOrigin::Network { peer } => Some(peer),
+            crate::dispatch::RequestOrigin::Embedded { .. } => None,
+        }
+    }
+
+    pub(crate) const fn principal(&self) -> Option<&rocketmq_security_api::Principal> {
+        self.authentication.principal()
+    }
+
     pub(crate) fn build(self) -> Result<RemotingRequest, RemotingRequestBuildError> {
         if self.command.is_response_type() {
             return Err(RemotingRequestBuildError::ResponseCommand);
@@ -178,19 +209,11 @@ impl RemotingRequestBuilder {
         if !self.original.matches_command(&self.command) {
             return Err(RemotingRequestBuildError::OriginalCommandMismatch);
         }
-        if self.original.request_id().owner_id() != self.lifecycle.session.id().owner_id() {
+        if self.original.request_id().owner_id() != self.session.id().owner_id() {
             return Err(RemotingRequestBuildError::SessionOwnerMismatch);
         }
 
-        let context = self.context.into_parts();
-        let meta = RequestMeta::new(self.received_at, context.deadline);
-        let control = RequestControlView::from_meta(
-            &meta,
-            self.lifecycle.session.state().clone(),
-            &self.lifecycle.parent_task_group,
-        );
-
-        match (&context.origin, &self.lifecycle.session) {
+        match (&self.origin, &self.session) {
             (RequestOrigin::Network { peer }, SessionView::Network { remote_addr, .. }) => {
                 if peer.address() != *remote_addr {
                     return Err(RemotingRequestBuildError::NetworkPeerMismatch);
@@ -203,7 +226,7 @@ impl RemotingRequestBuilder {
                 return Err(RemotingRequestBuildError::EmbeddedSessionMismatch);
             }
             (RequestOrigin::Embedded { .. }, SessionView::Embedded { .. }) => {
-                if context.authentication.principal().is_none() {
+                if self.authentication.principal().is_none() {
                     return Err(RemotingRequestBuildError::MissingEmbeddedAuthentication);
                 }
             }
@@ -215,11 +238,11 @@ impl RemotingRequestBuilder {
 
         Ok(RemotingRequest {
             original: self.original,
-            meta,
-            origin: context.origin,
-            authentication: context.authentication,
-            session: self.lifecycle.session,
-            control,
+            meta: self.meta,
+            origin: self.origin,
+            authentication: self.authentication,
+            session: self.session,
+            control: self.control,
             extensions: Default::default(),
             inline_response: self.inline_response,
             command: self.command,

--- a/rocketmq-transport/src/dispatch/response_plan.rs
+++ b/rocketmq-transport/src/dispatch/response_plan.rs
@@ -283,6 +283,29 @@ impl ResponsePlan {
         Self::new(head, body, body_len, body_part_count)
     }
 
+    #[allow(
+        dead_code,
+        reason = "DSP-03 body-free hook projection is consumed by the not-yet-wired private dispatcher"
+    )]
+    pub(crate) fn with_body_free_hook_head<T>(
+        &mut self,
+        apply: impl FnOnce(&mut RemotingCommand) -> rocketmq_error::RocketMQResult<T>,
+    ) -> rocketmq_error::RocketMQResult<T> {
+        debug_assert!(self.head.body().is_none());
+        let result = apply(&mut self.head);
+        if self.head.take_body().is_some() {
+            return Err(rocketmq_error::RocketMQError::invariant_violated(
+                "RPC hook attached a response body through the body-free V2 projection",
+            ));
+        }
+        if self.head.is_oneway_rpc() {
+            return Err(rocketmq_error::RocketMQError::invariant_violated(
+                "RPC hook marked a V2 response plan head as one-way",
+            ));
+        }
+        result
+    }
+
     fn into_materialization_parts(self) -> (RemotingCommand, ResponseBody, usize, usize) {
         (self.head, self.body, self.body_len, self.body_part_count)
     }

--- a/rocketmq-transport/src/error_response.rs
+++ b/rocketmq-transport/src/error_response.rs
@@ -19,9 +19,20 @@ use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::remoting_command_defaults::application_remoting_command_factory;
 use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
 
+use crate::dispatch::ResponsePlan;
+use crate::dispatch::ResponsePlanError;
+
 /// Convert a typed RocketMQ error into a remoting response command.
 pub fn command_from_error(error: &RocketMQError) -> RemotingCommand {
     command_from_error_with_factory(&application_remoting_command_factory(), error)
+}
+
+#[allow(
+    dead_code,
+    reason = "DSP-03 typed error plans are consumed by the not-yet-wired private dispatcher"
+)]
+pub(crate) fn response_plan_from_error(error: &RocketMQError) -> Result<ResponsePlan, ResponsePlanError> {
+    ResponsePlan::command(command_from_error(error))
 }
 
 /// Convert a typed RocketMQ error with an explicitly owned command factory.

--- a/rocketmq-transport/src/remoting.rs
+++ b/rocketmq-transport/src/remoting.rs
@@ -39,6 +39,33 @@ pub(crate) mod inner {
     use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
     use rocketmq_protocol::protocol::RemotingCommandType;
 
+    pub(crate) fn run_before_rpc_hooks(
+        snapshot: Option<&HookSnapshot>,
+        remote_address: SocketAddr,
+        request: &mut RemotingCommand,
+    ) -> RocketMQResult<()> {
+        if let Some(snapshot) = snapshot {
+            for hook in snapshot.hooks() {
+                hook.do_before_request(remote_address, request)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn run_after_rpc_hooks(
+        snapshot: Option<&HookSnapshot>,
+        remote_address: SocketAddr,
+        request: &RemotingCommand,
+        response: &mut RemotingCommand,
+    ) -> RocketMQResult<()> {
+        if let Some(snapshot) = snapshot {
+            for hook in snapshot.hooks() {
+                hook.do_after_response(remote_address, request, response)?;
+            }
+        }
+        Ok(())
+    }
+
     pub(crate) struct RemotingGeneralHandler<RP> {
         pub(crate) request_processor: RP,
         rpc_hooks: HookRegistry,
@@ -271,10 +298,8 @@ pub(crate) mod inner {
             remote_address: SocketAddr,
             request: Option<&mut RemotingCommand>,
         ) -> rocketmq_error::RocketMQResult<()> {
-            if let (Some(snapshot), Some(request)) = (snapshot, request) {
-                for hook in snapshot.hooks() {
-                    hook.do_before_request(remote_address, request)?;
-                }
+            if let Some(request) = request {
+                run_before_rpc_hooks(snapshot, remote_address, request)?;
             }
             Ok(())
         }
@@ -286,10 +311,8 @@ pub(crate) mod inner {
             request: &RemotingCommand,
             response: Option<&mut RemotingCommand>,
         ) -> rocketmq_error::RocketMQResult<()> {
-            if let (Some(snapshot), Some(response)) = (snapshot, response) {
-                for hook in snapshot.hooks() {
-                    hook.do_after_response(remote_address, request, response)?;
-                }
+            if let Some(response) = response {
+                run_after_rpc_hooks(snapshot, remote_address, request, response)?;
             }
             Ok(())
         }

--- a/rocketmq-transport/tests/authorized_dispatch_v2_tests.rs
+++ b/rocketmq-transport/tests/authorized_dispatch_v2_tests.rs
@@ -1,0 +1,60 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(feature = "test-support")]
+
+use bytes::Bytes;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::RejectRequestDecision;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestProcessorV2;
+use rocketmq_transport::api::v2::ResponseBodyKind;
+use rocketmq_transport::api::v2::ResponsePlan;
+
+#[derive(Clone)]
+struct IntegrationProcessor;
+
+impl RequestProcessorV2 for IntegrationProcessor {
+    async fn process(&mut self, _request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        Ok(HandlerOutcome::Reply(
+            ResponsePlan::bytes(
+                RemotingCommand::create_response_command_with_code(0),
+                Bytes::from_static(b"owned integration response"),
+            )
+            .expect("valid integration response plan"),
+        ))
+    }
+
+    fn reject_request(&self, _code: i32) -> RejectRequestDecision {
+        RejectRequestDecision::Reject(
+            ResponsePlan::command(RemotingCommand::create_response_command_with_code(2))
+                .expect("valid structured rejection"),
+        )
+    }
+}
+
+fn assert_production_v2_processor<P: RequestProcessorV2 + Clone + Sync + 'static>() {}
+
+#[test]
+fn v2_processor_and_affine_response_contracts_remain_available_without_exporting_the_dispatcher() {
+    assert_production_v2_processor::<IntegrationProcessor>();
+
+    let decision = IntegrationProcessor.reject_request(91);
+    let RejectRequestDecision::Reject(plan) = decision else {
+        panic!("integration processor should own its structured rejection")
+    };
+    assert_eq!(plan.body_kind(), ResponseBodyKind::Empty);
+    assert_eq!(plan.response_code(), 2);
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9790

### Brief Description

Adds the crate-private, network-only V2 authorized dispatcher execution flow. The dispatcher preserves canonical ingress identity and session ownership, performs ordering, authorization, deadline, and admission checks before the single admitted processor clone, and routes every inline response through the affine outcome, binding, canonical response sink, and typed write-observation path.

The change also freezes hook/body invariants, immutable one-way behavior, structured rejection semantics, typed error mapping, no-retry behavior after partial writes, and low-cardinality reporting for admitted failures that cannot reach a response attempt. It does not wire production coexistence routing or expose new public V2 APIs.

### How Did You Test This Change?

- `cargo test -p rocketmq-transport --lib dispatch::authorized_dispatcher::v2::tests` (25 passed)
- `cargo test -p rocketmq-transport --test authorized_dispatch_v2_tests` (1 passed)
- V1 dispatcher and public API contract suites (2, 18, 4, and 10 tests passed across the applicable suites)
- `cargo test -p rocketmq-transport` (passed, including 482 unit tests and 70 doctests with 16 ignored)
- `cargo test -p rocketmq-transport --all-features` (passed)
- `cargo test -p rocketmq-transport --doc --all-features` (passed)
- `cargo doc -p rocketmq-transport --no-deps --all-features` (passed; one pre-existing private intra-doc link warning in untouched TLS code)
- `cargo fmt -p rocketmq-transport -- --check` (passed)
- `cargo clippy -p rocketmq-transport --all-targets --all-features -- -D warnings` (passed)
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings` (passed)
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline` (passed)
- `.\scripts\check-error-hygiene.ps1` (reported only the repository's existing 18 baseline findings; changed files have zero matches)
- `git diff --check origin/main` (passed)

An independent Sol xhigh review approved the final implementation after re-running the focused V2, integration, V1, API-contract, formatting, and diff checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authorized request-dispatch flow with session ownership, identity, authentication, authorization, admission, and deadline validation.
  * Added consistent handling for replies, rejections, one-way requests, deferred responses, processing failures, and response delivery errors.
  * Added RPC hook support with response and body-safety validation.

* **Bug Fixes**
  * Prevented unauthorized processing, response generation, duplicate writes, and unsafe retries.
  * Improved session closure and failure handling when response delivery is uncertain.

* **Tests**
  * Added comprehensive coverage for authorization boundaries, deadlines, hooks, outcomes, identity validation, and delivery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->