### PR TITLE
[ISSUE #9826]🧪Verify broker response wire equivalence and lease lifetimes

### DIFF
--- a/rocketmq-broker/src/processor/default_pull_message_result_handler.rs
+++ b/rocketmq-broker/src/processor/default_pull_message_result_handler.rs
@@ -324,6 +324,32 @@ fn store_result(
     )?))
 }
 
+#[cfg(test)]
+pub(crate) fn pull_bytes_wire_fixture_parts(
+    response: RemotingCommand,
+    body: Bytes,
+) -> rocketmq_error::RocketMQResult<BrokerResponseParts> {
+    let PullMessageResult::Reply(parts) = bytes_result(response, body)? else {
+        return Err(rocketmq_error::RocketMQError::invariant_violated(
+            "the Pull bytes builder unexpectedly suspended",
+        ));
+    };
+    Ok(parts)
+}
+
+#[cfg(test)]
+pub(crate) fn pull_store_wire_fixture_parts(
+    response: RemotingCommand,
+    result: GetMessageResult,
+) -> rocketmq_error::RocketMQResult<BrokerResponseParts> {
+    let PullMessageResult::Reply(parts) = store_result(response, result)? else {
+        return Err(rocketmq_error::RocketMQError::invariant_violated(
+            "the Pull store-result builder unexpectedly suspended",
+        ));
+    };
+    Ok(parts)
+}
+
 impl<MS: BrokerReadStore> DefaultPullMessageResultHandler<MS> {
     /// Read message result and return (body bytes, last store timestamp)
     fn read_get_message_result(

--- a/rocketmq-broker/src/processor/query_message_processor.rs
+++ b/rocketmq-broker/src/processor/query_message_processor.rs
@@ -156,12 +156,16 @@ impl QueryResponseParts {
         self.into_legacy_command()
     }
 
-    fn into_handler_outcome(self) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+    fn into_broker_response_parts(self) -> rocketmq_error::RocketMQResult<BrokerResponseParts> {
         let parts = match self.body {
             Some(body) => BrokerResponseParts::bytes(self.head, body)?,
             None => BrokerResponseParts::command(self.head)?,
         };
-        parts.into_handler_outcome()
+        Ok(parts)
+    }
+
+    fn into_handler_outcome(self) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        self.into_broker_response_parts()?.into_handler_outcome()
     }
 }
 
@@ -435,6 +439,119 @@ where
                 .set_remark(format!("can not find message by offset: {}", request_header.offset)),
         ))
     }
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy)]
+pub(crate) enum QueryWireFixtureKind {
+    Query,
+    View,
+}
+
+#[cfg(test)]
+#[derive(Clone, Default)]
+struct QueryWireFixtureStore {
+    query_body: Option<bytes::Bytes>,
+    view_body: Option<bytes::Bytes>,
+}
+
+#[cfg(test)]
+impl QueryMessageStore for QueryWireFixtureStore {
+    async fn query_message(&self, _request: &QueryMessageRequest) -> Result<Option<QueryMessageResult>, StoreError> {
+        let Some(body) = self.query_body.clone() else {
+            return Ok(None);
+        };
+        let Some(selected) = SelectMappedBufferResult::from_bytes(0, body) else {
+            return Ok(None);
+        };
+        let mut result = QueryMessageResult {
+            index_last_update_phyoffset: 17,
+            index_last_update_timestamp: 23,
+            ..QueryMessageResult::default()
+        };
+        result.add_message(selected);
+        Ok(Some(result))
+    }
+
+    fn select_message_by_offset(&self, _offset: i64) -> Result<Option<SelectMappedBufferResult>, StoreError> {
+        Ok(self
+            .view_body
+            .clone()
+            .and_then(|body| SelectMappedBufferResult::from_bytes(0, body)))
+    }
+}
+
+#[cfg(test)]
+async fn query_wire_fixture_response(
+    kind: QueryWireFixtureKind,
+    body: Option<&[u8]>,
+) -> rocketmq_error::RocketMQResult<QueryResponseParts> {
+    use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandDefaults;
+
+    let body = body.map(bytes::Bytes::copy_from_slice);
+    let store = match kind {
+        QueryWireFixtureKind::Query => QueryWireFixtureStore {
+            query_body: body,
+            view_body: None,
+        },
+        QueryWireFixtureKind::View => QueryWireFixtureStore {
+            query_body: None,
+            view_body: body,
+        },
+    };
+    let factory = RemotingCommandFactory::new(RemotingCommandDefaults::default());
+    let mut processor = QueryMessageProcessor::new_with_factory(64, store, factory);
+    let mut request = match kind {
+        QueryWireFixtureKind::Query => factory.create_request_command(
+            RequestCode::QueryMessage,
+            QueryMessageRequestHeader {
+                topic: CheetahString::from_static_str("TopicA"),
+                key: CheetahString::from_static_str("KeyA"),
+                max_num: 32,
+                begin_timestamp: 0,
+                end_timestamp: i64::MAX,
+                index_type: None,
+                last_key: None,
+                topic_request_header: None,
+            },
+        ),
+        QueryWireFixtureKind::View => factory.create_request_command(
+            RequestCode::ViewMessageById,
+            ViewMessageRequestHeader {
+                topic: Some(CheetahString::from_static_str("TopicA")),
+                offset: 41,
+            },
+        ),
+    };
+    request.make_custom_header_to_net();
+    let response = match kind {
+        QueryWireFixtureKind::Query => processor.query_message_parts(&mut request).await?,
+        QueryWireFixtureKind::View => processor.view_message_by_id_parts(&mut request).await?,
+    };
+    Ok(response)
+}
+
+#[cfg(test)]
+pub(crate) async fn query_wire_fixture_legacy_command(
+    kind: QueryWireFixtureKind,
+    body: Option<&[u8]>,
+    opaque: i32,
+) -> rocketmq_error::RocketMQResult<RemotingCommand> {
+    let response = query_wire_fixture_response(kind, body).await?;
+    Ok(match kind {
+        QueryWireFixtureKind::Query => response.into_legacy_command_with_opaque(opaque),
+        QueryWireFixtureKind::View => response.into_legacy_command(),
+    })
+}
+
+#[cfg(test)]
+pub(crate) async fn query_wire_fixture_parts(
+    kind: QueryWireFixtureKind,
+    body: Option<&[u8]>,
+) -> rocketmq_error::RocketMQResult<BrokerResponseParts> {
+    query_wire_fixture_response(kind, body)
+        .await?
+        .into_broker_response_parts()
 }
 
 #[cfg(test)]

--- a/rocketmq-broker/src/processor/response_plan.rs
+++ b/rocketmq-broker/src/processor/response_plan.rs
@@ -290,3 +290,7 @@ where
 #[cfg(test)]
 #[path = "response_plan/tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "response_plan/tests/wire_equivalence.rs"]
+mod wire_equivalence;

--- a/rocketmq-broker/src/processor/response_plan/tests/wire_equivalence.rs
+++ b/rocketmq-broker/src/processor/response_plan/tests/wire_equivalence.rs
@@ -1,0 +1,687 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::PathBuf;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use bytes::BytesMut;
+use cheetah_string::CheetahString;
+use rocketmq_error::RocketMQError;
+use rocketmq_error::RocketMQResult;
+use rocketmq_protocol::code::request_code::RequestCode;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::header::pop_message_response_header::PopMessageResponseHeader;
+use rocketmq_protocol::protocol::header::pull_message_response_header::PullMessageResponseHeader;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandDefaults;
+use rocketmq_protocol::protocol::remoting_command_defaults::RemotingCommandFactory;
+use rocketmq_protocol::protocol::LanguageCode;
+use rocketmq_protocol::protocol::SerializeType;
+use rocketmq_protocol::version::CURRENT_VERSION;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use rocketmq_store::DefaultMappedFile;
+use rocketmq_store::GetMessageResult;
+use rocketmq_store::MappedFile;
+use rocketmq_store::SelectMappedBufferResult;
+use rocketmq_transport::api::v1::FileTransferMode;
+use rocketmq_transport::api::v1::ServerConfig;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestProcessorV2;
+use rocketmq_transport::api::v2::TransportServerV2;
+use rocketmq_transport::test_support::Connection;
+use rocketmq_transport::test_support::TestChannelBuilder;
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpListener;
+use tokio::net::TcpStream;
+use tokio::sync::oneshot;
+
+use crate::processor::default_pull_message_result_handler::pull_bytes_wire_fixture_parts;
+use crate::processor::default_pull_message_result_handler::pull_store_wire_fixture_parts;
+use crate::processor::query_message_processor::query_wire_fixture_legacy_command;
+use crate::processor::query_message_processor::query_wire_fixture_parts;
+use crate::processor::query_message_processor::QueryWireFixtureKind;
+
+use super::pop::attach_pop_response_header;
+use super::pop::pop_heap_response_parts;
+use super::pop::pop_segmented_response_parts;
+use super::BrokerResponseParts;
+use super::LegacyResponseDelivery;
+
+const INGRESS_OPAQUE: i32 = 9_271;
+const BUILDER_PLACEHOLDER_OPAQUE: i32 = -1;
+const MAX_TEST_FRAME_BYTES: usize = 1024 * 1024;
+
+enum FixtureBody {
+    Empty,
+    Bytes(Vec<u8>),
+    Segments(Vec<Vec<u8>>),
+    FileRegion { directory: PathBuf, body: Vec<u8> },
+}
+
+#[derive(Clone, Copy)]
+enum FixtureBuilder {
+    PullBytes,
+    PullStore,
+    PopHeap,
+    PopSegments,
+    Query,
+    View,
+}
+
+struct ExpectedFrame {
+    code: ResponseCode,
+    remark: Option<&'static str>,
+    ext_fields: &'static [(&'static str, &'static str)],
+    body: &'static [u8],
+}
+
+struct SemanticFixture {
+    label: &'static str,
+    request_code: RequestCode,
+    finalized_body_free_head: Option<RemotingCommand>,
+    body: FixtureBody,
+    builder: FixtureBuilder,
+    expected: ExpectedFrame,
+    builds: AtomicUsize,
+}
+
+enum LegacyFixtureProjection {
+    Parts(BrokerResponseParts),
+    Command(RemotingCommand),
+}
+
+impl SemanticFixture {
+    fn new(
+        label: &'static str,
+        request_code: RequestCode,
+        finalized_body_free_head: Option<RemotingCommand>,
+        body: FixtureBody,
+        builder: FixtureBuilder,
+        expected: ExpectedFrame,
+    ) -> Self {
+        let finalized_body_free_head = finalized_body_free_head.map(|mut head| {
+            head.set_opaque_mut(BUILDER_PLACEHOLDER_OPAQUE);
+            head.make_custom_header_to_net();
+            assert!(head.body().is_none());
+            head
+        });
+        Self {
+            label,
+            request_code,
+            finalized_body_free_head,
+            body,
+            builder,
+            expected,
+            builds: AtomicUsize::new(0),
+        }
+    }
+
+    fn finalized_head(&self, opaque: i32) -> RocketMQResult<RemotingCommand> {
+        let mut head = self.finalized_body_free_head.clone().ok_or_else(|| {
+            RocketMQError::invariant_violated("fixture builder does not own a finalized response head")
+        })?;
+        head.set_opaque_mut(opaque);
+        Ok(head)
+    }
+
+    fn pull_store_result(&self, build_index: usize) -> RocketMQResult<GetMessageResult> {
+        let selections = match &self.body {
+            FixtureBody::Segments(segments) => segments
+                .iter()
+                .enumerate()
+                .map(|(index, segment)| {
+                    SelectMappedBufferResult::from_bytes(index as u64, Bytes::copy_from_slice(segment))
+                        .ok_or_else(|| RocketMQError::invariant_violated("Pull segment length is not representable"))
+                })
+                .collect::<RocketMQResult<Vec<_>>>()?,
+            FixtureBody::FileRegion { directory, body } => {
+                let path = directory.join(format!("{build_index:020}"));
+                let mapped_file =
+                    DefaultMappedFile::try_new(CheetahString::from(path.to_string_lossy().into_owned()), 64)
+                        .map_err(|source| RocketMQError::internal("wire-equivalence-pull-mapped-file", source))?;
+                if !mapped_file.append_message_bytes(body) {
+                    return Err(RocketMQError::invariant_violated(
+                        "Pull FileRegion fixture did not fit its mapped file",
+                    ));
+                }
+                vec![mapped_file
+                    .try_file_range_selection(0, body.len())
+                    .map_err(|source| RocketMQError::internal("wire-equivalence-pull-file-range", source))?
+                    .ok_or_else(|| RocketMQError::invariant_violated("Pull FileRegion fixture was not published"))?]
+            }
+            _ => {
+                return Err(RocketMQError::invariant_violated(
+                    "Pull store fixture requires segments or a FileRegion",
+                ));
+            }
+        };
+        let mut result = GetMessageResult::new_result_size(selections.len());
+        for (index, selection) in selections.into_iter().enumerate() {
+            result.add_message(selection, index as u64, 1);
+        }
+        Ok(result)
+    }
+
+    async fn build_parts(&self, head_opaque: i32) -> RocketMQResult<BrokerResponseParts> {
+        let build_index = self.builds.fetch_add(1, Ordering::SeqCst);
+        match (&self.builder, &self.body) {
+            (FixtureBuilder::PullBytes, FixtureBody::Bytes(body)) => {
+                pull_bytes_wire_fixture_parts(self.finalized_head(head_opaque)?, Bytes::copy_from_slice(body))
+            }
+            (FixtureBuilder::PullStore, FixtureBody::Segments(_) | FixtureBody::FileRegion { .. }) => {
+                pull_store_wire_fixture_parts(self.finalized_head(head_opaque)?, self.pull_store_result(build_index)?)
+            }
+            (FixtureBuilder::PopHeap, FixtureBody::Bytes(body)) => {
+                pop_heap_response_parts(self.finalized_head(head_opaque)?, Some(Bytes::copy_from_slice(body)))
+            }
+            (FixtureBuilder::PopSegments, FixtureBody::Segments(segments)) => pop_segmented_response_parts(
+                self.finalized_head(head_opaque)?,
+                segments.iter().map(|segment| Bytes::copy_from_slice(segment)).collect(),
+            ),
+            (FixtureBuilder::Query, FixtureBody::Bytes(body)) => {
+                query_wire_fixture_parts(QueryWireFixtureKind::Query, Some(body)).await
+            }
+            (FixtureBuilder::Query, FixtureBody::Empty) => {
+                query_wire_fixture_parts(QueryWireFixtureKind::Query, None).await
+            }
+            (FixtureBuilder::View, FixtureBody::Bytes(body)) => {
+                query_wire_fixture_parts(QueryWireFixtureKind::View, Some(body)).await
+            }
+            (FixtureBuilder::View, FixtureBody::Empty) => {
+                query_wire_fixture_parts(QueryWireFixtureKind::View, None).await
+            }
+            _ => Err(RocketMQError::invariant_violated(
+                "wire equivalence fixture body does not match its builder",
+            )),
+        }
+    }
+
+    async fn build_legacy_projection(&self) -> RocketMQResult<LegacyFixtureProjection> {
+        let query_body = match &self.body {
+            FixtureBody::Bytes(body) => Some(body.as_slice()),
+            FixtureBody::Empty => None,
+            _ => None,
+        };
+        match self.builder {
+            FixtureBuilder::Query => {
+                self.builds.fetch_add(1, Ordering::SeqCst);
+                query_wire_fixture_legacy_command(QueryWireFixtureKind::Query, query_body, INGRESS_OPAQUE)
+                    .await
+                    .map(LegacyFixtureProjection::Command)
+            }
+            FixtureBuilder::View => {
+                self.builds.fetch_add(1, Ordering::SeqCst);
+                query_wire_fixture_legacy_command(QueryWireFixtureKind::View, query_body, INGRESS_OPAQUE)
+                    .await
+                    .map(LegacyFixtureProjection::Command)
+            }
+            _ => self
+                .build_parts(INGRESS_OPAQUE)
+                .await
+                .map(LegacyFixtureProjection::Parts),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct FixtureProcessor {
+    fixture: Arc<SemanticFixture>,
+}
+
+impl RequestProcessorV2 for FixtureProcessor {
+    async fn process(&mut self, _request: &mut RemotingRequest) -> RocketMQResult<HandlerOutcome> {
+        self.fixture
+            .build_parts(BUILDER_PLACEHOLDER_OPAQUE)
+            .await?
+            .into_handler_outcome()
+    }
+}
+
+async fn read_raw_frame(stream: &mut TcpStream) -> Vec<u8> {
+    let mut length_prefix = [0_u8; 4];
+    stream
+        .read_exact(&mut length_prefix)
+        .await
+        .expect("read complete RocketMQ frame length prefix");
+    let payload_len = i32::from_be_bytes(length_prefix);
+    assert!(
+        payload_len >= 4,
+        "invalid RocketMQ test frame payload length {payload_len}"
+    );
+    let payload_len = usize::try_from(payload_len).expect("positive test frame length");
+    assert!(payload_len <= MAX_TEST_FRAME_BYTES, "unexpectedly large test frame");
+
+    let mut frame = vec![0_u8; payload_len + length_prefix.len()];
+    frame[..length_prefix.len()].copy_from_slice(&length_prefix);
+    stream
+        .read_exact(&mut frame[length_prefix.len()..])
+        .await
+        .expect("read complete RocketMQ frame payload");
+    frame
+}
+
+async fn capture_legacy_frame(owner: &RuntimeOwner, fixture: &SemanticFixture) -> Vec<u8> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind V1 wire-equivalence listener");
+    let address = listener.local_addr().expect("V1 wire-equivalence address");
+    let mut peer = TcpStream::connect(address)
+        .await
+        .expect("connect V1 wire-equivalence peer");
+    let (server_stream, _) = listener.accept().await.expect("accept V1 wire-equivalence peer");
+    let channel_context = owner.root_context().component(format!("{}-v1-channel", fixture.label));
+    let connection = Connection::new(server_stream)
+        .with_file_region_io(channel_context.storage_io().clone(), FileTransferMode::Portable);
+    let channel = TestChannelBuilder::new(connection, channel_context.task_group().clone())
+        .addresses(address, address)
+        .build()
+        .expect("build V1 wire-equivalence channel");
+
+    match fixture
+        .build_legacy_projection()
+        .await
+        .expect("build V1 semantic response projection")
+    {
+        LegacyFixtureProjection::Parts(parts) => {
+            match parts
+                .deliver_legacy(&channel)
+                .await
+                .expect("deliver V1 semantic response")
+            {
+                LegacyResponseDelivery::Command(command) => channel
+                    .send_command(command.set_opaque(INGRESS_OPAQUE))
+                    .await
+                    .expect("send V1 command response through the real channel"),
+                LegacyResponseDelivery::Written => {}
+            }
+        }
+        LegacyFixtureProjection::Command(command) => channel
+            .send_command(command.set_opaque(INGRESS_OPAQUE))
+            .await
+            .expect("send the production V1 Query/View projection through the real channel"),
+    }
+
+    let frame = tokio::time::timeout(Duration::from_secs(2), read_raw_frame(&mut peer))
+        .await
+        .expect("V1 raw frame capture deadline");
+    peer.shutdown().await.expect("half-close the raw V1 peer");
+    let report = channel.close_with_report(Duration::from_secs(1)).await;
+    assert!(report.is_healthy(), "{}", report.to_json());
+    drop(channel);
+    let mut trailing = Vec::new();
+    peer.read_to_end(&mut trailing)
+        .await
+        .expect("read the drained V1 socket to EOF");
+    assert!(
+        trailing.is_empty(),
+        "{} V1 socket emitted trailing bytes",
+        fixture.label
+    );
+    frame
+}
+
+async fn capture_v2_frame(owner: &RuntimeOwner, fixture: Arc<SemanticFixture>) -> Vec<u8> {
+    let label = fixture.label;
+    let request_code = fixture.request_code;
+    let server = TransportServerV2::new(
+        Arc::new(ServerConfig {
+            bind_address: "127.0.0.1".to_owned(),
+            listen_port: 0,
+            ..ServerConfig::default()
+        }),
+        owner.root_context().component(format!("{label}-v2-server")),
+        FixtureProcessor { fixture },
+    );
+    let runner = owner.root_context().component(format!("{label}-v2-runner"));
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let (startup_tx, startup_rx) = oneshot::channel();
+    let (result_tx, result_rx) = oneshot::channel();
+    runner
+        .spawn_service(format!("{label}-v2-run"), async move {
+            let result = server
+                .try_run_with_shutdown_report_and_startup(
+                    async move {
+                        let _ = shutdown_rx.await;
+                    },
+                    startup_tx,
+                )
+                .await;
+            let _ = result_tx.send(result);
+        })
+        .expect("spawn owned V2 wire-equivalence server");
+
+    let address = startup_rx
+        .await
+        .expect("V2 startup channel")
+        .expect("V2 wire-equivalence server startup");
+    let mut stream = TcpStream::connect(address)
+        .await
+        .expect("connect raw V2 wire-equivalence client");
+    let mut request = RemotingCommand::create_remoting_command(request_code as i32).set_opaque(INGRESS_OPAQUE);
+    let request_frame = request
+        .encode_header_with_body_length(0)
+        .expect("encode raw V2 wire-equivalence request");
+    stream
+        .write_all(&request_frame)
+        .await
+        .expect("write raw V2 wire-equivalence request");
+
+    let frame = tokio::time::timeout(Duration::from_secs(2), read_raw_frame(&mut stream))
+        .await
+        .expect("V2 raw frame capture deadline");
+    stream.shutdown().await.expect("shutdown raw V2 client");
+    let _ = shutdown_tx.send(());
+    let report = tokio::time::timeout(Duration::from_secs(2), result_rx)
+        .await
+        .expect("V2 server shutdown deadline")
+        .expect("V2 server result channel")
+        .expect("V2 server shutdown report");
+    assert!(report.is_healthy(), "{}", report.to_json());
+    let mut trailing = Vec::new();
+    stream
+        .read_to_end(&mut trailing)
+        .await
+        .expect("read the drained V2 socket to EOF");
+    assert!(trailing.is_empty(), "{label} V2 socket emitted trailing bytes");
+    frame
+}
+
+fn assert_protocol_expectations(frame: &[u8], fixture: &SemanticFixture) {
+    let announced = i32::from_be_bytes(frame[..4].try_into().expect("complete frame prefix"));
+    assert_eq!(
+        usize::try_from(announced).expect("positive announced frame length"),
+        frame.len() - 4,
+        "{} announced payload length",
+        fixture.label
+    );
+    assert_eq!(
+        SerializeType::JSON.get_code(),
+        frame[4],
+        "{} raw serialization marker",
+        fixture.label
+    );
+
+    let mut encoded = BytesMut::from(frame);
+    let command = RemotingCommand::decode(&mut encoded)
+        .expect("decode captured response frame")
+        .expect("captured response is one complete frame");
+    assert!(encoded.is_empty(), "{} must contain exactly one frame", fixture.label);
+    assert_eq!(
+        fixture.expected.code as i32,
+        command.code(),
+        "{} response code",
+        fixture.label
+    );
+    assert_eq!(
+        INGRESS_OPAQUE,
+        command.opaque(),
+        "{} bound ingress opaque",
+        fixture.label
+    );
+    assert_eq!(1, command.flag(), "{} response flag bits", fixture.label);
+    assert!(command.is_response_type(), "{} response type", fixture.label);
+    assert!(!command.is_oneway_rpc(), "{} cannot be one-way", fixture.label);
+    assert_eq!(
+        fixture.expected.remark,
+        command.remark().map(|remark| remark.as_str()),
+        "{} response remark",
+        fixture.label
+    );
+    assert_eq!(LanguageCode::RUST, command.language(), "{} language", fixture.label);
+    assert_eq!(CURRENT_VERSION as i32, command.version(), "{} version", fixture.label);
+    assert_eq!(
+        SerializeType::JSON,
+        command.serialize_type(),
+        "{} serialize type",
+        fixture.label
+    );
+
+    let fields = command.ext_fields();
+    assert_eq!(
+        fixture.expected.ext_fields.len(),
+        fields.map_or(0, |fields| fields.len()),
+        "{} extension-field count",
+        fixture.label
+    );
+    for &(key, value) in fixture.expected.ext_fields {
+        assert_eq!(
+            Some(value),
+            fields.and_then(|fields| fields.get(key)).map(|value| value.as_str()),
+            "{} extension field {key}",
+            fixture.label
+        );
+    }
+    assert_eq!(
+        fixture.expected.body,
+        command.body().map(Bytes::as_ref).unwrap_or_default(),
+        "{} ordered response body",
+        fixture.label
+    );
+}
+
+fn finalized_pull_head() -> RemotingCommand {
+    test_command_factory()
+        .create_success_response_command_with_header(PullMessageResponseHeader {
+            suggest_which_broker_id: 1,
+            next_begin_offset: 11,
+            min_offset: 3,
+            max_offset: 29,
+            offset_delta: Some(2),
+            topic_sys_flag: Some(4),
+            group_sys_flag: Some(8),
+            forbidden_type: Some(0),
+        })
+        .set_remark("wire-equivalence-pull")
+}
+
+fn finalized_pop_head() -> RemotingCommand {
+    attach_pop_response_header(
+        test_command_factory()
+            .create_success_response_command()
+            .set_remark("wire-equivalence-pop"),
+        PopMessageResponseHeader {
+            pop_time: 101,
+            invisible_time: 30_000,
+            revive_qid: 7,
+            rest_num: 13,
+            start_offset_info: Some("0 1 2".into()),
+            msg_offset_info: Some("3 4 5".into()),
+            order_count_info: Some("6 7 8".into()),
+        },
+    )
+}
+
+fn test_command_factory() -> RemotingCommandFactory {
+    RemotingCommandFactory::new(RemotingCommandDefaults::default())
+}
+
+const PULL_EXT_FIELDS: &[(&str, &str)] = &[
+    ("suggestWhichBrokerId", "1"),
+    ("nextBeginOffset", "11"),
+    ("minOffset", "3"),
+    ("maxOffset", "29"),
+    ("offsetDelta", "2"),
+    ("topicSysFlag", "4"),
+    ("groupSysFlag", "8"),
+    ("forbiddenType", "0"),
+];
+const POP_EXT_FIELDS: &[(&str, &str)] = &[
+    ("popTime", "101"),
+    ("invisibleTime", "30000"),
+    ("reviveQid", "7"),
+    ("restNum", "13"),
+    ("startOffsetInfo", "0 1 2"),
+    ("msgOffsetInfo", "3 4 5"),
+    ("orderCountInfo", "6 7 8"),
+];
+const QUERY_SUCCESS_EXT_FIELDS: &[(&str, &str)] =
+    &[("indexLastUpdateTimestamp", "23"), ("indexLastUpdatePhyoffset", "17")];
+const QUERY_EMPTY_EXT_FIELDS: &[(&str, &str)] = &[("indexLastUpdateTimestamp", "0"), ("indexLastUpdatePhyoffset", "0")];
+
+#[tokio::test]
+async fn broker_special_paths_match_complete_v1_and_v2_wire_frames() {
+    let owner = RuntimeOwner::new(RuntimeConfig::server_default("broker-wire-equivalence"))
+        .expect("wire-equivalence runtime owner");
+    let directory = tempfile::tempdir().expect("wire-equivalence file-region directory");
+
+    let fixtures = [
+        Arc::new(SemanticFixture::new(
+            "pull-heap-bytes",
+            RequestCode::PullMessage,
+            Some(finalized_pull_head()),
+            FixtureBody::Bytes(b"pull-heap-body".to_vec()),
+            FixtureBuilder::PullBytes,
+            ExpectedFrame {
+                code: ResponseCode::Success,
+                remark: Some("wire-equivalence-pull"),
+                ext_fields: PULL_EXT_FIELDS,
+                body: b"pull-heap-body",
+            },
+        )),
+        Arc::new(SemanticFixture::new(
+            "pull-segments",
+            RequestCode::PullMessage,
+            Some(finalized_pull_head()),
+            FixtureBody::Segments(vec![b"pull-segment-a".to_vec(), b"pull-segment-b".to_vec()]),
+            FixtureBuilder::PullStore,
+            ExpectedFrame {
+                code: ResponseCode::Success,
+                remark: Some("wire-equivalence-pull"),
+                ext_fields: PULL_EXT_FIELDS,
+                body: b"pull-segment-apull-segment-b",
+            },
+        )),
+        Arc::new(SemanticFixture::new(
+            "pull-file-region",
+            RequestCode::PullMessage,
+            Some(finalized_pull_head()),
+            FixtureBody::FileRegion {
+                directory: directory.path().to_owned(),
+                body: b"pull-file-region-body".to_vec(),
+            },
+            FixtureBuilder::PullStore,
+            ExpectedFrame {
+                code: ResponseCode::Success,
+                remark: Some("wire-equivalence-pull"),
+                ext_fields: PULL_EXT_FIELDS,
+                body: b"pull-file-region-body",
+            },
+        )),
+        Arc::new(SemanticFixture::new(
+            "pop-heap-bytes",
+            RequestCode::PopMessage,
+            Some(finalized_pop_head()),
+            FixtureBody::Bytes(b"pop-heap-body".to_vec()),
+            FixtureBuilder::PopHeap,
+            ExpectedFrame {
+                code: ResponseCode::Success,
+                remark: Some("wire-equivalence-pop"),
+                ext_fields: POP_EXT_FIELDS,
+                body: b"pop-heap-body",
+            },
+        )),
+        Arc::new(SemanticFixture::new(
+            "pop-segments",
+            RequestCode::PopMessage,
+            Some(finalized_pop_head()),
+            FixtureBody::Segments(vec![b"pop-segment-a".to_vec(), b"pop-segment-b".to_vec()]),
+            FixtureBuilder::PopSegments,
+            ExpectedFrame {
+                code: ResponseCode::Success,
+                remark: Some("wire-equivalence-pop"),
+                ext_fields: POP_EXT_FIELDS,
+                body: b"pop-segment-apop-segment-b",
+            },
+        )),
+        Arc::new(SemanticFixture::new(
+            "query-bytes",
+            RequestCode::QueryMessage,
+            None,
+            FixtureBody::Bytes(b"query-result-body".to_vec()),
+            FixtureBuilder::Query,
+            ExpectedFrame {
+                code: ResponseCode::Success,
+                remark: None,
+                ext_fields: QUERY_SUCCESS_EXT_FIELDS,
+                body: b"query-result-body",
+            },
+        )),
+        Arc::new(SemanticFixture::new(
+            "query-empty-error",
+            RequestCode::QueryMessage,
+            None,
+            FixtureBody::Empty,
+            FixtureBuilder::Query,
+            ExpectedFrame {
+                code: ResponseCode::QueryNotFound,
+                remark: Some("query message failed, no result returned"),
+                ext_fields: QUERY_EMPTY_EXT_FIELDS,
+                body: b"",
+            },
+        )),
+        Arc::new(SemanticFixture::new(
+            "view-bytes",
+            RequestCode::ViewMessageById,
+            None,
+            FixtureBody::Bytes(b"view-result-body".to_vec()),
+            FixtureBuilder::View,
+            ExpectedFrame {
+                code: ResponseCode::Success,
+                remark: None,
+                ext_fields: &[],
+                body: b"view-result-body",
+            },
+        )),
+        Arc::new(SemanticFixture::new(
+            "view-empty-error",
+            RequestCode::ViewMessageById,
+            None,
+            FixtureBody::Empty,
+            FixtureBuilder::View,
+            ExpectedFrame {
+                code: ResponseCode::SystemError,
+                remark: Some("can not find message by offset: 41"),
+                ext_fields: &[],
+                body: b"",
+            },
+        )),
+    ];
+
+    for fixture in fixtures {
+        let legacy = capture_legacy_frame(&owner, fixture.as_ref()).await;
+        let v2 = capture_v2_frame(&owner, Arc::clone(&fixture)).await;
+
+        assert_eq!(legacy, v2, "{} must be raw-wire equivalent", fixture.label);
+        assert_protocol_expectations(&legacy, fixture.as_ref());
+        assert_protocol_expectations(&v2, fixture.as_ref());
+        assert_eq!(
+            2,
+            fixture.builds.load(Ordering::SeqCst),
+            "{} must build independent affine owners for V1 and V2",
+            fixture.label
+        );
+    }
+
+    let task_report = owner.shutdown_tasks().await;
+    assert!(task_report.is_healthy(), "{}", task_report.to_json());
+    let final_report = owner.shutdown_background();
+    assert!(final_report.is_healthy(), "{}", final_report.to_json());
+}

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/delivery_hooks.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/delivery_hooks.rs
@@ -13,6 +13,60 @@
 // limitations under the License.
 
 use super::harness::*;
+
+struct DispatchCountingLease {
+    file: std::fs::File,
+    accesses: Arc<AtomicUsize>,
+    drops: Arc<AtomicUsize>,
+}
+
+impl crate::file_region::FileRegionLease for DispatchCountingLease {
+    fn file(&self) -> &std::fs::File {
+        self.accesses.fetch_add(1, Ordering::SeqCst);
+        &self.file
+    }
+}
+
+impl Drop for DispatchCountingLease {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[derive(Default)]
+struct FileReplyState {
+    plan: Mutex<Option<ResponsePlan>>,
+    observations: Mutex<Vec<ResponseWriteObservationV2>>,
+    observed: tokio::sync::Notify,
+}
+
+#[derive(Clone)]
+struct FileReplyProcessor {
+    state: Arc<FileReplyState>,
+}
+
+impl RequestProcessorV2 for FileReplyProcessor {
+    async fn process(&mut self, _request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        Ok(HandlerOutcome::Reply(
+            self.state
+                .plan
+                .lock()
+                .expect("file reply plan lock")
+                .take()
+                .expect("file reply plan should be consumed once"),
+        ))
+    }
+
+    fn observe_response_write(&self, observation: ResponseWriteObservationV2) {
+        self.state
+            .observations
+            .lock()
+            .expect("file reply observation lock")
+            .push(observation);
+        self.state.observed.notify_one();
+    }
+}
+
 #[tokio::test]
 async fn admitted_reply_uses_body_free_hooks_resolve_bind_writer_and_one_observation_in_order() {
     let mut harness = DispatchHarness::new("dispatch-v2-reply").await;
@@ -82,6 +136,104 @@ async fn admitted_reply_uses_body_free_hooks_resolve_bind_writer_and_one_observa
             if receipt.request_id() == original.request_id()
                 && receipt.disposition() == ResponseDisposition::TransportWritten
     ));
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn file_region_crosses_v2_hooks_and_metric_projection_without_entering_the_observation() {
+    use std::io::Write;
+
+    let (mut harness, writer_barrier) =
+        DispatchHarness::new_with_post_start_barrier("dispatch-v2-file-region-ownership").await;
+    let accesses = Arc::new(AtomicUsize::new(0));
+    let drops = Arc::new(AtomicUsize::new(0));
+    let mut file = tempfile::tempfile().expect("temporary dispatch file");
+    file.write_all(b"dispatch-file-body").expect("write dispatch file body");
+    let lease = Arc::new(DispatchCountingLease {
+        file,
+        accesses: Arc::clone(&accesses),
+        drops: Arc::clone(&drops),
+    });
+    let region = crate::file_region::FileRegion::try_new(lease.clone(), 0, 18).expect("dispatch file region");
+    let plan = ResponsePlan::file_regions(
+        RemotingCommand::create_response_command_with_code(79),
+        crate::file_region::FileRegionSequence::single(region),
+    )
+    .expect("dispatch file-region response plan");
+    drop(lease);
+    assert_eq!(accesses.load(Ordering::SeqCst), 1);
+    assert_eq!(drops.load(Ordering::SeqCst), 0);
+
+    let state = Arc::new(FileReplyState {
+        plan: Mutex::new(Some(plan)),
+        ..FileReplyState::default()
+    });
+    let processor = FileReplyProcessor {
+        state: Arc::clone(&state),
+    };
+    let hook_events = Arc::new(Mutex::new(Vec::new()));
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+        processor,
+        vec![Arc::new(hook(false, false, Arc::clone(&hook_events)))],
+    ));
+    let command = request(false);
+    let (session, original) = harness.request_session(&command);
+
+    let outcome = dispatcher
+        .dispatch(&harness.authorized, session, harness.context(None), command, 256, None)
+        .await
+        .expect("dispatch file response");
+    assert!(matches!(outcome, DispatchOutcome::Accepted(_)));
+    writer_barrier.wait_reached().await;
+
+    assert_eq!(
+        hook_events.lock().expect("hook events lock").as_slice(),
+        ["before", "after"]
+    );
+    assert!(state.observations.lock().expect("observation lock").is_empty());
+    assert_eq!(
+        drops.load(Ordering::SeqCst),
+        0,
+        "canonical writer still owns the file plan"
+    );
+
+    writer_barrier.release();
+    let response = harness.receive().await;
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let observed = state.observed.notified();
+            if !state.observations.lock().expect("observation lock").is_empty() {
+                break;
+            }
+            observed.await;
+        }
+    })
+    .await
+    .expect("file response observation");
+
+    assert_eq!(response.opaque(), 811);
+    assert_eq!(response.code(), 79);
+    assert_eq!(response.body().map(Bytes::as_ref), Some(&b"dispatch-file-body"[..]));
+    assert!(accesses.load(Ordering::SeqCst) >= 2);
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+    let observation = state.observations.lock().expect("observation lock")[0];
+    assert_eq!(observation.request_id(), original.request_id());
+    assert_eq!(observation.original_code(), 91);
+    assert_eq!(observation.response_code(), 79);
+    assert_eq!(observation.body_kind(), ResponseBodyKind::FileRegions);
+    assert_eq!(observation.path(), ResponseWritePath::Inline);
+    assert!(matches!(
+        observation.outcome(),
+        ResponseWriteOutcomeV2::Written(receipt)
+            if receipt.request_id() == original.request_id()
+                && receipt.disposition() == ResponseDisposition::TransportWritten
+    ));
+    assert_eq!(
+        drops.load(Ordering::SeqCst),
+        1,
+        "scalar observation must not retain the lease"
+    );
+
     harness.shutdown().await;
 }
 

--- a/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/harness.rs
+++ b/rocketmq-transport/src/dispatch/authorized_dispatcher/v2/tests/harness.rs
@@ -492,7 +492,10 @@ impl DispatchHarness {
         let local_addr = "127.0.0.1:19131".parse().expect("local address");
         let remote_addr = "127.0.0.1:19132".parse().expect("remote address");
         let runner = tokio::spawn(run_connected_session(
-            Connection::new_with_plaintext_stream(transport),
+            Connection::new_with_plaintext_stream(transport).with_file_region_io(
+                runtime.blocking(rocketmq_runtime::BlockingLane::StorageIo).clone(),
+                crate::file_region::FileTransferMode::Portable,
+            ),
             local_addr,
             remote_addr,
             service.task_group().clone(),

--- a/rocketmq-transport/src/dispatch/response_plan.rs
+++ b/rocketmq-transport/src/dispatch/response_plan.rs
@@ -699,10 +699,20 @@ mod tests {
         let regions = FileRegionSequence::try_new(vec![region]).expect("validated region sequence");
 
         assert_eq!(Arc::strong_count(&lease), 2);
-        let plan = ResponsePlan::file_regions(response_head(), regions).expect("valid file-region response");
+        let mut plan = ResponsePlan::file_regions(response_head(), regions).expect("valid file-region response");
         assert_eq!(file_accesses.load(Ordering::SeqCst), 1);
         assert_metadata(&plan, ResponseBodyKind::FileRegions, 11, 1);
         assert_eq!(Arc::strong_count(&lease), 2);
+        plan.with_body_free_hook_head(|head| {
+            assert!(head.body().is_none());
+            head.set_remark_mut("hook-observed");
+            Ok(())
+        })
+        .expect("body-free hook projection");
+        assert_eq!(plan.response_code(), 7);
+        assert_eq!(plan.body_len(), 11);
+        assert_eq!(file_accesses.load(Ordering::SeqCst), 1);
+        assert_eq!(drops.load(Ordering::SeqCst), 0);
         let debug = format!("{plan:?}");
         assert!(!debug.contains("FileRegion {"));
         assert!(!debug.contains("offset"));

--- a/rocketmq-transport/src/dispatch/response_sink/plan_tests/harness_tests.rs
+++ b/rocketmq-transport/src/dispatch/response_sink/plan_tests/harness_tests.rs
@@ -309,6 +309,20 @@ impl NetworkHarness {
         let report = runtime.shutdown_tasks(Duration::from_secs(1)).await;
         assert!(report.is_healthy(), "{}", report.to_json());
     }
+
+    async fn close_and_collect_frames(mut self) -> Vec<RemotingCommand> {
+        self.peer.shutdown().await.expect("close peer write half");
+        self.runner.await.expect("connected session runner should drain");
+        drop(self.session);
+
+        let mut frames = Vec::new();
+        while let Some(frame) = self.peer.receive_command().await {
+            frames.push(frame.expect("drained response frame should decode"));
+        }
+        let report = self.runtime.shutdown_tasks(Duration::from_secs(1)).await;
+        assert!(report.is_healthy(), "{}", report.to_json());
+        frames
+    }
 }
 
 impl FileRegionLease for CountingLease {
@@ -322,6 +336,23 @@ impl Drop for CountingLease {
     fn drop(&mut self) {
         self.drops.fetch_add(1, Ordering::SeqCst);
     }
+}
+
+fn counting_file_plan(code: i32, opaque: i32, body: &[u8]) -> (ResponsePlan, Arc<AtomicUsize>, Arc<AtomicUsize>) {
+    let accesses = Arc::new(AtomicUsize::new(0));
+    let drops = Arc::new(AtomicUsize::new(0));
+    let mut file = tempfile::tempfile().expect("temporary counting lease file");
+    file.write_all(body).expect("write counting lease body");
+    let lease = Arc::new(CountingLease {
+        file,
+        accesses: Arc::clone(&accesses),
+        drops: Arc::clone(&drops),
+    });
+    let region = FileRegion::try_new(lease.clone(), 0, body.len() as u64).expect("counting file region");
+    let plan = ResponsePlan::file_regions(response_head(code, opaque), FileRegionSequence::single(region))
+        .expect("counting file response plan");
+    drop(lease);
+    (plan, accesses, drops)
 }
 
 #[path = "local.rs"]

--- a/rocketmq-transport/src/dispatch/response_sink/plan_tests/network.rs
+++ b/rocketmq-transport/src/dispatch/response_sink/plan_tests/network.rs
@@ -27,6 +27,7 @@ async fn network_plan_prepares_and_writes_all_four_bodies_before_issuing_receipt
     )
     .await;
     let encodes = Arc::new(AtomicUsize::new(0));
+    let (file_plan, file_accesses, file_drops) = counting_file_plan(94, 903, b"file-body");
     let plans = [
         ResponsePlan::command(response_head(91, 900)).expect("empty response plan"),
         ResponsePlan::bytes(
@@ -41,15 +42,11 @@ async fn network_plan_prepares_and_writes_all_four_bodies_before_issuing_receipt
             vec![Bytes::from_static(b"segment-"), Bytes::from_static(b"body")],
         )
         .expect("segments response plan"),
-        {
-            let mut file = tempfile::tempfile().expect("temporary file");
-            file.write_all(b"file-body").expect("write file body");
-            let region = FileRegion::try_new(Arc::new(file), 0, 9).expect("file region");
-            ResponsePlan::file_regions(response_head(94, 903), FileRegionSequence::single(region))
-                .expect("file response plan")
-        },
+        file_plan,
     ];
     let expected_bodies: [&[u8]; 4] = [b"", b"bytes-body", b"segment-body", b"file-body"];
+    assert_eq!(file_accesses.load(Ordering::SeqCst), 1);
+    assert_eq!(file_drops.load(Ordering::SeqCst), 0);
 
     for (index, (plan, expected_body)) in plans.into_iter().zip(expected_bodies).enumerate() {
         let owner = 801 + index as u64;
@@ -66,29 +63,30 @@ async fn network_plan_prepares_and_writes_all_four_bodies_before_issuing_receipt
         let received = harness.receive().await;
         assert_eq!(received.opaque(), 1_001 + index as i32);
         assert_eq!(received.body().map(Bytes::as_ref).unwrap_or_default(), expected_body);
+        if index == 3 {
+            assert!(file_accesses.load(Ordering::SeqCst) >= 2);
+            assert_eq!(file_drops.load(Ordering::SeqCst), 1);
+        }
     }
     assert_eq!(encodes.load(Ordering::SeqCst), 1);
+    assert_eq!(file_drops.load(Ordering::SeqCst), 1);
 
     harness.shutdown().await;
 }
 
 #[tokio::test]
 async fn network_plan_flush_failure_reports_exact_progress_and_never_issues_or_retries_a_receipt() {
-    let mut harness = NetworkHarness::new_with_flush_failure("network-plan-flush-failure").await;
+    let harness = NetworkHarness::new_with_flush_failure("network-plan-flush-failure").await;
+    let flushes = Arc::clone(&harness.flushes);
     let (control, _parent) = harness.control("network-plan-flush-failure-control", None);
     let sink = ResponseSink::network_plan(harness.session.clone(), AdmissionClass::Data, control);
     let duplicate = sink.clone();
+    let (plan, accesses, drops) = counting_file_plan(117, 1_117, b"written-before-flush-fails");
+    assert_eq!(accesses.load(Ordering::SeqCst), 1);
+    assert_eq!(drops.load(Ordering::SeqCst), 0);
 
     let error = sink
-        .send_plan(bind(
-            ResponsePlan::bytes(
-                response_head(117, 1_117),
-                Bytes::from_static(b"written-before-flush-fails"),
-            )
-            .expect("response plan"),
-            824,
-            1_117,
-        ))
+        .send_plan(bind(plan, 824, 1_117))
         .await
         .expect_err("flush failure must prevent a receipt");
     assert!(matches!(
@@ -112,20 +110,17 @@ async fn network_plan_flush_failure_reports_exact_progress_and_never_issues_or_r
             }
         })
     ));
-    let received = harness.receive().await;
+    let frames = harness.close_and_collect_frames().await;
+    assert_eq!(frames.len(), 1, "flush failure must write exactly one frame");
+    let received = &frames[0];
     assert_eq!(received.opaque(), 1_117);
     assert_eq!(
         received.body().map(Bytes::as_ref),
         Some(&b"written-before-flush-fails"[..])
     );
-    assert_eq!(harness.flushes.load(Ordering::SeqCst), 0);
-    let second = tokio::time::timeout(Duration::from_millis(25), harness.peer.receive_command()).await;
-    assert!(
-        !matches!(second, Ok(Some(Ok(_)))),
-        "terminal duplicate must not write a second frame"
-    );
-
-    harness.shutdown().await;
+    assert_eq!(flushes.load(Ordering::SeqCst), 0);
+    assert!(accesses.load(Ordering::SeqCst) >= 2);
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
 }
 
 #[tokio::test]
@@ -246,18 +241,7 @@ async fn network_plan_queue_rejection_is_not_started_and_drops_a_file_lease_once
         None,
     )
     .await;
-    let accesses = Arc::new(AtomicUsize::new(0));
-    let drops = Arc::new(AtomicUsize::new(0));
-    let mut file = tempfile::tempfile().expect("temporary file");
-    file.write_all(b"leased body").expect("write leased body");
-    let lease = Arc::new(CountingLease {
-        file,
-        accesses: Arc::clone(&accesses),
-        drops: Arc::clone(&drops),
-    });
-    let region = FileRegion::try_new(lease.clone(), 0, 11).expect("file region");
-    let plan = ResponsePlan::file_regions(response_head(99, 1_009), FileRegionSequence::single(region))
-        .expect("response plan");
+    let (plan, accesses, drops) = counting_file_plan(99, 1_009, b"leased body");
     let (control, _parent) = harness.control("network-plan-queue-reject-control", None);
     let sink = ResponseSink::network_plan(harness.session.clone(), AdmissionClass::Data, control);
     let duplicate = sink.clone();
@@ -281,9 +265,6 @@ async fn network_plan_queue_rejection_is_not_started_and_drops_a_file_lease_once
         })
     ));
     assert_eq!(accesses.load(Ordering::SeqCst), 1);
-    assert_eq!(Arc::strong_count(&lease), 1);
-    assert_eq!(drops.load(Ordering::SeqCst), 0);
-    drop(lease);
     assert_eq!(drops.load(Ordering::SeqCst), 1);
 
     harness.shutdown().await;
@@ -492,7 +473,7 @@ async fn session_close_after_writer_claim_but_before_start_stays_closed_and_writ
     let checked = Arc::new(tokio::sync::Notify::new());
     let resume = Arc::new(tokio::sync::Notify::new());
     let barrier = crate::write_strategy::WritePreflightBarrier::new(Arc::clone(&checked), Arc::clone(&resume));
-    let mut harness = NetworkHarness::new(
+    let harness = NetworkHarness::new(
         "network-plan-claimed-close",
         FrameLimits::default(),
         AdmissionLimits::default(),
@@ -508,13 +489,11 @@ async fn session_close_after_writer_claim_but_before_start_stays_closed_and_writ
         Arc::clone(&enqueued),
     );
     let duplicate = sink.clone();
-    let send = tokio::spawn(sink.send_plan(bind(
-        ResponsePlan::bytes(response_head(115, 1_115), Bytes::from_static(b"must-not-start")).expect("response plan"),
-        822,
-        1_115,
-    )));
+    let (plan, accesses, drops) = counting_file_plan(115, 1_115, b"must-not-start");
+    let send = tokio::spawn(sink.send_plan(bind(plan, 822, 1_115)));
     enqueued.notified().await;
     checked.notified().await;
+    assert_eq!(drops.load(Ordering::SeqCst), 0);
     harness.session.abort();
     assert!(matches!(
         send.await.expect("plan send task"),
@@ -537,13 +516,13 @@ async fn session_close_after_writer_claim_but_before_start_stays_closed_and_writ
         "unexpected duplicate result: {duplicate_result:?}"
     );
     resume.notify_one();
-    let observed = tokio::time::timeout(Duration::from_millis(25), harness.peer.receive_command()).await;
+    let frames = harness.close_and_collect_frames().await;
     assert!(
-        !matches!(observed, Ok(Some(Ok(_)))),
-        "session close before writer start must not touch the socket"
+        frames.is_empty(),
+        "session close before writer start must not write a frame"
     );
-
-    harness.shutdown().await;
+    assert_eq!(accesses.load(Ordering::SeqCst), 1);
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
 }
 
 #[tokio::test]
@@ -619,7 +598,7 @@ async fn cancelling_a_waiting_network_send_preserves_the_reason_without_deadline
     let checked = Arc::new(tokio::sync::Notify::new());
     let resume = Arc::new(tokio::sync::Notify::new());
     let barrier = crate::write_strategy::WritePreflightBarrier::new(Arc::clone(&checked), Arc::clone(&resume));
-    let mut harness = NetworkHarness::new(
+    let harness = NetworkHarness::new(
         "network-plan-waiting-cancel",
         FrameLimits::default(),
         AdmissionLimits::default(),
@@ -644,12 +623,10 @@ async fn cancelling_a_waiting_network_send_preserves_the_reason_without_deadline
         Arc::clone(&enqueued),
     );
     let duplicate = sink.clone();
-    let send = tokio::spawn(sink.send_plan(bind(
-        ResponsePlan::bytes(response_head(107, 1_107), Bytes::from_static(b"cancelled")).expect("response plan"),
-        815,
-        1_107,
-    )));
+    let (plan, accesses, drops) = counting_file_plan(107, 1_107, b"cancelled");
+    let send = tokio::spawn(sink.send_plan(bind(plan, 815, 1_107)));
     enqueued.notified().await;
+    assert_eq!(drops.load(Ordering::SeqCst), 0);
     parent.cancel();
     assert!(matches!(
         send.await.expect("plan send task"),
@@ -667,19 +644,16 @@ async fn cancelling_a_waiting_network_send_preserves_the_reason_without_deadline
             state: ResponseTerminalState::Cancelled
         })
     ));
+    assert_eq!(accesses.load(Ordering::SeqCst), 1);
+    assert_eq!(drops.load(Ordering::SeqCst), 0);
 
     resume.notify_one();
     blocker.await.expect("blocker task should complete");
-    assert_eq!(harness.receive().await.opaque(), 1_106);
-    assert!(
-        tokio::time::timeout(Duration::from_millis(25), harness.peer.receive_command())
-            .await
-            .is_err(),
-        "cancelled waiting response must not reach the socket"
-    );
     assert_eq!(harness.session.writer_snapshot().deadline_expired, 0);
-
-    harness.shutdown().await;
+    let frames = harness.close_and_collect_frames().await;
+    assert_eq!(frames.len(), 1, "parent cancellation must not retry the response");
+    assert_eq!(frames[0].opaque(), 1_106);
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
 }
 
 #[tokio::test(start_paused = true)]

--- a/rocketmq-transport/src/write_strategy.rs
+++ b/rocketmq-transport/src/write_strategy.rs
@@ -1176,6 +1176,10 @@ fn advance_segments(
 }
 
 #[cfg(test)]
+#[path = "write_strategy/brk02_tests.rs"]
+mod brk02_tests;
+
+#[cfg(test)]
 mod file_frame_tests {
     use std::error::Error;
     use std::fmt;

--- a/rocketmq-transport/src/write_strategy/brk02_tests.rs
+++ b/rocketmq-transport/src/write_strategy/brk02_tests.rs
@@ -1,0 +1,232 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs::File;
+use std::io::Write;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+#[cfg(all(target_os = "linux", feature = "linux-sendfile"))]
+use tokio::io::AsyncReadExt;
+
+use super::select_file_transfer;
+use super::SelectedFileTransfer;
+use crate::connection::Connection;
+use crate::file_region::FileRegion;
+use crate::file_region::FileRegionLease;
+use crate::file_region::FileRegionSequence;
+use crate::file_region::FileTransferMode;
+
+struct CountingLease {
+    file: File,
+    accesses: Arc<AtomicUsize>,
+    drops: Arc<AtomicUsize>,
+}
+
+impl FileRegionLease for CountingLease {
+    fn file(&self) -> &File {
+        self.accesses.fetch_add(1, Ordering::SeqCst);
+        &self.file
+    }
+}
+
+impl Drop for CountingLease {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+fn counting_region(body: &[u8]) -> (FileRegion, Arc<AtomicUsize>, Arc<AtomicUsize>) {
+    let mut file = tempfile::tempfile().expect("temporary transfer file");
+    file.write_all(body).expect("write transfer body");
+    let accesses = Arc::new(AtomicUsize::new(0));
+    let drops = Arc::new(AtomicUsize::new(0));
+    let lease = Arc::new(CountingLease {
+        file,
+        accesses: Arc::clone(&accesses),
+        drops: Arc::clone(&drops),
+    });
+    let region = FileRegion::try_new(lease.clone(), 0, body.len() as u64).expect("validated transfer region");
+    drop(lease);
+    (region, accesses, drops)
+}
+
+fn response_head(code: i32, opaque: i32) -> RemotingCommand {
+    RemotingCommand::create_response_command_with_code(code).set_opaque(opaque)
+}
+
+#[tokio::test]
+async fn forced_portable_and_auto_compat_fallback_are_selected_without_global_counters() {
+    let owner = RuntimeOwner::new(RuntimeConfig::default()).expect("runtime owner");
+    let blocking = owner
+        .root_context()
+        .component("brk02-auto-portable")
+        .storage_io()
+        .clone();
+    let body = b"auto-portable-file-region";
+    let (region, accesses, drops) = counting_region(body);
+
+    let forced = select_file_transfer(FileTransferMode::Portable, Some(blocking.clone()), true, true, &region)
+        .await
+        .expect("forced portable selection");
+    assert!(matches!(forced, SelectedFileTransfer::Portable { fallback: false, .. }));
+    let automatic = select_file_transfer(FileTransferMode::Auto, Some(blocking.clone()), false, false, &region)
+        .await
+        .expect("automatic compatibility selection");
+    assert!(matches!(
+        automatic,
+        SelectedFileTransfer::Portable { fallback: true, .. }
+    ));
+
+    let probe = region.clone();
+    let (server_io, client_io) = tokio::io::duplex(256 * 1024);
+    let mut server =
+        Connection::new_with_plaintext_stream(server_io).with_file_region_io(blocking, FileTransferMode::Auto);
+    let mut client = Connection::new_with_plaintext_stream(client_io);
+    let send = server.send_file_regions_response(response_head(701, 71), FileRegionSequence::single(region));
+    let receive = client.receive_command();
+    let (send_result, receive_result) = tokio::join!(send, receive);
+
+    send_result.expect("automatic portable file response");
+    let received = receive_result
+        .expect("automatic portable receive")
+        .expect("automatic portable frame");
+    assert_eq!(received.opaque(), 71);
+    assert_eq!(received.body().map(bytes::Bytes::as_ref), Some(&body[..]));
+    assert!(accesses.load(Ordering::SeqCst) >= 2);
+    assert_eq!(drops.load(Ordering::SeqCst), 0);
+    #[cfg(all(target_os = "linux", feature = "linux-sendfile"))]
+    assert_eq!(probe.cached_sendfile_support(), None);
+    drop(probe);
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+}
+
+#[cfg(feature = "tls")]
+#[tokio::test]
+async fn real_rustls_file_region_stays_portable_and_never_probes_sendfile() {
+    use tokio_rustls::rustls::pki_types::ServerName;
+
+    let tls_config = crate::config::TlsConfig {
+        enable: true,
+        test_mode_enable: true,
+        ..crate::config::TlsConfig::default()
+    };
+    let acceptor = crate::tls::build_server_acceptor(&tls_config).expect("test TLS acceptor");
+    let connector = tokio_rustls::TlsConnector::from(Arc::new(
+        crate::tls::build_client_config(&tls_config).expect("test TLS client config"),
+    ));
+    let server_name = ServerName::try_from("localhost").expect("test TLS server name");
+    let (server_io, client_io) = tokio::io::duplex(256 * 1024);
+    let (server_tls, client_tls) = tokio::join!(acceptor.accept(server_io), connector.connect(server_name, client_io));
+    let server_tls = server_tls.expect("server TLS handshake");
+    let client_tls = client_tls.expect("client TLS handshake");
+
+    let owner = RuntimeOwner::new(RuntimeConfig::default()).expect("runtime owner");
+    let blocking = owner
+        .root_context()
+        .component("brk02-rustls-portable")
+        .storage_io()
+        .clone();
+    let body = vec![0x6b; 32 * 1024];
+    let (region, accesses, drops) = counting_region(&body);
+    let probe = region.clone();
+    let mut server = Connection::new_with_tls_stream(server_tls).with_file_region_io(blocking, FileTransferMode::Auto);
+    let mut client = Connection::new_with_tls_stream(client_tls);
+    let send = server.send_file_regions_response(response_head(702, 72), FileRegionSequence::single(region));
+    let receive = client.receive_command();
+    let (send_result, receive_result) = tokio::join!(send, receive);
+
+    send_result.expect("TLS portable file response");
+    let received = receive_result.expect("TLS receive").expect("TLS frame");
+    assert_eq!(received.opaque(), 72);
+    assert_eq!(received.body().map(bytes::Bytes::as_ref), Some(body.as_slice()));
+    assert!(accesses.load(Ordering::SeqCst) >= 2);
+    assert_eq!(drops.load(Ordering::SeqCst), 0);
+    #[cfg(all(target_os = "linux", feature = "linux-sendfile"))]
+    assert_eq!(probe.cached_sendfile_support(), None);
+    drop(probe);
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+}
+
+#[cfg(all(target_os = "linux", feature = "linux-sendfile"))]
+async fn capture_real_tcp_file_frame(
+    region: FileRegion,
+    blocking: rocketmq_runtime::BlockingExecutor,
+    mode: FileTransferMode,
+) -> Vec<u8> {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind loopback listener");
+    let address = listener.local_addr().expect("loopback listener address");
+    let (client, accepted) = tokio::join!(tokio::net::TcpStream::connect(address), listener.accept());
+    let mut client = client.expect("connect loopback client");
+    let server = accepted.expect("accept loopback client").0;
+    let mut server = Connection::new(server).with_file_region_io(blocking, mode);
+
+    let send = server.send_file_regions_response(response_head(703, 73), FileRegionSequence::single(region));
+    let receive = async move {
+        let mut prefix = [0_u8; 4];
+        client.read_exact(&mut prefix).await.expect("read raw frame prefix");
+        let announced = i32::from_be_bytes(prefix);
+        let payload_len = usize::try_from(announced).expect("positive raw frame length");
+        let mut frame = Vec::with_capacity(payload_len + prefix.len());
+        frame.extend_from_slice(&prefix);
+        frame.resize(payload_len + prefix.len(), 0);
+        client
+            .read_exact(&mut frame[prefix.len()..])
+            .await
+            .expect("read complete raw frame payload");
+        frame
+    };
+    let (send_result, frame) = tokio::join!(send, receive);
+    send_result.expect("real TCP file response");
+    frame
+}
+
+#[cfg(all(target_os = "linux", feature = "linux-sendfile"))]
+#[tokio::test]
+async fn auto_sendfile_and_portable_produce_identical_complete_real_tcp_frames() {
+    const BODY_LEN: usize = 64 * 1024;
+
+    let owner = RuntimeOwner::new(RuntimeConfig::default()).expect("runtime owner");
+    let blocking = owner
+        .root_context()
+        .component("brk02-linux-sendfile")
+        .storage_io()
+        .clone();
+    let body = vec![0x73; BODY_LEN];
+    let (region, accesses, drops) = counting_region(&body);
+    let probe = region.clone();
+    let portable = capture_real_tcp_file_frame(region.clone(), blocking.clone(), FileTransferMode::Portable).await;
+    assert_eq!(probe.cached_sendfile_support(), None);
+    let automatic = capture_real_tcp_file_frame(region, blocking, FileTransferMode::Auto).await;
+
+    assert_eq!(
+        portable, automatic,
+        "portable and sendfile must emit identical wire bytes"
+    );
+    let announced = usize::try_from(i32::from_be_bytes(portable[..4].try_into().expect("raw prefix")))
+        .expect("positive raw frame length");
+    assert_eq!(portable.len(), announced + 4);
+    assert!(portable.len() >= BODY_LEN + 4);
+    assert_eq!(probe.cached_sendfile_support(), Some(true));
+    assert!(accesses.load(Ordering::SeqCst) >= 4);
+    assert_eq!(drops.load(Ordering::SeqCst), 0);
+    drop(probe);
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes(Closes)

- Fixes #9826

### Brief Description

- Add complete raw-frame equivalence coverage for the real Pull, Pop, Query, and View response builders across legacy and V2 delivery.
- Prove FileRegion leases remain live through hooks, metric projection, and canonical writer ownership, then drop exactly once across success, failure, cancellation, and session closure.
- Verify portable segments, Portable and Auto fallback, real TLS fallback, and Linux sendfile eligibility without expanding production routing or public APIs.

### How Did You Test This Change?

- `cargo fmt -p rocketmq-broker -- --check`
- `cargo fmt -p rocketmq-transport -- --check`
- Focused broker wire-equivalence tests with default and all features.
- Focused transport dispatcher, response-sink, lease, transfer-mode, and real TLS tests with default and all features.
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings`
- `cargo clippy -p rocketmq-transport --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- Fixed-nightly fuzz project check with locked dependencies, all targets, and all features.
- The Linux-only sendfile raw-frame test is platform-gated and was not executed on the Windows validation host.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved confidence that responses delivered through legacy and modern transport paths remain byte-for-byte compatible.
  * Strengthened file-based response handling across portable, automatic, TLS, and Linux transfer modes.
  * Verified response metadata, payloads, lease lifecycles, and delivery timing remain consistent.

* **Tests**
  * Added end-to-end coverage for Pull, Pop, Query, and View responses.
  * Expanded network and file-transfer validation, including compatibility fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->