### PR TITLE
[ISSUE #9804]🚀Add atomic deferred-response state machine

### DIFF
--- a/rocketmq-transport/src/dispatch.rs
+++ b/rocketmq-transport/src/dispatch.rs
@@ -13,6 +13,11 @@
 // limitations under the License.
 
 mod authorized_dispatcher;
+#[allow(
+    dead_code,
+    reason = "DEF-01 provides the deferred response foundation consumed by later DEF stages"
+)]
+mod deferred_response;
 mod embedded_dispatch;
 mod handler_outcome;
 mod legacy_processor_adapter;
@@ -36,6 +41,26 @@ pub(crate) use authorized_dispatcher::AuthorizedDispatchSession;
 pub(crate) use authorized_dispatcher::AuthorizedDispatchV2Error;
 pub use authorized_dispatcher::DispatchError;
 pub use authorized_dispatcher::DispatchOutcome;
+#[allow(
+    unused_imports,
+    reason = "DEF-01 exposes the private state machine to later deferred runtime stages"
+)]
+pub(crate) use deferred_response::ResponseSendClaim;
+#[allow(
+    unused_imports,
+    reason = "DEF-01 exposes the private state machine to later deferred runtime stages"
+)]
+pub(crate) use deferred_response::ResponseState;
+#[allow(
+    unused_imports,
+    reason = "DEF-01 exposes private state diagnostics to later deferred runtime stages"
+)]
+pub(crate) use deferred_response::ResponseStateError;
+#[allow(
+    unused_imports,
+    reason = "DEF-01 exposes private state diagnostics to later deferred runtime stages"
+)]
+pub(crate) use deferred_response::ResponseStateSnapshot;
 pub use embedded_dispatch::EmbeddedDispatchError;
 pub use embedded_dispatch::EmbeddedDispatchErrorKind;
 pub use embedded_dispatch::EmbeddedDispatchOutcome;

--- a/rocketmq-transport/src/dispatch/deferred_response.rs
+++ b/rocketmq-transport/src/dispatch/deferred_response.rs
@@ -1,0 +1,291 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Atomic lifecycle state for responses retained beyond the handler call.
+
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use super::ResponseTerminalState;
+use super::WriteProgress;
+
+const OPEN: u8 = 0;
+const REGISTERED: u8 = 1;
+const CLAIMED: u8 = 2;
+const SENDING: u8 = 3;
+const COMPLETED: u8 = 4;
+const FAILED_NOT_STARTED: u8 = 5;
+const FAILED_POSSIBLY_PARTIAL: u8 = 6;
+const CANCELLED: u8 = 7;
+const CLOSED: u8 = 8;
+
+/// One atomic owner for a deferred response lifecycle.
+///
+/// This state is allocated only when a later stage creates a deferred
+/// responder. Inline responses continue to use their stack-owned slot.
+pub(crate) struct ResponseState {
+    state: AtomicU8,
+}
+
+/// Stable internal view of the deferred response lifecycle.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ResponseStateSnapshot {
+    Open,
+    Registered,
+    Claimed,
+    Sending,
+    Terminal(ResponseTerminalState),
+}
+
+/// Operation rejected by the deferred response state machine.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ResponseTransition {
+    Register,
+    Claim,
+    BeginSending,
+    Complete,
+    Fail,
+    Cancel,
+    Close,
+}
+
+/// Failure to perform one deferred response state transition.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub(crate) enum ResponseStateError {
+    /// A previous operation already selected the terminal state.
+    #[error("deferred response already reached terminal state {state:?}")]
+    AlreadyCompleted { state: ResponseTerminalState },
+    /// The operation is not legal from the observed non-terminal state.
+    #[error("deferred response cannot perform {transition:?} from {state:?}")]
+    InvalidTransition {
+        transition: ResponseTransition,
+        state: ResponseStateSnapshot,
+    },
+}
+
+/// Affine ownership of the right to terminate `Sending`.
+///
+/// A newly created claim proves that canonical socket I/O has not started.
+/// Before entering any seam that might begin socket I/O, the owner must call
+/// [`Self::mark_possibly_partial`]. Dropping an unfinished claim records the
+/// most conservative progress reached by the owner.
+#[must_use]
+pub(crate) struct ResponseSendClaim {
+    state: Arc<ResponseState>,
+    drop_progress: WriteProgress,
+    active: bool,
+}
+
+impl ResponseState {
+    /// Creates the deferred-only state in `Open`.
+    pub(crate) const fn open() -> Self {
+        Self {
+            state: AtomicU8::new(OPEN),
+        }
+    }
+
+    /// Returns one acquire snapshot of the complete lifecycle state.
+    pub(crate) fn snapshot(&self) -> ResponseStateSnapshot {
+        snapshot(self.state.load(Ordering::Acquire))
+    }
+
+    /// Returns the terminal state, if a terminal transition has won.
+    pub(crate) fn terminal_state(&self) -> Option<ResponseTerminalState> {
+        match self.snapshot() {
+            ResponseStateSnapshot::Terminal(state) => Some(state),
+            ResponseStateSnapshot::Open
+            | ResponseStateSnapshot::Registered
+            | ResponseStateSnapshot::Claimed
+            | ResponseStateSnapshot::Sending => None,
+        }
+    }
+
+    /// Activates registry ownership of an open deferred response.
+    pub(crate) fn register(&self) -> Result<(), ResponseStateError> {
+        self.transition_exact(OPEN, REGISTERED, ResponseTransition::Register)
+    }
+
+    /// Claims one registered response for resume execution.
+    pub(crate) fn claim(&self) -> Result<(), ResponseStateError> {
+        self.transition_exact(REGISTERED, CLAIMED, ResponseTransition::Claim)
+    }
+
+    /// Acquires affine ownership of response delivery.
+    pub(crate) fn begin_sending(self: &Arc<Self>) -> Result<ResponseSendClaim, ResponseStateError> {
+        let mut observed = self.state.load(Ordering::Acquire);
+        loop {
+            match observed {
+                OPEN | CLAIMED => {
+                    match self
+                        .state
+                        .compare_exchange(observed, SENDING, Ordering::AcqRel, Ordering::Acquire)
+                    {
+                        Ok(_) => {
+                            return Ok(ResponseSendClaim {
+                                state: Arc::clone(self),
+                                drop_progress: WriteProgress::NotStarted,
+                                active: true,
+                            });
+                        }
+                        Err(actual) => observed = actual,
+                    }
+                }
+                actual => return Err(transition_error(ResponseTransition::BeginSending, actual)),
+            }
+        }
+    }
+
+    /// Cancels a response that has not begun delivery.
+    pub(crate) fn cancel(&self) -> Result<(), ResponseStateError> {
+        self.stop_with(CANCELLED, ResponseTransition::Cancel, |_| {})
+    }
+
+    /// Closes a response that has not begun delivery.
+    pub(crate) fn close(&self) -> Result<(), ResponseStateError> {
+        self.stop_with(CLOSED, ResponseTransition::Close, |_| {})
+    }
+
+    fn stop_with(
+        &self,
+        terminal: u8,
+        transition: ResponseTransition,
+        mut before_compare: impl FnMut(u8),
+    ) -> Result<(), ResponseStateError> {
+        let mut observed = self.state.load(Ordering::Acquire);
+        loop {
+            match observed {
+                OPEN | REGISTERED | CLAIMED => {
+                    before_compare(observed);
+                    match self
+                        .state
+                        .compare_exchange(observed, terminal, Ordering::AcqRel, Ordering::Acquire)
+                    {
+                        Ok(_) => return Ok(()),
+                        Err(actual) => observed = actual,
+                    }
+                }
+                actual => return Err(transition_error(transition, actual)),
+            }
+        }
+    }
+
+    fn transition_exact(
+        &self,
+        expected: u8,
+        target: u8,
+        transition: ResponseTransition,
+    ) -> Result<(), ResponseStateError> {
+        self.state
+            .compare_exchange(expected, target, Ordering::AcqRel, Ordering::Acquire)
+            .map(|_| ())
+            .map_err(|actual| transition_error(transition, actual))
+    }
+
+    fn finish_sending(&self, terminal: ResponseTerminalState) -> Result<(), ResponseStateError> {
+        let transition = match terminal {
+            ResponseTerminalState::Completed => ResponseTransition::Complete,
+            ResponseTerminalState::Failed { .. } => ResponseTransition::Fail,
+            ResponseTerminalState::Cancelled | ResponseTerminalState::Closed => {
+                unreachable!("a send claim can only complete or fail its response")
+            }
+        };
+        self.transition_exact(SENDING, encode_terminal(terminal), transition)
+    }
+}
+
+impl ResponseSendClaim {
+    /// Marks that zero socket output can no longer be proven.
+    ///
+    /// This progress change is monotonic and cannot be downgraded.
+    pub(crate) fn mark_possibly_partial(&mut self) {
+        self.drop_progress = WriteProgress::PossiblyPartial;
+    }
+
+    /// Records successful canonical response delivery.
+    pub(crate) fn complete(mut self) -> Result<(), ResponseStateError> {
+        let result = self.state.finish_sending(ResponseTerminalState::Completed);
+        self.active = false;
+        result
+    }
+
+    /// Records failed canonical response delivery without losing prior progress.
+    pub(crate) fn fail(mut self, progress: WriteProgress) -> Result<(), ResponseStateError> {
+        let progress = match (self.drop_progress, progress) {
+            (WriteProgress::PossiblyPartial, _) | (_, WriteProgress::PossiblyPartial) => WriteProgress::PossiblyPartial,
+            (WriteProgress::NotStarted, WriteProgress::NotStarted) => WriteProgress::NotStarted,
+        };
+        let result = self.state.finish_sending(ResponseTerminalState::Failed { progress });
+        self.active = false;
+        result
+    }
+}
+
+impl Drop for ResponseSendClaim {
+    fn drop(&mut self) {
+        if self.active {
+            let _ = self.state.finish_sending(ResponseTerminalState::Failed {
+                progress: self.drop_progress,
+            });
+            self.active = false;
+        }
+    }
+}
+
+fn transition_error(transition: ResponseTransition, actual: u8) -> ResponseStateError {
+    match snapshot(actual) {
+        ResponseStateSnapshot::Terminal(state) => ResponseStateError::AlreadyCompleted { state },
+        state @ (ResponseStateSnapshot::Open
+        | ResponseStateSnapshot::Registered
+        | ResponseStateSnapshot::Claimed
+        | ResponseStateSnapshot::Sending) => ResponseStateError::InvalidTransition { transition, state },
+    }
+}
+
+fn snapshot(state: u8) -> ResponseStateSnapshot {
+    match state {
+        OPEN => ResponseStateSnapshot::Open,
+        REGISTERED => ResponseStateSnapshot::Registered,
+        CLAIMED => ResponseStateSnapshot::Claimed,
+        SENDING => ResponseStateSnapshot::Sending,
+        COMPLETED => ResponseStateSnapshot::Terminal(ResponseTerminalState::Completed),
+        FAILED_NOT_STARTED => ResponseStateSnapshot::Terminal(ResponseTerminalState::Failed {
+            progress: WriteProgress::NotStarted,
+        }),
+        FAILED_POSSIBLY_PARTIAL => ResponseStateSnapshot::Terminal(ResponseTerminalState::Failed {
+            progress: WriteProgress::PossiblyPartial,
+        }),
+        CANCELLED => ResponseStateSnapshot::Terminal(ResponseTerminalState::Cancelled),
+        CLOSED => ResponseStateSnapshot::Terminal(ResponseTerminalState::Closed),
+        _ => unreachable!("ResponseState stores only module-owned monotonic state tags"),
+    }
+}
+
+const fn encode_terminal(state: ResponseTerminalState) -> u8 {
+    match state {
+        ResponseTerminalState::Completed => COMPLETED,
+        ResponseTerminalState::Failed {
+            progress: WriteProgress::NotStarted,
+        } => FAILED_NOT_STARTED,
+        ResponseTerminalState::Failed {
+            progress: WriteProgress::PossiblyPartial,
+        } => FAILED_POSSIBLY_PARTIAL,
+        ResponseTerminalState::Cancelled => CANCELLED,
+        ResponseTerminalState::Closed => CLOSED,
+    }
+}
+
+#[cfg(test)]
+#[path = "deferred_response/tests.rs"]
+mod tests;

--- a/rocketmq-transport/src/dispatch/deferred_response/tests.rs
+++ b/rocketmq-transport/src/dispatch/deferred_response/tests.rs
@@ -1,0 +1,257 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicU8;
+use std::sync::Arc;
+
+use super::*;
+
+#[path = "tests/races.rs"]
+mod races;
+
+#[derive(Clone, Copy, Debug)]
+enum ModelOperation {
+    Register,
+    Claim,
+    BeginSending,
+    Complete,
+    FailNotStarted,
+    FailPossiblyPartial,
+    Cancel,
+    Close,
+}
+
+const OPERATIONS: [ModelOperation; 8] = [
+    ModelOperation::Register,
+    ModelOperation::Claim,
+    ModelOperation::BeginSending,
+    ModelOperation::Complete,
+    ModelOperation::FailNotStarted,
+    ModelOperation::FailPossiblyPartial,
+    ModelOperation::Cancel,
+    ModelOperation::Close,
+];
+
+const STATES: [u8; 9] = [
+    OPEN,
+    REGISTERED,
+    CLAIMED,
+    SENDING,
+    COMPLETED,
+    FAILED_NOT_STARTED,
+    FAILED_POSSIBLY_PARTIAL,
+    CANCELLED,
+    CLOSED,
+];
+
+#[test]
+fn response_state_is_exactly_one_atomic_and_inline_state_remains_separate() {
+    assert_eq!(std::mem::size_of::<ResponseState>(), std::mem::size_of::<AtomicU8>());
+    assert_eq!(std::mem::align_of::<ResponseState>(), std::mem::align_of::<AtomicU8>());
+    assert!(!std::mem::needs_drop::<ResponseState>());
+
+    let inline = crate::dispatch::InlineResponseSlot::disabled();
+    assert_eq!(
+        std::mem::size_of_val(&inline),
+        std::mem::size_of::<crate::dispatch::InlineResponseSlot>()
+    );
+    assert!(!std::mem::needs_drop::<crate::dispatch::InlineResponseSlot>());
+}
+
+#[test]
+fn every_state_operation_pair_matches_the_reference_model() {
+    for initial in STATES {
+        for operation in OPERATIONS {
+            let state = Arc::new(ResponseState {
+                state: AtomicU8::new(initial),
+            });
+            let expected = model_transition(snapshot(initial), operation);
+            let (actual, claim) = apply_actual(&state, operation);
+
+            assert_eq!(
+                actual,
+                expected.as_ref().map(|_| ()).map_err(Clone::clone),
+                "operation {operation:?} from {:?}",
+                snapshot(initial)
+            );
+            assert_eq!(
+                state.snapshot(),
+                expected.unwrap_or_else(|_| snapshot(initial)),
+                "operation {operation:?} from {:?}",
+                snapshot(initial)
+            );
+            drop(claim);
+        }
+    }
+}
+
+#[test]
+fn legal_registered_paths_preserve_both_failure_progress_values() {
+    let completed = Arc::new(ResponseState::open());
+    completed.register().expect("register");
+    completed.claim().expect("claim");
+    completed
+        .begin_sending()
+        .expect("send claim")
+        .complete()
+        .expect("complete");
+    assert_eq!(completed.terminal_state(), Some(ResponseTerminalState::Completed));
+
+    for progress in [WriteProgress::NotStarted, WriteProgress::PossiblyPartial] {
+        let failed = Arc::new(ResponseState::open());
+        failed.register().expect("register");
+        failed.claim().expect("claim");
+        failed
+            .begin_sending()
+            .expect("send claim")
+            .fail(progress)
+            .expect("fail");
+        assert_eq!(
+            failed.terminal_state(),
+            Some(ResponseTerminalState::Failed { progress })
+        );
+    }
+}
+
+#[test]
+fn send_claim_drop_is_terminal_and_progress_never_downgrades() {
+    let not_started = Arc::new(ResponseState::open());
+    drop(not_started.begin_sending().expect("send claim"));
+    assert_eq!(
+        not_started.terminal_state(),
+        Some(ResponseTerminalState::Failed {
+            progress: WriteProgress::NotStarted,
+        })
+    );
+
+    let partial_drop = Arc::new(ResponseState::open());
+    let mut claim = partial_drop.begin_sending().expect("send claim");
+    claim.mark_possibly_partial();
+    drop(claim);
+    assert_eq!(
+        partial_drop.terminal_state(),
+        Some(ResponseTerminalState::Failed {
+            progress: WriteProgress::PossiblyPartial,
+        })
+    );
+
+    let partial_explicit = Arc::new(ResponseState::open());
+    let mut claim = partial_explicit.begin_sending().expect("send claim");
+    claim.mark_possibly_partial();
+    claim
+        .fail(WriteProgress::NotStarted)
+        .expect("an explicit failure cannot downgrade progress");
+    assert_eq!(
+        partial_explicit.terminal_state(),
+        Some(ResponseTerminalState::Failed {
+            progress: WriteProgress::PossiblyPartial,
+        })
+    );
+}
+
+#[test]
+fn consuming_completion_disarms_the_claim_drop_path() {
+    let state = Arc::new(ResponseState::open());
+    state.begin_sending().expect("send claim").complete().expect("complete");
+    assert_eq!(state.terminal_state(), Some(ResponseTerminalState::Completed));
+    assert_eq!(
+        state.close(),
+        Err(ResponseStateError::AlreadyCompleted {
+            state: ResponseTerminalState::Completed,
+        })
+    );
+}
+
+fn apply_actual(
+    state: &Arc<ResponseState>,
+    operation: ModelOperation,
+) -> (Result<(), ResponseStateError>, Option<ResponseSendClaim>) {
+    let claim_for_existing_sending = || ResponseSendClaim {
+        state: Arc::clone(state),
+        drop_progress: WriteProgress::NotStarted,
+        active: true,
+    };
+    match operation {
+        ModelOperation::Register => (state.register(), None),
+        ModelOperation::Claim => (state.claim(), None),
+        ModelOperation::BeginSending => match state.begin_sending() {
+            Ok(claim) => (Ok(()), Some(claim)),
+            Err(error) => (Err(error), None),
+        },
+        ModelOperation::Complete => (claim_for_existing_sending().complete(), None),
+        ModelOperation::FailNotStarted => (claim_for_existing_sending().fail(WriteProgress::NotStarted), None),
+        ModelOperation::FailPossiblyPartial => {
+            (claim_for_existing_sending().fail(WriteProgress::PossiblyPartial), None)
+        }
+        ModelOperation::Cancel => (state.cancel(), None),
+        ModelOperation::Close => (state.close(), None),
+    }
+}
+
+fn model_transition(
+    state: ResponseStateSnapshot,
+    operation: ModelOperation,
+) -> Result<ResponseStateSnapshot, ResponseStateError> {
+    if let ResponseStateSnapshot::Terminal(state) = state {
+        return Err(ResponseStateError::AlreadyCompleted { state });
+    }
+
+    let next = match (state, operation) {
+        (ResponseStateSnapshot::Open, ModelOperation::Register) => ResponseStateSnapshot::Registered,
+        (ResponseStateSnapshot::Registered, ModelOperation::Claim) => ResponseStateSnapshot::Claimed,
+        (ResponseStateSnapshot::Open | ResponseStateSnapshot::Claimed, ModelOperation::BeginSending) => {
+            ResponseStateSnapshot::Sending
+        }
+        (ResponseStateSnapshot::Sending, ModelOperation::Complete) => {
+            ResponseStateSnapshot::Terminal(ResponseTerminalState::Completed)
+        }
+        (ResponseStateSnapshot::Sending, ModelOperation::FailNotStarted) => {
+            ResponseStateSnapshot::Terminal(ResponseTerminalState::Failed {
+                progress: WriteProgress::NotStarted,
+            })
+        }
+        (ResponseStateSnapshot::Sending, ModelOperation::FailPossiblyPartial) => {
+            ResponseStateSnapshot::Terminal(ResponseTerminalState::Failed {
+                progress: WriteProgress::PossiblyPartial,
+            })
+        }
+        (
+            ResponseStateSnapshot::Open | ResponseStateSnapshot::Registered | ResponseStateSnapshot::Claimed,
+            ModelOperation::Cancel,
+        ) => ResponseStateSnapshot::Terminal(ResponseTerminalState::Cancelled),
+        (
+            ResponseStateSnapshot::Open | ResponseStateSnapshot::Registered | ResponseStateSnapshot::Claimed,
+            ModelOperation::Close,
+        ) => ResponseStateSnapshot::Terminal(ResponseTerminalState::Closed),
+        (state, operation) => {
+            return Err(ResponseStateError::InvalidTransition {
+                transition: model_transition_name(operation),
+                state,
+            });
+        }
+    };
+    Ok(next)
+}
+
+const fn model_transition_name(operation: ModelOperation) -> ResponseTransition {
+    match operation {
+        ModelOperation::Register => ResponseTransition::Register,
+        ModelOperation::Claim => ResponseTransition::Claim,
+        ModelOperation::BeginSending => ResponseTransition::BeginSending,
+        ModelOperation::Complete => ResponseTransition::Complete,
+        ModelOperation::FailNotStarted | ModelOperation::FailPossiblyPartial => ResponseTransition::Fail,
+        ModelOperation::Cancel => ResponseTransition::Cancel,
+        ModelOperation::Close => ResponseTransition::Close,
+    }
+}

--- a/rocketmq-transport/src/dispatch/deferred_response/tests/races.rs
+++ b/rocketmq-transport/src/dispatch/deferred_response/tests/races.rs
@@ -1,0 +1,187 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::sync::Barrier;
+
+use super::*;
+
+#[test]
+fn cancel_and_close_choose_exactly_one_terminal_winner() {
+    for _ in 0..256 {
+        let state = Arc::new(ResponseState::open());
+        let barrier = Arc::new(Barrier::new(3));
+
+        let cancel_state = Arc::clone(&state);
+        let cancel_barrier = Arc::clone(&barrier);
+        let cancel = std::thread::spawn(move || {
+            cancel_barrier.wait();
+            cancel_state.cancel()
+        });
+
+        let close_state = Arc::clone(&state);
+        let close_barrier = Arc::clone(&barrier);
+        let close = std::thread::spawn(move || {
+            close_barrier.wait();
+            close_state.close()
+        });
+
+        barrier.wait();
+        let cancel = cancel.join().expect("cancel thread");
+        let close = close.join().expect("close thread");
+        let terminal = state.terminal_state().expect("terminal winner");
+
+        assert_eq!(usize::from(cancel.is_ok()) + usize::from(close.is_ok()), 1);
+        match terminal {
+            ResponseTerminalState::Cancelled => {
+                assert_eq!(cancel, Ok(()));
+                assert_eq!(
+                    close,
+                    Err(ResponseStateError::AlreadyCompleted {
+                        state: ResponseTerminalState::Cancelled,
+                    })
+                );
+            }
+            ResponseTerminalState::Closed => {
+                assert_eq!(close, Ok(()));
+                assert_eq!(
+                    cancel,
+                    Err(ResponseStateError::AlreadyCompleted {
+                        state: ResponseTerminalState::Closed,
+                    })
+                );
+            }
+            other => panic!("unexpected terminal winner: {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn stop_races_retry_across_register_and_claim_progress() {
+    for close in [false, true] {
+        assert_stop_retries_after_lifecycle_advance(close, OPEN, |state| state.register());
+        assert_stop_retries_after_lifecycle_advance(close, REGISTERED, |state| state.claim());
+    }
+}
+
+fn assert_stop_retries_after_lifecycle_advance(
+    close: bool,
+    initial: u8,
+    advance: impl FnOnce(&ResponseState) -> Result<(), ResponseStateError>,
+) {
+    let state = Arc::new(ResponseState {
+        state: std::sync::atomic::AtomicU8::new(initial),
+    });
+    let observed = Arc::new(Barrier::new(2));
+    let resume = Arc::new(Barrier::new(2));
+
+    let stop_state = Arc::clone(&state);
+    let stop_observed = Arc::clone(&observed);
+    let stop_resume = Arc::clone(&resume);
+    let stop = std::thread::spawn(move || {
+        let mut first_compare = true;
+        let (terminal, transition) = if close {
+            (CLOSED, ResponseTransition::Close)
+        } else {
+            (CANCELLED, ResponseTransition::Cancel)
+        };
+        stop_state.stop_with(terminal, transition, |loaded| {
+            if first_compare {
+                assert_eq!(loaded, initial);
+                first_compare = false;
+                stop_observed.wait();
+                stop_resume.wait();
+            }
+        })
+    });
+
+    observed.wait();
+    advance(&state).expect("lifecycle state advances before the first stop CAS");
+    resume.wait();
+    assert_eq!(stop.join().expect("stop thread"), Ok(()));
+    assert_eq!(
+        state.terminal_state(),
+        Some(if close {
+            ResponseTerminalState::Closed
+        } else {
+            ResponseTerminalState::Cancelled
+        })
+    );
+}
+
+#[test]
+fn begin_sending_and_stop_have_one_linearized_owner() {
+    for close in [false, true] {
+        for _ in 0..256 {
+            let state = Arc::new(ResponseState::open());
+            let barrier = Arc::new(Barrier::new(3));
+
+            let send_state = Arc::clone(&state);
+            let send_barrier = Arc::clone(&barrier);
+            let send = std::thread::spawn(move || {
+                send_barrier.wait();
+                send_state.begin_sending()
+            });
+
+            let stop_state = Arc::clone(&state);
+            let stop_barrier = Arc::clone(&barrier);
+            let stop = std::thread::spawn(move || {
+                stop_barrier.wait();
+                if close {
+                    stop_state.close()
+                } else {
+                    stop_state.cancel()
+                }
+            });
+
+            barrier.wait();
+            let send = send.join().expect("send thread");
+            let stop = stop.join().expect("stop thread");
+            let stop_terminal = if close {
+                ResponseTerminalState::Closed
+            } else {
+                ResponseTerminalState::Cancelled
+            };
+
+            match send {
+                Ok(claim) => {
+                    assert_eq!(
+                        stop,
+                        Err(ResponseStateError::InvalidTransition {
+                            transition: if close {
+                                ResponseTransition::Close
+                            } else {
+                                ResponseTransition::Cancel
+                            },
+                            state: ResponseStateSnapshot::Sending,
+                        })
+                    );
+                    drop(claim);
+                    assert_eq!(
+                        state.terminal_state(),
+                        Some(ResponseTerminalState::Failed {
+                            progress: WriteProgress::NotStarted,
+                        })
+                    );
+                }
+                Err(ResponseStateError::AlreadyCompleted { state: winner }) => {
+                    assert_eq!(winner, stop_terminal);
+                    assert_eq!(stop, Ok(()));
+                    assert_eq!(state.terminal_state(), Some(stop_terminal));
+                }
+                Err(error) => panic!("unexpected begin-sending error: {error:?}"),
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9804

### Brief Description

Adds the crate-private atomic lifecycle foundation for deferred responses.

- Encodes `Open`, `Registered`, `Claimed`, `Sending`, and all terminal states in one `AtomicU8`.
- Uses monotonic CAS transitions with exact terminal-state and write-progress reporting.
- Returns an affine send claim whose Drop path cannot leave a response stuck in `Sending`.
- Retries cancel/close CAS operations when concurrent register/claim work advances through another legal source state.
- Keeps the existing inline response slot, response-sink completion slot, deferred registration seal, and public API unchanged.
- Adds an exhaustive state-operation reference model plus deterministic race tests that pause between load and CAS without adding state fields.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-transport -- --check`
- `cargo test -p rocketmq-transport --lib deferred_response`
- `cargo test -p rocketmq-transport --lib dispatch::handler_outcome`
- `cargo test -p rocketmq-transport --test public_api_contract`
- `cargo test -p rocketmq-transport --all-features -- --test-threads=1`
- `cargo doc -p rocketmq-transport --no-deps --all-features`
- `cargo clippy -p rocketmq-transport --no-deps --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `git diff --check`

The default parallel all-features run reproduced the existing shared transport-I/O counter interference in `authorized_dispatch_conformance_tests`; the isolated conformance test and the complete serialized suite both passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable lifecycle management for deferred responses.
  * Improved handling of response registration, sending, completion, cancellation, and closure.
  * Deferred responses now safely record failures and partial-write progress.

* **Bug Fixes**
  * Prevented conflicting response operations during concurrent processing.
  * Improved consistency when sending, stopping, or retrying responses simultaneously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->