### PR TITLE
[ISSUE #9794]🚀Add a crate-private V1 processor adapter for V2 dispatch

### DIFF
--- a/rocketmq-observability/src/metrics/catalog/generated.rs
+++ b/rocketmq-observability/src/metrics/catalog/generated.rs
@@ -374,6 +374,11 @@ const METRIC_LABELS_59: &[&str] = &[
     labels::STATE,
 ];
 
+const METRIC_LABELS_60: &[&str] = &[
+    labels::PROCESSOR,
+    labels::REQUEST_CODE,
+];
+
 pub const JAVA_METRICS: &[MetricDescriptor] = &[
     MetricDescriptor {
         name: metrics::PROCESSOR_WATERMARK,
@@ -1882,5 +1887,12 @@ pub const RUST_METRICS: &[MetricDescriptor] = &[
         unit: "",
         labels: METRIC_LABELS_59,
         source: MetricSource::Observability,
+    },
+    MetricDescriptor {
+        name: metrics::TRANSPORT_LEGACY_PROCESSOR_REQUESTS_TOTAL,
+        kind: MetricKind::Counter,
+        unit: "{request}",
+        labels: METRIC_LABELS_60,
+        source: MetricSource::Remoting,
     },
 ];

--- a/rocketmq-observability/src/metrics/catalog/schema/rust/catalog.toml
+++ b/rocketmq-observability/src/metrics/catalog/schema/rust/catalog.toml
@@ -973,3 +973,12 @@ unit = ""
 labels = ["BACKEND", "STATE"]
 source = "Observability"
 description = "Dashboard SQL connection pool state"
+
+[[metric]]
+index = 215
+symbol = "TRANSPORT_LEGACY_PROCESSOR_REQUESTS_TOTAL"
+kind = "Counter"
+unit = "{request}"
+labels = ["PROCESSOR", "REQUEST_CODE"]
+source = "Remoting"
+description = "Requests admitted through the V1 processor compatibility adapter"

--- a/rocketmq-observability/src/metrics/catalog/tests.rs
+++ b/rocketmq-observability/src/metrics/catalog/tests.rs
@@ -66,8 +66,8 @@ fn combined_catalog_contains_every_semantic_metric_once() {
         .collect::<HashSet<_>>();
 
     assert_eq!(JAVA_METRICS.len(), 94);
-    assert_eq!(RUST_METRICS.len(), 121);
-    assert_eq!(combined.len(), 215, "duplicate metric names across catalogs");
+    assert_eq!(RUST_METRICS.len(), 122);
+    assert_eq!(combined.len(), 216, "duplicate metric names across catalogs");
 }
 
 #[test]

--- a/rocketmq-observability/src/metrics/remoting.rs
+++ b/rocketmq-observability/src/metrics/remoting.rs
@@ -14,6 +14,7 @@
 
 pub use crate::semantic::metrics::RPC_LATENCY;
 pub use crate::semantic::metrics::TRANSPORT_INBOUND_DECODED_PLAINTEXT_BYTES;
+pub use crate::semantic::metrics::TRANSPORT_LEGACY_PROCESSOR_REQUESTS_TOTAL;
 pub use crate::semantic::metrics::TRANSPORT_LIFECYCLE_EVENTS_TOTAL;
 pub use crate::semantic::metrics::TRANSPORT_LIFECYCLE_LISTENER_LATENCY;
 pub use crate::semantic::metrics::TRANSPORT_OUTBOUND_ACCEPTED_PLAINTEXT_BYTES;
@@ -164,6 +165,9 @@ impl RemotingMetrics {
     pub fn record_lifecycle_listener_latency(&self, _latency_ms: u64, _event: &'static str) {}
 
     #[inline]
+    pub fn record_legacy_processor_request(&self, _processor: &'static str, _request_code: i32) {}
+
+    #[inline]
     pub fn record_rpc_latency(
         &self,
         _latency_ms: u64,
@@ -193,6 +197,7 @@ struct RemotingMetricInstruments {
     inbound_decoded_plaintext_bytes: opentelemetry::metrics::Counter<u64>,
     lifecycle_events: opentelemetry::metrics::Counter<u64>,
     lifecycle_listener_latency: opentelemetry::metrics::Histogram<u64>,
+    legacy_processor_requests: opentelemetry::metrics::Counter<u64>,
     rpc_latency: opentelemetry::metrics::Histogram<u64>,
 }
 
@@ -318,6 +323,22 @@ impl RemotingMetrics {
     }
 
     #[inline]
+    pub fn record_legacy_processor_request(&self, processor: &'static str, request_code: i32) {
+        if !self.is_active() {
+            return;
+        }
+        if let Some(instruments) = &self.instruments {
+            instruments.legacy_processor_requests.add(
+                1,
+                &[
+                    opentelemetry::KeyValue::new(crate::semantic::labels::PROCESSOR, processor),
+                    opentelemetry::KeyValue::new(crate::semantic::labels::REQUEST_CODE, i64::from(request_code)),
+                ],
+            );
+        }
+    }
+
+    #[inline]
     pub fn record_rpc_latency(
         &self,
         latency_ms: u64,
@@ -391,6 +412,12 @@ impl RemotingMetricInstruments {
             .with_unit("ms")
             .build();
 
+        let legacy_processor_requests = meter
+            .u64_counter(TRANSPORT_LEGACY_PROCESSOR_REQUESTS_TOTAL)
+            .with_description("Requests admitted through the V1 processor compatibility adapter")
+            .with_unit("{request}")
+            .build();
+
         let rpc_latency = meter
             .u64_histogram(RPC_LATENCY)
             .with_description("Rpc latency")
@@ -406,6 +433,7 @@ impl RemotingMetricInstruments {
             inbound_decoded_plaintext_bytes,
             lifecycle_events,
             lifecycle_listener_latency,
+            legacy_processor_requests,
             rpc_latency,
         }
     }
@@ -455,6 +483,7 @@ mod tests {
         metrics.record_inbound_decoded_plaintext_bytes(256);
         metrics.record_lifecycle_event("connected", "queued");
         metrics.record_lifecycle_listener_latency(2, "connected");
+        metrics.record_legacy_processor_request("test-processor", 10);
         metrics.record_rpc_latency(5, 10, 0, false, RESULT_SUCCESS);
     }
 }

--- a/rocketmq-observability/src/metrics/tests/remoting_metric_isolation.rs
+++ b/rocketmq-observability/src/metrics/tests/remoting_metric_isolation.rs
@@ -23,6 +23,7 @@ use crate::metrics::remoting::RemotingMetrics;
 use crate::metrics::remoting::RequestMetricsGuard;
 use crate::metrics::remoting::RPC_LATENCY;
 use crate::metrics::remoting::TRANSPORT_INBOUND_DECODED_PLAINTEXT_BYTES;
+use crate::metrics::remoting::TRANSPORT_LEGACY_PROCESSOR_REQUESTS_TOTAL;
 use crate::metrics::remoting::TRANSPORT_REQUESTS_TOTAL;
 use crate::metrics::remoting::TRANSPORT_REQUEST_LATENCY;
 use crate::TelemetryHandle;
@@ -149,6 +150,9 @@ fn request_guards_record_each_terminal_outcome_once_and_keep_instances_isolated(
     let second = RemotingMetrics::new(&second_provider.meter("rocketmq-transport"));
     first.record_inbound_decoded_plaintext_bytes(21);
     second.record_inbound_decoded_plaintext_bytes(17);
+    first.record_legacy_processor_request("broker-send", 10);
+    first.record_legacy_processor_request("broker-send", 10);
+    second.record_legacy_processor_request("namesrv-route", 20);
 
     let mut success = RequestMetricsGuard::start(first.clone(), 10, 5, false);
     success.complete_response(0);
@@ -190,6 +194,36 @@ fn request_guards_record_each_terminal_outcome_once_and_keep_instances_isolated(
     );
     assert_eq!(metric_value(&second_points, TRANSPORT_REQUEST_LATENCY), 1);
     assert_eq!(metric_value(&second_points, RPC_LATENCY), 1);
+
+    let first_legacy = first_points
+        .iter()
+        .filter(|point| point.metric == TRANSPORT_LEGACY_PROCESSOR_REQUESTS_TOTAL)
+        .collect::<Vec<_>>();
+    assert_eq!(first_legacy.len(), 1);
+    assert_eq!(first_legacy[0].value, 2);
+    assert_eq!(
+        first_legacy[0].attributes,
+        BTreeMap::from([
+            ("processor".to_owned(), CapturedValue::String("broker-send".to_owned()),),
+            ("request_code".to_owned(), CapturedValue::I64(10)),
+        ])
+    );
+    let second_legacy = second_points
+        .iter()
+        .filter(|point| point.metric == TRANSPORT_LEGACY_PROCESSOR_REQUESTS_TOTAL)
+        .collect::<Vec<_>>();
+    assert_eq!(second_legacy.len(), 1);
+    assert_eq!(second_legacy[0].value, 1);
+    assert_eq!(
+        second_legacy[0].attributes,
+        BTreeMap::from([
+            (
+                "processor".to_owned(),
+                CapturedValue::String("namesrv-route".to_owned()),
+            ),
+            ("request_code".to_owned(), CapturedValue::I64(20)),
+        ])
+    );
 
     let first_rpc = first_points
         .iter()

--- a/rocketmq-observability/src/semantic.rs
+++ b/rocketmq-observability/src/semantic.rs
@@ -106,6 +106,7 @@ pub mod metrics {
     pub const TRANSPORT_INBOUND_DECODED_PLAINTEXT_BYTES: &str = "rocketmq_transport_inbound_decoded_plaintext_bytes";
     pub const TRANSPORT_LIFECYCLE_EVENTS_TOTAL: &str = "rocketmq_transport_lifecycle_events_total";
     pub const TRANSPORT_LIFECYCLE_LISTENER_LATENCY: &str = "rocketmq_transport_lifecycle_listener_latency";
+    pub const TRANSPORT_LEGACY_PROCESSOR_REQUESTS_TOTAL: &str = "rocketmq_transport_legacy_processor_requests_total";
     pub const RPC_LATENCY: &str = "rocketmq_rpc_latency";
     pub const TIERED_STORE_MESSAGES_DISPATCH_TOTAL: &str = "rocketmq_tiered_store_messages_dispatch_total";
     pub const TIERED_STORE_MESSAGES_OUT_TOTAL: &str = "rocketmq_tiered_store_messages_out_total";

--- a/rocketmq-observability/tests/fixtures/metric_catalog_descriptors.tsv
+++ b/rocketmq-observability/tests/fixtures/metric_catalog_descriptors.tsv
@@ -213,3 +213,4 @@ rust	211	"rocketmq_dashboard_storage_operation_duration_milliseconds"	Histogram	
 rust	212	"rocketmq_dashboard_storage_operation_errors_total"	Counter	""	["backend","operation","error_kind"]	Observability
 rust	213	"rocketmq_dashboard_storage_capacity_bytes"	Gauge	"By"	["backend"]	Observability
 rust	214	"rocketmq_dashboard_storage_pool_connections"	Gauge	""	["backend","state"]	Observability
+rust	215	"rocketmq_transport_legacy_processor_requests_total"	Counter	"{request}"	["processor","request_code"]	Remoting

--- a/rocketmq-observability/tests/metric_catalog_contract.rs
+++ b/rocketmq-observability/tests/metric_catalog_contract.rs
@@ -23,9 +23,9 @@ use rocketmq_observability::metrics::catalog::RUST_METRICS;
 
 const FIXTURE: &str = include_str!("fixtures/metric_catalog_descriptors.tsv");
 const JAVA_DESCRIPTOR_COUNT: usize = 94;
-const RUST_DESCRIPTOR_COUNT: usize = 121;
+const RUST_DESCRIPTOR_COUNT: usize = 122;
 const TOTAL_DESCRIPTOR_COUNT: usize = JAVA_DESCRIPTOR_COUNT + RUST_DESCRIPTOR_COUNT;
-const DISTINCT_LABEL_SEQUENCE_COUNT: usize = 60;
+const DISTINCT_LABEL_SEQUENCE_COUNT: usize = 61;
 const DISTINCT_SOURCE_COUNT: usize = 14;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/rocketmq-transport/src/dispatch.rs
+++ b/rocketmq-transport/src/dispatch.rs
@@ -14,6 +14,7 @@
 
 mod authorized_dispatcher;
 mod handler_outcome;
+mod legacy_processor_adapter;
 mod remoting_request;
 mod request_context;
 mod request_control;
@@ -48,6 +49,20 @@ pub(crate) use handler_outcome::InlineResponseSlot;
 pub use handler_outcome::ProtocolNoResponse;
 pub use handler_outcome::ProtocolNoResponseError;
 pub use handler_outcome::ProtocolNoResponseReason;
+pub(crate) use legacy_processor_adapter::DispatchMetricsGuard;
+pub(crate) use legacy_processor_adapter::DispatchProcessor;
+pub(crate) use legacy_processor_adapter::DispatchProcessorError;
+pub(crate) use legacy_processor_adapter::ExplicitV2Processor;
+pub(crate) use legacy_processor_adapter::InternalProcessorCandidate;
+pub(crate) use legacy_processor_adapter::InternalProcessorOutcome;
+pub(crate) use legacy_processor_adapter::LegacyProcessorAdapter;
+pub(crate) use legacy_processor_adapter::LegacyProcessorAdapterError;
+pub(crate) use legacy_processor_adapter::LegacyReplyCandidate;
+#[allow(
+    unused_imports,
+    reason = "DSP-05 exposes the sealed legacy bridge to later coexistence routing"
+)]
+pub(crate) use legacy_processor_adapter::LegacyRequestBridge;
 pub use remoting_request::IngressRequestView;
 pub use remoting_request::RemotingRequest;
 pub use request_context::RequestContext;

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher.rs
@@ -413,7 +413,7 @@ fn admission_response(opaque: i32, error: &AdmissionError) -> RemotingCommand {
         .set_opaque(opaque)
 }
 
-fn deadline_response(opaque: i32) -> RemotingCommand {
+pub(super) fn deadline_response(opaque: i32) -> RemotingCommand {
     RemotingCommand::create_response_command_with_code_remark(
         ResponseCode::SystemError,
         "request deadline exceeded".to_owned(),

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher/v2.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher/v2.rs
@@ -35,10 +35,16 @@ use crate::admission::PartialFramePermit;
 use crate::dispatch::remoting_request::RemotingRequestBuildError;
 use crate::dispatch::remoting_request::RemotingRequestBuilder;
 use crate::dispatch::remoting_request::RequestLifecycleProvenance;
-use crate::dispatch::HandlerOutcome;
+use crate::dispatch::DispatchProcessor;
+use crate::dispatch::DispatchProcessorError;
+use crate::dispatch::ExplicitV2Processor;
 use crate::dispatch::HandlerOutcomeContractError;
+use crate::dispatch::InternalProcessorCandidate;
+use crate::dispatch::InternalProcessorOutcome;
+use crate::dispatch::LegacyProcessorAdapter;
+use crate::dispatch::LegacyProcessorAdapterError;
+use crate::dispatch::LegacyReplyCandidate;
 use crate::dispatch::OriginalRequestIdentity;
-use crate::dispatch::RemotingRequest;
 use crate::dispatch::RequestContext;
 use crate::dispatch::RequestTransport;
 use crate::dispatch::ResponseBindingError;
@@ -48,13 +54,8 @@ use crate::dispatch::ResponsePlanError;
 use crate::dispatch::ResponseSink;
 use crate::dispatch::WriteProgress;
 use crate::hook_registry::HookRegistry;
-use crate::hook_registry::HookSnapshot;
-use crate::remoting::inner::run_after_rpc_hooks;
-use crate::remoting::inner::run_before_rpc_hooks;
-use crate::runtime::processor_v2::RejectRequestDecision;
+use crate::runtime::processor::RequestProcessor;
 use crate::runtime::processor_v2::RequestProcessorV2;
-use crate::runtime::processor_v2::ResponseWriteObservationV2;
-use crate::runtime::processor_v2::ResponseWritePath;
 use crate::runtime::RPCHook;
 use crate::server::SessionHandle;
 use crate::session_executor::SessionDispatchError;
@@ -88,6 +89,8 @@ pub(crate) enum AuthorizedDispatchV2Error {
     ResponseBinding(#[from] ResponseBindingError),
     #[error(transparent)]
     HandlerContract(#[from] HandlerOutcomeContractError),
+    #[error(transparent)]
+    ProcessorAdapter(#[from] LegacyProcessorAdapterError),
     #[error("one-way requests cannot complete with {outcome}")]
     OneWayOutcome { outcome: &'static str },
     #[error("V2 response delivery failed: {kind:?}, progress={progress:?}")]
@@ -111,6 +114,7 @@ impl AuthorizedDispatchV2Error {
             Self::ResponsePlan(_) => "response_plan",
             Self::ResponseBinding(_) => "response_binding",
             Self::HandlerContract(_) => "handler_contract",
+            Self::ProcessorAdapter(_) => "processor_adapter",
             Self::OneWayOutcome { .. } => "one_way_outcome",
             Self::Response { .. } => "response",
         }
@@ -122,60 +126,14 @@ impl AuthorizedDispatchV2Error {
     dead_code,
     reason = "DSP-03 defines the private dispatcher core wired by the later coexistence stage"
 )]
-pub(crate) struct AuthorizedCommandDispatcherV2<P> {
-    processor: P,
+pub(crate) struct AuthorizedCommandDispatcherV2<D> {
+    processor: D,
     rpc_hooks: HookRegistry,
     #[cfg(test)]
     reported_failures: std::sync::Mutex<Vec<&'static str>>,
 }
 
-struct HandlerCandidate {
-    outcome: HandlerOutcome,
-    failure: Option<HandlerFailureOrigin>,
-}
-
-impl HandlerCandidate {
-    const fn success(outcome: HandlerOutcome) -> Self {
-        Self { outcome, failure: None }
-    }
-
-    const fn failure(outcome: HandlerOutcome, failure: HandlerFailureOrigin) -> Self {
-        Self {
-            outcome,
-            failure: Some(failure),
-        }
-    }
-}
-
-#[derive(Clone, Copy)]
-enum HandlerFailureOrigin {
-    BeforeHook,
-    ProcessorError,
-    Deadline,
-    AfterHook,
-    ProcessorErrorAfterHookError,
-}
-
-impl HandlerFailureOrigin {
-    const fn category(self) -> &'static str {
-        match self {
-            Self::BeforeHook => "before_hook",
-            Self::ProcessorError => "processor_error",
-            Self::Deadline => "deadline",
-            Self::AfterHook => "after_hook",
-            Self::ProcessorErrorAfterHookError => "processor_error_after_hook_error",
-        }
-    }
-
-    const fn after_hook_error(self) -> Self {
-        match self {
-            Self::ProcessorError => Self::ProcessorErrorAfterHookError,
-            Self::BeforeHook | Self::Deadline | Self::AfterHook | Self::ProcessorErrorAfterHookError => Self::AfterHook,
-        }
-    }
-}
-
-impl<P> AuthorizedCommandDispatcherV2<P>
+impl<P> AuthorizedCommandDispatcherV2<ExplicitV2Processor<P>>
 where
     P: RequestProcessorV2 + Clone + Sync + 'static,
 {
@@ -184,6 +142,38 @@ where
         reason = "DSP-03 construction remains private until later coexistence routing"
     )]
     pub(crate) fn new(processor: P, rpc_hooks: Vec<Arc<dyn RPCHook>>) -> Self {
+        Self::from_dispatch_processor(ExplicitV2Processor::new(processor), rpc_hooks)
+    }
+}
+
+impl From<DispatchProcessorError> for AuthorizedDispatchV2Error {
+    fn from(error: DispatchProcessorError) -> Self {
+        match error {
+            DispatchProcessorError::Legacy(error) => Self::ProcessorAdapter(error),
+            DispatchProcessorError::ResponsePlan(error) => Self::ResponsePlan(error),
+            DispatchProcessorError::HandlerContract(error) => Self::HandlerContract(error),
+        }
+    }
+}
+
+impl<P> AuthorizedCommandDispatcherV2<LegacyProcessorAdapter<P>>
+where
+    P: RequestProcessor + Clone + Sync + 'static,
+{
+    #[allow(
+        dead_code,
+        reason = "DSP-05 keeps legacy construction private until DSP-06 coexistence routing"
+    )]
+    pub(crate) fn new_legacy(processor: LegacyProcessorAdapter<P>, rpc_hooks: Vec<Arc<dyn RPCHook>>) -> Self {
+        Self::from_dispatch_processor(processor, rpc_hooks)
+    }
+}
+
+impl<D> AuthorizedCommandDispatcherV2<D>
+where
+    D: DispatchProcessor,
+{
+    fn from_dispatch_processor(processor: D, rpc_hooks: Vec<Arc<dyn RPCHook>>) -> Self {
         Self {
             processor,
             rpc_hooks: HookRegistry::new(rpc_hooks),
@@ -226,7 +216,7 @@ where
         let class = AdmissionClass::for_request_code(original.original_code());
         let lifecycle = RequestLifecycleProvenance::from_network_session(&session);
         let builder = RemotingRequestBuilder::new(original, request_started, context, lifecycle, command);
-        let ordering = self.processor.request_ordering(builder.ingress_view());
+        let ordering = self.processor.request_ordering(&builder);
 
         if builder.deadline().is_some_and(|deadline| deadline.is_expired()) {
             send_boundary_response(&session, original, deadline_response(original.original_opaque())).await?;
@@ -314,7 +304,7 @@ where
     )]
     async fn execute_admitted(
         &self,
-        mut processor: P,
+        mut processor: D,
         session: SessionHandle,
         class: AdmissionClass,
         original: OriginalRequestIdentity,
@@ -322,102 +312,152 @@ where
         request_started: Instant,
         builder: RemotingRequestBuilder,
     ) -> Result<(), AuthorizedDispatchV2Error> {
-        let response = ResponseSink::network_plan(session, class, builder.control().clone());
+        let request_bytes = builder.command().body().map_or(0, |body| body.len() as u64);
+        let mut metrics = processor.begin_admitted(original, request_bytes);
+        let response = ResponseSink::network_plan(session.clone(), class, builder.control().clone());
 
         if builder.deadline().is_some_and(|deadline| deadline.is_expired()) {
             let plan = ResponsePlan::command(deadline_response(original.original_opaque()))?;
-            if original.is_one_way() {
-                drop(plan);
-                self.report_failure_category(HandlerFailureOrigin::Deadline.category());
-                return Ok(());
-            }
-            return deliver_and_observe(&processor, response, original, request_started, plan).await;
+            let candidate = processor.deadline_candidate(plan);
+            return self
+                .finish_candidate(&processor, response, original, request_started, candidate, &mut metrics)
+                .await;
         }
 
-        match processor.reject_request(original.original_code()) {
-            RejectRequestDecision::Proceed => {}
-            RejectRequestDecision::Reject(plan) => {
-                if original.is_one_way() {
-                    drop(plan);
-                    return Ok(());
-                }
-                return deliver_and_observe(&processor, response, original, request_started, plan).await;
-            }
+        if let Some(candidate) = processor.reject_request(original.original_code())? {
+            return self
+                .finish_candidate(&processor, response, original, request_started, candidate, &mut metrics)
+                .await;
         }
 
         let mut request = builder.build()?;
         let hook_snapshot = self.rpc_hooks.snapshot();
-        let before_result = request.with_body_free_hook_command(|request_head| {
-            run_before_rpc_hooks(hook_snapshot.as_deref(), remote_address, request_head)
-        });
-        let candidate = match before_result {
-            Ok(()) => {
-                let processed = match request.meta().deadline() {
-                    Some(deadline) => deadline.timeout(processor.process(&mut request)).await,
-                    None => Ok(processor.process(&mut request).await),
-                };
-                match processed {
-                    Ok(Ok(outcome)) => apply_after_hook(
-                        &mut request,
-                        HandlerCandidate::success(outcome),
-                        hook_snapshot.as_deref(),
-                        remote_address,
-                    )?,
-                    Ok(Err(error)) => {
-                        let plan = crate::error_response::response_plan_from_error(&error)?;
-                        apply_after_hook(
-                            &mut request,
-                            HandlerCandidate::failure(
-                                HandlerOutcome::Reply(plan),
-                                HandlerFailureOrigin::ProcessorError,
-                            ),
-                            hook_snapshot.as_deref(),
-                            remote_address,
-                        )?
-                    }
-                    Err(_) => HandlerCandidate::failure(
-                        HandlerOutcome::Reply(ResponsePlan::command(deadline_response(original.original_opaque()))?),
-                        HandlerFailureOrigin::Deadline,
-                    ),
-                }
-            }
-            Err(error) => HandlerCandidate::failure(
-                HandlerOutcome::Reply(crate::error_response::response_plan_from_error(&error)?),
-                HandlerFailureOrigin::BeforeHook,
-            ),
-        };
+        let candidate = processor
+            .process(
+                &mut request,
+                hook_snapshot.as_deref(),
+                remote_address,
+                &session,
+                &response,
+            )
+            .await?;
+        let InternalProcessorCandidate {
+            outcome,
+            failure,
+            observe_write,
+        } = candidate;
+        let outcome = processor.resolve_outcome(&mut request, outcome)?;
+        self.finish_candidate(
+            &processor,
+            response,
+            original,
+            request_started,
+            InternalProcessorCandidate {
+                outcome,
+                failure,
+                observe_write,
+            },
+            &mut metrics,
+        )
+        .await
+    }
 
-        let outcome = request.resolve_handler_outcome(candidate.outcome)?;
-        if original.is_one_way() {
-            return match outcome {
-                HandlerOutcome::Reply(plan) => {
+    async fn finish_candidate(
+        &self,
+        processor: &D,
+        response: ResponseSink,
+        original: OriginalRequestIdentity,
+        request_started: Instant,
+        candidate: InternalProcessorCandidate,
+        metrics: &mut crate::dispatch::DispatchMetricsGuard,
+    ) -> Result<(), AuthorizedDispatchV2Error> {
+        let InternalProcessorCandidate {
+            outcome,
+            failure,
+            observe_write,
+        } = candidate;
+        match outcome {
+            InternalProcessorOutcome::V2(crate::dispatch::HandlerOutcome::Reply(plan)) => {
+                let response_code = plan.response_code();
+                if failure.is_some() {
+                    metrics.complete_process_request_failed(response_code);
+                }
+                if original.is_one_way() {
                     drop(plan);
-                    if let Some(failure) = candidate.failure {
+                    if failure.is_none() {
+                        metrics.complete_oneway();
+                    }
+                    if let Some(failure) = failure {
                         self.report_failure_category(failure.category());
                     }
-                    Ok(())
+                    return Ok(());
                 }
-                HandlerOutcome::Deferred(registration) => {
-                    drop(registration);
-                    Err(AuthorizedDispatchV2Error::OneWayOutcome { outcome: "deferred" })
-                }
-                HandlerOutcome::NoReply(marker) => {
-                    drop(marker);
-                    Err(AuthorizedDispatchV2Error::OneWayOutcome { outcome: "no_reply" })
-                }
-            };
-        }
-
-        match outcome {
-            HandlerOutcome::Reply(plan) => {
-                deliver_and_observe(&processor, response, original, request_started, plan).await
+                deliver_and_observe(
+                    processor,
+                    response,
+                    original,
+                    request_started,
+                    plan,
+                    observe_write,
+                    failure.is_some(),
+                    metrics,
+                )
+                .await
             }
-            HandlerOutcome::Deferred(registration) => {
+            InternalProcessorOutcome::LegacyReply(reply) => {
+                let response_code = reply.response_code();
+                if failure.is_some() {
+                    metrics.complete_process_request_failed(response_code);
+                }
+                if original.is_one_way() {
+                    drop(reply);
+                    if failure.is_none() {
+                        metrics.complete_oneway();
+                    }
+                    if let Some(failure) = failure {
+                        self.report_failure_category(failure.category());
+                    }
+                    return Ok(());
+                }
+                let plan = match reply {
+                    LegacyReplyCandidate::OwnedCommand(command) => ResponsePlan::from_legacy_command(command)
+                        .map_err(LegacyProcessorAdapterError::MalformedLegacyResponse)?,
+                    LegacyReplyCandidate::ValidatedPlan(plan) => plan,
+                };
+                deliver_and_observe(
+                    processor,
+                    response,
+                    original,
+                    request_started,
+                    plan,
+                    observe_write,
+                    failure.is_some(),
+                    metrics,
+                )
+                .await
+            }
+            InternalProcessorOutcome::V2(crate::dispatch::HandlerOutcome::Deferred(registration)) => {
+                if original.is_one_way() {
+                    drop(registration);
+                    return Err(AuthorizedDispatchV2Error::OneWayOutcome { outcome: "deferred" });
+                }
                 drop(registration);
                 Ok(())
             }
-            HandlerOutcome::NoReply(marker) => {
+            InternalProcessorOutcome::V2(crate::dispatch::HandlerOutcome::NoReply(marker)) => {
+                if original.is_one_way() {
+                    drop(marker);
+                    return Err(AuthorizedDispatchV2Error::OneWayOutcome { outcome: "no_reply" });
+                }
                 drop(marker);
+                Ok(())
+            }
+            InternalProcessorOutcome::LegacyAmbiguousNone => {
+                if original.is_one_way() {
+                    metrics.complete_oneway();
+                } else {
+                    metrics.complete_legacy_ambiguous_none();
+                }
                 Ok(())
             }
         }
@@ -455,55 +495,20 @@ where
 
 #[allow(
     dead_code,
-    reason = "DSP-03 hook application is reached through the not-yet-wired private dispatcher"
-)]
-fn apply_after_hook(
-    request: &mut RemotingRequest,
-    candidate: HandlerCandidate,
-    hook_snapshot: Option<&HookSnapshot>,
-    remote_address: std::net::SocketAddr,
-) -> Result<HandlerCandidate, AuthorizedDispatchV2Error> {
-    let HandlerCandidate { outcome, failure } = candidate;
-    let HandlerOutcome::Reply(mut plan) = outcome else {
-        return Ok(HandlerCandidate { outcome, failure });
-    };
-
-    let result = request.with_body_free_hook_request(|request_head| {
-        plan.with_body_free_hook_head(|response_head| {
-            run_after_rpc_hooks(hook_snapshot, remote_address, request_head, response_head)
-        })
-    });
-    match result {
-        Ok(()) => Ok(HandlerCandidate {
-            outcome: HandlerOutcome::Reply(plan),
-            failure,
-        }),
-        Err(error) => {
-            drop(plan);
-            let failure = failure
-                .map(HandlerFailureOrigin::after_hook_error)
-                .unwrap_or(HandlerFailureOrigin::AfterHook);
-            Ok(HandlerCandidate::failure(
-                HandlerOutcome::Reply(crate::error_response::response_plan_from_error(&error)?),
-                failure,
-            ))
-        }
-    }
-}
-
-#[allow(
-    dead_code,
     reason = "DSP-03 delivery is reached through the not-yet-wired private dispatcher"
 )]
-async fn deliver_and_observe<P>(
-    processor: &P,
+async fn deliver_and_observe<D>(
+    processor: &D,
     response: ResponseSink,
     original: OriginalRequestIdentity,
     request_started: Instant,
     plan: ResponsePlan,
+    observe_write: bool,
+    failure_recorded: bool,
+    metrics: &mut crate::dispatch::DispatchMetricsGuard,
 ) -> Result<(), AuthorizedDispatchV2Error>
 where
-    P: RequestProcessorV2,
+    D: DispatchProcessor,
 {
     let response_code = plan.response_code();
     let body_kind = plan.body_kind();
@@ -512,36 +517,30 @@ where
     let result = response.send_plan(bound).await;
     let write_elapsed = write_started.elapsed();
     let end_to_end_elapsed = request_started.elapsed();
-
-    match result {
-        Ok(receipt) => {
-            processor.observe_response_write(ResponseWriteObservationV2::from_result(
-                original.request_id(),
-                original.original_code(),
-                response_code,
-                body_kind,
-                ResponseWritePath::Inline,
-                write_elapsed,
-                end_to_end_elapsed,
-                Ok(receipt),
-            ));
-            Ok(())
+    let failure = result
+        .as_ref()
+        .err()
+        .map(|error| (error.kind(), error.write_progress()));
+    if !failure_recorded {
+        if failure.is_some() {
+            metrics.complete_write_channel_failed(response_code);
+        } else {
+            metrics.complete_response(response_code);
         }
-        Err(error) => {
-            let kind = error.kind();
-            let progress = error.write_progress();
-            processor.observe_response_write(ResponseWriteObservationV2::from_result(
-                original.request_id(),
-                original.original_code(),
-                response_code,
-                body_kind,
-                ResponseWritePath::Inline,
-                write_elapsed,
-                end_to_end_elapsed,
-                Err(error),
-            ));
-            Err(AuthorizedDispatchV2Error::Response { kind, progress })
-        }
+    }
+    if observe_write {
+        processor.observe_response_write(
+            original,
+            response_code,
+            body_kind,
+            write_elapsed,
+            end_to_end_elapsed,
+            result,
+        );
+    }
+    match failure {
+        Some((kind, progress)) => Err(AuthorizedDispatchV2Error::Response { kind, progress }),
+        None => Ok(()),
     }
 }
 

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests.rs
@@ -20,6 +20,8 @@ mod delivery_hooks;
 mod event_log;
 #[path = "tests/harness.rs"]
 mod harness;
+#[path = "tests/legacy_adapter.rs"]
+mod legacy_adapter;
 #[path = "tests/outcomes_deadlines.rs"]
 mod outcomes_deadlines;
 #[path = "tests/v1_v2_side_contract.rs"]

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/harness.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/harness.rs
@@ -16,6 +16,7 @@ pub(super) use std::future::Future;
 pub(super) use std::net::IpAddr;
 pub(super) use std::net::Ipv4Addr;
 pub(super) use std::pin::Pin;
+pub(super) use std::sync::atomic::AtomicBool;
 pub(super) use std::sync::atomic::AtomicU64;
 pub(super) use std::sync::atomic::AtomicUsize;
 pub(super) use std::sync::atomic::Ordering;
@@ -23,6 +24,7 @@ pub(super) use std::sync::Arc;
 pub(super) use std::sync::Mutex;
 pub(super) use std::task::Context;
 pub(super) use std::task::Poll;
+pub(super) use std::task::Waker;
 pub(super) use std::time::Duration;
 pub(super) use std::time::Instant;
 
@@ -43,13 +45,17 @@ pub(super) use crate::admission::AdmissionResource;
 pub(super) use crate::admission::AdmissionScope;
 pub(super) use crate::connection::Connection;
 pub(super) use crate::deadline::RequestDeadline;
+pub(super) use crate::dispatch::HandlerOutcome;
 pub(super) use crate::dispatch::ProtocolNoResponseReason;
+pub(super) use crate::dispatch::RemotingRequest;
 pub(super) use crate::dispatch::ResponseBodyKind;
 pub(super) use crate::dispatch::ResponseDisposition;
 pub(super) use crate::request_ordering::RequestOrdering;
 pub(super) use crate::request_ordering::RequestOrderingKey;
+pub(super) use crate::runtime::processor_v2::RejectRequestDecision;
 pub(super) use crate::runtime::processor_v2::ResponseWriteObservationV2;
 pub(super) use crate::runtime::processor_v2::ResponseWriteOutcomeV2;
+pub(super) use crate::runtime::processor_v2::ResponseWritePath;
 pub(super) use crate::security::TransportSecurity;
 pub(super) use crate::server::run_connected_session;
 pub(super) use crate::server::ConnectionHandler;
@@ -271,6 +277,47 @@ struct CaptureSession {
 struct FlushFailingStream {
     inner: tokio::io::DuplexStream,
     fail_flush: bool,
+    post_start_barrier: Option<Arc<PostStartWriteBarrier>>,
+}
+
+pub(super) struct PostStartWriteBarrier {
+    reached: tokio::sync::Notify,
+    released: AtomicBool,
+    writer_waker: Mutex<Option<Waker>>,
+}
+
+impl PostStartWriteBarrier {
+    fn new() -> Self {
+        Self {
+            reached: tokio::sync::Notify::new(),
+            released: AtomicBool::new(false),
+            writer_waker: Mutex::new(None),
+        }
+    }
+
+    fn poll_ready(&self, context: &Context<'_>) -> Poll<()> {
+        if self.released.load(Ordering::Acquire) {
+            return Poll::Ready(());
+        }
+        *self.writer_waker.lock().expect("post-start writer waker lock") = Some(context.waker().clone());
+        self.reached.notify_one();
+        if self.released.load(Ordering::Acquire) {
+            Poll::Ready(())
+        } else {
+            Poll::Pending
+        }
+    }
+
+    pub(super) async fn wait_reached(&self) {
+        self.reached.notified().await;
+    }
+
+    pub(super) fn release(&self) {
+        self.released.store(true, Ordering::Release);
+        if let Some(waker) = self.writer_waker.lock().expect("post-start writer waker lock").take() {
+            waker.wake();
+        }
+    }
 }
 
 impl AsyncRead for FlushFailingStream {
@@ -285,6 +332,13 @@ impl AsyncRead for FlushFailingStream {
 
 impl AsyncWrite for FlushFailingStream {
     fn poll_write(mut self: Pin<&mut Self>, context: &mut Context<'_>, buffer: &[u8]) -> Poll<std::io::Result<usize>> {
+        if self
+            .post_start_barrier
+            .as_ref()
+            .is_some_and(|barrier| barrier.poll_ready(context).is_pending())
+        {
+            return Poll::Pending;
+        }
         Pin::new(&mut self.inner).poll_write(context, buffer)
     }
 
@@ -293,6 +347,13 @@ impl AsyncWrite for FlushFailingStream {
         context: &mut Context<'_>,
         buffers: &[std::io::IoSlice<'_>],
     ) -> Poll<std::io::Result<usize>> {
+        if self
+            .post_start_barrier
+            .as_ref()
+            .is_some_and(|barrier| barrier.poll_ready(context).is_pending())
+        {
+            return Poll::Pending;
+        }
         Pin::new(&mut self.inner).poll_write_vectored(context, buffers)
     }
 
@@ -379,11 +440,34 @@ impl DispatchHarness {
         Self::new_with_options(name, AdmissionLimits::default(), false, security).await
     }
 
+    pub(super) async fn new_with_post_start_barrier(name: &'static str) -> (Self, Arc<PostStartWriteBarrier>) {
+        let barrier = Arc::new(PostStartWriteBarrier::new());
+        let harness = Self::new_with_stream_options(
+            name,
+            AdmissionLimits::default(),
+            false,
+            Arc::new(TransportSecurity::development_insecure_loopback(None, None)),
+            Some(Arc::clone(&barrier)),
+        )
+        .await;
+        (harness, barrier)
+    }
+
     pub(super) async fn new_with_options(
         name: &'static str,
         limits: AdmissionLimits,
         fail_flush: bool,
         security: Arc<TransportSecurity>,
+    ) -> Self {
+        Self::new_with_stream_options(name, limits, fail_flush, security, None).await
+    }
+
+    async fn new_with_stream_options(
+        name: &'static str,
+        limits: AdmissionLimits,
+        fail_flush: bool,
+        security: Arc<TransportSecurity>,
+        post_start_barrier: Option<Arc<PostStartWriteBarrier>>,
     ) -> Self {
         let runtime = RuntimeContext::from_current(name);
         let service = runtime.service_context(name);
@@ -393,6 +477,7 @@ impl DispatchHarness {
         let transport = FlushFailingStream {
             inner: transport,
             fail_flush,
+            post_start_barrier,
         };
         let (session_tx, session_rx) = oneshot::channel();
         let handler = Arc::new(CaptureSession {

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/legacy_adapter.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/legacy_adapter.rs
@@ -1,0 +1,836 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use bytes::Bytes;
+use rocketmq_error::RocketMQError;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+
+use super::harness::*;
+use crate::base::pending_request_table::PendingRequestTable;
+use crate::dispatch::legacy_processor_adapter::bridge_construction_counts;
+use crate::dispatch::DispatchOutcome;
+use crate::dispatch::LegacyProcessorAdapter;
+use crate::net::channel::Channel;
+use crate::request_ordering::RequestOrdering;
+use crate::request_ordering::RequestOrderingKey;
+use crate::runtime::connection_handler_context::ConnectionHandlerContext;
+use crate::runtime::processor::RequestProcessor;
+use crate::runtime::processor::ResponseWriteObservation;
+use crate::runtime::processor::ResponseWriteOutcome;
+use crate::runtime::RPCHook;
+use crate::session_view::SessionId;
+use crate::telemetry::TransportTelemetry;
+
+const PRIMARY_CODE: i32 = 310;
+const SENTINEL_CODE: i32 = 311;
+const ORIGINAL_OPAQUE: i32 = 811;
+const MUTATED_CODE: i32 = 1_310;
+const MUTATED_OPAQUE: i32 = 1_811;
+const REJECTION_CODE: i32 = 73;
+const DIRECT_CODE: i32 = 76;
+const PROCESSOR_NAME: &str = "dsp05-legacy-test";
+const ORDERING_KEY: RequestOrderingKey = RequestOrderingKey::new(9_794);
+
+type LegacyProcessInput = (i32, i32, bool, Option<usize>);
+
+#[derive(Clone, Copy)]
+enum LegacyBehavior {
+    Reply,
+    WaitReply,
+    NoneThenSentinel,
+    DirectChannelThenNone,
+    DirectChannelRefThenNone,
+    DirectContextThenNone,
+    ProcessorError,
+    MalformedThenSentinel,
+    RejectFalseSome,
+    RejectTrueSome,
+    RejectTrueMalformed,
+    RejectTrueNone,
+}
+
+#[derive(Default)]
+struct LegacyState {
+    clones: AtomicUsize,
+    rejects: AtomicUsize,
+    processes: AtomicUsize,
+    before_hooks: AtomicUsize,
+    after_hooks: AtomicUsize,
+    events: Mutex<Vec<&'static str>>,
+    ordering_inputs: Mutex<Vec<(i32, i32)>>,
+    process_inputs: Mutex<Vec<LegacyProcessInput>>,
+    observations: Mutex<Vec<ResponseWriteObservation>>,
+    returned_body_pointer: Mutex<Option<usize>>,
+    direct_channel: Mutex<Option<Channel>>,
+    entered: tokio::sync::Notify,
+    resume: tokio::sync::Notify,
+}
+
+struct LegacyProcessor {
+    behavior: LegacyBehavior,
+    state: Arc<LegacyState>,
+}
+
+impl Clone for LegacyProcessor {
+    fn clone(&self) -> Self {
+        self.state.clones.fetch_add(1, Ordering::SeqCst);
+        self.state.events.lock().expect("legacy event lock").push("clone");
+        Self {
+            behavior: self.behavior,
+            state: Arc::clone(&self.state),
+        }
+    }
+}
+
+impl LegacyProcessor {
+    fn reply(&self) -> RemotingCommand {
+        let body = Bytes::from(vec![19_u8; 257]);
+        *self
+            .state
+            .returned_body_pointer
+            .lock()
+            .expect("legacy returned body pointer lock") = Some(body.as_ptr() as usize);
+        RemotingCommand::create_response_command_with_code(ResponseCode::Success)
+            .set_opaque(-991)
+            .set_body(body)
+    }
+}
+
+impl RequestProcessor for LegacyProcessor {
+    async fn process_request(
+        &mut self,
+        channel: Channel,
+        context: ConnectionHandlerContext,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        self.state.processes.fetch_add(1, Ordering::SeqCst);
+        self.state.events.lock().expect("legacy event lock").push("process");
+        self.state
+            .process_inputs
+            .lock()
+            .expect("legacy process input lock")
+            .push((
+                request.code(),
+                request.opaque(),
+                request.is_oneway_rpc(),
+                request.body().map(|body| body.as_ptr() as usize),
+            ));
+
+        if request.code() == SENTINEL_CODE {
+            return Ok(Some(self.reply()));
+        }
+
+        match self.behavior {
+            LegacyBehavior::Reply
+            | LegacyBehavior::RejectFalseSome
+            | LegacyBehavior::RejectTrueSome
+            | LegacyBehavior::RejectTrueMalformed
+            | LegacyBehavior::RejectTrueNone => Ok(Some(self.reply())),
+            LegacyBehavior::WaitReply => {
+                self.state.entered.notify_one();
+                self.state.resume.notified().await;
+                Ok(Some(self.reply()))
+            }
+            LegacyBehavior::NoneThenSentinel => Ok(None),
+            LegacyBehavior::DirectChannelThenNone => {
+                *self.state.direct_channel.lock().expect("legacy direct channel lock") = Some(channel.clone());
+                channel
+                    .send_command(direct_response(request.opaque()))
+                    .await
+                    .map_err(|error| {
+                        RocketMQError::response_process_failed("dsp05-direct-channel", error.to_string())
+                    })?;
+                Ok(None)
+            }
+            LegacyBehavior::DirectChannelRefThenNone => {
+                *self.state.direct_channel.lock().expect("legacy direct channel lock") = Some(channel.clone());
+                let mut response = direct_response(request.opaque());
+                channel.send_command_ref(&mut response).await.map_err(|error| {
+                    RocketMQError::response_process_failed("dsp05-direct-channel-ref", error.to_string())
+                })?;
+                Ok(None)
+            }
+            LegacyBehavior::DirectContextThenNone => {
+                context
+                    .try_write_response(direct_response(request.opaque()))
+                    .await
+                    .map_err(|error| {
+                        RocketMQError::response_process_failed("dsp05-direct-context", error.to_string())
+                    })?;
+                Ok(None)
+            }
+            LegacyBehavior::ProcessorError => Err(RocketMQError::illegal_argument("legacy processor failure")),
+            LegacyBehavior::MalformedThenSentinel => {
+                Ok(Some(RemotingCommand::create_remoting_command(991).set_opaque(-991)))
+            }
+        }
+    }
+
+    fn reject_request(&self, code: i32) -> (bool, Option<RemotingCommand>) {
+        self.state.rejects.fetch_add(1, Ordering::SeqCst);
+        self.state.events.lock().expect("legacy event lock").push("reject");
+        match self.behavior {
+            LegacyBehavior::RejectFalseSome if code == PRIMARY_CODE => (
+                false,
+                Some(RemotingCommand::create_response_command_with_code(REJECTION_CODE)),
+            ),
+            LegacyBehavior::RejectTrueSome if code == PRIMARY_CODE => (
+                true,
+                Some(
+                    RemotingCommand::create_response_command_with_code(REJECTION_CODE)
+                        .set_opaque(-701)
+                        .set_body(Bytes::from_static(b"custom rejection")),
+                ),
+            ),
+            LegacyBehavior::RejectTrueMalformed if code == PRIMARY_CODE => (
+                true,
+                Some(RemotingCommand::create_remoting_command(REJECTION_CODE).set_opaque(-702)),
+            ),
+            LegacyBehavior::RejectTrueNone if code == PRIMARY_CODE => (true, None),
+            _ => (false, None),
+        }
+    }
+
+    fn request_ordering(&self, request: &RemotingCommand) -> RequestOrdering {
+        self.state.events.lock().expect("legacy event lock").push("ordering");
+        self.state
+            .ordering_inputs
+            .lock()
+            .expect("legacy ordering input lock")
+            .push((request.code(), request.opaque()));
+        RequestOrdering::Ordered(ORDERING_KEY)
+    }
+
+    fn observe_response_write(&self, observation: ResponseWriteObservation) {
+        self.state.events.lock().expect("legacy event lock").push("observe");
+        self.state
+            .observations
+            .lock()
+            .expect("legacy observation lock")
+            .push(observation);
+    }
+}
+
+struct LegacyHook {
+    state: Arc<LegacyState>,
+    label: &'static str,
+    mutate_request: bool,
+    fail_before: bool,
+    fail_after: bool,
+    mark_after_oneway: bool,
+}
+
+impl RPCHook for LegacyHook {
+    fn do_before_request(
+        &self,
+        _remote_addr: std::net::SocketAddr,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        self.state.before_hooks.fetch_add(1, Ordering::SeqCst);
+        self.state.events.lock().expect("legacy event lock").push(self.label);
+        if self.fail_before {
+            return Err(RocketMQError::illegal_argument("legacy before hook failure"));
+        }
+        if self.mutate_request {
+            request.set_code_mut(MUTATED_CODE);
+            request.set_opaque_mut(MUTATED_OPAQUE);
+        }
+        Ok(())
+    }
+
+    fn do_after_response(
+        &self,
+        _remote_addr: std::net::SocketAddr,
+        request: &RemotingCommand,
+        response: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<()> {
+        self.state.after_hooks.fetch_add(1, Ordering::SeqCst);
+        self.state.events.lock().expect("legacy event lock").push(self.label);
+        response.set_opaque_mut(-883);
+        if self.mark_after_oneway && request.code() == PRIMARY_CODE {
+            response.mark_oneway_rpc_ref();
+        }
+        if self.fail_after {
+            Err(RocketMQError::illegal_argument("legacy after hook failure"))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+type LegacyDispatcher = AuthorizedCommandDispatcherV2<LegacyProcessorAdapter<LegacyProcessor>>;
+type MetricCapture = Arc<parking_lot::Mutex<Vec<(&'static str, i32)>>>;
+
+fn legacy_dispatcher(
+    behavior: LegacyBehavior,
+    hooks: Vec<Arc<dyn RPCHook>>,
+) -> (Arc<LegacyDispatcher>, Arc<LegacyState>, MetricCapture) {
+    let state = Arc::new(LegacyState::default());
+    let processor = LegacyProcessor {
+        behavior,
+        state: Arc::clone(&state),
+    };
+    let (telemetry, metrics) = TransportTelemetry::with_legacy_processor_request_capture();
+    let adapter = LegacyProcessorAdapter::new(processor, PROCESSOR_NAME, telemetry, PendingRequestTable::new());
+    (
+        Arc::new(AuthorizedCommandDispatcherV2::new_legacy(adapter, hooks)),
+        state,
+        metrics,
+    )
+}
+
+fn hook(
+    state: &Arc<LegacyState>,
+    label: &'static str,
+    mutate_request: bool,
+    fail_before: bool,
+    fail_after: bool,
+) -> Arc<dyn RPCHook> {
+    Arc::new(LegacyHook {
+        state: Arc::clone(state),
+        label,
+        mutate_request,
+        fail_before,
+        fail_after,
+        mark_after_oneway: false,
+    })
+}
+
+fn malforming_after_hook(state: &Arc<LegacyState>) -> Arc<dyn RPCHook> {
+    Arc::new(LegacyHook {
+        state: Arc::clone(state),
+        label: "malformed-after-hook",
+        mutate_request: false,
+        fail_before: false,
+        fail_after: false,
+        mark_after_oneway: true,
+    })
+}
+
+fn command(code: i32, one_way: bool) -> RemotingCommand {
+    let mut command = RemotingCommand::create_remoting_command(code)
+        .set_opaque(ORIGINAL_OPAQUE)
+        .set_body(Bytes::from(vec![7_u8; 313]));
+    command.add_ext_field("dsp05", "ingress");
+    if one_way {
+        command.mark_oneway_rpc()
+    } else {
+        command
+    }
+}
+
+fn direct_response(opaque: i32) -> RemotingCommand {
+    RemotingCommand::create_response_command_with_code(DIRECT_CODE)
+        .set_opaque(opaque)
+        .set_body(Bytes::from_static(b"legacy direct response"))
+}
+
+async fn dispatch(
+    harness: &DispatchHarness,
+    dispatcher: &Arc<LegacyDispatcher>,
+    command: RemotingCommand,
+    deadline: Option<RequestDeadline>,
+) -> (DispatchOutcome, OriginalRequestIdentity) {
+    let (session, original) = harness.request_session(&command);
+    let outcome = dispatcher
+        .dispatch(
+            &harness.authorized,
+            session,
+            harness.context(deadline),
+            command,
+            512,
+            None,
+        )
+        .await
+        .expect("legacy adapter dispatch boundary");
+    (outcome, original)
+}
+
+async fn finish_harness(harness: &mut DispatchHarness) {
+    harness.drain_close_and_assert_eof().await;
+}
+
+#[tokio::test]
+async fn admitted_reply_preserves_order_clone_hooks_body_and_immutable_binding() {
+    let mut harness = DispatchHarness::new("dsp05-legacy-standard").await;
+    let state = Arc::new(LegacyState::default());
+    let hooks = vec![hook(&state, "hook", true, false, false)];
+    let processor = LegacyProcessor {
+        behavior: LegacyBehavior::Reply,
+        state: Arc::clone(&state),
+    };
+    let (telemetry, metrics) = TransportTelemetry::with_legacy_processor_request_capture();
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new_legacy(
+        LegacyProcessorAdapter::new(processor, PROCESSOR_NAME, telemetry, PendingRequestTable::new()),
+        hooks,
+    ));
+    let request = command(PRIMARY_CODE, false);
+    let request_body_pointer = request.body().expect("legacy request body").as_ptr() as usize;
+    let (outcome, original) = dispatch(&harness, &dispatcher, request, None).await;
+    assert!(matches!(outcome, DispatchOutcome::Accepted(_)));
+    let response = harness.receive().await;
+    harness.drain_requests().await;
+
+    assert_eq!(response.code(), ResponseCode::Success.to_i32());
+    assert_eq!(response.opaque(), ORIGINAL_OPAQUE);
+    assert!(response.is_response_type());
+    assert_eq!(response.body().map(|body| body.len()), Some(257));
+    assert_eq!(state.clones.load(Ordering::SeqCst), 1);
+    assert_eq!(state.rejects.load(Ordering::SeqCst), 1);
+    assert_eq!(state.processes.load(Ordering::SeqCst), 1);
+    assert_eq!(state.before_hooks.load(Ordering::SeqCst), 1);
+    assert_eq!(state.after_hooks.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        *state.ordering_inputs.lock().expect("legacy ordering input lock"),
+        vec![(PRIMARY_CODE, ORIGINAL_OPAQUE)]
+    );
+    assert_eq!(
+        *state.process_inputs.lock().expect("legacy process input lock"),
+        vec![(MUTATED_CODE, MUTATED_OPAQUE, false, Some(request_body_pointer))]
+    );
+    assert_eq!(
+        state.events.lock().expect("legacy event lock").as_slice(),
+        ["ordering", "clone", "reject", "hook", "process", "hook", "observe"]
+    );
+    {
+        let observations = state.observations.lock().expect("legacy observation lock");
+        assert_eq!(observations.len(), 1);
+        assert_eq!(observations[0].request_code, PRIMARY_CODE);
+        assert_eq!(observations[0].response_code, ResponseCode::Success.to_i32());
+        assert_eq!(observations[0].outcome, ResponseWriteOutcome::Sent);
+    }
+    assert_eq!(metrics.lock().as_slice(), [(PROCESSOR_NAME, PRIMARY_CODE)]);
+    assert_eq!(
+        original.request_id().owner_id(),
+        SessionId::from_session_owner(harness.session.session_id()).owner_id()
+    );
+    assert_eq!(
+        bridge_construction_counts(SessionId::from_session_owner(harness.session.session_id())),
+        (1, 1)
+    );
+
+    finish_harness(&mut harness).await;
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn rejection_tuple_is_exact_and_each_admitted_path_records_one_metric_and_observation() {
+    for (name, behavior, expected_code, expected_processes) in [
+        (
+            "dsp05-reject-false-some",
+            LegacyBehavior::RejectFalseSome,
+            ResponseCode::Success.to_i32(),
+            1,
+        ),
+        (
+            "dsp05-reject-true-some",
+            LegacyBehavior::RejectTrueSome,
+            REJECTION_CODE,
+            0,
+        ),
+        (
+            "dsp05-reject-true-none",
+            LegacyBehavior::RejectTrueNone,
+            ResponseCode::SystemBusy.to_i32(),
+            0,
+        ),
+    ] {
+        let mut harness = DispatchHarness::new(name).await;
+        let (dispatcher, state, metrics) = legacy_dispatcher(behavior, Vec::new());
+        let (outcome, _) = dispatch(&harness, &dispatcher, command(PRIMARY_CODE, false), None).await;
+        assert!(matches!(outcome, DispatchOutcome::Accepted(_)));
+        let response = harness.receive().await;
+        harness.drain_requests().await;
+
+        assert_eq!(response.code(), expected_code);
+        assert_eq!(response.opaque(), ORIGINAL_OPAQUE);
+        assert_eq!(state.clones.load(Ordering::SeqCst), 1);
+        assert_eq!(state.rejects.load(Ordering::SeqCst), 1);
+        assert_eq!(state.processes.load(Ordering::SeqCst), expected_processes);
+        {
+            let observations = state.observations.lock().expect("legacy observation lock");
+            assert_eq!(observations.len(), 1);
+            assert_eq!(observations[0].request_code, PRIMARY_CODE);
+            assert_eq!(observations[0].response_code, expected_code);
+        }
+        assert_eq!(metrics.lock().as_slice(), [(PROCESSOR_NAME, PRIMARY_CODE)]);
+
+        finish_harness(&mut harness).await;
+        harness.shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn before_processor_and_after_failures_preserve_the_v1_observation_table() {
+    for (
+        name,
+        behavior,
+        fail_before,
+        fail_after,
+        expected_code,
+        expected_processes,
+        expected_after,
+        expected_observations,
+    ) in [
+        (
+            "dsp05-before-error",
+            LegacyBehavior::Reply,
+            true,
+            false,
+            ResponseCode::InvalidParameter.to_i32(),
+            0,
+            0,
+            0,
+        ),
+        (
+            "dsp05-processor-error",
+            LegacyBehavior::ProcessorError,
+            false,
+            false,
+            ResponseCode::SystemError.to_i32(),
+            1,
+            1,
+            1,
+        ),
+        (
+            "dsp05-after-error",
+            LegacyBehavior::Reply,
+            false,
+            true,
+            ResponseCode::InvalidParameter.to_i32(),
+            1,
+            1,
+            0,
+        ),
+    ] {
+        let mut harness = DispatchHarness::new(name).await;
+        let state = Arc::new(LegacyState::default());
+        let processor = LegacyProcessor {
+            behavior,
+            state: Arc::clone(&state),
+        };
+        let (telemetry, metrics) = TransportTelemetry::with_legacy_processor_request_capture();
+        let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new_legacy(
+            LegacyProcessorAdapter::new(processor, PROCESSOR_NAME, telemetry, PendingRequestTable::new()),
+            vec![hook(&state, "hook", false, fail_before, fail_after)],
+        ));
+        let (outcome, _) = dispatch(&harness, &dispatcher, command(PRIMARY_CODE, false), None).await;
+        assert!(matches!(outcome, DispatchOutcome::Accepted(_)));
+        let response = harness.receive().await;
+        harness.drain_requests().await;
+
+        assert_eq!(response.code(), expected_code);
+        assert_eq!(response.opaque(), ORIGINAL_OPAQUE);
+        assert_eq!(state.clones.load(Ordering::SeqCst), 1);
+        assert_eq!(state.processes.load(Ordering::SeqCst), expected_processes);
+        assert_eq!(state.before_hooks.load(Ordering::SeqCst), 1);
+        assert_eq!(state.after_hooks.load(Ordering::SeqCst), expected_after);
+        assert_eq!(
+            state.observations.lock().expect("legacy observation lock").len(),
+            expected_observations
+        );
+        assert_eq!(metrics.lock().as_slice(), [(PROCESSOR_NAME, PRIMARY_CODE)]);
+
+        finish_harness(&mut harness).await;
+        harness.shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn none_oneway_and_both_network_direct_write_paths_use_a_sentinel_and_observe_only_the_sentinel() {
+    for (name, behavior, one_way, direct) in [
+        ("dsp05-none-sentinel", LegacyBehavior::NoneThenSentinel, false, false),
+        ("dsp05-oneway-sentinel", LegacyBehavior::Reply, true, false),
+        (
+            "dsp05-channel-direct-sentinel",
+            LegacyBehavior::DirectChannelThenNone,
+            false,
+            true,
+        ),
+        (
+            "dsp05-context-direct-sentinel",
+            LegacyBehavior::DirectContextThenNone,
+            false,
+            true,
+        ),
+    ] {
+        let mut harness = DispatchHarness::new(name).await;
+        let (dispatcher, state, metrics) = legacy_dispatcher(behavior, Vec::new());
+        dispatch(&harness, &dispatcher, command(PRIMARY_CODE, one_way), None).await;
+        dispatch(&harness, &dispatcher, command(SENTINEL_CODE, false), None).await;
+
+        let first = harness.receive().await;
+        if direct {
+            assert_eq!(first.code(), DIRECT_CODE);
+            assert_eq!(first.opaque(), ORIGINAL_OPAQUE);
+            let sentinel = harness.receive().await;
+            assert_eq!(sentinel.code(), ResponseCode::Success.to_i32());
+            assert_eq!(sentinel.opaque(), ORIGINAL_OPAQUE);
+        } else {
+            assert_eq!(first.code(), ResponseCode::Success.to_i32());
+            assert_eq!(first.opaque(), ORIGINAL_OPAQUE);
+        }
+        harness.drain_requests().await;
+        harness.assert_no_response().await;
+
+        assert_eq!(state.clones.load(Ordering::SeqCst), 2);
+        assert_eq!(state.processes.load(Ordering::SeqCst), 2);
+        {
+            let observations = state.observations.lock().expect("legacy observation lock");
+            assert_eq!(observations.len(), 1);
+            assert_eq!(observations[0].request_code, SENTINEL_CODE);
+        }
+        assert_eq!(
+            metrics.lock().as_slice(),
+            [(PROCESSOR_NAME, PRIMARY_CODE), (PROCESSOR_NAME, SENTINEL_CODE)]
+        );
+
+        finish_harness(&mut harness).await;
+        harness.shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn one_hook_snapshot_excludes_hooks_registered_while_the_processor_is_running() {
+    let mut harness = DispatchHarness::new("dsp05-hook-snapshot").await;
+    let state = Arc::new(LegacyState::default());
+    let processor = LegacyProcessor {
+        behavior: LegacyBehavior::WaitReply,
+        state: Arc::clone(&state),
+    };
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new_legacy(
+        LegacyProcessorAdapter::new(
+            processor,
+            PROCESSOR_NAME,
+            TransportTelemetry::noop(),
+            PendingRequestTable::new(),
+        ),
+        vec![hook(&state, "original-hook", false, false, false)],
+    ));
+    dispatch(&harness, &dispatcher, command(PRIMARY_CODE, false), None).await;
+    state.entered.notified().await;
+    dispatcher.register_rpc_hook(hook(&state, "late-hook", false, false, false));
+    state.resume.notify_one();
+    let response = harness.receive().await;
+    harness.drain_requests().await;
+
+    assert_eq!(response.code(), ResponseCode::Success.to_i32());
+    {
+        let events = state.events.lock().expect("legacy event lock");
+        assert_eq!(events.iter().filter(|event| **event == "original-hook").count(), 2);
+        assert!(!events.contains(&"late-hook"));
+    }
+
+    finish_harness(&mut harness).await;
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn malformed_legacy_head_fails_before_encoding_and_ordered_sentinel_still_drains() {
+    let mut harness = DispatchHarness::new("dsp05-malformed-response").await;
+    let (dispatcher, state, metrics) = legacy_dispatcher(LegacyBehavior::MalformedThenSentinel, Vec::new());
+    dispatch(&harness, &dispatcher, command(PRIMARY_CODE, false), None).await;
+    dispatch(&harness, &dispatcher, command(SENTINEL_CODE, false), None).await;
+    let sentinel = harness.receive().await;
+    harness.drain_requests().await;
+    harness.assert_no_response().await;
+
+    assert_eq!(sentinel.code(), ResponseCode::Success.to_i32());
+    assert_eq!(sentinel.opaque(), ORIGINAL_OPAQUE);
+    assert_eq!(state.observations.lock().expect("legacy observation lock").len(), 1);
+    assert_eq!(dispatcher.reported_failure_categories(), vec!["processor_adapter"]);
+    assert_eq!(
+        metrics.lock().as_slice(),
+        [(PROCESSOR_NAME, PRIMARY_CODE), (PROCESSOR_NAME, SENTINEL_CODE)]
+    );
+
+    finish_harness(&mut harness).await;
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn original_oneway_discards_invalid_rejection_processor_and_after_hook_commands_before_plan_validation() {
+    for (name, behavior, malformed_after_hook) in [
+        (
+            "dsp05-oneway-malformed-rejection",
+            LegacyBehavior::RejectTrueMalformed,
+            false,
+        ),
+        (
+            "dsp05-oneway-malformed-processor",
+            LegacyBehavior::MalformedThenSentinel,
+            false,
+        ),
+        ("dsp05-oneway-malformed-after-hook", LegacyBehavior::Reply, true),
+    ] {
+        let mut harness = DispatchHarness::new(name).await;
+        let state = Arc::new(LegacyState::default());
+        let processor = LegacyProcessor {
+            behavior,
+            state: Arc::clone(&state),
+        };
+        let hooks = malformed_after_hook
+            .then(|| malforming_after_hook(&state))
+            .into_iter()
+            .collect();
+        let (telemetry, metrics) = TransportTelemetry::with_legacy_processor_request_capture();
+        let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new_legacy(
+            LegacyProcessorAdapter::new(processor, PROCESSOR_NAME, telemetry, PendingRequestTable::new()),
+            hooks,
+        ));
+
+        dispatch(&harness, &dispatcher, command(PRIMARY_CODE, true), None).await;
+        dispatch(&harness, &dispatcher, command(SENTINEL_CODE, false), None).await;
+        let sentinel = harness.receive().await;
+        harness.drain_requests().await;
+        harness.assert_no_response().await;
+
+        assert_eq!(sentinel.code(), ResponseCode::Success.to_i32());
+        assert_eq!(sentinel.opaque(), ORIGINAL_OPAQUE);
+        {
+            let observations = state.observations.lock().expect("legacy observation lock");
+            assert_eq!(observations.len(), 1);
+            assert_eq!(observations[0].request_code, SENTINEL_CODE);
+        }
+        assert!(dispatcher.reported_failure_categories().is_empty());
+        assert_eq!(
+            metrics.lock().as_slice(),
+            [(PROCESSOR_NAME, PRIMARY_CODE), (PROCESSOR_NAME, SENTINEL_CODE)]
+        );
+
+        finish_harness(&mut harness).await;
+        harness.shutdown().await;
+    }
+}
+
+async fn post_start_public_direct_write_deadline(behavior: LegacyBehavior) {
+    let (mut harness, write_barrier) =
+        DispatchHarness::new_with_post_start_barrier("dsp05-direct-post-start-deadline").await;
+    let (dispatcher, state, metrics) = legacy_dispatcher(behavior, Vec::new());
+
+    dispatch(
+        &harness,
+        &dispatcher,
+        command(PRIMARY_CODE, false),
+        Some(RequestDeadline::after(Duration::from_millis(40))),
+    )
+    .await;
+    tokio::time::timeout(Duration::from_secs(2), write_barrier.wait_reached())
+        .await
+        .expect("direct write must reach the post-start socket barrier");
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    let direct_channel = state
+        .direct_channel
+        .lock()
+        .expect("legacy direct channel lock")
+        .take()
+        .expect("processor captured its direct-write channel");
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if direct_channel.legacy_response_terminal_state()
+                == Some(crate::dispatch::ResponseTerminalState::Failed {
+                    progress: crate::dispatch::WriteProgress::PossiblyPartial,
+                })
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("post-start cancellation must publish PossiblyPartial to the shared slot");
+
+    write_barrier.release();
+    let direct = harness.receive().await;
+    assert_eq!((direct.code(), direct.opaque()), (DIRECT_CODE, ORIGINAL_OPAQUE));
+
+    dispatch(&harness, &dispatcher, command(SENTINEL_CODE, false), None).await;
+    let sentinel = harness.receive().await;
+    harness.drain_requests().await;
+    harness.assert_no_response().await;
+    assert_eq!(sentinel.code(), ResponseCode::Success.to_i32());
+    assert_eq!(sentinel.opaque(), ORIGINAL_OPAQUE);
+    {
+        let observations = state.observations.lock().expect("legacy observation lock");
+        assert_eq!(observations.len(), 1);
+        assert_eq!(observations[0].request_code, SENTINEL_CODE);
+    }
+    assert!(dispatcher.reported_failure_categories().is_empty());
+    assert_eq!(
+        metrics.lock().as_slice(),
+        [(PROCESSOR_NAME, PRIMARY_CODE), (PROCESSOR_NAME, SENTINEL_CODE)]
+    );
+
+    drop(direct_channel);
+    finish_harness(&mut harness).await;
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn public_send_command_post_start_deadline_keeps_one_possibly_partial_owner_and_never_centrally_retries() {
+    post_start_public_direct_write_deadline(LegacyBehavior::DirectChannelThenNone).await;
+}
+
+#[tokio::test]
+async fn public_send_command_ref_post_start_deadline_keeps_one_possibly_partial_owner_and_never_centrally_retries() {
+    post_start_public_direct_write_deadline(LegacyBehavior::DirectChannelRefThenNone).await;
+}
+
+#[tokio::test]
+async fn pre_admission_deadline_and_explicit_v2_dispatch_record_no_legacy_metric_or_bridge_construction() {
+    let mut legacy = DispatchHarness::new("dsp05-pre-admission-zero").await;
+    let legacy_session_id = SessionId::from_session_owner(legacy.session.session_id());
+    let (dispatcher, state, metrics) = legacy_dispatcher(LegacyBehavior::Reply, Vec::new());
+    let (outcome, _) = dispatch(
+        &legacy,
+        &dispatcher,
+        command(PRIMARY_CODE, false),
+        Some(RequestDeadline::after(Duration::ZERO)),
+    )
+    .await;
+    assert_eq!(outcome, DispatchOutcome::Rejected);
+    let deadline = legacy.receive().await;
+    assert_eq!(deadline.opaque(), ORIGINAL_OPAQUE);
+    assert_eq!(state.clones.load(Ordering::SeqCst), 0);
+    assert_eq!(state.processes.load(Ordering::SeqCst), 0);
+    assert!(metrics.lock().is_empty());
+    assert_eq!(bridge_construction_counts(legacy_session_id), (0, 0));
+    finish_harness(&mut legacy).await;
+    legacy.shutdown().await;
+
+    let mut v2 = DispatchHarness::new("dsp05-v2-no-legacy-construction").await;
+    let v2_session_id = SessionId::from_session_owner(v2.session.session_id());
+    let (processor, _v2_state) = TestProcessor::new(Behavior::Reply);
+    let v2_dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(processor, Vec::new()));
+    let request = request(false);
+    let (session, _) = v2.request_session(&request);
+    v2_dispatcher
+        .dispatch(&v2.authorized, session, v2.context(None), request, 256, None)
+        .await
+        .expect("explicit V2 dispatch");
+    let _response = v2.receive().await;
+    v2.drain_requests().await;
+    assert_eq!(bridge_construction_counts(v2_session_id), (0, 0));
+    assert!(metrics.lock().is_empty());
+    finish_harness(&mut v2).await;
+    v2.shutdown().await;
+}

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/outcomes_deadlines.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/outcomes_deadlines.rs
@@ -173,7 +173,7 @@ async fn direct_expired_oneway_admission_completes_without_reaching_binding() {
 
     dispatcher
         .execute_admitted(
-            processor,
+            ExplicitV2Processor::new(processor),
             session.clone(),
             AdmissionClass::Data,
             original,
@@ -215,7 +215,7 @@ async fn one_way_deferred_outcome_is_a_policy_error_without_inline_write_or_obse
 
     let result = dispatcher
         .execute_admitted(
-            processor,
+            ExplicitV2Processor::new(processor),
             session.clone(),
             AdmissionClass::Data,
             one_way_original,
@@ -253,7 +253,7 @@ async fn one_way_no_reply_marker_failure_maps_resolves_and_drops_without_write()
 
     dispatcher
         .execute_admitted(
-            processor,
+            ExplicitV2Processor::new(processor),
             session.clone(),
             AdmissionClass::Control,
             original,
@@ -380,7 +380,7 @@ async fn deferred_transfer_and_reply_after_defer_resolve_once_without_inline_wri
 
         let result = dispatcher
             .execute_admitted(
-                processor,
+                ExplicitV2Processor::new(processor),
                 session.clone(),
                 AdmissionClass::Data,
                 original,

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/v1_v2_side_contract.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/v1_v2_side_contract.rs
@@ -44,9 +44,11 @@ use super::event_log::EventLog;
 use super::harness::*;
 use crate::admission::AdmissionController;
 use crate::admission::AdmissionLimits;
+use crate::base::pending_request_table::PendingRequestTable;
 use crate::config::ServerConfig;
 use crate::dispatch::AuthorizedCommandDispatcher;
 use crate::dispatch::HandlerOutcome;
+use crate::dispatch::LegacyProcessorAdapter;
 use crate::dispatch::ResponseBodyKind;
 use crate::dispatch::ResponseDisposition;
 use crate::dispatch::ResponsePlan;
@@ -606,6 +608,22 @@ fn record_v2_dispatch_clones(state: &V2State) {
     state.record_dispatch_clones.store(true, Ordering::SeqCst);
 }
 
+fn v1_adapter_dispatcher(
+    behavior: V1Behavior,
+    state: Arc<V1State>,
+    hooks: Vec<Arc<dyn RPCHook>>,
+) -> Arc<AuthorizedCommandDispatcherV2<LegacyProcessorAdapter<V1Processor>>> {
+    Arc::new(AuthorizedCommandDispatcherV2::new_legacy(
+        LegacyProcessorAdapter::new(
+            V1Processor::new(behavior, state),
+            "dsp04-v1-side-contract",
+            TransportTelemetry::noop(),
+            PendingRequestTable::new(),
+        ),
+        hooks,
+    ))
+}
+
 async fn wait_for_v2_observations(state: &V2State, expected: usize) {
     tokio::time::timeout(
         Duration::from_secs(2),
@@ -647,7 +665,10 @@ fn assert_v2_standard_observation(state: &V2State, request_id: crate::dispatch::
     ));
 }
 
-fn assert_no_v2_dispatch_failures(dispatcher: &AuthorizedCommandDispatcherV2<V2Processor>) {
+fn assert_no_v2_dispatch_failures<D>(dispatcher: &AuthorizedCommandDispatcherV2<D>)
+where
+    D: DispatchProcessor,
+{
     let failure_categories = dispatcher.reported_failure_categories();
     assert!(
         failure_categories.is_empty(),
@@ -699,6 +720,39 @@ async fn v1_and_v2_admitted_requests_share_ordering_hook_clone_binding_and_obser
     assert_no_v2_dispatch_failures(&dispatcher);
     v2.drain_close_and_assert_eof().await;
     v2.shutdown().await;
+
+    let mut adapted = DispatchHarness::new("v1-v2-side-contract-standard-adapter").await;
+    let adapted_state = Arc::new(V1State::new());
+    let adapted_dispatcher = v1_adapter_dispatcher(
+        V1Behavior::Standard,
+        Arc::clone(&adapted_state),
+        vec![Arc::new(SideHook {
+            events: adapted_state.events.clone(),
+            clear_oneway: false,
+        })],
+    );
+    adapted_state.record_dispatch_clones.store(true, Ordering::SeqCst);
+    let clone_baseline = adapted_state.clones.load(Ordering::SeqCst);
+    let command = v2_command(STANDARD, ORIGINAL_OPAQUE, false);
+    let (session, _) = adapted.request_session(&command);
+    adapted_dispatcher
+        .dispatch(&adapted.authorized, session, adapted.context(None), command, 256, None)
+        .await
+        .expect("adapted V1 standard side-contract dispatch should be admitted");
+    let response = adapted.receive().await;
+    adapted.drain_requests().await;
+
+    assert_eq!(response.code(), ResponseCode::Success.to_i32());
+    assert_eq!(response.opaque(), ORIGINAL_OPAQUE);
+    assert_eq!(adapted_state.clones.load(Ordering::SeqCst) - clone_baseline, 1);
+    assert_eq!(
+        adapted_state.events.snapshot(),
+        admitted_events(STANDARD, ORIGINAL_OPAQUE)
+    );
+    assert_v1_standard_observation(&adapted_state, STANDARD);
+    assert_no_v2_dispatch_failures(&adapted_dispatcher);
+    adapted.drain_close_and_assert_eof().await;
+    adapted.shutdown().await;
 }
 
 #[tokio::test]

--- a/rocketmq-transport/src/dispatch/handler_outcome.rs
+++ b/rocketmq-transport/src/dispatch/handler_outcome.rs
@@ -386,6 +386,17 @@ impl InlineResponseSlot {
             InlineResponseState::Completed => Err(HandlerOutcomeContractError::OutcomeAlreadyCompleted),
         }
     }
+
+    /// Consumes the affine inline reply state when an original one-way request
+    /// discards an owned legacy response before plan validation.
+    pub(crate) fn resolve_legacy_oneway_reply(&mut self) -> Result<(), HandlerOutcomeContractError> {
+        let state = std::mem::replace(&mut self.state, InlineResponseState::Completed);
+        match state {
+            InlineResponseState::Open | InlineResponseState::OpenWithDeferred => Ok(()),
+            InlineResponseState::DeferredTaken => Err(HandlerOutcomeContractError::ReplyAfterDeferredTaken),
+            InlineResponseState::Completed => Err(HandlerOutcomeContractError::OutcomeAlreadyCompleted),
+        }
+    }
 }
 
 fn validate_marker(

--- a/rocketmq-transport/src/dispatch/legacy_processor_adapter.rs
+++ b/rocketmq-transport/src/dispatch/legacy_processor_adapter.rs
@@ -1,0 +1,902 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Sealed compatibility processing behind the private V2 dispatch core.
+
+use std::future::Future;
+use std::net::SocketAddr;
+use std::sync::Arc;
+#[cfg(test)]
+use std::sync::Mutex;
+use std::time::Duration;
+
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_runtime::TaskGroup;
+
+use super::remoting_request::RemotingRequestBuilder;
+use super::HandlerOutcome;
+use super::HandlerOutcomeContractError;
+use super::OriginalRequestIdentity;
+use super::RemotingRequest;
+use super::RequestOrigin;
+use super::ResponseBodyKind;
+use super::ResponseError;
+use super::ResponsePlan;
+use super::ResponsePlanError;
+use super::ResponseReceipt;
+use super::ResponseSink;
+use crate::base::pending_request_table::PendingRequestTable;
+use crate::hook_registry::HookSnapshot;
+use crate::net::channel::Channel;
+use crate::net::channel::ChannelInner;
+use crate::remoting::inner::is_long_polling_request;
+use crate::remoting::inner::legacy_processor_error_response;
+use crate::remoting::inner::legacy_rejection_response;
+use crate::remoting::inner::run_after_rpc_hooks;
+use crate::remoting::inner::run_before_rpc_hooks;
+use crate::request_ordering::RequestOrdering;
+use crate::runtime::connection_handler_context::ConnectionHandlerContext;
+use crate::runtime::connection_handler_context::ConnectionHandlerContextWrapper;
+use crate::runtime::processor::RequestProcessor;
+use crate::runtime::processor::ResponseWriteObservation;
+use crate::runtime::processor::ResponseWriteOutcome;
+use crate::runtime::processor_v2::RejectRequestDecision;
+use crate::runtime::processor_v2::RequestProcessorV2;
+use crate::runtime::processor_v2::ResponseWriteObservationV2;
+use crate::runtime::processor_v2::ResponseWritePath;
+use crate::server::SessionHandle;
+use crate::session_view::EmbeddedSessionRecord;
+use crate::session_view::SessionId;
+use crate::session_view::SessionView;
+use crate::telemetry::TransportRequestMetricsGuard;
+use crate::telemetry::TransportTelemetry;
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+#[cfg(test)]
+static BRIDGE_CONSTRUCTIONS: Mutex<Vec<SessionId>> = Mutex::new(Vec::new());
+
+#[cfg(test)]
+static BRIDGE_CHANNEL_INNER_CONSTRUCTIONS: Mutex<Vec<SessionId>> = Mutex::new(Vec::new());
+
+#[cfg(test)]
+pub(super) fn bridge_construction_counts(session_id: SessionId) -> (usize, usize) {
+    let bridges = BRIDGE_CONSTRUCTIONS
+        .lock()
+        .expect("legacy bridge construction counter lock")
+        .iter()
+        .filter(|candidate| **candidate == session_id)
+        .count();
+    let channel_inners = BRIDGE_CHANNEL_INNER_CONSTRUCTIONS
+        .lock()
+        .expect("legacy bridge ChannelInner construction counter lock")
+        .iter()
+        .filter(|candidate| **candidate == session_id)
+        .count();
+    (bridges, channel_inners)
+}
+
+/// Separate legacy transport capability aggregate. It is never stored in a
+/// `RemotingRequest` and cannot be constructed from an arbitrary channel and
+/// context pair.
+#[allow(
+    dead_code,
+    reason = "DSP-05 defines the private bridge consumed by DSP-06 coexistence routing"
+)]
+pub(crate) struct LegacyRequestBridge {
+    channel: Channel,
+    context: ConnectionHandlerContext,
+    canonical_session_id: SessionId,
+}
+
+#[allow(
+    dead_code,
+    reason = "DSP-05 defines bridge construction and validation before DSP-06 routing"
+)]
+impl LegacyRequestBridge {
+    fn from_network_session(
+        session: &SessionHandle,
+        response: &ResponseSink,
+        response_table: PendingRequestTable,
+    ) -> Result<Self, LegacyProcessorAdapterError> {
+        let canonical_session_id = SessionId::from_session_owner(session.session_id());
+        #[cfg(test)]
+        BRIDGE_CONSTRUCTIONS
+            .lock()
+            .expect("legacy bridge construction counter lock")
+            .push(canonical_session_id);
+        if !response.is_network_transport() {
+            return Err(LegacyProcessorAdapterError::TransportKindMismatch);
+        }
+        if !response.is_network_owner(session) {
+            return Err(LegacyProcessorAdapterError::CompletionOwnerMismatch);
+        }
+        if !response.is_canonical_network_plan_owner(session) {
+            return Err(LegacyProcessorAdapterError::CompletionOwnerMismatch);
+        }
+        #[cfg(test)]
+        BRIDGE_CHANNEL_INNER_CONSTRUCTIONS
+            .lock()
+            .expect("legacy bridge ChannelInner construction counter lock")
+            .push(canonical_session_id);
+        let channel = session
+            .legacy_processor_channel(response.clone(), response_table)
+            .map_err(LegacyProcessorAdapterError::BridgeConstruction)?;
+        let context = Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let bridge = Self {
+            channel,
+            context,
+            canonical_session_id,
+        };
+        bridge.validate_network(session, response)?;
+        Ok(bridge)
+    }
+
+    fn from_embedded_session(
+        session: &EmbeddedSessionRecord,
+        response: &ResponseSink,
+        task_group: &TaskGroup,
+        response_table: PendingRequestTable,
+    ) -> Result<Self, LegacyProcessorAdapterError> {
+        let session_view = session.view();
+        let canonical_session_id = session_view.id();
+        #[cfg(test)]
+        BRIDGE_CONSTRUCTIONS
+            .lock()
+            .expect("legacy bridge construction counter lock")
+            .push(canonical_session_id);
+        if !response.is_local() {
+            return Err(LegacyProcessorAdapterError::TransportKindMismatch);
+        }
+        if !response.is_local_plan_owner(session_view.state(), task_group) {
+            return Err(LegacyProcessorAdapterError::CompletionOwnerMismatch);
+        }
+        #[cfg(test)]
+        BRIDGE_CHANNEL_INNER_CONSTRUCTIONS
+            .lock()
+            .expect("legacy bridge ChannelInner construction counter lock")
+            .push(canonical_session_id);
+        let inner = Arc::new(ChannelInner::new_local_legacy_bridge(
+            response.clone(),
+            task_group.clone(),
+            response_table,
+        ));
+        let channel =
+            Channel::new_canonical_embedded(inner, canonical_session_id, session_view.state().clone(), task_group);
+        let context = Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
+        let bridge = Self {
+            channel,
+            context,
+            canonical_session_id,
+        };
+        bridge.validate_embedded(session, response, task_group)?;
+        Ok(bridge)
+    }
+
+    fn validate_network(
+        &self,
+        session: &SessionHandle,
+        response: &ResponseSink,
+    ) -> Result<(), LegacyProcessorAdapterError> {
+        if self.canonical_session_id != SessionId::from_session_owner(session.session_id())
+            || self.channel.canonical_session_id() != Some(self.canonical_session_id)
+            || self.context.channel().canonical_session_id() != Some(self.canonical_session_id)
+        {
+            return Err(LegacyProcessorAdapterError::SessionMismatch);
+        }
+        if !self.channel.is_network_transport() || !response.is_network_transport() {
+            return Err(LegacyProcessorAdapterError::TransportKindMismatch);
+        }
+        if !self.channel.is_canonical_network_owner(session) {
+            return Err(LegacyProcessorAdapterError::WriterOwnerMismatch);
+        }
+        if !response.is_network_owner(session) {
+            return Err(LegacyProcessorAdapterError::CompletionOwnerMismatch);
+        }
+        if !self.channel.shares_inner(self.context.channel()) {
+            return Err(LegacyProcessorAdapterError::ChannelContextMismatch);
+        }
+        debug_assert!(self.channel.shares_inner(self.context.channel()));
+        debug_assert_eq!(self.channel.canonical_session_id(), Some(self.canonical_session_id));
+        debug_assert_eq!(
+            self.context.channel().canonical_session_id(),
+            Some(self.canonical_session_id)
+        );
+        debug_assert!(self.channel.is_network_transport());
+        debug_assert!(response.is_network_owner(session));
+        Ok(())
+    }
+
+    fn validate_embedded(
+        &self,
+        session: &EmbeddedSessionRecord,
+        response: &ResponseSink,
+        task_group: &TaskGroup,
+    ) -> Result<(), LegacyProcessorAdapterError> {
+        let session_view = session.view();
+        if self.canonical_session_id != session_view.id()
+            || self.channel.canonical_session_id() != Some(self.canonical_session_id)
+            || self.context.channel().canonical_session_id() != Some(self.canonical_session_id)
+        {
+            return Err(LegacyProcessorAdapterError::SessionMismatch);
+        }
+        if self.channel.is_network_transport() || !response.is_local() {
+            return Err(LegacyProcessorAdapterError::TransportKindMismatch);
+        }
+        if !response.is_local_plan_owner(session_view.state(), task_group) {
+            return Err(LegacyProcessorAdapterError::CompletionOwnerMismatch);
+        }
+        if !self.channel.is_canonical_embedded_owner(
+            self.canonical_session_id,
+            session_view.state(),
+            response,
+            task_group,
+        ) {
+            return Err(LegacyProcessorAdapterError::CompletionOwnerMismatch);
+        }
+        if !self.channel.shares_inner(self.context.channel()) {
+            return Err(LegacyProcessorAdapterError::ChannelContextMismatch);
+        }
+        debug_assert!(self.channel.shares_inner(self.context.channel()));
+        debug_assert_eq!(self.channel.canonical_session_id(), Some(self.canonical_session_id));
+        debug_assert_eq!(
+            self.context.channel().canonical_session_id(),
+            Some(self.canonical_session_id)
+        );
+        debug_assert!(!self.channel.is_network_transport());
+        debug_assert!(self.channel.is_canonical_embedded_owner(
+            self.canonical_session_id,
+            session_view.state(),
+            response,
+            task_group
+        ));
+        Ok(())
+    }
+
+    fn validate_request(&self, request: &RemotingRequest) -> Result<(), LegacyProcessorAdapterError> {
+        if request.session().id() != self.canonical_session_id {
+            return Err(LegacyProcessorAdapterError::SessionMismatch);
+        }
+        match (request.origin(), request.session(), self.channel.is_network_transport()) {
+            (RequestOrigin::Network { .. }, SessionView::Network { .. }, true)
+            | (RequestOrigin::Embedded { .. }, SessionView::Embedded { .. }, false) => Ok(()),
+            _ => Err(LegacyProcessorAdapterError::TransportKindMismatch),
+        }
+    }
+}
+
+/// Existing V1 processor plus the stable endpoint capabilities needed by each
+/// admitted bridge invocation.
+#[allow(
+    dead_code,
+    reason = "DSP-05 defines the private adapter consumed by DSP-06 coexistence routing"
+)]
+pub(crate) struct LegacyProcessorAdapter<P> {
+    processor: P,
+    processor_name: &'static str,
+    telemetry: TransportTelemetry,
+    response_table: PendingRequestTable,
+}
+
+#[allow(
+    dead_code,
+    reason = "DSP-05 defines private adapter construction before DSP-06 routing"
+)]
+impl<P> LegacyProcessorAdapter<P> {
+    pub(crate) fn new(
+        processor: P,
+        processor_name: &'static str,
+        telemetry: TransportTelemetry,
+        response_table: PendingRequestTable,
+    ) -> Self {
+        Self {
+            processor,
+            processor_name,
+            telemetry,
+            response_table,
+        }
+    }
+}
+
+impl<P> Clone for LegacyProcessorAdapter<P>
+where
+    P: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            processor: self.processor.clone(),
+            processor_name: self.processor_name,
+            telemetry: self.telemetry.clone(),
+            response_table: self.response_table.clone(),
+        }
+    }
+}
+
+/// Explicit wrapper preventing the V2 implementation from overlapping the
+/// legacy compatibility implementation.
+pub(crate) struct ExplicitV2Processor<P> {
+    processor: P,
+}
+
+impl<P> ExplicitV2Processor<P> {
+    pub(crate) const fn new(processor: P) -> Self {
+        Self { processor }
+    }
+}
+
+impl<P> Clone for ExplicitV2Processor<P>
+where
+    P: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            processor: self.processor.clone(),
+        }
+    }
+}
+
+/// Internal terminal result before immutable binding and delivery.
+#[allow(
+    dead_code,
+    reason = "legacy variants remain dormant until DSP-06 routes V1 processors through this seam"
+)]
+pub(crate) enum InternalProcessorOutcome {
+    V2(HandlerOutcome),
+    LegacyReply(LegacyReplyCandidate),
+    LegacyAmbiguousNone,
+}
+
+pub(crate) enum LegacyReplyCandidate {
+    OwnedCommand(RemotingCommand),
+    ValidatedPlan(ResponsePlan),
+}
+
+impl LegacyReplyCandidate {
+    pub(crate) fn response_code(&self) -> i32 {
+        match self {
+            Self::OwnedCommand(command) => command.code(),
+            Self::ValidatedPlan(plan) => plan.response_code(),
+        }
+    }
+
+    pub(crate) fn into_plan(self) -> Result<ResponsePlan, DispatchProcessorError> {
+        match self {
+            Self::OwnedCommand(command) => legacy_plan(command),
+            Self::ValidatedPlan(plan) => Ok(plan),
+        }
+    }
+}
+
+pub(crate) struct InternalProcessorCandidate {
+    pub(crate) outcome: InternalProcessorOutcome,
+    pub(crate) failure: Option<InternalFailureOrigin>,
+    pub(crate) observe_write: bool,
+}
+
+impl InternalProcessorCandidate {
+    fn success(outcome: InternalProcessorOutcome) -> Self {
+        Self {
+            outcome,
+            failure: None,
+            observe_write: true,
+        }
+    }
+
+    fn failure(outcome: InternalProcessorOutcome, failure: InternalFailureOrigin) -> Self {
+        Self {
+            outcome,
+            failure: Some(failure),
+            observe_write: true,
+        }
+    }
+
+    #[allow(
+        dead_code,
+        reason = "legacy observation policy remains dormant until DSP-06 coexistence routing"
+    )]
+    fn suppress_observation(mut self) -> Self {
+        self.observe_write = false;
+        self
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum InternalFailureOrigin {
+    BeforeHook,
+    ProcessorError,
+    Deadline,
+    AfterHook,
+    ProcessorErrorAfterHookError,
+}
+
+impl InternalFailureOrigin {
+    pub(crate) const fn category(self) -> &'static str {
+        match self {
+            Self::BeforeHook => "before_hook",
+            Self::ProcessorError => "processor_error",
+            Self::Deadline => "deadline",
+            Self::AfterHook => "after_hook",
+            Self::ProcessorErrorAfterHookError => "processor_error_after_hook_error",
+        }
+    }
+
+    const fn after_hook_error(self) -> Self {
+        match self {
+            Self::ProcessorError => Self::ProcessorErrorAfterHookError,
+            Self::BeforeHook | Self::Deadline | Self::AfterHook | Self::ProcessorErrorAfterHookError => Self::AfterHook,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[allow(
+    dead_code,
+    reason = "legacy bridge failures remain dormant until DSP-06 coexistence routing"
+)]
+pub(crate) enum LegacyProcessorAdapterError {
+    #[error("legacy bridge session provenance mismatch")]
+    SessionMismatch,
+    #[error("legacy bridge transport kind mismatch")]
+    TransportKindMismatch,
+    #[error("legacy bridge writer owner mismatch")]
+    WriterOwnerMismatch,
+    #[error("legacy bridge completion owner mismatch")]
+    CompletionOwnerMismatch,
+    #[error("legacy bridge channel and context do not share one inner channel")]
+    ChannelContextMismatch,
+    #[error("legacy bridge construction failed")]
+    BridgeConstruction(#[source] rocketmq_error::RocketMQError),
+    #[error("legacy processor returned a malformed response command")]
+    MalformedLegacyResponse(#[source] ResponsePlanError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum DispatchProcessorError {
+    #[error(transparent)]
+    Legacy(#[from] LegacyProcessorAdapterError),
+    #[error(transparent)]
+    ResponsePlan(#[from] ResponsePlanError),
+    #[error(transparent)]
+    HandlerContract(#[from] HandlerOutcomeContractError),
+}
+
+#[allow(dead_code, reason = "legacy metrics remain dormant until DSP-06 coexistence routing")]
+pub(crate) enum DispatchMetricsGuard {
+    ExplicitV2,
+    Legacy(TransportRequestMetricsGuard),
+}
+
+impl DispatchMetricsGuard {
+    pub(crate) fn complete_response(&mut self, response_code: i32) {
+        if let Self::Legacy(guard) = self {
+            guard.complete_response(response_code);
+        }
+    }
+
+    pub(crate) fn complete_oneway(&mut self) {
+        if let Self::Legacy(guard) = self {
+            guard.complete_oneway();
+        }
+    }
+
+    pub(crate) fn complete_legacy_ambiguous_none(&mut self) {
+        if let Self::Legacy(guard) = self {
+            guard.complete_legacy_ambiguous_none();
+        }
+    }
+
+    pub(crate) fn complete_process_request_failed(&mut self, response_code: i32) {
+        if let Self::Legacy(guard) = self {
+            let _ = response_code;
+            guard.complete_process_request_failed(
+                rocketmq_protocol::code::response_code::ResponseCode::SystemError.to_i32(),
+            );
+        }
+    }
+
+    pub(crate) fn complete_write_channel_failed(&mut self, response_code: i32) {
+        if let Self::Legacy(guard) = self {
+            guard.complete_write_channel_failed(response_code);
+        }
+    }
+}
+
+/// Sealed statically dispatched processor boundary used by the V2 core.
+pub(crate) trait DispatchProcessor: sealed::Sealed + Clone + Send + Sync + 'static {
+    fn request_ordering(&self, builder: &RemotingRequestBuilder) -> RequestOrdering;
+
+    fn begin_admitted(&self, original: OriginalRequestIdentity, request_bytes: u64) -> DispatchMetricsGuard;
+
+    fn reject_request(&self, request_code: i32) -> Result<Option<InternalProcessorCandidate>, DispatchProcessorError>;
+
+    fn deadline_candidate(&self, plan: ResponsePlan) -> InternalProcessorCandidate;
+
+    fn process(
+        &mut self,
+        request: &mut RemotingRequest,
+        hook_snapshot: Option<&HookSnapshot>,
+        remote_address: SocketAddr,
+        session: &SessionHandle,
+        response: &ResponseSink,
+    ) -> impl Future<Output = Result<InternalProcessorCandidate, DispatchProcessorError>> + Send;
+
+    fn resolve_outcome(
+        &self,
+        request: &mut RemotingRequest,
+        outcome: InternalProcessorOutcome,
+    ) -> Result<InternalProcessorOutcome, DispatchProcessorError>;
+
+    fn observe_response_write(
+        &self,
+        original: OriginalRequestIdentity,
+        response_code: i32,
+        body_kind: ResponseBodyKind,
+        write_elapsed: Duration,
+        end_to_end_elapsed: Duration,
+        result: Result<ResponseReceipt, ResponseError>,
+    );
+}
+
+impl<P> sealed::Sealed for ExplicitV2Processor<P> {}
+
+impl<P> DispatchProcessor for ExplicitV2Processor<P>
+where
+    P: RequestProcessorV2 + Clone + Sync + 'static,
+{
+    fn request_ordering(&self, builder: &RemotingRequestBuilder) -> RequestOrdering {
+        self.processor.request_ordering(builder.ingress_view())
+    }
+
+    fn begin_admitted(&self, _original: OriginalRequestIdentity, _request_bytes: u64) -> DispatchMetricsGuard {
+        DispatchMetricsGuard::ExplicitV2
+    }
+
+    fn reject_request(&self, request_code: i32) -> Result<Option<InternalProcessorCandidate>, DispatchProcessorError> {
+        Ok(match self.processor.reject_request(request_code) {
+            RejectRequestDecision::Proceed => None,
+            RejectRequestDecision::Reject(plan) => Some(InternalProcessorCandidate::success(
+                InternalProcessorOutcome::V2(HandlerOutcome::Reply(plan)),
+            )),
+        })
+    }
+
+    fn deadline_candidate(&self, plan: ResponsePlan) -> InternalProcessorCandidate {
+        InternalProcessorCandidate::failure(
+            InternalProcessorOutcome::V2(HandlerOutcome::Reply(plan)),
+            InternalFailureOrigin::Deadline,
+        )
+    }
+
+    #[allow(
+        clippy::manual_async_fn,
+        reason = "the sealed dispatcher boundary must state the Send guarantee required by SessionExecutor"
+    )]
+    fn process(
+        &mut self,
+        request: &mut RemotingRequest,
+        hook_snapshot: Option<&HookSnapshot>,
+        remote_address: SocketAddr,
+        _session: &SessionHandle,
+        _response: &ResponseSink,
+    ) -> impl Future<Output = Result<InternalProcessorCandidate, DispatchProcessorError>> + Send {
+        async move {
+            let before_result = request.with_body_free_hook_command(|request_head| {
+                run_before_rpc_hooks(hook_snapshot, remote_address, request_head)
+            });
+            let candidate = match before_result {
+                Ok(()) => {
+                    let processed = match request.meta().deadline() {
+                        Some(deadline) => deadline.timeout(self.processor.process(request)).await,
+                        None => Ok(self.processor.process(request).await),
+                    };
+                    match processed {
+                        Ok(Ok(outcome)) => apply_v2_after_hook(
+                            request,
+                            InternalProcessorCandidate::success(InternalProcessorOutcome::V2(outcome)),
+                            hook_snapshot,
+                            remote_address,
+                        )?,
+                        Ok(Err(error)) => {
+                            let plan = crate::error_response::response_plan_from_error(&error)?;
+                            apply_v2_after_hook(
+                                request,
+                                InternalProcessorCandidate::failure(
+                                    InternalProcessorOutcome::V2(HandlerOutcome::Reply(plan)),
+                                    InternalFailureOrigin::ProcessorError,
+                                ),
+                                hook_snapshot,
+                                remote_address,
+                            )?
+                        }
+                        Err(_) => InternalProcessorCandidate::failure(
+                            InternalProcessorOutcome::V2(HandlerOutcome::Reply(ResponsePlan::command(
+                                super::authorized_dispatcher::deadline_response(
+                                    request.original_identity().original_opaque(),
+                                ),
+                            )?)),
+                            InternalFailureOrigin::Deadline,
+                        ),
+                    }
+                }
+                Err(error) => InternalProcessorCandidate::failure(
+                    InternalProcessorOutcome::V2(HandlerOutcome::Reply(
+                        crate::error_response::response_plan_from_error(&error)?,
+                    )),
+                    InternalFailureOrigin::BeforeHook,
+                ),
+            };
+            Ok(candidate)
+        }
+    }
+
+    fn resolve_outcome(
+        &self,
+        request: &mut RemotingRequest,
+        outcome: InternalProcessorOutcome,
+    ) -> Result<InternalProcessorOutcome, DispatchProcessorError> {
+        let InternalProcessorOutcome::V2(outcome) = outcome else {
+            return Err(LegacyProcessorAdapterError::TransportKindMismatch.into());
+        };
+        Ok(InternalProcessorOutcome::V2(request.resolve_handler_outcome(outcome)?))
+    }
+
+    fn observe_response_write(
+        &self,
+        original: OriginalRequestIdentity,
+        response_code: i32,
+        body_kind: ResponseBodyKind,
+        write_elapsed: Duration,
+        end_to_end_elapsed: Duration,
+        result: Result<ResponseReceipt, ResponseError>,
+    ) {
+        self.processor
+            .observe_response_write(ResponseWriteObservationV2::from_result(
+                original.request_id(),
+                original.original_code(),
+                response_code,
+                body_kind,
+                ResponseWritePath::Inline,
+                write_elapsed,
+                end_to_end_elapsed,
+                result,
+            ));
+    }
+}
+
+impl<P> sealed::Sealed for LegacyProcessorAdapter<P> {}
+
+impl<P> DispatchProcessor for LegacyProcessorAdapter<P>
+where
+    P: RequestProcessor + Clone + Sync + 'static,
+{
+    fn request_ordering(&self, builder: &RemotingRequestBuilder) -> RequestOrdering {
+        self.processor.request_ordering(builder.command())
+    }
+
+    fn begin_admitted(&self, original: OriginalRequestIdentity, request_bytes: u64) -> DispatchMetricsGuard {
+        self.telemetry
+            .record_legacy_processor_request(self.processor_name, original.original_code());
+        DispatchMetricsGuard::Legacy(self.telemetry.request_guard(
+            original.original_code(),
+            request_bytes,
+            is_long_polling_request(original.original_code()),
+        ))
+    }
+
+    fn reject_request(&self, request_code: i32) -> Result<Option<InternalProcessorCandidate>, DispatchProcessorError> {
+        Ok(
+            legacy_rejection_response(self.processor.reject_request(request_code)).map(|command| {
+                InternalProcessorCandidate::success(InternalProcessorOutcome::LegacyReply(
+                    LegacyReplyCandidate::OwnedCommand(command),
+                ))
+            }),
+        )
+    }
+
+    fn deadline_candidate(&self, plan: ResponsePlan) -> InternalProcessorCandidate {
+        InternalProcessorCandidate::failure(
+            InternalProcessorOutcome::LegacyReply(LegacyReplyCandidate::ValidatedPlan(plan)),
+            InternalFailureOrigin::Deadline,
+        )
+        .suppress_observation()
+    }
+
+    #[allow(
+        clippy::manual_async_fn,
+        reason = "the sealed dispatcher boundary must state the Send guarantee required by SessionExecutor"
+    )]
+    fn process(
+        &mut self,
+        request: &mut RemotingRequest,
+        hook_snapshot: Option<&HookSnapshot>,
+        remote_address: SocketAddr,
+        session: &SessionHandle,
+        response: &ResponseSink,
+    ) -> impl Future<Output = Result<InternalProcessorCandidate, DispatchProcessorError>> + Send {
+        async move {
+            let bridge = LegacyRequestBridge::from_network_session(session, response, self.response_table.clone())?;
+            bridge.validate_request(request)?;
+
+            if let Err(error) = run_before_rpc_hooks(hook_snapshot, remote_address, request.legacy_command_mut()) {
+                return Ok(InternalProcessorCandidate::failure(
+                    InternalProcessorOutcome::LegacyReply(LegacyReplyCandidate::OwnedCommand(
+                        crate::error_response::command_from_error(&error),
+                    )),
+                    InternalFailureOrigin::BeforeHook,
+                )
+                .suppress_observation());
+            }
+
+            let deadline = request.meta().deadline();
+            let processed = {
+                let channel = bridge.channel.clone();
+                let context = bridge.context.clone();
+                let process = self
+                    .processor
+                    .process_request(channel, context, request.legacy_command_mut());
+                match deadline {
+                    Some(deadline) => deadline.timeout(process).await,
+                    None => Ok(process.await),
+                }
+            };
+            let (mut response, failure) = match processed {
+                Ok(Ok(response)) => (response, None),
+                Ok(Err(_)) => (
+                    Some(legacy_processor_error_response()),
+                    Some(InternalFailureOrigin::ProcessorError),
+                ),
+                Err(_) => {
+                    return Ok(InternalProcessorCandidate::failure(
+                        InternalProcessorOutcome::LegacyReply(LegacyReplyCandidate::OwnedCommand(
+                            super::authorized_dispatcher::deadline_response(
+                                request.original_identity().original_opaque(),
+                            ),
+                        )),
+                        InternalFailureOrigin::Deadline,
+                    )
+                    .suppress_observation());
+                }
+            };
+
+            let Some(mut response) = response.take() else {
+                return Ok(InternalProcessorCandidate::success(
+                    InternalProcessorOutcome::LegacyAmbiguousNone,
+                ));
+            };
+            if let Err(error) = run_after_rpc_hooks(hook_snapshot, remote_address, request.command(), &mut response) {
+                let failure = failure
+                    .map(InternalFailureOrigin::after_hook_error)
+                    .unwrap_or(InternalFailureOrigin::AfterHook);
+                return Ok(InternalProcessorCandidate::failure(
+                    InternalProcessorOutcome::LegacyReply(LegacyReplyCandidate::OwnedCommand(
+                        crate::error_response::command_from_error(&error),
+                    )),
+                    failure,
+                )
+                .suppress_observation());
+            }
+            let outcome = InternalProcessorOutcome::LegacyReply(LegacyReplyCandidate::OwnedCommand(response));
+            Ok(match failure {
+                Some(failure) => InternalProcessorCandidate::failure(outcome, failure),
+                None => InternalProcessorCandidate::success(outcome),
+            })
+        }
+    }
+
+    fn resolve_outcome(
+        &self,
+        request: &mut RemotingRequest,
+        outcome: InternalProcessorOutcome,
+    ) -> Result<InternalProcessorOutcome, DispatchProcessorError> {
+        match outcome {
+            InternalProcessorOutcome::LegacyReply(reply) => {
+                if request.original_identity().is_one_way() {
+                    request.resolve_legacy_oneway_reply()?;
+                    return Ok(InternalProcessorOutcome::LegacyReply(reply));
+                }
+                let plan = reply.into_plan()?;
+                let resolved = request.resolve_handler_outcome(HandlerOutcome::Reply(plan))?;
+                let HandlerOutcome::Reply(plan) = resolved else {
+                    return Err(LegacyProcessorAdapterError::TransportKindMismatch.into());
+                };
+                Ok(InternalProcessorOutcome::LegacyReply(
+                    LegacyReplyCandidate::ValidatedPlan(plan),
+                ))
+            }
+            InternalProcessorOutcome::LegacyAmbiguousNone => Ok(InternalProcessorOutcome::LegacyAmbiguousNone),
+            InternalProcessorOutcome::V2(_) => Err(LegacyProcessorAdapterError::TransportKindMismatch.into()),
+        }
+    }
+
+    fn observe_response_write(
+        &self,
+        original: OriginalRequestIdentity,
+        response_code: i32,
+        _body_kind: ResponseBodyKind,
+        write_elapsed: Duration,
+        end_to_end_elapsed: Duration,
+        result: Result<ResponseReceipt, ResponseError>,
+    ) {
+        self.processor.observe_response_write(ResponseWriteObservation {
+            request_code: original.original_code(),
+            response_code,
+            write_elapsed,
+            end_to_end_elapsed,
+            outcome: if result.is_ok() {
+                ResponseWriteOutcome::Sent
+            } else {
+                ResponseWriteOutcome::Failed
+            },
+        });
+    }
+}
+
+#[allow(
+    dead_code,
+    reason = "legacy response conversion remains dormant until DSP-06 coexistence routing"
+)]
+fn legacy_plan(command: RemotingCommand) -> Result<ResponsePlan, DispatchProcessorError> {
+    ResponsePlan::from_legacy_command(command)
+        .map_err(|error| LegacyProcessorAdapterError::MalformedLegacyResponse(error).into())
+}
+
+fn apply_v2_after_hook(
+    request: &mut RemotingRequest,
+    candidate: InternalProcessorCandidate,
+    hook_snapshot: Option<&HookSnapshot>,
+    remote_address: SocketAddr,
+) -> Result<InternalProcessorCandidate, DispatchProcessorError> {
+    let InternalProcessorCandidate {
+        outcome,
+        failure,
+        observe_write,
+    } = candidate;
+    let InternalProcessorOutcome::V2(HandlerOutcome::Reply(mut plan)) = outcome else {
+        return Ok(InternalProcessorCandidate {
+            outcome,
+            failure,
+            observe_write,
+        });
+    };
+    let result = request.with_body_free_hook_request(|request_head| {
+        plan.with_body_free_hook_head(|response_head| {
+            run_after_rpc_hooks(hook_snapshot, remote_address, request_head, response_head)
+        })
+    });
+    match result {
+        Ok(()) => Ok(InternalProcessorCandidate {
+            outcome: InternalProcessorOutcome::V2(HandlerOutcome::Reply(plan)),
+            failure,
+            observe_write,
+        }),
+        Err(error) => {
+            drop(plan);
+            let failure = failure
+                .map(InternalFailureOrigin::after_hook_error)
+                .unwrap_or(InternalFailureOrigin::AfterHook);
+            Ok(InternalProcessorCandidate::failure(
+                InternalProcessorOutcome::V2(HandlerOutcome::Reply(crate::error_response::response_plan_from_error(
+                    &error,
+                )?)),
+                failure,
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "legacy_processor_adapter/tests.rs"]
+mod tests;

--- a/rocketmq-transport/src/dispatch/legacy_processor_adapter/tests.rs
+++ b/rocketmq-transport/src/dispatch/legacy_processor_adapter/tests.rs
@@ -1,0 +1,560 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Mutex;
+use std::time::Duration;
+use std::time::Instant;
+
+use bytes::Bytes;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use rocketmq_runtime::TaskGroup;
+use tokio::sync::oneshot;
+
+use super::*;
+use crate::admission::AdmissionClass;
+use crate::admission::AdmissionController;
+use crate::admission::AdmissionLimits;
+use crate::connection::Connection;
+use crate::deadline::RequestDeadline;
+use crate::dispatch::RequestControlView;
+use crate::dispatch::RequestMeta;
+use crate::dispatch::ResponseBody;
+use crate::security::TransportSecurity;
+use crate::server::run_connected_session;
+use crate::server::ConnectionHandler;
+
+struct CaptureSession {
+    sender: Mutex<Option<oneshot::Sender<SessionHandle>>>,
+}
+
+impl ConnectionHandler for CaptureSession {
+    fn connected(&self, session: SessionHandle) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async move {
+            if let Some(sender) = self.sender.lock().expect("capture session lock").take() {
+                let _ = sender.send(session);
+            }
+        })
+    }
+
+    fn command(
+        &self,
+        _session: SessionHandle,
+        _command: RemotingCommand,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async {})
+    }
+}
+
+struct NetworkHarness {
+    runtime: RuntimeOwner,
+    first: SessionHandle,
+    second: SessionHandle,
+    first_peer: Connection,
+    second_peer: Connection,
+    first_runner: tokio::task::JoinHandle<()>,
+    second_runner: tokio::task::JoinHandle<()>,
+}
+
+impl NetworkHarness {
+    async fn new() -> Self {
+        let runtime = RuntimeOwner::new(RuntimeConfig::default()).expect("legacy bridge runtime owner");
+        let first_service = runtime.root_context().component("legacy-bridge-first");
+        let second_service = runtime.root_context().component("legacy-bridge-second");
+        let (first, first_peer, first_runner) = connected_session(first_service.task_group(), "first").await;
+        let (second, second_peer, second_runner) = connected_session(second_service.task_group(), "second").await;
+        Self {
+            runtime,
+            first,
+            second,
+            first_peer,
+            second_peer,
+            first_runner,
+            second_runner,
+        }
+    }
+
+    async fn shutdown(self) {
+        drop((self.first, self.second, self.first_peer, self.second_peer));
+        self.first_runner.await.expect("first session runner");
+        self.second_runner.await.expect("second session runner");
+        let report = self.runtime.shutdown_tasks().await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+    }
+
+    fn plan_response(&self, session: &SessionHandle) -> ResponseSink {
+        let view = session.session_view();
+        let control = RequestControlView::from_meta(
+            &RequestMeta::new(Instant::now(), None),
+            view.state().clone(),
+            session.task_group(),
+        );
+        ResponseSink::network_plan(session.clone(), AdmissionClass::Data, control)
+    }
+}
+
+async fn connected_session(
+    task_group: &TaskGroup,
+    name: &'static str,
+) -> (SessionHandle, Connection, tokio::task::JoinHandle<()>) {
+    let admission = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let security = Arc::new(TransportSecurity::development_insecure_loopback(None, None));
+    let (transport, peer) = tokio::io::duplex(64 * 1024);
+    let (session_tx, session_rx) = oneshot::channel();
+    let handler = Arc::new(CaptureSession {
+        sender: Mutex::new(Some(session_tx)),
+    });
+    let session_task_group = task_group.clone();
+    let (_, runner) = task_group
+        .spawn_service_with_handle(
+            format!("legacy-bridge-{name}-session"),
+            run_connected_session(
+                Connection::new_with_plaintext_stream(transport),
+                "127.0.0.1:19241".parse().expect("local address"),
+                "127.0.0.1:19242".parse().expect("remote address"),
+                session_task_group,
+                admission,
+                security,
+                None,
+                Duration::from_secs(30),
+                handler,
+            ),
+        )
+        .expect("spawn tracked legacy bridge session");
+    (
+        session_rx.await.expect("capture connected session"),
+        Connection::new_with_plaintext_stream(peer),
+        runner,
+    )
+}
+
+#[tokio::test]
+async fn network_bridge_uses_one_real_session_and_the_adapter_stable_response_table() {
+    let harness = NetworkHarness::new().await;
+    let response = harness.plan_response(&harness.first);
+    let stable_table = PendingRequestTable::new();
+    let bridge = LegacyRequestBridge::from_network_session(&harness.first, &response, stable_table.clone())
+        .expect("canonical network bridge");
+
+    assert_eq!(
+        bridge.canonical_session_id,
+        SessionId::from_session_owner(harness.first.session_id())
+    );
+    assert!(bridge.channel.shares_inner(bridge.context.channel()));
+    assert!(bridge.channel.is_canonical_network_owner(&harness.first));
+
+    let owner = bridge
+        .channel
+        .pending_request_owner()
+        .expect("network bridge response owner")
+        .clone();
+    let foreign_table = PendingRequestTable::new();
+    let (foreign_sender, _foreign_receiver) = oneshot::channel();
+    assert!(foreign_table
+        .register_for_owner(&owner, 71, RequestDeadline::from_timeout_millis(1_000), foreign_sender,)
+        .is_err());
+
+    let (sender, receiver) = oneshot::channel();
+    let _guard = stable_table
+        .register_for_owner(&owner, 71, RequestDeadline::from_timeout_millis(1_000), sender)
+        .expect("bridge owner belongs to stable adapter table");
+    assert!(stable_table.complete_response_for_owner(
+        &owner,
+        71,
+        RemotingCommand::create_response_command_with_code(0).set_opaque(71),
+    ));
+    assert_eq!(
+        receiver
+            .await
+            .expect("stable table completion")
+            .expect("response result")
+            .opaque(),
+        71
+    );
+
+    drop((bridge, response));
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn network_bridge_request_apis_use_the_canonical_writer_and_stable_endpoint_table() {
+    let mut harness = NetworkHarness::new().await;
+    let response = harness.plan_response(&harness.first);
+    let bridge = LegacyRequestBridge::from_network_session(&harness.first, &response, PendingRequestTable::new())
+        .expect("canonical network bridge");
+
+    let send_channel = bridge.channel.clone();
+    let completion_channel = bridge.channel.clone();
+    let peer = &mut harness.first_peer;
+    let (returned, ()) = tokio::join!(
+        send_channel.send_wait_response(RemotingCommand::create_remoting_command(601).set_opaque(8_601), 1_000,),
+        async move {
+            let outbound = peer
+                .receive_command()
+                .await
+                .expect("bridge peer remains open")
+                .expect("bridge request frame decodes");
+            assert_eq!(outbound.code(), 601);
+            assert_eq!(outbound.opaque(), 8_601);
+            assert!(completion_channel.complete_pending_response(
+                RemotingCommand::create_response_command_with_code(0).set_opaque(outbound.opaque()),
+            ));
+        },
+    );
+    assert_eq!(returned.expect("stable endpoint completion").opaque(), 8_601);
+
+    bridge
+        .channel
+        .send(RemotingCommand::create_remoting_command(602).set_opaque(8_602), None)
+        .await
+        .expect("bridge send uses canonical queued writer");
+    let sent = harness
+        .first_peer
+        .receive_command()
+        .await
+        .expect("bridge peer remains open")
+        .expect("bridge send frame decodes");
+    assert_eq!((sent.code(), sent.opaque()), (602, 8_602));
+
+    bridge
+        .channel
+        .send_command(RemotingCommand::create_remoting_command(0).set_opaque(8_604))
+        .await
+        .expect("request type wins over a response-code-shaped numeric code");
+    let sent_command = harness
+        .first_peer
+        .receive_command()
+        .await
+        .expect("bridge peer remains open")
+        .expect("bridge public send command frame decodes");
+    assert_eq!((sent_command.code(), sent_command.opaque()), (0, 8_604));
+    assert!(!sent_command.is_response_type());
+    assert_eq!(bridge.channel.legacy_response_terminal_state(), None);
+
+    let mut borrowed_request = RemotingCommand::create_remoting_command(0).set_opaque(8_605);
+    bridge
+        .channel
+        .send_command_ref(&mut borrowed_request)
+        .await
+        .expect("borrowed request type bypasses the legacy response slot");
+    let sent_command_ref = harness
+        .first_peer
+        .receive_command()
+        .await
+        .expect("bridge peer remains open")
+        .expect("bridge public borrowed command frame decodes");
+    assert_eq!((sent_command_ref.code(), sent_command_ref.opaque()), (0, 8_605));
+    assert!(!sent_command_ref.is_response_type());
+    assert_eq!(bridge.channel.legacy_response_terminal_state(), None);
+
+    bridge
+        .channel
+        .send_oneway(RemotingCommand::create_remoting_command(603).set_opaque(8_603), 1_000)
+        .await
+        .expect("bridge one-way uses canonical queued writer");
+    let sent_oneway = harness
+        .first_peer
+        .receive_command()
+        .await
+        .expect("bridge peer remains open")
+        .expect("bridge one-way frame decodes");
+    assert_eq!((sent_oneway.code(), sent_oneway.opaque()), (603, 8_603));
+    assert!(sent_oneway.is_oneway_rpc());
+    assert_eq!(bridge.channel.legacy_response_terminal_state(), None);
+
+    drop((bridge, response));
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn network_bridge_fails_closed_for_cross_session_same_id_writer_and_transport_mismatches() {
+    let harness = NetworkHarness::new().await;
+    assert_ne!(harness.first.session_id(), harness.second.session_id());
+    let first_response = harness.plan_response(&harness.first);
+    let second_response = harness.plan_response(&harness.second);
+    let table = PendingRequestTable::new();
+    let bridge = LegacyRequestBridge::from_network_session(&harness.first, &first_response, table.clone())
+        .expect("first canonical bridge");
+
+    assert!(matches!(
+        bridge.validate_network(&harness.second, &second_response),
+        Err(LegacyProcessorAdapterError::SessionMismatch)
+    ));
+
+    let second_id = SessionId::from_session_owner(harness.second.session_id());
+    let mut same_id_different_writer = harness
+        .first
+        .legacy_processor_channel(first_response.clone(), table)
+        .expect("first writer channel");
+    same_id_different_writer.set_canonical_session_id_for_test(second_id);
+    let forged = LegacyRequestBridge {
+        context: Arc::new(ConnectionHandlerContextWrapper::new(same_id_different_writer.clone())),
+        channel: same_id_different_writer,
+        canonical_session_id: second_id,
+    };
+    assert!(matches!(
+        forged.validate_network(&harness.second, &second_response),
+        Err(LegacyProcessorAdapterError::WriterOwnerMismatch)
+    ));
+
+    let (local, _receiver) = ResponseSink::local();
+    assert!(matches!(
+        LegacyRequestBridge::from_network_session(&harness.first, &local, PendingRequestTable::new(),),
+        Err(LegacyProcessorAdapterError::TransportKindMismatch)
+    ));
+
+    drop((bridge, forged, first_response, second_response, local));
+    harness.shutdown().await;
+}
+
+struct EmbeddedHarness {
+    runtime: RuntimeOwner,
+    task_group: TaskGroup,
+    record: EmbeddedSessionRecord,
+    response_table: PendingRequestTable,
+}
+
+impl EmbeddedHarness {
+    fn new(name: &'static str, session_id: u64) -> Self {
+        let runtime = RuntimeOwner::new(RuntimeConfig::default()).expect("embedded bridge runtime owner");
+        let task_group = runtime.root_context().component(name).task_group().clone();
+        Self {
+            runtime,
+            task_group,
+            record: EmbeddedSessionRecord::new(session_id),
+            response_table: PendingRequestTable::new(),
+        }
+    }
+
+    fn control(&self) -> RequestControlView {
+        let view = self.record.view();
+        RequestControlView::from_meta(
+            &RequestMeta::new(Instant::now(), None),
+            view.state().clone(),
+            &self.task_group,
+        )
+    }
+
+    async fn shutdown(self) {
+        drop(self.record);
+        let report = self.runtime.shutdown_tasks().await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+    }
+}
+
+#[tokio::test]
+async fn embedded_bridge_rejects_cross_completion_owner_and_network_transport() {
+    let harness = EmbeddedHarness::new("legacy-embedded-owner", 9_794);
+    let (first, _first_receiver) = ResponseSink::local_plan(harness.control());
+    let (second, _second_receiver) = ResponseSink::local_plan(harness.control());
+    let bridge = LegacyRequestBridge::from_embedded_session(
+        &harness.record,
+        &first,
+        &harness.task_group,
+        harness.response_table.clone(),
+    )
+    .expect("canonical embedded bridge");
+
+    let owner = bridge
+        .channel
+        .pending_request_owner()
+        .expect("embedded bridge response owner")
+        .clone();
+    let foreign_table = PendingRequestTable::new();
+    let (foreign_sender, _foreign_receiver) = oneshot::channel();
+    assert!(foreign_table
+        .register_for_owner(&owner, 72, RequestDeadline::from_timeout_millis(1_000), foreign_sender,)
+        .is_err());
+    let (sender, receiver) = oneshot::channel();
+    let _guard = harness
+        .response_table
+        .register_for_owner(&owner, 72, RequestDeadline::from_timeout_millis(1_000), sender)
+        .expect("embedded bridge owner belongs to stable endpoint table");
+    assert!(harness.response_table.complete_response_for_owner(
+        &owner,
+        72,
+        RemotingCommand::create_response_command_with_code(0).set_opaque(72),
+    ));
+    assert_eq!(
+        receiver
+            .await
+            .expect("embedded stable table completion")
+            .expect("embedded response result")
+            .opaque(),
+        72
+    );
+
+    assert!(matches!(
+        bridge.validate_embedded(&harness.record, &second, &harness.task_group),
+        Err(LegacyProcessorAdapterError::CompletionOwnerMismatch)
+    ));
+
+    let (legacy_local, _legacy_receiver) = ResponseSink::local();
+    assert!(matches!(
+        LegacyRequestBridge::from_embedded_session(
+            &harness.record,
+            &legacy_local,
+            &harness.task_group,
+            harness.response_table.clone(),
+        ),
+        Err(LegacyProcessorAdapterError::CompletionOwnerMismatch)
+    ));
+
+    let network_harness = NetworkHarness::new().await;
+    let network = network_harness.plan_response(&network_harness.first);
+    assert!(matches!(
+        LegacyRequestBridge::from_embedded_session(
+            &harness.record,
+            &network,
+            &harness.task_group,
+            harness.response_table.clone(),
+        ),
+        Err(LegacyProcessorAdapterError::TransportKindMismatch)
+    ));
+
+    drop((bridge, first, second, legacy_local, network));
+    network_harness.shutdown().await;
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn embedded_constructor_rejects_foreign_session_control_from_an_equal_numbered_runtime_group() {
+    let first = EmbeddedHarness::new("legacy-embedded-session-first", 9_796);
+    let second = EmbeddedHarness::new("legacy-embedded-session-second", 9_797);
+    assert_eq!(first.task_group.id(), second.task_group.id());
+
+    let (foreign_response, _foreign_receiver) = ResponseSink::local_plan(second.control());
+    assert!(matches!(
+        LegacyRequestBridge::from_embedded_session(
+            &first.record,
+            &foreign_response,
+            &second.task_group,
+            first.response_table.clone(),
+        ),
+        Err(LegacyProcessorAdapterError::CompletionOwnerMismatch)
+    ));
+
+    drop(foreign_response);
+    second.shutdown().await;
+    first.shutdown().await;
+}
+
+#[tokio::test]
+async fn embedded_constructor_rejects_foreign_task_owner_despite_the_same_group_id() {
+    let first = EmbeddedHarness::new("legacy-embedded-task-first", 9_798);
+    let second = EmbeddedHarness::new("legacy-embedded-task-second", 9_799);
+    assert_eq!(first.task_group.id(), second.task_group.id());
+
+    let (response, _receiver) = ResponseSink::local_plan(first.control());
+    assert!(matches!(
+        LegacyRequestBridge::from_embedded_session(
+            &first.record,
+            &response,
+            &second.task_group,
+            first.response_table.clone(),
+        ),
+        Err(LegacyProcessorAdapterError::CompletionOwnerMismatch)
+    ));
+
+    drop(response);
+    second.shutdown().await;
+    first.shutdown().await;
+}
+
+enum EmbeddedDirectPath {
+    Channel,
+    ChannelRef,
+    Context,
+}
+
+async fn embedded_direct_write_then_none(path: EmbeddedDirectPath) {
+    let harness = EmbeddedHarness::new("legacy-embedded-direct-none", 9_795);
+    let (response, receiver) = ResponseSink::local_plan(harness.control());
+    let bridge = LegacyRequestBridge::from_embedded_session(
+        &harness.record,
+        &response,
+        &harness.task_group,
+        harness.response_table.clone(),
+    )
+    .expect("canonical embedded bridge");
+    let command = RemotingCommand::create_response_command_with_code(0)
+        .set_opaque(811)
+        .set_body(Bytes::from_static(b"embedded direct response"));
+
+    let processor_result: Option<RemotingCommand> = match path {
+        EmbeddedDirectPath::Channel => {
+            bridge
+                .channel
+                .send_command(command)
+                .await
+                .expect("public channel direct write uses plan completion owner");
+            None
+        }
+        EmbeddedDirectPath::ChannelRef => {
+            let mut command = command;
+            bridge
+                .channel
+                .send_command_ref(&mut command)
+                .await
+                .expect("public borrowed channel direct write uses plan completion owner");
+            None
+        }
+        EmbeddedDirectPath::Context => {
+            bridge
+                .context
+                .try_write_response(command)
+                .await
+                .expect("context direct write uses plan completion owner");
+            None
+        }
+    };
+    assert!(processor_result.is_none(), "legacy None remains ambiguous");
+
+    let plan = receiver.receive().await.expect("one direct plan handoff");
+    assert_eq!(plan.response_code(), 0);
+    let ResponseBody::Bytes(body) = plan.test_body() else {
+        panic!("direct response body must remain owned bytes");
+    };
+    assert_eq!(body.as_ref(), b"embedded direct response");
+    let duplicate = bridge
+        .context
+        .try_write_response(RemotingCommand::create_response_command_with_code(1).set_opaque(811))
+        .await;
+    assert!(matches!(
+        duplicate,
+        Err(ResponseError::AlreadyCompleted {
+            state: crate::dispatch::ResponseTerminalState::Completed
+        })
+    ));
+
+    drop((bridge, response));
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn embedded_channel_direct_write_then_none_hands_off_once_without_a_central_send() {
+    embedded_direct_write_then_none(EmbeddedDirectPath::Channel).await;
+}
+
+#[tokio::test]
+async fn embedded_borrowed_channel_direct_write_then_none_hands_off_once_without_a_central_send() {
+    embedded_direct_write_then_none(EmbeddedDirectPath::ChannelRef).await;
+}
+
+#[tokio::test]
+async fn embedded_context_direct_write_then_none_hands_off_once_without_a_central_send() {
+    embedded_direct_write_then_none(EmbeddedDirectPath::Context).await;
+}

--- a/rocketmq-transport/src/dispatch/remoting_request.rs
+++ b/rocketmq-transport/src/dispatch/remoting_request.rs
@@ -203,6 +203,20 @@ impl RemotingRequest {
         &mut self.command
     }
 
+    /// Returns the mutable command exclusively for the crate-private V1
+    /// compatibility adapter.
+    ///
+    /// Keeping this narrow alias inside the request aggregate makes the
+    /// adapter's use of the historical command contract explicit without
+    /// adding transport capabilities to the public V2 surface.
+    #[allow(
+        dead_code,
+        reason = "DSP-05 legacy access remains private and dormant until DSP-06 routing"
+    )]
+    pub(crate) fn legacy_command_mut(&mut self) -> &mut RemotingCommand {
+        &mut self.command
+    }
+
     /// Returns the request-local extension of type `T`, when one was inserted.
     ///
     /// This is allocation-free when no extension has previously been inserted.
@@ -254,6 +268,12 @@ impl RemotingRequest {
         outcome: HandlerOutcome,
     ) -> Result<HandlerOutcome, HandlerOutcomeContractError> {
         self.inline_response.resolve(self.original, outcome)
+    }
+
+    /// Consumes the affine reply state for an original one-way legacy request
+    /// without requiring its discarded command to become a response plan.
+    pub(crate) fn resolve_legacy_oneway_reply(&mut self) -> Result<(), HandlerOutcomeContractError> {
+        self.inline_response.resolve_legacy_oneway_reply()
     }
 
     #[allow(

--- a/rocketmq-transport/src/dispatch/request_control.rs
+++ b/rocketmq-transport/src/dispatch/request_control.rs
@@ -172,6 +172,15 @@ impl RequestControlView {
         }
     }
 
+    /// Proves that this control observes the supplied session and task-group
+    /// owners rather than merely matching their diagnostic identifiers.
+    pub(crate) fn same_lifecycle_owner(&self, session: &SessionStateView, parent_task_group: &TaskGroup) -> bool {
+        self.session.same_canonical_owner(session)
+            // tokio-util 0.7.19 implements token equality with Arc::ptr_eq;
+            // child tokens and independently allocated owners compare unequal.
+            && self.parent_cancellation == parent_task_group.cancellation_token()
+    }
+
     /// Returns the canonical ingress deadline, when one was supplied.
     #[must_use]
     pub const fn deadline(&self) -> Option<RequestDeadline> {

--- a/rocketmq-transport/src/dispatch/response_plan.rs
+++ b/rocketmq-transport/src/dispatch/response_plan.rs
@@ -195,6 +195,17 @@ impl ResponsePlan {
         Ok(Self::new(head, ResponseBody::Bytes(body), body_len, 1))
     }
 
+    /// Moves one legacy response command into the owned plan representation.
+    ///
+    /// The body is detached before the head is validated, so a valid contiguous
+    /// body retains its original `Bytes` allocation without cloning or decoding.
+    pub(crate) fn from_legacy_command(mut command: RemotingCommand) -> Result<Self, ResponsePlanError> {
+        match command.take_body() {
+            Some(body) => Self::bytes(command, body),
+            None => Self::command(command),
+        }
+    }
+
     /// Creates a response from ordered body-only byte segments.
     ///
     /// Empty segments are discarded. The remaining segment bytes are accepted
@@ -490,6 +501,30 @@ mod tests {
         )
         .expect("valid segmented response");
         assert_metadata(&segments, ResponseBodyKind::Segments, 9, 2);
+    }
+
+    #[test]
+    fn legacy_command_conversion_moves_the_original_bytes_owner() {
+        let body = Bytes::from_static(b"legacy response body");
+        let body_pointer = body.as_ptr();
+        let plan =
+            ResponsePlan::from_legacy_command(response_head().set_body(body)).expect("valid legacy response command");
+
+        let ResponseBody::Bytes(moved) = plan.test_body() else {
+            panic!("non-empty legacy body must remain contiguous bytes");
+        };
+        assert_eq!(moved.as_ptr(), body_pointer);
+        assert_eq!(moved.as_ref(), b"legacy response body");
+    }
+
+    #[test]
+    fn legacy_command_conversion_rejects_a_malformed_head_before_encoding() {
+        let malformed = RemotingCommand::create_remoting_command(7).set_body(Bytes::from_static(b"body"));
+
+        assert!(matches!(
+            ResponsePlan::from_legacy_command(malformed),
+            Err(ResponsePlanError::RequestHead)
+        ));
     }
 
     #[test]

--- a/rocketmq-transport/src/dispatch/response_sink.rs
+++ b/rocketmq-transport/src/dispatch/response_sink.rs
@@ -35,6 +35,8 @@ use crate::dispatch::ResponseError;
 use crate::dispatch::ResponseReceipt;
 use crate::dispatch::ResponseTerminalState;
 use crate::server::SessionHandle;
+use crate::session_view::SessionStateView;
+use rocketmq_runtime::TaskGroup;
 
 use plan::LocalPlanSenderState;
 pub(crate) use plan::LocalResponsePlanReceiver;
@@ -118,7 +120,7 @@ impl LocalResponseSink {
         }
     }
 
-    fn complete_legacy_v1(
+    fn complete_legacy_v1_legacy_mode(
         &self,
         command: RemotingCommand,
         receipt: ResponseReceipt,
@@ -144,6 +146,17 @@ impl LocalResponseSink {
                 state.terminal_state = Some(ResponseTerminalState::Closed);
                 Err(ResponseError::SessionClosed)
             }
+        }
+    }
+
+    async fn complete_legacy_v1(
+        &self,
+        command: RemotingCommand,
+        receipt: ResponseReceipt,
+    ) -> Result<ResponseReceipt, ResponseError> {
+        match &self.mode {
+            LocalResponseMode::Legacy(_) => self.complete_legacy_v1_legacy_mode(command, receipt),
+            LocalResponseMode::Plan(_) => plan::complete_local_legacy(self.clone(), command, receipt).await,
         }
     }
 
@@ -218,6 +231,74 @@ impl ResponseSink {
         matches!(self, Self::Local(_))
     }
 
+    #[allow(
+        dead_code,
+        reason = "DSP-05 bridge provenance remains dormant until DSP-06 coexistence routing"
+    )]
+    pub(crate) const fn is_network_transport(&self) -> bool {
+        matches!(self, Self::Network(_))
+    }
+
+    #[allow(
+        dead_code,
+        reason = "DSP-05 bridge provenance remains dormant until DSP-06 coexistence routing"
+    )]
+    pub(crate) fn same_completion_owner(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Network(left), Self::Network(right)) => left.same_canonical_owner(right),
+            (Self::Local(left), Self::Local(right)) => match (&left.mode, &right.mode) {
+                (LocalResponseMode::Legacy(left), LocalResponseMode::Legacy(right)) => Arc::ptr_eq(left, right),
+                (LocalResponseMode::Plan(left), LocalResponseMode::Plan(right)) => Arc::ptr_eq(left, right),
+                (LocalResponseMode::Legacy(_), LocalResponseMode::Plan(_))
+                | (LocalResponseMode::Plan(_), LocalResponseMode::Legacy(_)) => false,
+            },
+            (Self::Network(_), Self::Local(_)) | (Self::Local(_), Self::Network(_)) => false,
+        }
+    }
+
+    /// Proves that this is the local plan capability whose control observes
+    /// the supplied embedded lifecycle owners.
+    pub(crate) fn is_local_plan_owner(&self, session: &SessionStateView, task_group: &TaskGroup) -> bool {
+        matches!(
+            self,
+            Self::Local(LocalResponseSink {
+                mode: LocalResponseMode::Plan(state),
+            }) if state.control().same_lifecycle_owner(session, task_group)
+        )
+    }
+
+    #[allow(
+        dead_code,
+        reason = "DSP-05 bridge provenance remains dormant until DSP-06 coexistence routing"
+    )]
+    pub(crate) fn is_network_owner(&self, session: &SessionHandle) -> bool {
+        matches!(self, Self::Network(owner) if owner.same_canonical_owner(session))
+    }
+
+    /// Proves this is the plan-bound view of a canonical network session. A bare
+    /// compatibility sink is not sufficient for the legacy adapter because it
+    /// has no shared completion slot.
+    pub(crate) fn is_canonical_network_plan_owner(&self, session: &SessionHandle) -> bool {
+        matches!(
+            self,
+            Self::Network(owner)
+                if owner.same_canonical_owner(session) && owner.response_plan_context().is_some()
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn terminal_state(&self) -> Option<ResponseTerminalState> {
+        match self {
+            Self::Network(session) => session.response_plan_context()?.terminal_state(),
+            Self::Local(LocalResponseSink {
+                mode: LocalResponseMode::Plan(state),
+            }) => state.terminal_state(),
+            Self::Local(LocalResponseSink {
+                mode: LocalResponseMode::Legacy(state),
+            }) => state.lock().terminal_state,
+        }
+    }
+
     pub(crate) fn reserve_legacy_v1_receipt(&self) -> Result<ResponseReceipt, ResponseError> {
         let disposition = match self {
             Self::Network(_) => ResponseDisposition::TransportWritten,
@@ -232,8 +313,11 @@ impl ResponseSink {
         receipt: ResponseReceipt,
     ) -> Result<ResponseReceipt, ResponseError> {
         match self {
+            Self::Network(session) if session.response_plan_context().is_some() => {
+                plan::complete_network_legacy(Arc::clone(session), command, receipt).await
+            }
             Self::Network(session) => session.connection().send_response(command).await.map(|()| receipt),
-            Self::Local(sink) => sink.complete_legacy_v1(command, receipt),
+            Self::Local(sink) => sink.complete_legacy_v1(command, receipt).await,
         }
     }
 

--- a/rocketmq-transport/src/dispatch/response_sink/plan.rs
+++ b/rocketmq-transport/src/dispatch/response_sink/plan.rs
@@ -73,6 +73,11 @@ impl NetworkResponsePlanContext {
     }
 
     #[cfg(test)]
+    pub(crate) fn terminal_state(&self) -> Option<ResponseTerminalState> {
+        self.slot.terminal_state()
+    }
+
+    #[cfg(test)]
     fn with_enqueue_gate(mut self, checked: Arc<tokio::sync::Notify>, resume: Arc<tokio::sync::Notify>) -> Self {
         self.enqueue_gate = Some((checked, resume));
         self
@@ -133,6 +138,15 @@ impl LocalPlanSenderState {
             self.sender_taken.store(true, Ordering::Release);
         }
         sender
+    }
+
+    pub(super) const fn control(&self) -> &RequestControlView {
+        &self.control
+    }
+
+    #[cfg(test)]
+    pub(super) fn terminal_state(&self) -> Option<ResponseTerminalState> {
+        self.slot.terminal_state()
     }
 
     pub(super) fn close_last_sender(&self) {
@@ -342,6 +356,33 @@ async fn send_network_plan(
     }
 }
 
+pub(super) async fn complete_network_legacy(
+    session: Arc<SessionHandle>,
+    command: rocketmq_protocol::protocol::remoting_command::RemotingCommand,
+    receipt: ResponseReceipt,
+) -> Result<ResponseReceipt, ResponseError> {
+    let Some(context) = session.response_plan_context() else {
+        return Err(ResponseError::SessionClosed);
+    };
+    let mut claim = context.slot().claim().await?;
+    claim.observe_transport_drop(context.transport_drop_handle());
+    if let Some(stop) = current_stop(context.control()) {
+        return Err(claim.finish_stop(stop));
+    }
+
+    let mut connection = session.connection();
+    match connection.send_response(command).await {
+        Ok(()) => {
+            claim.finish(ResponseTerminalState::Completed);
+            Ok(receipt)
+        }
+        Err(error) => {
+            claim.finish(terminal_for_error(&error));
+            Err(error)
+        }
+    }
+}
+
 async fn send_local_plan(sink: LocalResponseSink, bound: BoundResponsePlan) -> Result<ResponseReceipt, ResponseError> {
     let state = match &sink.mode {
         LocalResponseMode::Plan(state) => Arc::clone(state),
@@ -361,6 +402,27 @@ async fn send_local_plan(sink: LocalResponseSink, bound: BoundResponsePlan) -> R
     let plan = ResponsePlan::from_bound_parts(head, body);
     claim.commit_local_handoff(&state, plan)?;
     Ok(ResponseReceipt::new(request_id, ResponseDisposition::InProcessAccepted))
+}
+
+pub(super) async fn complete_local_legacy(
+    sink: LocalResponseSink,
+    command: rocketmq_protocol::protocol::remoting_command::RemotingCommand,
+    receipt: ResponseReceipt,
+) -> Result<ResponseReceipt, ResponseError> {
+    let state = match &sink.mode {
+        LocalResponseMode::Plan(state) => Arc::clone(state),
+        LocalResponseMode::Legacy(_) => return Err(ResponseError::SessionClosed),
+    };
+    let claim = state.slot.claim().await?;
+    if let Some(stop) = current_stop(&state.control) {
+        return Err(claim.finish_stop(stop));
+    }
+
+    let plan = ResponsePlan::from_legacy_command(command).map_err(|error| ResponseError::Encode {
+        source: rocketmq_error::RocketMQError::response_process_failed("legacy_response_plan", error.to_string()),
+    })?;
+    claim.commit_local_handoff(&state, plan)?;
+    Ok(receipt)
 }
 
 #[derive(Clone, Copy)]
@@ -470,6 +532,14 @@ impl ResponseCompletionSlot {
         Self {
             state: parking_lot::Mutex::new(ResponseCompletionState::Open),
             changed: tokio::sync::Notify::new(),
+        }
+    }
+
+    #[cfg(test)]
+    fn terminal_state(&self) -> Option<ResponseTerminalState> {
+        match &*self.state.lock() {
+            ResponseCompletionState::Terminal { state, .. } => Some(*state),
+            ResponseCompletionState::Open | ResponseCompletionState::Claimed => None,
         }
     }
 

--- a/rocketmq-transport/src/net/channel.rs
+++ b/rocketmq-transport/src/net/channel.rs
@@ -33,6 +33,7 @@ use rocketmq_error::RocketMQError;
 use rocketmq_runtime::ShutdownReport;
 use rocketmq_runtime::TaskGroup;
 use rocketmq_runtime::TaskId;
+use tokio_util::sync::CancellationToken;
 use tracing::error;
 use uuid::Uuid;
 
@@ -50,6 +51,9 @@ use crate::dispatch::ResponseSink;
 use crate::file_region::FileRegion;
 use crate::file_region::FileRegionSequence;
 use crate::proxy_protocol::ProxyProtocolMetadata;
+use crate::server::SessionHandle;
+use crate::session_view::SessionId;
+use crate::session_view::SessionStateView;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 
 pub type ChannelId = CheetahString;
@@ -111,6 +115,30 @@ pub struct Channel {
     ///
     /// Used for logging, routing, and distinguishing channels in maps/sets.
     channel_id: ChannelId,
+
+    /// Canonical owner retained only by the crate-private legacy adapter path.
+    #[allow(
+        dead_code,
+        reason = "DSP-05 canonical ownership remains dormant until DSP-06 coexistence routing"
+    )]
+    canonical_owner: Option<CanonicalChannelOwner>,
+}
+
+#[derive(Clone)]
+#[allow(
+    dead_code,
+    reason = "DSP-05 canonical ownership remains dormant until DSP-06 coexistence routing"
+)]
+enum CanonicalChannelOwner {
+    Network {
+        session_id: SessionId,
+        owner: SessionHandle,
+    },
+    Embedded {
+        session_id: SessionId,
+        session_state: SessionStateView,
+        task_cancellation: CancellationToken,
+    },
 }
 
 impl Channel {
@@ -134,6 +162,7 @@ impl Channel {
             transport_peer_address: remote_address,
             proxy_protocol: None,
             channel_id,
+            canonical_owner: None,
         }
     }
 
@@ -148,6 +177,126 @@ impl Channel {
         channel.transport_peer_address = transport_peer_address;
         channel.proxy_protocol = proxy_protocol;
         channel
+    }
+
+    #[allow(
+        dead_code,
+        reason = "DSP-05 bridge construction remains dormant until DSP-06 coexistence routing"
+    )]
+    pub(crate) fn new_canonical_network(inner: Arc<ChannelInner>, session: SessionHandle) -> Self {
+        let mut channel = Self::new_with_proxy_protocol(
+            inner,
+            session.local_addr(),
+            session.remote_addr(),
+            session.transport_peer_addr(),
+            session.proxy_protocol().cloned(),
+        );
+        channel.set_channel_id(format!("transport-session-{}", session.session_id()));
+        channel.canonical_owner = Some(CanonicalChannelOwner::Network {
+            session_id: SessionId::from_session_owner(session.session_id()),
+            owner: session,
+        });
+        channel
+    }
+
+    #[allow(
+        dead_code,
+        reason = "DSP-05 bridge construction remains dormant until DSP-06 embedded routing"
+    )]
+    pub(crate) fn new_canonical_embedded(
+        inner: Arc<ChannelInner>,
+        session_id: SessionId,
+        session_state: SessionStateView,
+        task_group: &TaskGroup,
+    ) -> Self {
+        let address = SocketAddr::from(([127, 0, 0, 1], 0));
+        let mut channel = Self::new(inner, address, address);
+        channel.set_channel_id(format!("embedded-proxy-{}", session_id.owner_id()));
+        channel.canonical_owner = Some(CanonicalChannelOwner::Embedded {
+            session_id,
+            session_state,
+            task_cancellation: task_group.cancellation_token(),
+        });
+        channel
+    }
+
+    #[allow(
+        dead_code,
+        reason = "DSP-05 bridge validation remains dormant until DSP-06 coexistence routing"
+    )]
+    pub(crate) fn canonical_session_id(&self) -> Option<SessionId> {
+        match self.canonical_owner.as_ref() {
+            Some(CanonicalChannelOwner::Network { session_id, .. }) => Some(*session_id),
+            Some(CanonicalChannelOwner::Embedded { session_id, .. }) => Some(*session_id),
+            None => None,
+        }
+    }
+
+    #[allow(
+        dead_code,
+        reason = "DSP-05 bridge validation remains dormant until DSP-06 coexistence routing"
+    )]
+    pub(crate) fn is_canonical_network_owner(&self, session: &SessionHandle) -> bool {
+        matches!(
+            self.canonical_owner.as_ref(),
+            Some(CanonicalChannelOwner::Network { owner, .. }) if owner.same_canonical_owner(session)
+        ) && self.inner.is_network()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_canonical_session_id_for_test(&mut self, session_id: SessionId) {
+        match self.canonical_owner.as_mut() {
+            Some(CanonicalChannelOwner::Network {
+                session_id: owner_session_id,
+                ..
+            })
+            | Some(CanonicalChannelOwner::Embedded {
+                session_id: owner_session_id,
+                ..
+            }) => *owner_session_id = session_id,
+            None => {}
+        }
+    }
+
+    #[allow(
+        dead_code,
+        reason = "DSP-05 bridge validation remains dormant until DSP-06 embedded routing"
+    )]
+    pub(crate) fn is_canonical_embedded_owner(
+        &self,
+        session_id: SessionId,
+        session_state: &SessionStateView,
+        response: &ResponseSink,
+        task_group: &TaskGroup,
+    ) -> bool {
+        matches!(
+            self.canonical_owner.as_ref(),
+            Some(CanonicalChannelOwner::Embedded {
+                session_id: owner_session_id,
+                session_state: owner_session_state,
+                task_cancellation,
+            }) if *owner_session_id == session_id
+                && owner_session_state.same_canonical_owner(session_state)
+                // tokio-util 0.7.19 implements equality with Arc::ptr_eq.
+                && *task_cancellation == task_group.cancellation_token()
+        ) && self.inner.is_local_response_owner(response)
+            && response.is_local_plan_owner(session_state, task_group)
+    }
+
+    #[allow(
+        dead_code,
+        reason = "DSP-05 bridge validation remains dormant until DSP-06 coexistence routing"
+    )]
+    pub(crate) fn shares_inner(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+
+    #[allow(
+        dead_code,
+        reason = "DSP-05 bridge validation remains dormant until DSP-06 coexistence routing"
+    )]
+    pub(crate) fn is_network_transport(&self) -> bool {
+        self.inner.is_network()
     }
 
     // === Address Mutators ===
@@ -271,6 +420,20 @@ impl Channel {
 
     pub(crate) fn pending_request_owner(&self) -> Option<&PendingRequestOwner> {
         self.inner.pending_request_owner()
+    }
+
+    /// Routes one response through this channel's stable correlation owner.
+    #[allow(
+        dead_code,
+        reason = "DSP-05 endpoint correlation remains dormant until DSP-06 response routing"
+    )]
+    pub(crate) fn complete_pending_response(&self, response: RemotingCommand) -> bool {
+        self.inner.complete_pending_response(response)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn legacy_response_terminal_state(&self) -> Option<crate::dispatch::ResponseTerminalState> {
+        self.inner.legacy_response_terminal_state()
     }
 
     pub(crate) async fn send_response(&self, command: RemotingCommand) -> Result<ResponseReceipt, ResponseError> {
@@ -520,6 +683,10 @@ pub struct ChannelInner {
     /// Correlation generation owned by this physical connection.
     pending_request_owner: Option<PendingRequestOwner>,
 
+    /// Plan-bound completion owner for response-shaped public writes made by
+    /// a legacy processor. Ordinary channels leave this absent.
+    legacy_plan_response: Option<ResponseSink>,
+
     /// Tracks the outbound send task for shutdown diagnostics.
     send_task_group: TaskGroup,
     send_task_id: Option<TaskId>,
@@ -650,6 +817,31 @@ impl ChannelInner {
             connection_state: ConnectionStateHandle::healthy(),
             response_table: PendingRequestTable::new(),
             pending_request_owner: None,
+            legacy_plan_response: None,
+            send_task_group: task_group,
+            send_task_id: None,
+        }
+    }
+
+    #[allow(
+        dead_code,
+        reason = "DSP-05 embedded bridge construction remains dormant until DSP-06 routing"
+    )]
+    pub(crate) fn new_local_legacy_bridge(
+        response: ResponseSink,
+        task_group: TaskGroup,
+        response_table: PendingRequestTable,
+    ) -> Self {
+        let (outbound_queue_tx, outbound_queue_rx) = flume::bounded(0);
+        drop(outbound_queue_rx);
+        let pending_request_owner = Some(response_table.new_owner());
+        Self {
+            outbound_queue_tx: parking_lot::Mutex::new(Some(outbound_queue_tx)),
+            connection: ChannelIo::Local(response.clone()),
+            connection_state: ConnectionStateHandle::healthy(),
+            response_table,
+            pending_request_owner,
+            legacy_plan_response: Some(response),
             send_task_group: task_group,
             send_task_id: None,
         }
@@ -707,7 +899,9 @@ impl ChannelInner {
     ///
     /// Unlike `new_transport_session`, this does not register another fixed child. The caller
     /// chooses the registration lifetime and the returned `ChannelInner` keeps the supplied
-    /// group alive for exactly as long as the snapshot remains reachable.
+    /// group alive for exactly as long as the snapshot remains reachable. Its
+    /// request APIs write through the supplied queued connection directly and
+    /// therefore do not create a second background send task.
     pub(crate) fn new_transport_session_with_task_group(
         connection: Connection,
         response_table: PendingRequestTable,
@@ -715,6 +909,17 @@ impl ChannelInner {
     ) -> rocketmq_error::RocketMQResult<Self> {
         let pending_request_owner = Some(response_table.new_owner());
         Self::try_new_with_send_task_group(connection, response_table, pending_request_owner, task_group, false)
+    }
+
+    pub(crate) fn new_legacy_network_bridge(
+        connection: Connection,
+        response: ResponseSink,
+        response_table: PendingRequestTable,
+        task_group: TaskGroup,
+    ) -> rocketmq_error::RocketMQResult<Self> {
+        let mut inner = Self::new_transport_session_with_task_group(connection, response_table, task_group)?;
+        inner.legacy_plan_response = Some(response);
+        Ok(inner)
     }
 
     fn try_new_with_send_task_group(
@@ -728,7 +933,7 @@ impl ChannelInner {
 
         // Use flume bounded channel for better performance
         // flume provides lock-free operations and better throughput than tokio::mpsc
-        let (outbound_queue_tx, outbound_queue_rx) = flume::bounded(if start_send_task { QUEUE_CAPACITY } else { 0 });
+        let (outbound_queue_tx, outbound_queue_rx) = flume::bounded(QUEUE_CAPACITY);
 
         let connection_state = connection.state_handle();
         let connection = Arc::new(tokio::sync::Mutex::new(connection));
@@ -751,11 +956,12 @@ impl ChannelInner {
             None
         };
         Ok(Self {
-            outbound_queue_tx: parking_lot::Mutex::new(Some(outbound_queue_tx)),
+            outbound_queue_tx: parking_lot::Mutex::new(start_send_task.then_some(outbound_queue_tx)),
             connection: ChannelIo::Network(connection),
             connection_state,
             response_table,
             pending_request_owner,
+            legacy_plan_response: None,
             send_task_group: task_group,
             send_task_id,
         })
@@ -806,6 +1012,49 @@ impl ChannelInner {
         self.pending_request_owner.as_ref()
     }
 
+    #[allow(
+        dead_code,
+        reason = "DSP-05 endpoint correlation remains dormant until DSP-06 response routing"
+    )]
+    fn complete_pending_response(&self, response: RemotingCommand) -> bool {
+        let Some(owner) = self.pending_request_owner.as_ref() else {
+            return false;
+        };
+        let opaque = response.opaque();
+        self.response_table.complete_response_for_owner(owner, opaque, response)
+    }
+
+    #[cfg(test)]
+    fn legacy_response_terminal_state(&self) -> Option<crate::dispatch::ResponseTerminalState> {
+        self.legacy_plan_response.as_ref()?.terminal_state()
+    }
+
+    fn direct_network_connection(&self) -> Option<&Arc<tokio::sync::Mutex<Connection>>> {
+        match (&self.connection, self.send_task_id) {
+            (ChannelIo::Network(connection), None) => Some(connection),
+            (ChannelIo::Network(_), Some(_)) | (ChannelIo::Local(_), _) => None,
+        }
+    }
+
+    #[allow(
+        dead_code,
+        reason = "DSP-05 bridge validation remains dormant until DSP-06 coexistence routing"
+    )]
+    fn is_network(&self) -> bool {
+        matches!(&self.connection, ChannelIo::Network(_))
+    }
+
+    #[allow(
+        dead_code,
+        reason = "DSP-05 bridge validation remains dormant until DSP-06 embedded routing"
+    )]
+    fn is_local_response_owner(&self, response: &ResponseSink) -> bool {
+        match &self.connection {
+            ChannelIo::Local(owner) => owner.same_completion_owner(response),
+            ChannelIo::Network(_) => false,
+        }
+    }
+
     fn outbound_queue_sender(&self) -> rocketmq_error::RocketMQResult<Sender<ChannelMessage>> {
         self.outbound_queue_tx
             .lock()
@@ -828,6 +1077,15 @@ impl ChannelInner {
 
     /// Sends a command through the serialized writer capability.
     pub async fn send_command(&self, command: RemotingCommand) -> rocketmq_error::RocketMQResult<()> {
+        // Request and response numeric codes overlap; only the protocol response
+        // flag selects the legacy completion owner.
+        if command.is_response_type() && self.legacy_plan_response.is_some() {
+            return self
+                .send_response(command)
+                .await
+                .map(|_| ())
+                .map_err(legacy_response_error);
+        }
         match &self.connection {
             ChannelIo::Network(connection) => connection.lock().await.send_command(command).await,
             ChannelIo::Local(response) => response.send(command).await.map_err(response_sink_error),
@@ -835,6 +1093,10 @@ impl ChannelInner {
     }
 
     pub(crate) async fn send_response(&self, command: RemotingCommand) -> Result<ResponseReceipt, ResponseError> {
+        if let Some(response) = self.legacy_plan_response.as_ref() {
+            let receipt = response.reserve_legacy_v1_receipt()?;
+            return response.complete_legacy_v1_reserved(command, receipt).await;
+        }
         match &self.connection {
             ChannelIo::Network(connection) => {
                 let receipt = ResponseReceipt::legacy_v1(ResponseDisposition::TransportWritten)?;
@@ -915,6 +1177,15 @@ impl ChannelInner {
 
     /// Sends a borrowed command through the serialized writer capability.
     pub async fn send_command_ref(&self, command: &mut RemotingCommand) -> rocketmq_error::RocketMQResult<()> {
+        // Keep request-shaped commands on the outbound request path even when
+        // their numeric code is also a valid response code.
+        if command.is_response_type() && self.legacy_plan_response.is_some() {
+            return self
+                .send_response_ref(command)
+                .await
+                .map(|_| ())
+                .map_err(legacy_response_error);
+        }
         match &self.connection {
             ChannelIo::Network(connection) => connection.lock().await.send_command_ref(command).await,
             ChannelIo::Local(response) => {
@@ -929,6 +1200,12 @@ impl ChannelInner {
         &self,
         command: &mut RemotingCommand,
     ) -> Result<ResponseReceipt, ResponseError> {
+        if let Some(response) = self.legacy_plan_response.as_ref() {
+            let receipt = response.reserve_legacy_v1_receipt()?;
+            let owned = command.clone();
+            let _ = command.take_body();
+            return response.complete_legacy_v1_reserved(owned, receipt).await;
+        }
         match &self.connection {
             ChannelIo::Network(connection) => {
                 let receipt = ResponseReceipt::legacy_v1(ResponseDisposition::TransportWritten)?;
@@ -1014,17 +1291,39 @@ impl ChannelInner {
                 .register_for_owner_with_bytes(owner, opaque, deadline, retained_bytes, response_tx)?;
         let reservation = ResponseReservation::Pending(guard.token());
 
-        // Enqueue request with response tracking
-        let outbound_queue_tx = self.outbound_queue_sender()?;
         deadline.ensure_before_send("channel")?;
-        outbound_queue_tx
-            .try_send((request, Some(reservation), Some(deadline), Some(progress.clone())))
-            .map_err(|error| match error {
-                flume::TrySendError::Full(_) => RocketMQError::network_queue_full("channel"),
-                flume::TrySendError::Disconnected(_) => {
-                    RocketMQError::network_connection_failed("channel", "outbound queue is closed")
+        if let Some(connection) = self.direct_network_connection() {
+            let mut connection = deadline
+                .timeout(connection.lock())
+                .await
+                .map_err(|_| RocketMQError::network_deadline_exceeded_before_send("channel"))?;
+            deadline.ensure_before_send("channel")?;
+            progress.set(OUTBOUND_WRITING);
+            if let Err(error) = connection
+                .send_command_with_deadline(request, deadline, "channel")
+                .await
+            {
+                if matches!(
+                    error,
+                    RocketMQError::Network(rocketmq_error::NetworkError::DeadlineExceededBeforeSend { .. })
+                ) {
+                    progress.set(OUTBOUND_FAILED_BEFORE_SEND);
                 }
-            })?;
+                return Err(error);
+            }
+            progress.set(OUTBOUND_SENT);
+        } else {
+            // Enqueue request with response tracking.
+            let outbound_queue_tx = self.outbound_queue_sender()?;
+            outbound_queue_tx
+                .try_send((request, Some(reservation), Some(deadline), Some(progress.clone())))
+                .map_err(|error| match error {
+                    flume::TrySendError::Full(_) => RocketMQError::network_queue_full("channel"),
+                    flume::TrySendError::Disconnected(_) => {
+                        RocketMQError::network_connection_failed("channel", "outbound queue is closed")
+                    }
+                })?;
+        }
 
         // Wait for response with timeout
         match deadline.timeout(&mut response_rx).await {
@@ -1074,6 +1373,17 @@ impl ChannelInner {
             return response.send(request).await.map_err(response_sink_error);
         }
 
+        if let Some(connection) = self.direct_network_connection() {
+            let mut connection = deadline
+                .timeout(connection.lock())
+                .await
+                .map_err(|_| RocketMQError::network_deadline_exceeded_before_send("channel"))?;
+            deadline.ensure_before_send("channel")?;
+            return connection
+                .send_command_with_deadline(request, deadline, "channel")
+                .await;
+        }
+
         let outbound_queue_tx = self.outbound_queue_sender()?;
         deadline.ensure_before_send("channel")?;
         outbound_queue_tx
@@ -1112,6 +1422,23 @@ impl ChannelInner {
         if let ChannelIo::Local(response) = &self.connection {
             return response.send(request).await.map_err(response_sink_error);
         }
+        if let Some(connection) = self.direct_network_connection() {
+            let mut connection = match deadline {
+                Some(deadline) => deadline
+                    .timeout(connection.lock())
+                    .await
+                    .map_err(|_| RocketMQError::network_deadline_exceeded_before_send("channel"))?,
+                None => connection.lock().await,
+            };
+            return match deadline {
+                Some(deadline) => {
+                    connection
+                        .send_command_with_deadline(request, deadline, "channel")
+                        .await
+                }
+                None => connection.send_command(request).await,
+            };
+        }
         let outbound_queue_tx = self.outbound_queue_sender()?;
         outbound_queue_tx
             .try_send((request, None, deadline, None))
@@ -1139,6 +1466,10 @@ impl ChannelInner {
 
 fn response_sink_error(error: crate::dispatch::ResponseSinkError) -> RocketMQError {
     RocketMQError::response_process_failed("embedded_response_sink", error.to_string())
+}
+
+fn legacy_response_error(error: ResponseError) -> RocketMQError {
+    RocketMQError::response_process_failed("legacy_response_sink", error.to_string())
 }
 
 #[cfg(test)]

--- a/rocketmq-transport/src/remoting.rs
+++ b/rocketmq-transport/src/remoting.rs
@@ -66,6 +66,23 @@ pub(crate) mod inner {
         Ok(())
     }
 
+    const REJECT_REQUEST_MSG: &str = "[REJECT REQUEST]system busy, start flow control for a while";
+
+    pub(crate) fn legacy_rejection_response(
+        rejection: crate::runtime::processor::RejectRequestResponse,
+    ) -> Option<RemotingCommand> {
+        let (rejected, response) = rejection;
+        rejected.then(|| {
+            response.unwrap_or_else(|| {
+                RemotingCommand::create_response_command_with_code_remark(ResponseCode::SystemBusy, REJECT_REQUEST_MSG)
+            })
+        })
+    }
+
+    pub(crate) fn legacy_processor_error_response() -> RemotingCommand {
+        RemotingCommand::create_response_command_with_code(ResponseCode::SystemError)
+    }
+
     pub(crate) struct RemotingGeneralHandler<RP> {
         pub(crate) request_processor: RP,
         rpc_hooks: HookRegistry,
@@ -145,17 +162,7 @@ pub(crate) mod inner {
                 is_long_polling_request(request_code),
             );
             let mut request_processor = self.request_processor.clone();
-            let reject_request = request_processor.reject_request(request_code);
-            const REJECT_REQUEST_MSG: &str = "[REJECT REQUEST]system busy, start flow control for a while";
-            if reject_request.0 {
-                let response = if let Some(response) = reject_request.1 {
-                    response
-                } else {
-                    RemotingCommand::create_response_command_with_code_remark(
-                        ResponseCode::SystemBusy,
-                        REJECT_REQUEST_MSG,
-                    )
-                };
+            if let Some(response) = legacy_rejection_response(request_processor.reject_request(request_code)) {
                 let response_code = response.code();
                 let write_started = Instant::now();
                 let result = ctx.channel().send_command(response.set_opaque(opaque)).await;
@@ -207,9 +214,7 @@ pub(crate) mod inner {
                     Ok(result) => result,
                     Err(_err) => {
                         metrics_guard.complete_process_request_failed(ResponseCode::SystemError.to_i32());
-                        Some(RemotingCommand::create_response_command_with_code(
-                            ResponseCode::SystemError,
-                        ))
+                        Some(legacy_processor_error_response())
                     }
                 }
             };
@@ -327,7 +332,7 @@ pub(crate) mod inner {
     }
 
     #[inline]
-    fn is_long_polling_request(request_code: i32) -> bool {
+    pub(crate) fn is_long_polling_request(request_code: i32) -> bool {
         matches!(
             RequestCode::from(request_code),
             RequestCode::PullMessage

--- a/rocketmq-transport/src/server.rs
+++ b/rocketmq-transport/src/server.rs
@@ -49,6 +49,7 @@ use crate::admission::AdmissionController;
 use crate::admission::AdmissionResource;
 use crate::admission::AdmissionScope;
 use crate::admission::AdmissionScopeHandle;
+use crate::base::pending_request_table::PendingRequestTable;
 use crate::codec::remoting_command_codec::FrameLimits;
 use crate::config::SocketOptions;
 use crate::config::TlsConfig;
@@ -66,6 +67,8 @@ use crate::dispatch::OriginalRequestIdentity;
 use crate::dispatch::RequestContext;
 use crate::dispatch::ResponseSink;
 use crate::file_region::FileTransferMode;
+use crate::net::channel::Channel;
+use crate::net::channel::ChannelInner;
 use crate::proxy_protocol::read_proxy_protocol;
 use crate::proxy_protocol::ProxyProtocolConfig;
 use crate::proxy_protocol::ProxyProtocolMetadata;
@@ -164,6 +167,32 @@ pub struct SessionHandle {
 impl SessionHandle {
     pub fn session_id(&self) -> u64 {
         self.send.session_id
+    }
+
+    #[allow(
+        dead_code,
+        reason = "DSP-05 bridge ownership remains dormant until DSP-06 coexistence routing"
+    )]
+    pub(crate) fn same_canonical_owner(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.send, &other.send)
+    }
+
+    #[allow(
+        dead_code,
+        reason = "DSP-05 bridge construction remains dormant until DSP-06 coexistence routing"
+    )]
+    pub(crate) fn legacy_processor_channel(
+        &self,
+        response: ResponseSink,
+        response_table: PendingRequestTable,
+    ) -> RocketMQResult<Channel> {
+        let inner = ChannelInner::new_legacy_network_bridge(
+            self.connection(),
+            response,
+            response_table,
+            self.task_group().clone(),
+        )?;
+        Ok(Channel::new_canonical_network(Arc::new(inner), self.clone()))
     }
 
     pub fn local_addr(&self) -> SocketAddr {

--- a/rocketmq-transport/src/session_view.rs
+++ b/rocketmq-transport/src/session_view.rs
@@ -154,6 +154,11 @@ impl SessionStateView {
         Self { state_rx, closed_rx }
     }
 
+    /// Proves that both views observe the same pair of lifecycle publishers.
+    pub(crate) fn same_canonical_owner(&self, other: &Self) -> bool {
+        self.state_rx.same_channel(&other.state_rx) && self.closed_rx.same_channel(&other.closed_rx)
+    }
+
     /// Returns whether the session is currently accepting inbound work.
     #[must_use]
     pub fn is_healthy(&self) -> bool {

--- a/rocketmq-transport/src/telemetry.rs
+++ b/rocketmq-transport/src/telemetry.rs
@@ -23,6 +23,9 @@ fn request_identity_span(identity: crate::dispatch::OriginalRequestIdentity) -> 
     )
 }
 
+#[cfg(test)]
+type LegacyProcessorRequestCapture = std::sync::Arc<parking_lot::Mutex<Vec<(&'static str, i32)>>>;
+
 /// Cloneable metrics and tracing capability for one transport composition.
 ///
 /// A no-op value is explicit and never consults process-global OpenTelemetry state.
@@ -34,6 +37,8 @@ pub struct TransportTelemetry {
     client: rocketmq_observability::metrics::client::ClientMetrics,
     #[cfg(any(feature = "observability", feature = "observability-traces"))]
     handle: Option<rocketmq_observability::TelemetryHandle>,
+    #[cfg(test)]
+    legacy_processor_requests: Option<LegacyProcessorRequestCapture>,
 }
 
 impl TransportTelemetry {
@@ -53,7 +58,24 @@ impl TransportTelemetry {
             #[cfg(feature = "observability")]
             client: rocketmq_observability::metrics::client::ClientMetrics::from_handle(telemetry),
             handle: Some(telemetry.clone()),
+            #[cfg(test)]
+            legacy_processor_requests: None,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_legacy_processor_request_capture() -> (Self, LegacyProcessorRequestCapture) {
+        let capture = std::sync::Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let telemetry = Self {
+            #[cfg(feature = "observability")]
+            remoting: Default::default(),
+            #[cfg(feature = "observability")]
+            client: Default::default(),
+            #[cfg(any(feature = "observability", feature = "observability-traces"))]
+            handle: None,
+            legacy_processor_requests: Some(std::sync::Arc::clone(&capture)),
+        };
+        (telemetry, capture)
     }
 
     #[inline]
@@ -124,6 +146,24 @@ impl TransportTelemetry {
 
         #[cfg(not(feature = "observability"))]
         let _ = (latency, event);
+    }
+
+    #[inline]
+    #[allow(
+        dead_code,
+        reason = "DSP-05 adapter metrics remain dormant until DSP-06 coexistence routing"
+    )]
+    pub(crate) fn record_legacy_processor_request(&self, processor: &'static str, request_code: i32) {
+        #[cfg(test)]
+        if let Some(capture) = &self.legacy_processor_requests {
+            capture.lock().push((processor, request_code));
+        }
+
+        #[cfg(feature = "observability")]
+        self.remoting.record_legacy_processor_request(processor, request_code);
+
+        #[cfg(not(feature = "observability"))]
+        let _ = (processor, request_code);
     }
 
     #[inline]
@@ -326,6 +366,7 @@ mod tests {
         telemetry.record_outbound_written_plaintext_bytes(128);
         telemetry.record_lifecycle_event("connected", "queued");
         telemetry.record_lifecycle_listener_latency(std::time::Duration::from_millis(1), "connected");
+        telemetry.record_legacy_processor_request("noop-legacy", 10);
         telemetry.record_nameserver_failover(TransportNameServerFailoverReason::ConnectFailure);
         telemetry.record_go_away(TransportGoAwayOutcome::Received);
         let identity = crate::dispatch::OriginalRequestIdentity::capture(

--- a/scripts/generate_metric_catalog.py
+++ b/scripts/generate_metric_catalog.py
@@ -30,7 +30,7 @@ SCHEMA_DIR = ROOT / "rocketmq-observability" / "src" / "metrics" / "catalog" / "
 GENERATED_PATH = ROOT / "rocketmq-observability" / "src" / "metrics" / "catalog" / "generated.rs"
 SEMANTIC_PATH = ROOT / "rocketmq-observability" / "src" / "semantic.rs"
 SCHEMA_VERSION = 1
-PARTITIONS = (("java", 0, 94), ("rust", 94, 121))
+PARTITIONS = (("java", 0, 94), ("rust", 94, 122))
 KIND_NAMES = {"Counter", "Gauge", "Histogram", "ObservableGauge", "UpDownCounter"}
 SOURCE_NAMES = {
     "Broker",


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9794

### Brief Description

Add a crate-private adapter that executes existing V1 `RequestProcessor` implementations through the V2 authorized dispatch core while preserving V1 hook, rejection, one-way, direct-write, response-observation, and ambiguous-`None` behavior.

The adapter owns one stable pending-request table, derives bridge capabilities from canonical session owners, and shares the central response completion slot with legacy direct writes for both network and embedded dispatch. The V2 fast path remains channel-free, the transport public API and production registration remain unchanged, and a low-cardinality admitted-request metric records legacy adapter usage.

The implementation also adds causal tests for owner provenance, public owned/borrowed `Channel` writes, request/response wire-type separation, stable request correlation, original one-way precedence, and post-start deadline races without central retries.

### How Did You Test This Change?

- `cargo check -p rocketmq-transport`
- `cargo test -p rocketmq-transport`
- `cargo clippy -p rocketmq-transport --all-targets -- -D warnings`
- `cargo clippy -p rocketmq-transport --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo fmt -p rocketmq-transport -- --check`
- `cargo fmt -p rocketmq-observability -- --check`
- Observability library tests across the supported feature combinations
- Observability metric catalog and public API contract tests
- `python scripts/generate_metric_catalog.py --check`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `.\scripts\check-error-hygiene.ps1`
- `git diff --check`

The full observability package tests retain one pre-existing `subscriber_installation_sites_are_tracked` failure caused by the unchanged authentication builder; the exact failure was reproduced from the base commit. The Python error architecture guard likewise retains the exact same 17 source-stringification and one redaction findings reproduced from the base commit. Ordinary Rustdoc validation passed; strict warning promotion encounters only pre-existing warnings in unchanged files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added compatibility support for processing legacy V1 requests through the modern dispatch flow.
  - Improved handling of legacy replies, one-way requests, deadlines, rejections, and processor errors.
  - Added safer response delivery across network and local transport paths.
  - Added telemetry for legacy processor requests, including processor and request-code details.

- **Bug Fixes**
  - Improved validation of request ownership and transport context.
  - Prevented ambiguous or malformed legacy responses from being incorrectly delivered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->