### PR TITLE
[ISSUE #9828]🚀Introduce registry-backed Pop deferred infrastructure

### DIFF
--- a/rocketmq-broker/src/long_polling/pop_deferred.rs
+++ b/rocketmq-broker/src/long_polling/pop_deferred.rs
@@ -1,0 +1,51 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(crate) mod deadline;
+pub(crate) mod index;
+pub(crate) mod service;
+
+#[cfg(test)]
+pub(crate) use deadline::LongPollingDeadline;
+#[cfg(test)]
+pub(crate) use deadline::LongPollingDeadlineErrorKind;
+#[cfg(test)]
+pub(crate) use index::PopArrival;
+#[cfg(test)]
+pub(crate) use index::PopCriteriaIndex;
+#[cfg(test)]
+pub(crate) use index::PopCriteriaKey;
+#[cfg(test)]
+pub(crate) use index::PopCriteriaLimits;
+#[cfg(test)]
+pub(crate) use index::PopIndexErrorKind;
+#[cfg(test)]
+pub(crate) use index::PopIndexSnapshot;
+#[cfg(test)]
+pub(crate) use index::PopMatchCriteria;
+#[cfg(test)]
+pub(crate) use index::PopSelectionOrder;
+#[cfg(test)]
+pub(crate) use service::PopDeferredPrepareErrorKind;
+#[cfg(test)]
+pub(crate) use service::PopDeferredService;
+#[cfg(test)]
+pub(crate) use service::PopRequestData;
+#[cfg(test)]
+pub(crate) use service::PopRetainedEstimate;
+
+#[cfg(test)]
+mod acceptance_tests;
+#[cfg(test)]
+mod core_tests;

--- a/rocketmq-broker/src/long_polling/pop_deferred/acceptance_tests.rs
+++ b/rocketmq-broker/src/long_polling/pop_deferred/acceptance_tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The RocketMQ Rust Authors
+// Copyright 2026 The RocketMQ Rust Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,11 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) mod long_polling_service;
-pub(crate) mod many_pull_request;
-pub(crate) mod notify_message_arriving_listener;
-pub(crate) mod polling_header;
-pub(crate) mod polling_result;
-pub(crate) mod pop_deferred;
-pub(crate) mod pop_request;
-pub(crate) mod pull_request;
+mod network;

--- a/rocketmq-broker/src/long_polling/pop_deferred/acceptance_tests/network.rs
+++ b/rocketmq-broker/src/long_polling/pop_deferred/acceptance_tests/network.rs
@@ -1,0 +1,792 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::net::SocketAddr;
+use std::num::NonZeroU64;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::time::Duration;
+
+use cheetah_string::CheetahString;
+use rocketmq_error::RocketMQError;
+use rocketmq_protocol::code::request_code::RequestCode;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::header::pop_message_request_header::PopMessageRequestHeader;
+use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_runtime::common::time_utils::current_millis;
+use rocketmq_runtime::ChildServiceContext;
+use rocketmq_runtime::RuntimeConfig;
+use rocketmq_runtime::RuntimeOwner;
+use rocketmq_runtime::ShutdownReport;
+use rocketmq_store::CqExtUnit;
+use rocketmq_store::MessageFilter;
+use rocketmq_transport::api::v1::AdmissionController;
+use rocketmq_transport::api::v1::AdmissionLimits;
+use rocketmq_transport::api::v1::ServerConfig;
+use rocketmq_transport::api::v2::DeferredAdmission;
+use rocketmq_transport::api::v2::DeferredClaimErrorKind;
+use rocketmq_transport::api::v2::DeferredExpiryMargins;
+use rocketmq_transport::api::v2::DeferredId;
+use rocketmq_transport::api::v2::DeferredResumeErrorKind;
+use rocketmq_transport::api::v2::DeferredTerminalReason;
+use rocketmq_transport::api::v2::DeferredWaitLimits;
+use rocketmq_transport::api::v2::DeferredWakeReason;
+use rocketmq_transport::api::v2::HandlerOutcome;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestOrdering;
+use rocketmq_transport::api::v2::RequestOrderingKey;
+use rocketmq_transport::api::v2::RequestOrigin;
+use rocketmq_transport::api::v2::RequestProcessorV2;
+use rocketmq_transport::api::v2::ResponsePlan;
+use rocketmq_transport::api::v2::TransportServerV2;
+use rocketmq_transport::test_support::Connection;
+use tokio::net::TcpStream;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+use tokio::sync::Notify;
+
+use super::super::*;
+use crate::long_polling::pop_deferred::service::PopDeferredWakeupObserver;
+
+const SENTINEL_CODE: i32 = 98_281;
+const ORDERING_KEY: u64 = 9_828;
+const TEST_POLL_MILLIS: u64 = 60_000;
+
+mod lifecycle_tests;
+mod provenance_tests;
+
+fn nonzero(value: usize) -> NonZeroUsize {
+    NonZeroUsize::new(value).expect("test value is non-zero")
+}
+
+fn assert_clean_shutdown(owner: &str, report: &ShutdownReport) {
+    assert!(report.is_healthy(), "{owner}: {}", report.to_json());
+    assert_eq!(report.aborted, 0, "{owner}: {}", report.to_json());
+    assert_eq!(report.panicked, 0, "{owner}: {}", report.to_json());
+    assert_eq!(report.timed_out, 0, "{owner}: {}", report.to_json());
+    assert_eq!(report.leaked, 0, "{owner}: {}", report.to_json());
+    assert!(report.remaining_tasks.is_empty(), "{owner}: {}", report.to_json());
+    for child in &report.children {
+        assert_clean_shutdown(owner, child);
+    }
+}
+
+fn service(
+    controller: &AdmissionController,
+    waiters: usize,
+    index_entries: usize,
+    entries_per_key: usize,
+) -> Arc<PopDeferredService> {
+    let admission = DeferredAdmission::try_configure(controller, DeferredWaitLimits::new(waiters, 16 * 1024 * 1024))
+        .expect("POP deferred admission");
+    Arc::new(PopDeferredService::new(
+        admission,
+        PopCriteriaLimits::new(nonzero(index_entries), nonzero(entries_per_key)),
+        DeferredExpiryMargins::new(Duration::from_millis(2), Duration::from_millis(2)),
+        nonzero(index_entries),
+    ))
+}
+
+fn request_header(topic: &str, group: &str, queue_id: i32, filter_tag: Option<i64>) -> PopMessageRequestHeader {
+    PopMessageRequestHeader {
+        consumer_group: CheetahString::from_string(group.to_owned()),
+        topic: CheetahString::from_string(topic.to_owned()),
+        queue_id,
+        max_msg_nums: 8,
+        invisible_time: 30_000,
+        poll_time: TEST_POLL_MILLIS,
+        born_time: current_millis(),
+        init_mode: 0,
+        exp_type: filter_tag.map(|_| CheetahString::from_static_str("TAG")),
+        exp: filter_tag.map(|tag| CheetahString::from_string(tag.to_string())),
+        order: Some(false),
+        attempt_id: None,
+        topic_request_header: None,
+    }
+}
+
+fn preflight_test_data(topic: &str, caller_host: &str) -> PopRequestData {
+    let mut header = request_header(topic, "GroupA", 0, None);
+    header.born_time = 10_000;
+    PopRequestData::from_test_header(header, caller_host.into())
+}
+
+fn request_command(topic: &str, group: &str, queue_id: i32, filter_tag: Option<i64>, opaque: i32) -> RemotingCommand {
+    let mut command = RemotingCommand::create_request_command(
+        RequestCode::PopMessage,
+        request_header(topic, group, queue_id, filter_tag),
+    )
+    .set_opaque(opaque);
+    command.make_custom_header_to_net();
+    command
+}
+
+fn expiring_request_command(topic: &str, group: &str, queue_id: i32, opaque: i32) -> RemotingCommand {
+    let mut header = request_header(topic, group, queue_id, None);
+    header.poll_time = 100;
+    let mut command = RemotingCommand::create_request_command(RequestCode::PopMessage, header).set_opaque(opaque);
+    command.make_custom_header_to_net();
+    command
+}
+
+struct MatchTagFilter(i64);
+
+impl MessageFilter for MatchTagFilter {
+    fn is_matched_by_consume_queue(&self, tags_code: Option<i64>, _cq_ext_unit: Option<&CqExtUnit>) -> bool {
+        tags_code == Some(self.0)
+    }
+
+    fn is_matched_by_commit_log(
+        &self,
+        _msg_buffer: Option<&[u8]>,
+        _properties: Option<&std::collections::HashMap<CheetahString, CheetahString>>,
+    ) -> bool {
+        true
+    }
+}
+
+#[derive(Clone, Copy)]
+struct RegistrationObservation {
+    id: DeferredId,
+    caller: SocketAddr,
+}
+
+#[derive(Default)]
+struct ProcessorBarrier {
+    before_outcome: Notify,
+    release_outcome: Notify,
+    commit_observed: Notify,
+}
+
+#[derive(Clone)]
+struct DeferredTestProcessor {
+    service: Arc<PopDeferredService>,
+    registrations: mpsc::UnboundedSender<RegistrationObservation>,
+    barrier: Arc<ProcessorBarrier>,
+    hold_before_outcome: bool,
+    rollback_registration: bool,
+}
+
+impl RequestProcessorV2 for DeferredTestProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        if request.command().code() == SENTINEL_CODE {
+            self.barrier.commit_observed.notify_one();
+            return ResponsePlan::command(RemotingCommand::create_response_command_with_code(
+                ResponseCode::Success,
+            ))
+            .map(HandlerOutcome::Reply)
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()));
+        }
+
+        let header = request
+            .command()
+            .decode_command_custom_header::<PopMessageRequestHeader>()?;
+        let caller = match request.origin() {
+            RequestOrigin::Network { peer } => peer.address(),
+            RequestOrigin::Embedded { .. } => {
+                return Err(RocketMQError::illegal_argument(
+                    "POP deferred test requires a trusted network peer",
+                ));
+            }
+            _ => return Err(RocketMQError::illegal_argument("unsupported POP request origin")),
+        };
+        let filter_tag = header.exp.as_ref().and_then(|value| value.parse::<i64>().ok());
+        let filter = filter_tag.map(|tag| Arc::new(MatchTagFilter(tag)) as rocketmq_store::ArcMessageFilter);
+        let subscription = filter.as_ref().map(|_| SubscriptionData::default());
+        let prepared = self
+            .service
+            .prepare(request, subscription, filter, PopRetainedEstimate::default())
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        let registration = self
+            .service
+            .register(prepared, request)
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        let id = registration.deferred_id();
+        self.registrations
+            .send(RegistrationObservation { id, caller })
+            .map_err(|_| RocketMQError::illegal_argument("registration observer closed"))?;
+        if self.rollback_registration {
+            drop(registration);
+            return Err(RocketMQError::illegal_argument("intentional POP registration rollback"));
+        }
+        if self.hold_before_outcome {
+            self.barrier.before_outcome.notify_one();
+            self.barrier.release_outcome.notified().await;
+        }
+        Ok(HandlerOutcome::Deferred(registration))
+    }
+
+    fn request_ordering(&self, _ingress: rocketmq_transport::api::v2::IngressRequestView<'_>) -> RequestOrdering {
+        RequestOrdering::Ordered(RequestOrderingKey::new(ORDERING_KEY))
+    }
+}
+
+struct RunningServer {
+    owner: RuntimeOwner,
+    action_context: ChildServiceContext,
+    shutdown: Option<oneshot::Sender<()>>,
+    result: oneshot::Receiver<ShutdownReport>,
+}
+
+impl RunningServer {
+    fn begin_shutdown(&mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+    }
+
+    async fn finish(mut self) {
+        self.begin_shutdown();
+        let report = self.result.await.expect("owned V2 server result channel");
+        assert_clean_shutdown("V2 server", &report);
+        let task_report = self.owner.shutdown_tasks().await;
+        assert_clean_shutdown("V2 runtime", &task_report);
+        let final_report = self.owner.shutdown_background();
+        assert_clean_shutdown("V2 runtime finalization", &final_report);
+    }
+}
+
+async fn start_server<P>(processor: P, controller: Arc<AdmissionController>) -> (Connection, SocketAddr, RunningServer)
+where
+    P: RequestProcessorV2 + Clone + Sync + 'static,
+{
+    let owner = RuntimeOwner::new(RuntimeConfig::server_default("broker-pop-deferred-acceptance"))
+        .expect("POP V2 test runtime owner");
+    let server_context = owner.root_context().component("pop-deferred.server");
+    let runner_context = owner.root_context().component("pop-deferred.runner");
+    let action_context = owner.root_context().component("pop-deferred.actions");
+    let server = TransportServerV2::new(
+        Arc::new(ServerConfig {
+            bind_address: "127.0.0.1".to_owned(),
+            listen_port: 0,
+            ..ServerConfig::default()
+        }),
+        server_context,
+        processor,
+    )
+    .with_admission_controller(controller);
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let (startup_tx, startup_rx) = oneshot::channel();
+    let (result_tx, result_rx) = oneshot::channel();
+    runner_context
+        .spawn_service("pop-deferred-v2-server", async move {
+            let result = server
+                .try_run_with_shutdown_report_and_startup(
+                    async move {
+                        let _ = shutdown_rx.await;
+                    },
+                    startup_tx,
+                )
+                .await
+                .expect("owned POP V2 server shutdown report");
+            let _ = result_tx.send(result);
+        })
+        .expect("spawn owned POP V2 server");
+    let address = startup_rx
+        .await
+        .expect("POP V2 startup channel")
+        .expect("POP V2 server startup");
+    let client = Connection::new(TcpStream::connect(address).await.expect("connect POP V2 client"));
+    (
+        client,
+        address,
+        RunningServer {
+            owner,
+            action_context,
+            shutdown: Some(shutdown_tx),
+            result: result_rx,
+        },
+    )
+}
+
+async fn commit_barrier(client: &mut Connection, barrier: &ProcessorBarrier, opaque: i32) {
+    client
+        .send_command(
+            RemotingCommand::create_remoting_command(SENTINEL_CODE)
+                .set_opaque(opaque)
+                .mark_oneway_rpc(),
+        )
+        .await
+        .expect("send ordered commit sentinel");
+    barrier.commit_observed.notified().await;
+}
+
+fn assert_released(service: &PopDeferredService) {
+    assert_eq!(service.index_snapshot(), PopIndexSnapshot::default());
+    let admission = service.admission_snapshot();
+    assert_eq!(admission.waiting_count(), 0);
+    assert_eq!(admission.retained_bytes(), 0);
+}
+
+#[tokio::test]
+async fn prepared_wake_replays_then_observed_resume_writes_one_bound_frame() {
+    const ORIGINAL_OPAQUE: i32 = 9_821;
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref(), 4, 4, 4);
+    let barrier = Arc::new(ProcessorBarrier::default());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+        barrier: Arc::clone(&barrier),
+        hold_before_outcome: true,
+        rollback_registration: false,
+    };
+    let (mut client, _address, running) = start_server(processor, Arc::clone(&controller)).await;
+    client
+        .send_command(request_command("TopicA", "GroupA", 0, None, ORIGINAL_OPAQUE))
+        .await
+        .expect("send deferred POP request");
+    let registered = registrations.recv().await.expect("observe POP registration");
+    barrier.before_outcome.notified().await;
+
+    let mut pending_claim = Box::pin(service.claim(registered.id, DeferredWakeReason::MessageArrived));
+    tokio::select! {
+        biased;
+        result = &mut pending_claim => panic!("prepared claim completed before dispatcher commit: {result:?}"),
+        _ = tokio::task::yield_now() => {}
+    }
+    barrier.release_outcome.notify_one();
+    let claim = pending_claim.await.expect("prepared wake replays after commit");
+    assert_eq!(claim.reason(), DeferredWakeReason::MessageArrived);
+    assert_eq!(service.index_snapshot().live(), 0);
+    assert_eq!(service.admission_snapshot().waiting_count(), 1);
+
+    let handler_started = Arc::new(Notify::new());
+    let handler_release = Arc::new(Notify::new());
+    let rereads = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let (receipt_tx, receipt_rx) = oneshot::channel();
+    let service_for_resume = Arc::clone(&service);
+    let started = Arc::clone(&handler_started);
+    let release = Arc::clone(&handler_release);
+    let reread_count = Arc::clone(&rereads);
+    let (observer, mut completion) = PopDeferredWakeupObserver::new();
+    running
+        .action_context
+        .spawn_service("pop-deferred-resume", async move {
+            let result = service_for_resume
+                .resume_claimed_observed(
+                    claim,
+                    rocketmq_transport::api::v2::DeferredResumeRetainedSize::default(),
+                    observer,
+                    move |resume, reason| async move {
+                        started.notify_one();
+                        release.notified().await;
+                        assert_eq!(reason, DeferredWakeReason::MessageArrived);
+                        assert_eq!(resume.request().caller_host().as_str(), registered.caller.to_string());
+                        reread_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        ResponsePlan::command(RemotingCommand::create_response_command_with_code(
+                            ResponseCode::PollingTimeout,
+                        ))
+                        .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+                    },
+                )
+                .await;
+            let _ = receipt_tx.send(result);
+        })
+        .expect("spawn owned POP resume assertion");
+    handler_started.notified().await;
+    assert_eq!(
+        service.admission_snapshot().waiting_count(),
+        0,
+        "wait admission is released before execution admission invokes the handler"
+    );
+    tokio::select! {
+        biased;
+        result = &mut completion => panic!("POP wake completion finished before canonical resume/write: {result:?}"),
+        _ = tokio::task::yield_now() => {}
+    }
+    handler_release.notify_one();
+    receipt_rx
+        .await
+        .expect("resume receipt channel")
+        .expect("accepted POP resume drains through canonical writing");
+    assert_eq!(
+        completion.await.expect("POP wake completion"),
+        crate::long_polling::long_polling_service::pop_long_polling_service::PopWakeupOutcome::ProcessingCompleted
+    );
+
+    let response = client
+        .receive_command()
+        .await
+        .expect("POP V2 connection remains open until the accepted write drains")
+        .expect("one POP timeout response frame");
+    assert_eq!(response.opaque(), ORIGINAL_OPAQUE);
+    assert_eq!(response.code(), ResponseCode::PollingTimeout as i32);
+    assert_eq!(rereads.load(std::sync::atomic::Ordering::SeqCst), 1);
+    assert_released(&service);
+    running.finish().await;
+    assert!(
+        client.receive_command().await.is_none(),
+        "owned shutdown reaches EOF after exactly one response frame"
+    );
+}
+
+#[tokio::test]
+async fn provisional_oldest_claim_does_not_hide_active_second_waiter() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref(), 4, 4, 4);
+    let first_barrier = Arc::new(ProcessorBarrier::default());
+    let second_barrier = Arc::new(ProcessorBarrier::default());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let first_processor = DeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx.clone(),
+        barrier: Arc::clone(&first_barrier),
+        hold_before_outcome: true,
+        rollback_registration: false,
+    };
+    let second_processor = DeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+        barrier: Arc::clone(&second_barrier),
+        hold_before_outcome: false,
+        rollback_registration: false,
+    };
+    let (mut first_client, _first_address, first_running) =
+        start_server(first_processor, Arc::clone(&controller)).await;
+    let (mut second_client, _second_address, second_running) =
+        start_server(second_processor, Arc::clone(&controller)).await;
+
+    first_client
+        .send_command(request_command("TopicA", "GroupA", 0, None, 81))
+        .await
+        .expect("send provisional oldest waiter");
+    let first = registrations.recv().await.expect("provisional registration");
+    first_barrier.before_outcome.notified().await;
+    second_client
+        .send_command(request_command("TopicA", "GroupA", 0, None, 82))
+        .await
+        .expect("send active second waiter");
+    let second = registrations.recv().await.expect("active second registration");
+    commit_barrier(&mut second_client, &second_barrier, 83).await;
+
+    let arrival = PopArrival::new("TopicA".into(), "GroupA".into(), 0);
+    let mut pending_first = Box::pin(service.claim_message(&arrival, PopSelectionOrder::Oldest));
+    tokio::select! {
+        biased;
+        result = &mut pending_first => panic!("provisional oldest claim completed before commit: {result:?}"),
+        _ = tokio::task::yield_now() => {}
+    }
+    let second_claim = service
+        .claim_message(&arrival, PopSelectionOrder::Oldest)
+        .await
+        .expect("second arrival remains claimable")
+        .expect("active second waiter is not hidden by the provisional candidate");
+    assert_eq!(second_claim.deferred_id(), second.id);
+    drop(second_claim);
+
+    drop(pending_first);
+    first_barrier.release_outcome.notify_one();
+    commit_barrier(&mut first_client, &first_barrier, 84).await;
+    let first_claim = service
+        .claim_message(&arrival, PopSelectionOrder::Oldest)
+        .await
+        .expect("cancelled provisional candidate reopens")
+        .expect("oldest waiter remains claimable after commit");
+    assert_eq!(first_claim.deferred_id(), first.id);
+    drop(first_claim);
+    assert_released(&service);
+
+    first_running.finish().await;
+    second_running.finish().await;
+}
+
+#[tokio::test]
+async fn service_shutdown_drains_accepted_resume_to_parent_cancelled_without_a_frame() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref(), 2, 2, 2);
+    let barrier = Arc::new(ProcessorBarrier::default());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+        barrier: Arc::clone(&barrier),
+        hold_before_outcome: false,
+        rollback_registration: false,
+    };
+    let (mut client, _address, running) = start_server(processor, Arc::clone(&controller)).await;
+    client
+        .send_command(request_command("TopicA", "GroupA", 0, None, 9_823))
+        .await
+        .expect("send deferred POP request");
+    let registered = registrations.recv().await.expect("observe POP registration");
+    commit_barrier(&mut client, &barrier, 9_824).await;
+    let claim = service
+        .claim(registered.id, DeferredWakeReason::MessageArrived)
+        .await
+        .expect("claim active POP waiter");
+
+    let handler_started = Arc::new(Notify::new());
+    let handler_release = Arc::new(Notify::new());
+    let handler_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let (receipt_tx, receipt_rx) = oneshot::channel();
+    let service_for_resume = Arc::clone(&service);
+    let started = Arc::clone(&handler_started);
+    let release = Arc::clone(&handler_release);
+    let calls = Arc::clone(&handler_calls);
+    running
+        .action_context
+        .spawn_service("pop-deferred-cancelled-resume", async move {
+            let result = service_for_resume
+                .resume_claimed(
+                    claim,
+                    rocketmq_transport::api::v2::DeferredResumeRetainedSize::default(),
+                    move |_resume, reason| async move {
+                        assert_eq!(reason, DeferredWakeReason::MessageArrived);
+                        calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        started.notify_one();
+                        release.notified().await;
+                        ResponsePlan::command(RemotingCommand::create_response_command_with_code(
+                            ResponseCode::PollingTimeout,
+                        ))
+                        .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+                    },
+                )
+                .await;
+            let _ = receipt_tx.send(result);
+        })
+        .expect("spawn owned POP resume cancellation assertion");
+    handler_started.notified().await;
+    assert_eq!(service.admission_snapshot().waiting_count(), 0);
+    assert!(matches!(
+        service.shutdown(),
+        rocketmq_transport::api::v2::DeferredRegistryShutdownOutcome::Completed(_)
+    ));
+    handler_release.notify_one();
+    let error = receipt_rx
+        .await
+        .expect("resume cancellation result channel")
+        .expect_err("service shutdown terminalizes the accepted resume");
+    assert_eq!(error.kind(), DeferredResumeErrorKind::Cancelled);
+    assert_eq!(
+        error.prior_terminal_reason(),
+        Some(DeferredTerminalReason::ParentCancelled)
+    );
+    assert_eq!(error.write_progress(), None);
+    assert_eq!(handler_calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+    assert_released(&service);
+
+    running.finish().await;
+    assert!(
+        client.receive_command().await.is_none(),
+        "lifecycle cancellation drains the accepted task without writing a response"
+    );
+}
+
+#[tokio::test]
+async fn matching_skips_filter_miss_then_advances_oldest_exact_wildcard_and_retry_waiters() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref(), 8, 8, 8);
+    let barrier = Arc::new(ProcessorBarrier::default());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+        barrier: Arc::clone(&barrier),
+        hold_before_outcome: false,
+        rollback_registration: false,
+    };
+    let (mut client, _address, running) = start_server(processor, Arc::clone(&controller)).await;
+
+    client
+        .send_command(request_command("TopicA", "GroupA", 0, Some(7), 1))
+        .await
+        .expect("send filtered exact waiter");
+    let filtered = registrations.recv().await.expect("filtered registration");
+    client
+        .send_command(request_command("TopicA", "GroupA", -1, None, 2))
+        .await
+        .expect("send wildcard waiter");
+    let wildcard = registrations.recv().await.expect("wildcard registration");
+    client
+        .send_command(request_command("TopicA", "GroupA", 0, None, 3))
+        .await
+        .expect("send second exact waiter");
+    let second_exact = registrations.recv().await.expect("second exact registration");
+    commit_barrier(&mut client, &barrier, 4).await;
+
+    let miss = PopArrival::new("TopicA".into(), "GroupA".into(), 0).with_filter_metadata(Some(6), 0, None, None);
+    let first = service
+        .claim_message(&miss, PopSelectionOrder::Oldest)
+        .await
+        .expect("filter miss is not a claim error")
+        .expect("wildcard waiter remains eligible after the oldest filter miss");
+    assert_eq!(first.deferred_id(), wildcard.id);
+    drop(first);
+
+    let matching = PopArrival::new("TopicA".into(), "GroupA".into(), 0).with_filter_metadata(Some(7), 0, None, None);
+    let second = service
+        .claim_message(&matching, PopSelectionOrder::Oldest)
+        .await
+        .expect("matching arrival")
+        .expect("oldest filtered exact waiter");
+    assert_eq!(second.deferred_id(), filtered.id);
+    drop(second);
+
+    let retry_topic = rocketmq_model::common::key_builder::KeyBuilder::build_pop_retry_topic_v2("TopicA", "GroupA");
+    let retry = PopArrival::from_retry_topic(retry_topic.into(), "GroupA".into(), 0);
+    let third = service
+        .claim_message(&retry, PopSelectionOrder::Oldest)
+        .await
+        .expect("retry arrival")
+        .expect("retry topic normalizes to the remaining exact waiter");
+    assert_eq!(third.deferred_id(), second_exact.id);
+    drop(third);
+    assert_released(&service);
+
+    running.finish().await;
+}
+
+#[tokio::test]
+async fn topic_fanout_and_forced_refresh_bypass_filter_then_cleanup() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref(), 2, 2, 2);
+    let barrier = Arc::new(ProcessorBarrier::default());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+        barrier: Arc::clone(&barrier),
+        hold_before_outcome: false,
+        rollback_registration: false,
+    };
+    let (mut client, _address, running) = start_server(processor, Arc::clone(&controller)).await;
+    client
+        .send_command(request_command("TopicA", "GroupA", 0, Some(7), 51))
+        .await
+        .expect("send forced-refresh waiter");
+    let registered = registrations.recv().await.expect("forced-refresh registration");
+    commit_barrier(&mut client, &barrier, 52).await;
+
+    assert_eq!(
+        service.consumer_groups_for_arrival(&"TopicA".into(), 0),
+        [CheetahString::from_static_str("GroupA")]
+    );
+    let arrival = PopArrival::new("TopicA".into(), "GroupA".into(), 0).with_filter_metadata(Some(99), 0, None, None);
+    assert!(service
+        .claim_message(&arrival, PopSelectionOrder::Oldest)
+        .await
+        .expect("normal filter miss")
+        .is_none());
+    let forced = service
+        .claim_forced(arrival, PopSelectionOrder::Oldest)
+        .await
+        .expect("forced refresh claim")
+        .expect("forced refresh bypasses the filter");
+    assert_eq!(forced.deferred_id(), registered.id);
+    assert_eq!(forced.reason(), DeferredWakeReason::ForcedRefresh);
+    drop(forced);
+    assert!(service.consumer_groups_for_arrival(&"TopicA".into(), 0).is_empty());
+    assert_released(&service);
+
+    running.finish().await;
+}
+
+#[tokio::test]
+async fn duplicate_claim_and_session_close_never_execute_or_write() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref(), 4, 4, 4);
+    let barrier = Arc::new(ProcessorBarrier::default());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+        barrier: Arc::clone(&barrier),
+        hold_before_outcome: false,
+        rollback_registration: false,
+    };
+    let (mut client, _address, running) = start_server(processor, Arc::clone(&controller)).await;
+    client
+        .send_command(request_command("TopicA", "GroupA", 0, None, 11))
+        .await
+        .expect("send deferred waiter");
+    let registered = registrations.recv().await.expect("registration");
+    commit_barrier(&mut client, &barrier, 12).await;
+
+    let first = service
+        .claim(registered.id, DeferredWakeReason::MessageArrived)
+        .await
+        .expect("first claim");
+    let duplicate = service
+        .claim(registered.id, DeferredWakeReason::Timeout)
+        .await
+        .expect_err("a live claim excludes every duplicate reason");
+    assert_eq!(duplicate.kind(), DeferredClaimErrorKind::AlreadyClaimed);
+    let (observer, completion) = PopDeferredWakeupObserver::new();
+    observer.complete_claim_error(&duplicate);
+    assert_eq!(
+        completion.await.expect("duplicate wake completion"),
+        crate::long_polling::long_polling_service::pop_long_polling_service::PopWakeupOutcome::AlreadyCompleted
+    );
+    drop(first);
+    assert_released(&service);
+
+    client
+        .send_command(request_command("TopicA", "GroupA", 0, None, 13))
+        .await
+        .expect("send timeout-first waiter");
+    let timeout_first = registrations.recv().await.expect("timeout-first registration");
+    commit_barrier(&mut client, &barrier, 14).await;
+    let (message, timeout) = tokio::join!(
+        service.claim(timeout_first.id, DeferredWakeReason::MessageArrived),
+        service.claim(timeout_first.id, DeferredWakeReason::Timeout),
+    );
+    match (message, timeout) {
+        (Ok(winner), Err(loser)) => {
+            assert_eq!(winner.reason(), DeferredWakeReason::MessageArrived);
+            assert_eq!(loser.kind(), DeferredClaimErrorKind::AlreadyClaimed);
+            drop(winner);
+        }
+        (Err(loser), Ok(winner)) => {
+            assert_eq!(winner.reason(), DeferredWakeReason::Timeout);
+            assert_eq!(loser.kind(), DeferredClaimErrorKind::AlreadyClaimed);
+            drop(winner);
+        }
+        (message, timeout) => panic!("exactly one concurrent reason must win: {message:?}, {timeout:?}"),
+    }
+    assert_released(&service);
+
+    client
+        .send_command(request_command("TopicA", "GroupA", 0, None, 15))
+        .await
+        .expect("send session-close waiter");
+    let closed = registrations.recv().await.expect("session-close registration");
+    commit_barrier(&mut client, &barrier, 16).await;
+    client.shutdown().await.expect("close the POP client session");
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while service.admission_snapshot().waiting_count() != 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("session cleanup releases the waiter");
+    assert_released(&service);
+    let closed_claim = service
+        .claim(closed.id, DeferredWakeReason::MessageArrived)
+        .await
+        .expect_err("closed session cannot execute POP recovery");
+    assert!(matches!(
+        closed_claim.kind(),
+        DeferredClaimErrorKind::SessionClosed
+            | DeferredClaimErrorKind::AlreadyCompleted
+            | DeferredClaimErrorKind::NotFound
+    ));
+    running.finish().await;
+    assert!(
+        client.receive_command().await.is_none(),
+        "claimed, dropped, and inactive-session waiters execute no resume handler and emit no frame"
+    );
+}

--- a/rocketmq-broker/src/long_polling/pop_deferred/acceptance_tests/network/lifecycle_tests.rs
+++ b/rocketmq-broker/src/long_polling/pop_deferred/acceptance_tests/network/lifecycle_tests.rs
@@ -1,0 +1,239 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+#[tokio::test]
+async fn lifecycle_owned_sweeper_claims_protocol_timeout_and_releases_index() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref(), 2, 2, 2);
+    let barrier = Arc::new(ProcessorBarrier::default());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+        barrier: Arc::clone(&barrier),
+        hold_before_outcome: false,
+        rollback_registration: false,
+    };
+    let (mut client, _address, running) = start_server(processor, Arc::clone(&controller)).await;
+    client
+        .send_command(expiring_request_command("TopicA", "GroupA", 0, 61))
+        .await
+        .expect("send expiring POP waiter");
+    let registered = registrations.recv().await.expect("expiring registration");
+    commit_barrier(&mut client, &barrier, 62).await;
+    assert!(service.index_contains(registered.id));
+
+    let (claims_tx, mut claims_rx) = mpsc::unbounded_channel();
+    service
+        .start_sweeper(
+            running.action_context.task_group(),
+            NonZeroU64::new(5).expect("non-zero sweep interval"),
+            move |claims| {
+                let claims_tx = claims_tx.clone();
+                async move {
+                    let _ = claims_tx.send(claims);
+                }
+            },
+        )
+        .expect("start lifecycle-owned POP sweeper");
+    let mut claims = tokio::time::timeout(Duration::from_secs(2), claims_rx.recv())
+        .await
+        .expect("owned sweeper callback")
+        .expect("owned sweeper claim batch");
+    assert_eq!(claims.len(), 1);
+    let claim = claims.pop().expect("one timeout claim");
+    assert_eq!(claim.deferred_id(), registered.id);
+    assert_eq!(claim.reason(), DeferredWakeReason::Timeout);
+    drop(claim);
+    assert_released(&service);
+
+    running.finish().await;
+}
+
+#[test]
+fn index_and_wait_admission_fail_before_responder_transfer_and_release_every_reservation() {
+    let index_controller = AdmissionController::new(AdmissionLimits::default());
+    let index_limited = service(&index_controller, 2, 1, 1);
+    let first = index_limited
+        .prepare_at(
+            preflight_test_data("TopicA", "127.0.0.1:1"),
+            None,
+            None,
+            PopRetainedEstimate::default(),
+            10_000,
+            tokio::time::Instant::now(),
+        )
+        .expect("first index reservation");
+    let Err(index_error) = index_limited.prepare_at(
+        preflight_test_data("TopicB", "127.0.0.1:2"),
+        None,
+        None,
+        PopRetainedEstimate::default(),
+        10_000,
+        tokio::time::Instant::now(),
+    ) else {
+        panic!("global POP index capacity must reject before responder transfer");
+    };
+    assert_eq!(index_error.kind(), PopDeferredPrepareErrorKind::Index);
+    drop(first);
+    assert_released(&index_limited);
+
+    let admission_controller = AdmissionController::new(AdmissionLimits::default());
+    let admission_limited = service(&admission_controller, 1, 2, 2);
+    let first = admission_limited
+        .prepare_at(
+            preflight_test_data("TopicA", "127.0.0.1:3"),
+            None,
+            None,
+            PopRetainedEstimate::default(),
+            10_000,
+            tokio::time::Instant::now(),
+        )
+        .expect("first wait permit");
+    let Err(admission_error) = admission_limited.prepare_at(
+        preflight_test_data("TopicB", "127.0.0.1:4"),
+        None,
+        None,
+        PopRetainedEstimate::default(),
+        10_000,
+        tokio::time::Instant::now(),
+    ) else {
+        panic!("independent wait admission must reject before responder transfer");
+    };
+    assert_eq!(admission_error.kind(), PopDeferredPrepareErrorKind::Admission);
+    assert_eq!(admission_limited.index_snapshot().reserved(), 1);
+    drop(first);
+    assert_released(&admission_limited);
+}
+
+#[tokio::test]
+async fn dropped_registration_rolls_back_registry_index_lease_and_wait_permit() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref(), 2, 2, 2);
+    let barrier = Arc::new(ProcessorBarrier::default());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+        barrier,
+        hold_before_outcome: false,
+        rollback_registration: true,
+    };
+    let (mut client, _address, running) = start_server(processor, Arc::clone(&controller)).await;
+    client
+        .send_command(request_command("TopicA", "GroupA", 0, None, 21))
+        .await
+        .expect("send rollback registration");
+    let rolled_back = registrations.recv().await.expect("observe provisional registration");
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while service.admission_snapshot().waiting_count() != 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("registration rollback releases every owner");
+    assert_released(&service);
+    let claim = service
+        .claim(rolled_back.id, DeferredWakeReason::MessageArrived)
+        .await
+        .expect_err("rolled-back identity is not claimable");
+    assert_eq!(claim.kind(), DeferredClaimErrorKind::NotFound);
+    running.finish().await;
+}
+
+#[tokio::test]
+async fn shutdown_between_registration_and_dispatch_commit_cleans_every_owner() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref(), 2, 2, 2);
+    let barrier = Arc::new(ProcessorBarrier::default());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+        barrier: Arc::clone(&barrier),
+        hold_before_outcome: true,
+        rollback_registration: false,
+    };
+    let (mut client, _address, running) = start_server(processor, Arc::clone(&controller)).await;
+    client
+        .send_command(request_command("TopicA", "GroupA", 0, None, 71))
+        .await
+        .expect("send register-shutdown race waiter");
+    let registered = registrations.recv().await.expect("race registration");
+    barrier.before_outcome.notified().await;
+    assert!(service.index_contains(registered.id));
+
+    assert!(matches!(
+        service.shutdown(),
+        rocketmq_transport::api::v2::DeferredRegistryShutdownOutcome::Completed(_)
+    ));
+    assert_released(&service);
+    barrier.release_outcome.notify_one();
+
+    running.finish().await;
+    assert!(
+        client.receive_command().await.is_none(),
+        "shutdown before commit emits no deferred response frame"
+    );
+}
+
+#[tokio::test]
+async fn shutdown_terminalizes_active_waiter_emits_no_frame_and_cannot_reopen() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref(), 2, 2, 2);
+    let barrier = Arc::new(ProcessorBarrier::default());
+    let (registration_tx, mut registrations) = mpsc::unbounded_channel();
+    let processor = DeferredTestProcessor {
+        service: Arc::clone(&service),
+        registrations: registration_tx,
+        barrier: Arc::clone(&barrier),
+        hold_before_outcome: false,
+        rollback_registration: false,
+    };
+    let (mut client, _address, running) = start_server(processor, Arc::clone(&controller)).await;
+    client
+        .send_command(request_command("TopicA", "GroupA", 0, None, 31))
+        .await
+        .expect("send shutdown waiter");
+    let registered = registrations.recv().await.expect("shutdown registration");
+    commit_barrier(&mut client, &barrier, 32).await;
+    assert!(service.index_contains(registered.id));
+
+    let outcome = service.shutdown();
+    assert!(matches!(
+        outcome,
+        rocketmq_transport::api::v2::DeferredRegistryShutdownOutcome::Completed(_)
+    ));
+    assert_released(&service);
+    let Err(reopen) = service.prepare_at(
+        preflight_test_data("TopicB", "127.0.0.1:5"),
+        None,
+        None,
+        PopRetainedEstimate::default(),
+        10_000,
+        tokio::time::Instant::now(),
+    ) else {
+        panic!("sealed POP service must reject new preparation before responder transfer");
+    };
+    assert_eq!(reopen.kind(), PopDeferredPrepareErrorKind::ServiceClosed);
+    assert_released(&service);
+
+    running.finish().await;
+    assert!(
+        client.receive_command().await.is_none(),
+        "service-stop cleanup emits no meaningless POP response frame"
+    );
+}

--- a/rocketmq-broker/src/long_polling/pop_deferred/acceptance_tests/network/provenance_tests.rs
+++ b/rocketmq-broker/src/long_polling/pop_deferred/acceptance_tests/network/provenance_tests.rs
@@ -1,0 +1,180 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use parking_lot::Mutex;
+use rocketmq_security_api::AuthenticatedRequestContext;
+use rocketmq_security_api::Decision;
+use rocketmq_security_api::Principal;
+use rocketmq_security_api::RequestPolicy;
+use rocketmq_transport::api::v1::TransportSecurity;
+use rocketmq_transport::api::v2::AuthorizedCommandDispatcherV2;
+use rocketmq_transport::api::v2::EmbeddedDispatchOutcome;
+use rocketmq_transport::test_support::EmbeddedRequestHarnessV2;
+
+use super::*;
+use crate::long_polling::pop_deferred::service::PopDeferredRegisterErrorKind;
+use crate::long_polling::pop_deferred::service::PreparedPopRegistration;
+
+fn success_reply() -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+    ResponsePlan::command(RemotingCommand::create_response_command_with_code(
+        ResponseCode::Success,
+    ))
+    .map(HandlerOutcome::Reply)
+    .map_err(|error| RocketMQError::illegal_argument(error.to_string()))
+}
+
+#[derive(Default)]
+struct ProvenanceProbeState {
+    prepared: Option<PreparedPopRegistration>,
+}
+
+#[derive(Clone)]
+struct ProvenanceProbeProcessor {
+    service: Arc<PopDeferredService>,
+    state: Arc<Mutex<ProvenanceProbeState>>,
+}
+
+impl RequestProcessorV2 for ProvenanceProbeProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let prepared = {
+            let mut state = self.state.lock();
+            state.prepared.take()
+        };
+        if let Some(prepared) = prepared {
+            let error = self
+                .service
+                .register(prepared, request)
+                .expect_err("a prepared proof cannot be paired with another request");
+            assert_eq!(error.kind(), PopDeferredRegisterErrorKind::ProvenanceMismatch);
+            return success_reply();
+        }
+
+        let prepared = self
+            .service
+            .prepare(request, None, None, PopRetainedEstimate::default())
+            .map_err(|error| RocketMQError::illegal_argument(error.to_string()))?;
+        self.state.lock().prepared = Some(prepared);
+        success_reply()
+    }
+}
+
+#[derive(Clone)]
+struct EmbeddedOriginProbeProcessor {
+    service: Arc<PopDeferredService>,
+    observed: Arc<Mutex<Option<PopDeferredPrepareErrorKind>>>,
+}
+
+impl RequestProcessorV2 for EmbeddedOriginProbeProcessor {
+    async fn process(&mut self, request: &mut RemotingRequest) -> rocketmq_error::RocketMQResult<HandlerOutcome> {
+        let Err(error) = self
+            .service
+            .prepare(request, None, None, PopRetainedEstimate::default())
+        else {
+            panic!("embedded POP must not create deferred state");
+        };
+        *self.observed.lock() = Some(error.kind());
+        success_reply()
+    }
+}
+
+struct AllowEmbeddedPolicy;
+
+impl RequestPolicy for AllowEmbeddedPolicy {
+    fn evaluate_authenticated(&self, _context: AuthenticatedRequestContext<'_>) -> Decision {
+        Decision::Allow
+    }
+}
+
+#[tokio::test]
+async fn cross_request_prepared_proof_fails_before_responder_take() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref(), 2, 2, 2);
+    let state = Arc::new(Mutex::new(ProvenanceProbeState::default()));
+    let processor = ProvenanceProbeProcessor {
+        service: Arc::clone(&service),
+        state: Arc::clone(&state),
+    };
+    let (mut client, _address, running) = start_server(processor, Arc::clone(&controller)).await;
+
+    client
+        .send_command(request_command("TopicA", "GroupA", 0, None, 41))
+        .await
+        .expect("send proof source request");
+    let first = client
+        .receive_command()
+        .await
+        .expect("proof source connection")
+        .expect("proof source inline reply");
+    assert_eq!(first.code(), ResponseCode::Success as i32);
+    assert_eq!(service.index_snapshot().reserved(), 1);
+    assert_eq!(service.admission_snapshot().waiting_count(), 1);
+
+    client
+        .send_command(request_command("TopicA", "GroupA", 0, None, 42))
+        .await
+        .expect("send mismatched proof target");
+    let second = client
+        .receive_command()
+        .await
+        .expect("proof target connection")
+        .expect("mismatched request still owns its inline responder");
+    assert_eq!(second.code(), ResponseCode::Success as i32);
+    assert!(state.lock().prepared.is_none());
+    assert_released(&service);
+
+    running.finish().await;
+}
+
+#[tokio::test]
+async fn embedded_origin_is_rejected_before_any_pop_reservation() {
+    let controller = Arc::new(AdmissionController::new(AdmissionLimits::default()));
+    let service = service(controller.as_ref(), 2, 2, 2);
+    let observed = Arc::new(Mutex::new(None));
+    let processor = EmbeddedOriginProbeProcessor {
+        service: Arc::clone(&service),
+        observed: Arc::clone(&observed),
+    };
+    let runtime = RuntimeOwner::new(RuntimeConfig::server_default("broker-pop-deferred-embedded-origin"))
+        .expect("embedded POP runtime owner");
+    let context = runtime.root_context().component("pop-deferred.embedded-origin");
+    let dispatcher = Arc::new(AuthorizedCommandDispatcherV2::new(
+        processor,
+        Vec::new(),
+        Arc::new(TransportSecurity::secure_enforced(
+            Some(Arc::new(AllowEmbeddedPolicy)),
+            None,
+        )),
+        Arc::clone(&controller),
+    ));
+    let harness = EmbeddedRequestHarnessV2::new(
+        dispatcher,
+        context.task_group().clone(),
+        Principal::new("broker-pop-deferred-test"),
+    );
+
+    let outcome = harness
+        .dispatch(None, request_command("TopicA", "GroupA", 0, None, 43))
+        .await
+        .expect("embedded POP rejection is an inline response");
+    assert!(matches!(outcome, EmbeddedDispatchOutcome::Reply(_)));
+    assert_eq!(*observed.lock(), Some(PopDeferredPrepareErrorKind::EmbeddedOrigin));
+    assert_released(&service);
+
+    drop(harness);
+    drop(context);
+    let task_report = runtime.shutdown_tasks().await;
+    assert_clean_shutdown("embedded POP runtime", &task_report);
+    let final_report = runtime.shutdown_background();
+    assert_clean_shutdown("embedded POP runtime finalization", &final_report);
+}

--- a/rocketmq-broker/src/long_polling/pop_deferred/core_tests.rs
+++ b/rocketmq-broker/src/long_polling/pop_deferred/core_tests.rs
@@ -1,0 +1,435 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::num::NonZeroUsize;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use cheetah_string::CheetahString;
+use rocketmq_model::common::key_builder::KeyBuilder;
+use rocketmq_protocol::protocol::header::namesrv::topic_operation_header::TopicRequestHeader;
+use rocketmq_protocol::protocol::header::pop_message_request_header::PopMessageRequestHeader;
+use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
+use rocketmq_protocol::rpc::rpc_request_header::RpcRequestHeader;
+use rocketmq_store::CqExtUnit;
+use rocketmq_store::MessageFilter;
+use rocketmq_transport::api::v1::AdmissionController;
+use rocketmq_transport::api::v1::AdmissionLimits;
+use rocketmq_transport::api::v2::DeferredAdmission;
+use rocketmq_transport::api::v2::DeferredExpiryMargins;
+use rocketmq_transport::api::v2::DeferredWaitLimits;
+
+use super::*;
+
+fn nonzero(value: usize) -> NonZeroUsize {
+    NonZeroUsize::new(value).expect("test value is non-zero")
+}
+
+fn request(born_time: u64, poll_time: u64) -> PopRequestData {
+    request_with_host(born_time, poll_time, CheetahString::from_static_str("127.0.0.1:10911"))
+}
+
+fn request_with_host(born_time: u64, poll_time: u64, caller_host: CheetahString) -> PopRequestData {
+    PopRequestData::from_test_header(
+        PopMessageRequestHeader {
+            consumer_group: CheetahString::from_static_str("group"),
+            topic: CheetahString::from_static_str("topic"),
+            queue_id: 3,
+            max_msg_nums: 8,
+            invisible_time: 30_000,
+            poll_time,
+            born_time,
+            init_mode: 0,
+            exp_type: None,
+            exp: None,
+            order: Some(false),
+            attempt_id: None,
+            topic_request_header: None,
+        },
+        caller_host,
+    )
+}
+
+fn service(max_entries: usize, per_key: usize) -> PopDeferredService {
+    let controller = AdmissionController::new(AdmissionLimits::default());
+    let admission =
+        DeferredAdmission::try_configure(&controller, DeferredWaitLimits::new(max_entries, 16 * 1024 * 1024))
+            .expect("deferred admission");
+    PopDeferredService::new(
+        admission,
+        PopCriteriaLimits::new(nonzero(max_entries), nonzero(per_key)),
+        DeferredExpiryMargins::new(Duration::from_millis(2), Duration::from_millis(2)),
+        nonzero(8),
+    )
+}
+
+fn criteria_key(queue_id: i32) -> PopCriteriaKey {
+    PopCriteriaKey::new(
+        CheetahString::from_static_str("topic"),
+        CheetahString::from_static_str("group"),
+        queue_id,
+    )
+}
+
+fn deadline_after(base: tokio::time::Instant, millis: u64) -> LongPollingDeadline {
+    LongPollingDeadline::checked(0, millis + 49, 0, base).expect("test deadline")
+}
+
+fn match_all_criteria() -> Arc<PopMatchCriteria> {
+    Arc::new(PopMatchCriteria::new(None, None))
+}
+
+struct ToggleFilter {
+    matches: Arc<AtomicBool>,
+}
+
+impl MessageFilter for ToggleFilter {
+    fn is_matched_by_consume_queue(&self, _tags_code: Option<i64>, _cq_ext_unit: Option<&CqExtUnit>) -> bool {
+        self.matches.load(Ordering::SeqCst)
+    }
+
+    fn is_matched_by_commit_log(
+        &self,
+        _msg_buffer: Option<&[u8]>,
+        _properties: Option<&HashMap<CheetahString, CheetahString>>,
+    ) -> bool {
+        self.matches.load(Ordering::SeqCst)
+    }
+}
+
+struct CountingFilter {
+    drops: Arc<AtomicUsize>,
+}
+
+impl Drop for CountingFilter {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+impl MessageFilter for CountingFilter {
+    fn is_matched_by_consume_queue(&self, _tags_code: Option<i64>, _cq_ext_unit: Option<&CqExtUnit>) -> bool {
+        true
+    }
+
+    fn is_matched_by_commit_log(
+        &self,
+        _msg_buffer: Option<&[u8]>,
+        _properties: Option<&HashMap<CheetahString, CheetahString>>,
+    ) -> bool {
+        true
+    }
+}
+
+#[test]
+fn deadline_preserves_legacy_strict_fifty_millisecond_formula() {
+    let monotonic_now = tokio::time::Instant::now();
+    let deadline = LongPollingDeadline::checked(1_000, 100, 1_049, monotonic_now).expect("live deadline");
+    assert_eq!(deadline.protocol_millis(), 1_051);
+    assert_eq!(deadline.protocol_at(), monotonic_now + Duration::from_millis(2));
+
+    let boundary = LongPollingDeadline::checked(1_000, 100, 1_050, monotonic_now).expect("strict boundary is live");
+    assert_eq!(boundary.protocol_at(), monotonic_now + Duration::from_millis(1));
+
+    let expired = LongPollingDeadline::checked(1_000, 100, 1_051, monotonic_now).expect_err("strictly later expires");
+    assert_eq!(expired.kind(), LongPollingDeadlineErrorKind::AlreadyExpired);
+}
+
+#[test]
+fn deadline_rejects_zero_and_checked_protocol_overflow() {
+    assert_eq!(
+        LongPollingDeadline::checked(1, 0, 0, tokio::time::Instant::now())
+            .expect_err("zero polling is not deferred")
+            .kind(),
+        LongPollingDeadlineErrorKind::ZeroPollTime
+    );
+    assert_eq!(
+        LongPollingDeadline::checked(u64::MAX, 1, 0, tokio::time::Instant::now())
+            .expect_err("protocol addition is checked")
+            .kind(),
+        LongPollingDeadlineErrorKind::ProtocolOverflow
+    );
+}
+
+#[test]
+fn index_reservations_enforce_both_limits_and_drop_to_zero() {
+    let index = PopCriteriaIndex::<u64>::new(PopCriteriaLimits::new(nonzero(2), nonzero(1)));
+    let first_key = PopCriteriaKey::new(
+        CheetahString::from_static_str("topic"),
+        CheetahString::from_static_str("group"),
+        0,
+    );
+    let second_key = PopCriteriaKey::new(
+        CheetahString::from_static_str("topic"),
+        CheetahString::from_static_str("group"),
+        1,
+    );
+    let first = index.reserve(first_key.clone()).expect("first reservation");
+    let per_key = match index.reserve(first_key) {
+        Ok(_) => panic!("per-key capacity must reject"),
+        Err(error) => error,
+    };
+    assert_eq!(per_key.kind(), PopIndexErrorKind::BucketCapacity);
+    let second = index.reserve(second_key.clone()).expect("second reservation");
+    let global = match index.reserve(second_key) {
+        Ok(_) => panic!("global capacity must reject"),
+        Err(error) => error,
+    };
+    assert_eq!(global.kind(), PopIndexErrorKind::GlobalCapacity);
+    assert_eq!(index.snapshot().reserved(), 2);
+    drop((first, second));
+    assert_eq!(index.snapshot(), PopIndexSnapshot::default());
+}
+
+#[test]
+fn index_merges_exact_and_wildcard_by_deadline_then_sequence_in_both_orders() {
+    let index = PopCriteriaIndex::<u64>::new(PopCriteriaLimits::new(nonzero(8), nonzero(8)));
+    let base = tokio::time::Instant::now();
+    let exact_first = index.reserve(criteria_key(3)).expect("exact reservation").publish(
+        10,
+        deadline_after(base, 30),
+        match_all_criteria(),
+    );
+    let wildcard = index.reserve(criteria_key(-1)).expect("wildcard reservation").publish(
+        20,
+        deadline_after(base, 10),
+        match_all_criteria(),
+    );
+    let exact_second = index
+        .reserve(criteria_key(3))
+        .expect("second exact reservation")
+        .publish(30, deadline_after(base, 30), match_all_criteria());
+    let arrival = PopArrival::new(
+        CheetahString::from_static_str("topic"),
+        CheetahString::from_static_str("group"),
+        3,
+    );
+
+    assert_eq!(
+        index.matching_ids(&arrival, PopSelectionOrder::Oldest, nonzero(8)),
+        vec![20, 10, 30]
+    );
+    assert_eq!(
+        index.matching_ids(&arrival, PopSelectionOrder::Newest, nonzero(8)),
+        vec![30, 10, 20]
+    );
+    drop((exact_first, wildcard, exact_second));
+    assert_eq!(index.snapshot(), PopIndexSnapshot::default());
+}
+
+#[test]
+fn filter_miss_keeps_membership_for_a_later_matching_arrival() {
+    let index = PopCriteriaIndex::<u64>::new(PopCriteriaLimits::new(nonzero(2), nonzero(2)));
+    let matches = Arc::new(AtomicBool::new(false));
+    let criteria = Arc::new(PopMatchCriteria::new(
+        Some(SubscriptionData::default()),
+        Some(Arc::new(ToggleFilter {
+            matches: Arc::clone(&matches),
+        })),
+    ));
+    let lease = index.reserve(criteria_key(3)).expect("reservation").publish(
+        7,
+        deadline_after(tokio::time::Instant::now(), 10),
+        criteria,
+    );
+    let arrival = PopArrival::new(
+        CheetahString::from_static_str("topic"),
+        CheetahString::from_static_str("group"),
+        3,
+    )
+    .with_filter_metadata(Some(42), 1, None, None);
+
+    assert!(index
+        .matching_ids(&arrival, PopSelectionOrder::Oldest, nonzero(1))
+        .is_empty());
+    assert!(index.contains(7));
+    assert_eq!(index.snapshot().live(), 1);
+    matches.store(true, Ordering::SeqCst);
+    assert_eq!(
+        index.matching_ids(&arrival, PopSelectionOrder::Oldest, nonzero(1)),
+        vec![7]
+    );
+    drop(lease);
+    assert_eq!(index.snapshot(), PopIndexSnapshot::default());
+}
+
+#[test]
+fn retry_topic_versions_normalize_to_the_original_topic_key() {
+    let index = PopCriteriaIndex::<u64>::new(PopCriteriaLimits::new(nonzero(2), nonzero(2)));
+    let lease = index.reserve(criteria_key(3)).expect("reservation").publish(
+        11,
+        deadline_after(tokio::time::Instant::now(), 10),
+        match_all_criteria(),
+    );
+    for retry in [
+        KeyBuilder::build_pop_retry_topic_v1("topic", "group"),
+        KeyBuilder::build_pop_retry_topic_v2("topic", "group"),
+    ] {
+        let arrival = PopArrival::from_retry_topic(
+            CheetahString::from_string(retry),
+            CheetahString::from_static_str("group"),
+            3,
+        );
+        assert_eq!(
+            index.matching_ids(&arrival, PopSelectionOrder::Oldest, nonzero(1)),
+            vec![11]
+        );
+    }
+    drop(lease);
+    assert_eq!(index.snapshot(), PopIndexSnapshot::default());
+}
+
+#[test]
+fn affine_index_lease_releases_record_and_owned_filter_exactly_once() {
+    let index = PopCriteriaIndex::<u64>::new(PopCriteriaLimits::new(nonzero(1), nonzero(1)));
+    let drops = Arc::new(AtomicUsize::new(0));
+    let lease = index.reserve(criteria_key(3)).expect("reservation").publish(
+        99,
+        deadline_after(tokio::time::Instant::now(), 10),
+        Arc::new(PopMatchCriteria::new(
+            Some(SubscriptionData::default()),
+            Some(Arc::new(CountingFilter {
+                drops: Arc::clone(&drops),
+            })),
+        )),
+    );
+    assert_eq!(lease.deferred_id(), 99);
+    assert_eq!(index.snapshot().live(), 1);
+    assert_eq!(drops.load(Ordering::SeqCst), 0);
+
+    drop(lease);
+
+    assert_eq!(index.snapshot(), PopIndexSnapshot::default());
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+    drop(index);
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn prepared_registration_owns_index_and_wait_capacity_until_drop() {
+    let service = service(2, 2);
+    let monotonic_now = tokio::time::Instant::now();
+    let prepared = service
+        .prepare_at(
+            request(10_000, 1_000),
+            None,
+            None,
+            PopRetainedEstimate::default(),
+            10_100,
+            monotonic_now,
+        )
+        .expect("prepare before responder transfer");
+    assert!(prepared.retained_bytes() > 0);
+    assert_eq!(
+        prepared.deadline().protocol_at(),
+        monotonic_now + Duration::from_millis(851)
+    );
+    assert_eq!(service.index_snapshot().reserved(), 1);
+    assert_eq!(service.admission_snapshot().waiting_count(), 1);
+    drop(prepared);
+    assert_eq!(service.index_snapshot(), PopIndexSnapshot::default());
+    assert_eq!(service.admission_snapshot().waiting_count(), 0);
+    assert_eq!(service.admission_snapshot().retained_bytes(), 0);
+}
+
+#[test]
+fn shutdown_rejects_prepare_before_reserving_business_or_wait_capacity() {
+    let service = service(2, 2);
+    let _ = service.shutdown();
+    let error = match service.prepare_at(
+        request(10_000, 1_000),
+        None,
+        None,
+        PopRetainedEstimate::default(),
+        10_100,
+        tokio::time::Instant::now(),
+    ) {
+        Ok(_) => panic!("closed service must reject preparation"),
+        Err(error) => error,
+    };
+    assert_eq!(error.kind(), PopDeferredPrepareErrorKind::ServiceClosed);
+    assert_eq!(service.index_snapshot(), PopIndexSnapshot::default());
+    assert_eq!(service.admission_snapshot().waiting_count(), 0);
+    assert_eq!(service.admission_snapshot().retained_bytes(), 0);
+}
+
+#[test]
+fn missing_effective_peer_fails_before_reserving_capacity() {
+    let service = service(2, 2);
+    let error = match service.prepare_at(
+        request_with_host(10_000, 1_000, CheetahString::new()),
+        None,
+        None,
+        PopRetainedEstimate::default(),
+        10_100,
+        tokio::time::Instant::now(),
+    ) {
+        Ok(_) => panic!("missing trusted peer must reject preparation"),
+        Err(error) => error,
+    };
+    assert_eq!(error.kind(), PopDeferredPrepareErrorKind::MissingCallerHost);
+    assert_eq!(service.index_snapshot(), PopIndexSnapshot::default());
+    assert_eq!(service.admission_snapshot().waiting_count(), 0);
+}
+
+#[test]
+fn typed_request_data_retains_no_transport_context() {
+    let request = request(7, 9);
+    assert_eq!(request.topic().as_str(), "topic");
+    assert_eq!(request.consumer_group().as_str(), "group");
+    assert_eq!(request.queue_id(), 3);
+    assert_eq!(request.caller_host().as_str(), "127.0.0.1:10911");
+    assert!(request.estimated_dynamic_bytes().expect("retained estimate is checked") >= "127.0.0.1:10911".len());
+    assert_eq!(request.header().born_time, 7);
+    assert_eq!(request.into_header().poll_time, 9);
+}
+
+#[test]
+fn retained_accounting_includes_nested_rpc_strings_and_rejects_overflow_before_take() {
+    let mut header = request(10_000, 1_000).into_header();
+    header.topic_request_header = Some(TopicRequestHeader {
+        lo: Some(true),
+        rpc: Some(RpcRequestHeader::new(
+            Some(CheetahString::from_static_str("tenant-a")),
+            Some(true),
+            Some(CheetahString::from_static_str("broker-a")),
+            Some(false),
+        )),
+    });
+    let data = PopRequestData::from_test_header(header, CheetahString::from_static_str("127.0.0.1:10911"));
+    let bytes = data
+        .estimated_dynamic_bytes()
+        .expect("nested retained accounting is checked");
+    assert!(bytes >= "tenant-a".len() + "broker-a".len() + "127.0.0.1:10911".len());
+
+    let service = service(2, 2);
+    let error = match service.prepare_at(
+        data,
+        None,
+        None,
+        PopRetainedEstimate::new(usize::MAX, 0, 0),
+        10_100,
+        tokio::time::Instant::now(),
+    ) {
+        Ok(_) => panic!("retained-size overflow must fail before responder transfer"),
+        Err(error) => error,
+    };
+    assert_eq!(error.kind(), PopDeferredPrepareErrorKind::RetainedSizeOverflow);
+    assert_eq!(service.index_snapshot(), PopIndexSnapshot::default());
+    assert_eq!(service.admission_snapshot().waiting_count(), 0);
+}

--- a/rocketmq-broker/src/long_polling/pop_deferred/deadline.rs
+++ b/rocketmq-broker/src/long_polling/pop_deferred/deadline.rs
@@ -1,0 +1,133 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+use std::time::Duration;
+
+const EARLY_WAKE_MILLIS: u64 = 50;
+
+/// Broker-owned POP protocol deadline, kept distinct from transport ownership.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct LongPollingDeadline {
+    protocol_millis: u64,
+    protocol_at: tokio::time::Instant,
+}
+
+impl LongPollingDeadline {
+    /// Converts the legacy millisecond predicate into one monotonic deadline.
+    ///
+    /// The old predicate was `now > (born + poll).saturating_sub(50)`. The
+    /// additional millisecond preserves that strict comparison exactly at the
+    /// integer-millisecond boundary.
+    pub(crate) fn checked(
+        born_time: u64,
+        poll_time: u64,
+        wall_now: u64,
+        monotonic_now: tokio::time::Instant,
+    ) -> Result<Self, LongPollingDeadlineError> {
+        if poll_time == 0 {
+            return Err(LongPollingDeadlineError::new(
+                LongPollingDeadlineErrorKind::ZeroPollTime,
+            ));
+        }
+        let expires = born_time
+            .checked_add(poll_time)
+            .ok_or_else(|| LongPollingDeadlineError::new(LongPollingDeadlineErrorKind::ProtocolOverflow))?;
+        let legacy_threshold = expires.saturating_sub(EARLY_WAKE_MILLIS);
+        if wall_now > legacy_threshold {
+            return Err(LongPollingDeadlineError::new(
+                LongPollingDeadlineErrorKind::AlreadyExpired,
+            ));
+        }
+        let remaining_millis = legacy_threshold
+            .checked_sub(wall_now)
+            .and_then(|remaining| remaining.checked_add(1))
+            .ok_or_else(|| LongPollingDeadlineError::new(LongPollingDeadlineErrorKind::ProtocolOverflow))?;
+        let protocol_millis = legacy_threshold
+            .checked_add(1)
+            .ok_or_else(|| LongPollingDeadlineError::new(LongPollingDeadlineErrorKind::ProtocolOverflow))?;
+        let protocol_at = monotonic_now
+            .checked_add(Duration::from_millis(remaining_millis))
+            .ok_or_else(|| LongPollingDeadlineError::new(LongPollingDeadlineErrorKind::MonotonicOverflow))?;
+        Ok(Self {
+            protocol_millis,
+            protocol_at,
+        })
+    }
+
+    #[must_use]
+    pub(crate) const fn protocol_millis(self) -> u64 {
+        self.protocol_millis
+    }
+
+    #[must_use]
+    pub(crate) const fn protocol_at(self) -> tokio::time::Instant {
+        self.protocol_at
+    }
+}
+
+/// Stable category for a checked POP protocol-deadline conversion failure.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum LongPollingDeadlineErrorKind {
+    ZeroPollTime,
+    ProtocolOverflow,
+    AlreadyExpired,
+    MonotonicOverflow,
+}
+
+impl LongPollingDeadlineErrorKind {
+    #[must_use]
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::ZeroPollTime => "zero_poll_time",
+            Self::ProtocolOverflow => "protocol_overflow",
+            Self::AlreadyExpired => "already_expired",
+            Self::MonotonicOverflow => "monotonic_overflow",
+        }
+    }
+}
+
+/// Typed, redacted deadline conversion failure.
+pub(crate) struct LongPollingDeadlineError {
+    kind: LongPollingDeadlineErrorKind,
+}
+
+impl LongPollingDeadlineError {
+    const fn new(kind: LongPollingDeadlineErrorKind) -> Self {
+        Self { kind }
+    }
+
+    #[must_use]
+    pub(crate) const fn kind(&self) -> LongPollingDeadlineErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Debug for LongPollingDeadlineError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("LongPollingDeadlineError")
+            .field("kind", &self.kind.as_str())
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Display for LongPollingDeadlineError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "POP long-polling deadline failed: {}", self.kind.as_str())
+    }
+}
+
+impl Error for LongPollingDeadlineError {}

--- a/rocketmq-broker/src/long_polling/pop_deferred/index.rs
+++ b/rocketmq-broker/src/long_polling/pop_deferred/index.rs
@@ -1,0 +1,909 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::alloc::Layout;
+use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::error::Error;
+use std::fmt;
+use std::num::NonZeroUsize;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::Weak;
+
+use cheetah_string::CheetahString;
+use parking_lot::Mutex;
+use rocketmq_transport::api::v2::DeferredId;
+
+use super::deadline::LongPollingDeadline;
+
+mod types;
+
+pub(crate) use types::PopArrival;
+pub(crate) use types::PopCriteriaKey;
+pub(crate) use types::PopCriteriaLimits;
+pub(crate) use types::PopMatchCriteria;
+pub(crate) use types::PopSelectionOrder;
+
+/// Bounded POP criteria index. Registry ownership remains authoritative.
+pub(crate) struct PopCriteriaIndex<I = DeferredId> {
+    inner: Arc<PopCriteriaIndexInner<I>>,
+}
+
+impl<I> Clone for PopCriteriaIndex<I> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl<I> PopCriteriaIndex<I>
+where
+    I: Copy + Eq,
+{
+    pub(crate) fn new(limits: PopCriteriaLimits) -> Self {
+        Self {
+            inner: Arc::new(PopCriteriaIndexInner {
+                limits,
+                state: Mutex::new(PopCriteriaIndexState::default()),
+            }),
+        }
+    }
+
+    pub(crate) fn try_retained_bytes_per_entry() -> Option<usize> {
+        let membership = arc_allocation_size::<PopIndexMembership>()?;
+        checked_retained_layout_sum([
+            std::mem::size_of::<PopIndexRecord<I>>(),
+            std::mem::size_of::<PopCriteriaKey>(),
+            std::mem::size_of::<PopIndexBucket<I>>(),
+            std::mem::size_of::<PopTopicQueueKey>(),
+            std::mem::size_of::<PopFanoutBucket>(),
+            std::mem::size_of::<PopFanoutGroup>(),
+            membership,
+        ])
+    }
+
+    /// Reserves index capacity before a deferred responder is taken.
+    pub(crate) fn reserve(&self, key: PopCriteriaKey) -> Result<PopIndexReservation<I>, PopIndexError> {
+        let mut state = self.inner.state.lock();
+        let total = state
+            .live
+            .checked_add(state.reserved)
+            .ok_or_else(|| PopIndexError::new(PopIndexErrorKind::GlobalCapacity))?;
+        if total >= self.inner.limits.max_entries.get() {
+            return Err(PopIndexError::new(PopIndexErrorKind::GlobalCapacity));
+        }
+        let next_sequence = state
+            .next_sequence
+            .checked_add(1)
+            .ok_or_else(|| PopIndexError::new(PopIndexErrorKind::SequenceExhausted))?;
+        let occupied = state.buckets.get(&key).map_or(0, |bucket| {
+            bucket
+                .entries
+                .len()
+                .saturating_add(bucket.candidates)
+                .saturating_add(bucket.reserved)
+        });
+        if occupied >= self.inner.limits.max_entries_per_key.get() {
+            return Err(PopIndexError::new(PopIndexErrorKind::BucketCapacity));
+        }
+
+        let fanout_key = PopTopicQueueKey::from_criteria(&key);
+        let group_exists = state.fanout.get(&fanout_key).is_some_and(|bucket| {
+            bucket
+                .groups
+                .iter()
+                .any(|group| group.consumer_group == key.consumer_group)
+        });
+        let bucket_missing = !state.buckets.contains_key(&key);
+        let fanout_missing = !state.fanout.contains_key(&fanout_key);
+        let additional_entry_capacity = state.buckets.get(&key).map_or(Ok(1), |bucket| {
+            bucket
+                .reserved
+                .checked_add(bucket.candidates)
+                .and_then(|pending| pending.checked_add(1))
+                .ok_or_else(|| PopIndexError::new(PopIndexErrorKind::Allocation))
+        })?;
+        if bucket_missing {
+            state
+                .buckets
+                .try_reserve(1)
+                .map_err(|_| PopIndexError::new(PopIndexErrorKind::Allocation))?;
+        }
+        if fanout_missing {
+            state
+                .fanout
+                .try_reserve(1)
+                .map_err(|_| PopIndexError::new(PopIndexErrorKind::Allocation))?;
+        }
+        let mut new_bucket = bucket_missing.then(PopIndexBucket::default);
+        if let Some(bucket) = new_bucket.as_mut() {
+            bucket
+                .entries
+                .try_reserve(additional_entry_capacity)
+                .map_err(|_| PopIndexError::new(PopIndexErrorKind::Allocation))?;
+        } else {
+            state
+                .buckets
+                .get_mut(&key)
+                .expect("existing POP bucket remains present")
+                .entries
+                .try_reserve(additional_entry_capacity)
+                .map_err(|_| PopIndexError::new(PopIndexErrorKind::Allocation))?;
+        }
+        let mut new_fanout = fanout_missing.then(PopFanoutBucket::default);
+        if !group_exists {
+            if let Some(bucket) = new_fanout.as_mut() {
+                bucket
+                    .groups
+                    .try_reserve(1)
+                    .map_err(|_| PopIndexError::new(PopIndexErrorKind::Allocation))?;
+            } else {
+                state
+                    .fanout
+                    .get_mut(&fanout_key)
+                    .expect("existing POP fanout bucket remains present")
+                    .groups
+                    .try_reserve(1)
+                    .map_err(|_| PopIndexError::new(PopIndexErrorKind::Allocation))?;
+            }
+        }
+        if let Some(bucket) = new_bucket {
+            state.buckets.insert(key.clone(), bucket);
+        }
+        if let Some(bucket) = new_fanout {
+            state.fanout.insert(fanout_key.clone(), bucket);
+        }
+
+        state
+            .buckets
+            .get_mut(&key)
+            .expect("reserved POP bucket exists")
+            .reserved += 1;
+        let fanout = state.fanout.entry(fanout_key.clone()).or_default();
+        if let Some(group) = fanout
+            .groups
+            .iter_mut()
+            .find(|group| group.consumer_group == key.consumer_group)
+        {
+            group.reserved += 1;
+        } else {
+            fanout.groups.push(PopFanoutGroup {
+                consumer_group: key.consumer_group.clone(),
+                live: 0,
+                reserved: 1,
+            });
+        }
+        state.next_sequence = next_sequence;
+        state.reserved += 1;
+        let sequence = next_sequence - 1;
+        drop(state);
+        Ok(PopIndexReservation {
+            inner: Some(Arc::clone(&self.inner)),
+            key: Some(key),
+            fanout_key: Some(fanout_key),
+            sequence,
+            membership: Arc::new(PopIndexMembership::default()),
+        })
+    }
+
+    #[cfg(test)]
+    /// Reserves at most `scan_limit` matching candidates for one test arrival.
+    ///
+    /// Filters run without the index mutex. Each successful match is then
+    /// revalidated and removed from availability under the mutex. A losing
+    /// concurrent arrival retries the next ordered candidate without spending
+    /// its scan budget, so a one-candidate budget cannot lose a second wake.
+    pub(crate) fn reserve_matching(
+        &self,
+        arrival: &PopArrival,
+        order: PopSelectionOrder,
+        scan_limit: NonZeroUsize,
+    ) -> Vec<PopCandidateReservation<I>> {
+        let mut remaining = scan_limit.get();
+        let mut reserved = Vec::new();
+        while remaining > 0 {
+            let Some(remaining_limit) = NonZeroUsize::new(remaining) else {
+                break;
+            };
+            let selection = self.reserve_next_matching(arrival, order, remaining_limit);
+            let inspected = selection.inspected();
+            if inspected == 0 {
+                break;
+            }
+            remaining -= inspected;
+            if let Some(candidate) = selection.into_candidate() {
+                reserved.push(candidate);
+            } else {
+                break;
+            }
+        }
+        reserved
+    }
+
+    /// Reserves only the first match in a bounded ordered prefix.
+    ///
+    /// Holding at most one candidate lets a claim wait on a provisional
+    /// registry entry without hiding later waiters from another arrival.
+    pub(crate) fn reserve_next_matching(
+        &self,
+        arrival: &PopArrival,
+        order: PopSelectionOrder,
+        scan_limit: NonZeroUsize,
+    ) -> PopCandidateSelection<I> {
+        let exact = PopCriteriaKey::from_parts(&arrival.topic, &arrival.consumer_group, arrival.queue_id);
+        let wildcard = PopCriteriaKey::from_parts(&arrival.topic, &arrival.consumer_group, -1);
+        let mut skipped = Vec::new();
+        let mut inspected = 0;
+        let mut conflicts = 0;
+        while inspected < scan_limit.get() && conflicts <= scan_limit.get() {
+            let Some(snapshot) = self.next_candidate(&exact, &wildcard, order, &skipped) else {
+                break;
+            };
+            if !snapshot.criteria.matches(arrival) {
+                skipped.push((snapshot.key, snapshot.order));
+                inspected += 1;
+                continue;
+            }
+            match self.try_reserve_candidate(snapshot) {
+                Some(candidate) => {
+                    inspected += 1;
+                    return PopCandidateSelection::new(Some(candidate), inspected);
+                }
+                None => conflicts += 1,
+            }
+        }
+        PopCandidateSelection::new(None, inspected)
+    }
+
+    #[cfg(test)]
+    /// Test-only identity projection that immediately releases each candidate.
+    pub(crate) fn matching_ids(&self, arrival: &PopArrival, order: PopSelectionOrder, limit: NonZeroUsize) -> Vec<I> {
+        self.reserve_matching(arrival, order, limit)
+            .iter()
+            .map(PopCandidateReservation::id)
+            .collect()
+    }
+
+    /// Returns a bounded topic/queue-to-consumer-group fanout projection.
+    ///
+    /// The exact and wildcard scopes each contribute at most `per_scope_limit`
+    /// groups. Each scope advances a round-robin cursor even when its groups
+    /// duplicate the other scope, preventing a hot group from permanently
+    /// hiding another group. The index stores only group refcounts, not a
+    /// request, responder, or transport capability.
+    pub(crate) fn consumer_groups(
+        &self,
+        topic: &CheetahString,
+        queue_id: i32,
+        per_scope_limit: NonZeroUsize,
+    ) -> Vec<CheetahString> {
+        let exact = PopTopicQueueKey::from_arrival(topic, queue_id);
+        let wildcard = PopTopicQueueKey::from_arrival(topic, -1);
+        let mut state = self.inner.state.lock();
+        let mut groups = Vec::new();
+        append_fanout_groups(&mut state, &exact, per_scope_limit, &mut groups);
+        if wildcard != exact {
+            append_fanout_groups(&mut state, &wildcard, per_scope_limit, &mut groups);
+        }
+        groups
+    }
+
+    fn next_candidate(
+        &self,
+        exact: &PopCriteriaKey,
+        wildcard: &PopCriteriaKey,
+        order: PopSelectionOrder,
+        skipped: &[(PopCriteriaKey, PopOrderKey)],
+    ) -> Option<PopIndexCandidateSnapshot<I>> {
+        let state = self.inner.state.lock();
+        let exact_candidate = candidate_from_bucket(&state, exact, order, skipped);
+        let wildcard_candidate = (wildcard != exact)
+            .then(|| candidate_from_bucket(&state, wildcard, order, skipped))
+            .flatten();
+        match (exact_candidate, wildcard_candidate) {
+            (Some(exact), Some(wildcard)) => {
+                let exact_first = match order {
+                    PopSelectionOrder::Oldest => exact.order <= wildcard.order,
+                    PopSelectionOrder::Newest => exact.order >= wildcard.order,
+                };
+                Some(if exact_first { exact } else { wildcard })
+            }
+            (Some(candidate), None) | (None, Some(candidate)) => Some(candidate),
+            (None, None) => None,
+        }
+    }
+
+    fn try_reserve_candidate(&self, snapshot: PopIndexCandidateSnapshot<I>) -> Option<PopCandidateReservation<I>> {
+        let mut state = self.inner.state.lock();
+        let bucket = state.buckets.get_mut(&snapshot.key)?;
+        let position = bucket
+            .entries
+            .binary_search_by_key(&snapshot.order, PopIndexRecord::order_key)
+            .ok()?;
+        if bucket.entries.get(position)?.id != snapshot.id {
+            return None;
+        }
+        let record = bucket.entries.remove(position)?;
+        record.membership.candidate_reserved.store(true, Ordering::Release);
+        bucket.candidates += 1;
+        Some(PopCandidateReservation {
+            inner: Arc::downgrade(&self.inner),
+            key: snapshot.key,
+            record: Some(record),
+        })
+    }
+
+    #[must_use]
+    pub(crate) fn snapshot(&self) -> PopIndexSnapshot {
+        let state = self.inner.state.lock();
+        PopIndexSnapshot {
+            live: state.live,
+            reserved: state.reserved,
+            buckets: state.buckets.len(),
+        }
+    }
+
+    pub(crate) fn contains(&self, id: I) -> bool {
+        self.inner
+            .state
+            .lock()
+            .buckets
+            .values()
+            .any(|bucket| bucket.entries.iter().any(|record| record.id == id))
+    }
+}
+
+fn arc_allocation_size<T>() -> Option<usize> {
+    let (layout, _) = Layout::new::<AtomicUsize>().extend(Layout::new::<AtomicUsize>()).ok()?;
+    let (layout, _) = layout.extend(Layout::new::<T>()).ok()?;
+    Some(layout.pad_to_align().size())
+}
+
+fn checked_retained_layout_sum<const N: usize>(parts: [usize; N]) -> Option<usize> {
+    parts
+        .into_iter()
+        .try_fold(0usize, |total, part| total.checked_add(part))
+}
+
+fn candidate_from_bucket<I: Copy>(
+    state: &PopCriteriaIndexState<I>,
+    key: &PopCriteriaKey,
+    order: PopSelectionOrder,
+    skipped: &[(PopCriteriaKey, PopOrderKey)],
+) -> Option<PopIndexCandidateSnapshot<I>> {
+    let bucket = state.buckets.get(key)?;
+    let is_available = |record: &&PopIndexRecord<I>| {
+        !skipped
+            .iter()
+            .any(|(skipped_key, skipped_order)| skipped_key == key && *skipped_order == record.order_key())
+    };
+    let record = match order {
+        PopSelectionOrder::Oldest => bucket.entries.iter().find(is_available),
+        PopSelectionOrder::Newest => bucket.entries.iter().rev().find(is_available),
+    }?;
+    Some(PopIndexCandidateSnapshot {
+        key: key.clone(),
+        id: record.id,
+        order: record.order_key(),
+        criteria: Arc::clone(&record.criteria),
+    })
+}
+
+fn append_fanout_groups<I>(
+    state: &mut PopCriteriaIndexState<I>,
+    key: &PopTopicQueueKey,
+    limit: NonZeroUsize,
+    groups: &mut Vec<CheetahString>,
+) {
+    let Some(bucket) = state.fanout.get_mut(key) else {
+        return;
+    };
+    let len = bucket.groups.len();
+    if len == 0 {
+        return;
+    }
+    let scan = len.min(limit.get());
+    for offset in 0..scan {
+        let position = (bucket.cursor + offset) % len;
+        let group = &bucket.groups[position];
+        if group.live > 0 && !groups.contains(&group.consumer_group) {
+            groups.push(group.consumer_group.clone());
+        }
+    }
+    bucket.cursor = (bucket.cursor + scan) % len;
+}
+
+fn insert_ordered<I>(entries: &mut VecDeque<PopIndexRecord<I>>, record: PopIndexRecord<I>) {
+    let position = entries
+        .binary_search_by_key(&record.order_key(), PopIndexRecord::order_key)
+        .unwrap_or_else(|position| position);
+    entries.insert(position, record);
+}
+
+fn bucket_is_empty<I>(bucket: &PopIndexBucket<I>) -> bool {
+    bucket.entries.is_empty() && bucket.reserved == 0 && bucket.candidates == 0
+}
+
+fn release_fanout_reservation<I>(
+    state: &mut PopCriteriaIndexState<I>,
+    key: &PopTopicQueueKey,
+    consumer_group: &CheetahString,
+) {
+    release_fanout(state, key, consumer_group, false);
+}
+
+fn release_fanout_live<I>(
+    state: &mut PopCriteriaIndexState<I>,
+    key: &PopTopicQueueKey,
+    consumer_group: &CheetahString,
+) {
+    release_fanout(state, key, consumer_group, true);
+}
+
+fn release_fanout<I>(
+    state: &mut PopCriteriaIndexState<I>,
+    key: &PopTopicQueueKey,
+    consumer_group: &CheetahString,
+    live: bool,
+) {
+    let mut remove_bucket = false;
+    if let Some(bucket) = state.fanout.get_mut(key) {
+        if let Some(position) = bucket
+            .groups
+            .iter()
+            .position(|group| &group.consumer_group == consumer_group)
+        {
+            let group = &mut bucket.groups[position];
+            if live {
+                debug_assert!(group.live > 0);
+                group.live -= 1;
+            } else {
+                debug_assert!(group.reserved > 0);
+                group.reserved -= 1;
+            }
+            if group.live == 0 && group.reserved == 0 {
+                bucket.groups.remove(position);
+                if bucket.groups.is_empty() {
+                    bucket.cursor = 0;
+                } else {
+                    bucket.cursor %= bucket.groups.len();
+                }
+            }
+        }
+        remove_bucket = bucket.groups.is_empty();
+    }
+    if remove_bucket {
+        state.fanout.remove(key);
+    }
+}
+
+struct PopCriteriaIndexInner<I> {
+    limits: PopCriteriaLimits,
+    state: Mutex<PopCriteriaIndexState<I>>,
+}
+
+struct PopCriteriaIndexState<I> {
+    buckets: HashMap<PopCriteriaKey, PopIndexBucket<I>>,
+    fanout: HashMap<PopTopicQueueKey, PopFanoutBucket>,
+    live: usize,
+    reserved: usize,
+    next_sequence: u64,
+}
+
+impl<I> Default for PopCriteriaIndexState<I> {
+    fn default() -> Self {
+        Self {
+            buckets: HashMap::new(),
+            fanout: HashMap::new(),
+            live: 0,
+            reserved: 0,
+            next_sequence: 0,
+        }
+    }
+}
+
+struct PopIndexBucket<I> {
+    entries: VecDeque<PopIndexRecord<I>>,
+    reserved: usize,
+    candidates: usize,
+}
+
+impl<I> Default for PopIndexBucket<I> {
+    fn default() -> Self {
+        Self {
+            entries: VecDeque::new(),
+            reserved: 0,
+            candidates: 0,
+        }
+    }
+}
+
+struct PopIndexRecord<I> {
+    id: I,
+    deadline: LongPollingDeadline,
+    sequence: u64,
+    criteria: Arc<PopMatchCriteria>,
+    membership: Arc<PopIndexMembership>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct PopOrderKey {
+    deadline: tokio::time::Instant,
+    sequence: u64,
+}
+
+impl<I> PopIndexRecord<I> {
+    const fn order_key(&self) -> PopOrderKey {
+        PopOrderKey {
+            deadline: self.deadline.protocol_at(),
+            sequence: self.sequence,
+        }
+    }
+}
+
+struct PopIndexCandidateSnapshot<I> {
+    key: PopCriteriaKey,
+    id: I,
+    order: PopOrderKey,
+    criteria: Arc<PopMatchCriteria>,
+}
+
+#[derive(Default)]
+struct PopIndexMembership {
+    live: AtomicBool,
+    candidate_reserved: AtomicBool,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct PopTopicQueueKey {
+    topic: CheetahString,
+    queue_id: i32,
+}
+
+impl PopTopicQueueKey {
+    fn from_criteria(key: &PopCriteriaKey) -> Self {
+        Self {
+            topic: key.topic.clone(),
+            queue_id: key.queue_id,
+        }
+    }
+
+    fn from_arrival(topic: &CheetahString, queue_id: i32) -> Self {
+        Self {
+            topic: topic.clone(),
+            queue_id,
+        }
+    }
+}
+
+#[derive(Default)]
+struct PopFanoutBucket {
+    groups: Vec<PopFanoutGroup>,
+    cursor: usize,
+}
+
+struct PopFanoutGroup {
+    consumer_group: CheetahString,
+    live: usize,
+    reserved: usize,
+}
+
+/// Capacity proof moved into the registry's synchronous builder.
+#[must_use]
+pub(crate) struct PopIndexReservation<I = DeferredId> {
+    inner: Option<Arc<PopCriteriaIndexInner<I>>>,
+    key: Option<PopCriteriaKey>,
+    fanout_key: Option<PopTopicQueueKey>,
+    sequence: u64,
+    membership: Arc<PopIndexMembership>,
+}
+
+impl<I> PopIndexReservation<I>
+where
+    I: Copy + Eq,
+{
+    /// Publishes the already-reserved record without a recoverable failure.
+    pub(crate) fn publish(
+        mut self,
+        id: I,
+        deadline: LongPollingDeadline,
+        criteria: Arc<PopMatchCriteria>,
+    ) -> PopIndexLease<I> {
+        let inner = self.inner.take().expect("armed POP index reservation owns its index");
+        let key = self.key.take().expect("armed POP index reservation owns its key");
+        let fanout_key = self
+            .fanout_key
+            .take()
+            .expect("armed POP index reservation owns its fanout key");
+        {
+            let mut state = inner.state.lock();
+            let bucket = state
+                .buckets
+                .get_mut(&key)
+                .expect("armed POP index reservation retains its bucket");
+            debug_assert!(bucket.reserved > 0);
+            bucket.reserved -= 1;
+            let record = PopIndexRecord {
+                id,
+                deadline,
+                sequence: self.sequence,
+                criteria,
+                membership: Arc::clone(&self.membership),
+            };
+            insert_ordered(&mut bucket.entries, record);
+            let fanout = state
+                .fanout
+                .get_mut(&fanout_key)
+                .expect("armed POP reservation retains its fanout bucket");
+            let group = fanout
+                .groups
+                .iter_mut()
+                .find(|group| group.consumer_group == key.consumer_group)
+                .expect("armed POP reservation retains its fanout group");
+            debug_assert!(group.reserved > 0);
+            group.reserved -= 1;
+            group.live += 1;
+            state.reserved -= 1;
+            state.live += 1;
+            self.membership.live.store(true, Ordering::Release);
+        }
+        PopIndexLease {
+            inner: Arc::downgrade(&inner),
+            key,
+            fanout_key,
+            id,
+            order: PopOrderKey {
+                deadline: deadline.protocol_at(),
+                sequence: self.sequence,
+            },
+            membership: Arc::clone(&self.membership),
+        }
+    }
+}
+
+impl<I> Drop for PopIndexReservation<I> {
+    fn drop(&mut self) {
+        let (Some(inner), Some(key), Some(fanout_key)) = (self.inner.take(), self.key.take(), self.fanout_key.take())
+        else {
+            return;
+        };
+        let mut state = inner.state.lock();
+        let remove_bucket = if let Some(bucket) = state.buckets.get_mut(&key) {
+            debug_assert!(bucket.reserved > 0);
+            bucket.reserved -= 1;
+            bucket_is_empty(bucket)
+        } else {
+            false
+        };
+        release_fanout_reservation(&mut state, &fanout_key, &key.consumer_group);
+        state.reserved -= 1;
+        if remove_bucket {
+            state.buckets.remove(&key);
+        }
+    }
+}
+
+/// Affine membership owner stored in `ResumePop`.
+#[must_use]
+pub(crate) struct PopIndexLease<I: Eq = DeferredId> {
+    inner: Weak<PopCriteriaIndexInner<I>>,
+    key: PopCriteriaKey,
+    fanout_key: PopTopicQueueKey,
+    id: I,
+    order: PopOrderKey,
+    membership: Arc<PopIndexMembership>,
+}
+
+impl<I> PopIndexLease<I>
+where
+    I: Copy + Eq,
+{
+    #[must_use]
+    pub(crate) const fn deferred_id(&self) -> I {
+        self.id
+    }
+}
+
+impl<I> Drop for PopIndexLease<I>
+where
+    I: Eq,
+{
+    fn drop(&mut self) {
+        let Some(inner) = self.inner.upgrade() else {
+            return;
+        };
+        let removed = {
+            let mut state = inner.state.lock();
+            if !self.membership.live.swap(false, Ordering::AcqRel) {
+                return;
+            }
+            let mut removed = None;
+            let mut remove_bucket = false;
+            if let Some(bucket) = state.buckets.get_mut(&self.key) {
+                if self.membership.candidate_reserved.swap(false, Ordering::AcqRel) {
+                    debug_assert!(bucket.candidates > 0);
+                    bucket.candidates -= 1;
+                } else if let Ok(position) = bucket
+                    .entries
+                    .binary_search_by_key(&self.order, PopIndexRecord::order_key)
+                {
+                    debug_assert!(bucket.entries.get(position).is_some_and(|record| record.id == self.id));
+                    removed = Some(bucket.entries.remove(position));
+                }
+                remove_bucket = bucket_is_empty(bucket);
+            }
+            state.live -= 1;
+            release_fanout_live(&mut state, &self.fanout_key, &self.key.consumer_group);
+            if remove_bucket {
+                state.buckets.remove(&self.key);
+            }
+            removed
+        };
+        drop(removed);
+    }
+}
+
+/// Affine claim opportunity held across registry claim arbitration.
+#[must_use]
+pub(crate) struct PopCandidateReservation<I: Eq = DeferredId> {
+    inner: Weak<PopCriteriaIndexInner<I>>,
+    key: PopCriteriaKey,
+    record: Option<PopIndexRecord<I>>,
+}
+
+/// One bounded selection result and the filter budget it consumed.
+#[must_use]
+pub(crate) struct PopCandidateSelection<I: Eq = DeferredId> {
+    candidate: Option<PopCandidateReservation<I>>,
+    inspected: usize,
+}
+
+impl<I> PopCandidateSelection<I>
+where
+    I: Eq,
+{
+    const fn new(candidate: Option<PopCandidateReservation<I>>, inspected: usize) -> Self {
+        Self { candidate, inspected }
+    }
+
+    #[must_use]
+    pub(crate) const fn inspected(&self) -> usize {
+        self.inspected
+    }
+
+    pub(crate) fn into_candidate(self) -> Option<PopCandidateReservation<I>> {
+        self.candidate
+    }
+}
+
+impl<I> PopCandidateReservation<I>
+where
+    I: Copy + Eq,
+{
+    #[must_use]
+    pub(crate) fn id(&self) -> I {
+        self.record.as_ref().expect("live POP candidate owns its record").id
+    }
+}
+
+impl<I> Drop for PopCandidateReservation<I>
+where
+    I: Eq,
+{
+    fn drop(&mut self) {
+        let Some(record) = self.record.take() else {
+            return;
+        };
+        let Some(inner) = self.inner.upgrade() else {
+            return;
+        };
+        let mut state = inner.state.lock();
+        let Some(bucket) = state.buckets.get_mut(&self.key) else {
+            debug_assert!(!record.membership.live.load(Ordering::Acquire));
+            return;
+        };
+        if !record.membership.candidate_reserved.swap(false, Ordering::AcqRel) {
+            debug_assert!(!record.membership.live.load(Ordering::Acquire));
+            return;
+        }
+        debug_assert!(bucket.candidates > 0);
+        bucket.candidates -= 1;
+        if record.membership.live.load(Ordering::Acquire) {
+            insert_ordered(&mut bucket.entries, record);
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PopIndexSnapshot {
+    live: usize,
+    reserved: usize,
+    buckets: usize,
+}
+
+impl PopIndexSnapshot {
+    #[must_use]
+    pub(crate) const fn live(self) -> usize {
+        self.live
+    }
+
+    #[must_use]
+    pub(crate) const fn reserved(self) -> usize {
+        self.reserved
+    }
+
+    #[must_use]
+    pub(crate) const fn buckets(self) -> usize {
+        self.buckets
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum PopIndexErrorKind {
+    GlobalCapacity,
+    BucketCapacity,
+    SequenceExhausted,
+    Allocation,
+}
+
+impl PopIndexErrorKind {
+    #[must_use]
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::GlobalCapacity => "global_capacity",
+            Self::BucketCapacity => "bucket_capacity",
+            Self::SequenceExhausted => "sequence_exhausted",
+            Self::Allocation => "allocation",
+        }
+    }
+}
+
+pub(crate) struct PopIndexError {
+    kind: PopIndexErrorKind,
+}
+
+impl PopIndexError {
+    const fn new(kind: PopIndexErrorKind) -> Self {
+        Self { kind }
+    }
+
+    #[must_use]
+    pub(crate) const fn kind(&self) -> PopIndexErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Debug for PopIndexError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PopIndexError")
+            .field("kind", &self.kind.as_str())
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Display for PopIndexError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "POP criteria index failed: {}", self.kind.as_str())
+    }
+}
+
+impl Error for PopIndexError {}
+
+#[cfg(test)]
+mod p1_tests;

--- a/rocketmq-broker/src/long_polling/pop_deferred/index/p1_tests.rs
+++ b/rocketmq-broker/src/long_polling/pop_deferred/index/p1_tests.rs
@@ -1,0 +1,350 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::alloc::Layout;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::num::NonZeroUsize;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::Barrier;
+use std::thread;
+
+use cheetah_string::CheetahString;
+use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
+use rocketmq_store::CqExtUnit;
+use rocketmq_store::MessageFilter;
+
+use super::*;
+
+fn nonzero(value: usize) -> NonZeroUsize {
+    NonZeroUsize::new(value).expect("test value is non-zero")
+}
+
+fn key(group: &str, queue_id: i32) -> PopCriteriaKey {
+    PopCriteriaKey::new(
+        CheetahString::from_static_str("topic"),
+        CheetahString::from_string(group.to_owned()),
+        queue_id,
+    )
+}
+
+fn arrival(group: &str, queue_id: i32) -> PopArrival {
+    PopArrival::new(
+        CheetahString::from_static_str("topic"),
+        CheetahString::from_string(group.to_owned()),
+        queue_id,
+    )
+}
+
+fn deadline(base: tokio::time::Instant, millis: u64) -> LongPollingDeadline {
+    LongPollingDeadline::checked(0, millis + 49, 0, base).expect("test deadline")
+}
+
+fn match_all() -> Arc<PopMatchCriteria> {
+    Arc::new(PopMatchCriteria::new(None, None))
+}
+
+struct TwoArrivalBarrierFilter {
+    barrier: Arc<Barrier>,
+    calls: AtomicUsize,
+}
+
+impl MessageFilter for TwoArrivalBarrierFilter {
+    fn is_matched_by_consume_queue(&self, _tags_code: Option<i64>, _cq_ext_unit: Option<&CqExtUnit>) -> bool {
+        if self.calls.fetch_add(1, Ordering::SeqCst) < 2 {
+            self.barrier.wait();
+        }
+        true
+    }
+
+    fn is_matched_by_commit_log(
+        &self,
+        _msg_buffer: Option<&[u8]>,
+        _properties: Option<&HashMap<CheetahString, CheetahString>>,
+    ) -> bool {
+        true
+    }
+}
+
+#[test]
+fn concurrent_arrival_loser_advances_to_second_waiter_with_one_candidate_budget() {
+    let index = PopCriteriaIndex::<u64>::new(PopCriteriaLimits::new(nonzero(2), nonzero(2)));
+    let filter = Arc::new(TwoArrivalBarrierFilter {
+        barrier: Arc::new(Barrier::new(2)),
+        calls: AtomicUsize::new(0),
+    });
+    let criteria = Arc::new(PopMatchCriteria::new(Some(SubscriptionData::default()), Some(filter)));
+    let base = tokio::time::Instant::now();
+    let first_lease = index.reserve(key("group", 3)).expect("first reservation").publish(
+        1,
+        deadline(base, 10),
+        Arc::clone(&criteria),
+    );
+    let second_lease =
+        index
+            .reserve(key("group", 3))
+            .expect("second reservation")
+            .publish(2, deadline(base, 20), criteria);
+    let start = Arc::new(Barrier::new(3));
+    let mut workers = Vec::new();
+    for _ in 0..2 {
+        let worker_index = index.clone();
+        let worker_start = Arc::clone(&start);
+        workers.push(thread::spawn(move || {
+            worker_start.wait();
+            worker_index.reserve_matching(&arrival("group", 3), PopSelectionOrder::Oldest, nonzero(1))
+        }));
+    }
+    start.wait();
+    let mut reservations = workers
+        .into_iter()
+        .flat_map(|worker| worker.join().expect("arrival worker"))
+        .collect::<Vec<_>>();
+    let mut ids = reservations.iter().map(PopCandidateReservation::id).collect::<Vec<_>>();
+    ids.sort_unstable();
+    assert_eq!(ids, vec![1, 2]);
+    assert!(
+        index
+            .reserve_matching(&arrival("group", 3), PopSelectionOrder::Oldest, nonzero(1))
+            .is_empty(),
+        "both affine candidates remain unavailable while their arrival owns them"
+    );
+
+    reservations.clear();
+    assert_eq!(
+        index.matching_ids(&arrival("group", 3), PopSelectionOrder::Oldest, nonzero(2)),
+        vec![1, 2]
+    );
+    drop((first_lease, second_lease));
+    assert_eq!(index.snapshot(), PopIndexSnapshot::default());
+}
+
+#[test]
+fn candidate_drop_reopens_but_lease_drop_retires_the_affine_membership() {
+    let index = PopCriteriaIndex::<u64>::new(PopCriteriaLimits::new(nonzero(1), nonzero(1)));
+    let lease = index.reserve(key("group", 3)).expect("reservation").publish(
+        7,
+        deadline(tokio::time::Instant::now(), 10),
+        match_all(),
+    );
+    let mut candidates = index.reserve_matching(&arrival("group", 3), PopSelectionOrder::Oldest, nonzero(1));
+    let candidate = candidates.pop().expect("candidate");
+    assert!(index
+        .reserve_matching(&arrival("group", 3), PopSelectionOrder::Oldest, nonzero(1))
+        .is_empty());
+    drop(candidate);
+    assert_eq!(
+        index.matching_ids(&arrival("group", 3), PopSelectionOrder::Oldest, nonzero(1)),
+        vec![7]
+    );
+
+    let candidate = index
+        .reserve_matching(&arrival("group", 3), PopSelectionOrder::Oldest, nonzero(1))
+        .pop()
+        .expect("candidate after release");
+    drop(lease);
+    drop(candidate);
+    assert_eq!(index.snapshot(), PopIndexSnapshot::default());
+    assert!(index.consumer_groups(&"topic".into(), 3, nonzero(1)).is_empty());
+}
+
+#[test]
+fn preflight_reserves_storage_for_every_candidate_and_pending_publish() {
+    let index = PopCriteriaIndex::<u64>::new(PopCriteriaLimits::new(nonzero(1_024), nonzero(1_024)));
+    let criteria_key = key("group", 3);
+    let base = tokio::time::Instant::now();
+    let mut leases = Vec::new();
+    loop {
+        let (len, capacity) = index
+            .inner
+            .state
+            .lock()
+            .buckets
+            .get(&criteria_key)
+            .map_or((0, 0), |bucket| (bucket.entries.len(), bucket.entries.capacity()));
+        if len > 0 && len == capacity {
+            break;
+        }
+        let id = leases.len() as u64;
+        leases.push(
+            index
+                .reserve(criteria_key.clone())
+                .expect("fill the current bucket allocation")
+                .publish(id, deadline(base, id + 1), match_all()),
+        );
+    }
+
+    let filled_capacity = index
+        .inner
+        .state
+        .lock()
+        .buckets
+        .get(&criteria_key)
+        .expect("filled bucket")
+        .entries
+        .capacity();
+    let candidates = index.reserve_matching(
+        &arrival("group", 3),
+        PopSelectionOrder::Oldest,
+        nonzero(filled_capacity),
+    );
+    assert_eq!(candidates.len(), filled_capacity);
+
+    let pending = index
+        .reserve(criteria_key.clone())
+        .expect("preflight accounts for candidate reinsertion");
+    let reserved_capacity = index
+        .inner
+        .state
+        .lock()
+        .buckets
+        .get(&criteria_key)
+        .expect("candidate-held bucket")
+        .entries
+        .capacity();
+    assert!(reserved_capacity > filled_capacity);
+    let last_id = filled_capacity as u64;
+    leases.push(pending.publish(last_id, deadline(base, last_id + 1), match_all()));
+    drop(candidates);
+
+    let state = index.inner.state.lock();
+    let bucket = state.buckets.get(&criteria_key).expect("restored bucket");
+    assert_eq!(bucket.entries.len(), filled_capacity + 1);
+    assert_eq!(bucket.entries.capacity(), reserved_capacity);
+    drop(state);
+    drop(leases);
+    assert_eq!(index.snapshot(), PopIndexSnapshot::default());
+}
+
+#[test]
+fn retained_floor_counts_worst_case_bucket_fanout_and_arc_membership() {
+    let (arc_header, _) = Layout::new::<AtomicUsize>()
+        .extend(Layout::new::<AtomicUsize>())
+        .expect("Arc header layout");
+    let (membership, _) = arc_header
+        .extend(Layout::new::<PopIndexMembership>())
+        .expect("Arc membership layout");
+    let membership = membership.pad_to_align().size();
+    let expected = [
+        std::mem::size_of::<PopIndexRecord<u64>>(),
+        std::mem::size_of::<PopCriteriaKey>(),
+        std::mem::size_of::<PopIndexBucket<u64>>(),
+        std::mem::size_of::<PopTopicQueueKey>(),
+        std::mem::size_of::<PopFanoutBucket>(),
+        std::mem::size_of::<PopFanoutGroup>(),
+        membership,
+    ]
+    .into_iter()
+    .try_fold(0usize, |total, part| total.checked_add(part))
+    .expect("test retained floor");
+    let previous_incomplete_floor = std::mem::size_of::<PopIndexRecord<u64>>()
+        + std::mem::size_of::<PopCriteriaKey>()
+        + std::mem::size_of::<PopFanoutGroup>()
+        + std::mem::size_of::<PopIndexMembership>();
+
+    assert_eq!(PopCriteriaIndex::<u64>::try_retained_bytes_per_entry(), Some(expected));
+    assert!(expected > previous_incomplete_floor);
+    assert_eq!(checked_retained_layout_sum([usize::MAX, 1]), None);
+}
+
+#[test]
+fn topic_queue_fanout_is_bounded_round_robin_and_cleans_up_exact_and_wildcard_groups() {
+    let index = PopCriteriaIndex::<u64>::new(PopCriteriaLimits::new(nonzero(4), nonzero(4)));
+    let base = tokio::time::Instant::now();
+    let mut leases = Vec::new();
+    for (id, group) in [(1, "a"), (2, "b"), (3, "c")] {
+        leases.push(index.reserve(key(group, 3)).expect("exact fanout reservation").publish(
+            id,
+            deadline(base, id * 10),
+            match_all(),
+        ));
+    }
+    leases.push(
+        index
+            .reserve(key("wildcard", -1))
+            .expect("wildcard fanout reservation")
+            .publish(4, deadline(base, 40), match_all()),
+    );
+
+    let mut observed = HashSet::new();
+    for _ in 0..3 {
+        let groups = index.consumer_groups(&"topic".into(), 3, nonzero(1));
+        assert!(groups.len() <= 2, "exact and wildcard scopes are independently bounded");
+        observed.extend(groups.into_iter().map(|group| group.to_string()));
+    }
+    assert_eq!(
+        observed,
+        HashSet::from(["a".to_owned(), "b".to_owned(), "c".to_owned(), "wildcard".to_owned()])
+    );
+
+    drop(leases);
+    assert!(index.consumer_groups(&"topic".into(), 3, nonzero(1)).is_empty());
+    assert_eq!(index.snapshot(), PopIndexSnapshot::default());
+}
+
+struct CountingMatchFilter(Arc<AtomicUsize>);
+
+impl MessageFilter for CountingMatchFilter {
+    fn is_matched_by_consume_queue(&self, _tags_code: Option<i64>, _cq_ext_unit: Option<&CqExtUnit>) -> bool {
+        self.0.fetch_add(1, Ordering::SeqCst);
+        true
+    }
+
+    fn is_matched_by_commit_log(
+        &self,
+        _msg_buffer: Option<&[u8]>,
+        _properties: Option<&HashMap<CheetahString, CheetahString>>,
+    ) -> bool {
+        true
+    }
+}
+
+#[test]
+fn ordered_selection_filters_and_reserves_only_the_bounded_merge_prefix() {
+    let index = PopCriteriaIndex::<u64>::new(PopCriteriaLimits::new(nonzero(16), nonzero(16)));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let criteria = Arc::new(PopMatchCriteria::new(
+        Some(SubscriptionData::default()),
+        Some(Arc::new(CountingMatchFilter(Arc::clone(&calls)))),
+    ));
+    let base = tokio::time::Instant::now();
+    let mut leases = Vec::new();
+    for id in 0..16 {
+        leases.push(
+            index
+                .reserve(key("group", if id % 2 == 0 { 3 } else { -1 }))
+                .expect("ordered reservation")
+                .publish(id, deadline(base, (16 - id) * 10), Arc::clone(&criteria)),
+        );
+    }
+
+    let oldest = index.reserve_matching(&arrival("group", 3), PopSelectionOrder::Oldest, nonzero(2));
+    assert_eq!(
+        oldest.iter().map(PopCandidateReservation::id).collect::<Vec<_>>(),
+        vec![15, 14]
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+    drop(oldest);
+    let newest = index.reserve_matching(&arrival("group", 3), PopSelectionOrder::Newest, nonzero(2));
+    assert_eq!(
+        newest.iter().map(PopCandidateReservation::id).collect::<Vec<_>>(),
+        vec![0, 1]
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 4);
+    drop(newest);
+    drop(leases);
+    assert_eq!(index.snapshot(), PopIndexSnapshot::default());
+}

--- a/rocketmq-broker/src/long_polling/pop_deferred/index/types.rs
+++ b/rocketmq-broker/src/long_polling/pop_deferred/index/types.rs
@@ -1,0 +1,179 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cheetah_string::CheetahString;
+use rocketmq_model::common::key_builder::KeyBuilder;
+use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
+use rocketmq_store::ArcMessageFilter;
+use rocketmq_store::CqExtUnit;
+use std::collections::HashMap;
+use std::num::NonZeroUsize;
+
+/// Fixed global and per-criteria admission limits for the POP business index.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct PopCriteriaLimits {
+    pub(super) max_entries: NonZeroUsize,
+    pub(super) max_entries_per_key: NonZeroUsize,
+}
+
+impl PopCriteriaLimits {
+    pub(crate) const fn new(max_entries: NonZeroUsize, max_entries_per_key: NonZeroUsize) -> Self {
+        Self {
+            max_entries,
+            max_entries_per_key,
+        }
+    }
+}
+
+/// Exact topic/group/queue membership key for a deferred POP request.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct PopCriteriaKey {
+    pub(super) topic: CheetahString,
+    pub(super) consumer_group: CheetahString,
+    pub(super) queue_id: i32,
+}
+
+impl PopCriteriaKey {
+    pub(crate) fn new(topic: CheetahString, consumer_group: CheetahString, queue_id: i32) -> Self {
+        Self {
+            topic,
+            consumer_group,
+            queue_id,
+        }
+    }
+
+    pub(crate) fn from_parts(topic: &CheetahString, consumer_group: &CheetahString, queue_id: i32) -> Self {
+        Self::new(topic.clone(), consumer_group.clone(), queue_id)
+    }
+
+    #[must_use]
+    pub(crate) const fn topic(&self) -> &CheetahString {
+        &self.topic
+    }
+
+    #[must_use]
+    pub(crate) const fn consumer_group(&self) -> &CheetahString {
+        &self.consumer_group
+    }
+
+    #[must_use]
+    pub(crate) const fn queue_id(&self) -> i32 {
+        self.queue_id
+    }
+}
+
+/// Filter state shared between the index record and affine resume ownership.
+pub(crate) struct PopMatchCriteria {
+    subscription: Option<SubscriptionData>,
+    filter: Option<ArcMessageFilter>,
+}
+
+impl PopMatchCriteria {
+    pub(crate) fn new(subscription: Option<SubscriptionData>, filter: Option<ArcMessageFilter>) -> Self {
+        Self { subscription, filter }
+    }
+
+    #[must_use]
+    pub(crate) const fn subscription(&self) -> Option<&SubscriptionData> {
+        self.subscription.as_ref()
+    }
+
+    #[must_use]
+    pub(crate) const fn filter(&self) -> Option<&ArcMessageFilter> {
+        self.filter.as_ref()
+    }
+
+    pub(super) fn matches(&self, arrival: &PopArrival) -> bool {
+        if arrival.force {
+            return true;
+        }
+        let (Some(filter), Some(_subscription)) = (&self.filter, &self.subscription) else {
+            return true;
+        };
+        let cq = CqExtUnit::new(
+            arrival.tags_code.unwrap_or_default(),
+            arrival.message_store_time,
+            arrival.filter_bitmap.clone(),
+        );
+        if !filter.is_matched_by_consume_queue(arrival.tags_code, Some(&cq)) {
+            return false;
+        }
+        arrival
+            .properties
+            .as_ref()
+            .is_none_or(|properties| filter.is_matched_by_commit_log(None, Some(properties)))
+    }
+}
+
+/// Owned message-arrival facts used before any registry claim is attempted.
+pub(crate) struct PopArrival {
+    pub(super) topic: CheetahString,
+    pub(super) consumer_group: CheetahString,
+    pub(super) queue_id: i32,
+    tags_code: Option<i64>,
+    message_store_time: i64,
+    filter_bitmap: Option<Vec<u8>>,
+    properties: Option<HashMap<CheetahString, CheetahString>>,
+    force: bool,
+}
+
+impl PopArrival {
+    pub(crate) fn new(topic: CheetahString, consumer_group: CheetahString, queue_id: i32) -> Self {
+        Self {
+            topic,
+            consumer_group,
+            queue_id,
+            tags_code: None,
+            message_store_time: 0,
+            filter_bitmap: None,
+            properties: None,
+            force: false,
+        }
+    }
+
+    /// Normalizes either POP retry-topic version with its trusted consumer group.
+    pub(crate) fn from_retry_topic(topic: CheetahString, consumer_group: CheetahString, queue_id: i32) -> Self {
+        let topic = KeyBuilder::parse_pop_retry_topic(topic.as_str(), consumer_group.as_str())
+            .map(|(_, normal)| CheetahString::from(normal))
+            .unwrap_or_else(|| topic.clone());
+        Self::new(topic, consumer_group, queue_id)
+    }
+
+    #[must_use]
+    pub(crate) fn with_filter_metadata(
+        mut self,
+        tags_code: Option<i64>,
+        message_store_time: i64,
+        filter_bitmap: Option<Vec<u8>>,
+        properties: Option<HashMap<CheetahString, CheetahString>>,
+    ) -> Self {
+        self.tags_code = tags_code;
+        self.message_store_time = message_store_time;
+        self.filter_bitmap = filter_bitmap;
+        self.properties = properties;
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn forced(mut self) -> Self {
+        self.force = true;
+        self
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PopSelectionOrder {
+    Oldest,
+    Newest,
+}

--- a/rocketmq-broker/src/long_polling/pop_deferred/service.rs
+++ b/rocketmq-broker/src/long_polling/pop_deferred/service.rs
@@ -1,0 +1,914 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::alloc::Layout;
+use std::convert::Infallible;
+use std::error::Error;
+use std::fmt;
+use std::future::Future;
+use std::num::NonZeroU64;
+use std::num::NonZeroUsize;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use cheetah_string::CheetahString;
+use rocketmq_error::RocketMQError;
+use rocketmq_protocol::protocol::header::pop_message_request_header::PopMessageRequestHeader;
+use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
+use rocketmq_runtime::common::time_utils::current_millis;
+use rocketmq_runtime::RuntimeResult;
+use rocketmq_runtime::TaskGroup;
+use rocketmq_runtime::TaskId;
+use rocketmq_store::ArcMessageFilter;
+use rocketmq_transport::api::v2::ClaimedDeferred;
+use rocketmq_transport::api::v2::DeferredAdmission;
+use rocketmq_transport::api::v2::DeferredAdmissionAcquireError;
+use rocketmq_transport::api::v2::DeferredAdmissionSnapshot;
+use rocketmq_transport::api::v2::DeferredClaimError;
+use rocketmq_transport::api::v2::DeferredClaimErrorKind;
+use rocketmq_transport::api::v2::DeferredExpiryBatch;
+use rocketmq_transport::api::v2::DeferredExpiryBatchStats;
+use rocketmq_transport::api::v2::DeferredExpiryError;
+use rocketmq_transport::api::v2::DeferredExpiryErrorKind;
+use rocketmq_transport::api::v2::DeferredExpiryMargins;
+use rocketmq_transport::api::v2::DeferredId;
+use rocketmq_transport::api::v2::DeferredParts;
+use rocketmq_transport::api::v2::DeferredRegistration;
+use rocketmq_transport::api::v2::DeferredRegistry;
+use rocketmq_transport::api::v2::DeferredRegistryError;
+use rocketmq_transport::api::v2::DeferredRegistryErrorKind;
+use rocketmq_transport::api::v2::DeferredRegistryShutdownOutcome;
+use rocketmq_transport::api::v2::DeferredResumeError;
+use rocketmq_transport::api::v2::DeferredResumeErrorKind;
+use rocketmq_transport::api::v2::DeferredResumeRetainedSize;
+use rocketmq_transport::api::v2::DeferredRetainedSizeParts;
+use rocketmq_transport::api::v2::DeferredTerminalReason;
+use rocketmq_transport::api::v2::DeferredWakeReason;
+use rocketmq_transport::api::v2::RemotingRequest;
+use rocketmq_transport::api::v2::RequestId;
+use rocketmq_transport::api::v2::RequestOrigin;
+use rocketmq_transport::api::v2::ResponsePlan;
+use rocketmq_transport::api::v2::ResponseReceipt;
+use rocketmq_transport::api::v2::SessionId;
+use rocketmq_transport::api::v2::TakeDeferredResponderError;
+use tokio::sync::oneshot;
+
+use crate::long_polling::long_polling_service::pop_long_polling_service::PopWakeupCompletion;
+use crate::long_polling::long_polling_service::pop_long_polling_service::PopWakeupOutcome;
+
+use super::deadline::LongPollingDeadline;
+use super::deadline::LongPollingDeadlineError;
+use super::index::PopArrival;
+use super::index::PopCriteriaIndex;
+use super::index::PopCriteriaKey;
+use super::index::PopCriteriaLimits;
+use super::index::PopIndexError;
+use super::index::PopIndexLease;
+use super::index::PopIndexReservation;
+use super::index::PopIndexSnapshot;
+use super::index::PopMatchCriteria;
+use super::index::PopSelectionOrder;
+
+/// Typed POP request data retained without a channel or connection context.
+pub(crate) struct PopRequestData {
+    header: PopMessageRequestHeader,
+    caller_host: CheetahString,
+}
+
+impl PopRequestData {
+    const fn new(header: PopMessageRequestHeader, caller_host: CheetahString) -> Self {
+        Self { header, caller_host }
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn from_test_header(header: PopMessageRequestHeader, caller_host: CheetahString) -> Self {
+        Self::new(header, caller_host)
+    }
+
+    #[must_use]
+    pub(crate) const fn header(&self) -> &PopMessageRequestHeader {
+        &self.header
+    }
+
+    #[must_use]
+    pub(crate) const fn topic(&self) -> &CheetahString {
+        &self.header.topic
+    }
+
+    #[must_use]
+    pub(crate) const fn consumer_group(&self) -> &CheetahString {
+        &self.header.consumer_group
+    }
+
+    #[must_use]
+    pub(crate) const fn queue_id(&self) -> i32 {
+        self.header.queue_id
+    }
+
+    /// Returns the trusted effective peer captured by the V2 ingress boundary.
+    #[must_use]
+    pub(crate) const fn caller_host(&self) -> &CheetahString {
+        &self.caller_host
+    }
+
+    fn try_estimated_dynamic_bytes(&self) -> Result<usize, PopDeferredPrepareError> {
+        let mut bytes = checked_retained_sum([
+            self.header.topic.len(),
+            self.header.consumer_group.len(),
+            self.caller_host.len(),
+        ])?;
+        for value in [
+            self.header.exp_type.as_ref(),
+            self.header.exp.as_ref(),
+            self.header.attempt_id.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            bytes = bytes
+                .checked_add(value.len())
+                .ok_or(PopDeferredPrepareError::RetainedSizeOverflow)?;
+        }
+        if let Some(rpc) = self
+            .header
+            .topic_request_header
+            .as_ref()
+            .and_then(|topic| topic.rpc.as_ref())
+        {
+            for value in [rpc.namespace.as_ref(), rpc.broker_name.as_ref()].into_iter().flatten() {
+                bytes = bytes
+                    .checked_add(value.len())
+                    .ok_or(PopDeferredPrepareError::RetainedSizeOverflow)?;
+            }
+        }
+        Ok(bytes)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn estimated_dynamic_bytes(&self) -> Result<usize, PopDeferredPrepareError> {
+        self.try_estimated_dynamic_bytes()
+    }
+
+    #[must_use]
+    pub(crate) fn into_header(self) -> PopMessageRequestHeader {
+        self.header
+    }
+}
+
+fn checked_retained_sum<const N: usize>(parts: [usize; N]) -> Result<usize, PopDeferredPrepareError> {
+    parts.into_iter().try_fold(0usize, |total, part| {
+        total
+            .checked_add(part)
+            .ok_or(PopDeferredPrepareError::RetainedSizeOverflow)
+    })
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct PreparedRequestProvenance {
+    request_id: RequestId,
+    session_id: SessionId,
+}
+
+impl PreparedRequestProvenance {
+    fn capture(request: &RemotingRequest) -> Self {
+        Self {
+            request_id: request.original_identity().request_id(),
+            session_id: request.session().id(),
+        }
+    }
+
+    fn matches(self, request: &RemotingRequest) -> bool {
+        self.request_id == request.original_identity().request_id() && self.session_id == request.session().id()
+    }
+}
+
+/// Caller-declared dynamic ownership not represented by inline `ResumePop`.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PopRetainedEstimate {
+    resume_bytes: usize,
+    filter_bytes: usize,
+    metadata_bytes: usize,
+}
+
+impl PopRetainedEstimate {
+    pub(crate) const fn new(resume_bytes: usize, filter_bytes: usize, metadata_bytes: usize) -> Self {
+        Self {
+            resume_bytes,
+            filter_bytes,
+            metadata_bytes,
+        }
+    }
+}
+
+/// Affine business ownership carried from registry claim into POP recovery.
+#[must_use]
+pub(crate) struct ResumePop {
+    request: PopRequestData,
+    criteria: Arc<PopMatchCriteria>,
+    protocol_wait_deadline: LongPollingDeadline,
+    index_lease: Option<PopIndexLease>,
+}
+
+impl ResumePop {
+    fn new(
+        request: PopRequestData,
+        criteria: Arc<PopMatchCriteria>,
+        protocol_wait_deadline: LongPollingDeadline,
+        index_lease: PopIndexLease,
+    ) -> Self {
+        Self {
+            request,
+            criteria,
+            protocol_wait_deadline,
+            index_lease: Some(index_lease),
+        }
+    }
+
+    #[must_use]
+    pub(crate) const fn request(&self) -> &PopRequestData {
+        &self.request
+    }
+
+    #[must_use]
+    pub(crate) fn subscription(&self) -> Option<&SubscriptionData> {
+        self.criteria.subscription()
+    }
+
+    #[must_use]
+    pub(crate) fn filter(&self) -> Option<&ArcMessageFilter> {
+        self.criteria.filter()
+    }
+
+    #[must_use]
+    pub(crate) const fn protocol_wait_deadline(&self) -> LongPollingDeadline {
+        self.protocol_wait_deadline
+    }
+
+    pub(crate) fn take_index_lease(&mut self) -> Option<PopIndexLease> {
+        self.index_lease.take()
+    }
+}
+
+/// Fully admitted pre-responder ownership for one POP registration.
+#[must_use]
+pub(crate) struct PreparedPopRegistration {
+    request: PopRequestData,
+    criteria: Arc<PopMatchCriteria>,
+    deadline: LongPollingDeadline,
+    reservation: PopIndexReservation,
+    permit: rocketmq_transport::api::v2::DeferredWaitPermit,
+    provenance: Option<PreparedRequestProvenance>,
+}
+
+impl PreparedPopRegistration {
+    #[must_use]
+    pub(crate) const fn deadline(&self) -> LongPollingDeadline {
+        self.deadline
+    }
+
+    #[must_use]
+    pub(crate) const fn retained_bytes(&self) -> usize {
+        self.permit.retained_bytes()
+    }
+}
+
+/// Private composition of POP wait admission, criteria indexing, and registry ownership.
+pub(crate) struct PopDeferredService {
+    admission: DeferredAdmission,
+    registry: DeferredRegistry<ResumePop>,
+    index: PopCriteriaIndex,
+    expiry_margins: DeferredExpiryMargins,
+    sweep_limit: NonZeroUsize,
+    closed: AtomicBool,
+}
+
+/// Affine completion owner for one V2 POP wake attempt.
+///
+/// The sender is completed only from the authoritative registry claim or
+/// canonical deferred resume/write result. Dropping it reports cancellation
+/// so legacy callers never wait forever for an accepted wake attempt.
+#[must_use]
+pub(crate) struct PopDeferredWakeupObserver {
+    sender: Option<oneshot::Sender<PopWakeupOutcome>>,
+}
+
+impl PopDeferredWakeupObserver {
+    pub(crate) fn new() -> (Self, PopWakeupCompletion) {
+        let (sender, completion) = oneshot::channel();
+        (Self { sender: Some(sender) }, completion)
+    }
+
+    pub(crate) fn complete_claim_error(self, error: &DeferredClaimError) {
+        self.complete(pop_wakeup_outcome_from_claim_error(error));
+    }
+
+    fn complete_resume_result(self, result: &Result<ResponseReceipt, DeferredResumeError>) {
+        self.complete(pop_wakeup_outcome_from_resume_result(result));
+    }
+
+    fn complete(mut self, outcome: PopWakeupOutcome) {
+        if let Some(sender) = self.sender.take() {
+            let _ = sender.send(outcome);
+        }
+    }
+}
+
+impl Drop for PopDeferredWakeupObserver {
+    fn drop(&mut self) {
+        if let Some(sender) = self.sender.take() {
+            let _ = sender.send(PopWakeupOutcome::ServiceCancelled);
+        }
+    }
+}
+
+impl PopDeferredService {
+    pub(crate) fn new(
+        admission: DeferredAdmission,
+        index_limits: PopCriteriaLimits,
+        expiry_margins: DeferredExpiryMargins,
+        sweep_limit: NonZeroUsize,
+    ) -> Self {
+        Self {
+            admission,
+            registry: DeferredRegistry::new(),
+            index: PopCriteriaIndex::new(index_limits),
+            expiry_margins,
+            sweep_limit,
+            closed: AtomicBool::new(false),
+        }
+    }
+
+    /// Completes every recoverable business-side allocation before responder transfer.
+    pub(crate) fn prepare(
+        &self,
+        request: &RemotingRequest,
+        subscription: Option<SubscriptionData>,
+        filter: Option<ArcMessageFilter>,
+        retained: PopRetainedEstimate,
+    ) -> Result<PreparedPopRegistration, PopDeferredPrepareError> {
+        let header = request
+            .command()
+            .decode_command_custom_header::<PopMessageRequestHeader>()
+            .map_err(PopDeferredPrepareError::Header)?;
+        let caller_host = match request.origin() {
+            RequestOrigin::Network { peer } => CheetahString::from_string(peer.address().to_string()),
+            RequestOrigin::Embedded { .. } => return Err(PopDeferredPrepareError::EmbeddedOrigin),
+            _ => return Err(PopDeferredPrepareError::EmbeddedOrigin),
+        };
+        let wall_now = current_millis();
+        self.prepare_data_at(
+            PopRequestData::new(header, caller_host),
+            subscription,
+            filter,
+            retained,
+            wall_now,
+            tokio::time::Instant::now(),
+            Some(PreparedRequestProvenance::capture(request)),
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn prepare_at(
+        &self,
+        request: PopRequestData,
+        subscription: Option<SubscriptionData>,
+        filter: Option<ArcMessageFilter>,
+        retained: PopRetainedEstimate,
+        wall_now: u64,
+        monotonic_now: tokio::time::Instant,
+    ) -> Result<PreparedPopRegistration, PopDeferredPrepareError> {
+        self.prepare_data_at(request, subscription, filter, retained, wall_now, monotonic_now, None)
+    }
+
+    fn prepare_data_at(
+        &self,
+        request: PopRequestData,
+        subscription: Option<SubscriptionData>,
+        filter: Option<ArcMessageFilter>,
+        retained: PopRetainedEstimate,
+        wall_now: u64,
+        monotonic_now: tokio::time::Instant,
+        provenance: Option<PreparedRequestProvenance>,
+    ) -> Result<PreparedPopRegistration, PopDeferredPrepareError> {
+        if self.closed.load(Ordering::Acquire) {
+            return Err(PopDeferredPrepareError::ServiceClosed);
+        }
+        if request.caller_host.is_empty() {
+            return Err(PopDeferredPrepareError::MissingCallerHost);
+        }
+        if self.expiry_margins.recovery().is_zero() || self.expiry_margins.write().is_zero() {
+            return Err(PopDeferredPrepareError::InvalidExpiryMargins);
+        }
+        let deadline = LongPollingDeadline::checked(
+            request.header.born_time,
+            request.header.poll_time,
+            wall_now,
+            monotonic_now,
+        )
+        .map_err(PopDeferredPrepareError::Deadline)?;
+        let key = PopCriteriaKey::from_parts(request.topic(), request.consumer_group(), request.queue_id());
+        let reservation = self.index.reserve(key).map_err(PopDeferredPrepareError::Index)?;
+        let criteria = Arc::new(PopMatchCriteria::new(subscription, filter));
+        let resume_bytes = retained
+            .resume_bytes
+            .checked_add(request.try_estimated_dynamic_bytes()?)
+            .ok_or(PopDeferredPrepareError::RetainedSizeOverflow)?;
+        let criteria_bytes = match_criteria_allocation_bytes().ok_or(PopDeferredPrepareError::RetainedSizeOverflow)?;
+        let filter_bytes = retained
+            .filter_bytes
+            .checked_add(criteria_bytes)
+            .ok_or(PopDeferredPrepareError::RetainedSizeOverflow)?;
+        let index_bytes = PopCriteriaIndex::<DeferredId>::try_retained_bytes_per_entry()
+            .ok_or(PopDeferredPrepareError::RetainedSizeOverflow)?;
+        let retained_parts = DeferredRetainedSizeParts::new(resume_bytes)
+            .with_filter_bytes(filter_bytes)
+            .with_secondary_index_bytes(index_bytes)
+            .with_metadata_bytes(retained.metadata_bytes);
+        let retained_size = DeferredRegistry::<ResumePop>::try_retained_size(retained_parts)
+            .map_err(PopDeferredPrepareError::Admission)?;
+        let permit = self
+            .admission
+            .try_reserve(retained_size)
+            .map_err(PopDeferredPrepareError::Admission)?;
+        let prepared = PreparedPopRegistration {
+            request,
+            criteria,
+            deadline,
+            reservation,
+            permit,
+            provenance,
+        };
+        if self.closed.load(Ordering::Acquire) {
+            drop(prepared);
+            return Err(PopDeferredPrepareError::ServiceClosed);
+        }
+        Ok(prepared)
+    }
+
+    /// Moves the prepared index reservation into `register_with`'s infallible builder.
+    pub(crate) fn register(
+        &self,
+        prepared: PreparedPopRegistration,
+        request: &mut RemotingRequest,
+    ) -> Result<DeferredRegistration, PopDeferredRegisterError> {
+        if !prepared
+            .provenance
+            .is_some_and(|provenance| provenance.matches(request))
+        {
+            return Err(PopDeferredRegisterError::ProvenanceMismatch);
+        }
+        if self.closed.load(Ordering::Acquire) {
+            return Err(PopDeferredRegisterError::ServiceClosed);
+        }
+        let responder = request
+            .take_deferred_responder()
+            .map_err(PopDeferredRegisterError::Responder)?;
+        let PreparedPopRegistration {
+            request,
+            criteria,
+            deadline,
+            reservation,
+            permit,
+            provenance: _,
+        } = prepared;
+        let parts = DeferredParts::new(responder, permit)
+            .try_with_expiry(deadline.protocol_at(), self.expiry_margins)
+            .map_err(PopDeferredRegisterError::Expiry)?;
+        self.registry
+            .register_with(parts, move |id| {
+                let index_lease = reservation.publish(id, deadline, Arc::clone(&criteria));
+                Ok::<_, Infallible>(ResumePop::new(request, criteria, deadline, index_lease))
+            })
+            .map_err(PopDeferredRegisterError::Registry)
+    }
+
+    pub(crate) async fn claim(
+        &self,
+        id: DeferredId,
+        reason: DeferredWakeReason,
+    ) -> Result<ClaimedDeferred<ResumePop>, DeferredClaimError> {
+        let mut claimed = self.registry.claim(id, reason).await?;
+        drop(claimed.resume_data_mut().take_index_lease());
+        Ok(claimed)
+    }
+
+    pub(crate) async fn claim_message(
+        &self,
+        arrival: &PopArrival,
+        order: PopSelectionOrder,
+    ) -> Result<Option<ClaimedDeferred<ResumePop>>, DeferredClaimError> {
+        self.claim_matching(arrival, order, DeferredWakeReason::MessageArrived)
+            .await
+    }
+
+    pub(crate) async fn claim_forced(
+        &self,
+        arrival: PopArrival,
+        order: PopSelectionOrder,
+    ) -> Result<Option<ClaimedDeferred<ResumePop>>, DeferredClaimError> {
+        self.claim_matching(&arrival.forced(), order, DeferredWakeReason::ForcedRefresh)
+            .await
+    }
+
+    /// Removes business-index visibility, then delegates execution and writing
+    /// to the canonical affine transport resume path.
+    pub(crate) async fn resume_claimed<F, Fut>(
+        &self,
+        claimed: ClaimedDeferred<ResumePop>,
+        handler_retained: DeferredResumeRetainedSize,
+        handler: F,
+    ) -> Result<ResponseReceipt, DeferredResumeError>
+    where
+        F: FnOnce(ResumePop, DeferredWakeReason) -> Fut + Send + 'static,
+        Fut: Future<Output = rocketmq_error::RocketMQResult<ResponsePlan>> + Send + 'static,
+    {
+        claimed.resume(handler_retained, handler).await
+    }
+
+    /// Resumes and writes one claimed POP response, completing the legacy
+    /// observer from the final canonical outcome rather than task submission.
+    pub(crate) async fn resume_claimed_observed<F, Fut>(
+        &self,
+        claimed: ClaimedDeferred<ResumePop>,
+        handler_retained: DeferredResumeRetainedSize,
+        observer: PopDeferredWakeupObserver,
+        handler: F,
+    ) -> Result<ResponseReceipt, DeferredResumeError>
+    where
+        F: FnOnce(ResumePop, DeferredWakeReason) -> Fut + Send + 'static,
+        Fut: Future<Output = rocketmq_error::RocketMQResult<ResponsePlan>> + Send + 'static,
+    {
+        let result = self.resume_claimed(claimed, handler_retained, handler).await;
+        observer.complete_resume_result(&result);
+        result
+    }
+
+    async fn claim_matching(
+        &self,
+        arrival: &PopArrival,
+        order: PopSelectionOrder,
+        reason: DeferredWakeReason,
+    ) -> Result<Option<ClaimedDeferred<ResumePop>>, DeferredClaimError> {
+        let mut last_race = None;
+        let mut remaining = self.sweep_limit.get();
+        while remaining > 0 {
+            let Some(remaining_limit) = NonZeroUsize::new(remaining) else {
+                break;
+            };
+            let selection = self.index.reserve_next_matching(arrival, order, remaining_limit);
+            let inspected = selection.inspected();
+            if inspected == 0 {
+                break;
+            }
+            remaining -= inspected;
+            let Some(candidate) = selection.into_candidate() else {
+                break;
+            };
+            let id = candidate.id();
+            match self.claim(id, reason).await {
+                Ok(claimed) => {
+                    drop(candidate);
+                    return Ok(Some(claimed));
+                }
+                Err(error) if is_skippable_candidate_error(error.kind()) => {
+                    drop(candidate);
+                    last_race = Some(error);
+                }
+                Err(error) => {
+                    drop(candidate);
+                    return Err(error);
+                }
+            }
+        }
+        match last_race {
+            Some(error) => Err(error),
+            None => Ok(None),
+        }
+    }
+
+    pub(crate) fn sweep_expired(&self) -> PopDeferredSweepBatch {
+        PopDeferredSweepBatch::from_transport(self.registry.sweep_expired(self.sweep_limit))
+    }
+
+    /// Projects a producer's topic/queue arrival into a bounded set of live
+    /// consumer groups without exposing requests or transport capabilities.
+    pub(crate) fn consumer_groups_for_arrival(&self, topic: &CheetahString, queue_id: i32) -> Vec<CheetahString> {
+        self.index.consumer_groups(topic, queue_id, self.sweep_limit)
+    }
+
+    /// Starts one lifecycle-owned bounded sweep loop; the callback owns each claim batch.
+    pub(crate) fn start_sweeper<F, Fut>(
+        self: &Arc<Self>,
+        task_group: &TaskGroup,
+        interval_millis: NonZeroU64,
+        handle_claims: F,
+    ) -> RuntimeResult<TaskId>
+    where
+        F: Fn(Vec<ClaimedDeferred<ResumePop>>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        let service = Arc::clone(self);
+        let cancellation = task_group.cancellation_token();
+        let interval = Duration::from_millis(interval_millis.get());
+        task_group.spawn_service("broker.pop-deferred.sweep", async move {
+            let _shutdown = PopSweepShutdownGuard(Arc::clone(&service));
+            loop {
+                if service.closed.load(Ordering::Acquire) {
+                    break;
+                }
+                if tokio::time::timeout(interval, cancellation.cancelled()).await.is_ok() {
+                    break;
+                }
+                if service.closed.load(Ordering::Acquire) {
+                    break;
+                }
+                let claims = service.sweep_expired().into_claims();
+                if !claims.is_empty() {
+                    handle_claims(claims).await;
+                }
+            }
+        })
+    }
+
+    #[must_use]
+    pub(crate) fn admission_snapshot(&self) -> DeferredAdmissionSnapshot {
+        self.admission.snapshot()
+    }
+
+    #[must_use]
+    pub(crate) fn index_snapshot(&self) -> PopIndexSnapshot {
+        self.index.snapshot()
+    }
+
+    pub(crate) fn index_contains(&self, id: DeferredId) -> bool {
+        self.index.contains(id)
+    }
+
+    #[must_use]
+    pub(crate) fn shutdown(&self) -> DeferredRegistryShutdownOutcome {
+        self.closed.store(true, Ordering::Release);
+        self.registry.shutdown()
+    }
+}
+
+fn match_criteria_allocation_bytes() -> Option<usize> {
+    Layout::array::<AtomicUsize>(2)
+        .and_then(|header| header.extend(Layout::new::<PopMatchCriteria>()))
+        .map(|(allocation, _)| allocation.pad_to_align().size())
+        .ok()
+}
+
+/// Timeout claims with business-index membership already detached.
+#[must_use]
+pub(crate) struct PopDeferredSweepBatch {
+    stats: DeferredExpiryBatchStats,
+    claims: Vec<ClaimedDeferred<ResumePop>>,
+}
+
+impl PopDeferredSweepBatch {
+    fn from_transport(batch: DeferredExpiryBatch<ResumePop>) -> Self {
+        let stats = batch.stats();
+        let mut claims = batch.into_claims();
+        for claim in &mut claims {
+            drop(claim.resume_data_mut().take_index_lease());
+        }
+        Self { stats, claims }
+    }
+
+    #[must_use]
+    pub(crate) const fn stats(&self) -> DeferredExpiryBatchStats {
+        self.stats
+    }
+
+    #[must_use]
+    pub(crate) fn into_claims(self) -> Vec<ClaimedDeferred<ResumePop>> {
+        self.claims
+    }
+}
+
+struct PopSweepShutdownGuard(Arc<PopDeferredService>);
+
+impl Drop for PopSweepShutdownGuard {
+    fn drop(&mut self) {
+        let _ = self.0.shutdown();
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum PopDeferredPrepareErrorKind {
+    ServiceClosed,
+    EmbeddedOrigin,
+    Header,
+    MissingCallerHost,
+    InvalidExpiryMargins,
+    RetainedSizeOverflow,
+    Deadline,
+    Index,
+    Admission,
+}
+
+pub(crate) enum PopDeferredPrepareError {
+    ServiceClosed,
+    EmbeddedOrigin,
+    Header(RocketMQError),
+    MissingCallerHost,
+    InvalidExpiryMargins,
+    RetainedSizeOverflow,
+    Deadline(LongPollingDeadlineError),
+    Index(PopIndexError),
+    Admission(DeferredAdmissionAcquireError),
+}
+
+impl PopDeferredPrepareError {
+    #[must_use]
+    pub(crate) const fn kind(&self) -> PopDeferredPrepareErrorKind {
+        match self {
+            Self::ServiceClosed => PopDeferredPrepareErrorKind::ServiceClosed,
+            Self::EmbeddedOrigin => PopDeferredPrepareErrorKind::EmbeddedOrigin,
+            Self::Header(_) => PopDeferredPrepareErrorKind::Header,
+            Self::MissingCallerHost => PopDeferredPrepareErrorKind::MissingCallerHost,
+            Self::InvalidExpiryMargins => PopDeferredPrepareErrorKind::InvalidExpiryMargins,
+            Self::RetainedSizeOverflow => PopDeferredPrepareErrorKind::RetainedSizeOverflow,
+            Self::Deadline(_) => PopDeferredPrepareErrorKind::Deadline,
+            Self::Index(_) => PopDeferredPrepareErrorKind::Index,
+            Self::Admission(_) => PopDeferredPrepareErrorKind::Admission,
+        }
+    }
+}
+
+impl fmt::Debug for PopDeferredPrepareError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PopDeferredPrepareError")
+            .field("kind", &self.kind())
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Display for PopDeferredPrepareError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "POP deferred preparation failed: {:?}", self.kind())
+    }
+}
+
+impl Error for PopDeferredPrepareError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Header(source) => Some(source),
+            Self::Deadline(source) => Some(source),
+            Self::Index(source) => Some(source),
+            Self::Admission(source) => Some(source),
+            Self::ServiceClosed
+            | Self::EmbeddedOrigin
+            | Self::MissingCallerHost
+            | Self::InvalidExpiryMargins
+            | Self::RetainedSizeOverflow => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum PopDeferredRegisterErrorKind {
+    ServiceClosed,
+    ProvenanceMismatch,
+    Responder,
+    Expiry(DeferredExpiryErrorKind),
+    Registry(DeferredRegistryErrorKind),
+}
+
+pub(crate) enum PopDeferredRegisterError {
+    ServiceClosed,
+    ProvenanceMismatch,
+    Responder(TakeDeferredResponderError),
+    Expiry(DeferredExpiryError),
+    Registry(DeferredRegistryError<ResumePop, Infallible>),
+}
+
+impl PopDeferredRegisterError {
+    #[must_use]
+    pub(crate) const fn kind(&self) -> PopDeferredRegisterErrorKind {
+        match self {
+            Self::ServiceClosed => PopDeferredRegisterErrorKind::ServiceClosed,
+            Self::ProvenanceMismatch => PopDeferredRegisterErrorKind::ProvenanceMismatch,
+            Self::Responder(_) => PopDeferredRegisterErrorKind::Responder,
+            Self::Expiry(source) => PopDeferredRegisterErrorKind::Expiry(source.kind()),
+            Self::Registry(source) => PopDeferredRegisterErrorKind::Registry(source.kind()),
+        }
+    }
+}
+
+impl fmt::Debug for PopDeferredRegisterError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PopDeferredRegisterError")
+            .field("kind", &self.kind())
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Display for PopDeferredRegisterError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "POP deferred registration failed: {:?}", self.kind())
+    }
+}
+
+impl Error for PopDeferredRegisterError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Responder(source) => Some(source),
+            Self::Expiry(source) => Some(source),
+            Self::Registry(source) => Some(source),
+            Self::ServiceClosed | Self::ProvenanceMismatch => None,
+        }
+    }
+}
+
+fn pop_wakeup_outcome_from_claim_error(error: &DeferredClaimError) -> PopWakeupOutcome {
+    match error.kind() {
+        DeferredClaimErrorKind::NotFound
+        | DeferredClaimErrorKind::AlreadyClaimed
+        | DeferredClaimErrorKind::AlreadyCompleted => PopWakeupOutcome::AlreadyCompleted,
+        DeferredClaimErrorKind::SessionClosed => PopWakeupOutcome::InactiveChannel,
+        DeferredClaimErrorKind::ParentCancelled => PopWakeupOutcome::ServiceCancelled,
+        DeferredClaimErrorKind::DeadlineExpired | DeferredClaimErrorKind::RegistryInvariant => {
+            PopWakeupOutcome::ProcessingFailed
+        }
+    }
+}
+
+const fn is_skippable_candidate_error(kind: DeferredClaimErrorKind) -> bool {
+    matches!(
+        kind,
+        DeferredClaimErrorKind::NotFound
+            | DeferredClaimErrorKind::AlreadyClaimed
+            | DeferredClaimErrorKind::AlreadyCompleted
+            | DeferredClaimErrorKind::SessionClosed
+            | DeferredClaimErrorKind::DeadlineExpired
+    )
+}
+
+fn pop_wakeup_outcome_from_resume_result(result: &Result<ResponseReceipt, DeferredResumeError>) -> PopWakeupOutcome {
+    let Err(error) = result else {
+        return PopWakeupOutcome::ProcessingCompleted;
+    };
+    match error.prior_terminal_reason() {
+        Some(DeferredTerminalReason::SessionClosed | DeferredTerminalReason::ReceiverDropped) => {
+            return PopWakeupOutcome::InactiveChannel;
+        }
+        Some(DeferredTerminalReason::ParentCancelled | DeferredTerminalReason::ServiceStopping) => {
+            return PopWakeupOutcome::ServiceCancelled;
+        }
+        Some(DeferredTerminalReason::ProcessorUnavailable) => {
+            return PopWakeupOutcome::ProcessorUnavailable;
+        }
+        _ => {}
+    }
+    match error.kind() {
+        DeferredResumeErrorKind::SessionClosed => PopWakeupOutcome::InactiveChannel,
+        DeferredResumeErrorKind::Cancelled => PopWakeupOutcome::ServiceCancelled,
+        DeferredResumeErrorKind::ExecutorClosing => PopWakeupOutcome::ServiceNotRunning,
+        DeferredResumeErrorKind::TaskTerminated
+        | DeferredResumeErrorKind::Admission
+        | DeferredResumeErrorKind::RetainedSizeOverflow
+        | DeferredResumeErrorKind::Response
+        | DeferredResumeErrorKind::ResponsePlan => PopWakeupOutcome::ProcessingFailed,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retired_candidate_errors_are_local_but_parent_and_invariant_fail_closed() {
+        for kind in [
+            DeferredClaimErrorKind::NotFound,
+            DeferredClaimErrorKind::AlreadyClaimed,
+            DeferredClaimErrorKind::AlreadyCompleted,
+            DeferredClaimErrorKind::SessionClosed,
+            DeferredClaimErrorKind::DeadlineExpired,
+        ] {
+            assert!(is_skippable_candidate_error(kind), "{kind:?}");
+        }
+        for kind in [
+            DeferredClaimErrorKind::ParentCancelled,
+            DeferredClaimErrorKind::RegistryInvariant,
+        ] {
+            assert!(!is_skippable_candidate_error(kind), "{kind:?}");
+        }
+    }
+}

--- a/rocketmq-broker/src/processor/pop_message_processor.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor.rs
@@ -15,6 +15,7 @@
 #![allow(unused_variables)]
 
 pub(crate) mod capability;
+mod resume;
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -30,13 +31,11 @@ use bytes::Bytes;
 use bytes::BytesMut;
 use cheetah_string::CheetahString;
 use parking_lot::Mutex;
-use rand::RngExt;
 use rocketmq_model::common::config::TopicConfig;
 use rocketmq_model::common::constant::consume_init_mode::ConsumeInitMode;
 use rocketmq_model::common::constant::PermName;
 use rocketmq_model::common::filter::expression_type::ExpressionType;
 use rocketmq_model::common::key_builder::KeyBuilder;
-use rocketmq_model::common::key_builder::POP_ORDER_REVIVE_QUEUE;
 use rocketmq_model::common::message::message_ext_broker_inner::MessageExtBrokerInner;
 use rocketmq_model::common::message::MessageConst;
 use rocketmq_model::common::message::MessageTrait;
@@ -44,14 +43,12 @@ use rocketmq_model::common::mix_all;
 use rocketmq_model::common::pop_ack_constants::PopAckConstants;
 use rocketmq_model::common::pop_retry_policy::PopRetryPolicy;
 use rocketmq_model::common::FAQUrl;
-use rocketmq_model::topic::TopicMessageType;
 use rocketmq_protocol::code::request_code::RequestCode;
 use rocketmq_protocol::code::response_code::ResponseCode;
 use rocketmq_protocol::common::message::message_decoder as MessageDecoder;
 use rocketmq_protocol::protocol::filter::filter_api::FilterAPI;
 use rocketmq_protocol::protocol::header::extra_info_util::ExtraInfoUtil;
 use rocketmq_protocol::protocol::header::pop_message_request_header::PopMessageRequestHeader;
-use rocketmq_protocol::protocol::header::pop_message_response_header::PopMessageResponseHeader;
 use rocketmq_protocol::protocol::heartbeat::subscription_data::SubscriptionData;
 use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
 use rocketmq_protocol::protocol::RemotingSerializable;
@@ -94,12 +91,11 @@ use crate::pop::rocksdb_store::pop_rocksdb_path;
 use crate::pop::rocksdb_store::PopConsumerRocksDbStore;
 use crate::processor::pop_message_processor::capability::PopBufferMergeContext;
 use crate::processor::pop_message_processor::capability::PopMessageProcessorContext;
+use crate::processor::pop_message_processor::resume::PopCallerHost;
+use crate::processor::pop_message_processor::resume::PopStoreReadOutcome;
+use crate::processor::pop_message_processor::resume::PopStoreReadRequest;
 use crate::processor::processor_service::pop_buffer_merge_service::PopBufferMergeService;
-use crate::processor::response_plan::pop::attach_pop_response_header;
 use crate::processor::response_plan::pop::deliver_pop_legacy;
-use crate::processor::response_plan::pop::pop_heap_response_parts;
-use crate::processor::response_plan::pop::pop_segmented_response_parts;
-use crate::processor::response_plan::pop::take_pop_body_segments;
 
 const BORN_TIME: &str = "bornTime";
 const QUEUE_LOCK_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
@@ -607,221 +603,48 @@ where
             .consumers
             .restore_pop_consumer_profile(&request_header.consumer_group, &durable_subscriptions);
 
-        let revive_qid = if request_header.order.unwrap_or(false) {
-            POP_ORDER_REVIVE_QUEUE
-        } else {
-            let revive_queue_num = policy.revive_queue_num as i64;
-            let ck_num = self.ck_message_number.fetch_add(1, Ordering::AcqRel);
-            ((ck_num % revive_queue_num + revive_queue_num) % revive_queue_num) as i32
-        };
-        let mut get_message_result = GetMessageResult::new_result_size(request_header.max_msg_nums as usize);
-
-        // Due to the design of the fields startOffsetInfo, msgOffsetInfo, and orderCountInfo,
-        // a single POP request could only invoke the popMsgFromQueue method once
-        // for either a normal topic or a retry topic's queue. Retry topics v1 and v2 are
-        // considered the same type because they share the same retry flag in previous fields.
-        // Therefore, needRetryV1 is designed as a subset of needRetry, and within a single request,
-        // only one type of retry topic is able to call popMsgFromQueue.
-        //Determine whether to pull a message from the retry queue using a random number and a set
-        // probability
-        let random_sample = rand::rng().random_range(0..100);
-        let use_priority_mode = topic_config.get_topic_message_type() == TopicMessageType::Priority
-            && !request_header.order.unwrap_or(false)
-            && random_sample < subscription_group_config.priority_factor();
-        let retry_probability = if use_priority_mode {
-            policy.pop_from_retry_probability_for_priority
-        } else {
-            policy.pop_from_retry_probability
-        };
-        let need_retry = random_sample < retry_probability;
-        let randomq = if use_priority_mode { 0 } else { random_sample };
-        let mut start_offset_info = String::with_capacity(64);
-        let mut msg_offset_info = String::with_capacity(64);
-        let mut order_count_info = if request_header.order.is_some() {
-            String::with_capacity(64)
-        } else {
-            String::new()
-        };
-        let pop_time = current_millis();
-
-        let mut rest_num = 0; // remaining number of messages to be fetched
-        if need_retry && !request_header.order.unwrap_or(false) {
-            for retry_topic in retry_policy.read_topics(&request_header.topic, &request_header.consumer_group) {
-                let retry_topic = CheetahString::from_string(retry_topic);
-                rest_num = self
-                    .pop_msg_from_topic_by_name(
-                        &retry_topic,
-                        true,
-                        &mut get_message_result,
-                        &request_header,
-                        revive_qid,
-                        channel.clone(),
-                        pop_time,
-                        message_filter.clone(),
-                        &mut start_offset_info,
-                        &mut msg_offset_info,
-                        &mut order_count_info,
-                        randomq,
-                        use_priority_mode.then_some(policy.priority_order_asc),
-                        rest_num,
-                    )
-                    .await;
-                if !get_message_result.message_mapped_list().is_empty() {
-                    break;
-                }
-            }
-        }
-        //request_header.queue_id < 0 means read all queue
-        rest_num = if request_header.queue_id < 0 {
-            // read all queue
-            self.pop_msg_from_topic(
+        match self
+            .read_pop_store(PopStoreReadRequest::new(
+                &request_header,
                 &topic_config,
-                false,
-                &mut get_message_result,
-                &request_header,
-                revive_qid,
-                channel.clone(),
-                pop_time,
+                &policy,
+                &retry_policy,
+                subscription_group_config.priority_factor(),
                 message_filter.clone(),
-                &mut start_offset_info,
-                &mut msg_offset_info,
-                &mut order_count_info,
-                randomq,
-                use_priority_mode.then_some(policy.priority_order_asc),
-                rest_num,
-            )
-            .await
-        } else {
-            self.pop_msg_from_queue(
-                &topic_config.topic_name.clone().unwrap_or_default(),
-                &request_header.attempt_id.clone().unwrap_or_default(),
-                false,
-                &mut get_message_result,
-                &request_header,
-                request_header.queue_id,
-                rest_num,
-                revive_qid,
-                channel.clone(),
-                pop_time,
-                message_filter.clone(),
-                &mut start_offset_info,
-                &mut msg_offset_info,
-                &mut order_count_info,
-            )
-            .await
-        };
-        // if not full , fetch retry again
-        if !need_retry
-            && get_message_result.message_mapped_list().len() < request_header.max_msg_nums as usize
-            && !request_header.order.unwrap_or(false)
+                PopCallerHost::Network(channel.remote_address()),
+                opaque,
+            ))
+            .await?
         {
-            for retry_topic in retry_policy.read_topics(&request_header.topic, &request_header.consumer_group) {
-                let retry_topic = CheetahString::from_string(retry_topic);
-                rest_num = self
-                    .pop_msg_from_topic_by_name(
-                        &retry_topic,
-                        true,
-                        &mut get_message_result,
-                        &request_header,
-                        revive_qid,
-                        channel.clone(),
-                        pop_time,
-                        message_filter.clone(),
-                        &mut start_offset_info,
-                        &mut msg_offset_info,
-                        &mut order_count_info,
-                        randomq,
-                        use_priority_mode.then_some(policy.priority_order_asc),
-                        rest_num,
-                    )
-                    .await;
-                if !get_message_result.message_mapped_list().is_empty() {
-                    break;
-                }
-            }
-        }
-        let mut final_response = self.context.command_factory.create_success_response_command();
-        final_response.set_opaque_mut(opaque);
-        if !get_message_result.message_mapped_list().is_empty() {
-            get_message_result.set_status(Some(GetMessageStatus::Found));
-            if rest_num > 0 {
-                // all queue pop can not notify specified queue pop, and vice versa
-                self.pop_long_polling_service.notify_message_arriving(
-                    &request_header.topic,
-                    request_header.queue_id,
-                    &request_header.consumer_group,
-                    None,
-                    0,
-                    None,
-                    None,
+            PopStoreReadOutcome::Found(parts) => deliver_pop_legacy(parts, &channel).await,
+            PopStoreReadOutcome::Empty { mut head, rest_num } => {
+                let polling_result = self.pop_long_polling_service.polling(
+                    ctx.clone(),
+                    request,
+                    PollingHeader::new_from_pop_message_request_header(&request_header),
+                    Some(subscription_data),
+                    message_filter,
                 );
-            }
-        } else {
-            let polling_result = self.pop_long_polling_service.polling(
-                ctx.clone(),
-                request,
-                PollingHeader::new_from_pop_message_request_header(&request_header),
-                Some(subscription_data),
-                message_filter,
-            );
-            match polling_result {
-                PollingResult::PollingSuc => {
-                    if rest_num > 0 {
-                        self.pop_long_polling_service.notify_message_arriving(
-                            &request_header.topic,
-                            request_header.queue_id,
-                            &request_header.consumer_group,
-                            None,
-                            0,
-                            None,
-                            None,
-                        );
+                match polling_result {
+                    PollingResult::PollingSuc => {
+                        if rest_num > 0 {
+                            self.pop_long_polling_service.notify_message_arriving(
+                                &request_header.topic,
+                                request_header.queue_id,
+                                &request_header.consumer_group,
+                                None,
+                                0,
+                                None,
+                                None,
+                            );
+                        }
+                        return Ok(None);
                     }
-                    return Ok(None);
+                    PollingResult::PollingFull => head.set_code_ref(ResponseCode::PollingFull),
+                    _ => head.set_code_ref(ResponseCode::PollingTimeout),
                 }
-                PollingResult::PollingFull => {
-                    final_response.set_code_ref(ResponseCode::PollingFull);
-                }
-                _ => {
-                    final_response.set_code_ref(ResponseCode::PollingTimeout);
-                }
+                Ok(Some(head))
             }
-            get_message_result.set_status(Some(GetMessageStatus::NoMessageInQueue));
-        }
-        let response_header = PopMessageResponseHeader {
-            pop_time,
-            invisible_time: request_header.invisible_time,
-            revive_qid: revive_qid as u32,
-            rest_num: rest_num as u64,
-            start_offset_info: Some(CheetahString::from_string(start_offset_info)),
-            msg_offset_info: Some(CheetahString::from_string(msg_offset_info)),
-            order_count_info: if order_count_info.is_empty() {
-                None
-            } else {
-                Some(CheetahString::from_string(order_count_info))
-            },
-        };
-        final_response.set_remark_mut(get_message_result.status().unwrap().to_string());
-
-        match ResponseCode::from(final_response.code()) {
-            ResponseCode::Success => {
-                let final_response = attach_pop_response_header(final_response, response_header);
-                if policy.transfer_msg_by_heap {
-                    let body = self.read_get_message_result(
-                        &get_message_result,
-                        &request_header.consumer_group,
-                        &request_header.topic,
-                        request_header.queue_id,
-                    );
-                    let parts = pop_heap_response_parts(final_response, body)?;
-                    deliver_pop_legacy(parts, &channel).await
-                } else {
-                    let body_segments = take_pop_body_segments(get_message_result);
-                    let parts = pop_segmented_response_parts(final_response, body_segments)?;
-                    deliver_pop_legacy(parts, &channel).await
-                }
-            }
-            _ => Ok(Some(final_response)),
         }
     }
 
@@ -836,7 +659,7 @@ where
         get_message_result: &mut GetMessageResult,
         request_header: &PopMessageRequestHeader,
         revive_qid: i32,
-        channel: Channel,
+        caller_host: PopCallerHost<'_>,
         pop_time: u64,
         message_filter: Option<ArcMessageFilter>,
         start_offset_info: &mut String,
@@ -858,7 +681,7 @@ where
                     queue_id,
                     rest_num,
                     revive_qid,
-                    channel.clone(),
+                    caller_host,
                     pop_time,
                     message_filter.clone(),
                     start_offset_info,
@@ -881,7 +704,7 @@ where
         get_message_result: &mut GetMessageResult,
         request_header: &PopMessageRequestHeader,
         revive_qid: i32,
-        channel: Channel,
+        caller_host: PopCallerHost<'_>,
         pop_time: u64,
         message_filter: Option<ArcMessageFilter>,
         start_offset_info: &mut String,
@@ -901,7 +724,7 @@ where
             get_message_result,
             request_header,
             revive_qid,
-            channel,
+            caller_host,
             pop_time,
             message_filter,
             start_offset_info,
@@ -928,7 +751,7 @@ where
         queue_id: i32,
         rest_num: i64,
         revive_qid: i32,
-        channel: Channel,
+        caller_host: PopCallerHost<'_>,
         pop_time: u64,
         message_filter: Option<ArcMessageFilter>,
         start_offset_info: &mut String,
@@ -1063,7 +886,7 @@ where
                         | GetMessageStatus::OffsetOverflowBadly
                         | GetMessageStatus::OffsetTooSmall => {
                             self.context.offsets.commit_offset(
-                                channel.remote_address().to_string().into(),
+                                caller_host.to_owned(),
                                 &request_header.consumer_group,
                                 topic,
                                 queue_id,
@@ -1142,7 +965,7 @@ where
                             order_count_info,
                         );
                         self.context.offsets.commit_offset(
-                            channel.remote_address().to_string().into(),
+                            caller_host.to_owned(),
                             &request_header.consumer_group,
                             topic,
                             queue_id,
@@ -1192,7 +1015,7 @@ where
                     {
                         if is_order {
                             self.context.offsets.commit_offset(
-                                channel.remote_address().to_string().into(),
+                                caller_host.to_owned(),
                                 &request_header.consumer_group,
                                 topic,
                                 queue_id,

--- a/rocketmq-broker/src/processor/pop_message_processor/resume.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor/resume.rs
@@ -1,0 +1,382 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::net::SocketAddr;
+
+use cheetah_string::CheetahString;
+use rand::RngExt;
+use rocketmq_model::common::config::TopicConfig;
+use rocketmq_model::common::key_builder::POP_ORDER_REVIVE_QUEUE;
+use rocketmq_model::common::pop_retry_policy::PopRetryPolicy;
+use rocketmq_model::topic::TopicMessageType;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::protocol::header::pop_message_request_header::PopMessageRequestHeader;
+use rocketmq_protocol::protocol::header::pop_message_response_header::PopMessageResponseHeader;
+use rocketmq_protocol::protocol::remoting_command::RemotingCommand;
+use rocketmq_runtime::common::time_utils::current_millis;
+use rocketmq_store::ArcMessageFilter;
+use rocketmq_store::BrokerReadWriteStore;
+use rocketmq_store::GetMessageResult;
+use rocketmq_store::GetMessageStatus;
+use rocketmq_transport::api::v2::DeferredWakeReason;
+use rocketmq_transport::api::v2::ResponsePlan;
+
+use super::PopMessageProcessor;
+use crate::long_polling::pop_deferred::service::ResumePop;
+use crate::processor::pop_message_processor::capability::PopPolicy;
+use crate::processor::response_plan::pop::attach_pop_response_header;
+use crate::processor::response_plan::pop::pop_heap_response_parts;
+use crate::processor::response_plan::pop::pop_segmented_response_parts;
+use crate::processor::response_plan::pop::take_pop_body_segments;
+use crate::processor::response_plan::BrokerResponseParts;
+
+/// Allocation-free caller identity until a store offset commit needs ownership.
+#[derive(Clone, Copy)]
+pub(super) enum PopCallerHost<'a> {
+    Network(SocketAddr),
+    Retained(&'a CheetahString),
+}
+
+impl PopCallerHost<'_> {
+    pub(super) fn to_owned(self) -> CheetahString {
+        match self {
+            Self::Network(address) => CheetahString::from_string(address.to_string()),
+            Self::Retained(address) => address.clone(),
+        }
+    }
+}
+
+/// Trusted, Channel-free inputs for one actual POP store reread.
+pub(super) struct PopStoreReadRequest<'a> {
+    request_header: &'a PopMessageRequestHeader,
+    topic_config: &'a TopicConfig,
+    policy: &'a PopPolicy,
+    retry_policy: &'a PopRetryPolicy,
+    priority_factor: i32,
+    message_filter: Option<ArcMessageFilter>,
+    caller_host: PopCallerHost<'a>,
+    opaque: i32,
+}
+
+impl<'a> PopStoreReadRequest<'a> {
+    pub(super) fn new(
+        request_header: &'a PopMessageRequestHeader,
+        topic_config: &'a TopicConfig,
+        policy: &'a PopPolicy,
+        retry_policy: &'a PopRetryPolicy,
+        priority_factor: i32,
+        message_filter: Option<ArcMessageFilter>,
+        caller_host: PopCallerHost<'a>,
+        opaque: i32,
+    ) -> Self {
+        Self {
+            request_header,
+            topic_config,
+            policy,
+            retry_policy,
+            priority_factor,
+            message_filter,
+            caller_host,
+            opaque,
+        }
+    }
+}
+
+/// Store reread result before the initial V1 path decides whether to suspend.
+pub(super) enum PopStoreReadOutcome {
+    Found(BrokerResponseParts),
+    Empty { head: RemotingCommand, rest_num: i64 },
+}
+
+struct PopResumeRequest {
+    header: PopMessageRequestHeader,
+    caller_host: CheetahString,
+    filter: Option<ArcMessageFilter>,
+}
+
+impl PopResumeRequest {
+    fn from_resume(resume: ResumePop) -> Self {
+        let request = Self {
+            header: resume.request().header().clone(),
+            caller_host: resume.request().caller_host().clone(),
+            filter: resume.filter().cloned(),
+        };
+        drop(resume);
+        request
+    }
+
+    #[cfg(test)]
+    fn for_test(header: PopMessageRequestHeader, caller_host: CheetahString, filter: Option<ArcMessageFilter>) -> Self {
+        Self {
+            header,
+            caller_host,
+            filter,
+        }
+    }
+}
+
+impl<MS> PopMessageProcessor<MS>
+where
+    MS: BrokerReadWriteStore,
+{
+    /// Replays the real POP store read without retaining a Channel or connection context.
+    pub(crate) async fn resume_pop(
+        &self,
+        resume: ResumePop,
+        reason: DeferredWakeReason,
+    ) -> rocketmq_error::RocketMQResult<ResponsePlan> {
+        self.resume_pop_request(PopResumeRequest::from_resume(resume), reason)
+            .await
+    }
+
+    async fn resume_pop_request(
+        &self,
+        request: PopResumeRequest,
+        reason: DeferredWakeReason,
+    ) -> rocketmq_error::RocketMQResult<ResponsePlan> {
+        match reason {
+            DeferredWakeReason::MessageArrived | DeferredWakeReason::Timeout | DeferredWakeReason::ForcedRefresh => {}
+        }
+        let Some(topic_config) = self.context.topics.select_topic_config(&request.header.topic) else {
+            let head = self.context.command_factory.create_response_command_with_code_remark(
+                ResponseCode::TopicNotExist,
+                "POP topic is no longer available",
+            );
+            return BrokerResponseParts::command(head)?.into_response_plan();
+        };
+        let Some(group_config) = self
+            .context
+            .subscriptions
+            .find_subscription_group_config(&request.header.consumer_group)
+        else {
+            let head = self.context.command_factory.create_response_command_with_code_remark(
+                ResponseCode::SubscriptionGroupNotExist,
+                "POP subscription group is no longer available",
+            );
+            return BrokerResponseParts::command(head)?.into_response_plan();
+        };
+        let policy = self.context.policy.snapshot();
+        let retry_policy = self.retry_policy_for_group(&request.header.consumer_group);
+        match self
+            .read_pop_store(PopStoreReadRequest::new(
+                &request.header,
+                &topic_config,
+                &policy,
+                &retry_policy,
+                group_config.priority_factor(),
+                request.filter,
+                PopCallerHost::Retained(&request.caller_host),
+                0,
+            ))
+            .await?
+        {
+            PopStoreReadOutcome::Found(parts) => parts.into_response_plan(),
+            PopStoreReadOutcome::Empty { mut head, .. } => {
+                head.set_code_ref(ResponseCode::PollingTimeout);
+                BrokerResponseParts::command(head)?.into_response_plan()
+            }
+        }
+    }
+
+    pub(super) async fn read_pop_store(
+        &self,
+        request: PopStoreReadRequest<'_>,
+    ) -> rocketmq_error::RocketMQResult<PopStoreReadOutcome> {
+        let PopStoreReadRequest {
+            request_header,
+            topic_config,
+            policy,
+            retry_policy,
+            priority_factor,
+            message_filter,
+            caller_host,
+            opaque,
+        } = request;
+        let revive_qid = if request_header.order.unwrap_or(false) {
+            POP_ORDER_REVIVE_QUEUE
+        } else {
+            let revive_queue_num = policy.revive_queue_num as i64;
+            let ck_num = self.ck_message_number.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+            ((ck_num % revive_queue_num + revive_queue_num) % revive_queue_num) as i32
+        };
+        let mut get_message_result = GetMessageResult::new_result_size(request_header.max_msg_nums as usize);
+        let random_sample = rand::rng().random_range(0..100);
+        let use_priority_mode = topic_config.get_topic_message_type() == TopicMessageType::Priority
+            && !request_header.order.unwrap_or(false)
+            && random_sample < priority_factor;
+        let retry_probability = if use_priority_mode {
+            policy.pop_from_retry_probability_for_priority
+        } else {
+            policy.pop_from_retry_probability
+        };
+        let need_retry = random_sample < retry_probability;
+        let random_q = if use_priority_mode { 0 } else { random_sample };
+        let mut start_offset_info = String::with_capacity(64);
+        let mut msg_offset_info = String::with_capacity(64);
+        let mut order_count_info = if request_header.order.is_some() {
+            String::with_capacity(64)
+        } else {
+            String::new()
+        };
+        let pop_time = current_millis();
+
+        let mut rest_num = 0;
+        if need_retry && !request_header.order.unwrap_or(false) {
+            for retry_topic in retry_policy.read_topics(&request_header.topic, &request_header.consumer_group) {
+                let retry_topic = CheetahString::from_string(retry_topic);
+                rest_num = self
+                    .pop_msg_from_topic_by_name(
+                        &retry_topic,
+                        true,
+                        &mut get_message_result,
+                        request_header,
+                        revive_qid,
+                        caller_host,
+                        pop_time,
+                        message_filter.clone(),
+                        &mut start_offset_info,
+                        &mut msg_offset_info,
+                        &mut order_count_info,
+                        random_q,
+                        use_priority_mode.then_some(policy.priority_order_asc),
+                        rest_num,
+                    )
+                    .await;
+                if !get_message_result.message_mapped_list().is_empty() {
+                    break;
+                }
+            }
+        }
+        rest_num = if request_header.queue_id < 0 {
+            self.pop_msg_from_topic(
+                topic_config,
+                false,
+                &mut get_message_result,
+                request_header,
+                revive_qid,
+                caller_host,
+                pop_time,
+                message_filter.clone(),
+                &mut start_offset_info,
+                &mut msg_offset_info,
+                &mut order_count_info,
+                random_q,
+                use_priority_mode.then_some(policy.priority_order_asc),
+                rest_num,
+            )
+            .await
+        } else {
+            self.pop_msg_from_queue(
+                &topic_config.topic_name.clone().unwrap_or_default(),
+                &request_header.attempt_id.clone().unwrap_or_default(),
+                false,
+                &mut get_message_result,
+                request_header,
+                request_header.queue_id,
+                rest_num,
+                revive_qid,
+                caller_host,
+                pop_time,
+                message_filter.clone(),
+                &mut start_offset_info,
+                &mut msg_offset_info,
+                &mut order_count_info,
+            )
+            .await
+        };
+        if !need_retry
+            && get_message_result.message_mapped_list().len() < request_header.max_msg_nums as usize
+            && !request_header.order.unwrap_or(false)
+        {
+            for retry_topic in retry_policy.read_topics(&request_header.topic, &request_header.consumer_group) {
+                let retry_topic = CheetahString::from_string(retry_topic);
+                rest_num = self
+                    .pop_msg_from_topic_by_name(
+                        &retry_topic,
+                        true,
+                        &mut get_message_result,
+                        request_header,
+                        revive_qid,
+                        caller_host,
+                        pop_time,
+                        message_filter.clone(),
+                        &mut start_offset_info,
+                        &mut msg_offset_info,
+                        &mut order_count_info,
+                        random_q,
+                        use_priority_mode.then_some(policy.priority_order_asc),
+                        rest_num,
+                    )
+                    .await;
+                if !get_message_result.message_mapped_list().is_empty() {
+                    break;
+                }
+            }
+        }
+
+        let mut head = self.context.command_factory.create_success_response_command();
+        head.set_opaque_mut(opaque);
+        if get_message_result.message_mapped_list().is_empty() {
+            get_message_result.set_status(Some(GetMessageStatus::NoMessageInQueue));
+            head.set_remark_mut(GetMessageStatus::NoMessageInQueue.to_string());
+            return Ok(PopStoreReadOutcome::Empty { head, rest_num });
+        }
+
+        get_message_result.set_status(Some(GetMessageStatus::Found));
+        if rest_num > 0 {
+            self.pop_long_polling_service.notify_message_arriving(
+                &request_header.topic,
+                request_header.queue_id,
+                &request_header.consumer_group,
+                None,
+                0,
+                None,
+                None,
+            );
+        }
+        let response_header = PopMessageResponseHeader {
+            pop_time,
+            invisible_time: request_header.invisible_time,
+            revive_qid: revive_qid as u32,
+            rest_num: rest_num as u64,
+            start_offset_info: Some(CheetahString::from_string(start_offset_info)),
+            msg_offset_info: Some(CheetahString::from_string(msg_offset_info)),
+            order_count_info: if order_count_info.is_empty() {
+                None
+            } else {
+                Some(CheetahString::from_string(order_count_info))
+            },
+        };
+        head.set_remark_mut(GetMessageStatus::Found.to_string());
+        let head = attach_pop_response_header(head, response_header);
+        let parts = if policy.transfer_msg_by_heap {
+            pop_heap_response_parts(
+                head,
+                self.read_get_message_result(
+                    &get_message_result,
+                    &request_header.consumer_group,
+                    &request_header.topic,
+                    request_header.queue_id,
+                ),
+            )?
+        } else {
+            pop_segmented_response_parts(head, take_pop_body_segments(get_message_result))?
+        };
+        Ok(PopStoreReadOutcome::Found(parts))
+    }
+}
+
+#[cfg(test)]
+#[path = "resume/tests.rs"]
+mod tests;

--- a/rocketmq-broker/src/processor/pop_message_processor/resume/tests.rs
+++ b/rocketmq-broker/src/processor/pop_message_processor/resume/tests.rs
@@ -1,0 +1,142 @@
+// Copyright 2026 The RocketMQ Rust Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use cheetah_string::CheetahString;
+use rocketmq_model::common::constant::consume_init_mode::ConsumeInitMode;
+use rocketmq_model::common::message::message_ext_broker_inner::MessageExtBrokerInner;
+use rocketmq_model::common::message::MessageTrait;
+use rocketmq_protocol::code::response_code::ResponseCode;
+use rocketmq_protocol::common::message::message_decoder::message_properties_to_string;
+use rocketmq_protocol::protocol::header::pop_message_request_header::PopMessageRequestHeader;
+use rocketmq_runtime::common::time_utils::current_millis;
+use rocketmq_store::MessageStoreConfig;
+use rocketmq_store::PutMessageStatus;
+use rocketmq_transport::api::v2::DeferredWakeReason;
+use rocketmq_transport::api::v2::ResponseBodyKind;
+
+use super::PopResumeRequest;
+use crate::broker_runtime::BrokerRuntime;
+use crate::config::broker_config::BrokerConfig;
+
+fn temp_test_root(label: &str) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!("rocketmq-rust-pop-resume-{}-{label}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&path);
+    std::fs::create_dir_all(&path).expect("create POP resume test root");
+    path
+}
+
+fn available_ha_port() -> usize {
+    std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+        .expect("reserve an ephemeral POP resume HA port")
+        .local_addr()
+        .expect("read the ephemeral POP resume HA port")
+        .port() as usize
+}
+
+async fn runtime(label: &str) -> (BrokerRuntime, PathBuf) {
+    let root = temp_test_root(label);
+    let broker_config = Arc::new(BrokerConfig {
+        store_path_root_dir: root.to_string_lossy().into_owned().into(),
+        auth_config_path: root.join("auth.json").to_string_lossy().into_owned().into(),
+        ..BrokerConfig::default()
+    });
+    let message_store_config = Arc::new(MessageStoreConfig {
+        store_path_root_dir: root.to_string_lossy().into_owned().into(),
+        ha_listen_port: available_ha_port(),
+        ..MessageStoreConfig::default()
+    });
+    let mut runtime = BrokerRuntime::new(broker_config, message_store_config);
+    runtime.initialize().await.expect("initialize POP resume runtime");
+    runtime.seed_pop_topic_and_group_for_test("topic-a", "group-a");
+    runtime
+        .start_message_store_for_test()
+        .await
+        .expect("start POP resume message store");
+    (runtime, root)
+}
+
+fn request() -> PopMessageRequestHeader {
+    PopMessageRequestHeader {
+        consumer_group: CheetahString::from_static_str("group-a"),
+        topic: CheetahString::from_static_str("topic-a"),
+        queue_id: 0,
+        max_msg_nums: 1,
+        invisible_time: 30_000,
+        poll_time: 60_000,
+        born_time: current_millis(),
+        init_mode: ConsumeInitMode::MIN,
+        exp_type: None,
+        exp: None,
+        order: Some(false),
+        attempt_id: None,
+        topic_request_header: None,
+    }
+}
+
+fn stored_message() -> MessageExtBrokerInner {
+    let mut message = MessageExtBrokerInner::default();
+    message.set_topic(CheetahString::from_static_str("topic-a"));
+    message.message_ext_inner.set_queue_id(0);
+    message.set_body(Bytes::from_static(b"deferred-pop-message"));
+    message.set_wait_store_msg_ok(false);
+    message.properties_string = message_properties_to_string(message.get_properties());
+    message
+}
+
+#[tokio::test]
+async fn actual_store_reread_builds_empty_then_message_found_plans() {
+    let (mut runtime, root) = runtime("empty-then-found").await;
+    let processor = runtime.pop_message_processor_for_test();
+
+    let empty = processor
+        .resume_pop_request(
+            PopResumeRequest::for_test(request(), CheetahString::from_static_str("127.0.0.1:19002"), None),
+            DeferredWakeReason::Timeout,
+        )
+        .await
+        .expect("empty POP resume reread");
+    assert_eq!(empty.response_code(), ResponseCode::PollingTimeout as i32);
+    assert_eq!(empty.body_kind(), ResponseBodyKind::Empty);
+    assert_eq!(empty.body_len(), 0);
+    drop(empty);
+
+    let put = processor
+        .context
+        .store
+        .put_local(stored_message())
+        .await
+        .expect("append POP resume message");
+    assert_eq!(put.put_message_status(), PutMessageStatus::PutOk);
+    runtime.reput_message_store_once_for_test().await;
+
+    let found = processor
+        .resume_pop_request(
+            PopResumeRequest::for_test(request(), CheetahString::from_static_str("127.0.0.1:19001"), None),
+            DeferredWakeReason::MessageArrived,
+        )
+        .await
+        .expect("real POP resume reread");
+
+    assert_eq!(found.response_code(), ResponseCode::Success as i32);
+    assert_ne!(found.body_kind(), ResponseBodyKind::Empty);
+    assert!(found.body_len() > 0);
+    drop(found);
+    runtime.shutdown_message_store_for_test().await;
+    let _ = std::fs::remove_dir_all(root);
+}


### PR DESCRIPTION
<!-- Please make sure the target branch is right. In most case, the target branch should be `main`. -->

### Which Issue(s) This PR Fixes(Closes)

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

- Fixes #9828

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

- Add private, registry-backed POP deferred infrastructure with exact deadline handling, bounded criteria indexing, filter-before-claim selection, checked retained accounting, and lifecycle-owned expiry sweeping.
- Extract a Channel-free POP store reread seam and canonical resume path while preserving the existing V1 route and deferring production V2 cutover to its planned migration stage.
- Cover provenance, responder ownership, claim-once behavior, timeout, shutdown, filter, fanout, retry-topic normalization, real store reread, and legacy V1 compatibility.

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ Rust, we expect every pull request to have undergone thorough testing. -->

- `cargo fmt -p rocketmq-broker -- --check`
- `cargo test -p rocketmq-broker pop_deferred --lib`
- `cargo test -p rocketmq-broker --all-features pop_deferred --lib`
- `cargo test -p rocketmq-broker --all-features pop_message_processor::resume::tests --lib`
- `cargo test -p rocketmq-broker --all-features process_request_with_valid_sql_returns_polling_timeout_without_persisting_filter_data --lib`
- `cargo test -p rocketmq-broker --all-features processor::response_plan::pop::tests --lib`
- `cargo clippy -p rocketmq-broker --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- `.\scripts\runtime-audit.ps1 -SkipBaseline -EnforceBoundaryBaseline`
- `cargo +nightly-2026-07-05 check --manifest-path fuzz/Cargo.toml --locked --all-targets --all-features`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deferred POP long polling, allowing requests to wait efficiently until matching messages arrive.
  * Deferred requests can resume with available messages or return a polling-timeout response when no messages arrive.
  * Added support for exact and wildcard consumer-group matching, filtering, retry topics, priority handling, and topic fanout.
  * Added safeguards for request validation, deadlines, capacity limits, duplicate claims, and shutdown handling.

* **Bug Fixes**
  * Improved cleanup and cancellation so abandoned, expired, or disconnected requests do not remain active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->