### PR TITLE
[ISSUE #9822]🚀Complete deferred runtime acceptance validation

### DIFF
--- a/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/outcomes_deadlines.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/outcomes_deadlines.rs
@@ -221,21 +221,39 @@ async fn dispatcher_commits_a_real_registry_registration_before_returning_deferr
         .lock()
         .expect("registered deferred id lock")
         .expect("processor should publish deferred id");
+    assert!(registry.test_contains(id));
+    assert_eq!(registry.test_index_counts(), (1, 1, 1));
+    assert_eq!(registry.test_claim_marker_count(), 0);
+    assert_eq!(admission.snapshot().waiting_count(), 1);
+    assert!(admission.snapshot().retained_bytes() > 0);
     let claimed = registry
         .claim(id, crate::dispatch::DeferredWakeReason::MessageArrived)
         .await
         .expect("commit should publish an active claim");
     assert_eq!(claimed.resume_data(), "dispatcher-owned deferred resume");
+    assert!(!registry.test_contains(id));
+    assert_eq!(registry.test_claim_marker_count(), 1);
     assert_eq!(admission.snapshot().waiting_count(), 1);
     harness.assert_no_response().await;
 
     let handler_admission = admission.clone();
+    let handler_controller = Arc::clone(&harness.admission_controller);
+    let handler_calls = Arc::new(AtomicUsize::new(0));
+    let calls = Arc::clone(&handler_calls);
     let receipt = claimed
         .resume(
             DeferredResumeRetainedSize::default(),
             move |resume, reason| async move {
+                calls.fetch_add(1, Ordering::SeqCst);
                 assert_eq!(handler_admission.snapshot().waiting_count(), 0);
                 assert_eq!(handler_admission.snapshot().retained_bytes(), 0);
+                let execution = handler_controller.snapshot();
+                assert_eq!(execution.queued.current_count, 0);
+                assert_eq!(execution.queued.current_bytes, 0);
+                assert_eq!(execution.inflight.current_count, 1);
+                assert!(execution.inflight.current_bytes > 0);
+                assert_eq!(execution.processors.current_count, 1);
+                assert!(execution.processors.current_bytes > 0);
                 assert_eq!(resume, "dispatcher-owned deferred resume");
                 assert_eq!(reason, DeferredWakeReason::MessageArrived);
                 ResponsePlan::command(RemotingCommand::create_response_command_with_code(0))
@@ -245,9 +263,26 @@ async fn dispatcher_commits_a_real_registry_registration_before_returning_deferr
         .await
         .expect("resume should use the same session executor and writer");
     assert_eq!(receipt.request_id(), original.request_id());
+    assert_eq!(handler_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(registry.test_index_counts(), (0, 0, 0));
+    assert_eq!(registry.test_claim_marker_count(), 0);
     assert_eq!(admission.snapshot().waiting_count(), 0);
+    assert_eq!(admission.snapshot().retained_bytes(), 0);
+    harness.drain_requests().await;
+    let execution = harness.admission_controller.snapshot();
+    assert_eq!(execution.queued.current_count, 0);
+    assert_eq!(execution.queued.current_bytes, 0);
+    assert_eq!(execution.inflight.current_count, 0);
+    assert_eq!(execution.inflight.current_bytes, 0);
+    assert_eq!(execution.processors.current_count, 0);
+    assert_eq!(execution.processors.current_bytes, 0);
     let response = harness.receive().await;
     assert_eq!(response.opaque(), original.original_opaque());
+    let writer = harness.session.writer_snapshot();
+    assert_eq!(writer.accepted, 1);
+    assert_eq!(writer.queued_items, 0);
+    assert_eq!(writer.queued_bytes, 0);
+    assert_eq!(writer.completed, 1);
     drop(dispatcher);
     drop(registry);
     assert_eq!(admission.snapshot().waiting_count(), 0);
@@ -315,7 +350,17 @@ async fn expired_resume_cancels_without_polling_the_handler_or_writing_a_respons
         Some(crate::dispatch::DeferredTerminalReason::OwnerDeadline)
     );
     assert!(!handler_called.load(Ordering::SeqCst));
+    assert_eq!(registry.test_index_counts(), (0, 0, 0));
+    assert_eq!(registry.test_claim_marker_count(), 0);
     assert_eq!(admission.snapshot().waiting_count(), 0);
+    assert_eq!(admission.snapshot().retained_bytes(), 0);
+    let execution = harness.admission_controller.snapshot();
+    assert_eq!(execution.queued.current_count, 0);
+    assert_eq!(execution.queued.current_bytes, 0);
+    assert_eq!(execution.inflight.current_count, 0);
+    assert_eq!(execution.inflight.current_bytes, 0);
+    assert_eq!(execution.processors.current_count, 0);
+    assert_eq!(execution.processors.current_bytes, 0);
     harness.assert_no_response().await;
     drop(dispatcher);
     drop(registry);
@@ -333,7 +378,9 @@ async fn real_registry_guards_rollback_on_unclaimed_wrong_and_oneway_handler_out
         let (fixture, registration) = real_registration_fixture(name, owner);
         assert!(fixture.registry.test_contains(fixture.id));
         assert_eq!(fixture.registry.test_index_counts(), (1, 1, 1));
+        assert_eq!(fixture.registry.test_claim_marker_count(), 0);
         assert_eq!(fixture.admission.snapshot().waiting_count(), 1);
+        assert!(fixture.admission.snapshot().retained_bytes() > 0);
         let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
             RollbackRegistrationProcessor {
                 registration: Arc::new(Mutex::new(Some(registration))),
@@ -353,6 +400,7 @@ async fn real_registry_guards_rollback_on_unclaimed_wrong_and_oneway_handler_out
         assert_eq!(dispatcher.reported_failure_categories(), ["handler_contract"]);
         assert!(!fixture.registry.test_contains(fixture.id));
         assert_eq!(fixture.registry.test_index_counts(), (0, 0, 0));
+        assert_eq!(fixture.registry.test_claim_marker_count(), 0);
         assert_eq!(fixture.admission.snapshot().waiting_count(), 0);
         assert_eq!(fixture.admission.snapshot().retained_bytes(), 0);
         harness.assert_no_response().await;

--- a/rocketmq-transport/src/dispatch/deferred_registry.rs
+++ b/rocketmq-transport/src/dispatch/deferred_registry.rs
@@ -764,6 +764,15 @@ where
         self.inner.sweep_expired(tokio::time::Instant::now(), limit)
     }
 
+    #[cfg(test)]
+    pub(crate) fn sweep_expired_at_for_test(
+        &self,
+        now: tokio::time::Instant,
+        limit: NonZeroUsize,
+    ) -> DeferredExpiryBatch<R> {
+        self.inner.sweep_expired(now, limit)
+    }
+
     /// Seals this registry and releases all state still owned by it.
     ///
     /// The winning call detaches registry indexes while holding the registry

--- a/rocketmq-transport/src/dispatch/deferred_registry/tests.rs
+++ b/rocketmq-transport/src/dispatch/deferred_registry/tests.rs
@@ -160,6 +160,17 @@ impl Harness {
     }
 }
 
+fn assert_registry_released<R>(registry: &DeferredRegistry<R>, admission: &DeferredAdmission)
+where
+    R: Send + 'static,
+{
+    assert_eq!(registry.test_index_counts(), (0, 0, 0));
+    assert_eq!(registry.test_claim_marker_count(), 0);
+    let snapshot = admission.snapshot();
+    assert_eq!(snapshot.waiting_count(), 0);
+    assert_eq!(snapshot.retained_bytes(), 0);
+}
+
 fn expiring_parts<R>(
     harness: &Harness,
     original: OriginalRequestIdentity,
@@ -386,6 +397,7 @@ fn underreported_permit_is_rejected_before_id_index_and_builder_with_exact_parts
     let recovered = error.into_parts().expect("preflight returns exact parts");
     assert_eq!(recovered.request_id(), original.request_id());
     assert_eq!(recovered.retained_bytes(), retained_bytes);
+    drop(recovered);
 
     let direct_original = harness.identity(101);
     let direct = registry
@@ -398,12 +410,13 @@ fn underreported_permit_is_rejected_before_id_index_and_builder_with_exact_parts
     let direct_request = direct.into_request().expect("direct preflight returns exact request");
     assert_eq!(direct_request.request_id(), direct_original.request_id());
     assert_eq!(direct_request.resume(), &8);
+    drop(direct_request);
     assert_eq!(
         sequence.load(Ordering::SeqCst),
         700,
         "retained-size preflight must run before deferred-id allocation"
     );
-    assert_eq!(registry.inner.index_counts(), (0, 0, 0));
+    assert_registry_released(&registry, &harness.admission);
 }
 
 #[test]
@@ -419,8 +432,7 @@ fn guard_drop_atomically_cleans_all_indexes_and_empty_session_bucket() {
         Some(EntryPhaseTag::Prepared)
     );
     drop(registration);
-    assert_eq!(registry.inner.index_counts(), (0, 0, 0));
-    assert_eq!(harness.admission.snapshot().waiting_count(), 0);
+    assert_registry_released(&registry, &harness.admission);
 }
 
 #[test]
@@ -435,10 +447,14 @@ fn duplicate_request_has_one_deterministic_owner_and_recovers_the_loser() {
         .register(DeferredRequest::new(2, harness.parts::<u64>(original)))
         .expect_err("same request cannot register twice");
     assert_eq!(loser.kind(), DeferredRegistryErrorKind::DuplicateRequest);
-    assert_eq!(loser.into_request().expect("loser request").resume(), &2);
+    assert_eq!(harness.admission.snapshot().waiting_count(), 2);
+    let loser = loser.into_request().expect("loser request");
+    assert_eq!(loser.resume(), &2);
+    drop(loser);
+    assert_eq!(harness.admission.snapshot().waiting_count(), 1);
     assert_eq!(registry.inner.index_counts(), (1, 1, 1));
     drop(winner);
-    assert_eq!(registry.inner.index_counts(), (0, 0, 0));
+    assert_registry_released(&registry, &harness.admission);
 }
 
 #[derive(Debug)]
@@ -476,7 +492,9 @@ fn typed_builder_failure_preserves_source_and_parts_while_outer_formatting_is_re
     let (source, parts) = error.into_builder_failure().expect("builder error and exact parts");
     assert_eq!(source.0, "secret business key");
     assert_eq!(parts.request_id(), original.request_id());
-    assert_eq!(registry.inner.index_counts(), (0, 0, 0));
+    assert_eq!(harness.admission.snapshot().waiting_count(), 1);
+    drop(parts);
+    assert_registry_released(&registry, &harness.admission);
 }
 
 struct ReentrantLease {
@@ -510,8 +528,7 @@ fn panicking_builder_rolls_back_after_reentrant_lease_drop_without_holding_the_l
     }));
     assert!(result.is_err());
     assert_eq!(drops.load(Ordering::SeqCst), 1);
-    assert_eq!(registry.inner.index_counts(), (0, 0, 0));
-    assert_eq!(harness.admission.snapshot().waiting_count(), 0);
+    assert_registry_released(&registry, &harness.admission);
 }
 
 #[tokio::test]
@@ -753,16 +770,22 @@ async fn activating_claim_is_published_without_a_second_ready_state_machine() {
     assert_eq!(claimed.reason(), DeferredWakeReason::ForcedRefresh);
 }
 
-#[tokio::test]
-async fn concurrent_claims_have_one_winner_and_transient_marker_diagnostics() {
-    let harness = Harness::new("deferred-registry-one-claim", 8113);
+async fn assert_first_claim_reason_wins(
+    name: &'static str,
+    owner: u64,
+    first_reason: DeferredWakeReason,
+    second_reason: DeferredWakeReason,
+) {
+    let harness = Harness::new(name, owner);
     let registry = DeferredRegistry::<u64>::new();
+    let parts = harness.parts::<u64>(harness.identity(owner as i32));
+    let state = parts.response_state();
     let registration = registry
-        .register(DeferredRequest::new(27, harness.parts::<u64>(harness.identity(13))))
+        .register(DeferredRequest::new(27, parts))
         .expect("prepared registration");
     let id = registration.deferred_id();
-    let first = registry.claim(id, DeferredWakeReason::MessageArrived);
-    let second = registry.claim(id, DeferredWakeReason::Timeout);
+    let first = registry.claim(id, first_reason);
+    let second = registry.claim(id, second_reason);
     tokio::pin!(first);
     tokio::pin!(second);
     tokio::select! {
@@ -777,13 +800,19 @@ async fn concurrent_claims_have_one_winner_and_transient_marker_diagnostics() {
     }
     registration.commit().expect("publish active registration");
     let claimed = first.await.expect("first waiter wins");
-    assert_eq!(claimed.reason(), DeferredWakeReason::MessageArrived);
+    assert_eq!(claimed.reason(), first_reason);
     let error = second.await.expect_err("second waiter observes the live marker");
     assert_eq!(error.kind(), DeferredClaimErrorKind::AlreadyClaimed);
     assert_eq!(error.request_id(), Some(claimed.request_id()));
-    assert_eq!(registry.inner.claim_marker_count(), 1);
+    assert_eq!(error.prior_terminal_reason(), None);
+    assert!(!registry.test_contains(id));
+    assert_eq!(registry.test_session_member_count(harness.session.view().id()), 1);
+    assert_eq!(registry.test_claim_marker_count(), 1);
     drop(claimed);
-    assert_eq!(registry.inner.claim_marker_count(), 0);
+    assert_eq!(
+        state.terminal_reason(),
+        Some(crate::dispatch::DeferredTerminalReason::ClaimDropped)
+    );
     assert_eq!(
         registry
             .claim(id, DeferredWakeReason::ForcedRefresh)
@@ -792,8 +821,25 @@ async fn concurrent_claims_have_one_winner_and_transient_marker_diagnostics() {
             .kind(),
         DeferredClaimErrorKind::NotFound
     );
-    assert_eq!(registry.inner.index_counts(), (0, 0, 0));
-    assert_eq!(harness.admission.snapshot().waiting_count(), 0);
+    assert_registry_released(&registry, &harness.admission);
+}
+
+#[tokio::test]
+async fn message_and_timeout_claims_freeze_the_first_reason_in_both_linearizations() {
+    assert_first_claim_reason_wins(
+        "deferred-registry-message-before-timeout",
+        8113,
+        DeferredWakeReason::MessageArrived,
+        DeferredWakeReason::Timeout,
+    )
+    .await;
+    assert_first_claim_reason_wins(
+        "deferred-registry-timeout-before-message",
+        8114,
+        DeferredWakeReason::Timeout,
+        DeferredWakeReason::MessageArrived,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -1033,11 +1079,10 @@ async fn claimed_session_cleanup_closes_marker_and_fresh_claim_is_not_found() {
     let harness = Harness::new("deferred-registry-claimed-cleanup", 8122);
     let cleanup = crate::dispatch::DeferredSessionCleanupOwner::new(harness.session.view().id());
     let registry = DeferredRegistry::<u64>::new();
+    let parts = harness.parts_with_cleanup::<u64>(harness.identity(204), &cleanup);
+    let state = parts.response_state();
     let registration = registry
-        .register(DeferredRequest::new(
-            9,
-            harness.parts_with_cleanup::<u64>(harness.identity(204), &cleanup),
-        ))
+        .register(DeferredRequest::new(9, parts))
         .expect("claimed cleanup registration");
     let id = registration.deferred_id();
     registration.commit().expect("claimed cleanup commit");
@@ -1054,13 +1099,22 @@ async fn claimed_session_cleanup_closes_marker_and_fresh_claim_is_not_found() {
     );
     assert_eq!(registry.inner.session_member_count(harness.session.view().id()), 0);
     assert_eq!(registry.inner.claim_marker_count(), 0);
+    assert_eq!(
+        state.terminal_reason(),
+        Some(crate::dispatch::DeferredTerminalReason::SessionClosed)
+    );
+    assert_eq!(harness.admission.snapshot().waiting_count(), 1);
     let error = registry
         .claim(id, DeferredWakeReason::Timeout)
         .await
         .expect_err("fresh post-cleanup claim has no tombstone");
     assert_eq!(error.kind(), DeferredClaimErrorKind::NotFound);
     drop(claimed);
-    assert_eq!(harness.admission.snapshot().waiting_count(), 0);
+    assert_eq!(
+        state.terminal_reason(),
+        Some(crate::dispatch::DeferredTerminalReason::SessionClosed)
+    );
+    assert_registry_released(&registry, &harness.admission);
 }
 
 #[test]
@@ -1080,8 +1134,7 @@ fn registry_shutdown_is_typed_idempotent_and_rejects_new_ownership() {
     assert_eq!(stats.in_progress_responses(), 0);
     assert_eq!(stats.invariant_failures(), 0);
     assert_eq!(registry.shutdown(), DeferredRegistryShutdownOutcome::AlreadyClosed);
-    assert_eq!(registry.inner.index_counts(), (0, 0, 0));
-    assert_eq!(harness.admission.snapshot().waiting_count(), 0);
+    assert_registry_released(&registry, &harness.admission);
 
     let called = Arc::new(AtomicBool::new(false));
     let builder_called = Arc::clone(&called);
@@ -1093,6 +1146,11 @@ fn registry_shutdown_is_typed_idempotent_and_rejects_new_ownership() {
         .expect_err("closed registry rejects registration");
     assert_eq!(error.kind(), DeferredRegistryErrorKind::ParentCancelled);
     assert!(!called.load(Ordering::SeqCst));
+    assert!(
+        error.into_parts().is_none(),
+        "lifecycle stop consumes and releases response ownership"
+    );
+    assert_registry_released(&registry, &harness.admission);
 }
 
 #[test]

--- a/rocketmq-transport/src/dispatch/deferred_registry/tests/expiry.rs
+++ b/rocketmq-transport/src/dispatch/deferred_registry/tests/expiry.rs
@@ -14,6 +14,20 @@
 
 use super::*;
 
+fn assert_expiry_registry_released<R>(registry: &DeferredRegistry<R>, harness: &Harness)
+where
+    R: Send + 'static,
+{
+    assert_registry_released(registry, &harness.admission);
+    let future = tokio::time::Instant::now() + Duration::from_secs(24 * 60 * 60);
+    let batch = registry.sweep_expired_at_for_test(future, NonZeroUsize::new(usize::MAX).expect("non-zero limit"));
+    assert_eq!(
+        batch.stats().examined(),
+        0,
+        "expiry index must not retain a stale entry"
+    );
+}
+
 fn parts_with_telemetry<R>(
     harness: &Harness,
     original: OriginalRequestIdentity,
@@ -88,8 +102,7 @@ fn parent_cancellation_is_frozen_before_successful_resume_drop_panics() {
     assert_eq!(terminals.len(), 1, "only the system terminal winner records a metric");
     assert_eq!(terminals[0].1, "parent_cancelled");
     drop(terminals);
-    assert_eq!(registry.inner.index_counts(), (0, 0, 0));
-    assert_eq!(harness.admission.snapshot().waiting_count(), 0);
+    assert_expiry_registry_released(&registry, &harness);
 }
 
 #[test]
@@ -116,8 +129,7 @@ fn session_close_is_frozen_before_builder_error_drop_panics() {
     assert_eq!(terminals.len(), 1, "only the system terminal winner records a metric");
     assert_eq!(terminals[0].1, "session_closed");
     drop(terminals);
-    assert_eq!(registry.inner.index_counts(), (0, 0, 0));
-    assert_eq!(harness.admission.snapshot().waiting_count(), 0);
+    assert_expiry_registry_released(&registry, &harness);
 }
 
 #[tokio::test(start_paused = true)]
@@ -131,6 +143,7 @@ async fn deferred_expiry_long_poll_uses_the_unified_timeout_claim() {
             DeferredExpiryMargins::new(Duration::from_secs(1), Duration::from_secs(1)),
         )
         .expect("attach protocol expiry");
+    let state = parts.response_state();
     let registration = registry
         .register(DeferredRequest::new(41, parts))
         .expect("register protocol expiry");
@@ -144,8 +157,98 @@ async fn deferred_expiry_long_poll_uses_the_unified_timeout_claim() {
     assert_eq!(claims.len(), 1);
     assert_eq!(claims[0].reason(), DeferredWakeReason::Timeout);
     drop(claims.pop());
-    assert_eq!(registry.inner.index_counts(), (0, 0, 0));
-    assert_eq!(harness.admission.snapshot().waiting_count(), 0);
+    assert_eq!(
+        state.terminal_reason(),
+        Some(crate::dispatch::DeferredTerminalReason::ClaimDropped)
+    );
+    assert_expiry_registry_released(&registry, &harness);
+}
+
+#[tokio::test(start_paused = true)]
+async fn message_claim_before_expiry_sweep_keeps_message_as_the_immutable_winner() {
+    let harness = Harness::new("deferred-expiry-message-before-sweep", 98206);
+    let registry = DeferredRegistry::<u64>::new();
+    let protocol_at = tokio::time::Instant::now() + Duration::from_secs(10);
+    let parts = expiring_parts::<u64>(&harness, harness.identity(312), None, None)
+        .try_with_expiry(
+            protocol_at,
+            DeferredExpiryMargins::new(Duration::from_secs(1), Duration::from_secs(1)),
+        )
+        .expect("attach message-first expiry");
+    let state = parts.response_state();
+    let registration = registry
+        .register(DeferredRequest::new(51, parts))
+        .expect("register message-first expiry");
+    let id = registration.deferred_id();
+    registration.commit().expect("publish message-first expiry");
+
+    let claimed = registry
+        .claim(id, DeferredWakeReason::MessageArrived)
+        .await
+        .expect("message claim wins before sweep");
+    assert_eq!(claimed.reason(), DeferredWakeReason::MessageArrived);
+    let batch = registry.sweep_expired_at_for_test(protocol_at, NonZeroUsize::new(1).expect("non-zero limit"));
+    assert_eq!(batch.stats().examined(), 0);
+    assert!(batch.into_claims().is_empty());
+    let loser = registry
+        .claim(id, DeferredWakeReason::Timeout)
+        .await
+        .expect_err("timeout observes the message claim marker");
+    assert_eq!(loser.kind(), DeferredClaimErrorKind::AlreadyClaimed);
+    assert_eq!(loser.request_id(), Some(claimed.request_id()));
+    assert_eq!(loser.prior_terminal_reason(), None);
+    assert_eq!(registry.test_claim_marker_count(), 1);
+    assert_eq!(harness.admission.snapshot().waiting_count(), 1);
+
+    drop(claimed);
+    assert_eq!(
+        state.terminal_reason(),
+        Some(crate::dispatch::DeferredTerminalReason::ClaimDropped)
+    );
+    assert_expiry_registry_released(&registry, &harness);
+}
+
+#[tokio::test(start_paused = true)]
+async fn expiry_sweep_before_message_claim_keeps_timeout_as_the_immutable_winner() {
+    let harness = Harness::new("deferred-expiry-sweep-before-message", 98207);
+    let registry = DeferredRegistry::<u64>::new();
+    let protocol_at = tokio::time::Instant::now() + Duration::from_secs(10);
+    let parts = expiring_parts::<u64>(&harness, harness.identity(313), None, None)
+        .try_with_expiry(
+            protocol_at,
+            DeferredExpiryMargins::new(Duration::from_secs(1), Duration::from_secs(1)),
+        )
+        .expect("attach sweep-first expiry");
+    let state = parts.response_state();
+    let registration = registry
+        .register(DeferredRequest::new(52, parts))
+        .expect("register sweep-first expiry");
+    let id = registration.deferred_id();
+    registration.commit().expect("publish sweep-first expiry");
+
+    let batch = registry.sweep_expired_at_for_test(protocol_at, NonZeroUsize::new(1).expect("non-zero limit"));
+    assert_eq!(batch.stats().examined(), 1);
+    assert_eq!(batch.stats().long_poll_claims(), 1);
+    let mut claims = batch.into_claims();
+    assert_eq!(claims.len(), 1);
+    let claimed = claims.pop().expect("sweep returns timeout owner");
+    assert_eq!(claimed.reason(), DeferredWakeReason::Timeout);
+    let loser = registry
+        .claim(id, DeferredWakeReason::MessageArrived)
+        .await
+        .expect_err("message observes the timeout claim marker");
+    assert_eq!(loser.kind(), DeferredClaimErrorKind::AlreadyClaimed);
+    assert_eq!(loser.request_id(), Some(claimed.request_id()));
+    assert_eq!(loser.prior_terminal_reason(), None);
+    assert_eq!(registry.test_claim_marker_count(), 1);
+    assert_eq!(harness.admission.snapshot().waiting_count(), 1);
+
+    drop(claimed);
+    assert_eq!(
+        state.terminal_reason(),
+        Some(crate::dispatch::DeferredTerminalReason::ClaimDropped)
+    );
+    assert_expiry_registry_released(&registry, &harness);
 }
 
 #[tokio::test(start_paused = true)]
@@ -180,8 +283,7 @@ async fn deferred_expiry_owner_cutoff_wins_without_a_timeout_claim() {
         state.terminal_reason(),
         Some(crate::dispatch::DeferredTerminalReason::OwnerDeadline)
     );
-    assert_eq!(registry.inner.index_counts(), (0, 0, 0));
-    assert_eq!(harness.admission.snapshot().waiting_count(), 0);
+    assert_expiry_registry_released(&registry, &harness);
 }
 
 #[tokio::test(start_paused = true)]
@@ -216,8 +318,7 @@ async fn deferred_expiry_cursor_does_not_let_provisional_entry_starve_active_ent
     let wrapped = registry.sweep_expired(NonZeroUsize::new(1).expect("non-zero limit"));
     assert_eq!(wrapped.stats().long_poll_claims(), 1);
     drop(wrapped);
-    assert_eq!(registry.inner.index_counts(), (0, 0, 0));
-    assert_eq!(harness.admission.snapshot().waiting_count(), 0);
+    assert_expiry_registry_released(&registry, &harness);
 }
 
 #[tokio::test(start_paused = true)]
@@ -257,8 +358,7 @@ async fn deferred_expiry_session_close_between_scan_and_claim_wins_deterministic
         state.terminal_reason(),
         Some(crate::dispatch::DeferredTerminalReason::SessionClosed)
     );
-    assert_eq!(registry.inner.index_counts(), (0, 0, 0));
-    assert_eq!(harness.admission.snapshot().waiting_count(), 0);
+    assert_expiry_registry_released(&registry, &harness);
 }
 
 #[tokio::test]
@@ -299,8 +399,9 @@ async fn shutdown_freezes_parent_over_session_for_ticket_state_and_one_metric() 
     let terminals = terminals.lock();
     assert_eq!(terminals.len(), 1, "only the terminal CAS winner records a metric");
     assert_eq!(terminals[0].1, "parent_cancelled");
+    drop(terminals);
     drop(registration);
-    assert_eq!(harness.admission.snapshot().waiting_count(), 0);
+    assert_expiry_registry_released(&registry, &harness);
 }
 
 async fn assert_owner_sweep_priority(parent: bool, expected: crate::dispatch::DeferredTerminalReason) {
@@ -330,8 +431,7 @@ async fn assert_owner_sweep_priority(parent: bool, expected: crate::dispatch::De
     assert_eq!(batch.stats().owner_expired(), 0);
     assert!(batch.into_claims().is_empty());
     assert_eq!(state.terminal_reason(), Some(expected));
-    assert_eq!(registry.inner.index_counts(), (0, 0, 0));
-    assert_eq!(harness.admission.snapshot().waiting_count(), 0);
+    assert_expiry_registry_released(&registry, &harness);
 }
 
 #[tokio::test(start_paused = true)]
@@ -395,7 +495,8 @@ async fn assert_owner_sweep_from_phase(phase: ProvisionalPhase, owner: u64) {
         state.terminal_reason(),
         Some(crate::dispatch::DeferredTerminalReason::OwnerDeadline)
     );
-    assert_eq!(registry.inner.index_counts(), (0, 0, 0));
+    assert_eq!(registry.test_index_counts(), (0, 0, 0));
+    assert_eq!(registry.test_claim_marker_count(), 0);
     let externally_owned = matches!(phase, ProvisionalPhase::Building | ProvisionalPhase::Activating);
     assert_eq!(
         harness.admission.snapshot().waiting_count(),
@@ -403,7 +504,7 @@ async fn assert_owner_sweep_from_phase(phase: ProvisionalPhase, owner: u64) {
     );
     drop(activating);
     drop(parts);
-    assert_eq!(harness.admission.snapshot().waiting_count(), 0);
+    assert_expiry_registry_released(&registry, &harness);
 }
 
 #[tokio::test(start_paused = true)]
@@ -446,8 +547,7 @@ async fn delayed_sweep_crossing_long_poll_and_owner_cutoff_chooses_owner() {
         state.terminal_reason(),
         Some(crate::dispatch::DeferredTerminalReason::OwnerDeadline)
     );
-    assert_eq!(registry.inner.index_counts(), (0, 0, 0));
-    assert_eq!(harness.admission.snapshot().waiting_count(), 0);
+    assert_expiry_registry_released(&registry, &harness);
 }
 
 #[tokio::test(start_paused = true)]
@@ -473,6 +573,5 @@ async fn owner_only_claim_marker_uses_canonical_deadline_before_claim_drop() {
         state.terminal_reason(),
         Some(crate::dispatch::DeferredTerminalReason::OwnerDeadline)
     );
-    assert_eq!(registry.inner.index_counts(), (0, 0, 0));
-    assert_eq!(harness.admission.snapshot().waiting_count(), 0);
+    assert_expiry_registry_released(&registry, &harness);
 }

--- a/rocketmq-transport/src/dispatch/deferred_responder.rs
+++ b/rocketmq-transport/src/dispatch/deferred_responder.rs
@@ -311,7 +311,10 @@ impl DeferredResponseSeed {
 
     pub(crate) fn into_responder(self, original: OriginalRequestIdentity) -> DeferredResponder {
         #[cfg(test)]
-        DEFERRED_STATE_ALLOCATIONS.with(|count| count.set(count.get() + 1));
+        {
+            DEFERRED_STATE_ALLOCATIONS.with(|count| count.set(count.get() + 1));
+            self.telemetry.record_deferred_state_construction();
+        }
         let state = Arc::new(ResponseState::observed(self.telemetry, original.original_code()));
         DeferredResponder {
             original,

--- a/rocketmq-transport/src/dispatch/deferred_resume.rs
+++ b/rocketmq-transport/src/dispatch/deferred_resume.rs
@@ -971,8 +971,14 @@ mod tests {
         );
         let snapshot = controller.snapshot();
         assert_eq!(snapshot.queued.current_count, 0);
+        assert_eq!(snapshot.queued.current_bytes, 0);
+        assert_eq!(snapshot.queued.rejected_count, 1);
         assert_eq!(snapshot.inflight.current_count, 0);
+        assert_eq!(snapshot.inflight.current_bytes, 0);
+        assert_eq!(snapshot.inflight.rejected_count, 0);
         assert_eq!(snapshot.processors.current_count, 0);
+        assert_eq!(snapshot.processors.current_bytes, 0);
+        assert_eq!(snapshot.processors.rejected_count, 0);
     }
 
     #[tokio::test]
@@ -1010,7 +1016,14 @@ mod tests {
         );
         let snapshot = controller.snapshot();
         assert_eq!(snapshot.queued.current_count, 0);
+        assert_eq!(snapshot.queued.current_bytes, 0);
+        assert_eq!(snapshot.queued.rejected_count, 0);
         assert_eq!(snapshot.inflight.current_count, 0);
+        assert_eq!(snapshot.inflight.current_bytes, 0);
+        assert_eq!(snapshot.inflight.rejected_count, 1);
+        assert_eq!(snapshot.processors.current_count, 0);
+        assert_eq!(snapshot.processors.current_bytes, 0);
+        assert_eq!(snapshot.processors.rejected_count, 0);
     }
 
     #[tokio::test]
@@ -1027,10 +1040,11 @@ mod tests {
             ..defaults
         };
         let (_runtime, controller, executor) = executor_with_limits("deferred-resume-processor-reject", limits);
-        let (job, completion, _wait_released, rejected, executions) =
+        let (job, completion, wait_released, rejected, executions) =
             probe_job(charge, RequestOrdering::Concurrent, None);
         let cell = Arc::new(ResumeJobCell::new(job));
         cell.release_wait_permit();
+        assert!(wait_released.load(Ordering::Acquire));
         let submitted = executor
             .deferred_resume_executor()
             .try_execute_resume(Arc::clone(&cell));
@@ -1038,18 +1052,23 @@ mod tests {
         drop(cell);
         rejected.notified().await;
         assert_eq!(executions.load(Ordering::Acquire), 0);
-        assert_eq!(
-            completion.wait().await.expect_err("processor rejection result").kind(),
-            DeferredResumeErrorKind::Admission
-        );
+        let error = completion.wait().await.expect_err("processor rejection result");
+        assert_eq!(error.kind(), DeferredResumeErrorKind::Admission);
+        assert_eq!(error.prior_terminal_reason(), None);
         let report = executor
             .drain_until(ShutdownDeadline::after(Duration::from_secs(1)))
             .await;
         assert_eq!(report.aborted, 0);
         let snapshot = controller.snapshot();
         assert_eq!(snapshot.queued.current_count, 0);
+        assert_eq!(snapshot.queued.current_bytes, 0);
+        assert_eq!(snapshot.queued.rejected_count, 0);
         assert_eq!(snapshot.inflight.current_count, 0);
+        assert_eq!(snapshot.inflight.current_bytes, 0);
+        assert_eq!(snapshot.inflight.rejected_count, 0);
         assert_eq!(snapshot.processors.current_count, 0);
+        assert_eq!(snapshot.processors.current_bytes, 0);
+        assert_eq!(snapshot.processors.rejected_count, 1);
     }
 
     #[tokio::test]

--- a/rocketmq-transport/src/dispatch/deferred_resume/tests/stop.rs
+++ b/rocketmq-transport/src/dispatch/deferred_resume/tests/stop.rs
@@ -78,6 +78,9 @@ async fn owner_cutoff_cancels_an_ordered_waiter_before_processor_execution() {
     assert_eq!(report.aborted, 0);
     let snapshot = controller.snapshot();
     assert_eq!(snapshot.queued.current_count, 0);
+    assert_eq!(snapshot.queued.current_bytes, 0);
     assert_eq!(snapshot.inflight.current_count, 0);
+    assert_eq!(snapshot.inflight.current_bytes, 0);
     assert_eq!(snapshot.processors.current_count, 0);
+    assert_eq!(snapshot.processors.current_bytes, 0);
 }

--- a/rocketmq-transport/src/dispatch/response_sink/plan_tests/network/deferred.rs
+++ b/rocketmq-transport/src/dispatch/response_sink/plan_tests/network/deferred.rs
@@ -132,24 +132,43 @@ async fn dropping_a_waiting_deferred_send_completes_rsp_and_def_not_started() {
             progress: WriteProgress::NotStarted
         })
     );
+    assert_eq!(state_for_assert.terminal_reason(), None);
+    let before_duplicate = harness.session.writer_snapshot();
+    let duplicate_error = duplicate
+        .send_plan(bind(
+            ResponsePlan::command(response_head(123, 1_123)).expect("duplicate plan"),
+            832,
+            1_123,
+        ))
+        .await;
     assert!(matches!(
-        duplicate
-            .send_plan(bind(
-                ResponsePlan::command(response_head(123, 1_123)).expect("duplicate plan"),
-                832,
-                1_123,
-            ))
-            .await,
+        duplicate_error,
         Err(ResponseError::AlreadyCompleted {
             state: ResponseTerminalState::Failed {
                 progress: WriteProgress::NotStarted
             }
         })
     ));
+    let after_duplicate = harness.session.writer_snapshot();
+    assert_eq!(after_duplicate.accepted, before_duplicate.accepted);
+    assert_eq!(after_duplicate.queued_items, before_duplicate.queued_items);
 
     resume.notify_one();
     blocker.await.expect("blocker task");
     assert_eq!(harness.receive().await.opaque(), 1_121);
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while harness.session.writer_snapshot().queued_items != 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("cancelled deferred envelope should leave the writer queue");
+    let writer = harness.session.writer_snapshot();
+    assert_eq!(writer.accepted, 2);
+    assert_eq!(writer.queued_items, 0);
+    assert_eq!(writer.queued_bytes, 0);
+    assert_eq!(writer.completed, 1);
+    assert_eq!(writer.failed, 1);
     harness.shutdown().await;
 }
 
@@ -199,23 +218,34 @@ async fn dropping_a_writer_claimed_deferred_send_completes_rsp_and_def_possibly_
             progress: WriteProgress::PossiblyPartial
         })
     );
+    assert_eq!(state_for_assert.terminal_reason(), None);
+    let before_duplicate = harness.session.writer_snapshot();
+    let duplicate_error = duplicate
+        .send_plan(bind(
+            ResponsePlan::command(response_head(125, 1_125)).expect("duplicate plan"),
+            834,
+            1_125,
+        ))
+        .await;
     assert!(matches!(
-        duplicate
-            .send_plan(bind(
-                ResponsePlan::command(response_head(125, 1_125)).expect("duplicate plan"),
-                834,
-                1_125,
-            ))
-            .await,
+        duplicate_error,
         Err(ResponseError::AlreadyCompleted {
             state: ResponseTerminalState::Failed {
                 progress: WriteProgress::PossiblyPartial
             }
         })
     ));
+    let after_duplicate = harness.session.writer_snapshot();
+    assert_eq!(after_duplicate.accepted, before_duplicate.accepted);
+    assert_eq!(after_duplicate.queued_items, before_duplicate.queued_items);
 
     resume.notify_one();
     assert_eq!(harness.receive().await.opaque(), 1_124);
+    let writer = harness.session.writer_snapshot();
+    assert_eq!(writer.accepted, 1);
+    assert_eq!(writer.queued_items, 0);
+    assert_eq!(writer.queued_bytes, 0);
+    assert_eq!(writer.completed, 1);
     harness.shutdown().await;
 }
 
@@ -277,23 +307,43 @@ async fn prestart_deadline_resumes_both_outer_claims_without_a_delegated_sending
             progress: WriteProgress::NotStarted
         })
     );
+    assert_eq!(state_for_assert.terminal_reason(), None);
+    let before_duplicate = harness.session.writer_snapshot();
+    let duplicate_error = duplicate
+        .send_plan(bind(
+            ResponsePlan::command(response_head(128, 1_128)).expect("duplicate plan"),
+            836,
+            1_128,
+        ))
+        .await;
     assert!(matches!(
-        duplicate
-            .send_plan(bind(
-                ResponsePlan::command(response_head(128, 1_128)).expect("duplicate plan"),
-                836,
-                1_128,
-            ))
-            .await,
+        duplicate_error,
         Err(ResponseError::AlreadyCompleted {
             state: ResponseTerminalState::Failed {
                 progress: WriteProgress::NotStarted
             }
         })
     ));
+    let after_duplicate = harness.session.writer_snapshot();
+    assert_eq!(after_duplicate.accepted, before_duplicate.accepted);
+    assert_eq!(after_duplicate.queued_items, before_duplicate.queued_items);
 
     resume.notify_one();
     blocker.await.expect("blocker task");
     assert_eq!(harness.receive().await.opaque(), 1_126);
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while harness.session.writer_snapshot().queued_items != 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("expired deferred envelope should leave the writer queue");
+    let writer = harness.session.writer_snapshot();
+    assert_eq!(writer.accepted, 2);
+    assert_eq!(writer.queued_items, 0);
+    assert_eq!(writer.queued_bytes, 0);
+    assert_eq!(writer.completed, 1);
+    assert_eq!(writer.failed, 1);
+    assert_eq!(writer.deadline_expired, 1);
     harness.shutdown().await;
 }

--- a/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/v2_server/tests.rs
+++ b/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/v2_server/tests.rs
@@ -19,7 +19,6 @@ use std::sync::Mutex;
 use bytes::Bytes;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
-use rocketmq_runtime::RuntimeContext;
 use rocketmq_security_api::IngressDecision;
 use rocketmq_security_api::IngressPolicy;
 use rocketmq_security_api::LayerEvaluation;
@@ -47,6 +46,16 @@ use crate::runtime::RPCHook;
 
 #[path = "tests/deferred_expiry.rs"]
 mod deferred_expiry;
+#[path = "tests/harness.rs"]
+mod harness;
+#[path = "tests/inline_deferred_state.rs"]
+mod inline_deferred_state;
+
+use harness::expect_start_error;
+use harness::loopback_server_config;
+use harness::start_server;
+use harness::start_server_with_shutdown_observer;
+use harness::V2TestRuntime;
 
 #[derive(Default)]
 struct ProcessorState {
@@ -238,50 +247,8 @@ impl RPCHook for OrderedHook {
     }
 }
 
-fn service_context(name: &'static str) -> ChildServiceContext {
-    RuntimeContext::from_current(name).service_context("transport-v2-test")
-}
-
 fn loopback_security() -> Arc<TransportSecurity> {
     Arc::new(TransportSecurity::development_insecure_loopback(None, None))
-}
-
-async fn start_server<P>(
-    server: TransportServerV2<P>,
-) -> (
-    crate::connection::Connection,
-    SocketAddr,
-    oneshot::Sender<()>,
-    tokio::task::JoinHandle<Result<ShutdownReport, ServerStartError>>,
-)
-where
-    P: RequestProcessorV2 + Clone + Sync + 'static,
-{
-    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind V2 test listener");
-    let address = listener.local_addr().expect("V2 test listener address");
-    let (shutdown_tx, shutdown_rx) = oneshot::channel();
-    let (startup_tx, startup_rx) = oneshot::channel();
-    let server_task = tokio::spawn(async move {
-        server
-            .try_serve_bound_listener_until_with_startup(
-                listener,
-                None,
-                async {
-                    let _ = shutdown_rx.await;
-                },
-                startup_tx,
-            )
-            .await
-    });
-    assert_eq!(
-        startup_rx
-            .await
-            .expect("V2 startup result channel")
-            .expect("V2 startup succeeds"),
-        address
-    );
-    let client = crate::connection::Connection::new(TcpStream::connect(address).await.expect("connect V2 client"));
-    (client, address, shutdown_tx, server_task)
 }
 
 async fn receive_deferred_registration(
@@ -357,6 +324,7 @@ impl RequestProcessorV2 for NetworkDeferredCleanupProcessor {
 
 #[tokio::test]
 async fn real_tcp_v2_routes_requests_once_and_drops_unexpected_responses_without_legacy_state() {
+    let runtime = V2TestRuntime::new("transport-v2-tcp");
     let state = Arc::new(ProcessorState::default());
     let security_calls = Arc::new(AtomicUsize::new(0));
     let admission = Arc::new(AdmissionController::new(AdmissionLimits::default()));
@@ -364,23 +332,19 @@ async fn real_tcp_v2_routes_requests_once_and_drops_unexpected_responses_without
         state: Arc::clone(&state),
         admission: Some(Arc::clone(&admission)),
     };
-    let server = TransportServerV2::new(
-        Arc::new(ServerConfig::default()),
-        service_context("transport-v2-tcp"),
-        processor,
-    )
-    .with_transport_security(
-        Arc::new(
-            TransportSecurity::development_insecure_loopback(None, None).with_ingress_policy(Arc::new(
-                CountingPolicy {
-                    calls: Arc::clone(&security_calls),
-                },
-            )),
-        ),
-        None,
-    )
-    .with_admission_controller(admission);
-    let (mut client, _address, shutdown_tx, server_task) = start_server(server).await;
+    let server = TransportServerV2::new(loopback_server_config(), runtime.service_context(), processor)
+        .with_transport_security(
+            Arc::new(
+                TransportSecurity::development_insecure_loopback(None, None).with_ingress_policy(Arc::new(
+                    CountingPolicy {
+                        calls: Arc::clone(&security_calls),
+                    },
+                )),
+            ),
+            None,
+        )
+        .with_admission_controller(admission);
+    let (mut client, _address, mut running) = start_server(runtime, server).await;
     state.clones.store(0, Ordering::SeqCst);
 
     client
@@ -481,9 +445,8 @@ async fn real_tcp_v2_routes_requests_once_and_drops_unexpected_responses_without
     );
     assert_eq!(oneway_sentinel.body(), Some(&Bytes::from_static(b"v2-tcp")));
 
-    let _ = shutdown_tx.send(());
-    let report = server_task.await.expect("join V2 server").expect("V2 shutdown report");
-    assert!(report.is_healthy(), "{}", report.to_json());
+    running.begin_shutdown();
+    running.finish().await;
     let eof = tokio::time::timeout(Duration::from_secs(1), client.receive_command())
         .await
         .expect("V2 shutdown should publish EOF");
@@ -506,23 +469,21 @@ async fn injected_boundary_conflicts_fail_before_hooks_are_merged() {
         before: Arc::clone(&before),
         after: Arc::clone(&after),
     });
+    let security_runtime = V2TestRuntime::new("transport-v2-conflict");
     let mut server = TransportServerV2::new_with_authorized_dispatcher(
-        Arc::new(ServerConfig::default()),
-        service_context("transport-v2-conflict"),
+        loopback_server_config(),
+        security_runtime.service_context(),
         Arc::clone(&dispatcher),
     )
     .with_transport_security(loopback_security(), None);
     server.register_rpc_hook(hook);
-    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind conflict listener");
-    let error = server
-        .try_serve_bound_listener_until(listener, None, std::future::pending::<()>())
-        .await
-        .expect_err("foreign security owner must fail");
+    let error = expect_start_error(security_runtime, server).await;
     assert!(matches!(error, ServerStartError::Configuration { .. }));
 
+    let admission_runtime = V2TestRuntime::new("transport-v2-admission-conflict");
     let mut admission_conflict = TransportServerV2::new_with_authorized_dispatcher(
-        Arc::new(ServerConfig::default()),
-        service_context("transport-v2-admission-conflict"),
+        loopback_server_config(),
+        admission_runtime.service_context(),
         Arc::clone(&dispatcher),
     )
     .with_admission_controller(Arc::new(AdmissionController::new(AdmissionLimits::default())));
@@ -530,21 +491,16 @@ async fn injected_boundary_conflicts_fail_before_hooks_are_merged() {
         before: Arc::clone(&before),
         after: Arc::clone(&after),
     }));
-    let listener = TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("bind admission conflict listener");
-    let error = admission_conflict
-        .try_serve_bound_listener_until(listener, None, std::future::pending::<()>())
-        .await
-        .expect_err("foreign admission owner must fail");
+    let error = expect_start_error(admission_runtime, admission_conflict).await;
     assert!(matches!(error, ServerStartError::Configuration { .. }));
 
+    let matching_runtime = V2TestRuntime::new("transport-v2-unpolluted");
     let matching_server = TransportServerV2::new_with_authorized_dispatcher(
-        Arc::new(ServerConfig::default()),
-        service_context("transport-v2-unpolluted"),
+        loopback_server_config(),
+        matching_runtime.service_context(),
         dispatcher,
     );
-    let (mut client, _address, shutdown_tx, server_task) = start_server(matching_server).await;
+    let (mut client, _address, mut running) = start_server(matching_runtime, matching_server).await;
     client
         .send_command(RemotingCommand::create_remoting_command(701).set_opaque(4_003))
         .await
@@ -556,15 +512,13 @@ async fn injected_boundary_conflicts_fail_before_hooks_are_merged() {
         .expect("unpolluted response");
     assert_eq!(before.load(Ordering::SeqCst), 0);
     assert_eq!(after.load(Ordering::SeqCst), 0);
-    let _ = shutdown_tx.send(());
-    let _ = server_task
-        .await
-        .expect("join unpolluted server")
-        .expect("shutdown report");
+    running.begin_shutdown();
+    running.finish().await;
 }
 
 #[tokio::test]
 async fn dispatcher_injection_immediately_drops_the_automatic_processor_source() {
+    let runtime = V2TestRuntime::new("transport-v2-processor-replacement");
     let automatic_drops = Arc::new(AtomicUsize::new(0));
     let injected_drops = Arc::new(AtomicUsize::new(0));
     let admission = Arc::new(AdmissionController::new(AdmissionLimits::default()));
@@ -577,8 +531,8 @@ async fn dispatcher_injection_immediately_drops_the_automatic_processor_source()
         admission,
     ));
     let server = TransportServerV2::new(
-        Arc::new(ServerConfig::default()),
-        service_context("transport-v2-processor-replacement"),
+        loopback_server_config(),
+        runtime.service_context(),
         DropTrackedProcessor {
             drops: Arc::clone(&automatic_drops),
         },
@@ -589,21 +543,19 @@ async fn dispatcher_injection_immediately_drops_the_automatic_processor_source()
     assert_eq!(injected_drops.load(Ordering::SeqCst), 0);
     drop(server);
     assert_eq!(injected_drops.load(Ordering::SeqCst), 1);
+    runtime.finish().await;
 }
 
 #[tokio::test]
 async fn shutdown_drains_accepted_work_and_flushes_its_writer_before_retirement() {
-    let listener = TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("bind draining V2 listener");
-    let address = listener.local_addr().expect("draining V2 listener address");
+    let runtime = V2TestRuntime::new("transport-v2-drain");
     let started = Arc::new(tokio::sync::Notify::new());
     let release = Arc::new(tokio::sync::Notify::new());
     let write_checked = Arc::new(tokio::sync::Notify::new());
     let resume_write = Arc::new(tokio::sync::Notify::new());
     let server = TransportServerV2::new(
-        Arc::new(ServerConfig::default()),
-        service_context("transport-v2-drain"),
+        loopback_server_config(),
+        runtime.service_context(),
         DrainingProcessor {
             started: Arc::clone(&started),
             release: Arc::clone(&release),
@@ -613,31 +565,8 @@ async fn shutdown_drains_accepted_work_and_flushes_its_writer_before_retirement(
         Arc::clone(&write_checked),
         Arc::clone(&resume_write),
     ));
-    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
-    let (shutdown_seen_tx, shutdown_seen_rx) = oneshot::channel::<()>();
-    let (startup_tx, startup_rx) = oneshot::channel();
-    let server_task = tokio::spawn(async move {
-        server
-            .try_serve_bound_listener_until_with_startup(
-                listener,
-                None,
-                async {
-                    let _ = shutdown_rx.await;
-                    let _ = shutdown_seen_tx.send(());
-                },
-                startup_tx,
-            )
-            .await
-    });
-    assert_eq!(
-        startup_rx
-            .await
-            .expect("draining startup channel")
-            .expect("draining startup succeeds"),
-        address
-    );
-    let mut client =
-        crate::connection::Connection::new(TcpStream::connect(address).await.expect("connect draining V2 client"));
+    let (mut client, _address, mut running, shutdown_seen_rx) =
+        start_server_with_shutdown_observer(runtime, server).await;
     client
         .send_command(RemotingCommand::create_remoting_command(704).set_opaque(4_006))
         .await
@@ -653,7 +582,7 @@ async fn shutdown_drains_accepted_work_and_flushes_its_writer_before_retirement(
         .await
         .expect("second processor starts before shutdown");
 
-    let _ = shutdown_tx.send(());
+    running.begin_shutdown();
     shutdown_seen_rx.await.expect("shutdown future completed");
     release.notify_one();
     resume_write.notify_one();
@@ -665,12 +594,99 @@ async fn shutdown_drains_accepted_work_and_flushes_its_writer_before_retirement(
         .expect("accepted response is flushed");
     assert_eq!(response.opaque(), 4_006);
     assert_eq!(response.body(), Some(&Bytes::from_static(b"drained-before-retire")));
-    let report = tokio::time::timeout(Duration::from_secs(2), server_task)
+    running.finish().await;
+}
+
+#[tokio::test]
+async fn shutdown_drains_a_writer_claimed_deferred_resume_to_one_receipt_and_frame() {
+    const OPAQUE: i32 = 4_108;
+
+    let runtime = V2TestRuntime::new("transport-v2-deferred-writer-drain");
+    let registry = DeferredRegistry::<usize>::new();
+    let admission_controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let deferred_admission =
+        DeferredAdmission::try_configure(&admission_controller, DeferredWaitLimits::new(4, 4 * 1024 * 1024))
+            .expect("writer-drain deferred admission");
+    let (registered_tx, mut registered_rx) = tokio::sync::mpsc::unbounded_channel();
+    let processor = NetworkDeferredCleanupProcessor {
+        registry: registry.clone(),
+        admission: deferred_admission.clone(),
+        registered: registered_tx,
+        precommit_opaque: -1,
+        release_precommit: Arc::new(tokio::sync::Notify::new()),
+    };
+    let write_checked = Arc::new(tokio::sync::Notify::new());
+    let resume_write = Arc::new(tokio::sync::Notify::new());
+    let server = TransportServerV2::new(loopback_server_config(), runtime.service_context(), processor)
+        .with_admission_controller(Arc::clone(&admission_controller))
+        .with_write_preflight_barrier(crate::write_strategy::WritePreflightBarrier::new(
+            Arc::clone(&write_checked),
+            Arc::clone(&resume_write),
+        ));
+    let (mut client, _address, mut running, shutdown_seen) = start_server_with_shutdown_observer(runtime, server).await;
+
+    client
+        .send_command(RemotingCommand::create_remoting_command(705).set_opaque(OPAQUE))
         .await
-        .expect("V2 shutdown awaits drain and writer")
-        .expect("join draining V2 server")
-        .expect("draining V2 shutdown report");
-    assert!(report.is_healthy(), "{}", report.to_json());
+        .expect("send writer-drain deferred request");
+    let registered = receive_deferred_registration(&mut registered_rx, OPAQUE).await;
+    let claim = registry
+        .claim(registered.id, DeferredWakeReason::MessageArrived)
+        .await
+        .expect("claim writer-drain deferred request");
+    let resume = claim.resume(
+        DeferredResumeRetainedSize::default(),
+        move |opaque, reason| async move {
+            assert_eq!(opaque, OPAQUE as usize);
+            assert_eq!(reason, DeferredWakeReason::MessageArrived);
+            Ok(ResponsePlan::bytes(
+                RemotingCommand::create_response_command_with_code(ResponseCode::Success),
+                Bytes::from_static(b"deferred-writer-drained"),
+            )
+            .expect("writer-drain deferred response plan"))
+        },
+    );
+    tokio::pin!(resume);
+    tokio::select! {
+        biased;
+        result = &mut resume => panic!("deferred resume completed before writer barrier: {result:?}"),
+        () = write_checked.notified() => {}
+    }
+
+    running.begin_shutdown();
+    shutdown_seen.await.expect("writer-drain shutdown observed");
+    tokio::select! {
+        biased;
+        result = &mut resume => panic!("deferred resume completed while writer remained blocked: {result:?}"),
+        () = tokio::task::yield_now() => {}
+    }
+    resume_write.notify_one();
+    resume.await.expect("writer-drain deferred response receipt");
+
+    let response = tokio::time::timeout(Duration::from_secs(1), client.receive_command())
+        .await
+        .expect("writer-drain response deadline")
+        .expect("writer-drain connection remains until flush")
+        .expect("writer-drain response frame");
+    assert_eq!(response.opaque(), OPAQUE);
+    assert_eq!(response.body(), Some(&Bytes::from_static(b"deferred-writer-drained")));
+    running.finish().await;
+    assert!(
+        client.receive_command().await.is_none(),
+        "shutdown emits no retry frame"
+    );
+
+    let snapshot = admission_controller.snapshot();
+    assert_eq!(snapshot.queued.current_count, 0);
+    assert_eq!(snapshot.queued.current_bytes, 0);
+    assert_eq!(snapshot.inflight.current_count, 0);
+    assert_eq!(snapshot.inflight.current_bytes, 0);
+    assert_eq!(snapshot.processors.current_count, 0);
+    assert_eq!(snapshot.processors.current_bytes, 0);
+    assert_eq!(registry.test_index_counts(), (0, 0, 0));
+    assert_eq!(registry.test_claim_marker_count(), 0);
+    assert_eq!(deferred_admission.snapshot().waiting_count(), 0);
+    assert_eq!(deferred_admission.snapshot().retained_bytes(), 0);
 }
 
 #[tokio::test]
@@ -680,6 +696,7 @@ async fn real_tcp_disconnect_cleans_deferred_state_before_drain_and_preserves_ot
     const HELD_OPAQUE: i32 = 5_102;
     const PRECOMMIT_OPAQUE: i32 = 5_103;
 
+    let runtime = V2TestRuntime::new("transport-v2-deferred-disconnect");
     let registry = DeferredRegistry::<usize>::new();
     let admission_controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
     let deferred_admission =
@@ -694,13 +711,9 @@ async fn real_tcp_disconnect_cleans_deferred_state_before_drain_and_preserves_ot
         precommit_opaque: PRECOMMIT_OPAQUE,
         release_precommit: Arc::clone(&release_precommit),
     };
-    let server = TransportServerV2::new(
-        Arc::new(ServerConfig::default()),
-        service_context("transport-v2-deferred-disconnect"),
-        processor,
-    )
-    .with_admission_controller(Arc::clone(&admission_controller));
-    let (mut first_client, address, shutdown_tx, server_task) = start_server(server).await;
+    let server = TransportServerV2::new(loopback_server_config(), runtime.service_context(), processor)
+        .with_admission_controller(Arc::clone(&admission_controller));
+    let (mut first_client, address, mut server_handle) = start_server(runtime, server).await;
     let mut second_client =
         crate::connection::Connection::new(TcpStream::connect(address).await.expect("connect second V2 client"));
 
@@ -842,19 +855,24 @@ async fn real_tcp_disconnect_cleans_deferred_state_before_drain_and_preserves_ot
         .expect("other-session response frame");
     assert_eq!(response.body(), Some(&Bytes::from_static(b"other-session-live")));
 
-    let _ = shutdown_tx.send(());
-    let report = tokio::time::timeout(Duration::from_secs(2), server_task)
-        .await
-        .expect("V2 server shutdown deadline")
-        .expect("join V2 deferred cleanup server")
-        .expect("V2 deferred cleanup shutdown report");
-    assert!(report.is_healthy(), "{}", report.to_json());
+    server_handle.begin_shutdown();
+    server_handle.finish().await;
     assert_eq!(registry.test_index_counts(), (0, 0, 0));
+    assert_eq!(registry.test_claim_marker_count(), 0);
     assert_eq!(deferred_admission.snapshot().waiting_count(), 0);
+    assert_eq!(deferred_admission.snapshot().retained_bytes(), 0);
+    let snapshot = admission_controller.snapshot();
+    assert_eq!(snapshot.queued.current_count, 0);
+    assert_eq!(snapshot.queued.current_bytes, 0);
+    assert_eq!(snapshot.inflight.current_count, 0);
+    assert_eq!(snapshot.inflight.current_bytes, 0);
+    assert_eq!(snapshot.processors.current_count, 0);
+    assert_eq!(snapshot.processors.current_bytes, 0);
 }
 
 #[tokio::test]
 async fn hooks_registered_before_and_after_injection_append_once_to_existing_registry() {
+    let runtime = V2TestRuntime::new("transport-v2-hook-merge");
     let state = Arc::new(ProcessorState::default());
     let admission = Arc::new(AdmissionController::new(AdmissionLimits::default()));
     let security = loopback_security();
@@ -875,8 +893,8 @@ async fn hooks_registered_before_and_after_injection_append_once_to_existing_reg
         Arc::clone(&admission),
     ));
     let mut server = TransportServerV2::new(
-        Arc::new(ServerConfig::default()),
-        service_context("transport-v2-hook-merge"),
+        loopback_server_config(),
+        runtime.service_context(),
         TcpV2Processor { state, admission: None },
     );
     server.register_rpc_hook(new_hook("pre-injection"));
@@ -885,7 +903,7 @@ async fn hooks_registered_before_and_after_injection_append_once_to_existing_reg
         .with_transport_security(Arc::clone(&security), None)
         .with_admission_controller(Arc::clone(&admission));
     server.register_rpc_hook(new_hook("post-injection"));
-    let (mut client, _address, shutdown_tx, server_task) = start_server(server).await;
+    let (mut client, _address, mut running) = start_server(runtime, server).await;
 
     client
         .send_command(RemotingCommand::create_remoting_command(701).set_opaque(4_004))
@@ -908,9 +926,6 @@ async fn hooks_registered_before_and_after_injection_append_once_to_existing_reg
         ]
     );
 
-    let _ = shutdown_tx.send(());
-    let _ = server_task
-        .await
-        .expect("join hook server")
-        .expect("hook shutdown report");
+    running.begin_shutdown();
+    running.finish().await;
 }

--- a/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/v2_server/tests/deferred_expiry.rs
+++ b/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/v2_server/tests/deferred_expiry.rs
@@ -24,9 +24,10 @@ use rocketmq_error::RocketMQError;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 
+use super::harness::loopback_server_config;
+use super::harness::start_server;
+use super::harness::V2TestRuntime;
 use super::loopback_security;
-use super::service_context;
-use super::start_server;
 use super::AdmissionController;
 use super::AdmissionLimits;
 use super::DeferredAdmission;
@@ -41,7 +42,6 @@ use super::HandlerOutcome;
 use super::RemotingRequest;
 use super::RequestProcessorV2;
 use super::ResponsePlan;
-use super::ServerConfig;
 use super::TransportServerV2;
 use crate::dispatch::DeferredExpiryMargins;
 use crate::dispatch::DeferredTerminalReason;
@@ -142,6 +142,8 @@ impl RequestProcessorV2 for TcpDeferredExpiryProcessor {
 }
 
 struct TcpExpiryHarness {
+    runtime: V2TestRuntime,
+    admission_controller: Arc<AdmissionController>,
     registry: DeferredRegistry<i32>,
     admission: DeferredAdmission,
     state: Arc<ExpiryProcessorState>,
@@ -151,6 +153,7 @@ struct TcpExpiryHarness {
 }
 
 fn expiry_harness(name: &'static str, policy: ExpiryPolicy) -> TcpExpiryHarness {
+    let runtime = V2TestRuntime::new(name);
     let registry = DeferredRegistry::<i32>::new();
     let admission_controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
     let admission = DeferredAdmission::try_configure(
@@ -168,11 +171,13 @@ fn expiry_harness(name: &'static str, policy: ExpiryPolicy) -> TcpExpiryHarness 
         registrations: registered_tx,
     };
     let (telemetry, terminals) = TransportTelemetry::with_deferred_terminal_capture();
-    let server = TransportServerV2::new(Arc::new(ServerConfig::default()), service_context(name), processor)
+    let server = TransportServerV2::new(loopback_server_config(), runtime.service_context(), processor)
         .with_transport_security(loopback_security(), None)
-        .with_admission_controller(admission_controller)
+        .with_admission_controller(Arc::clone(&admission_controller))
         .with_telemetry(telemetry);
     TcpExpiryHarness {
+        runtime,
+        admission_controller,
         registry,
         admission,
         state,
@@ -206,11 +211,7 @@ async fn await_commit_barrier(client: &mut crate::connection::Connection, state:
     state.committed.notified().await;
 }
 
-async fn advance_to(instant: tokio::time::Instant) {
-    tokio::time::advance(instant.saturating_duration_since(tokio::time::Instant::now())).await;
-}
-
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn real_tcp_protocol_timeout_sweeps_and_resumes_exactly_once() {
     let mut harness = expiry_harness(
         "transport-v2-protocol-expiry",
@@ -220,15 +221,16 @@ async fn real_tcp_protocol_timeout_sweeps_and_resumes_exactly_once() {
         },
     );
     let registry = harness.registry.clone();
+    let admission_controller = Arc::clone(&harness.admission_controller);
     let admission = harness.admission.clone();
     let state = Arc::clone(&harness.state);
     let terminals = Arc::clone(&harness.terminals);
-    let (mut client, _address, shutdown_tx, server_task) = start_server(harness.server).await;
+    let (mut client, _address, mut running) = start_server(harness.runtime, harness.server).await;
     let observed = send_deferred_request(&mut client, &mut harness.registrations, 9_001).await;
     await_commit_barrier(&mut client, &state, 9_011).await;
-    advance_to(observed.scheduled_at).await;
 
-    let batch = registry.sweep_expired(NonZeroUsize::new(8).expect("non-zero sweep"));
+    let batch =
+        registry.sweep_expired_at_for_test(observed.scheduled_at, NonZeroUsize::new(8).expect("non-zero sweep"));
     assert_eq!(batch.stats().long_poll_claims(), 1);
     assert_eq!(batch.stats().owner_expired(), 0);
     let mut claims = batch.into_claims();
@@ -265,25 +267,29 @@ async fn real_tcp_protocol_timeout_sweeps_and_resumes_exactly_once() {
     assert_eq!(state.resumes.load(Ordering::SeqCst), 1);
     assert!(!state.saw_owner_deadline.load(Ordering::SeqCst));
     assert_eq!(admission.snapshot().waiting_count(), 0);
+    assert_eq!(admission.snapshot().retained_bytes(), 0);
+    assert_eq!(registry.test_index_counts(), (0, 0, 0));
+    assert_eq!(registry.test_claim_marker_count(), 0);
+    let snapshot = admission_controller.snapshot();
+    assert_eq!(snapshot.queued.current_count, 0);
+    assert_eq!(snapshot.queued.current_bytes, 0);
+    assert_eq!(snapshot.inflight.current_count, 0);
+    assert_eq!(snapshot.inflight.current_bytes, 0);
+    assert_eq!(snapshot.processors.current_count, 0);
+    assert_eq!(snapshot.processors.current_bytes, 0);
     assert!(
         terminals.lock().is_empty(),
         "successful delivery has no terminal reason"
     );
+    running.begin_shutdown();
+    running.finish().await;
     assert!(
-        tokio::time::timeout(Duration::from_secs(1), client.receive_command())
-            .await
-            .is_err(),
+        client.receive_command().await.is_none(),
         "one timeout claim must produce exactly one response frame"
     );
-
-    let _ = shutdown_tx.send(());
-    server_task
-        .await
-        .expect("join protocol timeout server")
-        .expect("protocol timeout shutdown report");
 }
 
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn real_tcp_owner_cutoff_removes_without_resuming_or_writing() {
     let mut harness = expiry_harness(
         "transport-v2-owner-expiry",
@@ -294,15 +300,16 @@ async fn real_tcp_owner_cutoff_removes_without_resuming_or_writing() {
     );
     harness.server = harness.server.with_test_request_deadline(Duration::from_millis(350));
     let registry = harness.registry.clone();
+    let admission_controller = Arc::clone(&harness.admission_controller);
     let admission = harness.admission.clone();
     let state = Arc::clone(&harness.state);
     let terminals = Arc::clone(&harness.terminals);
-    let (mut client, _address, shutdown_tx, server_task) = start_server(harness.server).await;
+    let (mut client, _address, mut running) = start_server(harness.runtime, harness.server).await;
     let observed = send_deferred_request(&mut client, &mut harness.registrations, 9_002).await;
     await_commit_barrier(&mut client, &state, 9_012).await;
-    advance_to(observed.scheduled_at).await;
 
-    let batch = registry.sweep_expired(NonZeroUsize::new(8).expect("non-zero sweep"));
+    let batch =
+        registry.sweep_expired_at_for_test(observed.scheduled_at, NonZeroUsize::new(8).expect("non-zero sweep"));
     assert_eq!(batch.stats().long_poll_claims(), 0);
     assert_eq!(batch.stats().owner_expired(), 1);
     assert!(batch.into_claims().is_empty());
@@ -310,22 +317,26 @@ async fn real_tcp_owner_cutoff_removes_without_resuming_or_writing() {
     assert_eq!(state.resumes.load(Ordering::SeqCst), 0);
     assert!(state.saw_owner_deadline.load(Ordering::SeqCst));
     assert_eq!(admission.snapshot().waiting_count(), 0);
+    assert_eq!(admission.snapshot().retained_bytes(), 0);
+    assert_eq!(registry.test_index_counts(), (0, 0, 0));
+    assert_eq!(registry.test_claim_marker_count(), 0);
+    let snapshot = admission_controller.snapshot();
+    assert_eq!(snapshot.queued.current_count, 0);
+    assert_eq!(snapshot.queued.current_bytes, 0);
+    assert_eq!(snapshot.inflight.current_count, 0);
+    assert_eq!(snapshot.inflight.current_bytes, 0);
+    assert_eq!(snapshot.processors.current_count, 0);
+    assert_eq!(snapshot.processors.current_bytes, 0);
     assert_eq!(terminals.lock().as_slice(), [("pull_message", "owner_deadline")]);
+    running.begin_shutdown();
+    running.finish().await;
     assert!(
-        tokio::time::timeout(Duration::from_secs(1), client.receive_command())
-            .await
-            .is_err(),
+        client.receive_command().await.is_none(),
         "owner expiry must not synthesize a response frame"
     );
-
-    let _ = shutdown_tx.send(());
-    server_task
-        .await
-        .expect("join owner timeout server")
-        .expect("owner timeout shutdown report");
 }
 
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn real_tcp_parent_service_shutdown_terminalizes_accepted_resume_without_a_frame() {
     let mut harness = expiry_harness(
         "transport-v2-service-stop-expiry",
@@ -335,10 +346,11 @@ async fn real_tcp_parent_service_shutdown_terminalizes_accepted_resume_without_a
         },
     );
     let registry = harness.registry.clone();
+    let admission_controller = Arc::clone(&harness.admission_controller);
     let admission = harness.admission.clone();
     let state = Arc::clone(&harness.state);
     let terminals = Arc::clone(&harness.terminals);
-    let (mut client, _address, shutdown_tx, server_task) = start_server(harness.server).await;
+    let (mut client, _address, mut running) = start_server(harness.runtime, harness.server).await;
     let observed = send_deferred_request(&mut client, &mut harness.registrations, 9_003).await;
     let claim = registry
         .claim(observed.id, DeferredWakeReason::ForcedRefresh)
@@ -363,7 +375,7 @@ async fn real_tcp_parent_service_shutdown_terminalizes_accepted_resume_without_a
         () = entered.notified() => {}
     }
 
-    let _ = shutdown_tx.send(());
+    running.begin_shutdown();
     let error = (&mut resume)
         .await
         .expect_err("service stop cannot write a deferred response");
@@ -372,16 +384,22 @@ async fn real_tcp_parent_service_shutdown_terminalizes_accepted_resume_without_a
         Some(DeferredTerminalReason::ParentCancelled),
         "the server task-group cancellation precedes session retirement"
     );
-    let report = server_task
-        .await
-        .expect("join service stop server")
-        .expect("service stop shutdown report");
-    assert!(report.is_healthy(), "{}", report.to_json());
+    running.finish().await;
     let frame = client.receive_command().await;
     assert!(frame.is_none(), "service stop must not emit a response frame");
     assert_eq!(state.processes.load(Ordering::SeqCst), 1);
     assert_eq!(state.resumes.load(Ordering::SeqCst), 0);
     assert_eq!(admission.snapshot().waiting_count(), 0);
+    assert_eq!(admission.snapshot().retained_bytes(), 0);
+    assert_eq!(registry.test_index_counts(), (0, 0, 0));
+    assert_eq!(registry.test_claim_marker_count(), 0);
+    let snapshot = admission_controller.snapshot();
+    assert_eq!(snapshot.queued.current_count, 0);
+    assert_eq!(snapshot.queued.current_bytes, 0);
+    assert_eq!(snapshot.inflight.current_count, 0);
+    assert_eq!(snapshot.inflight.current_bytes, 0);
+    assert_eq!(snapshot.processors.current_count, 0);
+    assert_eq!(snapshot.processors.current_bytes, 0);
     assert_eq!(
         terminals.lock().as_slice(),
         [("pull_message", "parent_cancelled")],

--- a/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/v2_server/tests/harness.rs
+++ b/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/v2_server/tests/harness.rs
@@ -1,0 +1,224 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use rocketmq_runtime::ChildServiceContext;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use rocketmq_runtime::ShutdownReport;
+use tokio::net::TcpStream;
+use tokio::sync::oneshot;
+
+use super::RequestProcessorV2;
+use super::ServerConfig;
+use super::ServerStartError;
+use super::TransportServerV2;
+
+pub(super) struct V2TestRuntime {
+    owner: RuntimeOwner,
+    server_context: ChildServiceContext,
+    runner_context: ChildServiceContext,
+    task_name: String,
+}
+
+pub(super) fn loopback_server_config() -> Arc<ServerConfig> {
+    Arc::new(ServerConfig {
+        bind_address: "127.0.0.1".to_owned(),
+        listen_port: 0,
+        ..ServerConfig::default()
+    })
+}
+
+impl V2TestRuntime {
+    pub(super) fn new(name: &'static str) -> Self {
+        let owner = RuntimeOwner::new(RuntimeConfig::server_default(name)).expect("V2 test runtime owner");
+        let server_context = owner.root_context().component(format!("{name}.server"));
+        let runner_context = owner.root_context().component(format!("{name}.runner"));
+        Self {
+            owner,
+            server_context,
+            runner_context,
+            task_name: format!("{name}.serve"),
+        }
+    }
+
+    pub(super) fn service_context(&self) -> ChildServiceContext {
+        self.server_context.clone()
+    }
+
+    pub(super) async fn finish(self) {
+        finish_owner(self.owner).await;
+    }
+}
+
+pub(super) struct RunningV2Server {
+    owner: RuntimeOwner,
+    shutdown: Option<oneshot::Sender<()>>,
+    result: oneshot::Receiver<Result<ShutdownReport, ServerStartError>>,
+}
+
+impl RunningV2Server {
+    pub(super) fn begin_shutdown(&mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+    }
+
+    pub(super) async fn finish(mut self) -> ShutdownReport {
+        self.begin_shutdown();
+        let report = tokio::time::timeout(Duration::from_secs(2), &mut self.result)
+            .await
+            .expect("V2 owned server shutdown deadline")
+            .expect("V2 owned server result channel")
+            .expect("V2 owned server shutdown report");
+        assert_clean_shutdown("V2 server", &report);
+        finish_owner(self.owner).await;
+        report
+    }
+
+    async fn finish_start_error(mut self) -> ServerStartError {
+        self.shutdown.take();
+        let error = self
+            .result
+            .await
+            .expect("V2 failed-start result channel")
+            .expect_err("V2 server startup must fail");
+        finish_owner(self.owner).await;
+        error
+    }
+}
+
+pub(super) async fn start_server<P>(
+    runtime: V2TestRuntime,
+    server: TransportServerV2<P>,
+) -> (crate::connection::Connection, SocketAddr, RunningV2Server)
+where
+    P: RequestProcessorV2 + Clone + Sync + 'static,
+{
+    let (startup, running) = spawn_server(runtime, server, None);
+    let address = startup
+        .await
+        .expect("V2 owned startup result channel")
+        .expect("V2 owned startup succeeds");
+    let client =
+        crate::connection::Connection::new(TcpStream::connect(address).await.expect("connect V2 owned test client"));
+    (client, address, running)
+}
+
+pub(super) async fn start_server_with_shutdown_observer<P>(
+    runtime: V2TestRuntime,
+    server: TransportServerV2<P>,
+) -> (
+    crate::connection::Connection,
+    SocketAddr,
+    RunningV2Server,
+    oneshot::Receiver<()>,
+)
+where
+    P: RequestProcessorV2 + Clone + Sync + 'static,
+{
+    let (shutdown_seen, shutdown_observed) = oneshot::channel();
+    let (startup, running) = spawn_server(runtime, server, Some(shutdown_seen));
+    let address = startup
+        .await
+        .expect("V2 observed startup result channel")
+        .expect("V2 observed startup succeeds");
+    let client = crate::connection::Connection::new(
+        TcpStream::connect(address)
+            .await
+            .expect("connect observed V2 test client"),
+    );
+    (client, address, running, shutdown_observed)
+}
+
+pub(super) async fn expect_start_error<P>(runtime: V2TestRuntime, server: TransportServerV2<P>) -> ServerStartError
+where
+    P: RequestProcessorV2 + Clone + Sync + 'static,
+{
+    let (startup, running) = spawn_server(runtime, server, None);
+    let startup_error = startup
+        .await
+        .expect("V2 failed-start startup channel")
+        .expect_err("V2 startup must fail");
+    let result_error = running.finish_start_error().await;
+    assert_eq!(startup_error.to_string(), result_error.to_string());
+    result_error
+}
+
+fn spawn_server<P>(
+    runtime: V2TestRuntime,
+    server: TransportServerV2<P>,
+    shutdown_seen: Option<oneshot::Sender<()>>,
+) -> (oneshot::Receiver<Result<SocketAddr, ServerStartError>>, RunningV2Server)
+where
+    P: RequestProcessorV2 + Clone + Sync + 'static,
+{
+    let V2TestRuntime {
+        owner,
+        server_context: _,
+        runner_context,
+        task_name,
+    } = runtime;
+    let (shutdown, shutdown_rx) = oneshot::channel();
+    let (startup_tx, startup_rx) = oneshot::channel();
+    let (result_tx, result_rx) = oneshot::channel();
+    runner_context
+        .spawn_service(task_name, async move {
+            let result = server
+                .try_run_with_shutdown_report_and_startup(
+                    async move {
+                        let _ = shutdown_rx.await;
+                        if let Some(shutdown_seen) = shutdown_seen {
+                            let _ = shutdown_seen.send(());
+                        }
+                    },
+                    startup_tx,
+                )
+                .await;
+            let _ = result_tx.send(result);
+        })
+        .expect("spawn V2 server in owned TaskGroup");
+    (
+        startup_rx,
+        RunningV2Server {
+            owner,
+            shutdown: Some(shutdown),
+            result: result_rx,
+        },
+    )
+}
+
+async fn finish_owner(owner: RuntimeOwner) {
+    let report = owner.shutdown_tasks().await;
+    assert_clean_shutdown("V2 test runtime", &report);
+    let final_report = owner.shutdown_background();
+    assert_clean_shutdown("V2 test runtime finalization", &final_report);
+}
+
+fn assert_clean_shutdown(owner: &str, report: &ShutdownReport) {
+    assert!(report.is_healthy(), "{owner}: {}", report.to_json());
+    assert_eq!(report.aborted, 0, "{owner}: {}", report.to_json());
+    assert_eq!(report.panicked, 0, "{owner}: {}", report.to_json());
+    assert_eq!(report.timed_out, 0, "{owner}: {}", report.to_json());
+    assert_eq!(report.leaked, 0, "{owner}: {}", report.to_json());
+    assert_eq!(report.blocking_still_running, 0, "{owner}: {}", report.to_json());
+    assert_eq!(report.detached_still_running, 0, "{owner}: {}", report.to_json());
+    assert!(report.remaining_tasks.is_empty(), "{owner}: {}", report.to_json());
+    for child in &report.children {
+        assert_clean_shutdown(owner, child);
+    }
+}

--- a/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/v2_server/tests/inline_deferred_state.rs
+++ b/rocketmq-transport/src/remoting_server/rocketmq_tokio_server/v2_server/tests/inline_deferred_state.rs
@@ -1,0 +1,210 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use rocketmq_error::RocketMQError;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+
+use super::harness::loopback_server_config;
+use super::harness::start_server;
+use super::harness::V2TestRuntime;
+use super::loopback_security;
+use super::AdmissionController;
+use super::AdmissionLimits;
+use super::DeferredAdmission;
+use super::DeferredParts;
+use super::DeferredRegistry;
+use super::DeferredRequest;
+use super::DeferredRetainedSizeParts;
+use super::DeferredWaitLimits;
+use super::DeferredWakeReason;
+use super::HandlerOutcome;
+use super::ProtocolNoResponseReason;
+use super::RejectRequestDecision;
+use super::RemotingRequest;
+use super::RequestProcessorV2;
+use super::ResponsePlan;
+use super::TransportServerV2;
+use crate::telemetry::TransportTelemetry;
+
+const REPLY_CODE: i32 = 8_201;
+const ERROR_CODE: i32 = 8_202;
+const REJECT_CODE: i32 = 8_203;
+const DEFERRED_CODE: i32 = 8_204;
+const NO_REPLY_CODE: i32 = 39;
+
+#[derive(Clone)]
+struct ConstructionProbeProcessor {
+    registry: DeferredRegistry<i32>,
+    admission: DeferredAdmission,
+    registrations: tokio::sync::mpsc::UnboundedSender<crate::dispatch::DeferredId>,
+}
+
+impl RequestProcessorV2 for ConstructionProbeProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        match request.command().code() {
+            ERROR_CODE => Err(RocketMQError::illegal_argument("mapped processor failure")),
+            NO_REPLY_CODE => Ok(HandlerOutcome::NoReply(
+                request.protocol_no_response(ProtocolNoResponseReason::CallbackHandled)?,
+            )),
+            DEFERRED_CODE => {
+                let responder = request
+                    .take_deferred_responder()
+                    .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+                let retained = DeferredRegistry::<i32>::try_retained_size(DeferredRetainedSizeParts::new(0))
+                    .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+                let permit = self
+                    .admission
+                    .try_reserve(retained)
+                    .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+                let registration = self
+                    .registry
+                    .register(DeferredRequest::new(
+                        request.original_identity().original_opaque(),
+                        DeferredParts::new(responder, permit),
+                    ))
+                    .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+                self.registrations
+                    .send(registration.deferred_id())
+                    .map_err(|_| RocketMQError::illegal_argument("construction registration observer closed"))?;
+                Ok(HandlerOutcome::Deferred(registration))
+            }
+            REPLY_CODE => ResponsePlan::bytes(
+                RemotingCommand::create_response_command_with_code(ResponseCode::Success),
+                Bytes::from_static(b"inline-without-deferred-state"),
+            )
+            .map(HandlerOutcome::Reply)
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string())),
+            code => Err(RocketMQError::illegal_argument(format!(
+                "unexpected construction-probe request code {code}"
+            ))),
+        }
+    }
+
+    fn request_ordering(
+        &self,
+        _ingress: crate::dispatch::IngressRequestView<'_>,
+    ) -> crate::request_ordering::RequestOrdering {
+        crate::request_ordering::RequestOrdering::Ordered(crate::request_ordering::RequestOrderingKey::new(8_222))
+    }
+
+    fn reject_request(&self, code: i32) -> RejectRequestDecision {
+        if code == REJECT_CODE {
+            return RejectRequestDecision::Reject(
+                ResponsePlan::command(RemotingCommand::create_response_command_with_code(
+                    ResponseCode::NoPermission,
+                ))
+                .expect("construction-probe rejection plan"),
+            );
+        }
+        RejectRequestDecision::Proceed
+    }
+}
+
+#[tokio::test]
+async fn real_tcp_inline_paths_construct_zero_deferred_states_and_a_real_defer_constructs_one() {
+    let runtime = V2TestRuntime::new("transport-v2-inline-deferred-state");
+    let admission_controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let admission = DeferredAdmission::try_configure(
+        admission_controller.as_ref(),
+        DeferredWaitLimits::new(4, 4 * 1024 * 1024),
+    )
+    .expect("construction-probe deferred admission");
+    let registry = DeferredRegistry::<i32>::new();
+    let (registration_tx, mut registrations) = tokio::sync::mpsc::unbounded_channel();
+    let processor = ConstructionProbeProcessor {
+        registry: registry.clone(),
+        admission: admission.clone(),
+        registrations: registration_tx,
+    };
+    let (telemetry, constructions) = TransportTelemetry::with_deferred_state_construction_capture();
+    let server = TransportServerV2::new(loopback_server_config(), runtime.service_context(), processor)
+        .with_transport_security(loopback_security(), None)
+        .with_admission_controller(admission_controller)
+        .with_telemetry(telemetry);
+    let (mut client, _address, mut running) = start_server(runtime, server).await;
+
+    client
+        .send_command(RemotingCommand::create_remoting_command(REPLY_CODE).set_opaque(8_301))
+        .await
+        .expect("send inline reply request");
+    let reply = receive(&mut client, "inline reply").await;
+    assert_eq!((reply.code(), reply.opaque()), (ResponseCode::Success.to_i32(), 8_301));
+    assert_eq!(constructions.load(Ordering::SeqCst), 0);
+
+    client
+        .send_command(RemotingCommand::create_remoting_command(ERROR_CODE).set_opaque(8_302))
+        .await
+        .expect("send mapped processor error request");
+    let mapped = receive(&mut client, "mapped processor error").await;
+    assert_eq!(ResponseCode::from(mapped.code()), ResponseCode::InvalidParameter);
+    assert_eq!(mapped.opaque(), 8_302);
+    assert_eq!(constructions.load(Ordering::SeqCst), 0);
+
+    client
+        .send_command(RemotingCommand::create_remoting_command(REJECT_CODE).set_opaque(8_303))
+        .await
+        .expect("send rejected request");
+    let rejected = receive(&mut client, "rejected request").await;
+    assert_eq!(ResponseCode::from(rejected.code()), ResponseCode::NoPermission);
+    assert_eq!(rejected.opaque(), 8_303);
+    assert_eq!(constructions.load(Ordering::SeqCst), 0);
+
+    client
+        .send_command(RemotingCommand::create_remoting_command(NO_REPLY_CODE).set_opaque(8_304))
+        .await
+        .expect("send allowlisted no-reply request");
+    client
+        .send_command(RemotingCommand::create_remoting_command(REPLY_CODE).set_opaque(8_305))
+        .await
+        .expect("send no-reply ordering sentinel");
+    let sentinel = receive(&mut client, "no-reply ordering sentinel").await;
+    assert_eq!(sentinel.opaque(), 8_305, "NoReply must not synthesize a frame");
+    assert_eq!(constructions.load(Ordering::SeqCst), 0);
+
+    client
+        .send_command(RemotingCommand::create_remoting_command(DEFERRED_CODE).set_opaque(8_306))
+        .await
+        .expect("send genuine deferred request");
+    let id = tokio::time::timeout(Duration::from_secs(1), registrations.recv())
+        .await
+        .expect("genuine deferred registration deadline")
+        .expect("genuine deferred registration observer");
+    let claim = registry
+        .claim(id, DeferredWakeReason::MessageArrived)
+        .await
+        .expect("genuine deferred registration commits");
+    assert_eq!(constructions.load(Ordering::SeqCst), 1);
+    drop(claim);
+    assert_eq!(admission.snapshot().waiting_count(), 0);
+    assert_eq!(admission.snapshot().retained_bytes(), 0);
+
+    running.begin_shutdown();
+    running.finish().await;
+    assert_eq!(registry.test_index_counts(), (0, 0, 0));
+    assert_eq!(constructions.load(Ordering::SeqCst), 1);
+}
+
+async fn receive(client: &mut crate::connection::Connection, path: &'static str) -> RemotingCommand {
+    tokio::time::timeout(Duration::from_secs(1), client.receive_command())
+        .await
+        .unwrap_or_else(|_| panic!("{path} response deadline"))
+        .unwrap_or_else(|| panic!("{path} connection remains open"))
+        .unwrap_or_else(|error| panic!("{path} response frame: {error}"))
+}

--- a/rocketmq-transport/src/telemetry.rs
+++ b/rocketmq-transport/src/telemetry.rs
@@ -29,6 +29,8 @@ type LegacyProcessorRequestCapture = std::sync::Arc<parking_lot::Mutex<Vec<(&'st
 type LifecycleEventCapture = std::sync::Arc<parking_lot::Mutex<Vec<(&'static str, &'static str)>>>;
 #[cfg(test)]
 type DeferredTerminalCapture = std::sync::Arc<parking_lot::Mutex<Vec<(&'static str, &'static str)>>>;
+#[cfg(test)]
+type DeferredStateConstructionCapture = std::sync::Arc<std::sync::atomic::AtomicUsize>;
 
 /// Cloneable metrics and tracing capability for one transport composition.
 ///
@@ -47,6 +49,8 @@ pub struct TransportTelemetry {
     lifecycle_events: Option<LifecycleEventCapture>,
     #[cfg(test)]
     deferred_terminals: Option<DeferredTerminalCapture>,
+    #[cfg(test)]
+    deferred_state_constructions: Option<DeferredStateConstructionCapture>,
 }
 
 impl TransportTelemetry {
@@ -72,6 +76,8 @@ impl TransportTelemetry {
             lifecycle_events: None,
             #[cfg(test)]
             deferred_terminals: None,
+            #[cfg(test)]
+            deferred_state_constructions: None,
         }
     }
 
@@ -88,6 +94,7 @@ impl TransportTelemetry {
             legacy_processor_requests: Some(std::sync::Arc::clone(&capture)),
             lifecycle_events: None,
             deferred_terminals: None,
+            deferred_state_constructions: None,
         };
         (telemetry, capture)
     }
@@ -105,6 +112,7 @@ impl TransportTelemetry {
             legacy_processor_requests: None,
             lifecycle_events: Some(std::sync::Arc::clone(&capture)),
             deferred_terminals: None,
+            deferred_state_constructions: None,
         };
         (telemetry, capture)
     }
@@ -122,8 +130,35 @@ impl TransportTelemetry {
             legacy_processor_requests: None,
             lifecycle_events: None,
             deferred_terminals: Some(std::sync::Arc::clone(&capture)),
+            deferred_state_constructions: None,
         };
         (telemetry, capture)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_deferred_state_construction_capture() -> (Self, DeferredStateConstructionCapture) {
+        let capture = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let telemetry = Self {
+            #[cfg(feature = "observability")]
+            remoting: Default::default(),
+            #[cfg(feature = "observability")]
+            client: Default::default(),
+            #[cfg(any(feature = "observability", feature = "observability-traces"))]
+            handle: None,
+            legacy_processor_requests: None,
+            lifecycle_events: None,
+            deferred_terminals: None,
+            deferred_state_constructions: Some(std::sync::Arc::clone(&capture)),
+        };
+        (telemetry, capture)
+    }
+
+    #[cfg(test)]
+    #[inline]
+    pub(crate) fn record_deferred_state_construction(&self) {
+        if let Some(capture) = &self.deferred_state_constructions {
+            capture.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
     }
 
     #[inline]


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9822

### Brief Description

Complete the deferred runtime acceptance stage with deterministic state-machine, expiry, cancellation, writer-progress, resource-accounting, and lifecycle-drain coverage.

The V2 TCP tests now run the server through an owned `RuntimeOwner` and sibling service/task scopes, publish typed startup and shutdown results, and drain both server and root ownership without a current-runtime adapter or raw Tokio spawn. A composition-scoped test observer proves ordinary Reply, mapped error, rejection, and allowed NoReply paths construct no deferred response state, while a real deferred request constructs exactly one.

The acceptance matrix now verifies both message-versus-expiry linearizations, exact terminal winners, rollback ownership, duplicate operations, admission rejection, receiver abandonment, NotStarted/PossiblyPartial writer outcomes, shutdown, retained count/bytes, execution count/bytes, and accepted handler/writer drain behavior.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-transport -- --check`
- `cargo check -p rocketmq-transport --no-default-features`
- `cargo test -p rocketmq-transport remoting_server::rocketmq_tokio_server::v2_server::tests --lib -- --nocapture` (11 passed, repeated three times)
- `cargo test -p rocketmq-transport deferred_registry::tests --lib -- --nocapture` (52 passed, repeated three times)
- `cargo test -p rocketmq-transport --all-features -- --test-threads=1` (652 library tests, all integration tests, and 78 doctests passed; 16 doctests ignored)
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `.\scripts\check-error-hygiene.ps1` (only the pre-existing store/broker source-stringification and endpoint-state redaction findings remain)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of deferred message handling across successful resumes, cancellations, expirations, rollbacks, and duplicate submissions.
  - Ensured cancelled or expired operations release queued resources and close connections cleanly.
  - Improved server shutdown behavior so in-flight deferred responses drain predictably before termination.

- **Tests**
  - Expanded coverage for admission limits, response states, expiry handling, cleanup, and server lifecycle scenarios.
  - Added validation that non-deferred responses do not allocate unnecessary deferred state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->