### PR TITLE
[ISSUE #9800]🚀Add coexisting V1 and V2 authorized dispatcher entry points

### DIFF
--- a/rocketmq-transport/src/base/pending_request_table.rs
+++ b/rocketmq-transport/src/base/pending_request_table.rs
@@ -108,6 +108,13 @@ impl PendingRequestOwner {
     fn retire(&self) {
         self.accepting.store(false, Ordering::Release);
     }
+
+    pub(crate) fn same_owner(&self, other: &Self) -> bool {
+        self.table_id == other.table_id
+            && self.id == other.id
+            && Arc::ptr_eq(&self.accepting, &other.accepting)
+            && Arc::ptr_eq(&self.completion, &other.completion)
+    }
 }
 
 struct PendingRequest {

--- a/rocketmq-transport/src/dispatch.rs
+++ b/rocketmq-transport/src/dispatch.rs
@@ -25,12 +25,9 @@ mod response_plan;
 mod response_sink;
 
 pub use authorized_dispatcher::AuthorizedCommandDispatcher;
-#[allow(
-    unused_imports,
-    reason = "DSP-03 exposes the private V2 dispatcher core to later coexistence routing"
-)]
-pub(crate) use authorized_dispatcher::AuthorizedCommandDispatcherV2;
+pub use authorized_dispatcher::AuthorizedCommandDispatcherV2;
 pub use authorized_dispatcher::AuthorizedDispatchBoundary;
+pub(crate) use authorized_dispatcher::AuthorizedDispatchSession;
 #[allow(
     unused_imports,
     reason = "DSP-03 exposes the private V2 dispatcher failure to later coexistence routing"
@@ -49,12 +46,15 @@ pub(crate) use handler_outcome::InlineResponseSlot;
 pub use handler_outcome::ProtocolNoResponse;
 pub use handler_outcome::ProtocolNoResponseError;
 pub use handler_outcome::ProtocolNoResponseReason;
+#[cfg(test)]
+pub(crate) use legacy_processor_adapter::bridge_construction_counts;
 pub(crate) use legacy_processor_adapter::DispatchMetricsGuard;
 pub(crate) use legacy_processor_adapter::DispatchProcessor;
 pub(crate) use legacy_processor_adapter::DispatchProcessorError;
 pub(crate) use legacy_processor_adapter::ExplicitV2Processor;
 pub(crate) use legacy_processor_adapter::InternalProcessorCandidate;
 pub(crate) use legacy_processor_adapter::InternalProcessorOutcome;
+pub(crate) use legacy_processor_adapter::LegacyNetworkSession;
 pub(crate) use legacy_processor_adapter::LegacyProcessorAdapter;
 pub(crate) use legacy_processor_adapter::LegacyProcessorAdapterError;
 pub(crate) use legacy_processor_adapter::LegacyReplyCandidate;

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher.rs
@@ -19,6 +19,7 @@ use std::net::SocketAddr;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::Duration;
+use std::time::Instant;
 
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
@@ -58,6 +59,7 @@ use crate::remoting::inner::RemotingGeneralHandler;
 use crate::request_ordering::RequestOrdering;
 use crate::runtime::connection_handler_context::ConnectionHandlerContextWrapper;
 use crate::runtime::processor::RequestProcessor;
+use crate::runtime::processor_v2::RequestProcessorV2;
 use crate::runtime::RPCHook;
 use crate::security::TransportSecurity;
 use crate::session_executor::SessionDispatchError;
@@ -67,8 +69,8 @@ use crate::telemetry::TransportTelemetry;
 
 mod v2;
 
-pub(crate) use v2::AuthorizedCommandDispatcherV2;
 pub(crate) use v2::AuthorizedDispatchV2Error;
+pub(crate) use v2::AuthorizedDispatcherCore;
 
 /// Result of submitting a command to the shared dispatch boundary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -125,6 +127,18 @@ impl AuthorizedDispatchBoundary {
         self.security.profile()
     }
 
+    pub(crate) fn has_security_owner(&self, security: &Arc<TransportSecurity>) -> bool {
+        Arc::ptr_eq(&self.security, security)
+    }
+
+    pub(crate) fn security_owner(&self) -> Arc<TransportSecurity> {
+        Arc::clone(&self.security)
+    }
+
+    pub(crate) fn has_admission_owner(&self, admission: &Arc<AdmissionController>) -> bool {
+        Arc::ptr_eq(&self.admission, admission)
+    }
+
     pub(crate) fn session(
         self: &Arc<Self>,
         task_group: &TaskGroup,
@@ -135,6 +149,77 @@ impl AuthorizedDispatchBoundary {
             session_id: scope.session_id(),
             executor: SessionExecutor::try_new(task_group, scope)?,
         })
+    }
+}
+
+/// Public network dispatcher for the V2 request-processor contract.
+///
+/// The facade owns one security/admission boundary and one statically
+/// monomorphized V2 processor core. It does not construct legacy channel or
+/// pending-response capabilities.
+pub struct AuthorizedCommandDispatcherV2<P> {
+    boundary: Arc<AuthorizedDispatchBoundary>,
+    core: Arc<AuthorizedDispatcherCore<crate::dispatch::ExplicitV2Processor<P>>>,
+}
+
+impl<P> AuthorizedCommandDispatcherV2<P>
+where
+    P: RequestProcessorV2 + Clone + Sync + 'static,
+{
+    /// Creates a network-only V2 dispatcher.
+    #[must_use]
+    pub fn new(
+        request_processor: P,
+        rpc_hooks: Vec<Arc<dyn RPCHook>>,
+        security: Arc<TransportSecurity>,
+        admission: Arc<AdmissionController>,
+    ) -> Self {
+        Self {
+            boundary: Arc::new(AuthorizedDispatchBoundary::new(security, admission)),
+            core: Arc::new(AuthorizedDispatcherCore::new(request_processor, rpc_hooks)),
+        }
+    }
+
+    /// Returns the exact security and admission boundary used by this dispatcher.
+    #[must_use]
+    pub fn boundary(&self) -> Arc<AuthorizedDispatchBoundary> {
+        Arc::clone(&self.boundary)
+    }
+
+    pub(crate) fn register_rpc_hook(&self, hook: Arc<dyn RPCHook>) {
+        self.core.register_rpc_hook(hook);
+    }
+
+    pub(crate) async fn dispatch_network(
+        &self,
+        authorized_session: &AuthorizedDispatchSession,
+        session: crate::server::SessionHandle,
+        context: RequestContext,
+        command: RemotingCommand,
+        received_at: Instant,
+        retained_bytes: usize,
+        partial_frame_permit: Option<PartialFramePermit>,
+    ) -> Result<DispatchOutcome, AuthorizedDispatchV2Error> {
+        self.core
+            .dispatch_network(
+                authorized_session,
+                (),
+                session,
+                context,
+                command,
+                received_at,
+                retained_bytes,
+                partial_frame_permit,
+            )
+            .await
+    }
+
+    pub(crate) fn complete_network_response(&self, response: RemotingCommand) {
+        self.core.complete_network_response(&(), response);
+    }
+
+    pub(crate) fn close_network_session(&self) {
+        self.core.close_network_session(&());
     }
 }
 
@@ -247,6 +332,7 @@ impl AuthorizedDispatchSession {
 pub struct AuthorizedCommandDispatcher<RP> {
     boundary: Arc<AuthorizedDispatchBoundary>,
     handler: Arc<RemotingGeneralHandler<RP>>,
+    network: Arc<AuthorizedDispatcherCore<crate::dispatch::LegacyProcessorAdapter<RP>>>,
 }
 
 impl<RP> AuthorizedCommandDispatcher<RP>
@@ -279,14 +365,24 @@ where
                 error.to_string(),
             )
         })?;
+        let boundary = Arc::new(AuthorizedDispatchBoundary::new(security, admission));
+        let network_processor = request_processor.clone();
+        let handler = Arc::new(RemotingGeneralHandler::new_with_telemetry(
+            request_processor,
+            rpc_hooks.clone(),
+            response_table.clone(),
+            telemetry.clone(),
+        ));
+        let adapter = crate::dispatch::LegacyProcessorAdapter::new(
+            network_processor,
+            std::any::type_name::<RP>(),
+            telemetry,
+            response_table,
+        );
         Ok(Self {
-            boundary: Arc::new(AuthorizedDispatchBoundary::new(security, admission)),
-            handler: Arc::new(RemotingGeneralHandler::new_with_telemetry(
-                request_processor,
-                rpc_hooks,
-                response_table,
-                telemetry,
-            )),
+            boundary,
+            handler,
+            network: Arc::new(AuthorizedDispatcherCore::new_legacy(adapter, rpc_hooks)),
         })
     }
 
@@ -296,23 +392,49 @@ where
         Arc::clone(&self.boundary)
     }
 
-    pub(crate) fn response_table(&self) -> PendingRequestTable {
-        self.handler.response_table.clone()
-    }
-
     pub(crate) fn request_ordering(&self, command: &RemotingCommand) -> RequestOrdering {
         self.handler.request_processor.request_ordering(command)
     }
 
-    pub(crate) async fn process_network(
+    pub(crate) fn open_network_session(&self) -> crate::dispatch::LegacyNetworkSession {
+        self.network.open_network_session()
+    }
+
+    pub(crate) fn complete_network_response(
         &self,
-        context: &crate::runtime::connection_handler_context::ConnectionHandlerContext,
-        original_request_identity: Option<OriginalRequestIdentity>,
-        command: RemotingCommand,
+        session: &crate::dispatch::LegacyNetworkSession,
+        response: RemotingCommand,
     ) {
-        self.handler
-            .process_message_received(context, original_request_identity, command)
-            .await;
+        self.network.complete_network_response(session, response);
+    }
+
+    pub(crate) fn close_network_session(&self, session: &crate::dispatch::LegacyNetworkSession) {
+        self.network.close_network_session(session);
+    }
+
+    pub(crate) async fn dispatch_network(
+        &self,
+        authorized_session: &AuthorizedDispatchSession,
+        network_session: crate::dispatch::LegacyNetworkSession,
+        session: crate::server::SessionHandle,
+        context: RequestContext,
+        command: RemotingCommand,
+        received_at: Instant,
+        retained_bytes: usize,
+        partial_frame_permit: Option<PartialFramePermit>,
+    ) -> Result<DispatchOutcome, AuthorizedDispatchV2Error> {
+        self.network
+            .dispatch_network(
+                authorized_session,
+                network_session,
+                session,
+                context,
+                command,
+                received_at,
+                retained_bytes,
+                partial_frame_permit,
+            )
+            .await
     }
 
     /// Dispatches one embedded command without creating a listener, socket

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher/v2.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher/v2.rs
@@ -126,14 +126,17 @@ impl AuthorizedDispatchV2Error {
     dead_code,
     reason = "DSP-03 defines the private dispatcher core wired by the later coexistence stage"
 )]
-pub(crate) struct AuthorizedCommandDispatcherV2<D> {
+pub(crate) struct AuthorizedDispatcherCore<D> {
     processor: D,
     rpc_hooks: HookRegistry,
     #[cfg(test)]
     reported_failures: std::sync::Mutex<Vec<&'static str>>,
 }
 
-impl<P> AuthorizedCommandDispatcherV2<ExplicitV2Processor<P>>
+#[cfg(test)]
+type AuthorizedCommandDispatcherV2<D> = AuthorizedDispatcherCore<D>;
+
+impl<P> AuthorizedDispatcherCore<ExplicitV2Processor<P>>
 where
     P: RequestProcessorV2 + Clone + Sync + 'static,
 {
@@ -156,7 +159,7 @@ impl From<DispatchProcessorError> for AuthorizedDispatchV2Error {
     }
 }
 
-impl<P> AuthorizedCommandDispatcherV2<LegacyProcessorAdapter<P>>
+impl<P> AuthorizedDispatcherCore<LegacyProcessorAdapter<P>>
 where
     P: RequestProcessor + Clone + Sync + 'static,
 {
@@ -169,7 +172,7 @@ where
     }
 }
 
-impl<D> AuthorizedCommandDispatcherV2<D>
+impl<D> AuthorizedDispatcherCore<D>
 where
     D: DispatchProcessor,
 {
@@ -182,17 +185,31 @@ where
         }
     }
 
+    pub(crate) fn open_network_session(&self) -> D::NetworkSession {
+        self.processor.open_network_session()
+    }
+
+    pub(crate) fn complete_network_response(&self, session: &D::NetworkSession, response: RemotingCommand) {
+        self.processor.complete_network_response(session, response);
+    }
+
+    pub(crate) fn close_network_session(&self, session: &D::NetworkSession) {
+        self.processor.close_network_session(session);
+    }
+
     /// Admits one canonical network request into its existing session executor.
     #[allow(
         dead_code,
         reason = "DSP-03 dispatch remains private until later coexistence routing"
     )]
-    pub(crate) async fn dispatch(
+    pub(crate) async fn dispatch_network(
         self: &Arc<Self>,
         authorized_session: &AuthorizedDispatchSession,
+        network_session: D::NetworkSession,
         session: SessionHandle,
         context: RequestContext,
         command: RemotingCommand,
+        received_at: Instant,
         retained_bytes: usize,
         partial_frame_permit: Option<PartialFramePermit>,
     ) -> Result<DispatchOutcome, AuthorizedDispatchV2Error> {
@@ -212,7 +229,7 @@ where
             return Err(AuthorizedDispatchV2Error::OriginalIdentityMismatch);
         }
 
-        let request_started = Instant::now();
+        let request_started = received_at;
         let class = AdmissionClass::for_request_code(original.original_code());
         let lifecycle = RequestLifecycleProvenance::from_network_session(&session);
         let builder = RemotingRequestBuilder::new(original, request_started, context, lifecycle, command);
@@ -250,9 +267,10 @@ where
             move |_operation| async move {
                 let processor = admitted_dispatcher.processor.clone();
                 if let Err(error) = admitted_dispatcher
-                    .execute_admitted(
+                    .execute_admitted_network(
                         processor,
                         admitted_session,
+                        network_session,
                         class,
                         original,
                         remote_address,
@@ -302,10 +320,11 @@ where
         dead_code,
         reason = "DSP-03 admitted execution is reached through the not-yet-wired private dispatcher"
     )]
-    async fn execute_admitted(
+    async fn execute_admitted_network(
         &self,
         mut processor: D,
         session: SessionHandle,
+        network_session: D::NetworkSession,
         class: AdmissionClass,
         original: OriginalRequestIdentity,
         remote_address: std::net::SocketAddr,
@@ -338,6 +357,7 @@ where
                 hook_snapshot.as_deref(),
                 remote_address,
                 &session,
+                &network_session,
                 &response,
             )
             .await?;
@@ -463,9 +483,55 @@ where
         }
     }
 
-    #[cfg(test)]
-    fn register_rpc_hook(&self, hook: Arc<dyn RPCHook>) {
+    pub(crate) fn register_rpc_hook(&self, hook: Arc<dyn RPCHook>) {
         self.rpc_hooks.register(hook);
+    }
+
+    #[cfg(test)]
+    async fn execute_admitted(
+        &self,
+        processor: D,
+        session: SessionHandle,
+        class: AdmissionClass,
+        original: OriginalRequestIdentity,
+        remote_address: std::net::SocketAddr,
+        request_started: Instant,
+        builder: RemotingRequestBuilder,
+    ) -> Result<(), AuthorizedDispatchV2Error> {
+        self.execute_admitted_network(
+            processor,
+            session,
+            self.open_network_session(),
+            class,
+            original,
+            remote_address,
+            request_started,
+            builder,
+        )
+        .await
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn dispatch(
+        self: &Arc<Self>,
+        authorized_session: &AuthorizedDispatchSession,
+        session: SessionHandle,
+        context: RequestContext,
+        command: RemotingCommand,
+        retained_bytes: usize,
+        partial_frame_permit: Option<PartialFramePermit>,
+    ) -> Result<DispatchOutcome, AuthorizedDispatchV2Error> {
+        self.dispatch_network(
+            authorized_session,
+            self.open_network_session(),
+            session,
+            context,
+            command,
+            Instant::now(),
+            retained_bytes,
+            partial_frame_permit,
+        )
+        .await
     }
 
     fn report_admitted_failure(&self, error: &AuthorizedDispatchV2Error) {

--- a/rocketmq-transport/src/dispatch/legacy_processor_adapter.rs
+++ b/rocketmq-transport/src/dispatch/legacy_processor_adapter.rs
@@ -36,6 +36,7 @@ use super::ResponsePlan;
 use super::ResponsePlanError;
 use super::ResponseReceipt;
 use super::ResponseSink;
+use crate::base::pending_request_table::PendingRequestOwner;
 use crate::base::pending_request_table::PendingRequestTable;
 use crate::hook_registry::HookSnapshot;
 use crate::net::channel::Channel;
@@ -73,7 +74,7 @@ static BRIDGE_CONSTRUCTIONS: Mutex<Vec<SessionId>> = Mutex::new(Vec::new());
 static BRIDGE_CHANNEL_INNER_CONSTRUCTIONS: Mutex<Vec<SessionId>> = Mutex::new(Vec::new());
 
 #[cfg(test)]
-pub(super) fn bridge_construction_counts(session_id: SessionId) -> (usize, usize) {
+pub(crate) fn bridge_construction_counts(session_id: SessionId) -> (usize, usize) {
     let bridges = BRIDGE_CONSTRUCTIONS
         .lock()
         .expect("legacy bridge construction counter lock")
@@ -110,7 +111,7 @@ impl LegacyRequestBridge {
     fn from_network_session(
         session: &SessionHandle,
         response: &ResponseSink,
-        response_table: PendingRequestTable,
+        endpoint: &LegacyNetworkSession,
     ) -> Result<Self, LegacyProcessorAdapterError> {
         let canonical_session_id = SessionId::from_session_owner(session.session_id());
         #[cfg(test)]
@@ -133,7 +134,11 @@ impl LegacyRequestBridge {
             .expect("legacy bridge ChannelInner construction counter lock")
             .push(canonical_session_id);
         let channel = session
-            .legacy_processor_channel(response.clone(), response_table)
+            .legacy_processor_channel(
+                response.clone(),
+                endpoint.response_table.clone(),
+                endpoint.owner.clone(),
+            )
             .map_err(LegacyProcessorAdapterError::BridgeConstruction)?;
         let context = Arc::new(ConnectionHandlerContextWrapper::new(channel.clone()));
         let bridge = Self {
@@ -142,6 +147,9 @@ impl LegacyRequestBridge {
             canonical_session_id,
         };
         bridge.validate_network(session, response)?;
+        if !bridge.channel.has_pending_request_owner(&endpoint.owner) {
+            return Err(LegacyProcessorAdapterError::CompletionOwnerMismatch);
+        }
         Ok(bridge)
     }
 
@@ -278,6 +286,30 @@ impl LegacyRequestBridge {
     }
 }
 
+/// Stable response-correlation owner allocated once for one canonical V1
+/// network session and reused by every admitted legacy bridge in that session.
+#[derive(Clone)]
+pub(crate) struct LegacyNetworkSession {
+    response_table: PendingRequestTable,
+    owner: PendingRequestOwner,
+}
+
+impl LegacyNetworkSession {
+    #[cfg(test)]
+    pub(crate) fn for_test(response_table: PendingRequestTable) -> Self {
+        let owner = response_table.new_owner();
+        Self { response_table, owner }
+    }
+
+    pub(crate) fn response_table(&self) -> &PendingRequestTable {
+        &self.response_table
+    }
+
+    pub(crate) fn owner(&self) -> &PendingRequestOwner {
+        &self.owner
+    }
+}
+
 /// Existing V1 processor plus the stable endpoint capabilities needed by each
 /// admitted bridge invocation.
 #[allow(
@@ -307,6 +339,13 @@ impl<P> LegacyProcessorAdapter<P> {
             processor_name,
             telemetry,
             response_table,
+        }
+    }
+
+    pub(crate) fn open_network_session(&self) -> LegacyNetworkSession {
+        LegacyNetworkSession {
+            response_table: self.response_table.clone(),
+            owner: self.response_table.new_owner(),
         }
     }
 }
@@ -516,6 +555,14 @@ impl DispatchMetricsGuard {
 
 /// Sealed statically dispatched processor boundary used by the V2 core.
 pub(crate) trait DispatchProcessor: sealed::Sealed + Clone + Send + Sync + 'static {
+    type NetworkSession: Clone + Send + Sync + 'static;
+
+    fn open_network_session(&self) -> Self::NetworkSession;
+
+    fn complete_network_response(&self, session: &Self::NetworkSession, response: RemotingCommand);
+
+    fn close_network_session(&self, session: &Self::NetworkSession);
+
     fn request_ordering(&self, builder: &RemotingRequestBuilder) -> RequestOrdering;
 
     fn begin_admitted(&self, original: OriginalRequestIdentity, request_bytes: u64) -> DispatchMetricsGuard;
@@ -530,6 +577,7 @@ pub(crate) trait DispatchProcessor: sealed::Sealed + Clone + Send + Sync + 'stat
         hook_snapshot: Option<&HookSnapshot>,
         remote_address: SocketAddr,
         session: &SessionHandle,
+        network_session: &Self::NetworkSession,
         response: &ResponseSink,
     ) -> impl Future<Output = Result<InternalProcessorCandidate, DispatchProcessorError>> + Send;
 
@@ -556,6 +604,20 @@ impl<P> DispatchProcessor for ExplicitV2Processor<P>
 where
     P: RequestProcessorV2 + Clone + Sync + 'static,
 {
+    type NetworkSession = ();
+
+    fn open_network_session(&self) -> Self::NetworkSession {}
+
+    fn complete_network_response(&self, _session: &Self::NetworkSession, _response: RemotingCommand) {
+        tracing::warn!(
+            frame = "unexpected_response",
+            generation = "v2",
+            "unexpected response frame dropped on V2-only transport session"
+        );
+    }
+
+    fn close_network_session(&self, _session: &Self::NetworkSession) {}
+
     fn request_ordering(&self, builder: &RemotingRequestBuilder) -> RequestOrdering {
         self.processor.request_ordering(builder.ingress_view())
     }
@@ -590,6 +652,7 @@ where
         hook_snapshot: Option<&HookSnapshot>,
         remote_address: SocketAddr,
         _session: &SessionHandle,
+        _network_session: &Self::NetworkSession,
         _response: &ResponseSink,
     ) -> impl Future<Output = Result<InternalProcessorCandidate, DispatchProcessorError>> + Send {
         async move {
@@ -682,6 +745,35 @@ impl<P> DispatchProcessor for LegacyProcessorAdapter<P>
 where
     P: RequestProcessor + Clone + Sync + 'static,
 {
+    type NetworkSession = LegacyNetworkSession;
+
+    fn open_network_session(&self) -> Self::NetworkSession {
+        self.open_network_session()
+    }
+
+    fn complete_network_response(&self, session: &Self::NetworkSession, response: RemotingCommand) {
+        let opaque = response.opaque();
+        if !session
+            .response_table
+            .complete_response_for_owner(&session.owner, opaque, response)
+        {
+            tracing::warn!(
+                frame = "unmatched_response",
+                generation = "v1",
+                "response frame did not match pending work for its canonical session owner"
+            );
+        }
+    }
+
+    fn close_network_session(&self, session: &Self::NetworkSession) {
+        session.response_table.close_owner(&session.owner, || {
+            rocketmq_error::RocketMQError::network_connection_failed(
+                "legacy_session_pending_requests",
+                "canonical V1 network session closed",
+            )
+        });
+    }
+
     fn request_ordering(&self, builder: &RemotingRequestBuilder) -> RequestOrdering {
         self.processor.request_ordering(builder.command())
     }
@@ -724,10 +816,11 @@ where
         hook_snapshot: Option<&HookSnapshot>,
         remote_address: SocketAddr,
         session: &SessionHandle,
+        network_session: &Self::NetworkSession,
         response: &ResponseSink,
     ) -> impl Future<Output = Result<InternalProcessorCandidate, DispatchProcessorError>> + Send {
         async move {
-            let bridge = LegacyRequestBridge::from_network_session(session, response, self.response_table.clone())?;
+            let bridge = LegacyRequestBridge::from_network_session(session, response, network_session)?;
             bridge.validate_request(request)?;
 
             if let Err(error) = run_before_rpc_hooks(hook_snapshot, remote_address, request.legacy_command_mut()) {

--- a/rocketmq-transport/src/dispatch/legacy_processor_adapter/tests.rs
+++ b/rocketmq-transport/src/dispatch/legacy_processor_adapter/tests.rs
@@ -146,7 +146,8 @@ async fn network_bridge_uses_one_real_session_and_the_adapter_stable_response_ta
     let harness = NetworkHarness::new().await;
     let response = harness.plan_response(&harness.first);
     let stable_table = PendingRequestTable::new();
-    let bridge = LegacyRequestBridge::from_network_session(&harness.first, &response, stable_table.clone())
+    let endpoint = LegacyNetworkSession::for_test(stable_table.clone());
+    let bridge = LegacyRequestBridge::from_network_session(&harness.first, &response, &endpoint)
         .expect("canonical network bridge");
 
     assert_eq!(
@@ -193,7 +194,8 @@ async fn network_bridge_uses_one_real_session_and_the_adapter_stable_response_ta
 async fn network_bridge_request_apis_use_the_canonical_writer_and_stable_endpoint_table() {
     let mut harness = NetworkHarness::new().await;
     let response = harness.plan_response(&harness.first);
-    let bridge = LegacyRequestBridge::from_network_session(&harness.first, &response, PendingRequestTable::new())
+    let endpoint = LegacyNetworkSession::for_test(PendingRequestTable::new());
+    let bridge = LegacyRequestBridge::from_network_session(&harness.first, &response, &endpoint)
         .expect("canonical network bridge");
 
     let send_channel = bridge.channel.clone();
@@ -280,13 +282,76 @@ async fn network_bridge_request_apis_use_the_canonical_writer_and_stable_endpoin
 }
 
 #[tokio::test]
+async fn dropping_borrowed_bridge_keeps_session_owner_live_until_canonical_close() {
+    let mut harness = NetworkHarness::new().await;
+    let response = harness.plan_response(&harness.first);
+    let endpoint = LegacyNetworkSession::for_test(PendingRequestTable::new());
+    let first_bridge = LegacyRequestBridge::from_network_session(&harness.first, &response, &endpoint)
+        .expect("first borrowed network bridge");
+    drop(first_bridge);
+
+    let second_bridge = LegacyRequestBridge::from_network_session(&harness.first, &response, &endpoint)
+        .expect("later bridge keeps the same session owner");
+    let send_channel = second_bridge.channel.clone();
+    let endpoint_for_completion = endpoint.clone();
+    let peer = &mut harness.first_peer;
+    let (returned, ()) = tokio::join!(
+        send_channel.send_wait_response(RemotingCommand::create_remoting_command(604).set_opaque(8_604), 1_000),
+        async move {
+            let outbound = peer
+                .receive_command()
+                .await
+                .expect("peer stays open after first bridge drop")
+                .expect("later bridge request is written");
+            assert!(endpoint_for_completion.response_table().complete_response_for_owner(
+                endpoint_for_completion.owner(),
+                outbound.opaque(),
+                RemotingCommand::create_response_command_with_code(0).set_opaque(outbound.opaque()),
+            ));
+        },
+    );
+    assert_eq!(returned.expect("later request correlates").opaque(), 8_604);
+
+    let closing_channel = second_bridge.channel.clone();
+    let endpoint_for_close = endpoint.clone();
+    let peer = &mut harness.first_peer;
+    let (closed, ()) = tokio::join!(
+        closing_channel.send_wait_response(RemotingCommand::create_remoting_command(605).set_opaque(8_605), 5_000),
+        async move {
+            let outbound = peer
+                .receive_command()
+                .await
+                .expect("peer remains open until canonical close")
+                .expect("pending request is written before close");
+            assert_eq!(outbound.opaque(), 8_605);
+            assert_eq!(
+                endpoint_for_close
+                    .response_table()
+                    .close_owner(endpoint_for_close.owner(), || {
+                        rocketmq_error::RocketMQError::network_connection_failed(
+                            "test_session_close",
+                            "canonical owner closed",
+                        )
+                    }),
+                1
+            );
+        },
+    );
+    assert!(closed.is_err(), "only canonical owner close releases the waiter");
+
+    drop((second_bridge, response));
+    harness.shutdown().await;
+}
+
+#[tokio::test]
 async fn network_bridge_fails_closed_for_cross_session_same_id_writer_and_transport_mismatches() {
     let harness = NetworkHarness::new().await;
     assert_ne!(harness.first.session_id(), harness.second.session_id());
     let first_response = harness.plan_response(&harness.first);
     let second_response = harness.plan_response(&harness.second);
     let table = PendingRequestTable::new();
-    let bridge = LegacyRequestBridge::from_network_session(&harness.first, &first_response, table.clone())
+    let endpoint = LegacyNetworkSession::for_test(table.clone());
+    let bridge = LegacyRequestBridge::from_network_session(&harness.first, &first_response, &endpoint)
         .expect("first canonical bridge");
 
     assert!(matches!(
@@ -297,7 +362,7 @@ async fn network_bridge_fails_closed_for_cross_session_same_id_writer_and_transp
     let second_id = SessionId::from_session_owner(harness.second.session_id());
     let mut same_id_different_writer = harness
         .first
-        .legacy_processor_channel(first_response.clone(), table)
+        .legacy_processor_channel(first_response.clone(), table, endpoint.owner().clone())
         .expect("first writer channel");
     same_id_different_writer.set_canonical_session_id_for_test(second_id);
     let forged = LegacyRequestBridge {
@@ -311,8 +376,9 @@ async fn network_bridge_fails_closed_for_cross_session_same_id_writer_and_transp
     ));
 
     let (local, _receiver) = ResponseSink::local();
+    let local_endpoint = LegacyNetworkSession::for_test(PendingRequestTable::new());
     assert!(matches!(
-        LegacyRequestBridge::from_network_session(&harness.first, &local, PendingRequestTable::new(),),
+        LegacyRequestBridge::from_network_session(&harness.first, &local, &local_endpoint),
         Err(LegacyProcessorAdapterError::TransportKindMismatch)
     ));
 

--- a/rocketmq-transport/src/net/channel.rs
+++ b/rocketmq-transport/src/net/channel.rs
@@ -422,6 +422,11 @@ impl Channel {
         self.inner.pending_request_owner()
     }
 
+    pub(crate) fn has_pending_request_owner(&self, owner: &PendingRequestOwner) -> bool {
+        self.pending_request_owner()
+            .is_some_and(|candidate| candidate.same_owner(owner))
+    }
+
     /// Routes one response through this channel's stable correlation owner.
     #[allow(
         dead_code,
@@ -682,6 +687,10 @@ pub struct ChannelInner {
 
     /// Correlation generation owned by this physical connection.
     pending_request_owner: Option<PendingRequestOwner>,
+    /// Whether this channel is responsible for retiring its correlation owner.
+    /// DSP-06 session channels and per-request bridges borrow one stable owner
+    /// whose retirement belongs to the canonical reader session state.
+    pending_request_owner_authority: PendingRequestOwnerAuthority,
 
     /// Plan-bound completion owner for response-shaped public writes made by
     /// a legacy processor. Ordinary channels leave this absent.
@@ -690,6 +699,12 @@ pub struct ChannelInner {
     /// Tracks the outbound send task for shutdown diagnostics.
     send_task_group: TaskGroup,
     send_task_id: Option<TaskId>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PendingRequestOwnerAuthority {
+    Owned,
+    Borrowed,
 }
 
 enum ChannelIo {
@@ -817,6 +832,7 @@ impl ChannelInner {
             connection_state: ConnectionStateHandle::healthy(),
             response_table: PendingRequestTable::new(),
             pending_request_owner: None,
+            pending_request_owner_authority: PendingRequestOwnerAuthority::Borrowed,
             legacy_plan_response: None,
             send_task_group: task_group,
             send_task_id: None,
@@ -841,6 +857,7 @@ impl ChannelInner {
             connection_state: ConnectionStateHandle::healthy(),
             response_table,
             pending_request_owner,
+            pending_request_owner_authority: PendingRequestOwnerAuthority::Owned,
             legacy_plan_response: Some(response),
             send_task_group: task_group,
             send_task_id: None,
@@ -884,7 +901,14 @@ impl ChannelInner {
         parent_task_group: TaskGroup,
     ) -> rocketmq_error::RocketMQResult<Self> {
         let owner = response_table.new_owner();
-        Self::try_new_with_send_task_group(connection, response_table, Some(owner), parent_task_group, true)
+        Self::try_new_with_send_task_group(
+            connection,
+            response_table,
+            Some(owner),
+            parent_task_group,
+            true,
+            PendingRequestOwnerAuthority::Owned,
+        )
     }
 
     pub(crate) fn new_transport_session(
@@ -908,16 +932,41 @@ impl ChannelInner {
         task_group: TaskGroup,
     ) -> rocketmq_error::RocketMQResult<Self> {
         let pending_request_owner = Some(response_table.new_owner());
-        Self::try_new_with_send_task_group(connection, response_table, pending_request_owner, task_group, false)
+        Self::try_new_with_send_task_group(
+            connection,
+            response_table,
+            pending_request_owner,
+            task_group,
+            false,
+            PendingRequestOwnerAuthority::Owned,
+        )
+    }
+
+    pub(crate) fn new_transport_session_with_owner(
+        connection: Connection,
+        response_table: PendingRequestTable,
+        pending_request_owner: PendingRequestOwner,
+        task_group: TaskGroup,
+    ) -> rocketmq_error::RocketMQResult<Self> {
+        Self::try_new_with_send_task_group(
+            connection,
+            response_table,
+            Some(pending_request_owner),
+            task_group,
+            false,
+            PendingRequestOwnerAuthority::Borrowed,
+        )
     }
 
     pub(crate) fn new_legacy_network_bridge(
         connection: Connection,
         response: ResponseSink,
         response_table: PendingRequestTable,
+        pending_request_owner: PendingRequestOwner,
         task_group: TaskGroup,
     ) -> rocketmq_error::RocketMQResult<Self> {
-        let mut inner = Self::new_transport_session_with_task_group(connection, response_table, task_group)?;
+        let mut inner =
+            Self::new_transport_session_with_owner(connection, response_table, pending_request_owner, task_group)?;
         inner.legacy_plan_response = Some(response);
         Ok(inner)
     }
@@ -928,6 +977,7 @@ impl ChannelInner {
         pending_request_owner: Option<PendingRequestOwner>,
         task_group: TaskGroup,
         start_send_task: bool,
+        pending_request_owner_authority: PendingRequestOwnerAuthority,
     ) -> rocketmq_error::RocketMQResult<Self> {
         const QUEUE_CAPACITY: usize = 1024;
 
@@ -961,6 +1011,7 @@ impl ChannelInner {
             connection_state,
             response_table,
             pending_request_owner,
+            pending_request_owner_authority,
             legacy_plan_response: None,
             send_task_group: task_group,
             send_task_id,
@@ -983,7 +1034,10 @@ impl ChannelInner {
             }
         }
         report.elapsed = started_at.elapsed();
-        if let Some(owner) = self.pending_request_owner.as_ref() {
+        if self.pending_request_owner_authority == PendingRequestOwnerAuthority::Owned {
+            let Some(owner) = self.pending_request_owner.as_ref() else {
+                return report;
+            };
             self.response_table.close_owner(owner, || {
                 RocketMQError::network_connection_failed("channel", "connection closed")
             });
@@ -999,7 +1053,10 @@ impl Drop for ChannelInner {
         if let Some(task_id) = self.send_task_id {
             self.send_task_group.abort_task(task_id);
         }
-        if let Some(owner) = self.pending_request_owner.as_ref() {
+        if self.pending_request_owner_authority == PendingRequestOwnerAuthority::Owned {
+            let Some(owner) = self.pending_request_owner.as_ref() else {
+                return;
+            };
             self.response_table.close_owner(owner, || {
                 RocketMQError::network_connection_failed("channel", "connection dropped")
             });

--- a/rocketmq-transport/src/public_api_v2.rs
+++ b/rocketmq-transport/src/public_api_v2.rs
@@ -21,6 +21,7 @@
 
 pub use crate::deadline::RequestDeadline;
 pub use crate::dispatch::AuthenticationState;
+pub use crate::dispatch::AuthorizedCommandDispatcherV2;
 pub use crate::dispatch::DeferredRegistration;
 pub use crate::dispatch::EmbeddedCaller;
 pub use crate::dispatch::HandlerOutcome;
@@ -43,6 +44,7 @@ pub use crate::dispatch::ResponseReceipt;
 pub use crate::dispatch::WriteProgress;
 pub use crate::file_region::FileRegion;
 pub use crate::file_region::FileRegionSequence;
+pub use crate::remoting_server::rocketmq_tokio_server::TransportServerV2;
 pub use crate::request_ordering::RequestOrdering;
 pub use crate::request_ordering::RequestOrderingKey;
 pub use crate::runtime::processor_v2::LocalRequestProcessorV2;

--- a/rocketmq-transport/src/remoting_server/rocketmq_tokio_server.rs
+++ b/rocketmq-transport/src/remoting_server/rocketmq_tokio_server.rs
@@ -14,6 +14,7 @@
 
 use std::future::Future;
 use std::net::SocketAddr;
+#[cfg(all(test, not(doctest)))]
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
@@ -57,7 +58,6 @@ use crate::runtime::connection_handler_context::ConnectionHandlerContextWrapper;
 use crate::runtime::processor::RequestProcessor;
 use crate::runtime::RPCHook;
 use crate::security::TransportSecurity;
-use crate::server::ConnectionHandler as TransportConnectionHandler;
 use crate::server::TransportListener;
 use crate::telemetry::TransportTelemetry;
 use crate::tls::TlsServerRuntime;
@@ -69,6 +69,9 @@ mod connection_listener;
 mod launch;
 mod lifecycle_events;
 mod shutdown;
+mod v2_server;
+
+pub use v2_server::TransportServerV2;
 
 #[cfg(all(test, not(doctest)))]
 use connection_handler::TestRequestHook;

--- a/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/connection_handler.rs
+++ b/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/connection_handler.rs
@@ -14,6 +14,13 @@
 
 use super::lifecycle_events::LifecycleEventPublisher;
 use super::*;
+use crate::admission::PartialFramePermit;
+use crate::dispatch::AuthorizedCommandDispatcherV2;
+use crate::dispatch::AuthorizedDispatchSession;
+use crate::dispatch::LegacyNetworkSession;
+use crate::dispatch::RequestContext;
+use crate::runtime::processor_v2::RequestProcessorV2;
+use crate::server::AuthorizedFrameRoute;
 
 #[cfg(all(test, not(doctest)))]
 pub(super) enum TestRequestHookResult {
@@ -54,49 +61,39 @@ pub(super) struct InterceptingConnectionHandler<RP> {
 
 pub(super) struct RemotingSession<C> {
     context: C,
+    endpoint: LegacyNetworkSession,
     _shutdown_complete: mpsc::Sender<()>,
 }
 
-enum RemotingSessionAction {
-    Connect,
-    Command(rocketmq_protocol::protocol::remoting_command::RemotingCommand),
+pub(crate) struct V1NetworkRouteState {
+    #[cfg_attr(
+        not(test),
+        allow(dead_code, reason = "test interceptor observes the canonical V1 channel")
+    )]
+    context: ConnectionHandlerContext,
+    endpoint: LegacyNetworkSession,
+}
+
+pub(super) struct V2ConnectionHandler<P> {
+    pub(super) shutdown_complete_tx: mpsc::Sender<()>,
+    pub(super) conn_disconnect_notify: Option<broadcast::Sender<SocketAddr>>,
+    pub(super) dispatcher: Arc<AuthorizedCommandDispatcherV2<P>>,
+}
+
+pub(crate) struct V2NetworkRouteState {
+    _shutdown_complete: mpsc::Sender<()>,
 }
 
 impl<RP: RequestProcessor + Sync + Clone + 'static> ConnectionHandler<RP> {
-    async fn run(
-        &self,
-        session: crate::server::SessionHandle,
-        action: RemotingSessionAction,
-        #[cfg(all(test, not(doctest)))] command_interceptor: Option<&dyn SessionCommandInterceptor>,
-    ) {
-        let channel_id = match &action {
-            RemotingSessionAction::Connect => format!("transport-session-{}", session.session_id()),
-            RemotingSessionAction::Command(_) => {
-                let Some(channel_id) = self
-                    .sessions
-                    .get(&session.session_id())
-                    .map(|remoting_session| remoting_session.context.channel().channel_id().to_owned())
-                else {
-                    return;
-                };
-                channel_id
-            }
-        };
-        let channel_inner = match &action {
-            RemotingSessionAction::Connect => ChannelInner::new_transport_session(
-                session.connection(),
-                self.dispatcher.response_table(),
-                session.task_group().clone(),
-            ),
-            RemotingSessionAction::Command(_) => ChannelInner::new_transport_session_with_task_group(
-                session.connection(),
-                self.dispatcher.response_table(),
-                session.task_group().clone(),
-            ),
-        };
-        let Ok(channel_inner) = channel_inner else {
-            return;
-        };
+    async fn connected_state(&self, session: crate::server::SessionHandle) -> Option<V1NetworkRouteState> {
+        let endpoint = self.dispatcher.open_network_session();
+        let channel_inner = ChannelInner::new_transport_session_with_owner(
+            session.connection(),
+            endpoint.response_table().clone(),
+            endpoint.owner().clone(),
+            session.task_group().clone(),
+        )
+        .ok()?;
         let mut channel = Channel::new_with_proxy_protocol(
             Arc::new(channel_inner),
             session.local_addr(),
@@ -104,151 +101,261 @@ impl<RP: RequestProcessor + Sync + Clone + 'static> ConnectionHandler<RP> {
             session.transport_peer_addr(),
             session.proxy_protocol().cloned(),
         );
-        channel.set_channel_id(channel_id);
+        channel.set_channel_id(format!("transport-session-{}", session.session_id()));
+        let context = Arc::new(ConnectionHandlerContextWrapper::new(channel));
         let remoting_session = RemotingSession {
-            context: Arc::new(ConnectionHandlerContextWrapper::new(channel)),
+            context: context.clone(),
+            endpoint: endpoint.clone(),
             _shutdown_complete: self.shutdown_complete_tx.clone(),
         };
-        match action {
-            RemotingSessionAction::Connect => {
-                let event_channel = remoting_session.context.channel().clone();
-                self.sessions.insert(session.session_id(), remoting_session);
-                if let Some(publisher) = &self.event_publisher {
-                    let outcome = publisher
-                        .publish(TokioEvent::new(
-                            ConnectionNetEvent::CONNECTED(session.remote_addr()),
-                            session.remote_addr(),
-                            event_channel,
-                        ))
-                        .await;
-                    if !outcome.is_queued() {
-                        warn!(?outcome, event = "connected", "Remoting lifecycle event was not queued");
-                    }
-                }
+        let event_channel = context.channel().clone();
+        self.sessions.insert(session.session_id(), remoting_session);
+        if let Some(publisher) = &self.event_publisher {
+            let outcome = publisher
+                .publish(TokioEvent::new(
+                    ConnectionNetEvent::CONNECTED(session.remote_addr()),
+                    session.remote_addr(),
+                    event_channel,
+                ))
+                .await;
+            if !outcome.is_queued() {
+                warn!(?outcome, event = "connected", "Remoting lifecycle event was not queued");
             }
-            RemotingSessionAction::Command(command) => {
-                #[cfg(all(test, not(doctest)))]
-                if let Some(command_interceptor) = command_interceptor {
-                    if command_interceptor.intercept(
-                        command.code(),
-                        command.opaque(),
-                        remoting_session.context.channel().clone(),
-                        session.task_group().clone(),
-                    ) {
-                        return;
-                    }
-                }
-                let dispatcher = self.dispatcher.clone();
-                dispatcher
-                    .process_network(&remoting_session.context, session.original_request_identity(), command)
-                    .await;
+        }
+        Some(V1NetworkRouteState { context, endpoint })
+    }
+
+    async fn request(
+        &self,
+        state: &V1NetworkRouteState,
+        authorized_session: &AuthorizedDispatchSession,
+        session: crate::server::SessionHandle,
+        context: RequestContext,
+        command: rocketmq_protocol::protocol::remoting_command::RemotingCommand,
+        received_at: Instant,
+        retained_bytes: usize,
+        partial_frame_permit: Option<PartialFramePermit>,
+        #[cfg(all(test, not(doctest)))] command_interceptor: Option<&dyn SessionCommandInterceptor>,
+    ) -> bool {
+        #[cfg(all(test, not(doctest)))]
+        if let Some(command_interceptor) = command_interceptor {
+            if command_interceptor.intercept(
+                command.code(),
+                command.opaque(),
+                state.context.channel().clone(),
+                session.task_group().clone(),
+            ) {
+                return true;
+            }
+        }
+        self.dispatcher
+            .dispatch_network(
+                authorized_session,
+                state.endpoint.clone(),
+                session,
+                context,
+                command,
+                received_at,
+                retained_bytes,
+                partial_frame_permit,
+            )
+            .await
+            .is_ok()
+    }
+
+    async fn disconnected_state(&self, state: V1NetworkRouteState, session: crate::server::SessionHandle) {
+        let event_publisher = self.event_publisher.clone();
+        let conn_disconnect_notify = self.conn_disconnect_notify.clone();
+        let Some((_, remoting_session)) = self.sessions.remove(&session.session_id()) else {
+            return;
+        };
+        debug_assert!(remoting_session.endpoint.owner().same_owner(state.endpoint.owner()));
+        let channel_report = remoting_session
+            .context
+            .channel()
+            .close_with_report(Duration::from_secs(3))
+            .await;
+        channel_report.log_if_unhealthy();
+        if let Some(notify) = conn_disconnect_notify {
+            let _ = notify.send(session.remote_addr());
+        }
+        if let Some(publisher) = event_publisher {
+            let outcome = publisher
+                .publish(TokioEvent::new(
+                    ConnectionNetEvent::DISCONNECTED,
+                    session.remote_addr(),
+                    remoting_session.context.channel().clone(),
+                ))
+                .await;
+            if !outcome.is_queued() {
+                warn!(
+                    ?outcome,
+                    event = "disconnected",
+                    "Remoting lifecycle event was not queued"
+                );
             }
         }
     }
 }
 
-impl<RP: RequestProcessor + Sync + Clone + 'static> TransportConnectionHandler for ConnectionHandler<RP> {
-    fn connected(&self, session: crate::server::SessionHandle) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
-        Box::pin(async move {
-            self.run(
-                session,
-                RemotingSessionAction::Connect,
-                #[cfg(all(test, not(doctest)))]
-                None,
-            )
-            .await;
-        })
+impl<RP: RequestProcessor + Sync + Clone + 'static> AuthorizedFrameRoute for ConnectionHandler<RP> {
+    type SessionState = V1NetworkRouteState;
+
+    async fn connected(&self, session: crate::server::SessionHandle) -> Option<Self::SessionState> {
+        self.connected_state(session).await
     }
 
-    fn request_ordering(
+    async fn response(
         &self,
-        command: &rocketmq_protocol::protocol::remoting_command::RemotingCommand,
-    ) -> crate::request_ordering::RequestOrdering {
-        self.dispatcher.request_ordering(command)
-    }
-
-    fn command(
-        &self,
-        session: crate::server::SessionHandle,
+        state: &Self::SessionState,
+        _session: crate::server::SessionHandle,
         command: rocketmq_protocol::protocol::remoting_command::RemotingCommand,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
-        Box::pin(async move {
-            self.run(
-                session,
-                RemotingSessionAction::Command(command),
-                #[cfg(all(test, not(doctest)))]
-                None,
-            )
-            .await;
+    ) {
+        self.dispatcher.complete_network_response(&state.endpoint, command);
+    }
+
+    async fn request(
+        &self,
+        state: &Self::SessionState,
+        authorized_session: &AuthorizedDispatchSession,
+        session: crate::server::SessionHandle,
+        context: RequestContext,
+        command: rocketmq_protocol::protocol::remoting_command::RemotingCommand,
+        received_at: Instant,
+        retained_bytes: usize,
+        partial_frame_permit: Option<PartialFramePermit>,
+    ) -> bool {
+        self.request(
+            state,
+            authorized_session,
+            session,
+            context,
+            command,
+            received_at,
+            retained_bytes,
+            partial_frame_permit,
+            #[cfg(all(test, not(doctest)))]
+            None,
+        )
+        .await
+    }
+
+    async fn close_pending(&self, state: &Self::SessionState, _session: crate::server::SessionHandle) {
+        self.dispatcher.close_network_session(&state.endpoint);
+    }
+
+    async fn disconnected(&self, state: Self::SessionState, session: crate::server::SessionHandle) {
+        self.disconnected_state(state, session).await;
+    }
+}
+
+impl<P> AuthorizedFrameRoute for V2ConnectionHandler<P>
+where
+    P: RequestProcessorV2 + Clone + Sync + 'static,
+{
+    type SessionState = V2NetworkRouteState;
+
+    async fn connected(&self, _session: crate::server::SessionHandle) -> Option<Self::SessionState> {
+        Some(V2NetworkRouteState {
+            _shutdown_complete: self.shutdown_complete_tx.clone(),
         })
     }
 
-    fn disconnected(&self, session: crate::server::SessionHandle) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
-        let event_publisher = self.event_publisher.clone();
-        let conn_disconnect_notify = self.conn_disconnect_notify.clone();
-        Box::pin(async move {
-            let Some((_, remoting_session)) = self.sessions.remove(&session.session_id()) else {
-                return;
-            };
-            let channel_report = remoting_session
-                .context
-                .channel()
-                .close_with_report(Duration::from_secs(3))
-                .await;
-            channel_report.log_if_unhealthy();
-            if let Some(notify) = conn_disconnect_notify {
-                let _ = notify.send(session.remote_addr());
-            }
-            if let Some(publisher) = event_publisher {
-                let outcome = publisher
-                    .publish(TokioEvent::new(
-                        ConnectionNetEvent::DISCONNECTED,
-                        session.remote_addr(),
-                        remoting_session.context.channel().clone(),
-                    ))
-                    .await;
-                if !outcome.is_queued() {
-                    warn!(
-                        ?outcome,
-                        event = "disconnected",
-                        "Remoting lifecycle event was not queued"
-                    );
-                }
-            }
-        })
+    async fn response(
+        &self,
+        _state: &Self::SessionState,
+        _session: crate::server::SessionHandle,
+        command: rocketmq_protocol::protocol::remoting_command::RemotingCommand,
+    ) {
+        self.dispatcher.complete_network_response(command);
+    }
+
+    async fn request(
+        &self,
+        _state: &Self::SessionState,
+        authorized_session: &AuthorizedDispatchSession,
+        session: crate::server::SessionHandle,
+        context: RequestContext,
+        command: rocketmq_protocol::protocol::remoting_command::RemotingCommand,
+        received_at: Instant,
+        retained_bytes: usize,
+        partial_frame_permit: Option<PartialFramePermit>,
+    ) -> bool {
+        self.dispatcher
+            .dispatch_network(
+                authorized_session,
+                session,
+                context,
+                command,
+                received_at,
+                retained_bytes,
+                partial_frame_permit,
+            )
+            .await
+            .is_ok()
+    }
+
+    async fn close_pending(&self, _state: &Self::SessionState, _session: crate::server::SessionHandle) {
+        self.dispatcher.close_network_session();
+    }
+
+    async fn disconnected(&self, _state: Self::SessionState, session: crate::server::SessionHandle) {
+        if let Some(notify) = &self.conn_disconnect_notify {
+            let _ = notify.send(session.remote_addr());
+        }
     }
 }
 
 #[cfg(all(test, not(doctest)))]
-impl<RP: RequestProcessor + Sync + Clone + 'static> TransportConnectionHandler for InterceptingConnectionHandler<RP> {
-    fn connected(&self, session: crate::server::SessionHandle) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
-        self.inner.connected(session)
+impl<RP: RequestProcessor + Sync + Clone + 'static> AuthorizedFrameRoute for InterceptingConnectionHandler<RP> {
+    type SessionState = V1NetworkRouteState;
+
+    async fn connected(&self, session: crate::server::SessionHandle) -> Option<Self::SessionState> {
+        self.inner.connected_state(session).await
     }
 
-    fn request_ordering(
+    async fn response(
         &self,
-        command: &rocketmq_protocol::protocol::remoting_command::RemotingCommand,
-    ) -> crate::request_ordering::RequestOrdering {
-        self.inner.request_ordering(command)
-    }
-
-    fn command(
-        &self,
-        session: crate::server::SessionHandle,
+        state: &Self::SessionState,
+        _session: crate::server::SessionHandle,
         command: rocketmq_protocol::protocol::remoting_command::RemotingCommand,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
-        Box::pin(async move {
-            self.inner
-                .run(
-                    session,
-                    RemotingSessionAction::Command(command),
-                    Some(self.command_interceptor.as_ref()),
-                )
-                .await;
-        })
+    ) {
+        self.inner
+            .dispatcher
+            .complete_network_response(&state.endpoint, command);
     }
 
-    fn disconnected(&self, session: crate::server::SessionHandle) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
-        self.inner.disconnected(session)
+    async fn request(
+        &self,
+        state: &Self::SessionState,
+        authorized_session: &AuthorizedDispatchSession,
+        session: crate::server::SessionHandle,
+        context: RequestContext,
+        command: rocketmq_protocol::protocol::remoting_command::RemotingCommand,
+        received_at: Instant,
+        retained_bytes: usize,
+        partial_frame_permit: Option<PartialFramePermit>,
+    ) -> bool {
+        self.inner
+            .request(
+                state,
+                authorized_session,
+                session,
+                context,
+                command,
+                received_at,
+                retained_bytes,
+                partial_frame_permit,
+                Some(self.command_interceptor.as_ref()),
+            )
+            .await
+    }
+
+    async fn close_pending(&self, state: &Self::SessionState, _session: crate::server::SessionHandle) {
+        self.inner.dispatcher.close_network_session(&state.endpoint);
+    }
+
+    async fn disconnected(&self, state: Self::SessionState, session: crate::server::SessionHandle) {
+        self.inner.disconnected_state(state, session).await;
     }
 }

--- a/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/connection_listener.rs
+++ b/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/connection_listener.rs
@@ -148,6 +148,6 @@ impl<RP: RequestProcessor + Sync + 'static + Clone> ConnectionListener<RP> {
             event_publisher,
             sessions: dashmap::DashMap::new(),
         });
-        transport.run(connection_handler).await
+        transport.run_authorized(connection_handler).await
     }
 }

--- a/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/tests.rs
+++ b/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/tests.rs
@@ -22,6 +22,8 @@ use crate::config::TlsConfig;
 use crate::config::TlsMode;
 #[cfg(feature = "tls")]
 use crate::config::TlsServerConfig;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_runtime::RuntimeContext;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
@@ -49,6 +51,33 @@ use super::lifecycle_events::LifecycleEventConfig;
 use super::lifecycle_events::LifecycleEventPublishOutcome;
 use super::lifecycle_events::LifecycleEventPublisher;
 use super::shutdown::new_remoting_server_task_group_with_service_context;
+
+#[derive(Clone)]
+struct CorrelatingV1Processor;
+
+impl RequestProcessor for CorrelatingV1Processor {
+    async fn process_request(
+        &mut self,
+        channel: Channel,
+        _ctx: ConnectionHandlerContext,
+        request: &mut rocketmq_protocol::protocol::remoting_command::RemotingCommand,
+    ) -> RocketMQResult<Option<rocketmq_protocol::protocol::remoting_command::RemotingCommand>> {
+        let correlated = channel
+            .send_wait_response(
+                rocketmq_protocol::protocol::remoting_command::RemotingCommand::create_remoting_command(8_801)
+                    .set_opaque(request.opaque()),
+                30_000,
+            )
+            .await?;
+        Ok(Some(
+            rocketmq_protocol::protocol::remoting_command::RemotingCommand::create_response_command_with_code(
+                rocketmq_protocol::code::response_code::ResponseCode::Success,
+            )
+            .set_opaque(request.opaque())
+            .set_body(correlated.body().cloned().unwrap_or_default()),
+        ))
+    }
+}
 
 #[cfg(test)]
 mod runtime_test_support {
@@ -1330,4 +1359,162 @@ async fn run_shutdown_report_includes_tls_reload_task() {
         .expect("remoting shutdown report should include tls reload task group");
     assert!(tls_report.is_healthy(), "{}", tls_report.to_json());
     assert_eq!(tls_report.leaked, 0, "{}", tls_report.to_json());
+}
+
+#[tokio::test]
+async fn v1_network_response_frames_complete_the_exact_session_owner() {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind V1 correlation listener");
+    let address = listener.local_addr().expect("V1 correlation listener address");
+    let mut server = TransportServer::new(
+        Arc::new(ServerConfig::default()),
+        test_service_context("remoting-server-v1-correlation"),
+    );
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let (startup_tx, startup_rx) = oneshot::channel();
+    let server_task = tokio::spawn(async move {
+        server
+            .try_serve_bound_listener_until_with_startup(
+                listener,
+                CorrelatingV1Processor,
+                None,
+                None,
+                async {
+                    let _ = shutdown_rx.await;
+                },
+                startup_tx,
+            )
+            .await
+    });
+    assert_eq!(
+        startup_rx
+            .await
+            .expect("V1 startup channel")
+            .expect("V1 startup succeeds"),
+        address
+    );
+
+    let mut first = crate::connection::Connection::new(TcpStream::connect(address).await.expect("first V1 client"));
+    let mut second = crate::connection::Connection::new(TcpStream::connect(address).await.expect("second V1 client"));
+    first
+        .send_command(RemotingCommand::create_remoting_command(8_800).set_opaque(41))
+        .await
+        .expect("first inbound request");
+    second
+        .send_command(RemotingCommand::create_remoting_command(8_800).set_opaque(41))
+        .await
+        .expect("second inbound request");
+
+    let first_outbound = tokio::time::timeout(Duration::from_secs(1), first.receive_command())
+        .await
+        .expect("first outbound deadline")
+        .expect("first client connected")
+        .expect("first outbound request");
+    let second_outbound = tokio::time::timeout(Duration::from_secs(1), second.receive_command())
+        .await
+        .expect("second outbound deadline")
+        .expect("second client connected")
+        .expect("second outbound request");
+    assert_eq!((first_outbound.code(), first_outbound.opaque()), (8_801, 41));
+    assert_eq!((second_outbound.code(), second_outbound.opaque()), (8_801, 41));
+
+    first
+        .send_command(
+            RemotingCommand::create_response_command_with_code(ResponseCode::Success)
+                .set_opaque(41)
+                .set_body(b"first-owner".to_vec()),
+        )
+        .await
+        .expect("first correlated response");
+    second
+        .send_command(
+            RemotingCommand::create_response_command_with_code(ResponseCode::Success)
+                .set_opaque(41)
+                .set_body(b"second-owner".to_vec()),
+        )
+        .await
+        .expect("second correlated response");
+
+    let first_final = tokio::time::timeout(Duration::from_secs(1), first.receive_command())
+        .await
+        .expect("first final deadline")
+        .expect("first connection")
+        .expect("first final response");
+    let second_final = tokio::time::timeout(Duration::from_secs(1), second.receive_command())
+        .await
+        .expect("second final deadline")
+        .expect("second connection")
+        .expect("second final response");
+    assert_eq!(first_final.opaque(), 41);
+    assert_eq!(first_final.body(), Some(&bytes::Bytes::from_static(b"first-owner")));
+    assert_eq!(second_final.opaque(), 41);
+    assert_eq!(second_final.body(), Some(&bytes::Bytes::from_static(b"second-owner")));
+
+    first
+        .send_command(RemotingCommand::create_remoting_command(8_800).set_opaque(51))
+        .await
+        .expect("first concurrent request");
+    first
+        .send_command(RemotingCommand::create_remoting_command(8_800).set_opaque(52))
+        .await
+        .expect("second concurrent request");
+    let first_pending = tokio::time::timeout(Duration::from_secs(1), first.receive_command())
+        .await
+        .expect("first concurrent outbound deadline")
+        .expect("first connection")
+        .expect("first concurrent outbound");
+    let second_pending = tokio::time::timeout(Duration::from_secs(1), first.receive_command())
+        .await
+        .expect("second concurrent outbound deadline")
+        .expect("first connection")
+        .expect("second concurrent outbound");
+    assert_ne!(first_pending.opaque(), second_pending.opaque());
+    for outbound in [first_pending, second_pending] {
+        first
+            .send_command(
+                RemotingCommand::create_response_command_with_code(ResponseCode::Success)
+                    .set_opaque(outbound.opaque())
+                    .set_body(format!("owner-{}", outbound.opaque()).into_bytes()),
+            )
+            .await
+            .expect("complete same-session pending request");
+    }
+    let mut completed = Vec::new();
+    for _ in 0..2 {
+        let response = tokio::time::timeout(Duration::from_secs(1), first.receive_command())
+            .await
+            .expect("same-session final deadline")
+            .expect("first connection")
+            .expect("same-session final response");
+        completed.push((response.opaque(), response.body().cloned()));
+    }
+    completed.sort_by_key(|(opaque, _)| *opaque);
+    assert_eq!(
+        completed,
+        vec![
+            (51, Some(bytes::Bytes::from_static(b"owner-51"))),
+            (52, Some(bytes::Bytes::from_static(b"owner-52"))),
+        ]
+    );
+
+    let mut closing = crate::connection::Connection::new(TcpStream::connect(address).await.expect("closing V1 client"));
+    closing
+        .send_command(RemotingCommand::create_remoting_command(8_800).set_opaque(61))
+        .await
+        .expect("closing inbound request");
+    let _ = tokio::time::timeout(Duration::from_secs(1), closing.receive_command())
+        .await
+        .expect("closing outbound deadline")
+        .expect("closing connection")
+        .expect("closing outbound request");
+    drop(closing);
+
+    let _ = shutdown_tx.send(());
+    let report = tokio::time::timeout(Duration::from_secs(2), server_task)
+        .await
+        .expect("owner close releases pending waiter before drain")
+        .expect("join V1 correlation server")
+        .expect("V1 correlation shutdown report");
+    assert!(report.is_healthy(), "{}", report.to_json());
 }

--- a/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/v2_server.rs
+++ b/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/v2_server.rs
@@ -1,0 +1,550 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::connection_handler::V2ConnectionHandler;
+use super::shutdown::new_remoting_server_context;
+use super::*;
+use crate::dispatch::AuthorizedCommandDispatcherV2;
+use crate::runtime::processor_v2::RequestProcessorV2;
+
+/// Network server for the explicit V2 request-processor contract.
+///
+/// The server owns one statically selected V2 route and consumes itself at
+/// startup so capability preparation and hook installation can happen once.
+pub struct TransportServerV2<P> {
+    config: Arc<ServerConfig>,
+    service_context: ChildServiceContext,
+    request_processor: Option<P>,
+    dispatcher: Option<Arc<AuthorizedCommandDispatcherV2<P>>>,
+    rpc_hooks: Vec<Arc<dyn RPCHook>>,
+    transport_security: Option<Arc<TransportSecurity>>,
+    transport_principal: Option<Principal>,
+    admission: Option<Arc<AdmissionController>>,
+    telemetry: TransportTelemetry,
+    frame_limits: FrameLimits,
+    proxy_protocol: ProxyProtocolConfig,
+    #[cfg(test)]
+    write_preflight_barrier: Option<crate::write_strategy::WritePreflightBarrier>,
+}
+
+struct PreparedV2Server<P> {
+    dispatcher: Arc<AuthorizedCommandDispatcherV2<P>>,
+    tls_runtime: TlsServerRuntime,
+    task_group: TaskGroup,
+    file_region_blocking: BlockingExecutor,
+    file_transfer_mode: FileTransferMode,
+    transport_principal: Option<Principal>,
+    telemetry: TransportTelemetry,
+    frame_limits: FrameLimits,
+    proxy_protocol: ProxyProtocolConfig,
+    #[cfg(test)]
+    write_preflight_barrier: Option<crate::write_strategy::WritePreflightBarrier>,
+}
+
+impl<P> TransportServerV2<P>
+where
+    P: RequestProcessorV2 + Clone + Sync + 'static,
+{
+    /// Creates a V2 server that will move `request_processor` into its dispatcher at startup.
+    #[must_use]
+    pub fn new(config: Arc<ServerConfig>, service_context: ChildServiceContext, request_processor: P) -> Self {
+        Self {
+            config,
+            service_context,
+            request_processor: Some(request_processor),
+            dispatcher: None,
+            rpc_hooks: Vec::new(),
+            transport_security: None,
+            transport_principal: None,
+            admission: None,
+            telemetry: TransportTelemetry::noop(),
+            frame_limits: FrameLimits::java_compatibility(),
+            proxy_protocol: ProxyProtocolConfig::default(),
+            #[cfg(test)]
+            write_preflight_barrier: None,
+        }
+    }
+
+    /// Creates a V2 server with an explicit lifecycle owner.
+    #[must_use]
+    pub fn new_with_service_context(
+        config: Arc<ServerConfig>,
+        service_context: ChildServiceContext,
+        request_processor: P,
+    ) -> Self {
+        Self::new(config, service_context, request_processor)
+    }
+
+    /// Creates a V2 server bound to one transport recorder.
+    #[must_use]
+    pub fn new_with_telemetry(
+        config: Arc<ServerConfig>,
+        service_context: ChildServiceContext,
+        request_processor: P,
+        telemetry: TransportTelemetry,
+    ) -> Self {
+        Self {
+            telemetry,
+            ..Self::new(config, service_context, request_processor)
+        }
+    }
+
+    /// Creates a V2 server using an already-authorized dispatcher.
+    #[must_use]
+    pub fn new_with_authorized_dispatcher(
+        config: Arc<ServerConfig>,
+        service_context: ChildServiceContext,
+        dispatcher: Arc<AuthorizedCommandDispatcherV2<P>>,
+    ) -> Self {
+        Self {
+            config,
+            service_context,
+            request_processor: None,
+            dispatcher: Some(dispatcher),
+            rpc_hooks: Vec::new(),
+            transport_security: None,
+            transport_principal: None,
+            admission: None,
+            telemetry: TransportTelemetry::noop(),
+            frame_limits: FrameLimits::java_compatibility(),
+            proxy_protocol: ProxyProtocolConfig::default(),
+            #[cfg(test)]
+            write_preflight_barrier: None,
+        }
+    }
+
+    /// Replaces the no-op transport recorder before startup.
+    #[must_use]
+    pub fn with_telemetry(mut self, telemetry: TransportTelemetry) -> Self {
+        self.telemetry = telemetry;
+        self
+    }
+
+    /// Applies one validated frame profile to every accepted connection.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `frame_limits` is not a valid transport profile.
+    pub fn try_with_frame_limits(mut self, frame_limits: FrameLimits) -> RocketMQResult<Self> {
+        frame_limits.validate()?;
+        self.frame_limits = frame_limits;
+        Ok(self)
+    }
+
+    /// Enables trusted PROXY v1/v2 negotiation before TLS and Remoting decoding.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the PROXY protocol policy is inconsistent.
+    pub fn try_with_proxy_protocol(mut self, config: ProxyProtocolConfig) -> RocketMQResult<Self> {
+        config.validate()?;
+        self.proxy_protocol = config;
+        Ok(self)
+    }
+
+    /// Appends one hook to the server's ordered startup contribution.
+    pub fn register_rpc_hook(&mut self, hook: Arc<dyn RPCHook>) {
+        self.rpc_hooks.push(hook);
+    }
+
+    /// Installs transport authorization for accepted sessions.
+    #[must_use]
+    pub fn with_transport_security(mut self, security: Arc<TransportSecurity>, principal: Option<Principal>) -> Self {
+        self.transport_security = Some(security);
+        self.transport_principal = principal;
+        self
+    }
+
+    #[doc(hidden)]
+    #[must_use]
+    pub fn with_admission_controller(mut self, admission: Arc<AdmissionController>) -> Self {
+        self.admission = Some(admission);
+        self
+    }
+
+    /// Selects an existing dispatcher and immediately releases any automatic processor source.
+    #[must_use]
+    pub fn with_authorized_dispatcher(mut self, dispatcher: Arc<AuthorizedCommandDispatcherV2<P>>) -> Self {
+        drop(self.request_processor.take());
+        self.dispatcher = Some(dispatcher);
+        self
+    }
+
+    #[cfg(test)]
+    fn with_write_preflight_barrier(mut self, barrier: crate::write_strategy::WritePreflightBarrier) -> Self {
+        self.write_preflight_barrier = Some(barrier);
+        self
+    }
+
+    /// Binds the configured address and serves until `shutdown` resolves.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed startup error for binding, capability, or lifecycle failures.
+    pub async fn try_run_with_shutdown_report<S>(self, shutdown: S) -> Result<ShutdownReport, ServerStartError>
+    where
+        S: Future,
+    {
+        self.try_run_with_shutdown_report_inner(shutdown, None).await
+    }
+
+    /// Binds and publishes readiness after every startup capability is prepared.
+    ///
+    /// # Errors
+    ///
+    /// Returns and reports the same typed startup failure through `startup`.
+    pub async fn try_run_with_shutdown_report_and_startup<S>(
+        self,
+        shutdown: S,
+        startup: oneshot::Sender<Result<SocketAddr, ServerStartError>>,
+    ) -> Result<ShutdownReport, ServerStartError>
+    where
+        S: Future,
+    {
+        self.try_run_with_shutdown_report_inner(shutdown, Some(startup)).await
+    }
+
+    /// Serves an already-bound listener until `shutdown` resolves.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed startup error for listener inspection or capability preparation.
+    pub async fn try_serve_bound_listener_until<S>(
+        self,
+        listener: TcpListener,
+        conn_disconnect_notify: Option<broadcast::Sender<SocketAddr>>,
+        shutdown: S,
+    ) -> Result<ShutdownReport, ServerStartError>
+    where
+        S: Future,
+    {
+        self.try_serve_bound_listener_until_inner(listener, conn_disconnect_notify, shutdown, None)
+            .await
+    }
+
+    /// Serves a bound listener and publishes readiness after capability preparation.
+    ///
+    /// # Errors
+    ///
+    /// Returns and reports the same typed startup failure through `startup`.
+    pub async fn try_serve_bound_listener_until_with_startup<S>(
+        self,
+        listener: TcpListener,
+        conn_disconnect_notify: Option<broadcast::Sender<SocketAddr>>,
+        shutdown: S,
+        startup: oneshot::Sender<Result<SocketAddr, ServerStartError>>,
+    ) -> Result<ShutdownReport, ServerStartError>
+    where
+        S: Future,
+    {
+        self.try_serve_bound_listener_until_inner(listener, conn_disconnect_notify, shutdown, Some(startup))
+            .await
+    }
+
+    async fn try_run_with_shutdown_report_inner<S>(
+        self,
+        shutdown: S,
+        mut startup: Option<oneshot::Sender<Result<SocketAddr, ServerStartError>>>,
+    ) -> Result<ShutdownReport, ServerStartError>
+    where
+        S: Future,
+    {
+        let address = format!("{}:{}", self.config.bind_address, self.config.listen_port);
+        let listener = match TcpListener::bind(&address).await {
+            Ok(listener) => listener,
+            Err(error) => {
+                let error = ServerStartError::Bind {
+                    stage: "listener.bind",
+                    address,
+                    detail: error.to_string(),
+                };
+                notify_startup(&mut startup, Err(error.clone()));
+                return Err(error);
+            }
+        };
+        let local_address = match listener.local_addr() {
+            Ok(address) => address,
+            Err(error) => {
+                let error = ServerStartError::LocalAddress {
+                    stage: "listener.local_addr",
+                    address,
+                    detail: error.to_string(),
+                };
+                notify_startup(&mut startup, Err(error.clone()));
+                return Err(error);
+            }
+        };
+        let prepared = match self.prepare().await {
+            Ok(prepared) => prepared,
+            Err(error) => {
+                notify_startup(&mut startup, Err(error.clone()));
+                return Err(error);
+            }
+        };
+        notify_startup(&mut startup, Ok(local_address));
+        serve_v2(listener, shutdown, Some(broadcast::channel(100).0), prepared).await
+    }
+
+    async fn try_serve_bound_listener_until_inner<S>(
+        self,
+        listener: TcpListener,
+        conn_disconnect_notify: Option<broadcast::Sender<SocketAddr>>,
+        shutdown: S,
+        mut startup: Option<oneshot::Sender<Result<SocketAddr, ServerStartError>>>,
+    ) -> Result<ShutdownReport, ServerStartError>
+    where
+        S: Future,
+    {
+        let address = match listener.local_addr() {
+            Ok(address) => address,
+            Err(error) => {
+                let error = ServerStartError::LocalAddress {
+                    stage: "listener.local_addr",
+                    address: "pre-bound listener".to_owned(),
+                    detail: error.to_string(),
+                };
+                notify_startup(&mut startup, Err(error.clone()));
+                return Err(error);
+            }
+        };
+        let prepared = match self.prepare().await {
+            Ok(prepared) => prepared,
+            Err(error) => {
+                notify_startup(&mut startup, Err(error.clone()));
+                return Err(error);
+            }
+        };
+        notify_startup(&mut startup, Ok(address));
+        serve_v2(listener, shutdown, conn_disconnect_notify, prepared).await
+    }
+
+    async fn prepare(mut self) -> Result<PreparedV2Server<P>, ServerStartError> {
+        self.frame_limits
+            .validate()
+            .map_err(|error| configuration_error("frame_limits", error))?;
+        self.proxy_protocol
+            .validate()
+            .map_err(|error| configuration_error("proxy_protocol", error))?;
+
+        let injected = self.dispatcher.as_ref();
+        if let (Some(dispatcher), Some(security)) = (injected, self.transport_security.as_ref()) {
+            if !dispatcher.boundary().has_security_owner(security) {
+                return Err(configuration_message(
+                    "authorized_dispatcher.security",
+                    "configured security does not own the injected dispatcher boundary",
+                ));
+            }
+        }
+        if let (Some(dispatcher), Some(admission)) = (injected, self.admission.as_ref()) {
+            if !dispatcher.boundary().has_admission_owner(admission) {
+                return Err(configuration_message(
+                    "authorized_dispatcher.admission",
+                    "configured admission does not own the injected dispatcher boundary",
+                ));
+            }
+        }
+        if self.dispatcher.is_none() && self.request_processor.is_none() {
+            return Err(configuration_message(
+                "request_processor",
+                "automatic V2 startup has no processor source",
+            ));
+        }
+
+        let admission = match (self.dispatcher.as_ref(), self.admission.take()) {
+            (Some(dispatcher), _) => dispatcher.boundary().admission_controller(),
+            (None, Some(admission)) => admission,
+            (None, None) => {
+                let mut limits = AdmissionLimits::default();
+                limits.connections = ResourceLimit {
+                    count: DEFAULT_MAX_CONNECTIONS,
+                    ..limits.connections
+                };
+                limits.handshakes = ResourceLimit {
+                    count: DEFAULT_MAX_CONNECTIONS,
+                    ..limits.handshakes
+                };
+                Arc::new(
+                    AdmissionController::try_new_with_budget(limits, &self.service_context.process_budget()).map_err(
+                        |error| ServerStartError::Admission {
+                            stage: "admission.initialize",
+                            detail: error.to_string(),
+                        },
+                    )?,
+                )
+            }
+        };
+        let security = match (self.dispatcher.as_ref(), self.transport_security.take()) {
+            (Some(dispatcher), _) => dispatcher.boundary().security_owner(),
+            (None, Some(security)) => security,
+            (None, None) => {
+                warn!("V2 remoting server has no security profile; using development-insecure fallback");
+                Arc::new(TransportSecurity::development_insecure_loopback(None, None))
+            }
+        };
+        let dispatcher = match self.dispatcher.take() {
+            Some(dispatcher) => {
+                drop(self.request_processor.take());
+                dispatcher
+            }
+            None => {
+                let Some(processor) = self.request_processor.take() else {
+                    return Err(configuration_message(
+                        "request_processor",
+                        "automatic V2 startup has no processor source",
+                    ));
+                };
+                Arc::new(AuthorizedCommandDispatcherV2::new(
+                    processor,
+                    Vec::new(),
+                    security,
+                    admission,
+                ))
+            }
+        };
+
+        let remoting_context = new_remoting_server_context(&self.service_context);
+        let tls_runtime =
+            TlsServerRuntime::initialize_with_service_context(self.config.tls_config.clone(), &remoting_context)
+                .await
+                .map_err(|error| ServerStartError::Tls {
+                    stage: "tls.initialize",
+                    detail: error.to_string(),
+                })?;
+
+        // Hook mutation is deliberately the final preparation step. Failed
+        // validation and boundary conflicts cannot contaminate a shared dispatcher.
+        for hook in self.rpc_hooks {
+            dispatcher.register_rpc_hook(hook);
+        }
+
+        Ok(PreparedV2Server {
+            dispatcher,
+            tls_runtime,
+            task_group: remoting_context.task_group().clone(),
+            file_region_blocking: remoting_context.storage_io().clone(),
+            file_transfer_mode: self.config.file_transfer_mode,
+            transport_principal: self.transport_principal,
+            telemetry: self.telemetry,
+            frame_limits: self.frame_limits,
+            proxy_protocol: self.proxy_protocol,
+            #[cfg(test)]
+            write_preflight_barrier: self.write_preflight_barrier,
+        })
+    }
+}
+
+fn notify_startup(
+    startup: &mut Option<oneshot::Sender<Result<SocketAddr, ServerStartError>>>,
+    result: Result<SocketAddr, ServerStartError>,
+) {
+    if let Some(startup) = startup.take() {
+        let _ = startup.send(result);
+    }
+}
+
+fn configuration_error(stage: &'static str, error: RocketMQError) -> ServerStartError {
+    ServerStartError::Configuration {
+        stage,
+        detail: error.to_string(),
+        source: SharedRocketMQError::new(error),
+    }
+}
+
+fn configuration_message(stage: &'static str, detail: &'static str) -> ServerStartError {
+    configuration_error(
+        stage,
+        RocketMQError::ConfigInvalidValue {
+            key: stage,
+            value: "conflict".to_owned(),
+            reason: detail.to_owned(),
+        },
+    )
+}
+
+async fn serve_v2<P>(
+    listener: TcpListener,
+    shutdown: impl Future,
+    conn_disconnect_notify: Option<broadcast::Sender<SocketAddr>>,
+    prepared: PreparedV2Server<P>,
+) -> Result<ShutdownReport, ServerStartError>
+where
+    P: RequestProcessorV2 + Clone + Sync + 'static,
+{
+    let PreparedV2Server {
+        dispatcher,
+        tls_runtime,
+        task_group,
+        file_region_blocking,
+        file_transfer_mode,
+        transport_principal,
+        telemetry,
+        frame_limits,
+        proxy_protocol,
+        #[cfg(test)]
+        write_preflight_barrier,
+    } = prepared;
+    let (shutdown_complete_tx, mut shutdown_complete_rx) = mpsc::channel(1);
+    let route = Arc::new(V2ConnectionHandler {
+        shutdown_complete_tx: shutdown_complete_tx.clone(),
+        conn_disconnect_notify,
+        dispatcher: dispatcher.clone(),
+    });
+    let transport = TransportListener::new(
+        listener,
+        task_group.clone(),
+        tls_runtime.clone(),
+        dispatcher.boundary().admission_controller(),
+        DEFAULT_TLS_HANDSHAKE_TIMEOUT,
+    )
+    .with_authorized_dispatch(dispatcher.boundary(), transport_principal)
+    .with_file_region_io(file_region_blocking, file_transfer_mode)
+    .with_validated_frame_limits(frame_limits)
+    .with_validated_proxy_protocol(proxy_protocol)
+    .with_telemetry(telemetry);
+    #[cfg(test)]
+    let transport = match write_preflight_barrier {
+        Some(barrier) => transport.with_write_preflight_barrier(barrier),
+        None => transport,
+    };
+
+    tokio::select! {
+        result = transport.run_authorized(route) => {
+            if let Err(error) = result {
+                error!(cause = %error, "V2 remoting listener stopped with an error");
+            }
+        }
+        _ = shutdown => {
+            info!("Shutting down V2 remoting server");
+        }
+    }
+
+    let deadline = task_group
+        .shutdown_deadline()
+        .unwrap_or_else(|| ShutdownDeadline::after(Duration::from_secs(30)));
+    task_group.cancel();
+    drop(shutdown_complete_tx);
+    let _ = tokio::time::timeout(deadline.remaining(), shutdown_complete_rx.recv()).await;
+    let tls_report = tls_runtime
+        .shutdown_gracefully(deadline.remaining().min(Duration::from_secs(3)))
+        .await;
+    let mut report = task_group.shutdown_until(deadline).await;
+    if let Some(tls_report) = tls_report {
+        report.children.push(tls_report);
+    }
+    report.log_if_unhealthy();
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests;

--- a/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/v2_server/tests.rs
+++ b/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/v2_server/tests.rs
@@ -1,0 +1,648 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Mutex;
+
+use bytes::Bytes;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_runtime::RuntimeContext;
+use rocketmq_security_api::IngressDecision;
+use rocketmq_security_api::IngressPolicy;
+use rocketmq_security_api::LayerEvaluation;
+use rocketmq_security_api::SecurityRequestView;
+use tokio::net::TcpStream;
+
+use super::*;
+use crate::dispatch::bridge_construction_counts;
+use crate::dispatch::HandlerOutcome;
+use crate::dispatch::ProtocolNoResponseReason;
+use crate::dispatch::RemotingRequest;
+use crate::dispatch::ResponsePlan;
+use crate::runtime::processor_v2::RejectRequestDecision;
+use crate::runtime::RPCHook;
+
+#[derive(Default)]
+struct ProcessorState {
+    clones: AtomicUsize,
+    processes: AtomicUsize,
+    processor_admission_count: AtomicUsize,
+    ordered_entered: tokio::sync::Notify,
+    request_sequences: Mutex<Vec<u64>>,
+    session: Mutex<Option<crate::session_view::SessionId>>,
+}
+
+struct TcpV2Processor {
+    state: Arc<ProcessorState>,
+    admission: Option<Arc<AdmissionController>>,
+}
+
+impl Clone for TcpV2Processor {
+    fn clone(&self) -> Self {
+        self.state.clones.fetch_add(1, Ordering::SeqCst);
+        Self {
+            state: Arc::clone(&self.state),
+            admission: self.admission.clone(),
+        }
+    }
+}
+
+impl RequestProcessorV2 for TcpV2Processor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> RocketMQResult<HandlerOutcome> {
+        self.state.processes.fetch_add(1, Ordering::SeqCst);
+        self.state
+            .request_sequences
+            .lock()
+            .expect("request sequence capture lock")
+            .push(request.original_identity().request_id().sequence());
+        let signal_no_response = request.command().code() == 39 || request.original_identity().is_one_way();
+        if signal_no_response {
+            self.state.ordered_entered.notify_one();
+        }
+        if let Some(admission) = &self.admission {
+            self.state
+                .processor_admission_count
+                .store(admission.snapshot().processors.current_count, Ordering::SeqCst);
+        }
+        *self.state.session.lock().expect("session capture lock") = Some(request.session().id());
+        if request.command().code() == 39 {
+            return Ok(HandlerOutcome::NoReply(
+                request.protocol_no_response(ProtocolNoResponseReason::CallbackHandled)?,
+            ));
+        }
+        Ok(HandlerOutcome::Reply(
+            ResponsePlan::bytes(
+                RemotingCommand::create_response_command_with_code(ResponseCode::Success).set_opaque(-9),
+                Bytes::from_static(b"v2-tcp"),
+            )
+            .expect("test response plan"),
+        ))
+    }
+
+    fn request_ordering(
+        &self,
+        _ingress: crate::dispatch::IngressRequestView<'_>,
+    ) -> crate::request_ordering::RequestOrdering {
+        crate::request_ordering::RequestOrdering::Ordered(crate::request_ordering::RequestOrderingKey::new(9800))
+    }
+
+    fn reject_request(&self, code: i32) -> RejectRequestDecision {
+        if code == 703 {
+            return RejectRequestDecision::Reject(
+                ResponsePlan::command(RemotingCommand::create_response_command_with_code(44))
+                    .expect("test rejection plan"),
+            );
+        }
+        RejectRequestDecision::Proceed
+    }
+}
+
+struct DropTrackedProcessor {
+    drops: Arc<AtomicUsize>,
+}
+
+impl Clone for DropTrackedProcessor {
+    fn clone(&self) -> Self {
+        Self {
+            drops: Arc::clone(&self.drops),
+        }
+    }
+}
+
+impl Drop for DropTrackedProcessor {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+impl RequestProcessorV2 for DropTrackedProcessor {
+    async fn process(&mut self, _request: &mut RemotingRequest) -> RocketMQResult<HandlerOutcome> {
+        Ok(HandlerOutcome::Reply(
+            ResponsePlan::command(RemotingCommand::create_response_command_with_code(
+                ResponseCode::Success,
+            ))
+            .expect("drop-tracked response plan"),
+        ))
+    }
+}
+
+#[derive(Clone)]
+struct DrainingProcessor {
+    started: Arc<tokio::sync::Notify>,
+    release: Arc<tokio::sync::Notify>,
+}
+
+impl RequestProcessorV2 for DrainingProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> RocketMQResult<HandlerOutcome> {
+        if request.command().code() == 39 {
+            self.started.notify_one();
+            self.release.notified().await;
+            return Ok(HandlerOutcome::NoReply(
+                request.protocol_no_response(ProtocolNoResponseReason::CallbackHandled)?,
+            ));
+        }
+        Ok(HandlerOutcome::Reply(
+            ResponsePlan::bytes(
+                RemotingCommand::create_response_command_with_code(ResponseCode::Success),
+                Bytes::from_static(b"drained-before-retire"),
+            )
+            .expect("draining response plan"),
+        ))
+    }
+}
+
+struct CountingHook {
+    before: Arc<AtomicUsize>,
+    after: Arc<AtomicUsize>,
+}
+
+struct OrderedHook {
+    id: &'static str,
+    events: Arc<Mutex<Vec<(&'static str, &'static str)>>>,
+}
+
+struct CountingPolicy {
+    calls: Arc<AtomicUsize>,
+}
+
+impl IngressPolicy for CountingPolicy {
+    fn evaluate_ingress(&self, _request: SecurityRequestView<'_>) -> LayerEvaluation<IngressDecision> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(IngressDecision::AllowToContinue)
+    }
+}
+
+impl RPCHook for CountingHook {
+    fn do_before_request(&self, _remote_addr: SocketAddr, _request: &mut RemotingCommand) -> RocketMQResult<()> {
+        self.before.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    fn do_after_response(
+        &self,
+        _remote_addr: SocketAddr,
+        _request: &RemotingCommand,
+        _response: &mut RemotingCommand,
+    ) -> RocketMQResult<()> {
+        self.after.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+impl RPCHook for OrderedHook {
+    fn do_before_request(&self, _remote_addr: SocketAddr, _request: &mut RemotingCommand) -> RocketMQResult<()> {
+        self.events
+            .lock()
+            .expect("ordered hook event lock")
+            .push(("before", self.id));
+        Ok(())
+    }
+
+    fn do_after_response(
+        &self,
+        _remote_addr: SocketAddr,
+        _request: &RemotingCommand,
+        _response: &mut RemotingCommand,
+    ) -> RocketMQResult<()> {
+        self.events
+            .lock()
+            .expect("ordered hook event lock")
+            .push(("after", self.id));
+        Ok(())
+    }
+}
+
+fn service_context(name: &'static str) -> ChildServiceContext {
+    RuntimeContext::from_current(name).service_context("transport-v2-test")
+}
+
+fn loopback_security() -> Arc<TransportSecurity> {
+    Arc::new(TransportSecurity::development_insecure_loopback(None, None))
+}
+
+async fn start_server(
+    server: TransportServerV2<TcpV2Processor>,
+) -> (
+    crate::connection::Connection,
+    oneshot::Sender<()>,
+    tokio::task::JoinHandle<Result<ShutdownReport, ServerStartError>>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind V2 test listener");
+    let address = listener.local_addr().expect("V2 test listener address");
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let (startup_tx, startup_rx) = oneshot::channel();
+    let server_task = tokio::spawn(async move {
+        server
+            .try_serve_bound_listener_until_with_startup(
+                listener,
+                None,
+                async {
+                    let _ = shutdown_rx.await;
+                },
+                startup_tx,
+            )
+            .await
+    });
+    assert_eq!(
+        startup_rx
+            .await
+            .expect("V2 startup result channel")
+            .expect("V2 startup succeeds"),
+        address
+    );
+    let client = crate::connection::Connection::new(TcpStream::connect(address).await.expect("connect V2 client"));
+    (client, shutdown_tx, server_task)
+}
+
+#[tokio::test]
+async fn real_tcp_v2_routes_requests_once_and_drops_unexpected_responses_without_legacy_state() {
+    let state = Arc::new(ProcessorState::default());
+    let security_calls = Arc::new(AtomicUsize::new(0));
+    let admission = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let processor = TcpV2Processor {
+        state: Arc::clone(&state),
+        admission: Some(Arc::clone(&admission)),
+    };
+    let server = TransportServerV2::new(
+        Arc::new(ServerConfig::default()),
+        service_context("transport-v2-tcp"),
+        processor,
+    )
+    .with_transport_security(
+        Arc::new(
+            TransportSecurity::development_insecure_loopback(None, None).with_ingress_policy(Arc::new(
+                CountingPolicy {
+                    calls: Arc::clone(&security_calls),
+                },
+            )),
+        ),
+        None,
+    )
+    .with_admission_controller(admission);
+    let (mut client, shutdown_tx, server_task) = start_server(server).await;
+    state.clones.store(0, Ordering::SeqCst);
+
+    client
+        .send_command(RemotingCommand::create_response_command_with_code(91).set_opaque(4_001))
+        .await
+        .expect("send unexpected V2 response");
+    client
+        .send_command(RemotingCommand::create_remoting_command(701).set_opaque(4_002))
+        .await
+        .expect("send V2 request after unexpected response");
+    let response = tokio::time::timeout(Duration::from_secs(1), client.receive_command())
+        .await
+        .expect("V2 TCP response deadline")
+        .expect("V2 TCP client remains connected")
+        .expect("V2 TCP response frame");
+    assert_eq!(response.opaque(), 4_002);
+    assert_eq!(
+        response.get_type(),
+        rocketmq_protocol::protocol::RemotingCommandType::RESPONSE
+    );
+    assert_eq!(response.body(), Some(&Bytes::from_static(b"v2-tcp")));
+    assert_eq!(state.processes.load(Ordering::SeqCst), 1);
+    assert_eq!(state.clones.load(Ordering::SeqCst), 1);
+    assert_eq!(security_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(state.processor_admission_count.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        state
+            .request_sequences
+            .lock()
+            .expect("request sequence capture lock")
+            .as_slice(),
+        [1],
+        "the unexpected RESPONSE must not consume a request identity"
+    );
+    let session = state
+        .session
+        .lock()
+        .expect("session capture lock")
+        .expect("V2 session id");
+    assert_eq!(bridge_construction_counts(session), (0, 0));
+
+    client
+        .send_command(RemotingCommand::create_remoting_command(703).set_opaque(4_003))
+        .await
+        .expect("send V2 rejection request");
+    let rejected = tokio::time::timeout(Duration::from_secs(1), client.receive_command())
+        .await
+        .expect("V2 rejection deadline")
+        .expect("V2 connection after rejection")
+        .expect("V2 rejection response");
+    assert_eq!((rejected.code(), rejected.opaque()), (44, 4_003));
+
+    client
+        .send_command(RemotingCommand::create_remoting_command(39).set_opaque(4_004))
+        .await
+        .expect("send V2 protocol no-response request");
+    tokio::time::timeout(Duration::from_secs(1), state.ordered_entered.notified())
+        .await
+        .expect("no-response processor enters the ordered section");
+    client
+        .send_command(RemotingCommand::create_remoting_command(701).set_opaque(4_005))
+        .await
+        .expect("send sentinel after V2 protocol no-response");
+    let no_response_sentinel = tokio::time::timeout(Duration::from_secs(1), client.receive_command())
+        .await
+        .expect("protocol no-response sentinel deadline")
+        .expect("protocol no-response keeps the connection open")
+        .expect("protocol no-response sentinel frame");
+    assert_eq!(
+        (no_response_sentinel.code(), no_response_sentinel.opaque()),
+        (ResponseCode::Success.to_i32(), 4_005)
+    );
+    assert_eq!(no_response_sentinel.body(), Some(&Bytes::from_static(b"v2-tcp")));
+
+    client
+        .send_command(
+            RemotingCommand::create_remoting_command(701)
+                .set_opaque(4_006)
+                .mark_oneway_rpc(),
+        )
+        .await
+        .expect("send V2 one-way request");
+    tokio::time::timeout(Duration::from_secs(1), state.ordered_entered.notified())
+        .await
+        .expect("one-way processor enters the ordered section");
+    client
+        .send_command(RemotingCommand::create_remoting_command(701).set_opaque(4_007))
+        .await
+        .expect("send sentinel after V2 one-way request");
+    let oneway_sentinel = tokio::time::timeout(Duration::from_secs(1), client.receive_command())
+        .await
+        .expect("one-way sentinel deadline")
+        .expect("one-way keeps the connection open")
+        .expect("one-way sentinel frame");
+    assert_eq!(
+        (oneway_sentinel.code(), oneway_sentinel.opaque()),
+        (ResponseCode::Success.to_i32(), 4_007)
+    );
+    assert_eq!(oneway_sentinel.body(), Some(&Bytes::from_static(b"v2-tcp")));
+
+    let _ = shutdown_tx.send(());
+    let report = server_task.await.expect("join V2 server").expect("V2 shutdown report");
+    assert!(report.is_healthy(), "{}", report.to_json());
+    let eof = tokio::time::timeout(Duration::from_secs(1), client.receive_command())
+        .await
+        .expect("V2 shutdown should publish EOF");
+    assert!(eof.is_none(), "V2 shutdown must not leave an extra response frame");
+}
+
+#[tokio::test]
+async fn injected_boundary_conflicts_fail_before_hooks_are_merged() {
+    let state = Arc::new(ProcessorState::default());
+    let admission = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+        TcpV2Processor { state, admission: None },
+        Vec::new(),
+        loopback_security(),
+        admission,
+    ));
+    let before = Arc::new(AtomicUsize::new(0));
+    let after = Arc::new(AtomicUsize::new(0));
+    let hook = Arc::new(CountingHook {
+        before: Arc::clone(&before),
+        after: Arc::clone(&after),
+    });
+    let mut server = TransportServerV2::new_with_authorized_dispatcher(
+        Arc::new(ServerConfig::default()),
+        service_context("transport-v2-conflict"),
+        Arc::clone(&dispatcher),
+    )
+    .with_transport_security(loopback_security(), None);
+    server.register_rpc_hook(hook);
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind conflict listener");
+    let error = server
+        .try_serve_bound_listener_until(listener, None, std::future::pending::<()>())
+        .await
+        .expect_err("foreign security owner must fail");
+    assert!(matches!(error, ServerStartError::Configuration { .. }));
+
+    let mut admission_conflict = TransportServerV2::new_with_authorized_dispatcher(
+        Arc::new(ServerConfig::default()),
+        service_context("transport-v2-admission-conflict"),
+        Arc::clone(&dispatcher),
+    )
+    .with_admission_controller(Arc::new(AdmissionController::new(AdmissionLimits::default())));
+    admission_conflict.register_rpc_hook(Arc::new(CountingHook {
+        before: Arc::clone(&before),
+        after: Arc::clone(&after),
+    }));
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind admission conflict listener");
+    let error = admission_conflict
+        .try_serve_bound_listener_until(listener, None, std::future::pending::<()>())
+        .await
+        .expect_err("foreign admission owner must fail");
+    assert!(matches!(error, ServerStartError::Configuration { .. }));
+
+    let matching_server = TransportServerV2::new_with_authorized_dispatcher(
+        Arc::new(ServerConfig::default()),
+        service_context("transport-v2-unpolluted"),
+        dispatcher,
+    );
+    let (mut client, shutdown_tx, server_task) = start_server(matching_server).await;
+    client
+        .send_command(RemotingCommand::create_remoting_command(701).set_opaque(4_003))
+        .await
+        .expect("send request through unpolluted dispatcher");
+    let _ = tokio::time::timeout(Duration::from_secs(1), client.receive_command())
+        .await
+        .expect("unpolluted response deadline")
+        .expect("unpolluted connection")
+        .expect("unpolluted response");
+    assert_eq!(before.load(Ordering::SeqCst), 0);
+    assert_eq!(after.load(Ordering::SeqCst), 0);
+    let _ = shutdown_tx.send(());
+    let _ = server_task
+        .await
+        .expect("join unpolluted server")
+        .expect("shutdown report");
+}
+
+#[tokio::test]
+async fn dispatcher_injection_immediately_drops_the_automatic_processor_source() {
+    let automatic_drops = Arc::new(AtomicUsize::new(0));
+    let injected_drops = Arc::new(AtomicUsize::new(0));
+    let admission = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+        DropTrackedProcessor {
+            drops: Arc::clone(&injected_drops),
+        },
+        Vec::new(),
+        loopback_security(),
+        admission,
+    ));
+    let server = TransportServerV2::new(
+        Arc::new(ServerConfig::default()),
+        service_context("transport-v2-processor-replacement"),
+        DropTrackedProcessor {
+            drops: Arc::clone(&automatic_drops),
+        },
+    );
+
+    let server = server.with_authorized_dispatcher(dispatcher);
+    assert_eq!(automatic_drops.load(Ordering::SeqCst), 1);
+    assert_eq!(injected_drops.load(Ordering::SeqCst), 0);
+    drop(server);
+    assert_eq!(injected_drops.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn shutdown_drains_accepted_work_and_flushes_its_writer_before_retirement() {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind draining V2 listener");
+    let address = listener.local_addr().expect("draining V2 listener address");
+    let started = Arc::new(tokio::sync::Notify::new());
+    let release = Arc::new(tokio::sync::Notify::new());
+    let write_checked = Arc::new(tokio::sync::Notify::new());
+    let resume_write = Arc::new(tokio::sync::Notify::new());
+    let server = TransportServerV2::new(
+        Arc::new(ServerConfig::default()),
+        service_context("transport-v2-drain"),
+        DrainingProcessor {
+            started: Arc::clone(&started),
+            release: Arc::clone(&release),
+        },
+    )
+    .with_write_preflight_barrier(crate::write_strategy::WritePreflightBarrier::new(
+        Arc::clone(&write_checked),
+        Arc::clone(&resume_write),
+    ));
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let (shutdown_seen_tx, shutdown_seen_rx) = oneshot::channel::<()>();
+    let (startup_tx, startup_rx) = oneshot::channel();
+    let server_task = tokio::spawn(async move {
+        server
+            .try_serve_bound_listener_until_with_startup(
+                listener,
+                None,
+                async {
+                    let _ = shutdown_rx.await;
+                    let _ = shutdown_seen_tx.send(());
+                },
+                startup_tx,
+            )
+            .await
+    });
+    assert_eq!(
+        startup_rx
+            .await
+            .expect("draining startup channel")
+            .expect("draining startup succeeds"),
+        address
+    );
+    let mut client =
+        crate::connection::Connection::new(TcpStream::connect(address).await.expect("connect draining V2 client"));
+    client
+        .send_command(RemotingCommand::create_remoting_command(704).set_opaque(4_006))
+        .await
+        .expect("send response that reaches the writer");
+    tokio::time::timeout(Duration::from_secs(1), write_checked.notified())
+        .await
+        .expect("response writer claims the accepted frame");
+    client
+        .send_command(RemotingCommand::create_remoting_command(39).set_opaque(4_007))
+        .await
+        .expect("send accepted work that must drain");
+    tokio::time::timeout(Duration::from_secs(1), started.notified())
+        .await
+        .expect("second processor starts before shutdown");
+
+    let _ = shutdown_tx.send(());
+    shutdown_seen_rx.await.expect("shutdown future completed");
+    release.notify_one();
+    resume_write.notify_one();
+
+    let response = tokio::time::timeout(Duration::from_secs(1), client.receive_command())
+        .await
+        .expect("drained response deadline")
+        .expect("draining connection remains open")
+        .expect("accepted response is flushed");
+    assert_eq!(response.opaque(), 4_006);
+    assert_eq!(response.body(), Some(&Bytes::from_static(b"drained-before-retire")));
+    let report = tokio::time::timeout(Duration::from_secs(2), server_task)
+        .await
+        .expect("V2 shutdown awaits drain and writer")
+        .expect("join draining V2 server")
+        .expect("draining V2 shutdown report");
+    assert!(report.is_healthy(), "{}", report.to_json());
+}
+
+#[tokio::test]
+async fn hooks_registered_before_and_after_injection_append_once_to_existing_registry() {
+    let state = Arc::new(ProcessorState::default());
+    let admission = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let security = loopback_security();
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let new_hook = |id: &'static str| {
+        Arc::new(OrderedHook {
+            id,
+            events: Arc::clone(&events),
+        }) as Arc<dyn RPCHook>
+    };
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+        TcpV2Processor {
+            state: Arc::clone(&state),
+            admission: None,
+        },
+        vec![new_hook("dispatcher-initial")],
+        Arc::clone(&security),
+        Arc::clone(&admission),
+    ));
+    let mut server = TransportServerV2::new(
+        Arc::new(ServerConfig::default()),
+        service_context("transport-v2-hook-merge"),
+        TcpV2Processor { state, admission: None },
+    );
+    server.register_rpc_hook(new_hook("pre-injection"));
+    let mut server = server
+        .with_authorized_dispatcher(dispatcher)
+        .with_transport_security(Arc::clone(&security), None)
+        .with_admission_controller(Arc::clone(&admission));
+    server.register_rpc_hook(new_hook("post-injection"));
+    let (mut client, shutdown_tx, server_task) = start_server(server).await;
+
+    client
+        .send_command(RemotingCommand::create_remoting_command(701).set_opaque(4_004))
+        .await
+        .expect("send hook merge request");
+    let _ = tokio::time::timeout(Duration::from_secs(1), client.receive_command())
+        .await
+        .expect("hook response deadline")
+        .expect("hook connection")
+        .expect("hook response");
+    assert_eq!(
+        events.lock().expect("ordered hook event lock").as_slice(),
+        [
+            ("before", "dispatcher-initial"),
+            ("before", "pre-injection"),
+            ("before", "post-injection"),
+            ("after", "dispatcher-initial"),
+            ("after", "pre-injection"),
+            ("after", "post-injection"),
+        ]
+    );
+
+    let _ = shutdown_tx.send(());
+    let _ = server_task
+        .await
+        .expect("join hook server")
+        .expect("hook shutdown report");
+}

--- a/rocketmq-transport/src/server.rs
+++ b/rocketmq-transport/src/server.rs
@@ -49,6 +49,8 @@ use crate::admission::AdmissionController;
 use crate::admission::AdmissionResource;
 use crate::admission::AdmissionScope;
 use crate::admission::AdmissionScopeHandle;
+use crate::admission::PartialFramePermit;
+use crate::base::pending_request_table::PendingRequestOwner;
 use crate::base::pending_request_table::PendingRequestTable;
 use crate::codec::remoting_command_codec::FrameLimits;
 use crate::config::SocketOptions;
@@ -62,6 +64,7 @@ use crate::connection::SessionWriterDiagnostics;
 use crate::connection::SessionWriterSnapshot;
 use crate::dispatch::reserve_session_owner;
 use crate::dispatch::AuthorizedDispatchBoundary;
+use crate::dispatch::AuthorizedDispatchSession;
 use crate::dispatch::NetworkResponsePlanContext;
 use crate::dispatch::OriginalRequestIdentity;
 use crate::dispatch::RequestContext;
@@ -185,11 +188,13 @@ impl SessionHandle {
         &self,
         response: ResponseSink,
         response_table: PendingRequestTable,
+        pending_request_owner: PendingRequestOwner,
     ) -> RocketMQResult<Channel> {
         let inner = ChannelInner::new_legacy_network_bridge(
             self.connection(),
             response,
             response_table,
+            pending_request_owner,
             self.task_group().clone(),
         )?;
         Ok(Channel::new_canonical_network(Arc::new(inner), self.clone()))
@@ -418,6 +423,104 @@ pub trait ConnectionHandler: Send + Sync + 'static {
     }
 }
 
+/// Statically selected frame route used by production authorized servers.
+///
+/// The associated state makes per-session capabilities generation-specific
+/// without a runtime mode tag or a processor trait object.
+pub(crate) trait AuthorizedFrameRoute: Send + Sync + 'static {
+    type SessionState: Send + Sync + 'static;
+
+    fn connected(&self, session: SessionHandle) -> impl Future<Output = Option<Self::SessionState>> + Send;
+
+    fn response(
+        &self,
+        state: &Self::SessionState,
+        session: SessionHandle,
+        command: RemotingCommand,
+    ) -> impl Future<Output = ()> + Send;
+
+    #[allow(clippy::too_many_arguments)]
+    fn request(
+        &self,
+        state: &Self::SessionState,
+        authorized_session: &AuthorizedDispatchSession,
+        session: SessionHandle,
+        context: RequestContext,
+        command: RemotingCommand,
+        received_at: std::time::Instant,
+        retained_bytes: usize,
+        partial_frame_permit: Option<PartialFramePermit>,
+    ) -> impl Future<Output = bool> + Send;
+
+    fn close_pending(&self, state: &Self::SessionState, session: SessionHandle) -> impl Future<Output = ()> + Send;
+
+    fn disconnected(&self, state: Self::SessionState, session: SessionHandle) -> impl Future<Output = ()> + Send;
+}
+
+struct CompatibilityFrameRoute<H> {
+    handler: Arc<H>,
+}
+
+impl<H> AuthorizedFrameRoute for CompatibilityFrameRoute<H>
+where
+    H: ConnectionHandler,
+{
+    type SessionState = ();
+
+    async fn connected(&self, session: SessionHandle) -> Option<Self::SessionState> {
+        self.handler.connected(session).await;
+        Some(())
+    }
+
+    async fn response(&self, _state: &Self::SessionState, session: SessionHandle, command: RemotingCommand) {
+        self.handler.command(session, command).await;
+    }
+
+    async fn request(
+        &self,
+        _state: &Self::SessionState,
+        authorized_session: &AuthorizedDispatchSession,
+        session: SessionHandle,
+        context: RequestContext,
+        command: RemotingCommand,
+        _received_at: std::time::Instant,
+        retained_bytes: usize,
+        partial_frame_permit: Option<PartialFramePermit>,
+    ) -> bool {
+        let original = session.original_request_identity();
+        let class = AdmissionClass::for_request_code(
+            original.map_or_else(|| command.code(), OriginalRequestIdentity::original_code),
+        );
+        let ordering = self.handler.request_ordering(&command);
+        let request_handler = Arc::clone(&self.handler);
+        let request_session = session.clone().with_response_class(class);
+        let response = ResponseSink::Network(Arc::new(session.clone().with_response_class(class)));
+        authorized_session
+            .dispatch(
+                context,
+                original,
+                command,
+                retained_bytes,
+                partial_frame_permit,
+                ordering,
+                response,
+                move |request_operation, command| async move {
+                    request_handler
+                        .command(request_session.with_operation_context(request_operation), command)
+                        .await;
+                },
+            )
+            .await
+            .is_ok()
+    }
+
+    async fn close_pending(&self, _state: &Self::SessionState, _session: SessionHandle) {}
+
+    async fn disconnected(&self, _state: Self::SessionState, session: SessionHandle) {
+        self.handler.disconnected(session).await;
+    }
+}
+
 #[derive(Clone, Copy)]
 struct NegotiationTimeouts {
     protocol_detection: Duration,
@@ -478,6 +581,8 @@ pub struct TransportListener {
     file_transfer_mode: FileTransferMode,
     frame_limits: FrameLimits,
     proxy_protocol: ProxyProtocolConfig,
+    #[cfg(test)]
+    write_preflight_barrier: Option<crate::write_strategy::WritePreflightBarrier>,
 }
 
 impl TransportListener {
@@ -506,6 +611,8 @@ impl TransportListener {
             file_transfer_mode: FileTransferMode::Auto,
             frame_limits: FrameLimits::default(),
             proxy_protocol: ProxyProtocolConfig::default(),
+            #[cfg(test)]
+            write_preflight_barrier: None,
         }
     }
 
@@ -533,11 +640,32 @@ impl TransportListener {
         Ok(self)
     }
 
+    pub(crate) fn with_validated_frame_limits(mut self, frame_limits: FrameLimits) -> Self {
+        debug_assert!(frame_limits.validate().is_ok());
+        self.frame_limits = frame_limits;
+        self
+    }
+
     /// Applies the trusted PROXY protocol policy before TLS/application negotiation.
     pub fn try_with_proxy_protocol(mut self, config: ProxyProtocolConfig) -> RocketMQResult<Self> {
         config.validate()?;
         self.proxy_protocol = config;
         Ok(self)
+    }
+
+    pub(crate) fn with_validated_proxy_protocol(mut self, config: ProxyProtocolConfig) -> Self {
+        debug_assert!(config.validate().is_ok());
+        self.proxy_protocol = config;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_write_preflight_barrier(
+        mut self,
+        barrier: crate::write_strategy::WritePreflightBarrier,
+    ) -> Self {
+        self.write_preflight_barrier = Some(barrier);
+        self
     }
 
     #[allow(dead_code, reason = "custom security is used by the feature-gated session harness")]
@@ -585,9 +713,27 @@ impl TransportListener {
         self
     }
 
+    #[allow(
+        dead_code,
+        reason = "preserved low-level ConnectionHandler compatibility entry point"
+    )]
     pub async fn run<H>(self, handler: Arc<H>) -> RocketMQResult<()>
     where
         H: ConnectionHandler,
+    {
+        self.run_route(Arc::new(CompatibilityFrameRoute { handler })).await
+    }
+
+    pub(crate) async fn run_authorized<R>(self, route: Arc<R>) -> RocketMQResult<()>
+    where
+        R: AuthorizedFrameRoute,
+    {
+        self.run_route(route).await
+    }
+
+    async fn run_route<R>(self, route: Arc<R>) -> RocketMQResult<()>
+    where
+        R: AuthorizedFrameRoute,
     {
         let io_policy = self.io_policy.validate()?;
         let cancellation = self.task_group.cancellation_token();
@@ -635,12 +781,14 @@ impl TransportListener {
             let handshake_timeout = self.handshake_timeout;
             let session_io_policy = io_policy;
             let principal = self.principal.clone();
-            let handler = handler.clone();
+            let route = route.clone();
             let telemetry = self.telemetry.clone();
             let file_region_blocking = self.file_region_blocking.clone();
             let file_transfer_mode = self.file_transfer_mode;
             let frame_limits = self.frame_limits;
             let proxy_protocol = self.proxy_protocol.clone();
+            #[cfg(test)]
+            let write_preflight_barrier = self.write_preflight_barrier.clone();
             let spawn_group = session_group.clone();
             if spawn_group
                 .spawn_service("rocketmq.transport.session", async move {
@@ -681,11 +829,17 @@ impl TransportListener {
                         return;
                     };
                     let (connection, peer_is_tls) = negotiated.into_parts();
+                    #[cfg(test)]
+                    let mut connection = connection;
+                    #[cfg(test)]
+                    if let Some(barrier) = write_preflight_barrier {
+                        connection.set_write_preflight_barrier(barrier);
+                    }
                     let mut connection = connection.with_telemetry(telemetry);
                     if let Some(blocking) = file_region_blocking {
                         connection = connection.with_file_region_io(blocking, file_transfer_mode);
                     }
-                    run_framed_session(
+                    run_authorized_framed_session(
                         connection,
                         effective_local_addr,
                         effective_remote_addr,
@@ -698,7 +852,7 @@ impl TransportListener {
                         principal,
                         peer_is_tls,
                         session_io_policy,
-                        handler,
+                        route,
                     )
                     .await;
                 })
@@ -764,10 +918,90 @@ async fn run_framed_session_with_request_sequence<H>(
     peer_is_tls: bool,
     io_policy: SessionIoPolicy,
     request_sequence: AtomicU64,
-    #[cfg(test)] mut request_identity_exhausted: Option<tokio::sync::oneshot::Sender<()>>,
+    #[cfg(test)] request_identity_exhausted: Option<tokio::sync::oneshot::Sender<()>>,
     handler: Arc<H>,
 ) where
     H: ConnectionHandler,
+{
+    run_authorized_framed_session_with_request_sequence(
+        connection,
+        local_addr,
+        remote_addr,
+        transport_peer_addr,
+        proxy_protocol,
+        session_id,
+        scope,
+        task_group,
+        dispatch,
+        principal,
+        peer_is_tls,
+        io_policy,
+        request_sequence,
+        #[cfg(test)]
+        request_identity_exhausted,
+        Arc::new(CompatibilityFrameRoute { handler }),
+    )
+    .await;
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_authorized_framed_session<R>(
+    connection: Connection,
+    local_addr: SocketAddr,
+    remote_addr: SocketAddr,
+    transport_peer_addr: SocketAddr,
+    proxy_protocol: Option<Arc<ProxyProtocolMetadata>>,
+    session_id: u64,
+    scope: AdmissionScope,
+    task_group: TaskGroup,
+    dispatch: Arc<AuthorizedDispatchBoundary>,
+    principal: Option<Principal>,
+    peer_is_tls: bool,
+    io_policy: SessionIoPolicy,
+    route: Arc<R>,
+) where
+    R: AuthorizedFrameRoute,
+{
+    run_authorized_framed_session_with_request_sequence(
+        connection,
+        local_addr,
+        remote_addr,
+        transport_peer_addr,
+        proxy_protocol,
+        session_id,
+        scope,
+        task_group,
+        dispatch,
+        principal,
+        peer_is_tls,
+        io_policy,
+        AtomicU64::new(1),
+        #[cfg(test)]
+        None,
+        route,
+    )
+    .await;
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_authorized_framed_session_with_request_sequence<R>(
+    connection: Connection,
+    local_addr: SocketAddr,
+    remote_addr: SocketAddr,
+    transport_peer_addr: SocketAddr,
+    proxy_protocol: Option<Arc<ProxyProtocolMetadata>>,
+    session_id: u64,
+    scope: AdmissionScope,
+    task_group: TaskGroup,
+    dispatch: Arc<AuthorizedDispatchBoundary>,
+    principal: Option<Principal>,
+    peer_is_tls: bool,
+    io_policy: SessionIoPolicy,
+    request_sequence: AtomicU64,
+    #[cfg(test)] mut request_identity_exhausted: Option<tokio::sync::oneshot::Sender<()>>,
+    route: Arc<R>,
+) where
+    R: AuthorizedFrameRoute,
 {
     let connection_id = connection.connection_id().clone();
     let frame_limits = connection.frame_limits();
@@ -852,7 +1086,11 @@ async fn run_framed_session_with_request_sequence<H>(
         response_plan_context: None,
     };
 
-    handler.connected(session.clone()).await;
+    let Some(route_state) = route.connected(session.clone()).await else {
+        let _ = session.send.session_closed_tx.send(true);
+        let _ = session.retire().await;
+        return;
+    };
     let cancellation = task_group.cancellation_token();
     loop {
         let next = tokio::select! {
@@ -864,32 +1102,33 @@ async fn run_framed_session_with_request_sequence<H>(
             Ok(Some(Ok(decoded))) => decoded,
             Ok(Some(Err(_))) | Ok(None) | Err(_) => break,
         };
+        let received_at = std::time::Instant::now();
         let command = decoded.command;
-        let original_request_identity = if command.get_type() == RemotingCommandType::REQUEST {
-            let Some(identity) = OriginalRequestIdentity::capture(session_id, &session.send.request_sequence, &command)
-            else {
-                #[cfg(test)]
-                if let Some(signal) = request_identity_exhausted.take() {
-                    let _ = signal.send(());
-                }
-                tracing::error!(
-                    reason = "sequence_exhausted",
-                    "transport session stopped accepting because request identity allocation is exhausted"
-                );
-                break;
-            };
-            Some(identity)
-        } else {
-            None
-        };
         session
             .send
             .telemetry
             .record_inbound_decoded_plaintext_bytes(decoded.retained_frame_bytes);
+
+        if command.get_type() == RemotingCommandType::RESPONSE {
+            route.response(&route_state, session.clone(), command).await;
+            continue;
+        }
+
+        let Some(original_request_identity) =
+            OriginalRequestIdentity::capture(session_id, &session.send.request_sequence, &command)
+        else {
+            #[cfg(test)]
+            if let Some(signal) = request_identity_exhausted.take() {
+                let _ = signal.send(());
+            }
+            tracing::error!(
+                reason = "sequence_exhausted",
+                "transport session stopped accepting because request identity allocation is exhausted"
+            );
+            break;
+        };
         let partial_frame_permit = decoded.partial_frame_permit;
-        let class = AdmissionClass::for_request_code(
-            original_request_identity.map_or_else(|| command.code(), OriginalRequestIdentity::original_code),
-        );
+        let class = AdmissionClass::for_request_code(original_request_identity.original_code());
         let bytes = decoded.retained_frame_bytes;
         let context = RequestContext::network_with_security_profile(
             PeerInfo::new(remote_addr, peer_is_tls),
@@ -897,30 +1136,22 @@ async fn run_framed_session_with_request_sequence<H>(
             None,
             dispatch.security_profile(),
         );
-        let ordering = handler.request_ordering(&command);
-        let request_handler = handler.clone();
         let request_session = session
             .clone()
             .with_response_class(class)
-            .with_original_request_identity(original_request_identity);
-        let response = ResponseSink::Network(Arc::new(session.clone().with_response_class(class)));
-        if executor
-            .dispatch(
+            .with_original_request_identity(Some(original_request_identity));
+        if !route
+            .request(
+                &route_state,
+                &executor,
+                request_session,
                 context,
-                original_request_identity,
                 command,
+                received_at,
                 bytes,
                 partial_frame_permit,
-                ordering,
-                response,
-                move |request_operation, command| async move {
-                    request_handler
-                        .command(request_session.with_operation_context(request_operation), command)
-                        .await;
-                },
             )
             .await
-            .is_err()
         {
             break;
         }
@@ -929,11 +1160,12 @@ async fn run_framed_session_with_request_sequence<H>(
     // no longer accepts frames. Publish the session-close transition now so
     // read-only views observe shutdown without closing the response writer.
     let _ = session.send.session_closed_tx.send(true);
+    route.close_pending(&route_state, session.clone()).await;
     let request_deadline = task_group
         .shutdown_deadline()
         .unwrap_or_else(|| ShutdownDeadline::after(SESSION_RETIREMENT_TIMEOUT));
     executor.drain_until(request_deadline).await.log_if_unhealthy();
-    handler.disconnected(session.clone()).await;
+    route.disconnected(route_state, session.clone()).await;
     let _ = session.retire().await;
 }
 

--- a/rocketmq-transport/tests/authorized_dispatch_conformance_tests.rs
+++ b/rocketmq-transport/tests/authorized_dispatch_conformance_tests.rs
@@ -50,6 +50,7 @@ use rocketmq_transport::api::v1::DispatchError;
 use rocketmq_transport::api::v1::RequestContext;
 use rocketmq_transport::api::v1::RequestContextError;
 use rocketmq_transport::api::v1::RequestDeadline;
+use rocketmq_transport::api::v1::RequestOrdering;
 use rocketmq_transport::api::v1::RequestProcessor;
 use rocketmq_transport::api::v1::ResourceLimit;
 use rocketmq_transport::api::v1::ResponseSinkError;
@@ -113,6 +114,73 @@ impl RequestProcessor for ConformanceProcessor {
             )),
             ProcessorBehavior::Pending => future::pending().await,
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum CloneIdentityEvent {
+    Clone { from: usize, to: usize },
+    Ordering { generation: usize, code: i32 },
+    Process { generation: usize, code: i32 },
+}
+
+struct CloneIdentityProcessor {
+    generation: usize,
+    events: Arc<Mutex<Vec<CloneIdentityEvent>>>,
+}
+
+impl CloneIdentityProcessor {
+    fn supplied(events: Arc<Mutex<Vec<CloneIdentityEvent>>>) -> Self {
+        Self { generation: 0, events }
+    }
+}
+
+impl Clone for CloneIdentityProcessor {
+    fn clone(&self) -> Self {
+        let generation = self.generation + 1;
+        self.events
+            .lock()
+            .expect("clone identity event lock")
+            .push(CloneIdentityEvent::Clone {
+                from: self.generation,
+                to: generation,
+            });
+        Self {
+            generation,
+            events: Arc::clone(&self.events),
+        }
+    }
+}
+
+impl RequestProcessor for CloneIdentityProcessor {
+    async fn process_request(
+        &mut self,
+        _channel: Channel,
+        _ctx: ConnectionHandlerContext,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        self.events
+            .lock()
+            .expect("clone identity event lock")
+            .push(CloneIdentityEvent::Process {
+                generation: self.generation,
+                code: request.code(),
+            });
+        Ok(Some(
+            RemotingCommand::create_response_command_with_code(ResponseCode::Success)
+                .set_body(vec![self.generation as u8]),
+        ))
+    }
+
+    fn request_ordering(&self, request: &RemotingCommand) -> RequestOrdering {
+        self.events
+            .lock()
+            .expect("clone identity event lock")
+            .push(CloneIdentityEvent::Ordering {
+                generation: self.generation,
+                code: request.code(),
+            });
+        RequestOrdering::Concurrent
     }
 }
 
@@ -644,5 +712,130 @@ async fn unknown_raw_code_is_preserved_in_the_authorization_resource() {
     );
     assert_eq!(fixture.processor.calls.load(Ordering::SeqCst), 2);
     let report = fixture.service.task_group().shutdown(Duration::from_secs(1)).await;
+    report.assert_no_task_leak().expect("test tasks should be owned");
+}
+
+#[tokio::test]
+async fn v1_embedded_retains_the_supplied_processor_while_network_uses_its_admitted_clone() {
+    const EMBEDDED_CODE: i32 = 61_000;
+    const NETWORK_CODE: i32 = 61_001;
+
+    let runtime = RuntimeContext::from_current("authorized-dispatch-clone-identity");
+    let service = runtime.service_context("clone-identity");
+    let process_budget = service.process_budget();
+    let admission = Arc::new(
+        AdmissionController::try_new_with_budget(AdmissionLimits::default(), &process_budget)
+            .expect("test admission limits should be valid"),
+    );
+    let security = Arc::new(TransportSecurity::development_insecure_loopback(None, None));
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let dispatcher = Arc::new(
+        AuthorizedCommandDispatcher::try_new(
+            CloneIdentityProcessor::supplied(Arc::clone(&events)),
+            Vec::new(),
+            &process_budget,
+            TransportTelemetry::noop(),
+            Arc::clone(&security),
+            admission,
+        )
+        .expect("test dispatcher should fit the process budget"),
+    );
+
+    assert_eq!(
+        events.lock().expect("clone identity event lock").as_slice(),
+        [CloneIdentityEvent::Clone { from: 0, to: 1 }]
+    );
+    events.lock().expect("clone identity event lock").clear();
+
+    let embedded = dispatcher
+        .dispatch_embedded(
+            service.task_group(),
+            RequestContext::try_embedded(Some(Principal::new("clone-identity")), None)
+                .expect("embedded identity should be valid"),
+            RemotingCommand::create_remoting_command(EMBEDDED_CODE).set_opaque(60),
+        )
+        .await
+        .expect("embedded processor should respond");
+    assert_eq!(embedded.body().map(|body| body.as_ref()), Some([1_u8].as_slice()));
+    assert_eq!(
+        events.lock().expect("clone identity event lock").as_slice(),
+        [
+            CloneIdentityEvent::Ordering {
+                generation: 0,
+                code: EMBEDDED_CODE,
+            },
+            CloneIdentityEvent::Clone { from: 0, to: 1 },
+            CloneIdentityEvent::Process {
+                generation: 1,
+                code: EMBEDDED_CODE,
+            },
+        ]
+    );
+    events.lock().expect("clone identity event lock").clear();
+
+    let config = Arc::new(ServerConfig {
+        bind_address: "127.0.0.1".to_owned(),
+        listen_port: 0,
+        ..ServerConfig::default()
+    });
+    let mut server = TransportServer::new(config, service.component("network"))
+        .with_transport_security(Arc::clone(&security), Some(Principal::new("clone-identity")))
+        .with_authorized_dispatcher(Arc::clone(&dispatcher));
+    let (startup_tx, startup_rx) = oneshot::channel();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let automatic_events = Arc::new(Mutex::new(Vec::new()));
+    let server_task = tokio::spawn(async move {
+        server
+            .run_with_shutdown_report_and_startup(
+                CloneIdentityProcessor::supplied(automatic_events),
+                None,
+                async {
+                    let _ = shutdown_rx.await;
+                },
+                startup_tx,
+            )
+            .await
+    });
+    let address = startup_rx
+        .await
+        .expect("server should report startup")
+        .expect("server should bind");
+    assert!(events.lock().expect("clone identity event lock").is_empty());
+
+    let stream = TcpStream::connect(address).await.expect("client should connect");
+    let mut connection = Connection::new(stream);
+    connection
+        .send_command(RemotingCommand::create_remoting_command(NETWORK_CODE).set_opaque(61))
+        .await
+        .expect("network request should be written");
+    let network = tokio::time::timeout(Duration::from_secs(2), connection.receive_command())
+        .await
+        .expect("network request should complete before the test timeout")
+        .expect("network read should succeed")
+        .expect("server should return one response frame");
+    assert_eq!(network.body().map(|body| body.as_ref()), Some([2_u8].as_slice()));
+    assert_eq!(
+        events.lock().expect("clone identity event lock").as_slice(),
+        [
+            CloneIdentityEvent::Ordering {
+                generation: 1,
+                code: NETWORK_CODE,
+            },
+            CloneIdentityEvent::Clone { from: 1, to: 2 },
+            CloneIdentityEvent::Process {
+                generation: 2,
+                code: NETWORK_CODE,
+            },
+        ]
+    );
+
+    drop(connection);
+    let _ = shutdown_tx.send(());
+    let report = server_task
+        .await
+        .expect("server task should not panic")
+        .expect("server should report shutdown");
+    assert!(report.is_healthy(), "{}", report.to_json());
+    let report = service.task_group().shutdown(Duration::from_secs(1)).await;
     report.assert_no_task_leak().expect("test tasks should be owned");
 }

--- a/rocketmq-transport/tests/public_api_contract.rs
+++ b/rocketmq-transport/tests/public_api_contract.rs
@@ -674,6 +674,10 @@ fn validate_public_api_v2_boundary(boundary: &PublicBoundary) -> Result<(), Stri
         },
         PublicUse {
             module_path: String::new(),
+            use_tree: "crate::dispatch::AuthorizedCommandDispatcherV2".to_owned(),
+        },
+        PublicUse {
+            module_path: String::new(),
             use_tree: "crate::dispatch::DeferredRegistration".to_owned(),
         },
         PublicUse {
@@ -762,6 +766,10 @@ fn validate_public_api_v2_boundary(boundary: &PublicBoundary) -> Result<(), Stri
         },
         PublicUse {
             module_path: String::new(),
+            use_tree: "crate::remoting_server::rocketmq_tokio_server::TransportServerV2".to_owned(),
+        },
+        PublicUse {
+            module_path: String::new(),
             use_tree: "crate::request_ordering::RequestOrdering".to_owned(),
         },
         PublicUse {
@@ -815,7 +823,7 @@ fn validate_public_api_v2_boundary(boundary: &PublicBoundary) -> Result<(), Stri
     Ok(())
 }
 
-const CURATED_V2_REEXPORTS: &str = "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::DeferredRegistration; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::HandlerOutcome; pub use crate::dispatch::IngressRequestView; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::ProtocolNoResponse; pub use crate::dispatch::ProtocolNoResponseError; pub use crate::dispatch::ProtocolNoResponseReason; pub use crate::dispatch::RemotingRequest; pub use crate::dispatch::RequestControlView; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestMeta; pub use crate::dispatch::RequestOrigin; pub use crate::dispatch::ResponseBodyKind; pub use crate::dispatch::ResponseDisposition; pub use crate::dispatch::ResponseErrorKind; pub use crate::dispatch::ResponsePlan; pub use crate::dispatch::ResponsePlanError; pub use crate::dispatch::ResponseReceipt; pub use crate::dispatch::WriteProgress; pub use crate::file_region::FileRegion; pub use crate::file_region::FileRegionSequence; pub use crate::request_ordering::RequestOrdering; pub use crate::request_ordering::RequestOrderingKey; pub use crate::runtime::processor_v2::LocalRequestProcessorV2; pub use crate::runtime::processor_v2::RejectRequestDecision; pub use crate::runtime::processor_v2::RequestProcessorV2; pub use crate::runtime::processor_v2::ResponseWriteObservationV2; pub use crate::runtime::processor_v2::ResponseWriteOutcomeV2; pub use crate::runtime::processor_v2::ResponseWritePath; pub use crate::session_view::ProxyInfoSnapshot; pub use crate::session_view::SessionId; pub use crate::session_view::SessionStateView; pub use crate::session_view::SessionView;";
+const CURATED_V2_REEXPORTS: &str = "pub use crate::deadline::RequestDeadline; pub use crate::dispatch::AuthenticationState; pub use crate::dispatch::AuthorizedCommandDispatcherV2; pub use crate::dispatch::DeferredRegistration; pub use crate::dispatch::EmbeddedCaller; pub use crate::dispatch::HandlerOutcome; pub use crate::dispatch::IngressRequestView; pub use crate::dispatch::OriginalRequestIdentity; pub use crate::dispatch::ProtocolNoResponse; pub use crate::dispatch::ProtocolNoResponseError; pub use crate::dispatch::ProtocolNoResponseReason; pub use crate::dispatch::RemotingRequest; pub use crate::dispatch::RequestControlView; pub use crate::dispatch::RequestId; pub use crate::dispatch::RequestMeta; pub use crate::dispatch::RequestOrigin; pub use crate::dispatch::ResponseBodyKind; pub use crate::dispatch::ResponseDisposition; pub use crate::dispatch::ResponseErrorKind; pub use crate::dispatch::ResponsePlan; pub use crate::dispatch::ResponsePlanError; pub use crate::dispatch::ResponseReceipt; pub use crate::dispatch::WriteProgress; pub use crate::file_region::FileRegion; pub use crate::file_region::FileRegionSequence; pub use crate::remoting_server::rocketmq_tokio_server::TransportServerV2; pub use crate::request_ordering::RequestOrdering; pub use crate::request_ordering::RequestOrderingKey; pub use crate::runtime::processor_v2::LocalRequestProcessorV2; pub use crate::runtime::processor_v2::RejectRequestDecision; pub use crate::runtime::processor_v2::RequestProcessorV2; pub use crate::runtime::processor_v2::ResponseWriteObservationV2; pub use crate::runtime::processor_v2::ResponseWriteOutcomeV2; pub use crate::runtime::processor_v2::ResponseWritePath; pub use crate::session_view::ProxyInfoSnapshot; pub use crate::session_view::SessionId; pub use crate::session_view::SessionStateView; pub use crate::session_view::SessionView;";
 
 #[test]
 fn lib_rs_exposes_only_the_curated_versioned_boundary() {

--- a/rocketmq-transport/tests/public_api_v2.rs
+++ b/rocketmq-transport/tests/public_api_v2.rs
@@ -21,9 +21,14 @@ use cheetah_string::CheetahString;
 use rocketmq_error::RocketMQError;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_security_api::Principal;
+use rocketmq_transport::api::v1::AuthorizedCommandDispatcher;
+use rocketmq_transport::api::v1::DefaultRequestProcessor;
 use rocketmq_transport::api::v1::RequestDeadline as V1RequestDeadline;
 use rocketmq_transport::api::v1::RequestId as V1RequestId;
+use rocketmq_transport::api::v1::TransportServer;
+use rocketmq_transport::api::v1::TransportTelemetry;
 use rocketmq_transport::api::v2::AuthenticationState;
+use rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2;
 use rocketmq_transport::api::v2::DeferredRegistration;
 use rocketmq_transport::api::v2::EmbeddedCaller;
 use rocketmq_transport::api::v2::FileRegion;
@@ -58,6 +63,7 @@ use rocketmq_transport::api::v2::ResponseWritePath;
 use rocketmq_transport::api::v2::SessionId;
 use rocketmq_transport::api::v2::SessionStateView;
 use rocketmq_transport::api::v2::SessionView;
+use rocketmq_transport::api::v2::TransportServerV2;
 use rocketmq_transport::api::v2::WriteProgress;
 
 fn assert_same_deadline_type(_: &V1RequestDeadline, _: &V2RequestDeadline) {}
@@ -187,6 +193,7 @@ impl LocalRequestProcessorV2 for LocalOnlyProcessor {
     }
 }
 
+#[derive(Clone)]
 struct SendProcessor;
 
 impl RequestProcessorV2 for SendProcessor {
@@ -388,4 +395,43 @@ fn v2_processor_side_contracts_are_typed_and_body_free() {
     let _ = RequestOrdering::Concurrent;
     let _ = RequestOrdering::Ordered(RequestOrderingKey::new(9));
     let _: fn(&ResponseWriteObservationV2) = assert_response_write_observation_contract;
+}
+
+#[test]
+fn v2_network_dispatcher_and_server_are_public_nameable_facades() {
+    let runtime = rocketmq_runtime::RuntimeOwner::new(rocketmq_runtime::RuntimeConfig::default())
+        .expect("public V2 facade runtime");
+    let service_context = runtime.root_context().component("public-v2-facades");
+    let security =
+        std::sync::Arc::new(rocketmq_transport::api::v1::TransportSecurity::development_insecure_loopback(None, None));
+    let admission = std::sync::Arc::new(rocketmq_transport::api::v1::AdmissionController::new(
+        rocketmq_transport::api::v1::AdmissionLimits::default(),
+    ));
+
+    let v1_dispatcher: std::sync::Arc<AuthorizedCommandDispatcher<DefaultRequestProcessor>> = std::sync::Arc::new(
+        AuthorizedCommandDispatcher::try_new(
+            DefaultRequestProcessor,
+            Vec::new(),
+            &service_context.process_budget(),
+            TransportTelemetry::noop(),
+            std::sync::Arc::clone(&security),
+            std::sync::Arc::clone(&admission),
+        )
+        .expect("public V1 facade construction"),
+    );
+    let _: std::sync::Arc<rocketmq_transport::api::v1::AuthorizedDispatchBoundary> = v1_dispatcher.boundary();
+    let _: TransportServer<DefaultRequestProcessor> = TransportServer::new(
+        std::sync::Arc::new(rocketmq_transport::api::v1::ServerConfig::default()),
+        service_context.clone(),
+    );
+
+    let dispatcher: std::sync::Arc<AuthorizedCommandDispatcherV2<SendProcessor>> = std::sync::Arc::new(
+        AuthorizedCommandDispatcherV2::new(SendProcessor, Vec::new(), security, admission),
+    );
+    let _: std::sync::Arc<rocketmq_transport::api::v1::AuthorizedDispatchBoundary> = dispatcher.boundary();
+    let _: TransportServerV2<SendProcessor> = TransportServerV2::new_with_authorized_dispatcher(
+        std::sync::Arc::new(rocketmq_transport::api::v1::ServerConfig::default()),
+        service_context,
+        dispatcher,
+    );
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9800

### Brief Description

Add coexisting, statically selected V1 and V2 authorized network-dispatch entry points without changing the existing V1 public server or embedded API.

The change introduces a private monomorphized dispatcher core, a public and nameable `AuthorizedCommandDispatcherV2<P>`, and a consuming `TransportServerV2<P>` facade. Network REQUEST frames now enter exactly one security, admission, session-execution, processor-clone, binding, and write path. RESPONSE frames are classified before request identity or admission: V1 correlates them through one stable owner per canonical session, while V2 warns and drops unexpected responses without closing the connection.

V1 network processing now uses the crate-private legacy adapter while preserving the supplied processor for the existing embedded path. Borrowed per-request bridges cannot retire the session owner, pending waiters are released before accepted-work drain, V2 constructs no legacy channel/context state, and shutdown preserves responses whose writer handoff has already started.

### How Did You Test This Change?

- `cargo check -p rocketmq-transport --all-features --all-targets`
- `cargo test -p rocketmq-transport --all-features --no-fail-fast`
- Focused V1/V2 TCP, session-correlation, hook, boundary-conflict, shutdown, conformance, and public API contract tests
- `cargo clippy -p rocketmq-transport --no-deps --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `cargo fmt -p rocketmq-transport -- --check`
- `cargo doc -p rocketmq-transport --all-features --no-deps`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `git diff --check`

The enforcing runtime audit passed. `check-error-hygiene.ps1` retains the same 18 pre-existing findings reproduced from the exact base commit in an independent clean worktree; this change does not touch those paths. Rustdoc completed successfully with one pre-existing private intra-doc-link warning in the unchanged TLS module. Observability validation was not triggered because no observability code, schema, feature, or Cargo configuration changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public V2 transport server and authorized dispatcher API.
  * Added configurable telemetry, frame limits, proxy protocol, security, admission control, RPC hooks, and graceful shutdown reporting.
  * Improved network request routing and response correlation across concurrent connections.
* **Bug Fixes**
  * Prevented borrowed connection channels from incorrectly closing shared pending requests.
  * Added validation for mismatched security and admission-control ownership.
* **Tests**
  * Added coverage for V2 TCP processing, shutdown draining, hook ordering, ownership isolation, and public API compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->