### PR TITLE
[ISSUE #9824]🚀Unify Pull, Pop, and Query response plan construction

### DIFF
--- a/rocketmq-broker/src/processor.rs
+++ b/rocketmq-broker/src/processor.rs
@@ -85,6 +85,7 @@ pub(crate) mod query_message_processor;
 pub(crate) mod recall_message_processor;
 pub(crate) mod reply_message_processor;
 mod request_ordering;
+pub(crate) mod response_plan;
 pub(crate) mod send_message_processor;
 
 pub enum BrokerProcessorType<MS: BrokerStorePort, TS> {

--- a/rocketmq-broker/src/processor/default_pull_message_result_handler.rs
+++ b/rocketmq-broker/src/processor/default_pull_message_result_handler.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::any::Any;
-use std::fs::File;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -41,15 +40,11 @@ use rocketmq_runtime::common::time_utils::current_millis;
 use rocketmq_store::ArcMessageFilter;
 use rocketmq_store::BrokerReadStore;
 use rocketmq_store::BrokerStatsManager;
-use rocketmq_store::FileRangeTransferHandle;
 use rocketmq_store::GetMessageResult;
 use rocketmq_store::GetMessageStatus;
 use rocketmq_store::StatsType;
 use rocketmq_transport::api::v1::Channel;
 use rocketmq_transport::api::v1::ConnectionHandlerContext;
-use rocketmq_transport::api::v1::FileRegion;
-use rocketmq_transport::api::v1::FileRegionLease;
-use rocketmq_transport::api::v1::FileRegionSequence;
 use tracing::debug;
 use tracing::info;
 use tracing::warn;
@@ -63,35 +58,15 @@ use crate::processor::pull_message_processor::is_broadcast;
 use crate::processor::pull_message_processor::rewrite_response_for_static_topic;
 use crate::processor::pull_message_processor::static_topic_rewrite_error_response;
 use crate::processor::pull_message_processor::StaticTopicRewriteError;
+use crate::processor::pull_message_result_handler::PullMessageResult;
 use crate::processor::pull_message_result_handler::PullMessageResultHandler;
+use crate::processor::response_plan::store_response_parts;
+use crate::processor::response_plan::BrokerResponseParts;
 
 pub struct DefaultPullMessageResultHandler<MS: BrokerReadStore> {
     context: Arc<PullMessageProcessorContext<MS>>,
     consume_message_hook_list: Arc<Vec<Box<dyn ConsumeMessageHook>>>,
     broker_metrics_manager: Option<Arc<BrokerMetricsManager>>,
-}
-
-struct PullFileRegionLease {
-    handle: FileRangeTransferHandle,
-}
-
-impl FileRegionLease for PullFileRegionLease {
-    fn file(&self) -> &File {
-        self.handle.file()
-    }
-}
-
-fn pull_file_regions(get_message_result: &GetMessageResult) -> Option<FileRegionSequence> {
-    let mut regions = Vec::with_capacity(get_message_result.message_mapped_list().len());
-    for selected in get_message_result.message_mapped_list() {
-        let range = selected.file_range()?;
-        let position = range.position();
-        let len = u64::try_from(range.len()).ok()?;
-        let handle = range.try_transfer_handle().ok()?;
-        let region = FileRegion::try_new(Arc::new(PullFileRegionLease { handle }), position, len).ok()?;
-        regions.push(region);
-    }
-    FileRegionSequence::try_new(regions).ok()
 }
 
 impl<MS: BrokerReadStore> DefaultPullMessageResultHandler<MS> {
@@ -111,7 +86,7 @@ impl<MS: BrokerReadStore> DefaultPullMessageResultHandler<MS> {
 impl<MS: BrokerReadStore> PullMessageResultHandler for DefaultPullMessageResultHandler<MS> {
     async fn handle(
         &self,
-        mut get_message_result: GetMessageResult,
+        get_message_result: GetMessageResult,
         request: &mut RemotingCommand,
         request_header: PullMessageRequestHeader,
         channel: Channel,
@@ -123,7 +98,7 @@ impl<MS: BrokerReadStore> PullMessageResultHandler for DefaultPullMessageResultH
         mut response: RemotingCommand,
         mut mapping_context: TopicQueueMappingContext,
         _begin_time_mills: u64,
-    ) -> Option<RemotingCommand> {
+    ) -> rocketmq_error::RocketMQResult<PullMessageResult> {
         let client_address = channel.remote_address().to_string();
         let policy = self.context.policy();
         let topic_config = self.context.topics().select_topic_config(request_header.topic.as_ref());
@@ -147,7 +122,7 @@ impl<MS: BrokerReadStore> PullMessageResultHandler for DefaultPullMessageResultH
         );
         {
             let Some(response_header) = response.read_custom_header_mut::<PullMessageResponseHeader>() else {
-                return Some(static_topic_rewrite_error_response(
+                return command_result(static_topic_rewrite_error_response(
                     self.context.command_factory(),
                     StaticTopicRewriteError::MissingResponseHeader,
                     &mapping_context,
@@ -160,10 +135,10 @@ impl<MS: BrokerReadStore> PullMessageResultHandler for DefaultPullMessageResultH
                 &mut mapping_context,
                 code,
             ) {
-                Ok(Some(response)) => return Some(response),
+                Ok(Some(response)) => return command_result(response),
                 Ok(None) => {}
                 Err(error) => {
-                    return Some(static_topic_rewrite_error_response(
+                    return command_result(static_topic_rewrite_error_response(
                         self.context.command_factory(),
                         error,
                         &mapping_context,
@@ -238,36 +213,9 @@ impl<MS: BrokerReadStore> PullMessageResultHandler for DefaultPullMessageResultH
                         request_header.queue_id,
                         latency,
                     );
-                    if let Some(body) = body {
-                        response.set_body_mut_ref(body);
-                    }
-                    Some(response)
+                    bytes_result(response, body.unwrap_or_default())
                 } else {
-                    if let Some(regions) = pull_file_regions(&get_message_result) {
-                        if let Err(error) = channel.send_file_regions_response(response, regions).await {
-                            warn!(%error, "Failed to send owner-backed pull response");
-                        }
-                        return None;
-                    }
-
-                    let Some(header_bytes) =
-                        response.encode_header_with_body_length(get_message_result.buffer_total_size() as usize)
-                    else {
-                        warn!("Failed to encode pull response header");
-                        return None;
-                    };
-                    let mut frame_segments = Vec::with_capacity(get_message_result.message_mapped_list().len() + 1);
-                    frame_segments.push(header_bytes);
-                    for select_result in get_message_result.message_mapped_list_mut() {
-                        if let Some(message) = select_result.take() {
-                            frame_segments.push(message);
-                        }
-                    }
-                    if let Err(error) = channel.send_frame_segments(frame_segments).await {
-                        warn!(%error, "Failed to send segmented pull response");
-                    }
-
-                    None
+                    store_result(response, get_message_result)
                 }
             }
             ResponseCode::PullNotFound => {
@@ -298,12 +246,12 @@ impl<MS: BrokerReadStore> PullMessageResultHandler for DefaultPullMessageResultH
                     );
                     let suspended = self.context.suspend_pull_request(topic, queue_id, pull_request);
                     if suspended {
-                        return None;
+                        return Ok(PullMessageResult::Suspended);
                     }
                 }
-                Some(response)
+                command_result(response)
             }
-            ResponseCode::PullRetryImmediately => Some(response),
+            ResponseCode::PullRetryImmediately => command_result(response),
             ResponseCode::PullOffsetMoved => {
                 if policy.broker_role != BrokerRole::Slave || policy.offset_check_in_slave {
                     let response_header = response.read_custom_header_mut::<PullMessageResponseHeader>().unwrap();
@@ -340,11 +288,11 @@ impl<MS: BrokerReadStore> PullMessageResultHandler for DefaultPullMessageResultH
                         subscription_group_config.broker_id()
                     );
                 }
-                Some(response)
+                command_result(response)
             }
             _ => {
                 warn!("[BUG] impossible result code of get message: {}", response.code());
-                Some(response)
+                command_result(response)
             }
         }
     }
@@ -356,6 +304,24 @@ impl<MS: BrokerReadStore> PullMessageResultHandler for DefaultPullMessageResultH
     fn as_any(&self) -> &dyn Any {
         self
     }
+}
+
+fn command_result(response: RemotingCommand) -> rocketmq_error::RocketMQResult<PullMessageResult> {
+    Ok(PullMessageResult::Reply(BrokerResponseParts::command(response)?))
+}
+
+fn bytes_result(response: RemotingCommand, body: Bytes) -> rocketmq_error::RocketMQResult<PullMessageResult> {
+    Ok(PullMessageResult::Reply(BrokerResponseParts::bytes(response, body)?))
+}
+
+fn store_result(
+    response: RemotingCommand,
+    get_message_result: GetMessageResult,
+) -> rocketmq_error::RocketMQResult<PullMessageResult> {
+    Ok(PullMessageResult::Reply(store_response_parts(
+        response,
+        get_message_result.message_mapped_vec(),
+    )?))
 }
 
 impl<MS: BrokerReadStore> DefaultPullMessageResultHandler<MS> {
@@ -704,9 +670,54 @@ mod tests {
     use super::*;
     use rocketmq_store::DefaultMappedFile;
     use rocketmq_store::MappedFile;
+    use rocketmq_store::SelectMappedBufferResult;
+    use rocketmq_transport::api::v2::HandlerOutcome;
+    use rocketmq_transport::api::v2::ResponseBodyKind;
+    use rocketmq_transport::api::v2::ResponsePlan;
+
+    fn response_head() -> RemotingCommand {
+        RemotingCommand::create_response_command_with_code(ResponseCode::Success)
+    }
+
+    fn reply_plan(result: rocketmq_error::RocketMQResult<PullMessageResult>) -> ResponsePlan {
+        let PullMessageResult::Reply(parts) = result.expect("valid Pull result") else {
+            panic!("expected an immediate Pull reply");
+        };
+        let HandlerOutcome::Reply(plan) = parts.into_handler_outcome().expect("valid Pull response plan") else {
+            panic!("immediate Pull parts must map to a Reply outcome");
+        };
+        plan
+    }
 
     #[test]
-    fn pull_file_regions_preserve_multiple_store_ranges_without_snapshots() {
+    fn pull_result_distinguishes_immediate_reply_from_suspension() {
+        let immediate = command_result(response_head()).expect("valid immediate Pull result");
+        assert!(matches!(&immediate, PullMessageResult::Reply(_)));
+        let PullMessageResult::Reply(parts) = immediate else {
+            panic!("immediate Pull result must remain a reply");
+        };
+        let HandlerOutcome::Reply(plan) = parts.into_handler_outcome().expect("valid empty Pull plan") else {
+            panic!("immediate Pull parts must map to a Reply outcome");
+        };
+        let suspended = PullMessageResult::Suspended;
+
+        assert_eq!(plan.body_kind(), ResponseBodyKind::Empty);
+        assert!(matches!(suspended, PullMessageResult::Suspended));
+    }
+
+    #[test]
+    fn heap_pull_reply_exposes_bytes_at_the_v2_seam() {
+        let body = Bytes::from_static(b"heap-pull-body");
+        let plan = reply_plan(bytes_result(response_head(), body));
+
+        assert_eq!(plan.response_code(), ResponseCode::Success as i32);
+        assert_eq!(plan.body_kind(), ResponseBodyKind::Bytes);
+        assert_eq!(plan.body_len(), 14);
+        assert_eq!(plan.body_part_count(), 1);
+    }
+
+    #[test]
+    fn non_heap_pull_uses_file_regions_when_every_selection_has_a_range() {
         let directory = tempfile::tempdir().expect("temporary pull range directory");
         let path = directory.path().join("00000000000000000000");
         let mapped_file = DefaultMappedFile::try_new(CheetahString::from(path.to_string_lossy().into_owned()), 64)
@@ -727,11 +738,38 @@ mod tests {
         let mut result = GetMessageResult::new_result_size(2);
         result.add_message(first, 0, 1);
         result.add_message(second, 1, 1);
-        let regions = pull_file_regions(&result).expect("owner-backed region sequence");
-        assert_eq!(regions.len(), 15);
         assert!(result
             .message_mapped_list()
             .iter()
             .all(|selected| !selected.has_byte_snapshot()));
+
+        let plan = reply_plan(store_result(response_head(), result));
+        assert_eq!(plan.body_kind(), ResponseBodyKind::FileRegions);
+        assert_eq!(plan.body_len(), 15);
+        assert_eq!(plan.body_part_count(), 2);
+    }
+
+    #[test]
+    fn non_heap_pull_falls_back_to_ordered_body_only_segments() {
+        let directory = tempfile::tempdir().expect("temporary mixed pull directory");
+        let path = directory.path().join("00000000000000000000");
+        let mapped_file = DefaultMappedFile::try_new(CheetahString::from(path.to_string_lossy().into_owned()), 64)
+            .expect("mapped file");
+        assert!(mapped_file.append_message_bytes(b"file-first"));
+
+        let file_selection = mapped_file
+            .try_file_range_selection(0, 10)
+            .expect("file selection")
+            .expect("published file range");
+        let byte_selection =
+            SelectMappedBufferResult::from_bytes(10, Bytes::from_static(b"bytes-second")).expect("byte selection");
+        let mut result = GetMessageResult::new_result_size(2);
+        result.add_message(file_selection, 0, 1);
+        result.add_message(byte_selection, 1, 1);
+
+        let plan = reply_plan(store_result(response_head(), result));
+        assert_eq!(plan.body_kind(), ResponseBodyKind::Segments);
+        assert_eq!(plan.body_len(), 22);
+        assert_eq!(plan.body_part_count(), 2);
     }
 }

--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -95,6 +95,11 @@ use crate::pop::rocksdb_store::PopConsumerRocksDbStore;
 use crate::processor::pop_message_processor::capability::PopBufferMergeContext;
 use crate::processor::pop_message_processor::capability::PopMessageProcessorContext;
 use crate::processor::processor_service::pop_buffer_merge_service::PopBufferMergeService;
+use crate::processor::response_plan::pop::attach_pop_response_header;
+use crate::processor::response_plan::pop::deliver_pop_legacy;
+use crate::processor::response_plan::pop::pop_heap_response_parts;
+use crate::processor::response_plan::pop::pop_segmented_response_parts;
+use crate::processor::response_plan::pop::take_pop_body_segments;
 
 const BORN_TIME: &str = "bornTime";
 const QUEUE_LOCK_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
@@ -800,39 +805,20 @@ where
 
         match ResponseCode::from(final_response.code()) {
             ResponseCode::Success => {
+                let final_response = attach_pop_response_header(final_response, response_header);
                 if policy.transfer_msg_by_heap {
-                    if let Some(bytes) = self.read_get_message_result(
+                    let body = self.read_get_message_result(
                         &get_message_result,
                         &request_header.consumer_group,
                         &request_header.topic,
                         request_header.queue_id,
-                    ) {
-                        final_response.set_body_mut_ref(bytes);
-                    }
-                    final_response.set_command_custom_header_ref(response_header);
-                    Ok(Some(final_response))
+                    );
+                    let parts = pop_heap_response_parts(final_response, body)?;
+                    deliver_pop_legacy(parts, &channel).await
                 } else {
-                    //zero copy transfer
-                    let header_bytes = final_response
-                        .encode_header_with_body_length(get_message_result.buffer_total_size() as usize)
-                        .ok_or_else(|| {
-                            rocketmq_error::RocketMQError::Serialization(
-                                rocketmq_error::SerializationError::encode_failed(
-                                    "remoting-command",
-                                    "failed to encode POP response header",
-                                ),
-                            )
-                        })?;
-                    let mut frame_segments = Vec::with_capacity(get_message_result.message_mapped_list().len() + 1);
-                    frame_segments.push(header_bytes);
-                    for select_result in get_message_result.message_mapped_list_mut() {
-                        if let Some(message) = select_result.take() {
-                            frame_segments.push(message);
-                        }
-                    }
-                    channel.send_frame_segments(frame_segments).await?;
-
-                    Ok(None)
+                    let body_segments = take_pop_body_segments(get_message_result);
+                    let parts = pop_segmented_response_parts(final_response, body_segments)?;
+                    deliver_pop_legacy(parts, &channel).await
                 }
             }
             _ => Ok(Some(final_response)),

--- a/rocketmq-broker/src/processor/pull_message_processor.rs
+++ b/rocketmq-broker/src/processor/pull_message_processor.rs
@@ -68,7 +68,9 @@ use crate::filter::expression_message_filter::ExpressionMessageFilter;
 use crate::long_polling::long_polling_service::pull_request_hold_service::PullRequestProcessor;
 use crate::processor::default_pull_message_result_handler::DefaultPullMessageResultHandler;
 use crate::processor::pull_message_processor::capability::PullMessageProcessorContext;
+use crate::processor::pull_message_result_handler::PullMessageResult;
 use crate::processor::pull_message_result_handler::PullMessageResultHandler;
+use crate::processor::response_plan::LegacyResponseDelivery;
 
 fn store_read_max_msg_bytes(max_msg_bytes: Option<i32>) -> i32 {
     max_msg_bytes
@@ -781,7 +783,7 @@ where
     /// # Returns
     ///
     /// * `Ok(Some(response))` - Response to send to client
-    /// * `Ok(None)` - Request was suspended (cold data flow control or long polling)
+    /// * `Ok(None)` - Request was suspended or the V1 compatibility boundary wrote the response
     #[allow(unused_assignments)]
     async fn process_request_inner(
         &self,
@@ -1070,13 +1072,13 @@ where
             }
         };
         if let Some(get_message_result) = get_message_result {
-            return Ok(self
+            let result = self
                 .pull_message_result_handler
                 .handle(
                     get_message_result,
                     request,
                     request_header,
-                    channel,
+                    channel.clone(),
                     ctx,
                     subscription_data,
                     &subscription_group_config.unwrap(),
@@ -1086,7 +1088,13 @@ where
                     topic_queue_mapping_context,
                     begin_time_mills,
                 )
-                .await);
+                .await?;
+            return match result {
+                PullMessageResult::Reply(parts) => {
+                    Ok(legacy_pull_delivery_response(parts.deliver_legacy(&channel).await))
+                }
+                PullMessageResult::Suspended => Ok(None),
+            };
         }
         Ok(None)
     }
@@ -1216,6 +1224,19 @@ fn consumer_compensation_for_request_source(request_source: RequestSource) -> (C
     }
 }
 
+fn legacy_pull_delivery_response(
+    delivery: rocketmq_error::RocketMQResult<LegacyResponseDelivery>,
+) -> Option<RemotingCommand> {
+    match delivery {
+        Ok(LegacyResponseDelivery::Command(response)) => Some(response),
+        Ok(LegacyResponseDelivery::Written) => None,
+        Err(error) => {
+            warn!(%error, "Failed to send Pull response");
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -1227,6 +1248,7 @@ mod tests {
     use std::time::Duration;
 
     use crate::config::broker_config::BrokerConfig;
+    use bytes::Bytes;
     use rocketmq_model::common::consumer::consume_from_where::ConsumeFromWhere;
     use rocketmq_model::common::filter::expression_type::ExpressionType;
     use rocketmq_model::common::sys_flag::pull_sys_flag::PullSysFlag;
@@ -1248,14 +1270,18 @@ mod tests {
     use rocketmq_store::BrokerReadStore;
     use rocketmq_store::MessageStoreConfig;
     use rocketmq_store::MAX_PULL_MSG_SIZE;
+    use rocketmq_transport::api::v1::Channel;
     use rocketmq_transport::test_support::Connection;
+    use rocketmq_transport::test_support::TestChannelBuilder;
 
     use super::consumer_compensation_for_request_source;
     use super::is_broadcast;
+    use super::legacy_pull_delivery_response;
     use super::rewrite_response_for_static_topic;
     use super::spawn_wakeup_pull_task;
     use super::static_topic_rewrite_error_response;
     use super::store_read_max_msg_bytes;
+    use super::LegacyResponseDelivery;
     use super::PullMessageProcessor;
     use super::StaticTopicMappingField;
     use super::StaticTopicMappingItem;
@@ -1265,6 +1291,7 @@ mod tests {
     use crate::client::consumer_group_info::ConsumerGroupInfo;
     use crate::processor::default_pull_message_result_handler::DefaultPullMessageResultHandler;
     use crate::processor::pull_message_processor::capability::PullMessageProcessorContext;
+    use crate::processor::response_plan::BrokerResponseParts;
 
     fn temp_test_root(label: &str) -> PathBuf {
         let mut path = std::env::temp_dir();
@@ -1336,6 +1363,74 @@ mod tests {
             None,
         ));
         PullMessageProcessor::new(handler, context)
+    }
+
+    #[test]
+    fn legacy_pull_delivery_keeps_written_and_failed_responses_consumed() {
+        let command = RemotingCommand::create_response_command_with_code(ResponseCode::Success);
+        let returned = legacy_pull_delivery_response(Ok(LegacyResponseDelivery::Command(command)));
+        assert!(returned.is_some());
+
+        assert!(legacy_pull_delivery_response(Ok(LegacyResponseDelivery::Written)).is_none());
+
+        let write_error = rocketmq_error::RocketMQError::internal(
+            "pull-response-test",
+            std::io::Error::other("injected compatibility write failure"),
+        );
+        assert!(legacy_pull_delivery_response(Err(write_error)).is_none());
+    }
+
+    struct CountingBodyOwner {
+        drops: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl AsRef<[u8]> for CountingBodyOwner {
+        fn as_ref(&self) -> &[u8] {
+            b"segmented-pull-body"
+        }
+    }
+
+    impl Drop for CountingBodyOwner {
+        fn drop(&mut self) {
+            self.drops.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    async fn closed_pull_test_channel() -> Channel {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind Pull compatibility listener");
+        let address = listener.local_addr().expect("Pull compatibility address");
+        let stream = std::net::TcpStream::connect(address).expect("connect Pull compatibility stream");
+        let accepted = listener.accept().expect("accept Pull compatibility stream").0;
+        stream.set_nonblocking(true).expect("set Pull stream nonblocking");
+
+        let mut connection = Connection::new(tokio::net::TcpStream::from_std(stream).expect("Tokio Pull stream"));
+        connection.shutdown().await.expect("shut down Pull test connection");
+        drop(accepted);
+
+        TestChannelBuilder::new(connection, crate::test_task_group("pull-legacy-closed-channel"))
+            .addresses(address, address)
+            .build()
+            .expect("build closed Pull test channel")
+    }
+
+    #[tokio::test]
+    async fn segmented_legacy_write_failure_remains_consumed_and_drops_body_once() {
+        let channel = closed_pull_test_channel().await;
+        let drops = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let body = Bytes::from_owner(CountingBodyOwner {
+            drops: Arc::clone(&drops),
+        });
+        let parts = BrokerResponseParts::segments(
+            RemotingCommand::create_response_command_with_code(ResponseCode::Success),
+            vec![body],
+        )
+        .expect("segmented Pull response parts");
+        assert_eq!(0, drops.load(Ordering::SeqCst));
+
+        let returned = legacy_pull_delivery_response(parts.deliver_legacy(&channel).await);
+
+        assert!(returned.is_none(), "Pull compatibility keeps failed writes consumed");
+        assert_eq!(1, drops.load(Ordering::SeqCst));
     }
 
     fn request_with_subscription(topic: &str, group: &str, expression: &str, version: i64) -> PullMessageRequestHeader {

--- a/rocketmq-broker/src/processor/pull_message_result_handler.rs
+++ b/rocketmq-broker/src/processor/pull_message_result_handler.rs
@@ -24,13 +24,23 @@ use rocketmq_store::GetMessageResult;
 use rocketmq_transport::api::v1::Channel;
 use rocketmq_transport::api::v1::ConnectionHandlerContext;
 
+use crate::processor::response_plan::BrokerResponseParts;
+
+/// The explicit outcome of composing a Pull response.
+pub(crate) enum PullMessageResult {
+    /// An immediate response whose head and affine body are ready for delivery.
+    Reply(BrokerResponseParts),
+    /// The request was admitted to the existing long-poll owner.
+    Suspended,
+}
+
 /// Trait defining the behavior for handling the result of a pull message request.
 ///
 /// This trait is designed to be implemented by types that handle the result of a pull message
 /// request in a RocketMQ broker. It provides a method for processing the result of a message
 /// retrieval operation, along with various parameters related to the request and the broker's
 /// state.
-pub trait PullMessageResultHandler: Sync + Send + Any + 'static {
+pub(crate) trait PullMessageResultHandler: Sync + Send + Any + 'static {
     /// Handles the result of a pull message request.
     ///
     /// This method processes the result of a message retrieval operation (`get_message_result`),
@@ -53,8 +63,7 @@ pub trait PullMessageResultHandler: Sync + Send + Any + 'static {
     /// - `begin_time_mills`: The timestamp (in milliseconds) when the request began processing.
     ///
     /// # Returns
-    /// An optional `RemotingCommand` representing the response to the pull message request.
-    /// If `None`, it indicates that no response should be sent back to the client.
+    /// An explicit immediate response or suspension result.
     #[allow(
         clippy::too_many_arguments,
         reason = "existing pull result protocol context is tracked by the lint debt registry"
@@ -73,7 +82,7 @@ pub trait PullMessageResultHandler: Sync + Send + Any + 'static {
         response: RemotingCommand,
         mapping_context: TopicQueueMappingContext,
         begin_time_mills: u64,
-    ) -> Option<RemotingCommand>;
+    ) -> rocketmq_error::RocketMQResult<PullMessageResult>;
 
     /// Returns a mutable reference to `self` as a trait object of type `Any`.
     ///

--- a/rocketmq-broker/src/processor/query_message_processor.rs
+++ b/rocketmq-broker/src/processor/query_message_processor.rs
@@ -38,11 +38,15 @@ use rocketmq_transport::api::v1::request_code_not_supported_with_factory_remark_
 use rocketmq_transport::api::v1::Channel;
 use rocketmq_transport::api::v1::ConnectionHandlerContext;
 use rocketmq_transport::api::v1::RequestProcessor;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestProcessorV2;
 use tracing::info;
 use tracing::warn;
 
 use crate::failover::escape_bridge::EscapeBridge;
 use crate::failover::escape_bridge::MessageStoreUnavailable;
+use crate::processor::response_plan::BrokerResponseParts;
 
 pub(crate) struct QueryMessageStoreCapability<MS: BrokerReadStore> {
     escape_bridge: Weak<EscapeBridge<MS>>,
@@ -126,6 +130,41 @@ fn unsafe_index_query_remark(query_message_result: &QueryMessageResult) -> Optio
     })
 }
 
+struct QueryResponseParts {
+    head: RemotingCommand,
+    body: Option<bytes::Bytes>,
+}
+
+impl QueryResponseParts {
+    fn command(head: RemotingCommand) -> Self {
+        Self { head, body: None }
+    }
+
+    fn bytes(head: RemotingCommand, body: bytes::Bytes) -> Self {
+        Self { head, body: Some(body) }
+    }
+
+    fn into_legacy_command(mut self) -> RemotingCommand {
+        if let Some(body) = self.body {
+            self.head.set_body_mut_ref(body);
+        }
+        self.head
+    }
+
+    fn into_legacy_command_with_opaque(mut self, opaque: i32) -> RemotingCommand {
+        self.head.set_opaque_mut(opaque);
+        self.into_legacy_command()
+    }
+
+    fn into_handler_outcome(self) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let parts = match self.body {
+            Some(body) => BrokerResponseParts::bytes(self.head, body)?,
+            None => BrokerResponseParts::command(self.head)?,
+        };
+        parts.into_handler_outcome()
+    }
+}
+
 impl<S> RequestProcessor for QueryMessageProcessor<S>
 where
     S: QueryMessageStore + Clone,
@@ -156,6 +195,15 @@ where
                 Ok(Some(response))
             }
         }
+    }
+}
+
+impl<S> RequestProcessorV2 for QueryMessageProcessor<S>
+where
+    S: QueryMessageStore + Clone + 'static,
+{
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        self.process_v2_command(request.command_mut()).await
     }
 }
 
@@ -219,19 +267,55 @@ where
         }
     }
 
+    async fn process_v2_command(
+        &mut self,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let request_code = RequestCode::from(request.code());
+        info!("QueryMessageProcessor V2 received request code: {:?}", request_code);
+        let parts = match request_code {
+            RequestCode::QueryMessage => self.query_message_parts(request).await?,
+            RequestCode::ViewMessageById => self.view_message_by_id_parts(request).await?,
+            _ => {
+                warn!(
+                    "QueryMessageProcessor V2 received unknown request code: {:?}",
+                    request_code
+                );
+                QueryResponseParts::command(request_code_not_supported_with_factory_remark_and_opaque(
+                    &self.command_factory,
+                    request.code(),
+                    format!("QueryMessageProcessor request code {} not supported", request.code()),
+                    0,
+                ))
+            }
+        };
+        parts.into_handler_outcome()
+    }
+
     async fn query_message(
         &mut self,
         _channel: Channel,
         _ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+        let opaque = request.opaque();
+        Ok(Some(
+            self.query_message_parts(request)
+                .await?
+                .into_legacy_command_with_opaque(opaque),
+        ))
+    }
+
+    async fn query_message_parts(
+        &mut self,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<QueryResponseParts> {
         let mut response = self
             .command_factory
             .create_success_response_command_with_header(QueryMessageResponseHeader::default());
         let mut request_header = request.decode_command_custom_header::<QueryMessageRequestHeader>()?;
-        response.set_opaque_mut(request.opaque());
         let Some(ext_fields) = request.ext_fields() else {
-            return Ok(Some(
+            return Ok(QueryResponseParts::command(
                 response
                     .set_code(ResponseCode::SystemError)
                     .set_remark("ext fields is none"),
@@ -246,7 +330,7 @@ where
                 MessageConst::INDEX_KEY_TYPE | MessageConst::INDEX_UNIQUE_TYPE | MessageConst::INDEX_TAG_TYPE
             )
         }) {
-            return Ok(Some(
+            return Ok(QueryResponseParts::command(
                 response
                     .set_code(ResponseCode::SystemError)
                     .set_remark("indexType must be K, U, or T"),
@@ -273,14 +357,14 @@ where
         let query_message_result = match query_message_result {
             Ok(Some(query_message_result)) => query_message_result,
             Ok(None) => {
-                return Ok(Some(
+                return Ok(QueryResponseParts::command(
                     response
                         .set_code(ResponseCode::QueryNotFound)
                         .set_remark("query message failed, no result returned"),
                 ));
             }
             Err(_) => {
-                return Ok(Some(
+                return Ok(QueryResponseParts::command(
                     response
                         .set_code(ResponseCode::SystemError)
                         .set_remark("message store is none"),
@@ -288,21 +372,26 @@ where
             }
         };
 
-        let response_header = response.read_custom_header_mut::<QueryMessageResponseHeader>().unwrap();
+        let Some(response_header) = response.read_custom_header_mut::<QueryMessageResponseHeader>() else {
+            return Err(rocketmq_error::RocketMQError::invariant_violated(
+                "query response lost its required response header",
+            ));
+        };
         response_header.index_last_update_phyoffset = query_message_result.index_last_update_phyoffset;
         response_header.index_last_update_timestamp = query_message_result.index_last_update_timestamp;
 
         if query_message_result.buffer_total_size > 0 {
-            let message_data = query_message_result.get_message_data();
-            if let Some(body) = message_data {
-                response.set_body_mut_ref(body);
+            if let Some(body) = query_message_result.get_message_data() {
+                return Ok(QueryResponseParts::bytes(response, body));
             }
-            return Ok(Some(response));
+            return Ok(QueryResponseParts::command(response));
         }
         if let Some(remark) = unsafe_index_query_remark(&query_message_result) {
-            return Ok(Some(response.set_code(ResponseCode::SystemError).set_remark(remark)));
+            return Ok(QueryResponseParts::command(
+                response.set_code(ResponseCode::SystemError).set_remark(remark),
+            ));
         }
-        Ok(Some(
+        Ok(QueryResponseParts::command(
             response
                 .set_code(ResponseCode::QueryNotFound)
                 .set_remark("can not find message, maybe time range not correct"),
@@ -315,13 +404,22 @@ where
         _ctx: ConnectionHandlerContext,
         request: &mut RemotingCommand,
     ) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
-        let mut response = self.command_factory.create_success_response_command();
+        Ok(Some(
+            self.view_message_by_id_parts(request).await?.into_legacy_command(),
+        ))
+    }
+
+    async fn view_message_by_id_parts(
+        &mut self,
+        request: &mut RemotingCommand,
+    ) -> rocketmq_error::RocketMQResult<QueryResponseParts> {
+        let response = self.command_factory.create_success_response_command();
         let request_header = request.decode_command_custom_header::<ViewMessageRequestHeader>()?;
 
         let select_mapped_buffer_result = match self.query_store.select_message_by_offset(request_header.offset) {
             Ok(result) => result,
             Err(_) => {
-                return Ok(Some(
+                return Ok(QueryResponseParts::command(
                     response
                         .set_code(ResponseCode::SystemError)
                         .set_remark("message store is none"),
@@ -329,24 +427,64 @@ where
             }
         };
         if let Some(result) = select_mapped_buffer_result {
-            let message_data = result.get_bytes();
-            if let Some(body) = message_data {
-                response.set_body_mut_ref(body)
-            }
-            return Ok(Some(response));
+            return Ok(QueryResponseParts::bytes(response, result.into_owner_bytes()));
         }
-        Ok(Some(response.set_code(ResponseCode::SystemError).set_remark(format!(
-            "can not find message by offset: {}",
-            request_header.offset
-        ))))
+        Ok(QueryResponseParts::command(
+            response
+                .set_code(ResponseCode::SystemError)
+                .set_remark(format!("can not find message by offset: {}", request_header.offset)),
+        ))
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
+    use bytes::Bytes;
+    use rocketmq_runtime::RuntimeConfig;
+    use rocketmq_runtime::RuntimeOwner;
     use rocketmq_store::QueryMessageResult;
     use rocketmq_store::StorePorts;
+    use rocketmq_transport::api::v1::ServerConfig;
+    use rocketmq_transport::api::v2::ResponseBodyKind;
+    use rocketmq_transport::api::v2::TransportServerV2;
+    use rocketmq_transport::test_support::Connection;
+    use tokio::net::TcpStream;
+    use tokio::sync::oneshot;
+
+    #[derive(Clone, Default)]
+    struct TestQueryStore {
+        query_body: Option<Bytes>,
+        view_body: Option<Bytes>,
+    }
+
+    impl QueryMessageStore for TestQueryStore {
+        async fn query_message(
+            &self,
+            _request: &QueryMessageRequest,
+        ) -> Result<Option<QueryMessageResult>, StoreError> {
+            let Some(body) = self.query_body.clone() else {
+                return Ok(None);
+            };
+            let selected = SelectMappedBufferResult::from_bytes(0, body).expect("test body length is representable");
+            let mut result = QueryMessageResult {
+                index_last_update_phyoffset: 17,
+                index_last_update_timestamp: 23,
+                ..QueryMessageResult::default()
+            };
+            result.add_message(selected);
+            Ok(Some(result))
+        }
+
+        fn select_message_by_offset(&self, _offset: i64) -> Result<Option<SelectMappedBufferResult>, StoreError> {
+            Ok(self
+                .view_body
+                .clone()
+                .and_then(|body| SelectMappedBufferResult::from_bytes(0, body)))
+        }
+    }
 
     fn header(index_type: Option<&'static str>) -> QueryMessageRequestHeader {
         QueryMessageRequestHeader {
@@ -435,5 +573,185 @@ mod tests {
             panic!("closed provider must reject select");
         };
         assert_eq!(StoreErrorKind::NotStarted, select_error.kind());
+    }
+
+    #[tokio::test]
+    async fn v2_query_success_returns_one_owned_bytes_plan() {
+        let body = Bytes::from_static(b"query-body");
+        let mut processor = QueryMessageProcessor::new(
+            64,
+            TestQueryStore {
+                query_body: Some(body.clone()),
+                view_body: None,
+            },
+        );
+        let mut request = RemotingCommand::create_request_command(RequestCode::QueryMessage, header(None));
+        request.make_custom_header_to_net();
+
+        let outcome = processor
+            .process_v2_command(&mut request)
+            .await
+            .expect("V2 query response plan");
+        let HandlerOutcome::Reply(plan) = outcome else {
+            panic!("query success must return an inline reply");
+        };
+
+        assert_eq!(ResponseCode::Success as i32, plan.response_code());
+        assert_eq!(ResponseBodyKind::Bytes, plan.body_kind());
+        assert_eq!(body.len(), plan.body_len());
+        assert_eq!(1, plan.body_part_count());
+    }
+
+    #[tokio::test]
+    async fn v2_query_real_dispatcher_rebinds_the_original_opaque() {
+        const ORIGINAL_OPAQUE: i32 = 8_701;
+
+        let owner = RuntimeOwner::new(RuntimeConfig::server_default("broker-query-v2-dispatch-test"))
+            .expect("query V2 test runtime owner");
+        let server_context = owner.root_context().component("query-v2-server");
+        let runner_context = owner.root_context().component("query-v2-runner");
+        let processor = QueryMessageProcessor::new(
+            64,
+            TestQueryStore {
+                query_body: Some(Bytes::from_static(b"query-dispatch-body")),
+                view_body: None,
+            },
+        );
+        let server = TransportServerV2::new(
+            Arc::new(ServerConfig {
+                bind_address: "127.0.0.1".to_owned(),
+                listen_port: 0,
+                ..ServerConfig::default()
+            }),
+            server_context,
+            processor,
+        );
+        let (shutdown_sender, shutdown_receiver) = oneshot::channel();
+        let (startup_sender, startup_receiver) = oneshot::channel();
+        let (result_sender, result_receiver) = oneshot::channel();
+        runner_context
+            .spawn_service("query-v2-server", async move {
+                let result = server
+                    .try_run_with_shutdown_report_and_startup(
+                        async move {
+                            let _ = shutdown_receiver.await;
+                        },
+                        startup_sender,
+                    )
+                    .await;
+                let _ = result_sender.send(result);
+            })
+            .expect("spawn query V2 server");
+
+        let address = startup_receiver
+            .await
+            .expect("query V2 startup channel")
+            .expect("query V2 server startup");
+        let mut client = Connection::new(TcpStream::connect(address).await.expect("connect query V2 client"));
+        let mut request = RemotingCommand::create_request_command(RequestCode::QueryMessage, header(None))
+            .set_opaque(ORIGINAL_OPAQUE);
+        request.make_custom_header_to_net();
+        client.send_command(request).await.expect("send query V2 request");
+
+        let response = tokio::time::timeout(Duration::from_secs(1), client.receive_command())
+            .await
+            .expect("query V2 response deadline")
+            .expect("query V2 connection remains open")
+            .expect("query V2 response frame");
+        assert_eq!(ORIGINAL_OPAQUE, response.opaque());
+        assert_eq!(ResponseCode::Success as i32, response.code());
+        assert_eq!(Some(&Bytes::from_static(b"query-dispatch-body")), response.body());
+
+        client.shutdown().await.expect("shutdown query V2 client");
+        let _ = shutdown_sender.send(());
+        let report = tokio::time::timeout(Duration::from_secs(2), result_receiver)
+            .await
+            .expect("query V2 shutdown deadline")
+            .expect("query V2 shutdown result channel")
+            .expect("query V2 shutdown report");
+        assert!(report.is_healthy(), "{}", report.to_json());
+        let task_report = owner.shutdown_tasks().await;
+        assert!(task_report.is_healthy(), "{}", task_report.to_json());
+        let final_report = owner.shutdown_background();
+        assert!(final_report.is_healthy(), "{}", final_report.to_json());
+    }
+
+    #[tokio::test]
+    async fn v2_view_consumes_the_selected_owner_into_one_bytes_plan() {
+        let body = Bytes::from_static(b"view-body");
+        let mut processor = QueryMessageProcessor::new(
+            64,
+            TestQueryStore {
+                query_body: None,
+                view_body: Some(body.clone()),
+            },
+        );
+        let mut request = RemotingCommand::create_request_command(
+            RequestCode::ViewMessageById,
+            ViewMessageRequestHeader { topic: None, offset: 7 },
+        );
+        request.make_custom_header_to_net();
+
+        let outcome = processor
+            .process_v2_command(&mut request)
+            .await
+            .expect("V2 view response plan");
+        let HandlerOutcome::Reply(plan) = outcome else {
+            panic!("view success must return an inline reply");
+        };
+
+        assert_eq!(ResponseCode::Success as i32, plan.response_code());
+        assert_eq!(ResponseBodyKind::Bytes, plan.body_kind());
+        assert_eq!(body.len(), plan.body_len());
+    }
+
+    #[tokio::test]
+    async fn v2_query_not_found_returns_an_empty_reply_plan() {
+        let mut processor = QueryMessageProcessor::new(64, TestQueryStore::default());
+        let mut request = RemotingCommand::create_request_command(RequestCode::QueryMessage, header(None));
+        request.make_custom_header_to_net();
+
+        let outcome = processor
+            .process_v2_command(&mut request)
+            .await
+            .expect("V2 not-found response plan");
+        let HandlerOutcome::Reply(plan) = outcome else {
+            panic!("query not found must return an inline reply");
+        };
+
+        assert_eq!(ResponseCode::QueryNotFound as i32, plan.response_code());
+        assert_eq!(ResponseBodyKind::Empty, plan.body_kind());
+        assert_eq!(0, plan.body_len());
+    }
+
+    #[tokio::test]
+    async fn legacy_query_projection_keeps_opaque_and_body_behavior() {
+        let body = Bytes::from_static(b"legacy-query-body");
+        let mut processor = QueryMessageProcessor::new(
+            64,
+            TestQueryStore {
+                query_body: Some(body.clone()),
+                view_body: None,
+            },
+        );
+        let mut request =
+            RemotingCommand::create_request_command(RequestCode::QueryMessage, header(None)).set_opaque(-73);
+        request.make_custom_header_to_net();
+
+        let response = processor
+            .query_message_parts(&mut request)
+            .await
+            .expect("legacy query response parts")
+            .into_legacy_command_with_opaque(request.opaque());
+
+        assert_eq!(-73, response.opaque());
+        assert_eq!(Some(body.as_ref()), response.body().map(Bytes::as_ref));
+    }
+
+    #[test]
+    fn query_processor_is_a_send_v2_leaf() {
+        fn assert_v2_processor<T: RequestProcessorV2 + Clone + Send + Sync + 'static>() {}
+
+        assert_v2_processor::<QueryMessageProcessor<TestQueryStore>>();
     }
 }

--- a/rocketmq-broker/src/processor/response_plan.rs
+++ b/rocketmq-broker/src/processor/response_plan.rs
@@ -1,0 +1,292 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Broker-private ownership seam for immediate Pull, Pop, Query, and View responses.
+
+pub(crate) mod pop;
+
+use std::fs::File;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_error::SerializationError;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_store::FileRangeTransferHandle;
+use rocketmq_store::SelectMappedBufferResult;
+use rocketmq_transport::api::v1::Channel;
+use rocketmq_transport::api::v1::FileRegionLease;
+use rocketmq_transport::api::v2::FileRegion;
+use rocketmq_transport::api::v2::FileRegionSequence;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::ResponsePlan;
+use rocketmq_transport::api::v2::ResponsePlanError;
+
+const MAX_RESPONSE_BODY_LEN: u64 = i32::MAX as u64 - 4;
+
+/// The single affine body owner paired with a body-free Broker response head.
+#[derive(Debug)]
+pub(crate) enum BrokerResponseBodyOwner {
+    Empty,
+    Bytes(Bytes),
+    Segments(Vec<Bytes>),
+    FileRegions(FileRegionSequence),
+}
+
+/// A body-free response head and exactly one affine body owner.
+pub(crate) struct BrokerResponseParts {
+    head: RemotingCommand,
+    body: BrokerResponseBodyOwner,
+}
+
+/// An explicit result from the sole V1 compatibility-delivery boundary.
+pub(crate) enum LegacyResponseDelivery {
+    /// The legacy processor must return this command to its dispatcher.
+    Command(RemotingCommand),
+    /// The compatibility boundary wrote the response directly.
+    Written,
+}
+
+/// Typed failures while assembling a Broker-owned response body.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum BrokerResponseBuildError {
+    #[error("invalid Broker response plan: {0}")]
+    ResponsePlan(#[from] ResponsePlanError),
+}
+
+impl From<BrokerResponseBuildError> for RocketMQError {
+    fn from(error: BrokerResponseBuildError) -> Self {
+        Self::internal("broker-response-plan", error)
+    }
+}
+
+/// Descriptor plus storage admission retained by one transport file region.
+pub(crate) struct StoreFileRegionLease {
+    handle: FileRangeTransferHandle,
+}
+
+impl StoreFileRegionLease {
+    fn new(handle: FileRangeTransferHandle) -> Self {
+        Self { handle }
+    }
+}
+
+impl FileRegionLease for StoreFileRegionLease {
+    fn file(&self) -> &File {
+        self.handle.file()
+    }
+}
+
+impl BrokerResponseParts {
+    pub(crate) fn command(head: RemotingCommand) -> Result<Self, BrokerResponseBuildError> {
+        Self::new(head, BrokerResponseBodyOwner::Empty)
+    }
+
+    pub(crate) fn bytes(head: RemotingCommand, body: Bytes) -> Result<Self, BrokerResponseBuildError> {
+        if body.is_empty() {
+            return Self::command(head);
+        }
+        Self::new(head, BrokerResponseBodyOwner::Bytes(body))
+    }
+
+    pub(crate) fn segments(head: RemotingCommand, body_segments: Vec<Bytes>) -> Result<Self, BrokerResponseBuildError> {
+        if body_segments.iter().all(Bytes::is_empty) {
+            return Self::command(head);
+        }
+        Self::new(head, BrokerResponseBodyOwner::Segments(body_segments))
+    }
+
+    pub(crate) fn file_regions(
+        head: RemotingCommand,
+        regions: FileRegionSequence,
+    ) -> Result<Self, BrokerResponseBuildError> {
+        Self::new(head, BrokerResponseBodyOwner::FileRegions(regions))
+    }
+
+    fn new(head: RemotingCommand, body: BrokerResponseBodyOwner) -> Result<Self, BrokerResponseBuildError> {
+        validate_head(&head)?;
+        validate_body(&body)?;
+        Ok(Self { head, body })
+    }
+
+    pub(crate) fn into_response_plan(self) -> RocketMQResult<ResponsePlan> {
+        let result = match self.body {
+            BrokerResponseBodyOwner::Empty => ResponsePlan::command(self.head),
+            BrokerResponseBodyOwner::Bytes(body) => ResponsePlan::bytes(self.head, body),
+            BrokerResponseBodyOwner::Segments(segments) => ResponsePlan::segments(self.head, segments),
+            BrokerResponseBodyOwner::FileRegions(regions) => ResponsePlan::file_regions(self.head, regions),
+        };
+        result.map_err(|error| BrokerResponseBuildError::ResponsePlan(error).into())
+    }
+
+    pub(crate) fn into_handler_outcome(self) -> RocketMQResult<HandlerOutcome> {
+        self.into_response_plan().map(HandlerOutcome::Reply)
+    }
+
+    pub(crate) async fn deliver_legacy(mut self, channel: &Channel) -> RocketMQResult<LegacyResponseDelivery> {
+        match self.body {
+            BrokerResponseBodyOwner::Empty => Ok(LegacyResponseDelivery::Command(self.head)),
+            BrokerResponseBodyOwner::Bytes(body) => Ok(LegacyResponseDelivery::Command(self.head.set_body(body))),
+            BrokerResponseBodyOwner::Segments(mut segments) => {
+                let body_len = checked_body_len(segments.iter().map(|segment| segment.len() as u64))?;
+                let header = self.head.encode_header_with_body_length(body_len).ok_or_else(|| {
+                    RocketMQError::Serialization(SerializationError::encode_failed(
+                        "remoting-command",
+                        "failed to encode Broker compatibility response header",
+                    ))
+                })?;
+                let mut frame_segments = Vec::with_capacity(segments.len() + 1);
+                frame_segments.push(header);
+                frame_segments.append(&mut segments);
+                channel.send_frame_segments(frame_segments).await?;
+                Ok(LegacyResponseDelivery::Written)
+            }
+            BrokerResponseBodyOwner::FileRegions(regions) => {
+                channel.send_file_regions_response(self.head, regions).await?;
+                Ok(LegacyResponseDelivery::Written)
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn body(&self) -> &BrokerResponseBodyOwner {
+        &self.body
+    }
+}
+
+fn validate_head(head: &RemotingCommand) -> Result<(), BrokerResponseBuildError> {
+    if head.body().is_some() {
+        return Err(ResponsePlanError::HeadHasBody.into());
+    }
+    if !head.is_response_type() {
+        return Err(ResponsePlanError::RequestHead.into());
+    }
+    if head.is_oneway_rpc() {
+        return Err(ResponsePlanError::OneWayHead.into());
+    }
+    Ok(())
+}
+
+fn validate_body(body: &BrokerResponseBodyOwner) -> Result<(), BrokerResponseBuildError> {
+    match body {
+        BrokerResponseBodyOwner::Empty => Ok(()),
+        BrokerResponseBodyOwner::Bytes(body) => checked_body_len([body.len() as u64]).map(|_| ()),
+        BrokerResponseBodyOwner::Segments(segments) => {
+            checked_body_len(segments.iter().map(|segment| segment.len() as u64)).map(|_| ())
+        }
+        BrokerResponseBodyOwner::FileRegions(regions) => checked_body_len([regions.len()]).map(|_| ()),
+    }
+}
+
+fn checked_body_len(lengths: impl IntoIterator<Item = u64>) -> Result<usize, BrokerResponseBuildError> {
+    let mut body_len = 0_u64;
+    for len in lengths {
+        body_len = body_len.checked_add(len).ok_or(ResponsePlanError::BodyLengthOverflow)?;
+    }
+    if body_len > MAX_RESPONSE_BODY_LEN {
+        return Err(ResponsePlanError::BodyTooLarge { actual: body_len }.into());
+    }
+    usize::try_from(body_len).map_err(|_| ResponsePlanError::BodyLengthNotRepresentable { actual: body_len }.into())
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum StoreFileRegionStage {
+    TransferHandle,
+    Region,
+    Sequence,
+}
+
+fn try_store_file_regions_with<Available, Lease>(
+    selections: &[SelectMappedBufferResult],
+    mut available: Available,
+    mut lease: Lease,
+) -> Option<FileRegionSequence>
+where
+    Available: FnMut(usize, StoreFileRegionStage) -> bool,
+    Lease: FnMut(FileRangeTransferHandle) -> Arc<dyn FileRegionLease>,
+{
+    // File-region transfer is an optional optimization. Keep every selection untouched until the
+    // complete sequence exists so any unavailable stage can fall back without exposing its error.
+    if selections.is_empty() {
+        return None;
+    }
+
+    let mut ranges = Vec::with_capacity(selections.len());
+    for selection in selections {
+        let range = selection.file_range()?;
+        ranges.push(range);
+    }
+
+    let mut regions = Vec::with_capacity(ranges.len());
+    for (index, range) in ranges.into_iter().enumerate() {
+        let len = u64::try_from(range.len()).ok()?;
+        if !available(index, StoreFileRegionStage::TransferHandle) {
+            return None;
+        }
+        let handle = range.try_transfer_handle().ok()?;
+        let lease = lease(handle);
+        if !available(index, StoreFileRegionStage::Region) {
+            return None;
+        }
+        let region = FileRegion::try_new(lease, range.position(), len).ok()?;
+        regions.push(region);
+    }
+    if !available(regions.len(), StoreFileRegionStage::Sequence) {
+        return None;
+    }
+    FileRegionSequence::try_new(regions).ok()
+}
+
+/// Consumes store selections into ordered owner-backed body-only byte segments.
+pub(crate) fn store_body_segments(selections: Vec<SelectMappedBufferResult>) -> Vec<Bytes> {
+    selections
+        .into_iter()
+        .map(SelectMappedBufferResult::into_owner_bytes)
+        .collect()
+}
+
+/// Chooses all-file-regions or consumes every selection into ordered body segments.
+pub(crate) fn store_response_parts(
+    head: RemotingCommand,
+    selections: Vec<SelectMappedBufferResult>,
+) -> Result<BrokerResponseParts, BrokerResponseBuildError> {
+    store_response_parts_with(
+        head,
+        selections,
+        |_, _| true,
+        |handle| Arc::new(StoreFileRegionLease::new(handle)),
+    )
+}
+
+fn store_response_parts_with<Available, Lease>(
+    head: RemotingCommand,
+    selections: Vec<SelectMappedBufferResult>,
+    available: Available,
+    lease: Lease,
+) -> Result<BrokerResponseParts, BrokerResponseBuildError>
+where
+    Available: FnMut(usize, StoreFileRegionStage) -> bool,
+    Lease: FnMut(FileRangeTransferHandle) -> Arc<dyn FileRegionLease>,
+{
+    if let Some(regions) = try_store_file_regions_with(&selections, available, lease) {
+        BrokerResponseParts::file_regions(head, regions)
+    } else {
+        BrokerResponseParts::segments(head, store_body_segments(selections))
+    }
+}
+
+#[cfg(test)]
+#[path = "response_plan/tests.rs"]
+mod tests;

--- a/rocketmq-broker/src/processor/response_plan/pop.rs
+++ b/rocketmq-broker/src/processor/response_plan/pop.rs
@@ -1,0 +1,67 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::Bytes;
+use rocketmq_protocol::protocol::header::pop_message_response_header::PopMessageResponseHeader;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_store::GetMessageResult;
+use rocketmq_transport::api::v1::Channel;
+
+use super::store_body_segments;
+use super::BrokerResponseParts;
+use super::LegacyResponseDelivery;
+
+pub(crate) fn attach_pop_response_header(
+    mut head: RemotingCommand,
+    response_header: PopMessageResponseHeader,
+) -> RemotingCommand {
+    debug_assert!(head.body().is_none());
+    head.set_command_custom_header_ref(response_header);
+    head
+}
+
+pub(crate) fn pop_heap_response_parts(
+    head: RemotingCommand,
+    body: Option<Bytes>,
+) -> rocketmq_error::RocketMQResult<BrokerResponseParts> {
+    match body {
+        Some(body) => BrokerResponseParts::bytes(head, body).map_err(Into::into),
+        None => BrokerResponseParts::command(head).map_err(Into::into),
+    }
+}
+
+pub(crate) fn pop_segmented_response_parts(
+    head: RemotingCommand,
+    body_segments: Vec<Bytes>,
+) -> rocketmq_error::RocketMQResult<BrokerResponseParts> {
+    BrokerResponseParts::segments(head, body_segments).map_err(Into::into)
+}
+
+pub(crate) fn take_pop_body_segments(get_message_result: GetMessageResult) -> Vec<Bytes> {
+    store_body_segments(get_message_result.message_mapped_vec())
+}
+
+pub(crate) async fn deliver_pop_legacy(
+    parts: BrokerResponseParts,
+    channel: &Channel,
+) -> rocketmq_error::RocketMQResult<Option<RemotingCommand>> {
+    match parts.deliver_legacy(channel).await? {
+        LegacyResponseDelivery::Command(command) => Ok(Some(command)),
+        LegacyResponseDelivery::Written => Ok(None),
+    }
+}
+
+#[cfg(test)]
+#[path = "pop/tests.rs"]
+mod tests;

--- a/rocketmq-broker/src/processor/response_plan/pop/tests.rs
+++ b/rocketmq-broker/src/processor/response_plan/pop/tests.rs
@@ -1,0 +1,176 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use cheetah_string::CheetahString;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::header::pop_message_response_header::PopMessageResponseHeader;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_store::GetMessageResult;
+use rocketmq_store::SelectMappedBufferResult;
+use rocketmq_transport::api::v1::Channel;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::ResponseBodyKind;
+use rocketmq_transport::test_support::Connection;
+use rocketmq_transport::test_support::TestChannelBuilder;
+
+use super::attach_pop_response_header;
+use super::deliver_pop_legacy;
+use super::pop_heap_response_parts;
+use super::pop_segmented_response_parts;
+use super::take_pop_body_segments;
+
+fn response_header() -> PopMessageResponseHeader {
+    PopMessageResponseHeader {
+        pop_time: 17,
+        invisible_time: 23,
+        revive_qid: 3,
+        rest_num: 5,
+        start_offset_info: Some(CheetahString::from_static_str("start")),
+        msg_offset_info: Some(CheetahString::from_static_str("message")),
+        order_count_info: Some(CheetahString::from_static_str("order")),
+    }
+}
+
+fn assert_response_header(actual: &PopMessageResponseHeader, expected: &PopMessageResponseHeader) {
+    assert_eq!(actual.pop_time, expected.pop_time);
+    assert_eq!(actual.invisible_time, expected.invisible_time);
+    assert_eq!(actual.revive_qid, expected.revive_qid);
+    assert_eq!(actual.rest_num, expected.rest_num);
+    assert_eq!(actual.start_offset_info, expected.start_offset_info);
+    assert_eq!(actual.msg_offset_info, expected.msg_offset_info);
+    assert_eq!(actual.order_count_info, expected.order_count_info);
+}
+
+#[test]
+fn success_head_is_body_free_and_has_identical_heap_and_segment_metadata() {
+    let expected = response_header();
+    let heap_head = attach_pop_response_header(RemotingCommand::create_success_response_command(), expected.clone());
+    let segment_head = attach_pop_response_header(RemotingCommand::create_success_response_command(), expected.clone());
+
+    for head in [&heap_head, &segment_head] {
+        assert!(head.body().is_none());
+        let actual = head
+            .read_custom_header_ref::<PopMessageResponseHeader>()
+            .expect("POP response header must remain attached to the body-free head");
+        assert_response_header(actual, &expected);
+    }
+}
+
+#[test]
+fn heap_success_builds_one_bytes_reply_without_a_channel() {
+    let body = Bytes::from_static(b"heap-pop-body");
+    let head = attach_pop_response_header(RemotingCommand::create_success_response_command(), response_header());
+    let outcome = pop_heap_response_parts(head, Some(body.clone()))
+        .expect("heap response parts")
+        .into_handler_outcome()
+        .expect("heap response plan");
+    let HandlerOutcome::Reply(plan) = outcome else {
+        panic!("immediate POP success must be represented by a reply plan");
+    };
+
+    assert_eq!(ResponseCode::Success as i32, plan.response_code());
+    assert_eq!(ResponseBodyKind::Bytes, plan.body_kind());
+    assert_eq!(body.len(), plan.body_len());
+    assert_eq!(1, plan.body_part_count());
+}
+
+#[test]
+fn non_heap_success_moves_ordered_body_only_segments_into_a_reply() {
+    let first = Bytes::from_static(b"\0\0\0\x08body-one");
+    let second = Bytes::from_static(b"body-two");
+    let first_pointer = first.as_ptr();
+    let second_pointer = second.as_ptr();
+    let mut result = GetMessageResult::new();
+    result.add_message_inner(SelectMappedBufferResult::from_bytes(0, first).expect("first POP selection"));
+    result.add_message_inner(SelectMappedBufferResult::from_bytes(8, second).expect("second POP selection"));
+
+    let body_segments = take_pop_body_segments(result);
+    assert_eq!(2, body_segments.len());
+    assert_eq!(b"\0\0\0\x08body-one"[..], body_segments[0]);
+    assert_eq!(b"body-two"[..], body_segments[1]);
+    assert_eq!(first_pointer, body_segments[0].as_ptr());
+    assert_eq!(second_pointer, body_segments[1].as_ptr());
+
+    let body_len = body_segments.iter().map(Bytes::len).sum::<usize>();
+    let head = attach_pop_response_header(RemotingCommand::create_success_response_command(), response_header());
+    let outcome = pop_segmented_response_parts(head, body_segments)
+        .expect("segmented response parts")
+        .into_handler_outcome()
+        .expect("segmented response plan");
+    let HandlerOutcome::Reply(plan) = outcome else {
+        panic!("immediate non-heap POP success must be represented by a reply plan");
+    };
+
+    assert_eq!(ResponseCode::Success as i32, plan.response_code());
+    assert_eq!(ResponseBodyKind::Segments, plan.body_kind());
+    assert_eq!(body_len, plan.body_len());
+    assert_eq!(2, plan.body_part_count());
+}
+
+struct CountingBodyOwner {
+    body: &'static [u8],
+    drops: Arc<AtomicUsize>,
+}
+
+impl AsRef<[u8]> for CountingBodyOwner {
+    fn as_ref(&self) -> &[u8] {
+        self.body
+    }
+}
+
+impl Drop for CountingBodyOwner {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+async fn closed_test_channel() -> Channel {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind POP compatibility listener");
+    let address = listener.local_addr().expect("POP compatibility address");
+    let stream = std::net::TcpStream::connect(address).expect("connect POP compatibility stream");
+    let accepted = listener.accept().expect("accept POP compatibility stream").0;
+    stream.set_nonblocking(true).expect("set POP stream nonblocking");
+
+    let mut connection = Connection::new(tokio::net::TcpStream::from_std(stream).expect("Tokio POP stream"));
+    connection.shutdown().await.expect("shut down POP test connection");
+    drop(accepted);
+
+    TestChannelBuilder::new(connection, crate::test_task_group("pop-legacy-closed-channel"))
+        .addresses(address, address)
+        .build()
+        .expect("build closed POP test channel")
+}
+
+#[tokio::test]
+async fn segmented_legacy_write_failure_consumes_and_drops_body_once() {
+    let channel = closed_test_channel().await;
+    let drops = Arc::new(AtomicUsize::new(0));
+    let body = Bytes::from_owner(CountingBodyOwner {
+        body: b"segmented-pop-body",
+        drops: Arc::clone(&drops),
+    });
+    let head = attach_pop_response_header(RemotingCommand::create_success_response_command(), response_header());
+    let parts = pop_segmented_response_parts(head, vec![body]).expect("segmented POP response parts");
+    assert_eq!(0, drops.load(Ordering::SeqCst));
+
+    let result = deliver_pop_legacy(parts, &channel).await;
+
+    assert!(result.is_err(), "closed POP connection must reject the write");
+    assert_eq!(1, drops.load(Ordering::SeqCst));
+}

--- a/rocketmq-broker/src/processor/response_plan/tests.rs
+++ b/rocketmq-broker/src/processor/response_plan/tests.rs
@@ -1,0 +1,359 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+
+use cheetah_string::CheetahString;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_store::DefaultMappedFile;
+use rocketmq_store::MappedFile;
+use rocketmq_transport::api::v2::ResponseBodyKind;
+
+use super::*;
+
+fn response_head() -> RemotingCommand {
+    RemotingCommand::create_response_command_with_code(ResponseCode::Success)
+}
+
+struct DropBytes {
+    bytes: &'static [u8],
+    drops: Arc<AtomicUsize>,
+}
+
+struct CountingFileLease {
+    file: File,
+    drops: Arc<AtomicUsize>,
+}
+
+impl FileRegionLease for CountingFileLease {
+    fn file(&self) -> &File {
+        &self.file
+    }
+}
+
+impl Drop for CountingFileLease {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+struct CountingStoreLease {
+    inner: StoreFileRegionLease,
+    drops: Arc<AtomicUsize>,
+}
+
+impl FileRegionLease for CountingStoreLease {
+    fn file(&self) -> &File {
+        self.inner.file()
+    }
+}
+
+impl Drop for CountingStoreLease {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+impl AsRef<[u8]> for DropBytes {
+    fn as_ref(&self) -> &[u8] {
+        self.bytes
+    }
+}
+
+impl Drop for DropBytes {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[test]
+fn response_parts_reject_every_invalid_head_before_storing_an_owner() {
+    let with_body = response_head().set_body(Bytes::from_static(b"body"));
+    assert!(matches!(
+        BrokerResponseParts::command(with_body),
+        Err(BrokerResponseBuildError::ResponsePlan(ResponsePlanError::HeadHasBody))
+    ));
+
+    assert!(matches!(
+        BrokerResponseParts::command(RemotingCommand::create_remoting_command(11)),
+        Err(BrokerResponseBuildError::ResponsePlan(ResponsePlanError::RequestHead))
+    ));
+
+    assert!(matches!(
+        BrokerResponseParts::command(response_head().mark_oneway_rpc()),
+        Err(BrokerResponseBuildError::ResponsePlan(ResponsePlanError::OneWayHead))
+    ));
+}
+
+#[test]
+fn bytes_owner_moves_into_the_plan_without_a_builder_copy() {
+    let drops = Arc::new(AtomicUsize::new(0));
+    let body = Bytes::from_owner(DropBytes {
+        bytes: b"owner-backed-body",
+        drops: Arc::clone(&drops),
+    });
+    let pointer = body.as_ptr();
+
+    let parts = BrokerResponseParts::bytes(response_head(), body).expect("valid byte response parts");
+    let BrokerResponseBodyOwner::Bytes(stored) = parts.body() else {
+        panic!("non-empty bytes must remain the response owner");
+    };
+    assert_eq!(stored.as_ptr(), pointer);
+    assert_eq!(drops.load(Ordering::SeqCst), 0);
+
+    let plan = parts.into_response_plan().expect("valid byte response plan");
+    assert_eq!(plan.body_kind(), ResponseBodyKind::Bytes);
+    assert_eq!(plan.body_len(), 17);
+    assert_eq!(plan.body_part_count(), 1);
+    assert_eq!(drops.load(Ordering::SeqCst), 0);
+    drop(plan);
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn segments_are_body_only_ordered_and_move_their_backing_allocations() {
+    let first = Bytes::from_static(b"first");
+    let second = Bytes::from_static(b"second");
+    let first_pointer = first.as_ptr();
+    let second_pointer = second.as_ptr();
+
+    let parts = BrokerResponseParts::segments(response_head(), vec![first, Bytes::new(), second])
+        .expect("valid segmented response parts");
+    let BrokerResponseBodyOwner::Segments(stored) = parts.body() else {
+        panic!("non-empty segments must remain segmented");
+    };
+    assert_eq!(stored.len(), 3);
+    assert_eq!(stored[0].as_ptr(), first_pointer);
+    assert!(stored[1].is_empty());
+    assert_eq!(stored[2].as_ptr(), second_pointer);
+    assert_eq!(stored[0], b"first"[..]);
+    assert_eq!(stored[2], b"second"[..]);
+
+    let plan = parts.into_response_plan().expect("valid segmented response plan");
+    assert_eq!(plan.body_kind(), ResponseBodyKind::Segments);
+    assert_eq!(plan.body_len(), 11);
+    assert_eq!(plan.body_part_count(), 2);
+}
+
+#[test]
+fn empty_bytes_and_segments_normalize_to_an_empty_command_plan() {
+    let byte_plan = BrokerResponseParts::bytes(response_head(), Bytes::new())
+        .expect("valid empty bytes")
+        .into_response_plan()
+        .expect("valid empty byte plan");
+    let segment_plan = BrokerResponseParts::segments(response_head(), vec![Bytes::new()])
+        .expect("valid empty segments")
+        .into_response_plan()
+        .expect("valid empty segment plan");
+
+    assert_eq!(byte_plan.body_kind(), ResponseBodyKind::Empty);
+    assert_eq!(segment_plan.body_kind(), ResponseBodyKind::Empty);
+}
+
+#[test]
+fn handler_outcome_seam_exposes_reply_metadata() {
+    let outcome = BrokerResponseParts::bytes(response_head(), Bytes::from_static(b"reply"))
+        .expect("valid reply parts")
+        .into_handler_outcome()
+        .expect("valid reply outcome");
+
+    let HandlerOutcome::Reply(plan) = outcome else {
+        panic!("immediate Broker responses must become Reply outcomes");
+    };
+    assert_eq!(plan.response_code(), ResponseCode::Success as i32);
+    assert_eq!(plan.body_kind(), ResponseBodyKind::Bytes);
+    assert_eq!(plan.body_len(), 5);
+}
+
+#[test]
+fn all_store_file_ranges_become_one_affine_file_region_sequence() {
+    let directory = tempfile::tempdir().expect("temporary response-plan range directory");
+    let path = directory.path().join("00000000000000000000");
+    let mapped_file =
+        DefaultMappedFile::try_new(CheetahString::from(path.to_string_lossy().into_owned()), 64).expect("mapped file");
+    assert!(mapped_file.append_message_bytes(b"ordered-regions"));
+
+    let first = mapped_file
+        .try_file_range_selection(0, 8)
+        .expect("first selection")
+        .expect("published first range");
+    let second = mapped_file
+        .try_file_range_selection(8, 7)
+        .expect("second selection")
+        .expect("published second range");
+    assert!(!first.has_byte_snapshot());
+    assert!(!second.has_byte_snapshot());
+
+    let parts = store_response_parts(response_head(), vec![first, second]).expect("file-region response parts");
+    assert!(matches!(
+        parts.body(),
+        BrokerResponseBodyOwner::FileRegions(regions) if regions.len() == 15
+    ));
+
+    let plan = parts.into_response_plan().expect("file-region response plan");
+    assert_eq!(plan.body_kind(), ResponseBodyKind::FileRegions);
+    assert_eq!(plan.body_len(), 15);
+    assert_eq!(plan.body_part_count(), 2);
+}
+
+#[test]
+fn file_region_lease_moves_from_builder_to_plan_and_drops_once() {
+    let file = tempfile::tempfile().expect("temporary response-plan file");
+    file.set_len(16).expect("size temporary response-plan file");
+    let drops = Arc::new(AtomicUsize::new(0));
+    let region = FileRegion::try_new(
+        Arc::new(CountingFileLease {
+            file,
+            drops: Arc::clone(&drops),
+        }),
+        0,
+        16,
+    )
+    .expect("validated counting region");
+    let regions = FileRegionSequence::try_new(vec![region]).expect("validated counting sequence");
+
+    let parts = BrokerResponseParts::file_regions(response_head(), regions).expect("file-region response parts");
+    assert_eq!(drops.load(Ordering::SeqCst), 0);
+    let plan = parts.into_response_plan().expect("file-region response plan");
+    assert_eq!(plan.body_kind(), ResponseBodyKind::FileRegions);
+    assert_eq!(drops.load(Ordering::SeqCst), 0);
+
+    drop(plan);
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn mixed_store_sources_fall_back_to_all_segments_without_reordering() {
+    let directory = tempfile::tempdir().expect("temporary mixed response-plan directory");
+    let path = directory.path().join("00000000000000000000");
+    let mapped_file =
+        DefaultMappedFile::try_new(CheetahString::from(path.to_string_lossy().into_owned()), 64).expect("mapped file");
+    assert!(mapped_file.append_message_bytes(b"file-first"));
+
+    let file_selection = mapped_file
+        .try_file_range_selection(0, 10)
+        .expect("file selection")
+        .expect("published file range");
+    let bytes = Bytes::from_static(b"bytes-second");
+    let bytes_pointer = bytes.as_ptr();
+    let byte_selection = SelectMappedBufferResult::from_bytes(10, bytes).expect("byte selection");
+
+    let parts = store_response_parts(response_head(), vec![file_selection, byte_selection])
+        .expect("mixed-source response parts");
+    let BrokerResponseBodyOwner::Segments(segments) = parts.body() else {
+        panic!("mixed selections must use the all-segments fallback");
+    };
+    assert_eq!(segments.len(), 2);
+    assert_eq!(segments[0], b"file-first"[..]);
+    assert_eq!(segments[1], b"bytes-second"[..]);
+    assert_eq!(segments[1].as_ptr(), bytes_pointer);
+}
+
+fn assert_injected_file_region_failure_falls_back(
+    failure_index: usize,
+    failure_stage: StoreFileRegionStage,
+    expected_attempt_drops: usize,
+) {
+    let directory = tempfile::tempdir().expect("temporary injected-fallback directory");
+    let path = directory.path().join("00000000000000000000");
+    let mapped_file =
+        DefaultMappedFile::try_new(CheetahString::from(path.to_string_lossy().into_owned()), 64).expect("mapped file");
+    assert!(mapped_file.append_message_bytes(b"firstsecond"));
+
+    let first = mapped_file
+        .try_file_range_selection(0, 5)
+        .expect("first selection")
+        .expect("first range");
+    let second = mapped_file
+        .try_file_range_selection(5, 6)
+        .expect("second selection")
+        .expect("second range");
+    assert!(!first.has_byte_snapshot());
+    assert!(!second.has_byte_snapshot());
+
+    let attempt_drops = Arc::new(AtomicUsize::new(0));
+    let attempt_drops_for_lease = Arc::clone(&attempt_drops);
+    let parts = store_response_parts_with(
+        response_head(),
+        vec![first, second],
+        |index, stage| !(index == failure_index && stage == failure_stage),
+        move |handle| -> Arc<dyn FileRegionLease> {
+            Arc::new(CountingStoreLease {
+                inner: StoreFileRegionLease::new(handle),
+                drops: Arc::clone(&attempt_drops_for_lease),
+            })
+        },
+    )
+    .expect("optimization failure must use the segment fallback");
+
+    assert_eq!(attempt_drops.load(Ordering::SeqCst), expected_attempt_drops);
+    let BrokerResponseBodyOwner::Segments(segments) = parts.body() else {
+        panic!("failed file-region optimization must preserve all selections as segments");
+    };
+    assert_eq!(segments.len(), 2);
+    assert_eq!(segments[0], b"first"[..]);
+    assert_eq!(segments[1], b"second"[..]);
+
+    let plan = parts.into_response_plan().expect("fallback response plan");
+    assert_eq!(plan.body_kind(), ResponseBodyKind::Segments);
+    assert_eq!(plan.body_len(), 11);
+    assert_eq!(plan.body_part_count(), 2);
+    drop(plan);
+    assert_eq!(attempt_drops.load(Ordering::SeqCst), expected_attempt_drops);
+}
+
+#[test]
+fn transfer_handle_failure_after_one_region_falls_back_without_losing_owners() {
+    assert_injected_file_region_failure_falls_back(1, StoreFileRegionStage::TransferHandle, 1);
+}
+
+#[test]
+fn region_failure_after_one_region_falls_back_without_losing_owners() {
+    assert_injected_file_region_failure_falls_back(1, StoreFileRegionStage::Region, 2);
+}
+
+#[test]
+fn sequence_failure_releases_all_attempted_regions_before_segment_fallback() {
+    assert_injected_file_region_failure_falls_back(2, StoreFileRegionStage::Sequence, 2);
+}
+
+#[tokio::test]
+async fn legacy_heap_delivery_returns_an_explicit_command() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind test listener");
+    let address = listener.local_addr().expect("listener address");
+    let stream = std::net::TcpStream::connect(address).expect("connect test stream");
+    stream.set_nonblocking(true).expect("nonblocking test stream");
+    let _accepted = listener.accept().expect("accept test stream");
+    let connection = rocketmq_transport::test_support::Connection::new(
+        tokio::net::TcpStream::from_std(stream).expect("Tokio test stream"),
+    );
+    let channel = rocketmq_transport::test_support::TestChannelBuilder::new(
+        connection,
+        crate::test_task_group("broker-response-plan-command"),
+    )
+    .addresses(address, address)
+    .build()
+    .expect("test channel");
+
+    let delivery = BrokerResponseParts::bytes(response_head(), Bytes::from_static(b"legacy"))
+        .expect("valid legacy parts")
+        .deliver_legacy(&channel)
+        .await
+        .expect("legacy command delivery");
+    let LegacyResponseDelivery::Command(command) = delivery else {
+        panic!("heap compatibility delivery must return a command");
+    };
+    assert_eq!(command.body(), Some(&Bytes::from_static(b"legacy")));
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9824

### Brief Description

- Add broker-private affine response parts for empty, contiguous bytes, ordered body segments, and leased file regions.
- Move immediate Pull and Pop response construction behind channel-free builders while preserving their V1 compatibility delivery and long-poll behavior.
- Add an unregistered Query/ViewMessageById V2 leaf that moves existing owned bytes into a response plan and leaves opaque rebinding to the canonical dispatcher.
- Preserve ordered segment fallback when file-region optimization is unavailable, including partial lease cleanup, and split Pop planning helpers into a focused module.
- Add ownership, fallback, closed-connection compatibility, header parity, and real V2 TCP opaque-binding coverage.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-broker -- --check`: passed.
- `git diff --check`: passed.
- `cargo test -p rocketmq-broker --all-features --lib processor::response_plan -- --nocapture`: 16 passed.
- `cargo test -p rocketmq-broker --all-features --lib pull_message_processor -- --nocapture`: 27 passed.
- `cargo test -p rocketmq-broker --all-features --lib default_pull_message_result_handler -- --nocapture`: 4 passed.
- `cargo test -p rocketmq-broker --all-features --lib pop_message_processor -- --nocapture`: 30 passed.
- `cargo test -p rocketmq-broker --all-features --lib query_message_processor -- --nocapture`: 13 passed.
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings`: passed during independent review.
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`: passed.
- `cargo +nightly-2026-07-05 check --locked --all-targets --all-features` from `fuzz/`: passed with the existing Windows linker message warning.
- A full `cargo test -p rocketmq-broker --lib` run was attempted; it remains blocked by the pre-existing stack overflow in `three_controller_two_broker_controller_leader_failover_keeps_broker_view_consistent`, which also reproduces when isolated and is outside the changed processor paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved broker message responses for pull, POP, query, and view operations.
  * Added support for efficient segmented and file-based response delivery.
  * Added V2 request handling for query message operations.
  * Preserved compatibility with existing response delivery paths.

* **Bug Fixes**
  * Improved handling of suspended requests, delivery failures, and mixed response sources.
  * Added safer fallback behavior when optimized file delivery is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->