### PR TITLE
[ISSUE #9807]🐛Negative Controller heartbeat timeout wraps to u64::MAX

### DIFF
--- a/rocketmq-controller/src/processor/controller_request_processor.rs
+++ b/rocketmq-controller/src/processor/controller_request_processor.rs
@@ -577,7 +577,12 @@ impl ControllerRequestProcessor {
         if let Some(broker_id) = &request_header.broker_id {
             let heartbeat_timeout_mills = request_header.heartbeat_timeout_mills.ok_or_else(|| {
                 RocketMQError::request_header_error("BrokerHeartbeatRequestHeader.heartbeat_timeout_mills is missing")
-            })? as u64;
+            })?;
+            let heartbeat_timeout_mills = u64::try_from(heartbeat_timeout_mills).map_err(|_| {
+                RocketMQError::request_header_error(
+                    "BrokerHeartbeatRequestHeader.heartbeat_timeout_mills must be non-negative",
+                )
+            })?;
             self.heartbeat_manager.on_broker_heartbeat(
                 &request_header.cluster_name,
                 &request_header.broker_name,

--- a/rocketmq-controller/tests/controller_request_processor_contract_test.rs
+++ b/rocketmq-controller/tests/controller_request_processor_contract_test.rs
@@ -474,9 +474,9 @@ async fn controller_request_contract_broker_heartbeat() {
 }
 
 #[tokio::test]
-async fn controller_request_contract_broker_heartbeat_rejects_missing_timeout_header() {
+async fn controller_request_contract_broker_heartbeat_rejects_invalid_timeout_header() {
     let mut harness = ProcessorHarness::new().await;
-    let header = BrokerHeartbeatRequestHeader {
+    let mut header = BrokerHeartbeatRequestHeader {
         cluster_name: CheetahString::from_static_str(CLUSTER_NAME),
         broker_addr: CheetahString::from_static_str(BROKER_ADDR_1),
         broker_name: CheetahString::from_static_str(BROKER_NAME),
@@ -489,18 +489,21 @@ async fn controller_request_contract_broker_heartbeat_rejects_missing_timeout_he
         election_priority: Some(1),
     };
 
-    let error = match harness
-        .send_result(RemotingCommand::create_request_command(
-            RequestCode::BrokerHeartbeat,
-            header,
-        ))
-        .await
-    {
-        Ok(_) => panic!("missing heartbeat timeout should be rejected"),
-        Err(error) => error,
-    };
+    for heartbeat_timeout_mills in [None, Some(-1)] {
+        header.heartbeat_timeout_mills = heartbeat_timeout_mills;
+        let error = match harness
+            .send_result(RemotingCommand::create_request_command(
+                RequestCode::BrokerHeartbeat,
+                header.clone(),
+            ))
+            .await
+        {
+            Ok(_) => panic!("heartbeat timeout {heartbeat_timeout_mills:?} should be rejected"),
+            Err(error) => error,
+        };
 
-    assert_eq!(error.kind(), ErrorKind::RequestHeaderError);
+        assert_eq!(error.kind(), ErrorKind::RequestHeaderError);
+    }
 
     harness.shutdown().await;
 }


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #9807 

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid broker heartbeat timeout values are now rejected instead of being incorrectly converted into large positive values.
  * Heartbeat requests with missing or negative timeout values return a request header error.

* **Tests**
  * Expanded coverage verifies rejection of both missing and negative heartbeat timeout values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->